### PR TITLE
docs: regional residency user-facing docs (signup reorder, multi-region login, teardown CLI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,13 @@ bun run atlas-operator -- ops backfill-crm-leads [--dry-run] [--batch-size 500] 
 # run ad-hoc by an operator AND as the post-deploy staging-smoke gate:
 bun run atlas-operator -- ops smoke-crm --personas <path> [--wipe-twenty] [--twenty-base-url <url>] \
   [--twenty-api-key <key>] [--timeout-seconds 60] [--database-url <url>]
+# Surgically tear down throwaway /verify-prod-signup accounts (user+org+Stripe customer)
+# from ONE region's internal DB. DRY RUN by default; EXECUTE = ATLAS_TEARDOWN_OK=1 + --confirm:
+ATLAS_TEARDOWN_OK=1 bun run atlas-operator -- ops teardown-verify-accounts \
+  --region <us|eu|apac> --email <addr[,addr]> --confirm [--dry-run] [--force]
 ```
 
-`ops wipe` is the only subcommand that wipes the tenant DB: requires **both** `ATLAS_WIPE_OK=1` **and** `--confirm` (intentional double-gate). No backup is taken — wrap with `pg_dump` yourself. Operates on one DB per invocation. `ops smoke-crm` is an end-to-end verification of the demo→Twenty lead-capture pipeline — run ad-hoc by an operator and as the post-deploy Staging Smoke gate (`.github/workflows/staging-smoke.yml`), though not per-PR CI; its optional `--wipe-twenty` phase clears the Twenty workspace and is double-gated by `ATLAS_SMOKE_WIPE_OK=1`. One-shot migration backfills live next to their migration in `db/migrations/scripts/`.
+`ops wipe` is the only subcommand that wipes the tenant DB: requires **both** `ATLAS_WIPE_OK=1` **and** `--confirm` (intentional double-gate). No backup is taken — wrap with `pg_dump` yourself. Operates on one DB per invocation. `ops smoke-crm` is an end-to-end verification of the demo→Twenty lead-capture pipeline — run ad-hoc by an operator and as the post-deploy Staging Smoke gate (`.github/workflows/staging-smoke.yml`), though not per-PR CI; its optional `--wipe-twenty` phase clears the Twenty workspace and is double-gated by `ATLAS_SMOKE_WIPE_OK=1`. `ops teardown-verify-accounts` is the only subcommand that targets a **region's internal DB** (resolved from `ATLAS_REGION_<R>_DB_URL` via `--region`, or an explicit `--database-url`) rather than the tenant DB — there is **no `DATABASE_URL` fallback** (so you can't tear down the wrong DB by forgetting the flag); DRY RUN by default, EXECUTE double-gated by `ATLAS_TEARDOWN_OK=1` + `--confirm`, with a 12-workspace blast-radius cap and a plus-addressing guard (`--force` to override). One-shot migration backfills live next to their migration in `db/migrations/scripts/`.
 
 ## Architecture
 

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -13,6 +13,7 @@
     "actions",
     "social-providers",
     "signup",
+    "multi-region-login",
     "create-organization",
     "semantic-layer-wizard",
     "semantic-editor",

--- a/apps/docs/content/docs/guides/multi-region-login.mdx
+++ b/apps/docs/content/docs/guides/multi-region-login.mdx
@@ -1,0 +1,87 @@
+---
+title: Multi-Region Login
+description: How returning users are routed back to their workspace's region on the hosted SaaS, where each region is an independent identity stack.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<Callout type="info" title="SaaS multi-region only">
+This flow exists only on the hosted Atlas SaaS when more than one data region is configured. Self-hosted and single-region deployments authenticate against one API base and never engage the region front-door — sign-in is the standard email/password (or SSO) flow described in [Authentication](/deployment/authentication).
+</Callout>
+
+Under [regional identity isolation (ADR-0024)](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md), each region (US, EU, Asia Pacific) is a **fully independent stack** — its own internal database **and** its own [Better Auth](https://www.better-auth.com/) instance. An EU workspace's `user`, `organization`, `member`, and `session` rows live **only** in the EU database; the US API genuinely returns `401` for it. That isolation is the residency promise, but it creates a routing problem at login: a returning user types an email and password, and the browser must figure out **which region's API** to send them to *before* any session exists.
+
+This guide describes how that resolution works.
+
+## The returning-user front-door
+
+When a returning user opens `/login` on the multi-region SaaS and no region is yet known, Atlas shows an **email-first** step before the password field. Entering an email resolves which region owns the account, then reloads the login form pointed at that region's API.
+
+The resolution runs through a single region-agnostic edge endpoint on `app.useatlas.dev`:
+
+```
+POST /api/login/resolve-region
+Content-Type: application/json
+
+{ "email": "jane@acme.com" }
+```
+
+This endpoint lives on the web front-door, **not** on any regional API — no regional API is allowed to carry a dual global-identity role. It returns one of five outcomes:
+
+| Outcome | Meaning | What the UI does |
+|---------|---------|------------------|
+| `single` | The email exists in exactly one region | Apply that region and reload the login form against its API |
+| `multiple` | The email exists in more than one region | Show a region chooser (see [Same email = two accounts](#same-email--two-accounts)) |
+| `none` | No account found in any region | Offer signup |
+| `skip` | Region routing not configured (self-hosted / residency off) | Reveal the password field against the default API base |
+| `error` | The fan-out was inconclusive (a region or the region directory was unreachable) | Let the user retry — Atlas never silently mis-routes to the default region |
+
+### How the fan-out works
+
+The front-door resolves the region **without any global email→region store** — there is no central directory of who lives where. For each request it:
+
+1. **Fetches the region map** from `GET /api/v1/auth/region-map` — the list of selectable regions and their API bases. (`configured: false`, or no regions, means residency is not configured and yields `skip`.)
+2. **Checks the cookie fast-path** (below) — if an `atlas_region` cookie pins a region the map still knows, it routes there immediately and skips everything else. On this common path the email is **never hashed**.
+3. **Short-circuits a single region** — if only one region is configured, it routes there without probing (no ambiguity to resolve).
+4. **Hashes the email and fans out** — only when a real fan-out is needed. It computes `sha256(lower(email))` and forwards only the **hash** (the raw email never leaves the front-door) via a parallel `POST /api/v1/auth/region-probe` to every region with `{ "emailHash": "<64-hex sha256>" }`. Each region answers only `{ "exists": true | false }` about its **own** identity store.
+5. **Collects the hits.** One hit → `single`. More than one → `multiple`. Zero clean hits → `none`. If any region was unreachable, the result is `error` (retryable) rather than a false "no account".
+
+The match runs entirely inside Postgres against a `pgcrypto` functional index (`encode(digest(lower(email), 'sha256'), 'hex')`), so plaintext emails never leave the database.
+
+## The `atlas_region` cookie fast-path
+
+Once a user has selected a region (during signup or a prior login), Atlas persists `{ region, apiUrl }` in an `atlas_region` cookie (one-year lifetime). On the common same-browser return visit, this short-circuits the whole fan-out: the front-door reads the cookie's **region key**, re-resolves it to the **authoritative** `apiUrl` from the region map, and routes there without operating the existence oracle at all.
+
+<Callout type="warn" title="The cookie's apiUrl is never trusted">
+The `atlas_region` cookie is client-writable, so only its **region key** is honored. The actual API base is always re-derived from the server's region map — a tampered cookie can never repoint authenticated traffic at an attacker-controlled host. A stale cookie (a region that was removed) falls through to the cold fan-out. This same validation governs the pre-auth API base during signup; see [Self-Serve Signup](/guides/signup#region-selection).
+</Callout>
+
+The cookie is also what makes the rest of the session regional: the auth client reads it at load and binds its base URL to the region's API, so every credentialed call rides the host-only, same-site session cookie for that region (see [host-only session cookies](/deployment/authentication#cross-origin-deployment-self-hosted)).
+
+## Same email = two accounts
+
+Because identity is fully regional, **the same email address in two regions is two independent accounts** — separate `user.id`, separate credentials, separate workspaces — tied together only by the email string. This is a deliberate consequence of having no global membership store (ADR-0024 §6).
+
+When the front-door's probe fan-out finds the email in more than one region (`multiple`), the login page presents a **region chooser**. Picking a region routes the browser to that region's API and authenticates there. Each region is its own account, so:
+
+- Credentials, passkeys, and sessions do not carry across regions.
+- The in-session workspace switcher is **region-scoped** — it lists only the workspaces in the region you signed into.
+- Switching to a workspace in another region means signing in again against that region.
+
+A single sign-in that spans regions (an in-session step-up that mints a second regional session) is a possible future enhancement, not part of launch.
+
+## Security model
+
+The region probe is an **account-existence oracle** — exactly like any forgot-password flow, it can confirm whether a guessed address is registered. Atlas does not pretend otherwise; it bounds the exposure:
+
+- **Hash-only input.** `POST /api/v1/auth/region-probe` accepts *only* a 64-character lowercase hex sha256, never a raw email, so it can confirm a guessed address but can't be used to harvest a region's email list.
+- **Boolean-only output.** The probe returns just `{ exists }`.
+- **No global store.** The email→region mapping is computed transiently per request; each region only ever checks its own `user` table.
+- **Rate-limited at two layers.** The `app.useatlas.dev` front-door rate-limits per client IP (the primary per-user control), keying on the leftmost `X-Forwarded-For` hop set by the platform edge; every regional probe additionally rate-limits per IP as a backstop. For the regional probe's per-IP limit to key on the real client IP, set [`ATLAS_TRUST_PROXY=true`](/deployment/authentication#rate-limiting) on the regional APIs.
+
+## Related
+
+- [Self-Serve Signup](/guides/signup) — the new-user flow, where the region is chosen before account creation
+- [Authentication](/deployment/authentication) — auth modes, sessions, and host-only cookies
+- [Data Residency](/platform-ops/data-residency) — operator-side region configuration and migration
+- [ADR-0024: Regional identity isolation](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md) — the architecture decision behind this flow

--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -21,17 +21,24 @@ On [app.useatlas.dev](https://app.useatlas.dev), signup is available immediately
 
 ## How It Works
 
-The signup wizard is a five-step flow at `/signup`:
+The signup wizard is a step-by-step flow that starts at `/signup`. The order is **email → region → create account → name workspace → connect database → done**:
 
 | Step | Route | What happens |
 |------|-------|-------------|
-| 1. **Create account** | `/signup` | Email/password or OAuth (Google, GitHub, Microsoft) |
-| 2. **Name workspace** | `/signup/workspace` | Workspace name + auto-generated slug (max 48 chars) |
-| 3. **Choose region** | `/signup/region` | Select where workspace data is stored (SaaS only) |
-| 4. **Connect database** | `/signup/connect` | Paste a PostgreSQL or MySQL URL, test it, save |
-| 5. **Done** | `/signup/success` | Confirmation with next steps |
+| 1. **Enter email** | `/signup` | Work email entry. This is an identifier, **not** an account write yet — collecting it first lets Atlas point the browser at the right regional API before anything is created (and detect an existing account to divert to login) |
+| 2. **Choose region** | `/signup/region` | Select where workspace data is stored (SaaS multi-region only — skipped otherwise). Selecting a region repoints the browser at that region's API base *before* the first identity write |
+| 3. **Create account** | `/signup/account` | Email/password or OAuth (Google, GitHub, Microsoft), then email verification via a one-time code |
+| 4. **Name workspace** | `/signup/workspace` | Workspace name + auto-generated slug (max 48 chars) |
+| 5. **Connect database** | `/signup/connect` | Paste a PostgreSQL or MySQL URL, test it, save |
+| 6. **Done** | `/signup/success` | Confirmation with next steps |
 
 Each step validates before allowing the user to proceed. The database URL is tested against the live server before being saved.
+
+<Callout type="info" title="Region comes before account creation">
+The region step appears only when data residency is configured (the hosted SaaS with more than one region). When it is **not** configured — self-hosted, or a single-region SaaS — the region step is skipped entirely and signup is a five-step flow (email → create account → name workspace → connect → done).
+
+The ordering is deliberate: under [regional identity isolation (ADR-0024)](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md) each region is a fully independent stack with its own identity store, so the region must be chosen **before** the first account write — the workspace is created in the region of the API that serves it. See [Multi-Region Login](/guides/multi-region-login) for how returning users are routed back to their region.
+</Callout>
 
 ---
 
@@ -62,7 +69,7 @@ The freemium-domain denylist lives in code at `packages/api/src/lib/auth/busines
 Region selection appears only when data residency is configured on the platform. Self-hosted deployments and platforms without residency configured skip this step automatically.
 </Callout>
 
-In step 3, new users choose a data region for their workspace. This determines where all workspace data (conversations, audit logs, cached results) is physically stored.
+In the region step (step 2, right after email entry), new users choose a data region for their workspace. This determines where all workspace data (conversations, audit logs, cached results) is physically stored.
 
 ### Available Regions
 
@@ -84,11 +91,15 @@ The platform's default region is pre-selected. Users can choose a different regi
 
 ### How It Works
 
-1. The page loads available regions from `GET /api/v1/onboarding/regions`
-2. If residency is not configured (`configured: false`), the step is skipped and the user proceeds directly to database connection
+1. The page loads available regions from `GET /api/v1/onboarding/regions` — a **public, pre-auth** endpoint, because the picker renders before any account (and therefore any session) exists
+2. If residency is not configured (`configured: false`), the step is skipped and the user proceeds directly to account creation on the single API base
 3. The user selects a region and clicks **Continue**
-4. The selection is saved via `POST /api/v1/onboarding/assign-region`
-5. The user proceeds to the database connection step
+4. Selecting a region **repoints the browser's API base** at that region's `apiUrl` and persists the choice in an `atlas_region` cookie. There is no server round-trip — under [regional identity isolation (ADR-0024)](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md) the region is chosen before the first identity write, so there is no session yet to assign. The page then performs a full reload so the auth client rebuilds against the regional API
+5. Account creation, email verification, workspace naming, and database connection then all run against that regional API. The workspace's region is stamped from the API process's own `ATLAS_API_REGION` when the workspace is created — **the region a workspace lives in is the region of the API that created it**, by construction, not a value posted from the browser
+
+<Callout type="info" title="What happened to POST /api/v1/onboarding/assign-region?">
+Earlier builds saved the region with a `POST /api/v1/onboarding/assign-region` call after account creation. That post-hoc assignment is gone: the region is now established **before** the account exists, by repointing the API base via the `atlas_region` cookie. The `assign-region` endpoint still exists but is reduced to an idempotent confirmation of the ambient region stamp — the signup wizard no longer calls it.
+</Callout>
 
 ---
 
@@ -122,7 +133,7 @@ See [Social Providers](/guides/social-providers) for detailed OAuth setup instru
 
 ## Database Connection
 
-In step 4, the user pastes a database URL (`postgresql://` or `mysql://`). The wizard:
+In the connect step (step 5 with the region step, step 4 without it), the user pastes a database URL (`postgresql://` or `mysql://`). The wizard:
 
 1. **Validates the URL scheme** — only PostgreSQL and MySQL are supported
 2. **Tests connectivity** — creates a temporary connection, runs a health check, reports latency
@@ -151,8 +162,8 @@ The onboarding API is mounted at `/api/v1/onboarding`. All endpoints require man
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/social-providers` | None | List enabled OAuth providers |
-| `GET` | `/regions` | Session | List available data regions (returns `configured`, `defaultRegion`, `availableRegions`) |
-| `POST` | `/assign-region` | Session | Assign workspace to a data region (body: `{ region }`) |
+| `GET` | `/regions` | None | List available data regions (returns `configured`, `defaultRegion`, `availableRegions`). Public/pre-auth so the picker renders before signup |
+| `POST` | `/assign-region` | Session | Idempotent confirmation of the workspace's ambient region stamp. Retained for back-compat — the signup wizard no longer calls it (region is set by the regional API at workspace creation) |
 | `POST` | `/test-connection` | Session | Test a database URL without saving |
 | `POST` | `/complete` | Session | Save connection and finalize workspace setup |
 
@@ -270,6 +281,7 @@ Signup creates your first workspace. If you later need another one — a separat
 ## See Also
 
 - [Authentication](/deployment/authentication) — Auth mode setup and configuration
+- [Multi-Region Login](/guides/multi-region-login) — How returning users are routed back to their workspace's region
 - [Social Providers](/guides/social-providers) — Detailed OAuth setup per provider
 - [Admin Console](/guides/admin-console) — Manage connections and users after signup
 - [Create a Workspace](/guides/create-organization) — Add another workspace post-signup

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -887,6 +887,35 @@ A smoke run is **never read-only**: it enqueues the fixture personas and the flu
 
 **Exit codes:** `0` = clean (observed matches expected); `1` = argument/fixture parse error; `2` = outbox drain timed out; `3` = diff dirty (dispatcher misbehaved or Twenty unreachable); `4` = wipe phase failed; `5` = infrastructure failure (tenant DB unreachable, enqueue insert failed, or poll query errored).
 
+### ops teardown-verify-accounts
+
+<Callout type="warn" title="Destructive — targets a region's PROD identity DB">
+Surgically deletes the throwaway accounts left behind by a 3-region [`/verify-prod-signup`](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md) run — the **user + organization + Stripe customer** for each named email — from **one** region's internal database. It reuses the same SSOT teardown functions as the platform-admin workspace purge (`purgeStripeBillingForWorkspace` → soft-delete → `hardDeleteWorkspace`), so the cascade can't drift behind new org-scoped tables. **DRY RUN by default**; executing requires **both** `ATLAS_TEARDOWN_OK=1` in the env **and** `--confirm` on the command line (the same double-gate as `ops wipe`).
+</Callout>
+
+```bash
+# Preview (dry run — lists what would be torn down, deletes nothing)
+bun run atlas-operator -- ops teardown-verify-accounts \
+  --region us --email matt+us@useatlas.dev
+
+# Execute (double-gated)
+ATLAS_TEARDOWN_OK=1 bun run atlas-operator -- ops teardown-verify-accounts \
+  --region eu --email matt+eu@useatlas.dev --confirm
+```
+
+| Flag | Description |
+|------|-------------|
+| `--email <addr[,addr]>` | Required, repeatable and/or comma-separated. The account(s) to tear down (lower-cased and de-duped). A teardown with no explicit target is always refused — this command never "deletes every test-looking account". |
+| `--region <us\|eu\|apac>` | Selects the region DB by resolving `ATLAS_REGION_<R>_DB_URL`. |
+| `--database-url <url>` | Explicit region DB URL (escape hatch). Takes precedence over `--region` if both are passed. **There is no `DATABASE_URL` fallback** — you must pick a region explicitly so the wrong DB can't be torn down by forgetting the flag. |
+| `--confirm` | Required to execute. Second half of the double-gate (`ATLAS_TEARDOWN_OK=1` is the first). |
+| `--dry-run` | Force preview even when the execute gate is satisfied. |
+| `--force` | Allow addresses that don't look like throwaway verify accounts. By default, execute refuses any non-plus-addressed email (verify accounts are plus-addressed, e.g. `matt+us@useatlas.dev`) — `--force` overrides that guard. |
+
+**Safety:** one region DB per invocation; DRY RUN unless both gates are present; execute refuses more than 12 owned workspaces (blast-radius cap — a verification run only creates one account per region). Non-owner memberships and orphan user rows are surfaced as warnings for manual follow-up, never silently deleted. The stamped `organization.region` label is reported as mislocation evidence but never gated on — the physical DB selected by `--region`/`--database-url` is the ground truth.
+
+**Exit codes:** `0` = clean; `1` = gate/argument error, a per-org teardown error, **or** a left-behind Stripe linkage (a failed customer-delete / subscription-cancel is enqueued for durable retry, but the run still exits non-zero so a scripted cleanup fails loudly rather than reporting a clean success).
+
 ---
 
 ## See Also

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -14068,17 +14068,6 @@
               }
             }
           },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
           "404": {
             "description": "Onboarding requires managed auth mode",
             "content": {

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -1045,10 +1045,9 @@ const getRegionsRoute = createRoute({
       description: "Available regions",
       content: { "application/json": { schema: OnboardingRegionsResponseSchema } },
     },
-    401: {
-      description: "Authentication required",
-      content: { "application/json": { schema: z.record(z.string(), z.unknown()) } },
-    },
+    // No 401: `/regions` is PUBLIC (pre-auth) under ADR-0024 §4 — the region
+    // picker renders before any Better Auth session exists, so an
+    // authentication-required response is unreachable here.
     404: {
       description: "Onboarding requires managed auth mode",
       content: { "application/json": { schema: ErrorSchema } },


### PR DESCRIPTION
## Summary

User-facing docs for the v0.0.31 Regional Residency Routing feature (ADR-0024), now that it is released and live on prod (tag `d70e9e0d`). Every claim was verified against the current code.

- **`guides/signup.mdx`** — fix the stale signup step order to ADR-0024 §4: **email → region → create account → workspace → connect → done** (verified against `signup-steps.ts` `FULL_STEPS`; region step skipped → five steps when residency isn't configured). Replace the removed post-hoc `POST /api/v1/onboarding/assign-region` flow with the actual mechanism — the `atlas_region` cookie + pre-auth regional API base, with the org's region stamped from ambient `ATLAS_API_REGION` at workspace creation. Mark `GET /regions` as public/pre-auth in the API table.
- **New `guides/multi-region-login.mdx`** — the returning-user front-door: `POST /api/login/resolve-region` fan-out, the `atlas_region` cookie fast-path, the region chooser, and "same email = two accounts" (ADR-0024 §3/§6); the `GET /api/v1/auth/region-map` + `POST /api/v1/auth/region-probe` endpoints; and the hash-only / boolean-only / rate-limited / no-global-store security model. Added to the guides nav after `signup`.
- **`reference/cli.mdx` + `CLAUDE.md`** — document `atlas-operator ops teardown-verify-accounts` (region-DB target, `ATLAS_TEARDOWN_OK=1` + `--confirm` double-gate, no `DATABASE_URL` fallback, 12-workspace blast-radius cap, plus-addressing `--force` guard) — the other `ops` subcommands are already documented in the CLI reference, so this keeps them consistent and satisfies the cli.mdx↔CLAUDE.md alignment contract.
- **`packages/api/src/api/routes/onboarding.ts`** — remove the now-impossible `401` from `getRegionsRoute` (the route is public pre-auth via `withRequestId`, not `standardAuth`); regenerate `apps/docs/openapi.json` (the api-reference MDX did not change).

## Test plan
- [x] `/review-panel` — CLEAN after 2 rounds (silent-failure / type-design / pr-test clean round 1; docs-accuracy flagged 5 stale-number/precision items, all fixed and re-verified CLEAN)
- [x] Full `bun run test` green except 3 documented WSL2 sandbox flakes (`explore-backend`, `explore-workspace-override`, `python`) outside this change's dependency graph; `--affected` (incl. `onboarding.test.ts`) fully green
- [x] `lint`, `type`, `syncpack`, template/schema/openapi/oauth-helper drift, test-discipline, railway-watch, settings-readers, saas-env-doc, security-headers, pricing-parity, published-symbols — all pass
- [x] All internal doc links verified to resolve to real pages/anchors

Closes #4009