### PR TITLE
feat(billing): S5 — drift/parity alignment + stale token-markup cleanup (Structure B, #4040)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -77364,9 +77364,6 @@
                     "currentModel": {
                       "type": "string"
                     },
-                    "overagePerMillionTokens": {
-                      "type": "number"
-                    },
                     "subscription": {
                       "type": [
                         "object",
@@ -77462,7 +77459,6 @@
                     "seats",
                     "connections",
                     "currentModel",
-                    "overagePerMillionTokens",
                     "subscription"
                   ]
                 }

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -239,9 +239,10 @@ describe("billing routes", () => {
       // against the shared resolver guards against the picker advertising one
       // model while another is billed.
       expect(body.currentModel).toBe(resolveModelId(undefined, undefined));
-      // Structure B (#4034): the synthetic per-token overage rate is zeroed —
-      // usage is billed at provider cost via the at-cost meter, not a markup.
-      expect(body.overagePerMillionTokens).toBe(0);
+      // Structure B (#4040): the legacy synthetic per-token overage rate was
+      // dropped from the wire — usage is billed at provider cost via the at-cost
+      // meter (surfaced by the dollar usage gauge), so the field never returns.
+      expect(body).not.toHaveProperty("overagePerMillionTokens");
       // Total token budget = tokenBudgetPerSeat * seatCount = 2M * 3 = 6M
       expect(body.limits.totalTokenBudget).toBe(6_000_000);
       // #3418 — the plan picker's source of truth. All three paid tiers are

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -474,7 +474,6 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         max: isUnlimited(limits.maxConnections) ? null : limits.maxConnections,
       },
       currentModel,
-      overagePerMillionTokens: plan.overagePerMillionTokens,
       subscription: subscription ? {
         stripeSubscriptionId: subscription.stripeSubscriptionId,
         plan: subscription.plan,

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -211,7 +211,7 @@ describe("billing/plans", () => {
       // 2_000_000-token budget) pasted into includedUsageDollarsPerSeat. A real
       // at-cost credit is a small, positive dollar figure well under $1000/seat,
       // and lives on a categorically smaller scale than the per-seat token budget
-      // (the budget is ≥1000× the credit). Either bound trips on a token-scale
+      // (the budget is >1000× the credit). Either bound trips on a token-scale
       // value — independent of the exact $20 pinned above, so a future $-recalibration
       // stays green while a denomination slip fails.
       for (const tier of ["starter", "pro", "business", "trial"] as const) {

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -9,6 +9,7 @@ import {
   getPlanLimits,
   isUnlimited,
   computeTokenBudget,
+  computeUsageDollarBudget,
   getStripePlans,
   resolvePlanTierFromPriceId,
 } from "@atlas/api/lib/billing/plans";
@@ -113,16 +114,6 @@ describe("billing/plans", () => {
       expect(business.features.sla).toBe("99.9%");
     });
 
-    it("the synthetic per-token overage rate is zeroed on every tier (Structure B, #4034)", () => {
-      // Structure B bills AI usage at provider cost (zero markup) via the at-cost
-      // meter, not a per-token markup. The legacy synthetic rate is neutralized on
-      // every tier; the field is removed entirely when dollar-native enforcement
-      // lands (#4038).
-      for (const tier of ["free", "trial", "starter", "pro", "business", "locked"] as const) {
-        expect(getPlanDefinition(tier).overagePerMillionTokens).toBe(0);
-      }
-    });
-
     it("every paid tier carries the flat $20/seat at-cost credit; free/locked carry none (#4034)", () => {
       // Flat $20 on every paid tier (pooled per-seat via × seatCount); the trial
       // mirrors Starter. Free (BYOK/self-hosted) and locked (churned) carry no
@@ -185,6 +176,52 @@ describe("billing/plans", () => {
     it("uses minimum of 1 seat", () => {
       expect(computeTokenBudget("starter", 0)).toBe(2_000_000);
       expect(computeTokenBudget("starter", -1)).toBe(2_000_000);
+    });
+  });
+
+  // Structure B included-credit denomination parity (#4040). The drift these
+  // pin: the at-cost credit MUST stay denominated in dollars (a flat $20/seat
+  // pool), never re-conflated with the millions-scale token budget the old
+  // markup model used. A future edit that pasted a token-scale number into
+  // includedUsageDollarsPerSeat — or otherwise broke the `$20 × seats` pool
+  // relationship — fails here before it can reach enforcement (#4038).
+  describe("computeUsageDollarBudget (credit denomination, #4040)", () => {
+    it("pools the flat per-seat dollar credit by seat count", () => {
+      for (const tier of ["starter", "pro", "business", "trial"] as const) {
+        const perSeat = getPlanDefinition(tier).includedUsageDollarsPerSeat;
+        expect(perSeat).toBe(20);
+        expect(computeUsageDollarBudget(tier, 1)).toBe(perSeat);
+        expect(computeUsageDollarBudget(tier, 5)).toBe(perSeat * 5);
+        expect(computeUsageDollarBudget(tier, 25)).toBe(perSeat * 25);
+      }
+    });
+
+    it("floors seat count at 1 so a transient 0/negative count keeps one seat's credit", () => {
+      expect(computeUsageDollarBudget("starter", 0)).toBe(20);
+      expect(computeUsageDollarBudget("starter", -3)).toBe(20);
+    });
+
+    it("yields no credit for tiers without included usage (free/locked)", () => {
+      expect(computeUsageDollarBudget("free", 10)).toBe(0);
+      expect(computeUsageDollarBudget("locked", 10)).toBe(0);
+    });
+
+    it("keeps the credit dollar-denominated, never token-scale (mismatch guard)", () => {
+      // The tokens↔dollars slip this catches: a token-scale number (e.g. the old
+      // 2_000_000-token budget) pasted into includedUsageDollarsPerSeat. A real
+      // at-cost credit is a small, positive dollar figure well under $1000/seat,
+      // and lives on a categorically smaller scale than the per-seat token budget
+      // (the budget is ≥1000× the credit). Either bound trips on a token-scale
+      // value — independent of the exact $20 pinned above, so a future $-recalibration
+      // stays green while a denomination slip fails.
+      for (const tier of ["starter", "pro", "business", "trial"] as const) {
+        const def = getPlanDefinition(tier);
+        expect(def.includedUsageDollarsPerSeat).toBeGreaterThan(0);
+        expect(def.includedUsageDollarsPerSeat).toBeLessThan(1000);
+        expect(
+          def.limits.tokenBudgetPerSeat / def.includedUsageDollarsPerSeat,
+        ).toBeGreaterThan(1000);
+      }
     });
   });
 

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -5,7 +5,8 @@
  * AI-usage credit ($20/seat/month, billed at provider cost with zero markup).
  * Usage is enforced in dollars against that credit (`computeUsageDollarBudget`),
  * not a per-token markup; per-seat token budgets survive only as a non-enforcing
- * display / Stripe plan-metadata figure.
+ * display figure (`computeTokenBudget`) and as plan `limits` carried through
+ * `getStripePlans` into the @better-auth/stripe plugin's subscription record.
  *
  * Self-hosted deployments default to "free" (unlimited, BYOK only).
  * SaaS workspaces start as "trial" (14-day trial of Starter).

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -1,14 +1,18 @@
 /**
  * Plan definitions and limits for Atlas billing tiers.
  *
- * Per-seat pricing with model-aware token budgets.
+ * Structure B (#4034): a flat per-seat platform fee plus an included at-cost
+ * AI-usage credit ($20/seat/month, billed at provider cost with zero markup).
+ * Usage is enforced in dollars against that credit (`computeUsageDollarBudget`),
+ * not a per-token markup; per-seat token budgets survive only as a non-enforcing
+ * display / Stripe plan-metadata figure.
  *
  * Self-hosted deployments default to "free" (unlimited, BYOK only).
  * SaaS workspaces start as "trial" (14-day trial of Starter).
  * Paid tiers: "starter", "pro", "business".
  *
  * BYOT (Bring Your Own Token) is orthogonal — a boolean flag on the org
- * that bypasses token enforcement (unlimited queries when set).
+ * that bypasses usage enforcement (unlimited queries when set).
  */
 
 import type { PlanTier } from "@atlas/api/lib/db/internal";
@@ -78,17 +82,6 @@ export interface PlanDefinition {
    * working number — hot-reloadable, recalibrate ~30d post-launch.
    */
   includedUsageDollarsPerSeat: number;
-  /**
-   * DEPRECATED (Structure B, #4034): the legacy synthetic $/1M-token overage
-   * rate. Zeroed on every tier — Structure B bills usage at provider cost (zero
-   * markup) via the at-cost meter, not a per-token markup. Dollar-native
-   * enforcement (#4038) AND the at-cost meter repoint (#4039) have both landed:
-   * nothing now consults this rate — `checkPlanLimits` and the `OverageMeter`
-   * both denominate in real dollars/cents (`computeUsageDollarBudget` /
-   * `computeOverageDollars`). Fully vestigial; still emitted on the billing wire
-   * shape for back-compat, slated for removal in the drift/parity cleanup (#4040).
-   */
-  overagePerMillionTokens: number;
   limits: PlanLimits;
   features: PlanFeatures;
   trialDays?: number;
@@ -146,7 +139,6 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     pricePerSeat: 0,
     defaultModel: "user-configured",
     includedUsageDollarsPerSeat: 0,
-    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: UNLIMITED,
       maxSeats: UNLIMITED,
@@ -166,7 +158,6 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     // billing-page alias map for any legacy `ATLAS_MODEL` settings.
     defaultModel: "anthropic/claude-haiku-4.5",
     includedUsageDollarsPerSeat: 20,
-    overagePerMillionTokens: 0,
     trialDays: TRIAL_DAYS,
     limits: {
       tokenBudgetPerSeat: 2_000_000,
@@ -183,7 +174,6 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     pricePerSeat: 39,
     defaultModel: "anthropic/claude-haiku-4.5",
     includedUsageDollarsPerSeat: 20,
-    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 2_000_000,
       maxSeats: 10,
@@ -199,7 +189,6 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     pricePerSeat: 69,
     defaultModel: "anthropic/claude-sonnet-4.6",
     includedUsageDollarsPerSeat: 20,
-    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 5_000_000,
       maxSeats: 25,
@@ -225,7 +214,6 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     pricePerSeat: 0,
     defaultModel: "anthropic/claude-haiku-4.5",
     includedUsageDollarsPerSeat: 0,
-    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 0,
       maxSeats: 0,
@@ -241,7 +229,6 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     pricePerSeat: 149,
     defaultModel: "anthropic/claude-sonnet-4.6",
     includedUsageDollarsPerSeat: 20,
-    overagePerMillionTokens: 0,
     limits: {
       tokenBudgetPerSeat: 15_000_000,
       maxSeats: UNLIMITED,

--- a/packages/api/src/lib/metering.ts
+++ b/packages/api/src/lib/metering.ts
@@ -48,9 +48,10 @@ export interface UsageEvent {
    * Provider-cost USD for a `token` event's turn, from the Vercel AI Gateway
    * (`providerMetadata.gateway.cost`, summed across the turn's steps), #4036.
    * Persisted to `usage_events.gateway_cost_usd` as the at-cost dollar basis the
-   * Structure B credit + overage meter will draw against once #4038/#4039 land
-   * (captured-only today). Omit (or pass `null`) for non-token events and for
-   * non-gateway providers — the column is NULL there.
+   * Structure B credit + overage meter draw against: dollar enforcement (#4038)
+   * sums it into the period's `costUsd`, and the at-cost OverageMeter (#4039)
+   * bills the over-credit remainder in provider-cost cents. Omit (or pass `null`)
+   * for non-token events and for non-gateway providers — the column is NULL there.
    */
   gatewayCostUsd?: number | null;
   metadata?: Record<string, unknown>;

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -39,7 +39,6 @@ const validStatus = {
   seats: { count: 4, max: 10 },
   connections: { count: 1, max: 1 },
   currentModel: "claude-haiku-4-5",
-  overagePerMillionTokens: 1.0,
   subscription: {
     stripeSubscriptionId: "sub_123",
     plan: "starter_monthly",
@@ -266,8 +265,10 @@ describe("structural rejection", () => {
     expect(BillingStatusSchema.safeParse(missing).success).toBe(false);
   });
 
-  test("BillingStatusSchema requires seats / connections / currentModel / overagePerMillionTokens", () => {
-    const { seats: _s, ...missing } = validStatus;
-    expect(BillingStatusSchema.safeParse(missing).success).toBe(false);
+  test("BillingStatusSchema requires seats / connections / currentModel", () => {
+    for (const key of ["seats", "connections", "currentModel"] as const) {
+      const { [key]: _omit, ...missing } = validStatus;
+      expect(BillingStatusSchema.safeParse(missing).success).toBe(false);
+    }
   });
 });

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -114,9 +114,10 @@ export interface BillingUsage {
   tokenCount: number;
   /**
    * Output-equivalent (model-weighted) token spend for the period (#3989).
-   * Retained for display + the token-based OverageMeter (#3992); since #4038
-   * enforcement denominates in dollars (`costUsd`), not tokens. Optional for
-   * older-bundle tolerance; falls back to `tokenCount` when absent.
+   * Retained for display only: since #4038 enforcement denominates in dollars
+   * (`costUsd`), not tokens, and the at-cost OverageMeter repoint (#4039) bills
+   * overage in provider-cost cents, so no billing path reads this figure.
+   * Optional for older-bundle tolerance; falls back to `tokenCount` when absent.
    */
   weightedTokenCount?: number;
   seatCount: number;
@@ -215,7 +216,6 @@ export interface BillingStatus {
   seats: BillingSeatCount;
   connections: BillingConnectionCount;
   currentModel: string;
-  overagePerMillionTokens: number;
   subscription: BillingSubscription | null;
   /**
    * Optional so a web bundle pinned to an older published schema keeps
@@ -335,7 +335,6 @@ export const BillingStatusSchema = z.object({
   seats: BillingSeatCountSchema,
   connections: BillingConnectionCountSchema,
   currentModel: z.string(),
-  overagePerMillionTokens: z.number(),
   subscription: BillingSubscriptionSchema.nullable(),
   availablePlans: z.array(BillingAvailablePlanSchema).optional(),
 }) satisfies z.ZodType<BillingStatus>;

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -486,14 +486,11 @@ function PlanShell({ data }: { data: BillingStatus }) {
           <DetailRow label="Scheduled" value={cancelNotice} />
         )}
         {/*
-         * #3422 / #4038 — `overagePerMillionTokens` is a legacy display-only
-         * wire field, now permanently 0. Structure B (#4038) DOES meter overage,
-         * but at provider cost (zero markup) against the dollar usage credit —
-         * surfaced by the usage card above ("in overage, $X.XX so far"), not by a
-         * synthetic per-token rate. Rendering this zeroed field as "$X/M tokens"
-         * would imply a per-token charge that no longer exists, so the row is
-         * intentionally not surfaced. The field stays in the wire schema until the
-         * at-cost meter repoint (#4039) lets it be dropped (publish-sequencing).
+         * Structure B (#4038/#4039) meters overage at provider cost (zero markup)
+         * against the dollar usage credit — surfaced by the usage card above ("in
+         * overage, $X.XX so far"). There is no per-token overage rate: the legacy
+         * `overagePerMillionTokens` wire field was dropped in the drift/parity
+         * cleanup (#4040) once the at-cost meter repoint (#4039) landed.
          */}
       </DetailList>
 

--- a/packages/web/src/app/admin/model-config/__tests__/no-platform-guard.test.tsx
+++ b/packages/web/src/app/admin/model-config/__tests__/no-platform-guard.test.tsx
@@ -145,7 +145,6 @@ describe("/admin/model-config — free-tier placeholder copy (#2468)", () => {
       seats: { count: 1, max: null },
       connections: { count: 0, max: null },
       currentModel: "user-configured",
-      overagePerMillionTokens: 0,
       subscription: null,
     };
     const { container } = render(createElement(ModelConfigPage), { wrapper });
@@ -179,7 +178,6 @@ describe("/admin/model-config — free-tier placeholder copy (#2468)", () => {
       seats: { count: 1, max: null },
       connections: { count: 0, max: null },
       currentModel: "anthropic/claude-haiku-4.5",
-      overagePerMillionTokens: 0,
       subscription: null,
     };
     const { container } = render(createElement(ModelConfigPage), { wrapper });


### PR DESCRIPTION
## Summary

S5 of the Structure B re-denomination (#4034) — the drift-guard / parity alignment + stale-reference sweep that keeps the billing SSOT honest after S2 (#4037 ladder), S3 (#4038 dollar enforcement) and S4 (#4039 at-cost-cents OverageMeter repoint) all landed.

- **Removed the vestigial `overagePerMillionTokens` wire field** — the legacy synthetic $/1M-token overage rate, always `0` and read by no billing path since #4038/#4039. Dropped from `PlanDefinition` + all 6 plan defs, the `/api/v1/billing/status` response, the `@useatlas/schemas` `BillingStatus` interface + `BillingStatusSchema` zod, the web billing-page comment, and all test fixtures. OpenAPI spec regenerated (property + `required` entry gone). Its prior code comments explicitly slated it for removal in #4040 once #4039 landed.
- **Swept stale token-markup comments/headers to Structure B language** — `plans.ts` module header ("model-aware token budgets" → flat per-seat fee + at-cost dollar credit, dollar-enforced), `metering.ts` `gatewayCostUsd` ("once #4038/#4039 land… captured-only today" → both landed), `schemas/billing.ts` `weightedTokenCount` ("token-based OverageMeter" → at-cost cents repoint, display-only).
- **Added a credit-denomination parity net** (`plans.test.ts`) — pins `computeUsageDollarBudget` = `$20 × seats`, dollar-scale not token-scale (a token-scale paste into `includedUsageDollarsPerSeat` fails), free/locked = 0, seat-floor at 1. So a future tokens↔dollars mismatch can't reach enforcement (#4038).
- Verified `check-pricing-parity.sh`, enforcement-parity, and `reconcile-plan-tiers` all still green under the $39/$69/$149 ladder (no code change needed — `PAID_TIERS` unchanged).

## Acceptance criteria (#4040)
- [x] `check-pricing-parity.sh` green against the re-denominated SSOT
- [x] Included-credit parity assertion added (credit ↔ at-cost dollars consistent)
- [x] `reconcile-plan-tiers` verified under the $39/$69/$149 ladder
- [x] Stale token-markup references (comments/headers) swept to Structure B
- [x] CI gates green

## Review
Passed the internal review panel (silent-failure / type-design / pr-test / comment-analyzer), 2 rounds → CLEAN. Round-1 must-fix (un-regenerated `apps/docs/openapi.json`) fixed; round-1 MEDIUM/LOW (binding the mismatch-guard assertion, pinning field-absence in the route test, looping the schema-rejection test, comment precision) all addressed.

## Notes
- **Deploy-skew (considered, accepted):** dropping a required wire field could skew an old web bundle against the new API during a rolling deploy. Impact is bounded: the web consumes via `useAdminFetch` → `safeParse`, which degrades to a purpose-built `schema_mismatch` "version mismatch — try again later" state (not a crash) and self-heals on reload; the field is admin-only + display-only + never rendered; this is pre-launch and prod is `/release`-gated (web+api tag together). No `@useatlas/schemas` version bump — consistent with the S2/S3/S4 slice cadence (version handled at milestone `/release`).
- **Out of scope (→ #3993):** the customer-facing `apps/docs/.../billing-and-plans.mdx` still describes the old "no metered overage" model. That customer copy is owned by #3993 (copy re-sequenced after #4034), not this code-level drift/parity slice.

## Test plan
- [x] `bun run type`, `bun run lint` — clean
- [x] Affected tests: `plans.test.ts`, `billing.test.ts` (api), `billing.test.ts` (schemas), `no-platform-guard.test.tsx` (web), `reconcile-plan-tiers.test.ts` — pass
- [x] All drift/parity/discipline gates (openapi, pricing-parity, enforcement-parity, schema, template, syncpack, …) — pass
- [x] Full `bun run test` — 745/748; the 3 failures are the documented WSL2 sandbox/nsjail environmental flakes (`explore-backend`, `explore-workspace-override`, `python`), unrelated to this billing-only diff; they run green on CI's containerized `api-tests` shards

Closes #4040