### PR TITLE
fix(api): metric-run degraded-routing → 503/internal_error, not misleading 400/validation_failed (#4109)

### DIFF
--- a/packages/api/src/api/__tests__/metrics.test.ts
+++ b/packages/api/src/api/__tests__/metrics.test.ts
@@ -307,6 +307,26 @@ describe("POST /api/v1/metrics/{id}/run", () => {
     expect(res.status).toBe(400);
   });
 
+  it("maps a degraded routing lookup to a retryable 503, not a 400 wrong_connection (#4109)", async () => {
+    // When the internal-DB membership lookup faults, resolveMetricRun returns
+    // `routing_unavailable` rather than a confident `wrong_connection`. The route
+    // must surface that as a retryable 503 carrying the requestId — an operator
+    // debugging this sees the server-side fault, not a misleading user-input 400.
+    mockResolveMetricRun.mockResolvedValue({
+      kind: "routing_unavailable",
+      metricId: "prod_signups",
+      connectionId: "us-prod",
+    });
+    const res = await app.fetch(runMetricRequest("prod_signups", { connectionId: "us-prod" }));
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("routing_unavailable");
+    expect(body.retryable).toBe(true);
+    expect(body.requestId).toBeDefined();
+    // Routing couldn't be resolved, so the SQL pipeline must NOT run.
+    expect(mockRunUserQueryPipeline).not.toHaveBeenCalled();
+  });
+
   it("maps an RLS failure to 403", async () => {
     mockRunUserQueryPipeline.mockResolvedValueOnce({
       kind: "rls_failed",

--- a/packages/api/src/api/routes/metrics.ts
+++ b/packages/api/src/api/routes/metrics.ts
@@ -351,6 +351,33 @@ metrics.openapi(runMetricRoute, async (c) => {
           400,
         );
       }
+      if (resolution.kind === "routing_unavailable") {
+        // The internal-DB lookup that validates the explicit connection's group
+        // membership faulted. We can't prove or disprove membership, so this is
+        // a retryable server-side condition — NOT a confident wrong_connection
+        // 400 (#4109). Surface it as a 503 carrying the requestId so an operator
+        // sees the real fault, not a misleading user-input error.
+        log.warn(
+          {
+            requestId,
+            orgId,
+            metricId: resolution.metricId,
+            connectionId: resolution.connectionId,
+            category: "routing_unavailable",
+          },
+          "Metric-run group-membership lookup degraded (internal DB fault) — returning retryable 503",
+        );
+        return c.json(
+          {
+            error: "routing_unavailable",
+            message:
+              "Could not verify the connection's group membership right now (a transient internal error). Please retry shortly.",
+            retryable: true,
+            requestId,
+          } as never,
+          503,
+        );
+      }
 
       const { metric, targetConnectionId } = resolution;
       const explanation = metric.description

--- a/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
@@ -129,6 +129,7 @@ mock.module("@atlas/api/lib/env-routing/lookup", () => ({
     members: mockGroupMembers,
     primaryMember: mockPrimaryMember,
     currentMember,
+    degraded: false,
   }),
 }));
 

--- a/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
@@ -131,6 +131,7 @@ mock.module("@atlas/api/lib/env-routing/lookup", () => ({
     members: mockGroupMembers,
     primaryMember: mockPrimaryMember,
     currentMember,
+    degraded: false,
   }),
 }));
 

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -158,8 +158,8 @@ mock.module("@atlas/api/lib/env-routing/lookup", () => ({
     // #3044 "no environment context" path is reachable; everything else is the
     // 3-member `prod` group the scope-routing tests rely on.
     currentMember === "ungrouped-conn"
-      ? { members: ["ungrouped-conn"], primaryMember: "ungrouped-conn", currentMember }
-      : { groupId: "prod", members: ["us-int", "eu", "apac"], primaryMember: "us-int", currentMember },
+      ? { members: ["ungrouped-conn"], primaryMember: "ungrouped-conn", currentMember, degraded: false }
+      : { groupId: "prod", members: ["us-int", "eu", "apac"], primaryMember: "us-int", currentMember, degraded: false },
 }));
 
 mock.module("@atlas/api/lib/cache/index", () => ({

--- a/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
+++ b/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
@@ -55,6 +55,8 @@ describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
       members: ["conn-a"],
       primaryMember: "conn-a",
       currentMember: "conn-a",
+      // #4109 — a legitimate (non-fault) fallback is degraded: false.
+      degraded: false,
     });
     expect(mockQueryCalls).toHaveLength(0);
   });
@@ -66,6 +68,7 @@ describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
       members: ["conn-a"],
       primaryMember: "conn-a",
       currentMember: "conn-a",
+      degraded: false,
     });
     expect(mockQueryCalls).toHaveLength(0);
   });
@@ -77,9 +80,13 @@ describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
       members: ["conn-a"],
       primaryMember: "conn-a",
       currentMember: "conn-a",
+      degraded: false,
     });
     // The step-1 connection lookup ran but the step-2 queries didn't.
     expect(mockQueryCalls).toHaveLength(1);
+    // #4109 — a LEGITIMATE fallback (the install is simply ungrouped) is NOT
+    // flagged degraded; only a fault-induced fallback (the catch path) is.
+    expect(ctx.degraded).toBe(false);
   });
 
   it("connection not found (zero rows) → 1×1 fallback + suspect-grade warn", async () => {
@@ -89,15 +96,20 @@ describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
       members: ["conn-archived"],
       primaryMember: "conn-archived",
       currentMember: "conn-archived",
+      degraded: false,
     });
     expect(mockQueryCalls).toHaveLength(1);
   });
 
-  it("internalQuery throws → 1×1 fallback (catch-and-warn)", async () => {
+  it("internalQuery throws → 1×1 fallback flagged degraded (#4109 catch-and-warn)", async () => {
     mockShouldThrow = new Error("internal DB unreachable");
     const ctx = await loadGroupRoutingContext("org-1", "conn-a");
     expect(ctx.members).toEqual(["conn-a"]);
     expect(ctx.primaryMember).toBe("conn-a");
+    // #4109 — only the fault-induced fallback is flagged degraded, so a
+    // membership-sensitive caller (metric-run's explicit-connection check) can
+    // tell a transient outage from a definitive "not a member" verdict.
+    expect(ctx.degraded).toBe(true);
   });
 });
 
@@ -123,6 +135,8 @@ describe("loadGroupRoutingContext — multi-member resolution (post-cutover)", (
     expect(ctx.members).toEqual(["apac", "eu", "us-int"]);
     expect(ctx.primaryMember).toBe("apac"); // first by install_id
     expect(ctx.currentMember).toBe("eu");
+    // #4109 — a successful (non-fault) resolution is never degraded.
+    expect(ctx.degraded).toBe(false);
   });
 
   it("2-member group → first member is primary, currentMember reflects caller", async () => {

--- a/packages/api/src/lib/env-routing/lookup.ts
+++ b/packages/api/src/lib/env-routing/lookup.ts
@@ -33,6 +33,20 @@ export interface GroupRoutingContext {
   readonly primaryMember: string;
   /** The connection id this lookup was anchored on (echoed for caller convenience). */
   readonly currentMember: string;
+  /**
+   * `true` only when the routing lookup itself FAILED (internal-DB fault) and
+   * this is a fault-induced 1×1 fallback — distinct from a LEGITIMATE fallback
+   * (no bound org, no internal DB, install ungrouped, or install not-found),
+   * every one of which is `false`. Most callers ignore it and treat the
+   * fallback as a 1×1 group (correct: degraded routing safely collapses to
+   * single-env). A caller that needs membership CERTAINTY — e.g. metric-run's
+   * explicit-connection check (#4109) — reads it to tell a transient outage
+   * from a definitive "groupId is undefined" verdict, so a server fault isn't
+   * mistaken for a user-input error. Required (not optional) so a future
+   * fallback path can't silently default to the trustworthy state — the exact
+   * failure mode #4109 fixes.
+   */
+  readonly degraded: boolean;
 }
 
 /**
@@ -48,6 +62,8 @@ export async function loadGroupRoutingContext(
     members: [currentConnectionId],
     primaryMember: currentConnectionId,
     currentMember: currentConnectionId,
+    // Legitimate (non-fault) fallback; the catch block flips this to true.
+    degraded: false,
   };
 
   if (!orgId || !hasInternalDB()) {
@@ -116,6 +132,7 @@ export async function loadGroupRoutingContext(
       members: members.length > 0 ? members : [currentConnectionId],
       primaryMember,
       currentMember: currentConnectionId,
+      degraded: false,
     };
   } catch (err) {
     // Routing-lookup failure must not hard-fail the whole tool call —
@@ -125,6 +142,9 @@ export async function loadGroupRoutingContext(
       { err: err instanceof Error ? err.message : String(err), orgId, currentConnectionId },
       "Failed to resolve group routing context — falling back to single-env execution",
     );
-    return fallback;
+    // Flag this fallback `degraded` (the early-return fallbacks above don't):
+    // membership-sensitive callers must not read this fault-induced
+    // `groupId: undefined` as a definitive answer (#4109).
+    return { ...fallback, degraded: true };
   }
 }

--- a/packages/api/src/lib/semantic/__tests__/metric-run.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/metric-run.test.ts
@@ -6,7 +6,7 @@
  * the unknown-metric path, and the filters-unsupported guard.
  */
 
-import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -15,9 +15,13 @@ import * as path from "path";
 // Mock it so an explicit member-connection case resolves deterministically to a
 // group, and the default cases run with the internal DB "offline".
 let groupForConnection: Record<string, string | undefined> = {};
+// When set, internalQuery throws — simulating a transient internal-DB fault so
+// the resolver's degraded-routing path (#4109) can be exercised.
+let throwOnQuery: Error | null = null;
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   internalQuery: async (_sql: string, params: unknown[]) => {
+    if (throwOnQuery) throw throwOnQuery;
     // loadGroupRoutingContext step 1 query selects config->>'group_id' for the
     // install id at params[0].
     const connId = params?.[0] as string | undefined;
@@ -70,6 +74,11 @@ afterAll(() => {
 });
 
 describe("resolveMetricRun", () => {
+  beforeEach(() => {
+    groupForConnection = {};
+    throwOnQuery = null;
+  });
+
   it("resolves a default-group metric to default routing (undefined connection)", async () => {
     const res = await resolveMetricRun({ id: "total_gmv", semanticRoot: tmpRoot });
     expect(res.kind).toBe("ok");
@@ -138,7 +147,59 @@ describe("resolveMetricRun", () => {
     if (res.kind !== "ok") return;
     // Routes to the specific member, not the group id.
     expect(res.targetConnectionId).toBe("us-prod");
-    groupForConnection = {};
+  });
+
+  it("returns routing_unavailable (not wrong_connection) when the membership lookup faults (#4109)", async () => {
+    // The internal-DB lookup that validates an explicit member connection throws
+    // (transient fault). The resolver must NOT read the resulting `groupId:
+    // undefined` fallback as a definitive "not a member" and emit a confident
+    // wrong_connection (→ 400); it must surface the degradation so the route can
+    // map it to a retryable 503. `us-prod` ≠ the metric's group id "prod", so the
+    // membership lookup runs.
+    throwOnQuery = new Error("internal DB unreachable");
+    const res = await resolveMetricRun({
+      id: "prod_signups",
+      connectionId: "us-prod",
+      orgId: "org-1",
+      semanticRoot: tmpRoot,
+    });
+    expect(res.kind).toBe("routing_unavailable");
+    if (res.kind !== "routing_unavailable") return;
+    expect(res.metricId).toBe("prod_signups");
+    expect(res.connectionId).toBe("us-prod");
+  });
+
+  it("short-circuits an explicit group-id connection BEFORE the lookup, so a DB fault is irrelevant (#4109)", async () => {
+    // `connectionId === the metric's group token` ("prod") never needs the
+    // membership lookup. A transient internal-DB fault must NOT turn the common
+    // happy path (CLI passing the canonical group token) into a spurious 503 —
+    // pins that the short-circuit precedes the lookup.
+    throwOnQuery = new Error("internal DB unreachable");
+    const res = await resolveMetricRun({
+      id: "prod_signups",
+      connectionId: "prod",
+      orgId: "org-1",
+      semanticRoot: tmpRoot,
+    });
+    expect(res.kind).toBe("ok");
+    if (res.kind !== "ok") return;
+    expect(res.targetConnectionId).toBe("prod");
+  });
+
+  it("a default-group metric still rejects an explicit connection even under a DB fault (#4109)", async () => {
+    // An ungrouped (default-source) metric has no members, so the lookup is
+    // structurally skipped — the degraded arm can't leak into ungrouped metrics.
+    // A fault must therefore still yield wrong_connection, not routing_unavailable.
+    throwOnQuery = new Error("internal DB unreachable");
+    const res = await resolveMetricRun({
+      id: "total_gmv",
+      connectionId: "some-other",
+      orgId: "org-1",
+      semanticRoot: tmpRoot,
+    });
+    expect(res.kind).toBe("wrong_connection");
+    if (res.kind !== "wrong_connection") return;
+    expect(res.metricConnectionId).toBe("default");
   });
 
   it("rejects an explicit connection in a different group as wrong_connection", async () => {
@@ -153,7 +214,6 @@ describe("resolveMetricRun", () => {
     if (res.kind !== "wrong_connection") return;
     expect(res.group).toBe("prod");
     expect(res.metricConnectionId).toBe("prod");
-    groupForConnection = {};
   });
 
   it("rejects any explicit non-default connection for an ungrouped metric", async () => {

--- a/packages/api/src/lib/semantic/metric-run.ts
+++ b/packages/api/src/lib/semantic/metric-run.ts
@@ -71,11 +71,27 @@ export interface WrongConnection {
   readonly connectionId: string;
 }
 
+/**
+ * The routing lookup that validates an explicit member `connectionId` against
+ * the metric's group could not complete — the internal DB faulted. This is a
+ * retryable SERVER-side condition, not a user-input error: with the lookup
+ * down we can neither prove nor disprove membership, so we refuse to
+ * masquerade it as {@link WrongConnection} (a confident 400). The route maps
+ * it to a retryable 503 (CLAUDE.md "prefer errors over silent fallbacks").
+ */
+export interface RoutingUnavailable {
+  readonly kind: "routing_unavailable";
+  readonly metricId: string;
+  /** The explicit connection id whose group membership could not be verified. */
+  readonly connectionId: string;
+}
+
 export type MetricRunResolution =
   | ResolvedMetricRun
   | UnknownMetric
   | FiltersUnsupported
-  | WrongConnection;
+  | WrongConnection
+  | RoutingUnavailable;
 
 export interface ResolveMetricRunOpts {
   readonly id: string;
@@ -137,10 +153,18 @@ export async function resolveMetricRun(
     // connection's group and accept iff it matches the metric's group. A
     // default-source (ungrouped) metric has no members, so any explicit
     // non-default connectionId is rejected (#3281).
-    const isGroupMember =
-      metric.source !== DEFAULT_SEMANTIC_GROUP &&
-      (await loadGroupRoutingContext(opts.orgId, connectionId)).groupId ===
-        metric.source;
+    let isGroupMember = false;
+    if (metric.source !== DEFAULT_SEMANTIC_GROUP) {
+      const routing = await loadGroupRoutingContext(opts.orgId, connectionId);
+      if (routing.degraded) {
+        // Fault-induced fallback: `groupId: undefined` is the ABSENCE of an
+        // answer, not a "not a member" verdict, so we can't decide membership.
+        // Surface it as {@link RoutingUnavailable} (see there for why not a 400)
+        // rather than reading the fallback as a definitive mismatch (#4109).
+        return { kind: "routing_unavailable", metricId: metric.id, connectionId };
+      }
+      isGroupMember = routing.groupId === metric.source;
+    }
     if (!isGroupMember) {
       return {
         kind: "wrong_connection",

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -43,8 +43,8 @@ mock.module("@atlas/api/lib/tracing", () => ({
 mock.module("@atlas/api/lib/env-routing/lookup", () => ({
   loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) =>
     currentMember === "ungrouped-conn"
-      ? { members: ["ungrouped-conn"], primaryMember: "ungrouped-conn", currentMember }
-      : { groupId: "prod", members: [currentMember], primaryMember: currentMember, currentMember },
+      ? { members: ["ungrouped-conn"], primaryMember: "ungrouped-conn", currentMember, degraded: false }
+      : { groupId: "prod", members: [currentMember], primaryMember: currentMember, currentMember, degraded: false },
 }));
 
 // Capture how the egress path calls the primary resolver. Mock every export the

--- a/packages/api/src/lib/tools/__tests__/sql-fanout-audit.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-fanout-audit.test.ts
@@ -91,6 +91,7 @@ mock.module("@atlas/api/lib/env-routing/lookup", () => ({
     members: ["us-int", "eu"] as const,
     primaryMember: "us-int",
     currentMember,
+    degraded: false,
   }),
 }));
 

--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -157,8 +157,20 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
 // has "warehouse" + "warehouse_eu"; everything else is ungrouped (1×1 fallback,
 // groupId undefined). Lets the member-routing tests resolve a member id to its
 // group without a real internal DB.
+// #4109 — when set, the helper returns a fault-induced degraded 1×1 fallback
+// (groupId undefined, degraded true), simulating a transient internal-DB fault
+// in the membership lookup. Reset in beforeEach.
+let routingLookupDegraded = false;
 mock.module("@atlas/api/lib/env-routing/lookup", () => ({
   loadGroupRoutingContext: mock(async (_orgId: string | undefined, connectionId: string) => {
+    if (routingLookupDegraded) {
+      return {
+        members: [connectionId],
+        primaryMember: connectionId,
+        currentMember: connectionId,
+        degraded: true,
+      };
+    }
     const topology: Record<string, string> = {
       analytics: "analytics",
       analytics_eu: "analytics",
@@ -168,9 +180,9 @@ mock.module("@atlas/api/lib/env-routing/lookup", () => ({
     const groupId = topology[connectionId];
     if (groupId) {
       const members = Object.keys(topology).filter((c) => topology[c] === groupId);
-      return { groupId, members, primaryMember: members[0], currentMember: connectionId };
+      return { groupId, members, primaryMember: members[0], currentMember: connectionId, degraded: false };
     }
-    return { members: [connectionId], primaryMember: connectionId, currentMember: connectionId };
+    return { members: [connectionId], primaryMember: connectionId, currentMember: connectionId, degraded: false };
   }),
 }));
 
@@ -251,6 +263,7 @@ describe("MCP semantic tools", () => {
     mockExecuteSQLExecute.mockImplementation(async () => defaultExecuteSqlResult);
     billingGateVerdict = { allowed: true };
     mockCheckAgentBillingGate.mockClear();
+    routingLookupDegraded = false;
   });
 
   it("registers four typed tools", async () => {
@@ -1002,6 +1015,29 @@ describe("MCP semantic tools", () => {
     expect(result.isError).toBe(true);
     const envelope = parseAtlasMcpToolError(getContentText(result.content));
     expect(envelope!.code).toBe("validation_failed");
+    expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
+  });
+
+  it("runMetric surfaces a degraded routing lookup as retryable internal_error, not validation_failed (#4109)", async () => {
+    // When the internal-DB membership lookup faults, the helper returns a
+    // degraded 1×1 fallback. The MCP tool must NOT read that as a definitive
+    // "wrong datasource" (a terminal validation_failed the agent won't retry) —
+    // it must mirror the REST route and surface a retryable internal_error
+    // carrying request_id, so a transient fault isn't masqueraded as bad input.
+    routingLookupDegraded = true;
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "runMetric",
+      // "warehouse" ≠ the metric's group "analytics" → triggers the membership
+      // lookup, which now faults (degraded).
+      arguments: { id: "analytics_orders_count", connectionId: "warehouse" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.request_id).toBeDefined();
+    // Must short-circuit before touching SQL — the fault is in routing, not the query.
     expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
   });
 

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -453,9 +453,29 @@ export function registerSemanticTools(
             // metric against an arbitrary sibling connection is intentionally
             // out of scope — model it as a grouped metric and pass a member id
             // instead (decision recorded for #3281).
-            const isGroupMember =
-              metric.source !== DEFAULT_SEMANTIC_GROUP &&
-              (await loadGroupRoutingContext(workspaceId, connectionId)).groupId === metric.source;
+            let isGroupMember = false;
+            if (metric.source !== DEFAULT_SEMANTIC_GROUP) {
+              const routing = await loadGroupRoutingContext(workspaceId, connectionId);
+              if (routing.degraded) {
+                // #4109 — the internal-DB routing lookup faulted, so the
+                // `groupId: undefined` it returned is the ABSENCE of an answer,
+                // not a definitive "not a member". `validation_failed` is a
+                // terminal client error the agent won't retry, so emitting it
+                // here would masquerade a transient server fault as a confident
+                // wrong-datasource verdict. Mirror the REST route's
+                // `routing_unavailable` → 503 and surface a retryable
+                // `internal_error` carrying the request_id instead (CLAUDE.md
+                // "prefer errors over silent fallbacks").
+                return toEnvelopeResult(
+                  envelope(
+                    "internal_error",
+                    "Could not verify the connection's group membership right now (a transient internal error). Please retry shortly.",
+                    { request_id: requestId, retry_after: 2 },
+                  ),
+                );
+              }
+              isGroupMember = routing.groupId === metric.source;
+            }
             if (!isGroupMember) {
               return toEnvelopeResult(
                 envelope(


### PR DESCRIPTION
## Summary

A transient internal-DB fault during the metric-run **explicit-connection group-membership check** was surfacing as a confident user-input error instead of a retryable server fault:

- `loadGroupRoutingContext` is designed to **never throw** — on an internal-DB fault it logs a warn and returns a 1×1 fallback with `groupId: undefined`.
- Both metric-run transports read that fallback as a definitive *"not a member of the group"*: the REST route returned **400 `wrong_connection`** and the MCP `runMetric` tool returned a terminal **`validation_failed`** the agent won't retry. An operator debugging this saw a user-input error, not the DB outage.

### Fix
- **`env-routing/lookup.ts`** — `GroupRoutingContext` gains a **required** `degraded: boolean`, set `true` only on the catch-block (fault-induced) fallback and `false` on every legitimate fallback (no bound org / no internal DB / ungrouped / not-found) and the success path. Required (not optional) so a future fallback path can't silently default to the trustworthy state — the exact failure mode this fixes.
- **`semantic/metric-run.ts`** — new `routing_unavailable` `MetricRunResolution` arm, returned when the lookup came back `degraded`, instead of `wrong_connection`.
- **`api/routes/metrics.ts`** — maps `routing_unavailable` → retryable **503** carrying the route's `requestId` (+ `retryable: true`), with a `log.warn` breadcrumb.
- **`mcp/semantic-tools.ts`** (`runMetric`) — mirrors the fix: `degraded` → retryable **`internal_error`** envelope (`request_id` + `retry_after`) instead of `validation_failed`. Surfaced by the round-1 internal review; `internal_error` is already in `RUN_METRIC_ERROR_CODES`, so no contract/doc change.

The fix only changes the **fault** path. A genuine group mismatch (lookup succeeds, `groupId` differs) still returns 400 `wrong_connection` / `validation_failed`; the canonical-group-token happy path still short-circuits before the lookup; ungrouped metrics still reject an explicit connection.

## Test plan
- [x] `resolveMetricRun`: throwing internal-DB lookup + mismatched connectionId → `routing_unavailable` (not `wrong_connection`)
- [x] REST route: `routing_unavailable` → 503 `routing_unavailable` + `retryable` + `requestId`, pipeline not invoked
- [x] MCP `runMetric`: degraded lookup → retryable `internal_error` envelope w/ `request_id`, `executeSQL` not called
- [x] No regression: genuine mismatch → 400 `wrong_connection`; group-token connection short-circuits before the lookup (fault irrelevant); default-group metric + fault still `wrong_connection`
- [x] `lookup.ts`: full `degraded` truth table (`false` on every legit fallback + success, `true` only on the catch path)
- [x] `/ci` green — lint, type, full test (741 pass; 3 pre-existing WSL2 sandbox-env flakes only), syncpack, all drift/parity gates
- [x] Internal review panel (silent-failure, type-design, pr-test, comment) — CLEAN after round 2

Closes #4109