### PR TITLE
security(api): scope the workspace API key deliberately (#4110)

### DIFF
--- a/apps/docs/content/docs/guides/api-keys.mdx
+++ b/apps/docs/content/docs/guides/api-keys.mdx
@@ -72,6 +72,37 @@ The `atlas` CLI has **two** ways to authenticate, and most users only need the f
   (revocation takes effect on the next request). Because the key is pinned to one
   workspace, `--workspace` does not apply to it.
 
+### Scope: data plane + the datasource CLI, not console-admin
+
+A workspace API key is a **data-plane / CLI credential**. It authenticates:
+
+- the **query surface** — running SQL, metrics, and explore, plus conversations, sessions,
+  tables, and the semantic layer; and
+- the **datasource CLI surface** — `atlas datasource profile | create | list | get | test |
+  archive | restore | delete` (admin-floor, but reachable by an unattended key by design so
+  CI can provision and profile connections).
+
+It does **not** reach true console-admin: billing and BYOT-token entry, the install wizard,
+connection/workspace settings, audit, SSO/SCIM, and the like. Those assume an interactive
+human with a second factor enrolled; an unattended key pointed at one receives:
+
+```json
+{ "error": "api_key_not_permitted",
+  "message": "Workspace API keys are scoped to data operations (SQL, metrics, explore) and cannot access admin endpoints. Use an interactive admin session." }
+```
+
+Minting, listing, and revoking keys are themselves console-admin actions and require an
+interactive session — a key cannot mint another key.
+
+### RLS claims are bounded to the minter
+
+When the workspace uses [row-level security](/deployment/row-level-security), a key can
+carry RLS claim values so queries are filtered. Those claims are **bounded to the minting
+admin's own claims**: you can only embed a claim key/value you already hold (the
+claims-axis mirror of the role ceiling — a key never grants reach the minter lacks).
+Reserved identity claims (`sub`, `org_id`, `origin`, MFA-enrollment flags, …) can't be set
+at all. A claim outside your scope is rejected with `422 claim_not_allowed`.
+
 <Callout>
 The legacy `ATLAS_API_KEY` **operator god-key** (a single env-configured key for
 self-hosted simple-key auth mode) is a separate mechanism and is unchanged. Workspace

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -330,6 +330,7 @@ const passthrough = createMiddleware(async (_c, next) => { await next(); });
 
 mock.module("./routes/middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,

--- a/packages/api/src/api/__tests__/integrations-catalog.test.ts
+++ b/packages/api/src/api/__tests__/integrations-catalog.test.ts
@@ -80,6 +80,7 @@ const passthrough = createMiddleware(async (_c, next) => {
 
 mock.module("./routes/middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,
@@ -87,6 +88,7 @@ mock.module("./routes/middleware", () => ({
 }));
 mock.module("../routes/middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,
@@ -94,6 +96,7 @@ mock.module("../routes/middleware", () => ({
 }));
 mock.module("@atlas/api/api/routes/middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,

--- a/packages/api/src/api/routes/__tests__/admin-mfa-required.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-mfa-required.test.ts
@@ -209,6 +209,31 @@ describe("mfaRequired middleware", () => {
     expect(res.status).toBe(200);
   });
 
+  it("exempts a workspace API key actor even without MFA (#4110)", async () => {
+    // An api-key is the unattended-CI credential, not an interactive session
+    // that could enroll a TOTP/passkey — it is exempt from the MFA gate (its
+    // lifetime control is key expiry). Only ever reached on the key-allowed
+    // datasource routers; everywhere else adminAuth denied it first.
+    const app = new OpenAPIHono<AuthEnv>();
+    injectAuth(app, {
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "key-owner-1",
+        mode: "managed",
+        label: "ci@atlas.dev",
+        role: "admin",
+        activeOrganizationId: "org-1",
+        claims: Object.freeze({ api_key: true, twoFactorEnabled: false, passkeyCount: 0 }),
+      },
+    });
+    app.use(mfaRequired);
+    app.openapi(okRoute, (c) => c.json({ ok: true }, 200));
+
+    const res = await app.request("/admin/anything");
+    expect(res.status).toBe(200);
+  });
+
   it("blocks when both factors are absent (twoFactorEnabled=false, passkeyCount=0)", async () => {
     // The both-zero case is the canonical reject — admin with no second
     // factor of any kind. Asserted explicitly so a regression where

--- a/packages/api/src/api/routes/__tests__/admin-router.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-router.test.ts
@@ -363,3 +363,66 @@ describe("mfaRequired is wired into createAdminRouter / createPlatformRouter", (
     mockAuthResult = { authenticated: true, mode: "none", user: undefined };
   });
 });
+
+// ---------------------------------------------------------------------------
+// #4110 — workspace API key admin reach: denied by default, allowed only on
+// the explicitly key-allowed datasource CLI surface (allowApiKey: true).
+// ---------------------------------------------------------------------------
+
+describe("workspace API key admin reach (#4110)", () => {
+  const apiKeyActor = {
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "key-owner-1",
+      mode: "managed",
+      label: "ci@test.com",
+      role: "admin",
+      activeOrganizationId: "org-1",
+      // The api-key marker + no MFA claim — would 403 on mfaRequired if it
+      // weren't first denied at adminAuth (default) / exempted (allowApiKey).
+      claims: { api_key: true },
+    },
+  };
+
+  const ok = createRoute({
+    method: "get",
+    path: "/protected",
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: z.object({ ok: z.boolean() }) } },
+      },
+    },
+  });
+
+  beforeEach(() => {
+    mockHasInternalDB = true;
+  });
+
+  it("createAdminRouter() DENIES an api-key actor with 403 api_key_not_permitted", async () => {
+    mockAuthResult = apiKeyActor;
+    const router = createAdminRouter();
+    router.openapi(ok, (c) => c.json({ ok: true }, 200));
+
+    const res = await router.request("/protected");
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("api_key_not_permitted");
+
+    mockAuthResult = { authenticated: true, mode: "none", user: undefined };
+  });
+
+  it("createAdminRouter({ allowApiKey: true }) ALLOWS an api-key actor through both the deny + MFA gate", async () => {
+    mockAuthResult = apiKeyActor;
+    const router = createAdminRouter({ allowApiKey: true });
+    router.openapi(ok, (c) => c.json({ ok: true }, 200));
+
+    const res = await router.request("/protected");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+
+    mockAuthResult = { authenticated: true, mode: "none", user: undefined };
+  });
+});

--- a/packages/api/src/api/routes/__tests__/admin-workspace-keys.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-workspace-keys.test.ts
@@ -87,7 +87,27 @@ function authAs(role: "member" | "admin" | "owner", id = "minter-1"): void {
         label: `${role}@test.com`,
         role,
         activeOrganizationId: "org-alpha",
-        claims: { twoFactorEnabled: true },
+        // The minter's own claim bag. `tenant_id` is the RLS claim they hold —
+        // a key can embed it (within scope) but not any claim outside this bag.
+        claims: { twoFactorEnabled: true, tenant_id: "acme" },
+      },
+    }),
+  );
+}
+
+/** Authenticate as a workspace API key actor (the api_key marker claim). */
+function authAsApiKey(): void {
+  mocks.mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "key-owner-1",
+        mode: "managed",
+        label: "ci@test.com",
+        role: "admin",
+        activeOrganizationId: "org-alpha",
+        claims: { api_key: true, org_id: "org-alpha", sub: "key-owner-1", origin: "cli" },
       },
     }),
   );
@@ -131,9 +151,41 @@ describe("POST /api/v1/admin/workspace-keys", () => {
     expect(createApiKeyCalls.length).toBe(0);
   });
 
-  it("embeds the supplied RLS claims into the metadata", async () => {
+  it("embeds the supplied RLS claims into the metadata (within the minter's scope)", async () => {
+    // The minter holds `tenant_id: "acme"` (see authAs), so the key may carry it.
     await mint({ name: "ci-key", role: "member", claims: { tenant_id: "acme" } });
     expect(createApiKeyCalls[0].body.metadata.claims).toEqual({ tenant_id: "acme" });
+  });
+
+  it("rejects an RLS claim the minter does not hold (422) — no widening (#4110 AC3)", async () => {
+    // The minter holds tenant_id:"acme"; minting tenant_id:"globex" would grant
+    // RLS reach they don't have. Must be refused, and no key minted.
+    const res = await mint({ name: "ci-key", claims: { tenant_id: "globex" } });
+    expect(res.status).toBe(422);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("claim_not_allowed");
+    expect(createApiKeyCalls.length).toBe(0);
+  });
+
+  it("rejects a claim key the minter does not hold at all (422) — no fabrication (#4110 AC3)", async () => {
+    const res = await mint({ name: "ci-key", claims: { region: "us" } });
+    expect(res.status).toBe(422);
+    expect(createApiKeyCalls.length).toBe(0);
+  });
+
+  it("rejects a reserved identity claim key (422) — can't forge identity/MFA (#4110 AC3)", async () => {
+    const res = await mint({ name: "ci-key", claims: { sub: "someone-else" } });
+    expect(res.status).toBe(422);
+    expect(createApiKeyCalls.length).toBe(0);
+  });
+
+  it("denies a workspace API key actor from the mint surface (403) — keys are data-plane (#4110 AC1/AC2)", async () => {
+    authAsApiKey();
+    const res = await mint({ name: "ci-key" });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("api_key_not_permitted");
+    expect(createApiKeyCalls.length).toBe(0);
   });
 
   it("defaults the role to the minter's own when none is requested", async () => {

--- a/packages/api/src/api/routes/__tests__/platform-crm-outbox.test.ts
+++ b/packages/api/src/api/routes/__tests__/platform-crm-outbox.test.ts
@@ -103,6 +103,7 @@ const passthrough = createMiddleware(async (_c, next) => {
 
 mock.module("./routes/middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,
@@ -110,6 +111,7 @@ mock.module("./routes/middleware", () => ({
 }));
 mock.module("../middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,
@@ -117,6 +119,7 @@ mock.module("../middleware", () => ({
 }));
 mock.module("@atlas/api/api/routes/middleware", () => ({
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,

--- a/packages/api/src/api/routes/__tests__/platform-demo.test.ts
+++ b/packages/api/src/api/routes/__tests__/platform-demo.test.ts
@@ -163,6 +163,7 @@ const passthrough = createMiddleware(async (_c, next) => {
 
 const middlewareMock = {
   adminAuth: passthrough,
+  adminAuthAllowApiKey: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,

--- a/packages/api/src/api/routes/admin-mfa-required.ts
+++ b/packages/api/src/api/routes/admin-mfa-required.ts
@@ -65,6 +65,7 @@ import { createMiddleware } from "hono/factory";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { AuthEnv } from "@atlas/api/api/routes/middleware";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
+import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
 
 const log = createLogger("middleware:mfa");
@@ -215,6 +216,18 @@ export const mfaRequired = createMiddleware<AuthEnv>(async (c, next) => {
   // The deploy-mode guard in `platformAdminAuth` already prevents
   // `mode:"none"` from being a SaaS escape hatch.
   if (authResult.mode !== "managed") {
+    await next();
+    return;
+  }
+
+  // #4110 — a workspace API key is the unattended-CI credential, not an
+  // interactive session that could enroll a TOTP/passkey, so it is exempt from
+  // the MFA gate (its lifetime control is key expiry, not a second factor). This
+  // exemption is safe even though a key IS "managed" mode: on every admin router
+  // that does NOT explicitly allow keys, `adminAuth` already returned 403 before
+  // this middleware ran, so an api-key actor only ever reaches here on the
+  // `adminAuthAllowApiKey` datasource surface — exactly where it should pass.
+  if (resolveActorKind(authResult.user?.claims) === "api_key") {
     await next();
     return;
   }

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -286,7 +286,11 @@ const deleteRoute = createRoute({
 
 // ── Router ───────────────────────────────────────────────────────────────
 
-const adminOpenApiDatasources = createAdminRouter();
+// #4110 — `allowApiKey: true`: this is the datasource management CLI surface
+// (`atlas datasource list|get|test|create|archive|restore|delete`), admin-floor
+// but key-reachable by ADR-0027 gate-parity. Other admin routers use the
+// deny-by-default `createAdminRouter()`.
+const adminOpenApiDatasources = createAdminRouter({ allowApiKey: true });
 adminOpenApiDatasources.use(requireOrgContext());
 adminOpenApiDatasources.use(requirePermission("admin:connections"));
 

--- a/packages/api/src/api/routes/admin-router.ts
+++ b/packages/api/src/api/routes/admin-router.ts
@@ -31,6 +31,7 @@ import { validationHook } from "./validation-hook";
 import { eeOnError } from "./ee-error-handler";
 import {
   adminAuth,
+  adminAuthAllowApiKey,
   platformAdminAuth,
   requestContext,
   type AuthEnv,
@@ -93,9 +94,13 @@ export type OrgContextEnv = AuthEnv & {
  * Wires up: validationHook, adminAuth, requestContext, eeOnError.
  * Add `router.use(requireOrgContext())` for org-scoped routes.
  */
-export function createAdminRouter() {
+export function createAdminRouter(opts: { allowApiKey?: boolean } = {}) {
   const router = new OpenAPIHono<OrgContextEnv>({ defaultHook: validationHook });
-  router.use(adminAuth);
+  // #4110 — `allowApiKey` opts this router OUT of the workspace-API-key deny.
+  // Reserved for the datasource CLI surface (ADR-0027 gate-parity); paired with
+  // `mfaRequired`'s api-key exemption so a key clears the MFA gate here too. No
+  // other admin router should pass it.
+  router.use(opts.allowApiKey ? adminAuthAllowApiKey : adminAuth);
   // F-MFA — block admin access until the user has enrolled a TOTP second
   // factor. Order matters: must run after adminAuth (which sets authResult)
   // and before any handler. The middleware lets enrollment + sign-out

--- a/packages/api/src/api/routes/admin-workspace-keys.ts
+++ b/packages/api/src/api/routes/admin-workspace-keys.ts
@@ -41,7 +41,7 @@ import { AuthContext } from "@atlas/api/lib/effect/services";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { capRole, clampToOrgRole, getUserRole } from "@atlas/api/lib/auth/permissions";
-import { buildApiKeyMetadata } from "@atlas/api/lib/auth/api-key-metadata";
+import { buildApiKeyMetadata, boundClaimsToMinter } from "@atlas/api/lib/auth/api-key-metadata";
 import { ORG_ROLES } from "@atlas/api/lib/auth/types";
 import type { OrgRole } from "@atlas/api/lib/auth/types";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -150,8 +150,28 @@ adminWorkspaceKeys.openapi(mintRoute, async (c) => {
       const requestedRole = body.role ?? minterCeiling;
       const role: OrgRole = clampToOrgRole(capRole(requestedRole, minterCeiling));
 
+      // #4110 AC3 — bound the supplied RLS claims to the minter's OWN claim bag,
+      // the claims-axis mirror of the `capRole` ceiling above: a key must never
+      // carry RLS authority (or a forged identity claim) the minting admin
+      // doesn't already hold. Reserved identity/security keys are rejected
+      // outright; any other key must match the minter's own claim value exactly.
+      const claimCheck = boundClaimsToMinter(body.claims, user.claims);
+      if (!claimCheck.ok) {
+        return c.json(
+          {
+            error: "claim_not_allowed",
+            message:
+              claimCheck.reason === "reserved"
+                ? `The claim "${claimCheck.key}" is reserved by the auth layer and cannot be set on a workspace key.`
+                : `The claim "${claimCheck.key}" is not in your own access scope. A workspace key cannot carry RLS claims you do not hold.`,
+            requestId,
+          },
+          422,
+        );
+      }
+
       // The RLS claims to embed. Defaults to none (the workspace either has no
-      // RLS, or the caller supplies the specific claim values).
+      // RLS, or the caller supplies specific claim values within their own scope).
       const metadata = buildApiKeyMetadata({
         orgId,
         role,

--- a/packages/api/src/api/routes/datasources.ts
+++ b/packages/api/src/api/routes/datasources.ts
@@ -67,7 +67,7 @@ import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema } from "./shared-schemas";
-import { adminAuth, requestContext, type AuthEnv } from "./middleware";
+import { adminAuthAllowApiKey, requestContext, type AuthEnv } from "./middleware";
 
 const log = createLogger("datasources-routes");
 
@@ -179,7 +179,12 @@ const profileRoute = createRoute({
 
 export const datasources = new OpenAPIHono<AuthEnv>({ defaultHook: validationHook });
 
-datasources.use(adminAuth);
+// #4110 — workspace API keys are allowed here: this is the datasource CLI
+// surface (`atlas datasource profile`), admin-floor but key-reachable by
+// ADR-0027 gate-parity. The actor-kind stamping below distinguishes a key from
+// a human session in the audit. Other admin routers use the deny-by-default
+// `adminAuth`.
+datasources.use(adminAuthAllowApiKey);
 datasources.use(requestContext);
 
 // Normalize JSON parse errors into the standard API error format (mirrors explore.ts).

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -25,6 +25,7 @@ import {
   type RateLimitBucket,
 } from "@atlas/api/lib/auth/middleware";
 import { extractTrustDeviceIdentifier } from "@atlas/api/lib/auth/trust-device-cookie";
+import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
 import {
   detectMisrouting,
   isStrictRoutingEnabled,
@@ -49,6 +50,46 @@ const EXPIRED_AUTH_ERRORS = new Set([
 
 function authErrorCode(error: string): "session_expired" | "auth_error" {
   return EXPIRED_AUTH_ERRORS.has(error) ? "session_expired" : "auth_error";
+}
+
+/**
+ * #4110 — workspace API keys are DATA-PLANE credentials. They authenticate the
+ * `standardAuth` surface (run SQL/metrics/explore, conversations, sessions,
+ * tables, …) and the datasource CLI surface (ADR-0027 gate-parity:
+ * `atlas datasource …`), but are denied on true console-admin: billing /
+ * `/byot`, the install wizard, connection settings, audit, etc. — surfaces that
+ * assume an interactive human (MFA, secret entry, provisioning).
+ *
+ * Deny by DEFAULT at the single admin chokepoint (`adminAuth` /
+ * `platformAdminAuth`) so the boundary is ONE deliberate decision rather than
+ * "did the route happen to use `createAdminRouter`". Before this,
+ * `createAdminRouter` routes blocked keys only incidentally — via `mfaRequired`
+ * (a key carries no MFA claim → 403 `mfa_enrollment_required`, a confusing code)
+ * — while bare `.use(adminAuth)` routes (`billing` incl. `/byot`, `wizard`,
+ * `datasources /{id}/profile`) let them straight through. This closes that split:
+ * a clear, uniform 403 everywhere EXCEPT the explicitly key-allowed datasource
+ * routers, which use `adminAuthAllowApiKey` to opt out.
+ *
+ * Returns a 403 descriptor when the actor is an api-key, else `null`.
+ */
+function denyApiKeyOnAdmin(
+  authResult: AuthResult & { authenticated: true },
+  requestId: string,
+): { body: Record<string, unknown>; status: 403 } | null {
+  if (resolveActorKind(authResult.user?.claims) !== "api_key") return null;
+  log.warn(
+    { requestId, userId: authResult.user?.id },
+    "Workspace API key blocked from an admin route — keys are data-plane credentials",
+  );
+  return {
+    body: {
+      error: "api_key_not_permitted",
+      message:
+        "Workspace API keys are scoped to data operations (SQL, metrics, explore) and cannot access admin endpoints. Use an interactive admin session.",
+      requestId,
+    },
+    status: 403,
+  };
 }
 
 /**
@@ -283,58 +324,92 @@ async function checkMigrationWriteLock(
 // adminAuth — authenticate + enforce admin role + rate limit + IP allowlist
 // ---------------------------------------------------------------------------
 
-export const adminAuth = createMiddleware<AuthEnv>(async (c, next) => {
-  const requestId = crypto.randomUUID();
-  c.set("requestId", requestId);
+/**
+ * Build an admin-auth middleware.
+ *
+ * `allowApiKey` (default `false`) controls the #4110 data-plane boundary: by
+ * default a workspace API key is DENIED on admin routes (see
+ * {@link denyApiKeyOnAdmin}). The datasource CLI surface (`datasources.ts`
+ * profile + `admin-openapi-datasources.ts` create/list/test/…) sets
+ * `allowApiKey: true` because ADR-0027's gate-parity contract deliberately makes
+ * those admin-floor routes reachable by `atlas datasource …` in unattended CI.
+ * No other admin router should set it.
+ */
+function makeAdminAuth(opts: { allowApiKey?: boolean } = {}) {
+  return createMiddleware<AuthEnv>(async (c, next) => {
+    const requestId = crypto.randomUUID();
+    c.set("requestId", requestId);
 
-  const auth = await authenticate(c.req.raw, requestId);
-  if (!auth.ok) {
-    return c.json(auth.body, auth.status as 401, auth.headers);
-  }
-  const { authResult } = auth;
+    const auth = await authenticate(c.req.raw, requestId);
+    if (!auth.ok) {
+      return c.json(auth.body, auth.status as 401, auth.headers);
+    }
+    const { authResult } = auth;
 
-  // Defense-in-depth (#3342 L-1): `mode: "none"` is the no-auth local-dev
-  // carve-out and must never reach an admin gate in SaaS. Mirrors the
-  // platformAdminAuth guard below — the weaker tier was the unguarded one.
-  if (authResult.mode === "none" && isSaasDeployMode()) {
-    log.error({ requestId }, "mode:\"none\" reached adminAuth under SaaS deploy — rejecting");
-    return c.json({ error: "auth_misconfigured", message: "Admin auth is not configured.", requestId }, 500);
-  }
+    // #4110 — workspace API keys are data-plane credentials. Deny them on admin
+    // routes at this single chokepoint (clear 403, before role/MFA logic) UNLESS
+    // this is the explicitly key-allowed datasource CLI surface.
+    if (!opts.allowApiKey) {
+      const apiKeyBlocked = denyApiKeyOnAdmin(authResult, requestId);
+      if (apiKeyBlocked) {
+        return c.json(apiKeyBlocked.body, apiKeyBlocked.status);
+      }
+    }
 
-  // Enforce admin role — auth mode "none" (local dev) is an implicit admin
-  if (
-    authResult.mode !== "none" &&
-    (!authResult.user ||
-      (authResult.user.role !== "admin" &&
-        authResult.user.role !== "owner" &&
-        authResult.user.role !== "platform_admin"))
-  ) {
-    log.warn({ requestId, userId: authResult.user?.id, role: authResult.user?.role }, "Non-admin access attempt");
-    return c.json({ error: "forbidden_role", message: "Admin role required.", requestId }, 403);
-  }
+    // Defense-in-depth (#3342 L-1): `mode: "none"` is the no-auth local-dev
+    // carve-out and must never reach an admin gate in SaaS. Mirrors the
+    // platformAdminAuth guard below — the weaker tier was the unguarded one.
+    if (authResult.mode === "none" && isSaasDeployMode()) {
+      log.error({ requestId }, "mode:\"none\" reached adminAuth under SaaS deploy — rejecting");
+      return c.json({ error: "auth_misconfigured", message: "Admin auth is not configured.", requestId }, 500);
+    }
 
-  // Admin namespace gets its own rate-limit bucket (#2485). Interactive
-  // forms (Add Connection, Test, Delete in quick succession) burst easily
-  // past a low base RPM; bucketing them separately keeps a dogfood session
-  // from depleting the cheap-read budget shared with chat.
-  const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId, "admin");
-  if (blocked) {
-    return c.json(blocked.body, blocked.status as 429, blocked.headers);
-  }
+    // Enforce admin role — auth mode "none" (local dev) is an implicit admin
+    if (
+      authResult.mode !== "none" &&
+      (!authResult.user ||
+        (authResult.user.role !== "admin" &&
+          authResult.user.role !== "owner" &&
+          authResult.user.role !== "platform_admin"))
+    ) {
+      log.warn({ requestId, userId: authResult.user?.id, role: authResult.user?.role }, "Non-admin access attempt");
+      return c.json({ error: "forbidden_role", message: "Admin role required.", requestId }, 403);
+    }
 
-  const misrouted = await checkMisrouting(c, authResult, requestId);
-  if (misrouted) {
-    return c.json(misrouted.body, misrouted.status as 421);
-  }
+    // Admin namespace gets its own rate-limit bucket (#2485). Interactive
+    // forms (Add Connection, Test, Delete in quick succession) burst easily
+    // past a low base RPM; bucketing them separately keeps a dogfood session
+    // from depleting the cheap-read budget shared with chat.
+    const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId, "admin");
+    if (blocked) {
+      return c.json(blocked.body, blocked.status as 429, blocked.headers);
+    }
 
-  // No migration write-lock for admin routes — admins need to manage
-  // the workspace during migration (retry, cancel, configure).
+    const misrouted = await checkMisrouting(c, authResult, requestId);
+    if (misrouted) {
+      return c.json(misrouted.body, misrouted.status as 421);
+    }
 
-  c.set("authResult", authResult);
-  resolveModeForRequest(c, authResult, requestId);
-  setTrustDeviceIdentifier(c);
-  await next();
-});
+    // No migration write-lock for admin routes — admins need to manage
+    // the workspace during migration (retry, cancel, configure).
+
+    c.set("authResult", authResult);
+    resolveModeForRequest(c, authResult, requestId);
+    setTrustDeviceIdentifier(c);
+    await next();
+  });
+}
+
+/** Standard admin gate — denies workspace API keys (#4110). */
+export const adminAuth = makeAdminAuth();
+
+/**
+ * Admin gate that ALLOWS workspace API keys (#4110). Reserved for the datasource
+ * CLI surface — ADR-0027 gate-parity makes `atlas datasource …` key-reachable.
+ * Pairs with `mfaRequired`'s api-key exemption so a key clears the factory
+ * router's MFA gate too.
+ */
+export const adminAuthAllowApiKey = makeAdminAuth({ allowApiKey: true });
 
 // ---------------------------------------------------------------------------
 // platformAdminAuth — authenticate + enforce platform_admin role + rate limit + IP allowlist
@@ -349,6 +424,15 @@ export const platformAdminAuth = createMiddleware<AuthEnv>(async (c, next) => {
     return c.json(auth.body, auth.status as 401, auth.headers);
   }
   const { authResult } = auth;
+
+  // #4110 — a workspace API key is org-scoped and clamped to org roles, so it
+  // can never carry `platform_admin`; deny it here anyway for a clear 403 and a
+  // uniform admin boundary (a key clamped below the role check would otherwise
+  // 403 with the less precise `forbidden_role`).
+  const apiKeyBlocked = denyApiKeyOnAdmin(authResult, requestId);
+  if (apiKeyBlocked) {
+    return c.json(apiKeyBlocked.body, apiKeyBlocked.status);
+  }
 
   // Defense-in-depth: `mode: "none"` is the no-auth local-dev carve-out and
   // must never reach a platform gate in SaaS. If deploy mode is saas and we

--- a/packages/api/src/lib/auth/__tests__/api-key-metadata.test.ts
+++ b/packages/api/src/lib/auth/__tests__/api-key-metadata.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "bun:test";
 import {
   API_KEY_MARKER_CLAIM,
+  RESERVED_API_KEY_CLAIM_KEYS,
+  boundClaimsToMinter,
   buildApiKeyMetadata,
   parseApiKeyMetadata,
   type ApiKeyMetadata,
@@ -94,5 +96,58 @@ describe("parseApiKeyMetadata()", () => {
 
   it("exposes a stable reserved marker-claim key, distinct from origin", () => {
     expect(API_KEY_MARKER_CLAIM).toBe("api_key");
+  });
+});
+
+describe("boundClaimsToMinter() (#4110 AC3)", () => {
+  const minter = { tenant_id: "acme", region: ["us", "eu"], twoFactorEnabled: true };
+
+  it("is ok when no claims are requested", () => {
+    expect(boundClaimsToMinter(undefined, minter)).toEqual({ ok: true });
+    expect(boundClaimsToMinter({}, minter)).toEqual({ ok: true });
+  });
+
+  it("allows a scalar claim the minter holds with an equal value", () => {
+    expect(boundClaimsToMinter({ tenant_id: "acme" }, minter)).toEqual({ ok: true });
+  });
+
+  it("allows an array claim that matches the minter's value structurally", () => {
+    expect(boundClaimsToMinter({ region: ["us", "eu"] }, minter)).toEqual({ ok: true });
+  });
+
+  it("rejects a claim value the minter doesn't hold (no widening)", () => {
+    expect(boundClaimsToMinter({ tenant_id: "globex" }, minter)).toEqual({
+      ok: false,
+      key: "tenant_id",
+      reason: "not_in_minter_scope",
+    });
+  });
+
+  it("rejects a claim key absent from the minter's bag (no fabrication)", () => {
+    expect(boundClaimsToMinter({ department: "eng" }, minter)).toEqual({
+      ok: false,
+      key: "department",
+      reason: "not_in_minter_scope",
+    });
+  });
+
+  it("rejects narrowing a multi-value claim (must re-mint from a narrower session)", () => {
+    expect(boundClaimsToMinter({ region: ["us"] }, minter)).toMatchObject({
+      ok: false,
+      reason: "not_in_minter_scope",
+    });
+  });
+
+  it("rejects every reserved identity/security claim key", () => {
+    for (const key of RESERVED_API_KEY_CLAIM_KEYS) {
+      // Give the minter the key too, to prove the reserved check wins over scope.
+      const result = boundClaimsToMinter({ [key]: "x" }, { ...minter, [key]: "x" });
+      expect(result).toEqual({ ok: false, key, reason: "reserved" });
+    }
+  });
+
+  it("treats a missing minter bag as holding nothing", () => {
+    expect(boundClaimsToMinter({ tenant_id: "acme" }, null)).toMatchObject({ ok: false });
+    expect(boundClaimsToMinter(undefined, null)).toEqual({ ok: true });
   });
 });

--- a/packages/api/src/lib/auth/__tests__/managed.test.ts
+++ b/packages/api/src/lib/auth/__tests__/managed.test.ts
@@ -224,7 +224,7 @@ describe("validateManaged()", () => {
       });
       mockVerifyApiKey.mockResolvedValueOnce({
         valid: true,
-        key: { metadata: { atlasWorkspaceKey: true, orgId: "org_acme", role: "member" } },
+        key: { userId: "usr_2", metadata: { atlasWorkspaceKey: true, orgId: "org_acme", role: "member" } },
       });
       // Member was promoted to owner AFTER minting; the key must stay member.
       mockHasInternalDB = true;
@@ -244,7 +244,7 @@ describe("validateManaged()", () => {
         valid: true,
         // The key was minted when the owner was an admin; they've since been
         // removed from the workspace. The stored role must NOT be a floor.
-        key: { metadata: { atlasWorkspaceKey: true, orgId: "org_acme", role: "admin" } },
+        key: { userId: "usr_removed", metadata: { atlasWorkspaceKey: true, orgId: "org_acme", role: "admin" } },
       });
       mockHasInternalDB = true;
       mockInternalQuery = () => Promise.resolve([]); // no member row
@@ -285,6 +285,7 @@ describe("validateManaged()", () => {
       mockVerifyApiKey.mockResolvedValueOnce({
         valid: true,
         key: {
+          userId: "usr_3",
           metadata: {
             atlasWorkspaceKey: true,
             orgId: "org_acme",
@@ -309,6 +310,7 @@ describe("validateManaged()", () => {
       mockVerifyApiKey.mockResolvedValueOnce({
         valid: true,
         key: {
+          userId: "usr_4",
           metadata: {
             atlasWorkspaceKey: true,
             orgId: "org_real",
@@ -406,6 +408,25 @@ describe("validateManaged()", () => {
           userId: "usr_B",
           metadata: { atlasWorkspaceKey: true, orgId: "org_acme", role: "admin" },
         },
+      });
+      mockHasInternalDB = true;
+      mockInternalQuery = () => Promise.resolve([{ role: "admin" }]);
+
+      const result = await validateManaged(apiKeyRequest());
+      expect(result).toMatchObject({ authenticated: false, status: 401 });
+    });
+
+    it("fails closed (401) when the key is valid but resolves no owner (#4110 AC4)", async () => {
+      // verifyApiKey reports valid:true but the key carries neither userId nor
+      // referenceId — we can't bind the actor to a person, so we must NOT fall
+      // through trusting the session userId. Fail closed instead.
+      mockGetSession.mockResolvedValueOnce({
+        user: { id: "usr_noowner", email: "no@acme.com" },
+        session: { id: "key_noowner", userId: "usr_noowner" },
+      });
+      mockVerifyApiKey.mockResolvedValueOnce({
+        valid: true,
+        key: { metadata: { atlasWorkspaceKey: true, orgId: "org_acme", role: "admin" } },
       });
       mockHasInternalDB = true;
       mockInternalQuery = () => Promise.resolve([{ role: "admin" }]);

--- a/packages/api/src/lib/auth/api-key-metadata.ts
+++ b/packages/api/src/lib/auth/api-key-metadata.ts
@@ -117,6 +117,82 @@ export function buildApiKeyMetadata(input: BuildApiKeyMetadataInput): StoredApiK
 }
 
 /**
+ * Claim keys that the auth layer stamps AUTHORITATIVELY (identity, transport,
+ * MFA-enrollment state) and that must therefore never be settable as a
+ * caller-supplied mint-time RLS claim. Mirrors the identity claims
+ * `resolveApiKeyAuth` overwrites after the metadata spread (`sub`, `org_id`,
+ * `origin`, the api-key marker) plus the factor signals the admin-MFA gate
+ * reads (`twoFactorEnabled`, `passkeyCount`) and the role/ban fields the session
+ * path owns. Rejecting these at mint keeps a key's claim bag strictly RLS data —
+ * a key can't smuggle in a forged identity or an MFA-enrolled appearance.
+ */
+export const RESERVED_API_KEY_CLAIM_KEYS: ReadonlySet<string> = new Set([
+  "sub",
+  "org_id",
+  "origin",
+  API_KEY_MARKER_CLAIM,
+  "passkeyCount",
+  "twoFactorEnabled",
+  "effectiveRole",
+  "role",
+  "banned",
+  "banExpires",
+]);
+
+/**
+ * Outcome of {@link boundClaimsToMinter}: `ok` when every supplied claim is
+ * within the minter's own scope, otherwise the first offending `key` and why.
+ */
+export type BoundClaimsResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly key: string; readonly reason: "reserved" | "not_in_minter_scope" };
+
+/** Structural equality over JSON-serializable claim values (scalars + arrays of
+ * scalars — `rls.ts` rejects object-typed claims, so JSON compares faithfully
+ * and the object key-order caveat never bites). */
+function claimValuesEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * #4110 — bound caller-supplied mint claims to the minter's own claim bag.
+ *
+ * A workspace key must never carry RLS authority the minting admin doesn't
+ * already hold — the claims-axis mirror of the {@link capRole} ceiling on the
+ * role axis (a key grants no reach the minter lacks, ADR-0027 §2). For every
+ * claim the caller supplies:
+ *   - a {@link RESERVED_API_KEY_CLAIM_KEYS reserved} identity/security key is
+ *     rejected outright (`reason: "reserved"`), and
+ *   - any other key must be present in the minter's own claims with an EQUAL
+ *     value (`reason: "not_in_minter_scope"` otherwise) — no fabrication, no
+ *     widening.
+ *
+ * Narrowing a multi-value claim (e.g. minting `tenant_id: "acme"` from a session
+ * carrying `["acme", "globex"]`) is intentionally NOT supported here: re-mint
+ * from a session that already resolves the narrower value. An empty / absent
+ * `requested` bag is always `ok` (a key with no extra RLS claims).
+ */
+export function boundClaimsToMinter(
+  requested: Record<string, unknown> | undefined,
+  minterClaims: Record<string, unknown> | null | undefined,
+): BoundClaimsResult {
+  if (!requested) return { ok: true };
+  const minter = minterClaims ?? {};
+  for (const key of Object.keys(requested)) {
+    if (RESERVED_API_KEY_CLAIM_KEYS.has(key)) {
+      return { ok: false, key, reason: "reserved" };
+    }
+    if (
+      !Object.prototype.hasOwnProperty.call(minter, key) ||
+      !claimValuesEqual(requested[key], minter[key])
+    ) {
+      return { ok: false, key, reason: "not_in_minter_scope" };
+    }
+  }
+  return { ok: true };
+}
+
+/**
  * Narrow an untrusted Better Auth metadata bag into a typed {@link ApiKeyMetadata}.
  *
  * Returns `null` (fail-closed) when the bag is not a workspace-scoped key:

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -304,10 +304,22 @@ export async function resolveApiKeyAuth(
   // (`userId`), the scope from the verified key. If a request presented BOTH a
   // session cookie (user A) AND an `x-api-key` (user B's key) and the cookie won
   // `getSession`, we'd otherwise bind user A's identity to user B's key scope —
-  // breaking the "a leaked key traces to its owner" invariant. Assert the
-  // verified key's owner equals the resolved session user; fail closed on a
-  // mismatch rather than mis-attribute the actor.
-  if (keyOwner && keyOwner !== userId) {
+  // breaking the "a leaked key traces to its owner" invariant.
+  //
+  // #4110 AC4 — the binding is REQUIRED, not best-effort: a verified key whose
+  // owner can't be determined (`verifyApiKey` returned `valid:true` but neither
+  // `userId` nor `referenceId`) must fail closed, NOT fall through trusting the
+  // cookie/bearer `userId`. A real Better Auth key always carries an owner; a
+  // missing one signals a malformed/forged verify shape we won't bind to a
+  // person. Both the "no owner" and "owner mismatch" cases fail closed.
+  if (!keyOwner) {
+    log.error(
+      { userId },
+      "verifyApiKey reported valid but resolved no key owner — failing closed (cannot bind the actor to a person)",
+    );
+    return { authenticated: false, mode: "managed", status: 401, error: "API key could not be verified" };
+  }
+  if (keyOwner !== userId) {
     log.error(
       { userId, keyOwner },
       "API key owner does not match the resolved session user — failing closed (possible cookie+key credential mix)",


### PR DESCRIPTION
Closes #4110.

Resolves the three authority/scope decisions + one hardening item the milestone #77 milestone-wide review flagged on the workspace-scoped API key (#4046). No P0 was found — this makes the boundary deliberate and documented.

## Decision (AC1)
A workspace API key is a **data-plane / CLI credential**. It reaches:
- the **query surface** (`standardAuth`): SQL/metrics/explore, conversations, sessions, tables, semantic layer; and
- the **datasource CLI surface**: `atlas datasource profile | create | list | get | test | archive | restore | delete` — admin-floor, but key-reachable by **ADR-0027's gate-parity contract** (these were deliberately built for unattended CI in milestone #77, `actor_kind=api_key` stamping included).

It is **denied** on true console-admin: billing / `/byot`, the install wizard, connection/workspace settings, audit, SSO/SCIM, key minting, etc.

## What changed

**AC1 + AC2 — reach + the `mfaRequired` split.** Denied at one chokepoint: `adminAuth`/`platformAdminAuth` return a clear `403 api_key_not_permitted` instead of the confusing `mfa_enrollment_required` a key got *incidentally* on `createAdminRouter` routes (while bare-`adminAuth` routes let it through — the exact "split by accident" the issue named). `adminAuth` is now a small factory; `adminAuthAllowApiKey` opts the two datasource routers out of the deny, and `mfaRequired` exempts api-key actors (non-interactive — gated by key expiry, not a second factor; safe because every non-allowlisted admin router already denied the key at `adminAuth`).

**AC3 — mint claims bounded to the minter.** `boundClaimsToMinter` (pure, in `api-key-metadata.ts`) rejects reserved identity/security claim keys and any claim outside the minter's own bag — no widening, no fabrication. The claims-axis mirror of the existing `capRole` ceiling. Mint returns `422 claim_not_allowed` on violation.

**AC4 — owner-binding hardening.** `resolveApiKeyAuth` now fails closed (`401`) when `verifyApiKey` returns `valid:true` but resolves no key owner, instead of falling through and trusting the cookie/bearer identity (`managed.ts` ~line 310).

**Docs.** `api-keys.mdx` documents the data-plane + datasource-CLI scope and the claim-bounding rule.

## Tests
- `boundClaimsToMinter` unit matrix (reserved keys, widening, fabrication, array equality, narrowing rejection).
- `managed.test.ts`: AC4 "valid but no resolvable owner → 401"; four existing mocks given the `userId` a real Better Auth verify always returns.
- mint route: reject out-of-scope / fabricated / reserved claims (422); api-key actor denied from the mint surface (403).
- `admin-router.test.ts`: `createAdminRouter()` denies an api-key actor; `createAdminRouter({ allowApiKey: true })` allows it through both the deny + the MFA gate.
- `admin-mfa-required.test.ts`: api-key exemption.
- Four hardcoded middleware-mock factories updated for the new `adminAuthAllowApiKey` export (the known "new export breaks partial mocks" gotcha).

## Gates
- `tsgo --noEmit`: clean
- `eslint`: clean
- Affected isolated suite: **170/170 pass**

No `createRoute()` shape changes (the mint route already declared 403/422), so no OpenAPI drift. No DB/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)