### PR TITLE
refactor(cli): split operator subcommands into atlas-operator binary

### DIFF
--- a/.claude/commands/verify-prod-signup.md
+++ b/.claude/commands/verify-prod-signup.md
@@ -189,10 +189,10 @@ The verify accounts are real prod identities (user + org + members; a Stripe cus
 
 ```bash
 # DRY RUN first (default — lists exactly what would go, deletes nothing):
-bun run atlas -- ops teardown-verify-accounts --region eu --email matt+eu@useatlas.dev
+bun run atlas-operator -- ops teardown-verify-accounts --region eu --email matt+eu@useatlas.dev
 # EXECUTE (double-gated, like ops wipe): cancels Stripe + soft-deletes + hard-deletes
 #   the org and its now-orphaned user, reusing the platform-admin purge SSOT:
-ATLAS_TEARDOWN_OK=1 bun run atlas -- ops teardown-verify-accounts \
+ATLAS_TEARDOWN_OK=1 bun run atlas-operator -- ops teardown-verify-accounts \
   --region eu --email matt+eu@useatlas.dev --confirm
 # Repeat per region (--region us/eu/apac selects ATLAS_REGION_<R>_DB_URL). The shared
 # matt+multi@ chooser account exists in two regions — tear it down in EACH.
@@ -202,10 +202,10 @@ ATLAS_TEARDOWN_OK=1 bun run atlas -- ops teardown-verify-accounts \
 - **One region DB per invocation.** `--region` resolves `ATLAS_REGION_<R>_DB_URL`; there is **no `DATABASE_URL` fallback** (the wrong-DB footgun).
 - **Mislocated-account residue check (ADR-0024 / #3967):** the pre-fix verify runs created EU/APAC accounts *in the US DB*. Prove they're gone — a DRY RUN of the US DB against the EU/APAC emails must resolve **zero** orgs:
   ```bash
-  bun run atlas -- ops teardown-verify-accounts --region us \
+  bun run atlas-operator -- ops teardown-verify-accounts --region us \
     --email matt+eu@useatlas.dev,matt+apac@useatlas.dev   # expect: 0 workspace(s)
   ```
-- **NEVER `bun run atlas -- ops wipe`** against a prod region DB — it TRUNCATEs every public table and would destroy real tenants.
+- **NEVER `bun run atlas-operator -- ops wipe`** against a prod region DB — it TRUNCATEs every public table and would destroy real tenants.
 
 ---
 
@@ -224,7 +224,7 @@ ATLAS_TEARDOWN_OK=1 bun run atlas -- ops teardown-verify-accounts \
 The only thing keeping this HITL is the **email OTP** — everything else is already scriptable (the Playwright drive + the three `fetch` assertions above). To run it in CI:
 
 1. **Programmatic OTP read.** Give the test inbox an API (a Resend *inbound* route → webhook/store, or an IMAP/mailbox API for `useatlas.dev`) so the runner can poll for the 8-char code instead of a human. This is the single blocker.
-2. **Dedicated test identities.** Pre-provisioned `ci+us@ / ci+eu@ / ci+apac@useatlas.dev` (business-domain) with automatic surgical teardown after each run via `atlas ops teardown-verify-accounts --region <R> --email <ci+R@…> --confirm` (`ATLAS_TEARDOWN_OK=1`).
+2. **Dedicated test identities.** Pre-provisioned `ci+us@ / ci+eu@ / ci+apac@useatlas.dev` (business-domain) with automatic surgical teardown after each run via `atlas-operator ops teardown-verify-accounts --region <R> --email <ci+R@…> --confirm` (`ATLAS_TEARDOWN_OK=1`).
 3. **Cadence, not per-PR.** Run post-`/release` (a `staging-smoke`-style job gated on the prod promote) or nightly — not on every PR. It exercises live prod signup + Resend + residency routing, which is a soak check, not a unit gate.
 4. **Assert, don't screenshot.** In CI the routing + residency primitives above (1–7) are the pass/fail signal; the cross-region edge matrix (4), `resolve-region` (5), and raw probe (7) are session-light and deterministic. Keep screenshots as artifacts for triage only.
 5. **No `executeSQL` LLM dependence in the gate.** Criterion 4 (demo answer) needs the agent; keep that as a separate `@llm`-tagged check so the routing assertions (1–3) stay deterministic and cheap.

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -10,7 +10,7 @@ name: Staging Smoke
 #      would 401 here (Codex caught this on PR #2894). Note the path is
 #      /api/health, not /api/v1/health — the health router is mounted outside
 #      the /api/v1 prefix.
-#   2. The CRM lead-capture flusher path is alive — `atlas ops smoke-crm`
+#   2. The CRM lead-capture flusher path is alive — `atlas-operator ops smoke-crm`
 #      enqueues a tiny persona fixture into `crm_outbox`, waits for the
 #      flusher to drain, then asserts the resulting Twenty Persons match.
 #      The CLI talks to Postgres + Twenty DIRECTLY (not over HTTP), so it
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        # `atlas ops smoke-crm` runs straight off TS via bun and pulls in the
+        # `atlas-operator ops smoke-crm` runs straight off TS via bun and pulls in the
         # `@atlas/api` workspace + `pg` at runtime, so a full install is
         # required even though nothing is compiled.
         run: bun install --frozen-lockfile
@@ -145,7 +145,7 @@ jobs:
             echo "::error::Configure under Settings → Secrets and variables → Actions (see this workflow's header)."
             exit 1
           fi
-          bun run atlas -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml
+          bun run atlas-operator -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml
 
       - name: Post result to Slack #sandbox-atlas
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,23 +157,23 @@ bun run atlas -- diff    # Compare DB schema vs semantic layer
 
 > **Local dev runs either deploy mode; `self-hosted` is the trivial default.** `.env` ships `ATLAS_DEPLOY_MODE=self-hosted` + `ATLAS_DEPLOY_ENV=development`. With `development` set, even an unset/`auto` deploy mode now resolves to `self-hosted` (`resolveDeployMode`), so a missing value no longer face-plants the API onto the SaaS-only boot guards. To dev against the SaaS code path, set `ATLAS_DEPLOY_MODE=saas`: in `development` env the SaaS fail-closed boot guards (Turnstile #3795, rate-limit RPM #1983, billing, MCP spine, …) **relax to a no-op** (`relaxSaasGuardForDev` in `saas-guards.ts`) so it boots against your real local `.env` without the prod-only secrets — an **intentional local-dev footgun, gated solely on `development`; never set `ATLAS_DEPLOY_ENV=development` on a customer-facing deploy.** Don't set deploy vars on the `bun run dev` command line (the wrapper subshell drops them); they belong in `.env`. Full runbook + the `VERCEL_*`-breaks-sandbox-tests caveat: [docs/development/local-development.md](docs/development/local-development.md).
 
-### Operator subcommands (destructive)
+### Operator subcommands (destructive) — the `atlas-operator` binary
 
-The atlas-cli exposes a tenant-data operator surface (promoted from the gitignored `internal/` in #2635). All target the tenant DB at `ATLAS_TEAM_PG_URL` (falling back to `DATABASE_URL`).
+The tenant-data operator surface (promoted from the gitignored `internal/` in #2635) lives in its **own binary, `atlas-operator`** — split out of the published `atlas` CLI so the workspace-facing binary never ships tenant-destructive direct-DB tooling (ADR-0025 step 4, #4045). Run it with `bun run atlas-operator -- <command>` (root or `packages/cli` script). The published `atlas` CLI no longer dispatches these — it prints a redirect pointing here. All target the tenant DB at `ATLAS_TEAM_PG_URL` (falling back to `DATABASE_URL`).
 
 ```bash
-bun run atlas -- proactive enable --workspace <id|slug> --channels <c1,c2>
-bun run atlas -- proactive disable --workspace <id|slug>
-bun run atlas -- seed prompts --workspace <id|slug> --library ./prompts/library.yml
-bun run atlas -- seed workspace --workspace <id|slug> --group prod \
+bun run atlas-operator -- proactive enable --workspace <id|slug> --channels <c1,c2>
+bun run atlas-operator -- proactive disable --workspace <id|slug>
+bun run atlas-operator -- seed prompts --workspace <id|slug> --library ./prompts/library.yml
+bun run atlas-operator -- seed workspace --workspace <id|slug> --group prod \
   --connections us-prod=US_DB_URL:postgres:primary,eu-prod=EU_DB_URL:postgres
 # DESTRUCTIVE — TRUNCATE every public table (excluding migration bookkeeping):
-ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm [--database-url <url>]
+ATLAS_WIPE_OK=1 bun run atlas-operator -- ops wipe --confirm [--database-url <url>]
 # One-shot: enqueue every demo_leads row into crm_outbox for dispatch to Twenty:
-bun run atlas -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source demo]
+bun run atlas-operator -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source demo]
 # E2E check of the demo→Twenty lead pipeline (below Turnstile, via the outbox);
 # run ad-hoc by an operator AND as the post-deploy staging-smoke gate:
-bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] [--twenty-base-url <url>] \
+bun run atlas-operator -- ops smoke-crm --personas <path> [--wipe-twenty] [--twenty-base-url <url>] \
   [--twenty-api-key <key>] [--timeout-seconds 60] [--database-url <url>]
 ```
 

--- a/apps/docs/content/docs/architecture/enterprise.mdx
+++ b/apps/docs/content/docs/architecture/enterprise.mdx
@@ -30,7 +30,7 @@ Everything else flows from those two. If you've grepped for `requireEnterprise(`
 The core product is **AGPL-3.0**. Run it standalone, embed it via the SDK, ship it on Docker, Railway, or Vercel — no license key, no feature flags. Self-hosted deployments get:
 
 - The agent loop, tools (`executeSQL`, `explore`, plugin actions), and Vercel AI SDK integration
-- The semantic layer, `atlas init` / `atlas diff` / `atlas learn` CLI
+- The semantic layer, `atlas init` / `atlas diff` / `atlas-operator learn` CLI
 - Multi-tenant primitives (Better Auth org plugin, tenant-scoped pools, query result cache)
 - The admin console, audit log, role assignment via the built-in `admin`/`member`/`owner` triad
 - The full plugin ecosystem and Chat SDK adapters

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -396,7 +396,7 @@ Settings overrides require an internal database (`DATABASE_URL`). Without it, bo
 **Route:** `/admin/learned-patterns`
 
 <Callout type="info">
-Requires an internal database (`DATABASE_URL`). Patterns are proposed by the agent during conversations or by the `atlas learn` CLI command.
+Requires an internal database (`DATABASE_URL`). Patterns are proposed by the agent during conversations or by the `atlas-operator learn` CLI command.
 </Callout>
 
 Review, approve, and manage query patterns the agent has learned:

--- a/apps/docs/content/docs/guides/migration.mdx
+++ b/apps/docs/content/docs/guides/migration.mdx
@@ -33,18 +33,18 @@ data, so you can safely re-run after fixing errors or adding new data.
 
 ### Export from self-hosted
 
-Run `atlas export` against your self-hosted instance. This reads directly from
+Run `atlas-operator export` against your self-hosted instance. This reads directly from
 the internal database (no running API server required).
 
 ```bash
 # Basic export (global/unscoped data)
-atlas export
+atlas-operator export
 
 # Export a specific org's data
-atlas export --org org_abc123
+atlas-operator export --org org_abc123
 
 # Custom output path
-atlas export --output my-backup.json
+atlas-operator export --output my-backup.json
 ```
 
 The command produces a JSON bundle file (e.g. `atlas-export-2026-04-02.json`)
@@ -130,7 +130,7 @@ are present.
 
 ## CLI reference
 
-### `atlas export`
+### `atlas-operator export`
 
 Exports workspace data from the internal database to a portable JSON bundle.
 

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -569,8 +569,10 @@ The command reports how many entities were imported, how many were skipped (alre
 
 Analyze the audit log and propose semantic layer YAML improvements. This is Atlas's offline learning loop — it examines real query patterns and suggests additions to your entity files, joins, and glossary.
 
+> **Operator-only.** `learn` is direct-DB tooling and ships in the [`atlas-operator`](#operator-subcommands) binary, not the published `atlas` CLI.
+
 ```bash
-bun run atlas -- learn [options]
+bun run atlas-operator -- learn [options]
 ```
 
 | Flag | Description |
@@ -599,19 +601,19 @@ Pass `--auto-approve` to bypass the queue — new rows write `approval_status = 
 
 ```bash
 # Preview proposals (dry run, the default)
-atlas learn
+atlas-operator learn
 
 # Apply changes to YAML files
-atlas learn --apply
+atlas-operator learn --apply
 
 # Only analyze recent queries
-atlas learn --since 2026-03-01 --limit 500
+atlas-operator learn --since 2026-03-01 --limit 500
 
 # Generate query suggestions from audit log — new rows are pending review
-atlas learn --suggestions
+atlas-operator learn --suggestions
 
 # Skip the moderation queue — new rows are approved + published
-atlas learn --suggestions --auto-approve
+atlas-operator learn --suggestions --auto-approve
 ```
 
 ## improve
@@ -675,8 +677,10 @@ bun run atlas -- benchmark [options]
 
 Export workspace data to a portable migration bundle (JSON). Reads from the internal database. Used as the first step in a self-hosted → SaaS migration workflow. See [Migration guide](/guides/migration) for the full workflow.
 
+> **Operator-only.** `export` is direct-DB tooling and ships in the [`atlas-operator`](#operator-subcommands) binary, not the published `atlas` CLI.
+
 ```bash
-bun run atlas -- export [options]
+bun run atlas-operator -- export [options]
 ```
 
 | Flag | Description |
@@ -691,13 +695,13 @@ bun run atlas -- export [options]
 
 ```bash
 # Export all workspace data to a timestamped file
-bun run atlas -- export
+bun run atlas-operator -- export
 
 # Export to a specific file
-bun run atlas -- export --output backup.json
+bun run atlas-operator -- export --output backup.json
 
 # Export a specific organization's data
-bun run atlas -- export --org org_abc123
+bun run atlas-operator -- export --org org_abc123
 ```
 
 ## migrate-import
@@ -762,7 +766,7 @@ bun run atlas -- completions fish > ~/.config/fish/completions/atlas.fish
 
 ## Operator subcommands
 
-Operator-only tools for tenant-data ops, promoted from the gitignored `internal/` directory in [#2635](https://github.com/AtlasDevHQ/atlas/pull/2635) so they're type-checked, unit-tested, and discoverable. All subcommands target the tenant Postgres at `ATLAS_TEAM_PG_URL`, falling back to `DATABASE_URL` when unset. `--workspace` accepts either a literal `org_*` id or an `organization.slug`.
+Operator-only tools for tenant-data ops, promoted from the gitignored `internal/` directory in [#2635](https://github.com/AtlasDevHQ/atlas/pull/2635) so they're type-checked, unit-tested, and discoverable. They ship in a **separate `atlas-operator` binary** — split out of the published `atlas` CLI so the workspace-facing binary never carries tenant-destructive direct-DB tooling (ADR-0025 step 4, [#4045](https://github.com/AtlasDevHQ/atlas/issues/4045)). Run them with `bun run atlas-operator -- <command>`; the published `atlas` CLI prints a redirect if you try one there. This surface also includes the [`learn`](#learn) and [`export`](#export) commands above. The tenant-data subcommands (`proactive`, `seed`, `ops`) target the tenant Postgres at `ATLAS_TEAM_PG_URL`, falling back to `DATABASE_URL` when unset; `learn` and `export` instead read Atlas's **internal** database via `DATABASE_URL` (the two-database split). `--workspace` accepts either a literal `org_*` id or an `organization.slug`.
 
 The CLAUDE.md "Operator subcommands (destructive)" block is the source of truth for these — keep this page and CLAUDE.md aligned when adding subcommands.
 
@@ -771,7 +775,7 @@ The CLAUDE.md "Operator subcommands (destructive)" block is the source of truth 
 Turn proactive chat on for a workspace and opt one or more channels into the allowlist. Idempotent — re-running upserts `workspace_proactive_config` plus every channel row.
 
 ```bash
-bun run atlas -- proactive enable --workspace <id|slug> --channels <c1,c2,...>
+bun run atlas-operator -- proactive enable --workspace <id|slug> --channels <c1,c2,...>
 ```
 
 | Flag | Description |
@@ -784,7 +788,7 @@ bun run atlas -- proactive enable --workspace <id|slug> --channels <c1,c2,...>
 Flip the workspace toggle off. Channel rows are preserved so a later `enable` doesn't lose channel configs.
 
 ```bash
-bun run atlas -- proactive disable --workspace <id|slug>
+bun run atlas-operator -- proactive disable --workspace <id|slug>
 ```
 
 | Flag | Description |
@@ -796,7 +800,7 @@ bun run atlas -- proactive disable --workspace <id|slug>
 Seed a prompt-library collection + items from a YAML file. Replaces any prior collection with the same `(org_id, name)` and pins the org's demo industry so the starter-prompt resolver matches.
 
 ```bash
-bun run atlas -- seed prompts --workspace <id|slug> --library ./prompts/library.yml
+bun run atlas-operator -- seed prompts --workspace <id|slug> --library ./prompts/library.yml
 ```
 
 | Flag | Default | Description |
@@ -809,7 +813,7 @@ bun run atlas -- seed prompts --workspace <id|slug> --library ./prompts/library.
 Provision a connection group, member connections, and the accompanying semantic entities for that group. The `--connections` argument is a comma-separated list of `id=urlEnv:type[:primary]` entries — exactly one entry must carry `:primary`. Connection URLs are read from `process.env[urlEnv]` and encrypted at rest with the active `ATLAS_ENCRYPTION_KEYS` version.
 
 ```bash
-bun run atlas -- seed workspace \
+bun run atlas-operator -- seed workspace \
   --workspace <id|slug> \
   --group prod \
   --connections us-prod=US_DB_URL:postgres:primary,eu-prod=EU_DB_URL:postgres
@@ -830,7 +834,7 @@ bun run atlas -- seed workspace \
 </Callout>
 
 ```bash
-ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm [--database-url <url>]
+ATLAS_WIPE_OK=1 bun run atlas-operator -- ops wipe --confirm [--database-url <url>]
 ```
 
 | Flag | Description |
@@ -840,14 +844,14 @@ ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm [--database-url <url>]
 
 **Exit codes:** `0` = tables truncated; `1` = gate failed or wipe errored; `2` = zero tables matched the exclusion query (almost always a wrong-DB typo — nothing was truncated).
 
-The exclusion list (`__atlas_migrations`, `region_migrations`) lives next to the SQL in `packages/cli/src/commands/ops.ts:WIPE_EXCLUDED_TABLES`.
+The exclusion list (`__atlas_migrations`, `region_migrations`) lives next to the SQL in `packages/cli/src/commands/operator/ops.ts:WIPE_EXCLUDED_TABLES`.
 
 ### ops backfill-crm-leads
 
 One-shot migration backfill: enqueues every existing `demo_leads` row into `crm_outbox` so historical demo signups also dispatch to Twenty CRM. Idempotent — re-running is safe because `TwentyClient.upsertPerson` dedupes by primary email and the outbox uses a per-source idempotency key.
 
 ```bash
-bun run atlas -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source demo] [--database-url <url>]
+bun run atlas-operator -- ops backfill-crm-leads [--dry-run] [--batch-size 500] [--source demo] [--database-url <url>]
 ```
 
 | Flag | Description |
@@ -864,7 +868,7 @@ Already-run on prod against `demo_leads`; safe to re-run if a new region comes o
 End-to-end verification of the demo → Twenty CRM lead-capture pipeline. It injects fixture personas **below** the form/Turnstile layer (straight into `crm_outbox` via `enqueue`), waits for the lead-outbox flusher to drain, then lists Twenty over REST and diffs the resulting Persons + Notes against what the fixture declared. Because it makes live Twenty network calls it is **not** part of per-PR CI, but it is not local-only either: an operator runs it ad-hoc, **and** it is the post-deploy **Staging Smoke** gate (`.github/workflows/staging-smoke.yml`), which fires after a staging deploy to prove the flusher path is alive against the staging DB + Twenty. Changing or removing this subcommand will break that gate.
 
 ```bash
-bun run atlas -- ops smoke-crm --personas <path> [--wipe-twenty] \
+bun run atlas-operator -- ops smoke-crm --personas <path> [--wipe-twenty] \
   [--twenty-base-url <url>] [--twenty-api-key <key>] [--timeout-seconds 60] [--database-url <url>]
 ```
 

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -1045,8 +1045,8 @@ Destructive operator-CLI subcommands gated by explicit env confirmation. None of
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_WIPE_OK` | — | Required gate (`=1`) for the destructive `atlas ops wipe` subcommand. `TRUNCATE`s every public table in the tenant DB; takes no backup. Pair with `--confirm` on the command line. Source: `packages/cli/src/commands/ops.ts` |
-| `ATLAS_TEAM_PG_URL` | — | Canonical tenant-DB connection string for the operator CLI. Resolved by `packages/cli/lib/tenant-db.ts` in this precedence: `ATLAS_TEAM_PG_URL` → `DATABASE_URL` → exit with error. Read by every CLI operator subcommand that touches the tenant DB — `atlas ops` (wipe, etc.), `atlas proactive enable/disable`, `atlas seed`, and the `--db` override flag — plus one-shot `bun run` backfill scripts under `packages/api/src/lib/db/migrations/scripts/`. **Set explicitly before any destructive subcommand**: falling back to `DATABASE_URL` can target the wrong database. Not read by the API process |
+| `ATLAS_WIPE_OK` | — | Required gate (`=1`) for the destructive `atlas-operator ops wipe` subcommand. `TRUNCATE`s every public table in the tenant DB; takes no backup. Pair with `--confirm` on the command line. Source: `packages/cli/src/commands/operator/ops.ts` |
+| `ATLAS_TEAM_PG_URL` | — | Canonical tenant-DB connection string for the operator CLI (`atlas-operator`). Resolved by `packages/cli/lib/tenant-db.ts` in this precedence: `ATLAS_TEAM_PG_URL` → `DATABASE_URL` → exit with error. Read by every operator subcommand that touches the tenant DB — `atlas-operator ops` (wipe, etc.), `atlas-operator proactive enable/disable`, `atlas-operator seed`, and the `--database-url` override flag — plus one-shot `bun run` backfill scripts under `packages/api/src/lib/db/migrations/scripts/`. **Set explicitly before any destructive subcommand**: falling back to `DATABASE_URL` can target the wrong database. Not read by the API process |
 
 ---
 

--- a/docs/development/staging-environment.md
+++ b/docs/development/staging-environment.md
@@ -722,7 +722,7 @@ The chain is: **Railway staging-deploy success → GitHub `repository_dispatch` 
      route is public — no auth, no API code change needed.
    - **CRM smoke:**
      ```bash
-     bun run atlas -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml
+     bun run atlas-operator -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml
      ```
      with `TWENTY_API_KEY=$STAGING_TWENTY_API_KEY`,
      `TWENTY_BASE_URL=$STAGING_TWENTY_BASE_URL`, and
@@ -746,13 +746,13 @@ The chain is: **Railway staging-deploy success → GitHub `repository_dispatch` 
 
 ---
 
-## 5. Resetting the staging DB — `atlas ops wipe`
+## 5. Resetting the staging DB — `atlas-operator ops wipe`
 
 When staging accumulates drift, reset its internal DB with the operator wipe
 subcommand. It is **destructive** and **takes no backup**.
 
 ```bash
-ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm --database-url "$STAGING_DATABASE_URL"
+ATLAS_WIPE_OK=1 bun run atlas-operator -- ops wipe --confirm --database-url "$STAGING_DATABASE_URL"
 ```
 
 - **Double gate.** The command refuses to run unless **both**

--- a/docs/development/verify-crm-changes-locally.md
+++ b/docs/development/verify-crm-changes-locally.md
@@ -1,6 +1,6 @@
 # How to verify CRM changes locally
 
-The `atlas ops smoke-crm` CLI mechanizes the manual A1–A4 / B7 / C9 / D12
+The `atlas-operator ops smoke-crm` CLI mechanizes the manual A1–A4 / B7 / C9 / D12
 verification flow used during the 1.6.0 milestone. It exists because the
 filter-syntax regression in PR #2865 silently corrupted every customer
 Person record in production for several days before manual smoke caught
@@ -42,7 +42,7 @@ Twenty workspace + secret-rotation strategy that isn't built yet).
 # scripts/test-fixtures/crm-personas.yml and covers 10 personas across
 # every lead variant (4× sales-form, 1 demo, 1 signup, 1 demo→signup
 # stickiness pair, 1 demo→demo idempotency pair).
-bun run atlas -- ops smoke-crm \
+bun run atlas-operator -- ops smoke-crm \
   --personas ./scripts/test-fixtures/crm-personas.yml \
   --twenty-api-key "$TWENTY_API_KEY"
 
@@ -50,14 +50,14 @@ bun run atlas -- ops smoke-crm \
 # `ops wipe` double-confirm gate: needs BOTH the flag AND
 # ATLAS_SMOKE_WIPE_OK=1 in the env.
 ATLAS_SMOKE_WIPE_OK=1 \
-  bun run atlas -- ops smoke-crm \
+  bun run atlas-operator -- ops smoke-crm \
     --personas ./scripts/test-fixtures/crm-personas.yml \
     --twenty-api-key "$TWENTY_API_KEY" \
     --wipe-twenty
 
 # Tune the drain timeout (default 60s). The Twenty hosted instance can
 # be slow under spike load — raise this if you see TIMEOUT exits.
-bun run atlas -- ops smoke-crm \
+bun run atlas-operator -- ops smoke-crm \
   --personas ./scripts/test-fixtures/crm-personas.yml \
   --timeout-seconds 120
 ```

--- a/docs/prd/staging-environment.md
+++ b/docs/prd/staging-environment.md
@@ -35,7 +35,7 @@ Introduce a single staging environment fronting production. The shape is deliber
 User-visible promotion model:
 
 - **`main` push** → staging deploys automatically (api + web + www, no docs)
-- **Eyeball staging** — via `atlas ops smoke-crm`, click-through, or the `/verify` skill
+- **Eyeball staging** — via `atlas-operator ops smoke-crm`, click-through, or the `/verify` skill
 - **Tag a release** — `git tag -a v0.x.y && git push origin v0.x.y` triggers production deploy across all three regions in parallel. Pushing the explicit tag ref (not `--tags`) prevents accidentally publishing stale local tags into the prod trigger.
 - **Hotfix** — push fix to `main`, tag immediately. Don't wait for staging soak. Both deploys fire on the same commit; if prod's health check fails, Railway auto-rolls-back the bad region while staging keeps the failed code for reproduction.
 
@@ -62,11 +62,11 @@ The maintainer's daily loop changes by exactly two steps: (1) wait ~5 min for st
 13. As the maintainer, I want staging emails to clamp to `staging-mail@useatlas.dev`, so that I can verify rendering without spamming real-looking fake addresses or hurting Resend sender reputation.
 14. As the maintainer, I want to log into staging with a deterministic admin credential, so that I can manually exercise admin surfaces without running through full signup each time.
 15. As the maintainer, I want a `/staging` visual marker on the web app, so that I never confuse a staging tab with a prod tab during dogfood.
-16. As the maintainer, I want `atlas ops smoke-crm` to be runnable against the staging URLs out of the box, so that the post-deploy gate is one command not five.
+16. As the maintainer, I want `atlas-operator ops smoke-crm` to be runnable against the staging URLs out of the box, so that the post-deploy gate is one command not five.
 17. As the maintainer, I want staging to be a 4th region keyed `staging` and excluded from the residency router, so that no prod traffic gets misrouted to staging and staging never claims to be a residency target.
 18. As the maintainer, I want OAuth callback URLs for Slack/Linear/GitHub/Google staging apps to point to `api.staging.useatlas.dev`, so that real OAuth flows can be exercised against staging end-to-end.
 19. As the maintainer, I want a Railway-level kill switch for the staging deploy trigger, so that if staging itself is broken I can disable it without blocking prod releases.
-20. As the maintainer, I want `bun run atlas -- ops wipe --confirm` to work against the staging DB, so that I can reset state when staging accumulates drift.
+20. As the maintainer, I want `bun run atlas-operator -- ops wipe --confirm` to work against the staging DB, so that I can reset state when staging accumulates drift.
 
 ### Future contributor — once external contributions open up
 
@@ -156,7 +156,7 @@ Per-env Railway env vars for every secret in `.env.example`. No inheritance betw
 
 - New `.github/workflows/staging-smoke.yml`. Triggers on Railway staging-deploy success webhook. Runs:
   - `curl -fsS https://api.staging.useatlas.dev/api/health | jq -e '.region == "staging"'` — verifies the deploy actually landed and the region discriminator is set. `/health` is public, no auth; the existing route already surfaces `region` from `getApiRegion()`, so no API code change is needed for this check.
-  - `bun run atlas -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml` with `TWENTY_API_KEY=$STAGING_TWENTY_API_KEY`, `TWENTY_BASE_URL=$STAGING_TWENTY_BASE_URL`, `DATABASE_URL=$STAGING_DATABASE_URL` env vars. The CLI talks directly to Twenty + Postgres — no `--base-url` against the staging API host. A small personas fixture lives in `scripts/staging-smoke-personas.yml` and is committed to the repo.
+  - `bun run atlas-operator -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml` with `TWENTY_API_KEY=$STAGING_TWENTY_API_KEY`, `TWENTY_BASE_URL=$STAGING_TWENTY_BASE_URL`, `DATABASE_URL=$STAGING_DATABASE_URL` env vars. The CLI talks directly to Twenty + Postgres — no `--base-url` against the staging API host. A small personas fixture lives in `scripts/staging-smoke-personas.yml` and is committed to the repo.
 - Posts pass/fail to maintainer's Slack via the existing chat plugin (re-uses the `#sandbox-atlas` channel pattern from the proactive dogfood loop).
 
 ### Observability
@@ -216,7 +216,7 @@ Prior art: the existing test file's pattern for asserting Tag behavior under var
 ### Out of test scope
 
 - Railway service creation, CNAME wiring, OAuth app registration at providers — operator runbook validation, not code tests. The runbook lives at `docs/development/staging-environment.md`; correctness is verified by running through it once and capturing any drift.
-- The `atlas ops wipe` subcommand against staging — already covered by existing CLI tests; staging is just another DB URL to it.
+- The `atlas-operator ops wipe` subcommand against staging — already covered by existing CLI tests; staging is just another DB URL to it.
 
 ## Out of Scope
 
@@ -232,7 +232,7 @@ Prior art: the existing test file's pattern for asserting Tag behavior under var
 - **Pre-release tags** (`v0.1.0-rc.1`, `v0.1.0-canary.1`) — deferred until first enterprise customer requests an RC channel. KISS for now.
 - **PR-preview environments** (one staging instance per open PR) — Railway is not designed for this; cost is prohibitive and Vercel-style preview envs would require a different platform.
 - **Path-based staging gates** (`apps/www/serve.ts` → staged, rest of www → direct) — rejected in Q2 in favor of per-service rule for mental simplicity. Reconsider if www staging soak becomes a real friction.
-- **Persistent staging across DB wipes** — staging DB is wipe-on-demand (via `atlas ops wipe`), not wipe-on-deploy. Persistence is the default.
+- **Persistent staging across DB wipes** — staging DB is wipe-on-demand (via `atlas-operator ops wipe`), not wipe-on-deploy. Persistence is the default.
 - **Auto-rollback to prior tag on failed prod health check** — Railway already handles per-service health-check rollback. App-level "tag back to v0.x-1" logic is not introduced.
 
 ## Further Notes

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint packages/ ee/ plugins/ apps/ examples/ create-atlas/",
     "type": "bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build && bun run --filter '@useatlas/sdk' build && bun run --filter '@useatlas/react' build && tsgo --noEmit && bun run --filter '@atlas/web' type",
     "atlas": "bun packages/cli/bin/atlas.ts",
+    "atlas-operator": "bun packages/cli/bin/atlas-operator.ts",
     "mcp": "bun packages/mcp/bin/serve.ts",
     "db:up": "bash scripts/db-up.sh",
     "db:down": "docker compose down",

--- a/packages/api/src/lib/db/__tests__/upsert-suggestion.test.ts
+++ b/packages/api/src/lib/db/__tests__/upsert-suggestion.test.ts
@@ -12,7 +12,7 @@
  * user-facing visibility.
  *
  * ON CONFLICT preserves prior approval / status so a repeated
- * `atlas learn` run never overrides an admin's hide or approve decision
+ * `atlas-operator learn` run never overrides an admin's hide or approve decision
  * on an existing row — that would re-surface content the admin already
  * reviewed. The `--auto-approve` operator flag affects new rows only.
  */

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1989,7 +1989,7 @@ export async function upsertSuggestion(suggestion: {
   /**
    * When true, new rows land as `approval_status = 'approved'` and
    * `status = 'published'` — bypassing the admin moderation queue. Used
-   * only via `atlas learn --auto-approve`, which surfaces the explicit
+   * only via `atlas-operator learn --auto-approve`, which surfaces the explicit
    * operator intent. Existing rows are NOT retroactively approved on
    * ON CONFLICT: the ON CONFLICT clause below only refreshes metrics,
    * so an admin's prior hide or approve decision is preserved across

--- a/packages/api/src/lib/db/migrations/scripts/README.md
+++ b/packages/api/src/lib/db/migrations/scripts/README.md
@@ -23,13 +23,13 @@ environment.
 
 - The backfill fits inline in the migration (use a `DO $$ ... END $$` block).
 - The transform is recurring or part of normal operation — promote it to
-  the `atlas-cli` instead (`atlas seed`, `atlas proactive`, etc.).
+  the `atlas-cli` instead (`atlas-operator seed`, `atlas-operator proactive`, etc.).
 
 ## Existing scripts
 
 - `0027_backfill_region.ts` — accompanies `0027_organization_saas_columns.sql`
 - `0096_connections_to_workspace_plugins.ts` — sanity-check harness for `0096_drop_connections_table.sql` (1.5.3 cutover / ADR-0007)
 - `slack_installations_to_chat_cache.ts` — accompanies the runtime DDL emitted by `@useatlas/chat`'s `pg-adapter.ts`
-- `backfill-crm-leads.ts` — enqueues every existing `demo_leads` row into `crm_outbox` for dispatch to Twenty (#2736). Surfaced via `bun run atlas -- ops backfill-crm-leads`. Re-runs are safe — `TwentyClient.upsertPerson` dedupes by `emails.primaryEmail`. Lives here rather than under `atlas-cli` because it's a one-shot bridge for the cutover where demo signups began flowing through the outbox (#2730 / PR #2785).
+- `backfill-crm-leads.ts` — enqueues every existing `demo_leads` row into `crm_outbox` for dispatch to Twenty (#2736). Surfaced via `bun run atlas-operator -- ops backfill-crm-leads`. Re-runs are safe — `TwentyClient.upsertPerson` dedupes by `emails.primaryEmail`. Lives here rather than under `atlas-cli` because it's a one-shot bridge for the cutover where demo signups began flowing through the outbox (#2730 / PR #2785).
 
 See each script's header docblock for the prod-run date and the exact invocation. The Slack and CRM-leads scripts don't accompany a numbered migration: `chat_cache` is created at runtime by the chat plugin; the CRM-leads backfill is a one-shot bridge from the existing `demo_leads` to the new `crm_outbox` (0102) — naming them after the source table / domain is the clearest signal of intent.

--- a/packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts
+++ b/packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts
@@ -21,7 +21,7 @@
  * back-catalog bridge that has no latency requirement.
  *
  * Invocation:
- *   bun run atlas -- ops backfill-crm-leads [--dry-run] [--batch-size N] [--source demo]
+ *   bun run atlas-operator -- ops backfill-crm-leads [--dry-run] [--batch-size N] [--source demo]
  *
  * Or directly:
  *   DATABASE_URL=... bun run packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts [--dry-run]

--- a/packages/api/src/lib/learn/__tests__/suggestions.test.ts
+++ b/packages/api/src/lib/learn/__tests__/suggestions.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for `generateSuggestions` — asserts that the autoApprove option
- * threads through to `upsertSuggestion`. Covers #1482: atlas learn lands
+ * threads through to `upsertSuggestion`. Covers #1482: atlas-operator learn lands
  * rows in the pending moderation queue by default; `--auto-approve`
  * bypasses the queue with explicit operator intent.
  */

--- a/packages/api/src/lib/learn/suggestions.ts
+++ b/packages/api/src/lib/learn/suggestions.ts
@@ -94,7 +94,7 @@ export function _groupAuditRows(rows: AuditRow[]): Map<string, GroupedPattern> {
  * `false` (pending / draft) so CLI-populated rows land in the admin
  * moderation queue — matching the organic click-promoted path. Operators
  * who want to skip review in self-hosted deployments pass `true` via
- * `atlas learn --auto-approve`.
+ * `atlas-operator learn --auto-approve`.
  */
 export interface GenerateSuggestionsOptions {
   readonly autoApprove?: boolean;

--- a/packages/cli/bin/__tests__/operator-cli.test.ts
+++ b/packages/cli/bin/__tests__/operator-cli.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Operator-CLI split (ADR-0025 sub-decision 1 / sequencing step 4, #4045).
+ *
+ * Locks the packaging boundary: the operator-only subcommands
+ * (ops/seed/proactive/export/learn) are NOT reachable from the published
+ * `atlas` CLI and ARE reachable from the `atlas-operator` binary. Behavior +
+ * gates of the commands themselves are covered by the per-command suites in
+ * src/__tests__/{ops,seed,proactive,learn,ops-smoke-crm-cli,ops-teardown-verify}.test.ts
+ * (only the command *source* moved into commands/operator/; the suites stayed
+ * put). `export` has no standalone suite — its handler is exercised only by the
+ * routing/discriminator test in this file. This file pins the routing/help partition.
+ */
+
+import { describe, expect, test } from "bun:test";
+import * as path from "path";
+import {
+  OPERATOR_COMMANDS,
+  OPERATOR_SUBCOMMAND_HELP,
+  printOperatorOverviewHelp,
+  type OperatorCommand,
+} from "../../lib/operator-help";
+import {
+  SUBCOMMAND_HELP,
+  printSubcommandHelp,
+  printOverviewHelp,
+} from "../../lib/help";
+
+// Hardcoded on purpose (not derived from OPERATOR_COMMAND_NAMES) so the
+// equality assertion below actually catches drift in the source list. Typed as
+// OperatorCommand[] so it can index the now-literal-keyed OPERATOR_SUBCOMMAND_HELP.
+const OPERATOR_NAMES: OperatorCommand[] = [
+  "ops",
+  "seed",
+  "proactive",
+  "export",
+  "learn",
+];
+const BIN_DIR = path.join(import.meta.dir, "..");
+
+/**
+ * Run a CLI binary in a child process and capture its streams + exit code.
+ * `unsetEnv` removes those keys from the inherited environment (Bun.spawn's
+ * `env` replaces rather than merges, so we spread `process.env` first) — used to
+ * make the `export` DB-required path deterministic regardless of the runner's env.
+ */
+async function runBin(
+  file: string,
+  args: string[],
+  unsetEnv: string[] = [],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  let env: Record<string, string | undefined> | undefined;
+  if (unsetEnv.length) {
+    env = { ...process.env };
+    for (const key of unsetEnv) delete env[key];
+  }
+  const proc = Bun.spawn({
+    // Reuse the bun that's running the tests so PATH resolution can't miss.
+    cmd: [process.execPath, path.join(BIN_DIR, file), ...args],
+    cwd: BIN_DIR,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+/** Capture everything a function writes via console.log. */
+function captureLog(fn: () => void): string {
+  const lines: string[] = [];
+  const orig = console.log;
+  console.log = (...a: unknown[]) => {
+    lines.push(a.map((x) => String(x)).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.log = orig;
+  }
+  return lines.join("\n");
+}
+
+describe("operator CLI split (ADR-0025 step 4)", () => {
+  describe("command partitioning", () => {
+    test("OPERATOR_COMMANDS is exactly the five operator subcommands", () => {
+      expect([...OPERATOR_COMMANDS].sort()).toEqual([...OPERATOR_NAMES].sort());
+    });
+
+    test("operator help defines every operator subcommand", () => {
+      for (const name of OPERATOR_NAMES) {
+        expect(OPERATOR_SUBCOMMAND_HELP[name]).toBeDefined();
+      }
+    });
+
+    test("published SUBCOMMAND_HELP advertises none of them", () => {
+      for (const name of OPERATOR_NAMES) {
+        expect(SUBCOMMAND_HELP[name]).toBeUndefined();
+      }
+    });
+
+    test("published overview help lists no operator command", () => {
+      const text = captureLog(() => printOverviewHelp());
+      for (const name of OPERATOR_NAMES) {
+        // Command-column entries look like "  ops   …" / "  seed  …".
+        expect(text).not.toMatch(new RegExp(`^\\s+${name}\\s{2,}`, "m"));
+      }
+    });
+
+    test("operator overview help lists every operator command", () => {
+      const text = captureLog(() => printOperatorOverviewHelp());
+      for (const name of OPERATOR_NAMES) {
+        expect(text).toMatch(new RegExp(`^\\s+${name}\\s{2,}`, "m"));
+      }
+    });
+  });
+
+  describe("help rendering", () => {
+    test("printSubcommandHelp honors the operator bin name", () => {
+      const text = captureLog(() =>
+        printSubcommandHelp(OPERATOR_SUBCOMMAND_HELP.ops, "atlas-operator"),
+      );
+      expect(text).toContain("Usage: atlas-operator ops");
+    });
+
+    test("operator examples never reference the bare `atlas` bin", () => {
+      for (const name of OPERATOR_NAMES) {
+        for (const ex of OPERATOR_SUBCOMMAND_HELP[name].examples ?? []) {
+          expect(ex).not.toMatch(/(^|\s)atlas (ops|seed|proactive|export|learn)\b/);
+        }
+      }
+    });
+  });
+
+  describe("dispatch routing", () => {
+    test("`atlas` redirects operator commands to atlas-operator (exit 1, echoes the command)", async () => {
+      const { stderr, exitCode } = await runBin("atlas.ts", ["ops", "--help"]);
+      expect(exitCode).toBe(1);
+      expect(stderr.toLowerCase()).toContain("operator-only");
+      // The redirect must reconstruct the exact re-run invocation, command + args.
+      expect(stderr).toContain("atlas-operator -- ops --help");
+    }, 30000);
+
+    test("`atlas-operator` dispatches operator subcommand help (exit 0)", async () => {
+      const { stdout, exitCode } = await runBin("atlas-operator.ts", [
+        "ops",
+        "--help",
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Usage: atlas-operator ops");
+    }, 30000);
+
+    test("`atlas-operator` top-level help exits 0", async () => {
+      const { stdout, exitCode } = await runBin("atlas-operator.ts", ["--help"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Usage: atlas-operator <command>");
+    }, 30000);
+
+    // The `--help` cases short-circuit before the dispatch chain; these drive a
+    // real handler so a copy-paste mis-wire (e.g. the `seed` branch calling
+    // handleProactive, which still type-checks) is caught. Each command's
+    // no-subcommand path prints its own distinctive "Usage: atlas-operator <cmd>"
+    // and exits 1 without touching a DB, so reaching the WRONG handler prints the
+    // wrong banner. `export`/`learn` are covered separately below — their
+    // no-subcommand path connects to the internal DB rather than printing a
+    // usage banner, so they need a different DB-free discriminator.
+    for (const cmd of ["ops", "seed", "proactive"]) {
+      test(`\`atlas-operator ${cmd}\` reaches the ${cmd} handler`, async () => {
+        const { stdout, stderr, exitCode } = await runBin("atlas-operator.ts", [
+          cmd,
+        ]);
+        expect(exitCode).toBe(1);
+        expect(stdout + stderr).toContain(`Usage: atlas-operator ${cmd}`);
+      }, 30000);
+    }
+
+    test("`atlas-operator learn` reaches the learn handler", async () => {
+      // `--auto-approve` without `--suggestions` is rejected by handleLearn
+      // before any DB/fs access — a discriminator unique to that handler.
+      const { stdout, stderr, exitCode } = await runBin("atlas-operator.ts", [
+        "learn",
+        "--auto-approve",
+      ]);
+      expect(exitCode).toBe(1);
+      expect(stdout + stderr).toContain("--suggestions");
+    }, 30000);
+
+    test("`atlas-operator export` reaches the export handler", async () => {
+      // With DATABASE_URL unset, handleExport fails fast with its own message
+      // before connecting — uniquely identifies that handler, DB-free.
+      const { stdout, stderr, exitCode } = await runBin(
+        "atlas-operator.ts",
+        ["export"],
+        ["DATABASE_URL", "ATLAS_TEAM_PG_URL"],
+      );
+      expect(exitCode).not.toBe(0);
+      expect(stdout + stderr).toContain(
+        "DATABASE_URL is required for atlas-operator export",
+      );
+    }, 30000);
+
+    test("`atlas-operator` rejects unknown commands (exit 1)", async () => {
+      const { stderr, exitCode } = await runBin("atlas-operator.ts", [
+        "definitely-not-a-command",
+      ]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("Unknown operator command");
+    }, 30000);
+  });
+});

--- a/packages/cli/bin/atlas-operator.ts
+++ b/packages/cli/bin/atlas-operator.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env tsx
+/**
+ * Atlas operator CLI — internal, operator-only tooling that touches tenant data
+ * directly (no API, no gate chain).
+ *
+ * Split out of the published `atlas` CLI so the workspace-facing binary never
+ * ships tenant-destructive direct-DB tooling (ADR-0025 sub-decision 1 /
+ * sequencing step 4, #4045). Behavior and gates are unchanged from when these
+ * subcommands lived under `atlas` — this is packaging only.
+ *
+ * Usage:
+ *   bun run atlas-operator -- ops wipe --confirm
+ *   bun run atlas-operator -- ops backfill-crm-leads --dry-run
+ *   bun run atlas-operator -- ops smoke-crm --personas ./fixtures/personas.yml
+ *   bun run atlas-operator -- seed prompts --workspace <id|slug> --library ./prompts/library.yml
+ *   bun run atlas-operator -- proactive enable --workspace <id|slug> --channels <c1,c2>
+ *   bun run atlas-operator -- export --output backup.json
+ *   bun run atlas-operator -- learn --apply
+ *
+ * The tenant-data subcommands (ops, seed, proactive) target the tenant Postgres
+ * at ATLAS_TEAM_PG_URL (falling back to DATABASE_URL); export and learn instead
+ * read Atlas's internal DB via DATABASE_URL (the two-database split). All
+ * preserve their existing gates (ATLAS_WIPE_OK, --confirm, ATLAS_SMOKE_WIPE_OK,
+ * ATLAS_TEARDOWN_OK, …).
+ */
+
+import {
+  OPERATOR_SUBCOMMAND_HELP,
+  printOperatorOverviewHelp,
+  type OperatorCommand,
+} from "../lib/operator-help";
+import { printSubcommandHelp, wantsHelp } from "../lib/help";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  // Top-level help: atlas-operator --help, -h, or no command
+  if (!command || command === "--help" || command === "-h") {
+    printOperatorOverviewHelp();
+    process.exit(0);
+  }
+
+  // Per-subcommand --help. `Object.hasOwn` (not `in`) so inherited prototype
+  // keys like `toString` aren't mistaken for commands; it confirms `command` is
+  // a real own key, which makes the narrowing cast sound (OPERATOR_SUBCOMMAND_HELP
+  // is keyed by the literal OperatorCommand union, which a raw `string` can't index).
+  if (wantsHelp(args) && Object.hasOwn(OPERATOR_SUBCOMMAND_HELP, command)) {
+    printSubcommandHelp(
+      OPERATOR_SUBCOMMAND_HELP[command as OperatorCommand],
+      "atlas-operator",
+    );
+    process.exit(0);
+  }
+
+  if (command === "ops") {
+    const { handleOps } = await import("../src/commands/operator/ops");
+    return handleOps(args);
+  }
+
+  if (command === "seed") {
+    const { handleSeed } = await import("../src/commands/operator/seed");
+    return handleSeed(args);
+  }
+
+  if (command === "proactive") {
+    const { handleProactive } = await import(
+      "../src/commands/operator/proactive"
+    );
+    return handleProactive(args);
+  }
+
+  if (command === "export") {
+    const { handleExport } = await import("../src/commands/operator/export");
+    return handleExport(args);
+  }
+
+  if (command === "learn") {
+    const { handleLearn } = await import("../src/commands/operator/learn");
+    return handleLearn(args);
+  }
+
+  console.error(`Unknown operator command: ${command}\n`);
+  printOperatorOverviewHelp();
+  process.exit(1);
+}
+
+// Only run the CLI when this file is the entry point (not when imported by tests)
+const isEntryPoint =
+  (typeof Bun !== "undefined" && Bun.main === import.meta.path) ||
+  typeof Bun === "undefined"; // tsx / node fallback
+
+if (isEntryPoint) {
+  main().catch((err) => {
+    if (err instanceof Error && err.stack) {
+      console.error(err.stack);
+    } else {
+      console.error(err instanceof Error ? err.message : String(err));
+    }
+    process.exit(1);
+  });
+}

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -45,6 +45,7 @@ import {
   printOverviewHelp,
   wantsHelp,
 } from "../lib/help";
+import { OPERATOR_COMMANDS } from "../lib/operator-help";
 
 // ---------------------------------------------------------------------------
 // Re-exports for backward compatibility (tests import from "../atlas")
@@ -234,11 +235,6 @@ async function main() {
     return handleIndex(args);
   }
 
-  if (command === "learn") {
-    const { handleLearn } = await import("../src/commands/learn");
-    return handleLearn(args);
-  }
-
   if (command === "improve") {
     const { handleImprove } = await import("../src/commands/improve");
     return handleImprove(args);
@@ -323,11 +319,6 @@ async function main() {
     return;
   }
 
-  if (command === "export") {
-    const { handleExport } = await import("../src/commands/export");
-    return handleExport(args);
-  }
-
   if (command === "import") {
     const { handleImport } = await import("../src/commands/import");
     return handleImport(args);
@@ -354,21 +345,17 @@ async function main() {
     return handlePlugin(args);
   }
 
-  if (command === "proactive") {
-    const { handleProactive } = await import(
-      "../src/commands/proactive"
+  // Operator-only commands (ops/seed/proactive/export/learn) moved to the
+  // separate `atlas-operator` binary so the published `atlas` CLI never ships
+  // tenant-destructive direct-DB tooling (ADR-0025 step 4, #4045). Redirect
+  // rather than a bare "Unknown command" so operator muscle memory lands somewhere useful.
+  if (OPERATOR_COMMANDS.has(command)) {
+    console.error(
+      `[atlas] "${command}" is an operator-only command and has moved to the operator CLI.\n` +
+        `Run it with:  bun run atlas-operator -- ${command} ${args.slice(1).join(" ")}`.trimEnd() +
+        `\n(Operator tooling touches tenant data directly and is not shipped to workspaces — ADR-0025.)`,
     );
-    return handleProactive(args);
-  }
-
-  if (command === "seed") {
-    const { handleSeed } = await import("../src/commands/seed");
-    return handleSeed(args);
-  }
-
-  if (command === "ops") {
-    const { handleOps } = await import("../src/commands/ops");
-    return handleOps(args);
+    process.exit(1);
   }
 
   if (command !== "init") {

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -22,9 +22,12 @@ export interface SubcommandHelp {
 // Help printer
 // ---------------------------------------------------------------------------
 
-export function printSubcommandHelp(help: SubcommandHelp): void {
+export function printSubcommandHelp(
+  help: SubcommandHelp,
+  binName = "atlas",
+): void {
   console.log(`${help.description}\n`);
-  console.log(`Usage: atlas ${help.usage}\n`);
+  console.log(`Usage: ${binName} ${help.usage}\n`);
   if (help.subcommands?.length) {
     console.log("Subcommands:");
     const maxLen = Math.max(
@@ -284,50 +287,6 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
     ],
     examples: ["atlas index", "atlas index --stats"],
   },
-  learn: {
-    description:
-      "Analyze audit log and propose semantic layer YAML improvements.",
-    usage: "learn [options]",
-    flags: [
-      {
-        flag: "--apply",
-        description:
-          "Write proposed changes to YAML files (default: dry-run)",
-      },
-      {
-        flag: "--suggestions",
-        description:
-          "Generate query suggestions from the audit log (stored in the query_suggestions table). Can be combined with --apply, --since, --limit, and --source",
-      },
-      {
-        flag: "--auto-approve",
-        description:
-          "With --suggestions: skip the /admin/starter-prompts moderation queue and write new rows as approved+published. Requires explicit operator intent — default is pending/draft",
-      },
-      {
-        flag: "--limit <n>",
-        description:
-          "Max audit log entries to analyze (default: 1000)",
-      },
-      {
-        flag: "--since <date>",
-        description:
-          "Only analyze queries after this date (ISO 8601)",
-      },
-      {
-        flag: "--source <name>",
-        description:
-          "Read from/write to semantic/{name}/ subdirectory",
-      },
-    ],
-    examples: [
-      "atlas learn",
-      "atlas learn --apply",
-      "atlas learn --since 2026-03-01 --limit 500",
-      "atlas learn --source warehouse",
-      "atlas learn --suggestions --auto-approve",
-    ],
-  },
   improve: {
     description:
       "Analyze the semantic layer and propose data-driven improvements using database profiling and audit log patterns.",
@@ -373,29 +332,6 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas improve --apply",
       "atlas improve --min-confidence 0.7 --entities orders,users",
       "atlas improve --since 2026-03-01 --source warehouse",
-    ],
-  },
-  export: {
-    description:
-      "Export workspace data to a portable migration bundle (JSON). Reads from the internal database.",
-    usage: "export [options]",
-    flags: [
-      {
-        flag: "--output <path>",
-        description:
-          "Output file path (default: ./atlas-export-{date}.json)",
-      },
-      { flag: "-o <path>", description: "Alias for --output" },
-      {
-        flag: "--org <orgId>",
-        description:
-          "Export data for a specific org (default: global/unscoped)",
-      },
-    ],
-    examples: [
-      "atlas export",
-      "atlas export --output backup.json",
-      "atlas export --org org_abc123",
     ],
   },
   "migrate-import": {
@@ -664,135 +600,6 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas completions fish > ~/.config/fish/completions/atlas.fish",
     ],
   },
-  proactive: {
-    description:
-      "Enable or disable proactive chat for a workspace. Operates against the tenant Postgres at ATLAS_TEAM_PG_URL (falls back to DATABASE_URL).",
-    usage: "proactive <enable|disable> --workspace <id|slug> [options]",
-    subcommands: [
-      {
-        name: "enable",
-        description:
-          "Turn proactive chat on for a workspace + opt one or more channels in (idempotent upsert).",
-      },
-      {
-        name: "disable",
-        description:
-          "Flip workspace_proactive_config.enabled to false (channel config rows preserved).",
-      },
-    ],
-    flags: [
-      {
-        flag: "--workspace <id|slug>",
-        description:
-          "Workspace slug (resolved via organization.slug) or literal `org_*` id",
-      },
-      {
-        flag: "--channels <id1,id2,...>",
-        description:
-          "Comma-separated Slack channel ids to opt in (required for `enable`)",
-      },
-    ],
-    examples: [
-      "atlas proactive enable --workspace atlas --channels C0AAA,C0BBB",
-      "atlas proactive disable --workspace atlas",
-    ],
-  },
-  seed: {
-    description:
-      "Seed durable workspace data — starter prompt collections and connection groups. Operates against the tenant Postgres at ATLAS_TEAM_PG_URL (falls back to DATABASE_URL).",
-    usage: "seed <prompts|workspace> [options]",
-    subcommands: [
-      {
-        name: "prompts",
-        description:
-          "Seed a prompt-library collection + items from a YAML file into prompt_collections / prompt_items.",
-      },
-      {
-        name: "workspace",
-        description:
-          "Provision a connection group with one or more member connections + per-group semantic entities.",
-      },
-    ],
-    flags: [
-      {
-        flag: "--workspace <id|slug>",
-        description: "Target workspace (required)",
-      },
-      {
-        flag: "--library <path>",
-        description:
-          "Path to library YAML (seed prompts) — defaults to ./prompts/library.yml",
-      },
-      {
-        flag: "--group <name>",
-        description: "Connection group name (seed workspace, required)",
-      },
-      {
-        flag: "--group-id <id>",
-        description: "Connection group id (seed workspace, defaults to `g_<group>`)",
-      },
-      {
-        flag: "--connections <id=urlEnv:type[:primary],...>",
-        description:
-          "Group members. Each entry: connection id, env var holding the URL, db type (postgres|mysql|…), and optional `:primary` marker. Exactly one entry must be primary.",
-      },
-      {
-        flag: "--semantic <path>",
-        description:
-          "Optional path to a semantic/ directory whose entities/, metrics/, glossary/ are inserted scoped to the new group.",
-      },
-    ],
-    examples: [
-      "atlas seed prompts --workspace atlas --library ./prompts/library.yml",
-      "atlas seed workspace --workspace atlas --group prod --connections us-prod=US_DB_URL:postgres:primary,eu-prod=EU_DB_URL:postgres",
-    ],
-  },
-  ops: {
-    description:
-      "Operator-only tools that touch tenant data. Destructive subcommands require an explicit double-confirm flag.",
-    usage: "ops <wipe|backfill-crm-leads|smoke-crm> [options]",
-    subcommands: [
-      {
-        name: "wipe",
-        description:
-          "TRUNCATE every public table in the tenant DB (excluding migration bookkeeping) with RESTART IDENTITY CASCADE. Requires ATLAS_WIPE_OK=1 + --confirm. No backup is taken — wrap with pg_dump yourself.",
-      },
-      {
-        name: "backfill-crm-leads",
-        description:
-          "Enqueue every existing demo_leads row into crm_outbox so the flusher dispatches them to Twenty as Persons. Re-runs are safe (dedupe by primary email). Flags: --dry-run, --batch-size N (default 500), --source demo, --database-url <url>.",
-      },
-      {
-        name: "smoke-crm",
-        description:
-          "End-to-end CRM lead-capture verification — inject fixture personas below Turnstile via the outbox, wait for the flusher to drain, then diff the resulting Twenty Persons/Notes against the fixture. Makes live Twenty calls: run ad-hoc by an operator and as the post-deploy staging-smoke gate, not per-PR CI. Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1), --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60), --database-url <url>.",
-      },
-    ],
-    flags: [
-      {
-        flag: "--confirm",
-        description:
-          "wipe: required to proceed past the double-confirm gate. Pair with ATLAS_WIPE_OK=1 in the env.",
-      },
-      {
-        flag: "--wipe-twenty",
-        description:
-          "smoke-crm: clear the Twenty workspace before the run. Destructive — double-gated by ATLAS_SMOKE_WIPE_OK=1.",
-      },
-      {
-        flag: "--database-url <url>",
-        description:
-          "Override the target Postgres URL (defaults to ATLAS_TEAM_PG_URL, then DATABASE_URL).",
-      },
-    ],
-    examples: [
-      "ATLAS_WIPE_OK=1 atlas ops wipe --confirm",
-      "ATLAS_WIPE_OK=1 atlas ops wipe --confirm --database-url $US_DB_URL",
-      "atlas ops backfill-crm-leads --dry-run",
-      "atlas ops smoke-crm --personas ./fixtures/personas.yml",
-      "ATLAS_SMOKE_WIPE_OK=1 atlas ops smoke-crm --personas ./fixtures/personas.yml --wipe-twenty",
-    ],
-  },
 };
 
 // ---------------------------------------------------------------------------
@@ -806,10 +613,8 @@ export function printOverviewHelp(): void {
       "Commands:\n" +
       "  init             Profile DB and generate semantic layer\n" +
       "  import           Import semantic YAML files from disk into DB\n" +
-      "  export           Export workspace data to a migration bundle\n" +
       "  migrate-import   Import a migration bundle into a hosted instance\n" +
       "  index            Rebuild or inspect the semantic index\n" +
-      "  learn            Analyze audit log and propose YAML improvements\n" +
       "  improve          Analyze semantic layer and propose data-driven improvements\n" +
       "  diff             Compare DB schema against existing semantic layer\n" +
       "  query            Ask a question via the Atlas API\n" +
@@ -822,9 +627,6 @@ export function printOverviewHelp(): void {
       "  plugin           Manage plugins (list, create, add)\n" +
       "  benchmark        Run BIRD benchmark for text-to-SQL accuracy\n" +
       "  mcp              Start MCP server (stdio or SSE transport)\n" +
-      "  proactive        Enable/disable proactive chat for a workspace (operator)\n" +
-      "  seed             Seed durable workspace data — prompts, connection groups (operator)\n" +
-      "  ops              Operator-only destructive tools (e.g. wipe)\n" +
       "  completions      Output shell completion script (bash, zsh, fish)\n\n" +
       "Run atlas <command> --help for detailed usage of any command.",
   );

--- a/packages/cli/lib/learn/analyze.ts
+++ b/packages/cli/lib/learn/analyze.ts
@@ -1,5 +1,5 @@
 /**
- * Audit log analyzer for `atlas learn`.
+ * Audit log analyzer for `atlas-operator learn`.
  *
  * Reads successful SQL queries from the internal DB audit_log table,
  * parses each via node-sql-parser, and extracts structural patterns:

--- a/packages/cli/lib/learn/diff.ts
+++ b/packages/cli/lib/learn/diff.ts
@@ -1,5 +1,5 @@
 /**
- * Git-style diff output for `atlas learn` proposals.
+ * Git-style diff output for `atlas-operator learn` proposals.
  *
  * Generates unified diff format showing before/after YAML changes
  * for each file affected by proposals.

--- a/packages/cli/lib/learn/propose.ts
+++ b/packages/cli/lib/learn/propose.ts
@@ -1,5 +1,5 @@
 /**
- * Proposal generator for `atlas learn`.
+ * Proposal generator for `atlas-operator learn`.
  *
  * Compares analysis results against existing semantic layer YAML files
  * and generates concrete proposals: new query patterns, join discoveries,

--- a/packages/cli/lib/operator-help.ts
+++ b/packages/cli/lib/operator-help.ts
@@ -1,0 +1,268 @@
+/**
+ * Help system for the operator CLI (`atlas-operator`).
+ *
+ * The operator subcommands (`ops`, `seed`, `proactive`, `export`, `learn`) are
+ * internal, operator-only, direct-DB tooling. They were split out of the
+ * published `atlas` CLI so the workspace-facing binary never ships
+ * tenant-destructive direct-DB tooling (ADR-0025 sub-decision 1 / sequencing
+ * step 4, #4045). These help entries live here — NOT in `help.ts` — so the
+ * published CLI's help never advertises operator commands.
+ *
+ * Rendering reuses `printSubcommandHelp` from `help.ts` with the `atlas-operator`
+ * bin name so the printed `Usage:` line and the published-CLI help stay one code
+ * path.
+ */
+
+import type { SubcommandHelp } from "./help";
+
+/**
+ * The operator-only subcommands, owned exclusively by `bin/atlas-operator.ts`.
+ * Single source of truth for the command names — `OPERATOR_SUBCOMMAND_HELP` is
+ * `satisfies Record<OperatorCommand, …>`, so a name added here without a matching
+ * help entry (or vice-versa) is a compile error.
+ */
+export const OPERATOR_COMMAND_NAMES = [
+  "ops",
+  "seed",
+  "proactive",
+  "export",
+  "learn",
+] as const;
+
+export type OperatorCommand = (typeof OPERATOR_COMMAND_NAMES)[number];
+
+/** Runtime membership gate the published `atlas` CLI uses to redirect. */
+export const OPERATOR_COMMANDS: ReadonlySet<string> = new Set(
+  OPERATOR_COMMAND_NAMES,
+);
+
+// ---------------------------------------------------------------------------
+// Subcommand help definitions (relocated from help.ts SUBCOMMAND_HELP)
+// ---------------------------------------------------------------------------
+
+export const OPERATOR_SUBCOMMAND_HELP = {
+  learn: {
+    description:
+      "Analyze audit log and propose semantic layer YAML improvements.",
+    usage: "learn [options]",
+    flags: [
+      {
+        flag: "--apply",
+        description:
+          "Write proposed changes to YAML files (default: dry-run)",
+      },
+      {
+        flag: "--suggestions",
+        description:
+          "Generate query suggestions from the audit log (stored in the query_suggestions table). Can be combined with --apply, --since, --limit, and --source",
+      },
+      {
+        flag: "--auto-approve",
+        description:
+          "With --suggestions: skip the /admin/starter-prompts moderation queue and write new rows as approved+published. Requires explicit operator intent — default is pending/draft",
+      },
+      {
+        flag: "--limit <n>",
+        description:
+          "Max audit log entries to analyze (default: 1000)",
+      },
+      {
+        flag: "--since <date>",
+        description:
+          "Only analyze queries after this date (ISO 8601)",
+      },
+      {
+        flag: "--source <name>",
+        description:
+          "Read from/write to semantic/{name}/ subdirectory",
+      },
+    ],
+    examples: [
+      "atlas-operator learn",
+      "atlas-operator learn --apply",
+      "atlas-operator learn --since 2026-03-01 --limit 500",
+      "atlas-operator learn --source warehouse",
+      "atlas-operator learn --suggestions --auto-approve",
+    ],
+  },
+  export: {
+    description:
+      "Export workspace data to a portable migration bundle (JSON). Reads from the internal database.",
+    usage: "export [options]",
+    flags: [
+      {
+        flag: "--output <path>",
+        description:
+          "Output file path (default: ./atlas-export-{date}.json)",
+      },
+      { flag: "-o <path>", description: "Alias for --output" },
+      {
+        flag: "--org <orgId>",
+        description:
+          "Export data for a specific org (default: global/unscoped)",
+      },
+    ],
+    examples: [
+      "atlas-operator export",
+      "atlas-operator export --output backup.json",
+      "atlas-operator export --org org_abc123",
+    ],
+  },
+  proactive: {
+    description:
+      "Enable or disable proactive chat for a workspace. Operates against the tenant Postgres at ATLAS_TEAM_PG_URL (falls back to DATABASE_URL).",
+    usage: "proactive <enable|disable> --workspace <id|slug> [options]",
+    subcommands: [
+      {
+        name: "enable",
+        description:
+          "Turn proactive chat on for a workspace + opt one or more channels in (idempotent upsert).",
+      },
+      {
+        name: "disable",
+        description:
+          "Flip workspace_proactive_config.enabled to false (channel config rows preserved).",
+      },
+    ],
+    flags: [
+      {
+        flag: "--workspace <id|slug>",
+        description:
+          "Workspace slug (resolved via organization.slug) or literal `org_*` id",
+      },
+      {
+        flag: "--channels <id1,id2,...>",
+        description:
+          "Comma-separated Slack channel ids to opt in (required for `enable`)",
+      },
+    ],
+    examples: [
+      "atlas-operator proactive enable --workspace atlas --channels C0AAA,C0BBB",
+      "atlas-operator proactive disable --workspace atlas",
+    ],
+  },
+  seed: {
+    description:
+      "Seed durable workspace data — starter prompt collections and connection groups. Operates against the tenant Postgres at ATLAS_TEAM_PG_URL (falls back to DATABASE_URL).",
+    usage: "seed <prompts|workspace> [options]",
+    subcommands: [
+      {
+        name: "prompts",
+        description:
+          "Seed a prompt-library collection + items from a YAML file into prompt_collections / prompt_items.",
+      },
+      {
+        name: "workspace",
+        description:
+          "Provision a connection group with one or more member connections + per-group semantic entities.",
+      },
+    ],
+    flags: [
+      {
+        flag: "--workspace <id|slug>",
+        description: "Target workspace (required)",
+      },
+      {
+        flag: "--library <path>",
+        description:
+          "Path to library YAML (seed prompts) — defaults to ./prompts/library.yml",
+      },
+      {
+        flag: "--group <name>",
+        description: "Connection group name (seed workspace, required)",
+      },
+      {
+        flag: "--group-id <id>",
+        description: "Connection group id (seed workspace, defaults to `g_<group>`)",
+      },
+      {
+        flag: "--connections <id=urlEnv:type[:primary],...>",
+        description:
+          "Group members. Each entry: connection id, env var holding the URL, db type (postgres|mysql|…), and optional `:primary` marker. Exactly one entry must be primary.",
+      },
+      {
+        flag: "--semantic <path>",
+        description:
+          "Optional path to a semantic/ directory whose entities/, metrics/, glossary/ are inserted scoped to the new group.",
+      },
+    ],
+    examples: [
+      "atlas-operator seed prompts --workspace atlas --library ./prompts/library.yml",
+      "atlas-operator seed workspace --workspace atlas --group prod --connections us-prod=US_DB_URL:postgres:primary,eu-prod=EU_DB_URL:postgres",
+    ],
+  },
+  ops: {
+    description:
+      "Operator-only tools that touch tenant data. Destructive subcommands require an explicit double-confirm flag.",
+    usage:
+      "ops <wipe|backfill-crm-leads|smoke-crm|teardown-verify-accounts> [options]",
+    subcommands: [
+      {
+        name: "wipe",
+        description:
+          "TRUNCATE every public table in the tenant DB (excluding migration bookkeeping) with RESTART IDENTITY CASCADE. Requires ATLAS_WIPE_OK=1 + --confirm. No backup is taken — wrap with pg_dump yourself.",
+      },
+      {
+        name: "backfill-crm-leads",
+        description:
+          "Enqueue every existing demo_leads row into crm_outbox so the flusher dispatches them to Twenty as Persons. Re-runs are safe (dedupe by primary email). Flags: --dry-run, --batch-size N (default 500), --source demo, --database-url <url>.",
+      },
+      {
+        name: "smoke-crm",
+        description:
+          "End-to-end CRM lead-capture verification — inject fixture personas below Turnstile via the outbox, wait for the flusher to drain, then diff the resulting Twenty Persons/Notes against the fixture. Makes live Twenty calls: run ad-hoc by an operator and as the post-deploy staging-smoke gate, not per-PR CI. Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1), --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60), --database-url <url>.",
+      },
+      {
+        name: "teardown-verify-accounts",
+        description:
+          "Surgically delete throwaway /verify-prod-signup accounts (user + org + Stripe customer) from one region's internal DB. DRY RUN by default; EXECUTE requires ATLAS_TEARDOWN_OK=1 + --confirm. Flags: --email <addr[,addr]> (required, repeatable), --region <us|eu|apac> OR --database-url <url>, --dry-run, --force (allow non-plus-addressed emails).",
+      },
+    ],
+    flags: [
+      {
+        flag: "--confirm",
+        description:
+          "wipe: required to proceed past the double-confirm gate. Pair with ATLAS_WIPE_OK=1 in the env.",
+      },
+      {
+        flag: "--wipe-twenty",
+        description:
+          "smoke-crm: clear the Twenty workspace before the run. Destructive — double-gated by ATLAS_SMOKE_WIPE_OK=1.",
+      },
+      {
+        flag: "--database-url <url>",
+        description:
+          "Override the target Postgres URL (defaults to ATLAS_TEAM_PG_URL, then DATABASE_URL).",
+      },
+    ],
+    examples: [
+      "ATLAS_WIPE_OK=1 atlas-operator ops wipe --confirm",
+      "ATLAS_WIPE_OK=1 atlas-operator ops wipe --confirm --database-url $US_DB_URL",
+      "atlas-operator ops backfill-crm-leads --dry-run",
+      "atlas-operator ops smoke-crm --personas ./fixtures/personas.yml",
+      "ATLAS_SMOKE_WIPE_OK=1 atlas-operator ops smoke-crm --personas ./fixtures/personas.yml --wipe-twenty",
+    ],
+  },
+} satisfies Record<OperatorCommand, SubcommandHelp>;
+
+// ---------------------------------------------------------------------------
+// Overview help
+// ---------------------------------------------------------------------------
+
+export function printOperatorOverviewHelp(): void {
+  console.log(
+    "Atlas operator CLI — internal, operator-only tooling that touches tenant data directly.\n\n" +
+      "These commands bypass the API, its gates, and the tenant boundary — they are shipped to\n" +
+      "the platform operator, never to a workspace (ADR-0025, #4045). The tenant-data subcommands\n" +
+      "(ops, seed, proactive) target the tenant Postgres at ATLAS_TEAM_PG_URL (falling back to\n" +
+      "DATABASE_URL); export and learn read Atlas's internal DB via DATABASE_URL.\n\n" +
+      "Usage: atlas-operator <command> [options]\n\n" +
+      "Commands:\n" +
+      "  ops              Operator-only destructive tools (wipe, backfill-crm-leads, smoke-crm, teardown-verify-accounts)\n" +
+      "  seed             Seed durable workspace data — prompts, connection groups\n" +
+      "  proactive        Enable/disable proactive chat for a workspace\n" +
+      "  export           Export workspace data to a migration bundle\n" +
+      "  learn            Analyze audit log and propose semantic YAML improvements\n\n" +
+      "Run atlas-operator <command> --help for detailed usage of any command.",
+  );
+}

--- a/packages/cli/lib/smoke-crm/fixture.ts
+++ b/packages/cli/lib/smoke-crm/fixture.ts
@@ -1,5 +1,5 @@
 /**
- * Persona fixture parser for `atlas ops smoke-crm`.
+ * Persona fixture parser for `atlas-operator ops smoke-crm`.
  *
  * Reads a YAML document of personas and returns the discriminated union of
  * `LeadEvent` variants the saas-crm dispatcher consumes. Validation is

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "atlas": "bun bin/atlas.ts",
+    "atlas-operator": "bun bin/atlas-operator.ts",
     "test": "bun run scripts/test-isolated.ts"
   },
   "dependencies": {

--- a/packages/cli/src/__tests__/completions.test.ts
+++ b/packages/cli/src/__tests__/completions.test.ts
@@ -13,16 +13,24 @@ describe("completions", () => {
 
   describe("COMMANDS registry", () => {
     test("includes all CLI commands (bidirectional)", () => {
+      // Operator-only commands (learn, export, …) are NOT completed by the
+      // published `atlas` CLI — they live under `atlas-operator` (ADR-0025 step 4).
       const expected = [
         "init", "diff", "query", "doctor", "validate",
-        "mcp", "learn", "improve", "migrate", "plugin", "eval", "smoke",
-        "benchmark", "export", "migrate-import", "completions",
+        "mcp", "improve", "migrate", "plugin", "eval", "smoke",
+        "benchmark", "migrate-import", "completions",
       ];
       for (const cmd of expected) {
         expect(allCommands).toContain(cmd);
       }
       // Also catch unexpected additions to COMMANDS not reflected here
       expect(allCommands.length).toBe(expected.length);
+    });
+
+    test("does not complete operator-only commands (moved to atlas-operator)", () => {
+      for (const cmd of ["ops", "seed", "proactive", "export", "learn"]) {
+        expect(allCommands).not.toContain(cmd);
+      }
     });
 
     test("every command has a description", () => {

--- a/packages/cli/src/__tests__/learn-integration.test.ts
+++ b/packages/cli/src/__tests__/learn-integration.test.ts
@@ -28,7 +28,7 @@ import * as path from "path";
 import * as os from "os";
 
 // Hoisted bindings — populated in beforeAll once the OS state is set up.
-let handleLearn: (typeof import("../commands/learn"))["handleLearn"];
+let handleLearn: (typeof import("../commands/operator/learn"))["handleLearn"];
 let tmpRoot: string;
 let origCwd: string;
 let origDatabaseUrl: string | undefined;
@@ -112,7 +112,7 @@ dimensions:
   }));
 
   // Import AFTER chdir + env + mocks.
-  ({ handleLearn } = await import("../commands/learn"));
+  ({ handleLearn } = await import("../commands/operator/learn"));
 });
 
 // Silence console output during the suite so CI logs stay clean.

--- a/packages/cli/src/__tests__/learn.test.ts
+++ b/packages/cli/src/__tests__/learn.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for the `atlas learn` command — specifically the argument-parsing
+ * Tests for the `atlas-operator learn` command — specifically the argument-parsing
  * guards that prevent user intent from being silently ignored.
  *
  * The `--auto-approve` flag only affects query-suggestion rows, so it
  * must be combined with `--suggestions`. Without this guard, an operator
- * could pass `atlas learn --auto-approve` expecting rows to be published,
+ * could pass `atlas-operator learn --auto-approve` expecting rows to be published,
  * and get the YAML improvement path instead — with zero rows written.
  */
 import { describe, it, expect, afterEach, beforeEach, mock } from "bun:test";
@@ -37,7 +37,7 @@ afterEach(() => {
   mock.restore();
 });
 
-const { handleLearn } = await import("../commands/learn");
+const { handleLearn } = await import("../commands/operator/learn");
 
 describe("handleLearn — --auto-approve guard", () => {
   it("exits 1 when --auto-approve is passed without --suggestions", async () => {

--- a/packages/cli/src/__tests__/ops-smoke-crm-cli.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-cli.test.ts
@@ -13,7 +13,7 @@ import {
   pollOutboxUntilDrained,
   SMOKE_EXIT,
   type SmokeCrmDB,
-} from "../commands/ops-smoke-crm";
+} from "../commands/operator/ops-smoke-crm";
 import { createTwentyAdmin } from "../../lib/smoke-crm/twenty-admin";
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/ops-teardown-verify.test.ts
+++ b/packages/cli/src/__tests__/ops-teardown-verify.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `atlas ops teardown-verify-accounts` (#3974). The command tears
+ * Tests for `atlas-operator ops teardown-verify-accounts` (#3974). The command tears
  * down throwaway `/verify-prod-signup` accounts from a region's internal DB, so
  * the surface that matters is:
  *   1. The execute double-gate (ATLAS_TEARDOWN_OK=1 + --confirm) — missing
@@ -31,8 +31,8 @@ import {
   type RowQuery,
   type TeardownDeps,
   type VerifyTarget,
-} from "../commands/ops-teardown-verify";
-import { handleOps } from "../commands/ops";
+} from "../commands/operator/ops-teardown-verify";
+import { handleOps } from "../commands/operator/ops";
 import type { StripeTeardownOutcome } from "@atlas/api/lib/billing/workspace-teardown";
 
 // --- checkTeardownGate (mirrors checkWipeGate's double-gate contract) ---

--- a/packages/cli/src/__tests__/ops.test.ts
+++ b/packages/cli/src/__tests__/ops.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `atlas ops` — the wipe path is destructive and gated by both
+ * Tests for `atlas-operator ops` — the wipe path is destructive and gated by both
  * ATLAS_WIPE_OK=1 and --confirm, so the test surface focuses on:
  *   1. The double-confirm gate refuses to run when either gate is missing.
  *   2. The TRUNCATE SQL matches the pinned literal exactly — drift here
@@ -18,7 +18,7 @@ import {
   parseBatchSize,
   parseBackfillSource,
   resolveBackfillUrl,
-} from "../commands/ops";
+} from "../commands/operator/ops";
 import { DEFAULT_BATCH_SIZE } from "@atlas/api/lib/db/migrations/scripts/backfill-crm-leads";
 import type { TenantPgClient } from "../../lib/tenant-db";
 
@@ -197,7 +197,7 @@ describe("handleOps", () => {
       caught = err instanceof Error ? err : new Error(String(err));
     }
     expect(caught?.message).toBe("__process_exit__:1");
-    expect(errors.some((line) => line.includes("Usage: atlas ops"))).toBe(true);
+    expect(errors.some((line) => line.includes("Usage: atlas-operator ops"))).toBe(true);
   });
 
   it("exits 1 when `ops wipe` runs without ATLAS_WIPE_OK", async () => {
@@ -310,7 +310,7 @@ describe("parseBatchSize", () => {
   });
 
   it("throws when --batch-size is at end-of-args with no value", () => {
-    // Operator typo `bun run atlas -- ops backfill-crm-leads --batch-size`
+    // Operator typo `bun run atlas-operator -- ops backfill-crm-leads --batch-size`
     // should fail loud rather than silently use 500 — pinned per Codex
     // review on PR #2846.
     expect(() => parseBatchSize(["--batch-size"])).toThrow(/requires a value/);

--- a/packages/cli/src/__tests__/proactive.test.ts
+++ b/packages/cli/src/__tests__/proactive.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `atlas proactive` — replaces internal/enable-proactive-dogfood.ts
+ * Tests for `atlas-operator proactive` — replaces internal/enable-proactive-dogfood.ts
  * and internal/disable-proactive-dogfood.ts. Asserts the subcommand issues
  * the right SQL with the right args against a mocked pool, and that the
  * top-level handler's arg-parsing guards refuse invalid invocations.
@@ -11,7 +11,7 @@ import {
   resolveWorkspaceId,
   handleProactive,
   type ProactivePgClient,
-} from "../commands/proactive";
+} from "../commands/operator/proactive";
 
 // --- Mock pool factory ---
 
@@ -220,7 +220,7 @@ describe("handleProactive — arg-parsing guards", () => {
       caught = err instanceof Error ? err : new Error(String(err));
     }
     expect(caught?.message).toBe("__process_exit__:1");
-    expect(errors.some((line) => line.includes("Usage: atlas proactive"))).toBe(true);
+    expect(errors.some((line) => line.includes("Usage: atlas-operator proactive"))).toBe(true);
   });
 
   it("exits 1 when --workspace is omitted from `enable`", async () => {

--- a/packages/cli/src/__tests__/seed.test.ts
+++ b/packages/cli/src/__tests__/seed.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for `atlas seed` — covers the prompts + workspace SQL functions
+ * Tests for `atlas-operator seed` — covers the prompts + workspace SQL functions
  * and the arg-parsing helpers (parseConnectionsArg, parsePromptLibrary).
  * Mocks the DB pool so the assertions can pin specific SQL/args without
  * standing up Postgres.
@@ -13,7 +13,7 @@ import {
   handleSeed,
   type ResolvedConnectionSpec,
   type SemanticEntityRow,
-} from "../commands/seed";
+} from "../commands/operator/seed";
 import type { TenantPgClient } from "../../lib/tenant-db";
 
 // --- Mock pool ---
@@ -403,7 +403,7 @@ describe("handleSeed", () => {
       caught = err instanceof Error ? err : new Error(String(err));
     }
     expect(caught?.message).toBe("__process_exit__:1");
-    expect(errors.some((line) => line.includes("Usage: atlas seed"))).toBe(true);
+    expect(errors.some((line) => line.includes("Usage: atlas-operator seed"))).toBe(true);
   });
 
   it("exits 1 when `seed workspace` is missing --connections", async () => {

--- a/packages/cli/src/commands/operator/export.ts
+++ b/packages/cli/src/commands/operator/export.ts
@@ -1,12 +1,12 @@
 /**
- * atlas export -- Export workspace data to a portable migration bundle (JSON).
+ * atlas-operator export -- Export workspace data to a portable migration bundle (JSON).
  *
- * Extracted from atlas.ts to reduce monolith size.
+ * Operator-only direct-DB tooling, dispatched from bin/atlas-operator.ts (ADR-0025 step 4, #4045).
  */
 
 import * as fs from "fs";
 import pc from "picocolors";
-import { getFlag } from "../../lib/cli-utils";
+import { getFlag } from "../../../lib/cli-utils";
 
 export async function handleExport(args: string[]): Promise<void> {
   const outputArg = getFlag(args, "--output") ?? getFlag(args, "-o");
@@ -14,7 +14,7 @@ export async function handleExport(args: string[]): Promise<void> {
 
   // Require DATABASE_URL
   if (!process.env.DATABASE_URL) {
-    console.error(pc.red("DATABASE_URL is required for atlas export."));
+    console.error(pc.red("DATABASE_URL is required for atlas-operator export."));
     console.error(
       "  The export reads conversations, settings, and learned patterns from the internal database.",
     );

--- a/packages/cli/src/commands/operator/learn.ts
+++ b/packages/cli/src/commands/operator/learn.ts
@@ -1,7 +1,7 @@
 /**
- * atlas learn -- Analyze audit log and propose semantic layer YAML improvements.
+ * atlas-operator learn -- Analyze audit log and propose semantic layer YAML improvements.
  *
- * Extracted from atlas.ts to reduce monolith size.
+ * Operator-only direct-DB tooling, dispatched from bin/atlas-operator.ts (ADR-0025 step 4, #4045).
  */
 
 import * as fs from "fs";
@@ -12,7 +12,7 @@ import {
   requireFlagIdentifier,
   SEMANTIC_DIR,
   ENTITIES_DIR,
-} from "../../lib/cli-utils";
+} from "../../../lib/cli-utils";
 
 export async function handleLearn(args: string[]): Promise<void> {
   const applyMode = args.includes("--apply");
@@ -55,7 +55,7 @@ export async function handleLearn(args: string[]): Promise<void> {
 
   // Validate internal DB is configured
   if (!process.env.DATABASE_URL) {
-    console.error(pc.red("DATABASE_URL is required for atlas learn."));
+    console.error(pc.red("DATABASE_URL is required for atlas-operator learn."));
     console.error(
       "  The audit log is stored in the internal database.",
     );
@@ -98,16 +98,16 @@ export async function handleLearn(args: string[]): Promise<void> {
   );
   try {
     const { fetchAuditLog, analyzeQueries } = await import(
-      "../../lib/learn/analyze"
+      "../../../lib/learn/analyze"
     );
     const {
       loadEntities,
       loadGlossary,
       generateProposals,
       applyProposals,
-    } = await import("../../lib/learn/propose");
+    } = await import("../../../lib/learn/propose");
     const { formatDiff, formatSummary } = await import(
-      "../../lib/learn/diff"
+      "../../../lib/learn/diff"
     );
 
     // 1. Fetch audit log

--- a/packages/cli/src/commands/operator/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/operator/ops-smoke-crm.ts
@@ -1,5 +1,5 @@
 /**
- * `atlas ops smoke-crm` — automated CRM lead-capture verification.
+ * `atlas-operator ops smoke-crm` — automated CRM lead-capture verification.
  *
  * Mechanizes the 10-persona manual repro from PR #2865's comment thread:
  * inject leads BELOW the form/Turnstile layer via `enqueue`, wait for the
@@ -26,8 +26,8 @@
  */
 import { enqueue } from "@atlas/api/lib/lead-outbox/outbox";
 
-import { getFlag } from "../../lib/cli-utils";
-import { loadFixture, FixtureParseError } from "../../lib/smoke-crm/fixture";
+import { getFlag } from "../../../lib/cli-utils";
+import { loadFixture, FixtureParseError } from "../../../lib/smoke-crm/fixture";
 import {
   buildExpectedState,
   computeDiff,
@@ -36,8 +36,8 @@ import {
   type ObservedNote,
   type ObservedPerson,
   type ObservedState,
-} from "../../lib/smoke-crm/diff";
-import { createTwentyAdmin } from "../../lib/smoke-crm/twenty-admin";
+} from "../../../lib/smoke-crm/diff";
+import { createTwentyAdmin } from "../../../lib/smoke-crm/twenty-admin";
 import type { LeadEvent } from "@useatlas/twenty/lead-normalizer";
 
 const DEFAULT_TIMEOUT_SECONDS = 60;
@@ -258,7 +258,7 @@ export async function pollOutboxUntilDrained(
 /**
  * Top-level CLI entry point. Exit codes use `SMOKE_EXIT`. Catches every
  * known failure shape and prints an actionable message; an unhandled
- * defect bubbles out to bin/atlas.ts's top-level catch.
+ * defect bubbles out to bin/atlas-operator.ts's top-level catch.
  *
  * Uses `process.exitCode = X; return;` rather than `process.exit(X)` so
  * the `finally` block runs and the pg client is cleanly closed even on
@@ -340,7 +340,7 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
 
   // Connect to the tenant DB for the enqueue + poll phases. The connect
   // itself can fail (DB down, wrong URL) — surface that as INFRA, not as
-  // an unhandled rejection at the top of bin/atlas.ts.
+  // an unhandled rejection at the top of bin/atlas-operator.ts.
   const { Client } = await import("pg");
   const client = new Client({ connectionString: parsed.databaseUrl });
   try {

--- a/packages/cli/src/commands/operator/ops-teardown-verify.ts
+++ b/packages/cli/src/commands/operator/ops-teardown-verify.ts
@@ -1,5 +1,5 @@
 /**
- * `atlas ops teardown-verify-accounts` — surgically tear down the throwaway
+ * `atlas-operator ops teardown-verify-accounts` — surgically tear down the throwaway
  * `/verify-prod-signup` test accounts (user + org + Stripe customer) left in a
  * region's internal DB after a 3-region residency verification (ADR-0024,
  * #3974). This is the operator-side cleanup half of the residency regression
@@ -51,7 +51,7 @@ import {
   purgeStripeBillingForWorkspace,
   type StripeTeardownOutcome,
 } from "@atlas/api/lib/billing/workspace-teardown";
-import { getFlag } from "../../lib/cli-utils";
+import { getFlag } from "../../../lib/cli-utils";
 
 /** Env var that, set to exactly "1", is one half of the execute double-gate. */
 export const TEARDOWN_OK_ENV = "ATLAS_TEARDOWN_OK";

--- a/packages/cli/src/commands/operator/ops.ts
+++ b/packages/cli/src/commands/operator/ops.ts
@@ -1,5 +1,5 @@
 /**
- * atlas ops — operator-only tools that touch tenant data.
+ * atlas-operator ops — operator-only tools that touch tenant data.
  *
  * Subcommands:
  *   wipe                   TRUNCATE every public table in the tenant DB (excluding
@@ -38,8 +38,8 @@ import {
   BACKFILL_SOURCES,
   type BackfillSource,
 } from "@atlas/api/lib/db/migrations/scripts/backfill-crm-leads";
-import { getFlag } from "../../lib/cli-utils";
-import type { TenantPgClient } from "../../lib/tenant-db";
+import { getFlag } from "../../../lib/cli-utils";
+import type { TenantPgClient } from "../../../lib/tenant-db";
 
 /** Tables that must survive a wipe — migration bookkeeping. */
 export const WIPE_EXCLUDED_TABLES = [
@@ -282,7 +282,7 @@ export async function handleOps(args: string[]): Promise<void> {
   }
 
   console.error(
-    "Usage: atlas ops <wipe|backfill-crm-leads|smoke-crm|teardown-verify-accounts> [options]\n\n" +
+    "Usage: atlas-operator ops <wipe|backfill-crm-leads|smoke-crm|teardown-verify-accounts> [options]\n\n" +
       "Subcommands:\n" +
       "  wipe                 TRUNCATE every public table in the tenant DB. DESTRUCTIVE — requires ATLAS_WIPE_OK=1 + --confirm.\n" +
       "  backfill-crm-leads   Enqueue every demo_leads row into crm_outbox for dispatch to Twenty.\n" +

--- a/packages/cli/src/commands/operator/proactive.ts
+++ b/packages/cli/src/commands/operator/proactive.ts
@@ -1,5 +1,5 @@
 /**
- * atlas proactive — enable or disable proactive chat for a workspace.
+ * atlas-operator proactive — enable or disable proactive chat for a workspace.
  *
  * Replaces internal/enable-proactive-dogfood.ts and internal/disable-proactive-dogfood.ts.
  * Operates against the tenant Postgres pointed at by ATLAS_TEAM_PG_URL (defaults to
@@ -8,19 +8,19 @@
  * literal org id starting with `org_`.
  *
  * Usage:
- *   bun run atlas -- proactive enable --workspace <id|slug> --channels <id1,id2,...>
- *   bun run atlas -- proactive disable --workspace <id|slug>
+ *   bun run atlas-operator -- proactive enable --workspace <id|slug> --channels <id1,id2,...>
+ *   bun run atlas-operator -- proactive disable --workspace <id|slug>
  *
  * Idempotent: re-running enable upserts workspace_proactive_config + every channel row;
  * re-running disable flips workspace_proactive_config.enabled=false (channel rows
  * preserved so a later enable doesn't lose channel configs).
  */
-import { getFlag } from "../../lib/cli-utils";
+import { getFlag } from "../../../lib/cli-utils";
 import {
   resolveTenantUrl,
   resolveWorkspaceId,
   type TenantPgClient,
-} from "../../lib/tenant-db";
+} from "../../../lib/tenant-db";
 
 export { resolveWorkspaceId };
 
@@ -89,7 +89,7 @@ export async function handleProactive(args: string[]): Promise<void> {
   const subcommand = args[1];
   if (subcommand !== "enable" && subcommand !== "disable") {
     console.error(
-      "Usage: atlas proactive <enable|disable> --workspace <id|slug> [--channels <ids>]\n\n" +
+      "Usage: atlas-operator proactive <enable|disable> --workspace <id|slug> [--channels <ids>]\n\n" +
         "Subcommands:\n" +
         "  enable   Turn on proactive chat for a workspace + opt one or more channels in.\n" +
         "  disable  Flip the workspace toggle off (channel rows preserved).\n",

--- a/packages/cli/src/commands/operator/seed.ts
+++ b/packages/cli/src/commands/operator/seed.ts
@@ -1,5 +1,5 @@
 /**
- * atlas seed — seed durable workspace data into the tenant Postgres.
+ * atlas-operator seed — seed durable workspace data into the tenant Postgres.
  *
  * Subcommands:
  *   prompts   Seed a prompt-library collection + items from a YAML file
@@ -14,12 +14,12 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import * as yaml from "js-yaml";
-import { getFlag } from "../../lib/cli-utils";
+import { getFlag } from "../../../lib/cli-utils";
 import {
   resolveTenantUrl,
   resolveWorkspaceId,
   type TenantPgClient,
-} from "../../lib/tenant-db";
+} from "../../../lib/tenant-db";
 
 // --- seed prompts ---
 
@@ -462,7 +462,7 @@ export async function handleSeed(args: string[]): Promise<void> {
   if (subcommand === "workspace") return handleSeedWorkspace(args);
 
   console.error(
-    "Usage: atlas seed <prompts|workspace> [options]\n\n" +
+    "Usage: atlas-operator seed <prompts|workspace> [options]\n\n" +
       "Subcommands:\n" +
       "  prompts    Seed a prompt-library collection + items from a YAML file.\n" +
       "  workspace  Provision a connection group + member connections + semantic entities.\n",

--- a/packages/cli/src/completions.ts
+++ b/packages/cli/src/completions.ts
@@ -77,17 +77,6 @@ export const COMMANDS: Record<string, CommandSpec> = {
       "--port": "Port for SSE transport",
     },
   },
-  learn: {
-    description: "Analyze audit log and propose YAML improvements",
-    flags: {
-      "--apply": "Write proposed changes to YAML files",
-      "--limit": "Max audit log entries to analyze",
-      "--since": "Only analyze queries after this date",
-      "--source": "Read from/write to semantic/{name}/ subdirectory",
-      "--suggestions": "Generate query suggestions from audit log",
-      "--auto-approve": "With --suggestions: skip admin moderation queue",
-    },
-  },
   improve: {
     description: "Analyze semantic layer and propose data-driven improvements",
     flags: {
@@ -152,14 +141,6 @@ export const COMMANDS: Record<string, CommandSpec> = {
       "--db": "Filter to a single database",
       "--csv": "CSV output",
       "--resume": "Resume from existing JSONL results file",
-    },
-  },
-  export: {
-    description: "Export workspace data to a migration bundle",
-    flags: {
-      "--output": "Output file path (default: ./atlas-export-{date}.json)",
-      "-o": "Alias for --output",
-      "--org": "Export data for a specific org",
     },
   },
   "migrate-import": {

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -1,4 +1,4 @@
-/** Migration bundle types — wire format for atlas export/import. */
+/** Migration bundle types — wire format for `atlas-operator export` / `atlas import`. */
 
 import type { MessageRole, Surface } from "./conversation";
 import type { LearnedPattern } from "./learned-pattern";

--- a/scripts/staging-smoke-personas.yml
+++ b/scripts/staging-smoke-personas.yml
@@ -1,4 +1,4 @@
-# Staging smoke fixture — drives `atlas ops smoke-crm` from
+# Staging smoke fixture — drives `atlas-operator ops smoke-crm` from
 # `.github/workflows/staging-smoke.yml` after every staging deploy.
 #
 # This is the MINIMAL counterpart to the full coverage matrix in

--- a/scripts/test-fixtures/crm-personas.yml
+++ b/scripts/test-fixtures/crm-personas.yml
@@ -1,4 +1,4 @@
-# CRM smoke-test fixture — drives `atlas ops smoke-crm`.
+# CRM smoke-test fixture — drives `atlas-operator ops smoke-crm`.
 #
 # Each persona enqueues one `crm_outbox` row that the flusher dispatches to
 # Twenty. The smoke command asserts that after the flusher drains:


### PR DESCRIPTION
## Summary

Pulls the operator/tenant-data subcommands (`ops`, `seed`, `proactive`, `export`, `learn`) — all direct-DB, operator-only — out of the published `atlas` CLI into a **separate `atlas-operator` binary**, so the workspace-facing CLI never ships tenant-destructive direct-DB tooling. **Behavior and gates are unchanged — packaging only** (ADR-0025 sub-decision 1 / sequencing step 4; the ADR is being authored in a parallel branch, so references are paired with this issue for resolvability).

- **Moved** `packages/cli/src/commands/{ops,seed,proactive,export,learn,ops-smoke-crm,ops-teardown-verify}.ts` → `src/commands/operator/` (git renames, 92–99% similarity; only import depth + `atlas`→`atlas-operator` strings changed).
- **New** `bin/atlas-operator.ts` (the operator namespace) + `lib/operator-help.ts` (single-source-of-truth `OPERATOR_COMMAND_NAMES` tuple; the help record is `satisfies Record<OperatorCommand, …>` so a missing/extra entry is a compile error).
- The published `atlas` CLI **drops the 5 dispatches** + their `help`/`completions` entries and **redirects** any operator command with an actionable message pointing at `atlas-operator` (exit 1 — never silently runs).
- Wired root + `packages/cli` `atlas-operator` npm scripts.
- Updated CLAUDE.md, `cli.mdx`, `environment-variables.mdx`, staging runbooks, the **`staging-smoke.yml` CI workflow**, and the smoke fixtures to the new invocation. Historical changelog/research/comparison references to the feature name were intentionally left (not invocation docs).

## Test plan

- [x] New `bin/__tests__/operator-cli.test.ts` locks the partition from both sides (published help advertises none; operator help advertises all 5) and drives **all five** dispatch branches end-to-end (catches a copy-paste mis-wire), plus the redirect, unknown-command, and `--help` paths.
- [x] All 7 relocated per-command suites pass with updated import paths + `Usage:` assertions.
- [x] `/review-panel` (silent-failure · type-design · pr-test · comment-analyzer) — CLEAN after 3 rounds.
- [x] `/ci`: lint, type, syncpack, and all 12 drift/check scripts pass; full test suite 744/747 (the 3 failures are the documented WSL2 sandbox flakes — `ATLAS_SANDBOX_URL`/python sandbox — not in this diff; API `--affected` 317/317 green).

Closes #4045

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split operator subcommands into a separate `atlas-operator` CLI binary
> - Introduces [bin/atlas-operator.ts](https://github.com/AtlasDevHQ/atlas/pull/4055/files#diff-d995a3be81c21f6fbd1282ee7148b1221e1ab61e4faede3eea2bda0eb29d1d13) as a new CLI entrypoint that routes operator-only commands (`ops`, `seed`, `proactive`, `export`, `learn`) with their own help output.
> - Moves operator command handlers from `packages/cli/src/commands/` into a new `operator/` subdirectory and updates all import paths accordingly.
> - Removes operator commands from the published `atlas` CLI completions, help registry, and overview; the `atlas` binary now prints a redirect message and exits with code 1 when these commands are attempted.
> - Adds `atlas-operator` npm scripts at the repo root and in `packages/cli/package.json` to invoke the new entrypoint.
> - Updates all documentation, workflow files, and internal comments to reference `atlas-operator` instead of `atlas` for operator commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3df2a90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->