### PR TITLE
fix(www): align advertised base price to Structure B ladder + guard it (#4060)

### DIFF
--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -32,7 +32,7 @@ All database connections are read-only. Credentials stay on your infrastructure.
 ## Deployment
 
 - **Self-hosted** (free, AGPL-3.0): Docker, Railway, or Vercel. `bun create atlas-agent my-app`
-- **Atlas Cloud** (managed): Starter ($29/seat/mo), Pro ($59/seat/mo), and Business ($99/seat/mo) plans at https://app.useatlas.dev — all with 14-day free trial
+- **Atlas Cloud** (managed): Starter ($39/seat/mo), Pro ($69/seat/mo), and Business ($149/seat/mo) plans at https://app.useatlas.dev — all with 14-day free trial
 
 ## Tech stack
 

--- a/apps/www/src/app/pricing/entitlements.generated.ts
+++ b/apps/www/src/app/pricing/entitlements.generated.ts
@@ -15,6 +15,21 @@
 /** Marketing comparison-table columns, in display order. */
 export type PricingColumn = "selfHosted" | "starter" | "pro" | "business";
 
+/**
+ * Per-seat monthly base price (USD) for each marketing column, mirrored from
+ * `plans.ts` `pricePerSeat` — Atlas's internal price SSOT (kept in lockstep
+ * with the Stripe `STRIPE_*_PRICE_ID` Price objects, which it does not
+ * auto-sync). The pricing page reads the paid columns (`starter`/`pro`/
+ * `business`) for its tier cards instead of hand-coding them, so an advertised
+ * base price can't drift from `plans.ts`; `scripts/check-pricing-parity.sh`
+ * fails CI when this file is stale relative to `plans.ts`. `selfHosted` is 0
+ * for ladder completeness — the Self-Hosted card hard-codes "Free" and doesn't
+ * read it.
+ */
+export const TIER_MONTHLY_PRICE: Readonly<Record<PricingColumn, number>> = {
+  selfHosted: 0, starter: 39, pro: 69, business: 149,
+};
+
 /** Comparison-table section a gated feature renders under. */
 export type EntitlementSection = "hosting" | "security & compliance";
 

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -6,6 +6,7 @@ import { TalkToSalesDialog } from "../../components/talk-to-sales-dialog";
 import {
   ENTITLEMENT_ROWS,
   ENTITLEMENT_SECTION_ORDER,
+  TIER_MONTHLY_PRICE,
   type EntitlementRow,
   type EntitlementSection,
   type FeatureId,
@@ -59,6 +60,11 @@ interface FAQ {
 // Data
 // ---------------------------------------------------------------------------
 
+// Paid-tier base prices are read from TIER_MONTHLY_PRICE — the generated
+// mirror of `plans.ts` `pricePerSeat` (Atlas's internal price SSOT) — never
+// hand-coded, so an advertised base price can't drift from `plans.ts` (#4060).
+// Self-Hosted is the free OSS tier and renders "Free forever", so it stays
+// `null` rather than the mirror's $0.
 const TIERS: Tier[] = [
   {
     kind: "open source",
@@ -81,7 +87,7 @@ const TIERS: Tier[] = [
   {
     kind: "atlas cloud",
     name: "Starter",
-    monthlyPrice: 29,
+    monthlyPrice: TIER_MONTHLY_PRICE.starter,
     tagline: "Solo + small teams.",
     badge: "14-day free trial",
     cta: "Start free trial",
@@ -101,7 +107,7 @@ const TIERS: Tier[] = [
   {
     kind: "atlas cloud",
     name: "Pro",
-    monthlyPrice: 59,
+    monthlyPrice: TIER_MONTHLY_PRICE.pro,
     tagline: "Growing teams.",
     badge: "14-day free trial",
     cta: "Start free trial",
@@ -123,7 +129,7 @@ const TIERS: Tier[] = [
   {
     kind: "enterprise",
     name: "Business",
-    monthlyPrice: 99,
+    monthlyPrice: TIER_MONTHLY_PRICE.business,
     tagline: "Regulated teams at scale.",
     badge: "14-day free trial",
     cta: "Start free trial",

--- a/apps/www/src/components/landing/deploy.tsx
+++ b/apps/www/src/components/landing/deploy.tsx
@@ -1,4 +1,10 @@
 import { type CSSProperties } from "react";
+import { TIER_MONTHLY_PRICE } from "../../app/pricing/entitlements.generated";
+
+// "from $X" advertises the Atlas Cloud entry price — the Starter tier — read
+// from the generated mirror of `plans.ts` `pricePerSeat` (Atlas's internal
+// price SSOT) so this landing figure can't drift from `plans.ts` (#4060).
+const CLOUD_FROM_PRICE = TIER_MONTHLY_PRICE.starter;
 
 function SelfHostCard() {
   return (
@@ -117,7 +123,7 @@ function CloudCard() {
             // atlas cloud
           </p>
           <p className="text-[38px] font-semibold leading-none tracking-[-0.03em] text-fg">
-            <span className="text-base font-normal text-fg-muted">from </span>$29
+            <span className="text-base font-normal text-fg-muted">from </span>${CLOUD_FROM_PRICE}
             <span className="ml-1 text-base font-normal text-fg-muted">/ seat</span>
           </p>
           <p className="mt-2 text-sm text-fg">Hosted. Zero ops.</p>

--- a/packages/api/src/lib/billing/__tests__/pricing-entitlement-artifact.test.ts
+++ b/packages/api/src/lib/billing/__tests__/pricing-entitlement-artifact.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from "bun:test";
 import type { PlanTier } from "@useatlas/types";
 import { isPlanEligible } from "@atlas/api/lib/integrations/install/plan-rank";
+import { getPlanDefinition } from "../plans";
 import {
   FEATURE_ENTITLEMENTS,
   isFeatureEntitled,
@@ -24,6 +25,7 @@ import {
   SECTION_ORDER,
   assertDisplayExhaustive,
   buildEntitlementRows,
+  buildTierMonthlyPrice,
   renderArtifact,
   type PricingColumn,
 } from "../pricing-entitlement-artifact";
@@ -123,6 +125,44 @@ describe("buildEntitlementRows", () => {
     for (const row of buildEntitlementRows()) {
       expect(row.label).toBe(FEATURE_DISPLAY[row.feature].label);
       expect(row.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("buildTierMonthlyPrice — the base-price mirror (#4060)", () => {
+  it("mirrors plans.ts pricePerSeat for every column (SSOT-derived)", () => {
+    // The load-bearing invariant: the page's advertised base price equals the
+    // tier's pricePerSeat in plans.ts — Atlas's internal price SSOT — so the
+    // page can't advertise a price plans.ts doesn't declare.
+    const prices = buildTierMonthlyPrice();
+    for (const [column, tier] of Object.entries(COLUMN_TIERS) as [
+      PricingColumn,
+      PlanTier,
+    ][]) {
+      expect(prices[column]).toBe(getPlanDefinition(tier).pricePerSeat);
+    }
+  });
+
+  it("matches the locked Structure B ladder (hard-coded oracle, not SSOT-derived)", () => {
+    // A tripwire pinned to the locked $39/$69/$149 ladder (#4034), independent
+    // of the live SSOT: changing plans.ts pricePerSeat forces an intentional
+    // update here (and a regenerate), so a fat-fingered price can't sail
+    // through just because both the mirror and an SSOT-derived assertion moved
+    // together. Self-Hosted is the free OSS column → $0.
+    expect(buildTierMonthlyPrice()).toEqual({
+      selfHosted: 0,
+      starter: 39,
+      pro: 69,
+      business: 149,
+    });
+  });
+
+  it("renders TIER_MONTHLY_PRICE into the artifact source", () => {
+    const src = renderArtifact();
+    expect(src).toContain("export const TIER_MONTHLY_PRICE");
+    const prices = buildTierMonthlyPrice();
+    for (const [column, price] of Object.entries(prices)) {
+      expect(src).toContain(`${column}: ${price}`);
     }
   });
 });

--- a/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
+++ b/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
@@ -26,6 +26,7 @@ import {
   FEATURE_ENTITLEMENTS,
   type GatedFeature,
 } from "@atlas/api/lib/billing/feature-entitlement";
+import { getPlanDefinition } from "@atlas/api/lib/billing/plans";
 import { isPlanEligible } from "@atlas/api/lib/integrations/install/plan-rank";
 import type { PlanTier } from "@useatlas/types";
 
@@ -181,15 +182,44 @@ export function buildEntitlementRows(): GeneratedEntitlementRow[] {
 }
 
 /**
+ * Per-column monthly base price (USD per seat), mirrored from `plans.ts`
+ * `pricePerSeat` — Atlas's internal price SSOT. (`pricePerSeat` must be kept in
+ * lockstep with the Stripe `STRIPE_*_PRICE_ID` Price objects, which it does not
+ * auto-sync; the parity guard only proves page == `plans.ts`, not `plans.ts` ==
+ * Stripe.) Keyed by the same {@link COLUMN_TIERS} ladder as the entitlement
+ * cells, so the marketing page's advertised base price is derived from the same
+ * tier definitions the rest of the app reads and can't silently diverge (#4060:
+ * the page once advertised $29/$59/$99 while `plans.ts` declared $39/$69/$149).
+ * The page consumes only the paid columns (`starter`/`pro`/`business`); the
+ * `selfHosted` column (the `free` tier) is 0 for ladder completeness, but the
+ * page hard-codes the Self-Hosted card to `null` ("Free forever") and never
+ * reads this 0.
+ */
+export function buildTierMonthlyPrice(): Record<PricingColumn, number> {
+  const columns = Object.entries(COLUMN_TIERS) as [PricingColumn, PlanTier][];
+  return Object.fromEntries(
+    columns.map(([column, tier]) => [
+      column,
+      getPlanDefinition(tier).pricePerSeat,
+    ]),
+  ) as Record<PricingColumn, number>;
+}
+
+/**
  * Render the full artifact source. The whole file is machine-written, so the
  * drift guard compares the rendered string against the on-disk file verbatim
  * (no marker splice needed). The shape is a flat list of rows, each with
- * per-column booleans — a pure data module with zero `@atlas/api` import, so
- * the marketing bundle never pulls in the API package.
+ * per-column booleans, plus the per-column base price — a pure data module
+ * with zero `@atlas/api` import, so the marketing bundle never pulls in the
+ * API package.
  */
 export function renderArtifact(): string {
   const rows = buildEntitlementRows();
   const columnNames = Object.keys(COLUMN_TIERS) as PricingColumn[];
+  const tierPrice = buildTierMonthlyPrice();
+  const priceLiteral = columnNames
+    .map((c) => `${c}: ${tierPrice[c]}`)
+    .join(", ");
 
   // Derive every emitted union from its source so there is exactly one
   // spelling per union, not a hand-written literal that can drift from the
@@ -239,6 +269,21 @@ export function renderArtifact(): string {
 
 /** Marketing comparison-table columns, in display order. */
 export type PricingColumn = ${columnUnion};
+
+/**
+ * Per-seat monthly base price (USD) for each marketing column, mirrored from
+ * \`plans.ts\` \`pricePerSeat\` — Atlas's internal price SSOT (kept in lockstep
+ * with the Stripe \`STRIPE_*_PRICE_ID\` Price objects, which it does not
+ * auto-sync). The pricing page reads the paid columns (\`starter\`/\`pro\`/
+ * \`business\`) for its tier cards instead of hand-coding them, so an advertised
+ * base price can't drift from \`plans.ts\`; \`scripts/check-pricing-parity.sh\`
+ * fails CI when this file is stale relative to \`plans.ts\`. \`selfHosted\` is 0
+ * for ladder completeness — the Self-Hosted card hard-codes "Free" and doesn't
+ * read it.
+ */
+export const TIER_MONTHLY_PRICE: Readonly<Record<PricingColumn, number>> = {
+  ${priceLiteral},
+};
 
 /** Comparison-table section a gated feature renders under. */
 export type EntitlementSection = ${sectionUnion};

--- a/scripts/__tests__/check-pricing-parity.test.sh
+++ b/scripts/__tests__/check-pricing-parity.test.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCRIPT="$SCRIPT_DIR/check-pricing-parity.sh"
 ARTIFACT="$ROOT/apps/www/src/app/pricing/entitlements.generated.ts"
+LLMS="$ROOT/apps/www/public/llms.txt"
 
 if [ ! -f "$SCRIPT" ]; then
   echo "::error::script under test not found at $SCRIPT" >&2
@@ -21,6 +22,10 @@ if [ ! -f "$SCRIPT" ]; then
 fi
 if [ ! -f "$ARTIFACT" ]; then
   echo "::error::generated artifact not found at $ARTIFACT" >&2
+  exit 2
+fi
+if [ ! -f "$LLMS" ]; then
+  echo "::error::llms.txt not found at $LLMS" >&2
   exit 2
 fi
 
@@ -41,10 +46,18 @@ check() {
   fi
 }
 
-# Back the artifact up so we always restore the committed file, even on error.
+# Back both mutated files up so we always restore the committed files, even on
+# error (the artifact for the SSOT-mirror fixtures, llms.txt for the static
+# base-price fixture).
 BACKUP="$(mktemp)"
+LLMS_BACKUP="$(mktemp)"
 cp "$ARTIFACT" "$BACKUP"
-restore() { cp "$BACKUP" "$ARTIFACT"; rm -f "$BACKUP"; }
+cp "$LLMS" "$LLMS_BACKUP"
+restore() {
+  cp "$BACKUP" "$ARTIFACT"
+  cp "$LLMS_BACKUP" "$LLMS"
+  rm -f "$BACKUP" "$LLMS_BACKUP"
+}
 trap restore EXIT
 
 # --- in-sync artifact passes ------------------------------------------------
@@ -68,8 +81,30 @@ sed -i '0,/pro: false, business: true/{s/pro: false, business: true/pro: true, b
 check fail "an injected Pro-column over-claim trips the gate"
 cp "$BACKUP" "$ARTIFACT"
 
-# --- restored artifact passes again -----------------------------------------
-check pass "restored artifact is in sync again"
+# Mutate a TIER_MONTHLY_PRICE base price (#4060): regress Starter $39 → $29, the
+# original drift this guard exists to prevent. The on-disk price no longer
+# matches what the generator renders from plans.ts, so the gate must fail.
+sed -i 's/starter: 39/starter: 29/' "$ARTIFACT"
+check fail "a regressed base price in the artifact trips the gate"
+cp "$BACKUP" "$ARTIFACT"
+
+# Static llms.txt drift (#4060): change an advertised per-seat price so it no
+# longer matches the artifact's SSOT-derived figure. The artifact itself stays
+# in sync, so only the llms.txt parity step can catch this.
+sed -i 's#\$39/seat/mo#$29/seat/mo#' "$LLMS"
+check fail "a stale base price in llms.txt trips the gate"
+cp "$LLMS_BACKUP" "$LLMS"
+
+# Tier/price swap in llms.txt (#4060): exchange Starter's and Pro's prices,
+# keeping the SET of price tokens {39,69,149} intact. A membership-only check
+# would pass this; the tier-label-bound check must catch that Starter no longer
+# reads $39/seat.
+sed -i 's#Starter (\$39/seat/mo), Pro (\$69/seat/mo)#Starter ($69/seat/mo), Pro ($39/seat/mo)#' "$LLMS"
+check fail "a tier/price swap in llms.txt trips the gate"
+cp "$LLMS_BACKUP" "$LLMS"
+
+# --- restored files pass again ----------------------------------------------
+check pass "restored artifact + llms.txt are in sync again"
 
 echo ""
 echo "check-pricing-parity.test.sh: $PASS passed, $FAIL failed"

--- a/scripts/check-pricing-parity.sh
+++ b/scripts/check-pricing-parity.sh
@@ -38,3 +38,50 @@ echo ":: Verifying pricing entitlement artifact against FEATURE_ENTITLEMENTS..."
 bun scripts/generate-pricing-entitlements.ts --check
 
 echo "Pricing-parity drift check passed — entitlement artifact is in sync with FEATURE_ENTITLEMENTS."
+
+# --- static llms.txt base-price parity (#4060) ------------------------------
+# apps/www/public/llms.txt is a static marketing asset: it can't import the
+# generated mirror (it's not TS), so its per-seat prices are hand-maintained
+# and could silently drift from plans.ts — the exact #4060 bug class, in the
+# one surface the generated mirror can't reach. The --check above already
+# proved the artifact's TIER_MONTHLY_PRICE matches plans.ts, so assert llms.txt
+# advertises those same per-seat prices, each BOUND TO ITS TIER LABEL on the
+# line ("Starter ($39/seat/mo)") — a membership-only check would pass a
+# Starter↔Pro price swap that merely preserves the set of price tokens.
+echo ":: Verifying apps/www/public/llms.txt base prices against the artifact..."
+ARTIFACT="apps/www/src/app/pricing/entitlements.generated.ts"
+LLMS="apps/www/public/llms.txt"
+
+# The per-column base prices live on a single generated line, e.g.
+#   selfHosted: 0, starter: 39, pro: 69, business: 149,
+# Entitlement-row cells render booleans (`starter: false`), so a numeric
+# `selfHosted: <n>` uniquely identifies the TIER_MONTHLY_PRICE values line —
+# read it once rather than grepping `<tier>: <n>` over the whole file, so the
+# read stays robust if the generator ever emits other per-column numerics.
+# `|| true` keeps the empty result from tripping `set -e`/`pipefail` so the
+# actionable -z branch below can run instead of a bare exit.
+price_line="$(grep -E 'selfHosted: [0-9]+' "$ARTIFACT" | head -n1 || true)"
+if [ -z "$price_line" ]; then
+  echo "Could not find the TIER_MONTHLY_PRICE values in $ARTIFACT — has the generated format changed?" >&2
+  exit 1
+fi
+
+# Tier key -> the capitalized label it appears under in llms.txt.
+for pair in "starter:Starter" "pro:Pro" "business:Business"; do
+  key="${pair%%:*}"
+  label="${pair##*:}"
+  price="$(printf '%s' "$price_line" | grep -oE "${key}: [0-9]+" | grep -oE '[0-9]+' || true)"
+  if [ -z "$price" ]; then
+    echo "Could not read the ${key} price from $ARTIFACT — has TIER_MONTHLY_PRICE moved?" >&2
+    exit 1
+  fi
+  # ERE: `${label} \(\$${price}/seat` → e.g. `Starter \(\$39/seat` (literal
+  # paren + dollar), binding the price to its tier label on the same line.
+  if ! grep -qE "${label} \(\\\$${price}/seat" "$LLMS"; then
+    echo "llms.txt: ${label} must advertise \$${price}/seat (from $ARTIFACT) — it has drifted from plans.ts." >&2
+    echo "Update apps/www/public/llms.txt so ${label} reads \$${price}/seat." >&2
+    exit 1
+  fi
+done
+
+echo "llms.txt base prices match the drift-checked artifact."


### PR DESCRIPTION
## Summary

The marketing site advertised **$29 / $59 / $99** per seat while the code/Stripe ladder (`plans.ts` `pricePerSeat`) charges the locked Structure B **$39 / $69 / $149** (#4034). This re-aligns every `apps/www` base-price surface to the SSOT and extends the pricing-parity drift guard so base price can't silently diverge again — the milestone's truthfulness mandate.

- **Page + landing read a generated mirror, not literals.** Added `TIER_MONTHLY_PRICE` (per-column mirror of `plans.ts` `pricePerSeat`) to the generated artifact (`apps/www/src/app/pricing/entitlements.generated.ts`); `pricing-content.tsx` and `landing/deploy.tsx` now read it. The annual toggle + "~17% saved" FAQ cascade automatically (annual = `monthlyPrice * 10`): $39→$390/yr, $69→$690/yr, $149→$1490/yr. Self-Hosted stays `null` ("Free forever").
- **Static `llms.txt` corrected** ($29/$59/$99 → $39/$69/$149) — it can't import the mirror, so the literal is fixed directly.
- **Guard extended.** `pricePerSeat` is the price SSOT; the generated mirror is verbatim-drift-checked by `scripts/check-pricing-parity.sh`, which now also asserts the static `llms.txt` prices match the artifact, **bound to each tier label** (a membership-only check would miss a Starter↔Pro swap). New unit tests (SSOT-derived + a hard-coded $39/$69/$149 oracle tripwire) and adversarial fixtures (artifact base-price regression, `llms.txt` drift, tier/price swap) cover it.

## Out of scope (tracked)

Non-`apps/www` surfaces still showing $29/$59/$99 — `apps/docs/.../billing-and-plans.mdx` (customer-facing, live-wrong), `environment-variables.mdx`, and `settings.ts` `STRIPE_*_PRICE_ID` descriptions — are a different app and tracked in **#4061** (same milestone). This PR is www-only per the issue scope.

## Note on price authority

The guard proves `page == plans.ts` (`pricePerSeat`, Atlas's internal price SSOT). It does **not** prove `plans.ts == Stripe`: the actual charge runs off the `STRIPE_*_PRICE_ID` Price objects, which are configured independently and not auto-synced. Comments are scoped accordingly.

## Test plan

- [x] `bun run lint`, `bun run type` — clean
- [x] `bun scripts/.../pricing-entitlement-artifact.test.ts` — 16 pass (incl. 3 new base-price tests)
- [x] `scripts/check-pricing-parity.sh` — green (artifact + llms.txt parity)
- [x] `scripts/__tests__/check-pricing-parity.test.sh` — 8/8 (incl. base-price regression, llms.txt drift, tier/price swap fixtures)
- [x] All `/ci` drift gates — pass
- [x] `--affected` tests green; the 3 full-suite failures are the documented `VERCEL_*`-env sandbox flake (untouched by this diff)
- [x] Internal review panel — CLEAN after 3 rounds

Closes #4060