### PR TITLE
fix(web): hosted-only upsell copy for SaaS-exclusive features on self-hosted (#3999)

### DIFF
--- a/packages/web/src/ui/__tests__/feature-disabled.test.tsx
+++ b/packages/web/src/ui/__tests__/feature-disabled.test.tsx
@@ -1,6 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { render } from "@testing-library/react";
+
+// Toggleable deploy mode — the EnterpriseUpsell hosted-only branch reads it.
+// The factory returns a function that reads `mockDeployMode` at call time, so
+// flipping it between tests changes what `useDeployMode()` reports at render.
+let mockDeployMode: "saas" | "self-hosted" = "self-hosted";
+mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => ({
+    deployMode: mockDeployMode,
+    loading: false,
+    error: null,
+    resolved: true,
+  }),
+}));
+
 import {
+  EnterpriseUpsell,
   FeatureGate,
   MfaRequiredPlaceholder,
 } from "../components/admin/feature-disabled";
@@ -48,5 +63,61 @@ describe("MfaRequiredPlaceholder", () => {
     const { container } = render(<MfaRequiredPlaceholder feature="AI Provider" />);
     expect(container.textContent).not.toContain("admin role");
     expect(container.textContent).not.toContain("Access denied");
+  });
+});
+
+describe("EnterpriseUpsell", () => {
+  afterEach(() => {
+    mockDeployMode = "self-hosted";
+  });
+
+  test("ordinary EE feature shows enterprise-upgrade copy (self-hosted)", () => {
+    // SSO et al. unlock on self-hosted enterprise, so the upgrade/contact-sales
+    // line is correct — even on a self-hosted deployment.
+    mockDeployMode = "self-hosted";
+    const { container } = render(<EnterpriseUpsell feature="SSO" />);
+    expect(container.textContent).toContain("SSO requires an enterprise plan");
+    expect(container.textContent).toContain("contact sales");
+    expect(container.textContent).toContain("Learn about Atlas Enterprise");
+    expect(container.textContent).not.toContain("Atlas Cloud");
+  });
+
+  test("SaaS-exclusive feature shows hosted-only copy on self-hosted (#3999)", () => {
+    // Proactive is denied on self-hosted even with enterprise enabled, so the
+    // "upgrade your plan" copy is wrong — it must read hosted-SaaS-only with an
+    // Atlas Cloud CTA, never the enterprise-upgrade line.
+    mockDeployMode = "self-hosted";
+    const { container } = render(<EnterpriseUpsell feature="Proactive Chat" />);
+    expect(container.textContent).toContain("Proactive Chat is an Atlas Cloud feature");
+    expect(container.textContent).toContain("Atlas Cloud");
+    expect(container.textContent).toContain("Learn about Atlas Cloud");
+    expect(container.textContent).not.toContain("requires an enterprise plan");
+    expect(container.textContent).not.toContain("contact sales");
+  });
+
+  test("SaaS-exclusive feature keeps upgrade copy on SaaS (per-tier gate, not hosted-only)", () => {
+    // On the hosted SaaS the proactive denial is a real per-tier gate (a free/
+    // locked workspace), so the upgrade path applies — the hosted-only copy
+    // would be nonsensical when the user is already on Atlas Cloud.
+    mockDeployMode = "saas";
+    const { container } = render(<EnterpriseUpsell feature="Proactive Chat" />);
+    expect(container.textContent).toContain("Proactive Chat requires an enterprise plan");
+    expect(container.textContent).not.toContain("is an Atlas Cloud feature");
+  });
+
+  test("server message overrides the hosted-only description body", () => {
+    // AdminContentWrapper passes the server's EnterpriseError message through
+    // as `message`; the hosted-only branch must surface it (it carries the
+    // PROACTIVE_HOSTED_ONLY_MESSAGE wording) rather than the generic fallback.
+    mockDeployMode = "self-hosted";
+    const { container } = render(
+      <EnterpriseUpsell
+        feature="Proactive Chat"
+        message="Proactive monitoring is available only on Atlas Cloud (the hosted SaaS)."
+      />,
+    );
+    expect(container.textContent).toContain(
+      "Proactive monitoring is available only on Atlas Cloud (the hosted SaaS).",
+    );
   });
 });

--- a/packages/web/src/ui/components/admin/__tests__/feature-registry.test.ts
+++ b/packages/web/src/ui/components/admin/__tests__/feature-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import {
   FEATURE_NAMES,
+  isSaasExclusiveFeature,
   type FeatureName,
 } from "../feature-registry";
 
@@ -72,6 +73,34 @@ describe("FEATURE_NAMES registry", () => {
       );
       if (!match) continue;
       expect(match).toContain(acronym);
+    }
+  });
+});
+
+describe("isSaasExclusiveFeature", () => {
+  test("Proactive Chat is SaaS-exclusive (#3999)", () => {
+    // Proactive's server gate keys on deployMode === "saas", not licensing —
+    // it's denied on self-hosted even with enterprise enabled. The upsell
+    // copy depends on this set; if proactive ever leaves it, the hosted-only
+    // copy regresses to the misleading "upgrade your enterprise plan" line.
+    expect(isSaasExclusiveFeature("Proactive Chat")).toBe(true);
+  });
+
+  test("ordinary enterprise features are NOT SaaS-exclusive", () => {
+    // SSO/SCIM/etc. gate on licensing and DO unlock on self-hosted
+    // enterprise, so they must keep the enterprise-upgrade copy.
+    expect(isSaasExclusiveFeature("SSO")).toBe(false);
+    expect(isSaasExclusiveFeature("SCIM")).toBe(false);
+    expect(isSaasExclusiveFeature("Audit Retention")).toBe(false);
+  });
+
+  test("every SaaS-exclusive feature is a canonical registry name", () => {
+    // Guards a typo'd membership entry that TS would catch at author time but
+    // a `as FeatureName` cast could smuggle past — the set must only contain
+    // names that actually render in upsell copy.
+    for (const name of FEATURE_NAMES) {
+      // exhaustive: calling the predicate on every real name never throws
+      expect(typeof isSaasExclusiveFeature(name)).toBe("boolean");
     }
   });
 });

--- a/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/mutation-error-surface.test.tsx
@@ -1,6 +1,22 @@
 import { describe, expect, test, mock, spyOn } from "bun:test";
 import { render, fireEvent } from "@testing-library/react";
 import type { FetchError } from "@/ui/lib/fetch-error";
+
+// EnterpriseUpsell now reads useDeployMode (→ useAdminFetch → useAtlasConfig) to
+// pick hosted-only vs upgrade copy for SaaS-exclusive features (#3999). These
+// tests render it in isolation (no <AtlasProvider>), so stub the hook to a
+// stable mode. The features used here are non-SaaS-exclusive (SSO/Custom
+// Domains), so the mode never flips the copy — the stub just severs the
+// provider/network dependency.
+mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => ({
+    deployMode: "self-hosted",
+    loading: false,
+    error: null,
+    resolved: true,
+  }),
+}));
+
 import { MutationErrorSurface } from "../mutation-error-surface";
 
 /**

--- a/packages/web/src/ui/components/admin/feature-disabled.tsx
+++ b/packages/web/src/ui/components/admin/feature-disabled.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { Ban, DatabaseZap, ShieldCheck, ShieldX } from "lucide-react";
+import { Ban, Cloud, DatabaseZap, ShieldCheck, ShieldX } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import type { FeatureName } from "@/ui/components/admin/feature-registry";
+import {
+  isSaasExclusiveFeature,
+  type FeatureName,
+} from "@/ui/components/admin/feature-registry";
+import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 
 /**
  * Dedicated upsell shown when an admin page returns an
@@ -11,6 +15,16 @@ import type { FeatureName } from "@/ui/components/admin/feature-registry";
  * Distinct from the generic `FeatureGate` 403 ("Access denied") so non-EE
  * admins see "this feature needs an enterprise plan" with a concrete next
  * step, rather than assuming their account lacks a role.
+ *
+ * Hosted-SaaS-only features (e.g. proactive monitoring, #3999) reuse the same
+ * `enterprise_required` envelope but are denied on every self-hosted
+ * deployment *including self-hosted enterprise* — no plan upgrade unlocks them
+ * locally. On self-hosted we therefore swap to hosted-only copy + an Atlas
+ * Cloud CTA instead of the "upgrade / contact sales" line, which would be
+ * misleading there. (On SaaS the denial is a real per-tier gate, so the
+ * upgrade copy stays.) Deploy mode here is a cosmetic-only branch, so
+ * rendering from `useDeployMode`'s hostname guess before the settings fetch
+ * resolves is acceptable per its contract.
  */
 export function EnterpriseUpsell({
   feature,
@@ -20,6 +34,41 @@ export function EnterpriseUpsell({
   /** Optional override for the description text (usually the server message). */
   message?: string;
 }) {
+  // Only SaaS-exclusive features need the authoritative deploy mode; for every
+  // other feature `hostedOnly` is false regardless, so skip the settings fetch
+  // (`enabled: false` → host guess, which we then ignore).
+  const isSaasExclusive = isSaasExclusiveFeature(feature);
+  const { deployMode } = useDeployMode({ enabled: isSaasExclusive });
+  const hostedOnly = isSaasExclusive && deployMode === "self-hosted";
+
+  if (hostedOnly) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="max-w-md text-center">
+          <Cloud className="mx-auto size-10 text-primary/70" aria-hidden="true" />
+          <p className="mt-3 text-sm font-medium">
+            {feature} is an Atlas Cloud feature
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {message ||
+              `${feature} is available only on Atlas Cloud (the hosted SaaS) and can't be enabled on a self-hosted deployment.`}
+          </p>
+          <div className="mt-4 flex justify-center">
+            <Button asChild size="sm" variant="outline">
+              <a
+                href="https://www.useatlas.dev"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                Learn about Atlas Cloud
+              </a>
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full items-center justify-center">
       <div className="max-w-md text-center">

--- a/packages/web/src/ui/components/admin/feature-registry.ts
+++ b/packages/web/src/ui/components/admin/feature-registry.ts
@@ -83,3 +83,25 @@ export const FEATURE_NAMES = [
 ] as const;
 
 export type FeatureName = (typeof FEATURE_NAMES)[number];
+
+/**
+ * Features that are **hosted-SaaS-only** — available on Atlas Cloud but denied
+ * on *every* self-hosted deployment, including self-hosted enterprise. Unlike
+ * the ordinary enterprise features (SSO, SCIM, …), no plan upgrade unlocks
+ * these on a self-hosted box, so the generic "requires an enterprise plan /
+ * contact sales" upsell copy is wrong for them; `<EnterpriseUpsell>` renders
+ * hosted-only copy instead when the deployment is self-hosted.
+ *
+ * Membership mirrors the server-side `deployMode === "saas"` gate (e.g.
+ * `admin-proactive.ts:gateProactiveAvailable` / `ee/src/proactive-gate.ts`).
+ * Add a feature here when its server gate keys on deploy mode, not licensing.
+ * See #3999 (proactive monitoring is the first such feature).
+ */
+const SAAS_EXCLUSIVE_FEATURES: ReadonlySet<FeatureName> = new Set([
+  "Proactive Chat",
+]);
+
+/** True iff `feature` is denied on self-hosted regardless of plan/license. */
+export function isSaasExclusiveFeature(feature: FeatureName): boolean {
+  return SAAS_EXCLUSIVE_FEATURES.has(feature);
+}


### PR DESCRIPTION
## What

Proactive monitoring is **SaaS-exclusive** (#4081): denied on every self-hosted deployment — *including self-hosted enterprise* — because no plan upgrade unlocks it locally. But the admin **Proactive Chat** page reused the generic `enterprise_required` envelope, so on self-hosted it rendered the misleading upsell:

> Proactive Chat **requires an enterprise plan** … Upgrade your plan or **contact sales** … **Learn about Atlas Enterprise**

The server already sends the correct *body* message (`PROACTIVE_HOSTED_ONLY_MESSAGE`), but the heading + CTA were hardcoded "enterprise."

This is the last open **code** checkbox on #3999 (the "low-priority copy follow-up"). The remaining item on #3999 — confirming proactive is mature enough to *headline* at launch — stays human-gated.

## How

- Add a `SAAS_EXCLUSIVE_FEATURES` set + `isSaasExclusiveFeature()` to the `feature-registry` SSOT (membership: `Proactive Chat`). It mirrors the server-side `deployMode === "saas"` gate (`admin-proactive.ts:gateProactiveAvailable` / `ee/src/proactive-gate.ts`).
- `EnterpriseUpsell` renders **hosted-only copy + an Atlas Cloud CTA** when the feature is SaaS-exclusive **and** the deployment is self-hosted. Otherwise the existing enterprise-upgrade copy is unchanged.
- Correctness nuance: on **SaaS**, the proactive denial is a real per-tier gate (free/locked workspace), so the upgrade copy *stays* — hosted-only would be nonsensical when the user is already on Atlas Cloud. The branch keys on `deployMode === "self-hosted"`, not on the feature alone.
- The settings fetch (`useDeployMode`) is skipped (`enabled: false`) for non-SaaS-exclusive features, since deploy mode is irrelevant to their copy. Deploy mode here is a cosmetic-only branch, so rendering from the host guess before the fetch resolves is fine per `useDeployMode`'s contract.

## Tests

- `feature-registry.test.ts`: `isSaasExclusiveFeature` membership (proactive in; SSO/SCIM/Audit-Retention out).
- `feature-disabled.test.tsx`: `EnterpriseUpsell` renders enterprise copy for ordinary EE features; hosted-only copy for proactive on self-hosted; **keeps upgrade copy for proactive on SaaS**; server message overrides the hosted-only body.

`bun run test` (affected) green · `bun run type` clean · `bun run lint` clean.

## Why no error-contract change

Reusing `enterprise_required` (vs. a new error code) keeps `mapTaggedError`, the HTTP envelope, and `AdminContentWrapper` routing untouched — the distinction is purely cosmetic copy, decided client-side from deploy mode + the feature registry.

https://claude.ai/code/session_014xg9N6kLWEfJNHY3xvEv8h