### PR TITLE
docs(site): standardize SQL-validation copy to canonical 7-layer pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ docker compose up
 
 1. User (or agent) asks a natural language question — over MCP, the chat widget, the API, Slack, or Teams
 2. Agent explores the **YAML semantic layer** — entities, glossary, metrics, query patterns
-3. Agent writes SQL, validated through a multi-layer security pipeline (regex guard, AST parse, table whitelist, auto-LIMIT, statement timeout)
+3. Agent writes SQL, validated through a 7-layer security pipeline (empty check, regex guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout)
 4. Results are returned with charts and an interpreted narrative
 
 ```
-Question → YAML semantic layer → SQL generation → Multi-layer validation → Query execution → Charts + narrative
+Question → YAML semantic layer → SQL generation → 7-layer validation → Query execution → Charts + narrative
 ```
 
 ### Generate the semantic layer

--- a/apps/docs/content/docs/architecture/mcp-performance.mdx
+++ b/apps/docs/content/docs/architecture/mcp-performance.mdx
@@ -88,7 +88,7 @@ For each scenario, the bottleneck order is:
 
 4. **OAuth verify (`verifyAccessToken`)** — local JWT signature check against a cached JWKS. Confirmed ~negligible — even at 1k frames/s, this is well under 1% of CPU. The audit attribution `azp` claim (issue [#2067](https://github.com/AtlasDevHQ/atlas/issues/2067), shipped in [#2101](https://github.com/AtlasDevHQ/atlas/pull/2101)) lives here; an extra `O(1)` map read.
 
-5. **SQL validation** — the four-layer guard in [`packages/api/src/lib/tools/sql.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/sql.ts) (`validateSQL`: regex mutation guard → AST parse → semantic-layer table whitelist → connection-id binding). Per-call cost is sub-millisecond on typical queries; even at 1k frames/s with 60% SQL share this is under 5% of CPU.
+5. **SQL validation** — the four-check `validateSQL` guard in [`packages/api/src/lib/tools/sql.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/sql.ts) (empty check → regex mutation guard → AST parse → connection-scoped table whitelist) — the pre-execution validation stage, canonical layers 0–3; the full runtime pipeline adds RLS injection, auto-LIMIT, and a statement timeout for 7 layers in total. Per-call cost is sub-millisecond on typical queries; even at 1k frames/s with 60% SQL share this is under 5% of CPU.
 
 6. **LLM provider latency (when in the loop)** — not exercised by these scripts. Hosted MCP is dispatch-only; the model lives in the calling agent (Claude Desktop, Cursor, etc.). Provider latency contributes to the **agent's** time-to-answer, not the hosted endpoint's tool-dispatch latency. Observe via OTel spans from [#2029](https://github.com/AtlasDevHQ/atlas/issues/2029).
 

--- a/apps/docs/content/docs/architecture/mcp-tool-annotations.mdx
+++ b/apps/docs/content/docs/architecture/mcp-tool-annotations.mdx
@@ -36,7 +36,7 @@ Catalog forms also ask for short / long descriptions of the server itself. These
 - **Tagline alternates (in case 80 chars is too long for the field):**
   - *Natural-language data analyst. Semantic layer + validated SQL.* (60 chars)
   - *Text-to-SQL that respects your schema, glossary, and metrics.* (60 chars)
-- **Long (200–300 words):** Lead with the moat (semantic layer + 4-layer SQL validation prevents the agent from hallucinating tables, joining wrong, or running unbounded scans). Explain what an agent gets when it connects: typed tools that read the catalog, fetch entity definitions, disambiguate domain terms, and run pre-defined metrics. Close with the install command for whichever surface the catalog targets — `bunx @useatlas/mcp init --hosted` for the SaaS, or the stdio `claude_desktop_config.json` snippet for self-hosted.
+- **Long (200–300 words):** Lead with the moat (semantic layer + 7-layer SQL validation prevents the agent from hallucinating tables, joining wrong, or running unbounded scans). Explain what an agent gets when it connects: typed tools that read the catalog, fetch entity definitions, disambiguate domain terms, and run pre-defined metrics. Close with the install command for whichever surface the catalog targets — `bunx @useatlas/mcp init --hosted` for the SaaS, or the stdio `claude_desktop_config.json` snippet for self-hosted.
 
 ## How this maps to the LLM-facing rubric
 

--- a/apps/docs/content/docs/comparisons/vanna.mdx
+++ b/apps/docs/content/docs/comparisons/vanna.mdx
@@ -51,7 +51,7 @@ Atlas also learns from usage, but through a different mechanism: `atlas learn` r
 
 Atlas enforces read-only access through a [7-layer SQL validation pipeline](/security/sql-validation): empty check, regex mutation guard, AST parsing (single SELECT only), table whitelist (only semantic layer entities), RLS injection, auto LIMIT, and statement timeout.
 
-Vanna v2.0 added parameterized queries and row-level security, but does not include multi-layer SQL validation. The generated SQL is passed to your database connection with basic guardrails. You're responsible for adding additional protections -- read-only database users, mutation guards, and timeout enforcement.
+Vanna v2.0 added parameterized queries and row-level security, but does not include a 7-layer SQL validation pipeline. The generated SQL is passed to your database connection with basic guardrails. You're responsible for adding additional protections -- read-only database users, mutation guards, and timeout enforcement.
 
 <Callout type="warn">
   If you use Vanna in production, ensure your database connection uses a read-only user and implement your own query validation layer.

--- a/apps/docs/content/docs/getting-started/connect-your-data.mdx
+++ b/apps/docs/content/docs/getting-started/connect-your-data.mdx
@@ -32,7 +32,7 @@ Pick your database below and follow the steps. Each section is self-contained. F
 <Step>
 ### Create a read-only PostgreSQL user
 
-Atlas enforces SELECT-only via a multi-layer SQL validation pipeline. For defense-in-depth, connect with a read-only user:
+Atlas enforces SELECT-only via a 7-layer SQL validation pipeline. For defense-in-depth, connect with a read-only user:
 
 ```sql
 CREATE USER atlas_reader WITH PASSWORD 'your-strong-password';

--- a/apps/docs/content/docs/guides/approval-workflows.mdx
+++ b/apps/docs/content/docs/guides/approval-workflows.mdx
@@ -27,7 +27,7 @@ When a user runs a query, the SQL validation pipeline checks the query against a
 ### Flow
 
 1. User submits a query via the chat agent
-2. SQL passes validation (4-layer pipeline)
+2. SQL passes pre-execution validation (the four `validateSQL` checks — empty check, regex guard, AST parse, table whitelist)
 3. Approval rules are checked against the validated query's tables and columns
 4. If a rule matches: query is queued and the agent tells the user approval is required
 5. An admin reviews the request in the admin console (or via API)

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -6,7 +6,7 @@ description: Connect Claude Desktop, Claude Code, Cursor, Continue, ChatGPT, or 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-Atlas exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets any MCP-compatible agent — Claude Desktop, Claude Code, Cursor, Continue, ChatGPT, VS Code — query your data through Atlas's semantic layer and validated SQL pipeline. The agent reads your entity YAMLs, picks the right tables, writes a query, and Atlas runs it through the same 4-layer SQL validation, RLS, and audit pipeline as the chat UI.
+Atlas exposes a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets any MCP-compatible agent — Claude Desktop, Claude Code, Cursor, Continue, ChatGPT, VS Code — query your data through Atlas's semantic layer and validated SQL pipeline. The agent reads your entity YAMLs, picks the right tables, writes a query, and Atlas runs it through the same 7-layer SQL validation pipeline (which includes RLS injection) and audit logging as the chat UI.
 
 There are two ways to run the server. **Hosted** (`mcp.useatlas.dev`) speaks Streamable HTTP with OAuth 2.1 + Dynamic Client Registration + PKCE — the standard MCP authorization flow that Claude Desktop, ChatGPT, and Cursor implement out of the box. **Self-hosted** runs as a local stdio process pointed at your own datasource and inherits whatever shell/env you launch it under. Same agent, same tools, same semantic layer — different transport and identity model.
 
@@ -487,7 +487,7 @@ When a returned term has `status: "ambiguous"`, `searchGlossary` returns an `amb
 
 ### runMetric
 
-Execute a canonical metric defined under `semantic/metrics/`. Looks the metric up by `id`, runs its authoritative SQL through the **same** pipeline as `executeSQL` (4-layer validation, RLS injection, auto-LIMIT, statement timeout, audit logging), and returns the result.
+Execute a canonical metric defined under `semantic/metrics/`. Looks the metric up by `id`, runs its authoritative SQL through the **same** 7-layer pipeline as `executeSQL` (empty check, regex guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout) plus audit logging, and returns the result.
 
 ```
 id: "orders_count"

--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -840,7 +840,7 @@ dialect: "This datasource uses ClickHouse. Use toStartOfMonth() for date truncat
 
 ### `connection.validate` — Custom Query Validation
 
-Replace the standard SQL validation pipeline with a custom validator. Use this when your datasource speaks a non-SQL query language -- SOQL, GraphQL, MQL, or any custom query DSL where the standard 4-layer SQL validation (empty check, regex guard, AST parse, table whitelist) does not apply.
+Replace the standard SQL validation pipeline with a custom validator. Use this when your datasource speaks a non-SQL query language -- SOQL, GraphQL, MQL, or any custom query DSL where the standard pre-execution SQL validation stage -- the four `validateSQL` checks (empty check, regex guard, AST parse, table whitelist), not the full 7-layer pipeline -- does not apply.
 
 **Signature:**
 

--- a/apps/docs/content/docs/plugins/cookbook.mdx
+++ b/apps/docs/content/docs/plugins/cookbook.mdx
@@ -811,7 +811,7 @@ function createSOQLConnection(config: { instanceUrl: string; accessToken: string
 
 Key points:
 
-- **`validate` completely replaces** the standard 4-layer SQL validation (empty check, regex guard, AST parse, table whitelist). It is your responsibility to enforce safety.
+- **`validate` completely replaces** the pre-execution validation stage — the four `validateSQL` checks (empty check, regex guard, AST parse, table whitelist), not the full 7-layer pipeline. It is your responsibility to enforce safety.
 - **`reason` is user-facing** — it appears in error responses shown to the agent and in audit logs.
 - **Auto-LIMIT is skipped** for custom-validated connections since non-SQL languages may not support `LIMIT`.
 - **RLS injection is skipped** for custom-validated connections since the SQL rewriter can't parse non-SQL queries.
@@ -955,7 +955,7 @@ plugins: [
 ```
 
 Key points:
-- **`validate` completely replaces** the standard 4-layer SQL validation — it is your responsibility to enforce safety
+- **`validate` completely replaces** the pre-execution validation stage — the four `validateSQL` checks (empty check, regex guard, AST parse, table whitelist), not the full 7-layer pipeline — it is your responsibility to enforce safety
 - **`reason` is user-facing** — it appears in error responses shown to the agent and in audit logs
 - **Auto-LIMIT and RLS are skipped** for custom-validated connections since non-SQL languages may not support them
 - **Hooks still fire** — queries rewritten by `beforeQuery` hooks are re-validated through `validateSOQL`

--- a/apps/docs/content/docs/plugins/datasources/elasticsearch.mdx
+++ b/apps/docs/content/docs/plugins/datasources/elasticsearch.mdx
@@ -167,7 +167,7 @@ bun run atlas -- init
 ## SQL query surface
 
 Ask a tabular or aggregate question over a single index in chat and the agent
-answers through the standard `executeSQL` tool — the same 4-layer validation
+answers through the standard `executeSQL` tool — the same SQL validation
 pipeline as any SQL datasource. The connection POSTs your statement to the
 engine's SQL API, follows the response `cursor` across pages up to the row cap,
 and normalizes the result to Atlas's `{ columns, rows }`.
@@ -316,7 +316,7 @@ is queried over the SQL surface (per-workspace DSL routing is a later slice).
 ## Security
 
 - **Read-only.** Only `SELECT` reaches the cluster, through Atlas's standard
-  4-layer validation (regex DML/DDL guard → AST single-`SELECT` parse → index
+  SQL validation (regex DML/DDL guard → AST single-`SELECT` parse → index
   whitelist → auto-`LIMIT` + statement timeout) plus the `SHOW`/`DESCRIBE` guard.
 - **Secrets encrypted at rest.** `apiKey`, `password`, `awsSecretAccessKey`, and
   `awsSessionToken` are `secret: true` — encrypted via `encryptSecretFields` and

--- a/apps/docs/content/docs/security/passkeys.mdx
+++ b/apps/docs/content/docs/security/passkeys.mdx
@@ -366,5 +366,5 @@ gate and works on any browser.
   in depth.
 - [Row-Level Security](./row-level-security) — tenant data isolation,
   also fail-closed.
-- [SQL Validation](./sql-validation) — the four-layer query gate, the
+- [SQL Validation](./sql-validation) — the seven-layer query gate, the
   other half of the admin-side defense in depth.

--- a/apps/docs/content/docs/security/two-factor-auth.mdx
+++ b/apps/docs/content/docs/security/two-factor-auth.mdx
@@ -227,5 +227,5 @@ the extra factor; the API will not gate their routes either way.
 - [Passkeys](./passkeys) — the recommended second factor; same gate,
   no backup codes required when paired with a second device.
 - [Row-Level Security](./row-level-security) — tenant data isolation, also fail-closed.
-- [SQL Validation](./sql-validation) — the four-layer query gate, the
+- [SQL Validation](./sql-validation) — the seven-layer query gate, the
   other half of the admin-side defense in depth.

--- a/apps/www/public/brand/README.md
+++ b/apps/www/public/brand/README.md
@@ -49,7 +49,7 @@ Output is RGBA with transparent background. Drop the new file into this director
 
 ## Brand voice (one paragraph for catalog forms)
 
-> Atlas is a deploy-anywhere text-to-SQL data analyst agent. It connects to your data warehouse over a semantic layer (typed entities, joins, metrics, glossary) and validated SQL execution (4-layer parser + table whitelist + auto-LIMIT + statement timeout) so an AI agent can answer business questions without hallucinating tables, joining wrong, or running unbounded scans. Self-hosted under AGPL-3.0; hosted SaaS at app.useatlas.dev.
+> Atlas is a deploy-anywhere text-to-SQL data analyst agent. It connects to your data warehouse over a semantic layer (typed entities, joins, metrics, glossary) and validated SQL execution (a 7-layer pipeline: empty check, regex guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout) so an AI agent can answer business questions without hallucinating tables, joining wrong, or running unbounded scans. Self-hosted under AGPL-3.0; hosted SaaS at app.useatlas.dev.
 
 Drop this into long-description fields verbatim or trim to fit the form's word count. Pair with the catalog tool annotations at [`apps/docs/content/docs/architecture/mcp-tool-annotations.mdx`](../../../../apps/docs/content/docs/architecture/mcp-tool-annotations.mdx) for the per-tool entries on MCP catalog forms.
 

--- a/apps/www/src/app/terms/page.tsx
+++ b/apps/www/src/app/terms/page.tsx
@@ -104,7 +104,7 @@ const SECTIONS: LegalSectionData[] = [
     legal: [
       "Atlas warrants that the Service will materially perform as described in the documentation. Customer’s exclusive remedy and Atlas’s sole liability for breach of this warranty is, at Atlas’s option, to repair the Service or terminate the agreement and refund unused prepaid fees.",
       'EXCEPT AS EXPRESSLY STATED, THE SERVICE IS PROVIDED "AS IS" AND ATLAS DISCLAIMS ALL OTHER WARRANTIES, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.',
-      "AI-generated SQL is non-deterministic. Atlas’s 4-layer validation pipeline (empty check, regex guard, AST parse, table whitelist) reduces risk; it does not eliminate it. Customer remains responsible for reviewing query output and for the appropriateness of using AI-generated SQL in its environment.",
+      "AI-generated SQL is non-deterministic. Atlas’s 7-layer validation pipeline (empty check, regex guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout) reduces risk; it does not eliminate it. Customer remains responsible for reviewing query output and for the appropriateness of using AI-generated SQL in its environment.",
     ],
     plain:
       "We warrant the product works as documented. Beyond that, AI-generated SQL is non-deterministic — our validators reduce risk, but you remain responsible for reviewing query output before acting on it.",


### PR DESCRIPTION
## Summary
Standardizes customer-facing SQL-validation copy to the canonical **7-layer** read-only pipeline (empty check, regex mutation guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout — matching CLAUDE.md and `packages/api/src/lib/tools/sql.ts`).

- **Full-pipeline descriptions → "7-layer"**: `README.md`, `apps/www/src/app/terms/page.tsx`, `apps/www/public/brand/README.md` (brand boilerplate, missed by the issue's file list but the same class of full-pipeline copy), and docs `guides/mcp`, `guides/approval-workflows`, `getting-started/connect-your-data`, `comparisons/vanna`, `security/passkeys`, `security/two-factor-auth`, `architecture/mcp-tool-annotations`.
- **Validation-stage references left as the stage, made unambiguous (NOT force-changed to 7)** per the issue's deliberate split: `plugins/authoring-guide`, `plugins/cookbook` (×2), `plugins/datasources/elasticsearch`, `architecture/mcp-performance` — these describe the four pre-execution `validateSQL` checks a custom `validate()` replaces.
- **`approval-workflows` flow step** reframed to the pre-execution validation stage (not "7-layer"): the approval gate fires *between* validation and execution (`sql.ts:1399` — `validation → approval → RLS → auto-LIMIT → execute`), so only layers 0–3 have run at that point. Caught by the internal review panel.
- Out of scope, untouched: `architecture/entitlements.mdx` ("4-layer gating model" — plan-gating, not SQL); `security/sql-validation.mdx` "first four layers (0-3)" (canonical, correct).

## Test plan
- [x] Internal review panel (2 rounds → CLEAN)
- [x] `bun run lint`, `bun run type` — clean
- [x] Doc-parity tests (`catalog-annotations`, `oauth-client` — read the modified `.mdx`): 33 pass / 0 fail
- [x] Template drift, syncpack, test-discipline — pass
- [x] **`apps/www` build passes** (AC); **docs build passes** (AC)

Closes #4065