### PR TITLE
feat(billing): S4 — OverageMeter at-cost cents repoint + OBS-1 hash id (#4039)

### DIFF
--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -371,10 +371,10 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     }
 
     // Per-seat token budget, retained for the wire's `limits.totalTokenBudget`
-    // (display only). The token-budget *concept* also survives server-side for
-    // the token OverageMeter (#3992/#4039), which computes it independently via
-    // computeTokenBudget — it does NOT read this HTTP field. Enforcement no
-    // longer uses it: the budget is now a dollar credit (#4038).
+    // (display only). Neither enforcement nor the OverageMeter reads it anymore:
+    // the enforced budget is a dollar credit (#4038) and overage is billed at
+    // cost in cents (#4039). This figure is surfaced purely so the billing/usage
+    // pages can still show a token-budget number.
     const totalTokenBudget = computeTokenBudget(workspace.plan_tier, seatCount);
     const tokenLimit = isUnlimited(totalTokenBudget) ? null : totalTokenBudget;
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -431,6 +431,10 @@ describe("migrateAuthTables", () => {
             // capture, Structure B WS2, #4036); ALTERs Atlas-internal tables, no
             // FK to a Better Auth table, so it runs in every auth mode — must be listed.
             { name: "0155_usage_gateway_cost_usd.sql" },
+            // 0156 ALTERs overage_meter_reports (re-denominate the overage ledger
+            // to at-cost cents, Structure B WS2, #4039); Atlas-internal, no FK to
+            // a Better Auth table, so it runs in every auth mode — must be listed.
+            { name: "0156_overage_meter_reports_cost_cents.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
@@ -105,9 +105,10 @@ mock.module("@atlas/api/lib/billing/enforcement", () => ({
   severityOf: () => 0,
   // Imported by overage-meter.ts (loaded transitively via server.ts → the
   // ensureOverageSubscriptionItem seam). Omitting it surfaces as "Export named
-  // 'computeOverageTokens' not found" once that import forces enforcement to
-  // link against this partial mock (#3992). Real trivial impl — never called here.
-  computeOverageTokens: (usage: number, limit: number) => Math.max(0, usage - limit),
+  // 'computeOverageDollars' not found" once that import forces enforcement to
+  // link against this partial mock (#3992/#4039). Real trivial impl — never called here.
+  computeOverageDollars: (costUsd: number, creditUsd: number) =>
+    creditUsd <= 0 ? 0 : Math.max(0, costUsd - creditUsd),
 }));
 
 const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -151,7 +151,6 @@ let checkPlanLimits: typeof import("@atlas/api/lib/billing/enforcement").checkPl
 let checkResourceLimit: typeof import("@atlas/api/lib/billing/enforcement").checkResourceLimit;
 let invalidatePlanCache: typeof import("@atlas/api/lib/billing/enforcement").invalidatePlanCache;
 let buildMetricStatus: typeof import("@atlas/api/lib/billing/enforcement").buildMetricStatus;
-let computeOverageTokens: typeof import("@atlas/api/lib/billing/enforcement").computeOverageTokens;
 let computeOverageDollars: typeof import("@atlas/api/lib/billing/enforcement").computeOverageDollars;
 let resolveAbuseCeilingPercent: typeof import("@atlas/api/lib/billing/enforcement").resolveAbuseCeilingPercent;
 let resolveSpendPolicy: typeof import("@atlas/api/lib/billing/enforcement").resolveSpendPolicy;
@@ -167,7 +166,6 @@ beforeAll(async () => {
     checkResourceLimit,
     invalidatePlanCache,
     buildMetricStatus,
-    computeOverageTokens,
     computeOverageDollars,
     resolveAbuseCeilingPercent,
     resolveSpendPolicy,
@@ -1012,24 +1010,6 @@ describe("computeOverageDollars (#4038)", () => {
 
   it("guards an invalid (<=0) credit — no overage from a misconfigured credit", () => {
     expect(computeOverageDollars(10, 0)).toBe(0);
-  });
-});
-
-// computeOverageTokens survives for the token OverageMeter (#3992/#4039) even
-// though enforcement no longer uses it — keep it under test.
-describe("computeOverageTokens (token OverageMeter, #3990)", () => {
-  it("reports zero overage at or under budget", () => {
-    expect(computeOverageTokens(1_000_000, 2_000_000)).toBe(0);
-    expect(computeOverageTokens(2_000_000, 2_000_000)).toBe(0);
-  });
-
-  it("reports the excess over budget as overage tokens", () => {
-    expect(computeOverageTokens(2_100_000, 2_000_000)).toBe(100_000);
-    expect(computeOverageTokens(3_000_000, 2_000_000)).toBe(1_000_000);
-  });
-
-  it("guards an invalid (<=0) limit", () => {
-    expect(computeOverageTokens(1_000_000, 0)).toBe(0);
   });
 });
 

--- a/packages/api/src/lib/billing/__tests__/overage-meter-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/overage-meter-pg.test.ts
@@ -8,8 +8,8 @@
  *   - The `recordOverageReport` upsert's `GREATEST(...)` MONOTONICITY — the
  *     property that makes a late/retried tick unable to regress the cumulative
  *     (and so unable to re-bill). The unit test only string-matches the SQL.
- *   - The `chk_overage_meter_reports_tokens_nonneg` CHECK actually rejecting a
- *     negative cumulative.
+ *   - The `chk_overage_meter_reports_cost_cents_nonneg` CHECK (migration 0156)
+ *     actually rejecting a negative cumulative.
  *   - The `reportPeriodOverages` scan SELECT, which reads `organization.byot`,
  *     `.plan_tier`, `."stripeCustomerId"` and joins `subscription` — exactly
  *     the `column "X" does not exist` class that broke the plan-tier reconcile
@@ -30,7 +30,7 @@ import {
   type InternalPool,
 } from "@atlas/api/lib/db/internal";
 import {
-  getReportedOverageTokens,
+  getReportedOverageCents,
   recordOverageReport,
   reportPeriodOverages,
   type OverageWorkspaceRow,
@@ -127,38 +127,38 @@ describeIfPg("OverageMeter ledger + sweep (real Postgres)", () => {
   }
 
   it(
-    "advances the cumulative monotonically — GREATEST keeps a late/retried lower tick from regressing it",
+    "advances the cumulative cents monotonically — GREATEST keeps a late/retried lower tick from regressing it",
     async () => {
       const base = {
         orgId: "org_mono",
         periodStartISO: PERIOD,
         stripeCustomerId: "cus_mono",
       };
-      await recordOverageReport({ ...base, reportedTokens: 500, eventIdentifier: "id_0" });
-      expect(await getReportedOverageTokens("org_mono", PERIOD)).toBe(500);
+      await recordOverageReport({ ...base, reportedCents: 500, eventIdentifier: "id_0" });
+      expect(await getReportedOverageCents("org_mono", PERIOD)).toBe(500);
 
       // A stale/retried tick carrying a LOWER cumulative must not regress it.
-      await recordOverageReport({ ...base, reportedTokens: 300, eventIdentifier: "id_stale" });
-      expect(await getReportedOverageTokens("org_mono", PERIOD)).toBe(500);
+      await recordOverageReport({ ...base, reportedCents: 300, eventIdentifier: "id_stale" });
+      expect(await getReportedOverageCents("org_mono", PERIOD)).toBe(500);
 
       // A genuine advance moves it forward.
-      await recordOverageReport({ ...base, reportedTokens: 700, eventIdentifier: "id_1" });
-      expect(await getReportedOverageTokens("org_mono", PERIOD)).toBe(700);
+      await recordOverageReport({ ...base, reportedCents: 700, eventIdentifier: "id_1" });
+      expect(await getReportedOverageCents("org_mono", PERIOD)).toBe(700);
     },
     PG_TEST_TIMEOUT_MS,
   );
 
   it(
-    "enforces the non-negative CHECK on reported_tokens",
+    "enforces the non-negative CHECK on reported_cost_cents",
     async () => {
       // Assert the SPECIFIC non-negative CHECK fired (not just any SQL error).
       await expect(
         pool.query(
-          `INSERT INTO overage_meter_reports (org_id, period_start, stripe_customer_id, reported_tokens)
+          `INSERT INTO overage_meter_reports (org_id, period_start, stripe_customer_id, reported_cost_cents)
            VALUES ('org_neg', $1, 'cus', -1)`,
           [PERIOD],
         ),
-      ).rejects.toThrow("chk_overage_meter_reports_tokens_nonneg");
+      ).rejects.toThrow("chk_overage_meter_reports_cost_cents_nonneg");
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/billing/__tests__/overage-meter.test.ts
+++ b/packages/api/src/lib/billing/__tests__/overage-meter.test.ts
@@ -1,11 +1,13 @@
 /**
- * Unit tests for the OverageMeter reporter (#3992).
+ * Unit tests for the OverageMeter reporter (#3992; at-cost cents repoint #4039).
  *
- * Covers the four acceptance criteria at the module boundary:
+ * Covers the acceptance criteria at the module boundary:
  *   - period overage reported idempotently + reconcilably (ledger-backed):
  *     the same delta reported twice bills once;
+ *   - overage is denominated in at-cost CENTS (dollars → cents), not tokens;
+ *   - OBS-1: the `meter_event` identifier is bounded ≤100 chars via a hash of
+ *     `(orgId|period|baseline)`, retaining the baseline-keyed crash-window dedup;
  *   - the metered item is added as a second subscription item per tier;
- *   - delta math / identifier determinism (the idempotency primitives);
  *   - BYOT workspaces are NEVER reported.
  *
  * The meaty per-workspace path takes its I/O as injected deps (CLAUDE.md:
@@ -22,6 +24,7 @@ import type {
   WorkspaceOverageDeps,
   OverageReportRecord,
 } from "@atlas/api/lib/billing/overage-meter";
+import type { UsageCurrentPeriod } from "@atlas/api/lib/metering";
 
 // ── Mocked internal DB (drives the ledger reads/writes + the sweep scan) ──
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
@@ -42,11 +45,14 @@ mock.module("@atlas/api/lib/billing/stripe-client", () => ({
   _resetStripeClientCache: () => {},
 }));
 
-// ── Quiet logger ──────────────────────────────────────────────────────────
+// ── Quiet logger (error captured so the cost-basis-gap alert is assertable) ──
+const errorCalls: unknown[][] = [];
 const stubLogger = {
   info: () => {},
   warn: () => {},
-  error: () => {},
+  error: (...args: unknown[]) => {
+    errorCalls.push(args);
+  },
   debug: () => {},
   fatal: () => {},
   trace: () => {},
@@ -65,9 +71,10 @@ const {
   OVERAGE_METER_EVENT_NAME,
   OVERAGE_REPORT_INTERVAL_MS,
   getOveragePriceIdForTier,
+  dollarsToCents,
   computeReportableDelta,
   buildOverageEventIdentifier,
-  getReportedOverageTokens,
+  getReportedOverageCents,
   recordOverageReport,
   reportWorkspaceOverage,
   reportPeriodOverages,
@@ -76,6 +83,9 @@ const {
 
 const NOW = new Date("2026-06-15T12:00:00.000Z");
 const PERIOD_START = "2026-06-01T00:00:00.000Z";
+
+// computeUsageDollarBudget("starter", 1) = $20/seat × 1 seat (plans.ts).
+const STARTER_CREDIT_USD = 20;
 
 // ── Stripe doubles ──────────────────────────────────────────────────────
 interface MeterDouble {
@@ -110,17 +120,8 @@ function makeDeps(overrides: Partial<WorkspaceOverageDeps> = {}): {
   const recordCalls: OverageReportRecord[] = [];
   const deps: WorkspaceOverageDeps = {
     getSeatCount: async () => 1,
-    getCurrentPeriodUsage: async () => ({
-      queryCount: 0,
-      tokenCount: 0,
-      weightedTokenCount: 0,
-      costUsd: 0,
-      activeUsers: 0,
-      periodStart: PERIOD_START,
-      periodEnd: "2026-07-01T00:00:00.000Z",
-      periodSource: "utc-month",
-    }),
-    getReportedOverageTokens: async () => 0,
+    getCurrentPeriodUsage: async () => usageWithCost(0),
+    getReportedOverageCents: async () => 0,
     recordOverageReport: async (r) => {
       recordCalls.push(r);
     },
@@ -128,8 +129,6 @@ function makeDeps(overrides: Partial<WorkspaceOverageDeps> = {}): {
   };
   return { deps, recordCalls };
 }
-
-const STARTER_BUDGET = 2_000_000; // plans.ts starter tokenBudgetPerSeat × 1 seat
 
 function starterRow(overrides: Partial<OverageWorkspaceRow> = {}): OverageWorkspaceRow {
   return {
@@ -144,11 +143,38 @@ function starterRow(overrides: Partial<OverageWorkspaceRow> = {}): OverageWorksp
 beforeEach(() => {
   hasDb = true;
   stripeForSweep = null;
+  errorCalls.length = 0;
   mockInternalQuery.mockReset();
   mockInternalQuery.mockImplementation(() => Promise.resolve([]));
 });
 
+/** Did the cost-basis-gap `log.error` (reason `cost_basis_missing`) fire? */
+function sawCostBasisAlert(): boolean {
+  return errorCalls.some(
+    (args) =>
+      typeof args[0] === "object" &&
+      args[0] !== null &&
+      (args[0] as Record<string, unknown>).reason === "cost_basis_missing",
+  );
+}
+
 // ───────────────────────────────────────────────────────────────────────
+describe("dollarsToCents", () => {
+  it("rounds at-cost dollars to the nearest whole cent", () => {
+    expect(dollarsToCents(5)).toBe(500);
+    expect(dollarsToCents(2.5)).toBe(250);
+    expect(dollarsToCents(12.347)).toBe(1235); // rounded
+    expect(dollarsToCents(0.004)).toBe(0); // sub-half-cent rounds down
+  });
+
+  it("is 0 for non-positive or non-finite input (never a negative quantity)", () => {
+    expect(dollarsToCents(0)).toBe(0);
+    expect(dollarsToCents(-3)).toBe(0);
+    expect(dollarsToCents(Number.NaN)).toBe(0);
+    expect(dollarsToCents(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
 describe("computeReportableDelta", () => {
   it("reports the gap when current overage exceeds what's already reported", () => {
     expect(computeReportableDelta(500, 0)).toBe(500);
@@ -169,7 +195,7 @@ describe("computeReportableDelta", () => {
   });
 });
 
-describe("buildOverageEventIdentifier", () => {
+describe("buildOverageEventIdentifier (OBS-1)", () => {
   it("is deterministic on the baseline (re-report after crash → same id)", () => {
     const a = buildOverageEventIdentifier("org_1", PERIOD_START, 500);
     const b = buildOverageEventIdentifier("org_1", PERIOD_START, 500);
@@ -183,10 +209,26 @@ describe("buildOverageEventIdentifier", () => {
   });
 
   it("scopes by org and period", () => {
-    expect(buildOverageEventIdentifier("org_1", PERIOD_START, 500)).toContain("org_1");
     expect(buildOverageEventIdentifier("org_1", PERIOD_START, 500)).not.toBe(
       buildOverageEventIdentifier("org_2", PERIOD_START, 500),
     );
+    expect(buildOverageEventIdentifier("org_1", PERIOD_START, 500)).not.toBe(
+      buildOverageEventIdentifier("org_1", "2026-07-01T00:00:00.000Z", 500),
+    );
+  });
+
+  it("is bounded ≤100 chars regardless of org-id length (the OBS-1 fix)", () => {
+    // Better-Auth org ids are unbounded TEXT; the old raw spelling overflowed
+    // Stripe's 100-char identifier cap for a long id, stranding that org's
+    // overage. The hash makes the identifier fixed-width.
+    const longOrg = "org_" + "a".repeat(512);
+    const id = buildOverageEventIdentifier(longOrg, PERIOD_START, 123456789);
+    expect(id.length).toBeLessThanOrEqual(100);
+    // Hashed — the raw (overflowing) org id is NOT embedded verbatim.
+    expect(id).not.toContain(longOrg);
+    expect(id.startsWith("atlas-overage-")).toBe(true);
+    // Still deterministic for the long id (dedup intact).
+    expect(id).toBe(buildOverageEventIdentifier(longOrg, PERIOD_START, 123456789));
   });
 });
 
@@ -209,11 +251,12 @@ describe("getOveragePriceIdForTier", () => {
   });
 });
 
-describe("getReportedOverageTokens", () => {
+describe("getReportedOverageCents", () => {
   it("returns 0 when no ledger row exists", async () => {
     mockInternalQuery.mockResolvedValueOnce([]);
-    await expect(getReportedOverageTokens("org_1", PERIOD_START)).resolves.toBe(0);
+    await expect(getReportedOverageCents("org_1", PERIOD_START)).resolves.toBe(0);
     const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("reported_cost_cents");
     expect(sql).toContain("FROM overage_meter_reports");
     expect(sql).toContain("org_id = $1");
     expect(sql).toContain("period_start = $2");
@@ -221,38 +264,41 @@ describe("getReportedOverageTokens", () => {
   });
 
   it("coerces the pg BIGINT string back to a number", async () => {
-    mockInternalQuery.mockResolvedValueOnce([{ reported_tokens: "12345" }]);
-    await expect(getReportedOverageTokens("org_1", PERIOD_START)).resolves.toBe(12345);
+    mockInternalQuery.mockResolvedValueOnce([{ reported_cost_cents: "12345" }]);
+    await expect(getReportedOverageCents("org_1", PERIOD_START)).resolves.toBe(12345);
   });
 
   it("THROWS on a present-but-uncoercible value (fail closed, never silently 0 → no double-bill)", async () => {
-    mockInternalQuery.mockResolvedValueOnce([{ reported_tokens: "not-a-number" }]);
+    mockInternalQuery.mockResolvedValueOnce([{ reported_cost_cents: "not-a-number" }]);
     // Returning 0 here would re-key the identifier on baseline 0 and re-report
     // the whole cumulative; throwing routes to the safe per-workspace skip+retry.
-    await expect(getReportedOverageTokens("org_1", PERIOD_START)).rejects.toThrow();
+    await expect(getReportedOverageCents("org_1", PERIOD_START)).rejects.toThrow();
   });
 
   it("no-ops to 0 without an internal DB", async () => {
     hasDb = false;
-    await expect(getReportedOverageTokens("org_1", PERIOD_START)).resolves.toBe(0);
+    await expect(getReportedOverageCents("org_1", PERIOD_START)).resolves.toBe(0);
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 });
 
 describe("recordOverageReport", () => {
-  it("upserts the cumulative with GREATEST + composite-PK conflict", async () => {
+  it("upserts the cumulative cents with GREATEST + composite-PK conflict", async () => {
     await recordOverageReport({
       orgId: "org_1",
       periodStartISO: PERIOD_START,
       stripeCustomerId: "cus_1",
-      reportedTokens: 500,
+      reportedCents: 500,
       eventIdentifier: "id_1",
     });
     const [sql, params] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("INSERT INTO overage_meter_reports");
+    expect(sql).toContain("reported_cost_cents");
     expect(sql).toContain("ON CONFLICT (org_id, period_start) DO UPDATE");
     // Monotonic: never regress the cumulative (would re-bill).
-    expect(sql).toContain("GREATEST(overage_meter_reports.reported_tokens, EXCLUDED.reported_tokens)");
+    expect(sql).toContain(
+      "GREATEST(overage_meter_reports.reported_cost_cents, EXCLUDED.reported_cost_cents)",
+    );
     expect(params).toEqual(["org_1", PERIOD_START, "cus_1", 500, "id_1"]);
   });
 
@@ -262,7 +308,7 @@ describe("recordOverageReport", () => {
       orgId: "org_1",
       periodStartISO: PERIOD_START,
       stripeCustomerId: "cus_1",
-      reportedTokens: 500,
+      reportedCents: 500,
       eventIdentifier: "id_1",
     });
     expect(mockInternalQuery).not.toHaveBeenCalled();
@@ -270,11 +316,12 @@ describe("recordOverageReport", () => {
 });
 
 describe("reportWorkspaceOverage", () => {
-  it("reports the period overage delta to the meter and advances the ledger", async () => {
+  it("reports the at-cost overage delta in CENTS and advances the ledger", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps, recordCalls } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
-      getReportedOverageTokens: async () => 0,
+      // $5 over the $20 credit → 500 cents of overage.
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 5),
+      getReportedOverageCents: async () => 0,
     });
 
     await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
@@ -287,52 +334,97 @@ describe("reportWorkspaceOverage", () => {
     };
     expect(params.event_name).toBe(OVERAGE_METER_EVENT_NAME);
     expect(params.payload.stripe_customer_id).toBe("cus_1");
-    expect(params.payload.value).toBe("500"); // delta, as a string
+    expect(params.payload.value).toBe("500"); // delta cents, as a string
     // Identifier is keyed on the BASELINE (reportedSoFar = 0 here), not the
     // new cumulative — so a crash-retry from the un-advanced ledger reuses it.
     expect(params.identifier).toBe(buildOverageEventIdentifier("org_1", PERIOD_START, 0));
 
     expect(recordCalls).toHaveLength(1);
-    expect(recordCalls[0].reportedTokens).toBe(500); // cumulative, not delta
+    expect(recordCalls[0].reportedCents).toBe(500); // cumulative cents, not delta
     // The recorded identifier MUST equal the one sent — the crash-window dedup
     // relies on the retry reproducing it.
     expect(recordCalls[0].eventIdentifier).toBe(params.identifier);
   });
 
-  it("falls back to raw token count when the weighted field is absent", async () => {
+  it("rounds fractional at-cost dollars to whole cents", async () => {
+    const { stripe, meterCreate } = makeMeterStripe();
+    const { deps } = makeDeps({
+      // $2.347 over credit → 234.7¢ → 235¢ (nearest cent).
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 2.347),
+      getReportedOverageCents: async () => 0,
+    });
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
+    const params = meterCreate.mock.calls[0][0] as { payload: { value: string } };
+    expect(params.payload.value).toBe("235");
+  });
+
+  it("skips a $0 at-cost basis with a LOUD operator alert when tokens were recorded (safe but visible under-bill)", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps } = makeDeps({
       getCurrentPeriodUsage: async () => ({
         queryCount: 0,
-        tokenCount: STARTER_BUDGET + 500,
-        // weighted field absent (un-backfilled / future shape change)
-        weightedTokenCount: undefined as unknown as number,
-        costUsd: 0,
+        tokenCount: 5_000_000, // tokens recorded…
+        weightedTokenCount: 5_000_000,
+        costUsd: 0, // …but no at-cost basis (non-gateway / pre-#4036 / broken capture)
         activeUsers: 0,
         periodStart: PERIOD_START,
         periodEnd: "2026-07-01T00:00:00.000Z",
         periodSource: "utc-month",
       }),
-      getReportedOverageTokens: async () => 0,
+      getReportedOverageCents: async () => 0,
+    });
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
+    expect(meterCreate).not.toHaveBeenCalled();
+    // A silent skip here would let a fleet-wide capture regression zero overage
+    // revenue unnoticed — mirror enforcement.ts's cost-basis-gap alert (#4038).
+    expect(sawCostBasisAlert()).toBe(true);
+  });
+
+  it("does NOT fire the cost-basis alert on a legitimately-under-credit skip", async () => {
+    const { stripe } = makeMeterStripe();
+    const { deps } = makeDeps({
+      // Real at-cost basis, simply under the credit — a normal quiet skip.
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD - 1),
+    });
+    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
+    expect(sawCostBasisAlert()).toBe(false);
+  });
+
+  it("reuses the baseline-keyed identifier across ticks when the ledger hasn't advanced (crash-window dedup)", async () => {
+    // Models the prod hazard: tick 1 bills Stripe but crashes before the ledger
+    // records, so the baseline stays 0; tick 2 sees HIGHER usage. The identifier
+    // must stay keyed on the unchanged baseline (0) so Stripe dedupes the overlap
+    // (keeps tick 1's value) instead of double-billing the grown amount.
+    const { stripe, meterCreate } = makeMeterStripe();
+    let costUsd = STARTER_CREDIT_USD + 5; // 500 cents
+    const { deps } = makeDeps({
+      getCurrentPeriodUsage: async () => usageWithCost(costUsd),
+      getReportedOverageCents: async () => 0, // ledger never advanced (crash before record)
     });
 
-    await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
-    const params = meterCreate.mock.calls[0][0] as { payload: { value: string } };
-    expect(params.payload.value).toBe("500"); // billed on raw, not silently zero
+    await reportWorkspaceOverage(stripe, starterRow(), NOW, deps);
+    costUsd = STARTER_CREDIT_USD + 9; // usage grew to 900 cents before the retry
+    await reportWorkspaceOverage(stripe, starterRow(), NOW, deps);
+
+    const id1 = (meterCreate.mock.calls[0][0] as { identifier: string }).identifier;
+    const id2 = (meterCreate.mock.calls[1][0] as { identifier: string }).identifier;
+    expect(id2).toBe(id1); // same baseline (0) → same identifier → Stripe dedupes
+    expect(id1).toBe(buildOverageEventIdentifier("org_1", PERIOD_START, 0));
   });
 
   it("reports only the DELTA past what's already reported, recording the new cumulative", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps, recordCalls } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 250),
-      getReportedOverageTokens: async () => 100,
+      // $2.50 over credit → 250 cents current overage.
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 2.5),
+      getReportedOverageCents: async () => 100,
     });
 
     await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("reported");
 
     const params = meterCreate.mock.calls[0][0] as { payload: { value: string }; identifier: string };
     expect(params.payload.value).toBe("150"); // 250 current − 100 reported
-    expect(recordCalls[0].reportedTokens).toBe(250);
+    expect(recordCalls[0].reportedCents).toBe(250);
     // Identifier is keyed on the BASELINE (100), not the delta or the cumulative
     // — pins the baseline-keying for a non-zero baseline.
     expect(params.identifier).toBe(buildOverageEventIdentifier("org_1", PERIOD_START, 100));
@@ -340,10 +432,10 @@ describe("reportWorkspaceOverage", () => {
 
   it("is idempotent — the same overage reported twice bills once", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
-    // Second tick: the ledger already holds the full cumulative.
+    // Second tick: the ledger already holds the full cumulative (500 cents).
     const { deps } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
-      getReportedOverageTokens: async () => 500,
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 5),
+      getReportedOverageCents: async () => 500,
     });
 
     await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
@@ -353,8 +445,8 @@ describe("reportWorkspaceOverage", () => {
   it("reconciles a downward correction without a negative meter event", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 300),
-      getReportedOverageTokens: async () => 500, // ledger ahead of current
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 3), // 300 cents
+      getReportedOverageCents: async () => 500, // ledger ahead of current
     });
 
     await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
@@ -366,8 +458,8 @@ describe("reportWorkspaceOverage", () => {
     const getSeatCount = mock(async () => 1);
     const { deps, recordCalls } = makeDeps({
       getSeatCount,
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 10_000),
-      getReportedOverageTokens: async () => 0,
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 100),
+      getReportedOverageCents: async () => 0,
     });
 
     await expect(
@@ -382,7 +474,7 @@ describe("reportWorkspaceOverage", () => {
   it("skips non-paid tiers (trial / free / locked)", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 10_000),
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 100),
     });
     for (const tier of ["trial", "free", "locked"]) {
       await expect(
@@ -395,7 +487,7 @@ describe("reportWorkspaceOverage", () => {
   it("skips a workspace with no Stripe customer id", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 10_000),
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 100),
     });
     await expect(
       reportWorkspaceOverage(stripe, starterRow({ stripe_customer_id: null }), NOW, deps),
@@ -403,10 +495,10 @@ describe("reportWorkspaceOverage", () => {
     expect(meterCreate).not.toHaveBeenCalled();
   });
 
-  it("skips when usage is within budget (no overage)", async () => {
+  it("skips when usage is within the credit (no overage)", async () => {
     const { stripe, meterCreate } = makeMeterStripe();
     const { deps } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET - 1),
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD - 1),
     });
     await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).resolves.toBe("skipped");
     expect(meterCreate).not.toHaveBeenCalled();
@@ -417,8 +509,8 @@ describe("reportWorkspaceOverage", () => {
       throw new Error("stripe 503");
     });
     const { deps, recordCalls } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
-      getReportedOverageTokens: async () => 0,
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 5),
+      getReportedOverageCents: async () => 0,
     });
 
     await expect(reportWorkspaceOverage(stripe, starterRow(), NOW, deps)).rejects.toThrow("stripe 503");
@@ -429,8 +521,8 @@ describe("reportWorkspaceOverage", () => {
   it("re-throws (so the tick retries) when Stripe billed but the ledger record fails", async () => {
     const { stripe, meterCreate } = makeMeterStripe(); // Stripe succeeds
     const { deps } = makeDeps({
-      getCurrentPeriodUsage: async () => usageWith(STARTER_BUDGET + 500),
-      getReportedOverageTokens: async () => 0,
+      getCurrentPeriodUsage: async () => usageWithCost(STARTER_CREDIT_USD + 5),
+      getReportedOverageCents: async () => 0,
       recordOverageReport: async () => {
         throw new Error("pg down");
       },
@@ -566,8 +658,8 @@ describe("reportPeriodOverages", () => {
 });
 
 describe("constants", () => {
-  it("uses the configured Stripe meter event name", () => {
-    expect(OVERAGE_METER_EVENT_NAME).toBe("atlas_token_overage");
+  it("uses the at-cost cents Stripe meter event name (distinct from the token meter)", () => {
+    expect(OVERAGE_METER_EVENT_NAME).toBe("atlas_usage_overage_cents");
   });
 
   it("ticks on a positive interval", () => {
@@ -576,12 +668,12 @@ describe("constants", () => {
 });
 
 // ── helpers ────────────────────────────────────────────────────────────
-function usageWith(weighted: number): import("@atlas/api/lib/metering").UsageCurrentPeriod {
+function usageWithCost(costUsd: number): UsageCurrentPeriod {
   return {
     queryCount: 0,
-    tokenCount: weighted,
-    weightedTokenCount: weighted,
-    costUsd: 0,
+    tokenCount: 0,
+    weightedTokenCount: 0,
+    costUsd,
     activeUsers: 0,
     periodStart: PERIOD_START,
     periodEnd: "2026-07-01T00:00:00.000Z",

--- a/packages/api/src/lib/billing/config-validation.ts
+++ b/packages/api/src/lib/billing/config-validation.ts
@@ -50,12 +50,14 @@ export const ANNUAL_PRICE_ID_ENV_VARS = [
 export type MonthlyPriceIdEnvVar = (typeof MONTHLY_PRICE_ID_ENV_VARS)[number];
 
 /**
- * Per-tier metered-overage price-ID setting keys (#3992). One Stripe Price per
- * paid tier, each metered (`usage_type=metered`) and pointing at the single
- * shared `atlas_token_overage` Billing Meter (#3991). Required for a paid
- * tier's token overage to be billed: the `OverageMeter` reporter maps a
- * workspace's tier → overage price when adding the metered subscription item,
- * and reports the period's output-equivalent overage delta to the meter.
+ * Per-tier metered-overage price-ID setting keys (#3992; at-cost repoint #4039).
+ * One Stripe Price per paid tier, each metered (`usage_type=metered`) and
+ * pointing at the single shared at-cost overage Billing Meter
+ * (`atlas_usage_overage_cents`) at `unit_amount = 1` (1 cent / metered unit).
+ * Required for a paid tier's usage overage to be billed: the `OverageMeter`
+ * reporter maps a workspace's tier → overage price when adding the metered
+ * subscription item, and reports the period's at-cost overage delta in CENTS to
+ * the meter (billed 1:1 with provider cost).
  *
  * A missing one is an operator-actionable boot WARNING (not a crash), the same
  * posture as the monthly price IDs (#3703): the overage price IDs are likewise

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -520,20 +520,6 @@ export async function checkPlanLimits(
 // ---------------------------------------------------------------------------
 
 /**
- * Output-equivalent tokens consumed BEYOND the included token budget. 0 when at
- * or under budget; never negative.
- *
- * NOTE (#4038): enforcement no longer calls this — dollar enforcement uses
- * {@link computeOverageDollars}. It survives because the token-based
- * `OverageMeter` (#3992, overage-meter.ts) still reports token deltas to its
- * Stripe price until the at-cost meter repoint lands (#4039).
- */
-export function computeOverageTokens(currentUsage: number, limit: number): number {
-  if (limit <= 0) return 0;
-  return Math.max(0, currentUsage - limit);
-}
-
-/**
  * At-cost overage in USD: dollars spent BEYOND the included credit (#4038).
  * Structure B bills usage at provider cost (zero markup), so the overage cost
  * IS the excess spend — the former `(overageTokens / 1e6) * rate`

--- a/packages/api/src/lib/billing/overage-meter.ts
+++ b/packages/api/src/lib/billing/overage-meter.ts
@@ -1,31 +1,40 @@
 /**
- * OverageMeter — idempotent, reconcilable Stripe Billing Meters reporter (#3992).
+ * OverageMeter — idempotent, reconcilable Stripe Billing Meters reporter
+ * (#3992; re-denominated to at-cost dollars/cents #4039, Structure B).
  *
- * Each billing period a paid workspace can run past its included token budget
- * (the metered soft-cap band in `enforcement.ts`, #3990). This module flushes
- * that overage to Stripe's Billing Meters API (`meter_events`) on a scheduler
- * tick so the customer is actually invoiced for it, and adds the per-tier
- * metered price as a SECOND subscription item so the meter has a price to bill
- * against.
+ * Each billing period a paid workspace can run past its included at-cost usage
+ * credit (the metered soft-cap band in `enforcement.ts`, #3990/#4038). This
+ * module flushes that overage to Stripe's Billing Meters API (`meter_events`)
+ * on a scheduler tick so the customer is actually invoiced for it, and adds the
+ * per-tier metered price as a SECOND subscription item so the meter has a price
+ * to bill against.
  *
- * ## What is reported
+ * ## What is reported — at-cost CENTS
  *
- * Overage is denominated in **output-equivalent tokens** (#3989) — the same
- * weighted unit `enforcement.ts` meters the budget in, so the value reported is
- * the real billed quantity. The shared `atlas_token_overage` meter (#3991) is
- * priced at $1 / 1M output-equivalent tokens (`plans.ts`
- * `overagePerMillionTokens = 1.0`).
+ * Structure B (#4034) bills usage overage at provider COST (zero markup), so
+ * the overage is denominated in real dollars: `costUsd − includedCredit`
+ * (#4038's `computeOverageDollars`, where `costUsd` is the summed at-cost Vercel
+ * AI Gateway spend, #4036, and the credit is `$20/seat`). The reported quantity
+ * is that overage converted to **integer cents** (`dollarsToCents`), sent to the
+ * shared at-cost {@link OVERAGE_METER_EVENT_NAME} meter. Its overage price is
+ * `unit_amount = 1` (1 cent / metered unit), so `cents × $0.01 = the at-cost
+ * dollars` — billed 1:1, at cost.
+ *
+ * Cents (not fractional dollars) so the meter's summed total and the
+ * baseline-keyed dedup stay integer-exact (no float drift / rounding seam). The
+ * ledger column is `reported_cost_cents` — see migration 0156 for the full unit
+ * rationale.
  *
  * ## Idempotency + reconciliation (ledger-backed)
  *
  * `overage_meter_reports` records, per (org, billing period), the CUMULATIVE
- * overage already reported to Stripe (`reported_tokens`). Each tick:
+ * overage cents already reported to Stripe (`reported_cost_cents`). Each tick:
  *
- *   1. compute the period's current overage (weighted usage − budget),
- *   2. delta = currentOverage − reported_tokens (floored at 0),
+ *   1. compute the period's current overage cents (at-cost spend − credit),
+ *   2. delta = currentOverageCents − reported_cost_cents (floored at 0),
  *   3. if delta > 0, send ONE `meter_event` carrying `payload.value = delta`
- *      and `payload.stripe_customer_id`, then advance `reported_tokens` to the
- *      new cumulative.
+ *      and `payload.stripe_customer_id`, then advance `reported_cost_cents` to
+ *      the new cumulative.
  *
  * So the **same delta reported twice bills once**: the second tick sees the
  * advanced cumulative and computes a zero delta. The ledger is the primary
@@ -36,8 +45,8 @@
  * retried next tick, so overage is never silently lost. The remaining hazard is
  * a crash in the sub-second window AFTER Stripe accepts the event but BEFORE the
  * ledger advances. The deterministic `meter_event` identifier closes it: it is
- * keyed on the **baseline** (`reported_tokens` BEFORE this report), NOT the new
- * cumulative — so a retry from the same un-advanced ledger reuses the SAME
+ * keyed on the **baseline** (`reported_cost_cents` BEFORE this report), NOT the
+ * new cumulative — so a retry from the same un-advanced ledger reuses the SAME
  * identifier even if usage grew in between, and Stripe (which keeps the first
  * value per identifier within its rolling 24h window) never double-counts the
  * overlap. A baseline key fails toward a bounded, safe-direction under-bill in
@@ -50,10 +59,15 @@
  * ## Never reported
  *
  * BYOT workspaces accrue no metered usage (they bring their own keys and bypass
- * token enforcement entirely) and are excluded by the sweep scan; non-paid tiers
- * (free / trial / locked) are excluded by tier membership; and an unlimited- or
- * zero-budget workspace is skipped by the per-workspace budget check. All bail
- * before any meter event.
+ * usage enforcement entirely) and are excluded by the sweep scan; non-paid tiers
+ * (free / trial / locked) are excluded by tier membership; and a zero-credit
+ * workspace is skipped by the per-workspace credit check. A workspace whose
+ * at-cost basis sums to $0 (non-gateway provider, or token rows predating #4036)
+ * reads zero overage and is likewise skipped — a safe under-bill, never an
+ * over-bill — but it is surfaced as an operator `log.error` alert first (the
+ * loud cost-basis-gap posture mirrored from enforcement.ts, #4038), so a
+ * fleet-wide capture regression that silently zeros overage revenue can't hide.
+ * All bail before any meter event.
  *
  * ## Gating
  *
@@ -63,6 +77,8 @@
  * seam runs on the Stripe webhook path in `lib/auth/server.ts`.
  */
 
+import { createHash } from "node:crypto";
+
 import type Stripe from "stripe";
 
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
@@ -70,12 +86,11 @@ import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
 import { getCurrentPeriodUsage, type UsageCurrentPeriod } from "@atlas/api/lib/metering";
 import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
 import {
-  computeTokenBudget,
-  isUnlimited,
+  computeUsageDollarBudget,
   resolvePlanTierFromPriceId,
   type PaidPlanTier,
 } from "@atlas/api/lib/billing/plans";
-import { computeOverageTokens } from "@atlas/api/lib/billing/enforcement";
+import { computeOverageDollars } from "@atlas/api/lib/billing/enforcement";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import {
   OVERAGE_PRICE_ID_ENV_VAR_BY_TIER,
@@ -86,11 +101,18 @@ import { PLAN_TIERS, type PlanTier } from "@useatlas/types";
 
 const log = createLogger("billing:overage-meter");
 
-/** Stripe Billing Meter `event_name` for token overage (#3991). */
-export const OVERAGE_METER_EVENT_NAME = "atlas_token_overage";
+/**
+ * Stripe Billing Meter `event_name` for at-cost usage overage (#4039). Distinct
+ * from the superseded token meter (`atlas_token_overage`, #3991) — a meter sums
+ * every event under its `event_name` regardless of unit, so the cents
+ * re-denomination REQUIRES a fresh meter rather than reusing the token one. The
+ * value carried is integer cents (see {@link dollarsToCents}); the sandbox/live
+ * meter is created with this exact `event_name`.
+ */
+export const OVERAGE_METER_EVENT_NAME = "atlas_usage_overage_cents";
 
 /**
- * The paid tiers that accrue billable token overage — DERIVED from the
+ * The paid tiers that accrue billable usage overage — DERIVED from the
  * drift-proof tier→price map so a new {@link PaidPlanTier} (which the map's
  * `satisfies` forces to be added there) automatically appears here too, rather
  * than being silently never-billed by a hand-maintained parallel list.
@@ -131,26 +153,39 @@ export function getOveragePriceIdForTier(
 }
 
 /**
- * The reportable overage delta: how many output-equivalent tokens past what's
- * already been reported the workspace has now consumed. Floored at 0 — a
- * downward correction (usage re-counted lower, or a stale ledger ahead of
- * current) must never produce a NEGATIVE meter event (which would credit the
- * customer for usage they actually had). Pure.
+ * Convert an at-cost overage in USD to the integer cents the meter is reported
+ * in (and the ledger stores). Rounded to the nearest cent — the at-cost dollars
+ * are fractions of a cent precise (`gateway.cost`), but Stripe bills in whole
+ * cents, so reporting whole cents is what the customer is actually charged.
+ * Floored at 0 and finite-guarded: a non-finite or negative input (downward
+ * correction) yields 0, never a negative meter quantity. Pure.
+ */
+export function dollarsToCents(overageDollars: number): number {
+  if (!Number.isFinite(overageDollars) || overageDollars <= 0) return 0;
+  return Math.round(overageDollars * 100);
+}
+
+/**
+ * The reportable overage delta: how many at-cost CENTS past what's already been
+ * reported the workspace has now consumed. Floored at 0 — a downward correction
+ * (cost re-counted lower, or a stale ledger ahead of current) must never produce
+ * a NEGATIVE meter event (which would credit the customer for usage they
+ * actually had). Pure.
  */
 export function computeReportableDelta(
-  currentOverageTokens: number,
-  alreadyReportedTokens: number,
+  currentOverageCents: number,
+  alreadyReportedCents: number,
 ): number {
-  if (!Number.isFinite(currentOverageTokens) || !Number.isFinite(alreadyReportedTokens)) {
+  if (!Number.isFinite(currentOverageCents) || !Number.isFinite(alreadyReportedCents)) {
     return 0;
   }
-  return Math.max(0, Math.trunc(currentOverageTokens) - Math.trunc(alreadyReportedTokens));
+  return Math.max(0, Math.trunc(currentOverageCents) - Math.trunc(alreadyReportedCents));
 }
 
 /**
  * Deterministic Stripe `meter_event` identifier for a report. Keyed on the
- * BASELINE — the `reported_tokens` cumulative BEFORE this report — NOT the new
- * cumulative or the delta. The baseline is read from the ledger, which only
+ * BASELINE — the `reported_cost_cents` cumulative BEFORE this report — NOT the
+ * new cumulative or the delta. The baseline is read from the ledger, which only
  * advances on a successful record, so a crash-before-record (or a concurrent
  * pod) retries from the SAME baseline and reuses the SAME identifier even if
  * usage grew in between. Stripe keeps the first value per identifier within its
@@ -158,15 +193,28 @@ export function computeReportableDelta(
  * bounded under-bill, the safe direction — see the module doc). Successive
  * reports use strictly increasing baselines, so each identifier covers a
  * distinct `[baseline, …)` range.
+ *
+ * OBS-1 (#4039): the determinism tuple `(orgId, period, baseline)` is hashed
+ * (SHA-256, first 32 hex chars) rather than concatenated raw. Stripe rejects a
+ * `meter_event` identifier over 100 chars, and the old
+ * `atlas-overage-${orgId}-…` spelling overflowed that cap for a long org id
+ * (Better-Auth org ids are unbounded TEXT) — stranding that org's overage,
+ * never billed. The hash is fixed-width (`atlas-overage-` + 32 = 46 chars), so
+ * the identifier is ≤100 chars for ANY org id while preserving the exact same
+ * baseline-keyed crash-window dedup (same tuple → same hash → same identifier).
  */
 export function buildOverageEventIdentifier(
   orgId: string,
   periodStartISO: string,
-  baselineTokens: number,
+  baselineCents: number,
 ): string {
   const periodKey = Date.parse(periodStartISO);
   const period = Number.isFinite(periodKey) ? periodKey : periodStartISO;
-  return `atlas-overage-${orgId}-${period}-${baselineTokens}`;
+  const digest = createHash("sha256")
+    .update(`${orgId}|${period}|${baselineCents}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `atlas-overage-${digest}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -174,22 +222,22 @@ export function buildOverageEventIdentifier(
 // ---------------------------------------------------------------------------
 
 /**
- * The cumulative overage tokens already reported to Stripe for `(orgId,
+ * The cumulative overage CENTS already reported to Stripe for `(orgId,
  * periodStart)`, or 0 when no row exists yet. Postgres returns `BIGINT` as a
  * string via `pg`, so coerce + validate rather than trust the wire type.
  */
-export async function getReportedOverageTokens(
+export async function getReportedOverageCents(
   orgId: string,
   periodStartISO: string,
 ): Promise<number> {
   if (!hasInternalDB()) return 0;
-  const rows = await internalQuery<{ reported_tokens: number | string | null }>(
-    `SELECT reported_tokens FROM overage_meter_reports
+  const rows = await internalQuery<{ reported_cost_cents: number | string | null }>(
+    `SELECT reported_cost_cents FROM overage_meter_reports
       WHERE org_id = $1 AND period_start = $2
       LIMIT 1`,
     [orgId, periodStartISO],
   );
-  const raw = rows[0]?.reported_tokens;
+  const raw = rows[0]?.reported_cost_cents;
   if (raw == null) return 0; // no row / NULL — fresh period
   const parsed = typeof raw === "string" ? Number(raw) : raw;
   if (typeof parsed !== "number" || !Number.isFinite(parsed) || parsed < 0) {
@@ -200,7 +248,7 @@ export async function getReportedOverageTokens(
     // Throwing routes to the per-workspace sweep guard (warn + count failed +
     // skip + retry next tick): loud AND a safe under-bill, never a double-bill.
     throw new Error(
-      `overage_meter_reports.reported_tokens is not a non-negative number for org ${orgId} period ${periodStartISO}: ${String(raw)}`,
+      `overage_meter_reports.reported_cost_cents is not a non-negative number for org ${orgId} period ${periodStartISO}: ${String(raw)}`,
     );
   }
   return parsed;
@@ -210,25 +258,27 @@ export interface OverageReportRecord {
   readonly orgId: string;
   readonly periodStartISO: string;
   readonly stripeCustomerId: string;
-  /** New cumulative reported total for the period (NOT the delta). */
-  readonly reportedTokens: number;
+  /** New cumulative reported cents for the period (NOT the delta). */
+  readonly reportedCents: number;
   readonly eventIdentifier: string;
 }
 
 /**
  * Upsert the ledger to the new cumulative reported total. `GREATEST` keeps
- * `reported_tokens` monotonic within a period — a late/retried tick carrying an
- * older cumulative can never regress it, which would re-report already-billed
- * tokens. `ON CONFLICT` keys on the composite PK `(org_id, period_start)`.
+ * `reported_cost_cents` monotonic within a period — a late/retried tick carrying
+ * an older cumulative can never regress it, which would re-report already-billed
+ * overage. `ON CONFLICT` keys on the composite PK `(org_id, period_start)`. The
+ * superseded `reported_tokens` column is left untouched (its `NOT NULL DEFAULT
+ * 0` satisfies the omitted insert) until the N+1 contract drop (the #4039 follow-up).
  */
 export async function recordOverageReport(record: OverageReportRecord): Promise<void> {
   if (!hasInternalDB()) return;
   await internalQuery(
     `INSERT INTO overage_meter_reports
-       (org_id, period_start, stripe_customer_id, reported_tokens, last_event_identifier, updated_at)
+       (org_id, period_start, stripe_customer_id, reported_cost_cents, last_event_identifier, updated_at)
      VALUES ($1, $2, $3, $4, $5, now())
      ON CONFLICT (org_id, period_start) DO UPDATE SET
-       reported_tokens = GREATEST(overage_meter_reports.reported_tokens, EXCLUDED.reported_tokens),
+       reported_cost_cents = GREATEST(overage_meter_reports.reported_cost_cents, EXCLUDED.reported_cost_cents),
        stripe_customer_id = EXCLUDED.stripe_customer_id,
        last_event_identifier = EXCLUDED.last_event_identifier,
        updated_at = now()`,
@@ -236,7 +286,7 @@ export async function recordOverageReport(record: OverageReportRecord): Promise<
       record.orgId,
       record.periodStartISO,
       record.stripeCustomerId,
-      record.reportedTokens,
+      record.reportedCents,
       record.eventIdentifier,
     ],
   );
@@ -270,14 +320,14 @@ export type OverageReportOutcome = "reported" | "skipped";
 export interface WorkspaceOverageDeps {
   readonly getSeatCount: (orgId: string) => Promise<number>;
   readonly getCurrentPeriodUsage: (orgId: string, now: Date) => Promise<UsageCurrentPeriod>;
-  readonly getReportedOverageTokens: (orgId: string, periodStartISO: string) => Promise<number>;
+  readonly getReportedOverageCents: (orgId: string, periodStartISO: string) => Promise<number>;
   readonly recordOverageReport: (record: OverageReportRecord) => Promise<void>;
 }
 
 const defaultWorkspaceOverageDeps: WorkspaceOverageDeps = {
   getSeatCount,
   getCurrentPeriodUsage,
-  getReportedOverageTokens,
+  getReportedOverageCents,
   recordOverageReport,
 };
 
@@ -295,7 +345,7 @@ export async function reportWorkspaceOverage(
   deps: WorkspaceOverageDeps = defaultWorkspaceOverageDeps,
 ): Promise<OverageReportOutcome> {
   // BYOT never accrues metered usage — they bring their own keys and bypass
-  // token enforcement entirely (#3990). Checked first, defensively: the sweep's
+  // usage enforcement entirely (#3990). Checked first, defensively: the sweep's
   // scan already excludes BYOT, but this keeps the function boundary honest so
   // a direct caller can never report a BYOT workspace.
   if (row.byot === true) return "skipped";
@@ -305,24 +355,46 @@ export async function reportWorkspaceOverage(
   if (!row.stripe_customer_id) return "skipped";
 
   const seatCount = await deps.getSeatCount(row.org_id);
-  const budget = computeTokenBudget(tier, seatCount);
-  // Unlimited budget → there is no "over budget", so nothing to meter.
-  if (isUnlimited(budget) || budget <= 0) return "skipped";
+  // The included at-cost usage credit ($20/seat, Structure B #4038). There is no
+  // "unlimited" dollar credit; a non-positive credit means nothing to meter.
+  const creditUsd = computeUsageDollarBudget(tier, seatCount);
+  if (creditUsd <= 0) return "skipped";
 
   const usage = await deps.getCurrentPeriodUsage(row.org_id, now);
-  // Denominate in output-equivalent tokens (#3989) — the same weighted unit the
-  // budget is enforced in. `getCurrentPeriodUsage` already COALESCEs
-  // `weighted_quantity` to the raw `quantity` for token rows predating
-  // migration 0152 in its SQL aggregate, so `weightedTokenCount` is never under
-  // raw for un-backfilled history. The `?? tokenCount` is a defensive belt
-  // (matching `enforcement.ts`): if a future shape change made the field arrive
-  // undefined, denominate on raw rather than silently treat usage as zero.
-  const weightedUsage = usage.weightedTokenCount ?? usage.tokenCount;
-  const currentOverage = computeOverageTokens(weightedUsage, budget);
-  if (currentOverage <= 0) return "skipped";
+  // COST-BASIS GAP ALERT (#4039): the meter denominates on `usage.costUsd`, which
+  // sums `gateway_cost_usd` — NULL for non-gateway providers and for token rows
+  // predating #4036, and $0 if the at-cost capture pipeline breaks fleet-wide.
+  // When tokens were recorded but the basis summed to $0, the overage reads $0
+  // and this workspace is silently NOT billed for overage. That is a safe
+  // under-bill (never an over-bill), but a SILENT one — and a fleet-wide capture
+  // regression would zero ALL overage revenue while `reportPeriodOverages` logs
+  // look identical to a quiet period. Surface it as an operator-visible alert
+  // here, matching the sibling `log.error` in enforcement.ts (#4038) so the same
+  // metering-impaired dashboards fire on both the enforce and the bill paths.
+  // Still proceed (skip on $0 overage below) — loud, never blocking.
+  if (usage.tokenCount > 0 && usage.costUsd === 0) {
+    log.error(
+      {
+        orgId: row.org_id,
+        tier,
+        tokenCount: usage.tokenCount,
+        periodStart: usage.periodStart,
+        reason: "cost_basis_missing",
+      },
+      "Overage meter has no cost basis — tokens recorded but gateway_cost_usd summed to $0; " +
+        "workspace will not be billed for overage (non-gateway provider, token rows predating #4036, or broken capture) (#4039)",
+    );
+  }
+  // Denominate against the summed at-cost provider spend (`usage.costUsd`, #4036)
+  // — the EXACT zero-markup dollars Atlas paid — minus the credit (#4038's
+  // `computeOverageDollars`), the SAME numerator enforcement reads, then convert
+  // to integer cents for the meter.
+  const overageDollars = computeOverageDollars(usage.costUsd, creditUsd);
+  const currentOverageCents = dollarsToCents(overageDollars);
+  if (currentOverageCents <= 0) return "skipped";
 
-  const reportedSoFar = await deps.getReportedOverageTokens(row.org_id, usage.periodStart);
-  const delta = computeReportableDelta(currentOverage, reportedSoFar);
+  const reportedSoFar = await deps.getReportedOverageCents(row.org_id, usage.periodStart);
+  const delta = computeReportableDelta(currentOverageCents, reportedSoFar);
   if (delta <= 0) return "skipped";
 
   // Identifier is keyed on the BASELINE (reportedSoFar) — see
@@ -347,7 +419,7 @@ export async function reportWorkspaceOverage(
       orgId: row.org_id,
       periodStartISO: usage.periodStart,
       stripeCustomerId: row.stripe_customer_id,
-      reportedTokens: currentOverage,
+      reportedCents: currentOverageCents,
       eventIdentifier: identifier,
     });
   } catch (err) {
@@ -363,7 +435,7 @@ export async function reportWorkspaceOverage(
         err: err instanceof Error ? err.message : String(err),
         orgId: row.org_id,
         periodStart: usage.periodStart,
-        cumulative: currentOverage,
+        cumulativeCents: currentOverageCents,
         identifier,
       },
       "Stripe meter billed but ledger record failed — reconciliation required (will retry; dedup prevents double-bill)",
@@ -376,10 +448,10 @@ export async function reportWorkspaceOverage(
       orgId: row.org_id,
       tier,
       periodStart: usage.periodStart,
-      delta,
-      cumulative: currentOverage,
+      deltaCents: delta,
+      cumulativeCents: currentOverageCents,
     },
-    "Reported token overage delta to Stripe meter",
+    "Reported at-cost overage delta (cents) to Stripe meter",
   );
   return "reported";
 }
@@ -495,8 +567,9 @@ const defaultEnsureOverageItemDeps: EnsureOverageItemDeps = {
 
 /**
  * Ensure a paid subscription carries its tier's metered-overage price as a
- * SECOND subscription item (#3992) — the price the `atlas_token_overage` meter
- * bills against. Idempotent: a no-op when the item is already present, and
+ * SECOND subscription item (#3992) — the price the at-cost
+ * {@link OVERAGE_METER_EVENT_NAME} meter bills against. Idempotent: a no-op when
+ * the item is already present, and
  * runs on every `customer.subscription.{created,updated}` webhook so it is
  * path-agnostic (checkout, upgrade, downgrade all converge here).
  *

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -82,12 +82,11 @@ export interface PlanDefinition {
    * DEPRECATED (Structure B, #4034): the legacy synthetic $/1M-token overage
    * rate. Zeroed on every tier — Structure B bills usage at provider cost (zero
    * markup) via the at-cost meter, not a per-token markup. Dollar-native
-   * enforcement has now landed (#4038): `checkPlanLimits` denominates the
-   * included budget and overage in real dollars (`computeUsageDollarBudget` /
-   * `computeOverageDollars`) and no longer consults this rate. It survives only
-   * because the token-based OverageMeter (#3992) keeps reporting token deltas to
-   * its Stripe price until the at-cost meter repoint lands (#4039); removed with
-   * that repoint.
+   * enforcement (#4038) AND the at-cost meter repoint (#4039) have both landed:
+   * nothing now consults this rate — `checkPlanLimits` and the `OverageMeter`
+   * both denominate in real dollars/cents (`computeUsageDollarBudget` /
+   * `computeOverageDollars`). Fully vestigial; still emitted on the billing wire
+   * shape for back-compat, slated for removal in the drift/parity cleanup (#4040).
    */
   overagePerMillionTokens: number;
   limits: PlanLimits;
@@ -279,11 +278,12 @@ export function isUnlimited(value: number): boolean {
  * Compute the total token budget for a workspace based on its plan and seat count.
  * Returns -1 (unlimited) for free tier or when tokenBudgetPerSeat is unlimited.
  *
- * NOTE (#4038): token budgets are no longer the *enforcement* denominator —
- * dollar enforcement reads `computeUsageDollarBudget` below. `computeTokenBudget`
- * survives because the token-based `OverageMeter` (#3992) still reports token
- * deltas to its Stripe price until the at-cost meter repoint lands (#4039), and
- * the billing page still surfaces a token budget figure (`limits.totalTokenBudget`).
+ * NOTE (#4038/#4039): token budgets are no longer the *enforcement* denominator
+ * (dollar enforcement reads `computeUsageDollarBudget` below) NOR the overage
+ * basis (the at-cost `OverageMeter` repoint, #4039, denominates in dollars/cents
+ * via `computeUsageDollarBudget` + `computeOverageDollars`). `computeTokenBudget`
+ * survives only because the billing/usage pages still surface a token-budget
+ * figure (`limits.totalTokenBudget`) for display.
  */
 export function computeTokenBudget(tier: PlanTier, seatCount: number): number {
   const limits = getPlanLimits(tier);

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -186,7 +186,9 @@ describe("runMigrations", () => {
     //   Billing Meters overage reporter, WS2, #3992) = 155.
     //   Plus 0155 (usage_events/token_usage.gateway_cost_usd at-cost capture,
     //   Structure B WS2, #4036) = 156.
-    expect(count).toBe(156);
+    //   Plus 0156 (overage_meter_reports.reported_cost_cents — re-denominate the
+    //   overage ledger from tokens to at-cost cents, Structure B WS2, #4039) = 157.
+    expect(count).toBe(157);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -371,6 +373,7 @@ describe("runMigrations", () => {
         "0153_region_db_subscription_scim_parity.sql",
         "0154_overage_meter_reports.sql",
         "0155_usage_gateway_cost_usd.sql",
+        "0156_overage_meter_reports_cost_cents.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0156_overage_meter_reports_cost_cents.sql
+++ b/packages/api/src/lib/db/migrations/0156_overage_meter_reports_cost_cents.sql
@@ -1,0 +1,67 @@
+-- Migration 0156: re-denominate the overage-meter ledger from output-equivalent
+-- TOKENS to at-cost CENTS (#4039, Structure B WS2 — S4).
+--
+-- Structure B (#4034) bills usage overage at provider COST (zero markup), so the
+-- `OverageMeter` reporter (lib/billing/overage-meter.ts) now flushes each paid
+-- workspace's at-cost dollar overage — `costUsd − includedCredit` (#4038's
+-- `computeOverageDollars`) — to a NEW dollar-denominated Stripe Billing Meter,
+-- in place of the token deltas it reported to the old `atlas_token_overage`
+-- meter (#3992).
+--
+-- ## Unit decision: INTEGER CENTS (the issue left this to the implementer)
+--
+-- The meter event `value`, this ledger column, and the delta math are ALL in
+-- integer cents. Cents (not fractional dollars) because:
+--   • Lossless: Stripe sums meter-event values; integers carry no float drift,
+--     and the baseline-keyed crash-window dedup stays exact (no rounding seam
+--     between the stored baseline and the reported delta).
+--   • The Stripe overage price is `unit_amount = 1` (1 cent / metered unit), so
+--     `cents reported × $0.01 = the at-cost dollars` — billed 1:1, at cost.
+--   • Reuses this table's existing BIGINT + non-negative-CHECK shape unchanged
+--     (just renamed + re-semantic'd), so the migration surface is minimal.
+-- The column is named `reported_cost_cents` (not the issue's suggested
+-- `reported_cost_usd`) so the name states the actual stored unit.
+--
+-- ## Expand-contract phase 1 of 2 (two-phase column swap)
+--
+-- This is the EXPAND phase: it ADDs `reported_cost_cents` and the reporter
+-- switches its reads/writes to it in this same release. The old
+-- `reported_tokens` column is LEFT IN PLACE — its `NOT NULL DEFAULT 0` means
+-- inserts that no longer mention it still satisfy the constraint, so the N-1↔N
+-- deploy-overlap window never hits a missing column. The CONTRACT phase (drop
+-- `reported_tokens` + its CHECK, and remove the schema.ts mirror) ships in a
+-- later release (N+1), once no running code reads or writes it. Tracked as the
+-- #4039 follow-up.
+--
+-- ## No backfill — the new meter starts fresh, on purpose
+--
+-- `reported_tokens` and `reported_cost_cents` are DIFFERENT units (tokens vs
+-- cents) with no per-row cost basis to convert between them, AND they track
+-- cumulative-reported against DIFFERENT Stripe meters (`atlas_token_overage`
+-- vs the new at-cost cents meter). The new meter has been told nothing yet, so
+-- its cumulative legitimately starts at 0 — a fresh `DEFAULT 0` column is the
+-- CORRECT baseline, not a data loss. (Operationally the old token meter/prices
+-- are deactivated at cutover so the same period is never billed on both; on the
+-- pre-customer sandbox/staging this overlap carries no real overage.)
+--
+-- Mirrored in db/schema.ts (overageMeterReports.reportedCents) in the same PR
+-- per the schema-drift discipline; `reported_tokens`/`reportedTokens` stay
+-- mirrored until the N+1 contract drop. NOT Better-Auth-dependent (no FK to a
+-- BA table), so it runs in every auth mode like 0154 itself.
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run; the CHECK uses
+-- drop-then-add (Postgres has no `ADD CONSTRAINT IF NOT EXISTS`) — the migration
+-- is recorded in __atlas_migrations so it runs exactly once regardless.
+
+ALTER TABLE overage_meter_reports
+  ADD COLUMN IF NOT EXISTS reported_cost_cents BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE overage_meter_reports
+  DROP CONSTRAINT IF EXISTS chk_overage_meter_reports_cost_cents_nonneg;
+
+ALTER TABLE overage_meter_reports
+  ADD CONSTRAINT chk_overage_meter_reports_cost_cents_nonneg
+    CHECK (reported_cost_cents >= 0);
+
+COMMENT ON COLUMN overage_meter_reports.reported_cost_cents IS
+  'Cumulative at-cost overage CENTS reported to the Stripe at-cost overage meter for this (org, period). Monotonic within a period (advanced via GREATEST). Integer cents bill 1:1 against the unit_amount=1 metered price (#4039, Structure B). Supersedes reported_tokens (dropped in a later release).';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2551,16 +2551,23 @@ export const stripePurgedSubscriptions = pgTable(
 );
 
 /**
- * Overage-meter report ledger (#3992) — idempotency + reconciliation for the
- * `OverageMeter` reporter that flushes each billing period's token overage to
- * Stripe Billing Meters on a scheduler tick. One row per (org, billing period):
- * `reported_tokens` is the CUMULATIVE output-equivalent overage already reported
- * to Stripe for that period. Each tick reports only `currentOverage -
- * reported_tokens` (the delta) and advances `reported_tokens`, so the same delta
- * reported twice bills once (the second tick computes a zero delta). The CHECK
- * keeps the cumulative non-negative; the upsert uses GREATEST so a late/retried
- * tick can never regress it (which would re-report already-billed tokens).
- * Mirrors `migrations/0154_overage_meter_reports.sql`.
+ * Overage-meter report ledger (#3992; re-denominated to at-cost cents #4039) —
+ * idempotency + reconciliation for the `OverageMeter` reporter that flushes each
+ * billing period's usage overage to a Stripe Billing Meter on a scheduler tick.
+ * One row per (org, billing period): `reported_cost_cents` is the CUMULATIVE
+ * at-cost overage CENTS already reported to Stripe for that period. Each tick
+ * reports only `currentOverage − reported_cost_cents` (the delta) and advances
+ * `reported_cost_cents`, so the same delta reported twice bills once (the second
+ * tick computes a zero delta). The CHECK keeps the cumulative non-negative; the
+ * upsert uses GREATEST so a late/retried tick can never regress it (which would
+ * re-report already-billed overage).
+ *
+ * `reported_tokens` is the SUPERSEDED token-denominated cumulative (#3992). It
+ * is the EXPAND phase of a two-phase column swap: the reporter no longer
+ * reads/writes it (it moved to `reported_cost_cents` in #4039), but it stays
+ * mirrored here until the N+1 CONTRACT migration drops it, so the schema-drift
+ * check passes during the overlap window. Mirrors
+ * `migrations/0154_overage_meter_reports.sql` + `0156_overage_meter_reports_cost_cents.sql`.
  */
 export const overageMeterReports = pgTable(
   "overage_meter_reports",
@@ -2568,7 +2575,9 @@ export const overageMeterReports = pgTable(
     orgId: text("org_id").notNull(),
     periodStart: timestamp("period_start", { withTimezone: true }).notNull(),
     stripeCustomerId: text("stripe_customer_id").notNull(),
+    // Superseded by reportedCents (#4039); kept until the N+1 contract drop.
     reportedTokens: bigint("reported_tokens", { mode: "number" }).notNull().default(0),
+    reportedCents: bigint("reported_cost_cents", { mode: "number" }).notNull().default(0),
     lastEventIdentifier: text("last_event_identifier"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -2576,6 +2585,7 @@ export const overageMeterReports = pgTable(
   (t) => [
     primaryKey({ columns: [t.orgId, t.periodStart] }),
     check("chk_overage_meter_reports_tokens_nonneg", sql`reported_tokens >= 0`),
+    check("chk_overage_meter_reports_cost_cents_nonneg", sql`reported_cost_cents >= 0`),
     index("idx_overage_meter_reports_updated").on(t.updatedAt),
   ],
 );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1827,17 +1827,17 @@ export function makeSchedulerLive(
         );
       }
 
-      // ── Periodic fiber: token-overage meter reporter (#3992) ─────────────
-      // Flushes each paid workspace's current-period token overage to Stripe
-      // Billing Meters (`meter_events`), idempotently (ledger-backed: same delta
-      // reported twice bills once). Like the teardown sweep it needs only
-      // `STRIPE_SECRET_KEY` (to call Stripe) + an internal DB (to hold the
-      // ledger + read usage) — NOT the webhook secret. The sweep query excludes
-      // BYOT and non-paid tiers (free/trial/locked); an unlimited-/zero-budget
-      // workspace is skipped by the per-workspace budget check.
+      // ── Periodic fiber: at-cost overage meter reporter (#3992; #4039) ────
+      // Flushes each paid workspace's current-period at-cost usage overage (in
+      // cents) to Stripe Billing Meters (`meter_events`), idempotently
+      // (ledger-backed: same delta reported twice bills once). Like the teardown
+      // sweep it needs only `STRIPE_SECRET_KEY` (to call Stripe) + an internal DB
+      // (to hold the ledger + read usage) — NOT the webhook secret. The sweep
+      // query excludes BYOT and non-paid tiers (free/trial/locked); a zero-credit
+      // workspace is skipped by the per-workspace credit check.
       // The `yield* Migration` barrier above already sequences this after
-      // `MigrationLive`, so the eager boot tick can't race migration 0154
-      // creating `overage_meter_reports`.
+      // `MigrationLive`, so the eager boot tick can't race migration 0154/0156
+      // on `overage_meter_reports`.
       const overageReportEnabled = yield* Effect.try({
         try: () => {
           if (!process.env.STRIPE_SECRET_KEY) return false;
@@ -1891,11 +1891,11 @@ export function makeSchedulerLive(
         );
         log.info(
           { intervalMs: OVERAGE_REPORT_INTERVAL_MS },
-          "Token-overage meter reporter started",
+          "At-cost overage meter reporter started",
         );
       } else {
         log.debug(
-          "Token-overage meter reporter not started — Stripe or internal DB not configured",
+          "At-cost overage meter reporter not started — Stripe or internal DB not configured",
         );
       }
 

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -256,12 +256,12 @@ export interface UsageCurrentPeriod {
   /**
    * At-cost provider spend in USD for the period (#4036): the sum of
    * `gateway_cost_usd` over `token` events — the EXACT zero-markup dollars Atlas
-   * paid the Vercel AI Gateway. Captured now; the Structure B included credit
-   * ($20/seat) + overage meter will draw against this once the re-denomination
-   * lands (#4038/#4039) — until then `weightedTokenCount` above remains the
-   * active budget denominator and this is for display only. Rows with a NULL
-   * `gateway_cost_usd` (non-gateway providers, or token rows predating migration
-   * 0155) simply don't contribute.
+   * paid the Vercel AI Gateway. This is the LIVE Structure B billing numerator:
+   * dollar enforcement (#4038) denominates the included credit ($20/seat) against
+   * it, and the at-cost overage meter (#4039) reports `costUsd − credit` in cents.
+   * `weightedTokenCount` above is no longer a billing denominator (display only).
+   * Rows with a NULL `gateway_cost_usd` (non-gateway providers, or token rows
+   * predating migration 0155) simply don't contribute.
    */
   costUsd: number;
   activeUsers: number;

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -891,12 +891,14 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     saasVisible: false,
   },
 
-  // Stripe Billing — per-tier metered-overage price IDs (#3992). One metered
-  // (usage_type=metered) Stripe Price per paid tier, each pointing at the single
-  // shared `atlas_token_overage` Billing Meter (#3991). The `OverageMeter`
-  // reporter maps a workspace's tier → overage price (added as a SECOND
-  // subscription item) and reports the period's output-equivalent overage delta
-  // to the meter. Platform-scoped + hot-reloadable (same as the monthly IDs):
+  // Stripe Billing — per-tier metered-overage price IDs (#3992; at-cost repoint
+  // #4039). One metered (usage_type=metered) Stripe Price per paid tier, each
+  // pointing at the single shared at-cost overage Billing Meter
+  // (`atlas_usage_overage_cents`) at `unit_amount = 1` (1 cent / metered unit).
+  // The `OverageMeter` reporter maps a workspace's tier → overage price (added
+  // as a SECOND subscription item) and reports the period's at-cost overage
+  // delta in CENTS to the meter, so the bill equals provider cost 1:1.
+  // Platform-scoped + hot-reloadable (same as the monthly IDs):
   // `getOveragePriceIdForTier()` reads them per-operation via `getSettingAuto`,
   // so an operator can change the metered price from Admin → Settings without a
   // redeploy. `saasVisible: false` keeps them off the per-tenant settings page.
@@ -906,7 +908,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: "STRIPE_STARTER_OVERAGE_PRICE_ID",
     section: "Billing",
     label: "Starter Overage Price ID (metered)",
-    description: "Stripe Price ID for the Starter plan's metered token overage ($1 / 1M output-equivalent tokens). Added as a second subscription item; required for Starter overage to be billed.",
+    description: "Stripe Price ID for the Starter plan's at-cost metered usage overage (billed in cents, 1:1 with provider cost). Added as a second subscription item; required for Starter overage to be billed.",
     type: "string",
     envVar: "STRIPE_STARTER_OVERAGE_PRICE_ID",
     scope: "platform",
@@ -916,7 +918,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: "STRIPE_PRO_OVERAGE_PRICE_ID",
     section: "Billing",
     label: "Pro Overage Price ID (metered)",
-    description: "Stripe Price ID for the Pro plan's metered token overage ($1 / 1M output-equivalent tokens). Added as a second subscription item; required for Pro overage to be billed.",
+    description: "Stripe Price ID for the Pro plan's at-cost metered usage overage (billed in cents, 1:1 with provider cost). Added as a second subscription item; required for Pro overage to be billed.",
     type: "string",
     envVar: "STRIPE_PRO_OVERAGE_PRICE_ID",
     scope: "platform",
@@ -926,7 +928,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
     section: "Billing",
     label: "Business Overage Price ID (metered)",
-    description: "Stripe Price ID for the Business plan's metered token overage ($1 / 1M output-equivalent tokens). Added as a second subscription item; required for Business overage to be billed.",
+    description: "Stripe Price ID for the Business plan's at-cost metered usage overage (billed in cents, 1:1 with provider cost). Added as a second subscription item; required for Business overage to be billed.",
     type: "string",
     envVar: "STRIPE_BUSINESS_OVERAGE_PRICE_ID",
     scope: "platform",


### PR DESCRIPTION
## Summary

Part of #4034 (re-denominate the overage stack to **Structure B**). Re-points the #3992 `OverageMeter` reporter and its Stripe meter/price from output-equivalent **tokens** to **at-cost cents** (zero markup), and carries the OBS-1 fix.

- **`overage-meter.ts`** — report the period's at-cost dollar overage (`costUsd − includedCredit`, #4038's `computeOverageDollars` + `computeUsageDollarBudget`) converted to **integer cents** to a new shared meter `atlas_usage_overage_cents`, instead of token deltas. A `unit_amount=1` (1¢/unit) price bills it 1:1 at cost.
- **OBS-1 fix** — `buildOverageEventIdentifier` now hashes `(orgId|period|baseline)` (SHA-256, first 32 hex) → fixed-width `atlas-overage-<32hex>` (46 chars), **≤100 chars for any org id**. The old raw `atlas-overage-${orgId}-…` overflowed Stripe's 100-char cap for long Better-Auth org ids (that org's overage stranded, never billed), while the hash preserves the exact baseline-keyed crash-window dedup.
- **Ledger re-denomination** — migration `0156` adds `overage_meter_reports.reported_cost_cents` (BIGINT, non-negative CHECK) + schema mirror. **Two-phase / expand-contract**: `reported_tokens` is left in place (reads/writes moved off it) until the N+1 contract drop. No backfill (different unit, fresh meter).
- **Meter-unit decision: integer cents** (the issue left this to the implementer) — lossless meter sum + baseline dedup, reuses the BIGINT+CHECK shape, `unit_amount=1` bills exactly at cost. Documented in the migration header.
- **Cost-basis-gap alert** (review-panel finding) — the reporter now raises the same `log.error` enforcement does when tokens were recorded but the at-cost basis is $0, so a fleet-wide capture regression can't silently zero overage revenue.
- Removed the now-dead `computeOverageTokens`; refreshed stale token→cents comments across `plans.ts` / `billing.ts` / `settings.ts` / `config-validation.ts` / `layers.ts` / `metering.ts`.

## Test plan

- [x] Unit: at-cost cents delta reporting, `dollarsToCents` rounding, idempotency/baseline-keying, the **cross-tick crash-window dedup** (ledger un-advanced + usage grows → same identifier), and the cost-basis alert (positive + negative control)
- [x] OBS-1: identifier ≤100 chars for a 516-char org id, deterministic, hashed
- [x] Real-Postgres: `reported_cost_cents` monotonic GREATEST + non-negative CHECK + sweep scan (`overage-meter-pg.test.ts`); full `migrate-pg` smoke green (157 migrations)
- [x] Migration-count bumped in both `db/` and `auth/` migrate tests
- [x] `/ci`: lint, type, full api test suite (every `-pg` verified in isolation), syncpack, schema-drift, openapi-drift, template-drift + all check scripts — green
- [x] Internal review panel: CLEAN after the cost-basis-gap fix (silent-failure re-review confirmed resolved)

## Out of scope (HITL — `/release`)

The **prod live-mode** dollar meter + prices and the prod `STRIPE_*_OVERAGE_PRICE_ID` repoint are left for `/release`; an agent must not touch the live account. Sandbox (test-mode) objects are created operationally. The vestigial `overagePerMillionTokens` wire field removal is deferred to the #4040 parity cleanup.

Closes #4039

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repoint overage metering to at-cost cents with hashed idempotency keys
> - Replaces token-based overage reporting with dollar/cent-denominated reporting: `reportWorkspaceOverage` now computes overage as `costUsd` beyond included credit, converts to whole cents via `dollarsToCents`, and posts meter events under the new event name `atlas_usage_overage_cents`.
> - Adds a `reported_cost_cents` BIGINT column to `overage_meter_reports` (migration `0156`) with a non-negative CHECK constraint; the old `reported_tokens` column is retained for compatibility during transition.
> - Changes `buildOverageEventIdentifier` to produce a SHA-256-derived 32-hex-char hash prefixed with `atlas-overage-`, avoiding Stripe's 100-char identifier limit while preserving baseline-keyed idempotency.
> - Removes `computeOverageTokens` from [enforcement.ts](https://github.com/AtlasDevHQ/atlas/pull/4056/files#diff-3ecb99a717cdab167aa5a2669b09fd54eed51ef0232923e22e073e0b32d142a8); callers must use `computeOverageDollars` instead.
> - Risk: meter events are now sent to a distinct Stripe meter (`atlas_usage_overage_cents`); the old `atlas_token_overage` meter will no longer receive events after this deploy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b24f6b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->