### PR TITLE
fix(api): staging signup region picker offers the staging arm, not prod edges

### DIFF
--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -1009,7 +1009,7 @@ onboarding.openapi(
 
 import { residencyDomainError } from "./shared-residency";
 import { ResidencyError } from "@atlas/api/lib/residency/errors";
-import { buildAvailableRegions } from "@atlas/api/lib/residency/picker";
+import { buildSignupRegions, isRegionSelectable } from "@atlas/api/lib/residency/picker";
 import { RegionPickerItemSchema } from "@useatlas/schemas";
 
 // OnboardingRegionSchema previously duplicated this shape inline; the signup
@@ -1142,12 +1142,44 @@ onboarding.openapi(getRegionsRoute, async (c) => {
     }
 
     try {
-      const defaultRegion = mod.getDefaultRegion();
+      const configDefault = mod.getDefaultRegion();
       const regions = mod.getConfiguredRegions();
+      const apiRegion = getApiRegion();
+      // A set `ATLAS_API_REGION` that names no configured region is an operator
+      // misconfig (a typo'd value never falls back — `getApiRegion()` only
+      // defaults when the var is *empty*). The home-arm collapse can't fire, so
+      // the full selectable set is served — correct on a real prod arm, but on a
+      // deploy whose true home is non-selectable this is the #4131 cross-origin
+      // dead-end. Either way the misconfig should be visible, so surface it as a
+      // named, monitorable event (same event pattern as `onboarding.regions_error`
+      // below, at warn level since the picker still serves a usable set).
+      if (apiRegion && !regions[apiRegion]) {
+        log.warn(
+          { event: "onboarding.region_identity_unknown", requestId, apiRegion, configured: Object.keys(regions) },
+          "ATLAS_API_REGION does not match any configured region — serving the full selectable picker",
+        );
+      }
       // Exclude regions flagged `selectable: false` (e.g. the internal `staging`
       // arm) from the customer-facing picker — they exist for the boot guard +
       // routing only, never as a selectable residency choice for signups (#3948).
-      const availableRegions = buildAvailableRegions(regions, defaultRegion);
+      // Passing this deploy's own region collapses the picker to the home arm
+      // when that arm is itself non-selectable (the api-staging soak deploy claims
+      // `ATLAS_API_REGION=staging` but ships the shared prod config), so staging
+      // signup doesn't POST to the prod edges and dead-end cross-origin (#4131).
+      // `buildSignupRegions` also reports the OFFERED default (the collapsed arm),
+      // not the config default, so the page pre-selects a region that is actually
+      // in the list (the cross-field invariant the signup page relies on).
+      const { defaultRegion, availableRegions } = buildSignupRegions(regions, configDefault, { apiRegion });
+      // Parity breadcrumb: when the config default itself isn't an offerable
+      // region, `buildSignupRegions` promoted a fallback arm so signup still
+      // completes — but the misconfig (a non-selectable/unknown `defaultRegion`)
+      // should be visible, not silently corrected (mirrors the warn above).
+      if (!isRegionSelectable(regions[configDefault])) {
+        log.warn(
+          { event: "onboarding.default_region_unselectable", requestId, configDefault, offered: availableRegions.map((r) => r.id) },
+          "Configured default region is unknown or non-selectable — pre-selecting the first offered region",
+        );
+      }
       return c.json({ configured: true, defaultRegion, availableRegions }, 200);
     } catch (err) {
       if (err instanceof ResidencyError && err.code === "not_configured") {

--- a/packages/api/src/lib/residency/__tests__/picker.test.ts
+++ b/packages/api/src/lib/residency/__tests__/picker.test.ts
@@ -5,7 +5,12 @@
  * but must never be a selectable residency choice for real signups (#3948).
  */
 import { describe, it, expect } from "bun:test";
-import { buildAvailableRegions, isRegionSelectable } from "@atlas/api/lib/residency/picker";
+import {
+  buildAvailableRegions,
+  buildSignupRegions,
+  isRegionSelectable,
+  type RegionPickerOptions,
+} from "@atlas/api/lib/residency/picker";
 import type { ResidencyConfig } from "@atlas/api/lib/config";
 
 type Regions = ResidencyConfig["regions"];
@@ -57,6 +62,160 @@ describe("buildAvailableRegions (#3948)", () => {
     // region must not leak that region into the picker.
     const ids = buildAvailableRegions(REGIONS, "staging").map((r) => r.id);
     expect(ids).not.toContain("staging");
+  });
+});
+
+describe("buildAvailableRegions — home-region override (#4131)", () => {
+  // The api-staging soak service builds from the shared PROD config (us/eu/apac +
+  // a non-selectable `staging` arm) but claims `ATLAS_API_REGION=staging`. Without
+  // the home-region override the picker served there offered us/eu/apac, whose
+  // apiUrls point at the PROD edges — picking one cross-origins the account-create
+  // POST (`net::ERR_FAILED`) and dead-ends staging signup. The inverse of #3948:
+  // there the staging arm leaked INTO the prod picker; here the staging deploy
+  // served the PROD arms instead of its own.
+  it("offers only the home arm when this deploy's region is non-selectable (staging)", () => {
+    const available = buildAvailableRegions(REGIONS, "us", { apiRegion: "staging" });
+    expect(available).toEqual([
+      { id: "staging", label: "Staging", isDefault: true, apiUrl: "https://api.staging.useatlas.dev" },
+    ]);
+  });
+
+  it("serves NO prod apiUrls on the staging deploy", () => {
+    const urls = buildAvailableRegions(REGIONS, "us", { apiRegion: "staging" }).map((r) => r.apiUrl);
+    expect(urls).toEqual(["https://api.staging.useatlas.dev"]);
+    expect(urls).not.toContain("https://api.useatlas.dev");
+    expect(urls).not.toContain("https://api-eu.useatlas.dev");
+    expect(urls).not.toContain("https://api-apac.useatlas.dev");
+  });
+
+  it("offers the full selectable set when this deploy's home region IS selectable (prod us)", () => {
+    const ids = buildAvailableRegions(REGIONS, "us", { apiRegion: "us" }).map((r) => r.id);
+    expect(ids.toSorted()).toEqual(["apac", "eu", "us"]);
+    expect(ids).not.toContain("staging");
+  });
+
+  it("offers the full set with the config default unchanged when the home region is selectable but not the default (prod eu/apac deploy)", () => {
+    // The api-eu / api-apac prod deploys ship the SAME shared config
+    // (defaultRegion "us") but claim ATLAS_API_REGION=eu/apac. Their home arm is
+    // selectable, so the picker must NOT collapse and must NOT re-mark the home
+    // arm as default — "us" stays the default, eu/apac are offered alongside it.
+    const available = buildAvailableRegions(REGIONS, "us", { apiRegion: "eu" });
+    expect(available.map((r) => r.id).toSorted()).toEqual(["apac", "eu", "us"]);
+    expect(available.find((r) => r.id === "eu")?.isDefault).toBe(false);
+    expect(available.find((r) => r.id === "us")?.isDefault).toBe(true);
+  });
+
+  it("is unchanged (full selectable set) when no api region is given — back-compat", () => {
+    const idsUndefined = buildAvailableRegions(REGIONS, "us", { apiRegion: undefined }).map((r) => r.id);
+    const idsNull = buildAvailableRegions(REGIONS, "us", { apiRegion: null }).map((r) => r.id);
+    const idsNoOpts = buildAvailableRegions(REGIONS, "us").map((r) => r.id);
+    expect(idsUndefined.toSorted()).toEqual(["apac", "eu", "us"]);
+    expect(idsNull.toSorted()).toEqual(["apac", "eu", "us"]);
+    expect(idsNoOpts.toSorted()).toEqual(["apac", "eu", "us"]);
+  });
+
+  it("falls through to the selectable set when the home region id is unknown/misconfigured", () => {
+    // A typo'd ATLAS_API_REGION must not crash on the missing arm nor strand the
+    // picker on a single non-existent region — fall back to the normal selectable
+    // set. (`getApiRegion()` only defaults an *empty* var, so a wrong value
+    // genuinely reaches here.)
+    const ids = buildAvailableRegions(REGIONS, "us", { apiRegion: "nope" }).map((r) => r.id);
+    expect(ids.toSorted()).toEqual(["apac", "eu", "us"]);
+  });
+});
+
+describe("buildSignupRegions — offered default ∈ picker list (#4131)", () => {
+  // Cross-field invariant: the signup page pre-selects the region named by the
+  // response `defaultRegion`, so it MUST be present in availableRegions as the
+  // isDefault item — otherwise the naive Continue click dead-ends on the
+  // "contact support" path. The home-arm collapse returns a single arm that is
+  // not the config default, so the route must report the OFFERED default.
+  it("reports the collapsed home arm as the default on the staging deploy", () => {
+    const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, "us", { apiRegion: "staging" });
+    expect(defaultRegion).toBe("staging");
+    // The reported default is present in the list and is the isDefault item.
+    const def = availableRegions.find((r) => r.id === defaultRegion);
+    expect(def?.isDefault).toBe(true);
+    expect(availableRegions.map((r) => r.id)).toEqual(["staging"]);
+  });
+
+  it("keeps the config default on a selectable-home prod deploy (us)", () => {
+    const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, "us", { apiRegion: "us" });
+    expect(defaultRegion).toBe("us");
+    expect(availableRegions.find((r) => r.id === "us")?.isDefault).toBe(true);
+  });
+
+  it("keeps the config default 'us' even when served by a non-default prod arm (eu)", () => {
+    const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, "us", { apiRegion: "eu" });
+    expect(defaultRegion).toBe("us");
+    expect(availableRegions.map((r) => r.id)).toContain("us");
+    expect(availableRegions.find((r) => r.id === "us")?.isDefault).toBe(true);
+  });
+
+  it("keeps the config default when no api region is given — back-compat", () => {
+    const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, "eu");
+    expect(defaultRegion).toBe("eu");
+    expect(availableRegions.find((r) => r.id === "eu")?.isDefault).toBe(true);
+  });
+
+  // The fallback edge: a misconfig where the config default is itself
+  // non-selectable or unknown. Echoing it would re-strand the invariant (the
+  // returned default would be absent from the list), so the first offered arm is
+  // promoted instead. Unreachable in the shared prod config (default "us" is
+  // selectable) but config validation permits it, so pin the behavior.
+  it("promotes the first offered arm when the config default is non-selectable", () => {
+    const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, "staging");
+    // Never echoes the non-selectable "staging" as the default.
+    expect(defaultRegion).not.toBe("staging");
+    // Invariant: the returned default is in the list AND is the isDefault item.
+    expect(availableRegions.map((r) => r.id)).toContain(defaultRegion);
+    expect(availableRegions.find((r) => r.id === defaultRegion)?.isDefault).toBe(true);
+    // Exactly one isDefault arm (the promoted one).
+    expect(availableRegions.filter((r) => r.isDefault).map((r) => r.id)).toEqual([defaultRegion]);
+  });
+
+  it("promotes the first offered arm when the config default is an unknown id", () => {
+    const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, "zz", { apiRegion: "us" });
+    expect(defaultRegion).not.toBe("zz");
+    expect(availableRegions.map((r) => r.id)).toContain(defaultRegion);
+    expect(availableRegions.find((r) => r.id === defaultRegion)?.isDefault).toBe(true);
+  });
+
+  it("returns the config default with an empty list when no region is selectable", () => {
+    // The deliberate carve-out: with nothing offerable there is no in-list arm to
+    // promote, so the config default is echoed alongside an empty list. The signup
+    // page reads `availableRegions.length === 0` as "nothing to pick" and skips
+    // the step, so the out-of-list default never reaches a pre-select. Pins the
+    // `!first` guard against a refactor that drops it (→ `first.id` on undefined).
+    const empty: Regions = {};
+    expect(buildSignupRegions(empty, "us")).toEqual({ defaultRegion: "us", availableRegions: [] });
+    // Same when every configured region is non-selectable.
+    const allNonSelectable: Regions = { staging: { label: "Staging", selectable: false } };
+    expect(buildSignupRegions(allNonSelectable, "staging")).toEqual({
+      defaultRegion: "staging",
+      availableRegions: [],
+    });
+  });
+
+  it("keeps the invariant (default ∈ list, or list empty) across configs", () => {
+    // Property check over the reachable + misconfig shapes: the reported default
+    // is always selectable from the offered list (the page never pre-selects a
+    // region absent from the picker), unless there is nothing to offer at all.
+    const cases: Array<[string, RegionPickerOptions | undefined]> = [
+      ["us", undefined],
+      ["us", { apiRegion: "staging" }],
+      ["us", { apiRegion: "eu" }],
+      ["staging", undefined],
+      ["zz", { apiRegion: "us" }],
+      ["eu", { apiRegion: "nope" }],
+    ];
+    for (const [configDefault, opts] of cases) {
+      const { defaultRegion, availableRegions } = buildSignupRegions(REGIONS, configDefault, opts);
+      if (availableRegions.length > 0) {
+        expect(availableRegions.map((r) => r.id)).toContain(defaultRegion);
+        expect(availableRegions.find((r) => r.id === defaultRegion)?.isDefault).toBe(true);
+      }
+    }
   });
 });
 

--- a/packages/api/src/lib/residency/picker.ts
+++ b/packages/api/src/lib/residency/picker.ts
@@ -31,13 +31,58 @@ export function isRegionSelectable(region: RegionConfig | undefined): boolean {
 }
 
 /**
+ * Options for {@link buildAvailableRegions} / {@link buildSignupRegions}.
+ *
+ * `apiRegion` is a *named* field (not a third positional `string`) on purpose:
+ * `defaultRegion` and `apiRegion` are both region ids, and a positional swap of
+ * the two would type-check while silently re-introducing #4131 — the staging
+ * deploy would serve the prod arms again. The named option makes the call site
+ * self-documenting and un-swappable.
+ */
+export interface RegionPickerOptions {
+  /**
+   * THIS deploy's own region identity (`getApiRegion()` — `ATLAS_API_REGION`,
+   * falling back to `residency.defaultRegion`, else `null`). Drives the
+   * home-arm collapse below.
+   */
+  readonly apiRegion?: string | null;
+}
+
+/**
  * Project the configured regions to the signup picker, excluding any region
  * that is not selectable (see {@link isRegionSelectable}).
+ *
+ * When `apiRegion` (this deploy's own region) names a region that is *not*
+ * selectable — the api-staging soak service claims `ATLAS_API_REGION=staging`
+ * while building from the shared prod config, so its home arm is the
+ * non-selectable `staging` entry — the picker offers ONLY that home arm. Every
+ * public arm's `apiUrl` points at a *different* deploy (e.g. `api.useatlas.dev`),
+ * so serving them here would cross-origin the account-create POST and dead-end
+ * signup (#4131 — the inverse of #3948, where a staging arm leaked INTO the prod
+ * picker; here the staging deploy was serving the prod arms instead of its own).
+ * For any other case (`apiRegion` selectable, unset, or an unknown id) the full
+ * selectable set is returned, unchanged.
+ *
+ * NOTE: this returns the picker *list* only. The route must pair it with the
+ * matching offered default via {@link buildSignupRegions} — see the cross-field
+ * invariant documented there.
  */
 export function buildAvailableRegions(
   regions: ResidencyConfig["regions"],
   defaultRegion: string,
+  opts?: RegionPickerOptions,
 ): RegionPickerItem[] {
+  const apiRegion = opts?.apiRegion;
+  // `regions[apiRegion]` types as a non-undefined `RegionConfig` (the repo's
+  // tsconfig has `noUncheckedIndexedAccess` off) but is `undefined` at runtime
+  // for an unknown id — the `homeCfg &&` guard is LOAD-BEARING (a typo'd
+  // `ATLAS_API_REGION` must fall through, not throw on `homeCfg.label`). The
+  // `apiRegion &&` guard is also required: it narrows `apiRegion` to `string`.
+  const homeCfg = apiRegion ? regions[apiRegion] : undefined;
+  if (apiRegion && homeCfg && !isRegionSelectable(homeCfg)) {
+    // Sole option, so mark it default — the picker pre-selects the default arm.
+    return [{ id: apiRegion, label: homeCfg.label, isDefault: true, apiUrl: homeCfg.apiUrl }];
+  }
   return Object.entries(regions)
     .filter(([, cfg]) => isRegionSelectable(cfg))
     // `apiUrl` carries the region→base map to the signup picker so the browser
@@ -45,4 +90,42 @@ export function buildAvailableRegions(
     // write (ADR-0024 §4). Passed through verbatim — `undefined` when the region
     // config omits it (single-region / local dev), where no repoint is possible.
     .map(([id, cfg]) => ({ id, label: cfg.label, isDefault: id === defaultRegion, apiUrl: cfg.apiUrl }));
+}
+
+/**
+ * The full signup region projection the `/regions` route returns: the picker
+ * list AND the id the signup page should pre-select.
+ *
+ * Cross-field invariant (upheld for every non-empty list): the signup page
+ * pre-selects the region named by the response `defaultRegion`
+ * (`page.tsx` → `setSelected(data.defaultRegion)`), so that id MUST be present in
+ * `availableRegions` as the `isDefault` item. `buildAvailableRegions`'s home-arm
+ * collapse can return a single arm that is NOT the config `defaultRegion` (the
+ * staging deploy offers only `staging` while the config default is `us`) —
+ * reporting the unchanged config default there would pre-select a region absent
+ * from the list and dead-end the naive Continue click on the "contact support"
+ * path (#4131). So the offered default is the marked `isDefault` arm; and if the
+ * config default is itself non-selectable or unknown (no arm marked — a misconfig
+ * the shared prod config never hits, but config validation permits), the FIRST
+ * offered arm is promoted to default rather than echoing the out-of-list config
+ * id. Only a genuinely empty selectable set yields a default absent from the
+ * (also empty) list — which the page reads as "nothing to pick" and skips.
+ */
+export function buildSignupRegions(
+  regions: ResidencyConfig["regions"],
+  defaultRegion: string,
+  opts?: RegionPickerOptions,
+): { defaultRegion: string; availableRegions: RegionPickerItem[] } {
+  const availableRegions = buildAvailableRegions(regions, defaultRegion, opts);
+  const marked = availableRegions.find((r) => r.isDefault);
+  if (marked) return { defaultRegion: marked.id, availableRegions };
+  // No arm is marked default → the config `defaultRegion` is non-selectable or an
+  // unknown id (the collapse path didn't fire). Echoing it would name a region
+  // ABSENT from the list and re-create the #4131 pre-select dead-end, so promote
+  // the first offered arm instead, keeping the invariant (default ∈ list, marked
+  // isDefault). The route emits `onboarding.default_region_unselectable` so the
+  // misconfig is surfaced rather than silently corrected.
+  const [first, ...rest] = availableRegions;
+  if (!first) return { defaultRegion, availableRegions };
+  return { defaultRegion: first.id, availableRegions: [{ ...first, isDefault: true }, ...rest] };
 }


### PR DESCRIPTION
## Summary
- **Bug:** On `app.staging.useatlas.dev/signup` the region step offered US/EU/APAC whose `apiUrl`s point at the **prod** edges. Picking one POSTed account creation to `https://api.useatlas.dev/...` → `net::ERR_FAILED` (cross-origin to a different deploy), so the staging web signup funnel couldn't complete. The api-staging soak service ships the **shared prod** residency config (us/eu/apac + a non-selectable `staging` arm) but claims `ATLAS_API_REGION=staging`; the picker filtered out the non-selectable staging arm and served the prod arms. This is the **inverse of #3948** (there a staging arm leaked *into* the prod picker; here the staging deploy served the *prod* arms instead of its own).
- **Fix (server-only):** `buildAvailableRegions` is now home-region aware — when this deploy's own region (`getApiRegion()`) is itself a non-selectable arm, the picker offers **only that home arm** (same-origin, so no cross-origin POST). A new `buildSignupRegions` wrapper also reports the **offered** default (the collapsed arm), upholding the cross-field invariant the signup page relies on (`setSelected(data.defaultRegion)`) — otherwise the naive "Continue" click re-dead-ended on the "contact support" path.
- The third arg is a **named `{ apiRegion }` option** (`RegionPickerOptions`) so a `defaultRegion`/`apiRegion` positional swap can't silently re-introduce #4131. Two named `log.warn`s (`onboarding.region_identity_unknown`, `onboarding.default_region_unselectable`) surface `ATLAS_API_REGION` / `defaultRegion` misconfigs instead of silently serving the prod set.
- The web region page (`signup/region/page.tsx`) is an **unchanged pure consumer** of the server-returned list + apiUrls — no client change needed.

## Test plan
- [x] `packages/api/src/lib/residency/__tests__/picker.test.ts` — staging collapse serves **no prod apiUrls** (the AC); full set on prod us/eu/apac with config default preserved; back-compat (undefined/null/no-opts); unknown `ATLAS_API_REGION` falls through; `buildSignupRegions` cross-field invariant (default ∈ list ∧ is the `isDefault` item) incl. non-selectable/unknown config-default promotion + empty-set carve-out (23 tests)
- [x] Internal review panel (silent-failure, type-design, test-coverage, comment) — 3 rounds to CLEAN
- [x] `/ci` — lint, type, full test (741 pass; 3 pre-existing WSL2 sandbox env flakes unrelated to this diff), syncpack, all drift/parity gates green

Closes #4131