### PR TITLE
chore(ship): token-cheap PR-review sweep + conditional reviewer wait

### DIFF
--- a/.claude/commands/ship-batch.md
+++ b/.claude/commands/ship-batch.md
@@ -43,13 +43,16 @@ Agent(
   run_in_background: true,
   description: "ship #<N>",
   prompt: "Run /ship-issue <N>. Follow it exactly — worktree isolation, craft loop,
-           /review-panel until clean (max 3 rounds), /ci, /pr, subscribe_pr_activity,
-           then service EVERY external reviewer (any bot/human, reviewer-agnostic) to
-           convergence per Step 5 — sweep reviews + comments + the PR body, address
-           actionable findings back-and-forth, acknowledge (never block on) approvability /
-           needs-human verdicts. Merge only when green AND own-branch AND external reviews
-           converged (wait out any in-progress 'eyes' review first — never merge or ask while a bot is mid-review). Halt and report if a review can't converge, a gate is broken, or
-           anything is ambiguous. Report PR + each reviewer's verdict + outcome."
+           /review-panel until clean (max 3 rounds), /ci, /pr, then drive to merge per
+           Step 5: wait for the first full CI to complete (gh pr checks --watch), then run
+           `bash scripts/pr-review-status.sh <N>` ONCE. If it reports no third-party
+           reviewer, converge on CI green + clean panel — do NOT wait for bots that don't
+           exist. If a reviewer IS present (reviewer-agnostic, any bot/human), categorize +
+           fix actionable findings back-and-forth, acknowledge (never block on) approvability /
+           needs-human verdicts, and wait out any EYES-UP review via the bounded subagent poll
+           before merging. Merge only when green AND own-branch AND Step-5-converged. Halt and
+           report if a review can't converge, a gate is broken, or anything is ambiguous.
+           Report PR + each reviewer's verdict (if any) + outcome."
 )
 ```
 

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -49,44 +49,37 @@ Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fas
 ```
 All gates must pass. Fix anything red (these are usually small). Run full `bun run test` once here even if `--affected` was green.
 
-**Step 5 — Open the PR, then service it to convergence**
+**Step 5 — Open the PR, then drive it to merge**
 
 ```
 /pr
 ```
-`/pr` branches/commits/pushes and opens the PR with `Closes #<N>`. Then **keep this session alive to service CI + every external reviewer**:
+`/pr` branches/commits/pushes and opens the PR with `Closes #<N>`. Two gates must be green on the head SHA: the **internal `/review-panel`** (already run in Step 3) and **required CI**. Third-party review bots are now the *exception* — the panel is the review — so handle them only when one is actually on the PR. The settling point is the **first full CI completion**, not an open-ended wait for reviewers that may not exist.
 
-```
-subscribe_pr_activity for the new PR
-```
-
-External reviewers (review bots AND humans) post *after* `/pr` and are **slower than required CI** — so do NOT merge the instant CI greens. Give them a round, then sweep them explicitly before every merge attempt.
-
-**The external-review loop — reviewer-agnostic.** Read whatever reviewers are installed; never hardcode names (today Macroscope + Greptile; tomorrow Codex, Claude, Cline, a human — same handling):
-
-1. **Sweep every reviewer on the current head SHA.** They post in *three different places* — miss one and you miss the review:
+1. **Wait for the first full CI run to complete** on the head SHA:
    ```bash
-   gh pr view <N> -R AtlasDevHQ/atlas --json reviews,latestReviews,headRefOid,body
-   gh api repos/AtlasDevHQ/atlas/issues/<N>/comments   # bot summaries (Macroscope, …) post here
-   gh api repos/AtlasDevHQ/atlas/pulls/<N>/comments     # inline review threads
+   gh pr checks <N> -R AtlasDevHQ/atlas --watch
    ```
-   ⚠️ Some bots edit their summary **into the PR body** between markers (Greptile: `<!-- greptile_comment -->`) — `reviews`/`comments` both miss it; only `--json body` catches it. Ignore your own (author) output and stale verdicts on superseded SHAs — only the latest per reviewer on the head SHA counts; a flag may already be fixed by a later commit, so reconcile against the merged diff, don't assume it's live.
+   A required check that goes red is serviced like a panel finding — fix, `git commit -o <files>`, push (which re-runs CI) → back to (1). `--admin` is only for a genuinely *broken* gate, never a slow one.
 
-   ⚠️ **Don't sweep a review that's still running, and NEVER surface a merge decision while a bot still has "eyes" on the PR.** An in-progress review hasn't reached a verdict — reading it now gets a stale/empty result, and merging *or* asking the human while it's mid-review is exactly the premature call we're avoiding (#3839). Greptile shows its state in the **body block**: 👀 while reviewing, 👍 when done, and a `Last reviewed commit` tag at the bottom naming the SHA it actually reviewed. Greptile has finished the **current head iff that SHA equals `headRefOid`** (a fresh push re-triggers it, so the tag lags — eyes up — until it catches up):
+2. **Once CI is complete, take ONE review snapshot** — reviewer-agnostic, no hardcoded names:
    ```bash
-   HEAD_SHA=$(gh pr view <N> -R AtlasDevHQ/atlas --json headRefOid -q .headRefOid)
-   GREPTILE_SHA=$(gh pr view <N> -R AtlasDevHQ/atlas --json body -q '.body' \
-     | grep -i 'Last reviewed commit' | grep -oE '/commit/[0-9a-f]{40}' | grep -oE '[0-9a-f]{40}' | tail -1)
-   # eyes still up while GREPTILE_SHA != HEAD_SHA (or the block is absent right after a push)
+   bash scripts/pr-review-status.sh <N>
    ```
-   If any review bot is still mid-review on the head SHA, it is **not converged** — wait it out (bounded: poll ~every 30–60s, up to ~10 min), then re-sweep. Do **not** merge and do **not** `AskUserQuestion` while eyes are up. If it still hasn't landed after the bound, proceed advisory and say so in the report — `main` is staging, a late bot review is fixed forward, never a block.
-2. **Categorize each reviewer's latest output:**
-   - **Actionable finding** (a code concern, or a summary flagging real behavior/risk) → treat like a panel finding: fix it, `git commit -o <files>`, push. The push re-triggers the reviewers on the new SHA → **back to step 1.** This is the back-and-forth — iterate until no reviewer has an open actionable finding.
-   - **Ambiguous / architecturally significant fix** → `AskUserQuestion`; don't guess.
-   - **Approvability / "needs human review" / policy sign-off with no code ask** → **acknowledge only.** Quote it in the report. It does **NOT** block the merge and is **NOT** a halt — `main` deploys to staging, not prod (`prod` is `/release`-gated behind a human). Never sit waiting on a human-approval verdict.
-3. **Converged** when, on the head SHA: required CI green, internal panel was clean, **every review bot has actually finished reviewing the head SHA (no lingering "eyes" — e.g. Greptile's `Last reviewed commit` == `headRefOid`),** and every external reviewer is either re-reviewed-clean or carries only an acknowledged non-actionable verdict → **merge.** (A required check that goes red after a push is serviced the same way — fix, `git commit -o`, push, re-sweep — not a new path.)
+   It sweeps every reviewer in all three places (formal reviews + inline threads + known body-blocks like Macroscope/Greptile), compares each against head, and writes the full payloads to `.pr-review/<N>/` (read a specific `inline.json`/`issue.json` entry only when you need a finding's full prose). Its **VERDICT** drives the next move:
+   - **`SETTLED — CI-gated only; no third-party reviewer`** (the common case) → there is nothing to poll. Required CI green + the Step-3 panel clean ⇒ **converged → merge.** Do **not** wait for bots that don't exist. (CI-status issue-comments like the Lighthouse `github-actions[bot]` summary are not a reviewer and don't count.)
+   - **`SETTLED — present, all caught up`** → a reviewer is on the PR and has reviewed head → go to (3).
+   - **`EYES-UP — behind head`** (exit 10) → a bot is mid-review on an older SHA (a fresh push re-triggered it). Do **not** merge and do **not** `AskUserQuestion` while eyes are up (#3839). **Delegate the wait to a subagent** so the poll iterations never land in this thread:
+     > Run `bash scripts/pr-review-status.sh <N>` every ~45s until it no longer exits 10 (EYES-UP clears) or ~10 min elapses; return only the final snapshot — do not paste intermediate runs.
 
-Cap the back-and-forth at **3 reviewer rounds** like the panel; if it won't converge, STOP and ask.
+     Then act on the returned verdict. If the bound elapses still eyes-up, proceed advisory and say so in the report — `main` is staging; a late bot review is fixed forward, never a block.
+
+3. **A reviewer is present — categorize its findings** (only when (2) reported one):
+   - **Actionable** (code concern, or a summary flagging real behavior/risk) → fix it, `git commit -o <files>`, push. The push re-triggers CI and the bot → **back to (1).** Iterate until no reviewer has an open actionable finding.
+   - **Ambiguous / architecturally significant** → `AskUserQuestion`; don't guess.
+   - **Approvability / "needs human review" / policy sign-off with no code ask** → **acknowledge only.** Quote it in the report. It does **NOT** block the merge and is **NOT** a halt — `main` deploys to staging, not prod. Never sit waiting on a human-approval verdict.
+
+**Converged** when, on the head SHA: required CI green, the Step-3 panel was clean, and **either** no external reviewer is present **or** every present reviewer is re-reviewed-clean / carries only an acknowledged non-actionable verdict → **merge.** Cap the reviewer back-and-forth at **3 rounds** like the panel; if it won't converge, STOP and ask.
 
 **HARD HALTS (never autonomous):**
 - **Fork PR** (`isCrossRepository: true`) → STOP, surface provenance, get human sign-off. Never `--admin` past `fork-pr-gate`.

--- a/.claude/commands/ship-milestone.md
+++ b/.claude/commands/ship-milestone.md
@@ -29,13 +29,16 @@ Agent(
   run_in_background: true,
   description: "ship #<N>",
   prompt: "Run /ship-issue <N>. Follow it exactly — worktree isolation, craft loop,
-           /review-panel until clean (max 3 rounds), /ci, /pr, subscribe_pr_activity,
-           then service EVERY external reviewer (any bot/human, reviewer-agnostic) to
-           convergence per Step 5 — sweep reviews + comments + the PR body, address
-           actionable findings back-and-forth, acknowledge (never block on) approvability /
-           needs-human verdicts. Merge only when green AND own-branch AND external reviews
-           converged (wait out any in-progress 'eyes' review first — never merge or ask while a bot is mid-review). Halt and report if a review can't converge, a gate is broken, or
-           anything is ambiguous. Report the PR + each reviewer's verdict + outcome."
+           /review-panel until clean (max 3 rounds), /ci, /pr, then drive to merge per
+           Step 5: wait for the first full CI to complete (gh pr checks --watch), then run
+           `bash scripts/pr-review-status.sh <N>` ONCE. If it reports no third-party
+           reviewer, converge on CI green + clean panel — do NOT wait for bots that don't
+           exist. If a reviewer IS present (reviewer-agnostic, any bot/human), categorize +
+           fix actionable findings back-and-forth, acknowledge (never block on) approvability /
+           needs-human verdicts, and wait out any EYES-UP review via the bounded subagent poll
+           before merging. Merge only when green AND own-branch AND Step-5-converged. Halt and
+           report if a review can't converge, a gate is broken, or anything is ambiguous.
+           Report the PR + each reviewer's verdict (if any) + outcome."
 )
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ tsconfig.tsbuildinfo
 .expert-cache/
 # Local CI wrapper logs (scripts/ci-local.sh)
 .ci-local/
+# PR review-sweep snapshots (scripts/pr-review-status.sh)
+.pr-review/
 create-atlas/templates/*/semantic/
 create-atlas/templates/*/bin/
 create-atlas/templates/*/lib/

--- a/scripts/pr-review-status.sh
+++ b/scripts/pr-review-status.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# pr-review-status.sh — token-cheap snapshot of a PR's external-review state.
+#
+# WHY THIS EXISTS
+#   /ship-issue Step 5 services every external reviewer to convergence. The
+#   mechanical half of that loop swept THREE gh endpoints (formal reviews,
+#   issue-comment bot summaries, inline review threads) plus the full PR body,
+#   then did SHA / "eyes-up" math by hand — and POLLED on a 30-60s cadence for
+#   up to 10 minutes, up to 3 rounds. Every poll iteration re-billed all the
+#   prior verbose JSON in the agent loop (the same re-billing multiplier
+#   scripts/ci-local.sh kills for /ci). This wrapper does all the collection +
+#   SHA math once and prints ONE compact snapshot: reviewers, the commit each
+#   reviewed vs head, a required-check rollup, and the inline findings. The raw
+#   payloads land in .pr-review/<pr>/ so the model can read ONE reviewer's full
+#   prose only when it needs to judge a borderline finding — instead of carrying
+#   every reviewer's full prose through every poll.
+#
+# WHAT IT DOES NOT DO (on purpose)
+#   It collects and compacts; it does NOT categorize. Judging "actionable code
+#   concern" vs "ambiguous/architectural" vs "ack-only approvability note", and
+#   then FIXING the actionable ones, needs the conversation context and stays in
+#   the /ship-issue thread. Unlike ci-local.sh (fully mechanical pass/fail), the
+#   review loop is only PARTLY mechanical — so this is a partial blackbox, by
+#   design, not a shortfall.
+#
+# REVIEWER-AGNOSTIC
+#   It enumerates EVERY reviewer / comment author from the data — it never limits
+#   the reviewer set to a known list. It additionally extracts richer "eyes-up"
+#   state from bots whose protocol it knows (Macroscope / Greptile body blocks);
+#   a brand-new bot is still listed generically, just without that refinement.
+#   Extend KNOWN-BOT PROTOCOLS below as new bots appear; never gate the reviewer
+#   set on names.
+#
+# EYES-UP (the poll gate)
+#   A bot reviewer is "behind head" when the latest commit it reviewed != the PR
+#   head SHA — it may re-review on the new push, so treat it as still having eyes
+#   on the PR until it catches up or the caller's 10-min bound elapses (exactly
+#   the /ship-issue discipline). Exit code encodes ONLY this poll decision:
+#     exit 10  = a bot is still behind head (EYES-UP)  -> keep polling
+#     exit 0   = no bot is behind head (SETTLED)        -> hand snapshot to the model
+#     exit 1   = error (bad args / gh failure)
+#   Required-check state is shown for context but does NOT drive the exit code —
+#   CI is serviced by `gh pr checks --watch`, not by this poll.
+#
+# USAGE
+#   bash scripts/pr-review-status.sh <PR> [REPO]      # REPO defaults to AtlasDevHQ/atlas
+#   PR_REVIEW_PREVIEW=N   chars of each finding/summary preview (default 140)
+
+set -uo pipefail
+
+PR="${1:-}"
+REPO="${2:-AtlasDevHQ/atlas}"
+PREVIEW="${PR_REVIEW_PREVIEW:-140}"
+
+if [ -z "$PR" ] || ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "usage: bash scripts/pr-review-status.sh <PR-number> [owner/repo]" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="$ROOT/.pr-review/$PR"
+rm -rf "$DIR"
+mkdir -p "$DIR"
+
+fetch() { # fetch <outfile> <gh-args...>
+  local out="$1"; shift
+  if ! gh "$@" >"$DIR/$out" 2>"$DIR/$out.err"; then
+    echo "ERROR: gh $* failed:" >&2
+    sed 's/^/  /' "$DIR/$out.err" >&2
+    exit 1
+  fi
+}
+
+# One fetch per source. --paginate so a long review thread isn't truncated.
+fetch meta.json   pr view "$PR" -R "$REPO" \
+  --json headRefOid,state,mergeable,baseRefName,title,body,statusCheckRollup,isCrossRepository,author
+fetch reviews.json     api --paginate "repos/$REPO/pulls/$PR/reviews"
+fetch issue.json       api --paginate "repos/$REPO/issues/$PR/comments"
+fetch inline.json      api --paginate "repos/$REPO/pulls/$PR/comments"
+
+HEAD="$(jq -r '.headRefOid' "$DIR/meta.json")"
+HEAD_SHORT="${HEAD:0:8}"
+
+echo "PR #$PR  $REPO  head=$HEAD_SHORT"
+jq -r '"state: \(.state)   mergeable: \(.mergeable // "?")   base: \(.baseRefName)   "
+       + (if .isCrossRepository then "⚠ FORK PR (cross-repo) — human sign-off required" else "" end)
+       + "\n" + .title' "$DIR/meta.json"
+echo ""
+
+# ---- Required-ish checks (informational; does not drive exit code) ----
+echo "CHECKS"
+jq -r '
+  (.statusCheckRollup // []) as $c
+  | if ($c|length)==0 then "  (no checks reported yet)"
+    else
+      ( $c | map({name: (.name // .context // "?"),
+                  st: ((.conclusion // .state // .status // "PENDING") | ascii_upcase)}) ) as $rows
+      | ( $rows | group_by(.st) | map("\(.[0].st)=\(length)") | join("  ") ) as $roll
+      | ( [ $rows[] | select(.st|test("FAIL|ERROR|CANCEL|TIMED")) | "  ✗ \(.name)  \(.st)" ] ) as $bad
+      | ( [ $rows[] | select(.st|test("PENDING|PROGRESS|QUEUED|WAITING|EXPECTED")) | "  … \(.name)  \(.st)" ] ) as $pend
+      | ( "  rollup: " + $roll )
+        + (if ($bad|length)>0  then "\n" + ($bad  | join("\n")) else "" end)
+        + (if ($pend|length)>0 then "\n" + ($pend | join("\n")) else "" end)
+    end
+' "$DIR/meta.json"
+echo ""
+
+# ---- Reviewers: latest commit each touched (reviews + inline), vs head ----
+# A reviewer/author is a "bot" if the API types it as Bot or the login ends [bot].
+# This table is informational — it shows the SHA each reviewer last touched. It
+# does NOT drive the poll gate (see BEHIND_LOGINS below and the body-block check).
+REVIEWER_JQ='
+  ( [ $reviews[0][]? | {login: .user.login, bot: (.user.type=="Bot"), commit: .commit_id, when: .submitted_at} ]
+    + [ $inline[0][]?  | {login: .user.login, bot: (.user.type=="Bot"), commit: .commit_id, when: .created_at} ]
+  )
+  | map(select(.login != null))
+  | group_by(.login)
+  | map( (max_by(.when)) as $l
+         | { login: $l.login,
+             bot: ($l.bot or ($l.login|test("\\[bot\\]$"))),
+             commit: $l.commit,
+             athead: ($l.commit == $head) } )
+'
+echo "REVIEWERS  (latest activity per author; @head? = reviewed the current head SHA)"
+jq -rn --arg head "$HEAD" \
+  --slurpfile reviews "$DIR/reviews.json" --slurpfile inline "$DIR/inline.json" \
+  "$REVIEWER_JQ"' as $r
+   | if ($r|length)==0 then "  (no reviewers yet)"
+     else ( $r[] | "  \(if .bot then "🤖" else "👤" end) \(.login)\t"
+                   + (if .commit==null then "(no commit)" else .commit[0:8] end)
+                   + "\t@head: \(if .athead then "yes" else "NO" end)" )
+     end'
+# Informational only (NOT the poll gate): which bots last touched a non-head SHA.
+# A formal review / inline comment on an older SHA usually just means "reviewed an
+# earlier push and is done" — it is NOT a reliable "still reviewing" signal, so it
+# must not drive the poll (it false-positives on done-but-old reviews). The poll
+# gate is the body-block check below.
+BEHIND_LOGINS="$(jq -rn --arg head "$HEAD" \
+  --slurpfile reviews "$DIR/reviews.json" --slurpfile inline "$DIR/inline.json" \
+  "$REVIEWER_JQ"' | [ .[] | select(.bot and (.athead|not)) | .login ] | join(",")')"
+echo ""
+
+# ---- KNOWN-BOT PROTOCOLS: the poll gate (summary SHA in the PR body) --------
+# A bot that reports the SHA it last reviewed in the PR body lets us tell
+# "still reviewing" (body SHA behind head, right after a push) from "done" (body
+# SHA == head). This is the RELIABLE in-progress signal — the original Step 5
+# used exactly Greptile's body block for it.
+#   Macroscope: "summarized <shortsha>" inside <!-- Macroscope ... --> markers.
+#   Greptile:   "Last reviewed commit <sha>" inside <!-- greptile_comment -->.
+# Add new body-reporting bots here; do NOT gate the reviewer set on names. A bot
+# with no body protocol simply can't be detected as in-progress — the caller's
+# bounded poll + advisory fallback covers that (matches the original discipline).
+BODY_SUMMARY="$(jq -r '.body // ""' "$DIR/meta.json" \
+  | grep -ioE 'summarized [0-9a-f]{7,40}|Last reviewed commit[^0-9a-f]*[0-9a-f]{7,40}' \
+  | grep -oiE '[0-9a-f]{7,40}' | tail -1 || true)"
+BODY_BEHIND=0
+if [ -n "$BODY_SUMMARY" ]; then
+  if [ "${HEAD:0:${#BODY_SUMMARY}}" = "$BODY_SUMMARY" ]; then
+    echo "BODY SUMMARY (bot)  @ ${BODY_SUMMARY:0:8}  — matches head ✓ (reviewer finished current head)"
+  else
+    echo "BODY SUMMARY (bot)  @ ${BODY_SUMMARY:0:8}  — behind head $HEAD_SHORT → still reviewing (eyes up)"
+    BODY_BEHIND=1
+  fi
+  echo ""
+fi
+
+# ---- Inline findings: the likely-actionable threads ------------------------
+INLINE_N="$(jq 'length' "$DIR/inline.json")"
+echo "INLINE FINDINGS ($INLINE_N)  — full bodies: .pr-review/$PR/inline.json"
+jq -r --argjson n "$PREVIEW" --arg head "$HEAD" '
+  .[]
+  | (.body // "" | gsub("(?s)<!--.*?-->";"") | gsub("\\s+";" ") | .[0:$n]) as $prev
+  | ([ .body // "" | scan("(?i)\\*\\*(Critical|High|Medium|Low)\\*\\*") ] | flatten | .[0] // "") as $sev
+  | (.commit_id // "") as $cid
+  | "  [\(.user.login)] \(.path):\(.line // "—")"
+    + (if $sev!="" then "  «\($sev)»" else "" end)
+    + (if $cid==$head or $cid=="" then "" else "  (on \($cid[0:8]), not head)" end)
+    + "\n     \($prev)"
+' "$DIR/inline.json"
+[ "$INLINE_N" = "0" ] && echo "  (none)"
+echo ""
+
+# ---- Bot/summary issue-comments (Lighthouse, Macroscope summary, etc.) -----
+ISSUE_N="$(jq 'length' "$DIR/issue.json")"
+echo "ISSUE-COMMENT SUMMARIES ($ISSUE_N)  — full bodies: .pr-review/$PR/issue.json"
+jq -r --argjson n "$PREVIEW" '
+  .[]
+  | (.body // "" | gsub("(?s)<!--.*?-->";"") | gsub("\\s+";" ") | .[0:$n]) as $prev
+  | "  [\(.user.login)]\n     \($prev)"
+' "$DIR/issue.json"
+[ "$ISSUE_N" = "0" ] && echo "  (none)"
+echo ""
+
+# ---- Is any external code-review reviewer actually PRESENT? ----------------
+# Present == at least one formal review, OR one inline review-thread, OR a known
+# review body-block (Macroscope/Greptile). CI-status issue-comments (e.g. the
+# Lighthouse github-actions[bot] summary) do NOT count — they aren't a reviewer.
+# This is what makes third-party handling self-disabling: with no review bot on
+# the PR, there is nothing to poll, so the loop converges on CI alone.
+# (Limitation: a hypothetical reviewer that posts ONLY an issue-comment summary
+# with no body-block would be missed — extend the body-block patterns above for it.)
+REVIEWS_N="$(jq 'length' "$DIR/reviews.json")"
+PRESENT=0
+if [ "$REVIEWS_N" -gt 0 ] || [ "$INLINE_N" -gt 0 ] || [ -n "$BODY_SUMMARY" ]; then PRESENT=1; fi
+
+# ---- Verdict + poll-gate exit code ----
+# Poll gate (exit 10) is the body-block in-progress signal ONLY. BEHIND_LOGINS is
+# surfaced as context but never blocks — a done-but-old review must not stall the loop.
+echo "------------------------------------------------------------"
+if [ "$PRESENT" -eq 0 ]; then
+  echo "EXTERNAL REVIEWERS: none active — no formal reviews, no inline threads, no known review body-block."
+  echo "VERDICT: SETTLED — CI-gated only; no third-party reviewer to wait for or poll."
+  exit 0
+fi
+if [ "$BODY_BEHIND" -eq 1 ]; then
+  echo "EXTERNAL REVIEWERS: present — a body-reporting bot is mid-review (behind head $HEAD_SHORT)."
+  echo "VERDICT: EYES-UP — keep polling until it reaches $HEAD_SHORT or the bound elapses"
+  echo "         (a fresh push re-triggers it; the poll is bounded — see /ship-issue Step 5)."
+  exit 10
+fi
+if [ -n "$BEHIND_LOGINS" ] && [ -z "$BODY_SUMMARY" ]; then
+  # No body-block signal at all, and a bot's latest formal/inline review is on an
+  # older SHA. Genuinely ambiguous (could be re-reviewing, could be done) — but with
+  # no in-progress signal we don't poll. A body-block AT head (handled above) would
+  # have superseded this.
+  echo "EXTERNAL REVIEWERS: present — $BEHIND_LOGINS last reviewed an older SHA (no in-progress signal)."
+  echo "VERDICT: SETTLED — not waiting (a lagging review with no in-progress signal won't be polled)."
+  echo "         Treat its findings as possibly superseded by later commits; judge them, and re-snapshot after any new push."
+  exit 0
+fi
+echo "EXTERNAL REVIEWERS: present — all caught up to head $HEAD_SHORT."
+echo "VERDICT: SETTLED — categorize each finding (actionable / ambiguous / ack-only) and fix actionable ones in-thread."
+exit 0


### PR DESCRIPTION
## What

Extends the `/ci` token-cheap pattern (#4139) to the next-biggest command, `/ship-issue`. Its **Step 5 external-review convergence loop** had the same shape `/ci` did: it swept three `gh` endpoints (formal reviews + inline threads + PR body) by hand and **polled them every 30–60s for up to 10 min, ×3 rounds** — every iteration re-billing the accumulated verbose JSON in the agent loop.

- **`scripts/pr-review-status.sh`** (new) — one fetch per source, raw payloads to `.pr-review/<PR>/`, prints **one compact snapshot** (reviewers + the SHA each reviewed vs head, a check rollup, inline findings, summary pointers). The `ci-local.sh` analogue. The model reads one reviewer's full prose only when it must judge a borderline finding.
- **`ship-issue.md` Step 5** rewritten — **first full CI completion** is the settling point (`gh pr checks --watch`), then **one** snapshot. The bounded eyes-up poll is delegated to a subagent so its iterations never accumulate in the loop thread.
- **`ship-batch.md` / `ship-milestone.md`** dispatch prompts updated to match (dropped the stale `subscribe_pr_activity` / sweep-three-places wording). They inherit the saving per worker.
- **`.gitignore`** — ignore `.pr-review/`.

## Conditional external-reviewer wait (the bigger win)

Third-party review bots are now the *exception* — the internal `/review-panel` is the review. So the wait is made **conditional on a reviewer actually being present**:

- **no review bot on the PR** (the common case) → snapshot reports `SETTLED — CI-gated only`; the loop converges on CI + clean panel instead of polling for phantoms. (Lighthouse / CI-status issue-comments are not a reviewer and don't count.)
- **a reviewer is present** → categorize + fix; the **only** poll trigger is the reliable in-progress signal — a bot's **body-block SHA lagging head** (Macroscope `summarized <sha>` / Greptile `Last reviewed commit`). A stale formal-review commit no longer false-positives a wait.

## Deliberate restraint

Unlike `/ci` (fully mechanical pass/fail → full black-box, ~97%), the review loop is only **partly** mechanical: collection + SHA math + polling get distilled, but **categorizing** actionable-vs-ack-only and **fixing** need the conversation context and stay in the thread. Partial black-box by design.

## Validation

- `bash scripts/pr-review-status.sh` exercised against 3 real PRs: #3981 (reviewer caught up → `SETTLED`, judge findings), #3964 (body-block at head supersedes a lagging formal-review → `SETTLED`, no false poll), #4119 (Lighthouse-only → `SETTLED — CI-gated only`). `bash -n` clean; reviewer-agnostic (enumerates all reviewers, never gates the set on names).
- `scripts/ci-local.sh`: **26/27 gates pass.** The lone `test` failure is the known pre-existing WSL2 sandbox flake set (`explore-backend`, `python`, `explore-workspace-override` — `just-bash` vs `vercel-sandbox`, `VERCEL_*` set locally), the same three #4139 reported. This PR touches **zero TypeScript** — doc + one standalone shell script.

## Notes

- No code in any gated surface changes; the script is not eslint/test-scanned (`test-discipline` passes).
- Blog note: #4143 (sibling to #4142).