### PR TITLE
docs: list Elasticsearch in supported-datasource enumerations (#4067)

### DIFF
--- a/apps/docs/content/docs/getting-started/connect-your-data.mdx
+++ b/apps/docs/content/docs/getting-started/connect-your-data.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect Your Data
-description: Connect Atlas to PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB, Salesforce, or any REST/OpenAPI service (Stripe, GitHub, Notion, Twenty).
+description: Connect Atlas to PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB, Elasticsearch, Salesforce, or any REST/OpenAPI service (Stripe, GitHub, Notion, Twenty).
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -8,7 +8,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
-Atlas is a semantic layer for any query layer — SQL warehouses **and** REST/OpenAPI services — answered through one model and one safety pipeline. Atlas has built-in support for **PostgreSQL** and **MySQL**. Additional SQL datasources — **BigQuery**, **ClickHouse**, **Snowflake**, **DuckDB** (CSV/Parquet), and **Salesforce** — are available as plugins.
+Atlas is a semantic layer for any query layer — SQL warehouses **and** REST/OpenAPI services — answered through one model and one safety pipeline. Atlas has built-in support for **PostgreSQL** and **MySQL**. Additional SQL datasources — **BigQuery**, **ClickHouse**, **Snowflake**, **DuckDB** (CSV/Parquet), **[Elasticsearch / OpenSearch](/plugins/datasources/elasticsearch)**, and **Salesforce** — are available as plugins.
 
 You can also connect any **REST API with an OpenAPI 3.x spec** — **Stripe**, **GitHub**, **Notion**, **Twenty**, or your own service. The agent reads the spec into an operation graph and calls operations through the `executeRestOperation` tool, under the same read-only-by-default safety model as SQL. See the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) guide, or jump to [REST & OpenAPI APIs](#rest--openapi-apis) below.
 
@@ -830,6 +830,7 @@ Non-SELECT SQL (INSERT, UPDATE, DELETE, DROP, etc.) is always rejected. There is
 | ClickHouse | SQL validation + `readonly: 1` per-query setting |
 | Snowflake | SQL validation (use a SELECT-only role for defense-in-depth) |
 | DuckDB | SQL validation + `READ_ONLY` open mode |
+| [Elasticsearch](/plugins/datasources/elasticsearch) | SQL validation + Query DSL default-deny validator |
 | Salesforce | SOQL is inherently read-only |
 
 ### Recommended production settings

--- a/apps/docs/content/docs/getting-started/hosted.mdx
+++ b/apps/docs/content/docs/getting-started/hosted.mdx
@@ -69,7 +69,7 @@ FLUSH PRIVILEGES;
 Atlas enforces SELECT-only queries at the application level, but a read-only user provides defense-in-depth.
 
 <Callout type="info">
-For BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce, see the database-specific setup in [Connect Your Data](/getting-started/connect-your-data). The database preparation steps (creating users, granting permissions) apply to all deployment modes. To connect a REST API instead — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service — see the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic); add it from **Admin &gt; Connections** (a credential for pre-wired vendors, or a spec URL plus credential for any other API).
+For BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce, see the database-specific setup in [Connect Your Data](/getting-started/connect-your-data); for Elasticsearch / OpenSearch, see the [Elasticsearch datasource guide](/plugins/datasources/elasticsearch). The database preparation steps (creating users, granting permissions) apply to all deployment modes. To connect a REST API instead — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service — see the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic); add it from **Admin &gt; Connections** (a credential for pre-wired vendors, or a spec URL plus credential for any other API).
 </Callout>
 </Step>
 
@@ -186,7 +186,7 @@ Atlas connects to your database over the network and runs read-only queries. Que
 Yes. Your semantic layer (entity definitions, metrics, glossary) can be exported as YAML files for a self-hosted deployment. See the [Migration](/guides/migration) guide for step-by-step instructions.
 </Accordion>
 <Accordion title="What databases are supported?">
-PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB (CSV/Parquet), and Salesforce. PostgreSQL and MySQL are built-in; others are available as plugins from the [Plugin Marketplace](/guides/plugin-marketplace).
+PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB (CSV/Parquet), Elasticsearch, and Salesforce. PostgreSQL and MySQL are built-in; others are available as plugins from the [Plugin Marketplace](/guides/plugin-marketplace).
 
 Atlas is not limited to SQL — you can also connect any **REST API with an OpenAPI 3.x spec** (Stripe, GitHub, Notion, Twenty, or your own service) via the built-in [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic). The agent queries it through the `executeRestOperation` tool under the same read-only-by-default safety model.
 </Accordion>


### PR DESCRIPTION
## Summary
- Elasticsearch (`@useatlas/elasticsearch`) ships as a datasource but was missing from the supported-datasource lists in the getting-started docs. This adds it so the canonical set is consistent across docs + README + site.
- **`connect-your-data.mdx`** — added Elasticsearch to the frontmatter `description`, the "Additional SQL datasources" intro list (linked to the dedicated plugin guide), and the read-only-enforcement table (linked, since it's the one datasource whose setup lives off-page).
- **`hosted.mdx`** — added Elasticsearch to the per-datasource setup callout (routed to the Elasticsearch guide rather than Connect Your Data, which doesn't walk through ES setup) and the "What databases are supported?" FAQ.

## Audit of the surfaces named in the issue
- `connect-your-data.mdx` — fixed (was missing ES).
- `hosted.mdx` — fixed (was missing ES).
- `plugins/datasources/index.mdx` — already enumerates Elasticsearch (cards + comparison table). No change.
- `integrations/admin-console.mdx` — already enumerates Elasticsearch / OpenSearch. No change.
- `README.md` datasource lines — already list Elasticsearch in canonical order (lines 29, 138). No change.

Canonical set now consistent: PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch, Salesforce + REST/OpenAPI.

## Test plan
- [x] `apps/docs` builds clean (`bun run build` — 1916 static pages, compiled successfully).
- [x] New `/plugins/datasources/elasticsearch` link resolves to the existing dedicated page.
- [x] Read-only-enforcement wording ("SQL validation + Query DSL default-deny validator") matches `plugins/datasources/index.mdx` and the dedicated ES page.
- [x] Internal review panel: CLEAN. lint, type, `--affected` tests: all pass.

Closes #4067