### PR TITLE
feat(cli): api-key credential parity on metric run / explore / datasource (#4112)

### DIFF
--- a/apps/docs/content/docs/guides/api-keys.mdx
+++ b/apps/docs/content/docs/guides/api-keys.mdx
@@ -59,18 +59,27 @@ The `atlas` CLI has **two** ways to authenticate, and most users only need the f
 
 - **Workspace API key (unattended CI only).** For a headless CI job where no human ever
   logs in, mint a workspace-scoped key on the `/admin/api-keys` page and pass it via the
-  `ATLAS_API_KEY` environment variable (or `--api-key` on a command):
+  `ATLAS_API_KEY` environment variable (or `--api-key` on a command). Four
+  REST-backed workspace commands honor it as a workspace key — `atlas sql`,
+  `atlas metric run`, `atlas explore`, and `atlas datasource …` — so a CI job never
+  needs an interactive `atlas login` for them (other workspace commands, such as
+  `atlas entities`, still require the `atlas login` session):
 
   ```bash
-  ATLAS_API_KEY=atlas_wk_… atlas sql "SELECT count(*) FROM orders"
+  export ATLAS_API_KEY=atlas_wk_…
+  atlas sql "SELECT count(*) FROM orders"
+  atlas metric run weekly_active_users
+  atlas explore "cat catalog.yml"
+  atlas datasource list
   ```
 
   The CLI sends a workspace key on the `x-api-key` header (the session bearer uses
-  `Authorization: Bearer`). The key resolves live to its **owning member's** workspace,
-  role, and RLS claim — it is delegated human access bound to one workspace, audited to
-  the person who minted it (`actor_kind = api_key`), and revocable from the same page
-  (revocation takes effect on the next request). Because the key is pinned to one
-  workspace, `--workspace` does not apply to it.
+  `Authorization: Bearer`); a command uses exactly one of the two, never both. The key
+  resolves live to its **owning member's** workspace, role, and RLS claim — it is
+  delegated human access bound to one workspace, audited to the person who minted it
+  (`actor_kind = api_key`), and revocable from the same page (revocation takes effect on
+  the next request). Because the key is pinned to one workspace, `--workspace` does not
+  apply to it.
 
 <Callout>
 The legacy `ATLAS_API_KEY` **operator god-key** (a single env-configured key for

--- a/packages/cli/src/__tests__/credential.test.ts
+++ b/packages/cli/src/__tests__/credential.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared CLI credential primitives (#4112) — unit tests.
+ *
+ * `lib/credential.ts` is the single source of the workspace-credential XOR and
+ * its precedence/parse/header rules that `sql`/`metric`/`explore`/`datasource`
+ * all reach through. The command suites exercise these indirectly; this pins the
+ * three helpers directly so a regression surfaces here rather than as a confusing
+ * cross-command failure.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  credentialHeaders,
+  readApiKeyFlag,
+  resolveCredential,
+  type CliCredential,
+} from "../lib/credential";
+
+describe("credentialHeaders", () => {
+  it("sends a session token on Authorization: Bearer", () => {
+    expect(credentialHeaders({ token: "sess_abc" })).toEqual({ Authorization: "Bearer sess_abc" });
+  });
+
+  it("sends a workspace key on x-api-key (never Authorization)", () => {
+    const headers = credentialHeaders({ apiKey: "atlas_wk_abc" });
+    expect(headers).toEqual({ "x-api-key": "atlas_wk_abc" });
+    expect(headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("resolveCredential — precedence (#4112)", () => {
+  const session = { token: "sess_abc" };
+
+  it("prefers an api key over a stored session", () => {
+    expect(resolveCredential("atlas_wk_abc", session)).toEqual({ apiKey: "atlas_wk_abc" });
+  });
+
+  it("falls back to the session when no api key is present", () => {
+    expect(resolveCredential(undefined, session)).toEqual({ token: "sess_abc" });
+  });
+
+  it("returns null when neither is present (fail-closed)", () => {
+    expect(resolveCredential(undefined, null)).toBeNull();
+  });
+
+  it("treats an empty-string api key as absent (no `apiKey: \"\"` credential)", () => {
+    // An empty key is not a credential; it must fall through to the session, not
+    // produce an `{ apiKey: "" }` — which `credentialHeaders` (a truthiness
+    // branch) would otherwise route to a malformed `Authorization: Bearer undefined`.
+    expect(resolveCredential("", session)).toEqual({ token: "sess_abc" });
+  });
+});
+
+describe("readApiKeyFlag — both flag forms (#4112)", () => {
+  it("reads the space form `--api-key <key>`", () => {
+    expect(readApiKeyFlag(["sql", "SELECT 1", "--api-key", "k1"])).toBe("k1");
+  });
+
+  it("reads the inline form `--api-key=<key>`", () => {
+    expect(readApiKeyFlag(["sql", "SELECT 1", "--api-key=k2"])).toBe("k2");
+  });
+
+  it("returns undefined when the flag is absent", () => {
+    expect(readApiKeyFlag(["sql", "SELECT 1"])).toBeUndefined();
+  });
+
+  it("returns undefined for a dangling `--api-key` with no value", () => {
+    expect(readApiKeyFlag(["sql", "SELECT 1", "--api-key"])).toBeUndefined();
+  });
+
+  it("does not consume a following flag as the key value", () => {
+    expect(readApiKeyFlag(["sql", "SELECT 1", "--api-key", "--json"])).toBeUndefined();
+  });
+});
+
+describe("CliCredential — type-level XOR (compile-time)", () => {
+  it("each branch is assignable to the union; the helpers narrow", () => {
+    // A purely structural assertion: both single-field shapes are valid
+    // CliCredentials, and the headers helper maps each to its one wire header.
+    const tokenCred: CliCredential = { token: "t" };
+    const keyCred: CliCredential = { apiKey: "k" };
+    expect(credentialHeaders(tokenCred)).toHaveProperty("Authorization");
+    expect(credentialHeaders(keyCred)).toHaveProperty("x-api-key");
+  });
+});

--- a/packages/cli/src/__tests__/datasource-client.test.ts
+++ b/packages/cli/src/__tests__/datasource-client.test.ts
@@ -21,6 +21,7 @@ interface CapturedCall {
   url: string;
   method: string;
   authorization: string | null;
+  apiKey: string | null;
   body: string | undefined;
 }
 
@@ -42,6 +43,10 @@ function stubFetch(
         init?.headers && typeof init.headers === "object"
           ? ((init.headers as Record<string, string>).Authorization ?? null)
           : null,
+      apiKey:
+        init?.headers && typeof init.headers === "object"
+          ? ((init.headers as Record<string, string>)["x-api-key"] ?? null)
+          : null,
       body: typeof init?.body === "string" ? init.body : undefined,
     });
     return new Response(body === undefined ? "" : JSON.stringify(body), {
@@ -53,7 +58,12 @@ function stubFetch(
 }
 
 function opts(fetchImpl: typeof fetch): DatasourceClientOptions {
-  return { baseUrl: BASE, token: TOKEN, fetchImpl };
+  return { baseUrl: BASE, credential: { token: TOKEN }, fetchImpl };
+}
+
+const API_KEY = "atlas_wk_xyz";
+function apiKeyOpts(fetchImpl: typeof fetch): DatasourceClientOptions {
+  return { baseUrl: BASE, credential: { apiKey: API_KEY }, fetchImpl };
 }
 
 describe("datasource-client route mapping (#4044)", () => {
@@ -66,6 +76,14 @@ describe("datasource-client route mapping (#4044)", () => {
     expect(calls[0].method).toBe("GET");
     expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections`);
     expect(calls[0].authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0].apiKey).toBeNull();
+  });
+
+  it("an api-key credential sends x-api-key (not Authorization) — #4112", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { connections: [] });
+    await listDatasources(apiKeyOpts(fetchImpl));
+    expect(calls[0].apiKey).toBe(API_KEY);
+    expect(calls[0].authorization).toBeNull();
   });
 
   it("list tolerates a missing connections array", async () => {
@@ -218,7 +236,7 @@ describe("datasource-client error mapping (#4044)", () => {
 
   it("a network failure → network", async () => {
     const fetchImpl = (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
-    const err = await listDatasources({ baseUrl: BASE, token: TOKEN, fetchImpl }).catch((e) => e);
+    const err = await listDatasources({ baseUrl: BASE, credential: { token: TOKEN }, fetchImpl }).catch((e) => e);
     expect((err as DatasourceCliError).kind).toBe("network");
     expect((err as DatasourceCliError).message).toContain(BASE);
   });
@@ -229,7 +247,7 @@ describe("datasource-client error mapping (#4044)", () => {
       e.name = "TimeoutError";
       return Promise.reject(e);
     }) as unknown as typeof fetch;
-    const err = await testDatasource({ baseUrl: BASE, token: TOKEN, fetchImpl }, "x").catch((e) => e);
+    const err = await testDatasource({ baseUrl: BASE, credential: { token: TOKEN }, fetchImpl }, "x").catch((e) => e);
     expect((err as DatasourceCliError).kind).toBe("network");
     expect((err as DatasourceCliError).message).toContain("Timed out");
     expect((err as DatasourceCliError).message).toContain("test datasource");
@@ -253,7 +271,7 @@ describe("datasource-client error mapping (#4044)", () => {
         status: 502,
         headers: { "Content-Type": "text/html" },
       })) as unknown as typeof fetch;
-    const err = await listDatasources({ baseUrl: BASE, token: TOKEN, fetchImpl }).catch((e) => e);
+    const err = await listDatasources({ baseUrl: BASE, credential: { token: TOKEN }, fetchImpl }).catch((e) => e);
     expect((err as DatasourceCliError).kind).toBe("request_failed");
     expect((err as DatasourceCliError).message).toContain("HTTP 502");
   });
@@ -317,6 +335,10 @@ function stubNdjsonStream(chunks: string[]): { fetchImpl: typeof fetch; calls: C
         init?.headers && typeof init.headers === "object"
           ? ((init.headers as Record<string, string>).Authorization ?? null)
           : null,
+      apiKey:
+        init?.headers && typeof init.headers === "object"
+          ? ((init.headers as Record<string, string>)["x-api-key"] ?? null)
+          : null,
       body: typeof init?.body === "string" ? init.body : undefined,
     });
     const encoder = new TextEncoder();
@@ -357,7 +379,17 @@ describe("datasource-client profile streaming (#4052)", () => {
     expect(calls[0].method).toBe("POST");
     expect(calls[0].url).toBe(`${BASE}/api/v1/datasources/prod-us/profile`);
     expect(calls[0].authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0].apiKey).toBeNull();
     expect(calls[0].body).toBe("{}");
+  });
+
+  it("an api-key credential sends x-api-key on the profile stream too (#4112)", async () => {
+    // profileDatasource has its OWN credentialHeaders() call site, distinct from
+    // the generic request() one — pin the key path here, not just on the bearer.
+    const { fetchImpl, calls } = stubNdjsonStream([`${resultLine}\n`]);
+    await profileDatasource(apiKeyOpts(fetchImpl), { id: "prod-us" });
+    expect(calls[0].apiKey).toBe(API_KEY);
+    expect(calls[0].authorization).toBeNull();
   });
 
   it("passes a schema override in the body when supplied", async () => {

--- a/packages/cli/src/__tests__/datasource-command.test.ts
+++ b/packages/cli/src/__tests__/datasource-command.test.ts
@@ -70,6 +70,120 @@ describe("runDatasource — auth + dispatch guards (#4044)", () => {
   });
 });
 
+/** Like stubFetch but captures request headers so the credential path is assertable. */
+function stubFetchHeaders(
+  status: number,
+  body: unknown,
+): { fetchImpl: typeof fetch; calls: Array<{ url: string; headers: Record<string, string> }> } {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      new Headers(init.headers as Record<string, string>).forEach((v, k) => {
+        headers[k] = v;
+      });
+    }
+    calls.push({ url: typeof url === "string" ? url : url.toString(), headers });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("runDatasource — workspace API key (#4112 unattended CI)", () => {
+  it("sends the key on x-api-key (not Authorization) when ATLAS_API_KEY is set, with no session", async () => {
+    const { fetchImpl, calls } = stubFetchHeaders(200, { connections: [] });
+    const { io } = capture();
+    const code = await runDatasource(
+      ["datasource", "list"],
+      { baseUrl: BASE, session: null, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_wk_abc");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("the --api-key flag overrides ATLAS_API_KEY (deps.apiKey)", async () => {
+    const { fetchImpl, calls } = stubFetchHeaders(200, { connections: [] });
+    const { io } = capture();
+    const code = await runDatasource(
+      ["datasource", "list", "--api-key", "flag_key"],
+      { baseUrl: BASE, session: null, apiKey: "env_key", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("flag_key");
+  });
+
+  it("does not mistake the --api-key value for the datasource id positional", async () => {
+    const { fetchImpl, calls } = stubFetchHeaders(200, { id: "prod-us", dbType: "postgres" });
+    const { io } = capture();
+    const code = await runDatasource(
+      ["datasource", "get", "--api-key", "flag_key", "prod-us"],
+      { baseUrl: BASE, session: null, fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].url).toBe(`${BASE}/api/v1/admin/connections/prod-us`);
+  });
+
+  it("the api-key path takes precedence over a stored session", async () => {
+    const { fetchImpl, calls } = stubFetchHeaders(200, { connections: [] });
+    const { io } = capture();
+    await runDatasource(
+      ["datasource", "list"],
+      { baseUrl: BASE, session: SESSION, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_wk_abc");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("list --json falls back to a null workspaceId on the api-key path (no local session)", async () => {
+    const { fetchImpl } = stubFetchHeaders(200, { connections: [{ id: "prod-us" }] });
+    const { io, out } = capture();
+    const code = await runDatasource(
+      ["datasource", "list", "--json"],
+      { baseUrl: BASE, session: null, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out.join("\n"));
+    expect(parsed.workspaceId).toBeNull();
+    expect(parsed.datasources[0].id).toBe("prod-us");
+  });
+
+  it("create does not mistake the --api-key value for the id positional", async () => {
+    const { fetchImpl, bodies } = stubFetchCapturing(201, { id: "prod-us", dbType: "postgres" });
+    const { io } = capture();
+    const code = await runDatasource(
+      ["datasource", "create", "--api-key", "flag_key", "prod-us"],
+      {
+        baseUrl: BASE,
+        session: null,
+        apiKey: "env_key",
+        fetchImpl,
+        secretCapture: secretDeps({ envValue: "postgres://u:p@h/db" }),
+      },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(bodies[0]).id).toBe("prod-us");
+  });
+
+  it("with neither a session nor an api-key, refuses with a login + ATLAS_API_KEY hint", async () => {
+    const { io, err } = capture();
+    const code = await runDatasource(["datasource", "list"], deps(undefined, null), io);
+    expect(code).toBe(1);
+    const joined = err.join("\n");
+    expect(joined).toContain("atlas login");
+    expect(joined).toContain("ATLAS_API_KEY");
+  });
+});
+
 describe("runDatasource — list (#4044)", () => {
   it("renders a table of the workspace's datasources", async () => {
     const { fetchImpl } = stubFetch(200, {

--- a/packages/cli/src/__tests__/explore.test.ts
+++ b/packages/cli/src/__tests__/explore.test.ts
@@ -111,6 +111,75 @@ describe("runExplore — request shaping", () => {
   });
 });
 
+describe("runExplore — workspace API key (#4112 unattended CI)", () => {
+  it("sends the key on x-api-key (not Authorization) when ATLAS_API_KEY is set, with no session", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { output: "ok" });
+    const { io } = capture();
+    const code = await runExplore(
+      ["explore", "ls"],
+      { baseUrl: BASE, session: null, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("x-api-key")).toBe("atlas_wk_abc");
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("the --api-key flag overrides ATLAS_API_KEY and never leaks into the command", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { output: "ok" });
+    const { io } = capture();
+    const code = await runExplore(
+      ["explore", "ls", "entities/", "--api-key", "flag_key"],
+      { baseUrl: BASE, session: null, apiKey: "env_key", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("x-api-key")).toBe("flag_key");
+    // Neither the flag nor its value pollutes the explore command the server runs.
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ command: "ls entities/" });
+  });
+
+  it("accepts the inline --api-key=<key> form and strips it from the command", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { output: "ok" });
+    const { io } = capture();
+    const code = await runExplore(
+      ["explore", "cat catalog.yml", "--api-key=inline_key"],
+      { baseUrl: BASE, session: null, fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("x-api-key")).toBe("inline_key");
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ command: "cat catalog.yml" });
+  });
+
+  it("the api-key path takes precedence over a stored session", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { output: "ok" });
+    const { io } = capture();
+    await runExplore(
+      ["explore", "ls"],
+      { baseUrl: BASE, session: SESSION, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    const headers = new Headers(calls[0].init?.headers);
+    expect(headers.get("x-api-key")).toBe("atlas_wk_abc");
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("with neither a session nor an api-key, refuses with a login + ATLAS_API_KEY hint", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { output: "" });
+    const { io, err } = capture();
+    const code = await runExplore(["explore", "ls"], deps(fetchImpl, null), io);
+    expect(code).toBe(1);
+    const joined = err.join("\n");
+    expect(joined).toContain("atlas login");
+    expect(joined).toContain("ATLAS_API_KEY");
+    expect(calls).toHaveLength(0);
+  });
+});
+
 describe("runExplore — output", () => {
   it("prints the command output on success (exit 0)", async () => {
     const { fetchImpl } = stubFetch(200, { output: "file1.yml\nfile2.yml" });

--- a/packages/cli/src/__tests__/metric-command.test.ts
+++ b/packages/cli/src/__tests__/metric-command.test.ts
@@ -16,17 +16,27 @@ function capture(): { io: MetricIO; out: string[]; err: string[] } {
   return { io: { out: (l) => out.push(l), err: (l) => err.push(l) }, out, err };
 }
 
-/** Single-canned-response fetch capturing requests + their bodies. */
+/** Single-canned-response fetch capturing requests + their bodies + headers. */
 function stubFetch(
   status: number,
   body: unknown,
-): { fetchImpl: typeof fetch; calls: Array<{ method: string; url: string; body: string }> } {
-  const calls: Array<{ method: string; url: string; body: string }> = [];
+): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ method: string; url: string; body: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ method: string; url: string; body: string; headers: Record<string, string> }> = [];
   const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      new Headers(init.headers as Record<string, string>).forEach((v, k) => {
+        headers[k] = v;
+      });
+    }
     calls.push({
       method: init?.method ?? "GET",
       url: typeof url === "string" ? url : url.toString(),
       body: typeof init?.body === "string" ? init.body : "",
+      headers,
     });
     return new Response(JSON.stringify(body), {
       status,
@@ -150,6 +160,97 @@ describe("runMetricCommand — execution", () => {
     const joined = out.join("\n");
     expect(joined).toContain("region");
     expect(joined).toContain("us");
+  });
+});
+
+describe("runMetricCommand — workspace API key (#4112 unattended CI)", () => {
+  it("sends the key on x-api-key (not Authorization) when ATLAS_API_KEY is set, with no session", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_SCALAR);
+    const { io } = capture();
+    const code = await runMetricCommand(
+      ["metric", "run", "total_gmv"],
+      { baseUrl: BASE, session: null, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_wk_abc");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("the --api-key flag overrides ATLAS_API_KEY (deps.apiKey)", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_SCALAR);
+    const { io } = capture();
+    const code = await runMetricCommand(
+      ["metric", "run", "total_gmv", "--api-key", "flag_key"],
+      { baseUrl: BASE, session: null, apiKey: "env_key", fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("flag_key");
+  });
+
+  it("does not mistake the --api-key value for the metric id positional", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_SCALAR);
+    const { io } = capture();
+    const code = await runMetricCommand(
+      ["metric", "run", "--api-key", "flag_key", "total_gmv"],
+      { baseUrl: BASE, session: null, fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].url).toBe(`${BASE}/api/v1/metrics/total_gmv/run`);
+  });
+
+  it("honors the inline --api-key=<key> form and does not silently fall back to the session", async () => {
+    // Regression: a space-only flag reader drops `--api-key=key` and would run as
+    // the ambient session — wrong identity, no error. The key must win here.
+    const { fetchImpl, calls } = stubFetch(200, OK_SCALAR);
+    const { io } = capture();
+    const code = await runMetricCommand(
+      ["metric", "run", "total_gmv", "--api-key=inline_key"],
+      { baseUrl: BASE, session: SESSION, fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("inline_key");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+    expect(calls[0].url).toBe(`${BASE}/api/v1/metrics/total_gmv/run`);
+  });
+
+  it("the api-key path takes precedence over a stored session", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_SCALAR);
+    const { io } = capture();
+    await runMetricCommand(
+      ["metric", "run", "total_gmv"],
+      { baseUrl: BASE, session: SESSION, apiKey: "atlas_wk_abc", fetchImpl },
+      io,
+    );
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_wk_abc");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("with neither a session nor an api-key, refuses with a login + ATLAS_API_KEY hint", async () => {
+    const { io, err } = capture();
+    const code = await runMetricCommand(["metric", "run", "total_gmv"], deps(undefined, null), io);
+    expect(code).toBe(1);
+    const joined = err.join("\n");
+    expect(joined).toContain("atlas login");
+    expect(joined).toContain("ATLAS_API_KEY");
+  });
+
+  it("does not mistake the --connection value for the metric id positional", async () => {
+    // Pre-existing argv gap surfaced by adding a second value flag: the id finder
+    // must skip a value-taking flag's value, not return it as the id.
+    const { fetchImpl, calls } = stubFetch(200, { ...OK_SCALAR, id: "prod_signups" });
+    const { io } = capture();
+    const code = await runMetricCommand(
+      ["metric", "run", "--connection", "us-prod", "prod_signups"],
+      deps(fetchImpl),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].url).toBe(`${BASE}/api/v1/metrics/prod_signups/run`);
+    expect(JSON.parse(calls[0].body)).toEqual({ connectionId: "us-prod" });
   });
 });
 

--- a/packages/cli/src/__tests__/sql-command.test.ts
+++ b/packages/cli/src/__tests__/sql-command.test.ts
@@ -201,6 +201,22 @@ describe("runSqlCommand — workspace API key (#4046 unattended CI)", () => {
     expect(JSON.parse(calls[0].body)).toEqual({ sql: "SELECT 7" });
   });
 
+  it("honors the inline --api-key=<key> form and does not silently fall back to the session", async () => {
+    // Regression: a space-only flag reader drops `--api-key=key` and would run as
+    // the ambient session — wrong identity, no error. The key must win here.
+    const { fetchImpl, calls } = stubFetch(200, OK_ROWS);
+    const { io } = capture();
+    const code = await runSqlCommand(
+      ["sql", "SELECT 1", "--api-key=inline_key"],
+      { baseUrl: BASE, session: SESSION, fetchImpl },
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("inline_key");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+    expect(JSON.parse(calls[0].body)).toEqual({ sql: "SELECT 1" });
+  });
+
   it("the api-key path takes precedence over a stored session", async () => {
     const { fetchImpl, calls } = stubFetch(200, OK_ROWS);
     const { io } = capture();

--- a/packages/cli/src/commands/datasource.ts
+++ b/packages/cli/src/commands/datasource.ts
@@ -27,6 +27,7 @@
 
 import { renderTable } from "../../lib/output";
 import { resolveApiBaseUrl } from "../lib/api-base";
+import { readApiKeyFlag, resolveCredential } from "../lib/credential";
 import { readSession, type StoredSession } from "../lib/credentials";
 import { createProgressTracker } from "../progress";
 import {
@@ -66,6 +67,8 @@ Commands:
 
 Options:
   --json              Machine-readable JSON output
+  --api-key <key>     Use a workspace API key instead of your \`atlas login\` session
+                      (unattended CI). Overrides ATLAS_API_KEY.
   --description <s>   (create) Human-readable description
   --schema <s>        (create) Schema to scope to (e.g. a Postgres schema)
   --group <id>        (create) Attach to an existing environment/group
@@ -80,7 +83,10 @@ Every datasource command requires the workspace admin role (admin/owner); a
 non-admin member is denied with an actionable message.
 \`profile\` is long-running: it streams per-table progress and is cancellable
 (Ctrl-C). Generated entities land as DRAFTS — publish them from the admin console.
-Requires \`atlas login\` first. Set ATLAS_API_URL to target a non-local API.`;
+
+Authentication: \`atlas login\` for interactive use (ambient session reuse — no
+key needed), OR a workspace API key via --api-key / ATLAS_API_KEY for unattended
+CI. Set ATLAS_API_URL to target a non-local API.`;
 
 /** The id-taking lifecycle subcommands (everything except `list` and `create`). */
 const ID_SUBCOMMANDS = ["get", "test", "profile", "archive", "restore", "delete"] as const;
@@ -109,6 +115,12 @@ const defaultIO: DatasourceIO = {
 export interface DatasourceRunDeps {
   readonly baseUrl: string;
   readonly session: StoredSession | null;
+  /**
+   * A workspace-scoped API key for unattended CI (#4046), resolved from the
+   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
+   * precedence over the stored session — CI never goes through `atlas login`.
+   */
+  readonly apiKey?: string;
   readonly fetchImpl?: typeof fetch;
   /**
    * Secret-capture probes + prompt for `create` (injected so tests exercise the
@@ -118,9 +130,22 @@ export interface DatasourceRunDeps {
   readonly secretCapture?: SecretCaptureDeps;
 }
 
-/** First non-flag argument after the subcommand (the datasource id), if any. */
+/**
+ * First non-flag argument after the subcommand (the datasource id), if any.
+ * Skips the value consumed by `--api-key <key>` (the one value-taking flag the
+ * id-subcommands accept) so the key is never mistaken for the id.
+ */
 function positionalId(args: string[]): string | undefined {
-  return args.slice(2).find((a) => !a.startsWith("--"));
+  for (let i = 2; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--api-key") {
+      i++; // skip the key value
+      continue;
+    }
+    if (a.startsWith("--")) continue;
+    return a;
+  }
+  return undefined;
 }
 
 /** The `create` flags that consume the following argument as their value. */
@@ -134,7 +159,9 @@ const CREATE_VALUE_FLAGS = ["--description", "--schema", "--group", "--new-group
  * flags like `--json` consume nothing. Returns undefined when no id is present.
  */
 function createPositionalId(args: string[]): string | undefined {
-  const valueFlags = new Set<string>(CREATE_VALUE_FLAGS);
+  // `--api-key <key>` is a global credential flag (not create metadata), but it
+  // still consumes its following token — include it so the key isn't read as id.
+  const valueFlags = new Set<string>([...CREATE_VALUE_FLAGS, "--api-key"]);
   // Skip args[0] ("datasource") and args[1] ("create").
   for (let i = 2; i < args.length; i++) {
     const a = args[i];
@@ -260,14 +287,19 @@ export async function runDatasource(
     return 1;
   }
 
-  if (!deps.session) {
-    io.err("Not logged in. Run `atlas login` first.");
+  // A workspace API key (#4046, unattended CI) takes precedence over a stored
+  // login; the flag (either `--api-key key` or `--api-key=key`) wins over the env
+  // var (deps.apiKey). Keys are workspace-pinned, so no rebind is needed.
+  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
+  const credential = resolveCredential(apiKey, deps.session);
+  if (!credential) {
+    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
     return 1;
   }
 
   const opts: DatasourceClientOptions = {
     baseUrl: deps.baseUrl,
-    token: deps.session.token,
+    credential,
     ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
   };
   const json = args.includes("--json");
@@ -291,10 +323,14 @@ export async function runDatasource(
 
   try {
     const datasources = await listDatasources(opts);
+    // An api-key path has no local session, so the bound workspace id isn't
+    // known client-side — the server resolves it from the key. Fall back to
+    // null (the empty-state line and JSON envelope both tolerate it).
+    const workspaceId = deps.session?.workspaceId ?? null;
     if (json) {
-      io.out(JSON.stringify({ workspaceId: deps.session.workspaceId, datasources }, null, 2));
+      io.out(JSON.stringify({ workspaceId, datasources }, null, 2));
     } else {
-      renderList(io, deps.session.workspaceId, datasources);
+      renderList(io, workspaceId, datasources);
     }
     return 0;
   } catch (err) {
@@ -553,6 +589,15 @@ function liveSecretCapture(): SecretCaptureDeps {
 export async function handleDatasource(args: string[]): Promise<void> {
   const baseUrl = resolveApiBaseUrl();
   const session = readSession(baseUrl);
-  const code = await runDatasource(args, { baseUrl, session, secretCapture: liveSecretCapture() });
+  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
+  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
+  // interactive login). `--api-key` (parsed in runDatasource) overrides it.
+  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
+  const code = await runDatasource(args, {
+    baseUrl,
+    session,
+    ...(apiKey ? { apiKey } : {}),
+    secretCapture: liveSecretCapture(),
+  });
   if (code !== 0) process.exit(code);
 }

--- a/packages/cli/src/commands/explore.ts
+++ b/packages/cli/src/commands/explore.ts
@@ -16,11 +16,12 @@
  */
 
 import { resolveApiBaseUrl } from "../lib/api-base";
+import { credentialHeaders, resolveCredential } from "../lib/credential";
 import { readSession, type StoredSession } from "../lib/credentials";
 
 const USAGE = `Run a read-only command against your logged-in workspace's semantic layer.
 
-Usage: atlas explore <command...> [--json]
+Usage: atlas explore <command...> [--api-key <key>] [--json]
 
 Examples:
   atlas explore ls
@@ -29,12 +30,17 @@ Examples:
   atlas explore "find . -name '*.yml'" --json
 
 Options:
+  --api-key <key>     Use a workspace API key instead of your \`atlas login\` session
+                      (unattended CI). Overrides ATLAS_API_KEY.
   --json              Machine-readable JSON output ({ "output": "..." })
 
 Only read-only commands run (ls/cat/grep/find/head/tail/wc/awk/sed/pipes). The
 server sandboxes execution scoped to the semantic layer — writes, shell escapes,
 and path traversal are rejected.
-Requires \`atlas login\` first. Set ATLAS_API_URL to target a non-local API.`;
+
+Authentication: \`atlas login\` for interactive use (ambient session reuse — no
+key needed), OR a workspace API key via --api-key / ATLAS_API_KEY for unattended
+CI. Set ATLAS_API_URL to target a non-local API.`;
 
 /** stdout/stderr sink — injected so tests can capture output. */
 export interface ExploreIO {
@@ -51,6 +57,12 @@ const defaultIO: ExploreIO = {
 export interface ExploreRunDeps {
   readonly baseUrl: string;
   readonly session: StoredSession | null;
+  /**
+   * A workspace-scoped API key for unattended CI (#4046), resolved from the
+   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
+   * precedence over the stored session — CI never goes through `atlas login`.
+   */
+  readonly apiKey?: string;
   readonly fetchImpl?: typeof fetch;
 }
 
@@ -61,6 +73,39 @@ interface ExploreResponse {
 
 /** CLI-owned flags stripped from the argv before the rest becomes the command. */
 const CLI_FLAGS = new Set(["--json", "--help", "-h"]);
+const API_KEY_FLAG = "--api-key";
+
+/**
+ * Split the argv into the explore command string and the optional `--api-key`
+ * value. The command is every token after the literal EXCEPT this CLI's own
+ * flags (`--json`/`--help`/`-h`) and the credential flag (`--api-key <key>` or
+ * `--api-key=<key>`) — so neither the key nor the flag itself leaks into the
+ * command the server runs, while a command's own `--`-style argument (e.g.
+ * `grep --include='*.yml'`) is preserved.
+ */
+function parseExploreArgs(args: string[]): { command: string; apiKey?: string } {
+  const tokens = args.slice(1);
+  const positional: string[] = [];
+  let apiKey: string | undefined;
+  for (let i = 0; i < tokens.length; i++) {
+    const a = tokens[i];
+    if (a === API_KEY_FLAG) {
+      const next = tokens[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        apiKey = next;
+        i++; // consume the value token
+      }
+      continue;
+    }
+    if (a.startsWith(`${API_KEY_FLAG}=`)) {
+      apiKey = a.slice(API_KEY_FLAG.length + 1);
+      continue;
+    }
+    if (CLI_FLAGS.has(a)) continue;
+    positional.push(a);
+  }
+  return { command: positional.join(" ").trim(), ...(apiKey ? { apiKey } : {}) };
+}
 
 /**
  * Run the explore command. Returns an exit code (0 success, 1 failure) without
@@ -84,19 +129,20 @@ export async function runExplore(
   }
 
   const json = args.includes("--json");
-  const command = args
-    .slice(1)
-    .filter((a) => !CLI_FLAGS.has(a))
-    .join(" ")
-    .trim();
+  const { command, apiKey: argApiKey } = parseExploreArgs(args);
 
   if (!command) {
     io.out(USAGE);
     return 1;
   }
 
-  if (!deps.session) {
-    io.err("Not logged in. Run `atlas login` first.");
+  // A workspace API key (#4046, unattended CI) takes precedence over a stored
+  // login; the flag wins over the env var (deps.apiKey). Keys are
+  // workspace-pinned, so no rebind is needed.
+  const apiKey = argApiKey ?? deps.apiKey;
+  const credential = resolveCredential(apiKey, deps.session);
+  if (!credential) {
+    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
     return 1;
   }
 
@@ -108,7 +154,7 @@ export async function runExplore(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${deps.session.token}`,
+        ...credentialHeaders(credential),
       },
       body: JSON.stringify({ command }),
       signal: AbortSignal.timeout(30_000),
@@ -158,6 +204,10 @@ export async function runExplore(
 export async function handleExplore(args: string[]): Promise<void> {
   const baseUrl = resolveApiBaseUrl();
   const session = readSession(baseUrl);
-  const code = await runExplore(args, { baseUrl, session });
+  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
+  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
+  // interactive login). `--api-key` (parsed in runExplore) overrides it.
+  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
+  const code = await runExplore(args, { baseUrl, session, ...(apiKey ? { apiKey } : {}) });
   if (code !== 0) process.exit(code);
 }

--- a/packages/cli/src/commands/metric.ts
+++ b/packages/cli/src/commands/metric.ts
@@ -21,6 +21,7 @@
 
 import { renderTable } from "../../lib/output";
 import { resolveApiBaseUrl } from "../lib/api-base";
+import { readApiKeyFlag, resolveCredential } from "../lib/credential";
 import { readSession, type StoredSession } from "../lib/credentials";
 import {
   MetricCliError,
@@ -38,11 +39,16 @@ Arguments:
 
 Options:
   --connection <id>   Run against a specific datasource in the metric's group
+  --api-key <key>     Use a workspace API key instead of your \`atlas login\` session
+                      (unattended CI). Overrides ATLAS_API_KEY.
   --json              Machine-readable JSON output
 
 The metric's SQL is used exactly as defined (authoritative). Group routing is
 honored — a grouped metric runs against its own group's datasource.
-Requires \`atlas login\` first. Set ATLAS_API_URL to target a non-local API.`;
+
+Authentication: \`atlas login\` for interactive use (ambient session reuse — no
+key needed), OR a workspace API key via --api-key / ATLAS_API_KEY for unattended
+CI. Set ATLAS_API_URL to target a non-local API.`;
 
 /** stdout/stderr sink — injected so tests can capture output. */
 export interface MetricIO {
@@ -59,6 +65,12 @@ const defaultIO: MetricIO = {
 export interface MetricRunDeps {
   readonly baseUrl: string;
   readonly session: StoredSession | null;
+  /**
+   * A workspace-scoped API key for unattended CI (#4046), resolved from the
+   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
+   * precedence over the stored session — CI never goes through `atlas login`.
+   */
+  readonly apiKey?: string;
   readonly fetchImpl?: typeof fetch;
 }
 
@@ -67,6 +79,27 @@ function getFlagValue(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
   if (idx === -1 || idx === args.length - 1) return undefined;
   return args[idx + 1];
+}
+
+/** Flags whose following token is a value, not the metric id positional. */
+const METRIC_VALUE_FLAGS = new Set(["--connection", "--api-key"]);
+
+/**
+ * The metric id: the first non-flag positional after `run`, skipping any token
+ * consumed by a value-taking flag (`--connection <id>`, `--api-key <key>`) so a
+ * flag's value can never be mistaken for the id.
+ */
+function findMetricId(args: string[]): string | undefined {
+  for (let i = 2; i < args.length; i++) {
+    const a = args[i];
+    if (METRIC_VALUE_FLAGS.has(a)) {
+      i++; // skip the value token this flag consumes
+      continue;
+    }
+    if (a.startsWith("--")) continue;
+    return a;
+  }
+  return undefined;
 }
 
 /** Render a metric result for humans: scalar inline, or a table for rows. */
@@ -117,15 +150,22 @@ export async function runMetricCommand(
     return 1;
   }
 
-  // The metric id is the first non-flag positional after `run`.
-  const id = args.slice(2).find((a) => !a.startsWith("--"));
+  // The metric id is the first non-flag positional after `run` (skipping any
+  // value consumed by `--connection`/`--api-key`).
+  const id = findMetricId(args);
   if (!id) {
-    io.err("Usage: atlas metric run <id> [--connection <id>] [--json]");
+    io.err("Usage: atlas metric run <id> [--connection <id>] [--api-key <key>] [--json]");
     return 1;
   }
 
-  if (!deps.session) {
-    io.err("Not logged in. Run `atlas login` first.");
+  // A workspace API key (#4046, unattended CI) takes precedence over a stored
+  // login; the flag (either `--api-key key` or `--api-key=key`) wins over the env
+  // var (deps.apiKey) so an interactive override is possible. Keys are
+  // workspace-pinned, so no rebind is needed.
+  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
+  const credential = resolveCredential(apiKey, deps.session);
+  if (!credential) {
+    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
     return 1;
   }
 
@@ -134,7 +174,7 @@ export async function runMetricCommand(
 
   const opts: MetricClientOptions = {
     baseUrl: deps.baseUrl,
-    token: deps.session.token,
+    credential,
     ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
   };
 
@@ -164,6 +204,10 @@ export async function runMetricCommand(
 export async function handleMetric(args: string[]): Promise<void> {
   const baseUrl = resolveApiBaseUrl();
   const session = readSession(baseUrl);
-  const code = await runMetricCommand(args, { baseUrl, session });
+  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
+  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
+  // interactive login). `--api-key` (parsed in runMetricCommand) overrides it.
+  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
+  const code = await runMetricCommand(args, { baseUrl, session, ...(apiKey ? { apiKey } : {}) });
   if (code !== 0) process.exit(code);
 }

--- a/packages/cli/src/commands/sql.ts
+++ b/packages/cli/src/commands/sql.ts
@@ -26,6 +26,7 @@
 
 import { formatCsvValue, quoteCsvField, renderTable } from "../../lib/output";
 import { resolveApiBaseUrl } from "../lib/api-base";
+import { readApiKeyFlag } from "../lib/credential";
 import { readSession, type StoredSession } from "../lib/credentials";
 import { resolveActiveWorkspace, formatWorkspaceError } from "../lib/workspaces";
 import {
@@ -158,8 +159,9 @@ export async function runSqlCommand(
   }
 
   // A workspace API key (#4046, unattended CI) takes precedence over a stored
-  // login. The flag wins over the env var so an interactive override is possible.
-  const apiKey = getFlagValue(args, "--api-key") ?? deps.apiKey;
+  // login. The flag (either `--api-key key` or `--api-key=key`) wins over the env
+  // var so an interactive override is possible.
+  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
   // `--workspace` in EITHER form — space (`--workspace x`) or inline
   // (`--workspace=x`). `resolveActiveWorkspace` accepts both, so the api-key
   // guard below must reject both; a space-only check would let `--workspace=x`
@@ -180,7 +182,7 @@ export async function runSqlCommand(
 
     const opts: SqlClientOptions = {
       baseUrl: deps.baseUrl,
-      apiKey,
+      credential: { apiKey },
       ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
     };
     return runAndRender(opts, sql, connectionId, json, csv, io);
@@ -210,7 +212,7 @@ export async function runSqlCommand(
 
   const opts: SqlClientOptions = {
     baseUrl: deps.baseUrl,
-    token: deps.session.token,
+    credential: { token: deps.session.token },
     ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
   };
   return runAndRender(opts, sql, connectionId, json, csv, io);

--- a/packages/cli/src/lib/credential.ts
+++ b/packages/cli/src/lib/credential.ts
@@ -1,0 +1,81 @@
+/**
+ * The workspace credential the REST-backed CLI clients updated in #4112
+ * (`sql`/`metric`/`explore`/`datasource`) authenticate with (ADR-0027 §5). The
+ * legacy `query`/`import`/`init` commands route `ATLAS_API_KEY` through the
+ * separate operator-Bearer path and do NOT use this type.
+ *
+ * Authorization rides on exactly ONE of two mutually-exclusive credential
+ * classes — never both:
+ *  - the `atlas login` device-flow SESSION bearer (interactive / ambient reuse),
+ *    sent as `Authorization: Bearer <token>`; OR
+ *  - a workspace-scoped API key for UNATTENDED CI (#4046), sent as
+ *    `x-api-key: <key>` (the Better Auth `apiKey()` plugin's header).
+ *
+ * Modelled as an XOR (a discriminated union), NOT two independent optionals, so
+ * "exactly one credential" is a compile-time invariant the clients can't violate
+ * — there is no representable `{ token, apiKey }` (both) or `{}` (neither) state.
+ * The server resolves whichever header it sees to the bound workspace and runs
+ * the full gate chain; the CLI never re-derives any of that and never sends an
+ * org/workspace field.
+ */
+export type CliCredential =
+  | { readonly token: string; readonly apiKey?: never }
+  | { readonly apiKey: string; readonly token?: never };
+
+/**
+ * The auth header for a credential: `x-api-key` for a workspace key, otherwise
+ * `Authorization: Bearer` for a device-flow session. The XOR type guarantees
+ * exactly one branch applies — there is no "both/neither" runtime ambiguity to
+ * defend against.
+ */
+export function credentialHeaders(credential: CliCredential): Record<string, string> {
+  return credential.apiKey
+    ? { "x-api-key": credential.apiKey }
+    : { Authorization: `Bearer ${credential.token}` };
+}
+
+/**
+ * Read the `--api-key <key>` flag from argv, accepting BOTH the space form
+ * (`--api-key foo`) and the inline form (`--api-key=foo`). Single-sourced here so
+ * `sql`/`metric`/`datasource` honour an explicitly-passed key identically: a
+ * command that matched only the space form would silently drop `--api-key=foo`
+ * and fall back to the ambient `atlas login` session — running as the wrong
+ * identity with no surfaced error. Returns undefined when the flag is absent (or
+ * its space form has no value), so the caller falls through to `ATLAS_API_KEY`.
+ *
+ * `explore` does NOT use this — it must also strip the flag + value out of the
+ * command string it forwards to the server, so it parses argv in one pass
+ * (`parseExploreArgs`) that handles both forms identically.
+ */
+export function readApiKeyFlag(args: string[]): string | undefined {
+  const prefix = "--api-key=";
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--api-key") {
+      const next = args[i + 1];
+      // `--api-key` with no following value (or another flag next) yields nothing.
+      return next !== undefined && !next.startsWith("--") ? next : undefined;
+    }
+    if (a.startsWith(prefix)) return a.slice(prefix.length);
+  }
+  return undefined;
+}
+
+/**
+ * Resolve which credential a command should use, applying the precedence the four
+ * REST-backed subcommands share (#4112) — `metric`/`explore`/`datasource` call
+ * this directly; `sql` applies the same precedence inline (it interleaves the
+ * `--workspace` rebind guard). A workspace API key (the `--api-key` flag or
+ * `ATLAS_API_KEY`, already collapsed into `apiKey` by the caller) wins over a
+ * stored `atlas login` session — unattended CI never goes through `atlas login`.
+ * Returns `null` when neither is present, so the caller can surface a single
+ * "log in or set ATLAS_API_KEY" message.
+ */
+export function resolveCredential(
+  apiKey: string | undefined,
+  session: { readonly token: string } | null,
+): CliCredential | null {
+  if (apiKey) return { apiKey };
+  if (session) return { token: session.token };
+  return null;
+}

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -16,18 +16,20 @@
  *   restore  → POST   /api/v1/admin/restore-connection      { connectionId }
  *   delete   → DELETE /api/v1/admin/connections/{id}
  *
- * Authorization rides entirely on the `atlas login` workspace credential: the
- * stored Better Auth session bearer (stamped `origin='cli'` server-side) is
- * sent as `Authorization: Bearer <token>`. The routes resolve it live to
- * `{ orgId, role }` through the same gate chain a web admin session clears, so
- * the call operates on ONLY the bound workspace's datasources and is denied
- * (403) when the credential's role isn't admin. The CLI never re-derives any of
- * that — it just surfaces the typed outcome.
+ * Authorization rides on the workspace credential — a `atlas login` device-flow
+ * SESSION bearer (`Authorization: Bearer`) XOR a workspace-scoped API key for
+ * unattended CI (#4046, `x-api-key`); see {@link CliCredential}. The routes
+ * resolve it live to `{ orgId, role }` through the same gate chain a web admin
+ * session clears, so the call operates on ONLY the bound workspace's datasources
+ * and is denied (403) when the credential's role isn't admin. The CLI never
+ * re-derives any of that — it just surfaces the typed outcome.
  *
  * `fetch` is injectable so the route mapping + status-code handling are
  * unit-testable without a live server (mirrors `device-flow.ts`). No function
  * here calls `process.exit` or `console`; the command handler owns presentation.
  */
+
+import { credentialHeaders, type CliCredential } from "./credential";
 
 type FetchImpl = typeof fetch;
 
@@ -60,8 +62,11 @@ export class DatasourceCliError extends Error {
 export interface DatasourceClientOptions {
   /** Normalized Atlas API base URL (no trailing slash). */
   readonly baseUrl: string;
-  /** The stored `atlas login` session bearer. */
-  readonly token: string;
+  /**
+   * The workspace credential — a session bearer XOR a workspace API key (never
+   * both). See {@link CliCredential}.
+   */
+  readonly credential: CliCredential;
   /** Injectable for tests; defaults to the global `fetch`. */
   readonly fetchImpl?: FetchImpl;
   /** Per-request timeout in ms (default 30s). */
@@ -118,7 +123,7 @@ async function request(
     res = await fetchImpl(`${opts.baseUrl}${spec.path}`, {
       method: spec.method,
       headers: {
-        Authorization: `Bearer ${opts.token}`,
+        ...credentialHeaders(opts.credential),
         ...(spec.body !== undefined ? { "Content-Type": "application/json" } : {}),
       },
       ...(spec.body !== undefined ? { body: JSON.stringify(spec.body) } : {}),
@@ -451,7 +456,7 @@ export async function profileDatasource(
     res = await fetchImpl(`${opts.baseUrl}/api/v1/datasources/${encodeURIComponent(args.id)}/profile`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${opts.token}`,
+        ...credentialHeaders(opts.credential),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(args.schema ? { schema: args.schema } : {}),

--- a/packages/cli/src/lib/metric-client.ts
+++ b/packages/cli/src/lib/metric-client.ts
@@ -7,18 +7,20 @@
  * This maps one workspace CLI subcommand onto one route and surfaces the typed
  * outcome.
  *
- * Authorization rides entirely on the `atlas login` workspace credential: the
- * stored Better Auth session bearer (stamped `origin='cli'` server-side) is
- * sent as `Authorization: Bearer <token>`. The route resolves it live to
- * `{ orgId, role }`, runs billing gate-0, and executes the metric's
- * authoritative SQL against ONLY the bound workspace — the CLI never re-derives
- * any of that.
+ * Authorization rides on the workspace credential — a `atlas login` device-flow
+ * SESSION bearer (`Authorization: Bearer`) XOR a workspace-scoped API key for
+ * unattended CI (#4046, `x-api-key`); see {@link CliCredential}. Either way the
+ * route resolves it live to `{ orgId, role }`, runs billing gate-0, and executes
+ * the metric's authoritative SQL against ONLY the bound workspace — the CLI never
+ * re-derives any of that.
  *
  * `fetch` is injectable so the route mapping + status-code handling are
  * unit-testable without a live server (mirrors `datasource-client.ts`). No
  * function here calls `process.exit` or `console`; the command handler owns
  * presentation.
  */
+
+import { credentialHeaders, type CliCredential } from "./credential";
 
 type FetchImpl = typeof fetch;
 
@@ -61,8 +63,11 @@ export interface MetricRunResult {
 export interface MetricClientOptions {
   /** Normalized Atlas API base URL (no trailing slash). */
   readonly baseUrl: string;
-  /** The stored `atlas login` session bearer. */
-  readonly token: string;
+  /**
+   * The workspace credential — a session bearer XOR a workspace API key (never
+   * both). See {@link CliCredential}.
+   */
+  readonly credential: CliCredential;
   /** Injectable for tests; defaults to the global `fetch`. */
   readonly fetchImpl?: FetchImpl;
   /** Per-request timeout in ms (default 60s — a metric query can be slower than metadata). */
@@ -115,7 +120,7 @@ export async function runMetric(
       {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${opts.token}`,
+          ...credentialHeaders(opts.credential),
           "Content-Type": "application/json",
         },
         body: JSON.stringify(args.connectionId ? { connectionId: args.connectionId } : {}),

--- a/packages/cli/src/lib/sql-client.ts
+++ b/packages/cli/src/lib/sql-client.ts
@@ -24,6 +24,8 @@
  * here calls `process.exit` or `console`; the command handler owns presentation.
  */
 
+import { credentialHeaders, type CliCredential } from "./credential";
+
 type FetchImpl = typeof fetch;
 
 /** The kinds of failure a raw-SQL call can surface, each with an actionable message. */
@@ -65,15 +67,10 @@ export interface SqlClientOptions {
   /** Normalized Atlas API base URL (no trailing slash). */
   readonly baseUrl: string;
   /**
-   * The stored `atlas login` session bearer (`Authorization: Bearer`). Mutually
-   * exclusive with {@link apiKey}; exactly one credential must be supplied.
+   * The workspace credential — a session bearer XOR a workspace API key (never
+   * both). See {@link CliCredential}.
    */
-  readonly token?: string;
-  /**
-   * A workspace-scoped API key for unattended CI (#4046), sent as `x-api-key`.
-   * Mutually exclusive with {@link token}.
-   */
-  readonly apiKey?: string;
+  readonly credential: CliCredential;
   /** Injectable for tests; defaults to the global `fetch`. */
   readonly fetchImpl?: FetchImpl;
   /** Per-request timeout in ms (default 60s — a SQL query can be slower than metadata). */
@@ -116,19 +113,12 @@ export async function runSql(opts: SqlClientOptions, args: RunSqlArgs): Promise<
   const fetchImpl = opts.fetchImpl ?? fetch;
   const timeoutMs = opts.timeoutMs ?? 60_000;
 
-  // Exactly one credential class. A workspace API key (#4046) goes on `x-api-key`
-  // (the apiKey() plugin header); a device-flow session goes on `Authorization:
-  // Bearer`. Never send both — the server resolves whichever it sees.
-  const authHeader: Record<string, string> = opts.apiKey
-    ? { "x-api-key": opts.apiKey }
-    : { Authorization: `Bearer ${opts.token ?? ""}` };
-
   let res: Response;
   try {
     res = await fetchImpl(`${opts.baseUrl}/api/v1/execute-sql`, {
       method: "POST",
       headers: {
-        ...authHeader,
+        ...credentialHeaders(opts.credential),
         "Content-Type": "application/json",
       },
       // ONLY sql (+ optional connectionId) — never an org/workspace field. The


### PR DESCRIPTION
Closes #4112.

## Problem
Milestone #77 was framed as the REST-backed command suite **& API keys** for unattended CI, but the workspace API-key credential (`--api-key` / `ATLAS_API_KEY` → `x-api-key` header) was wired into **only** `atlas sql`. `atlas metric run`, `atlas explore`, and `atlas datasource *` were session-bearer-only — the servers accept `x-api-key` on all of them, so a CI job could run raw SQL with a key but had to do an interactive `atlas login` for the rest.

## What changed
- **New `CliCredential` XOR type** (`packages/cli/src/lib/credential.ts`) — a session bearer **XOR** a workspace key, never both/neither, as a compile-time invariant (AC #2: "expressed as an XOR in the client types, not two independent optionals"). Replaces the prior `token?`/`apiKey?` two-optionals shape on the client option interfaces. `credentialHeaders()` maps each branch to its one wire header; `resolveCredential()` single-sources the "api-key wins over session" precedence.
- **Threaded through** all three HTTP clients (`sql`/`metric`/`datasource`) + the four command files, so `metric run`, `explore`, and `datasource *` now accept `--api-key`/`ATLAS_API_KEY` and send `x-api-key`, mirroring `atlas sql` (AC #1). Keys are workspace-pinned, so the credential is resolved before dispatch with no rebind.
- **`readApiKeyFlag()`** handles both `--api-key key` and `--api-key=key`, so an explicitly-passed inline key is never silently dropped in favor of the ambient session (a wrong-identity footgun the internal review panel flagged on `sql`/`metric`).
- **Tests** (AC #3): per-command credential-precedence tests mirroring `sql-command.test.ts`'s api-key block, a direct `credential.test.ts` unit suite (precedence / both flag forms / empty-key fall-through), and an api-key assertion on `profileDatasource`'s own header call site.
- **Docs**: scoped the api-keys guide to the four REST-backed commands that honor a workspace key (the legacy `query`/`import`/`init` `Authorization: Bearer` path is unchanged).

AC #4 (pin sql-only as intentional) does not apply — this adds the parity rather than pinning the asymmetry.

## Verification
- `bun run lint` ✅ · `bun run type` ✅ · full `@atlas/cli` suite (43 files) ✅ · `check-test-discipline.sh` ✅ · `syncpack lint` ✅ (no `package.json` changes)
- Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy), 2 rounds to converge: fixed one MEDIUM (inline `--api-key=` silent session fallback) + a doc overclaim; final round CLEAN.

## Notes
- All changed consumers are within `packages/cli/src` — no external package imports the changed client internals.
- Overlaps the wire-type SSOT follow-up (#4111, in a parallel branch) on the shared-credential concept; this keeps the XOR CLI-local. Whichever lands second re-merges `main`.