### PR TITLE
fix(web): stop stale atlas_region cookie from misrouting returning login (#4090)

### DIFF
--- a/create-atlas/scripts/prepare-templates.sh
+++ b/create-atlas/scripts/prepare-templates.sh
@@ -122,6 +122,11 @@ done
 echo ":: Syncing docker auth override"
 mkdir -p "$TEMPLATES/docker/src/lib/auth"
 cp "$WEB_SRC/lib/auth/client.ts" "$TEMPLATES/docker/src/lib/auth/"
+# Web-only auth helpers the UI imports (e.g. sign-out.ts → @/lib/auth/sign-out,
+# pulled in by user-menu/auth-guard). The auth/ subdir is curated rather than
+# copied wholesale (API source owns lib/auth/ here), so each web helper is an
+# explicit copy.
+cp "$WEB_SRC/lib/auth/sign-out.ts" "$TEMPLATES/docker/src/lib/auth/"
 
 # ── Step 3: Sync nextjs-standalone template ──────────────────────────
 # The nextjs-standalone template merges API source with Next.js-specific
@@ -148,6 +153,10 @@ find "$TEMPLATES/nextjs-standalone/src" -name 'test-setup.ts' -delete 2>/dev/nul
 cp "$NEXTJS_EXAMPLE/src/lib/api-url.ts"      "$TEMPLATES/nextjs-standalone/src/lib/"
 mkdir -p "$TEMPLATES/nextjs-standalone/src/lib/auth"
 cp "$NEXTJS_EXAMPLE/src/lib/auth/client.ts"   "$TEMPLATES/nextjs-standalone/src/lib/auth/"
+# Web-only auth helpers the UI imports (sign-out.ts → @/lib/auth/sign-out, pulled
+# in by user-menu/auth-guard). Step 3's `rm -rf src/lib` + `cp -r $API_SRC/lib`
+# lays down API auth source; this overlays the web-side helper it doesn't have.
+cp "$WEB_SRC/lib/auth/sign-out.ts"            "$TEMPLATES/nextjs-standalone/src/lib/auth/"
 
 # Copy ALL web lib files (utils, format, data-table, parsers, compose-refs, etc.)
 for f in "$WEB_SRC"/lib/*.ts; do

--- a/packages/web/src/app/accept-invitation/[id]/page.tsx
+++ b/packages/web/src/app/accept-invitation/[id]/page.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Database, Mail, AlertTriangle, LogOut } from "lucide-react";
 import { authClient, type OrgInvitationDetail } from "@/lib/auth/client";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 
 interface PageProps {
@@ -133,7 +134,7 @@ export default function AcceptInvitationPage({ params }: PageProps) {
 
   async function handleSignOut() {
     try {
-      await authClient.signOut();
+      await signOutForgettingRegion(() => authClient.signOut());
     } catch (err) {
       // intentionally ignored: best-effort sign-out — even if the request
       // fails, route to /login so the user can retry with the right account.

--- a/packages/web/src/app/api/login/resolve-region/route.test.ts
+++ b/packages/web/src/app/api/login/resolve-region/route.test.ts
@@ -4,8 +4,9 @@
  * Exercises the real handler (fetch mocked) to pin the adapter logic the pure
  * `resolveRegion` tests can't reach: the per-client-IP front-door rate limiter
  * (the PRIMARY oracle control), the probeRegion HTTP-status→throw mapping (an
- * in-map 404 is INCONCLUSIVE → `error`, never a false `none`), the cookie
- * fast-path skipping the fan-out, and input validation.
+ * in-map 404 is INCONCLUSIVE → `error`, never a false `none`), the
+ * cookie→`cookieRegion` wiring (a stale cookie never overrides the email
+ * lookup — #4090), and input validation.
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
@@ -104,13 +105,26 @@ describe("POST /api/login/resolve-region", () => {
     expect((await res.json()).outcome).toBe("error");
   });
 
-  it("cookie fast-path skips the probe fan-out and routes from the authoritative map", async () => {
+  it("#4090: a stale atlas_region cookie never overrides the email lookup", async () => {
+    // Cookie pins eu (from a signed-out EU session), but the email exists only
+    // in us. The route must fan out (not short-circuit on the cookie) and route
+    // to the email's TRUE region.
     const cookie = encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "https://evil.example" }));
-    const res = await post("alice@corp.com", { ip: "203.0.113.23", cookie });
+    probeExists = { "https://api.useatlas.dev": true };
+    const res = await post("matt+us@useatlas.dev", { ip: "203.0.113.23", cookie });
     expect(res.status).toBe(200);
-    // Authoritative apiUrl from the map — NOT the tampered cookie apiUrl.
-    expect(await res.json()).toEqual({ outcome: "single", region: "eu", apiUrl: "https://api-eu.useatlas.dev" });
-    expect(fetchCalls.some((u) => u.endsWith("/api/v1/auth/region-probe"))).toBe(false);
+    expect(await res.json()).toEqual({ outcome: "single", region: "us", apiUrl: "https://api.useatlas.dev" });
+    // The fan-out ran — the cookie did NOT skip the oracle.
+    expect(fetchCalls.some((u) => u.endsWith("/api/v1/auth/region-probe"))).toBe(true);
+  });
+
+  it("#4090: returns none for a non-existent email even with an atlas_region cookie", async () => {
+    // No region confirms a hit; the cookie must not conjure a `single`.
+    const cookie = encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "https://api-eu.useatlas.dev" }));
+    probeExists = { "https://api.useatlas.dev": false, "https://api-eu.useatlas.dev": false };
+    const res = await post("ghost@nowhere.com", { ip: "203.0.113.27", cookie });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ outcome: "none" });
   });
 
   it("returns error when the region map cannot be fetched", async () => {

--- a/packages/web/src/app/forbidden.tsx
+++ b/packages/web/src/app/forbidden.tsx
@@ -11,6 +11,7 @@ import {
 import { ShieldX } from "lucide-react";
 import Link from "next/link";
 import { authClient } from "@/lib/auth/client";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 
 export default function Forbidden() {
   return (
@@ -32,7 +33,7 @@ export default function Forbidden() {
           <Button
             variant="ghost"
             className="w-full"
-            onClick={() => authClient.signOut().then(() => window.location.assign("/login"))}
+            onClick={() => signOutForgettingRegion(() => authClient.signOut()).then(() => window.location.assign("/login"))}
           >
             Sign in as a different user
           </Button>

--- a/packages/web/src/lib/__tests__/login-frontdoor.test.ts
+++ b/packages/web/src/lib/__tests__/login-frontdoor.test.ts
@@ -3,8 +3,10 @@
  *
  * No network: `fetchRegionMap` + `probe` are injected. These pin the routing
  * verdicts AND the security invariants — only the HASH is fanned out (never the
- * raw email), the cookie fast-path skips the probe oracle, and an unreachable
- * region never produces a confident false "none".
+ * raw email), the email fan-out is the sole authority on region (a stale
+ * `atlas_region` cookie can neither misroute nor fabricate a region — #4090; it
+ * only breaks a multi-region tie), and an unreachable region never produces a
+ * confident false "none".
  */
 
 import { describe, it, expect } from "bun:test";
@@ -89,28 +91,78 @@ describe("resolveRegion", () => {
     expect(r).toEqual({ outcome: "skip" });
   });
 
-  it("cookie fast-path routes to the cookie region WITHOUT probing, using the map's authoritative apiUrl", async () => {
-    const { probe, calls } = probeHitting();
+  it("#4090: a stale cookie region NEVER overrides the email's true region", async () => {
+    // Cookie says "eu" (left over from a signed-out EU session), but the email
+    // only exists in "us". The fan-out is authoritative — route to us, and DON'T
+    // short-circuit on the cookie.
+    const { probe, calls } = probeHitting("https://api.useatlas.dev");
     const r = await resolveRegion({
-      email: "a@b.co",
+      email: "matt+us@useatlas.dev",
+      cookieRegion: "eu",
+      fetchRegionMap: mapOf(MAP),
+      probe,
+    });
+    expect(r).toEqual({ outcome: "single", region: "us", apiUrl: "https://api.useatlas.dev" });
+    expect(calls.length).toBeGreaterThan(0); // the oracle is consulted, not skipped
+  });
+
+  it("#4090: returns none for a non-existent email even when an atlas_region cookie is present", async () => {
+    // The cookie must not conjure a `single` for an email that exists nowhere.
+    const { probe } = probeHitting();
+    const r = await resolveRegion({
+      email: "ghost@nowhere.com",
+      cookieRegion: "eu",
+      fetchRegionMap: mapOf(MAP),
+      probe,
+    });
+    expect(r).toEqual({ outcome: "none" });
+  });
+
+  it("uses the cookie as a tiebreaker among multi-region hits (skips the chooser)", async () => {
+    // The email exists in both us and eu; a returning user whose cookie pins eu
+    // lands on eu directly (with the map's authoritative apiUrl) instead of the
+    // chooser.
+    const { probe } = probeHitting("https://api.useatlas.dev", "https://api-eu.useatlas.dev");
+    const r = await resolveRegion({
+      email: "alice@corp.com",
       cookieRegion: "eu",
       fetchRegionMap: mapOf(MAP),
       probe,
     });
     expect(r).toEqual({ outcome: "single", region: "eu", apiUrl: "https://api-eu.useatlas.dev" });
-    expect(calls).toHaveLength(0); // the oracle is short-circuited
   });
 
-  it("a stale cookie region (not in the map) falls through to the fan-out", async () => {
-    const { probe, calls } = probeHitting("https://api-eu.useatlas.dev");
+  it("ignores a cookie that names no confirmed hit — the chooser still appears", async () => {
+    // Multi-region hits us+eu, but the cookie pins apac (not a hit). The cookie
+    // can't fabricate a region, so the user still chooses — with BOTH real hits.
+    const { probe } = probeHitting("https://api.useatlas.dev", "https://api-eu.useatlas.dev");
     const r = await resolveRegion({
-      email: "a@b.co",
-      cookieRegion: "antarctica",
+      email: "alice@corp.com",
+      cookieRegion: "apac",
+      fetchRegionMap: mapOf(MAP),
+      probe,
+    });
+    expect(r.outcome).toBe("multiple");
+    if (r.outcome === "multiple") {
+      expect(r.regions.map((x) => x.region).sort()).toEqual(["eu", "us"]);
+    }
+  });
+
+  it("tiebreaks to the cookie region even when a THIRD region errored (still has ≥2 hits)", async () => {
+    // us + eu both confirm; apac throws. With 2 confirmed hits the verdict is
+    // `multiple`, so the cookie tiebreaker still applies — a probe failure
+    // elsewhere must not dead-end a returning multi-region user into `error`.
+    const probe = async (apiUrl: string) => {
+      if (apiUrl === "https://api-apac.useatlas.dev") throw new Error("network");
+      return apiUrl === "https://api.useatlas.dev" || apiUrl === "https://api-eu.useatlas.dev";
+    };
+    const r = await resolveRegion({
+      email: "alice@corp.com",
+      cookieRegion: "eu",
       fetchRegionMap: mapOf(MAP),
       probe,
     });
     expect(r).toEqual({ outcome: "single", region: "eu", apiUrl: "https://api-eu.useatlas.dev" });
-    expect(calls.length).toBeGreaterThan(0);
   });
 
   it("single-region deployment routes without probing", async () => {

--- a/packages/web/src/lib/auth/__tests__/sign-out.test.ts
+++ b/packages/web/src/lib/auth/__tests__/sign-out.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `signOutForgettingRegion` — every sign-out must forget the `atlas_region`
+ * routing hint so a stale region can't pin the next sign-in on this browser
+ * (ADR-0024 §3, #4090).
+ *
+ * Real cookie effects against happy-dom's `document.cookie` (the same surface
+ * `clearRegionSignal` writes), so the test pins the actual observable: the
+ * cookie is gone, cleared BEFORE the sign-out round-trip and regardless of
+ * whether it succeeds.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { signOutForgettingRegion } from "../sign-out";
+import { REGION_COOKIE } from "@/lib/api-url";
+
+/** True iff a non-empty `atlas_region` cookie is present. */
+function hasRegionCookie(): boolean {
+  return document.cookie
+    .split("; ")
+    .some((c) => c.startsWith(`${REGION_COOKIE}=`) && c !== `${REGION_COOKIE}=`);
+}
+
+/** Seed the cookie a previous (now signed-out) regional session would leave. */
+function seedRegionCookie(): void {
+  const value = encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "https://api-eu.useatlas.dev" }));
+  document.cookie = `${REGION_COOKIE}=${value}; path=/`;
+}
+
+describe("signOutForgettingRegion", () => {
+  beforeEach(() => {
+    document.cookie = `${REGION_COOKIE}=; path=/; max-age=0`;
+  });
+
+  it("clears the atlas_region cookie BEFORE delegating to signOut", async () => {
+    seedRegionCookie();
+    expect(hasRegionCookie()).toBe(true);
+
+    let presentDuringSignOut: boolean | null = null;
+    await signOutForgettingRegion(async () => {
+      presentDuringSignOut = hasRegionCookie();
+      return { data: { success: true }, error: null };
+    });
+
+    // Forgotten before the request ran — not after, so the hint can't survive a
+    // signOut that hangs or the page navigating away mid-flight.
+    expect(presentDuringSignOut).toBe(false);
+    expect(hasRegionCookie()).toBe(false);
+  });
+
+  it("returns the wrapped signOut's result untouched", async () => {
+    const result = await signOutForgettingRegion(async () => ({
+      data: null,
+      error: { message: "server said no" },
+    }));
+    expect(result).toEqual({ data: null, error: { message: "server said no" } });
+  });
+
+  it("still clears the cookie when signOut rejects (transport failure)", async () => {
+    seedRegionCookie();
+    await expect(
+      signOutForgettingRegion(async () => {
+        throw new Error("API unreachable");
+      }),
+    ).rejects.toThrow("API unreachable");
+    // The client-only hint is gone regardless of the server round-trip.
+    expect(hasRegionCookie()).toBe(false);
+  });
+});

--- a/packages/web/src/lib/auth/sign-out.ts
+++ b/packages/web/src/lib/auth/sign-out.ts
@@ -1,0 +1,32 @@
+/**
+ * Sign-out wrapper that forgets the regional routing hint (ADR-0024 §3, #4090).
+ *
+ * The `atlas_region` cookie is a non-httpOnly, ~1-year hint the login
+ * front-door's `resolve-region` reads as a tiebreaker. If it outlives a
+ * sign-out it pins the *next* sign-in on this browser — a different user on a
+ * shared machine, a multi-region user, or someone whose account migrated
+ * regions — to the prior session's region. Clearing it on every sign-out lets
+ * the next returning user resolve their own region from scratch.
+ *
+ * `resolveRegion` no longer lets a stale cookie misroute or fabricate a region
+ * (the fan-out is authoritative), so this is defense-in-depth — but it keeps
+ * the routing hint honest rather than leaving a dead session's region behind.
+ *
+ * The clear runs first and unconditionally: `atlas_region` is a client-only
+ * cookie, so forgetting the hint must not hinge on the server round-trip
+ * succeeding, and a stale hint is worse than none. The caller still owns the
+ * sign-out result (navigation, error surfacing) and its own error handling — we
+ * delegate to the provided thunk and return its value untouched.
+ */
+
+import { clearRegionSignal } from "@/lib/api-url";
+
+/**
+ * Forget the `atlas_region` routing hint, then run the caller's sign-out.
+ * Generic over the thunk's return so each call site keeps the Better Auth
+ * result shape it already branches on (e.g. AuthGuard's `{ error }` check).
+ */
+export async function signOutForgettingRegion<T>(signOut: () => Promise<T>): Promise<T> {
+  clearRegionSignal();
+  return signOut();
+}

--- a/packages/web/src/lib/login-frontdoor.ts
+++ b/packages/web/src/lib/login-frontdoor.ts
@@ -12,9 +12,12 @@
  * Design invariants (the security contract the probe ADR calls for):
  *   - The raw email never leaves the front-door — only its hash is fanned out.
  *   - There is no global email→region store; the hash is transient per request.
- *   - The `atlas_region` cookie short-circuits the probe fan-out (the oracle):
- *     a known region is re-resolved to its AUTHORITATIVE apiUrl from the
- *     region-map, never from the client-writable cookie's own apiUrl.
+ *   - The hashed-email fan-out is the SOLE authority on which region(s) host an
+ *     account. The `atlas_region` cookie is only a tiebreaker among confirmed
+ *     hits — it never short-circuits the lookup, overrides it, or conjures a
+ *     region for an email that exists nowhere (#4090). When it does break a tie,
+ *     the region is re-resolved to its AUTHORITATIVE apiUrl from the region-map,
+ *     never from the client-writable cookie's own apiUrl.
  *
  * `resolveRegion` takes `fetchRegionMap` + `probe` as injected dependencies so
  * the routing logic is unit-testable without network; the edge route
@@ -104,7 +107,11 @@ export function parseRegionCookie(raw: string | null | undefined): string | null
 export interface ResolveRegionDeps {
   /** The typed email (raw; hashed internally, never forwarded raw). */
   email: string;
-  /** The region key from a valid `atlas_region` cookie, or null. */
+  /**
+   * The region key from a valid `atlas_region` cookie, or null. Used ONLY as a
+   * tiebreaker among confirmed multi-region hits — never to short-circuit or
+   * override the email fan-out (#4090).
+   */
   cookieRegion: string | null;
   /** Fetch the region-routing map (throws on network failure). */
   fetchRegionMap: () => Promise<RegionRoutingMap>;
@@ -115,11 +122,18 @@ export interface ResolveRegionDeps {
 /**
  * Resolve a typed email to a region without any global storage.
  *
- * Order: fetch the map → cookie fast-path (skip the oracle) → single-region
- * short-circuit → hashed-email fan-out. A region that errors during the
- * fan-out is never reported as a confident "none": if no region confirmed a
- * hit AND at least one probe failed, the result is `error` (retry) rather than
- * a false negative that would dead-end a real returning user.
+ * Order: fetch the map → single-region short-circuit → hashed-email fan-out →
+ * cookie tiebreaker. The email lookup is ALWAYS authoritative: the
+ * `atlas_region` cookie never short-circuits or overrides it, so a stale cookie
+ * can neither route a returning user to the wrong region nor conjure a `single`
+ * for an email that exists nowhere (#4090). The cookie only breaks a genuine
+ * tie — narrowing a multi-region `multiple` to the cookie's region when that
+ * region is itself one of the confirmed hits.
+ *
+ * A region that errors during the fan-out is never reported as a confident
+ * "none": if no region confirmed a hit AND at least one probe failed, the
+ * result is `error` (retry) rather than a false negative that would dead-end a
+ * real returning user.
  */
 export async function resolveRegion(deps: ResolveRegionDeps): Promise<RegionResolution> {
   const { email, cookieRegion, fetchRegionMap, probe } = deps;
@@ -136,14 +150,6 @@ export async function resolveRegion(deps: ResolveRegionDeps): Promise<RegionReso
 
   if (!map.configured || map.regions.length === 0) {
     return { outcome: "skip" };
-  }
-
-  // Fast path — a cookie-pinned region the map still knows: route there with
-  // its authoritative apiUrl and skip the probe fan-out (the oracle) entirely.
-  if (cookieRegion) {
-    const hit = map.regions.find((r) => r.id === cookieRegion);
-    if (hit) return { outcome: "single", region: hit.id, apiUrl: hit.apiUrl };
-    // A stale cookie (region removed) falls through to the cold fan-out.
   }
 
   // Single-region deployment: route to it without probing — there is no
@@ -174,12 +180,24 @@ export async function resolveRegion(deps: ResolveRegionDeps): Promise<RegionReso
     // No confirmed hit. If a region was unreachable we can't claim "no
     // account" — that would dead-end a returning user whose region just
     // happened to error. Only a clean all-regions-answered sweep yields "none".
+    // A stale `atlas_region` cookie is deliberately NOT consulted here: the
+    // email genuinely exists nowhere, so the verdict is `none`/`error` (#4090).
     return failures > 0
       ? { outcome: "error", message: "Could not reach every region. Please try again." }
       : { outcome: "none" };
   }
   if (hits.length === 1) {
     return { outcome: "single", region: hits[0].region, apiUrl: hits[0].apiUrl };
+  }
+
+  // Multiple regions host this email. Use the cookie as a tiebreaker ONLY when
+  // it names one of the confirmed hits — a returning multi-region user skips the
+  // chooser and lands on their last-used region with its authoritative apiUrl. A
+  // cookie that matches no hit is ignored (it can never fabricate or override a
+  // region), so the chooser still appears.
+  if (cookieRegion) {
+    const pinned = hits.find((h) => h.region === cookieRegion);
+    if (pinned) return { outcome: "single", region: pinned.region, apiUrl: pinned.apiUrl };
   }
   return { outcome: "multiple", regions: hits };
 }

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -19,6 +19,7 @@ import Link from "next/link";
 import { AdminSidebar } from "./admin-sidebar";
 import { AdminTopBar } from "./admin-top-bar";
 import { useAtlasConfig } from "@/ui/context";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 import { LoadingState } from "./loading-state";
 import { ChangePasswordDialog } from "./change-password-dialog";
 import { MfaGateProvider, useMfaGate } from "./mfa-gate-context";
@@ -144,7 +145,7 @@ function AdminLayoutInner({ children }: { children: ReactNode }) {
               variant="ghost"
               className="w-full"
               onClick={() => {
-                authClient.signOut()
+                signOutForgettingRegion(() => authClient.signOut())
                   .then(() => window.location.assign("/login"))
                   .catch((err: unknown) => {
                     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
+++ b/packages/web/src/ui/components/admin/mfa-enrollment-dialog.tsx
@@ -24,6 +24,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useAtlasConfig } from "@/ui/context";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 import { useMfaGate } from "./mfa-gate-context";
 
 export function MfaEnrollmentDialog() {
@@ -42,8 +43,7 @@ export function MfaEnrollmentDialog() {
   }
 
   function handleSignOut() {
-    void authClient
-      .signOut()
+    void signOutForgettingRegion(() => authClient.signOut())
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         // Recovery is the same either way (navigate to /login), but log the

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 import { AtlasProvider } from "@/ui/context";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { PUBLIC_ROUTE_PREFIXES } from "@/lib/public-routes";
@@ -107,7 +108,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         //   (b) a true transport failure (API down / DNS / CORS preflight) — the
         //       platform `fetch()` rejects and the throw propagates (no
         //       `catchAllError`, no catch in the client proxy) → the `catch`.
-        const result = await authClient.signOut();
+        const result = await signOutForgettingRegion(() => authClient.signOut());
         if (result?.error) {
           console.warn(
             "[atlas] stale-session signOut returned an HTTP error; cookie not cleared, staying put to avoid a redirect loop (reload once the API is reachable):",

--- a/packages/web/src/ui/components/chat/sidebar-user-menu.tsx
+++ b/packages/web/src/ui/components/chat/sidebar-user-menu.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar";
 import { authClient } from "@/lib/auth/client";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 import { deriveInitials } from "@/ui/components/user-menu";
 import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
 
@@ -92,7 +93,7 @@ export function SidebarUserMenu() {
     if (signingOut) return;
     setSigningOut(true);
     try {
-      await authClient.signOut();
+      await signOutForgettingRegion(() => authClient.signOut());
       window.location.assign("/login");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/web/src/ui/components/user-menu.tsx
+++ b/packages/web/src/ui/components/user-menu.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAtlasConfig } from "@/ui/context";
+import { signOutForgettingRegion } from "@/lib/auth/sign-out";
 import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
 
 const THEME_OPTIONS = [
@@ -54,7 +55,7 @@ export function UserMenu() {
     if (signingOut) return;
     setSigningOut(true);
     try {
-      await authClient.signOut();
+      await signOutForgettingRegion(() => authClient.signOut());
       window.location.assign("/login");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

The login front-door's `resolve-region` (ADR-0024 §3, #3973) had a **cookie fast-path** that trusted a non-httpOnly, ~1-year `atlas_region` cookie over the email→region fan-out. A cookie left behind from a signed-out session shadowed the lookup: it routed *any* email to the cookie's region — including an account that actually lives in a different region — and fabricated `single` for non-existent emails.

- **`resolveRegion` — the hashed-email fan-out is now the sole authority.** The `atlas_region` cookie is consulted only as a tiebreaker among confirmed multi-region hits — it never short-circuits the lookup, overrides it, or conjures a region for an email that exists nowhere. The no-hit path deliberately ignores the cookie (so a stale cookie can't manufacture a `single`). A cookie that names no confirmed hit still falls through to the chooser. The authoritative `apiUrl` always comes from the region-map, never the client-writable cookie.
- **Sign-out now forgets the routing hint.** New `signOutForgettingRegion` helper clears the client-only cookie first and unconditionally, then delegates to the caller's `signOut` thunk (returning its value untouched so each call site keeps its own error handling). Wired into all seven sign-out call sites (user menu, sidebar menu, admin layout, auth-guard recovery, forbidden, accept-invitation, MFA dialog). Defense-in-depth now that `resolveRegion` can't be fooled, and it keeps the hint honest.

## Test Plan

- [x] Unit tests added/updated
- Regression tests at both layers (pure resolver `login-frontdoor.test.ts` + route adapter `resolve-region/route.test.ts`):
  - stale-cookie-region ≠ email-region → routes to the email's **true** region (the prod repro: cookie `eu`, email in `us` → `us`)
  - stale cookie + non-existent email → `{outcome: "none"}`
  - cookie tiebreaks multi-region hits (skips the chooser), but is ignored when it names no confirmed hit; still tiebreaks when a third region's probe errored
  - tampered-cookie `apiUrl` is ignored in favor of the map's authoritative base
- New `sign-out.test.ts` (real happy-dom cookie): cookie cleared **before** the sign-out round-trip and even when `signOut` rejects; the thunk's result is returned untouched
- [x] Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy): CLEAN

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — full suite green except one pre-existing network-dependent flake in `packages/api` (`admin-model-config.test.ts`, untouched by this web-only diff; it calls the real gateway catalog and times out against the sandbox proxy)
- [x] Lint passes (`bun run lint`)
- [ ] Labels added (type + area)

Closes #4090

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjpAiyqmoLtj2BpdwLbBaM)_