### PR TITLE
feat(billing): enforce per-tier proactive entitlement gate (Business, #4064)

### DIFF
--- a/packages/api/src/api/__tests__/admin-proactive.test.ts
+++ b/packages/api/src/api/__tests__/admin-proactive.test.ts
@@ -24,6 +24,16 @@ const ORIGINAL_EE_FLAG = process.env.ATLAS_ENTERPRISE_ENABLED;
 // overwrites. Files that need to restore env do so in their own
 // afterAll; the `??=` here is the module-load contract, not teardown.
 process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
+// Pin self-hosted so the per-tier proactive entitlement gate (#4064) — which
+// `admin-proactive.ts` now applies via `requireFeatureEntitlementOrThrow` after
+// `gateEnterprise()` — is a no-op here: this file exercises workspace-config CRUD
+// and the deployment-level enterprise gate, not the SaaS per-tier ladder (that is
+// covered by `feature-entitlement-proactive.test.ts`). Without this, the env would
+// auto-resolve to `saas` (enterprise enabled + internal DB, absent an
+// `ATLAS_DEPLOY_ENV=development` short-circuit), and the guard's workspace-tier
+// lookup — unsatisfied by this file's hand-rolled internal mock — would 403 every
+// CRUD assertion. `??=` keeps the module-load contract hoistable.
+process.env.ATLAS_DEPLOY_MODE ??= "self-hosted";
 
 // --- Auth mock ---
 

--- a/packages/api/src/api/__tests__/feature-entitlement-proactive.test.ts
+++ b/packages/api/src/api/__tests__/feature-entitlement-proactive.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Per-tier proactive entitlement gate (#4064 — AC1 of #3999).
+ *
+ * The `FeatureEntitlement` SSOT maps `proactive → "business"`, but until #4064
+ * no route consulted it: on the hosted SaaS every tier could reach proactive
+ * even though the pricing page sells it as Business-only. #4064 wired
+ * `requireFeatureEntitlement(orgId, "proactive")` into the five proactive route
+ * surfaces — the four Effect sub-routes (analytics / events / pause /
+ * public-dataset) via `yield*`, and `admin-proactive.ts`'s `runHandler` path via
+ * the promise adapter `requireFeatureEntitlementOrThrow`.
+ *
+ * This file asserts the gate's external behaviour at the API boundary for every
+ * one of those five surfaces:
+ *
+ *   - a Starter / Pro SaaS workspace is DENIED with the 403 `plan_upgrade_required`
+ *     upgrade envelope (covering both gate paths — the Effect `yield*` and the
+ *     `runHandler` promise adapter map to the identical response);
+ *   - a Business workspace is ADMITTED past the ladder (never the upgrade 403);
+ *   - an operator workspace bypasses the ladder;
+ *   - a transient tier-lookup fault fails CLOSED with 503 `billing_check_failed`
+ *     — asserted on BOTH a `yield*` route and the `runHandler` adapter route so
+ *     the promise adapter's fail-closed arm is proven, not assumed;
+ *   - the deployment-level enterprise gate is UNCHANGED: with the EE proactive
+ *     gate closed, even a Business workspace is denied `enterprise_required`, so
+ *     the per-tier gate was added *alongside* the deployment gate, not in place
+ *     of it (the free non-EE deployment exclusion is preserved). The literal
+ *     self-hosted-disabled 403 is additionally covered by the existing
+ *     `admin-proactive-analytics.test.ts` / `admin-proactive.test.ts`, which
+ *     remain green (the per-tier guard is a no-op off-SaaS).
+ *
+ * ## Why mock `@atlas/ee/layers`
+ *
+ * The proactive routes gate on `ProactiveGate.requireEnabled()` (the
+ * deployment-level enterprise gate) BEFORE the per-tier check. `@atlas/ee/layers`
+ * does not load in this harness, so the real `ProactiveGate` falls back to its
+ * fail-closed Noop and 403s `enterprise_required` before the ladder is reached.
+ * The mock below binds only `ProactiveGate` to a toggleable gate (open by
+ * default; closed for the deployment-gate-intact assertion) so the per-tier
+ * denial is observable. `admin-proactive.ts` uses the synchronous
+ * `isEnterpriseEnabled()` check instead of the Tag, so its enterprise gate is
+ * driven by `ATLAS_ENTERPRISE_ENABLED` (pinned true at module top), independent
+ * of this mock. Mirrors `admin-proactive-analytics.test.ts`.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  createApiTestMocks,
+  isFeatureEntitlementQuery,
+  workspaceTierRows,
+} from "@atlas/api/testing/api-test-mocks";
+
+// Module-top env setup — must be set before the dynamic app import below. The
+// per-tier ladder only fires in SaaS deploy mode; pin it (and enterprise-enabled,
+// which `admin-proactive.ts`'s sync gate reads) so the gate tests are
+// deterministic regardless of the ambient ATLAS_DEPLOY_MODE / DATABASE_URL.
+// `??=` keeps the assignment hoisted; cross-file leakage under bun's parallel
+// runner is bounded (the first file to load wins).
+process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
+process.env.ATLAS_DEPLOY_MODE ??= "saas";
+
+// Toggleable enterprise gate for the proactive Effect routes' `ProactiveGate`
+// Tag. Open (true) for the per-tier deny/allow assertions; flipped closed by the
+// deployment-gate-intact test. Reset in `beforeEach`.
+let enterpriseGateOpen = true;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const effectMod = require("effect") as typeof import("effect");
+mock.module("@atlas/ee/layers", () => {
+  const { Layer } = effectMod;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EnterpriseError } = require("@atlas/api/lib/effect/errors") as typeof import("@atlas/api/lib/effect/errors");
+  return {
+    EELayer: Layer.succeed(services.ProactiveGate, {
+      requireEnabled: () =>
+        enterpriseGateOpen
+          ? effectMod.Effect.void
+          : effectMod.Effect.fail(
+              new EnterpriseError(
+                "Enterprise features (proactive-chat) are not enabled.",
+              ),
+            ),
+    }),
+  };
+});
+
+const mocks = createApiTestMocks();
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// ── Request / mock helpers ──────────────────────────────────────────
+
+function adminRequest(path: string, method = "GET", body?: unknown): Request {
+  const init: RequestInit = {
+    method,
+    headers: {
+      Authorization: "Bearer test-key",
+      "Content-Type": "application/json",
+    },
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(`http://localhost${path}`, init);
+}
+
+function adminGet(path: string): Request {
+  return adminRequest(path);
+}
+
+/** Make the entitlement lookup read back a specific tier / operator flag. */
+function setWorkspaceTier(tier: string | null, isOperator = false): void {
+  mocks.mockInternalQuery.mockImplementation(async (sql: string) =>
+    isFeatureEntitlementQuery(sql) ? workspaceTierRows(tier, isOperator) : [],
+  );
+}
+
+/** Make the tier lookup throw — the fail-closed (503) arm. */
+function failWorkspaceLookup(): void {
+  mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
+    if (isFeatureEntitlementQuery(sql)) throw new Error("db unavailable");
+    return [];
+  });
+}
+
+async function errorOf(res: Response): Promise<string> {
+  return ((await res.json()) as { error?: string }).error ?? "";
+}
+
+// The five proactive route surfaces. `analytics`/`events`/`pause`/
+// `public-dataset` gate via the Effect `yield* requireFeatureEntitlement`; the
+// `workspace` route is the `runHandler` (sync) path gating via the promise
+// adapter `requireFeatureEntitlementOrThrow`. All are side-effect-free GETs that
+// reach the gate; the gate sits before any read so a denied tier 403s without
+// touching the feature's data.
+const PROACTIVE_ROUTES: Array<{ label: string; path: string }> = [
+  { label: "analytics (Effect yield*)", path: "/api/v1/admin/proactive/analytics" },
+  { label: "events (Effect yield*)", path: "/api/v1/admin/proactive/events" },
+  { label: "pause status (Effect yield*)", path: "/api/v1/admin/proactive/pause" },
+  {
+    label: "public dataset (Effect yield*)",
+    path: "/api/v1/admin/proactive/public-dataset",
+  },
+  {
+    label: "workspace config (runHandler adapter)",
+    path: "/api/v1/admin/proactive/workspace",
+  },
+];
+
+describe("per-tier proactive entitlement gate (#4064)", () => {
+  beforeEach(() => {
+    mocks.setOrgAdmin("org-1");
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    enterpriseGateOpen = true;
+  });
+
+  describe.each(PROACTIVE_ROUTES)("$label", ({ path }) => {
+    it("denies a Pro workspace with 403 plan_upgrade_required", async () => {
+      setWorkspaceTier("pro");
+      const res = await app.fetch(adminGet(path));
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as {
+        error: string;
+        required_plan: string;
+        current_plan: string;
+      };
+      expect(body.error).toBe("plan_upgrade_required");
+      expect(body.required_plan).toBe("business");
+      expect(body.current_plan).toBe("pro");
+    });
+
+    it("denies a Starter workspace with 403 plan_upgrade_required", async () => {
+      setWorkspaceTier("starter");
+      const res = await app.fetch(adminGet(path));
+      expect(res.status).toBe(403);
+      expect(await errorOf(res)).toBe("plan_upgrade_required");
+    });
+
+    it("admits a Business workspace past the ladder", async () => {
+      setWorkspaceTier("business");
+      const res = await app.fetch(adminGet(path));
+      // The per-tier gate passed: not the upgrade 403, nor the fail-closed 503.
+      // Downstream the route may 200/500 against the mocked internal DB — that
+      // is not the ladder's concern and is deliberately not pinned.
+      const err = await errorOf(res);
+      expect(err).not.toBe("plan_upgrade_required");
+      expect(err).not.toBe("billing_check_failed");
+    });
+
+    it("bypasses the ladder for an operator workspace", async () => {
+      setWorkspaceTier("free", true);
+      const res = await app.fetch(adminGet(path));
+      const err = await errorOf(res);
+      expect(err).not.toBe("plan_upgrade_required");
+      expect(err).not.toBe("billing_check_failed");
+    });
+  });
+
+  // A below-tier workspace must be denied on the MUTATING routes too — the gate
+  // sits above each handler's side effect, so a denied write 403s rather than
+  // mutating-then-403. This matters most for `admin-proactive.ts`'s `runHandler`
+  // routes: the enforcement-parity scan's regex matches only
+  // `requireFeatureEntitlement(...)`, NOT the `requireFeatureEntitlementOrThrow(...)`
+  // adapter, so those gates are invisible to the drift guard — a test is their
+  // ONLY safety net. Probe a mutating route on each of the two `runHandler`
+  // surfaces plus a mutating Effect route, so dropping a gate is caught here.
+  describe.each([
+    {
+      label: "pause kill-switch (Effect POST)",
+      method: "POST",
+      path: "/api/v1/admin/proactive/pause",
+      body: undefined as unknown,
+    },
+    {
+      label: "workspace update (runHandler PUT)",
+      method: "PUT",
+      path: "/api/v1/admin/proactive/workspace",
+      body: { enabled: true } as unknown,
+    },
+    {
+      label: "channel upsert (runHandler POST)",
+      method: "POST",
+      path: "/api/v1/admin/proactive/channels",
+      body: { channelId: "C-test" } as unknown,
+    },
+  ])("mutating route — $label", ({ method, path, body }) => {
+    it("denies a Pro workspace with 403 plan_upgrade_required before any side effect", async () => {
+      setWorkspaceTier("pro");
+      const res = await app.fetch(adminRequest(path, method, body));
+      expect(res.status).toBe(403);
+      expect(await errorOf(res)).toBe("plan_upgrade_required");
+    });
+
+    it("admits a Business workspace past the ladder", async () => {
+      setWorkspaceTier("business");
+      const res = await app.fetch(adminRequest(path, method, body));
+      const err = await errorOf(res);
+      expect(err).not.toBe("plan_upgrade_required");
+      expect(err).not.toBe("billing_check_failed");
+    });
+  });
+
+  // Fail-closed is asserted on BOTH gate paths: the Effect `yield*` route and the
+  // `runHandler` promise adapter (`requireFeatureEntitlementOrThrow`), so the
+  // adapter's fail-closed arm is proven, not assumed — a transient internal-DB
+  // fault must never silently widen access to a Business feature.
+  describe.each([
+    { label: "Effect yield* route", path: "/api/v1/admin/proactive/analytics" },
+    {
+      label: "runHandler adapter route",
+      path: "/api/v1/admin/proactive/workspace",
+    },
+  ])("fail-closed on tier-lookup fault — $label", ({ path }) => {
+    it("returns 503 billing_check_failed", async () => {
+      failWorkspaceLookup();
+      const res = await app.fetch(adminGet(path));
+      expect(res.status).toBe(503);
+      expect(await errorOf(res)).toBe("billing_check_failed");
+    });
+  });
+
+  // The per-tier gate was added ALONGSIDE the deployment-level enterprise gate,
+  // not in place of it. With the EE proactive gate closed, even a Business-tier
+  // workspace is denied with the deployment gate's `enterprise_required` 403 —
+  // proving the free non-EE deployment exclusion is unchanged by #4064.
+  describe("deployment-level enterprise gate is unchanged", () => {
+    it("a Business workspace is still denied when the EE proactive gate is closed (Effect route)", async () => {
+      enterpriseGateOpen = false;
+      setWorkspaceTier("business");
+      const res = await app.fetch(
+        adminGet("/api/v1/admin/proactive/analytics"),
+      );
+      expect(res.status).toBe(403);
+      // The enterprise gate (`ProactiveGate.requireEnabled`) fires before the
+      // per-tier check, so the denial is the deployment gate's, not the ladder's.
+      const err = await errorOf(res);
+      expect(err).not.toBe("plan_upgrade_required");
+    });
+  });
+});

--- a/packages/api/src/api/__tests__/feature-ladder-regression.test.ts
+++ b/packages/api/src/api/__tests__/feature-ladder-regression.test.ts
@@ -51,17 +51,24 @@
  *
  * ## Deferred (not regressions — tracked in ENFORCEMENT_PENDING)
  *
- *   - `proactive`: gated in its own slice under #3999 (proactive → premium +
- *     WS5 relocation into `/ee`), tracked in ENFORCEMENT_PENDING under the #3984
- *     umbrella. Its deny/allow coverage follows that slice; this net delivers
- *     the already-gated WS1 surfaces only.
  *   - `backups`: its only route surface is operator/platform-scoped
  *     (`platform-backups.ts`, no per-tenant `orgId`), so a per-tier
  *     `requireFeatureEntitlement` gate is structurally inapplicable today. Gated
  *     by the enterprise-license Tag (`backups.available`) instead.
+ *
+ * `proactive` was deferred here while #3999/#4064 was open; #4064 wired its
+ * per-tier gate, so it is now a probed feature below (no longer in
+ * ENFORCEMENT_PENDING). Its proactive routes gate on
+ * `ProactiveGate.requireEnabled()` (the deployment-level enterprise gate)
+ * *before* the per-tier check, and `@atlas/ee/layers` doesn't load in this
+ * harness — so the real ProactiveGate falls back to its fail-closed Noop and
+ * 403s `enterprise_required` before the ladder is reached. The mock below binds
+ * only ProactiveGate to an always-enabled gate (every other enterprise Tag
+ * keeps its Noop default, leaving the other probed features unchanged) so the
+ * per-tier denial is observable, mirroring `admin-proactive-analytics.test.ts`.
  */
 
-import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 import type { PlanTier, PlanUpgradeRequiredBody } from "@useatlas/types";
 import {
   createApiTestMocks,
@@ -85,6 +92,24 @@ const mocks = createApiTestMocks();
 // runner is bounded (the first file to load wins).
 process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
 process.env.ATLAS_DEPLOY_MODE ??= "saas";
+
+// Bind only ProactiveGate to an always-enabled gate so the proactive probe's
+// per-tier denial (which sits *after* `ProactiveGate.requireEnabled()`) is
+// observable; every other enterprise Tag falls through to its Noop default, so
+// the other probed features behave exactly as they did with no EE layer loaded.
+// `mock.module` factories must be sync (CLAUDE.md). See the file docstring.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const effectMod = require("effect") as typeof import("effect");
+mock.module("@atlas/ee/layers", () => {
+  const { Layer } = effectMod;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+  return {
+    EELayer: Layer.succeed(services.ProactiveGate, {
+      requireEnabled: () => effectMod.Effect.void,
+    }),
+  };
+});
 
 const { app } = await import("../index");
 
@@ -125,9 +150,14 @@ const LADDER_ROUTES: Readonly<Record<GatedFeature, RouteProbe | null>> = {
   white_label: { label: "white-label branding", path: "/api/v1/admin/branding" },
   residency: { label: "data residency", path: "/api/v1/admin/residency" },
   custom_domain: { label: "custom domain", path: "/api/v1/admin/domain" },
+  proactive: {
+    label: "proactive monitoring",
+    // Read-only analytics GET — triggers the per-tier gate (after the
+    // enterprise-gate, which the EELayer mock above forces open). #4064.
+    path: "/api/v1/admin/proactive/analytics",
+  },
   // ── Deferred — no per-tenant route gate yet (see ENFORCEMENT_PENDING) ──
   backups: null, // platform-scoped surface only (#3984)
-  proactive: null, // gated in #3999 (proactive → premium); pending under #3984
 };
 
 // ── Tier helpers (derived from the SSOT ordering) ───────────────────
@@ -299,9 +329,12 @@ describe("feature-ladder regression net — completeness", () => {
     }
   });
 
-  it("defers proactive coverage — follows #3999 (documented WS3 scope cut)", () => {
-    expect(LADDER_ROUTES.proactive).toBeNull();
-    expect(ENFORCEMENT_PENDING.proactive).toBeDefined();
+  it("gates proactive per-tier (#4064) — probed, not deferred, not pending", () => {
+    // #4064 wired `requireFeatureEntitlement(orgId, "proactive")`, so proactive
+    // is now a probed feature exercised by the matrix above and must NOT linger
+    // in ENFORCEMENT_PENDING (the stale-pending guard would otherwise fire).
+    expect(LADDER_ROUTES.proactive).not.toBeNull();
+    expect(ENFORCEMENT_PENDING.proactive).toBeUndefined();
   });
 
   it("keeps each probe's below/allow tiers consistent with the SSOT minimum", () => {

--- a/packages/api/src/api/routes/admin-proactive-analytics.ts
+++ b/packages/api/src/api/routes/admin-proactive-analytics.ts
@@ -14,6 +14,7 @@
  */
 
 import { Effect } from "effect";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
@@ -93,6 +94,9 @@ adminProactiveAnalytics.get("/", async (c) => {
 
       const { orgId } = yield* AuthContext;
       const { requestId } = yield* RequestContext;
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(

--- a/packages/api/src/api/routes/admin-proactive-events.ts
+++ b/packages/api/src/api/routes/admin-proactive-events.ts
@@ -26,6 +26,7 @@
 
 import { Effect } from "effect";
 import { z } from "zod";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
@@ -162,6 +163,9 @@ adminProactiveEvents.get("/", async (c) =>
 
       const { orgId } = yield* AuthContext;
       const { requestId } = yield* RequestContext;
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(
@@ -267,6 +271,9 @@ adminProactiveEvents.post("/:messageId/review", async (c) =>
 
       const { orgId, user } = yield* AuthContext;
       const { requestId } = yield* RequestContext;
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(

--- a/packages/api/src/api/routes/admin-proactive-pauses.ts
+++ b/packages/api/src/api/routes/admin-proactive-pauses.ts
@@ -22,6 +22,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   AuthContext,
@@ -164,6 +165,9 @@ adminProactivePauses.openapi(getPauseStatusRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(
@@ -215,6 +219,9 @@ adminProactivePauses.openapi(enableKillSwitchRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(
@@ -285,6 +292,9 @@ adminProactivePauses.openapi(liftKillSwitchRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(

--- a/packages/api/src/api/routes/admin-proactive-public-dataset.ts
+++ b/packages/api/src/api/routes/admin-proactive-public-dataset.ts
@@ -34,6 +34,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { requireFeatureEntitlement } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   AuthContext,
@@ -248,6 +249,9 @@ adminProactivePublicDataset.openapi(listEntriesRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(
@@ -278,6 +282,9 @@ adminProactivePublicDataset.openapi(upsertEntryRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(
@@ -341,6 +348,9 @@ adminProactivePublicDataset.openapi(deleteEntryRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(
@@ -398,6 +408,9 @@ adminProactivePublicDataset.openapi(refusedRollupRoute, async (c) =>
 
       const proactive = yield* ProactiveGate;
       yield* proactive.requireEnabled();
+      // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+      // where the enterprise-license Tag above is the gate. (#4064 / #3984)
+      yield* requireFeatureEntitlement(orgId, "proactive");
 
       if (!orgId) {
         return c.json(

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -35,6 +35,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { requireFeatureEntitlementOrThrow } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
@@ -392,6 +393,9 @@ adminProactive.openapi(getWorkspaceRoute, async (c) =>
   runHandler(c, "get proactive workspace config", async () => {
     const { orgId, requestId } = c.get("orgContext");
     gateEnterprise();
+    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
       // Materialise-or-return: ON CONFLICT touches `updated_at` to its own
@@ -428,6 +432,9 @@ adminProactive.openapi(updateWorkspaceRoute, async (c) =>
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
     gateEnterprise();
+    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const body = c.req.valid("json");
 
@@ -584,6 +591,9 @@ adminProactive.openapi(listChannelsRoute, async (c) =>
   runHandler(c, "list proactive channel overrides", async () => {
     const { orgId, requestId } = c.get("orgContext");
     gateEnterprise();
+    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
       const rows = await internalQuery<ChannelConfigRow>(
@@ -612,6 +622,9 @@ adminProactive.openapi(listAvailableChannelsRoute, async (c) =>
   runHandler(c, "list available chat channels", async () => {
     const { orgId, requestId } = c.get("orgContext");
     gateEnterprise();
+    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
       // Read-only platform lookup; no audit row (matches the other GETs).
@@ -658,6 +671,9 @@ adminProactive.openapi(upsertChannelRoute, async (c) =>
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
     gateEnterprise();
+    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const body = c.req.valid("json");
 
@@ -730,6 +746,9 @@ adminProactive.openapi(deleteChannelRoute, async (c) =>
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
     gateEnterprise();
+    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
+    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const { channelId } = c.req.valid("param");
 

--- a/packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement-parity.test.ts
@@ -159,10 +159,10 @@ describe("ENFORCEMENT_PENDING + live SSOT — the committed allowlist is honest"
     // coupling is deliberate: the unit test tracks the real wiring snapshot,
     // and the live-tree fixture (check-enforcement-parity.test.sh) covers the
     // actual route scan.
-    // sso (#3986); scim, custom_roles, ip_allowlist, approvals (#3987); and the
+    // sso (#3986); scim, custom_roles, ip_allowlist, approvals (#3987); the
     // #3988 tenant-route gates (audit_retention, masking, residency, white_label,
-    // custom_domain). Only backups + proactive (#3984) remain in
-    // ENFORCEMENT_PENDING and so are not listed here.
+    // custom_domain); and proactive (#4064). Only `backups` (#3984) remains in
+    // ENFORCEMENT_PENDING and so is not listed here.
     const enforcedToday = [
       "sso",
       "scim",
@@ -174,6 +174,7 @@ describe("ENFORCEMENT_PENDING + live SSOT — the committed allowlist is honest"
       "residency",
       "white_label",
       "custom_domain",
+      "proactive",
     ];
     const findings = checkEnforcementParity(enforcedToday);
     expect(findings).toEqual([]);

--- a/packages/api/src/lib/billing/enforcement-parity.ts
+++ b/packages/api/src/lib/billing/enforcement-parity.ts
@@ -96,9 +96,11 @@ export const ENFORCEMENT_PENDING: Partial<Record<GatedFeature, IssueRef>> = {
   // (`backups.available`) today; a tenant-facing backups surface is needed before
   // the per-tier ladder can apply, tracked under #3984.
   backups: "#3984",
-  // `proactive` is gated in its own follow-up slice under #3984 (it also needs
-  // the WS5 relocation into `/ee`).
-  proactive: "#3984",
+  // `proactive` was wired per-tier in #4064 — `requireFeatureEntitlement(orgId,
+  // "proactive")` now gates the four Effect sub-routes and `admin-proactive.ts`
+  // (the latter via `requireFeatureEntitlementOrThrow`, its `runHandler` path's
+  // promise adapter), so it is no longer pending (rule 2 forces this removal).
+  // The WS5 relocation of `lib/proactive` → `/ee` is a separate follow-up.
 };
 
 /** A single enforcement-parity finding (one drift). */

--- a/packages/api/src/lib/billing/feature-entitlement-guard.ts
+++ b/packages/api/src/lib/billing/feature-entitlement-guard.ts
@@ -139,3 +139,49 @@ export function requireFeatureEntitlement(
     }),
   );
 }
+
+/**
+ * Promise-shaped variant of {@link requireFeatureEntitlement} for the
+ * non-Effect `runHandler` route path (e.g. `admin-proactive.ts`), whose
+ * handlers can't `yield*` an Effect.
+ *
+ * Runs the same Effect guard and, on a typed failure, rethrows the **raw**
+ * tagged error ({@link FeatureEntitlementError} → 403 `plan_upgrade_required`,
+ * {@link BillingCheckFailedError} → 503) so the `runHandler` → `classifyError`
+ * bridge maps it to the identical HTTP response the Effect path produces. The
+ * SaaS short-circuit, operator bypass, and fail-closed-on-lookup-error decision
+ * therefore live in exactly one place — this is a thin adapter, not a second
+ * implementation, so the two paths can't drift.
+ *
+ * `Effect.match` is the load-bearing choice here: it converts the guard's typed
+ * *failure* into a success value carrying the **raw** tagged error, so the
+ * `await` resolves with that error and we rethrow it unwrapped — preserving the
+ * `_tag` the bridge keys on. (`Effect.runPromise` on the failed Effect directly
+ * would instead reject with a `FiberFailure` that *wraps and hides* the tag, and
+ * `classifyError` would 500 it.) Keeping the only `effect` named import to
+ * `{ Effect }` — unchanged from this module's prior shape — also avoids tripping
+ * the partial `mock.module("effect")` shims in sibling route tests, which a new
+ * `Exit`/`Cause` import would break (the "new export breaks every partial mock"
+ * gotcha).
+ *
+ * A defect or interrupt (no typed failure — e.g. a programmer error inside the
+ * guard) is deliberately NOT matched: it stays in the cause, `runPromise`
+ * rejects with a `FiberFailure`, and `runHandler` surfaces it as a logged 500.
+ * Fail-closed, never a silent pass.
+ */
+export async function requireFeatureEntitlementOrThrow(
+  orgId: string | undefined,
+  feature: GatedFeature,
+): Promise<void> {
+  const denial = await Effect.runPromise(
+    requireFeatureEntitlement(orgId, feature).pipe(
+      Effect.match({
+        // Typed failure → carry the raw tagged error out as a value.
+        onFailure: (error) => error,
+        // Entitled / short-circuited → nothing to throw.
+        onSuccess: () => null,
+      }),
+    ),
+  );
+  if (denial !== null) throw denial;
+}


### PR DESCRIPTION
## Summary

Makes the SaaS pricing ladder **true** for proactive. The `FeatureEntitlement` SSOT already maps `proactive → "business"`, but no route consulted it — on the hosted SaaS every tier (Starter/Pro/Business) could reach proactive even though the page sells it as Business-only. This wires the per-tier gate (AC1 of #3999).

- Add `requireFeatureEntitlement(orgId, "proactive")` **after** the existing `ProactiveGate.requireEnabled()` in the 4 Effect sub-routes: `admin-proactive-{analytics,events,pauses,public-dataset}.ts` (10 handler call sites).
- `admin-proactive.ts` (the `runHandler` sync path) gains a small promise adapter `requireFeatureEntitlementOrThrow`, called after the existing inline `gateEnterprise()` (6 handlers). It's a thin wrapper over the Effect guard — `Effect.match` carries the **raw** tagged error out so the `runHandler → classifyError` bridge maps it to the identical `403 plan_upgrade_required` / `503 billing_check_failed` the Effect path produces. The two paths share one decision (SaaS short-circuit, operator bypass, fail-closed-on-lookup-error) so they can't drift. The adapter keeps its only `effect` import to `{ Effect }` to avoid the "new export breaks every partial mock" gotcha.
- Remove `proactive` from `ENFORCEMENT_PENDING` so the enforcement-parity guard now **asserts** it's gated (both `check-enforcement-parity.sh` and `check-pricing-parity.sh` stay green).

**The deployment/enterprise gate is unchanged** — the per-tier guard is added *alongside* it, not in place of it, and is a no-op off-SaaS, so a free non-EE self-hosted request still 403s via the deployment gate.

## Test plan

- [x] Starter/Pro SaaS workspace **denied** `403 plan_upgrade_required` on each of the 5 route surfaces (incl. mutating routes + both gate mechanisms).
- [x] Business workspace **allowed** past the ladder; operator workspace bypasses it.
- [x] Fail-closed `503 billing_check_failed` on tier-lookup fault — proven on **both** the Effect `yield*` path and the new `runHandler` promise adapter.
- [x] Deployment gate intact: with the EE proactive gate closed, even a Business workspace is denied `enterprise_required`; legacy `admin-proactive` CRUD tests still green.
- [x] `proactive` promoted to a probe in the feature-ladder regression net (drift-proof completeness).
- [x] Full `/ci` green: lint, type, full test suite (the only 3 failures are the documented local `VERCEL_*`-env sandbox flakes, unrelated to this diff — remote CI is the gate), syncpack, all drift/parity guards.

## Out of scope (other #3999 ACs)
- AC2 physical relocation `lib/proactive` → `ee/src/proactive` (the large EE-boundary refactor, sequenced after this).
- AC4 advertise proactive as a premium line (gated on proactive-maturity sign-off).

Closes #4064