### PR TITLE
chore(web): overage copy → at-cost usage + spend-policy (#3993)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -77300,6 +77300,17 @@
                         "overageCost": {
                           "type": "number"
                         },
+                        "spendPolicy": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "continue",
+                            "cutoff",
+                            null
+                          ]
+                        },
                         "periodStart": {
                           "type": "string"
                         },

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -88,7 +88,7 @@ const TIERS: Tier[] = [
     ctaHref: "https://app.useatlas.dev/signup?plan=starter",
     ctaSecondary: "no card · work email",
     features: [
-      "~100 AI queries/seat/mo included",
+      "$20/seat AI-usage credit, then at cost",
       "Up to 10 seats",
       "1 database connection",
       "Default model: Haiku 4.5",
@@ -109,7 +109,7 @@ const TIERS: Tier[] = [
     ctaSecondary: "no card · work email",
     highlighted: true,
     features: [
-      "~250 AI queries/seat/mo included",
+      "$20/seat AI-usage credit, then at cost",
       "Up to 25 seats",
       "3 database connections",
       "Default model: Sonnet 4.6",
@@ -130,7 +130,7 @@ const TIERS: Tier[] = [
     ctaHref: "https://app.useatlas.dev/signup?plan=business",
     ctaSecondary: "or talk to sales",
     features: [
-      "~750 AI queries/seat/mo included",
+      "$20/seat AI-usage credit, then at cost",
       "Unlimited seats & connections",
       "Default model: Sonnet 4.6",
       "BYOK for unlimited queries",
@@ -158,13 +158,14 @@ const CORE_SECTION: ComparisonSection = {
     { feature: "Notebooks & dashboards", selfHosted: true, starter: true, pro: true, business: true },
     { feature: "Admin console & API", selfHosted: true, starter: true, pro: true, business: true },
     { feature: "MCP server", selfHosted: true, starter: true, pro: true, business: true },
-    { feature: "AI queries/seat/mo", selfHosted: "Unlimited (BYOK)", starter: "~100", pro: "~250", business: "~750" },
+    { feature: "Included AI-usage credit", selfHosted: "Unlimited (BYOK)", starter: "$20/seat/mo", pro: "$20/seat/mo", business: "$20/seat/mo" },
+    { feature: "Usage billing", selfHosted: "BYOK (you pay your provider)", starter: "At cost, no markup", pro: "At cost, no markup", business: "At cost, no markup" },
     { feature: "BYOK (unlimited queries)", selfHosted: "Default", starter: true, pro: true, business: true },
     { feature: "Default model", selfHosted: "Your choice", starter: "Haiku 4.5", pro: "Sonnet 4.6", business: "Sonnet 4.6" },
     { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
     { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
     { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 6" },
-    { feature: "When you hit the budget", selfHosted: "No limit (BYOK)", starter: "Warn → 10% grace → pause", pro: "Warn → 10% grace → pause", business: "Warn → 10% grace → pause" },
+    { feature: "Past the included credit", selfHosted: "No limit (BYOK)", starter: "At cost, to spend cap", pro: "At cost, to spend cap", business: "At cost, to spend cap" },
   ],
 };
 
@@ -256,17 +257,17 @@ const FAQS: FAQ[] = [
   {
     question: "Can I switch models?",
     answer:
-      "Yes. Every plan lets you choose any supported model (Claude, GPT, etc.). Your per-seat budget is a flat token count — every token counts the same regardless of which model produced it, so a more capable model simply consumes the shared budget faster. Switch to BYOK to remove token limits entirely.",
+      "Yes. Every plan lets you choose any supported model (Claude, GPT, etc.). AI usage is billed at provider cost with no markup, so switching to a more capable model simply draws down your included usage credit faster — and costs more per query once you're past it. Switch to BYOK to bill your own provider directly instead.",
   },
   {
-    question: "What happens when I hit my token budget?",
+    question: "What happens when I use up my included usage?",
     answer:
-      "Each paid plan includes a per-seat monthly token budget that scales with your seat count. As you approach it you'll get a usage warning (from ~80%), and you keep working through a 10% grace buffer past 100%. At 110% new requests are paused until you upgrade, add seats, or your billing period resets. There is no metered per-token overage charge — it's a hard cap with a grace buffer, not pay-as-you-go. To remove token limits entirely, switch to BYOK at any time and use your own API key.",
+      "Every paid plan includes $20/seat per month of AI usage, billed at provider cost with zero markup and pooled across your seats. You'll get a warning as you approach it (from ~80%). Past the credit, you choose what happens: by default Atlas keeps serving at the same provider cost — your billing page shows \"in overage, $X.XX so far\" — bounded by a spend cap that backstops runaway usage; or set your workspace to cut off at the credit so nothing bills beyond it. There's no per-token markup and no flat lockout. Switch to BYOK at any time to bill your own provider directly.",
   },
   {
     question: "Is there a free option?",
     answer:
-      "Yes — self-hosted Atlas is free and always will be (AGPL-3.0). Deploy on your own infrastructure with unlimited everything. For Atlas Cloud, all paid plans include a 14-day free trial with no credit card required (work email required — see below). Every trial runs at Starter-tier usage limits (2M tokens/seat, up to 10 seats, 1 connection) for 14 days, regardless of the plan you start from.",
+      "Yes — self-hosted Atlas is free and always will be (AGPL-3.0). Deploy on your own infrastructure with unlimited everything. For Atlas Cloud, all paid plans include a 14-day free trial with no credit card required (work email required — see below). Every trial runs at Starter-tier limits ($20/seat of included AI usage, up to 10 seats, 1 connection) for 14 days, regardless of the plan you start from.",
   },
   {
     question: "What email can I sign up with?",

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -122,10 +122,19 @@ mock.module("@atlas/api/lib/metering", () => ({
 // ATLAS_PROVIDER is a deploy-level choice resolved from env, so the mock
 // returns the saved model only for that key (mirrors the real store).
 let mockSettingLiveValue: string | undefined = undefined;
+// Live ATLAS_SPEND_POLICY value (#3993) — drives resolveSpendPolicy. Unset ⇒
+// default "continue"; a test sets "cutoff" to exercise the cutoff branch.
+let mockSpendPolicyValue: string | undefined = undefined;
 
 mock.module("@atlas/api/lib/settings", () => ({
   getSettingLive: mock((key: string) =>
-    Promise.resolve(key === "ATLAS_MODEL" ? mockSettingLiveValue : undefined),
+    Promise.resolve(
+      key === "ATLAS_MODEL"
+        ? mockSettingLiveValue
+        : key === "ATLAS_SPEND_POLICY"
+          ? mockSpendPolicyValue
+          : undefined,
+    ),
   ),
   getSetting: mock(() => undefined),
   getSettingAuto: mock(() => undefined),
@@ -183,6 +192,7 @@ describe("billing routes", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
     mockSettingLiveValue = undefined;
+    mockSpendPolicyValue = undefined;
     mockAuthenticateRequest.mockImplementation(() =>
       Promise.resolve({
         authenticated: true,
@@ -297,6 +307,38 @@ describe("billing routes", () => {
       expect(body.usage.costUsd).toBe(70);
       expect(body.usage.overageCost).toBe(10);
       expect(body.limits.totalUsageDollars).toBe(60);
+      // #3993 — the spend policy is surfaced for the "past the credit" line;
+      // the settings mock leaves ATLAS_SPEND_POLICY unset ⇒ default "continue".
+      expect(body.usage.spendPolicy).toBe("continue");
+    });
+
+    it("forwards the cutoff spend policy and hard-blocks over the credit (#3993)", async () => {
+      // Same 3 seats → $60 credit, $70 spend, but the workspace is on the
+      // `cutoff` policy: resolveUsageCeiling clamps the ceiling to 100% of the
+      // credit, so anything over the credit is hard_limit (not metered). Pins
+      // the route faithfully forwarding the resolved policy on the cutoff branch
+      // — the one branch the default-driven tests can't see.
+      mockSpendPolicyValue = "cutoff";
+      mockInternalQuery.mockImplementation((...args: unknown[]) => {
+        const sql = args[0];
+        if (typeof sql === "string" && sql.includes("member")) {
+          return Promise.resolve([{ count: 3 }]);
+        }
+        return Promise.resolve([]);
+      });
+      const meteringMod = await import("@atlas/api/lib/metering");
+      (meteringMod.getCurrentPeriodUsage as ReturnType<typeof mock>).mockImplementationOnce(() =>
+        Promise.resolve({ ...mockUsage, costUsd: 70 }),
+      );
+
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.usage.spendPolicy).toBe("cutoff");
+      expect(body.usage.usageOverageStatus).toBe("hard_limit");
+      expect(body.usage.overageCost).toBe(10);
+      expect(body.limits.totalUsageDollars).toBe(60);
     });
 
     it("never reports overage for a BYOT workspace, even over the credit (#3990)", async () => {
@@ -327,6 +369,8 @@ describe("billing routes", () => {
       expect(body.usage.overageCost).toBe(0);
       // BYOT bypasses enforcement → no dollar credit gauge.
       expect(body.limits.totalUsageDollars).toBeNull();
+      // #3993 — BYOT has no enforced credit, so no spend-policy line either.
+      expect(body.usage.spendPolicy).toBeNull();
     });
 
     it("reports zero overage when under the credit (#3990)", async () => {

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -32,7 +32,7 @@ import {
 } from "@atlas/api/lib/db/internal";
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
 import { getPlanDefinition, getPlanLimits, getStripePlans, computeTokenBudget, computeUsageDollarBudget, isUnlimited, type PaidPlanTier } from "@atlas/api/lib/billing/plans";
-import { buildMetricStatus, resolveUsageCeiling, computeOverageDollars } from "@atlas/api/lib/billing/enforcement";
+import { buildMetricStatus, resolveUsageCeiling, computeOverageDollars, type SpendPolicy } from "@atlas/api/lib/billing/enforcement";
 import { getSeatCount } from "@atlas/api/lib/billing/seat-count";
 import { effectiveTrialEndsAt } from "@atlas/api/lib/billing/trial-expiry";
 import { getSettingLive } from "@atlas/api/lib/settings";
@@ -398,19 +398,34 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     // through verbatim — hence the explicit undefined-vs-null distinction rather
     // than a `?? default` coalesce. The gauge denominates against the at-cost
     // spend (`usage.costUsd`, #4036) — the same numerator enforcement reads.
-    const ceilingPercent = enforcesBudget
-      ? yield* Effect.promise(() =>
+    // Resolve the ceiling AND the spend policy from the same call — the page
+    // surfaces the policy (`continue` vs `cutoff`, #3993) so a customer knows
+    // what happens past their credit *before* they hit the 429, not just at it.
+    // `ceilingPercent`: number (a bounded multiple of the credit), null
+    // (operator-disabled ceiling), or undefined (resolution failed → let
+    // buildMetricStatus fall to its conservative default). `spendPolicy`: null
+    // when there's no enforced credit or resolution failed (page omits the line).
+    type CeilingResolution = {
+      spendPolicy: SpendPolicy | null;
+      ceilingPercent: number | null | undefined;
+    };
+    const ceiling: CeilingResolution = enforcesBudget
+      ? yield* Effect.promise<CeilingResolution>(() =>
           resolveUsageCeiling(orgId)
-            .then((r) => r.ceilingPercent)
+            .then((r) => ({ spendPolicy: r.spendPolicy, ceilingPercent: r.ceilingPercent }))
             .catch((err) => {
               log.warn(
                 { err: err instanceof Error ? err.message : String(err), orgId },
                 "Failed to resolve usage ceiling for billing page — using default classification",
               );
-              return undefined;
+              return { spendPolicy: null, ceilingPercent: undefined };
             }),
         )
-      : null;
+      : { spendPolicy: null, ceilingPercent: null };
+    const ceilingPercent = ceiling.ceilingPercent;
+    // Only meaningful when a dollar credit is enforced; null for BYOT / free /
+    // unlimited (no gauge) and on resolution failure ⇒ the page omits the line.
+    const spendPolicy = ceiling.spendPolicy;
     const usageOverage = enforcesBudget && usageDollarsLimit !== null
       ? buildMetricStatus("usd", usage.costUsd, usageDollarsLimit, ceilingPercent === undefined ? undefined : ceilingPercent)
       : { usagePercent: 0, status: "ok" as const };
@@ -461,6 +476,7 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         usageDollarsPercent: usageOverage.usagePercent,
         usageOverageStatus: usageOverage.status,
         overageCost,
+        spendPolicy,
         periodStart: usage.periodStart,
         periodEnd: usage.periodEnd,
         periodSource: usage.periodSource,

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -169,6 +169,36 @@ describe("enum strict rejection", () => {
   test("canonical tuples match expected values", () => {
     expect(OVERAGE_STATUSES).toEqual(["ok", "warning", "soft_limit", "metered", "hard_limit"]);
   });
+
+  // #3993 — the spend policy drives the billing page's "past the credit" line.
+  test("parses each spend policy, null, and absence as usage.spendPolicy", () => {
+    for (const policy of ["continue", "cutoff"] as const) {
+      expect(
+        BillingStatusSchema.parse({
+          ...validStatus,
+          usage: { ...validStatus.usage, spendPolicy: policy },
+        }).usage.spendPolicy,
+      ).toBe(policy);
+    }
+    // Null (no enforced credit / resolution failed) and absence (older bundle)
+    // both parse — the page omits the line in either case.
+    expect(
+      BillingStatusSchema.parse({
+        ...validStatus,
+        usage: { ...validStatus.usage, spendPolicy: null },
+      }).usage.spendPolicy,
+    ).toBeNull();
+    expect(BillingStatusSchema.parse(validStatus).usage.spendPolicy).toBeUndefined();
+  });
+
+  test("an unknown spendPolicy fails parse", () => {
+    expect(
+      BillingStatusSchema.safeParse({
+        ...validStatus,
+        usage: { ...validStatus.usage, spendPolicy: "throttle" },
+      }).success,
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -45,6 +45,18 @@ const OVERAGE_STATUSES = ["ok", "warning", "soft_limit", "metered", "hard_limit"
 const OverageStatusEnum = z.enum(OVERAGE_STATUSES) satisfies z.ZodType<OverageStatus>;
 const PlanTierEnum = z.enum(PLAN_TIERS);
 
+// Workspace spend posture past the included at-cost credit (#4038), the wire
+// mirror of the `SpendPolicy` union in `lib/billing/enforcement.ts`. The wire
+// layer must not import `@atlas/api`, so the two literals are hand-kept in sync
+// here (module-local tuple, not re-exported, to avoid widening the published
+// value surface). The `satisfies` below pins the enum to exactly these literals
+// locally; an enforcement-side change that adds a policy then surfaces at the
+// API route, where the resolved `SpendPolicy` is type-checked against this
+// schema in `c.json` (billing.ts) — so the by-convention mirror can't silently
+// drift.
+const SPEND_POLICIES = ["continue", "cutoff"] as const;
+const SpendPolicyEnum = z.enum(SPEND_POLICIES) satisfies z.ZodType<"continue" | "cutoff">;
+
 // ---------------------------------------------------------------------------
 // Interfaces — TS companions to the Zod schemas below. Declared here
 // because no other package needs the BillingStatus interface outside the
@@ -139,6 +151,16 @@ export interface BillingUsage {
    * Optional for older-bundle tolerance; absent ⇒ render as 0.
    */
   overageCost?: number;
+  /**
+   * #4038 / #3993 — the workspace's spend policy past the included credit:
+   * `continue` (default — keep serving at provider cost up to the spend cap) or
+   * `cutoff` (block new requests the moment the credit is spent). Lets the
+   * billing page tell a customer what happens past their credit *before* they
+   * hit it, not just at the 429. Null when no dollar credit is enforced
+   * (BYOT / free / locked / unlimited) or when resolution failed; optional for
+   * older-bundle tolerance (absent ⇒ omit the policy line).
+   */
+  spendPolicy?: "continue" | "cutoff" | null;
   periodStart: string;
   periodEnd: string;
   /**
@@ -259,6 +281,7 @@ export const BillingUsageSchema = z.object({
   usageDollarsPercent: z.number(),
   usageOverageStatus: OverageStatusEnum,
   overageCost: z.number().optional(),
+  spendPolicy: SpendPolicyEnum.nullable().optional(),
   periodStart: z.string(),
   periodEnd: z.string(),
   periodSource: z.enum(["stripe", "utc-month"]).optional(),

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -860,6 +860,25 @@ function UsageShell({ data }: { data: BillingStatus }) {
               </span>
             </p>
           )}
+          {/* #3993 — surface the spend policy past the included credit so the
+              customer knows what happens *before* they hit it: `continue`
+              (default) keeps serving at provider cost up to the spend cap;
+              `cutoff` blocks new requests at the credit. Null (resolution
+              failed / no enforced credit) ⇒ omit. The setting is workspace-
+              scoped and editable in Admin → Settings (Billing). */}
+          {usage.spendPolicy != null && (
+            <p className="text-[11px] text-muted-foreground">
+              {usage.spendPolicy === "cutoff"
+                ? "Past your included credit, new requests are paused — nothing bills beyond it (spend cutoff)."
+                : "Past your included credit, usage continues at provider cost (no markup), bounded by your spend cap."}{" "}
+              <a
+                href="/admin/settings#setting-ATLAS_SPEND_POLICY"
+                className="underline-offset-2 hover:underline"
+              >
+                Change
+              </a>
+            </p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Re-aligns the **pricing page**, **pricing FAQ**, and the **admin billing page** to the final Structure B overage behavior — written once against shipped reality (`plans.ts`, the `ATLAS_SPEND_POLICY` setting, at-cost enforcement), after the #4034 re-denomination landed.

- **Pricing/FAQ copy** now describes: AI usage billed **at provider cost (zero markup)** beyond the included **$20/seat credit**; the customer-controlled **spend policy** (continue at cost up to the spend cap, or cut off at the credit); and the **spend cap** as the runaway backstop. Removed the stale `$1/1M` token-markup framing, the flat hard-cap `Warn → 10% grace → pause` wording, and the **"no metered per-token overage charge"** claim. The "Can I switch models?" FAQ is now accurate under at-cost (`gateway.cost`) accounting.
- **Billing page** surfaces the resolved **spend-policy state** ("past your credit, usage continues at provider cost… / new requests are paused…") alongside the already-present at-cost usage gauge and "in overage, $X.XX so far" surface.
- Adds an optional `usage.spendPolicy` wire field (`@useatlas/schemas`), resolved from the **same `resolveUsageCeiling` call** the route already made — **zero extra DB reads**. Optional + nullable for older-bundle tolerance; the page omits the line when null.

Stale-string sweep across `packages/web` and `apps/www` is clean; the pricing-parity drift guard stays green (it mirrors the entitlement artifact, which is untouched).

## Test plan

- [x] `packages/schemas` billing schema test — parses each policy, `null`, absence; rejects an unknown policy
- [x] `packages/api` billing route test — `continue` default + BYOT→`null` + a new `cutoff`→`hard_limit` end-to-end case
- [x] `bun run type`, `bun run lint`, pricing-parity, settings-readers, published-symbols, schema/template/test-discipline drift — all green
- [x] OpenAPI spec regenerated (`apps/docs/openapi.json`) — `spendPolicy` captured
- [x] Affected isolated tests green (full-suite's 3 sandbox failures are the documented local `VERCEL_*`-env flake, unrelated to this diff)

Closes #3993