### PR TITLE
docs(marketing): lead public headlines with the run-anywhere analyst anchor (SQL + REST, #4070)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Atlas</h1>
 
 <p align="center">
-  Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
+  Atlas is the AI data analyst you can run anywhere. It answers plain-English questions across your SQL warehouses and REST APIs, grounded in a YAML semantic layer that humans author and AI agents consume.
 </p>
 
 <p align="center">

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Atlas
-description: Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
+description: Atlas is the AI data analyst you can run anywhere. It answers plain-English questions across your SQL warehouses and REST APIs, grounded in a YAML semantic layer that humans author and AI agents consume.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -9,7 +9,7 @@ import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 Ask questions of your data in plain English. Atlas is the trust layer between your business questions and your data — SQL warehouses or REST/OpenAPI services — agent-native, YAML-defined, deploy-anywhere.
 
-> Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
+> Atlas is the AI data analyst you can run anywhere. It answers plain-English questions across your SQL warehouses and REST APIs, grounded in a YAML semantic layer that humans author and AI agents consume.
 
 ## Pick your path
 

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -18,7 +18,7 @@ const jetbrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "Atlas — Ask your data anything, trust the answer.",
   description:
-    "Atlas is an AI data analyst that turns plain-English questions into safe, validated SQL, grounded in a semantic layer you control. Run it in the cloud or self-host it — open source.",
+    "Atlas is the AI data analyst you can run anywhere. It answers plain-English questions across your SQL warehouses and REST APIs, grounded in a semantic layer you control. Run it in the cloud or self-host it — open source.",
   openGraph: {
     title: "Atlas — Ask your data anything, trust the answer.",
     description:
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Atlas — Ask your data anything, trust the answer.",
     description:
-      "Plain-English questions, safe validated SQL, grounded in a semantic layer you control. Cloud or self-hosted, open source.",
+      "Plain-English questions answered across your SQL warehouses and REST APIs, grounded in a semantic layer you control. Cloud or self-hosted, open source.",
     images: ["/og.png"],
   },
 };

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -6,7 +6,7 @@ const HEADLINE_LINES = ["Ask your data anything.", "Trust the answer."] as const
 const ITALIC_LINE_INDEX = 1;
 
 const SUBHEAD =
-  "Atlas is an AI data analyst that turns plain-English questions into safe, validated SQL, grounded in a semantic layer you control.";
+  "Atlas is an AI data analyst you can run anywhere. It turns plain-English questions into trustworthy answers across your SQL warehouses and REST APIs, grounded in a semantic layer you control.";
 
 /**
  * The hero's payload: a plain-English question and the validated answer it

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -6,7 +6,7 @@ const HEADLINE_LINES = ["Ask your data anything.", "Trust the answer."] as const
 const ITALIC_LINE_INDEX = 1;
 
 const SUBHEAD =
-  "Atlas is an AI data analyst you can run anywhere. It turns plain-English questions into trustworthy answers across your SQL warehouses and REST APIs, grounded in a semantic layer you control.";
+  "Atlas is the AI data analyst you can run anywhere. It turns plain-English questions into trustworthy answers across your SQL warehouses and REST APIs, grounded in a semantic layer you control.";
 
 /**
  * The hero's payload: a plain-English question and the validated answer it


### PR DESCRIPTION
## What

Standardizes the public headline framing on the category anchor — **"the AI data analyst you can run anywhere"** — reflecting answers across **SQL warehouses *and* REST/OpenAPI sources**, while keeping the **YAML semantic layer** as the stated differentiator. Text-to-SQL is one capability, not the identity.

Implements the drafted copy from #4070 faithfully.

## Changes
- **`README.md:4`** hero — anchor-led one-liner (was the moat-leading "YAML-defined semantic layer for analytics …").
- **`apps/docs/content/docs/index.mdx`** — frontmatter `description` (SEO/social lead) + the intro blockquote both lead with the anchor and SQL + REST scope.
- **`apps/www/src/components/landing/hero.tsx`** `SUBHEAD` — "an AI data analyst you can run anywhere … answers across your SQL warehouses and REST APIs, grounded in a semantic layer you control."
- **`apps/www/src/app/layout.tsx`** — meta `description` + `twitter.description` aligned with the new anchor + SQL/REST scope (the `openGraph` validator-stat hook is intentionally left intact).

## Out of scope (deliberately narrow)
- README mechanism/body copy (`:25`, `:51`, `:205`), the `:130` competitor-category table header, and `apps/www/public/llms.txt` — SQL-pipeline copy / datasource lists owned by sibling batch workers; left untouched to avoid collisions.

## Verification
- `apps/www` build: pass. `apps/docs` build: pass.
- Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy): **CLEAN** — pure copy change, no error/type/test/comment surface.
- Local gates: lint, type, syncpack, all drift/guard checks — pass. No test imports the 4 changed files (`--affected` empty).

## ⚠ Brand-visible copy
Hero wording is brand-facing; per #4070 it requires human sign-off on the exact final wording before merge.

Closes #4070