### PR TITLE
fix(api): stamp actor_kind=api_key + re-thread atlasMode on the sibling CLI routes

### DIFF
--- a/packages/api/src/api/__tests__/datasources.test.ts
+++ b/packages/api/src/api/__tests__/datasources.test.ts
@@ -363,6 +363,28 @@ describe("POST /datasources/{id}/profile — NDJSON streaming (#4052)", () => {
     expect(capturedContext.actorKind).toBe("human");
   });
 
+  it("stamps actor.kind=api_key for an unattended workspace API key (#4046 / ADR-0027 §6)", async () => {
+    // The api-key auth path marks the resolved user with claims.api_key=true and
+    // keeps origin=cli (the CLI transport). The profiler persists drafts under
+    // this bound context, so the trail must distinguish the unattended key from
+    // a human device-flow login rather than flatten both to `human`.
+    mockAuthenticateRequest.mockResolvedValue({
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: {
+        id: "user-1",
+        mode: "managed",
+        label: "Alice",
+        role: "admin",
+        activeOrganizationId: "org-1",
+        claims: { sub: "user-1", org_id: "org-1", origin: "cli", api_key: true },
+      },
+    } as unknown as AuthResult);
+    await app.fetch(profileRequest("prod-us"));
+    expect(capturedContext.agentOrigin).toBe("cli");
+    expect(capturedContext.actorKind).toBe("api_key");
+  });
+
   it("closes the live connection after profiling settles", async () => {
     await app.fetch(profileRequest("prod-us"));
     expect(fakeConnection.close).toHaveBeenCalled();

--- a/packages/api/src/api/__tests__/metrics.test.ts
+++ b/packages/api/src/api/__tests__/metrics.test.ts
@@ -106,13 +106,17 @@ mock.module("@atlas/api/lib/semantic/metric-run", () => ({
 // (AsyncLocalStorage) by reading getRequestContext() inside the pipeline mock,
 // plus the opts the route forwards (sql + connectionId).
 type PipelineOpts = { sql: string; explanation: string; connectionId?: string };
-let capturedContext: { agentOrigin?: unknown; actorKind?: unknown } = {};
+let capturedContext: { agentOrigin?: unknown; actorKind?: unknown; atlasMode?: unknown } = {};
 let capturedOpts: PipelineOpts | undefined;
 const mockRunUserQueryPipeline: Mock<(opts: PipelineOpts) => Promise<UserQueryOutcome>> = mock(
   async (opts: PipelineOpts) => {
     const { getRequestContext } = await import("@atlas/api/lib/logger");
     const ctx = getRequestContext();
-    capturedContext = { agentOrigin: ctx?.agentOrigin, actorKind: ctx?.actor?.kind };
+    capturedContext = {
+      agentOrigin: ctx?.agentOrigin,
+      actorKind: ctx?.actor?.kind,
+      atlasMode: ctx?.atlasMode,
+    };
     capturedOpts = opts;
     return {
       kind: "ok" as const,
@@ -147,10 +151,11 @@ app.route("/api/v1/metrics", metrics);
 function runMetricRequest(
   id: string,
   body?: Record<string, unknown>,
+  headers?: Record<string, string>,
 ): Request {
   return new Request(`http://localhost/api/v1/metrics/${id}/run`, {
     method: "POST",
-    headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
+    headers: { Authorization: "Bearer test", "Content-Type": "application/json", ...headers },
     body: JSON.stringify(body ?? {}),
   });
 }
@@ -182,7 +187,11 @@ beforeEach(() => {
   mockRunUserQueryPipeline.mockImplementation(async (opts: PipelineOpts) => {
     const { getRequestContext } = await import("@atlas/api/lib/logger");
     const ctx = getRequestContext();
-    capturedContext = { agentOrigin: ctx?.agentOrigin, actorKind: ctx?.actor?.kind };
+    capturedContext = {
+      agentOrigin: ctx?.agentOrigin,
+      actorKind: ctx?.actor?.kind,
+      atlasMode: ctx?.atlasMode,
+    };
     capturedOpts = opts;
     return {
       kind: "ok" as const,
@@ -327,6 +336,53 @@ describe("POST /api/v1/metrics/{id}/run", () => {
     await app.fetch(runMetricRequest("total_gmv"));
     expect(capturedContext.agentOrigin).toBe("cli");
     expect(capturedContext.actorKind).toBe("human");
+  });
+
+  it("stamps actor.kind=api_key for an unattended workspace API key (#4046 / ADR-0027 §6)", async () => {
+    // The api-key auth path marks the resolved user with claims.api_key=true and
+    // keeps origin=cli (the CLI transport). This metric run is written to
+    // audit_log by runUserQueryPipeline, so the trail must distinguish the
+    // unattended key from a human device-flow login — parity with execute-sql.
+    mockAuthenticateRequest.mockResolvedValue({
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: {
+        id: "user-1",
+        mode: "managed",
+        label: "Alice",
+        role: "member",
+        activeOrganizationId: "org-1",
+        claims: { sub: "user-1", org_id: "org-1", origin: "cli", api_key: true },
+      },
+    } as unknown as AuthResult);
+    await app.fetch(runMetricRequest("total_gmv"));
+    expect(capturedContext.agentOrigin).toBe("cli");
+    expect(capturedContext.actorKind).toBe("api_key");
+  });
+
+  it("re-threads the developer atlasMode through the inner bind (withRequestContext replaces, not merges)", async () => {
+    // Regression guard for the sibling-route parity gap: the inner
+    // withRequestContext is AsyncLocalStorage.run, which REPLACES the context.
+    // Dropping atlasMode would silently downgrade a developer-mode caller to the
+    // published overlay inside runUserQueryPipeline (it reads
+    // reqCtx.atlasMode ?? "published" for connection mode-visibility + the table
+    // whitelist scope). Use an owner + the developer-mode header so standardAuth
+    // resolves atlasMode="developer" (members always resolve to published, which
+    // would mask the bug).
+    mockAuthenticateRequest.mockResolvedValue({
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: {
+        id: "user-1",
+        mode: "managed",
+        label: "Alice",
+        role: "owner",
+        activeOrganizationId: "org-1",
+        claims: { sub: "user-1", org_id: "org-1", origin: "cli" },
+      },
+    } as unknown as AuthResult);
+    await app.fetch(runMetricRequest("total_gmv", undefined, { "x-atlas-mode": "developer" }));
+    expect(capturedContext.atlasMode).toBe("developer");
   });
 
   it("falls back to origin=cli when the credential carries no origin claim", async () => {

--- a/packages/api/src/api/routes/datasources.ts
+++ b/packages/api/src/api/routes/datasources.ts
@@ -63,6 +63,7 @@ import {
   type AgentBillingGateResult,
 } from "@atlas/api/lib/billing/agent-gate";
 import { isRequestOrigin } from "@atlas/api/lib/approvals/types";
+import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema } from "./shared-schemas";
@@ -296,6 +297,13 @@ datasources.openapi(profileRoute, async (c) => {
   const agentOrigin =
     typeof claimOrigin === "string" && isRequestOrigin(claimOrigin) ? claimOrigin : "cli";
 
+  // `actor.kind` is the *who*, distinct from `origin` (the transport): `api_key`
+  // for an UNATTENDED workspace key (#4046 / ADR-0027 §6), else `human`. The
+  // profiler persists drafts under the org inside this bound context, so the
+  // marker is kept correct for parity with the sibling routes (shared via
+  // `resolveActorKind`) rather than flattened to `human`.
+  const actorKind = resolveActorKind(user?.claims);
+
   // --- Stream NDJSON. The progress bridge writes a line per profiler callback;
   // the profiler runs inside the bound request context (origin=cli + actor.kind)
   // so its draft-persist + any approval/audit path traces to the owning member. ---
@@ -339,7 +347,7 @@ datasources.openapi(profileRoute, async (c) => {
             user,
             atlasMode,
             trustDeviceIdentifier,
-            actor: { kind: "human" },
+            actor: { kind: actorKind },
             agentOrigin,
           },
           () =>

--- a/packages/api/src/api/routes/execute-sql.ts
+++ b/packages/api/src/api/routes/execute-sql.ts
@@ -44,10 +44,10 @@
  *  - Audited with a credential-derived origin (`cli` for a device-flow `atlas`
  *    bearer; left undefined for a non-CLI session, never mislabeled) + a distinct
  *    `actor_kind` traceable to the owning member: the handler binds `agentOrigin`
- *    (derived from the credential's `origin` claim, NOT hardcoded) +
- *    `actor: { kind: "human" }` into the request context so the audit row written
- *    by the pipeline traces to the real member who minted the device-flow login
- *    (ADR-0027 §6). The unattended-key `api_key` actor_kind layers in with #4046.
+ *    (derived from the credential's `origin` claim, NOT hardcoded) + an
+ *    `actor.kind` of `api_key` for an unattended workspace key (#4046) or `human`
+ *    otherwise, so the audit row written by the pipeline distinguishes a leaked
+ *    CI key from the real member who minted a device-flow login (ADR-0027 §6).
  *  - Rate limit reuses the standard per-identity bucket (inherited from
  *    `standardAuth`); per-workspace pool + auto-LIMIT + statement timeout bound
  *    the blast radius (ADR-0027 §7).
@@ -64,7 +64,7 @@ import {
   type AgentBillingGateResult,
 } from "@atlas/api/lib/billing/agent-gate";
 import { isRequestOrigin } from "@atlas/api/lib/approvals/types";
-import { API_KEY_MARKER_CLAIM } from "@atlas/api/lib/auth/api-key-metadata";
+import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import type { UserQueryOutcome } from "@atlas/api/lib/tools/sql";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema } from "./shared-schemas";
@@ -376,10 +376,11 @@ executeSql.openapi(executeSqlRoute, async (c) => {
       // human who approved a device-flow `atlas login` in a browser → `human`; an
       // UNATTENDED workspace API key (#4046 / ADR-0027 §6) → `api_key`, so a
       // leaked CI key vs a compromised human session are distinguishable in the
-      // audit trail. The marker is stamped on the resolved user by the api-key
-      // auth path (`managed.ts` → `claims.api_key`).
-      const actorKind: "human" | "api_key" =
-        user?.claims?.[API_KEY_MARKER_CLAIM] === true ? "api_key" : "human";
+      // audit trail. Shared with the sibling CLI routes (metrics/explore/
+      // datasources) via `resolveActorKind` so the marker — stamped on the
+      // resolved user by the api-key auth path (`managed.ts` → `claims.api_key`)
+      // — is read consistently across the whole surface a key can reach.
+      const actorKind = resolveActorKind(user?.claims);
 
       // Re-establish the request context as a SUPERSET of the middleware's bind
       // (`user` + `atlasMode` + `trustDeviceIdentifier`) PLUS the audit origin +

--- a/packages/api/src/api/routes/explore.ts
+++ b/packages/api/src/api/routes/explore.ts
@@ -38,6 +38,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { isRequestOrigin } from "@atlas/api/lib/approvals/types";
+import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 
@@ -162,20 +163,25 @@ explore.openapi(
         ? claimsOrigin
         : undefined;
 
+    // `actor.kind` derives from the credential — `api_key` for an unattended
+    // workspace key (#4046 / ADR-0027 §6), else `human` — shared with the
+    // sibling routes via `resolveActorKind`. Explore writes no `audit_log` row,
+    // so the marker only feeds the approval context here, but it is kept correct
+    // for parity so the CLI-reachable surface can't drift.
+    const actorKind = resolveActorKind(user?.claims);
+
     // Re-establish the request context as a SUPERSET of the middleware's bind
     // (`user` + `atlasMode` + `trustDeviceIdentifier`) PLUS the audit origin +
     // a distinct actor kind, so any downstream approval/audit path traces to
     // the real owning member (ADR-0027 sub-decision 6) AND `exploreTool.execute`
     // still resolves the correct org-scoped, mode-specific semantic root.
-    // `actor.kind` is `human` for the device-flow human; unattended workspace
-    // keys (a distinct kind) are #4046's responsibility.
     return withRequestContext(
       {
         requestId,
         user,
         atlasMode,
         trustDeviceIdentifier,
-        actor: { kind: "human" },
+        actor: { kind: actorKind },
         ...(agentOrigin ? { agentOrigin } : {}),
       },
       async () => {

--- a/packages/api/src/api/routes/metrics.ts
+++ b/packages/api/src/api/routes/metrics.ts
@@ -39,6 +39,7 @@ import {
 } from "@atlas/api/lib/billing/agent-gate";
 import { resolveMetricRun } from "@atlas/api/lib/semantic/metric-run";
 import { isRequestOrigin } from "@atlas/api/lib/approvals/types";
+import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import type { UserQueryOutcome } from "@atlas/api/lib/tools/sql";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema } from "./shared-schemas";
@@ -359,18 +360,43 @@ metrics.openapi(runMetricRoute, async (c) => {
       // Origin for approval-rule matching + audit: the credential's resolved
       // origin claim (`cli` for an `atlas login` device-flow bearer), falling
       // back to `cli` — this endpoint is the workspace CLI metric-run surface.
-      // `actor.kind = human`: the device-flow login is a person who approved in
-      // a browser (ADR-0027 §6). The unattended-key `api_key` actor_kind is
-      // #4046's responsibility, not this slice.
       const claimOrigin = user?.claims?.origin;
       const agentOrigin =
         typeof claimOrigin === "string" && isRequestOrigin(claimOrigin) ? claimOrigin : "cli";
 
-      // Bind the actor + origin into AsyncLocalStorage so runUserQueryPipeline's
-      // RLS claims, approval matching, and audit row all see the bound caller.
+      // `actor.kind` is the *who*, distinct from `origin` (the transport): a
+      // human who approved a device-flow `atlas login` → `human`; an UNATTENDED
+      // workspace API key (#4046 / ADR-0027 §6) → `api_key`. This metric run is
+      // written to `audit_log` by `runUserQueryPipeline`, so flattening it to
+      // `human` would make a leaked CI key indistinguishable from a compromised
+      // human session in the trail — shared with the sibling routes via
+      // `resolveActorKind`.
+      const actorKind = resolveActorKind(user?.claims);
+
+      // The outer `requestContext` middleware bound these (it ran first); we
+      // re-thread them through the inner bind because `withRequestContext` is
+      // `AsyncLocalStorage.run` — it REPLACES the context, it does not merge.
+      // Dropping `atlasMode` would silently downgrade a developer-mode caller to
+      // the published overlay inside `runUserQueryPipeline` (it reads
+      // `reqCtx.atlasMode ?? "published"` for connection mode-visibility AND the
+      // table whitelist scope), so a draft metric / freshly-profiled draft
+      // connection would resolve against the wrong overlay.
+      const atlasMode = c.get("atlasMode");
+      const trustDeviceIdentifier = c.get("trustDeviceIdentifier");
+
+      // Bind the actor + origin + mode into AsyncLocalStorage so
+      // runUserQueryPipeline's RLS claims, approval matching, audit row, and
+      // mode-scoped connection + whitelist resolution all see the bound caller.
       const outcome = yield* Effect.promise(() =>
         withRequestContext(
-          { requestId, user, agentOrigin, actor: { kind: "human" } },
+          {
+            requestId,
+            user,
+            atlasMode,
+            trustDeviceIdentifier,
+            agentOrigin,
+            actor: { kind: actorKind },
+          },
           async () => {
             const { runUserQueryPipeline } = await import("@atlas/api/lib/tools/sql");
             return runUserQueryPipeline({

--- a/packages/api/src/lib/auth/api-key-metadata.ts
+++ b/packages/api/src/lib/auth/api-key-metadata.ts
@@ -47,6 +47,24 @@ import { parseRole } from "@atlas/api/lib/auth/permissions";
 export const API_KEY_MARKER_CLAIM = "api_key" as const;
 
 /**
+ * Resolve the audit `actor.kind` for a request from its resolved user's claims:
+ * `"api_key"` when the workspace-API-key auth path stamped
+ * {@link API_KEY_MARKER_CLAIM} (`managed.ts` → `claims.api_key = true`), else
+ * `"human"` (a device-flow `atlas login` bearer or any interactive session).
+ *
+ * This is the *who*, kept distinct from the `claims.origin` *transport* (see
+ * {@link API_KEY_MARKER_CLAIM}). Shared by every CLI-reachable REST route
+ * (execute-sql, metrics, explore, datasources) so an unattended CI key is
+ * stamped consistently across the whole surface it can reach — flattening it to
+ * `"human"` on any one route would be a lie in the audit trail (ADR-0027 §6).
+ */
+export function resolveActorKind(
+  claims: Record<string, unknown> | null | undefined,
+): "human" | "api_key" {
+  return claims?.[API_KEY_MARKER_CLAIM] === true ? "api_key" : "human";
+}
+
+/**
  * The canonical workspace-API-key metadata shape, as resolved back from an
  * untrusted Better Auth metadata bag. `role` is optional because a malformed /
  * absent role is tolerated (the live member role is authoritative at use time);


### PR DESCRIPTION
## Why

Milestone-wide review of #77 (CLI REST-backed suite & API keys) surfaced one real cross-PR bug that per-branch review structurally couldn't see: the #4046 workspace-API-key audit discriminator (`actor_kind=api_key`; migration `0160` / ADR-0027 §6) was wired into the `execute-sql` route but **not** its three siblings.

Flagged independently by 5 of 6 review specialists (security, silent-failure, consistency, guidelines, tests).

## What was wrong

- **`metrics.ts` audited API-key runs as `human`.** The route is `standardAuth` (reachable by `x-api-key`) and writes to `audit_log` via `runUserQueryPipeline`, but hardcoded `actor: { kind: "human" }`. So a metric run by a leaked/unattended workspace key was indistinguishable from a compromised human session in the trail — defeating the exact purpose migration `0160` added the `api_key` enum value for.
- **`metrics.ts` also dropped `atlasMode` + `trustDeviceIdentifier`** when re-binding the request context. `withRequestContext` is `AsyncLocalStorage.run` — it *replaces*, not merges — so a developer-mode caller was silently downgraded to the **published** overlay for connection mode-visibility AND the table whitelist scope (a draft metric / freshly-profiled draft connection would resolve against the wrong overlay). The three sibling routes already re-thread these.

## Change

- Extract **`resolveActorKind`** into `lib/auth/api-key-metadata.ts` and use it in all four CLI-reachable routes (`execute-sql`, `metrics`, `explore`, `datasources`) so the marker is read consistently across the whole surface a key can reach.
- Re-thread `atlasMode`/`trustDeviceIdentifier` in `metrics.ts` to match the siblings.
- `explore`/`datasources` write no `audit_log` row today, but are kept correct for parity + approval context (and so the surface can't drift).
- Remove the now-stale `// ... #4046's responsibility, not this slice` deferral comments — #4046 shipped in this milestone.

## Tests

- `actor.kind=api_key` parity tests on `metrics` + `datasources` (mirrors the existing `execute-sql` case).
- `metrics` `atlasMode` re-thread regression guard (owner + `x-atlas-mode: developer` → resolves developer → asserts it survives the inner bind).
- Local: 91 pass / 0 fail across the 4 affected test files; repo `bun run type` green; eslint clean.

## Scope

Closeout polish for #77 (no open issues remain in the milestone). The broader P2s from the same review (workspace-key blast radius, arbitrary RLS claims on mint, CLI api-key parity, wire-type SSOT) are filed as separate tracked issues — not blockers.