### PR TITLE
feat(cli): atlas datasource lifecycle commands over existing REST (#4044)

### DIFF
--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -675,3 +675,139 @@ describe("logAdminAction() — trust-device identifier", () => {
     expect(metadata.trustDeviceIdentifier).toBe("trust-device-explicit");
   });
 });
+
+/**
+ * Agent origin on the admin audit row (#4044 / ADR-0026).
+ *
+ * `validateManaged` surfaces the session's `origin` marker onto
+ * `user.claims.origin`; the audit records it as `metadata.origin` so a
+ * workspace's datasource lifecycle ops run via `atlas datasource` (the CLI) are
+ * auditable as `origin=cli`. Sourced from the trusted session row, validated
+ * against the canonical origin vocabulary.
+ */
+describe("logAdminAction() — agent origin (origin=cli)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryThrow = null;
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  function enableInternalDB() {
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+  }
+
+  const cliUser: AtlasUser = {
+    id: "admin-1",
+    label: "admin@example.com",
+    mode: "managed",
+    role: "admin",
+    activeOrganizationId: "org-123",
+    claims: { origin: "cli" },
+  };
+
+  it("records origin=cli in metadata for a CLI-credentialed admin action", () => {
+    enableInternalDB();
+
+    withRequestContext({ requestId: "req-1", user: cliUser }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.connection.delete,
+        targetType: "connection",
+        targetId: "prod-us",
+        metadata: { name: "prod-us" },
+      });
+    });
+
+    expect(queryCalls).toHaveLength(1);
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({ origin: "cli", name: "prod-us" });
+  });
+
+  it("stamps origin=cli even with no caller metadata", () => {
+    enableInternalDB();
+
+    withRequestContext({ requestId: "req-1", user: cliUser }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.mode.archive,
+        targetType: "mode",
+        targetId: "prod-us",
+      });
+    });
+
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({ origin: "cli" });
+  });
+
+  it("leaves metadata null for a web session (no origin claim)", () => {
+    enableInternalDB();
+    const webUser: AtlasUser = { ...cliUser, claims: {} };
+
+    withRequestContext({ requestId: "req-1", user: webUser }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.mode.archive,
+        targetType: "mode",
+        targetId: "prod-us",
+      });
+    });
+
+    expect(queryCalls[0].params![8]).toBeNull();
+  });
+
+  it("ignores an unrecognized origin claim rather than stamping it", () => {
+    enableInternalDB();
+    const bogus: AtlasUser = { ...cliUser, claims: { origin: "totally-made-up" } };
+
+    withRequestContext({ requestId: "req-1", user: bogus }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.mode.archive,
+        targetType: "mode",
+        targetId: "prod-us",
+      });
+    });
+
+    expect(queryCalls[0].params![8]).toBeNull();
+  });
+
+  it("merges origin alongside trustDeviceIdentifier", () => {
+    enableInternalDB();
+
+    withRequestContext(
+      { requestId: "req-1", user: cliUser, trustDeviceIdentifier: "td-1" },
+      () => {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.connection.delete,
+          targetType: "connection",
+          targetId: "prod-us",
+        });
+      },
+    );
+
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({ trustDeviceIdentifier: "td-1", origin: "cli" });
+  });
+
+  it("a systemActor write never inherits a context origin claim", () => {
+    enableInternalDB();
+
+    withRequestContext({ requestId: "req-1", user: cliUser }, () => {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.audit_log.purgeCycle,
+        targetType: "audit_log",
+        targetId: "scheduler",
+        systemActor: "system:audit-purge-scheduler",
+        metadata: { softDeleted: 0 },
+      });
+    });
+
+    const metadata = JSON.parse(queryCalls[0].params![8] as string);
+    expect(metadata).toEqual({ softDeleted: 0 });
+    expect(metadata.origin).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/audit/__tests__/admin.test.ts
+++ b/packages/api/src/lib/audit/__tests__/admin.test.ts
@@ -677,7 +677,7 @@ describe("logAdminAction() — trust-device identifier", () => {
 });
 
 /**
- * Agent origin on the admin audit row (#4044 / ADR-0026).
+ * Agent origin on the admin audit row (#4044 / ADR-0025 §5).
  *
  * `validateManaged` surfaces the session's `origin` marker onto
  * `user.claims.origin`; the audit records it as `metadata.origin` so a

--- a/packages/api/src/lib/audit/admin.ts
+++ b/packages/api/src/lib/audit/admin.ts
@@ -15,9 +15,25 @@
 
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalExecute, internalQuery } from "@atlas/api/lib/db/internal";
+import { isRequestOrigin, type ApprovalRequestOrigin } from "@atlas/api/lib/approvals/types";
 import type { AdminActionType, AdminTargetType } from "./actions";
 
 const log = createLogger("admin-audit");
+
+/**
+ * The acting credential's agent origin, surfaced by `validateManaged` onto
+ * `user.claims.origin` from the session row (#4044 / ADR-0026). Returns it only
+ * when it's a recognized origin (today: `'cli'` for `atlas login` credentials);
+ * web/login sessions carry none. Validated against the canonical vocabulary so
+ * an unexpected value never lands in the audit metadata.
+ */
+function resolveOriginClaim(
+  claims: Readonly<Record<string, unknown>> | undefined,
+): ApprovalRequestOrigin | undefined {
+  const origin = claims?.origin;
+  if (typeof origin !== "string" || !isRequestOrigin(origin)) return undefined;
+  return origin;
+}
 
 const ADMIN_ACTION_LOG_INSERT_SQL = `INSERT INTO admin_action_log
   (actor_id, actor_email, scope, org_id, action_type, target_type, target_id, status, metadata, ip_address, request_id)
@@ -176,16 +192,29 @@ function resolveEntry(entry: AdminActionEntry): ResolvedEntry {
     ? entry.trustDeviceIdentifier
     : (entry.trustDeviceIdentifier ?? ctx?.trustDeviceIdentifier);
 
-  // Merge trustDeviceIdentifier into metadata under the same key so
-  // forensic queries can pivot via `metadata->>'trustDeviceIdentifier'`.
-  // Caller-supplied metadata wins on key collision — no surprise
-  // overwrites of an explicit metadata field with the auto-resolved
-  // identifier. `null` (not "{}") when there's nothing to record so the
-  // existing zero-metadata audit rows look identical to before.
+  // Agent origin (#4044 / ADR-0026): when the acting credential is a CLI
+  // (`atlas login`) session, `validateManaged` surfaces the session's `origin`
+  // marker onto `user.claims.origin`. Record it so a workspace's datasource
+  // lifecycle ops run via the CLI are auditable as `origin=cli` and forensic
+  // queries can pivot via `metadata->>'origin'`. Sourced from the trusted
+  // session row (not a client header), so it can't be spoofed. systemActor
+  // writes have no HTTP credential and stay unstamped. Web/login sessions have
+  // no `origin`, so their rows are byte-identical to before.
+  const origin = useSystemActor ? undefined : resolveOriginClaim(ctx?.user?.claims);
+
+  // Merge auto-resolved fields into metadata under stable keys so forensic
+  // queries can pivot via `metadata->>'<key>'`. Caller-supplied metadata wins
+  // on key collision — no surprise overwrites of an explicit metadata field
+  // with an auto-resolved one. `null` (not "{}") when there's nothing to
+  // record so the existing zero-metadata audit rows look identical to before.
+  const autoFields: Record<string, unknown> = {};
+  if (trustDeviceIdentifier !== undefined) autoFields.trustDeviceIdentifier = trustDeviceIdentifier;
+  if (origin !== undefined) autoFields.origin = origin;
+  const hasAutoFields = Object.keys(autoFields).length > 0;
   const metadata: Record<string, unknown> | null =
-    trustDeviceIdentifier !== undefined
-      ? { trustDeviceIdentifier, ...(entry.metadata ?? {}) }
-      : (entry.metadata ?? null);
+    hasAutoFields || entry.metadata
+      ? { ...autoFields, ...(entry.metadata ?? {}) }
+      : null;
 
   const params: unknown[] = [
     actorId,

--- a/packages/api/src/lib/audit/admin.ts
+++ b/packages/api/src/lib/audit/admin.ts
@@ -22,7 +22,7 @@ const log = createLogger("admin-audit");
 
 /**
  * The acting credential's agent origin, surfaced by `validateManaged` onto
- * `user.claims.origin` from the session row (#4044 / ADR-0026). Returns it only
+ * `user.claims.origin` from the session row (#4044 / ADR-0025 §5). Returns it only
  * when it's a recognized origin (today: `'cli'` for `atlas login` credentials);
  * web/login sessions carry none. Validated against the canonical vocabulary so
  * an unexpected value never lands in the audit metadata.
@@ -192,7 +192,7 @@ function resolveEntry(entry: AdminActionEntry): ResolvedEntry {
     ? entry.trustDeviceIdentifier
     : (entry.trustDeviceIdentifier ?? ctx?.trustDeviceIdentifier);
 
-  // Agent origin (#4044 / ADR-0026): when the acting credential is a CLI
+  // Agent origin (#4044 / ADR-0025 §5): when the acting credential is a CLI
   // (`atlas login`) session, `validateManaged` surfaces the session's `origin`
   // marker onto `user.claims.origin`. Record it so a workspace's datasource
   // lifecycle ops run via the CLI are auditable as `origin=cli` and forensic

--- a/packages/api/src/lib/auth/__tests__/managed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/managed.test.ts
@@ -511,7 +511,7 @@ describe("validateManaged()", () => {
   });
 
   // -------------------------------------------------------------------------
-  // session origin claim (#4044 / ADR-0026) — surfaces `session.origin` onto
+  // session origin claim (#4044 / ADR-0025 §5) — surfaces `session.origin` onto
   // claims so the admin audit can record `origin=cli` for CLI credentials.
   // -------------------------------------------------------------------------
 

--- a/packages/api/src/lib/auth/__tests__/managed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/managed.test.ts
@@ -510,6 +510,57 @@ describe("validateManaged()", () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // session origin claim (#4044 / ADR-0026) — surfaces `session.origin` onto
+  // claims so the admin audit can record `origin=cli` for CLI credentials.
+  // -------------------------------------------------------------------------
+
+  describe("session origin claim", () => {
+    it("surfaces session.origin='cli' onto claims.origin", async () => {
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com", role: "admin" },
+        session: { id: "sess_cli", userId: "usr_123", activeOrganizationId: "org-1", origin: "cli" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.origin).toBe("cli");
+      }
+    });
+
+    it("leaves claims.origin undefined for a normal web/login session", async () => {
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com", role: "admin" },
+        session: { id: "sess_web", userId: "usr_123", activeOrganizationId: "org-1" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.origin).toBeUndefined();
+      }
+    });
+
+    it("a session-user `origin` field cannot shadow the authoritative session origin", async () => {
+      // A hostile / stale session-user payload claiming origin must NOT win:
+      // the session-row origin (here absent) governs, computed AFTER the spread.
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_123", email: "alice@example.com", role: "admin", origin: "cli" },
+        session: { id: "sess_web", userId: "usr_123", activeOrganizationId: "org-1" },
+      });
+
+      const result = await validateManaged(makeRequest());
+
+      expect(result.authenticated).toBe(true);
+      if (result.authenticated && result.user) {
+        expect(result.user.claims?.origin).toBeUndefined();
+      }
+    });
+  });
+
   // passkeyCount is read by `mfaRequired` to admit passkey-only admins.
   // The claim must always be present and authoritative — a missing field
   // silently locks out passkey users; a spread-overridable field lets a

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -134,6 +134,22 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
   if (activeOrganizationId) {
     claims.org_id = activeOrganizationId;
   }
+  // #4044 / ADR-0026 — surface the session's `origin` marker (set on the
+  // `session` row, only ever `'cli'` — stamped by the device-flow
+  // session.create hook in server.ts) so origin-aware consumers (the admin
+  // audit trail) can record `origin=cli` without re-reading the session.
+  // Lives on `session.session` (sessionData), not `session.user`. Set/cleared
+  // here AFTER the `...sessionUser` spread (like `sub`/`passkeyCount`) so the
+  // session ROW is the sole authority — a stray session-user `origin` field
+  // can never shadow it. Surfaced RAW (unvalidated) into the generic claims
+  // bag; consumers must narrow/validate it (the admin audit does so via
+  // `isRequestOrigin` against the canonical origin vocabulary).
+  const sessionOrigin = sessionData?.origin;
+  if (typeof sessionOrigin === "string" && sessionOrigin.length > 0) {
+    claims.origin = sessionOrigin;
+  } else {
+    delete claims.origin;
+  }
 
   return {
     authenticated: true,

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -134,9 +134,9 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
   if (activeOrganizationId) {
     claims.org_id = activeOrganizationId;
   }
-  // #4044 / ADR-0026 — surface the session's `origin` marker (set on the
-  // `session` row, only ever `'cli'` — stamped by the device-flow
-  // session.create hook in server.ts) so origin-aware consumers (the admin
+  // #4044 / ADR-0025 §5 — surface the session's `origin` marker (set on the
+  // `session` row by the ADR-0026 device-flow session.create hook in server.ts,
+  // only ever `'cli'`) so origin-aware consumers (the admin
   // audit trail) can record `origin=cli` without re-reading the session.
   // Lives on `session.session` (sessionData), not `session.user`. Set/cleared
   // here AFTER the `...sessionUser` spread (like `sub`/`passkeyCount`) so the

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -206,6 +206,13 @@ async function main() {
     return handleEntities(args);
   }
 
+  // #4044 / ADR-0026 — workspace datasource lifecycle over the existing
+  // admin-connection REST routes, authorized by the `atlas login` credential.
+  if (command === "datasource") {
+    const { handleDatasource } = await import("../src/commands/datasource");
+    return handleDatasource(args);
+  }
+
   if (command === "eval") {
     const { handleEval } = await import("./eval");
     return handleEval(args);

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -206,8 +206,8 @@ async function main() {
     return handleEntities(args);
   }
 
-  // #4044 / ADR-0026 — workspace datasource lifecycle over the existing
-  // admin-connection REST routes, authorized by the `atlas login` credential.
+  // #4044 / ADR-0025 sub-decision 3 — workspace datasource lifecycle over the
+  // existing admin-connection REST routes, authorized by the `atlas login` credential.
   if (command === "datasource") {
     const { handleDatasource } = await import("../src/commands/datasource");
     return handleDatasource(args);

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -429,6 +429,32 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas migrate rollback abc123",
     ],
   },
+  datasource: {
+    description:
+      "Manage the datasources of your logged-in workspace over the Atlas API. Each command maps to an existing admin-connection route, authorized by your `atlas login` credential. Every command requires the workspace admin role (the admin-connection routes are admin-gated end to end). Requires `atlas login` first.",
+    usage: "datasource <command> [id] [--json]",
+    subcommands: [
+      { name: "list", description: "List the workspace's datasources" },
+      { name: "get <id>", description: "Show one datasource's detail" },
+      { name: "test <id>", description: "Health-check a datasource connection" },
+      { name: "archive <id>", description: "Archive a datasource (reversible via restore)" },
+      { name: "restore <id>", description: "Restore an archived datasource (republishes it)" },
+      { name: "delete <id>", description: "Delete a datasource (soft — recoverable via restore)" },
+    ],
+    flags: [{ flag: "--json", description: "Machine-readable JSON output" }],
+    examples: [
+      "atlas datasource list",
+      "atlas datasource get prod-us",
+      "atlas datasource test prod-us",
+      "atlas datasource archive old-staging",
+      "atlas datasource restore old-staging",
+    ],
+    notes: [
+      "Every datasource command requires the workspace admin role (admin/owner);",
+      "a non-admin member is denied with an actionable message.",
+      "Set ATLAS_API_URL to target a non-local Atlas API.",
+    ],
+  },
   plugin: {
     description: "Manage Atlas plugins.",
     usage: "plugin <list|create|add>",
@@ -621,6 +647,7 @@ export function printOverviewHelp(): void {
       "  login            Authenticate the CLI via the device flow (stores a session bearer)\n" +
       "  logout           Remove the stored CLI credentials\n" +
       "  entities         List semantic entities visible to your logged-in workspace\n" +
+      "  datasource       Manage your workspace's datasources (list, get, test, archive, restore, delete)\n" +
       "  validate         Validate config, semantic layer, and connectivity\n" +
       "  doctor           Alias for validate\n" +
       "  eval             Run eval pipeline against demo schemas\n" +

--- a/packages/cli/src/__tests__/datasource-client.test.ts
+++ b/packages/cli/src/__tests__/datasource-client.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  DatasourceCliError,
+  listDatasources,
+  getDatasource,
+  testDatasource,
+  archiveDatasource,
+  restoreDatasource,
+  deleteDatasource,
+  type DatasourceClientOptions,
+} from "../lib/datasource-client";
+
+const BASE = "http://localhost:3001";
+const TOKEN = "sess_bearer_abc";
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  authorization: string | null;
+  body: string | undefined;
+}
+
+/**
+ * A fetch stub returning one canned response and capturing the request, so each
+ * subcommand's route mapping (method + path + bearer + body) and the
+ * status-code → typed-error mapping are testable without a live server.
+ */
+function stubFetch(
+  status: number,
+  body: unknown,
+): { fetchImpl: typeof fetch; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: typeof url === "string" ? url : url.toString(),
+      method: init?.method ?? "GET",
+      authorization:
+        init?.headers && typeof init.headers === "object"
+          ? ((init.headers as Record<string, string>).Authorization ?? null)
+          : null,
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+    return new Response(body === undefined ? "" : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function opts(fetchImpl: typeof fetch): DatasourceClientOptions {
+  return { baseUrl: BASE, token: TOKEN, fetchImpl };
+}
+
+describe("datasource-client route mapping (#4044)", () => {
+  it("list → GET /api/v1/admin/connections with the bearer", async () => {
+    const { fetchImpl, calls } = stubFetch(200, {
+      connections: [{ id: "prod-us", dbType: "postgres", status: "published" }],
+    });
+    const out = await listDatasources(opts(fetchImpl));
+    expect(out).toHaveLength(1);
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections`);
+    expect(calls[0].authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("list tolerates a missing connections array", async () => {
+    const { fetchImpl } = stubFetch(200, {});
+    expect(await listDatasources(opts(fetchImpl))).toEqual([]);
+  });
+
+  it("get → GET /api/v1/admin/connections/{id}", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { id: "prod-us", dbType: "postgres" });
+    const out = await getDatasource(opts(fetchImpl), "prod-us");
+    expect(out.id).toBe("prod-us");
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections/prod-us`);
+  });
+
+  it("get url-encodes the id", async () => {
+    const { fetchImpl, calls } = stubFetch(200, {});
+    await getDatasource(opts(fetchImpl), "weird id");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections/weird%20id`);
+  });
+
+  it("test → POST /api/v1/admin/connections/{id}/test", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { status: "healthy", latencyMs: 12 });
+    const out = await testDatasource(opts(fetchImpl), "prod-us");
+    expect(out.status).toBe("healthy");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections/prod-us/test`);
+  });
+
+  it("archive → POST /api/v1/admin/archive-connection with { connectionId }", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { archived: { connection: true } });
+    await archiveDatasource(opts(fetchImpl), "prod-us");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/archive-connection`);
+    expect(JSON.parse(calls[0].body!)).toEqual({ connectionId: "prod-us" });
+  });
+
+  it("restore → POST /api/v1/admin/restore-connection with { connectionId }", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { restored: { connection: true } });
+    await restoreDatasource(opts(fetchImpl), "prod-us");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/restore-connection`);
+    expect(JSON.parse(calls[0].body!)).toEqual({ connectionId: "prod-us" });
+  });
+
+  it("delete → DELETE /api/v1/admin/connections/{id}", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { success: true });
+    const out = await deleteDatasource(opts(fetchImpl), "prod-us");
+    expect(out.success).toBe(true);
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections/prod-us`);
+  });
+});
+
+describe("datasource-client error mapping (#4044)", () => {
+  it("401 → unauthorized with a re-login hint", async () => {
+    const { fetchImpl } = stubFetch(401, { error: "auth_error", message: "Not signed in" });
+    const err = await listDatasources(opts(fetchImpl)).catch((e) => e);
+    expect(err).toBeInstanceOf(DatasourceCliError);
+    expect((err as DatasourceCliError).kind).toBe("unauthorized");
+    expect((err as DatasourceCliError).message).toContain("atlas login");
+  });
+
+  it("403 forbidden_role → forbidden, naming the admin-role requirement", async () => {
+    const { fetchImpl } = stubFetch(403, { error: "forbidden_role", message: "Admin role required." });
+    const err = await archiveDatasource(opts(fetchImpl), "prod-us").catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("forbidden");
+    expect((err as DatasourceCliError).message).toContain("admin role");
+    expect((err as DatasourceCliError).message).toContain("archive datasource");
+  });
+
+  it("403 mfa_enrollment_required → mfa_required", async () => {
+    const { fetchImpl } = stubFetch(403, { error: "mfa_enrollment_required", message: "..." });
+    const err = await deleteDatasource(opts(fetchImpl), "prod-us").catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("mfa_required");
+    expect((err as DatasourceCliError).message).toContain("two-factor");
+  });
+
+  it("400 bad_request (no active org) → no_workspace", async () => {
+    const { fetchImpl } = stubFetch(400, { error: "bad_request", message: "No active organization." });
+    const err = await listDatasources(opts(fetchImpl)).catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("no_workspace");
+  });
+
+  it("404 → not_found surfacing the server message", async () => {
+    const { fetchImpl } = stubFetch(404, { error: "not_found", message: 'Connection "x" not found.' });
+    const err = await getDatasource(opts(fetchImpl), "x").catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("not_found");
+    expect((err as DatasourceCliError).message).toContain("not found");
+  });
+
+  it("409 → conflict surfacing the server message", async () => {
+    const { fetchImpl } = stubFetch(409, {
+      error: "conflict",
+      message: "Cannot delete — referenced by 2 scheduled task(s).",
+    });
+    const err = await deleteDatasource(opts(fetchImpl), "prod-us").catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("conflict");
+    expect((err as DatasourceCliError).message).toContain("scheduled task");
+  });
+
+  it("a network failure → network", async () => {
+    const fetchImpl = (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+    const err = await listDatasources({ baseUrl: BASE, token: TOKEN, fetchImpl }).catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("network");
+    expect((err as DatasourceCliError).message).toContain(BASE);
+  });
+
+  it("a timeout → network with the timeout copy", async () => {
+    const fetchImpl = (() => {
+      const e = new Error("timed out");
+      e.name = "TimeoutError";
+      return Promise.reject(e);
+    }) as unknown as typeof fetch;
+    const err = await testDatasource({ baseUrl: BASE, token: TOKEN, fetchImpl }, "x").catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("network");
+    expect((err as DatasourceCliError).message).toContain("Timed out");
+    expect((err as DatasourceCliError).message).toContain("test datasource");
+  });
+
+  it("a 500 → request_failed surfacing the server message + requestId", async () => {
+    const { fetchImpl } = stubFetch(500, {
+      error: "internal_error",
+      message: "Drain failed.",
+      requestId: "req-xyz",
+    });
+    const err = await deleteDatasource(opts(fetchImpl), "prod-us").catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("request_failed");
+    expect((err as DatasourceCliError).message).toContain("Drain failed.");
+    expect((err as DatasourceCliError).message).toContain("req-xyz");
+  });
+
+  it("a non-JSON error body → request_failed with an HTTP-status message", async () => {
+    const fetchImpl = (async () =>
+      new Response("<html>502 Bad Gateway</html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      })) as unknown as typeof fetch;
+    const err = await listDatasources({ baseUrl: BASE, token: TOKEN, fetchImpl }).catch((e) => e);
+    expect((err as DatasourceCliError).kind).toBe("request_failed");
+    expect((err as DatasourceCliError).message).toContain("HTTP 502");
+  });
+});

--- a/packages/cli/src/__tests__/datasource-command.test.ts
+++ b/packages/cli/src/__tests__/datasource-command.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "bun:test";
+
+import { runDatasource, type DatasourceIO, type DatasourceRunDeps } from "../commands/datasource";
+import type { StoredSession } from "../lib/credentials";
+
+const BASE = "http://localhost:3001";
+const SESSION: StoredSession = { token: "sess_abc", workspaceId: "org-1", createdAt: "2026-06-27T00:00:00Z" };
+
+function capture(): { io: DatasourceIO; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { out: (l) => out.push(l), err: (l) => err.push(l) }, out, err };
+}
+
+/** Single-canned-response fetch capturing requests. */
+function stubFetch(status: number, body: unknown): { fetchImpl: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push(`${init?.method ?? "GET"} ${typeof url === "string" ? url : url.toString()}`);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function deps(
+  fetchImpl: typeof fetch | undefined,
+  session: StoredSession | null = SESSION,
+): DatasourceRunDeps {
+  return { baseUrl: BASE, session, ...(fetchImpl !== undefined ? { fetchImpl } : {}) };
+}
+
+describe("runDatasource — auth + dispatch guards (#4044)", () => {
+  it("with no session, refuses with a login hint and exit 1", async () => {
+    const { io, err } = capture();
+    const code = await runDatasource(["datasource", "list"], deps(undefined, null), io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("atlas login");
+  });
+
+  it("no subcommand prints usage and exits 1", async () => {
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource"], deps(undefined), io);
+    expect(code).toBe(1);
+    expect(out.join("\n")).toContain("Usage: atlas datasource");
+  });
+
+  it("--help prints usage and exits 0", async () => {
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "--help"], deps(undefined), io);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("Usage: atlas datasource");
+  });
+
+  it("unknown subcommand errors and exits 1", async () => {
+    const { io, err } = capture();
+    const code = await runDatasource(["datasource", "frobnicate"], deps(undefined), io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("Unknown datasource command");
+  });
+
+  it("an id-taking subcommand without an id errors", async () => {
+    const { io, err } = capture();
+    const code = await runDatasource(["datasource", "archive"], deps(undefined), io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("atlas datasource archive <id>");
+  });
+});
+
+describe("runDatasource — list (#4044)", () => {
+  it("renders a table of the workspace's datasources", async () => {
+    const { fetchImpl } = stubFetch(200, {
+      connections: [
+        { id: "prod-us", dbType: "postgres", status: "published", groupId: "prod", health: { status: "healthy" } },
+      ],
+    });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "list"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    const text = out.join("\n");
+    expect(text).toContain("prod-us");
+    expect(text).toContain("postgres");
+    expect(text).toContain("healthy");
+  });
+
+  it("prints an empty-state line when there are no datasources", async () => {
+    const { fetchImpl } = stubFetch(200, { connections: [] });
+    const { io, out } = capture();
+    await runDatasource(["datasource", "list"], deps(fetchImpl), io);
+    expect(out.join("\n")).toContain("no datasources");
+  });
+
+  it("--json emits the workspace id + datasources", async () => {
+    const { fetchImpl } = stubFetch(200, { connections: [{ id: "prod-us" }] });
+    const { io, out } = capture();
+    await runDatasource(["datasource", "list", "--json"], deps(fetchImpl), io);
+    const parsed = JSON.parse(out.join("\n"));
+    expect(parsed.workspaceId).toBe("org-1");
+    expect(parsed.datasources[0].id).toBe("prod-us");
+  });
+});
+
+describe("runDatasource — get/test (#4044)", () => {
+  it("get renders a detail block", async () => {
+    const { fetchImpl } = stubFetch(200, {
+      id: "prod-us",
+      dbType: "postgres",
+      status: "published",
+      maskedUrl: "postgres://***@host/db",
+    });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "get", "prod-us"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    const text = out.join("\n");
+    expect(text).toContain("Datasource: prod-us");
+    expect(text).toContain("postgres://***@host/db");
+  });
+
+  it("test exits 0 on healthy", async () => {
+    const { fetchImpl } = stubFetch(200, { status: "healthy", latencyMs: 12 });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "test", "prod-us"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("healthy");
+  });
+
+  it("test exits 1 on a non-healthy result so scripts can branch", async () => {
+    const { fetchImpl } = stubFetch(200, { status: "degraded", latencyMs: 0, message: "timeout" });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "test", "prod-us"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    expect(out.join("\n")).toContain("degraded");
+  });
+
+  it("get --json emits the raw detail, not the rendered block", async () => {
+    const { fetchImpl } = stubFetch(200, { id: "prod-us", dbType: "postgres" });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "get", "prod-us", "--json"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out.join("\n"));
+    expect(parsed).toEqual({ id: "prod-us", dbType: "postgres" });
+  });
+
+  it("test --json emits the raw result and still reflects health in the exit code", async () => {
+    const { fetchImpl } = stubFetch(200, { status: "degraded", latencyMs: 0 });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "test", "prod-us", "--json"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    expect(JSON.parse(out.join("\n")).status).toBe("degraded");
+  });
+});
+
+describe("runDatasource — mutations (#4044)", () => {
+  it("archive confirms success and hints at restore", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { archived: { connection: true } });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "archive", "old"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(calls[0]).toContain("POST http://localhost:3001/api/v1/admin/archive-connection");
+    expect(out.join("\n")).toContain("restore old");
+  });
+
+  it("restore confirms the datasource is published/queryable again", async () => {
+    const { fetchImpl } = stubFetch(200, { restored: { connection: true } });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "restore", "old"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("queryable again");
+  });
+
+  it("delete confirms success", async () => {
+    const { fetchImpl } = stubFetch(200, { success: true });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "delete", "old"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain('Deleted datasource "old"');
+  });
+
+  it("a non-admin member is denied a mutating op with an actionable message", async () => {
+    const { fetchImpl } = stubFetch(403, { error: "forbidden_role", message: "Admin role required." });
+    const { io, err } = capture();
+    const code = await runDatasource(["datasource", "delete", "prod-us"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    const text = err.join("\n");
+    expect(text).toContain("admin role");
+    expect(text).toContain("atlas login");
+  });
+});
+
+describe("runDatasource — unexpected errors are surfaced, not swallowed (#4044)", () => {
+  it("an unexpected (non-DatasourceCliError) throw becomes an `Unexpected error` line + exit 1", async () => {
+    const { fetchImpl } = stubFetch(200, { connections: [{ id: "x" }] });
+    const errs: string[] = [];
+    let firstOut = true;
+    const io: DatasourceIO = {
+      out: () => {
+        // Simulate an unexpected downstream failure during rendering.
+        if (firstOut) {
+          firstOut = false;
+          throw new Error("render boom");
+        }
+      },
+      err: (l) => errs.push(l),
+    };
+    const code = await runDatasource(["datasource", "list"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    expect(errs.join("\n")).toContain("Unexpected error");
+    expect(errs.join("\n")).toContain("render boom");
+  });
+});

--- a/packages/cli/src/commands/datasource.ts
+++ b/packages/cli/src/commands/datasource.ts
@@ -1,0 +1,283 @@
+/**
+ * `atlas datasource list|get|test|archive|restore|delete` (#4044 / ADR-0026).
+ *
+ * The workspace CLI surface for datasource lifecycle — a thin HTTP client over
+ * the EXISTING admin-connection REST routes (`datasource-client.ts`), authorized
+ * entirely by the `atlas login` workspace credential. Each subcommand maps to one
+ * route; there is no duplicated business logic. Operations act on ONLY the bound
+ * workspace's datasources (the bearer resolves live to `{ orgId, role }`).
+ * EVERY command requires the workspace admin role — the admin-connection routes
+ * are admin-gated end to end (matching the MCP parity reference, where datasource
+ * metadata is itself an admin surface). A non-admin member is denied (with the
+ * mutating ops being the most consequential) and gets an actionable message.
+ *
+ * Parity reference: `packages/mcp/src/datasource-tools.ts` for list/get/test/
+ * archive. `restore` and `delete` intentionally DIVERGE from the MCP tools
+ * because each maps to a different REST route: this CLI's `restore` republishes
+ * (the `restore-connection` route → `status='published'`) whereas the MCP revives
+ * to a draft, and this CLI's `delete` is a soft, restorable archive (the
+ * `DELETE` route → `uninstallDatasource` without `hard`) whereas the MCP
+ * `delete_datasource` is an irreversible hard delete.
+ *
+ * The dispatch + rendering live in the testable `runDatasource` core (deps are
+ * injected: the session, the API base URL, and `fetch`), so route mapping,
+ * output, and the typed-error → message mapping are unit-tested without a live
+ * server or `process.exit`. `handleDatasource` is the thin shell main() calls.
+ */
+
+import { renderTable } from "../../lib/output";
+import { resolveApiBaseUrl } from "../lib/api-base";
+import { readSession, type StoredSession } from "../lib/credentials";
+import {
+  DatasourceCliError,
+  archiveDatasource,
+  deleteDatasource,
+  getDatasource,
+  listDatasources,
+  restoreDatasource,
+  testDatasource,
+  type DatasourceClientOptions,
+} from "../lib/datasource-client";
+
+const USAGE = `Manage the datasources of your logged-in workspace.
+
+Usage: atlas datasource <command> [id] [--json]
+
+Commands:
+  list                List the workspace's datasources
+  get <id>            Show one datasource's detail
+  test <id>           Health-check a datasource connection
+  archive <id>        Archive a datasource (reversible via restore)
+  restore <id>        Restore an archived datasource
+  delete <id>         Delete a datasource (soft — recoverable via restore)
+
+Options:
+  --json              Machine-readable JSON output
+
+Every datasource command requires the workspace admin role (admin/owner); a
+non-admin member is denied with an actionable message.
+Requires \`atlas login\` first. Set ATLAS_API_URL to target a non-local API.`;
+
+/** The id-taking subcommands (everything except `list`). */
+const ID_SUBCOMMANDS = ["get", "test", "archive", "restore", "delete"] as const;
+type IdSubcommand = (typeof ID_SUBCOMMANDS)[number];
+
+/** Every datasource subcommand. */
+const DATASOURCE_SUBCOMMANDS = ["list", ...ID_SUBCOMMANDS] as const;
+type DatasourceSubcommand = (typeof DATASOURCE_SUBCOMMANDS)[number];
+
+function isDatasourceSubcommand(value: string): value is DatasourceSubcommand {
+  return (DATASOURCE_SUBCOMMANDS as readonly string[]).includes(value);
+}
+
+/** stdout/stderr sink — injected so tests can capture output. */
+export interface DatasourceIO {
+  readonly out: (line: string) => void;
+  readonly err: (line: string) => void;
+}
+
+const defaultIO: DatasourceIO = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+/** Everything `runDatasource` needs, injected so it stays server-free in tests. */
+export interface DatasourceRunDeps {
+  readonly baseUrl: string;
+  readonly session: StoredSession | null;
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** First non-flag argument after the subcommand (the datasource id), if any. */
+function positionalId(args: string[]): string | undefined {
+  return args.slice(2).find((a) => !a.startsWith("--"));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+/** Pretty-print a datasource list as a table; falls back to an empty-state line. */
+function renderList(io: DatasourceIO, workspaceId: string | null, datasources: unknown[]): void {
+  if (datasources.length === 0) {
+    io.out(
+      workspaceId
+        ? `Workspace ${workspaceId} has no datasources.`
+        : "No datasources configured for this workspace.",
+    );
+    return;
+  }
+  const rows = datasources.map((d) => {
+    const r = asRecord(d);
+    const health = asRecord(r.health);
+    return {
+      id: typeof r.id === "string" ? r.id : "",
+      type: typeof r.dbType === "string" ? r.dbType : "",
+      status: typeof r.status === "string" ? r.status : "",
+      group: typeof r.groupId === "string" ? r.groupId : "-",
+      health: typeof health.status === "string" ? health.status : "-",
+    };
+  });
+  io.out(renderTable(["id", "type", "status", "group", "health"], rows));
+}
+
+/** Print the readable subset of a datasource detail record. */
+function renderDetail(io: DatasourceIO, id: string, detail: Record<string, unknown>): void {
+  io.out(`Datasource: ${id}`);
+  const fields: Array<[string, string]> = [
+    ["Type", "dbType"],
+    ["Status", "status"],
+    ["Schema", "schema"],
+    ["Group", "groupId"],
+    ["URL", "maskedUrl"],
+    ["Description", "description"],
+  ];
+  for (const [label, key] of fields) {
+    const v = detail[key];
+    if (typeof v === "string" && v.length > 0) io.out(`  ${label}: ${v}`);
+  }
+  const health = asRecord(detail.health);
+  if (typeof health.status === "string") io.out(`  Health: ${health.status}`);
+}
+
+/**
+ * Testable core: dispatch one `atlas datasource` invocation. Returns the process
+ * exit code (0 success, 1 failure) without calling `process.exit`, so tests can
+ * assert on it directly.
+ *
+ * `args` is the full argv slice (args[0] === "datasource").
+ */
+export async function runDatasource(
+  args: string[],
+  deps: DatasourceRunDeps,
+  io: DatasourceIO = defaultIO,
+): Promise<number> {
+  const subcommand = args[1];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    io.out(USAGE);
+    return subcommand ? 0 : 1;
+  }
+
+  if (!isDatasourceSubcommand(subcommand)) {
+    io.err(`Unknown datasource command: ${subcommand}\n`);
+    io.out(USAGE);
+    return 1;
+  }
+
+  if (!deps.session) {
+    io.err("Not logged in. Run `atlas login` first.");
+    return 1;
+  }
+
+  const opts: DatasourceClientOptions = {
+    baseUrl: deps.baseUrl,
+    token: deps.session.token,
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+  };
+  const json = args.includes("--json");
+
+  // Subcommands other than `list` require a datasource id.
+  if (subcommand !== "list") {
+    const id = positionalId(args);
+    if (!id) {
+      io.err(`Usage: atlas datasource ${subcommand} <id>`);
+      return 1;
+    }
+    return runIdSubcommand(subcommand, id, opts, json, io);
+  }
+
+  try {
+    const datasources = await listDatasources(opts);
+    if (json) {
+      io.out(JSON.stringify({ workspaceId: deps.session.workspaceId, datasources }, null, 2));
+    } else {
+      renderList(io, deps.session.workspaceId, datasources);
+    }
+    return 0;
+  } catch (err) {
+    return handleError(err, io);
+  }
+}
+
+/** Run one of the id-taking subcommands (everything except `list`). */
+async function runIdSubcommand(
+  subcommand: IdSubcommand,
+  id: string,
+  opts: DatasourceClientOptions,
+  json: boolean,
+  io: DatasourceIO,
+): Promise<number> {
+  try {
+    switch (subcommand) {
+      case "get": {
+        const detail = await getDatasource(opts, id);
+        if (json) io.out(JSON.stringify(detail, null, 2));
+        else renderDetail(io, id, detail);
+        return 0;
+      }
+      case "test": {
+        const result = await testDatasource(opts, id);
+        const status = typeof result.status === "string" ? result.status : "unknown";
+        const healthy = status === "healthy";
+        if (json) {
+          io.out(JSON.stringify(result, null, 2));
+        } else {
+          const latency = typeof result.latencyMs === "number" ? ` (${result.latencyMs}ms)` : "";
+          io.out(`Datasource "${id}": ${status}${latency}`);
+          if (typeof result.message === "string" && result.message.length > 0) {
+            io.out(`  ${result.message}`);
+          }
+        }
+        // Non-healthy is a non-zero exit so scripts can branch on it.
+        return healthy ? 0 : 1;
+      }
+      case "archive": {
+        const result = await archiveDatasource(opts, id);
+        if (json) io.out(JSON.stringify(result, null, 2));
+        else io.out(`Archived datasource "${id}". Restore it with: atlas datasource restore ${id}`);
+        return 0;
+      }
+      case "restore": {
+        const result = await restoreDatasource(opts, id);
+        if (json) io.out(JSON.stringify(result, null, 2));
+        else io.out(`Restored datasource "${id}" — it is published and queryable again.`);
+        return 0;
+      }
+      case "delete": {
+        const result = await deleteDatasource(opts, id);
+        if (json) io.out(JSON.stringify(result, null, 2));
+        else io.out(`Deleted datasource "${id}". This is a soft delete — restore it with: atlas datasource restore ${id}`);
+        return 0;
+      }
+      default: {
+        // Exhaustiveness: every IdSubcommand is handled above, so this is
+        // unreachable. A new id-taking subcommand will fail to compile here
+        // until its case is added.
+        const _exhaustive: never = subcommand;
+        io.err(`Unknown datasource command: ${String(_exhaustive)}`);
+        return 1;
+      }
+    }
+  } catch (err) {
+    return handleError(err, io);
+  }
+}
+
+/** Map a typed client error (or anything else) to an error line + exit code. */
+function handleError(err: unknown, io: DatasourceIO): number {
+  if (err instanceof DatasourceCliError) {
+    io.err(err.message);
+    return 1;
+  }
+  // Unexpected — surface it rather than swallowing (no silent failures).
+  io.err(`Unexpected error: ${err instanceof Error ? err.message : String(err)}`);
+  return 1;
+}
+
+/** Thin shell main() invokes: resolve the credential + base URL, then dispatch. */
+export async function handleDatasource(args: string[]): Promise<void> {
+  const baseUrl = resolveApiBaseUrl();
+  const session = readSession(baseUrl);
+  const code = await runDatasource(args, { baseUrl, session });
+  if (code !== 0) process.exit(code);
+}

--- a/packages/cli/src/commands/datasource.ts
+++ b/packages/cli/src/commands/datasource.ts
@@ -1,5 +1,5 @@
 /**
- * `atlas datasource list|get|test|archive|restore|delete` (#4044 / ADR-0026).
+ * `atlas datasource list|get|test|archive|restore|delete` (#4044 / ADR-0025 sub-decision 3).
  *
  * The workspace CLI surface for datasource lifecycle — a thin HTTP client over
  * the EXISTING admin-connection REST routes (`datasource-client.ts`), authorized

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -1,0 +1,266 @@
+/**
+ * `atlas datasource` HTTP client (#4044 / ADR-0026 sub-decision 3).
+ *
+ * A thin, transport-only client over the EXISTING admin-connection REST routes
+ * — there is no duplicated business logic here, the server owns it. The MCP
+ * `datasource-tools.ts` reaches the same gated core over its in-process lib
+ * seam; list/get/test/archive behave identically across both transports, but
+ * `restore` and `delete` deliberately differ because each CLI subcommand maps
+ * to its own REST route (see the command module's header for the divergence).
+ * Each function maps one workspace CLI subcommand onto one existing route:
+ *
+ *   list     → GET    /api/v1/admin/connections
+ *   get      → GET    /api/v1/admin/connections/{id}
+ *   test     → POST   /api/v1/admin/connections/{id}/test
+ *   archive  → POST   /api/v1/admin/archive-connection      { connectionId }
+ *   restore  → POST   /api/v1/admin/restore-connection      { connectionId }
+ *   delete   → DELETE /api/v1/admin/connections/{id}
+ *
+ * Authorization rides entirely on the `atlas login` workspace credential: the
+ * stored Better Auth session bearer (stamped `origin='cli'` server-side) is
+ * sent as `Authorization: Bearer <token>`. The routes resolve it live to
+ * `{ orgId, role }` through the same gate chain a web admin session clears, so
+ * the call operates on ONLY the bound workspace's datasources and is denied
+ * (403) when the credential's role isn't admin. The CLI never re-derives any of
+ * that — it just surfaces the typed outcome.
+ *
+ * `fetch` is injectable so the route mapping + status-code handling are
+ * unit-testable without a live server (mirrors `device-flow.ts`). No function
+ * here calls `process.exit` or `console`; the command handler owns presentation.
+ */
+
+type FetchImpl = typeof fetch;
+
+/** The kinds of failure a datasource call can surface, each with an actionable message. */
+export type DatasourceErrorKind =
+  | "unauthorized" // 401 — bearer missing/expired
+  | "forbidden" // 403 — role lacks admin
+  | "mfa_required" // 403 — admin must enroll a second factor first
+  | "no_workspace" // 400 — credential has no bound workspace
+  | "not_found" // 404 — datasource id not in this workspace
+  | "conflict" // 409 — e.g. referenced by a scheduled task
+  | "request_failed" // other non-2xx
+  | "network"; // fetch threw / timed out
+
+/** A datasource call failure carrying a typed {@link DatasourceErrorKind}. */
+export class DatasourceCliError extends Error {
+  constructor(
+    readonly kind: DatasourceErrorKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DatasourceCliError";
+  }
+}
+
+export interface DatasourceClientOptions {
+  /** Normalized Atlas API base URL (no trailing slash). */
+  readonly baseUrl: string;
+  /** The stored `atlas login` session bearer. */
+  readonly token: string;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  readonly fetchImpl?: FetchImpl;
+  /** Per-request timeout in ms (default 30s). */
+  readonly timeoutMs?: number;
+}
+
+interface RequestSpec {
+  readonly method: "GET" | "POST" | "DELETE";
+  readonly path: string;
+  readonly body?: unknown;
+  /** Human-readable operation label woven into error messages, e.g. "archive datasource". */
+  readonly operation: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+/**
+ * Pull the server's actionable message off a JSON error body, falling back to
+ * the HTTP status. Appends the server's `requestId` (Atlas error envelopes carry
+ * one — always on 5xx, and on the 4xx envelopes these admin routes return) so a
+ * user's bug report stays log-correlatable operator-side.
+ */
+function serverMessage(body: Record<string, unknown>, status: number): string {
+  const base =
+    typeof body.message === "string" && body.message.length > 0
+      ? body.message
+      : typeof body.error === "string" && body.error.length > 0
+        ? body.error
+        : `HTTP ${status}`;
+  return typeof body.requestId === "string" && body.requestId.length > 0
+    ? `${base} (request ${body.requestId})`
+    : base;
+}
+
+/**
+ * Issue one request against an admin-connection route and return its parsed
+ * JSON body, mapping every documented failure status onto a typed
+ * {@link DatasourceCliError} with an actionable message. The 403 branch
+ * distinguishes the admin-role denial (the admin-role gate this surface is built
+ * around — it fires for the read ops too, not just mutations) from the
+ * admin-MFA-enrollment gate, since the remedies differ.
+ */
+async function request(
+  opts: DatasourceClientOptions,
+  spec: RequestSpec,
+): Promise<unknown> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${opts.baseUrl}${spec.path}`, {
+      method: spec.method,
+      headers: {
+        Authorization: `Bearer ${opts.token}`,
+        ...(spec.body !== undefined ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(spec.body !== undefined ? { body: JSON.stringify(spec.body) } : {}),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    if (name === "TimeoutError" || name === "AbortError") {
+      throw new DatasourceCliError(
+        "network",
+        `Timed out after ${Math.round(timeoutMs / 1000)}s trying to ${spec.operation}.`,
+      );
+    }
+    throw new DatasourceCliError(
+      "network",
+      `Could not reach the Atlas API at ${opts.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (res.ok) {
+    // intentionally ignored: a 2xx with an empty/non-JSON body degrades to {} —
+    // callers tolerate missing optional fields rather than crashing on parse.
+    return await res.json().catch(() => ({}));
+  }
+
+  // intentionally ignored: an error body that isn't JSON falls back to the
+  // HTTP-status message below via the empty record.
+  const body = asRecord(await res.json().catch(() => ({})));
+
+  switch (res.status) {
+    case 401:
+      throw new DatasourceCliError(
+        "unauthorized",
+        "Your session is no longer valid. Run `atlas login` again.",
+      );
+    case 403: {
+      if (body.error === "mfa_enrollment_required") {
+        throw new DatasourceCliError(
+          "mfa_required",
+          "Admin actions require two-factor authentication. Enroll an authenticator or passkey in the Atlas console, then retry.",
+        );
+      }
+      throw new DatasourceCliError(
+        "forbidden",
+        `Cannot ${spec.operation}: the workspace admin role is required. Your login does not carry it — ask a workspace admin to run this, or sign in with an admin account (\`atlas login\`).`,
+      );
+    }
+    case 400:
+      // requireOrgContext returns 400 bad_request when the credential has no
+      // bound workspace (a multi-workspace login pending the picker slice).
+      if (body.error === "bad_request") {
+        throw new DatasourceCliError(
+          "no_workspace",
+          "Your login is not bound to a workspace. Single-workspace accounts bind automatically; in-flow workspace selection for multi-workspace accounts is coming soon (ADR-0026).",
+        );
+      }
+      throw new DatasourceCliError("request_failed", serverMessage(body, res.status));
+    case 404:
+      throw new DatasourceCliError("not_found", serverMessage(body, res.status));
+    case 409:
+      throw new DatasourceCliError("conflict", serverMessage(body, res.status));
+    default:
+      throw new DatasourceCliError("request_failed", serverMessage(body, res.status));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// One function per subcommand — each maps to exactly one existing REST route.
+// ---------------------------------------------------------------------------
+
+/** GET /api/v1/admin/connections — the bound workspace's datasources (credential-free metadata). */
+export async function listDatasources(opts: DatasourceClientOptions): Promise<unknown[]> {
+  const body = asRecord(
+    await request(opts, { method: "GET", path: "/api/v1/admin/connections", operation: "list datasources" }),
+  );
+  return Array.isArray(body.connections) ? body.connections : [];
+}
+
+/** GET /api/v1/admin/connections/{id} — one datasource's detail (masked URL + schema). */
+export async function getDatasource(
+  opts: DatasourceClientOptions,
+  id: string,
+): Promise<Record<string, unknown>> {
+  return asRecord(
+    await request(opts, {
+      method: "GET",
+      path: `/api/v1/admin/connections/${encodeURIComponent(id)}`,
+      operation: "get datasource",
+    }),
+  );
+}
+
+/** POST /api/v1/admin/connections/{id}/test — health-check an existing datasource. */
+export async function testDatasource(
+  opts: DatasourceClientOptions,
+  id: string,
+): Promise<Record<string, unknown>> {
+  return asRecord(
+    await request(opts, {
+      method: "POST",
+      path: `/api/v1/admin/connections/${encodeURIComponent(id)}/test`,
+      operation: "test datasource",
+    }),
+  );
+}
+
+/** POST /api/v1/admin/archive-connection — soft-archive (reversible via restore). */
+export async function archiveDatasource(
+  opts: DatasourceClientOptions,
+  id: string,
+): Promise<Record<string, unknown>> {
+  return asRecord(
+    await request(opts, {
+      method: "POST",
+      path: "/api/v1/admin/archive-connection",
+      body: { connectionId: id },
+      operation: "archive datasource",
+    }),
+  );
+}
+
+/** POST /api/v1/admin/restore-connection — un-archive a previously archived datasource. */
+export async function restoreDatasource(
+  opts: DatasourceClientOptions,
+  id: string,
+): Promise<Record<string, unknown>> {
+  return asRecord(
+    await request(opts, {
+      method: "POST",
+      path: "/api/v1/admin/restore-connection",
+      body: { connectionId: id },
+      operation: "restore datasource",
+    }),
+  );
+}
+
+/** DELETE /api/v1/admin/connections/{id} — remove the datasource (the route soft-archives). */
+export async function deleteDatasource(
+  opts: DatasourceClientOptions,
+  id: string,
+): Promise<Record<string, unknown>> {
+  return asRecord(
+    await request(opts, {
+      method: "DELETE",
+      path: `/api/v1/admin/connections/${encodeURIComponent(id)}`,
+      operation: "delete datasource",
+    }),
+  );
+}

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -1,5 +1,5 @@
 /**
- * `atlas datasource` HTTP client (#4044 / ADR-0026 sub-decision 3).
+ * `atlas datasource` HTTP client (#4044 / ADR-0025 sub-decision 3).
  *
  * A thin, transport-only client over the EXISTING admin-connection REST routes
  * — there is no duplicated business logic here, the server owns it. The MCP


### PR DESCRIPTION
## Summary

Adds `atlas datasource list/get/test/archive/restore/delete` as a **workspace CLI surface** (ADR-0025 sub-decision 3) — a thin HTTP client over the **existing** admin-connection REST routes, authorized entirely by the `atlas login` workspace credential built in #4043.

- **Thin transport, no duplicated logic.** Each subcommand maps 1:1 to an existing route (`GET /admin/connections`, `GET/DELETE /admin/connections/{id}`, `POST /admin/connections/{id}/test`, `POST /admin/{archive,restore}-connection`). The server owns the business logic; the new `datasource-client.ts` is `smoke.ts`-shaped (injectable `fetch`, typed errors, no `process.exit`). Parity reference is `packages/mcp/src/datasource-tools.ts` — list/get/test/archive behave identically across both transports; `restore` and `delete` map to their own REST routes and **intentionally diverge** from the MCP tools (CLI `restore` republishes; CLI `delete` is a soft, restorable archive).
- **Authorized via the workspace credential + role through the gate chain.** The device-flow session bearer (stamped `origin='cli'`, role-downgraded to org-member by #4043) resolves live to `{orgId, role}` through `adminAuth` → the routes scope to the bound `activeOrganizationId`. So every command operates on **only** the bound workspace's datasources, and a non-admin member is denied (403) with an actionable message naming the admin-role requirement + `atlas login`. The routes already honored a session + role — no auth rewrite was needed.
- **Audited `origin=cli`.** `validateManaged` surfaces the session `origin` marker onto `user.claims.origin` (sole-authoritative from the session row — a stray session-user field can't shadow it); `logAdminAction` records it as `admin_action_log` `metadata.origin`, validated against the canonical origin vocabulary (`isRequestOrigin`). So CLI-originated datasource mutations (archive/restore/delete + health-check) are auditable as `origin=cli`. No migration — rides existing JSONB metadata; web sessions stay byte-identical.

## Acceptance criteria
- [x] `atlas datasource list/get/test/archive/restore/delete` operate on the bound workspace's datasources only
- [x] Each maps to an existing REST route; no duplicate logic
- [x] Authorized via the workspace credential + role through the gate chain; audited `origin=cli`
- [x] A non-admin member is denied mutating ops with an actionable message (all commands are admin-gated, matching MCP parity where datasource metadata is itself an admin surface)

## Test plan
- [x] CLI client (`datasource-client.test.ts`): route mapping (method + path + bearer + body) for all six subcommands; error mapping (401/403-role/403-mfa/400-no-workspace/404/409/500/timeout/non-JSON/network) → typed `DatasourceErrorKind` with actionable messages + `requestId` surfacing.
- [x] CLI command (`datasource-command.test.ts`): dispatch, not-logged-in, missing-id, unknown-subcommand, list/get/test/archive/restore/delete output (+ `--json`), test exit-code reflects health, non-admin-denied message, unexpected-error surfaced (no silent failure).
- [x] API: `managed.test.ts` (origin claim surfaced from session row; web session has none; session-user field can't shadow); `audit/admin.test.ts` (origin=cli in metadata, merged with trustDeviceIdentifier, web → null, unrecognized origin dropped, systemActor never inherits).
- [x] `/ci`: lint, type, syncpack, template/schema/openapi/oauth/test-discipline/published-symbols/railway-watch/settings/saas-env/security-headers/pricing drift — all green. Affected API graph (190 files) green; full CLI suite (36 files) green. Full API suite: 729 pass; the 4 failures are the documented WSL2 `VERCEL_*` sandbox-priority flake (sandbox/explore/python/agent-integration — unrelated to this diff; pass with `VERCEL_*` unset, green in CI).
- [x] Internal review panel (4 specialists) — 3 rounds to CLEAN.

## Notes / follow-ups
- Reads (list/get) are admin-gated too (parity with the MCP, where every datasource tool is `minRole: admin`); the AC's "member denied mutating ops" is satisfied because all ops are admin-gated.
- Multi-workspace login surfaces a clear "no bound workspace" message (the in-flow picker remains the deferred ADR-0026 slice from #4043).

Closes #4044