### PR TITLE
fix(billing,www): proactive monitoring → 'chat' section, not security & compliance

### DIFF
--- a/apps/www/src/app/pricing/entitlements.generated.ts
+++ b/apps/www/src/app/pricing/entitlements.generated.ts
@@ -31,7 +31,7 @@ export const TIER_MONTHLY_PRICE: Readonly<Record<PricingColumn, number>> = {
 };
 
 /** Comparison-table section a gated feature renders under. */
-export type EntitlementSection = "hosting" | "security & compliance";
+export type EntitlementSection = "chat" | "hosting" | "security & compliance";
 
 /**
  * The entitlement sections in render order. Iterate this (rather than
@@ -40,11 +40,11 @@ export type EntitlementSection = "hosting" | "security & compliance";
  * gap, not a quiet omission.
  */
 export const ENTITLEMENT_SECTION_ORDER: readonly EntitlementSection[] = [
-  "hosting", "security & compliance",
+  "chat", "hosting", "security & compliance",
 ];
 
 /** Stable wire id of a gated feature (matches the SSOT key). */
-export type FeatureId = "residency" | "backups" | "white_label" | "custom_domain" | "sso" | "scim" | "custom_roles" | "ip_allowlist" | "approvals" | "audit_retention" | "masking" | "proactive";
+export type FeatureId = "proactive" | "residency" | "backups" | "white_label" | "custom_domain" | "sso" | "scim" | "custom_roles" | "ip_allowlist" | "approvals" | "audit_retention" | "masking";
 
 /** One per-tier entitlement row mirrored from the SSOT. */
 export interface EntitlementRow {
@@ -65,6 +65,12 @@ export interface EntitlementRow {
  * feature in code.
  */
 export const ENTITLEMENT_ROWS: readonly EntitlementRow[] = [
+  {
+    feature: "proactive",
+    label: "Proactive monitoring",
+    section: "chat",
+    cells: { selfHosted: false, starter: true, pro: true, business: true },
+  },
   {
     feature: "residency",
     label: "Data residency",
@@ -130,11 +136,5 @@ export const ENTITLEMENT_ROWS: readonly EntitlementRow[] = [
     label: "PII detection & masking",
     section: "security & compliance",
     cells: { selfHosted: false, starter: false, pro: false, business: true },
-  },
-  {
-    feature: "proactive",
-    label: "Proactive monitoring",
-    section: "security & compliance",
-    cells: { selfHosted: false, starter: true, pro: true, business: true },
   },
 ];

--- a/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
+++ b/packages/api/src/lib/billing/pricing-entitlement-artifact.ts
@@ -49,7 +49,7 @@ export const COLUMN_TIERS = {
 export type PricingColumn = keyof typeof COLUMN_TIERS;
 
 /** Comparison-table section a gated feature renders under. */
-export type EntitlementSection = "hosting" | "security & compliance";
+export type EntitlementSection = "chat" | "hosting" | "security & compliance";
 
 interface FeatureDisplay {
   /** Row label shown verbatim in the comparison table. */
@@ -69,8 +69,9 @@ interface FeatureDisplay {
  * (Proactive monitoring) was gated by the SSOT but never listed on the page.
  * Surfacing it here is deliberate — WS4 of #3984 advertises proactive
  * monitoring — so the mirror adds a "Proactive monitoring" row the prior copy
- * did not have. Unlike the Business-only rows around it, proactive unlocks on
- * every paid plan (min `trial`, #3999); its cells render ✓ for starter/pro/
+ * did not have, in its own `chat` section (it's a chat capability, not security
+ * & compliance — #3984). Unlike the Business-only enterprise rows, proactive
+ * unlocks on every paid plan (min `trial`, #3999); its cells render ✓ for starter/pro/
  * business and ✗ for self-hosted (a hosted-SaaS-only feature), derived from the
  * SSOT like every other row.
  */
@@ -99,12 +100,13 @@ export const FEATURE_DISPLAY: Record<GatedFeature, FeatureDisplay> = {
   },
   proactive: {
     label: "Proactive monitoring",
-    section: "security & compliance",
+    section: "chat",
   },
 };
 
 /** Section render order in the artifact. */
 export const SECTION_ORDER: readonly EntitlementSection[] = [
+  "chat",
   "hosting",
   "security & compliance",
 ];


### PR DESCRIPTION
## What
Proactive monitoring is a **chat** capability, but the pricing-comparison SSOT (`pricing-entitlement-artifact.ts`) placed it under **"security & compliance"**, rendering it next to SSO / SCIM / PII masking. That's the wrong mental bucket for a buyer.

## How
- Add a `"chat"` `EntitlementSection`, placed **first** in `SECTION_ORDER` so it renders right after the hand-maintained `core` section (which already holds the "Chat integrations" row) — keeping proactive adjacent to the other chat capability.
- Move `proactive` from `security & compliance` → `chat`.
- Regenerated the www mirror (`entitlements.generated.ts`).
- Refreshed the now-stale doc comment ("the rows around it").

Cells are unchanged (✓ starter/pro/business, ✗ self-hosted — derived from the entitlement SSOT). `check-pricing-parity.sh` green; `bun run type` clean.

Part of #3984 (WS4 — make the pricing page reflect reality).

https://claude.ai/code/session_014xg9N6kLWEfJNHY3xvEv8h