### PR TITLE
feat(billing): Structure B ladder $39/$69/$149 + $20/seat at-cost credit (S2, #4037)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -77153,6 +77153,9 @@
                         "pricePerSeat": {
                           "type": "number"
                         },
+                        "includedUsageDollarsPerSeat": {
+                          "type": "number"
+                        },
                         "defaultModel": {
                           "type": "string"
                         },

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -221,7 +221,9 @@ describe("billing routes", () => {
       expect(body.plan.tier).toBe("starter");
       expect(body.plan.displayName).toBe("Starter");
       expect(body.plan.byot).toBe(false);
-      expect(body.plan.pricePerSeat).toBe(29);
+      expect(body.plan.pricePerSeat).toBe(39);
+      // Structure B at-cost included credit ($20/seat, #4034) surfaced on the wire.
+      expect(body.plan.includedUsageDollarsPerSeat).toBe(20);
       expect(body.limits.tokenBudgetPerSeat).toBeGreaterThan(0);
       // #3438 — the chat-integration cap the install gate enforces must reach
       // the wire so the billing page can display it (Starter = 1).
@@ -235,7 +237,9 @@ describe("billing routes", () => {
       // against the shared resolver guards against the picker advertising one
       // model while another is billed.
       expect(body.currentModel).toBe(resolveModelId(undefined, undefined));
-      expect(body.overagePerMillionTokens).toBe(1.0);
+      // Structure B (#4034): the synthetic per-token overage rate is zeroed —
+      // usage is billed at provider cost via the at-cost meter, not a markup.
+      expect(body.overagePerMillionTokens).toBe(0);
       // Total token budget = tokenBudgetPerSeat * seatCount = 2M * 3 = 6M
       expect(body.limits.totalTokenBudget).toBe(6_000_000);
       // #3418 — the plan picker's source of truth. All three paid tiers are
@@ -249,7 +253,7 @@ describe("billing routes", () => {
       expect(body.availablePlans[0]).toMatchObject({
         tier: "starter",
         displayName: "Starter",
-        pricePerSeat: 29,
+        pricePerSeat: 39,
         tokenBudgetPerSeat: 2_000_000,
         maxSeats: 10,
         maxConnections: 1,
@@ -265,10 +269,13 @@ describe("billing routes", () => {
       expect(body.plan.trialDays).toBeNull();
     });
 
-    it("surfaces metered overage + accrued cost when over budget (#3990)", async () => {
+    it("surfaces the metered band over budget, with no synthetic overage cost (Structure B, #4034)", async () => {
       // Starter: 2M/seat. 3 seats → 6M budget. Spend 7M (≈117%) — over budget
       // but, with the ceiling disabled in this test's settings mock, metered
-      // (served + billed), never hard-blocked. 1M overage at $1.00/M = $1.00.
+      // (served), never hard-blocked. The metered BAND is still reported
+      // (overageTokens = 1M), but Structure B zeroes the synthetic $/Mtok rate,
+      // so the accrued overageCost is $0 — real at-cost overage is billed via the
+      // at-cost meter (#4038/#4039), not this display field.
       mockInternalQuery.mockImplementation((...args: unknown[]) => {
         const sql = args[0];
         if (typeof sql === "string" && sql.includes("member")) {
@@ -287,7 +294,7 @@ describe("billing routes", () => {
       const body = await res.json() as any;
       expect(body.usage.tokenOverageStatus).toBe("metered");
       expect(body.usage.overageTokens).toBe(1_000_000);
-      expect(body.usage.overageCost).toBeCloseTo(1.0, 6);
+      expect(body.usage.overageCost).toBe(0);
     });
 
     it("never reports overage for a BYOT workspace, even over budget (#3990)", async () => {

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -424,7 +424,8 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         displayName: plan.displayName,
         pricePerSeat: plan.pricePerSeat,
         // Structure B at-cost included credit ($/seat/mo), #4034 — pooled
-        // per-seat. The billing page renders the included-usage line from this.
+        // per-seat. Surfaced now so the billing page can render an included-credit
+        // line once the in-app $ display lands (#4038).
         includedUsageDollarsPerSeat: plan.includedUsageDollarsPerSeat,
         defaultModel: plan.defaultModel,
         byot: workspace.byot,

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -423,6 +423,9 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         tier: workspace.plan_tier,
         displayName: plan.displayName,
         pricePerSeat: plan.pricePerSeat,
+        // Structure B at-cost included credit ($/seat/mo), #4034 — pooled
+        // per-seat. The billing page renders the included-usage line from this.
+        includedUsageDollarsPerSeat: plan.includedUsageDollarsPerSeat,
         defaultModel: plan.defaultModel,
         byot: workspace.byot,
         trialEndsAt: workspace.trial_ends_at,

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -452,9 +452,12 @@ describe("billing/enforcement", () => {
   });
 
   // ── Starter tier — Metered overage (100% → AbuseCeiling) (#3990) ──
-  // The 110% hard block is gone: usage past 100% is METERED (served, billed),
-  // not cut off, until the abuse ceiling (default 500%). Starter overage rate
-  // is $1.00 / 1M output-equivalent tokens.
+  // The 110% hard block is gone: usage past 100% is METERED (served), not cut
+  // off, until the abuse ceiling (default 500%). Under Structure B (#4034) the
+  // synthetic per-token overage rate is zeroed on every paid tier, so the
+  // "$X.XX so far" cost suffix is NOT appended (it gates on rate > 0) — real
+  // at-cost overage is billed via the at-cost meter (#4038/#4039), not this
+  // display suffix. These tests still pin the metered-BAND classification.
 
   it("meters (does not block) at exactly 100% token usage", async () => {
     mockWorkspace = makeWorkspace();
@@ -465,30 +468,30 @@ describe("billing/enforcement", () => {
     const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
     expect(tokenMetric!.status).toBe("metered");
     expect(tokenMetric!.usagePercent).toBe(100);
-    // Exactly at budget → zero overage tokens → $0.00 so far.
-    expect(result.warning!.message).toContain("$0.00 so far");
+    // Structure B: no synthetic "$X.XX so far" cost suffix (rate is 0).
+    expect(result.warning!.message).not.toContain("$");
   });
 
-  it("meters at 105% and surfaces the accrued overage cost", async () => {
+  it("meters at 105% without a synthetic overage cost suffix (Structure B, #4034)", async () => {
     mockWorkspace = makeWorkspace();
-    // 105% of 2,000,000 = 2,100,000 → 100,000 tokens of overage.
-    // 100,000 / 1,000,000 * $1.00 = $0.10.
+    // 105% of 2,000,000 = 2,100,000 → 100,000 tokens of overage (metered band),
+    // but the zeroed rate means no "$X.XX so far" suffix.
     mockUsage = { queryCount: 0, tokenCount: 2_100_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
     expect(result.warning).toBeDefined();
     const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
     expect(tokenMetric!.status).toBe("metered");
-    expect(result.warning!.message).toContain("$0.10 so far");
+    expect(result.warning!.message).not.toContain("$");
   });
 
   it("meters at 150% (well past the old 110% block) without cutting off", async () => {
     mockWorkspace = makeWorkspace();
-    // 150% of 2,000,000 = 3,000,000 → 1,000,000 overage → $1.00.
+    // 150% of 2,000,000 = 3,000,000 → 1,000,000 overage tokens (metered band).
     mockUsage = { queryCount: 0, tokenCount: 3_000_000, activeUsers: 0, periodStart: "", periodEnd: "" };
     const result = expectAllowed(await checkPlanLimits("org-1", SEATS));
     const tokenMetric = result.warning!.metrics.find((m) => m.metric === "tokens");
     expect(tokenMetric!.status).toBe("metered");
-    expect(result.warning!.message).toContain("$1.00 so far");
+    expect(result.warning!.message).not.toContain("$");
   });
 
   it("meters at 109% (the old grace-buffer top) instead of blocking", async () => {

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -88,10 +88,10 @@ describe("billing/plans", () => {
       expect(def.trialDays).toBe(14);
     });
 
-    it("plan definitions include pricing and model info", () => {
-      expect(getPlanDefinition("starter").pricePerSeat).toBe(29);
-      expect(getPlanDefinition("pro").pricePerSeat).toBe(59);
-      expect(getPlanDefinition("business").pricePerSeat).toBe(99);
+    it("plan definitions include pricing and model info (Structure B ladder, #4034)", () => {
+      expect(getPlanDefinition("starter").pricePerSeat).toBe(39);
+      expect(getPlanDefinition("pro").pricePerSeat).toBe(69);
+      expect(getPlanDefinition("business").pricePerSeat).toBe(149);
       expect(getPlanDefinition("starter").defaultModel).toBe("anthropic/claude-haiku-4.5");
       expect(getPlanDefinition("pro").defaultModel).toBe("anthropic/claude-sonnet-4.6");
       expect(getPlanDefinition("business").defaultModel).toBe("anthropic/claude-sonnet-4.6");
@@ -113,10 +113,36 @@ describe("billing/plans", () => {
       expect(business.features.sla).toBe("99.9%");
     });
 
-    it("overage rate is flat across all paid tiers", () => {
-      expect(getPlanDefinition("starter").overagePerMillionTokens).toBe(1.0);
-      expect(getPlanDefinition("pro").overagePerMillionTokens).toBe(1.0);
-      expect(getPlanDefinition("business").overagePerMillionTokens).toBe(1.0);
+    it("the synthetic per-token overage rate is zeroed on every tier (Structure B, #4034)", () => {
+      // Structure B bills AI usage at provider cost (zero markup) via the at-cost
+      // meter, not a per-token markup. The legacy synthetic rate is neutralized on
+      // every tier; the field is removed entirely when dollar-native enforcement
+      // lands (#4038).
+      for (const tier of ["free", "trial", "starter", "pro", "business", "locked"] as const) {
+        expect(getPlanDefinition(tier).overagePerMillionTokens).toBe(0);
+      }
+    });
+
+    it("every paid tier carries the flat $20/seat at-cost credit; free/locked carry none (#4034)", () => {
+      // Flat $20 on every paid tier (pooled per-seat via × seatCount); the trial
+      // mirrors Starter. Free (BYOK/self-hosted) and locked (churned) carry no
+      // included credit.
+      expect(getPlanDefinition("starter").includedUsageDollarsPerSeat).toBe(20);
+      expect(getPlanDefinition("pro").includedUsageDollarsPerSeat).toBe(20);
+      expect(getPlanDefinition("business").includedUsageDollarsPerSeat).toBe(20);
+      expect(getPlanDefinition("trial").includedUsageDollarsPerSeat).toBe(20);
+      expect(getPlanDefinition("free").includedUsageDollarsPerSeat).toBe(0);
+      expect(getPlanDefinition("locked").includedUsageDollarsPerSeat).toBe(0);
+    });
+
+    it("margin floor = seat price − included credit is positive on every paid tier (#4034)", () => {
+      // The gap between the seat fee and the included at-cost credit is the
+      // guaranteed per-seat margin floor (entry $39 − $20 = $19), independent of
+      // usage. Pins the "credit sized below the seat price" invariant.
+      for (const tier of ["starter", "pro", "business"] as const) {
+        const def = getPlanDefinition(tier);
+        expect(def.pricePerSeat - def.includedUsageDollarsPerSeat).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -81,10 +81,12 @@ export interface PlanDefinition {
   /**
    * DEPRECATED (Structure B, #4034): the legacy synthetic $/1M-token overage
    * rate. Zeroed on every tier — Structure B bills usage at provider cost (zero
-   * markup) via the at-cost meter, not a per-token markup. Retained only so the
-   * field doesn't break the wire type mid-migration; removed when the
-   * dollar-native enforcement lands (#4038). Token-weighting stays for
-   * display/budget-fallback only, never the billing path.
+   * markup) via the at-cost meter, not a per-token markup. Zeroing here only
+   * neutralizes the DISPLAY accrual (`computeOverageCost` → $0); the token-based
+   * OverageMeter (#3992) keeps reporting token deltas to its Stripe price until
+   * the at-cost meter repoint lands (#4039). Retained only so the field doesn't
+   * break the wire type mid-migration; removed when dollar-native enforcement
+   * lands (#4038).
    */
   overagePerMillionTokens: number;
   limits: PlanLimits;

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -68,7 +68,24 @@ export interface PlanDefinition {
   pricePerSeat: number;
   /** Default AI model for this plan tier. */
   defaultModel: string;
-  /** Cost in USD per 1M output-equivalent tokens above the included budget. 0 = no overage. */
+  /**
+   * Included at-cost usage credit per seat per month, in USD (Structure B,
+   * #4034). Pooled per-seat: the workspace's included usage budget is
+   * `includedUsageDollarsPerSeat × seatCount`, so team size ladders the pool and
+   * there is no per-tier credit ladder. 0 = no included credit (free/locked).
+   * AI usage is metered at provider cost (zero markup) and drawn against this;
+   * enforcement against it lands in #4038. The flat $20 on every paid tier is a
+   * working number — hot-reloadable, recalibrate ~30d post-launch.
+   */
+  includedUsageDollarsPerSeat: number;
+  /**
+   * DEPRECATED (Structure B, #4034): the legacy synthetic $/1M-token overage
+   * rate. Zeroed on every tier — Structure B bills usage at provider cost (zero
+   * markup) via the at-cost meter, not a per-token markup. Retained only so the
+   * field doesn't break the wire type mid-migration; removed when the
+   * dollar-native enforcement lands (#4038). Token-weighting stays for
+   * display/budget-fallback only, never the billing path.
+   */
   overagePerMillionTokens: number;
   limits: PlanLimits;
   features: PlanFeatures;
@@ -126,6 +143,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     displayName: "Self-Hosted",
     pricePerSeat: 0,
     defaultModel: "user-configured",
+    includedUsageDollarsPerSeat: 0,
     overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: UNLIMITED,
@@ -145,6 +163,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     // hyphen format (`claude-haiku-4-5`) is migrated lazily by the
     // billing-page alias map for any legacy `ATLAS_MODEL` settings.
     defaultModel: "anthropic/claude-haiku-4.5",
+    includedUsageDollarsPerSeat: 20,
     overagePerMillionTokens: 0,
     trialDays: TRIAL_DAYS,
     limits: {
@@ -159,9 +178,10 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
   starter: {
     name: "starter",
     displayName: "Starter",
-    pricePerSeat: 29,
+    pricePerSeat: 39,
     defaultModel: "anthropic/claude-haiku-4.5",
-    overagePerMillionTokens: 1.0,
+    includedUsageDollarsPerSeat: 20,
+    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 2_000_000,
       maxSeats: 10,
@@ -174,9 +194,10 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
   pro: {
     name: "pro",
     displayName: "Pro",
-    pricePerSeat: 59,
+    pricePerSeat: 69,
     defaultModel: "anthropic/claude-sonnet-4.6",
-    overagePerMillionTokens: 1.0,
+    includedUsageDollarsPerSeat: 20,
+    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 5_000_000,
       maxSeats: 25,
@@ -201,6 +222,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     displayName: "Locked",
     pricePerSeat: 0,
     defaultModel: "anthropic/claude-haiku-4.5",
+    includedUsageDollarsPerSeat: 0,
     overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 0,
@@ -214,9 +236,10 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
   business: {
     name: "business",
     displayName: "Business",
-    pricePerSeat: 99,
+    pricePerSeat: 149,
     defaultModel: "anthropic/claude-sonnet-4.6",
-    overagePerMillionTokens: 1.0,
+    includedUsageDollarsPerSeat: 20,
+    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 15_000_000,
       maxSeats: UNLIMITED,

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -12,7 +12,8 @@ const validStatus = {
   plan: {
     tier: "starter" as const,
     displayName: "Starter",
-    pricePerSeat: 29,
+    pricePerSeat: 39,
+    includedUsageDollarsPerSeat: 20,
     defaultModel: "claude-haiku-4-5",
     byot: false,
     trialEndsAt: null,
@@ -87,6 +88,20 @@ describe("happy-path parses", () => {
     const parsed = BillingStatusSchema.parse(validStatus);
     const serialized = JSON.parse(JSON.stringify(parsed));
     expect(BillingStatusSchema.parse(serialized)).toEqual(validStatus);
+  });
+
+  test("preserves the Structure B includedUsageDollarsPerSeat credit (#4037)", () => {
+    const parsed = BillingStatusSchema.parse(validStatus);
+    expect(parsed.plan.includedUsageDollarsPerSeat).toBe(20);
+  });
+
+  test("tolerates an older bundle omitting includedUsageDollarsPerSeat", () => {
+    // The credit is optional on the wire; a web bundle pinned to a pre-#4037
+    // published schema must still parse a response without the field.
+    const { includedUsageDollarsPerSeat: _omit, ...planNoCredit } = validStatus.plan;
+    const older = { ...validStatus, plan: planNoCredit };
+    const parsed = BillingStatusSchema.parse(older);
+    expect(parsed.plan.includedUsageDollarsPerSeat).toBeUndefined();
   });
 });
 

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -59,9 +59,9 @@ export interface BillingPlan {
   /**
    * Included at-cost usage credit per seat per month, in USD (Structure B,
    * #4034). Pooled per-seat — the workspace's included usage budget is
-   * `includedUsageDollarsPerSeat × seatCount`. The billing page renders the
-   * included-credit line from this. Optional for older-bundle tolerance; absent
-   * ⇒ the credit line is hidden.
+   * `includedUsageDollarsPerSeat × seatCount`. Surfaced for the billing page's
+   * future included-credit line (in-app $ display: #4038). Optional for
+   * older-bundle tolerance; absent ⇒ no credit line.
    */
   includedUsageDollarsPerSeat?: number;
   defaultModel: string;

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -56,6 +56,14 @@ export interface BillingPlan {
   tier: PlanTier;
   displayName: string;
   pricePerSeat: number;
+  /**
+   * Included at-cost usage credit per seat per month, in USD (Structure B,
+   * #4034). Pooled per-seat — the workspace's included usage budget is
+   * `includedUsageDollarsPerSeat × seatCount`. The billing page renders the
+   * included-credit line from this. Optional for older-bundle tolerance; absent
+   * ⇒ the credit line is hidden.
+   */
+  includedUsageDollarsPerSeat?: number;
   defaultModel: string;
   byot: boolean;
   /** Raw `organization.trial_ends_at` — may be null even on a live trial (pre-backfill workspaces). */
@@ -221,6 +229,7 @@ export const BillingPlanSchema = z.object({
   tier: PlanTierEnum,
   displayName: z.string(),
   pricePerSeat: z.number(),
+  includedUsageDollarsPerSeat: z.number().optional(),
   defaultModel: z.string(),
   byot: z.boolean(),
   trialEndsAt: z.string().nullable(),


### PR DESCRIPTION
## Summary

Re-denominate the `plans.ts` pricing SSOT to the Structure B ladder + flat per-seat at-cost credit (part of #4034). This is the pricing-SSOT + wire change; the dollar-native enforcement + spend policy + in-app $ usage display land in **#4038**.

- **`plans.ts`**: `pricePerSeat` → Starter **$39** / Pro **$69** / Business **$149**. New **`includedUsageDollarsPerSeat`** field — flat **$20** on every paid tier (trial mirrors Starter; free/locked = 0), pooled per-seat (`budget = $20 × seatCount`; team size ladders the pool — no per-tier credit ladder). The synthetic `$/1M-token` overage rate is **zeroed** on every tier (Structure B bills usage at provider cost via the at-cost meter, not a markup); the field is removed when dollar-native enforcement lands (#4038).
- **Wire**: `includedUsageDollarsPerSeat` carried on `BillingPlan` (`@useatlas/schemas`, optional for older-bundle tolerance) and surfaced by the billing route; the in-app admin billing page auto-shows the new seat price via the wire. OpenAPI spec regenerated.

## ⚠ Interim sequencing note (resolved in #4039)

Zeroing `overagePerMillionTokens` neutralizes only the **display** accrual (`computeOverageCost` → $0). The token-based `OverageMeter` (#3992) still reports token deltas to its existing Stripe overage price until the at-cost meter repoint (**#4039**). So in the window between this slice and #4039, an over-budget workspace would see "$0 overage" in-app while the token meter could still invoice. This only affects **staging** (prod is `/release`-gated and the prod Stripe step is HITL), and the chain lands #4038/#4039 before any prod release. The internal review panel flagged this; it is intentional and sequenced.

## Test plan

- [x] `bun run type`, `lint`, `syncpack` clean
- [x] `plans.test.ts` (ladder, $20 credit incl. trial, zeroed rate across all 6 tiers, margin-floor invariant)
- [x] `billing.test.ts` (wire price + credit; metered band still reported with $0 synthetic cost)
- [x] `enforcement.test.ts` (metered band re-asserted with no `$` suffix — the zeroed-rate behavior)
- [x] `schemas/billing.test.ts` (new optional credit parses; older-bundle omission tolerated)
- [x] `platform-admin.test.ts` MRR reads prices dynamically — auto-adapts
- [x] Drift gates green: pricing-parity, openapi-drift, schema-drift, published-symbols
- [x] Affected isolated suite 12/12

Internal review panel: 1 round → fixes applied (metered-band test, comment tense, schema fixture). Rebased onto `main` after #4036 merged.

Closes #4037

https://claude.ai/code/session_017AjYJfsEshwZhc3GFGpJci

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restructure billing plan pricing to $39/$69/$149 with $20/seat at-cost usage credit
> - Updates `pricePerSeat` for starter/pro/business tiers to $39/$69/$149 in [plans.ts](https://github.com/AtlasDevHQ/atlas/pull/4042/files#diff-f09fe4fe21636eae174f5763cac07ffa4ef3c07004a5a30155befec1ae1441b8)
> - Adds `includedUsageDollarsPerSeat` field ($20 for paid/trial tiers, $0 for free/locked) to plan definitions, API responses, and schemas
> - Sets `overagePerMillionTokens` to 0 for all paid tiers, replacing per-token synthetic overage cost with the new at-cost credit model
> - Behavioral Change: `GET /api/v1/billing` responses now include `plan.includedUsageDollarsPerSeat` and no longer return a synthetic overage cost suffix in metered budget messages
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54c563a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->