### PR TITLE
fix(billing,www,docs): data residency is all-paid-tier, not Business-only

### DIFF
--- a/apps/docs/content/docs/comparisons/cube.mdx
+++ b/apps/docs/content/docs/comparisons/cube.mdx
@@ -24,7 +24,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 | **Chat integrations** | Slack, Teams, Discord, Telegram, Google Chat, GitHub, Linear, WhatsApp | None built-in |
 | **Admin console** | Built-in (connections, users, plugins, semantic editor, analytics, billing) | Cube Cloud dashboard |
 | **Notebook** | Built-in (cells, fork/branch, export) | No |
-| **Enterprise features** | SSO/SCIM, custom roles, IP allowlists, approval workflows, PII masking, data residency | Enterprise tier |
+| **Enterprise features** | SSO/SCIM, custom roles, IP allowlists, approval workflows, PII masking | Enterprise tier |
 | **Data residency** | 3-region deployment (US, EU, APAC) with misrouting detection | Cube Cloud regions |
 
 ## Different Layers of the Stack

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -34,15 +34,15 @@ On [app.useatlas.dev](https://app.useatlas.dev), billing is fully managed. View 
 | **Default model** | claude-haiku-4.5 | claude-sonnet-4.6 | claude-sonnet-4.6 | BYOK |
 | **Custom domain** | — | ✓ | ✓ | N/A |
 | **SSO / SCIM** | — | — | ✓ | N/A |
-| **Data residency** | — | — | ✓ | N/A |
+| **Data residency (3 regions)** | ✓ | ✓ | ✓ | N/A |
 | **SLA** | — | — | 99.9% | N/A |
 
 Annual billing is available for Starter, Pro, and Business (pay for 10 months, get 12).
 
 - **Trial** — Auto-assigned to the first workspace a user creates on SaaS. One trial per user: further workspaces you create start **locked** (blocked until subscribed) rather than receiving a fresh trial. Same limits as Starter (10 seats, 1 connection, $20/seat at-cost usage credit). Expires after 14 days, then queries are blocked until the workspace upgrades. (For workspaces provisioned over MCP by `start_trial`, the 14-day clock starts when the account is **claimed** on the web — before that the workspace sits on a short 72-hour unclaimed-grace window. See [Self-Serve Signup](/guides/signup#claiming-a-self-serve-mcp-trial).)
-- **Starter** — Entry paid tier. Per-seat billing via Stripe.
+- **Starter** — Entry paid tier. Per-seat billing via Stripe. Every paid tier picks its data region (US/EU/APAC) at signup and can manage residency.
 - **Pro** — More capable default model, more seats and connections, custom domain support. (The included usage credit is a flat $20/seat on every paid tier.)
-- **Business** — Unlimited seats and connections. Includes SSO, SCIM, data residency, and SLA.
+- **Business** — Unlimited seats and connections. Includes SSO, SCIM, and SLA.
 - **Self-Hosted** (free) — No billing enforcement. All features available, no Stripe needed. Uses your own API keys (BYOK).
 
 ### The Included Usage Credit

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Atlas data residency controls let operators assign workspaces to geographic regions (e.g. `eu-west`, `us-east`). Each region maps to a dedicated database, ensuring tenant data stays in the correct jurisdiction.
 
 <Callout type="info" title="SaaS Feature">
-  Data residency is available on [app.useatlas.dev](https://app.useatlas.dev) Business plans. Self-hosted deployments manage database routing directly. This feature is part of the Atlas commercial offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate and license split.
+  Data residency is available on all [app.useatlas.dev](https://app.useatlas.dev) paid plans (Starter, Pro, Business) — every workspace picks its region (US/EU/APAC) at signup. Self-hosted deployments manage database routing directly. This feature is part of the Atlas commercial (SaaS) offering — see the [Enterprise (`/ee`) boundary](/architecture/enterprise) for details on the gate and license split.
 </Callout>
 
 <Callout title="Prerequisites">

--- a/apps/www/src/app/pricing/entitlements.generated.ts
+++ b/apps/www/src/app/pricing/entitlements.generated.ts
@@ -75,7 +75,7 @@ export const ENTITLEMENT_ROWS: readonly EntitlementRow[] = [
     feature: "residency",
     label: "Data residency",
     section: "hosting",
-    cells: { selfHosted: false, starter: false, pro: false, business: true },
+    cells: { selfHosted: false, starter: true, pro: true, business: true },
   },
   {
     feature: "backups",

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -101,6 +101,7 @@ const TIERS: Tier[] = [
       "BYOK for unlimited queries",
       "Notebooks & dashboards",
       "1 chat integration",
+      "Data residency (3 regions)",
       "Email support",
     ],
   },
@@ -123,6 +124,7 @@ const TIERS: Tier[] = [
       "Notebooks & dashboards",
       "3 chat integrations",
       "Custom domain",
+      "Data residency (3 regions)",
       "Priority email support",
     ],
   },
@@ -195,15 +197,15 @@ const SECTION_PREFIX_ROWS: Partial<Record<EntitlementSection, ComparisonRow[]>> 
   };
 
 // Per-feature display overrides: a feature whose entitlement is a boolean in
-// the SSOT but reads better as free text in one column (e.g. residency's
-// "3 regions" for Business). Keyed by the artifact's `FeatureId` union — a
-// misspelled key is a compile error, not a silent no-op — and the override
-// applies only where the entitlement is already true, so it never widens what
-// a tier unlocks beyond what the SSOT grants.
+// the SSOT but reads better as free text (e.g. residency's "3 regions" on every
+// paid tier — region choice is universal at signup). Keyed by the artifact's
+// `FeatureId` union — a misspelled key is a compile error, not a silent no-op —
+// and the override applies only where the entitlement is already true, so it
+// never widens what a tier unlocks beyond what the SSOT grants.
 const CELL_LABEL_OVERRIDES: Partial<
   Record<FeatureId, Partial<Record<PricingColumn, string>>>
 > = {
-  residency: { business: "3 regions" },
+  residency: { starter: "3 regions", pro: "3 regions", business: "3 regions" },
 };
 
 /**

--- a/apps/www/src/app/terms/page.tsx
+++ b/apps/www/src/app/terms/page.tsx
@@ -72,7 +72,7 @@ const SECTIONS: LegalSectionData[] = [
     legal: [
       "As between the parties, Customer owns Customer Data. Customer grants Atlas a limited license to process Customer Data solely to provide the Service.",
       "Atlas does not use Customer Data to train AI models. Atlas does not sell Customer Data. Atlas does not access Customer’s data warehouse contents except to execute queries that Customer’s authorized users explicitly issue. Query text is forwarded to the configured LLM provider (Anthropic, OpenAI, etc.) for processing under that provider’s terms.",
-      "Atlas implements technical and organizational measures consistent with industry standards: encryption in transit (TLS 1.2+) and at rest (AES-256), least-privilege access, logged admin operations, configurable PII detection on result sets, and Business-plan data residency. Further detail is in the Data Processing Addendum at useatlas.dev/dpa.",
+      "Atlas implements technical and organizational measures consistent with industry standards: encryption in transit (TLS 1.2+) and at rest (AES-256), least-privilege access, logged admin operations, configurable PII detection on result sets, and data residency on all paid plans. Further detail is in the Data Processing Addendum at useatlas.dev/dpa.",
     ],
     plain:
       "You retain ownership of your data. We do not train models on it, sell it, or access your warehouse beyond executing queries your users explicitly issue. Encrypted in transit and at rest.",

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -492,10 +492,11 @@ let mockInternalQueryResult: unknown[] | Error = [];
 function invokeInternalQueryMock(sql?: string): Promise<unknown[]> {
   // The per-tier feature-entitlement guard (WS1 #3988) resolves the workspace's
   // plan_tier before every residency route in SaaS deploy mode (which this
-  // monorepo's test env resolves to). Residency gates to Business, so the
-  // entitlement read returns `business` independent of `mockInternalQueryResult`
-  // (which drives the residency migration-row queries / rejection paths) — so a
-  // test exercising a DB-rejection migration path still passes the gate first.
+  // monorepo's test env resolves to). Residency is now an all-paid feature
+  // (SSOT minimum `trial`); returning `business` here clears that floor
+  // independent of `mockInternalQueryResult` (which drives the residency
+  // migration-row queries / rejection paths) — so a test exercising a
+  // DB-rejection migration path still passes the gate first.
   if (
     sql &&
     /plan_tier[\s\S]*is_operator_workspace|is_operator_workspace[\s\S]*plan_tier/.test(

--- a/packages/api/src/api/__tests__/feature-entitlement-routes.test.ts
+++ b/packages/api/src/api/__tests__/feature-entitlement-routes.test.ts
@@ -9,7 +9,7 @@
  *   - PII masking + compliance reports (`masking`, Business)
  *   - white-label branding (`white_label`, Business)
  *   - custom domain (`custom_domain`, Pro+)
- *   - data residency (`residency`, Business)
+ *   - data residency (`residency`, all paid tiers — trial floor)
  *
  * These assert the gate's external behavior at the API boundary: a below-tier
  * workspace is denied with the `plan_upgrade_required` upgrade envelope BEFORE
@@ -122,12 +122,8 @@ const BUSINESS_FEATURES: Array<{
     path: "/api/v1/admin/branding",
     mutate: { method: "PUT", path: "/api/v1/admin/branding", body: { logoText: "Acme" } },
   },
-  {
-    feature: "residency",
-    label: "data residency",
-    path: "/api/v1/admin/residency",
-    mutate: { method: "PUT", path: "/api/v1/admin/residency", body: { region: "us-east" } },
-  },
+  // NOTE: `residency` moved OUT of this Business-gated set — its SSOT minimum is
+  // now `trial` (all paid tiers). It has its own all-paid block below.
 ];
 
 describe("per-tier feature-entitlement route gates (#3988)", () => {
@@ -240,6 +236,68 @@ describe("per-tier feature-entitlement route gates (#3988)", () => {
     });
 
     it("fails closed with 503 when the tier lookup throws", async () => {
+      failWorkspaceLookup();
+      const res = await app.fetch(adminRequest(path));
+      expect(res.status).toBe(503);
+      expect(await errorOf(res)).toBe("billing_check_failed");
+    });
+  });
+
+  // Data residency is the all-paid floor (residency = "trial"): region choice is
+  // universal at signup, and the residency management surface is included at
+  // every active paid tier. Denied only below trial (free / churned locked) —
+  // mirrors proactive (#3999). Proves the SSOT's trial minimum is enforced.
+  describe("data residency — all paid tiers", () => {
+    const path = "/api/v1/admin/residency";
+
+    it("denies a free-tier workspace with 403 plan_upgrade_required (the floor below trial)", async () => {
+      setWorkspaceTier("free");
+      const res = await app.fetch(adminRequest(path));
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as {
+        error: string;
+        required_plan: string;
+        current_plan: string;
+      };
+      expect(body.error).toBe("plan_upgrade_required");
+      expect(body.required_plan).toBe("trial");
+      expect(body.current_plan).toBe("free");
+    });
+
+    it("denies a churned (locked) workspace with 403 plan_upgrade_required", async () => {
+      setWorkspaceTier("locked");
+      const res = await app.fetch(adminRequest(path));
+      expect(res.status).toBe(403);
+      expect(await errorOf(res)).toBe("plan_upgrade_required");
+    });
+
+    it.each(["trial", "starter", "pro", "business"])(
+      "admits an active %s workspace past the ladder",
+      async (tier) => {
+        setWorkspaceTier(tier);
+        const res = await app.fetch(adminRequest(path));
+        const err = await errorOf(res);
+        expect(err).not.toBe("plan_upgrade_required");
+        expect(err).not.toBe("billing_check_failed");
+      },
+    );
+
+    it("denies a free workspace on the mutating PUT before any side effect", async () => {
+      setWorkspaceTier("free");
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/residency", "PUT", { region: "us-east" }),
+      );
+      expect(res.status).toBe(403);
+      expect(await errorOf(res)).toBe("plan_upgrade_required");
+    });
+
+    it("bypasses the ladder for an operator workspace", async () => {
+      setWorkspaceTier("free", true);
+      const res = await app.fetch(adminRequest(path));
+      expect(await errorOf(res)).not.toBe("plan_upgrade_required");
+    });
+
+    it("fails closed with 503 billing_check_failed when the tier lookup throws", async () => {
       failWorkspaceLookup();
       const res = await app.fetch(adminRequest(path));
       expect(res.status).toBe(503);

--- a/packages/api/src/api/__tests__/feature-entitlement-routes.test.ts
+++ b/packages/api/src/api/__tests__/feature-entitlement-routes.test.ts
@@ -303,5 +303,51 @@ describe("per-tier feature-entitlement route gates (#3988)", () => {
       expect(res.status).toBe(503);
       expect(await errorOf(res)).toBe("billing_check_failed");
     });
+
+    // The residency router gates SIX endpoints on the same `residency`
+    // entitlement, but the cases above only probe GET / and PUT /. The four
+    // migration routes are the highest-stakes residency surface — opening region
+    // migration to all paid tiers is this change's explicit design point — and
+    // the enforcement-parity scan only proves the gate is consulted by AT LEAST
+    // ONE call site, so a refactor dropping the `yield*` on a migration route
+    // would slip past it. Probe each migration route at the boundary (mirrors the
+    // proactive sibling's per-route describe.each). Bodies/params are valid so the
+    // request reaches the in-handler gate rather than 400-ing on validation first.
+    const MIGRATION_ROUTES: Array<{
+      label: string;
+      method: string;
+      path: string;
+      body?: unknown;
+    }> = [
+      { label: "GET /migration (status)", method: "GET", path: "/api/v1/admin/residency/migration" },
+      {
+        label: "POST /migrate (request migration)",
+        method: "POST",
+        path: "/api/v1/admin/residency/migrate",
+        body: { targetRegion: "eu-west" },
+      },
+      { label: "POST /migrate/{id}/retry", method: "POST", path: "/api/v1/admin/residency/migrate/mig_1/retry" },
+      { label: "POST /migrate/{id}/cancel", method: "POST", path: "/api/v1/admin/residency/migrate/mig_1/cancel" },
+    ];
+
+    it.each(MIGRATION_ROUTES)(
+      "denies a free-tier workspace on $label before any side effect",
+      async ({ method, path: routePath, body }) => {
+        setWorkspaceTier("free");
+        const res = await app.fetch(adminRequest(routePath, method, body));
+        expect(res.status).toBe(403);
+        expect(await errorOf(res)).toBe("plan_upgrade_required");
+      },
+    );
+
+    it("admits an active starter workspace on POST /migrate — the all-tier migration trigger passes the ladder", async () => {
+      setWorkspaceTier("starter");
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/residency/migrate", "POST", { targetRegion: "eu-west" }),
+      );
+      const err = await errorOf(res);
+      expect(err).not.toBe("plan_upgrade_required");
+      expect(err).not.toBe("billing_check_failed");
+    });
   });
 });

--- a/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/feature-entitlement.test.ts
@@ -46,14 +46,17 @@ const TIER_RANK: Record<PlanTier, number> = {
 const TIER_OVERRIDES: Partial<Record<GatedFeature, MinPlanTier>> = {
   custom_domain: "pro",
   proactive: "trial",
+  // All-paid: region choice is universal at signup; residency management is
+  // included at every active paid tier (not a Business differentiator).
+  residency: "trial",
 };
 
 describe("FEATURE_ENTITLEMENTS map", () => {
   it("defaults every gated feature to Business except the recorded overrides", () => {
     // The PRD locks the default tier line at Business. An override (Pro+ for
-    // custom_domain, all-paid `trial` for proactive) is an intentional
-    // single-line change in the SSOT; this pins the exact override set so a
-    // stray re-tier is caught.
+    // custom_domain, all-paid `trial` for proactive + residency) is an
+    // intentional single-line change in the SSOT; this pins the exact override
+    // set so a stray re-tier is caught.
     for (const feature of ALL_FEATURES) {
       const expected = TIER_OVERRIDES[feature] ?? "business";
       expect(FEATURE_ENTITLEMENTS[feature]).toBe(expected);

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -102,10 +102,14 @@ describe("billing/plans", () => {
       const starter = getPlanDefinition("starter");
       expect(starter.features.customDomain).toBe(false);
       expect(starter.features.sso).toBe(false);
+      // Data residency is all-paid-tier, not a Business differentiator
+      // (FEATURE_ENTITLEMENTS.residency = "trial").
+      expect(starter.features.dataResidency).toBe(true);
 
       const pro = getPlanDefinition("pro");
       expect(pro.features.customDomain).toBe(true);
       expect(pro.features.sso).toBe(false);
+      expect(pro.features.dataResidency).toBe(true);
 
       const business = getPlanDefinition("business");
       expect(business.features.customDomain).toBe(true);

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -99,11 +99,14 @@ describe("billing/plans", () => {
     });
 
     it("plan features are tier-appropriate", () => {
+      // Data residency is the all-paid floor, not a Business differentiator
+      // (FEATURE_ENTITLEMENTS.residency = "trial") — so it is set from the trial
+      // tier (the lowest active SaaS tier) up, including starter/pro.
+      expect(getPlanDefinition("trial").features.dataResidency).toBe(true);
+
       const starter = getPlanDefinition("starter");
       expect(starter.features.customDomain).toBe(false);
       expect(starter.features.sso).toBe(false);
-      // Data residency is all-paid-tier, not a Business differentiator
-      // (FEATURE_ENTITLEMENTS.residency = "trial").
       expect(starter.features.dataResidency).toBe(true);
 
       const pro = getPlanDefinition("pro");

--- a/packages/api/src/lib/billing/__tests__/pricing-entitlement-artifact.test.ts
+++ b/packages/api/src/lib/billing/__tests__/pricing-entitlement-artifact.test.ts
@@ -35,13 +35,14 @@ const COLUMNS = Object.keys(COLUMN_TIERS) as PricingColumn[];
 
 describe("COLUMN_TIERS — the column → tier ladder", () => {
   // The whole mirror's correctness rests on COLUMN_TIERS mapping each marketing
-  // column to the right PlanTier. Every gated feature is currently Business-min,
-  // so the live artifact is monochrome (every gated cell is {…, business: true})
-  // — which means the SSOT-driven tests below can't, on their own, tell `pro`
-  // apart from `business`. A fat-fingered `pro: "business"` would produce an
-  // identical artifact and slip through. These hard-coded oracles pin the
-  // ladder independently of the live SSOT, so a column→tier typo (or a future
-  // feature legitimately re-tiered to Pro+) is caught.
+  // column to the right PlanTier. The live SSOT now spans tiers (custom_domain
+  // is Pro-min; proactive + residency are trial-min; the rest Business-min), so
+  // the artifact is no longer monochrome — but leaning on whichever features
+  // happen to sit at a given tier is brittle: a future re-tier would silently
+  // change what these tests cover. These hard-coded oracles pin the column→tier
+  // ladder independently of the live SSOT, so a column→tier typo (e.g. a
+  // fat-fingered `pro: "business"`) is caught even when no live feature would
+  // distinguish the two columns on its own.
   it("maps each column to its intended tier (hard-coded oracle, not SSOT-derived)", () => {
     expect(COLUMN_TIERS).toEqual({
       selfHosted: "free",

--- a/packages/api/src/lib/billing/feature-entitlement.ts
+++ b/packages/api/src/lib/billing/feature-entitlement.ts
@@ -79,7 +79,17 @@ export const FEATURE_ENTITLEMENTS: Readonly<Record<GatedFeature, MinPlanTier>> =
   approvals: "business",
   audit_retention: "business",
   masking: "business",
-  residency: "business",
+  // All-paid override (not the Business default): data residency is available
+  // to every paying plan, not a Business differentiator. Region *choice* is
+  // already universal — the signup picker (`GET /api/v1/onboarding/regions` →
+  // buildAvailableRegions) is gated only by a region's `selectable` config flag,
+  // never by tier — so every workspace picks its US/EU/APAC region at signup.
+  // Pinning the entitlement at `trial` (the lowest active SaaS tier) makes the
+  // residency *management* surface (view/reassign/migrate, /api/v1/admin/residency)
+  // match that: included at every active paid tier, denied only to `locked` and
+  // the no-tier fail-closed-to-`free` case. The pricing page renders this in
+  // lockstep via the generated artifact.
+  residency: "trial",
   backups: "business",
   white_label: "business",
   // Pro+ override (not the Business default): the custom-domain route has always

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -167,7 +167,9 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxChatIntegrations: 1,
       monthlyProactiveClassifierCap: 5_000,
     },
-    features: { ...NO_FEATURES },
+    // Data residency is available at every active paid tier (entitlement floor
+    // is `trial`); see FEATURE_ENTITLEMENTS.residency.
+    features: { ...NO_FEATURES, dataResidency: true },
   },
   starter: {
     name: "starter",
@@ -182,7 +184,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxChatIntegrations: 1,
       monthlyProactiveClassifierCap: 5_000,
     },
-    features: { ...NO_FEATURES },
+    features: { ...NO_FEATURES, dataResidency: true },
   },
   pro: {
     name: "pro",
@@ -200,7 +202,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     features: {
       customDomain: true,
       sso: false,
-      dataResidency: false,
+      dataResidency: true,
       sla: null,
     },
   },


### PR DESCRIPTION
## Problem

The www pricing page (and docs) showed **Data residency (3 regions)** as a **Business-only** feature, but the **signup flow lets every tier pick a region** — so residency reads as gated when it isn't.

Root cause: two different things were conflated under "residency":

1. **Choosing your data region (US/EU/APAC) at signup** — already **universal**. `GET /api/v1/onboarding/regions` → `buildAvailableRegions` is gated only by a region's `selectable` config flag, **never by tier**.
2. **Residency *management*** (view / reassign / migrate, `/api/v1/admin/residency`) — gated by `FEATURE_ENTITLEMENTS.residency = "business"`.

The pricing page label "Data residency (3 regions)" presented the universal region menu as a Business perk.

## Decision

Make residency **genuinely all-paid-tier**. `FEATURE_ENTITLEMENTS.residency: "business" → "trial"` (the lowest active SaaS tier) — included at every active paid tier, denied only to `free`/`locked`. Same shape as proactive (#3999).

## Changes

- **SSOT** (`feature-entitlement.ts`): `residency` → `trial` (the one edit that drives both enforcement and the pricing page).
- **www artifact** (`entitlements.generated.ts`): regenerated from the SSOT → residency row `{ selfHosted: false, starter: true, pro: true, business: true }`. `check-pricing-parity` green.
- **www pricing** (`pricing-content.tsx`): "Data residency (3 regions)" added to Starter + Pro cards (already on Business); cell-label override extended to all paid columns.
- **plans.ts**: `dataResidency` → `true` for trial/starter/pro (unused display metadata, kept honest).
- **docs**: `billing-and-plans` pricing table + tier prose, `data-residency` callout (Business → all paid plans), `cube` comparison cell.
- **tests**: `residency` moved out of the Business-gated route set into a new **all-paid** block (deny free/locked, admit trial/starter/pro/business, operator bypass, fail-closed 503); SSOT-derived ladder + matrix tests auto-adapt; `TIER_OVERRIDES` records the new override.

## Design note: region *migration* is intentionally all-tier

This opens the whole residency admin surface — **including region migration** — to all paid tiers, **by design**. Self-service region correction is the point: if a customer picks US by mistake at signup, they can move themselves instead of filing a support ticket. The single `residency` entitlement gating the whole surface is intentional; no separate migration gate.

## Verification

- `check-pricing-parity` ✓ · `check-openapi-drift` ✓ (no route-schema change)
- `bun run type` (api + web + www) ✓
- Affected API tests (12 files incl. `enforcement-parity`, `pricing-entitlement-artifact`) ✓
- `feature-entitlement` / `plans` / `feature-ladder-regression` / `feature-entitlement-routes` / `admin-residency` ✓

https://claude.ai/code/session_01Ngh6DxDdNdZVv6W65hPfCA