### PR TITLE
fix(web): convert /dashboards index to a client component (#4089)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/__tests__/no-ssr-cookie-forward.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/__tests__/no-ssr-cookie-forward.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Regression guard for #4089.
+ *
+ * The session cookie is host-only to the API origin (ADR-0024 §5), so a server
+ * component on `app.useatlas.dev` can never read it from the incoming request
+ * headers and forward it to the cross-origin API — the SSR fetch sees no
+ * session and 401s, bouncing logged-in users to /login. Authed workspace data
+ * must be fetched from the BROWSER (a `"use client"` component), where the
+ * host-only cookie attaches automatically.
+ *
+ * This guard fails if any `page.tsx` under the (workspace) route group is a
+ * server component (no `"use client"` directive) that reads the `cookie`
+ * request header — the exact antipattern that caused #4089.
+ */
+
+// .../dashboards/__tests__ → up two to the (workspace) route group root.
+const WORKSPACE_ROOT = join(import.meta.dir, "..", "..");
+
+function collectPageFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "__tests__") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectPageFiles(full));
+    } else if (entry === "page.tsx") {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("no SSR cookie forwarding in (workspace) pages (#4089)", () => {
+  test("no server-component page reads the cookie request header", () => {
+    const pages = collectPageFiles(WORKSPACE_ROOT);
+    // Sanity check: the crawler found pages (so a path/refactor bug can't make
+    // this guard silently vacuous).
+    expect(pages.length).toBeGreaterThan(0);
+
+    const offenders = pages.filter((file) => {
+      const src = readFileSync(file, "utf8");
+      const isClient = /^\s*["']use client["']/m.test(src);
+      if (isClient) return false;
+      // The host-only-cookie-forward smell, two ways a server component can
+      // reach the request cookie:
+      //   (a) the raw header — `headers().get("cookie")` / `.get('cookie')`
+      const readsCookieHeader = /\.get\(\s*["']cookie["']\s*\)/.test(src);
+      //   (b) forwarding a `cookie:` field into a server-side `fetch(...)`'s
+      //       headers — catches the `next/headers` `cookies()` variant too,
+      //       regardless of how the value was obtained.
+      const forwardsCookieToFetch =
+        /\bfetch\(/.test(src) && /headers:\s*\{[^}]*\bcookie\b[^}]*\}/s.test(src);
+      return readsCookieHeader || forwardsCookieToFetch;
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/__tests__/page.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/__tests__/page.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, test, mock, afterEach, beforeEach } from "bun:test";
+
+const replaceCalls: string[] = [];
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: () => {},
+    replace: (url: string) => replaceCalls.push(url),
+    back: () => {},
+  }),
+  usePathname: () => "/dashboards",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  redirect: () => {},
+  notFound: () => {},
+}));
+
+import { render, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import DashboardsPage from "../page";
+import { dashboardsWrapper, stubDashboardsFetch } from "../../../../ui/components/dashboards/__tests__/_fixtures";
+
+const originalFetch = globalThis.fetch;
+
+/** Stub the dashboards list endpoint with an arbitrary status / body. */
+function stubDashboardsStatus(status: number, body: unknown = {}) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    if (url.endsWith("/api/v1/dashboards")) {
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+}
+
+describe("DashboardsPage (redirect index)", () => {
+  beforeEach(() => {
+    replaceCalls.length = 0;
+  });
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("redirects to the most-recently-updated dashboard", async () => {
+    stubDashboardsFetch([
+      { id: "d-old", title: "Old", updatedAt: "2026-04-24T10:00:00Z", cardCount: 1 },
+      { id: "d-new", title: "New", updatedAt: "2026-04-25T10:00:00Z", cardCount: 2 },
+    ]);
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+
+    await waitFor(() =>
+      expect(replaceCalls).toContain("/dashboards/d-new"),
+    );
+    // AC#1: a logged-in user with dashboards is NEVER bounced to /login.
+    expect(replaceCalls).not.toContain("/login?redirect=/dashboards");
+  });
+
+  test("renders the empty state when there are no dashboards", async () => {
+    stubDashboardsFetch([]);
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+
+    await screen.findByText("No dashboards yet");
+    // The genuine empty state is NOT a redirect — no navigation should fire.
+    expect(replaceCalls).toHaveLength(0);
+  });
+
+  test("bounces an unauthenticated visitor (401) to /login", async () => {
+    stubDashboardsStatus(401, { error: "auth_required", message: "Not authenticated" });
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+
+    await waitFor(() =>
+      expect(replaceCalls).toContain("/login?redirect=/dashboards"),
+    );
+  });
+
+  test("bounces a forbidden visitor (403) to /login", async () => {
+    stubDashboardsStatus(403, { error: "forbidden", message: "Access denied" });
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+
+    await waitFor(() =>
+      expect(replaceCalls).toContain("/login?redirect=/dashboards"),
+    );
+  });
+
+  test("shows an error card (not a /login bounce) on a server error", async () => {
+    stubDashboardsStatus(500, { message: "Internal error" });
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+
+    await screen.findByText("Couldn’t load your dashboards");
+    // The server-authored body message reaches the card via friendlyError() —
+    // the page renders the real error, not a canned "HTTP 500" fallback.
+    await screen.findByText("Internal error");
+    expect(replaceCalls).toHaveLength(0);
+  });
+
+  test("the error card's Try again button refetches and then redirects", async () => {
+    stubDashboardsStatus(500, { message: "Internal error" });
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+    await screen.findByText("Couldn’t load your dashboards");
+
+    // Recover the endpoint, then click retry — refetch() must re-run the query
+    // and the now-successful list redirects to the most-recent dashboard.
+    stubDashboardsFetch([
+      { id: "d-1", title: "Recovered", updatedAt: "2026-04-25T10:00:00Z", cardCount: 1 },
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(replaceCalls).toContain("/dashboards/d-1"));
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/page.tsx
@@ -1,79 +1,83 @@
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
-import Link from "next/link";
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { getApiBaseUrl } from "../../shared/lib";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { friendlyError } from "@/ui/lib/fetch-error";
 import { DashboardsEmptyState } from "./empty-state";
 import { selectMostRecentDashboardId } from "./select-recent";
 import type { Dashboard } from "@/ui/lib/types";
 
-interface DashboardsListResponse {
-  dashboards: Dashboard[];
-  total?: number;
-}
+/**
+ * /dashboards is a redirect-only index: it lists the workspace's dashboards
+ * and forwards to the most-recently-updated one (or shows the empty state when
+ * there are none).
+ *
+ * This is a CLIENT component on purpose. The previous server component read the
+ * incoming request's `cookie` header and forwarded it to the cross-origin API
+ * (`api.useatlas.dev`). Under ADR-0024 §5 the session cookie is host-only to
+ * the API origin, so the browser never sends it to `app.useatlas.dev` — the SSR
+ * fetch saw no session, 401'd, and bounced *logged-in* users to /login (#4089).
+ * Fetching from the browser (like /notebook and /admin) lets the host-only
+ * cookie attach automatically via `useAdminFetch`'s credentialed fetch — the
+ * same browser-side credential path every other workspace route already uses.
+ */
+export default function DashboardsPage() {
+  const router = useRouter();
+  const { data, loading, error, refetch } = useAdminFetch<{
+    dashboards: Dashboard[];
+  }>("/api/v1/dashboards");
 
-type FetchResult =
-  | { ok: true; data: DashboardsListResponse }
-  | { ok: false; reason: "auth-required" | "server-error" | "network-error" };
+  // 401/403 is the genuine auth gate. Preserve the original /login bounce so an
+  // unauthenticated visitor still lands on sign-in. (AuthGuard also recovers
+  // unauthenticated users globally in managed mode; keeping this explicit makes
+  // the gate mode-agnostic and independent of that backstop.)
+  const isAuthError = error?.status === 401 || error?.status === 403;
 
-async function fetchDashboardsList(): Promise<FetchResult> {
-  const headerStore = await headers();
-  const cookieHeader = headerStore.get("cookie") ?? "";
+  const targetId = data
+    ? selectMostRecentDashboardId(data.dashboards ?? [])
+    : null;
 
-  try {
-    const res = await fetch(`${getApiBaseUrl()}/api/v1/dashboards`, {
-      headers: { cookie: cookieHeader },
-      cache: "no-store",
-    });
-    if (res.status === 401 || res.status === 403) {
-      return { ok: false, reason: "auth-required" };
+  useEffect(() => {
+    if (isAuthError) {
+      router.replace("/login?redirect=/dashboards");
+      return;
     }
-    if (!res.ok) {
-      console.error(
-        `[dashboards-redirect] API returned ${res.status} listing dashboards`,
-      );
-      return { ok: false, reason: "server-error" };
+    if (targetId) {
+      router.replace(`/dashboards/${targetId}`);
     }
-    const data = (await res.json()) as DashboardsListResponse;
-    if (!data || !Array.isArray(data.dashboards)) {
-      console.error(
-        "[dashboards-redirect] Unexpected response shape from /api/v1/dashboards",
-      );
-      return { ok: false, reason: "server-error" };
-    }
-    return { ok: true, data };
-  } catch (err) {
-    console.error(
-      "[dashboards-redirect] Failed to fetch dashboards:",
-      err instanceof Error ? err.message : err,
-    );
-    return { ok: false, reason: "network-error" };
-  }
-}
+  }, [isAuthError, targetId, router]);
 
-export default async function DashboardsPage() {
-  const result = await fetchDashboardsList();
+  // Auth bounce or dashboard redirect in flight — render nothing rather than
+  // flashing the empty/error chrome before navigation lands.
+  if (isAuthError || targetId) return null;
 
-  if (!result.ok) {
-    if (result.reason === "auth-required") redirect("/login?redirect=/dashboards");
+  if (error) {
     return (
       <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-16 text-center">
         <h1 className="text-base font-medium text-zinc-900 dark:text-zinc-100">
           Couldn&rsquo;t load your dashboards
         </h1>
         <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-          {result.reason === "network-error"
-            ? "Could not reach the server. Check your connection and try again."
-            : "The server encountered an error. Try refreshing the page."}
+          {friendlyError(error)}
         </p>
-        <Button asChild size="sm" variant="outline" className="mt-6">
-          <Link href="/dashboards">Try again</Link>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-6"
+          onClick={() => refetch()}
+        >
+          Try again
         </Button>
       </div>
     );
   }
 
-  const targetId = selectMostRecentDashboardId(result.data.dashboards);
-  if (!targetId) return <DashboardsEmptyState />;
-  redirect(`/dashboards/${targetId}`);
+  // Still loading the list (no data yet) — render nothing; the route's
+  // loading.tsx and the workspace shell already provide chrome.
+  if (loading || !data) return null;
+
+  // Loaded with no dashboards.
+  return <DashboardsEmptyState />;
 }


### PR DESCRIPTION
## Summary

Closes #4089.

`/dashboards` was the **only** authed workspace page rendered as a **server component**. It read the incoming request's `cookie` header and forwarded it to the cross-origin API (`api.useatlas.dev`):

```ts
const cookieHeader = (await headers()).get("cookie") ?? "";
const res = await fetch(`${getApiBaseUrl()}/api/v1/dashboards`, { headers: { cookie: cookieHeader } });
```

Under **ADR-0024 §5** the session cookie (`__Secure-atlas.session_token`) is **host-only to the API origin**, so the browser never sends it to `app.useatlas.dev`. The cookie header the server component read therefore carried no session token → forwarding it to the API → `adminAuth` saw no session → **401** → logged-in users bounced to `/login`. (The #4086 eviction of the legacy parent-domain `.useatlas.dev` cookie in v0.0.34 unmasked a latent incompatibility dating to v0.0.31; v0.0.34's own code is sound.)

A server component has no cookie jar, so `credentials: "include"` can't fix it. Every *other* workspace route is a client component, which is why they work.

**Fix (issue's recommended Option 1):** convert `/dashboards` to a **client component** that fetches `/api/v1/dashboards` via `useAdminFetch` — the same browser-side credentialed path `/notebook` and `/admin` already use, where the host-only cookie attaches automatically. Behavior preserved:

- **401/403** → `router.replace("/login?redirect=/dashboards")` (the real auth gate; `AuthGuard` also backstops globally in managed mode)
- **other error** → retryable error card (`friendlyError`)
- **empty** → `DashboardsEmptyState`
- **non-empty** → redirect to the most-recently-updated dashboard

A regression guard test (`no-ssr-cookie-forward.test.ts`) fails if any `(workspace)` page is a server component forwarding the `cookie` request header.

### Acceptance criteria
- [x] A logged-in user can open `/dashboards` without being bounced to `/login`
- [x] Fix uses the same browser-side credential path as `/notebook` and `/admin` (no server-side cookie forwarding)
- [x] No SSR page forwards the host-only session cookie (enforced by the new grep-guard test)
- [x] Genuinely-unauthenticated access (401/403) still routes to `/login`

## Test Plan

- [x] Manual testing — N/A locally (host-only-cookie prod behavior); covered by tests below
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

New tests (`packages/web/src/app/(workspace)/dashboards/__tests__/`):
- `page.test.tsx` — redirect-to-most-recent (asserts **no** `/login` bounce), empty state, 401 → `/login`, 403 → `/login`, server-error card surfaces the body message, and the "Try again" button refetches + redirects.
- `no-ssr-cookie-forward.test.ts` — structural guard: no `(workspace)` server-component page reads the cookie request header or forwards a `cookie:` field into a server-side `fetch`.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — full suite green except one pre-existing, environment-induced timeout in `packages/api` `admin-model-config.test.ts` (the `getGatewayCatalog` test makes a real outbound call to the AI gateway, which hangs in this sandbox instead of fast-failing to the bundled fallback). Byte-identical to `origin/main`; unrelated to this web-only diff.
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [x] Labels added (`bug`, `area: web`)
- [ ] CHANGELOG.md updated — internal redirect-routing fix, no separate changelog entry

https://claude.ai/code/session_01AD1JJCPLcyuCdAgdcKKaHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AD1JJCPLcyuCdAgdcKKaHd)_