### PR TITLE
docs: lock canonical plugin count (24) + counting rule behind a CI gate (#4066)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,12 @@ jobs:
       - name: Adversarial fixtures for the pricing-parity gate (#3996)
         run: bash scripts/__tests__/check-pricing-parity.test.sh
 
+      - name: Check canonical plugin count is consistent across surfaces (#4066)
+        run: bash scripts/check-plugin-count.sh
+
+      - name: Adversarial fixtures for the plugin-count gate (#4066)
+        run: bash scripts/__tests__/check-plugin-count.test.sh
+
       - name: Check entitlement SSOT ↔ route-layer enforcement drift (#3997)
         run: bash scripts/check-enforcement-parity.sh
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `A
 | **Agent-native** | MCP server first — Claude Desktop, Cursor, Continue with `bunx @useatlas/mcp init` | Bolted-on AI feature | Standalone chat UI |
 | **Embeddable** | Script tag, React component, headless API, MCP, Slack, Teams | Standalone app | Standalone app |
 | **Deploy anywhere** | Docker, Railway, Vercel, or your own infra | Vendor-hosted | Vendor-hosted |
-| **Plugin ecosystem** | 21 plugins across 5 types — extend anything | Closed | Limited |
+| **Plugin ecosystem** | 24 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
 | **Multi-database** | PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch, Salesforce | Usually one | Usually one |
 | **REST APIs as datasources** | Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated; generic OpenAPI installs auto-refresh | None | None |
@@ -191,7 +191,7 @@ atlas/
 │   ├── types/            # @useatlas/types — Shared wire-format types
 │   ├── schemas/          # @useatlas/schemas — Shared Zod schemas
 │   └── plugin-sdk/       # @useatlas/plugin-sdk — Plugin type definitions
-├── plugins/              # 21 plugins (datasource, context, interaction, action, sandbox)
+├── plugins/              # 24 plugins (datasource, context, interaction, action, sandbox)
 ├── ee/                   # @atlas/ee — Enterprise features (source-available, commercial license)
 ├── create-atlas/         # Scaffolding CLI (bun create atlas-agent)
 ├── apps/

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -104,10 +104,15 @@ const ROWS: ReadonlyArray<Row> = [
 //   - "24 plugins across 5 types" = directories under plugins/ whose
 //     definePlugin() declares a PluginType (the `obsidian` client app extends
 //     Obsidian's own Plugin class and declares none, so it's excluded). This
-//     is a hand-counted figure — recount it whenever plugins/ changes.
-//     Last recount (#4071): 25 dirs under plugins/, 24 declare a PluginType
-//     (only `obsidian` excluded). Per-type: 7 datasource, 6 sandbox,
-//     5 interaction, 5 action, 1 context = 24.
+//     is the CANONICAL plugin count + counting rule (#4066). It is no longer
+//     hand-maintained: scripts/check-plugin-count.sh derives it from plugins/
+//     and fails CI if this cell — or any other surface in that script's
+//     authoritative SURFACES list (README, the docs comparisons, llms.txt, the
+//     launch posts, the blog page, the brand-asset generator) — drifts from the
+//     derived total. The per-type breakdown below is point-in-time context, not
+//     an enforced figure: as of #4066, 25 dirs under plugins/, 24 declare a
+//     PluginType (only `obsidian` excluded) — 7 datasource, 6 sandbox,
+//     5 interaction, 5 action, 1 context = 24. Bump this cell when CI says so.
 //   - The REST/OpenAPI datasources named on the landing page (Stripe, Notion,
 //     GitHub, any OpenAPI spec) are OpenAPI presets in
 //     packages/api/src/lib/openapi/data-candidates.ts, NOT plugins/ entries —

--- a/scripts/__tests__/check-plugin-count.test.sh
+++ b/scripts/__tests__/check-plugin-count.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Adversarial fixture suite for scripts/check-plugin-count.sh (#4066).
+#
+# Locks in the gate's two jobs against silent regression:
+#   1. DERIVATION from plugins/ — counts dirs that declare a PluginType, excludes
+#      a typeless host-app dir, tolerates a formatter-wrapped multiline `types:`
+#      array, fails loudly on a plugin dir with no src/, and refuses a 0 count.
+#   2. SURFACE PARITY — passes when every surface states the derived "<N> plugins",
+#      fails on a stale count, a missing count, and a "<N>+ plugins" variant.
+#
+# The fixtures are pointed at a scaffolded temp tree via PLUGIN_COUNT_ROOT, so
+# they never touch the real repo; the suite then ends with one real-repo sanity
+# case that runs the gate against the actual tree (default ROOT). The SURFACES
+# list is read out of the script under test (not duplicated here), so the
+# scaffold can't drift from the gate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-plugin-count.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+
+# Read the gate's authoritative surface list so this suite stays in lockstep
+# with it (a surface added to the script is scaffolded here automatically).
+mapfile -t SURFACES < <(sed -n '/^SURFACES=(/,/^)/p' "$SCRIPT" | grep -oE '"[^"]+"' | tr -d '"')
+if [ "${#SURFACES[@]}" -eq 0 ]; then
+  echo "::error::could not read SURFACES from $SCRIPT — has its format changed?" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# Scaffold a temp tree: $1 typed plugin dirs (each a single-line `types:`
+# declaration) and every surface stating "$1 plugins". Returns the tree path.
+scaffold() {
+  local n="$1" tmp i s
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/plugins"
+  for ((i = 1; i <= n; i++)); do
+    mkdir -p "$tmp/plugins/p$i/src"
+    printf 'export default definePlugin({ types: ["datasource"] as const });\n' \
+      > "$tmp/plugins/p$i/src/index.ts"
+  done
+  for s in "${SURFACES[@]}"; do
+    mkdir -p "$tmp/$(dirname "$s")"
+    printf 'intro line\n%s plugins power Atlas.\n' "$n" > "$tmp/$s"
+  done
+  printf '%s' "$tmp"
+}
+
+# run_case EXPECTED NAME TREE — run the gate against TREE, assert pass/fail, clean up.
+run_case() {
+  local expected="$1" name="$2" tree="$3" status=0
+  # Refuse to run against an unbuilt fixture: an empty/missing tree would make
+  # the gate fall back to the real repo (ROOT's `:-` treats "" as unset), which
+  # would silently turn a pass-case into a green no-op against the live tree.
+  if [ -z "$tree" ] || [ ! -d "$tree" ]; then
+    echo "  FAIL $name — scaffold produced no usable tree (got '$tree')" >&2
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  (PLUGIN_COUNT_ROOT="$tree" bash "$SCRIPT" >/dev/null 2>&1) || status=$?
+  if { [ "$expected" = pass ] && [ "$status" -eq 0 ]; } ||
+     { [ "$expected" = fail ] && [ "$status" -ne 0 ]; }; then
+    echo "  ok   $name (expected $expected)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $name — expected $expected, got status=$status" >&2
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tree"
+}
+
+# --- derivation -------------------------------------------------------------
+
+# Clean tree: 3 typed plugins, every surface says "3 plugins".
+run_case pass "clean tree — derived count matches every surface" "$(scaffold 3)"
+
+# A typeless host-app dir (the `obsidian` case) is excluded from the count.
+tree="$(scaffold 3)"
+mkdir -p "$tree/plugins/obsidian/src"
+printf 'export default class Foo extends Plugin {}\n' > "$tree/plugins/obsidian/src/index.ts"
+run_case pass "typeless dir is excluded (count stays 3)" "$tree"
+
+# A formatter-wrapped multiline `types:` array must still be counted: adding it
+# makes the derived count 4, so the surfaces (saying "4") stay in parity.
+tree="$(scaffold 4)"
+rm -rf "$tree/plugins/p4"
+mkdir -p "$tree/plugins/p4/src"
+cat > "$tree/plugins/p4/src/index.ts" <<'EOF'
+export default definePlugin({
+  types: [
+    "context",
+  ] as const,
+});
+EOF
+run_case pass "multiline types: array is counted (locks the grep -z fix)" "$tree"
+
+# A plugin dir with no src/ can't have its PluginType derived → fail loudly,
+# never a silent undercount.
+tree="$(scaffold 3)"
+mkdir -p "$tree/plugins/no_src"
+run_case fail "plugin dir with no src/ fails loudly" "$tree"
+
+# Zero typed plugins (a dir with src/ but no PluginType) trips the 0-count guard.
+tree="$(scaffold 0)"
+mkdir -p "$tree/plugins/untyped/src"
+printf 'export default definePlugin({});\n' > "$tree/plugins/untyped/src/index.ts"
+run_case fail "zero typed plugins is rejected" "$tree"
+
+# --- surface parity ---------------------------------------------------------
+
+# Stale count (below derived): one surface lags at "2 plugins" while count is 3.
+tree="$(scaffold 3)"
+printf 'intro line\n2 plugins power Atlas.\n' > "$tree/${SURFACES[0]}"
+run_case fail "stale count below derived is caught" "$tree"
+
+# Over-count (above derived): a surface bumped to "4 plugins" with no new plugin.
+tree="$(scaffold 3)"
+printf 'intro line\n4 plugins power Atlas.\n' > "$tree/${SURFACES[0]}"
+run_case fail "over-count above derived is caught" "$tree"
+
+# A correct mention must not mask a stale sibling mention in the same surface.
+tree="$(scaffold 3)"
+printf 'intro line\n3 plugins today (was 2 plugins last year).\n' > "$tree/${SURFACES[0]}"
+run_case fail "a stale mention alongside the correct one is caught" "$tree"
+
+# Missing count: a surface no longer states any "<n> plugins".
+tree="$(scaffold 3)"
+printf 'intro line\nAtlas has a rich plugin ecosystem.\n' > "$tree/${SURFACES[0]}"
+run_case fail "missing count on one surface is caught" "$tree"
+
+# "<N>+ plugins" variant must be rejected (the canonical form is bare "<N>").
+tree="$(scaffold 3)"
+printf 'intro line\n3+ plugins power Atlas.\n' > "$tree/${SURFACES[0]}"
+run_case fail "an N+ variant is rejected" "$tree"
+
+# A listed surface missing entirely fails loudly.
+tree="$(scaffold 3)"
+rm -f "$tree/${SURFACES[0]}"
+run_case fail "a missing surface file fails loudly" "$tree"
+
+# --- real tree sanity -------------------------------------------------------
+# The actual repo must pass with the default (un-overridden) ROOT.
+real_status=0
+(bash "$SCRIPT" >/dev/null 2>&1) || real_status=$?
+if [ "$real_status" -eq 0 ]; then
+  echo "  ok   real repo passes the gate (expected pass)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL real repo does not pass the gate — status=$real_status" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "check-plugin-count.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/check-plugin-count.sh
+++ b/scripts/check-plugin-count.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# check-plugin-count.sh — CI check that the canonical plugin count is stated
+# identically across every marketing/docs surface, and that it matches the
+# actual plugins/ directory (#4066).
+#
+# THE COUNTING RULE (canonical, single source of truth):
+#   A "plugin" is a directory under plugins/ whose definePlugin() declares a
+#   PluginType via a `types: [...]` array (one of: datasource, context,
+#   interaction, action, sandbox). The `obsidian` client app extends Obsidian's
+#   own Plugin class and declares no PluginType, so it is excluded — it is a
+#   host-app surface, not an Atlas plugin in the catalog sense.
+#
+# The count is DERIVED here from plugins/ (not hand-maintained), so it stays
+# honest as plugins/ grows: add a plugin that declares a PluginType and every
+# surface in SURFACES (below) must restate the new total or this gate goes red.
+# Every surface embeds the count as human-readable prose rather than importing a
+# derived constant — even the .tsx surfaces (the landing comparison table, the
+# blog announcement page, and the brand-asset generator), which *could* import TS
+# but state the figure as display copy. So all of them are kept in lockstep by
+# the same string assertion: each must state exactly "<N> plugins" and carry no
+# stale "<other> plugins".
+#
+# This replaces the formerly hand-counted figure in
+# apps/www/src/components/landing/comparison.tsx (previously a recount-on-change
+# CLAIM-ACCURACY note) with this enforced derivation.
+#
+# Run locally: bash scripts/check-plugin-count.sh
+
+set -euo pipefail
+
+# ROOT defaults to the repo root (this script lives in scripts/), so the gate
+# runs correctly from any cwd. PLUGIN_COUNT_ROOT overrides it so the adversarial
+# fixture suite (scripts/__tests__/check-plugin-count.test.sh) can point the
+# same logic at a scaffolded temp tree.
+ROOT="${PLUGIN_COUNT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Guard against an empty/unresolvable ROOT: `cd ""` is a silent no-op that would
+# leave the gate scanning whatever cwd it was launched from.
+if [ -z "$ROOT" ] || ! cd "$ROOT"; then
+  echo "check-plugin-count: could not resolve/enter the repo root (ROOT='$ROOT')." >&2
+  exit 1
+fi
+
+# --- Derive the canonical count from plugins/ -------------------------------
+# Count plugin directories whose source declares a `types:` array containing at
+# least one PluginType literal (e.g. `types: ["datasource"] as const`). A dir
+# with no PluginType (the `obsidian` host app) is excluded by construction.
+#
+# - grep -z treats each file as one NUL-delimited record, so the `[[:space:]]`
+#   and `[^]]` classes span newlines — a `types:` array a formatter has wrapped
+#   across lines still matches and is never silently undercounted.
+# - The quote class accepts ", ' or ` around the literal so a re-quoted (but
+#   still valid) PluginType matches the documented rule, not just Prettier's
+#   double-quote default.
+PLUGIN_TYPE_RE='types:[[:space:]]*\[[^]]*["'\''`](datasource|context|interaction|action|sandbox)["'\''`]'
+
+count=0
+typed_dirs=()
+for d in plugins/*/; do
+  [ -d "$d" ] || continue
+  # A plugin dir with no src/ can't have its PluginType derived — fail loudly
+  # rather than letting `grep`'s "No such file" exit silently drop it from the
+  # count (a silent undercount would then "correct" every surface to a wrong N).
+  if [ ! -d "${d}src" ]; then
+    echo "check-plugin-count: ${d} has no src/ directory — cannot derive its PluginType." >&2
+    echo "  Update the derivation in scripts/check-plugin-count.sh if the plugin layout changed." >&2
+    exit 1
+  fi
+  # Distinguish a legitimate no-match (grep exit 1 → not a typed plugin) from a
+  # read/I-O error (exit >=2 → unreadable path). The latter must fail loudly,
+  # never be misread as "not a plugin" and silently undercounted.
+  set +e
+  grep -rzqE "$PLUGIN_TYPE_RE" "${d}src"
+  rc=$?
+  set -e
+  case "$rc" in
+    0) count=$((count + 1)); typed_dirs+=("$(basename "$d")") ;;
+    1) : ;; # no PluginType declared — excluded by construction (e.g. obsidian)
+    *) echo "check-plugin-count: grep failed (exit $rc) scanning ${d}src — cannot derive its PluginType." >&2
+       echo "  A read error must not be silently undercounted; fix the unreadable path under ${d}src." >&2
+       exit 1 ;;
+  esac
+done
+
+if [ "$count" -eq 0 ]; then
+  echo "check-plugin-count: derived a plugin count of 0 — the PluginType detection in this script has broken." >&2
+  echo "Expected plugin dirs under plugins/ to declare a \`types: [\"datasource\"|...]\` array. Fix the derivation regex." >&2
+  exit 1
+fi
+
+N="$count"
+echo ":: Canonical plugin count derived from plugins/: ${N} (${typed_dirs[*]})"
+
+# --- Surfaces that must restate the canonical count -------------------------
+# Every marketing/docs surface that quotes a plugin count. Each must state
+# exactly "<N> plugins" (at least once) and carry no stale "<other> plugins".
+# Add a surface here whenever a new one starts quoting the count.
+SURFACES=(
+  "README.md"
+  "apps/www/src/components/landing/comparison.tsx"
+  "apps/www/src/app/blog/announcing-atlas/page.tsx"
+  "apps/www/public/llms.txt"
+  "apps/www/content/social/twitter-launch.md"
+  "apps/www/content/social/linkedin-launch.md"
+  "apps/docs/content/docs/comparisons/metabase.mdx"
+  "apps/docs/content/docs/comparisons/cube.mdx"
+  "apps/docs/content/docs/comparisons/thoughtspot.mdx"
+  "apps/docs/content/docs/comparisons/vanna.mdx"
+  "scripts/generate-brand-assets.tsx"
+)
+
+# Matches a quoted count like "24 plugins" or "21+ plugins" (one space), so a
+# bare-number check can both confirm the right count and flag a stale one.
+COUNT_RE='[0-9]+\+?[[:space:]]plugins'
+
+fail=0
+for surface in "${SURFACES[@]}"; do
+  if [ ! -f "$surface" ]; then
+    echo "check-plugin-count: listed surface not found: $surface" >&2
+    echo "  Remove it from SURFACES in scripts/check-plugin-count.sh if it was intentionally deleted/renamed." >&2
+    fail=1
+    continue
+  fi
+
+  # Every distinct "<n>[+] plugins" token in the file must equal exactly "<N>"
+  # with no trailing "+". A no-match leaves the loop empty → found_canonical
+  # stays 0 and the missing-count branch fires (never a silent skip).
+  found_canonical=0
+  while IFS= read -r token; do
+    [ -n "$token" ] || continue
+    num="$(printf '%s' "$token" | grep -oE '[0-9]+\+?')"
+    if [ "$num" = "$N" ]; then
+      found_canonical=1
+    else
+      echo "$surface: states \"$token\" but the canonical plugin count is ${N}." >&2
+      echo "  Update it to \"${N} plugins\" (derived from plugins/)." >&2
+      fail=1
+    fi
+  done < <(grep -oiE "$COUNT_RE" "$surface" || true)
+
+  if [ "$found_canonical" -eq 0 ]; then
+    echo "$surface: does not state the canonical \"${N} plugins\" anywhere." >&2
+    echo "  Add/restore the \"${N} plugins\" figure, or drop this file from SURFACES if it no longer quotes a count." >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "Plugin-count parity check FAILED. Canonical count is ${N} (see the counting rule atop scripts/check-plugin-count.sh)." >&2
+  exit 1
+fi
+
+echo "Plugin-count parity check passed — every surface states the canonical \"${N} plugins\"."

--- a/scripts/generate-brand-assets.tsx
+++ b/scripts/generate-brand-assets.tsx
@@ -50,7 +50,7 @@ const assets: Asset[] = [
           <span>·</span>
           <span>7 databases</span>
           <span>·</span>
-          <span>20+ plugins</span>
+          <span>24 plugins</span>
           <span>·</span>
           <span>Open source</span>
         </div>


### PR DESCRIPTION
## Summary

The plugin count was stated four ways across docs and the site (`20+` / `21` / `21+` / `24`). This locks **one** canonical figure + counting rule, derives it from the real `plugins/` directory, aligns the residual stale surfaces, and enforces it so it can't drift again.

- **Canonical: 24 plugins across 5 types.** Rule: directories under `plugins/` whose `definePlugin()` declares a `PluginType` via a `types: [...]` array. 25 dirs; only `obsidian` (the Obsidian host-app surface, which extends Obsidian's own `Plugin` and declares no `PluginType`) is excluded. Per-type: 7 datasource, 6 sandbox, 5 interaction, 5 action, 1 context = 24.
- **Swept residual stale surfaces:** `README.md` (two `21 plugins` lines) and `scripts/generate-brand-assets.tsx` (`20+ plugins`). The rest (`apps/www`, `apps/docs/comparisons/*`, llms.txt, launch posts) were already on 24 from #4071/#4075.
- **New `scripts/check-plugin-count.sh`** (AC #3): derives the count from `plugins/` and asserts every marketing/docs surface states exactly `<N> plugins` — fails CI in **both** drift directions (a surface goes stale, OR `plugins/` grows without a restate). Wired into the CI `drift` job (blocks merge via the `ci` aggregator).
- **New `scripts/__tests__/check-plugin-count.test.sh`**: 12 adversarial fixtures per the sibling-gate convention; reads the `SURFACES` list out of the gate so the scaffold can't drift from it.
- Retired the hand-counted CLAIM-ACCURACY note in `comparison.tsx` in favor of the enforced derivation.

## Test plan
- [x] `bash scripts/check-plugin-count.sh` → derives 24, all surfaces in parity
- [x] `bash scripts/__tests__/check-plugin-count.test.sh` → 12/12 (clean, typeless-exclusion, multiline `types:`, missing-src, zero-count, stale below/above, stray-stale-alongside-correct, missing-count, N+ variant, missing-surface, real-repo sanity)
- [x] `bun run lint`, `bun run type` clean; syncpack + all drift/parity/discipline gates pass
- [x] Full `bun run test`: only pre-existing WSL2 sandbox/ordering flakes fail (outside this change's source graph; `--affected` confirms)

Closes #4066