### PR TITLE
fix(www): chat-integration claims — Google Chat coming soon, other 7 live (#3995)

### DIFF
--- a/apps/www/src/app/blog/announcing-atlas/page.tsx
+++ b/apps/www/src/app/blog/announcing-atlas/page.tsx
@@ -282,8 +282,9 @@ export default function AnnouncingAtlas() {
             headless API, and the MCP server
           </DefItem>
           <DefItem term="Eight integrations">
-            Six chat platforms — Slack live today; Teams, Discord, Telegram,
-            WhatsApp, and Google Chat wired — plus Linear and GitHub, also wired
+            Six chat platforms — Slack, Teams, Discord, Telegram, and WhatsApp
+            live today; Google Chat coming soon — plus Linear and GitHub, also
+            live
           </DefItem>
           <DefItem term="Enterprise controls">
             SSO (SAML/OIDC), SCIM provisioning, custom roles, IP allowlists,

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -140,7 +140,7 @@ const TIERS: Tier[] = [
       "Unlimited seats & connections",
       "Default model: Sonnet 4.6",
       "BYOK for unlimited queries",
-      "All 8 integrations (6 chat + Linear + GitHub)",
+      "8 integrations: 6 chat + Linear + GitHub (Google Chat coming soon)",
       "SSO, SCIM & custom roles",
       "IP allowlist & approval workflows",
       "PII masking & audit retention",
@@ -170,7 +170,7 @@ const CORE_SECTION: ComparisonSection = {
     { feature: "Default model", selfHosted: "Your choice", starter: "Haiku 4.5", pro: "Sonnet 4.6", business: "Sonnet 4.6" },
     { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
     { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
-    { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 6" },
+    { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 6 (Google Chat soon)" },
     { feature: "Past the included credit", selfHosted: "No limit (BYOK)", starter: "At cost, to spend cap", pro: "At cost, to spend cap", business: "At cost, to spend cap" },
   ],
 };

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -7,12 +7,12 @@
  * from `process.env`, and returns the set of adapter instances the chat
  * plugin should activate at boot.
  *
- * In milestone 1.5.2, only `install_model === "oauth"` adapters
- * instantiate. The non-Slack chat Platforms (Teams, Discord, gchat,
- * Telegram, WhatsApp) ship as catalog placeholders with
- * `install_model === "static-bot"` and `enabled === false` — visible to
- * ops, not customer-installable, and never instantiated here. Their
- * install handlers land in 1.5.3.
+ * Both install models instantiate here: `install_model === "oauth"`
+ * (Slack) and `install_model === "static-bot"` (Teams, Discord, gchat,
+ * Telegram, WhatsApp) — the Phase D static-bot family (#2994) all ship
+ * real builders + install handlers now. Each adapter builds only when its
+ * required env vars are present and the catalog row is `enabled`;
+ * otherwise it's skipped with a diagnostic (see `buildChatAdapterRegistry`).
  *
  * Pure-ish: takes the catalog entry list + an env reader as input,
  * returns the adapter set. Side effects are limited to (a) constructing
@@ -71,10 +71,11 @@ export interface ChatCatalogEntry {
 
 /**
  * Map of platform slug → instantiated adapter. Slug-keyed `Partial`
- * `Record` so future adapters (1.5.3 static-bot platforms) extend by
- * adding map entries — no shape change to the type, no consumer
- * rewrites. Today only `slack` is populated; the other keys are
- * structurally allowed but never set.
+ * `Record` so future platforms extend by adding map entries — no shape
+ * change to the type, no consumer rewrites. Every wired platform (slack +
+ * the static-bot family: telegram/discord/whatsapp/gchat/teams) populates
+ * its slug when enabled with creds present; the `Partial` keeps the type
+ * extensible for any future platform.
  */
 export type ChatAdapterSet = Partial<{
   readonly [K in ChatAdapterName]: ChatAdapterInstance<K>;
@@ -82,11 +83,11 @@ export type ChatAdapterSet = Partial<{
 
 /**
  * Per-slug adapter instance type. Slack has its concrete `SlackAdapter`
- * class from `@chat-adapter/slack`; Telegram (1.5.3 #2748 — first
- * static-bot Platform) narrows to the structural Chat SDK `Adapter` type
- * because `@chat-adapter/telegram` doesn't export a public class
- * symbol the way Slack does. The remaining slugs stay on the
- * `{ name }` placeholder until their adapter class lands.
+ * class from `@chat-adapter/slack`; the static-bot family (Telegram,
+ * Discord, WhatsApp, gchat, Teams) narrows to the structural Chat SDK
+ * `Adapter` type because those `@chat-adapter/*` packages don't export a
+ * public class symbol the way Slack does. The `{ name }` fallback is for
+ * any future slug whose adapter class hasn't landed yet.
  */
 type ChatAdapterInstance<K extends ChatAdapterName> = K extends "slack"
   ? SlackAdapter
@@ -140,7 +141,8 @@ interface ChatAdapterBuilder<Adapter> {
 // ---------------------------------------------------------------------------
 
 /**
- * Slack — the only OAuth chat Platform that instantiates in 1.5.2.
+ * Slack — the OAuth chat Platform (the rest of the family installs via
+ * static-bot).
  *
  * Required env vars (all four must be present):
  *   - SLACK_CLIENT_ID, SLACK_CLIENT_SECRET — App Registration OAuth credentials


### PR DESCRIPTION
## What

Operator-verified prod-live status for the WS4 integration-claims accuracy pass (#3995): **Slack, Teams, Discord, Telegram, WhatsApp, Linear, GitHub are live; Google Chat is coming soon** (code-ready — `gchat-static-bot-handler.ts` exists — but not yet published to the Google Workspace Marketplace).

## Changes
- **pricing** — `"All 8 integrations (6 chat + Linear + GitHub)"` → `"8 integrations: 6 chat + Linear + GitHub (Google Chat coming soon)"`; business chat row `"All 6"` → `"All 6 (Google Chat soon)"`.
- **blog** (`announcing-atlas`) — the non-Slack platforms are now **live** (the post said "wired"); Google Chat reframed from "wired" to **coming soon**.

Counts stay internally consistent (6 chat / 8 integrations describe built breadth; one not-yet-live, clearly marked). The landing comparison "6 chat platforms" breadth claim is left as-is (it's a capability claim, not a per-tier availability promise).

## Checks
- `check-pricing-parity.sh` green (chat is a numeric limit, not a gated entitlement, so it's not parity-gated).
- eslint clean on both files.

## Out of scope (noted)
`plugins/chat/src/adapter-registry.ts` header comments ("only `slack` is populated", non-Slack are "catalog placeholders") are **stale** — install handlers now exist for all platforms. Doc-only follow-up.

Addresses the chat-platform half of #3995 with verified prod status; residency claim already truthful (#3967 shipped), SOC2/ISO copy untouched, counts reconciled earlier (#4071).

https://claude.ai/code/session_014xg9N6kLWEfJNHY3xvEv8h