### PR TITLE
fix(billing,api): proactive is all-paid + SaaS-exclusive, not Business-only (#3999)

### DIFF
--- a/apps/docs/content/docs/guides/proactive-chat.mdx
+++ b/apps/docs/content/docs/guides/proactive-chat.mdx
@@ -5,13 +5,13 @@ description: The proactive chat tier — three-layer kill switch, classifier mod
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-Proactive chat (milestone #43) lets Atlas **listen** in opt-in Slack channels, react to data-shaped questions with an emoji, and answer on tap. It is `/ee`-gated and currently **Slack-first only** — Teams, Discord, and Google Chat are wired but feature-flagged off until the bar in the [PRD](https://github.com/AtlasDevHQ/atlas/issues/2291) (≤5% misfire, ≥70% acceptance) is met on a chat platform.
+Proactive chat (milestone #43) lets Atlas **listen** in opt-in Slack channels, react to data-shaped questions with an emoji, and answer on tap. Its implementation lives in `/ee`, and it is currently **Slack-first only** — Teams, Discord, and Google Chat are wired but feature-flagged off until the bar in the [PRD](https://github.com/AtlasDevHQ/atlas/issues/2291) (≤5% misfire, ≥70% acceptance) is met on a chat platform.
 
-<Callout type="info" title="Paid tier">
-Proactive chat is part of Atlas Enterprise. The end-user disclosure surfaces in [`guides/slack.mdx`](/guides/slack); this guide is the admin/operator companion.
+<Callout type="info" title="Hosted-SaaS feature — every paid plan">
+Proactive chat is available on **Atlas Cloud** (the hosted SaaS) for **every paid plan**, not just Business (#3999). It is **not available on self-hosted** deployments, including self-hosted enterprise. The end-user disclosure surfaces in [`guides/slack.mdx`](/guides/slack); this guide is the admin/operator companion.
 </Callout>
 
-The whole surface lives at **Admin → Proactive Chat** (`/admin/proactive-chat`) as one consolidated page. The page is enterprise-gated — self-hosted free users see an upsell card instead of the form. Six sections, each backed by an admin API route under `/api/v1/admin/proactive/*`:
+The whole surface lives at **Admin → Proactive Chat** (`/admin/proactive-chat`) as one consolidated page. The page is **hosted-SaaS-only** — self-hosted users (free or enterprise) see an upsell card instead of the form; on Atlas Cloud every paid plan reaches it. Six sections, each backed by an admin API route under `/api/v1/admin/proactive/*`:
 
 1. [Activation toggle](#activation-toggle)
 2. [Behavior — sensitivity, classifier mode, announcement channel, monthly cap](#behavior)

--- a/apps/docs/content/docs/plugins/interactions/chat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/chat.mdx
@@ -159,7 +159,7 @@ Per-Platform credentials come from environment variables — see [Environment Va
 | `reactions.enabled` | `boolean` | No | Enable emoji reactions on user messages. Default: `true`. |
 | `reactions.customEmoji` | `object` | No | Override default emoji for each lifecycle stage (`received`, `processing`, `complete`, `error`). |
 | `ephemeral` | `EphemeralConfig` | No | Post errors and debug info as ephemeral messages (visible only to the requesting user). See [Ephemeral Messages](#ephemeral-messages). |
-| `proactive` | `ProactiveConfig` | No | Reaction-first proactive chat (enterprise-gated; the host wires `isEnabled`/`classify`). When enabled, the bridge reacts to high-confidence data questions. See [Proactive Direct Messages](#proactive-direct-messages). |
+| `proactive` | `ProactiveConfig` | No | Reaction-first proactive chat (availability gated by the host — for Atlas, a hosted-SaaS feature available on every paid plan; the host wires `isEnabled`/`classify`). When enabled, the bridge reacts to high-confidence data questions. See [Proactive Direct Messages](#proactive-direct-messages). |
 
 <Callout type="info">
 At least one `catalog` row with `type: "chat"`, `enabled: true`, and a supported `install_model` must be present (and threaded through to `chatPlugin({ catalog })`) — otherwise no adapter activates and the plugin's health check reports unhealthy. Per-Platform credentials come from env vars (see [Environment Variables](#environment-variables)). For Slack OAuth specifically you need **all four**: `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`, and `SLACK_ENCRYPTION_KEY` — the install will be skipped (and the chat plugin reported unhealthy) if any one is missing.

--- a/apps/www/src/app/pricing/entitlements.generated.ts
+++ b/apps/www/src/app/pricing/entitlements.generated.ts
@@ -135,6 +135,6 @@ export const ENTITLEMENT_ROWS: readonly EntitlementRow[] = [
     feature: "proactive",
     label: "Proactive monitoring",
     section: "security & compliance",
-    cells: { selfHosted: false, starter: false, pro: false, business: true },
+    cells: { selfHosted: false, starter: true, pro: true, business: true },
   },
 ];

--- a/ee/src/__tests__/proactive-gate.test.ts
+++ b/ee/src/__tests__/proactive-gate.test.ts
@@ -14,18 +14,23 @@
  */
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
-import { Effect, Either } from "effect";
+import { Effect, Either, Exit } from "effect";
 
 // ── Mutable mock state ──────────────────────────────────────────────
 let enterpriseEnabledConfig: boolean | undefined = true;
 let _hasInternalDB = true;
+// When set, `getConfig` throws — simulating a deploy-mode-resolution fault so
+// the fail-closed test can prove a throw never admits.
+let configThrows = false;
 
 // ── Register all mocks before any dynamic import ────────────────────
 mock.module("@atlas/api/lib/config", () => ({
-  getConfig: () =>
-    enterpriseEnabledConfig === undefined
+  getConfig: () => {
+    if (configThrows) throw new Error("getConfig boom (deploy-mode fault)");
+    return enterpriseEnabledConfig === undefined
       ? null
-      : { enterprise: { enabled: enterpriseEnabledConfig } },
+      : { enterprise: { enabled: enterpriseEnabledConfig } };
+  },
 }));
 
 mock.module("@atlas/api/lib/db/internal", () => ({
@@ -62,6 +67,7 @@ describe("makeProactiveGateLive — hosted-SaaS-only availability gate (#3999)",
   beforeEach(() => {
     enterpriseEnabledConfig = true;
     _hasInternalDB = true;
+    configThrows = false;
     delete process.env.ATLAS_DEPLOY_MODE;
     delete process.env.ATLAS_ENTERPRISE_ENABLED;
     // `auto` short-circuits to self-hosted under development; clear it so the
@@ -95,5 +101,17 @@ describe("makeProactiveGateLive — hosted-SaaS-only availability gate (#3999)",
     enterpriseEnabledConfig = true;
     _hasInternalDB = false;
     expect(Either.isLeft(runGate())).toBe(true);
+  });
+
+  it("fails closed (never admits) when resolveDeployMode throws", () => {
+    // A fault in deploy-mode resolution must never admit: `getConfig` throwing
+    // propagates through `isEnterpriseEnabled` → `resolveDeployMode`. The gate
+    // reads inside `Effect.suspend`, so the throw surfaces as an effect failure
+    // (defect → 500), never `Effect.void`. `runSyncExit` captures it without
+    // the throw escaping construction.
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    configThrows = true;
+    const exit = Effect.runSyncExit(makeProactiveGateLive().requireEnabled());
+    expect(Exit.isFailure(exit)).toBe(true);
   });
 });

--- a/ee/src/__tests__/proactive-gate.test.ts
+++ b/ee/src/__tests__/proactive-gate.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for `makeProactiveGateLive` — the deployment-level proactive
+ * availability gate (#3999).
+ *
+ * Proactive is a hosted-SaaS-only feature: the gate admits a request iff
+ * `resolveDeployMode() === "saas"` and fails with `EnterpriseError` on every
+ * self-hosted deployment — *including self-hosted enterprise* (the #3999
+ * exclusion). The route tests exercise this through the `ProactiveGate` Tag;
+ * this pins the live shape's predicate directly.
+ *
+ * Mocks mirror `deploy-mode.test.ts` (the gate's predicate is `resolveDeployMode`):
+ * `getConfig` drives the enterprise flag, `hasInternalDB` the auto-mode probe,
+ * and the logger is stubbed to keep the services import chain quiet.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Effect, Either } from "effect";
+
+// ── Mutable mock state ──────────────────────────────────────────────
+let enterpriseEnabledConfig: boolean | undefined = true;
+let _hasInternalDB = true;
+
+// ── Register all mocks before any dynamic import ────────────────────
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () =>
+    enterpriseEnabledConfig === undefined
+      ? null
+      : { enterprise: { enabled: enterpriseEnabledConfig } },
+}));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => _hasInternalDB,
+  getInternalDB: () => ({
+    query: async () => ({ rows: [], rowCount: 0 }),
+    end: async () => {},
+    on: () => {},
+  }),
+  internalQuery: async () => [],
+  internalExecute: () => {},
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// Import under test AFTER mocks are installed. `EnterpriseError` is imported
+// from the same core module the gate constructs, so `instanceof` is identity.
+const { makeProactiveGateLive } = await import("../proactive-gate");
+const { EnterpriseError } = await import("@atlas/api/lib/effect/errors");
+
+/** Run `requireEnabled` to an Either — Right(void) = admitted, Left(err) = denied. */
+function runGate() {
+  return Effect.runSync(Effect.either(makeProactiveGateLive().requireEnabled()));
+}
+
+describe("makeProactiveGateLive — hosted-SaaS-only availability gate (#3999)", () => {
+  beforeEach(() => {
+    enterpriseEnabledConfig = true;
+    _hasInternalDB = true;
+    delete process.env.ATLAS_DEPLOY_MODE;
+    delete process.env.ATLAS_ENTERPRISE_ENABLED;
+    // `auto` short-circuits to self-hosted under development; clear it so the
+    // saas cases aren't flipped by an ambient repo `.env`.
+    delete process.env.ATLAS_DEPLOY_ENV;
+  });
+
+  it("admits when deploy mode resolves to saas (enterprise enabled)", () => {
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    expect(Either.isRight(runGate())).toBe(true);
+  });
+
+  it("denies with EnterpriseError on explicit self-hosted, even with enterprise enabled (#3999 SaaS-exclusivity)", () => {
+    // The new exclusion: a self-hosted *enterprise* box (EE on) no longer gets
+    // proactive. Without #3999 the prior `isEnterpriseEnabled()` gate admitted it.
+    process.env.ATLAS_DEPLOY_MODE = "self-hosted";
+    enterpriseEnabledConfig = true;
+    const r = runGate();
+    expect(Either.isLeft(r)).toBe(true);
+    if (Either.isLeft(r)) expect(r.left).toBeInstanceOf(EnterpriseError);
+  });
+
+  it("denies when saas is requested but enterprise is disabled (resolveDeployMode falls back to self-hosted)", () => {
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    enterpriseEnabledConfig = false;
+    expect(Either.isLeft(runGate())).toBe(true);
+  });
+
+  it("denies in auto mode on a typical self-hosted box (no internal DB)", () => {
+    // No ATLAS_DEPLOY_MODE → auto. Enterprise on but no internal DB → self-hosted.
+    enterpriseEnabledConfig = true;
+    _hasInternalDB = false;
+    expect(Either.isLeft(runGate())).toBe(true);
+  });
+});

--- a/ee/src/proactive-gate.ts
+++ b/ee/src/proactive-gate.ts
@@ -16,8 +16,12 @@
  * "proactive")` gate then admits all paid plans (min `trial`) — see
  * `feature-entitlement.ts`.
  *
- * `requireEnabled` re-reads `resolveDeployMode()` on every call so a runtime
- * change to `ATLAS_DEPLOY_MODE` propagates without restart.
+ * `requireEnabled` re-reads `resolveDeployMode()` inside `Effect.suspend` on
+ * every run so the read stays within the effect lifecycle — a fault fails the
+ * effect rather than throwing at construction time — and a runtime change to
+ * `ATLAS_DEPLOY_MODE` propagates without restart. The denial message is the
+ * shared `PROACTIVE_HOSTED_ONLY_MESSAGE` constant so the sync inline gate in
+ * `admin-proactive.ts` can't drift from this one.
  */
 
 import { Effect, Layer } from "effect";
@@ -25,19 +29,17 @@ import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
 import {
   ProactiveGate,
+  PROACTIVE_HOSTED_ONLY_MESSAGE,
   type ProactiveGateShape,
 } from "@atlas/api/lib/effect/services";
 
 export const makeProactiveGateLive = (): ProactiveGateShape => ({
   requireEnabled: () =>
-    resolveDeployMode() === "saas"
-      ? Effect.void
-      : Effect.fail(
-          new EnterpriseError(
-            "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS). " +
-              "It is not available on self-hosted deployments.",
-          ),
-        ),
+    Effect.suspend(() =>
+      resolveDeployMode() === "saas"
+        ? Effect.void
+        : Effect.fail(new EnterpriseError(PROACTIVE_HOSTED_ONLY_MESSAGE)),
+    ),
 });
 
 export const ProactiveGateLive: Layer.Layer<ProactiveGate> = Layer.sync(

--- a/ee/src/proactive-gate.ts
+++ b/ee/src/proactive-gate.ts
@@ -1,21 +1,27 @@
 /**
- * Proactive-chat enterprise gate — slice 10/11 of #2017 (#2572).
+ * Proactive-chat availability gate — slice 10/11 of #2017 (#2572).
  *
  * Replaces the four `requireEnterpriseEffect("proactive-chat")` calls in
  * `packages/api/src/api/routes/admin-proactive*.ts`. The no-op default
  * in `lib/effect/services.ts:NoopProactiveGateLayer` fails with
- * `EnterpriseError` so non-enterprise tenants see 403
- * `enterprise_required` and route through `EnterpriseUpsell` /
- * `<FeatureGate feature="Proactive Chat">`.
+ * `EnterpriseError` so denied tenants see 403 `enterprise_required` and
+ * route through `EnterpriseUpsell` / `<FeatureGate feature="Proactive Chat">`.
  *
- * `requireEnabled` re-reads `isEnterpriseEnabled()` on every call so a
- * runtime flip of `ATLAS_ENTERPRISE_ENABLED` propagates without
- * restart — same semantics as the original
- * `requireEnterpriseEffect("proactive-chat")` it replaces.
+ * **Proactive is a hosted-SaaS-only feature (#3999).** The gate keys on
+ * `resolveDeployMode() === "saas"`, not `isEnterpriseEnabled()`: it is denied on
+ * every self-hosted deployment, *including self-hosted enterprise*, so proactive
+ * is no longer a self-hostable `ee/` capability. (On SaaS, `resolveDeployMode`
+ * already requires enterprise to be enabled, so the prior enterprise condition
+ * is subsumed.) Within SaaS, the per-tier `requireFeatureEntitlement(_,
+ * "proactive")` gate then admits all paid plans (min `trial`) — see
+ * `feature-entitlement.ts`.
+ *
+ * `requireEnabled` re-reads `resolveDeployMode()` on every call so a runtime
+ * change to `ATLAS_DEPLOY_MODE` propagates without restart.
  */
 
 import { Effect, Layer } from "effect";
-import { isEnterpriseEnabled } from "./index";
+import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
 import {
   ProactiveGate,
@@ -24,12 +30,12 @@ import {
 
 export const makeProactiveGateLive = (): ProactiveGateShape => ({
   requireEnabled: () =>
-    isEnterpriseEnabled()
+    resolveDeployMode() === "saas"
       ? Effect.void
       : Effect.fail(
           new EnterpriseError(
-            "Enterprise features (proactive-chat) are not enabled. " +
-              "Set ATLAS_ENTERPRISE_ENABLED=true or configure enterprise.enabled in atlas.config.ts.",
+            "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS). " +
+              "It is not available on self-hosted deployments.",
           ),
         ),
 });

--- a/packages/api/src/api/__tests__/admin-proactive.test.ts
+++ b/packages/api/src/api/__tests__/admin-proactive.test.ts
@@ -13,6 +13,10 @@ import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 // Real ADMIN_ACTIONS so audit-row assertions pin to canonical strings.
 import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
 import type { AnnouncementOutcome } from "@atlas/api/lib/proactive/types";
+import {
+  isFeatureEntitlementQuery,
+  workspaceTierRows,
+} from "@atlas/api/testing/api-test-mocks";
 
 // --- Enterprise gate: flip the env var so the real `isEnterpriseEnabled`
 //     resolves true without reshaping the @atlas/ee/index surface. Tests
@@ -25,16 +29,17 @@ const ORIGINAL_EE_FLAG = process.env.ATLAS_ENTERPRISE_ENABLED;
 // overwrites. Files that need to restore env do so in their own
 // afterAll; the `??=` here is the module-load contract, not teardown.
 process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
-// Pin self-hosted so the per-tier proactive entitlement gate (#4064) — which
-// `admin-proactive.ts` now applies via `requireFeatureEntitlementOrThrow` after
-// `gateEnterprise()` — is a no-op here: this file exercises workspace-config CRUD
-// and the deployment-level enterprise gate, not the SaaS per-tier ladder (that is
-// covered by `feature-entitlement-proactive.test.ts`). Without this, the env would
-// auto-resolve to `saas` (enterprise enabled + internal DB, absent an
-// `ATLAS_DEPLOY_ENV=development` short-circuit), and the guard's workspace-tier
-// lookup — unsatisfied by this file's hand-rolled internal mock — would 403 every
-// CRUD assertion. `??=` keeps the module-load contract hoistable.
-process.env.ATLAS_DEPLOY_MODE ??= "self-hosted";
+// Pin SaaS deploy mode: proactive is now a hosted-SaaS-only feature (#3999), so
+// `gateProactiveAvailable()` admits a route only when `resolveDeployMode() ===
+// "saas"`. The happy-path CRUD assertions therefore need `saas` (the prior
+// `self-hosted` pin would now deny every route). The per-tier ladder (min
+// `trial`) that fires after the gate via `requireFeatureEntitlementOrThrow` is
+// satisfied by a paid-tier row returned from the internal mock's
+// entitlement-query special-case below — transparent to the route-query queue.
+// Deny paths flip enterprise off (so `resolveDeployMode` falls back to
+// self-hosted) or set self-hosted explicitly. `??=` keeps the module-load
+// contract hoistable.
+process.env.ATLAS_DEPLOY_MODE ??= "saas";
 
 // --- Auth mock ---
 
@@ -141,12 +146,26 @@ type InternalQueryCall = { sql: string; params: unknown[] };
 let lastQueries: InternalQueryCall[] = [];
 let mockInternalRows: unknown[][] = [];
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
-  async (sql: string, params?: unknown[]) => {
-    lastQueries.push({ sql, params: params ?? [] });
-    return mockInternalRows.shift() ?? [];
-  },
-);
+// Default internal-query behavior. Extracted so `resetMocks` can restore it
+// each test — `mockClear()` keeps the implementation, so a test that installs a
+// custom `mockImplementation` (the DB-throws path) would otherwise leak it.
+const defaultInternalQuery = async (
+  sql: string,
+  params?: unknown[],
+): Promise<unknown[]> => {
+  // Per-tier proactive gate (#3999, min `trial`): on SaaS every route calls
+  // `requireFeatureEntitlementOrThrow(orgId, "proactive")`, which issues a
+  // workspace-tier lookup. Answer it with a paid (`business`) tier so the
+  // ladder admits — transparently: it does NOT consume the `mockInternalRows`
+  // queue or appear in `lastQueries`, so each test's scripted route queries
+  // stay aligned. The deployment gate is exercised separately via deploy mode.
+  if (isFeatureEntitlementQuery(sql)) return workspaceTierRows("business");
+  lastQueries.push({ sql, params: params ?? [] });
+  return mockInternalRows.shift() ?? [];
+};
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> =
+  mock(defaultInternalQuery);
 
 let mockHasInternalDB = true;
 
@@ -293,12 +312,14 @@ function nowChannelRow(overrides: Partial<Record<string, unknown>>) {
 
 function resetMocks() {
   process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+  process.env.ATLAS_DEPLOY_MODE = "saas";
   mockHasInternalDB = true;
   mockDirectoryResult = { ok: false, reason: "no_chat_installation" };
   mockListWorkspaceChannels.mockClear();
   lastQueries = [];
   mockInternalRows = [];
   mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(defaultInternalQuery);
   mockLogAdminAction.mockClear();
   mockAnnounceActivation.mockClear();
   mockAnnounceCalls = [];
@@ -352,6 +373,17 @@ describe("GET /api/v1/admin/proactive/workspace", () => {
     expect(json.error).toBe("enterprise_required");
   });
 
+  it("returns 403 on a self-hosted deployment even with enterprise enabled (SaaS-exclusive, #3999)", async () => {
+    // Proactive is hosted-SaaS-only: self-hosted *enterprise* (EE on, deploy
+    // mode self-hosted) is now denied too, not just self-hosted free. The reset
+    // in beforeEach restores `saas`.
+    process.env.ATLAS_DEPLOY_MODE = "self-hosted";
+    const res = await request("GET", "/workspace");
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("enterprise_required");
+  });
+
   it("returns 401 when unauthenticated", async () => {
     mockAuthenticateRequest.mockImplementation(() =>
       Promise.resolve({
@@ -389,7 +421,11 @@ describe("GET /api/v1/admin/proactive/workspace", () => {
   });
 
   it("returns 500 with requestId when the DB throws", async () => {
-    mockInternalQuery.mockImplementationOnce(async () => {
+    // The route's own DB query throws; the per-tier entitlement lookup (which
+    // fires first on SaaS) must still succeed so this exercises the route's 500
+    // path, not the guard's fail-closed 503. `resetMocks` restores the default.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (isFeatureEntitlementQuery(sql)) return workspaceTierRows("business");
       throw new Error("boom");
     });
     const res = await request("GET", "/workspace");

--- a/packages/api/src/api/__tests__/feature-entitlement-proactive.test.ts
+++ b/packages/api/src/api/__tests__/feature-entitlement-proactive.test.ts
@@ -1,45 +1,52 @@
 /**
- * Per-tier proactive entitlement gate (#4064 — AC1 of #3999).
+ * Per-tier proactive entitlement gate (#4064 → re-tiered in #3999).
  *
- * The `FeatureEntitlement` SSOT maps `proactive → "business"`, but until #4064
- * no route consulted it: on the hosted SaaS every tier could reach proactive
- * even though the pricing page sells it as Business-only. #4064 wired
- * `requireFeatureEntitlement(orgId, "proactive")` into the five proactive route
- * surfaces — the four Effect sub-routes (analytics / events / pause /
- * public-dataset) via `yield*`, and `admin-proactive.ts`'s `runHandler` path via
- * the promise adapter `requireFeatureEntitlementOrThrow`.
+ * Proactive is a **hosted-SaaS feature available to every paying plan**, not a
+ * Business-tier differentiator (#3999). Two gates apply, in order, on every
+ * proactive route:
  *
- * This file asserts the gate's external behaviour at the API boundary for every
- * one of those five surfaces:
+ *   1. the deployment-level availability gate (`ProactiveGate.requireEnabled` /
+ *      `admin-proactive.ts`'s sync `gateProactiveAvailable`), which admits only
+ *      `deployMode === "saas"` — proactive is denied on every self-hosted
+ *      deployment, including self-hosted enterprise; and
+ *   2. the per-tier ladder (`requireFeatureEntitlement(orgId, "proactive")`,
+ *      SSOT minimum `trial`), which on SaaS admits every active paid plan and
+ *      denies only the `free` floor and the churn (`locked`) tier.
  *
- *   - a Starter / Pro SaaS workspace is DENIED with the 403 `plan_upgrade_required`
- *     upgrade envelope (covering both gate paths — the Effect `yield*` and the
- *     `runHandler` promise adapter map to the identical response);
- *   - a Business workspace is ADMITTED past the ladder (never the upgrade 403);
+ * This file asserts gate (2)'s external behaviour at the API boundary for the
+ * five proactive route surfaces — the four Effect `yield*` sub-routes
+ * (analytics / events / pause / public-dataset) and `admin-proactive.ts`'s
+ * `runHandler` path via the promise adapter `requireFeatureEntitlementOrThrow`:
+ *
+ *   - a `free` (the floor below `trial`) SaaS workspace is DENIED with the 403
+ *     `plan_upgrade_required` upgrade envelope carrying `required_plan: "trial"`
+ *     (covering both gate paths — the Effect `yield*` and the `runHandler`
+ *     promise adapter map to the identical response);
+ *   - a churned (`locked`) workspace is DENIED;
+ *   - every active paid plan (`trial`/`starter`/`pro`/`business`) is ADMITTED
+ *     past the ladder (never the upgrade 403);
  *   - an operator workspace bypasses the ladder;
  *   - a transient tier-lookup fault fails CLOSED with 503 `billing_check_failed`
  *     — asserted on BOTH a `yield*` route and the `runHandler` adapter route so
  *     the promise adapter's fail-closed arm is proven, not assumed;
- *   - the deployment-level enterprise gate is UNCHANGED: with the EE proactive
- *     gate closed, even a Business workspace is denied `enterprise_required`, so
- *     the per-tier gate was added *alongside* the deployment gate, not in place
- *     of it (the free non-EE deployment exclusion is preserved). The literal
- *     self-hosted-disabled 403 is additionally covered by the existing
- *     `admin-proactive-analytics.test.ts` / `admin-proactive.test.ts`, which
- *     remain green (the per-tier guard is a no-op off-SaaS).
+ *   - the deployment-level availability gate is INDEPENDENT: with it closed,
+ *     even an entitled paid workspace is denied (`enterprise_required`), proving
+ *     the per-tier gate was added *alongside* the availability gate, not in
+ *     place of it. The literal self-hosted-denied 403 is additionally covered by
+ *     `admin-proactive-analytics.test.ts` / `admin-proactive.test.ts`.
  *
  * ## Why mock `@atlas/ee/layers`
  *
  * The proactive routes gate on `ProactiveGate.requireEnabled()` (the
- * deployment-level enterprise gate) BEFORE the per-tier check. `@atlas/ee/layers`
+ * deployment-level availability gate) BEFORE the per-tier check. `@atlas/ee/layers`
  * does not load in this harness, so the real `ProactiveGate` falls back to its
  * fail-closed Noop and 403s `enterprise_required` before the ladder is reached.
  * The mock below binds only `ProactiveGate` to a toggleable gate (open by
- * default; closed for the deployment-gate-intact assertion) so the per-tier
- * denial is observable. `admin-proactive.ts` uses the synchronous
- * `isEnterpriseEnabled()` check instead of the Tag, so its enterprise gate is
- * driven by `ATLAS_ENTERPRISE_ENABLED` (pinned true at module top), independent
- * of this mock. Mirrors `admin-proactive-analytics.test.ts`.
+ * default — standing in for SaaS deploy mode; closed for the availability-gate
+ * assertion) so the per-tier denial is observable. `admin-proactive.ts`'s sync
+ * `gateProactiveAvailable` reads `resolveDeployMode()` instead of the Tag, so its
+ * availability gate is driven by `ATLAS_DEPLOY_MODE` (pinned `saas` at module
+ * top), independent of this mock. Mirrors `admin-proactive-analytics.test.ts`.
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -51,17 +58,18 @@ import {
 
 // Module-top env setup — must be set before the dynamic app import below. The
 // per-tier ladder only fires in SaaS deploy mode; pin it (and enterprise-enabled,
-// which `admin-proactive.ts`'s sync gate reads) so the gate tests are
+// which `resolveDeployMode` requires for `saas`) so the gate tests are
 // deterministic regardless of the ambient ATLAS_DEPLOY_MODE / DATABASE_URL.
 // `??=` keeps the assignment hoisted; cross-file leakage under bun's parallel
 // runner is bounded (the first file to load wins).
 process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
 process.env.ATLAS_DEPLOY_MODE ??= "saas";
 
-// Toggleable enterprise gate for the proactive Effect routes' `ProactiveGate`
-// Tag. Open (true) for the per-tier deny/allow assertions; flipped closed by the
-// deployment-gate-intact test. Reset in `beforeEach`.
-let enterpriseGateOpen = true;
+// Toggleable availability gate for the proactive Effect routes' `ProactiveGate`
+// Tag. Open (true) for the per-tier deny/allow assertions — standing in for SaaS
+// deploy mode; flipped closed by the availability-gate-intact test. Reset in
+// `beforeEach`.
+let availabilityGateOpen = true;
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const effectMod = require("effect") as typeof import("effect");
@@ -74,11 +82,11 @@ mock.module("@atlas/ee/layers", () => {
   return {
     EELayer: Layer.succeed(services.ProactiveGate, {
       requireEnabled: () =>
-        enterpriseGateOpen
+        availabilityGateOpen
           ? effectMod.Effect.void
           : effectMod.Effect.fail(
               new EnterpriseError(
-                "Enterprise features (proactive-chat) are not enabled.",
+                "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS).",
               ),
             ),
     }),
@@ -148,17 +156,22 @@ const PROACTIVE_ROUTES: Array<{ label: string; path: string }> = [
   },
 ];
 
-describe("per-tier proactive entitlement gate (#4064)", () => {
+// Every active paid/trial plan must reach proactive (#3999). Trial is the SSOT
+// minimum (starter-equivalent, the lowest active SaaS tier). Mutable `string[]`
+// so `it.each` accepts it (its overload rejects a `readonly` tuple).
+const ADMITTED_TIERS: string[] = ["trial", "starter", "pro", "business"];
+
+describe("per-tier proactive entitlement gate (#4064 / #3999 — all paid plans)", () => {
   beforeEach(() => {
     mocks.setOrgAdmin("org-1");
     mocks.hasInternalDB = true;
     mocks.mockInternalQuery.mockReset();
-    enterpriseGateOpen = true;
+    availabilityGateOpen = true;
   });
 
   describe.each(PROACTIVE_ROUTES)("$label", ({ path }) => {
-    it("denies a Pro workspace with 403 plan_upgrade_required", async () => {
-      setWorkspaceTier("pro");
+    it("denies a free-tier workspace with 403 plan_upgrade_required (the floor below trial)", async () => {
+      setWorkspaceTier("free");
       const res = await app.fetch(adminGet(path));
       expect(res.status).toBe(403);
       const body = (await res.json()) as {
@@ -167,27 +180,30 @@ describe("per-tier proactive entitlement gate (#4064)", () => {
         current_plan: string;
       };
       expect(body.error).toBe("plan_upgrade_required");
-      expect(body.required_plan).toBe("business");
-      expect(body.current_plan).toBe("pro");
+      expect(body.required_plan).toBe("trial");
+      expect(body.current_plan).toBe("free");
     });
 
-    it("denies a Starter workspace with 403 plan_upgrade_required", async () => {
-      setWorkspaceTier("starter");
+    it("denies a churned (locked) workspace with 403 plan_upgrade_required", async () => {
+      setWorkspaceTier("locked");
       const res = await app.fetch(adminGet(path));
       expect(res.status).toBe(403);
       expect(await errorOf(res)).toBe("plan_upgrade_required");
     });
 
-    it("admits a Business workspace past the ladder", async () => {
-      setWorkspaceTier("business");
-      const res = await app.fetch(adminGet(path));
-      // The per-tier gate passed: not the upgrade 403, nor the fail-closed 503.
-      // Downstream the route may 200/500 against the mocked internal DB — that
-      // is not the ladder's concern and is deliberately not pinned.
-      const err = await errorOf(res);
-      expect(err).not.toBe("plan_upgrade_required");
-      expect(err).not.toBe("billing_check_failed");
-    });
+    it.each(ADMITTED_TIERS)(
+      "admits an active %s workspace past the ladder",
+      async (tier) => {
+        setWorkspaceTier(tier);
+        const res = await app.fetch(adminGet(path));
+        // The per-tier gate passed: not the upgrade 403, nor the fail-closed 503.
+        // Downstream the route may 200/500 against the mocked internal DB — that
+        // is not the ladder's concern and is deliberately not pinned.
+        const err = await errorOf(res);
+        expect(err).not.toBe("plan_upgrade_required");
+        expect(err).not.toBe("billing_check_failed");
+      },
+    );
 
     it("bypasses the ladder for an operator workspace", async () => {
       setWorkspaceTier("free", true);
@@ -226,15 +242,15 @@ describe("per-tier proactive entitlement gate (#4064)", () => {
       body: { channelId: "C-test" } as unknown,
     },
   ])("mutating route — $label", ({ method, path, body }) => {
-    it("denies a Pro workspace with 403 plan_upgrade_required before any side effect", async () => {
-      setWorkspaceTier("pro");
+    it("denies a free-tier workspace with 403 plan_upgrade_required before any side effect", async () => {
+      setWorkspaceTier("free");
       const res = await app.fetch(adminRequest(path, method, body));
       expect(res.status).toBe(403);
       expect(await errorOf(res)).toBe("plan_upgrade_required");
     });
 
-    it("admits a Business workspace past the ladder", async () => {
-      setWorkspaceTier("business");
+    it("admits an active paid (starter) workspace past the ladder", async () => {
+      setWorkspaceTier("starter");
       const res = await app.fetch(adminRequest(path, method, body));
       const err = await errorOf(res);
       expect(err).not.toBe("plan_upgrade_required");
@@ -245,7 +261,7 @@ describe("per-tier proactive entitlement gate (#4064)", () => {
   // Fail-closed is asserted on BOTH gate paths: the Effect `yield*` route and the
   // `runHandler` promise adapter (`requireFeatureEntitlementOrThrow`), so the
   // adapter's fail-closed arm is proven, not assumed — a transient internal-DB
-  // fault must never silently widen access to a Business feature.
+  // fault must never silently widen access to a paid feature.
   describe.each([
     { label: "Effect yield* route", path: "/api/v1/admin/proactive/analytics" },
     {
@@ -261,20 +277,21 @@ describe("per-tier proactive entitlement gate (#4064)", () => {
     });
   });
 
-  // The per-tier gate was added ALONGSIDE the deployment-level enterprise gate,
-  // not in place of it. With the EE proactive gate closed, even a Business-tier
-  // workspace is denied with the deployment gate's `enterprise_required` 403 —
-  // proving the free non-EE deployment exclusion is unchanged by #4064.
-  describe("deployment-level enterprise gate is unchanged", () => {
-    it("a Business workspace is still denied when the EE proactive gate is closed (Effect route)", async () => {
-      enterpriseGateOpen = false;
+  // The per-tier ladder was added ALONGSIDE the deployment-level availability
+  // gate, not in place of it. With the availability gate closed (standing in for
+  // a non-SaaS deployment), even an entitled paid workspace is denied with the
+  // availability gate's `enterprise_required` 403 — proving the self-hosted
+  // exclusion (#3999) is independent of the per-tier check.
+  describe("deployment-level availability gate is independent of the ladder", () => {
+    it("an entitled paid workspace is still denied when the availability gate is closed (Effect route)", async () => {
+      availabilityGateOpen = false;
       setWorkspaceTier("business");
       const res = await app.fetch(
         adminGet("/api/v1/admin/proactive/analytics"),
       );
       expect(res.status).toBe(403);
-      // The enterprise gate (`ProactiveGate.requireEnabled`) fires before the
-      // per-tier check, so the denial is the deployment gate's, not the ladder's.
+      // The availability gate (`ProactiveGate.requireEnabled`) fires before the
+      // per-tier check, so the denial is the availability gate's, not the ladder's.
       const err = await errorOf(res);
       expect(err).not.toBe("plan_upgrade_required");
     });

--- a/packages/api/src/api/__tests__/feature-ladder-regression.test.ts
+++ b/packages/api/src/api/__tests__/feature-ladder-regression.test.ts
@@ -224,8 +224,10 @@ describe.each(PROBED)(
   ({ path, min }) => {
     const belowTiers = belowTiersFor(min);
     const allowTiers = atOrAboveTiersFor(min);
-    // The highest paying tier still below the minimum. Always present — every
-    // gated minimum is `pro`/`business`, asserted in the completeness suite.
+    // The highest recognized tier still below the minimum (e.g. `pro` for a
+    // Business-min feature; `free` for proactive's all-paid `trial` min, #3999).
+    // Always present — every gated minimum is at least `trial`, so `free`/`locked`
+    // sit below it; the completeness suite asserts a deny is always provable.
     const closestBelow = belowTiers[0];
 
     beforeEach(() => {

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -35,7 +35,7 @@ import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
-import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
 import { requireFeatureEntitlementOrThrow } from "@atlas/api/lib/billing/feature-entitlement-guard";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { runHandler } from "@atlas/api/lib/effect/hono";
@@ -373,17 +373,22 @@ adminProactive.use(requireOrgContext());
 adminProactive.use(requirePermission("admin:settings"));
 
 /**
- * Sync enterprise gate. Sibling admin-proactive route files use
+ * Sync availability gate. Sibling admin-proactive route files use
  * `runEffect` + `yield* ProactiveGate`; this file's `runHandler`-based
  * handlers can't yield the Tag (ConditionalEELayer is async via the
- * lazy EE-layer import), so the equivalent sync check is inlined.
- * Resulting `EnterpriseError` has the same `_tag` + payload as the Tag.
+ * lazy EE-layer import), so the equivalent sync check is inlined — it must
+ * stay in lockstep with `ProactiveGate` (ee/src/proactive-gate.ts).
+ *
+ * Proactive is a hosted-SaaS-only feature (#3999): denied on every
+ * self-hosted deployment, *including self-hosted enterprise*. Keys on
+ * `resolveDeployMode() === "saas"`, not `isEnterpriseEnabled()`. The resulting
+ * `EnterpriseError` has the same `_tag` + payload as the Tag.
  */
-function gateEnterprise(): void {
-  if (!isEnterpriseEnabled()) {
+function gateProactiveAvailable(): void {
+  if (resolveDeployMode() !== "saas") {
     throw new EnterpriseError(
-      "Enterprise features (proactive-chat) are not enabled. " +
-        "Set ATLAS_ENTERPRISE_ENABLED=true or configure enterprise.enabled in atlas.config.ts.",
+      "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS). " +
+        "It is not available on self-hosted deployments.",
     );
   }
 }
@@ -392,9 +397,10 @@ function gateEnterprise(): void {
 adminProactive.openapi(getWorkspaceRoute, async (c) =>
   runHandler(c, "get proactive workspace config", async () => {
     const { orgId, requestId } = c.get("orgContext");
-    gateEnterprise();
-    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
-    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    gateProactiveAvailable();
+    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
+    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
+    // gate. (#3999 / #4064 / #3984)
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
@@ -431,9 +437,10 @@ adminProactive.openapi(updateWorkspaceRoute, async (c) =>
   runHandler(c, "update proactive workspace config", async () => {
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
-    gateEnterprise();
-    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
-    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    gateProactiveAvailable();
+    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
+    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
+    // gate. (#3999 / #4064 / #3984)
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const body = c.req.valid("json");
@@ -603,9 +610,10 @@ adminProactive.openapi(updateWorkspaceRoute, async (c) =>
 adminProactive.openapi(listChannelsRoute, async (c) =>
   runHandler(c, "list proactive channel overrides", async () => {
     const { orgId, requestId } = c.get("orgContext");
-    gateEnterprise();
-    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
-    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    gateProactiveAvailable();
+    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
+    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
+    // gate. (#3999 / #4064 / #3984)
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
@@ -634,9 +642,10 @@ adminProactive.openapi(listChannelsRoute, async (c) =>
 adminProactive.openapi(listAvailableChannelsRoute, async (c) =>
   runHandler(c, "list available chat channels", async () => {
     const { orgId, requestId } = c.get("orgContext");
-    gateEnterprise();
-    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
-    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    gateProactiveAvailable();
+    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
+    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
+    // gate. (#3999 / #4064 / #3984)
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
@@ -691,9 +700,10 @@ adminProactive.openapi(upsertChannelRoute, async (c) =>
   runHandler(c, "upsert proactive channel override", async () => {
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
-    gateEnterprise();
-    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
-    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    gateProactiveAvailable();
+    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
+    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
+    // gate. (#3999 / #4064 / #3984)
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const body = c.req.valid("json");
@@ -766,9 +776,10 @@ adminProactive.openapi(deleteChannelRoute, async (c) =>
   runHandler(c, "delete proactive channel override", async () => {
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
-    gateEnterprise();
-    // Per-tier ladder: on SaaS proactive is Business-only. No-op off-SaaS,
-    // where gateEnterprise() above is the gate. (#4064 / #3984)
+    gateProactiveAvailable();
+    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
+    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
+    // gate. (#3999 / #4064 / #3984)
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const { channelId } = c.req.valid("param");

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -41,7 +41,7 @@ import { internalQuery } from "@atlas/api/lib/db/internal";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { ProactiveService } from "@atlas/api/lib/effect/services";
+import { ProactiveService, PROACTIVE_HOSTED_ONLY_MESSAGE } from "@atlas/api/lib/effect/services";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
@@ -377,19 +377,21 @@ adminProactive.use(requirePermission("admin:settings"));
  * `runEffect` + `yield* ProactiveGate`; this file's `runHandler`-based
  * handlers can't yield the Tag (ConditionalEELayer is async via the
  * lazy EE-layer import), so the equivalent sync check is inlined — it must
- * stay in lockstep with `ProactiveGate` (ee/src/proactive-gate.ts).
+ * stay in lockstep with `ProactiveGate` (ee/src/proactive-gate.ts). Both throw
+ * `EnterpriseError(PROACTIVE_HOSTED_ONLY_MESSAGE)` (shared constant so the copy
+ * can't drift); the resulting error carries the same `_tag` + payload as the Tag.
  *
  * Proactive is a hosted-SaaS-only feature (#3999): denied on every
  * self-hosted deployment, *including self-hosted enterprise*. Keys on
- * `resolveDeployMode() === "saas"`, not `isEnterpriseEnabled()`. The resulting
- * `EnterpriseError` has the same `_tag` + payload as the Tag.
+ * `resolveDeployMode() === "saas"`, not `isEnterpriseEnabled()`.
+ *
+ * Every route below pairs this with `requireFeatureEntitlementOrThrow(orgId,
+ * "proactive")` — the per-tier ladder (on SaaS, all paid plans, min `trial`;
+ * a no-op off-SaaS, where this gate is the sole arbiter). (#3999 / #4064 / #3984)
  */
 function gateProactiveAvailable(): void {
   if (resolveDeployMode() !== "saas") {
-    throw new EnterpriseError(
-      "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS). " +
-        "It is not available on self-hosted deployments.",
-    );
+    throw new EnterpriseError(PROACTIVE_HOSTED_ONLY_MESSAGE);
   }
 }
 
@@ -398,9 +400,7 @@ adminProactive.openapi(getWorkspaceRoute, async (c) =>
   runHandler(c, "get proactive workspace config", async () => {
     const { orgId, requestId } = c.get("orgContext");
     gateProactiveAvailable();
-    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
-    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
-    // gate. (#3999 / #4064 / #3984)
+    // Per-tier ladder (no-op off-SaaS — see gateProactiveAvailable above).
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
@@ -438,9 +438,7 @@ adminProactive.openapi(updateWorkspaceRoute, async (c) =>
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
     gateProactiveAvailable();
-    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
-    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
-    // gate. (#3999 / #4064 / #3984)
+    // Per-tier ladder (no-op off-SaaS — see gateProactiveAvailable above).
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const body = c.req.valid("json");
@@ -611,9 +609,7 @@ adminProactive.openapi(listChannelsRoute, async (c) =>
   runHandler(c, "list proactive channel overrides", async () => {
     const { orgId, requestId } = c.get("orgContext");
     gateProactiveAvailable();
-    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
-    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
-    // gate. (#3999 / #4064 / #3984)
+    // Per-tier ladder (no-op off-SaaS — see gateProactiveAvailable above).
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
@@ -643,9 +639,7 @@ adminProactive.openapi(listAvailableChannelsRoute, async (c) =>
   runHandler(c, "list available chat channels", async () => {
     const { orgId, requestId } = c.get("orgContext");
     gateProactiveAvailable();
-    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
-    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
-    // gate. (#3999 / #4064 / #3984)
+    // Per-tier ladder (no-op off-SaaS — see gateProactiveAvailable above).
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     try {
@@ -701,9 +695,7 @@ adminProactive.openapi(upsertChannelRoute, async (c) =>
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
     gateProactiveAvailable();
-    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
-    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
-    // gate. (#3999 / #4064 / #3984)
+    // Per-tier ladder (no-op off-SaaS — see gateProactiveAvailable above).
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const body = c.req.valid("json");
@@ -777,9 +769,7 @@ adminProactive.openapi(deleteChannelRoute, async (c) =>
     const { orgId, requestId } = c.get("orgContext");
     const authResult = c.get("authResult");
     gateProactiveAvailable();
-    // Per-tier ladder: on SaaS proactive is available to all paid plans (min
-    // `trial`). No-op off-SaaS, where gateProactiveAvailable() above is the
-    // gate. (#3999 / #4064 / #3984)
+    // Per-tier ladder (no-op off-SaaS — see gateProactiveAvailable above).
     await requireFeatureEntitlementOrThrow(orgId, "proactive");
 
     const { channelId } = c.req.valid("param");

--- a/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
@@ -39,17 +39,21 @@ const TIER_RANK: Record<PlanTier, number> = {
 
 // Features whose minimum tier intentionally overrides the Business default.
 // `custom_domain` sits at Pro+ (#3988): the custom-domain route has always
-// documented "Pro or Business plan … required to create a domain". Every other
-// gated feature must remain at the Business default.
+// documented "Pro or Business plan … required to create a domain". `proactive`
+// sits at `trial` (#3999): a hosted-SaaS feature available to all paid plans,
+// not a Business-tier differentiator. Every other gated feature must remain at
+// the Business default.
 const TIER_OVERRIDES: Partial<Record<GatedFeature, MinPlanTier>> = {
   custom_domain: "pro",
+  proactive: "trial",
 };
 
 describe("FEATURE_ENTITLEMENTS map", () => {
-  it("defaults every gated feature to Business except the recorded Pro+ overrides", () => {
-    // The PRD locks the default tier line at Business. A Pro+ override is an
-    // intentional single-line change in the SSOT; this pins the exact override
-    // set so a stray re-tier is caught.
+  it("defaults every gated feature to Business except the recorded overrides", () => {
+    // The PRD locks the default tier line at Business. An override (Pro+ for
+    // custom_domain, all-paid `trial` for proactive) is an intentional
+    // single-line change in the SSOT; this pins the exact override set so a
+    // stray re-tier is caught.
     for (const feature of ALL_FEATURES) {
       const expected = TIER_OVERRIDES[feature] ?? "business";
       expect(FEATURE_ENTITLEMENTS[feature]).toBe(expected);
@@ -113,6 +117,20 @@ describe("isFeatureEntitled — tier × feature matrix", () => {
     expect(isFeatureEntitled("starter", "custom_domain")).toBe(false);
     expect(isFeatureEntitled("pro", "custom_domain")).toBe(true);
     expect(isFeatureEntitled("business", "custom_domain")).toBe(true);
+  });
+
+  it("treats proactive as all-paid (trial-gated): denied for locked/free, allowed for every active SaaS plan", () => {
+    // #3999: proactive unlocks on every paying plan, not just Business. `trial`
+    // (starter-equivalent, the lowest active SaaS tier) and up are entitled;
+    // only the churn tier `locked` and the no-billing `free` floor are denied.
+    // SaaS-exclusivity (self-hosted denied) is a deploy-mode gate, not this
+    // predicate — see ProactiveGate / admin-proactive `gateProactiveAvailable`.
+    expect(isFeatureEntitled("locked", "proactive")).toBe(false);
+    expect(isFeatureEntitled("free", "proactive")).toBe(false);
+    expect(isFeatureEntitled("trial", "proactive")).toBe(true);
+    expect(isFeatureEntitled("starter", "proactive")).toBe(true);
+    expect(isFeatureEntitled("pro", "proactive")).toBe(true);
+    expect(isFeatureEntitled("business", "proactive")).toBe(true);
   });
 
   it("fails closed for the `locked` churn tier on every feature", () => {

--- a/packages/api/src/lib/billing/feature-entitlement.ts
+++ b/packages/api/src/lib/billing/feature-entitlement.ts
@@ -18,7 +18,8 @@
  *     (`free < trial < starter < pro < business`, `locked` = no entitlement).
  *
  * The default tier line is **Business** for every feature; a feature that
- * should sit at Pro+ instead is a single-line override in the map below.
+ * should unlock earlier (Pro+, or all paid plans via `trial`) instead is a
+ * single-line override in the map below.
  *
  * The request-time guard (`requireFeatureEntitlement`) that resolves a
  * workspace's tier and returns the standard upgrade/403 lives in
@@ -59,8 +60,9 @@ export type GatedFeature =
 /**
  * Feature → minimum plan tier. The default line is **Business** for every
  * gated capability, matching the current /pricing page. Where a feature
- * should unlock earlier (Pro+), change its value here — that single edit moves
- * both enforcement and the SSOT-rendered page in lockstep.
+ * should unlock earlier — Pro+, or all paid plans via `trial` (e.g. proactive,
+ * #3999) — change its value here; that single edit moves both enforcement and
+ * the SSOT-rendered page in lockstep.
  *
  * Keyed by {@link GatedFeature} so adding a feature without assigning a tier
  * is a compile error — the ladder can't drift open. Values are typed
@@ -86,7 +88,16 @@ export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, MinPlanTier>> =
   // product's established intent. #3988 / #3984 acceptance criteria explicitly
   // permit custom domain to sit at Pro+ where the SSOT says so.
   custom_domain: "pro",
-  proactive: "business",
+  // All-paid override (not the Business default): proactive is a hosted-SaaS
+  // feature available to every paying plan, not a Business-tier differentiator
+  // (#3999). Its minimum is `trial` — the lowest active SaaS tier (SaaS has no
+  // persistent `free` tier; `trial` is starter-equivalent), so every active
+  // SaaS workspace gets it and only the churn tier (`locked`) is denied.
+  // SaaS-exclusivity — self-hosted, *including* self-hosted-enterprise, is
+  // denied — is enforced separately by the deployment-level gate (ProactiveGate
+  // / admin-proactive.ts `gateProactive`, keyed on `deployMode === "saas"`); the
+  // per-tier predicate here is a no-op off-SaaS.
+  proactive: "trial",
 };
 
 /**

--- a/packages/api/src/lib/billing/feature-entitlement.ts
+++ b/packages/api/src/lib/billing/feature-entitlement.ts
@@ -91,12 +91,14 @@ export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, MinPlanTier>> =
   // All-paid override (not the Business default): proactive is a hosted-SaaS
   // feature available to every paying plan, not a Business-tier differentiator
   // (#3999). Its minimum is `trial` — the lowest active SaaS tier (SaaS has no
-  // persistent `free` tier; `trial` is starter-equivalent), so every active
-  // SaaS workspace gets it and only the churn tier (`locked`) is denied.
+  // persistent `free` tier; `trial` is starter-equivalent), so every SaaS
+  // workspace with a resolved active tier gets it; only the churn tier
+  // (`locked`) — and any workspace with no resolved tier, which fails closed to
+  // `free` — is denied.
   // SaaS-exclusivity — self-hosted, *including* self-hosted-enterprise, is
   // denied — is enforced separately by the deployment-level gate (ProactiveGate
-  // / admin-proactive.ts `gateProactive`, keyed on `deployMode === "saas"`); the
-  // per-tier predicate here is a no-op off-SaaS.
+  // / admin-proactive.ts `gateProactiveAvailable`, keyed on `deployMode ===
+  // "saas"`); the per-tier predicate here is a no-op off-SaaS.
   proactive: "trial",
 };
 

--- a/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
+++ b/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
@@ -68,8 +68,11 @@ interface FeatureDisplay {
  * before this mirror existed, with one intentional addition: `proactive`
  * (Proactive monitoring) was gated by the SSOT but never listed on the page.
  * Surfacing it here is deliberate — WS4 of #3984 advertises proactive
- * monitoring as the premium line the SSOT now gates per-tier — so the mirror
- * adds a "Proactive monitoring" row the prior copy did not have.
+ * monitoring — so the mirror adds a "Proactive monitoring" row the prior copy
+ * did not have. Unlike the Business-only rows around it, proactive unlocks on
+ * every paid plan (min `trial`, #3999); its cells render ✓ for starter/pro/
+ * business and ✗ for self-hosted (a hosted-SaaS-only feature), derived from the
+ * SSOT like every other row.
  */
 export const FEATURE_DISPLAY: Record<GatedFeature, FeatureDisplay> = {
   // hosting

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2811,14 +2811,27 @@ export const NoopDomainsLayer: Layer.Layer<Domains> = Layer.sync(
 type EnterpriseErrorForProactive =
   import("@atlas/api/lib/effect/errors").EnterpriseError;
 
+/**
+ * Denial message for the proactive availability gate. Shared verbatim by the
+ * live EE gate (`ee/src/proactive-gate.ts:makeProactiveGateLive`) and the
+ * inlined sync gate (`api/routes/admin-proactive.ts:gateProactiveAvailable`),
+ * which must stay in lockstep (#3999) — a single constant so the two copies
+ * can't drift on wording.
+ */
+export const PROACTIVE_HOSTED_ONLY_MESSAGE =
+  "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS). " +
+  "It is not available on self-hosted deployments.";
+
 export interface ProactiveGateShape {
-  /** Effect-style guard. `Effect.void` when enterprise is enabled,
+  /** Effect-style guard. `Effect.void` when proactive is available (the
+   * hosted SaaS — `resolveDeployMode() === "saas"`),
    * `Effect.fail(EnterpriseError)` otherwise. The route layer's
    * `classifyError` maps that to a 403 `enterprise_required` envelope.
    *
-   * Re-reads the enterprise flag on every call (Effect wrapper closes
-   * over the EE-side `isEnterpriseEnabled()`) so a runtime flip
-   * propagates without restart. */
+   * Re-reads the deploy mode on every call so a runtime change to
+   * `ATLAS_DEPLOY_MODE` propagates without restart. Hosted-SaaS-only
+   * (#3999): denied on every self-hosted deployment, including
+   * self-hosted enterprise. */
   readonly requireEnabled: () => Effect.Effect<
     void,
     EnterpriseErrorForProactive


### PR DESCRIPTION
## Why

Part of wrapping up **v0.0.33** (#3984 / #3999). #4064 wired `proactive: "business"` into the `FeatureEntitlement` SSOT, so on the hosted SaaS a Starter/Pro workspace was **denied** proactive monitoring. The correct model (per product): **proactive is a paid hosted-SaaS feature available on every paid plan — not a Business-tier differentiator — and not available on self-hosted at all.**

## What changed

**Core logic**
- **SSOT** (`feature-entitlement.ts`): `proactive: "business"` → `"trial"`. SaaS has no persistent `free` tier (`trial` is starter-equivalent, the lowest active SaaS tier), so every active SaaS workspace is entitled and only churned (`locked`) / `free` are denied. The www pricing mirror (`entitlements.generated.ts`) regenerated from the SSOT — Starter/Pro now render ✓, self-hosted ✗.
- **SaaS-exclusivity**: the deployment-level gate — `ProactiveGate` (`ee/src/proactive-gate.ts`) and `admin-proactive.ts`'s sync `gateProactiveAvailable` — now keys on `resolveDeployMode() === "saas"` instead of `isEnterpriseEnabled()`. Proactive is denied on **every** self-hosted deployment, *including self-hosted enterprise* (previously it was available there).

**Decision (minimal scope):** kept the `enterprise_required` 403 envelope (maps to 403 + the existing upsell), message updated to name Atlas Cloud — avoids introducing a new error code + frontend plumbing. Flag if you'd prefer a dedicated `hosted_only` code.

**Tests / docs**
- Re-tiered the SSOT predicate test + the per-tier ladder regression net (now proves free/locked denied, trial+ admitted for proactive).
- Flipped `admin-proactive.test.ts` to SaaS mode with a transparent entitlement-query mock (doesn't disturb the route-query queue); added a self-hosted-enterprise **exclusion** case.
- New `ee/src/__tests__/proactive-gate.test.ts` — deploy-mode unit test for the gate.
- Corrected the proactive-chat admin guide + the chat-plugin contract doc ("Enterprise" → "hosted-SaaS, every paid plan").

## Verification

- **529 tests green** (319 api + 210 ee), incl. reactive chat unaffected (`chat.test.ts` 82, `chat-resume.test.ts` 16).
- `bun run type` ✓ · `bun run lint` ✓ · `check-pricing-parity.sh` ✓ · `check-ee-imports.sh` ✓.

## Follow-ups (not in this PR)
- Self-hosted UI: the `<FeatureGate feature="Proactive Chat">` upsell still reads "enterprise"; on self-hosted it should read "hosted-SaaS-only." Low-priority copy.
- The broader "should a trial preview *all* paid features?" question (would touch SSO/SCIM/etc.) is deliberately out of scope here.

https://claude.ai/code/session_014xg9N6kLWEfJNHY3xvEv8h