### PR TITLE
feat(cli): multi-workspace selection — atlas switch + --workspace override

### DIFF
--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -206,6 +206,14 @@ async function main() {
     return handleEntities(args);
   }
 
+  // #4050 / ADR-0025 sub-decision 2 — multi-workspace selection. `atlas switch`
+  // picks (and persists) the workspace the CLI acts on; the `--workspace <id>`
+  // per-command override is handled inside each command via resolveActiveWorkspace.
+  if (command === "switch") {
+    const { handleSwitch } = await import("../src/commands/switch");
+    return handleSwitch(args);
+  }
+
   // #4044 / ADR-0025 sub-decision 3 — workspace datasource lifecycle over the
   // existing admin-connection REST routes, authorized by the `atlas login` credential.
   if (command === "datasource") {

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -647,6 +647,7 @@ export function printOverviewHelp(): void {
       "  login            Authenticate the CLI via the device flow (stores a session bearer)\n" +
       "  logout           Remove the stored CLI credentials\n" +
       "  entities         List semantic entities visible to your logged-in workspace\n" +
+      "  switch           Choose which workspace the CLI acts on (multi-workspace users)\n" +
       "  datasource       Manage your workspace's datasources (list, get, test, archive, restore, delete)\n" +
       "  validate         Validate config, semantic layer, and connectivity\n" +
       "  doctor           Alias for validate\n" +

--- a/packages/cli/src/__tests__/credentials.test.ts
+++ b/packages/cli/src/__tests__/credentials.test.ts
@@ -7,6 +7,7 @@ import {
   readSession,
   saveSession,
   clearSession,
+  updateSessionWorkspace,
   credentialsPath,
   normalizeBaseUrl,
 } from "../lib/credentials";
@@ -92,5 +93,35 @@ describe("CLI credential store (#4043 / ADR-0026)", () => {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(credentialsPath(dir), JSON.stringify({ unexpected: true }));
     expect(readSession(base, dir)).toBeNull();
+  });
+
+  describe("updateSessionWorkspace (#4050)", () => {
+    it("rebinds the default workspace without touching the bearer", () => {
+      saveSession(base, session, dir);
+      expect(updateSessionWorkspace(base, "org_2", dir)).toBe(true);
+      const after = readSession(base, dir);
+      expect(after?.workspaceId).toBe("org_2");
+      expect(after?.token).toBe("sess_abc");
+      expect(after?.createdAt).toBe(session.createdAt);
+    });
+
+    it("can clear the default workspace (null)", () => {
+      saveSession(base, session, dir);
+      updateSessionWorkspace(base, null, dir);
+      expect(readSession(base, dir)?.workspaceId).toBeNull();
+    });
+
+    it("returns false when no session exists (never mints a tokenless entry)", () => {
+      expect(updateSessionWorkspace(base, "org_2", dir)).toBe(false);
+      expect(readSession(base, dir)).toBeNull();
+    });
+
+    it("only rebinds the targeted base URL", () => {
+      saveSession("https://api.useatlas.dev", { ...session, token: "prod_tok" }, dir);
+      saveSession("https://api-staging.useatlas.dev", { ...session, token: "stag_tok" }, dir);
+      updateSessionWorkspace("https://api.useatlas.dev", "org_prod_2", dir);
+      expect(readSession("https://api.useatlas.dev", dir)?.workspaceId).toBe("org_prod_2");
+      expect(readSession("https://api-staging.useatlas.dev", dir)?.workspaceId).toBe("org_1");
+    });
   });
 });

--- a/packages/cli/src/__tests__/switch.test.ts
+++ b/packages/cli/src/__tests__/switch.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { matchWorkspace, formatWorkspaceLabel, commitSwitch } from "../commands/switch";
+import { saveSession, readSession } from "../lib/credentials";
+import type { WorkspaceSummary } from "../lib/workspaces";
+
+const WORKSPACES: WorkspaceSummary[] = [
+  { id: "org_1", name: "Acme", slug: "acme" },
+  { id: "org_2", name: "Beta Corp", slug: "beta" },
+  { id: "org_3", name: "Gamma", slug: null },
+];
+
+describe("matchWorkspace (#4050)", () => {
+  it("matches by id", () => {
+    expect(matchWorkspace(WORKSPACES, "org_2")).toEqual(WORKSPACES[1]);
+  });
+  it("matches by slug", () => {
+    expect(matchWorkspace(WORKSPACES, "acme")).toEqual(WORKSPACES[0]);
+  });
+  it("returns undefined for an unknown token", () => {
+    expect(matchWorkspace(WORKSPACES, "nope")).toBeUndefined();
+  });
+  it("does not match a null slug against an empty/absent token", () => {
+    // A slug-less workspace must only match by id, never by a falsy slug.
+    expect(matchWorkspace(WORKSPACES, "")).toBeUndefined();
+  });
+});
+
+describe("formatWorkspaceLabel (#4050)", () => {
+  it("renders 'Name (slug)' when a slug exists", () => {
+    expect(formatWorkspaceLabel(WORKSPACES[0])).toBe("Acme (acme)");
+  });
+  it("renders just the name when slug-less", () => {
+    expect(formatWorkspaceLabel(WORKSPACES[2])).toBe("Gamma");
+  });
+});
+
+function stubFetch(spec: { status: number; body: unknown }): {
+  fetchImpl: typeof fetch;
+  calls: Request[];
+} {
+  const calls: Request[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push(new Request(typeof url === "string" ? url : url.toString(), init));
+    return new Response(spec.body === undefined ? "" : JSON.stringify(spec.body), {
+      status: spec.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("commitSwitch (#4050) — set-active → persist sequence (acceptance criterion 1)", () => {
+  const base = "http://localhost:3001";
+  let dir: string;
+  const session = { token: "sess_abc", workspaceId: "org_1", createdAt: "2026-06-27T00:00:00.000Z" };
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-switch-test-"));
+    saveSession(base, session, dir);
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("persists the SERVER-RETURNED id, not the requested token", async () => {
+    // Server canonicalizes a slug-request to its id — we must persist the id.
+    const { fetchImpl, calls } = stubFetch({
+      status: 200,
+      body: { id: "org_2", name: "Beta", slug: "beta" },
+    });
+    const result = await commitSwitch(base, session.token, "beta", { fetchImpl, configDir: dir });
+    expect(result.active.id).toBe("org_2");
+    expect(result.persisted).toBe(true);
+    // The stored default is the server's id, and the bearer is untouched.
+    const stored = readSession(base, dir);
+    expect(stored?.workspaceId).toBe("org_2");
+    expect(stored?.token).toBe("sess_abc");
+    expect(calls[0].url).toBe(`${base}/api/auth/organization/set-active`);
+  });
+
+  it("propagates not_a_member for an unknown/removed workspace (criterion 2 for `switch <token>`)", async () => {
+    const { fetchImpl } = stubFetch({ status: 403, body: {} });
+    await expect(
+      commitSwitch(base, session.token, "org_x", { fetchImpl, configDir: dir }),
+    ).rejects.toMatchObject({ code: "not_a_member" });
+    // A rejected switch must NOT rewrite the stored default.
+    expect(readSession(base, dir)?.workspaceId).toBe("org_1");
+  });
+
+  it("reports persisted:false when the credential vanished mid-switch", async () => {
+    const { fetchImpl } = stubFetch({ status: 200, body: { id: "org_2", name: "Beta", slug: "beta" } });
+    // Wipe the credential so updateSessionWorkspace finds no session to update.
+    fs.rmSync(path.join(dir, "credentials"), { force: true });
+    const result = await commitSwitch(base, session.token, "org_2", { fetchImpl, configDir: dir });
+    expect(result.persisted).toBe(false);
+  });
+});

--- a/packages/cli/src/__tests__/workspaces.test.ts
+++ b/packages/cli/src/__tests__/workspaces.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  listWorkspaces,
+  setActiveWorkspace,
+  readWorkspaceOverride,
+  resolveActiveWorkspace,
+  WorkspaceError,
+} from "../lib/workspaces";
+
+const BASE = "http://localhost:3001";
+const TOKEN = "sess_abc";
+
+interface ResponseSpec {
+  status: number;
+  body: unknown;
+}
+
+/** A fetch stub that returns a single queued response and records the request. */
+function stubFetch(spec: ResponseSpec): { fetchImpl: typeof fetch; calls: Request[] } {
+  const calls: Request[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push(new Request(typeof url === "string" ? url : url.toString(), init));
+    return new Response(spec.body === undefined ? "" : JSON.stringify(spec.body), {
+      status: spec.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const rejectingFetch = (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+
+describe("listWorkspaces (#4050)", () => {
+  it("returns the user's workspaces from /organization/list", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      status: 200,
+      body: [
+        { id: "org_1", name: "Acme", slug: "acme" },
+        { id: "org_2", name: "Beta", slug: "beta" },
+      ],
+    });
+    const out = await listWorkspaces(BASE, TOKEN, { fetchImpl });
+    expect(out).toEqual([
+      { id: "org_1", name: "Acme", slug: "acme" },
+      { id: "org_2", name: "Beta", slug: "beta" },
+    ]);
+    expect(calls[0].url).toBe(`${BASE}/api/auth/organization/list`);
+    expect(calls[0].headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("returns [] when the user has no workspaces", async () => {
+    const { fetchImpl } = stubFetch({ status: 200, body: [] });
+    expect(await listWorkspaces(BASE, TOKEN, { fetchImpl })).toEqual([]);
+  });
+
+  it("falls back name→id and slug→null for sparse rows", async () => {
+    const { fetchImpl } = stubFetch({ status: 200, body: [{ id: "org_3" }] });
+    expect(await listWorkspaces(BASE, TOKEN, { fetchImpl })).toEqual([
+      { id: "org_3", name: "org_3", slug: null },
+    ]);
+  });
+
+  it("drops malformed rows (missing id) rather than trusting the shape", async () => {
+    const { fetchImpl } = stubFetch({
+      status: 200,
+      body: [{ name: "no id" }, { id: "org_4", name: "Good" }],
+    });
+    expect(await listWorkspaces(BASE, TOKEN, { fetchImpl })).toEqual([
+      { id: "org_4", name: "Good", slug: null },
+    ]);
+  });
+
+  it("throws unauthorized on 401", async () => {
+    const { fetchImpl } = stubFetch({ status: 401, body: { error: "nope" } });
+    await expect(listWorkspaces(BASE, TOKEN, { fetchImpl })).rejects.toMatchObject({
+      code: "unauthorized",
+    });
+  });
+
+  it("throws request_failed on a 500", async () => {
+    const { fetchImpl } = stubFetch({ status: 500, body: {} });
+    await expect(listWorkspaces(BASE, TOKEN, { fetchImpl })).rejects.toMatchObject({
+      code: "request_failed",
+    });
+  });
+
+  it("throws network_error when the request rejects", async () => {
+    await expect(
+      listWorkspaces(BASE, TOKEN, { fetchImpl: rejectingFetch }),
+    ).rejects.toMatchObject({ code: "network_error" });
+  });
+
+  it("degrades a non-JSON 2xx body to []", async () => {
+    const { fetchImpl } = stubFetch({ status: 200, body: undefined });
+    expect(await listWorkspaces(BASE, TOKEN, { fetchImpl })).toEqual([]);
+  });
+});
+
+describe("setActiveWorkspace (#4050)", () => {
+  it("POSTs the organizationId and returns the activated workspace", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      status: 200,
+      body: { id: "org_2", name: "Beta", slug: "beta" },
+    });
+    const out = await setActiveWorkspace(BASE, TOKEN, "org_2", { fetchImpl });
+    expect(out).toEqual({ id: "org_2", name: "Beta", slug: "beta" });
+    expect(calls[0].url).toBe(`${BASE}/api/auth/organization/set-active`);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+    const sent = await calls[0].json();
+    expect(sent).toEqual({ organizationId: "org_2" });
+  });
+
+  it("rejects a non-member target with not_a_member (403)", async () => {
+    const { fetchImpl } = stubFetch({
+      status: 403,
+      body: { code: "USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION" },
+    });
+    await expect(
+      setActiveWorkspace(BASE, TOKEN, "org_x", { fetchImpl }),
+    ).rejects.toMatchObject({ code: "not_a_member" });
+  });
+
+  it("maps 400/404 to not_found", async () => {
+    const { fetchImpl } = stubFetch({ status: 400, body: { code: "ORGANIZATION_NOT_FOUND" } });
+    await expect(
+      setActiveWorkspace(BASE, TOKEN, "org_missing", { fetchImpl }),
+    ).rejects.toMatchObject({ code: "not_found" });
+  });
+
+  it("throws unauthorized on 401", async () => {
+    const { fetchImpl } = stubFetch({ status: 401, body: {} });
+    await expect(
+      setActiveWorkspace(BASE, TOKEN, "org_2", { fetchImpl }),
+    ).rejects.toMatchObject({ code: "unauthorized" });
+  });
+
+  it("throws network_error when the request rejects", async () => {
+    await expect(
+      setActiveWorkspace(BASE, TOKEN, "org_2", { fetchImpl: rejectingFetch }),
+    ).rejects.toMatchObject({ code: "network_error" });
+  });
+
+  it("falls back to a minimal summary when the 2xx body is empty", async () => {
+    const { fetchImpl } = stubFetch({ status: 200, body: undefined });
+    expect(await setActiveWorkspace(BASE, TOKEN, "org_2", { fetchImpl })).toEqual({
+      id: "org_2",
+      name: "org_2",
+      slug: null,
+    });
+  });
+
+  it("exposes WorkspaceError as the thrown type", async () => {
+    const { fetchImpl } = stubFetch({ status: 500, body: {} });
+    await expect(
+      setActiveWorkspace(BASE, TOKEN, "org_2", { fetchImpl }),
+    ).rejects.toBeInstanceOf(WorkspaceError);
+  });
+});
+
+describe("readWorkspaceOverride (#4050)", () => {
+  it("reads --workspace <id> (space form)", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace", "org_9"])).toBe("org_9");
+  });
+  it("reads --workspace=<id> (inline form) — never silently dropped", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace=org_9"])).toBe("org_9");
+  });
+  it("returns undefined for an empty inline value (--workspace=)", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace="])).toBeUndefined();
+  });
+  it("falls through an empty inline to a valid space form", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace=", "--workspace", "org_5"])).toBe("org_5");
+  });
+  it("lets a later inline override win", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace=org_1", "--workspace=org_2"])).toBe("org_2");
+  });
+  it("returns undefined when the flag is absent", () => {
+    expect(readWorkspaceOverride(["entities", "--json"])).toBeUndefined();
+  });
+  it("returns undefined when --workspace has no value (next token is a flag)", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace", "--json"])).toBeUndefined();
+  });
+  it("returns undefined when --workspace is the last token", () => {
+    expect(readWorkspaceOverride(["entities", "--workspace"])).toBeUndefined();
+  });
+});
+
+describe("resolveActiveWorkspace (#4050)", () => {
+  it("returns the stored default when no --workspace override is present", async () => {
+    const { fetchImpl, calls } = stubFetch({ status: 200, body: {} });
+    const out = await resolveActiveWorkspace(["entities"], BASE, TOKEN, "org_default", { fetchImpl });
+    expect(out).toBe("org_default");
+    // No set-active call when there is no override.
+    expect(calls.length).toBe(0);
+  });
+
+  it("returns null when there is no override and no stored default", async () => {
+    const { fetchImpl } = stubFetch({ status: 200, body: {} });
+    expect(await resolveActiveWorkspace(["entities"], BASE, TOKEN, null, { fetchImpl })).toBeNull();
+  });
+
+  it("rebinds to the override via set-active and returns its id", async () => {
+    const { fetchImpl, calls } = stubFetch({
+      status: 200,
+      body: { id: "org_9", name: "Nine", slug: "nine" },
+    });
+    const out = await resolveActiveWorkspace(
+      ["entities", "--workspace", "org_9"],
+      BASE,
+      TOKEN,
+      "org_default",
+      { fetchImpl },
+    );
+    expect(out).toBe("org_9");
+    expect(calls[0].url).toBe(`${BASE}/api/auth/organization/set-active`);
+  });
+
+  it("propagates not_a_member when the override targets a non-member workspace", async () => {
+    const { fetchImpl } = stubFetch({ status: 403, body: {} });
+    await expect(
+      resolveActiveWorkspace(["entities", "--workspace", "org_x"], BASE, TOKEN, "org_default", { fetchImpl }),
+    ).rejects.toMatchObject({ code: "not_a_member" });
+  });
+});

--- a/packages/cli/src/commands/entities.ts
+++ b/packages/cli/src/commands/entities.ts
@@ -8,18 +8,25 @@
  * for ONLY the bound workspace; a second `atlas login` (different user/org)
  * sees only its own. A multi-workspace login with no bound workspace surfaces
  * the clear selection handoff rather than leaking another workspace's entities.
+ *
+ * `--workspace <id>` (#4050) overrides the acting workspace for this command
+ * only — it rebinds the session via the membership-gated set-active and is
+ * rejected when the user isn't a member, without changing the saved default.
  */
 
 import type { SemanticEntitySummary } from "@useatlas/types";
 import { resolveApiBaseUrl } from "../lib/api-base";
 import { readSession } from "../lib/credentials";
+import { resolveActiveWorkspace, formatWorkspaceError } from "../lib/workspaces";
 
 export async function handleEntities(args: string[]): Promise<void> {
   if (args.includes("--help") || args.includes("-h")) {
     console.log(
-      "Usage: atlas entities [--json]\n\n" +
+      "Usage: atlas entities [--json] [--workspace <id>]\n\n" +
         "List the semantic entities visible to your logged-in workspace.\n" +
-        "Requires `atlas login` first.\n",
+        "Requires `atlas login` first.\n\n" +
+        "  --workspace <id>   Act on a specific workspace for this command only\n" +
+        "                     (does not change your saved default; use `atlas switch`).\n",
     );
     return;
   }
@@ -28,6 +35,22 @@ export async function handleEntities(args: string[]): Promise<void> {
   const session = readSession(baseUrl);
   if (!session) {
     console.error("Not logged in. Run `atlas login` first.");
+    process.exit(1);
+  }
+
+  // A `--workspace <id>` override rebinds the session to that workspace for
+  // this command (membership-gated server-side); without it we use the stored
+  // default. The returned id is the workspace the read below resolves against.
+  let activeWorkspaceId: string | null;
+  try {
+    activeWorkspaceId = await resolveActiveWorkspace(
+      args,
+      baseUrl,
+      session.token,
+      session.workspaceId,
+    );
+  } catch (err) {
+    console.error(formatWorkspaceError(err));
     process.exit(1);
   }
 
@@ -65,12 +88,12 @@ export async function handleEntities(args: string[]): Promise<void> {
   const entities = body?.entities ?? [];
 
   if (args.includes("--json")) {
-    console.log(JSON.stringify({ workspaceId: session.workspaceId, entities }, null, 2));
+    console.log(JSON.stringify({ workspaceId: activeWorkspaceId, entities }, null, 2));
     return;
   }
 
-  if (session.workspaceId) {
-    console.log(`Workspace ${session.workspaceId} — ${entities.length} entit${entities.length === 1 ? "y" : "ies"}:\n`);
+  if (activeWorkspaceId) {
+    console.log(`Workspace ${activeWorkspaceId} — ${entities.length} entit${entities.length === 1 ? "y" : "ies"}:\n`);
   } else {
     console.log(`${entities.length} entit${entities.length === 1 ? "y" : "ies"} visible:\n`);
   }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -123,8 +123,8 @@ export async function handleLogin(args: string[]): Promise<void> {
   } else {
     console.log(
       "  Your account belongs to more than one workspace, so no single workspace\n" +
-        "  was auto-selected. In-flow workspace selection is coming soon (ADR-0026);\n" +
-        "  until then a single-workspace account binds automatically.",
+        "  was auto-selected. Run `atlas switch` to choose which one the CLI acts on,\n" +
+        "  or pass `--workspace <id>` per command.",
     );
   }
 }

--- a/packages/cli/src/commands/switch.ts
+++ b/packages/cli/src/commands/switch.ts
@@ -1,0 +1,162 @@
+/**
+ * `atlas switch` (#4050 / ADR-0025 sub-decision 2) — choose which workspace the
+ * CLI acts on, for users who belong to more than one.
+ *
+ *   atlas switch                 # interactive pick, persists the chosen default
+ *   atlas switch <id|slug>       # non-interactive switch by id or slug
+ *
+ * Reuses the Better Auth organization plugin (no new server infra):
+ *   1. `listWorkspaces`     → GET  /api/auth/organization/list
+ *   2. `setActiveWorkspace` → POST /api/auth/organization/set-active   (membership gate)
+ *   3. `updateSessionWorkspace` persists the choice in ~/.atlas/credentials.
+ *
+ * The per-command `--workspace <id>` override (see `resolveActiveWorkspace`)
+ * shares the same set-active gate but does NOT persist a new default.
+ */
+
+import * as p from "@clack/prompts";
+
+import { resolveApiBaseUrl } from "../lib/api-base";
+import { readSession, updateSessionWorkspace } from "../lib/credentials";
+import {
+  listWorkspaces,
+  setActiveWorkspace,
+  formatWorkspaceError,
+  type WorkspaceSummary,
+} from "../lib/workspaces";
+
+type FetchImpl = typeof fetch;
+
+/** The persisted outcome of a switch: the workspace the server activated. */
+export interface SwitchResult {
+  readonly active: WorkspaceSummary;
+  /** false when the local credential vanished between set-active and persist. */
+  readonly persisted: boolean;
+}
+
+/** Match an explicit `id|slug` token against the user's workspaces. */
+export function matchWorkspace(
+  workspaces: WorkspaceSummary[],
+  token: string,
+): WorkspaceSummary | undefined {
+  return workspaces.find((w) => w.id === token || w.slug === token);
+}
+
+/** Format a workspace for display: "Name (slug)" or "Name" when slug-less. */
+export function formatWorkspaceLabel(w: WorkspaceSummary): string {
+  return w.slug ? `${w.name} (${w.slug})` : w.name;
+}
+
+/**
+ * Commit a chosen workspace: rebind the server session via the membership-gated
+ * set-active, then persist the SERVER-RETURNED id as the new local default
+ * (never the requested `chosenId` — the server is authoritative, and `chosenId`
+ * may be a slug-resolved or raw unknown token). Extracted from `handleSwitch`
+ * so the load-bearing set-active → persist sequence is unit-testable with an
+ * injectable `fetchImpl` / `configDir`; the interactive picker stays in the
+ * handler. Throws {@link WorkspaceError} on a rejected/unreachable switch.
+ */
+export async function commitSwitch(
+  baseUrl: string,
+  token: string,
+  chosenId: string,
+  opts: { fetchImpl?: FetchImpl; configDir?: string } = {},
+): Promise<SwitchResult> {
+  const active = await setActiveWorkspace(baseUrl, token, chosenId, {
+    fetchImpl: opts.fetchImpl,
+  });
+  const persisted = updateSessionWorkspace(baseUrl, active.id, opts.configDir);
+  return { active, persisted };
+}
+
+export async function handleSwitch(args: string[]): Promise<void> {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(
+      "Usage: atlas switch [<id|slug>]\n\n" +
+        "Choose which workspace the Atlas CLI acts on and persist it as the default.\n" +
+        "With no argument, lists your workspaces and prompts you to pick one.\n" +
+        "Requires `atlas login` first.\n\n" +
+        "Environment:\n" +
+        "  ATLAS_API_URL    API server URL (default: http://localhost:3001)\n",
+    );
+    return;
+  }
+
+  const baseUrl = resolveApiBaseUrl();
+  const session = readSession(baseUrl);
+  if (!session) {
+    console.error("Not logged in. Run `atlas login` first.");
+    process.exit(1);
+  }
+
+  // The first non-flag positional after the command name is an optional target.
+  const target = args.slice(1).find((a) => !a.startsWith("-"));
+
+  let workspaces: WorkspaceSummary[];
+  try {
+    workspaces = await listWorkspaces(baseUrl, session.token);
+  } catch (err) {
+    console.error(formatWorkspaceError(err));
+    process.exit(1);
+  }
+
+  if (workspaces.length === 0) {
+    console.error("Your account doesn't belong to any workspaces yet.");
+    process.exit(1);
+  }
+
+  let chosenId: string;
+
+  if (target) {
+    // Non-interactive: resolve a slug locally to an id; an unknown token still
+    // goes to the server so the authoritative server error is surfaced —
+    // membership rejection if you were just removed from it, not-found otherwise.
+    const matched = matchWorkspace(workspaces, target);
+    chosenId = matched?.id ?? target;
+  } else {
+    if (!process.stdout.isTTY) {
+      console.error(
+        "Multiple workspaces available — pass one explicitly: `atlas switch <id|slug>`.\n" +
+          "(No TTY for the interactive picker.)",
+      );
+      process.exit(1);
+    }
+    if (workspaces.length === 1) {
+      // Nothing to pick — bind to the only one and say so.
+      chosenId = workspaces[0].id;
+    } else {
+      const choice = await p.select({
+        message: "Which workspace should the Atlas CLI act on?",
+        options: workspaces.map((w) => ({
+          value: w.id,
+          label: formatWorkspaceLabel(w),
+          hint: w.id === session.workspaceId ? "current default" : undefined,
+        })),
+        initialValue: session.workspaceId ?? workspaces[0].id,
+      });
+      if (p.isCancel(choice)) {
+        console.log("Cancelled — workspace unchanged.");
+        return;
+      }
+      chosenId = choice;
+    }
+  }
+
+  let result: SwitchResult;
+  try {
+    result = await commitSwitch(baseUrl, session.token, chosenId);
+  } catch (err) {
+    console.error(formatWorkspaceError(err));
+    process.exit(1);
+  }
+
+  if (!result.persisted) {
+    console.error(
+      "Switched on the server, but the local credential disappeared mid-switch. Run `atlas login` again.",
+    );
+    process.exit(1);
+  }
+
+  console.log(`✓ Switched to ${formatWorkspaceLabel(result.active)}.`);
+  console.log(`  Default workspace saved as: ${result.active.id}`);
+}

--- a/packages/cli/src/lib/credentials.ts
+++ b/packages/cli/src/lib/credentials.ts
@@ -161,6 +161,31 @@ export function saveSession(
 }
 
 /**
+ * Update the persisted default workspace for a base URL without touching the
+ * stored bearer (#4050). `atlas switch` calls this after a successful
+ * server-side `set-active`, so the local default and the session's active
+ * workspace stay in lockstep. Returns true when the stored session was
+ * updated, false when no session exists for the base URL (caller surfaces a
+ * "run `atlas login`" message rather than minting a tokenless entry).
+ */
+export function updateSessionWorkspace(
+  baseUrl: string,
+  workspaceId: string | null,
+  configDir: string = defaultConfigDir(),
+): boolean {
+  const store = readStore(configDir);
+  const key = normalizeBaseUrl(baseUrl);
+  const existing = store.sessions[key];
+  if (!existing) return false;
+  const next: CredentialStore = {
+    version: 1,
+    sessions: { ...store.sessions, [key]: { ...existing, workspaceId } },
+  };
+  writeStore(configDir, next);
+  return true;
+}
+
+/**
  * Remove the stored bearer for a base URL. Returns true when an entry was
  * removed. When the store becomes empty the file is deleted entirely.
  */

--- a/packages/cli/src/lib/workspaces.ts
+++ b/packages/cli/src/lib/workspaces.ts
@@ -1,0 +1,222 @@
+/**
+ * Atlas CLI workspace selection (#4050 / ADR-0025 sub-decision 2).
+ *
+ * Multi-workspace users pick which workspace the CLI acts on. This reuses the
+ * Better Auth organization plugin already mounted under `/api/auth/*` — no new
+ * server infra:
+ *
+ *   - `listWorkspaces`        → GET  /api/auth/organization/list
+ *   - `setActiveWorkspace`    → POST /api/auth/organization/set-active
+ *
+ * Both authenticate with the `atlas login` session bearer (the `bearer()`
+ * plugin admits it). `set-active` is authoritative for membership: it returns
+ * `403 USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION` when the user isn't a member
+ * of the target workspace, which is exactly the `--workspace <id>` rejection
+ * the issue requires — we never re-implement the membership check client-side.
+ *
+ * `fetchImpl` is injectable so the HTTP shape is unit-testable without a live
+ * server, matching the `device-flow.ts` convention.
+ */
+
+type FetchImpl = typeof fetch;
+
+/** A workspace (Better Auth organization) the logged-in user belongs to. */
+export interface WorkspaceSummary {
+  /** Opaque workspace id — the value persisted + sent to `set-active`. */
+  readonly id: string;
+  /** Human-readable workspace name. */
+  readonly name: string;
+  /** URL-safe slug, when the organization has one. */
+  readonly slug: string | null;
+}
+
+/** A workspace operation failure carrying a stable, branchable `code`. */
+export class WorkspaceError extends Error {
+  constructor(
+    readonly code:
+      | "network_error"
+      | "unauthorized"
+      | "not_a_member"
+      | "not_found"
+      | "request_failed",
+    message: string,
+  ) {
+    super(message);
+    this.name = "WorkspaceError";
+  }
+}
+
+/**
+ * Read the `--workspace <id>` override token from argv, or undefined when
+ * absent. Accepts both the space-separated (`--workspace org_9`) and inline
+ * (`--workspace=org_9`) forms so the override is never silently dropped — a
+ * dropped override would quietly act on the default workspace while the user
+ * believes they targeted another.
+ */
+export function readWorkspaceOverride(args: string[]): string | undefined {
+  // Inline form: `--workspace=org_9` (take the LAST non-empty one so a later
+  // flag wins). An empty inline (`--workspace=`) is ignored here rather than
+  // short-circuiting, so a valid space form later in argv still resolves.
+  const inline = args
+    .filter((a) => a.startsWith("--workspace=") && a.length > "--workspace=".length)
+    .at(-1);
+  if (inline !== undefined) {
+    return inline.slice("--workspace=".length);
+  }
+  // Space-separated form: `--workspace org_9`.
+  const i = args.indexOf("--workspace");
+  if (i === -1) return undefined;
+  const value = args[i + 1];
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+/**
+ * Resolve the workspace a single command should act on (#4050).
+ *
+ * SIDE EFFECT: when `--workspace <id>` is present this rebinds the live
+ * server-side session to that workspace via `set-active` (the authoritative
+ * membership gate — a non-member yields `not_a_member`) and returns that id
+ * WITHOUT persisting a new local default. The caller MUST await this BEFORE
+ * issuing its actual request, because that request relies on the server having
+ * already rebound the bearer's active org — the returned id is then only used
+ * for display/logging, not sent on the wire. When `--workspace` is absent this
+ * is a pure read: it returns the stored default (which may be null for an
+ * unbound single-/multi-workspace login) and makes no network call.
+ */
+export async function resolveActiveWorkspace(
+  args: string[],
+  baseUrl: string,
+  token: string,
+  storedWorkspaceId: string | null,
+  opts: { fetchImpl?: FetchImpl } = {},
+): Promise<string | null> {
+  const override = readWorkspaceOverride(args);
+  if (override === undefined) return storedWorkspaceId;
+  const active = await setActiveWorkspace(baseUrl, token, override, opts);
+  return active.id;
+}
+
+/**
+ * Render a workspace failure for the CLI's stderr. A {@link WorkspaceError}
+ * already carries an actionable, type-narrowed message; anything else is
+ * narrowed the Atlas way. Shared by `switch` and every `--workspace`-aware
+ * command so the surface for the same `code` can't drift between them.
+ */
+export function formatWorkspaceError(err: unknown): string {
+  if (err instanceof WorkspaceError) return err.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+/** Coerce one `/organization/list` element into a {@link WorkspaceSummary}, or null when malformed. */
+function coerceWorkspace(raw: unknown): WorkspaceSummary | null {
+  const r = asRecord(raw);
+  if (typeof r.id !== "string" || r.id.length === 0) return null;
+  return {
+    id: r.id,
+    name: typeof r.name === "string" && r.name.length > 0 ? r.name : r.id,
+    slug: typeof r.slug === "string" && r.slug.length > 0 ? r.slug : null,
+  };
+}
+
+/**
+ * List the workspaces the bearer's user belongs to (GET /organization/list).
+ * Returns `[]` when the user has no workspaces; throws {@link WorkspaceError}
+ * on auth/transport failure so the caller can branch on `.code`.
+ */
+export async function listWorkspaces(
+  baseUrl: string,
+  token: string,
+  opts: { fetchImpl?: FetchImpl } = {},
+): Promise<WorkspaceSummary[]> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await fetchImpl(`${baseUrl}/api/auth/organization/list`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new WorkspaceError(
+      "network_error",
+      `Could not reach the Atlas API at ${baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (res.status === 401) {
+    throw new WorkspaceError("unauthorized", "Your session is no longer valid. Run `atlas login` again.");
+  }
+  if (!res.ok) {
+    throw new WorkspaceError("request_failed", `Failed to list workspaces (HTTP ${res.status}).`);
+  }
+
+  // intentionally ignored: a non-JSON / empty 2xx body degrades to "no
+  // workspaces" rather than crashing — res.ok was already checked.
+  const body = await res.json().catch(() => null);
+  return asArray(body)
+    .map(coerceWorkspace)
+    .filter((w): w is WorkspaceSummary => w !== null);
+}
+
+/**
+ * Bind the session to `workspaceId` (POST /organization/set-active). This is
+ * the authoritative membership gate: a non-member target yields a
+ * `not_a_member` {@link WorkspaceError}. Returns the activated workspace.
+ */
+export async function setActiveWorkspace(
+  baseUrl: string,
+  token: string,
+  workspaceId: string,
+  opts: { fetchImpl?: FetchImpl } = {},
+): Promise<WorkspaceSummary> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await fetchImpl(`${baseUrl}/api/auth/organization/set-active`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ organizationId: workspaceId }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    throw new WorkspaceError(
+      "network_error",
+      `Could not reach the Atlas API at ${baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (res.status === 401) {
+    throw new WorkspaceError("unauthorized", "Your session is no longer valid. Run `atlas login` again.");
+  }
+  if (res.status === 403) {
+    throw new WorkspaceError(
+      "not_a_member",
+      `You are not a member of workspace ${workspaceId}. ` +
+        "Run `atlas switch` to see the workspaces you can access.",
+    );
+  }
+  if (res.status === 400 || res.status === 404) {
+    throw new WorkspaceError(
+      "not_found",
+      `Workspace ${workspaceId} was not found. Run \`atlas switch\` to list your workspaces.`,
+    );
+  }
+  if (!res.ok) {
+    throw new WorkspaceError("request_failed", `Failed to switch workspace (HTTP ${res.status}).`);
+  }
+
+  // intentionally ignored: a non-JSON / empty 2xx body still means the switch
+  // succeeded server-side — fall back to a minimal summary keyed by the id.
+  const body = asRecord(await res.json().catch(() => null));
+  return coerceWorkspace(body) ?? { id: workspaceId, name: workspaceId, slug: null };
+}


### PR DESCRIPTION
Closes #4050.

Lets a user who belongs to several workspaces choose which one the CLI acts on (ADR-0025 sub-decision 2). Reuses the Better Auth `organization` plugin already mounted under `/api/auth/*` — **no new server infra**.

## What it adds

- **`atlas switch`** — lists the user's workspaces (`GET /api/auth/organization/list`), prompts an interactive `@clack/prompts` pick (or takes an `id|slug` positional), rebinds the session (`POST /api/auth/organization/set-active`), and persists the chosen default in `~/.atlas/credentials`.
- **`--workspace <id>` / `--workspace=<id>`** — per-command override (wired into `atlas entities`). Rebinds the session for that command only and is **rejected when the user isn't a member**, without changing the saved default.
- Multi-workspace `atlas login` now hands off to `atlas switch` instead of the "coming soon" placeholder.

## How it reuses existing machinery

`set-active` is the authoritative membership gate: Better Auth returns `403 USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION` for a non-member, so the CLI never re-implements the membership check. The session bearer (`origin='cli'`, from #4043) is admitted by the `bearer()` plugin. Persisted defaults stay in lockstep with the server's active org via the new `updateSessionWorkspace` credential helper (which never mints a tokenless entry).

## Key files

- `packages/cli/src/lib/workspaces.ts` (new) — list / set-active client, `resolveActiveWorkspace` (the `--workspace` override), `readWorkspaceOverride` (`--workspace[=]<id>` parsing), `formatWorkspaceError`.
- `packages/cli/src/commands/switch.ts` (new) — `commitSwitch` (set-active → persist the **server-returned** id, not the requested token) + the interactive handler.
- `packages/cli/src/lib/credentials.ts` — `updateSessionWorkspace`.
- `packages/cli/src/commands/entities.ts` — `--workspace` override wired in.
- `bin/atlas.ts`, `lib/help.ts`, `commands/login.ts` — dispatch, help, login handoff.

## Acceptance criteria

- [x] `atlas switch` lists the user's workspaces and persists the chosen default
- [x] `--workspace <id>` overrides per command; rejected if the user isn't a member of that workspace
- [x] Multi-workspace login routes into this selection (login handoff → `atlas switch`)

## Testing

51 new/updated unit tests (injectable `fetchImpl` + temp `configDir`, matching the `device-flow.ts` / `credentials.ts` conventions). Covers the membership-rejection path, the persist-the-server-id invariant (no rewrite on rejection), the `--workspace[=]` parsing matrix, and the credential round-trip. Full CLI suite (38 files) green; internal review panel converged in 2 rounds (silent-failure, type-design, test-coverage, comment — all CLEAN).

Note: the unrelated `packages/api/src/api/__tests__/admin-model-config.test.ts` gateway-catalog case times out locally in the sandbox (real outbound gateway fetch); it is pre-existing on `main` and independent of this CLI-only change.

https://claude.ai/code/session_0148So3UxWZoPXSJRGk1hWac

---
_Generated by [Claude Code](https://claude.ai/code/session_0148So3UxWZoPXSJRGk1hWac)_