### PR TITLE
feat(auth): reject plus-addressed email signups except useatlas.dev

### DIFF
--- a/ee/src/onboarding/__tests__/provision-trial.test.ts
+++ b/ee/src/onboarding/__tests__/provision-trial.test.ts
@@ -177,6 +177,35 @@ describe("provisionTrialWorkspace", () => {
     expect(calls.mcpLead).toHaveLength(0);
   });
 
+  it("maps a plus-addressing rejection from the signup hook to plus_addressing (#4091, actionable not internal_error)", async () => {
+    // #4091 rejects plus-addressed signups in the SAME shared user.create.before
+    // hook, throwing a typed PLUS_ADDRESSING_NOT_ALLOWED APIError out of
+    // `signUpEmail`. The provisioner must recognize it and surface the distinct
+    // `plus_addressing` code (→ a validation_failed envelope with a hint at the
+    // MCP layer) — NOT the generic internal_error/"please retry" a bare rethrow
+    // would produce. A deny is permanent, not transient.
+    const { APIError } = await import("better-auth/api");
+    const { PLUS_ADDRESSING_NOT_ALLOWED_CODE, PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE } =
+      await import("@atlas/api/lib/auth/business-email");
+    const { deps, calls } = stubDeps({
+      signUpEmail: async () => {
+        throw new APIError("BAD_REQUEST", {
+          code: PLUS_ADDRESSING_NOT_ALLOWED_CODE,
+          message: PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE,
+        });
+      },
+    });
+    await expect(
+      provisionTrialWorkspace({ email: "user+trial@acme.com", orgName: "Acme" }, deps),
+    ).rejects.toMatchObject({
+      code: "plus_addressing",
+      message: PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE,
+    });
+    expect(calls.createOrg).toHaveLength(0);
+    expect(calls.grace).toHaveLength(0);
+    expect(calls.mcpLead).toHaveLength(0);
+  });
+
   it("rethrows a non-business-email signup throw unchanged (a generic failure stays generic)", async () => {
     // Anything other than the business-email rejection propagates untouched, so
     // the MCP layer maps it to internal_error — only the recognized deny is

--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -57,6 +57,7 @@ export type TrialProvisioningCode =
   | "not_saas"
   | "invalid_input"
   | "business_email"
+  | "plus_addressing"
   | "signup_failed"
   | "org_failed"
   | "trial_not_assigned";
@@ -222,6 +223,8 @@ function isValidEmail(email: string): boolean {
  * @throws {TrialProvisioningError} `not_saas` when deploy mode isn't SaaS;
  *   `invalid_input` for empty/malformed email or name; `business_email` when the
  *   address is freemium/disposable (the shared #3650 signup-hook deny);
+ *   `plus_addressing` when the address is plus-addressed on a non-exempt domain
+ *   (the shared #4091 signup-hook deny);
  *   `signup_failed` / `org_failed` when the Better Auth path returns no id;
  *   `trial_not_assigned` when the org landed on neither `trial` nor `locked`.
  */
@@ -292,6 +295,18 @@ export async function provisionTrialWorkspace(
       throw new TrialProvisioningError(
         "business_email",
         recognizer.BUSINESS_EMAIL_REQUIRED_MESSAGE,
+      );
+    }
+    // Plus-addressing reject (#4091) — same shared signup hook, distinct typed
+    // deny. Map to the `plus_addressing` code (→ a validation_failed envelope
+    // with a tailored hint at the MCP layer) so an agent tells the user to use
+    // their primary work email rather than re-typing the same plus-tagged one —
+    // NOT the generic internal_error a bare rethrow produces. A deny is
+    // permanent, not transient.
+    if (recognizer?.isPlusAddressingRejection(err)) {
+      throw new TrialProvisioningError(
+        "plus_addressing",
+        recognizer.PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE,
       );
     }
     throw err;

--- a/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email-signup-wiring.test.ts
@@ -32,7 +32,10 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { APIError } from "better-auth/api";
 import { buildPlugins, buildAuthOptions, parseAuthSecret } from "../server";
-import { BUSINESS_EMAIL_REQUIRED_CODE } from "../business-email";
+import {
+  BUSINESS_EMAIL_REQUIRED_CODE,
+  PLUS_ADDRESSING_NOT_ALLOWED_CODE,
+} from "../business-email";
 import { _setConfigForTest, type ResolvedConfig } from "@atlas/api/lib/config";
 
 function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
@@ -159,6 +162,28 @@ describe("databaseHooks.user.create.before — business-email deny wiring (SaaS)
     // promote:false with no DB query, so a clean business email falls through.
     expect(await rejection("founder@acme.com")).toBeUndefined();
   });
+
+  it("rejects a plus-addressed business signup with the typed plus-addressing code (#4091)", async () => {
+    const err = await rejection("user+trial@acme.com");
+    expect(err, "plus-addressed business signup must be rejected by the composed hook").toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(PLUS_ADDRESSING_NOT_ALLOWED_CODE);
+  });
+
+  it("rejects a plus-addressed freemium signup with the business-email code (business-email gate runs first)", async () => {
+    // A freemium domain is denied by the business-email gate before the
+    // plus-addressing check runs — so the more fundamental "use your work email"
+    // reason wins. Confirms deterministic ordering, not a generic duplicate error.
+    const err = await rejection("user+1@gmail.com");
+    expect(err, "plus-addressed freemium signup must still be rejected").toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(BUSINESS_EMAIL_REQUIRED_CODE);
+  });
+
+  it("allows plus-addressing on the exempt useatlas.dev domain (verify-prod-signup throwaways)", async () => {
+    // Atlas's own /verify-prod-signup E2E flow signs up plus-addressed
+    // @useatlas.dev accounts (matt+us@useatlas.dev); the exemption keeps them
+    // signable, and the ops teardown-verify-accounts guard keys on that plus-tag.
+    expect(await rejection("matt+us@useatlas.dev")).toBeUndefined();
+  });
 });
 
 describe("databaseHooks.user.create.before — business-email policy is SaaS-only", () => {
@@ -184,5 +209,10 @@ describe("databaseHooks.user.create.before — business-email policy is SaaS-onl
   it("does NOT deny when deploy mode is unresolved (config null → not saas)", async () => {
     _setConfigForTest(null);
     expect(await rejection("operator@gmail.com")).toBeUndefined();
+  });
+
+  it("does NOT deny a plus-addressed signup in self-hosted mode (#4091 is SaaS-only)", async () => {
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+    expect(await rejection("operator+tag@acme.com")).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/auth/__tests__/business-email.test.ts
+++ b/packages/api/src/lib/auth/__tests__/business-email.test.ts
@@ -14,12 +14,19 @@ import {
   BUSINESS_EMAIL_REQUIRED_CODE,
   BUSINESS_EMAIL_REQUIRED_MESSAGE,
   FREEMIUM_EMAIL_DOMAINS,
+  PLUS_ADDRESSING_EXEMPT_DOMAINS,
+  PLUS_ADDRESSING_NOT_ALLOWED_CODE,
+  PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE,
   assertBusinessEmail,
+  assertNoPlusAddressing,
   classifyBusinessEmail,
   extractEmailDomain,
+  extractEmailLocalPart,
+  hasDisallowedPlusAddressing,
   isBusinessEmailRejection,
   isDisposableEmail,
   isFreemiumEmailDomain,
+  isPlusAddressingRejection,
 } from "../business-email";
 
 describe("extractEmailDomain", () => {
@@ -130,6 +137,128 @@ describe("assertBusinessEmail", () => {
     expect(thrownBy(() => assertBusinessEmail(null))).toBeUndefined();
     expect(thrownBy(() => assertBusinessEmail(undefined))).toBeUndefined();
     expect(thrownBy(() => assertBusinessEmail(""))).toBeUndefined();
+  });
+});
+
+describe("extractEmailLocalPart", () => {
+  it("returns the local-part before the last @ (case preserved)", () => {
+    expect(extractEmailLocalPart("Alice@Acme.com")).toBe("Alice");
+    expect(extractEmailLocalPart("matt+us@useatlas.dev")).toBe("matt+us");
+    // The last @ is the delimiter, so an (illegal) embedded @ stays in the local.
+    expect(extractEmailLocalPart("weird+a@b@corp.example")).toBe("weird+a@b");
+  });
+
+  it("returns undefined for malformed / local-less input", () => {
+    expect(extractEmailLocalPart("no-at-sign")).toBeUndefined();
+    expect(extractEmailLocalPart("@domain.com")).toBeUndefined();
+  });
+});
+
+describe("hasDisallowedPlusAddressing", () => {
+  it("flags plus-addressed business and freemium domains", () => {
+    expect(hasDisallowedPlusAddressing("user+tag@acme.com")).toBe(true);
+    expect(hasDisallowedPlusAddressing("user+1@gmail.com")).toBe(true);
+  });
+
+  it("exempts plus-addressing on useatlas.dev (case-insensitive domain match)", () => {
+    expect(hasDisallowedPlusAddressing("matt+us@useatlas.dev")).toBe(false);
+    expect(hasDisallowedPlusAddressing("matt+eu@USEATLAS.DEV")).toBe(false);
+  });
+
+  it("allows non-plus addresses on any domain", () => {
+    expect(hasDisallowedPlusAddressing("user@acme.com")).toBe(false);
+    expect(hasDisallowedPlusAddressing("user@useatlas.dev")).toBe(false);
+  });
+
+  it("flags any position/count of + in the local-part (contains, not a single interior tag)", () => {
+    // The rule is "local-part contains a +", so a leading, trailing, or
+    // multiple-+ local all count — pins the `includes("+")` contract against a
+    // future refactor to a narrower anchored regex.
+    expect(hasDisallowedPlusAddressing("+tag@acme.com")).toBe(true);
+    expect(hasDisallowedPlusAddressing("user+@acme.com")).toBe(true);
+    expect(hasDisallowedPlusAddressing("a+b+c@acme.com")).toBe(true);
+    // …and the exemption still wins regardless of how many + the local has.
+    expect(hasDisallowedPlusAddressing("a+b+c@useatlas.dev")).toBe(false);
+  });
+
+  it("is safe (false) on empty / malformed input", () => {
+    expect(hasDisallowedPlusAddressing("")).toBe(false);
+    expect(hasDisallowedPlusAddressing("no-at-sign+tag")).toBe(false);
+  });
+
+  it("keeps the exempt list non-empty, lower-case, and including useatlas.dev", () => {
+    expect(PLUS_ADDRESSING_EXEMPT_DOMAINS.has("useatlas.dev")).toBe(true);
+    for (const d of PLUS_ADDRESSING_EXEMPT_DOMAINS) {
+      expect(d).toBe(d.toLowerCase());
+    }
+  });
+});
+
+describe("assertNoPlusAddressing", () => {
+  function thrownBy(fn: () => void): unknown {
+    try {
+      fn();
+    } catch (err) {
+      return err;
+    }
+    return undefined;
+  }
+
+  it("rejects a plus-addressed business email with a typed 400 APIError", () => {
+    const err = thrownBy(() => assertNoPlusAddressing("user+tag@acme.com"));
+    expect(err).toBeInstanceOf(APIError);
+    const apiErr = err as APIError;
+    expect(apiErr.statusCode).toBe(400);
+    expect(apiErr.body?.code).toBe(PLUS_ADDRESSING_NOT_ALLOWED_CODE);
+    expect(apiErr.body?.message).toBe(PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE);
+  });
+
+  it("rejects a plus-addressed freemium email too (domain-agnostic for non-exempt)", () => {
+    const err = thrownBy(() => assertNoPlusAddressing("user+1@gmail.com"));
+    expect(err).toBeInstanceOf(APIError);
+    expect((err as APIError).body?.code).toBe(PLUS_ADDRESSING_NOT_ALLOWED_CODE);
+  });
+
+  it("allows plus-addressing on the exempt useatlas.dev domain", () => {
+    expect(thrownBy(() => assertNoPlusAddressing("matt+us@useatlas.dev"))).toBeUndefined();
+    expect(thrownBy(() => assertNoPlusAddressing("matt+eu@USEATLAS.DEV"))).toBeUndefined();
+  });
+
+  it("allows a non-plus business email", () => {
+    expect(thrownBy(() => assertNoPlusAddressing("founder@acme.com"))).toBeUndefined();
+  });
+
+  it("is a no-op for null/empty email (Better Auth owns the required-field case)", () => {
+    expect(thrownBy(() => assertNoPlusAddressing(null))).toBeUndefined();
+    expect(thrownBy(() => assertNoPlusAddressing(undefined))).toBeUndefined();
+    expect(thrownBy(() => assertNoPlusAddressing(""))).toBeUndefined();
+  });
+});
+
+describe("isPlusAddressingRejection", () => {
+  it("recognizes the thrown plus-addressing rejection by stable code", () => {
+    let caught: unknown;
+    try {
+      assertNoPlusAddressing("user+tag@acme.com");
+    } catch (err) {
+      caught = err;
+    }
+    expect(isPlusAddressingRejection(caught)).toBe(true);
+  });
+
+  it("does not match unrelated errors (including the business-email reject)", () => {
+    expect(isPlusAddressingRejection(new Error("boom"))).toBe(false);
+    expect(isPlusAddressingRejection(new APIError("BAD_REQUEST", { code: "OTHER" }))).toBe(false);
+    expect(isPlusAddressingRejection(undefined)).toBe(false);
+    // The two rejections carry distinct codes — neither recognizer cross-matches.
+    let businessErr: unknown;
+    try {
+      assertBusinessEmail("user@gmail.com");
+    } catch (err) {
+      businessErr = err;
+    }
+    expect(isPlusAddressingRejection(businessErr)).toBe(false);
+    expect(isBusinessEmailRejection(businessErr)).toBe(true);
   });
 });
 

--- a/packages/api/src/lib/auth/business-email.ts
+++ b/packages/api/src/lib/auth/business-email.ts
@@ -6,9 +6,10 @@
  * (`signUpEmail` → `databaseHooks.user.create.before`), enforcing the policy in
  * that one hook makes web and MCP identical by construction.
  *
- * Two hard denies, both surfaced through a single typed `business_email_required`
- * rejection so the web layer shows one actionable message and the MCP envelope
- * (#3649) maps one stable code:
+ * The business-email policy has two hard denies, both surfaced through a single
+ * typed `business_email_required` rejection so the web layer shows one actionable
+ * message and the MCP envelope (#3649) maps one stable code (the plus-addressing
+ * reject below is a separate policy with its own code):
  *
  *  1. **Disposable / throwaway mailboxes** — detected via `better-auth-harmony`'s
  *     `validateEmail` (the same `mailchecker` engine, 50k+ domains, that the
@@ -23,6 +24,17 @@
  * The `normalizedEmail` unique column (collapsing `+alias`/dot/case variants, the
  * teeth behind one-trial-per-user) is contributed by the `emailHarmony` plugin
  * itself; this module only owns the *deny* decision.
+ *
+ * A third, separately-typed deny lives here too: the **plus-addressing reject**
+ * (#4091, {@link assertNoPlusAddressing}) — an explicit-intent layer on top of
+ * the `normalizedEmail` normalization that blocks `user+tag@domain` signups for
+ * every domain except an exempt allowlist ({@link PLUS_ADDRESSING_EXEMPT_DOMAINS},
+ * fixed to `useatlas.dev`). It carries its OWN code/message
+ * ({@link PLUS_ADDRESSING_NOT_ALLOWED_CODE}) so a plus-addressed signup gets a
+ * clear "use your primary work email" rejection rather than the freemium/
+ * disposable "use your work email" message or a duplicate-key error. The exempt
+ * allowlist is fixed in code (no override path), consistent with the
+ * business-email policy being a code module rather than an operator knob.
  *
  * Template-synced to create-atlas, so this stays dependency-light: a plain
  * `APIError` (Better Auth's HTTP error type) is thrown, no Atlas-internal imports.
@@ -122,6 +134,47 @@ export const FREEMIUM_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Plus-addressing reject (#4091).
+ *
+ * Email plus-addressing (`user+tag@acme.com`) lets one real inbox mint an
+ * unbounded number of distinct-looking addresses — and because every signup
+ * provisions a fresh user + org, that's a trial-farming / per-org-limit-evasion
+ * vector. `emailHarmony`'s `normalizedEmail` UNIQUE column already collapses
+ * `+tag` variants of the SAME base inbox (so a second plus-variant collides),
+ * but that surfaces as a confusing "account already exists" duplicate error and
+ * still accepts+stores the first plus-addressed address. This is the explicit,
+ * intentional reject layered on top: a clear typed error stating intent, not a
+ * unique-constraint side effect.
+ *
+ * EXEMPTION: Atlas's own `/verify-prod-signup` 3-region E2E flow depends on
+ * plus-addressed `@useatlas.dev` throwaway accounts (`matt+us@useatlas.dev`) —
+ * that plus-tag is the signature the `ops teardown-verify-accounts` guard keys
+ * on (`isThrowawayVerifyEmail`). So `useatlas.dev` MUST stay allowed; everyone
+ * else gets blocked. A hardcoded policy constant (not a settings knob) because
+ * this is a security policy, not an operator tuning knob.
+ */
+export const PLUS_ADDRESSING_NOT_ALLOWED_CODE = "PLUS_ADDRESSING_NOT_ALLOWED" as const;
+
+/**
+ * User-facing rejection message for a plus-addressed signup. Actionable (tells
+ * the user what to do) and leaks no internal details (no mention of the
+ * anti-abuse rationale or the exempt domain). The web signup form renders this
+ * verbatim (`res.error.message`).
+ */
+export const PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE =
+  "Plus-addressed emails aren't supported — use your primary work email.";
+
+/**
+ * Domains exempt from the plus-addressing reject — plus-addressing is allowed
+ * here. Lower-case registrable hosts, matched exactly (case-insensitively) via
+ * {@link extractEmailDomain}. Fixed to `["useatlas.dev"]` (no override path) for
+ * the verify-prod-signup carve-out documented above.
+ */
+export const PLUS_ADDRESSING_EXEMPT_DOMAINS: ReadonlySet<string> = new Set([
+  "useatlas.dev",
+]);
+
+/**
  * Extract the lower-cased domain (everything after the last `@`) from an email
  * address. Returns `undefined` for input with no `@` or an empty domain.
  */
@@ -130,6 +183,38 @@ export function extractEmailDomain(email: string): string | undefined {
   if (at < 0) return undefined;
   const domain = email.slice(at + 1).trim().toLowerCase();
   return domain.length > 0 ? domain : undefined;
+}
+
+/**
+ * Extract the local-part (everything before the last `@`) from an email address.
+ * Case is preserved (unlike {@link extractEmailDomain}) — the caller only needs
+ * to test for a literal `+`, which is case-irrelevant. Returns `undefined` for
+ * input with no `@` or an empty local-part.
+ */
+export function extractEmailLocalPart(email: string): string | undefined {
+  const at = email.lastIndexOf("@");
+  if (at <= 0) return undefined;
+  const local = email.slice(0, at);
+  return local.length > 0 ? local : undefined;
+}
+
+/**
+ * True when the email uses plus-addressing (its local-part contains a `+`) AND
+ * its domain is NOT on the {@link PLUS_ADDRESSING_EXEMPT_DOMAINS} allowlist.
+ * Empty/malformed input is reported as `false` (Better Auth owns the
+ * required-field / format case; an address with no resolvable local-part can't
+ * be plus-addressed). An address with a `+` but no resolvable domain (e.g.
+ * `a+b@`) fails closed to `true` — the exemption can't apply, and it's malformed
+ * anyway.
+ */
+export function hasDisallowedPlusAddressing(email: string): boolean {
+  const local = extractEmailLocalPart(email);
+  if (!local || !local.includes("+")) return false;
+  const domain = extractEmailDomain(email);
+  if (domain !== undefined && PLUS_ADDRESSING_EXEMPT_DOMAINS.has(domain)) {
+    return false;
+  }
+  return true;
 }
 
 /** True when the email's domain is on the freemium/consumer denylist. */
@@ -239,4 +324,55 @@ export function isBusinessEmailRejection(err: unknown): boolean {
   if (!(err instanceof APIError)) return false;
   const body = err.body as Partial<BusinessEmailErrorBody> | undefined;
   return body?.code === BUSINESS_EMAIL_REQUIRED_CODE;
+}
+
+/**
+ * Shape of the {@link APIError} body thrown on a plus-addressing rejection
+ * (#4091) — the typed contract shared by the producer
+ * ({@link assertNoPlusAddressing}), the recognizer
+ * ({@link isPlusAddressingRejection}), and the MCP `start_trial` envelope
+ * mapping. Distinct from {@link BusinessEmailErrorBody} so the two denies never
+ * cross-match and a plus-addressed signup surfaces its own actionable message
+ * rather than a generic duplicate/validation error.
+ */
+export interface PlusAddressingErrorBody {
+  code: typeof PLUS_ADDRESSING_NOT_ALLOWED_CODE;
+  message: typeof PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE;
+}
+
+/**
+ * Throw a typed {@link APIError} when `email` uses disallowed plus-addressing.
+ * No-op for an exempt domain ({@link PLUS_ADDRESSING_EXEMPT_DOMAINS}), a
+ * non-plus address, and a null/empty email (Better Auth's own validation owns
+ * the "email required" case).
+ *
+ * Called from `databaseHooks.user.create.before` (SaaS deploy mode only)
+ * alongside {@link assertBusinessEmail} so it gates EVERY SaaS signup path (web,
+ * social, MCP `start_trial`) identically. The throw aborts user creation; Better
+ * Auth serializes the `APIError` to a 400 carrying
+ * {@link PLUS_ADDRESSING_NOT_ALLOWED_CODE} + {@link PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE}.
+ *
+ * This is additive to (not a replacement for) the `emailHarmony`
+ * `normalizedEmail` normalization — see the file header.
+ */
+export function assertNoPlusAddressing(email: string | null | undefined): void {
+  if (!email) return;
+  if (!hasDisallowedPlusAddressing(email)) return;
+  const body: PlusAddressingErrorBody = {
+    code: PLUS_ADDRESSING_NOT_ALLOWED_CODE,
+    message: PLUS_ADDRESSING_NOT_ALLOWED_MESSAGE,
+  };
+  throw new APIError("BAD_REQUEST", body);
+}
+
+/**
+ * Recognize a plus-addressing rejection on a caught error. Used by the MCP
+ * `start_trial` provisioner to map the shared-signup-path failure to its typed
+ * `plus_addressing` envelope. Matches on the stable
+ * {@link PLUS_ADDRESSING_NOT_ALLOWED_CODE}, not a message string.
+ */
+export function isPlusAddressingRejection(err: unknown): boolean {
+  if (!(err instanceof APIError)) return false;
+  const body = err.body as Partial<PlusAddressingErrorBody> | undefined;
+  return body?.code === PLUS_ADDRESSING_NOT_ALLOWED_CODE;
 }

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -74,7 +74,10 @@ import { ac, owner as ownerRole, admin as adminRole, member as memberRole } from
 import { blockNativeMemberRoleUpdate, blockNativeMemberRemoval } from "@atlas/api/lib/auth/org-member-guards";
 import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { enforceBanOnSessionCreate } from "@atlas/api/lib/auth/admin-user-ops";
-import { assertBusinessEmail } from "@atlas/api/lib/auth/business-email";
+import {
+  assertBusinessEmail,
+  assertNoPlusAddressing,
+} from "@atlas/api/lib/auth/business-email";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
 import { userHasConsumedTrial, claimTrialGrant, extendTrialOnClaim } from "@atlas/api/lib/billing/trial-eligibility";
 import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
@@ -3526,8 +3529,18 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
             // (this one plus emailHarmony's normalization hook); a throw from
             // any of them aborts creation, so ordering between them doesn't
             // matter here.
+            //
+            // Plus-addressing reject (#4091) runs in the SAME SaaS-only block,
+            // AFTER the business-email gate: a freemium/disposable plus-addressed
+            // address (`a+1@gmail.com`) gets the more fundamental "use your work
+            // email" rejection, while a plus-addressed BUSINESS address
+            // (`a+1@acme.com`) gets the distinct PLUS_ADDRESSING_NOT_ALLOWED code.
+            // `useatlas.dev` is exempt so the /verify-prod-signup throwaways
+            // (`matt+us@useatlas.dev`) still sign up. Both asserts are OUTSIDE
+            // the try/catch for the same propagate-the-APIError reason.
             if (getConfig()?.deployMode === "saas") {
               assertBusinessEmail(user.email);
+              assertNoPlusAddressing(user.email);
             }
 
             try {

--- a/packages/mcp/src/__tests__/onboarding.test.ts
+++ b/packages/mcp/src/__tests__/onboarding.test.ts
@@ -218,16 +218,27 @@ describe("start_trial tool", () => {
       code:
         | "invalid_input"
         | "business_email"
+        | "plus_addressing"
         | "signup_failed"
         | "not_saas"
         | "org_failed"
         | "trial_not_assigned";
       envelopeCode: "validation_failed" | "forbidden" | "internal_error";
       expectHint?: boolean;
+      // Substring the hint must contain, pinning the distinct per-code wording
+      // (not just "a hint exists") so plus_addressing can't silently collapse
+      // into the generic business_email/signup_failed hint.
+      expectHintIncludes?: string;
       expectRequestId?: boolean;
     }> = [
       { code: "invalid_input", envelopeCode: "validation_failed" },
       { code: "business_email", envelopeCode: "validation_failed", expectHint: true },
+      {
+        code: "plus_addressing",
+        envelopeCode: "validation_failed",
+        expectHint: true,
+        expectHintIncludes: "you+tag",
+      },
       { code: "signup_failed", envelopeCode: "validation_failed", expectHint: true },
       { code: "not_saas", envelopeCode: "forbidden" },
       { code: "org_failed", envelopeCode: "internal_error", expectRequestId: true },
@@ -251,6 +262,11 @@ describe("start_trial tool", () => {
       const err = parseAtlasMcpToolError(arr[0]!.text);
       expect(err?.code).toBe(tc.envelopeCode);
       if (tc.expectHint) expect(typeof err?.hint).toBe("string");
+      if (tc.expectHintIncludes) {
+        expect(err?.hint, `hint for ${tc.code} must carry its distinct wording`).toContain(
+          tc.expectHintIncludes,
+        );
+      }
       if (tc.expectRequestId) {
         // Assert the shape, not mere truthiness — the literal string
         // "undefined" would pass `toBeTruthy()`. request_id is a UUID.

--- a/packages/mcp/src/onboarding.ts
+++ b/packages/mcp/src/onboarding.ts
@@ -138,6 +138,17 @@ function provisioningErrorResult(
           hint: "Personal and disposable email addresses aren't supported for Atlas trials — start the trial again with your work email.",
         }),
       );
+    case "plus_addressing":
+      // A plus-addressed signup on a non-exempt domain (the shared #4091
+      // signup-hook deny). Wire code stays `validation_failed` (the closed MCP
+      // envelope catalog has no dedicated code, and a plus-tagged address IS
+      // invalid trial input), but the tailored hint tells the agent to use the
+      // primary work email rather than re-typing the same plus-tagged address.
+      return toEnvelopeResult(
+        envelope("validation_failed", err.message, {
+          hint: "Plus-addressed emails (you+tag@domain) aren't supported — start the trial again with your primary work email.",
+        }),
+      );
     case "signup_failed":
       return toEnvelopeResult(
         envelope("validation_failed", err.message, {
@@ -152,6 +163,13 @@ function provisioningErrorResult(
       return toEnvelopeResult(
         envelope("internal_error", err.message, { request_id: requestId }),
       );
+    default: {
+      // Exhaustiveness guard: a new TrialProvisioningCode that forgets a case
+      // here fails to compile (tsconfig has no noImplicitReturns, so without
+      // this arm a missing case would silently return undefined).
+      const _exhaustive: never = err.code;
+      return _exhaustive;
+    }
   }
 }
 

--- a/scripts/ee-stub/src/onboarding/provision-trial.ts
+++ b/scripts/ee-stub/src/onboarding/provision-trial.ts
@@ -40,6 +40,7 @@ export type TrialProvisioningCode =
   | "not_saas"
   | "invalid_input"
   | "business_email"
+  | "plus_addressing"
   | "signup_failed"
   | "org_failed"
   | "trial_not_assigned";


### PR DESCRIPTION
## Summary

Plus-addressing (`user+tag@domain`) lets one real inbox mint an unbounded number of distinct-looking signups, each provisioning a fresh user + org — a trial-farming / per-org-limit-evasion vector. This adds an **explicit, intentionally-typed reject** layered on top of `emailHarmony`'s `normalizedEmail` collapse (additive, not a replacement).

- **`assertNoPlusAddressing()`** in `packages/api/src/lib/auth/business-email.ts` throws a distinct typed `APIError` (`PLUS_ADDRESSING_NOT_ALLOWED`, own actionable message — *not* a generic duplicate/validation error) when the local-part contains `+`, except for an exempt-domain allowlist fixed to `["useatlas.dev"]`.
- Wired into the shared `databaseHooks.user.create.before` hook (**SaaS-only**, after the business-email gate) so it gates **web, social OAuth, and MCP `start_trial`** at one chokepoint. A freemium plus address (`a+1@gmail.com`) still gets the more fundamental "use your work email" reject; a business plus address (`a+1@acme.com`) gets `PLUS_ADDRESSING_NOT_ALLOWED`.
- **`useatlas.dev` stays exempt** so Atlas's own `/verify-prod-signup` throwaway accounts (`matt+us@useatlas.dev`) still sign up and the `ops teardown-verify-accounts` plus-tag signature is preserved.
- MCP path maps the reject to a new `plus_addressing` `TrialProvisioningError` code → a `validation_failed` envelope with a tailored hint (permanent deny, not a retry-inviting `internal_error`).
- **Self-hosted is unaffected** — no plus-addressing restriction.
- No migration (pure policy logic).

## Test Plan

- [x] Manual testing — n/a (pure policy; covered by unit + wiring tests)
- [x] Unit tests added/updated — `business-email.test.ts` (helpers, typed-error contract, exemption, cross-recognizer isolation, multi-`+`/leading-`+` edge cases)
- [x] Unit tests added/updated — `business-email-signup-wiring.test.ts` (composed hook: blocked plus on business domain, freemium ordering, allowed `useatlas.dev` plus, self-hosted no-deny), `provision-trial.test.ts` + `onboarding.test.ts` (MCP `plus_addressing` envelope + distinct hint)
- [ ] E2E tests added/updated — n/a

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — all change-relevant suites green; one pre-existing network-flaky gateway-catalog test (`admin-model-config`) times out in the sandbox, unrelated to this diff
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — n/a (anti-abuse policy, no user-facing changelog surface)

Closes #4091

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiV5HPDDgJkYMbjchXbqwA)_