### PR TITLE
chore(db,auth): drop user.stripeCustomerId column (phase 2 / release N+1) (#4013)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -442,6 +442,9 @@ describe("migrateAuthTables", () => {
             // 0158 adds the `origin` column to Better Auth's "session" table
             // (ADR-0026, #4043) — a MANAGED_AUTH_MIGRATION, skipped outside
             // managed mode, so it is intentionally absent here.
+            // 0159 drops user.stripeCustomerId from Better Auth's "user" table
+            // (#4013 two-phase drop) — a MANAGED_AUTH_MIGRATION, skipped outside
+            // managed mode, so it is intentionally absent here.
           ],
         };
       }

--- a/packages/api/src/lib/auth/__tests__/stripe-plugin-enablement.test.ts
+++ b/packages/api/src/lib/auth/__tests__/stripe-plugin-enablement.test.ts
@@ -111,6 +111,36 @@ describe("Stripe plugin enablement (#3447)", () => {
     expect(errorLogs.filter((msg) => msg.includes("Stripe"))).toEqual([]);
   });
 
+  // #4013 — the registered stripe plugin must NOT declare user.stripeCustomerId
+  // in its schema. @better-auth/stripe's getSchema declares it unconditionally,
+  // and Atlas runs Better Auth's auto-migrate at boot, so an un-stripped schema
+  // would re-add the column that migration 0159 drops on every restart.
+  // buildPlugins() strips it via stripPluginUserStripeCustomerIdField.
+  it("strips user.stripeCustomerId from the registered stripe plugin's schema (#4013)", () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_dummy";
+    process.env.DATABASE_URL = "postgres://fake:fake@localhost:5432/fake";
+    process.env.STRIPE_STARTER_PRICE_ID = "price_starter_test";
+    process.env.STRIPE_PRO_PRICE_ID = "price_pro_test";
+
+    const stripe = findStripePlugin(buildPlugins()) as
+      | { schema?: { [table: string]: { fields?: Record<string, unknown> } } }
+      | undefined;
+    expect(stripe).toBeDefined();
+
+    // The user-level customer field is gone…
+    expect(stripe?.schema?.user?.fields?.stripeCustomerId).toBeUndefined();
+    // …but the org-scoped schema Atlas billing depends on is untouched. These
+    // positive assertions are the load-bearing guard: if a plugin upgrade stops
+    // declaring organization.stripeCustomerId / subscription (i.e. reshapes the
+    // schema), they fail loudly so the strip can be re-evaluated. (A purely
+    // *negative* assertion on user.stripeCustomerId can't detect a reshape — it
+    // passes vacuously when the path no longer resolves; the strip helper's
+    // runtime log.warn covers that version-independent case.)
+    expect(stripe?.schema?.organization?.fields?.stripeCustomerId).toBeDefined();
+    expect(stripe?.schema?.subscription).toBeDefined();
+  });
+
   it("does NOT register the plugin when STRIPE_WEBHOOK_SECRET is missing, and logs an error (existing branch)", () => {
     process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
     delete process.env.STRIPE_WEBHOOK_SECRET;

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2063,7 +2063,9 @@ export function buildStripePluginOptions(deps: {
     // EU/APAC signups have run post-residency-fix yet). No Atlas code reads
     // `user.stripeCustomerId` (the CRM conversion stamp uses the org/subscription
     // customer). Root cause #4012; the now-unwritten column is dropped in the
-    // release-N+1 migration #4013 (two-phase drop discipline).
+    // release-N+1 migration 0159 (#4013, two-phase drop discipline) — paired
+    // with `stripPluginUserStripeCustomerIdField` in buildPlugins(), without
+    // which Better Auth's boot-time auto-migrate would re-add the column.
     createCustomerOnSignUp: false,
     // #3416 — Atlas subscriptions are ORG-scoped, not user-scoped. With
     // org mode on, the plugin maintains `organization.stripeCustomerId`
@@ -2311,6 +2313,54 @@ export function buildStripePluginOptions(deps: {
       );
     },
   };
+}
+
+/**
+ * Remove the plugin-declared `user.stripeCustomerId` field from a constructed
+ * @better-auth/stripe plugin, in place (#4013).
+ *
+ * The plugin's `getSchema` declares `user.stripeCustomerId` UNCONDITIONALLY
+ * (plugin v1.6.20, `src/schema.ts`: `const user = { user: { fields: {
+ * stripeCustomerId } } }` is in `baseSchema` on every code path — enabling
+ * `organization` mode is purely additive). The Atlas migration runner applies
+ * migration 0159's `DROP COLUMN` once, but Better Auth's schema-diff
+ * auto-migrate (`ctx.runMigrations`) runs on EVERY boot, BEFORE the Atlas
+ * runner — so without this strip it re-adds the dropped column on the next
+ * restart, resurrecting the cross-region drift #4013 eliminates. Better Auth's
+ * `mergeSchema` only renames fields (sets `fieldName`/`modelName`); it cannot
+ * remove one — so the plugin's `schema` option can't do this, leaving in-place
+ * mutation of the constructed plugin as the only available seam.
+ *
+ * Safe because Atlas billing is strictly ORG-scoped — nothing reads the
+ * user-level customer in practice:
+ *   - the subscription-upgrade / billing-portal reads of `user.stripeCustomerId`
+ *     sit in the `else` branch of `customerType === "organization"`, and Atlas
+ *     sends `customerType: "organization"` on every call;
+ *   - the signup-hook read is dead via `createCustomerOnSignUp: false` (#4014);
+ *   - the webhook reverse-lookup (`findReferenceByStripeCustomerId`) queries the
+ *     `user` table only when the `organization` lookup misses, which Atlas's
+ *     org-only customers never trigger.
+ * `organization.stripeCustomerId` and the `subscription` schema (which org
+ * billing depends on) are left untouched. Pinned by
+ * stripe-plugin-enablement.test.ts.
+ *
+ * The param requires `schema.user.fields` so an upstream rename/removal of
+ * `user` breaks this build at the call site; the runtime `log.warn` covers the
+ * version-independent case (a self-hosted plugin bump we don't type-check)
+ * where the field is gone — turning a silent strip-no-op (which would let
+ * auto-migrate resurrect the column) into a greppable boot-log breadcrumb.
+ */
+function stripPluginUserStripeCustomerIdField(plugin: {
+  schema: { user: { fields: Record<string, unknown> } };
+}): void {
+  const { fields } = plugin.schema.user;
+  if ("stripeCustomerId" in fields) {
+    delete fields.stripeCustomerId;
+    return;
+  }
+  log.warn(
+    "@better-auth/stripe no longer declares user.stripeCustomerId — the #4013 schema strip is now a no-op. Verify Better Auth's boot auto-migrate does not re-add the column (the plugin schema likely changed on upgrade).",
+  );
 }
 
 export function buildPlugins() {
@@ -2765,9 +2815,15 @@ export function buildPlugins() {
           throw new Error("getStripeClient() returned null despite STRIPE_SECRET_KEY being set");
         }
 
-        plugins.push(
-          stripePlugin(buildStripePluginOptions({ stripeClient, webhookSecret })),
+        const stripeBuilt = stripePlugin(
+          buildStripePluginOptions({ stripeClient, webhookSecret }),
         );
+        // #4013 — strip the plugin's unconditionally-declared
+        // `user.stripeCustomerId` field so Better Auth's boot-time auto-migrate
+        // never re-adds the column that migration 0159 drops. Org-scoped billing
+        // is unaffected (see stripPluginUserStripeCustomerIdField).
+        stripPluginUserStripeCustomerIdField(stripeBuilt);
+        plugins.push(stripeBuilt);
 
         log.info("Stripe billing plugin enabled");
       } catch (err) {

--- a/packages/api/src/lib/db/__tests__/migrate-pg-with-auth.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg-with-auth.test.ts
@@ -44,6 +44,9 @@ const PG_TEST_TIMEOUT_MS = 30_000;
  *   - `user.id` — FK target for 0048's `trusted_device.user_id`
  *   - `user.emailVerified` — UPDATEd by 0050 backfill
  *   - `user.role` — cleared by 0118 (`SET role = NULL WHERE role = 'admin'`)
+ *   - `user.stripeCustomerId` — DROPped by 0159 (#4013). Seeded here to mirror
+ *     the US prod `user` table (the only region that had it), so the drop is
+ *     actually exercised rather than a silent `IF EXISTS` no-op.
  *   - `session.userId` — read by 0050 to scope the backfill
  *   - `organization.id` — ALTERed by 0027 / 0042 / 0090
  *   - `member.role` — backfilled by 0118 from `user.role='admin'`
@@ -63,6 +66,7 @@ const BETTER_AUTH_BOOTSTRAP_SQL = `
     "emailVerified" BOOLEAN NOT NULL DEFAULT false,
     name TEXT,
     role TEXT,
+    "stripeCustomerId" TEXT,
     "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
   );
 
@@ -196,6 +200,49 @@ describeIfPg("migrate-pg-with-auth (real Postgres, Better Auth tables present)",
         `SELECT id, role FROM "user" WHERE id IN ('u-0118-promote', 'u-0118-owner')`,
       );
       expect(users.rows.every((r) => r.role === null)).toBe(true);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  // ── 0159 column drop (#4013) ──
+  //
+  // The fixture seeds `user."stripeCustomerId"` (mirroring US prod, the only
+  // region that had it). After the full migration set runs, 0159 must have
+  // dropped it. A regression that omits 0159 from MANAGED_AUTH_MIGRATIONS — so
+  // it never runs against the Better Auth `user` table — fails here.
+  it(
+    "0159: drops user.stripeCustomerId from the Better Auth user table",
+    async () => {
+      const col = await pool.query(
+        `SELECT 1 FROM information_schema.columns
+          WHERE table_schema = $1 AND table_name = 'user'
+            AND column_name = 'stripeCustomerId'`,
+        [schemaName],
+      );
+      expect(col.rows).toHaveLength(0);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "0159: re-applying the DROP no-ops on a column-less user table (EU/APAC path)",
+    async () => {
+      // The migration set above already dropped the column, so the table now
+      // has no `stripeCustomerId` — the same state EU/APAC always had (they
+      // never registered the stripe plugin, so Better Auth never declared it).
+      // Re-running 0159's DROP must succeed via `IF EXISTS`. Guards against a
+      // regression that removes `IF EXISTS`, which would pass the US (column-
+      // present) case above yet crash boot in the 2 column-less regions.
+      await pool.query(
+        `ALTER TABLE "user" DROP COLUMN IF EXISTS "stripeCustomerId"`,
+      );
+      const col = await pool.query(
+        `SELECT 1 FROM information_schema.columns
+          WHERE table_schema = $1 AND table_name = 'user'
+            AND column_name = 'stripeCustomerId'`,
+        [schemaName],
+      );
+      expect(col.rows).toHaveLength(0);
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -192,7 +192,9 @@ describe("runMigrations", () => {
     //   device flow, ADR-0026, #4043) = 158.
     //   Plus 0158 (origin marker column on Better Auth's "session" table,
     //   ADR-0026, #4043) = 159.
-    expect(count).toBe(159);
+    //   Plus 0159 (drop @better-auth/stripe's user.stripeCustomerId column,
+    //   phase-2 two-phase drop, #4013) = 160.
+    expect(count).toBe(160);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -380,6 +382,7 @@ describe("runMigrations", () => {
         "0156_overage_meter_reports_cost_cents.sql",
         "0157_approval_surface_cli.sql",
         "0158_session_origin_column.sql",
+        "0159_drop_user_stripe_customer_id.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -988,6 +988,13 @@ export const MANAGED_AUTH_MIGRATIONS = [
   // atlas-login device flow can stamp `origin='cli'` for key-scoping
   // (ADR-0026 / #4043).
   "0158_session_origin_column.sql",
+  // Drops the @better-auth/stripe plugin's user-level "stripeCustomerId" column
+  // from Better Auth's "user" table — phase 2 of the two-phase drop (#4013).
+  // MANAGED_AUTH because it ALTERs Better Auth's "user" table, which only
+  // exists in managed mode. Paired with a buildPlugins() schema strip so Better
+  // Auth's auto-migrate never re-adds the column (see server.ts / the migration
+  // header).
+  "0159_drop_user_stripe_customer_id.sql",
 ];
 
 /**

--- a/packages/api/src/lib/db/migrations/0159_drop_user_stripe_customer_id.sql
+++ b/packages/api/src/lib/db/migrations/0159_drop_user_stripe_customer_id.sql
@@ -1,0 +1,35 @@
+-- 0159_drop_user_stripe_customer_id.sql
+--
+-- Phase 2 (release N+1) of the two-phase removal of the @better-auth/stripe
+-- plugin's user-level "stripeCustomerId" column from Better Auth's "user"
+-- table (#4013). Phase 1 (#4014, shipped in v0.0.32) set
+-- createCustomerOnSignUp:false, so nothing has written this column since.
+--
+-- Atlas billing is strictly ORG-scoped: it uses organization.stripeCustomerId,
+-- never the user-level one, so the column is dead. The plugin's
+-- subscription-upgrade / billing-portal reads of user.stripeCustomerId sit in
+-- the customerType !== "organization" branch (Atlas always sends
+-- "organization"); the signup-hook write/read is off via
+-- createCustomerOnSignUp:false (#4014); the webhook reverse-lookup hits the
+-- user table only when the organization lookup misses, which Atlas's org-only
+-- customers never trigger. See the buildPlugins() strip below.
+--
+-- Idempotent across the region drift documented in #4013: US "user" HAS the
+-- column (camelCase); EU/APAC never had it (they don't register the stripe
+-- plugin, so Better Auth never declared it there). IF EXISTS handles both.
+--
+-- COMPANION CHANGE (same PR, load-bearing): buildPlugins() in lib/auth/server.ts
+-- strips user.stripeCustomerId from the stripe plugin's declared schema. This
+-- DROP applies once (the migration runner records it), but Better Auth's
+-- schema-diff auto-migrate (ctx.runMigrations) runs on every boot, before the
+-- Atlas runner — so without the strip it would re-add the column on the next
+-- restart (the plugin's getSchema declares it unconditionally), resurrecting
+-- exactly the column this migration drops. The strip + this DROP are durable
+-- only together.
+--
+-- expand-contract: N+1 contract drop; createCustomerOnSignUp — the only writer
+-- that ever fired in Atlas's org-only config (the plugin's other write is in
+-- the non-org customerType branch Atlas never sends) — was removed in v0.0.32
+-- (#4014), so no draining N-1 pod writes the column during the deploy-overlap
+-- window. (#4013)
+ALTER TABLE "user" DROP COLUMN IF EXISTS "stripeCustomerId";


### PR DESCRIPTION
## What

Phase 2 (release N+1) of the two-phase removal of the `@better-auth/stripe` plugin's user-level **`user."stripeCustomerId"`** column. Phase 1 (#4014, shipped in **v0.0.32**) set `createCustomerOnSignUp: false`, so nothing has written the column since; **v0.0.33** then shipped on top of it — a full release boundary has passed, so the drop is deploy-safe.

## The non-obvious part — why a plain DROP migration isn't enough

A naive `ALTER TABLE "user" DROP COLUMN` is **not durable on US**. Atlas runs Better Auth's schema-diff auto-migrate (`ctx.runMigrations`, `auth/migrate.ts`) on **every boot**, **before** the Atlas migration runner. The stripe plugin's `getSchema` declares `user.stripeCustomerId` **unconditionally** (`@better-auth/stripe@1.6.20`; enabling `organization` mode is purely additive), and Better Auth's `mergeSchema` can only *rename* fields, not remove them. So after the migration drops the column, BA's auto-migrate **re-adds it on the next restart** — resurrecting exactly the cross-region drift this issue eliminates. (EU/APAC stay clean only because they don't register the stripe plugin.)

The durable fix is therefore **two coupled changes**:

1. **Migration `0159`** — idempotent `DROP COLUMN IF EXISTS` (handles US-has / EU-APAC-missing). Joins `MANAGED_AUTH_MIGRATIONS` (it ALTERs Better Auth's `user` table).
2. **`buildPlugins()` schema strip** — `stripPluginUserStripeCustomerIdField()` removes `user.stripeCustomerId` from the constructed plugin's declared schema so BA's auto-migrate never re-creates it. The strip + the DROP are durable **only together**.

## Why it's safe (org-scoped billing)

Atlas billing is strictly **org-scoped** — it uses `organization.stripeCustomerId`, never the user-level column. Every plugin consumer of `user.stripeCustomerId` is dead for Atlas:
- subscription-upgrade / billing-portal reads sit in the `customerType !== "organization"` branch (Atlas always sends `"organization"`);
- the signup-hook write is off via `createCustomerOnSignUp: false`;
- the webhook reverse-lookup (`findReferenceByStripeCustomerId`) queries `user` only when the `organization` lookup misses — which org-only customers never trigger.

Verified no Atlas/`ee`/`cli` code reads the column. The operator verify-teardown (`ops-teardown-verify.ts`) already **deliberately** queries only `organization."stripeCustomerId"`.

## Tests

- Migration count/list bumps (`db/migrate.test.ts` 159→160, applied-list + `MANAGED_AUTH_MIGRATIONS`).
- **Real-PG smoke** (`migrate-pg-with-auth.test.ts`): the `user` fixture seeds `stripeCustomerId` (mirrors US prod) → asserts the column is dropped; plus an **EU/APAC** case proving `IF EXISTS` no-ops on a column-less `user` table.
- **Schema-strip unit test** (`stripe-plugin-enablement.test.ts`): `buildPlugins()`'s stripe plugin has no `user.stripeCustomerId` but retains `organization.stripeCustomerId` + `subscription`. The strip helper also emits a runtime `log.warn` if a future plugin upgrade reshapes the schema (silent-no-op guard).

## Review panel

Four specialist reviewers (silent-failure, type-design, test-coverage, comments) — **CLEAN**, zero CRITICAL/HIGH. Three converging MEDIUM advisories addressed inline: the silent-no-op guard (runtime warn + tightened param type), comment-accuracy tightening, and the EU/APAC absent-column test.

## Operator notes (non-blocking)

- A webhook for an **unmapped** Stripe customer (no matching org — a path Atlas's org-scoped subscriptions never hit) will, post-drop, log a `column does not exist` ERROR from the plugin's dead user-fallback instead of the prior clean "no org/user found" WARN. Functionally identical (no subscription created, 200 returned); plugin-owned, not actionable here. Worth a brief log-noise watch after deploy.
- **Optional follow-up (issue step 4):** the 3 legacy US users still carry user-level Stripe customers. Harmless (billing uses the org customer), but Stripe clutter — a live-Stripe cleanup for an operator, intentionally out of scope for this code change.

Closes #4013
