### PR TITLE
fix(query): atlas query works over a workspace datasource (#4124)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -2139,6 +2139,11 @@
                   "conversationId": {
                     "type": "string",
                     "format": "uuid"
+                  },
+                  "connectionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
                   }
                 },
                 "required": [

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -252,6 +252,8 @@ mock.module("@atlas/api/lib/billing/claim-gate", () => ({
 }));
 
 // Import after mocks are registered
+const { createAtlasUser } = await import("@atlas/api/lib/auth/types");
+const { getRequestContext } = await import("@atlas/api/lib/logger");
 const { app } = await import("../index");
 
 // --- Helpers ---
@@ -500,6 +502,76 @@ describe("POST /api/v1/query", () => {
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.error).toBe("configuration_error");
     expect(mockRunAgent).not.toHaveBeenCalled();
+  });
+
+  // ── #4124: a bound workspace resolves its datasource from the per-tenant
+  // ConnectionRegistry inside the agent loop, NOT the env-level
+  // ATLAS_DATASOURCE_URL. The env gate (validateEnvironment + resolveDatasourceUrl)
+  // is the self-hosted single-tenant fallback — running it for a SaaS workspace
+  // wrongly blocked the NL agent with MISSING_DATASOURCE_URL because a
+  // multi-tenant deployment never sets a process-level datasource URL. ──
+
+  function authedWorkspaceUser() {
+    return {
+      authenticated: true as const,
+      mode: "managed" as const,
+      user: createAtlasUser("u-4124", "managed", "Workspace User", {
+        activeOrganizationId: "org-acme",
+      }),
+    };
+  }
+
+  it("runs the agent for a bound workspace even when ATLAS_DATASOURCE_URL is unset (skips the env gate)", async () => {
+    // SaaS shape: a workspace is bound, but there is NO process-level datasource.
+    delete process.env.ATLAS_DATASOURCE_URL;
+    mockAuthenticateRequest.mockResolvedValueOnce(authedWorkspaceUser());
+
+    const response = await app.fetch(makeQueryRequest({ question: "how many users?" }));
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.answer).toBe("The answer is 42.");
+    expect(mockRunAgent).toHaveBeenCalledTimes(1);
+    // The env-level startup gate must NOT be consulted for a bound workspace —
+    // the connection resolves from the workspace's ConnectionRegistry downstream.
+    expect(mockValidateEnvironment).not.toHaveBeenCalled();
+  });
+
+  it("threads connectionId from the request body into the agent's request context", async () => {
+    delete process.env.ATLAS_DATASOURCE_URL;
+    mockAuthenticateRequest.mockResolvedValueOnce(authedWorkspaceUser());
+
+    let capturedConnectionId: string | undefined = "UNSET";
+    mockRunAgent.mockImplementationOnce(() => {
+      // The route → executeAgentQuery binds connectionId onto the RequestContext;
+      // the agent's executeSQL tool reads it from there to resolve the workspace's
+      // registered connection (instead of env ATLAS_DATASOURCE_URL).
+      capturedConnectionId = getRequestContext()?.connectionId;
+      return Promise.resolve(makeAgentResult());
+    });
+
+    const response = await app.fetch(
+      makeQueryRequest({ question: "rows in the actions table", connectionId: "ds_actions" }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedConnectionId).toBe("ds_actions");
+  });
+
+  it("leaves the request-context connectionId unset when the body omits it (workspace default resolves)", async () => {
+    delete process.env.ATLAS_DATASOURCE_URL;
+    mockAuthenticateRequest.mockResolvedValueOnce(authedWorkspaceUser());
+
+    let capturedConnectionId: string | undefined = "UNSET";
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedConnectionId = getRequestContext()?.connectionId;
+      return Promise.resolve(makeAgentResult());
+    });
+
+    const response = await app.fetch(makeQueryRequest({ question: "how many users?" }));
+    expect(response.status).toBe(200);
+    // No explicit connectionId → none bound; downstream resolves the workspace's
+    // default/published connection via getForOrg(orgId, "default").
+    expect(capturedConnectionId).toBeUndefined();
   });
 
   it("returns 400 for malformed JSON", async () => {

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -41,6 +41,15 @@ const log = createLogger("query");
 export const QueryRequestSchema = z.object({
   question: z.string().trim().min(1, "question must not be empty"),
   conversationId: z.string().uuid().optional(),
+  /**
+   * Optional explicit datasource connection id. Omit to run against the
+   * workspace's default (published) connection. Resolved against the bound
+   * workspace's `ConnectionRegistry` server-side (mirrors `/api/v1/execute-sql`);
+   * a connection id in another workspace simply isn't found. Workspace isolation
+   * derives from the credential — there is NO org/workspace/owner field here a
+   * caller could spoof (#4124).
+   */
+  connectionId: z.string().min(1).max(256).optional(),
 });
 
 export const QueryResponseSchema = z.object({
@@ -230,36 +239,57 @@ query.openapi(
         // HTTP envelope in the catch below; the 80–109% warning band
         // arrives on `queryResult.planWarning`.
 
-        // --- Startup diagnostics ---
-        const diagnostics = await validateEnvironment();
-        if (diagnostics.length > 0) {
-          return c.json(
-            {
-              error: "configuration_error",
-              message: diagnostics.map((d) => d.message).join("\n\n"),
-              diagnostics,
-            },
-            400,
-          );
+        // --- Datasource availability gate ---
+        // A bound workspace resolves its datasource from the per-tenant
+        // `ConnectionRegistry` (DB-driven) INSIDE the agent loop — exactly like
+        // `/api/v1/execute-sql`. The env-level `validateEnvironment()` +
+        // `resolveDatasourceUrl()` checks below only apply to the self-hosted
+        // single-tenant fallback (`ATLAS_DATASOURCE_URL`). Running them for a
+        // SaaS workspace wrongly blocked the NL agent with
+        // `MISSING_DATASOURCE_URL`, because a multi-tenant deployment never sets
+        // a process-level datasource URL (the connection lives in the workspace's
+        // registered datasources) — so the NL `/query` path could never run on
+        // SaaS even though `executeSQL` did (#4124).
+        const orgId = authResult.user?.activeOrganizationId;
+        if (!orgId) {
+          // --- Startup diagnostics (self-hosted single-tenant only) ---
+          const diagnostics = await validateEnvironment();
+          if (diagnostics.length > 0) {
+            return c.json(
+              {
+                error: "configuration_error",
+                message: diagnostics.map((d) => d.message).join("\n\n"),
+                diagnostics,
+              },
+              400,
+            );
+          }
+
+          const { resolveDatasourceUrl: resolveUrl } = await import("@atlas/api/lib/db/connection");
+          if (!resolveUrl()) {
+            return c.json(
+              {
+                error: "no_datasource",
+                message:
+                  "No analytics datasource configured. Set ATLAS_DATASOURCE_URL to query your data.",
+              },
+              400,
+            );
+          }
         }
-    
-        const { resolveDatasourceUrl: resolveUrl } = await import("@atlas/api/lib/db/connection");
-        if (!resolveUrl()) {
-          return c.json(
-            {
-              error: "no_datasource",
-              message:
-                "No analytics datasource configured. Set ATLAS_DATASOURCE_URL to query your data.",
-            },
-            400,
-          );
-        }
-    
-        const { question, conversationId: parsedConversationId } = c.req.valid("json");
+
+        const { question, conversationId: parsedConversationId, connectionId } = c.req.valid("json");
         let conversationId = parsedConversationId;
-    
+
         try {
-          const queryResult = await executeAgentQuery(question, requestId);
+          // Thread the explicit connectionId (when supplied) into the agent run;
+          // `executeAgentQuery` binds it onto the RequestContext so the agent's
+          // `executeSQL` tool resolves the workspace's registered connection via
+          // `ConnectionRegistry` instead of the env-level `ATLAS_DATASOURCE_URL`
+          // (#4124). When omitted, the workspace's default connection resolves.
+          const queryResult = await executeAgentQuery(question, requestId, {
+            ...(connectionId ? { connectionId } : {}),
+          });
     
           // Persist conversation — best-effort. createConversation awaits an INSERT; addMessage calls are fire-and-forget.
           if (hasInternalDB()) {

--- a/packages/cli/bin/__tests__/query.test.ts
+++ b/packages/cli/bin/__tests__/query.test.ts
@@ -217,24 +217,42 @@ describe("handleActionApproval", () => {
     }
   });
 
-  test("passes API key in Authorization header", async () => {
-    const originalFetch = globalThis.fetch;
+  // #4124 — credential parity with `sql`: a device-flow SESSION rides
+  // `Authorization: Bearer`, a workspace API KEY rides `x-api-key` (the Better
+  // Auth `apiKey()` plugin's header), NEVER `Authorization: Bearer`.
+  test("passes a session bearer in the Authorization header", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = mock((_input: unknown, init?: RequestInit) => {
+    const fetchImpl = mock((_input: unknown, init?: RequestInit) => {
       capturedHeaders = new Headers(init?.headers);
       return Promise.resolve(
         new Response(JSON.stringify({ status: "approved" }), { status: 200 }),
       );
     }) as unknown as typeof fetch;
 
-    try {
-      await handleActionApproval(
-        "http://localhost:3001/api/v1/actions/abc/approve",
-        "my-secret-key",
+    await handleActionApproval(
+      "http://localhost:3001/api/v1/actions/abc/approve",
+      { token: "sess_abc" },
+      fetchImpl,
+    );
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer sess_abc");
+    expect(capturedHeaders?.get("x-api-key")).toBeNull();
+  });
+
+  test("passes a workspace API key in the x-api-key header (not Authorization)", async () => {
+    let capturedHeaders: Headers | undefined;
+    const fetchImpl = mock((_input: unknown, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: "approved" }), { status: 200 }),
       );
-      expect(capturedHeaders?.get("Authorization")).toBe("Bearer my-secret-key");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    }) as unknown as typeof fetch;
+
+    await handleActionApproval(
+      "http://localhost:3001/api/v1/actions/abc/approve",
+      { apiKey: "atlas_key_xyz" },
+      fetchImpl,
+    );
+    expect(capturedHeaders?.get("x-api-key")).toBe("atlas_key_xyz");
+    expect(capturedHeaders?.get("Authorization")).toBeNull();
   });
 });

--- a/packages/cli/src/__tests__/query-command.test.ts
+++ b/packages/cli/src/__tests__/query-command.test.ts
@@ -1,0 +1,290 @@
+/**
+ * `atlas query` command-core auth-parity tests (#4124).
+ *
+ * Exercises the testable `runQueryCommand` core with an injected session,
+ * api-key, base URL, and stub `fetch` — no live server. Pins the credential
+ * resolution at PARITY with `atlas sql` (the regression #4124 fixed):
+ *  - a logged-in `atlas login` SESSION authenticates with NO key needed, sent
+ *    as `Authorization: Bearer <token>` (the old code ignored the session);
+ *  - a workspace API KEY (`--api-key` / `ATLAS_API_KEY`) rides `x-api-key`, the
+ *    Better Auth `apiKey()` plugin's header — NEVER `Authorization: Bearer`
+ *    (the old code sent keys as a Bearer, so the server rejected them);
+ *  - a key wins over a session (unattended CI never goes through `atlas login`);
+ *  - no credential at all → an actionable "log in or set ATLAS_API_KEY" error.
+ * Plus the request shape (POST /api/v1/query, body carries question [+ optional
+ * connectionId]) and the json/csv guards.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  runQueryCommand,
+  type QueryIO,
+  type QueryRunDeps,
+} from "../commands/query";
+import type { StoredSession } from "../lib/credentials";
+
+const BASE = "http://localhost:3001";
+const SESSION: StoredSession = {
+  token: "sess_abc",
+  workspaceId: "org-1",
+  createdAt: "2026-06-29T00:00:00Z",
+};
+
+const OK_RESPONSE = {
+  answer: "There are 42 users.",
+  sql: ["SELECT COUNT(*) FROM users"],
+  data: [{ columns: ["count"], rows: [{ count: 42 }] }],
+  steps: 1,
+  usage: { totalTokens: 150 },
+};
+
+function capture(): { io: QueryIO; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { out: (l) => out.push(l), err: (l) => err.push(l) }, out, err };
+}
+
+/** Single-canned-response fetch capturing requests + their bodies + headers. */
+function stubFetch(
+  status: number,
+  body: unknown,
+): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ method: string; url: string; body: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ method: string; url: string; body: string; headers: Record<string, string> }> = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      new Headers(init.headers as Record<string, string>).forEach((v, k) => {
+        headers[k] = v;
+      });
+    }
+    calls.push({
+      method: init?.method ?? "GET",
+      url: typeof url === "string" ? url : url.toString(),
+      body: typeof init?.body === "string" ? init.body : "",
+      headers,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function deps(
+  fetchImpl: typeof fetch | undefined,
+  overrides: Partial<QueryRunDeps> = {},
+): QueryRunDeps {
+  return {
+    baseUrl: BASE,
+    session: SESSION,
+    ...(fetchImpl !== undefined ? { fetchImpl } : {}),
+    ...overrides,
+  };
+}
+
+describe("runQueryCommand — guards", () => {
+  it("with no credential (no session, no key), refuses with a login hint and exits 1", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io, err } = capture();
+    const code = await runQueryCommand(
+      ["query", "how many users?"],
+      deps(fetchImpl, { session: null }),
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("atlas login");
+    expect(err.join("\n")).toContain("ATLAS_API_KEY");
+    // No request should have gone out without a credential.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("no question positional prints usage and exits 1", async () => {
+    const { io, err } = capture();
+    const code = await runQueryCommand(["query"], deps(undefined), io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain('atlas query "your question"');
+  });
+
+  it("--json and --csv together are rejected", async () => {
+    const { io, err } = capture();
+    const code = await runQueryCommand(
+      ["query", "q", "--json", "--csv"],
+      deps(undefined),
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toContain("mutually exclusive");
+  });
+});
+
+describe("runQueryCommand — credential parity with `atlas sql` (#4124)", () => {
+  it("authenticates a logged-in session with Authorization: Bearer (no key needed)", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(["query", "how many users?"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].headers["authorization"]).toBe("Bearer sess_abc");
+    // A session must NOT be sent as an api key.
+    expect(calls[0].headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("sends a workspace API key via x-api-key, NOT Authorization (the #4124 bug)", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "how many users?", "--api-key", "atlas_key_xyz"],
+      deps(fetchImpl, { session: null }),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_key_xyz");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("reads ATLAS_API_KEY (deps.apiKey) and rides x-api-key", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "how many users?"],
+      deps(fetchImpl, { session: null, apiKey: "atlas_env_key" }),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_env_key");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("a --api-key flag wins over both ATLAS_API_KEY and a stored session", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "how many users?", "--api-key", "flag_key"],
+      deps(fetchImpl, { apiKey: "env_key" }),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls[0].headers["x-api-key"]).toBe("flag_key");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+});
+
+describe("runQueryCommand — request shape", () => {
+  it("POSTs to /api/v1/query with the question in the body", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(["query", "top 5 customers"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/query`);
+    expect(JSON.parse(calls[0].body)).toEqual({ question: "top 5 customers" });
+  });
+
+  it("threads --connection into the request body (and not the question positional)", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "top categories", "--connection", "warehouse"],
+      deps(fetchImpl),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(calls[0].body)).toEqual({
+      question: "top categories",
+      connectionId: "warehouse",
+    });
+  });
+
+  it("does not mistake the --api-key value for the question positional", async () => {
+    const { fetchImpl, calls } = stubFetch(200, OK_RESPONSE);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "--api-key", "atlas_key", "real question"],
+      deps(fetchImpl, { session: null }),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(calls[0].body)).toEqual({ question: "real question" });
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_key");
+  });
+
+  it("renders --json as the raw response and exits 0", async () => {
+    const { fetchImpl } = stubFetch(200, OK_RESPONSE);
+    const { io, out } = capture();
+    const code = await runQueryCommand(["query", "q", "--json"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    expect(JSON.parse(out.join("\n"))).toMatchObject({ answer: "There are 42 users." });
+  });
+});
+
+describe("runQueryCommand — auto-approve credential propagation (#4124 seam)", () => {
+  // The action-approval POST carries the SAME regression surface as the query
+  // request: a key sent as `Authorization: Bearer` is server-rejected. Pin that
+  // the credential resolved for the query is threaded into the approval call too.
+  const RESPONSE_WITH_PENDING = {
+    answer: "I need your approval to send a notification.",
+    sql: [],
+    data: [],
+    steps: 1,
+    usage: { totalTokens: 10 },
+    pendingActions: [
+      {
+        id: "act-1",
+        type: "notification",
+        target: "#revenue",
+        summary: "Send notification to #revenue",
+        approveUrl: "http://localhost:3001/api/v1/actions/act-1/approve",
+        denyUrl: "http://localhost:3001/api/v1/actions/act-1/deny",
+      },
+    ],
+    // Consumed by the approval POST's response (handleActionApproval reads `status`).
+    status: "approved",
+  };
+
+  it("propagates a SESSION into the auto-approved action POST (Authorization: Bearer)", async () => {
+    const { fetchImpl, calls } = stubFetch(200, RESPONSE_WITH_PENDING);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "notify #revenue", "--auto-approve"],
+      deps(fetchImpl),
+      io,
+    );
+    expect(code).toBe(0);
+    // calls[0] = POST /query, calls[1] = POST the action approveUrl.
+    expect(calls).toHaveLength(2);
+    expect(calls[1].url).toBe("http://localhost:3001/api/v1/actions/act-1/approve");
+    expect(calls[1].headers["authorization"]).toBe("Bearer sess_abc");
+    expect(calls[1].headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("propagates a workspace API KEY into the auto-approved action POST (x-api-key, not Bearer)", async () => {
+    const { fetchImpl, calls } = stubFetch(200, RESPONSE_WITH_PENDING);
+    const { io } = capture();
+    const code = await runQueryCommand(
+      ["query", "notify #revenue", "--auto-approve", "--api-key", "atlas_key_xyz"],
+      deps(fetchImpl, { session: null }),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].headers["x-api-key"]).toBe("atlas_key_xyz");
+    expect(calls[1].headers["authorization"]).toBeUndefined();
+  });
+});
+
+describe("runQueryCommand — HTTP error handling", () => {
+  it("maps a 401 to an actionable auth-failed message and exits 1", async () => {
+    const { fetchImpl } = stubFetch(401, { error: "auth_error", message: "Not signed in" });
+    const { io, err } = capture();
+    const code = await runQueryCommand(["query", "q"], deps(fetchImpl), io);
+    expect(code).toBe(1);
+    const text = err.join("\n");
+    expect(text).toContain("Authentication failed");
+    expect(text).toContain("atlas login");
+  });
+});

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -1,7 +1,22 @@
 /**
  * atlas query — Ask a natural language question via the Atlas API.
  *
- * Extracted from atlas.ts to reduce monolith size.
+ * The NL happy path (Shape A): the caller asks a question, Atlas's server-side
+ * LLM writes + runs the SQL and returns a narrative answer. `atlas sql` is the
+ * advanced raw-SQL surface (Shape B).
+ *
+ * Authorization rides on the SAME workspace credential as `sql`/`datasource`/
+ * `explore` (#4112 / ADR-0027 §5): the `atlas login` device-flow SESSION bearer
+ * (sent as `Authorization: Bearer`) for interactive use, OR a workspace-scoped
+ * API key for unattended CI (`--api-key` / `ATLAS_API_KEY`, sent as `x-api-key`
+ * — the Better Auth `apiKey()` plugin's header, NOT `Authorization: Bearer`).
+ * The credential resolution is single-sourced through `lib/credential` so
+ * `query` can't drift from the other REST-backed subcommands (#4124).
+ *
+ * The dispatch + rendering live in the testable `runQueryCommand` core (the
+ * session, the API base URL, the api-key, and `fetch` are injected), so credential
+ * resolution, request shape, and output are unit-tested without a live server or
+ * `process.exit`. `handleQuery` is the thin shell main() calls.
  */
 
 import * as p from "@clack/prompts";
@@ -12,6 +27,14 @@ import {
   quoteCsvField,
   renderTable,
 } from "../../lib/output";
+import { resolveApiBaseUrl } from "../lib/api-base";
+import {
+  readApiKeyFlag,
+  resolveCredential,
+  credentialHeaders,
+  type CliCredential,
+} from "../lib/credential";
+import { readSession, type StoredSession } from "../lib/credentials";
 
 // --- Types ---
 
@@ -38,23 +61,51 @@ interface QueryAPIError {
   message: string;
 }
 
+/** stdout/stderr sink — injected so tests can capture output (mirrors `sql.ts`). */
+export interface QueryIO {
+  readonly out: (line: string) => void;
+  readonly err: (line: string) => void;
+}
+
+const defaultIO: QueryIO = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+/** Everything `runQueryCommand` needs, injected so it stays server-free in tests. */
+export interface QueryRunDeps {
+  readonly baseUrl: string;
+  readonly session: StoredSession | null;
+  /**
+   * A workspace-scoped API key for unattended CI (#4046), resolved from the
+   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
+   * precedence over the stored session — CI never goes through `atlas login`.
+   */
+  readonly apiKey?: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
 // --- Action approval ---
 
 /**
- * Call the approve or deny endpoint for a pending action.
+ * Call the approve or deny endpoint for a pending action, authorized by the
+ * same workspace credential the query ran under (session bearer XOR API key —
+ * the latter rides `x-api-key`, never `Authorization: Bearer`).
+ *
  * Returns { ok: true, status } on success, { ok: false, error } on failure.
  */
 export async function handleActionApproval(
   url: string,
-  apiKey?: string,
+  credential?: CliCredential,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<{ ok: boolean; status?: string; error?: string }> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    ...(credential ? credentialHeaders(credential) : {}),
   };
-  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
   try {
-    const res = await fetch(url, {
+    const res = await fetchImpl(url, {
       method: "POST",
       headers,
       signal: AbortSignal.timeout(30_000),
@@ -89,36 +140,54 @@ export async function handleActionApproval(
   }
 }
 
-// --- Main handler ---
+// --- Testable core ---
 
-export async function handleQuery(args: string[]): Promise<void> {
-  // Parse the question -- first positional arg after "query"
-  const question = args.find(
-    (a, i) =>
-      i > 0 &&
-      !a.startsWith("--") &&
-      (i === 1 || args[i - 1] !== "--connection"),
-  );
+/**
+ * Testable core: dispatch one `atlas query` invocation. Returns the process exit
+ * code (0 success, 1 failure) without calling `process.exit`, so tests can assert
+ * on it directly (mirrors `runSqlCommand`).
+ *
+ * `args` is the full argv slice (args[0] === "query").
+ */
+export async function runQueryCommand(
+  args: string[],
+  deps: QueryRunDeps,
+  io: QueryIO = defaultIO,
+): Promise<number> {
+  // The question is the first positional after "query" that isn't a flag and
+  // isn't the value consumed by a value-taking flag (`--connection <id>`,
+  // `--api-key <key>`). The inline forms (`--connection=x`, `--api-key=x`) start
+  // with `--`, so they're skipped by the flag check.
+  const question = args.find((a, i) => {
+    if (i === 0 || a.startsWith("--")) return false;
+    const prev = args[i - 1];
+    if (prev === "--connection" || prev === "--api-key") return false;
+    return true;
+  });
 
   if (!question) {
-    console.error(
+    io.err(
       'Usage: atlas query "your question" [options]\n\n' +
         "Options:\n" +
         "  --json               Raw JSON output (pipe-friendly)\n" +
         "  --csv                CSV output (headers + rows only)\n" +
         "  --quiet              Data only -- no narrative, SQL, or stats\n" +
         "  --auto-approve       Auto-approve any pending actions\n" +
-        "  --connection <id>    Query a specific datasource\n\n" +
+        "  --connection <id>    Query a specific datasource\n" +
+        "  --api-key <key>      Use a workspace API key instead of your `atlas login` session\n\n" +
+        "Authentication:\n" +
+        "  `atlas login` for interactive use (ambient session reuse -- no key needed),\n" +
+        "  OR a workspace API key via --api-key / ATLAS_API_KEY for unattended CI.\n\n" +
         "Environment:\n" +
         "  ATLAS_API_URL        API server URL (default: http://localhost:3001)\n" +
-        "  ATLAS_API_KEY        API key for authentication\n\n" +
+        "  ATLAS_API_KEY        Workspace API key for unattended authentication\n\n" +
         "Examples:\n" +
         '  atlas query "top 5 customers by revenue"\n' +
         '  atlas query "monthly GMV trend" --json\n' +
         '  atlas query "count of orders" --csv\n' +
         '  atlas query "top categories" --connection warehouse',
     );
-    process.exit(1);
+    return 1;
   }
 
   const jsonOutput = args.includes("--json");
@@ -128,29 +197,38 @@ export async function handleQuery(args: string[]): Promise<void> {
   const connectionId = getFlag(args, "--connection");
 
   if (jsonOutput && csvOutput) {
-    console.error("Error: --json and --csv are mutually exclusive.");
-    process.exit(1);
+    io.err("Error: --json and --csv are mutually exclusive.");
+    return 1;
   }
 
-  const apiUrl = (
-    process.env.ATLAS_API_URL ?? "http://localhost:3001"
-  ).replace(/\/$/, "");
-  const apiKey = process.env.ATLAS_API_KEY;
+  // Resolve the workspace credential exactly like `sql`/`datasource`: a key
+  // (the `--api-key` flag, else `ATLAS_API_KEY`) wins over the stored login.
+  // A key rides `x-api-key`; a session bearer rides `Authorization: Bearer`.
+  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
+  const credential = resolveCredential(apiKey, deps.session);
+  if (!credential) {
+    io.err(
+      "Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.",
+    );
+    return 1;
+  }
 
-  // Build request
+  const apiUrl = deps.baseUrl.replace(/\/$/, "");
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    ...credentialHeaders(credential),
   };
-  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
   const body = { question, ...(connectionId && { connectionId }) };
 
   // Call the API
-  if (!jsonOutput && !csvOutput) process.stderr.write("Thinking...\n");
+  if (!jsonOutput && !csvOutput) io.err("Thinking...");
 
   let res: Response;
   try {
-    res = await fetch(`${apiUrl}/api/v1/query`, {
+    res = await fetchImpl(`${apiUrl}/api/v1/query`, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
@@ -159,21 +237,17 @@ export async function handleQuery(args: string[]): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (/abort|timeout/i.test(msg)) {
-      console.error("Error: Request timed out after 120 seconds.");
-      console.error(
+      io.err("Error: Request timed out after 120 seconds.");
+      io.err(
         "  The query may be too complex, or the server may be overloaded.",
       );
     } else if (/ECONNREFUSED|fetch failed/i.test(msg)) {
-      console.error(
-        `Error: Cannot connect to Atlas API at ${apiUrl}`,
-      );
-      console.error(
-        "  Is the server running? Start it with: bun run dev:api",
-      );
+      io.err(`Error: Cannot connect to Atlas API at ${apiUrl}`);
+      io.err("  Is the server running? Start it with: bun run dev:api");
     } else {
-      console.error(`Error: ${msg}`);
+      io.err(`Error: ${msg}`);
     }
-    process.exit(1);
+    return 1;
   }
 
   // Handle HTTP errors
@@ -195,43 +269,43 @@ export async function handleQuery(args: string[]): Promise<void> {
     }
 
     if (res.status === 401 || res.status === 403) {
-      console.error(`Error: Authentication failed -- ${message}`);
-      console.error("  Set ATLAS_API_KEY to a valid API key.");
+      io.err(`Error: Authentication failed -- ${message}`);
+      io.err(
+        "  Run `atlas login`, or set ATLAS_API_KEY to a valid workspace API key.",
+      );
     } else if (res.status === 429) {
-      console.error(`Error: Rate limit exceeded -- ${message}`);
+      io.err(`Error: Rate limit exceeded -- ${message}`);
     } else if (errorCode === "no_datasource") {
-      console.error(`Error: ${message}`);
-      console.error(
-        "  The API server has no datasource configured. Set ATLAS_DATASOURCE_URL on the server.",
+      io.err(`Error: ${message}`);
+      io.err(
+        "  No datasource is available for this workspace. Add one in the Atlas console, or set ATLAS_DATASOURCE_URL on a self-hosted server.",
       );
     } else if (errorCode === "configuration_error") {
-      console.error(
-        `Error: Server configuration problem -- ${message}`,
-      );
+      io.err(`Error: Server configuration problem -- ${message}`);
     } else {
-      console.error(`Error: ${message}`);
+      io.err(`Error: ${message}`);
     }
-    process.exit(1);
+    return 1;
   }
 
   let data: QueryAPIResponse;
   try {
     data = (await res.json()) as QueryAPIResponse;
   } catch {
-    console.error("Error: Failed to parse API response as JSON.");
-    console.error(
+    io.err("Error: Failed to parse API response as JSON.");
+    io.err(
       `  The server at ${apiUrl} returned a 200 status but the body was not valid JSON.`,
     );
-    process.exit(1);
+    return 1;
   }
 
   // Runtime validation of response shape
   if (!Array.isArray(data.data)) {
-    console.error(
+    io.err(
       "Error: Unexpected API response -- the server may be running a different version.",
     );
-    if (data.answer) console.log(`\n${data.answer}`);
-    process.exit(1);
+    if (data.answer) io.out(`\n${data.answer}`);
+    return 1;
   }
   if (!Array.isArray(data.sql)) data.sql = [];
   if (!data.usage || typeof data.usage.totalTokens !== "number") {
@@ -240,88 +314,78 @@ export async function handleQuery(args: string[]): Promise<void> {
 
   // --- JSON output: print raw response and exit ---
   if (jsonOutput) {
-    console.log(JSON.stringify(data, null, 2));
-    return;
+    io.out(JSON.stringify(data, null, 2));
+    return 0;
   }
 
   // --- CSV output: headers + rows, no narrative ---
   if (csvOutput) {
     for (const dataset of data.data) {
-      console.log(dataset.columns.map(quoteCsvField).join(","));
+      io.out(dataset.columns.map(quoteCsvField).join(","));
       for (const row of dataset.rows) {
         const cells = dataset.columns.map((col) =>
           quoteCsvField(formatCsvValue(row[col])),
         );
-        console.log(cells.join(","));
+        io.out(cells.join(","));
       }
     }
-    return;
+    return 0;
   }
 
   // --- Table output (default) ---
 
   // Narrative answer
   if (!quietOutput && data.answer) {
-    console.log(`\n${data.answer}\n`);
+    io.out(`\n${data.answer}\n`);
   }
 
   // Data tables
   for (const dataset of data.data) {
     if (dataset.columns.length > 0 && dataset.rows.length > 0) {
-      console.log(renderTable(dataset.columns, dataset.rows));
-      console.log();
+      io.out(renderTable(dataset.columns, dataset.rows));
+      io.out("");
     }
   }
 
   // Footer: SQL + stats
   if (!quietOutput) {
     if (data.sql.length > 0) {
-      console.log(pc.dim(`SQL: ${data.sql[data.sql.length - 1]}`));
+      io.out(pc.dim(`SQL: ${data.sql[data.sql.length - 1]}`));
     }
     const tokens =
       typeof data.usage?.totalTokens === "number"
         ? data.usage.totalTokens.toLocaleString()
         : "n/a";
-    console.log(
-      pc.dim(`Steps: ${data.steps ?? "?"} | Tokens: ${tokens}`),
-    );
+    io.out(pc.dim(`Steps: ${data.steps ?? "?"} | Tokens: ${tokens}`));
   }
 
   // --- Handle pending actions ---
   if (data.pendingActions?.length) {
-    console.log();
-    console.log(
-      pc.yellow(
-        `${data.pendingActions.length} action(s) require approval:`,
-      ),
+    io.out("");
+    io.out(
+      pc.yellow(`${data.pendingActions.length} action(s) require approval:`),
     );
 
     if (autoApprove) {
       // Auto-approve all pending actions
       for (const action of data.pendingActions) {
-        process.stderr.write(
-          `  Approving: ${action.summary}... `,
-        );
+        io.err(`  Approving: ${action.summary}... `);
         const result = await handleActionApproval(
           action.approveUrl,
-          apiKey,
+          credential,
+          fetchImpl,
         );
         if (result.ok) {
-          console.error(
-            pc.green(`${result.status ?? "approved"}`),
-          );
+          io.err(pc.green(`${result.status ?? "approved"}`));
         } else {
-          console.error(pc.red(`failed: ${result.error}`));
+          io.err(pc.red(`failed: ${result.error}`));
         }
       }
     } else if (process.stdout.isTTY) {
       // Interactive TTY mode -- prompt per action
       for (const action of data.pendingActions) {
-        console.log(
-          `\n  ${pc.bold(action.type)}: ${action.summary}`,
-        );
-        if (action.target)
-          console.log(`  Target: ${action.target}`);
+        io.out(`\n  ${pc.bold(action.type)}: ${action.summary}`);
+        if (action.target) io.out(`  Target: ${action.target}`);
 
         const choice = await p.select({
           message: "What would you like to do?",
@@ -333,42 +397,47 @@ export async function handleQuery(args: string[]): Promise<void> {
         });
 
         if (p.isCancel(choice) || choice === "skip") {
-          console.log(pc.dim(`  Skipped. Approve/deny later:`));
-          console.log(
-            pc.dim(
-              `    Approve: curl -X POST ${action.approveUrl}`,
-            ),
-          );
-          console.log(
-            pc.dim(
-              `    Deny:    curl -X POST ${action.denyUrl}`,
-            ),
-          );
+          io.out(pc.dim(`  Skipped. Approve/deny later:`));
+          io.out(pc.dim(`    Approve: curl -X POST ${action.approveUrl}`));
+          io.out(pc.dim(`    Deny:    curl -X POST ${action.denyUrl}`));
           continue;
         }
 
         const url =
-          choice === "approve"
-            ? action.approveUrl
-            : action.denyUrl;
-        const result = await handleActionApproval(url, apiKey);
+          choice === "approve" ? action.approveUrl : action.denyUrl;
+        const result = await handleActionApproval(url, credential, fetchImpl);
         if (result.ok) {
-          console.log(
-            pc.green(
-              `  Action ${result.status ?? choice}d.`,
-            ),
-          );
+          io.out(pc.green(`  Action ${result.status ?? choice}d.`));
         } else {
-          console.log(pc.red(`  Failed: ${result.error}`));
+          io.out(pc.red(`  Failed: ${result.error}`));
         }
       }
     } else {
       // Non-TTY, no --auto-approve -- print URLs and exit
       for (const action of data.pendingActions) {
-        console.log(`\n  ${action.type}: ${action.summary}`);
-        console.log(`    Approve: ${action.approveUrl}`);
-        console.log(`    Deny:    ${action.denyUrl}`);
+        io.out(`\n  ${action.type}: ${action.summary}`);
+        io.out(`    Approve: ${action.approveUrl}`);
+        io.out(`    Deny:    ${action.denyUrl}`);
       }
     }
   }
+
+  return 0;
+}
+
+// --- Main handler ---
+
+/** Thin shell main() invokes: resolve the credential inputs + base URL, dispatch. */
+export async function handleQuery(args: string[]): Promise<void> {
+  const baseUrl = resolveApiBaseUrl();
+  const session = readSession(baseUrl);
+  // ATLAS_API_KEY (#4046) is the unattended-CI credential — NOT persisted to
+  // ~/.atlas/credentials. `--api-key` (parsed in runQueryCommand) overrides it.
+  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
+  const code = await runQueryCommand(args, {
+    baseUrl,
+    session,
+    ...(apiKey ? { apiKey } : {}),
+  });
+  if (code !== 0) process.exit(code);
 }


### PR DESCRIPTION
## Summary

`atlas query` (the flagship NL text-to-SQL action) was unusable against a workspace datasource for two **independent** reasons. Both are fixed here.

### Bug A — CLI auth (`packages/cli/src/commands/query.ts`)
`query` read only `ATLAS_API_KEY` and sent it as `Authorization: Bearer`, **ignoring** the `atlas login` device-flow session — unlike `sql`/`datasource`/`explore`. API keys must ride `x-api-key` (the Better Auth `apiKey()` plugin's header), so the server tried to validate the key as a session JWT and returned *"Not signed in"*.

- Ported `sql.ts`'s credential resolution into a new testable `runQueryCommand` core (injected `session`/`apiKey`/`fetch`, returns an exit code — no `process.exit`): `readSession` fallback for logged-in users, `x-api-key` for `--api-key`/`ATLAS_API_KEY`, single-sourced through `lib/credential` so `query` can't drift from the other REST-backed subcommands.
- `handleActionApproval` now takes the resolved `CliCredential` (XOR session/key) instead of always sending a Bearer — the `--auto-approve` action POST rides the same credential as the query.

### Bug B — server connection routing (`/api/v1/query`)
The NL path ignored `connectionId` and bailed on the **env-level** `ATLAS_DATASOURCE_URL` gate (`validateEnvironment()` → `MISSING_DATASOURCE_URL`), so on a multi-tenant SaaS workspace (no process-level datasource) the agent could never run — even though `executeSQL`/`/api/v1/execute-sql` resolved the workspace connection correctly.

- Added `connectionId` to `QueryRequestSchema` (`min(1).max(256)`, mirroring `/execute-sql`).
- Scoped the env-level `validateEnvironment()`/`resolveDatasourceUrl()` gate to the **self-hosted no-org** path; a bound workspace resolves its datasource from the per-tenant `ConnectionRegistry` inside the agent loop.
- Threaded `connectionId` into `executeAgentQuery`, which binds it onto the `RequestContext` so the agent's `executeSQL` tool resolves the workspace's registered connection (or its default when omitted).

## Notes for reviewers
- **Workspace isolation is preserved**: `connectionId` is not a tenancy field — the org derives from the credential server-side; a cross-workspace id simply isn't found (`getForOrg(orgId, connectionId)`).
- A bound workspace with **zero registered connections** (or a typo'd `connectionId`) no longer gets the clean `no_datasource` 400; the failure narrates through the agent instead (the `executeSQL` tool maps connection-resolution errors to a `{success:false}` tool result → 200 with an explanation, never a 500). Verified against `lib/tools/sql.ts:1370`.

## Test plan
- [x] CLI auth parity with `sql`: session→`Authorization: Bearer`, key→`x-api-key`, flag>env>session precedence, no-credential fail-closed (zero requests), `--auto-approve` propagates the same credential into the action POST
- [x] API `connectionId` routing on `/query`: context threading, env-gate skipped for a bound workspace (no `ATLAS_DATASOURCE_URL`), self-hosted env-gate retained, default-connection when omitted
- [x] Internal review panel (silent-failure / type-design / comments / tests) — CLEAN
- [x] `bun run type`, `bun run lint`, affected suites (API 22/22, CLI 44/44), full local `ci-local.sh` (the only failing gate was the documented WSL2 `VERCEL_*` sandbox-test flake — all 3 pass with those vars unset; `openapi.json` regenerated + committed)

Closes #4124