### PR TITLE
fix(api): evict legacy parent-domain auth cookie shadowing session (#4086)

### DIFF
--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -18,8 +18,7 @@ import {
   context as otelContext,
 } from "@opentelemetry/api";
 import { createLogger } from "@atlas/api/lib/logger";
-import { buildLegacyCookieDeletions } from "@atlas/api/lib/auth/legacy-cookie-cleanup";
-import { resolveCookiePrefix } from "@atlas/api/lib/env-profile";
+import { legacyCookieCleanupMiddleware } from "@atlas/api/lib/auth/legacy-cookie-cleanup-middleware";
 import { validationHook } from "./routes/validation-hook";
 import { chat } from "./routes/chat";
 import { health } from "./routes/health";
@@ -175,30 +174,12 @@ app.use("/api/*", async (c, next) => {
 // A browser that logged in pre-switch still carries `Domain=<registrable>`
 // copies of the session cookie that SHADOW the new host-only one; Better Auth
 // reads the stale shadow first, so every authed call 401s once the ~30s
-// cookie-cache (`session_data`) lapses and the app bounces to /login. The helper
-// is self-limiting — it emits deletions only when the request actually carries
-// the duplicate session-token cookie — and also restores the ADR-0024 §5
-// residency invariant (the parent-domain cookie was reaching every region edge).
-// See lib/auth/legacy-cookie-cleanup.ts.
-app.use("/api/*", async (c, next) => {
-  await next();
-  try {
-    const deletions = buildLegacyCookieDeletions({
-      cookieHeader: c.req.header("cookie"),
-      host: c.req.header("host"),
-      cookiePrefix: resolveCookiePrefix(process.env),
-    });
-    for (const setCookie of deletions) {
-      c.res.headers.append("set-cookie", setCookie);
-    }
-  } catch (err) {
-    // Cleanup is best-effort; a failure must never break the auth response.
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "Legacy parent-domain cookie cleanup failed (#4086)",
-    );
-  }
-});
+// cookie-cache (`session_data`) lapses and the app bounces to /login. The
+// middleware is self-limiting — it emits deletions only when the request
+// actually carries the duplicate session-token cookie — and also restores the
+// ADR-0024 §5 residency invariant (the parent-domain cookie was reaching every
+// region edge). See lib/auth/legacy-cookie-cleanup{,-middleware}.ts.
+app.use("/api/*", legacyCookieCleanupMiddleware);
 
 app.route("/api/v1/chat", chat);
 app.route("/api/health", health);

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -18,6 +18,8 @@ import {
   context as otelContext,
 } from "@opentelemetry/api";
 import { createLogger } from "@atlas/api/lib/logger";
+import { buildLegacyCookieDeletions } from "@atlas/api/lib/auth/legacy-cookie-cleanup";
+import { resolveCookiePrefix } from "@atlas/api/lib/env-profile";
 import { validationHook } from "./routes/validation-hook";
 import { chat } from "./routes/chat";
 import { health } from "./routes/health";
@@ -166,6 +168,36 @@ app.use("/api/*", async (c, next) => {
     method: c.req.method,
     status: c.res.status,
   });
+});
+
+// #4086 — evict legacy parent-domain (cross-subdomain) auth cookies left over
+// from before ADR-0024 §5 switched managed-mode sessions to HOST-ONLY cookies.
+// A browser that logged in pre-switch still carries `Domain=<registrable>`
+// copies of the session cookie that SHADOW the new host-only one; Better Auth
+// reads the stale shadow first, so every authed call 401s once the ~30s
+// cookie-cache (`session_data`) lapses and the app bounces to /login. The helper
+// is self-limiting — it emits deletions only when the request actually carries
+// the duplicate session-token cookie — and also restores the ADR-0024 §5
+// residency invariant (the parent-domain cookie was reaching every region edge).
+// See lib/auth/legacy-cookie-cleanup.ts.
+app.use("/api/*", async (c, next) => {
+  await next();
+  try {
+    const deletions = buildLegacyCookieDeletions({
+      cookieHeader: c.req.header("cookie"),
+      host: c.req.header("host"),
+      cookiePrefix: resolveCookiePrefix(process.env),
+    });
+    for (const setCookie of deletions) {
+      c.res.headers.append("set-cookie", setCookie);
+    }
+  } catch (err) {
+    // Cleanup is best-effort; a failure must never break the auth response.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Legacy parent-domain cookie cleanup failed (#4086)",
+    );
+  }
 });
 
 app.route("/api/v1/chat", chat);

--- a/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup-middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup-middleware.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { buildLegacyCookieDeletions } from "../legacy-cookie-cleanup";
+
+/**
+ * Wiring test for the #4086 cleanup middleware: confirms that appending the
+ * helper's deletions via `c.res.headers.append("set-cookie", …)` AFTER `next()`
+ * actually surfaces as distinct `Set-Cookie` response headers in Hono — and that
+ * it leaves the route's own response (incl. its own Set-Cookie) intact. Mirrors
+ * the middleware in `api/index.ts` without standing up the full Atlas app.
+ */
+function makeApp() {
+  const app = new Hono();
+  app.use("/api/*", async (c, next) => {
+    await next();
+    const deletions = buildLegacyCookieDeletions({
+      cookieHeader: c.req.header("cookie"),
+      host: c.req.header("host"),
+      cookiePrefix: "atlas",
+    });
+    for (const setCookie of deletions) c.res.headers.append("set-cookie", setCookie);
+  });
+  // A route that authenticates and sets its OWN (host-only) session cookie,
+  // standing in for Better Auth's response.
+  app.get("/api/auth/get-session", (c) => {
+    c.header("set-cookie", "__Secure-atlas.session_token=fresh.sig; Path=/; HttpOnly; Secure; SameSite=Lax", { append: true });
+    return c.json({ ok: true });
+  });
+  return app;
+}
+
+describe("#4086 cleanup middleware wiring", () => {
+  it("appends parent-domain deletions when the shadow cookie is present", async () => {
+    const app = makeApp();
+    const res = await app.request("https://api.useatlas.dev/api/auth/get-session", {
+      headers: {
+        host: "api.useatlas.dev",
+        cookie:
+          "__Secure-atlas.session_token=hostonly.sig; __Secure-atlas.session_token=staleparent.sig",
+      },
+    });
+    const setCookies = res.headers.getSetCookie();
+    // The route's own host-only cookie survives…
+    expect(setCookies.some((c) => c.startsWith("__Secure-atlas.session_token=fresh.sig"))).toBe(true);
+    // …and the parent-domain deletions are appended.
+    expect(setCookies).toContain(
+      "__Secure-atlas.session_token=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+    );
+    expect(setCookies).toContain(
+      "__Secure-atlas.session_data=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+    );
+  });
+
+  it("appends nothing for a clean browser (no duplicate session token)", async () => {
+    const app = makeApp();
+    const res = await app.request("https://api.useatlas.dev/api/auth/get-session", {
+      headers: {
+        host: "api.useatlas.dev",
+        cookie: "__Secure-atlas.session_token=hostonly.sig; __Secure-atlas.session_data=cache",
+      },
+    });
+    const setCookies = res.headers.getSetCookie();
+    // Only the route's own cookie; no Max-Age=0 deletions.
+    expect(setCookies).toEqual(["__Secure-atlas.session_token=fresh.sig; Path=/; HttpOnly; Secure; SameSite=Lax"]);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup-middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup-middleware.test.ts
@@ -1,31 +1,33 @@
 import { describe, it, expect } from "bun:test";
 import { Hono } from "hono";
-import { buildLegacyCookieDeletions } from "../legacy-cookie-cleanup";
+import { createLegacyCookieCleanupMiddleware } from "../legacy-cookie-cleanup-middleware";
 
 /**
- * Wiring test for the #4086 cleanup middleware: confirms that appending the
- * helper's deletions via `c.res.headers.append("set-cookie", …)` AFTER `next()`
- * actually surfaces as distinct `Set-Cookie` response headers in Hono — and that
- * it leaves the route's own response (incl. its own Set-Cookie) intact. Mirrors
- * the middleware in `api/index.ts` without standing up the full Atlas app.
+ * Wiring test for the #4086 cleanup middleware. Drives the EXACT production
+ * middleware (`createLegacyCookieCleanupMiddleware`, the same factory wired in
+ * `api/index.ts`) — only the cookie-prefix source is injected, so the test
+ * doesn't hinge on the ambient `ATLAS_DEPLOY_ENV`. Confirms the post-`next()`
+ * append surfaces as distinct `Set-Cookie` headers in Hono, fires on the
+ * `/api/v1/*` surface that actually broke (#4086), leaves the route's own
+ * response intact, and that a cleanup failure can never break the response.
  */
-function makeApp() {
+const SHADOW_COOKIE =
+  "__Secure-atlas.session_token=hostonly.sig; __Secure-atlas.session_token=staleparent.sig";
+const ROUTE_COOKIE =
+  "__Secure-atlas.session_token=fresh.sig; Path=/; HttpOnly; Secure; SameSite=Lax";
+
+/** App with the real middleware and a route that sets its OWN host-only cookie. */
+function makeApp(resolvePrefix: () => string = () => "atlas") {
   const app = new Hono();
-  app.use("/api/*", async (c, next) => {
-    await next();
-    const deletions = buildLegacyCookieDeletions({
-      cookieHeader: c.req.header("cookie"),
-      host: c.req.header("host"),
-      cookiePrefix: "atlas",
-    });
-    for (const setCookie of deletions) c.res.headers.append("set-cookie", setCookie);
-  });
-  // A route that authenticates and sets its OWN (host-only) session cookie,
-  // standing in for Better Auth's response.
+  app.use("/api/*", createLegacyCookieCleanupMiddleware(resolvePrefix));
+  // Stands in for Better Auth's response (sets its own host-only session cookie).
   app.get("/api/auth/get-session", (c) => {
-    c.header("set-cookie", "__Secure-atlas.session_token=fresh.sig; Path=/; HttpOnly; Secure; SameSite=Lax", { append: true });
+    c.header("set-cookie", ROUTE_COOKIE, { append: true });
     return c.json({ ok: true });
   });
+  // The exact endpoint #4086 reported 401-looping — a non-200 /api/v1/* route
+  // that sets NO cookie of its own.
+  app.post("/api/v1/onboarding/use-demo", (c) => c.json({ error: "unauthorized" }, 401));
   return app;
 }
 
@@ -33,11 +35,7 @@ describe("#4086 cleanup middleware wiring", () => {
   it("appends parent-domain deletions when the shadow cookie is present", async () => {
     const app = makeApp();
     const res = await app.request("https://api.useatlas.dev/api/auth/get-session", {
-      headers: {
-        host: "api.useatlas.dev",
-        cookie:
-          "__Secure-atlas.session_token=hostonly.sig; __Secure-atlas.session_token=staleparent.sig",
-      },
+      headers: { host: "api.useatlas.dev", cookie: SHADOW_COOKIE },
     });
     const setCookies = res.headers.getSetCookie();
     // The route's own host-only cookie survives…
@@ -51,6 +49,23 @@ describe("#4086 cleanup middleware wiring", () => {
     );
   });
 
+  it("fires on a non-200 /api/v1/* response (the #4086 endpoint), not just /api/auth/*", async () => {
+    // Guards against a future "it's an auth cookie" refactor narrowing the glob
+    // to /api/auth/* — which would re-break the reported use-demo 401 loop.
+    const app = makeApp();
+    const res = await app.request("https://api.useatlas.dev/api/v1/onboarding/use-demo", {
+      method: "POST",
+      headers: { host: "api.useatlas.dev", cookie: SHADOW_COOKIE },
+    });
+    expect(res.status).toBe(401);
+    const setCookies = res.headers.getSetCookie();
+    // The route set no cookie of its own → the deletions are the sole Set-Cookie.
+    expect(setCookies).toEqual([
+      "__Secure-atlas.session_token=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+      "__Secure-atlas.session_data=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+    ]);
+  });
+
   it("appends nothing for a clean browser (no duplicate session token)", async () => {
     const app = makeApp();
     const res = await app.request("https://api.useatlas.dev/api/auth/get-session", {
@@ -59,8 +74,23 @@ describe("#4086 cleanup middleware wiring", () => {
         cookie: "__Secure-atlas.session_token=hostonly.sig; __Secure-atlas.session_data=cache",
       },
     });
-    const setCookies = res.headers.getSetCookie();
     // Only the route's own cookie; no Max-Age=0 deletions.
-    expect(setCookies).toEqual(["__Secure-atlas.session_token=fresh.sig; Path=/; HttpOnly; Secure; SameSite=Lax"]);
+    expect(res.headers.getSetCookie()).toEqual([ROUTE_COOKIE]);
+  });
+
+  it("best-effort: a cleanup failure leaves the route response intact", async () => {
+    // Force the helper path to throw (prefix resolution is inside the try) and
+    // assert the committed auth response still returns — a cleanup failure must
+    // never convert a good 200 into a 500.
+    const app = makeApp(() => {
+      throw new Error("prefix boom");
+    });
+    const res = await app.request("https://api.useatlas.dev/api/auth/get-session", {
+      headers: { host: "api.useatlas.dev", cookie: SHADOW_COOKIE },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    // The route's own cookie is untouched; no deletions were appended.
+    expect(res.headers.getSetCookie()).toEqual([ROUTE_COOKIE]);
   });
 });

--- a/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup.test.ts
+++ b/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "bun:test";
+import {
+  countSessionTokenCookies,
+  parentCookieDomains,
+  buildLegacyCookieDeletions,
+} from "../legacy-cookie-cleanup";
+
+/**
+ * #4086 — the legacy cross-subdomain cookie that shadows the host-only one.
+ *
+ * The header below is the real shape captured from a broken prod browser: two
+ * `__Secure-atlas.session_token` cookies (the live host-only one + the stale
+ * `Domain=.useatlas.dev` one) plus the host-only passkey cookie. The
+ * `session_data` cache cookie has already lapsed (its 30s window), which is the
+ * exact moment auth starts 401ing.
+ */
+const SHADOWED_HEADER =
+  "__Secure-atlas.better-auth-passkey=xUf.sig; " +
+  "__Secure-atlas.session_token=ndlpHostOnly.sig; " +
+  "__Secure-atlas.session_token=p6wZStaleParent.sig";
+
+/** A clean, migrated browser: exactly one host-only session token. */
+const CLEAN_HEADER =
+  "__Secure-atlas.better-auth-passkey=xUf.sig; " +
+  "__Secure-atlas.session_token=ndlpHostOnly.sig; " +
+  "__Secure-atlas.session_data=eyJ.cache";
+
+describe("countSessionTokenCookies", () => {
+  it("counts both spellings of the session-token cookie, ignoring others", () => {
+    expect(countSessionTokenCookies(SHADOWED_HEADER, "atlas")).toBe(2);
+    expect(countSessionTokenCookies(CLEAN_HEADER, "atlas")).toBe(1);
+  });
+
+  it("does not count session_data or passkey cookies", () => {
+    const onlyOthers =
+      "__Secure-atlas.session_data=x; __Secure-atlas.better-auth-passkey=y";
+    expect(countSessionTokenCookies(onlyOthers, "atlas")).toBe(0);
+  });
+
+  it("counts a bare (non-__Secure-) spelling for http dev", () => {
+    expect(
+      countSessionTokenCookies("atlas.session_token=a; atlas.session_token=b", "atlas"),
+    ).toBe(2);
+  });
+
+  it("respects the cookie prefix (staging vs prod isolation)", () => {
+    // A prod cookie must not be counted against the staging prefix.
+    expect(countSessionTokenCookies(SHADOWED_HEADER, "atlas-staging")).toBe(0);
+  });
+
+  it("tolerates malformed / empty segments", () => {
+    expect(countSessionTokenCookies(";; =novalue; __Secure-atlas.session_token=a", "atlas")).toBe(1);
+  });
+});
+
+describe("parentCookieDomains", () => {
+  it("returns the registrable parent for a regional API host", () => {
+    expect(parentCookieDomains("api.useatlas.dev")).toEqual(["useatlas.dev"]);
+    expect(parentCookieDomains("api-eu.useatlas.dev")).toEqual(["useatlas.dev"]);
+    expect(parentCookieDomains("api-apac.useatlas.dev")).toEqual(["useatlas.dev"]);
+  });
+
+  it("walks every ancestor for a deeper host (covers staging-style hosts)", () => {
+    expect(parentCookieDomains("api.staging.useatlas.dev")).toEqual([
+      "staging.useatlas.dev",
+      "useatlas.dev",
+    ]);
+  });
+
+  it("never returns the full host (host-only needs no cleanup) nor a bare TLD", () => {
+    const parents = parentCookieDomains("api.useatlas.dev");
+    expect(parents).not.toContain("api.useatlas.dev");
+    expect(parents).not.toContain("dev");
+  });
+
+  it("returns [] for a registrable-domain or single-label host", () => {
+    expect(parentCookieDomains("useatlas.dev")).toEqual([]);
+    expect(parentCookieDomains("localhost")).toEqual([]);
+  });
+
+  it("strips a port and lowercases", () => {
+    expect(parentCookieDomains("API.useatlas.dev:443")).toEqual(["useatlas.dev"]);
+  });
+});
+
+describe("buildLegacyCookieDeletions", () => {
+  it("emits parent-domain deletions for the #4086 shadow (prod)", () => {
+    const out = buildLegacyCookieDeletions({
+      cookieHeader: SHADOWED_HEADER,
+      host: "api.useatlas.dev",
+      cookiePrefix: "atlas",
+    });
+    // session_token + session_data, one parent domain → 2 deletions.
+    expect(out).toEqual([
+      "__Secure-atlas.session_token=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+      "__Secure-atlas.session_data=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+    ]);
+  });
+
+  it("targets the PARENT domain only — never the live host-only cookie", () => {
+    const out = buildLegacyCookieDeletions({
+      cookieHeader: SHADOWED_HEADER,
+      host: "api.useatlas.dev",
+      cookiePrefix: "atlas",
+    });
+    // A deletion scoped to the full host would clobber the live session — assert
+    // none is. (Host-only cookies carry no Domain; Domain=api.useatlas.dev is a
+    // distinct cookie, but emitting it would still be a smell.)
+    for (const sc of out) expect(sc).not.toContain("Domain=api.useatlas.dev");
+  });
+
+  it("is a NO-OP for a clean (already-migrated) browser", () => {
+    expect(
+      buildLegacyCookieDeletions({
+        cookieHeader: CLEAN_HEADER,
+        host: "api.useatlas.dev",
+        cookiePrefix: "atlas",
+      }),
+    ).toEqual([]);
+  });
+
+  it("is a no-op without a cookie header or host", () => {
+    expect(buildLegacyCookieDeletions({ cookieHeader: null, host: "api.useatlas.dev", cookiePrefix: "atlas" })).toEqual([]);
+    expect(buildLegacyCookieDeletions({ cookieHeader: SHADOWED_HEADER, host: null, cookiePrefix: "atlas" })).toEqual([]);
+  });
+
+  it("omits Secure for a bare-prefix (http dev) shadow", () => {
+    const out = buildLegacyCookieDeletions({
+      cookieHeader: "atlas.session_token=a; atlas.session_token=b",
+      host: "api.staging.useatlas.dev",
+      cookiePrefix: "atlas",
+    });
+    expect(out).toContain("atlas.session_token=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax");
+    expect(out).toContain("atlas.session_token=; Domain=staging.useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax");
+    for (const sc of out) expect(sc).not.toContain("Secure");
+  });
+
+  it("does not fire for a different deployment's prefix", () => {
+    expect(
+      buildLegacyCookieDeletions({
+        cookieHeader: SHADOWED_HEADER,
+        host: "api.useatlas.dev",
+        cookiePrefix: "atlas-staging",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup.test.ts
+++ b/packages/api/src/lib/auth/__tests__/legacy-cookie-cleanup.test.ts
@@ -81,6 +81,12 @@ describe("parentCookieDomains", () => {
   it("strips a port and lowercases", () => {
     expect(parentCookieDomains("API.useatlas.dev:443")).toEqual(["useatlas.dev"]);
   });
+
+  it("returns [] for a non-LDH / malformed host (defense-in-depth)", () => {
+    // A label outside [a-z0-9-] never flows into a `Set-Cookie: Domain=…` value.
+    expect(parentCookieDomains("evil_host.useatlas.dev")).toEqual([]);
+    expect(parentCookieDomains("has space.useatlas.dev")).toEqual([]);
+  });
 });
 
 describe("buildLegacyCookieDeletions", () => {
@@ -141,6 +147,49 @@ describe("buildLegacyCookieDeletions", () => {
         cookieHeader: SHADOWED_HEADER,
         host: "api.useatlas.dev",
         cookiePrefix: "atlas-staging",
+      }),
+    ).toEqual([]);
+  });
+
+  it("emits Domain=useatlas.dev deletions for a regional edge host (ADR-0024 §5)", () => {
+    // The parent-domain cookie leaking to api-eu is the residency violation the
+    // fix cites — assert the full deletion strings, not just the parent walk.
+    const out = buildLegacyCookieDeletions({
+      cookieHeader: SHADOWED_HEADER,
+      host: "api-eu.useatlas.dev",
+      cookiePrefix: "atlas",
+    });
+    expect(out).toEqual([
+      "__Secure-atlas.session_token=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+      "__Secure-atlas.session_data=; Domain=useatlas.dev; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure",
+    ]);
+  });
+
+  it("never targets a __Host- name even when one is present in the count", () => {
+    // A browser carrying both a __Host- and a __Secure- session token trips the
+    // ≥2 count, but __Host- forbids Domain= so it can't be the shadow — the
+    // emitted deletions must use the __Secure- spelling only.
+    const out = buildLegacyCookieDeletions({
+      cookieHeader:
+        "__Host-atlas.session_token=hostprefixed.sig; __Secure-atlas.session_token=hostonly.sig",
+      host: "api.useatlas.dev",
+      cookiePrefix: "atlas",
+    });
+    expect(out.length).toBeGreaterThan(0);
+    for (const sc of out) expect(sc).not.toContain("__Host-");
+  });
+
+  it("is a no-op end-to-end for a registrable-domain / localhost host", () => {
+    // Covers the `domains.length === 0` branch through the public entry point,
+    // not just via parentCookieDomains.
+    expect(
+      buildLegacyCookieDeletions({ cookieHeader: SHADOWED_HEADER, host: "useatlas.dev", cookiePrefix: "atlas" }),
+    ).toEqual([]);
+    expect(
+      buildLegacyCookieDeletions({
+        cookieHeader: "atlas.session_token=a; atlas.session_token=b",
+        host: "localhost",
+        cookiePrefix: "atlas",
       }),
     ).toEqual([]);
   });

--- a/packages/api/src/lib/auth/__tests__/post-signup-session-durability.test.ts
+++ b/packages/api/src/lib/auth/__tests__/post-signup-session-durability.test.ts
@@ -73,11 +73,14 @@ function makeAuth(): { auth: ReturnType<typeof betterAuth>; getOtp: () => string
           capturedOtp = data.otp;
         },
       }),
-    ] as unknown as BuildAuthOptionsDeps["plugins"],
+      // `BuildAuthOptionsDeps["plugins"]` is `any[]` (Better Auth's plugin types
+      // are un-unifiable union generics — see `buildPlugins`), so this minimal
+      // set is assignable with no cast.
+    ],
     trustedOrigins: ["http://localhost:3000"],
     bootstrapAdmin: { mode: "none" },
   };
-  const auth = betterAuth(buildAuthOptions(deps) as Parameters<typeof betterAuth>[0]);
+  const auth = betterAuth(buildAuthOptions(deps));
   return { auth, getOtp: () => capturedOtp };
 }
 

--- a/packages/api/src/lib/auth/__tests__/post-signup-session-durability.test.ts
+++ b/packages/api/src/lib/auth/__tests__/post-signup-session-durability.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "bun:test";
+import { betterAuth } from "better-auth";
+import { bearer } from "better-auth/plugins";
+import { emailOTP } from "better-auth/plugins/email-otp";
+import { buildAuthOptions, parseAuthSecret, type BuildAuthOptionsDeps } from "../server";
+
+/**
+ * Post-signup session-durability net (#4018 / #4086).
+ *
+ * #4018 fixed a brand-new signup landing in a broken app: after the OTP-verify
+ * step every authed call 401'd. The durable regression net it left lived on the
+ * WEB side (`buildAuthHeaders` unit tests + the OTP-hydration ordering) and in
+ * the `/verify-prod-signup` primitive-8 runbook — there was no SERVER-side test
+ * pinning the actual contract the web fix depends on. #4086 re-reported the same
+ * dead-end (`POST /api/v1/onboarding/use-demo` → 401, `set-auth-token` returned
+ * with "no Set-Cookie") against `v0.0.33`.
+ *
+ * The server-side contract the whole flow rests on, asserted here against a LIVE
+ * Better Auth instance built through the SAME `buildAuthOptions` path production
+ * uses:
+ *
+ *   In managed mode with `requireEmailVerification` on, the email-OTP
+ *   `verify-email` step (`autoSignInAfterVerification`) MUST establish a durable,
+ *   HOST-ONLY session cookie (ADR-0024 §5) that a subsequent COOKIE-ONLY request
+ *   — no `Authorization` bearer, exactly how Atlas's `/api/v1` REST layer
+ *   authenticates after #4018 — authenticates with.
+ *
+ * The `bearer()` plugin is loaded (as in production `buildPlugins()`) precisely
+ * because the failure mode in #4086 was the response carrying ONLY the bearer
+ * (`set-auth-token`) and no usable cookie. The bearer plugin's own after-hook
+ * derives `set-auth-token` FROM the session `Set-Cookie`, so its presence here
+ * proves the cookie is emitted — and the cookie-only `get-session` below proves
+ * the cookie, not the bearer, is the durable credential the REST layer reads.
+ *
+ * Uses the in-memory adapter (`database: undefined`) like
+ * `rate-limit-integration.test.ts` — the cookie-establishment path is Better
+ * Auth core + Atlas's `emailVerification` wiring, identical across adapters.
+ */
+
+const SECRET = parseAuthSecret("0123456789abcdef0123456789abcdef");
+
+/**
+ * Capture the plaintext OTP. Production's `emailOTP` sender dispatches the code
+ * by email (`storeOTP: "hashed"`, so the verification row holds only a hash);
+ * a test sender lets us read the code the user would type. Mirrors the exact
+ * production `emailOTP` options (8-char, `overrideDefaultEmailVerification`,
+ * client-owned send) so a drift in those is exercised through this flow.
+ */
+function makeAuth(): { auth: ReturnType<typeof betterAuth>; getOtp: () => string | null } {
+  let capturedOtp: string | null = null;
+  const deps: BuildAuthOptionsDeps = {
+    env: {
+      // Rate limiting off so the multi-call flow never trips a bucket.
+      ATLAS_AUTH_RATE_LIMIT_ENABLED: "false",
+      // The production posture: verification required → autoSignIn off at signup,
+      // session established at verify-email via autoSignInAfterVerification.
+      ATLAS_REQUIRE_EMAIL_VERIFICATION: "true",
+    } as NodeJS.ProcessEnv,
+    secret: SECRET,
+    baseURL: "http://localhost:3000",
+    database: undefined,
+    cookiePrefix: "atlas",
+    socialProviders: undefined,
+    plugins: [
+      bearer(),
+      emailOTP({
+        otpLength: 8,
+        expiresIn: 600,
+        sendVerificationOnSignUp: false,
+        overrideDefaultEmailVerification: true,
+        storeOTP: "hashed",
+        sendVerificationOTP: async (data) => {
+          capturedOtp = data.otp;
+        },
+      }),
+    ] as unknown as BuildAuthOptionsDeps["plugins"],
+    trustedOrigins: ["http://localhost:3000"],
+    bootstrapAdmin: { mode: "none" },
+  };
+  const auth = betterAuth(buildAuthOptions(deps) as Parameters<typeof betterAuth>[0]);
+  return { auth, getOtp: () => capturedOtp };
+}
+
+function authPost(path: string, body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(`http://localhost:3000/api/auth${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-atlas-client-ip": "192.0.2.77",
+      origin: "http://localhost:3000",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Join the response's Set-Cookie header(s) into one newline-delimited string. */
+function joinSetCookie(res: Response): string {
+  const cookies =
+    typeof res.headers.getSetCookie === "function"
+      ? res.headers.getSetCookie()
+      : [res.headers.get("set-cookie") ?? ""];
+  return cookies.join("\n");
+}
+
+/** Extract the `atlas.session_token=<value>` cookie pair, or "" if absent. */
+function sessionCookiePair(setCookie: string): string {
+  const m = setCookie.match(/(atlas\.session_token=[^;]+)/);
+  return m ? m[1] : "";
+}
+
+/**
+ * Drive a full signup → send-OTP → verify-email flow and return the verify
+ * response plus the session cookie it issued.
+ */
+async function signupThroughOtp(
+  auth: ReturnType<typeof betterAuth>,
+  getOtp: () => string | null,
+  email: string,
+): Promise<{ verify: Response; setCookie: string; cookiePair: string }> {
+  const signup = await auth.handler(
+    authPost("/sign-up/email", { name: "Durable", email, password: "correct horse battery staple" }),
+  );
+  expect(signup.status).toBe(200);
+  // requireEmailVerification → no session yet at signup.
+  expect(sessionCookiePair(joinSetCookie(signup))).toBe("");
+
+  const send = await auth.handler(
+    authPost("/email-otp/send-verification-otp", { email, type: "email-verification" }),
+  );
+  expect(send.status).toBe(200);
+  const otp = getOtp();
+  expect(otp).toBeTruthy();
+
+  const verify = await auth.handler(authPost("/email-otp/verify-email", { email, otp }));
+  const setCookie = joinSetCookie(verify);
+  return { verify, setCookie, cookiePair: sessionCookiePair(setCookie) };
+}
+
+describe("post-signup session durability — managed OTP-verify (#4018 / #4086)", () => {
+  it("verify-email issues a durable HOST-ONLY session cookie (ADR-0024 §5)", async () => {
+    const { auth, getOtp } = makeAuth();
+    const { verify, setCookie, cookiePair } = await signupThroughOtp(
+      auth,
+      getOtp,
+      `durable-host-${Date.now()}@example.com`,
+    );
+
+    expect(verify.status).toBe(200);
+    // The session cookie MUST be present — #4086's reported symptom was
+    // `verify-email` returning a bearer with no usable session cookie.
+    expect(cookiePair).not.toBe("");
+    expect(setCookie).toContain("atlas.session_token");
+    // Host-only: no parent-domain attribute, or a regional session token would
+    // be sent to every region's API host (ADR-0024 §5). SameSite=Lax so the
+    // host-only cookie still rides credentialed same-site cross-origin fetches
+    // from app.useatlas.dev. (Secure is verified at deploy — http baseURL here.)
+    expect(setCookie).not.toContain("Domain=");
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie).toContain("HttpOnly");
+  }, 20_000);
+
+  it("a COOKIE-ONLY request authenticates against the verify-email session (no bearer)", async () => {
+    const { auth, getOtp } = makeAuth();
+    const { cookiePair } = await signupThroughOtp(
+      auth,
+      getOtp,
+      `durable-cookie-${Date.now()}@example.com`,
+    );
+    expect(cookiePair).not.toBe("");
+
+    // Replay the cookie with NO Authorization header — exactly how Atlas's
+    // `/api/v1` REST layer authenticates after #4018 (cookie-only in managed
+    // mode). This is the regression #4086 reports: the cookie-only path 401'd.
+    const getSession = await auth.handler(
+      new Request("http://localhost:3000/api/auth/get-session", {
+        method: "GET",
+        headers: {
+          "x-atlas-client-ip": "192.0.2.77",
+          origin: "http://localhost:3000",
+          cookie: cookiePair,
+        },
+      }),
+    );
+    expect(getSession.status).toBe(200);
+    const body = (await getSession.json()) as { user?: { emailVerified?: boolean } } | null;
+    // A 200 with a `null` body is the failure shape #4086 observed
+    // (`get-session` → 200, body `null`). The session must be real.
+    expect(body?.user).toBeTruthy();
+    expect(body?.user?.emailVerified).toBe(true);
+  }, 20_000);
+
+  it("verify-email also exposes the bearer, but the cookie is the durable credential", async () => {
+    // #4086's evidence was `set-auth-token` present, cookie missing. The
+    // bearer plugin derives `set-auth-token` FROM the session Set-Cookie, so
+    // the two travel together — assert both, so a future change that drops the
+    // cookie while keeping the bearer (the exact reported regression) fails.
+    const { auth, getOtp } = makeAuth();
+    const { verify, cookiePair } = await signupThroughOtp(
+      auth,
+      getOtp,
+      `durable-bearer-${Date.now()}@example.com`,
+    );
+    expect(verify.headers.get("set-auth-token")).toBeTruthy();
+    expect(cookiePair).not.toBe("");
+  }, 20_000);
+
+  it("negative control: with NO cookie and NO bearer, get-session is unauthenticated", async () => {
+    // Proves the cookie above is what authenticates — not some always-on
+    // default that would make the positive tests vacuous.
+    const { auth } = makeAuth();
+    const getSession = await auth.handler(
+      new Request("http://localhost:3000/api/auth/get-session", {
+        method: "GET",
+        headers: { "x-atlas-client-ip": "192.0.2.77", origin: "http://localhost:3000" },
+      }),
+    );
+    // Better Auth returns 200 + `null` body for an anonymous get-session.
+    const body = (await getSession.json()) as unknown;
+    expect(body).toBeNull();
+  }, 20_000);
+});

--- a/packages/api/src/lib/auth/legacy-cookie-cleanup-middleware.ts
+++ b/packages/api/src/lib/auth/legacy-cookie-cleanup-middleware.ts
@@ -1,0 +1,66 @@
+/**
+ * `/api/*` response middleware that evicts the legacy parent-domain
+ * (cross-subdomain) auth cookie shadowing the new host-only session (#4086).
+ *
+ * Thin Hono glue around the pure {@link buildLegacyCookieDeletions} helper —
+ * kept in its own module (not inlined in `api/index.ts`) so the wiring test can
+ * drive the EXACT production middleware rather than a hand-copied mirror that
+ * could silently drift. The helper stays Hono-free; this file owns the coupling.
+ *
+ * Runs AFTER `next()`: it observes the route's finished response (Better Auth's
+ * own `Set-Cookie` included) and APPENDS the parent-domain deletions, so the
+ * live host-only cookie is never disturbed. The whole append is best-effort —
+ * a cleanup failure must never turn a good auth response into a 500 — so it is
+ * caught and logged, never re-thrown. See `legacy-cookie-cleanup.ts` for the
+ * root-cause analysis and the self-limiting (≥2 duplicate) detection.
+ */
+import type { MiddlewareHandler } from "hono";
+import { createLogger } from "@atlas/api/lib/logger";
+import { resolveCookiePrefix } from "@atlas/api/lib/env-profile";
+import { buildLegacyCookieDeletions } from "./legacy-cookie-cleanup";
+
+const log = createLogger("auth");
+
+/**
+ * Build the cleanup middleware. `resolvePrefix` defaults to the deployment's
+ * resolved cookie prefix (`resolveCookiePrefix(process.env)`); tests inject a
+ * fixed prefix so the assertion doesn't hinge on the ambient `ATLAS_DEPLOY_ENV`
+ * (which would otherwise flip the prefix between `atlas`/`atlas-dev`/`atlas-staging`).
+ */
+export function createLegacyCookieCleanupMiddleware(
+  resolvePrefix: () => string = () => resolveCookiePrefix(process.env),
+): MiddlewareHandler {
+  return async (c, next) => {
+    await next();
+    try {
+      const deletions = buildLegacyCookieDeletions({
+        cookieHeader: c.req.header("cookie"),
+        host: c.req.header("host"),
+        cookiePrefix: resolvePrefix(),
+      });
+      if (deletions.length === 0) return;
+      for (const setCookie of deletions) {
+        c.res.headers.append("set-cookie", setCookie);
+      }
+      // Migration telemetry: lets an operator watch the affected-browser tail
+      // drain post-deploy. No cookie VALUES are logged (host + count only).
+      log.info(
+        { host: c.req.header("host"), count: deletions.length },
+        "Evicted legacy parent-domain auth cookie shadow (#4086)",
+      );
+    } catch (err) {
+      // Cleanup is best-effort; a failure must never break the auth response.
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          path: c.req.path,
+          host: c.req.header("host"),
+        },
+        "Legacy parent-domain cookie cleanup failed (#4086)",
+      );
+    }
+  };
+}
+
+/** Production singleton — reads the cookie prefix from the deployment env. */
+export const legacyCookieCleanupMiddleware = createLegacyCookieCleanupMiddleware();

--- a/packages/api/src/lib/auth/legacy-cookie-cleanup.ts
+++ b/packages/api/src/lib/auth/legacy-cookie-cleanup.ts
@@ -12,11 +12,17 @@
  * `api.useatlas.dev` carries TWO `__Secure-<prefix>.session_token` cookies —
  * the stale parent-domain one AND the new host-only one. Better Auth reads the
  * stale shadow first → it points at a dead session → 401. The session survives
- * for exactly one `session.cookieCache.maxAge` window (default 30s) because the
- * `session_data` cache cookie has no parent-domain twin; once it lapses, every
- * authenticated call (`/api/v1/*`, `get-session`) 401s and the app bounces to
- * `/login`. Region-wide, and the parent-domain cookie also leaks to every region
- * edge (`api-eu`/`api-apac`), which independently violates ADR-0024 §5.
+ * for exactly one `session.cookieCache.maxAge` window (Atlas default
+ * `SESSION_COOKIE_CACHE_DEFAULT_SEC` = 30s, operator-tunable — NOT Better Auth's
+ * 300s framework default) because the *live* `session_data` cache cookie is
+ * host-only and points at the real session; any legacy parent-domain
+ * `session_data` twin is short-lived and expired long before this window, so
+ * nothing keeps the dead shadow alive. Once the live cache lapses, Better Auth
+ * falls back to the `session_token` cookie, reads the stale parent-domain shadow
+ * first → dead session → every authenticated call (`/api/v1/*`, `get-session`)
+ * 401s and the app bounces to `/login`. The parent-domain cookie also leaks to
+ * every region edge (`api-eu`/`api-apac`), which independently violates
+ * ADR-0024 §5.
  *
  * This module detects the shadow — the session-token cookie name present more
  * than once in the request `Cookie` header — and produces `Set-Cookie`
@@ -28,11 +34,24 @@
  * the same response has no `Domain` and is a distinct cookie, so it is never
  * touched.
  *
+ * Detection is name-only — the `Cookie` header carries no `Domain`, so a browser
+ * holding ONLY the stale parent-domain cookie (count = 1) is indistinguishable
+ * from a clean host-only browser and is not cleaned until a successful re-login
+ * mints the host-only twin (flipping the count to 2). That is an accepted
+ * limitation: a single cookie can't be proven stale from the request alone.
+ *
  * Pure + dependency-free so it can be unit-tested without standing up Hono or
- * Better Auth; the API wires it as a `/api/*` response middleware.
+ * Better Auth; the API wires it as a `/api/*` response middleware (see
+ * `legacy-cookie-cleanup-middleware.ts`).
  */
 
-/** Better Auth session cookie suffixes that can carry a parent-domain shadow. */
+/**
+ * Session cookie suffixes a deletion targets. `session_token` is the actual
+ * shadow that breaks auth; `session_data` is cleared defensively in case the
+ * legacy `crossSubDomainCookies` config also minted a parent-domain cache twin —
+ * in practice it has long since expired (see the module docblock), so that
+ * deletion is usually a harmless no-op rather than a load-bearing one.
+ */
 const SESSION_COOKIE_SUFFIXES = ["session_token", "session_data"] as const;
 
 /** Cookie name prefixes the browser may attach (RFC 6265bis cookie prefixes). */
@@ -68,8 +87,10 @@ export function countSessionTokenCookies(cookieHeader: string, cookiePrefix: str
 /**
  * The parent domains of `host` that a legacy cross-subdomain cookie could have
  * been scoped to — every domain suffix with ≥ 2 labels, EXCLUDING the full host
- * itself (host-only cookies need no cleanup) and never the bare public-suffix
- * label (a 1-label suffix like `dev`, which browsers reject for `Domain=`).
+ * itself (host-only cookies need no cleanup) and never a 1-label suffix (like
+ * `dev`, which browsers reject for `Domain=`). A multi-label public suffix
+ * (e.g. `co.uk`) IS emitted, but the browser rejects `Domain=co.uk`, so it stays
+ * a harmless no-op — Atlas's `useatlas.dev` never reaches that case.
  *
  * `api.useatlas.dev` → `["useatlas.dev"]`;
  * `api.staging.useatlas.dev` → `["staging.useatlas.dev", "useatlas.dev"]`.
@@ -82,6 +103,10 @@ export function countSessionTokenCookies(cookieHeader: string, cookiePrefix: str
 export function parentCookieDomains(host: string): string[] {
   const hostname = host.trim().toLowerCase().split(":")[0]; // strip any :port
   if (!hostname) return [];
+  // Defense-in-depth: only a well-formed LDH host (letters/digits/hyphen/dot)
+  // ever flows into a `Set-Cookie: Domain=…` value, so a malformed or injected
+  // Host header can never reach the response header.
+  if (!/^[a-z0-9.-]+$/.test(hostname)) return [];
   const labels = hostname.split(".").filter(Boolean);
   // Need ≥ 3 labels for a parent that is itself ≥ 2 labels (e.g. a.b.c → b.c).
   const out: string[] = [];

--- a/packages/api/src/lib/auth/legacy-cookie-cleanup.ts
+++ b/packages/api/src/lib/auth/legacy-cookie-cleanup.ts
@@ -1,0 +1,140 @@
+/**
+ * Migration cleanup for legacy cross-subdomain auth cookies (#4086).
+ *
+ * Before ADR-0024 §5, managed-mode Better Auth was configured with
+ * `advanced.crossSubDomainCookies`, so the session cookies were minted with a
+ * parent-domain attribute (`Domain=useatlas.dev`, stored by the browser as
+ * `.useatlas.dev` and sent to every subdomain). ADR-0024 §5 switched to
+ * HOST-ONLY cookies (no `Domain`, scoped to the issuing region host) but never
+ * CLEARED the parent-domain cookies already sitting in users' browsers.
+ *
+ * The result, for anyone who logged in before the switch: a request to
+ * `api.useatlas.dev` carries TWO `__Secure-<prefix>.session_token` cookies —
+ * the stale parent-domain one AND the new host-only one. Better Auth reads the
+ * stale shadow first → it points at a dead session → 401. The session survives
+ * for exactly one `session.cookieCache.maxAge` window (default 30s) because the
+ * `session_data` cache cookie has no parent-domain twin; once it lapses, every
+ * authenticated call (`/api/v1/*`, `get-session`) 401s and the app bounces to
+ * `/login`. Region-wide, and the parent-domain cookie also leaks to every region
+ * edge (`api-eu`/`api-apac`), which independently violates ADR-0024 §5.
+ *
+ * This module detects the shadow — the session-token cookie name present more
+ * than once in the request `Cookie` header — and produces `Set-Cookie`
+ * deletions scoped to each parent domain of the request host, so the browser
+ * evicts the legacy cookie on its next request to ANY endpoint. It is
+ * self-limiting: a clean browser (or one already migrated) has the name at most
+ * once, so no deletions are emitted. The deletion targets the parent-domain
+ * cookie only (it carries `Domain=`); the host-only cookie Better Auth sets in
+ * the same response has no `Domain` and is a distinct cookie, so it is never
+ * touched.
+ *
+ * Pure + dependency-free so it can be unit-tested without standing up Hono or
+ * Better Auth; the API wires it as a `/api/*` response middleware.
+ */
+
+/** Better Auth session cookie suffixes that can carry a parent-domain shadow. */
+const SESSION_COOKIE_SUFFIXES = ["session_token", "session_data"] as const;
+
+/** Cookie name prefixes the browser may attach (RFC 6265bis cookie prefixes). */
+const NAME_PREFIXES = ["__Secure-", "__Host-", ""] as const;
+
+/**
+ * Parse a raw `Cookie` request header into the list of cookie NAMES present
+ * (values dropped). Tolerant of malformed segments. Order preserved.
+ */
+function cookieNames(cookieHeader: string): string[] {
+  return cookieHeader
+    .split(";")
+    .map((pair) => pair.trim())
+    .filter(Boolean)
+    .map((pair) => {
+      const eq = pair.indexOf("=");
+      return (eq === -1 ? pair : pair.slice(0, eq)).trim();
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Count how many cookies in the header are the session-token cookie for this
+ * prefix — across all cookie-prefix spellings (`__Secure-`/`__Host-`/none). A
+ * count ≥ 2 is the shadow signature: a host-only cookie AND a leftover
+ * parent-domain cookie of the same name.
+ */
+export function countSessionTokenCookies(cookieHeader: string, cookiePrefix: string): number {
+  const targets = new Set(NAME_PREFIXES.map((p) => `${p}${cookiePrefix}.session_token`));
+  return cookieNames(cookieHeader).filter((name) => targets.has(name)).length;
+}
+
+/**
+ * The parent domains of `host` that a legacy cross-subdomain cookie could have
+ * been scoped to — every domain suffix with ≥ 2 labels, EXCLUDING the full host
+ * itself (host-only cookies need no cleanup) and never the bare public-suffix
+ * label (a 1-label suffix like `dev`, which browsers reject for `Domain=`).
+ *
+ * `api.useatlas.dev` → `["useatlas.dev"]`;
+ * `api.staging.useatlas.dev` → `["staging.useatlas.dev", "useatlas.dev"]`.
+ *
+ * This is a deliberately simple label walk, not a Public Suffix List lookup:
+ * it over-covers (emits a deletion for each ancestor), and a deletion for a
+ * domain the browser holds no cookie on is a harmless no-op. It never emits the
+ * full host, so it can't collide with the live host-only cookie.
+ */
+export function parentCookieDomains(host: string): string[] {
+  const hostname = host.trim().toLowerCase().split(":")[0]; // strip any :port
+  if (!hostname) return [];
+  const labels = hostname.split(".").filter(Boolean);
+  // Need ≥ 3 labels for a parent that is itself ≥ 2 labels (e.g. a.b.c → b.c).
+  const out: string[] = [];
+  // i is the index of the first label of the suffix; suffix must be ≥ 2 labels
+  // (labels.length - i >= 2) and must not be the full host (i >= 1).
+  for (let i = 1; i <= labels.length - 2; i++) {
+    out.push(labels.slice(i).join("."));
+  }
+  return out;
+}
+
+/**
+ * Build the `Set-Cookie` deletion headers that evict the legacy parent-domain
+ * session cookies — or `[]` when no shadow is present (the common, steady-state
+ * path). Each deletion matches the legacy cookie by name + `Domain` + `Path`
+ * with `Max-Age=0`; `__Secure-`-prefixed names carry `Secure` (required for the
+ * browser to accept the deletion of a `__Secure-` cookie).
+ *
+ * `__Host-` cookies are intentionally never targeted: the `__Host-` prefix
+ * forbids a `Domain` attribute, so such a cookie is always host-only and can
+ * never be the parent-domain shadow.
+ */
+export function buildLegacyCookieDeletions(args: {
+  cookieHeader: string | null | undefined;
+  host: string | null | undefined;
+  cookiePrefix: string;
+}): string[] {
+  const { cookieHeader, host, cookiePrefix } = args;
+  if (!cookieHeader || !host) return [];
+  // Only act on the shadow signature — keeps this a no-op for clean browsers.
+  if (countSessionTokenCookies(cookieHeader, cookiePrefix) < 2) return [];
+
+  const domains = parentCookieDomains(host);
+  if (domains.length === 0) return [];
+
+  // Mirror the cookie-prefix spelling the browser actually sent so the deletion
+  // name matches exactly. `__Host-` is excluded (it forbids a `Domain`, so it
+  // can never be the parent-domain shadow). Prod is `__Secure-` (https); a bare
+  // prefix only occurs on http dev, which is never cross-subdomain — but handle
+  // it for completeness.
+  const present = new Set(cookieNames(cookieHeader));
+  const secure = present.has(`__Secure-${cookiePrefix}.session_token`);
+  const namePrefix = secure ? "__Secure-" : "";
+  const secureAttr = secure ? "; Secure" : "";
+
+  const deletions: string[] = [];
+  for (const suffix of SESSION_COOKIE_SUFFIXES) {
+    const name = `${namePrefix}${cookiePrefix}.${suffix}`;
+    for (const domain of domains) {
+      deletions.push(
+        `${name}=; Domain=${domain}; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${secureAttr}`,
+      );
+    }
+  }
+  return deletions;
+}


### PR DESCRIPTION
## Summary

Brand-new signups — and **every** user who logged in before the ADR-0024 §5 host-only switch — got logged out ~30s after authenticating: `get-session` → 200/`null`, every `/api/v1/*` call `401`, app bounces to `/login`. **Confirmed live in a real prod browser** (not a headless artifact).

**Root cause:** a stale `Domain=.useatlas.dev` `__Secure-atlas.session_token` cookie — left over from when managed-mode Better Auth used `crossSubDomainCookies` — **shadows** the new **host-only** (`api.useatlas.dev`) cookie. The browser sends both to the API; Better Auth reads the stale shadow first → dead session → `401`. The session survives exactly one `session.cookieCache.maxAge` window (30s) because the `session_data` cache cookie has no parent-domain twin; once it lapses, auth dies.

Proof the **server is correct**: `curl` (no legacy cookie) is durable across the cliff (30/30), the session is always valid in the DB (bearer auth works throughout), and the current host-only config matches Better Auth guidance. The migration to host-only just never **cleared** the old parent-domain cookies. The leaked `.useatlas.dev` cookie also reached `api-eu`/`api-apac`, independently violating ADR-0024 §5.

**Fix:** a self-limiting `/api/*` response middleware (`lib/auth/legacy-cookie-cleanup.ts`) that detects the shadow (session-token cookie present 2+ times in the request `Cookie` header) and emits `Set-Cookie … Domain=<parent>; Max-Age=0` deletions scoped to each parent domain of the request host.
- **No-op** for clean/migrated browsers (count < 2).
- **Never** touches the host-only cookie (distinct cookie — it carries no `Domain`).
- Affected users **self-heal on their next request to any endpoint** after deploy — no user action needed.
- Restores the ADR-0024 §5 residency invariant.

## Test plan
- [x] `legacy-cookie-cleanup` unit tests (16) — detection, parent-domain walk, deletion shape, no-op/clean cases, prefix isolation
- [x] middleware wiring test (2) — deletions surface as distinct `Set-Cookie`, host-only cookie survives, clean browser gets none
- [x] `post-signup-session-durability` (4) — server-side host-only contract over the managed OTP-verify path
- [x] lint, type-check, syncpack, all 11 drift/parity gates green; `auth.test.ts` + app-construction green
- [ ] Real-browser confirm post-deploy: log in, idle > 30s, navigate — stays authenticated; the legacy `.useatlas.dev` cookie is gone
- [ ] `/verify-prod-signup` primitive 8 green in all 3 regions after `/release`

## Notes
- Immediate manual unblock for an affected user: delete the `.useatlas.dev` `__Secure-atlas.session_token` cookie (keep the `api.useatlas.dev` one).
- Local `bun run test` shows pre-existing **environmental** failures only (WSL2 sandbox: `python`/`explore`; no local Postgres: 2 `@atlas/mcp` DB tests) — none touch `lib/auth` or the API app; CI runs them on Linux + Postgres.

Closes #4086