### PR TITLE
fix(web): stale atlas_region cookie not cleared on sign-out → resolve-region misroutes returning login

### DIFF
--- a/packages/web/src/app/api/login/resolve-region/route.test.ts
+++ b/packages/web/src/app/api/login/resolve-region/route.test.ts
@@ -104,13 +104,26 @@ describe("POST /api/login/resolve-region", () => {
     expect((await res.json()).outcome).toBe("error");
   });
 
-  it("cookie fast-path skips the probe fan-out and routes from the authoritative map", async () => {
+  it("cookie fast-path probes the hinted region and routes when the email exists there", async () => {
+    probeExists = { "https://api-eu.useatlas.dev": true };
     const cookie = encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "https://evil.example" }));
     const res = await post("alice@corp.com", { ip: "203.0.113.23", cookie });
     expect(res.status).toBe(200);
     // Authoritative apiUrl from the map — NOT the tampered cookie apiUrl.
     expect(await res.json()).toEqual({ outcome: "single", region: "eu", apiUrl: "https://api-eu.useatlas.dev" });
-    expect(fetchCalls.some((u) => u.endsWith("/api/v1/auth/region-probe"))).toBe(false);
+    // Only the cookie's region was probed (not a full fan-out).
+    expect(fetchCalls.filter((u) => u.endsWith("/api/v1/auth/region-probe"))).toHaveLength(1);
+  });
+
+  it("cookie fast-path falls through to full fan-out when the email is NOT in the hinted region", async () => {
+    // Email exists in us, cookie says eu → must not trust the cookie.
+    probeExists = { "https://api.useatlas.dev": true };
+    const cookie = encodeURIComponent(JSON.stringify({ region: "eu", apiUrl: "https://api-eu.useatlas.dev" }));
+    const res = await post("bob@corp.com", { ip: "203.0.113.24", cookie });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ outcome: "single", region: "us", apiUrl: "https://api.useatlas.dev" });
+    // Full fan-out ran (probed both regions).
+    expect(fetchCalls.filter((u) => u.endsWith("/api/v1/auth/region-probe"))).toHaveLength(2);
   });
 
   it("returns error when the region map cannot be fetched", async () => {

--- a/packages/web/src/lib/__tests__/login-frontdoor.test.ts
+++ b/packages/web/src/lib/__tests__/login-frontdoor.test.ts
@@ -89,8 +89,8 @@ describe("resolveRegion", () => {
     expect(r).toEqual({ outcome: "skip" });
   });
 
-  it("cookie fast-path routes to the cookie region WITHOUT probing, using the map's authoritative apiUrl", async () => {
-    const { probe, calls } = probeHitting();
+  it("cookie fast-path probes the hinted region and routes when the email exists there", async () => {
+    const { probe, calls } = probeHitting("https://api-eu.useatlas.dev");
     const r = await resolveRegion({
       email: "a@b.co",
       cookieRegion: "eu",
@@ -98,7 +98,20 @@ describe("resolveRegion", () => {
       probe,
     });
     expect(r).toEqual({ outcome: "single", region: "eu", apiUrl: "https://api-eu.useatlas.dev" });
-    expect(calls).toHaveLength(0); // the oracle is short-circuited
+    expect(calls).toHaveLength(1); // only the cookie region was probed
+    expect(calls[0].apiUrl).toBe("https://api-eu.useatlas.dev");
+  });
+
+  it("cookie fast-path falls through to full fan-out when the email is NOT in the hinted region", async () => {
+    const { probe, calls } = probeHitting("https://api.useatlas.dev"); // exists in us, not eu
+    const r = await resolveRegion({
+      email: "a@b.co",
+      cookieRegion: "eu",
+      fetchRegionMap: mapOf(MAP),
+      probe,
+    });
+    expect(r).toEqual({ outcome: "single", region: "us", apiUrl: "https://api.useatlas.dev" });
+    expect(calls.length).toBeGreaterThan(1); // full fan-out ran
   });
 
   it("a stale cookie region (not in the map) falls through to the fan-out", async () => {

--- a/packages/web/src/lib/login-frontdoor.ts
+++ b/packages/web/src/lib/login-frontdoor.ts
@@ -138,12 +138,23 @@ export async function resolveRegion(deps: ResolveRegionDeps): Promise<RegionReso
     return { outcome: "skip" };
   }
 
-  // Fast path — a cookie-pinned region the map still knows: route there with
-  // its authoritative apiUrl and skip the probe fan-out (the oracle) entirely.
+  // Cookie hint — probe the hinted region before trusting the fast-path. If
+  // the email exists there, skip the full fan-out (common case: returning user
+  // on their own browser). If it doesn't, fall through so the cookie NEVER
+  // overrides the email-based lookup.
   if (cookieRegion) {
     const hit = map.regions.find((r) => r.id === cookieRegion);
-    if (hit) return { outcome: "single", region: hit.id, apiUrl: hit.apiUrl };
-    // A stale cookie (region removed) falls through to the cold fan-out.
+    if (hit) {
+      const emailHash = await hashEmail(email);
+      try {
+        const exists = await probe(hit.apiUrl, emailHash);
+        if (exists) return { outcome: "single", region: hit.id, apiUrl: hit.apiUrl };
+      } catch {
+        // Probe failed — fall through to the full fan-out (inconclusive).
+      }
+    }
+    // Cookie region doesn't contain the email, or probe failed.
+    // Fall through to cold fan-out.
   }
 
   // Single-region deployment: route to it without probing — there is no

--- a/packages/web/src/ui/components/chat/sidebar-user-menu.tsx
+++ b/packages/web/src/ui/components/chat/sidebar-user-menu.tsx
@@ -28,6 +28,7 @@ import {
 import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar";
 import { authClient } from "@/lib/auth/client";
 import { deriveInitials } from "@/ui/components/user-menu";
+import { clearRegionSignal } from "@/lib/api-url";
 import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
 
 interface OrgOption {
@@ -93,6 +94,7 @@ export function SidebarUserMenu() {
     setSigningOut(true);
     try {
       await authClient.signOut();
+      clearRegionSignal();
       window.location.assign("/login");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/web/src/ui/components/user-menu.tsx
+++ b/packages/web/src/ui/components/user-menu.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useAtlasConfig } from "@/ui/context";
+import { clearRegionSignal } from "@/lib/api-url";
 import { setTheme, useThemeMode, type ThemeMode } from "@/ui/hooks/use-dark-mode";
 
 const THEME_OPTIONS = [
@@ -55,6 +56,7 @@ export function UserMenu() {
     setSigningOut(true);
     try {
       await authClient.signOut();
+      clearRegionSignal();
       window.location.assign("/login");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Closes #4090

## Changes

### 1. Fix resolve-region cookie fast-path (login-frontdoor.ts)
The cookie fast-path previously returned the cookie's region **without any probe** — it trusted the cookie even when an explicit email was provided. If the cookie said "eu" but the email's account lived in "us", the user was routed to the wrong region and login failed.

**Fix**: Instead of unconditionally skipping the probe fan-out, the cookie now acts as a **hint**: probe the cookie's region first. If the email exists there (common case: returning user on their own browser), return immediately with 1 probe. If the email doesn't exist there, fall through to the full fan-out — the cookie NEVER overrides the email-based lookup.

### 2. Clear atlas_region cookie on sign-out (user-menu.tsx, sidebar-user-menu.tsx)
The `atlas_region` cookie had a ~1-year expiry and was never cleared on sign-out. A stale cookie left by a previous session in region A could misroute the next user's login (or even a non-existent email) to region A.

**Fix**: Both sign-out handlers now call `clearRegionSignal()` after `authClient.signOut()` succeeds, deleting the cookie.

## Testing
- Tests updated: cookie fast-path now expects the hinted region to be probed; new test for email-not-in-cookie-region fallthrough.
- **Platform note**: Local `bun install` timed out on Windows (known msys2/network-mount issue), so full test suite could not be run locally. CI on Linux is the real verification gate. The changes are minimal and well-covered by updated unit tests.
