### PR TITLE
fix(api,cli): milestone #77 sibling-route consistency cleanups (#4113)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -11559,7 +11559,7 @@
             }
           },
           "503": {
-            "description": "Billing subsystem unavailable (fail-closed)",
+            "description": "Billing or connection-resolution subsystem unavailable (fail-closed)",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/datasources.test.ts
+++ b/packages/api/src/api/__tests__/datasources.test.ts
@@ -86,6 +86,12 @@ type GateResult =
 const mockCheckAgentBillingGate: Mock<(orgId: string | undefined) => Promise<GateResult>> = mock(
   () => Promise.resolve({ allowed: true }),
 );
+// Curated stub: the route reaches `agent-gate` ONLY for `checkAgentBillingGate`.
+// Spreading the real module would transitively load the internal-DB graph
+// (defeating this standalone-router isolation), so we stub just the reached
+// export — same convention as the sibling metrics.test.ts. `BillingBlockedError`
+// is not referenced by this route, so omitting it is safe; Bun's per-file
+// `--isolate` keeps the partial mock from leaking.
 mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   checkAgentBillingGate: mockCheckAgentBillingGate,
 }));
@@ -319,6 +325,23 @@ describe("POST /datasources/{id}/profile — connection resolution (#4052)", () 
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.error).toBe("reconnect_required");
   });
+
+  it("503 resolve_unavailable when the resolver THROWS before the stream (correlated requestId, #4113)", async () => {
+    // A transient internal-DB fault from the dynamic import or resolveLiveConnection
+    // must fail closed to a 503 carrying THIS route's requestId — never escape to
+    // the global handler (fresh uncorrelated id) or start the stream. Distinct from
+    // the resolver's typed not_found/unsupported/reconnect outcomes above.
+    mockResolveLiveConnection.mockRejectedValue(new Error("internal DB down"));
+    const res = await app.fetch(profileRequest("prod-us"));
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("resolve_unavailable");
+    expect(body.retryable).toBe(true);
+    expect(typeof body.requestId).toBe("string");
+    // The stream never started: the profiler + connection-close are never reached.
+    expect(mockProfileLiveDatasource).not.toHaveBeenCalled();
+    expect(fakeConnection.close).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -383,6 +406,29 @@ describe("POST /datasources/{id}/profile — NDJSON streaming (#4052)", () => {
     await app.fetch(profileRequest("prod-us"));
     expect(capturedContext.agentOrigin).toBe("cli");
     expect(capturedContext.actorKind).toBe("api_key");
+  });
+
+  it("does NOT mislabel a non-cli session as cli (origin derived from claims, not hardcoded — #4113)", async () => {
+    // A real CLI credential always stamps origin=cli; a credential WITHOUT the
+    // claim (e.g. an admin web session reaching this route) must leave agentOrigin
+    // undefined, not be forced to "cli". Standardized to the undefined fallback
+    // across the four sibling CLI routes so origin-scoped approval matching can't
+    // see a fabricated origin.
+    mockAuthenticateRequest.mockResolvedValue({
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: {
+        id: "user-1",
+        mode: "managed",
+        label: "Alice",
+        role: "admin",
+        activeOrganizationId: "org-1",
+        claims: { sub: "user-1", org_id: "org-1" }, // no origin claim
+      },
+    } as unknown as AuthResult);
+    await app.fetch(profileRequest("prod-us"));
+    expect(capturedContext.agentOrigin).toBeUndefined();
+    expect(capturedContext.actorKind).toBe("human");
   });
 
   it("closes the live connection after profiling settles", async () => {

--- a/packages/api/src/api/__tests__/metrics.test.ts
+++ b/packages/api/src/api/__tests__/metrics.test.ts
@@ -295,6 +295,22 @@ describe("POST /api/v1/metrics/{id}/run", () => {
     expect(body.error).toBe("invalid_request");
   });
 
+  it("normalizes a malformed JSON body to a 400 invalid_request via onError (#4113 parity)", async () => {
+    // The new metrics.onError mirrors the sibling routes: a body that fails to
+    // parse surfaces the Atlas envelope, not Hono's default. Build the request
+    // with a raw malformed string (runMetricRequest always JSON.stringifies).
+    const res = await app.fetch(
+      new Request("http://localhost/api/v1/metrics/total_gmv/run", {
+        method: "POST",
+        headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
+        body: "{ not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_request");
+  });
+
   it("rejects a connection outside the metric's group with 400", async () => {
     mockResolveMetricRun.mockResolvedValue({
       kind: "wrong_connection",
@@ -385,7 +401,12 @@ describe("POST /api/v1/metrics/{id}/run", () => {
     expect(capturedContext.atlasMode).toBe("developer");
   });
 
-  it("falls back to origin=cli when the credential carries no origin claim", async () => {
+  it("leaves agentOrigin undefined when the credential carries no origin claim (#4113 — not mislabeled cli)", async () => {
+    // A real CLI credential always stamps origin=cli; a credential WITHOUT the
+    // claim (e.g. a web session reaching this route) must leave agentOrigin
+    // undefined, not be forced to "cli". Standardized to the undefined fallback
+    // across the four sibling CLI routes so origin-scoped approval matching can't
+    // see a fabricated origin.
     mockAuthenticateRequest.mockResolvedValue({
       authenticated: true as const,
       mode: "managed" as const,
@@ -399,10 +420,10 @@ describe("POST /api/v1/metrics/{id}/run", () => {
       },
     } as unknown as AuthResult);
     await app.fetch(runMetricRequest("total_gmv"));
-    expect(capturedContext.agentOrigin).toBe("cli");
+    expect(capturedContext.agentOrigin).toBeUndefined();
   });
 
-  it("coerces a bogus origin claim to cli (never passes an unvetted origin through)", async () => {
+  it("never passes an unvetted origin through — a bogus claim drops to undefined, not cli (#4113)", async () => {
     mockAuthenticateRequest.mockResolvedValue({
       authenticated: true as const,
       mode: "managed" as const,
@@ -416,7 +437,7 @@ describe("POST /api/v1/metrics/{id}/run", () => {
       },
     } as unknown as AuthResult);
     await app.fetch(runMetricRequest("total_gmv"));
-    expect(capturedContext.agentOrigin).toBe("cli");
+    expect(capturedContext.agentOrigin).toBeUndefined();
   });
 
   it("uses default routing (no connectionId) for a default-group metric", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-workspace-keys.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-workspace-keys.test.ts
@@ -54,6 +54,14 @@ let createApiKeyImpl: (opts: CreateApiKeyCall) => Promise<{ id?: string; key?: s
   async () => ({ id: "key_minted", key: "atlas_wk_thefullsecret" });
 
 // Override the harness auth/server mock with one that exposes api.createApiKey.
+// Curated stub, documented for mock-all-exports (CLAUDE.md): the ONLY real
+// `auth/server` exports this admin router's graph reaches are `getAuthInstance`
+// (reshaped here to expose `createApiKey`) and `SESSION_ORIGIN_CLI` (statically
+// imported by managed.ts), so this two-key stub is complete. The shared harness
+// mock (`__mocks__/api-test-mocks.ts`) additionally lists `listAllUsers`/
+// `setUserRole`/`setBanStatus`/`setPasswordChangeRequired`/`deleteUser`, but those
+// are NOT real exports of auth/server (stale harness residue, grep-confirmed) —
+// reproducing them here would mirror a phantom shape, not satisfy any importer.
 mock.module("@atlas/api/lib/auth/server", () => ({
   getAuthInstance: () => ({
     api: {

--- a/packages/api/src/api/routes/__tests__/explore.test.ts
+++ b/packages/api/src/api/routes/__tests__/explore.test.ts
@@ -46,6 +46,19 @@ mock.module("@atlas/api/lib/residency/readonly", () => ({
   isWorkspaceMigrating: async () => false,
 }));
 
+// The IP allowlist runs inside `standardAuth` via `runEnterprise(IpAllowlistPolicy…)`.
+// Curated stub: `runEnterprise` is the ONLY enterprise-layer export the route's
+// middleware path reaches, so we stub just it (the others — `EnterpriseLayer`,
+// `getEnterpriseRuntime` — aren't on this graph; provided as inert names to keep
+// the module's load-time shape complete). `ipAllowed` toggles the
+// `ip_not_allowed` 403 branch; default-allow keeps every other test green.
+let ipAllowed = true;
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  runEnterprise: async () => ({ allowed: ipAllowed }),
+  EnterpriseLayer: undefined,
+  getEnterpriseRuntime: () => null,
+}));
+
 // Capture what the route binds into the request context so we can assert the
 // origin=cli + actor.kind audit triple (ADR-0027 sub-decision 6) actually flows.
 let capturedContexts: Array<Record<string, unknown>> = [];
@@ -118,6 +131,7 @@ beforeEach(() => {
   capturedContexts = [];
   exploreCalls = [];
   exploreImpl = async () => "(no output)";
+  ipAllowed = true;
 });
 
 describe("POST /api/v1/explore — auth", () => {
@@ -133,6 +147,21 @@ describe("POST /api/v1/explore — auth", () => {
     exploreImpl = async () => "catalog.yml\nentities";
     const res = await post({ command: "ls" });
     expect(res.status).toBe(200);
+  });
+
+  it("returns 403 ip_not_allowed (the route's only 403 — standardAuth IP allowlist) with a requestId", async () => {
+    // Explore has NO role gate; the sole 403 it can produce comes from the
+    // shared standardAuth IP allowlist. Pin that path here (the milestone-#77
+    // review flagged it as uncovered) — including the requestId for correlation.
+    fakeAuth = userAuth({ role: "member" });
+    ipAllowed = false;
+    const res = await post({ command: "ls" });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; requestId?: string };
+    expect(body.error).toBe("ip_not_allowed");
+    expect(body.requestId).toBeDefined();
+    // The IP gate runs before the handler — the facade is never invoked.
+    expect(exploreCalls).toHaveLength(0);
   });
 });
 
@@ -182,10 +211,17 @@ describe("POST /api/v1/explore — facade reuse + output", () => {
 });
 
 describe("POST /api/v1/explore — request validation", () => {
-  it("returns 422 for an empty command", async () => {
+  it("returns 422 with the shared validation_error envelope for an empty command", async () => {
+    // Pins the parity the dropped inline hook was about (#4113): validation now
+    // falls through to the router's shared `validationHook`, which returns the
+    // same `{ error: "validation_error", message, details }` envelope as the
+    // sibling routes — not a bespoke per-route shape.
     fakeAuth = userAuth();
     const res = await post({ command: "   " });
     expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; details?: unknown[] };
+    expect(body.error).toBe("validation_error");
+    expect(Array.isArray(body.details)).toBe(true);
     expect(exploreCalls).toHaveLength(0);
   });
 

--- a/packages/api/src/api/routes/datasources.ts
+++ b/packages/api/src/api/routes/datasources.ts
@@ -64,6 +64,7 @@ import {
 } from "@atlas/api/lib/billing/agent-gate";
 import { isRequestOrigin } from "@atlas/api/lib/approvals/types";
 import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
+import type { ResolveLiveConnectionResult } from "@atlas/api/lib/datasources/mcp-lifecycle";
 import type { ProfileProgressCallbacks } from "@atlas/api/lib/profiler";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema } from "./shared-schemas";
@@ -167,7 +168,7 @@ const profileRoute = createRoute({
       content: { "application/json": { schema: ErrorSchema } },
     },
     503: {
-      description: "Billing subsystem unavailable (fail-closed)",
+      description: "Billing or connection-resolution subsystem unavailable (fail-closed)",
       content: { "application/json": { schema: ErrorSchema } },
     },
   },
@@ -266,11 +267,38 @@ datasources.openapi(profileRoute, async (c) => {
 
   // --- Resolve the live connection (the ONE resolver — #3667). This happens
   // BEFORE the stream commits, so its non-ok outcomes map to HTTP status codes;
-  // once the stream starts, every failure rides as a terminal NDJSON event. ---
-  const { resolveLiveConnection, profileLiveDatasource } = await import(
-    "@atlas/api/lib/datasources/mcp-lifecycle"
-  );
-  const resolved = await resolveLiveConnection(orgId, id);
+  // once the stream starts, every failure rides as a terminal NDJSON event. The
+  // dynamic `import()` + the resolve both reach the internal DB, so a transient
+  // fault here is wrapped to a 503 carrying THIS route's requestId — left
+  // unwrapped it would escape to the global handler, which mints a fresh,
+  // uncorrelated id (matches the fail-closed billing-gate pattern above). ---
+  let lifecycle: typeof import("@atlas/api/lib/datasources/mcp-lifecycle");
+  let resolved: ResolveLiveConnectionResult;
+  try {
+    lifecycle = await import("@atlas/api/lib/datasources/mcp-lifecycle");
+    resolved = await lifecycle.resolveLiveConnection(orgId, id);
+  } catch (err) {
+    log.error(
+      {
+        requestId,
+        orgId,
+        datasourceId: id,
+        err: err instanceof Error ? err : new Error(String(err)),
+        category: "connection_resolve_error",
+      },
+      "Datasource connection resolve threw before the stream — returning 503",
+    );
+    return c.json(
+      {
+        error: "resolve_unavailable",
+        message:
+          "Unable to resolve the datasource connection right now. Please try again shortly.",
+        retryable: true,
+        requestId,
+      },
+      503,
+    );
+  }
   if (resolved.kind === "not_found") {
     return c.json(
       {
@@ -291,11 +319,15 @@ datasources.openapi(profileRoute, async (c) => {
   const connection = resolved.connection;
 
   // Audit origin derives from the credential's claim, never hardcoded — a
-  // device-flow `atlas` bearer carries `origin: "cli"`. Falls back to `cli`:
-  // this IS the workspace CLI profiling surface.
+  // device-flow `atlas` bearer AND a workspace API key both carry
+  // `origin: "cli"`; a non-CLI session leaves it undefined so it is not
+  // mislabeled. A real CLI credential ALWAYS stamps the claim, so this fallback
+  // only ever fires for a non-CLI caller — defaulting to "cli" there would
+  // mislabel it in the origin-scoped approval/audit context. Standardized to the
+  // `undefined` fallback across the four sibling CLI routes (#4113).
   const claimOrigin = user?.claims?.origin;
   const agentOrigin =
-    typeof claimOrigin === "string" && isRequestOrigin(claimOrigin) ? claimOrigin : "cli";
+    typeof claimOrigin === "string" && isRequestOrigin(claimOrigin) ? claimOrigin : undefined;
 
   // `actor.kind` is the *who*, distinct from `origin` (the transport): `api_key`
   // for an UNATTENDED workspace key (#4046 / ADR-0027 §6), else `human`. The
@@ -348,10 +380,10 @@ datasources.openapi(profileRoute, async (c) => {
             atlasMode,
             trustDeviceIdentifier,
             actor: { kind: actorKind },
-            agentOrigin,
+            ...(agentOrigin ? { agentOrigin } : {}),
           },
           () =>
-            profileLiveDatasource({
+            lifecycle.profileLiveDatasource({
               connection,
               connectionId: id,
               // #3546 — persist the generated layer to the org store as DRAFTS

--- a/packages/api/src/api/routes/explore.ts
+++ b/packages/api/src/api/routes/explore.ts
@@ -228,12 +228,7 @@ explore.openapi(
       },
     );
   },
-  (result, c) => {
-    if (!result.success) {
-      return c.json(
-        { error: "validation_error", message: "Invalid request body.", details: result.error.issues },
-        422,
-      );
-    }
-  },
+  // Validation failures fall through to the router's shared `defaultHook`
+  // (`validationHook`) — the same 422 envelope (`{ error: "validation_error",
+  // message, details }`) the sibling routes use. No inline third-arg hook (#4113).
 );

--- a/packages/api/src/api/routes/metrics.ts
+++ b/packages/api/src/api/routes/metrics.ts
@@ -29,6 +29,7 @@
  */
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
 import { Effect } from "effect";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext } from "@atlas/api/lib/effect/services";
@@ -235,6 +236,18 @@ export const metrics = new OpenAPIHono<AuthEnv>({ defaultHook: validationHook })
 metrics.use(standardAuth);
 metrics.use(requestContext);
 
+// Normalize JSON parse errors from @hono/zod-openapi into the standard API
+// error format. Mirrors execute-sql.ts / explore.ts / datasources.ts.
+metrics.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    if (err.res) return err.res;
+    if (err.status === 400) {
+      return c.json({ error: "invalid_request", message: "Invalid JSON body." }, 400);
+    }
+  }
+  throw err;
+});
+
 metrics.openapi(runMetricRoute, async (c) => {
   return runEffect(
     c,
@@ -357,12 +370,18 @@ metrics.openapi(runMetricRoute, async (c) => {
         ? `CLI metric run ${metric.id}: ${metric.description}`
         : `CLI metric run ${metric.id}`;
 
-      // Origin for approval-rule matching + audit: the credential's resolved
-      // origin claim (`cli` for an `atlas login` device-flow bearer), falling
-      // back to `cli` — this endpoint is the workspace CLI metric-run surface.
+      // Audit origin derives from the credential's claim, never hardcoded — a
+      // device-flow `atlas` bearer AND a workspace API key both carry
+      // `origin: "cli"`; a non-CLI session (e.g. a web session reaching this
+      // route) leaves it undefined so it is not mislabeled. A real CLI credential
+      // ALWAYS stamps the claim, so this fallback only ever fires for a non-CLI
+      // caller — defaulting to "cli" there would mislabel it in the
+      // origin-scoped approval/audit context. Standardized to the `undefined`
+      // fallback across the four sibling CLI routes (#4113); validated against
+      // the canonical vocabulary so an unexpected value can't land in the context.
       const claimOrigin = user?.claims?.origin;
       const agentOrigin =
-        typeof claimOrigin === "string" && isRequestOrigin(claimOrigin) ? claimOrigin : "cli";
+        typeof claimOrigin === "string" && isRequestOrigin(claimOrigin) ? claimOrigin : undefined;
 
       // `actor.kind` is the *who*, distinct from `origin` (the transport): a
       // human who approved a device-flow `atlas login` → `human`; an UNATTENDED
@@ -394,8 +413,8 @@ metrics.openapi(runMetricRoute, async (c) => {
             user,
             atlasMode,
             trustDeviceIdentifier,
-            agentOrigin,
             actor: { kind: actorKind },
+            ...(agentOrigin ? { agentOrigin } : {}),
           },
           async () => {
             const { runUserQueryPipeline } = await import("@atlas/api/lib/tools/sql");

--- a/packages/cli/src/__tests__/explore.test.ts
+++ b/packages/cli/src/__tests__/explore.test.ts
@@ -169,19 +169,52 @@ describe("runExplore — HTTP error handling", () => {
     expect(err.join("\n").toLowerCase()).toContain("atlas login");
   });
 
-  it("403 reports the workspace is not accessible and exits 1", async () => {
-    const { fetchImpl } = stubFetch(403, { error: "forbidden" });
+  it("403 ip_not_allowed surfaces the server message + requestId, not a hardcoded role copy (#4113)", async () => {
+    // Explore is standardAuth with NO role gate — its only 403 is `ip_not_allowed`
+    // from the IP allowlist. The command must surface the server's actionable
+    // message + requestId, NOT the old hardcoded "current role" copy.
+    const { fetchImpl } = stubFetch(403, {
+      error: "ip_not_allowed",
+      message: "Your IP address is not in the workspace's allowlist.",
+      requestId: "req-ip-1",
+    });
     const { io, err } = capture();
     const code = await runExplore(["explore", "ls"], deps(fetchImpl), io);
     expect(code).toBe(1);
-    expect(err.join("\n").toLowerCase()).toContain("not accessible");
+    const joined = err.join("\n");
+    expect(joined).toContain("not in the workspace's allowlist");
+    expect(joined).toContain("(request req-ip-1)");
+    expect(joined.toLowerCase()).not.toContain("current role");
   });
 
-  it("non-ok HTTP status reports failure and exits 1", async () => {
-    const { fetchImpl } = stubFetch(500, { error: "internal_error" });
+  it("non-ok HTTP status surfaces the server message + requestId and exits 1", async () => {
+    const { fetchImpl } = stubFetch(500, {
+      error: "internal_error",
+      message: "An unexpected error occurred (ref: abc12345).",
+      requestId: "abc12345-0000",
+    });
     const { io, err } = capture();
     const code = await runExplore(["explore", "ls"], deps(fetchImpl), io);
     expect(code).toBe(1);
-    expect(err.join("\n")).toContain("500");
+    const joined = err.join("\n");
+    expect(joined).toContain("An unexpected error occurred");
+    expect(joined).toContain("(request abc12345-0000)");
+  });
+
+  it("non-ok HTTP status with a non-JSON body falls back to the HTTP-status message", async () => {
+    // A 5xx that isn't JSON degrades via asRecord(null) → {} to serverMessage's
+    // `HTTP <status>` fallback rather than crashing on parse.
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: typeof url === "string" ? url : url.toString(), init });
+      return new Response("<html>502 Bad Gateway</html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      });
+    }) as unknown as typeof fetch;
+    const { io, err } = capture();
+    const code = await runExplore(["explore", "ls"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("HTTP 502");
   });
 });

--- a/packages/cli/src/__tests__/metric-command.test.ts
+++ b/packages/cli/src/__tests__/metric-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 
 import { runMetricCommand, type MetricIO, type MetricRunDeps } from "../commands/metric";
+import { runMetric, MetricCliError } from "../lib/metric-client";
 import type { StoredSession } from "../lib/credentials";
 
 const BASE = "http://localhost:3001";
@@ -222,12 +223,26 @@ describe("runMetricCommand — error mapping", () => {
     expect(joined).toContain("(request req-9)");
   });
 
-  it("maps a 503 to request_failed", async () => {
+  it("surfaces a 503 (datasource/subsystem unavailable) with the server message", async () => {
     const { fetchImpl } = stubFetch(503, { error: "no_datasource", message: "Datasource unavailable." });
     const { io, err } = capture();
     const code = await runMetricCommand(["metric", "run", "total_gmv"], deps(fetchImpl), io);
     expect(code).toBe(1);
     expect(err.join("\n")).toContain("Datasource unavailable.");
+  });
+
+  it("surfaces a 429 (rate limited) with the server message + requestId", async () => {
+    const { fetchImpl } = stubFetch(429, {
+      error: "rate_limited",
+      message: "Too many requests. Please wait before trying again.",
+      requestId: "req-rl",
+    });
+    const { io, err } = capture();
+    const code = await runMetricCommand(["metric", "run", "total_gmv"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    const joined = err.join("\n");
+    expect(joined).toContain("Too many requests");
+    expect(joined).toContain("(request req-rl)");
   });
 
   it("surfaces a network/timeout failure with the base URL", async () => {
@@ -240,5 +255,45 @@ describe("runMetricCommand — error mapping", () => {
     const code = await runMetricCommand(["metric", "run", "total_gmv"], deps(fetchImpl), io);
     expect(code).toBe(1);
     expect(err.join("\n")).toContain("Timed out");
+  });
+
+  it("surfaces a generic (non-abort) network failure via the shared unreachableMessage (#4113)", async () => {
+    // A non-Timeout/Abort throw takes the `unreachableMessage` branch of the
+    // consolidated http.ts helper — pins the generic-failure path the abort/
+    // timeout tests route around, with the base URL interpolated.
+    const fetchImpl = (async () => {
+      const e = new TypeError("fetch failed");
+      throw e;
+    }) as unknown as typeof fetch;
+    const { io, err } = capture();
+    const code = await runMetricCommand(["metric", "run", "total_gmv"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain(`Could not reach the Atlas API at ${BASE}`);
+  });
+});
+
+// The command renders `err.message` for any MetricCliError, so the new typed
+// kinds (#4113 parity with sql-client) are only observable on the thrown error.
+// Pin them at the client layer so 429/503 stop collapsing into `request_failed`.
+describe("runMetric — typed error kinds (parity with sql-client #4113)", () => {
+  async function kindFor(status: number, body: unknown): Promise<string> {
+    const { fetchImpl } = stubFetch(status, body);
+    try {
+      await runMetric({ baseUrl: BASE, token: "t", fetchImpl }, { id: "total_gmv" });
+      throw new Error("expected runMetric to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MetricCliError);
+      return (err as MetricCliError).kind;
+    }
+  }
+
+  it("maps 429 → rate_limited", async () => {
+    expect(await kindFor(429, { error: "rate_limited", message: "Slow down." })).toBe("rate_limited");
+  });
+
+  it("maps 503 → unavailable", async () => {
+    expect(await kindFor(503, { error: "no_datasource", message: "Datasource unavailable." })).toBe(
+      "unavailable",
+    );
   });
 });

--- a/packages/cli/src/commands/explore.ts
+++ b/packages/cli/src/commands/explore.ts
@@ -17,6 +17,7 @@
 
 import { resolveApiBaseUrl } from "../lib/api-base";
 import { readSession, type StoredSession } from "../lib/credentials";
+import { asRecord, serverMessage } from "../lib/http";
 
 const USAGE = `Run a read-only command against your logged-in workspace's semantic layer.
 
@@ -124,19 +125,19 @@ export async function runExplore(
     io.err("Your session is no longer valid. Run `atlas login` again.");
     return 1;
   }
-  if (res.status === 403) {
-    io.err("This workspace is not accessible with your current role.");
-    return 1;
-  }
   if (!res.ok) {
-    // The server returns 200 even for non-zero-exit commands (a `grep`
-    // no-match), so a non-ok status here is a genuine request failure.
-    let detail = "";
-    // intentionally ignored: a non-JSON error body degrades to the status code
-    // below rather than crashing.
-    const body = (await res.json().catch(() => null)) as { message?: string } | null;
-    if (body?.message) detail = `: ${body.message}`;
-    io.err(`Request failed (HTTP ${res.status})${detail}.`);
+    // The server returns 200 even for non-zero-exit commands (a `grep` no-match),
+    // so a non-ok status here is a genuine request failure. Surface the server's
+    // actionable message + requestId (Atlas error envelopes carry one) via the
+    // shared `serverMessage`, parity with `atlas sql`/`metric`/`datasource`.
+    // Explore is `standardAuth` with NO role gate — its only 403 is
+    // `ip_not_allowed`, whose server message already names the cause, so there is
+    // no role-specific copy to hardcode (the prior branch did, incorrectly).
+    // intentionally ignored: a non-JSON error body's `res.json()` rejects → the
+    // `.catch(() => null)` yields null → `asRecord(null)` returns {} → serverMessage
+    // degrades to its `HTTP <status>` fallback rather than crashing.
+    const body = asRecord(await res.json().catch(() => null));
+    io.err(serverMessage(body, res.status));
     return 1;
   }
 

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -29,7 +29,7 @@
  * here calls `process.exit` or `console`; the command handler owns presentation.
  */
 
-type FetchImpl = typeof fetch;
+import { asRecord, isAbortOrTimeout, serverMessage, unreachableMessage, type FetchImpl } from "./http";
 
 /** The kinds of failure a datasource call can surface, each with an actionable message. */
 export type DatasourceErrorKind =
@@ -76,28 +76,6 @@ interface RequestSpec {
   readonly operation: string;
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-}
-
-/**
- * Pull the server's actionable message off a JSON error body, falling back to
- * the HTTP status. Appends the server's `requestId` (Atlas error envelopes carry
- * one — always on 5xx, and on the 4xx envelopes these admin routes return) so a
- * user's bug report stays log-correlatable operator-side.
- */
-function serverMessage(body: Record<string, unknown>, status: number): string {
-  const base =
-    typeof body.message === "string" && body.message.length > 0
-      ? body.message
-      : typeof body.error === "string" && body.error.length > 0
-        ? body.error
-        : `HTTP ${status}`;
-  return typeof body.requestId === "string" && body.requestId.length > 0
-    ? `${base} (request ${body.requestId})`
-    : base;
-}
-
 /**
  * Issue one request against an admin-connection route and return its parsed
  * JSON body, mapping every documented failure status onto a typed
@@ -125,17 +103,13 @@ async function request(
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err) {
-    const name = err instanceof Error ? err.name : "";
-    if (name === "TimeoutError" || name === "AbortError") {
+    if (isAbortOrTimeout(err)) {
       throw new DatasourceCliError(
         "network",
         `Timed out after ${Math.round(timeoutMs / 1000)}s trying to ${spec.operation}.`,
       );
     }
-    throw new DatasourceCliError(
-      "network",
-      `Could not reach the Atlas API at ${opts.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    throw new DatasourceCliError("network", unreachableMessage(opts.baseUrl, err));
   }
 
   if (res.ok) {
@@ -460,14 +434,13 @@ export async function profileDatasource(
       ...(args.signal ? { signal: args.signal } : {}),
     });
   } catch (err) {
-    const name = err instanceof Error ? err.name : "";
-    if (name === "AbortError") {
+    // No request timeout here (profiling is legitimately long), so an abort is
+    // ALWAYS a caller cancellation (SIGINT), never a deadline — kept inline as a
+    // distinct "cancelled" message rather than the shared timeout path.
+    if (err instanceof Error && err.name === "AbortError") {
       throw new DatasourceCliError("network", `Profiling of "${args.id}" was cancelled.`);
     }
-    throw new DatasourceCliError(
-      "network",
-      `Could not reach the Atlas API at ${opts.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    throw new DatasourceCliError("network", unreachableMessage(opts.baseUrl, err));
   }
 
   // Pre-stream gate failure (auth/billing/role/not-found/unsupported/reconnect)

--- a/packages/cli/src/lib/http.ts
+++ b/packages/cli/src/lib/http.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared HTTP primitives for the workspace CLI clients (#4113 — milestone #77
+ * sibling-consistency cleanup).
+ *
+ * Each workspace CLI client (`sql-client`, `metric-client`, `datasource-client`,
+ * and the `explore` command) is a thin, transport-only wrapper over one REST
+ * route. The body-narrowing + error-shaping helpers below were byte-identical
+ * copies pasted across them; consolidating here gives the wire contract ONE
+ * definition, so a change to how a server error becomes user-facing copy (or how
+ * a `requestId` is appended) can't drift between siblings.
+ *
+ * Nothing here calls `process.exit`, `console`, or `fetch` directly — the
+ * clients inject `fetch` and own presentation, keeping these pure + unit-testable.
+ */
+
+/** The global `fetch`, injectable so clients stay unit-testable without a live server. */
+export type FetchImpl = typeof fetch;
+
+/** Narrow an unknown parsed-JSON value to a record; non-objects (incl. `null`) → `{}`. */
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+/**
+ * Pull the server's actionable message off a JSON error body, falling back to
+ * the HTTP status. Appends the server's `requestId` (Atlas error envelopes carry
+ * one) so a bug report stays log-correlatable operator-side.
+ */
+export function serverMessage(body: Record<string, unknown>, status: number): string {
+  const base =
+    typeof body.message === "string" && body.message.length > 0
+      ? body.message
+      : typeof body.error === "string" && body.error.length > 0
+        ? body.error
+        : `HTTP ${status}`;
+  return typeof body.requestId === "string" && body.requestId.length > 0
+    ? `${base} (request ${body.requestId})`
+    : base;
+}
+
+/**
+ * Whether a thrown `fetch` rejection is an abort/timeout rather than a genuine
+ * transport failure. `AbortSignal.timeout(...)` rejects with a `TimeoutError`; a
+ * caller-driven abort (Ctrl-C) rejects with an `AbortError`. The clients map
+ * both to their `network` error kind with a deadline-specific message.
+ */
+export function isAbortOrTimeout(err: unknown): boolean {
+  const name = err instanceof Error ? err.name : "";
+  return name === "TimeoutError" || name === "AbortError";
+}
+
+/** The "couldn't reach the API" message shared verbatim across the clients. */
+export function unreachableMessage(baseUrl: string, err: unknown): string {
+  return `Could not reach the Atlas API at ${baseUrl}: ${err instanceof Error ? err.message : String(err)}`;
+}

--- a/packages/cli/src/lib/metric-client.ts
+++ b/packages/cli/src/lib/metric-client.ts
@@ -20,7 +20,7 @@
  * presentation.
  */
 
-type FetchImpl = typeof fetch;
+import { asRecord, isAbortOrTimeout, serverMessage, unreachableMessage, type FetchImpl } from "./http";
 
 /** The kinds of failure a metric-run call can surface, each with an actionable message. */
 export type MetricErrorKind =
@@ -30,6 +30,8 @@ export type MetricErrorKind =
   | "not_found" // 404 — metric id not in this workspace
   | "approval_required" // 409 — the metric's SQL tripped an approval rule
   | "invalid_request" // 400 — unsupported filters / wrong connection
+  | "rate_limited" // 429 — per-identity bucket, workspace throttle, or concurrency cap
+  | "unavailable" // 503 — datasource/enterprise subsystem unavailable (or fail-closed billing)
   | "request_failed" // other non-2xx
   | "network"; // fetch threw / timed out
 
@@ -75,27 +77,6 @@ export interface RunMetricArgs {
   readonly connectionId?: string;
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-}
-
-/**
- * Pull the server's actionable message off a JSON error body, falling back to
- * the HTTP status. Appends the server's `requestId` (Atlas error envelopes
- * carry one) so a bug report stays log-correlatable operator-side.
- */
-function serverMessage(body: Record<string, unknown>, status: number): string {
-  const base =
-    typeof body.message === "string" && body.message.length > 0
-      ? body.message
-      : typeof body.error === "string" && body.error.length > 0
-        ? body.error
-        : `HTTP ${status}`;
-  return typeof body.requestId === "string" && body.requestId.length > 0
-    ? `${base} (request ${body.requestId})`
-    : base;
-}
-
 /**
  * Execute a canonical metric by id against the bound workspace via
  * `POST /api/v1/metrics/{id}/run`, mapping every documented failure status onto
@@ -123,17 +104,13 @@ export async function runMetric(
       },
     );
   } catch (err) {
-    const name = err instanceof Error ? err.name : "";
-    if (name === "TimeoutError" || name === "AbortError") {
+    if (isAbortOrTimeout(err)) {
       throw new MetricCliError(
         "network",
         `Timed out after ${Math.round(timeoutMs / 1000)}s running metric "${args.id}".`,
       );
     }
-    throw new MetricCliError(
-      "network",
-      `Could not reach the Atlas API at ${opts.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    throw new MetricCliError("network", unreachableMessage(opts.baseUrl, err));
   }
 
   if (res.ok) {
@@ -175,6 +152,11 @@ export async function runMetric(
       );
     case 409:
       throw new MetricCliError("approval_required", serverMessage(body, res.status));
+    case 429:
+      // Per-identity rate-limit bucket, a workspace throttle, or the pipeline's
+      // concurrency cap — all 429. Surface the server's message (it names the
+      // remedy / retry hint) under a distinct kind, parity with `atlas sql`.
+      throw new MetricCliError("rate_limited", serverMessage(body, res.status));
     case 400:
       if (body.error === "bad_request") {
         throw new MetricCliError(
@@ -183,6 +165,11 @@ export async function runMetric(
         );
       }
       throw new MetricCliError("invalid_request", serverMessage(body, res.status));
+    case 503:
+      // Datasource/enterprise subsystem unavailable, or a fail-closed billing
+      // check (#3433) — a transient "try again", not an upgrade prompt. Distinct
+      // kind, parity with `atlas sql`; the server message carries the detail.
+      throw new MetricCliError("unavailable", serverMessage(body, res.status));
     default:
       throw new MetricCliError("request_failed", serverMessage(body, res.status));
   }

--- a/packages/cli/src/lib/sql-client.ts
+++ b/packages/cli/src/lib/sql-client.ts
@@ -24,7 +24,7 @@
  * here calls `process.exit` or `console`; the command handler owns presentation.
  */
 
-type FetchImpl = typeof fetch;
+import { asRecord, isAbortOrTimeout, serverMessage, unreachableMessage, type FetchImpl } from "./http";
 
 /** The kinds of failure a raw-SQL call can surface, each with an actionable message. */
 export type SqlErrorKind =
@@ -86,27 +86,6 @@ export interface RunSqlArgs {
   readonly connectionId?: string;
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-}
-
-/**
- * Pull the server's actionable message off a JSON error body, falling back to
- * the HTTP status. Appends the server's `requestId` (Atlas error envelopes carry
- * one) so a bug report stays log-correlatable operator-side.
- */
-function serverMessage(body: Record<string, unknown>, status: number): string {
-  const base =
-    typeof body.message === "string" && body.message.length > 0
-      ? body.message
-      : typeof body.error === "string" && body.error.length > 0
-        ? body.error
-        : `HTTP ${status}`;
-  return typeof body.requestId === "string" && body.requestId.length > 0
-    ? `${base} (request ${body.requestId})`
-    : base;
-}
-
 /**
  * Execute one validated SELECT against the bound workspace via
  * `POST /api/v1/execute-sql`, mapping every documented failure status onto a
@@ -139,17 +118,13 @@ export async function runSql(opts: SqlClientOptions, args: RunSqlArgs): Promise<
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err) {
-    const name = err instanceof Error ? err.name : "";
-    if (name === "TimeoutError" || name === "AbortError") {
+    if (isAbortOrTimeout(err)) {
       throw new SqlCliError(
         "network",
         `Timed out after ${Math.round(timeoutMs / 1000)}s running the query.`,
       );
     }
-    throw new SqlCliError(
-      "network",
-      `Could not reach the Atlas API at ${opts.baseUrl}: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    throw new SqlCliError("network", unreachableMessage(opts.baseUrl, err));
   }
 
   if (res.ok) {


### PR DESCRIPTION
Closes #4113.

Grab-bag of P2/P3 sibling-route consistency cleanups from the milestone #77 milestone-wide review — none a correctness bug; together they remove the "execute-sql got the polish, the siblings didn't" drift. Internal review panel: **2 rounds → CLEAN** (round 1 found code clean on both the silent-failure and type-design axes; addressed a comment factual-error + 3 test-coverage gaps + LOW nits in round 2). Required CI green locally.

### Checklist (all 8 items + the explore-test follow-up)
- **`atlas explore` 403 + requestId** — the `!res.ok` branch now surfaces `serverMessage(body)` + the server `requestId` via the shared helper; dropped the hardcoded "not accessible with your current role" copy (explore is `standardAuth` with no role gate — its only 403 is `ip_not_allowed`, whose server message already names the cause).
- **`metric-client` 429/503** — added `rate_limited` (429) and `unavailable` (503) to `MetricErrorKind` + the switch, at parity with `SqlErrorKind`.
- **`agentOrigin` divergence** — standardized all four CLI routes on the **`undefined` fallback** (was `"cli"` on metrics/datasources). A real CLI credential always stamps `origin: "cli"`, so the fallback only ever fires for a non-CLI caller — defaulting to `"cli"` there would mislabel it in the origin-scoped approval/audit context. execute-sql/explore already did this; metrics/datasources now match.
- **datasource-profile pre-stream resolve** — wrapped the `import()` + `resolveLiveConnection` (before the stream commits) in a try/catch → `503 resolve_unavailable` carrying the route's own `requestId` (matches the fail-closed billing-gate pattern above it), so a transient internal-DB fault no longer escapes to the global handler with a fresh uncorrelated id.
- **`metrics.ts` onError** — added the malformed-JSON-body `.onError` normalizer the other three routes have (Atlas envelope, not Hono default).
- **`explore.ts` validation hook** — dropped the inline `.openapi()` third-arg hook so it uses the shared `defaultHook: validationHook` like the siblings.
- **Extract `packages/cli/src/lib/http.ts`** — consolidated the byte-identical `asRecord` + `serverMessage` + `FetchImpl` + the timeout/abort detection (`isAbortOrTimeout`) + the "couldn't reach the API" message (`unreachableMessage`) out of the three clients into one module.
- **Mock discipline** — documented the curated `agent-gate` stub in `datasources.test.ts` consistently with `metrics.test.ts`; corrected `admin-workspace-keys.test.ts` to keep only the two **real** `auth/server` exports the admin router reaches (`getAuthInstance` + `SESSION_ORIGIN_CLI`) with an honest comment (the harness's extra 5 are phantom/stale residue, grep-confirmed).
- **explore route test** (from the #4108 review comment) — `explore.test.ts` already pinned auth floor / prose / origin-actor binding; added the missing `403 ip_not_allowed` path via a curated `runEnterprise` mock. Also added the CLI-side 403 test (server message + requestId, not the old role copy).

### Tests added
- datasources route: `503 resolve_unavailable` when the resolver throws before the stream (asserts requestId + that the stream/connection-close never start).
- metrics route: malformed-JSON → `400 invalid_request` via the new `onError`.
- metric-client: client-level `runMetric` kind assertions (`429 → rate_limited`, `503 → unavailable`) — only observable on `.kind` since the command renders `err.message` either way; plus a generic-network test pinning the consolidated `unreachableMessage`.
- explore route 422 now asserts the shared `validation_error` envelope (pins the dropped-inline-hook parity).
- agentOrigin parity: "non-cli session not mislabeled" on metrics + datasources.

### Merge note
`origin/main` advanced by #4116 ("api-key credential parity") mid-flight, which reshaped the same three CLI clients (`token` → `credential: CliCredential` + `credentialHeaders`). Merged `origin/main` and reconciled: the only conflicts were the import region in the three clients (kept both the `./credential` and the new `./http` imports). #4116's credential work is preserved; my consolidation layers on top. Verified post-merge: `tsgo` clean, all CLI client/command tests green, `@atlas/api` 744/744.

API-route changes touched only `metrics.ts`/`explore.ts`/`datasources.ts` (no `@atlas/mcp` changes).
