### PR TITLE
chore(models): bump SaaS default to Claude Sonnet 5, extend freshness…

### DIFF
--- a/.github/workflows/model-freshness.yml
+++ b/.github/workflows/model-freshness.yml
@@ -4,8 +4,15 @@ name: Model freshness check
 # Haiku than we've pinned in our defaults" gap. Hits the gateway's
 # /v1/models endpoint monthly, compares against the IDs hardcoded in
 # our defaults/recommended/fallback sites, and opens a tracking issue
-# when our pins are behind. No auto-bumps — the labels we use are
-# tier-stable choices that humans should curate.
+# when any of the three pinned tiers is behind. No auto-bumps — the
+# labels we use are tier-stable choices that humans should curate.
+#
+# Pin source: `MODEL_OPTIONS` in packages/web/src/app/admin/billing/page.tsx
+# — the live SaaS tier picker, which always carries exactly one current
+# gateway-format (slash+dot) ID per tier. providers.ts's `gateway:` key
+# only holds whichever single tier is the platform default (Sonnet today)
+# and can't tell us what's pinned for the other two tiers, so it's the
+# wrong extraction source for this check.
 
 on:
   schedule:
@@ -34,21 +41,39 @@ jobs:
           latest_opus=$(latest_for "anthropic/claude-opus-")
           latest_sonnet=$(latest_for "anthropic/claude-sonnet-")
           latest_haiku=$(latest_for "anthropic/claude-haiku-")
-          pinned_opus=$(grep -oE 'gateway: "anthropic/claude-opus-[0-9.]+"' \
-            packages/api/src/lib/providers.ts \
-            | grep -oE 'anthropic/claude-opus-[0-9.]+')
+
+          model_options=$(sed -n '/^const MODEL_OPTIONS = \[/,/^\] as const;/p' \
+            packages/web/src/app/admin/billing/page.tsx)
+          pinned_for() {
+            echo "$model_options" | grep -oE "anthropic/claude-$1-[0-9]+(\.[0-9]+)?" | head -1
+          }
+          pinned_opus=$(pinned_for opus)
+          pinned_sonnet=$(pinned_for sonnet)
+          pinned_haiku=$(pinned_for haiku)
+
           echo "Latest on gateway — opus:$latest_opus sonnet:$latest_sonnet haiku:$latest_haiku"
-          echo "Pinned (providers.ts gateway): $pinned_opus"
+          echo "Pinned (billing/page.tsx MODEL_OPTIONS) — opus:$pinned_opus sonnet:$pinned_sonnet haiku:$pinned_haiku"
+
+          drift=false
+          drifted_tiers=""
+          for tier in opus sonnet haiku; do
+            pinned_var="pinned_$tier"
+            latest_var="latest_$tier"
+            if [ "${!pinned_var}" != "${!latest_var}" ]; then
+              drift=true
+              drifted_tiers="$drifted_tiers $tier"
+            fi
+          done
+
           {
             echo "latest_opus=$latest_opus"
             echo "latest_sonnet=$latest_sonnet"
             echo "latest_haiku=$latest_haiku"
             echo "pinned_opus=$pinned_opus"
-            if [ "$pinned_opus" != "$latest_opus" ]; then
-              echo "drift=true"
-            else
-              echo "drift=false"
-            fi
+            echo "pinned_sonnet=$pinned_sonnet"
+            echo "pinned_haiku=$pinned_haiku"
+            echo "drift=$drift"
+            echo "drifted_tiers=${drifted_tiers# }"
           } >> "$GITHUB_OUTPUT"
       - name: Open tracking issue on drift
         if: steps.drift.outputs.drift == 'true'
@@ -61,6 +86,9 @@ jobs:
           LATEST_SONNET: ${{ steps.drift.outputs.latest_sonnet }}
           LATEST_HAIKU: ${{ steps.drift.outputs.latest_haiku }}
           PINNED_OPUS: ${{ steps.drift.outputs.pinned_opus }}
+          PINNED_SONNET: ${{ steps.drift.outputs.pinned_sonnet }}
+          PINNED_HAIKU: ${{ steps.drift.outputs.pinned_haiku }}
+          DRIFTED_TIERS: ${{ steps.drift.outputs.drifted_tiers }}
         run: |
           set -euo pipefail
           existing=$(gh issue list -R "$GITHUB_REPOSITORY" \
@@ -70,30 +98,36 @@ jobs:
             echo "Drift issue #$existing already open — skipping."
             exit 0
           fi
-          title="chore: model defaults drift vs Vercel AI Gateway (Opus $PINNED_OPUS → $LATEST_OPUS)"
+          status_line() {
+            # $1=label $2=pinned $3=latest
+            if [ "$2" != "$3" ]; then printf '⚠️  %s: `%s` → `%s`' "$1" "$2" "$3"
+            else printf '✅ %s: `%s` (current)' "$1" "$2"
+            fi
+          }
+          title="chore: model defaults drift vs Vercel AI Gateway ($DRIFTED_TIERS)"
           # Build the body as a single printf — heredocs inside the
           # YAML run: block need column-0 terminators, which we can't
           # provide without breaking GitHub's indentation parser.
           body=$(printf '%s\n' \
-            "Monthly freshness check detected drift between our pinned Opus default and Vercel AI Gateway's latest Opus." \
+            "Monthly freshness check detected drift between our pinned defaults and Vercel AI Gateway's latest catalog." \
             "" \
-            "**Latest on gateway:**" \
-            "- opus:   \`$LATEST_OPUS\`" \
-            "- sonnet: \`$LATEST_SONNET\`" \
-            "- haiku:  \`$LATEST_HAIKU\`" \
-            "" \
-            "**Currently pinned (providers.ts gateway default):** \`$PINNED_OPUS\`" \
+            "**Tier status (pinned → latest):**" \
+            "- $(status_line opus "$PINNED_OPUS" "$LATEST_OPUS")" \
+            "- $(status_line sonnet "$PINNED_SONNET" "$LATEST_SONNET")" \
+            "- $(status_line haiku "$PINNED_HAIKU" "$LATEST_HAIKU")" \
             "" \
             "### Sites to update when bumping" \
             "" \
-            "1. \`packages/web/src/app/admin/billing/page.tsx\` — \`MODEL_OPTIONS\` (SaaS tier picker)" \
-            "2. \`packages/api/src/lib/billing/plans.ts\` — \`defaultModel\` per plan tier (only if the tier-flagship changed)" \
+            "1. \`packages/web/src/app/admin/billing/page.tsx\` — \`MODEL_OPTIONS\` (SaaS tier picker) + \`LEGACY_MODEL_ALIASES\` (roll the old version forward)" \
+            "2. \`packages/api/src/lib/billing/plans.ts\` — \`defaultModel\` per plan tier (only if the tier-flagship changed; Starter/Trial/Locked stay on Haiku by design)" \
             "3. \`packages/api/src/lib/providers.ts\` — \`PROVIDER_DEFAULTS.anthropic\` + \`.gateway\` (and \`.bedrock\` once AWS GAs the new version)" \
-            "4. \`packages/api/src/lib/anthropic-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` (sparkles in BYOT direct picker)" \
-            "5. \`packages/api/src/lib/gateway-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` + \`FALLBACK_MODELS\` (gateway picker)" \
-            "6. \`packages/web/src/app/admin/model-config/page.tsx\` — \`PLATFORM_MODEL_LABELS\` (admin UI label map)" \
+            "4. \`packages/cli/src/doctor.ts\` and \`create-atlas/index.ts\` — each has its own mirrored \`PROVIDER_DEFAULTS\`/\`PROVIDER_DEFAULT_MODEL\` map; keep in lockstep with #3" \
+            "5. \`packages/api/src/lib/anthropic-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` (sparkles in BYOT direct picker)" \
+            "6. \`packages/api/src/lib/gateway-catalog.ts\` — \`RECOMMENDED_MODEL_IDS\` + \`FALLBACK_MODELS\` (gateway picker)" \
+            "7. \`packages/web/src/app/admin/model-config/page.tsx\` — \`PLATFORM_MODEL_LABELS\` (admin UI label map; additive, keep old entries)" \
+            "8. Docs: \`apps/docs/content/docs/guides/billing-and-plans.mdx\` (Default model row) + \`apps/docs/content/docs/reference/environment-variables.mdx\` (gateway default table)" \
             "" \
-            "The BYOT-direct picker (Anthropic / OpenAI / Bedrock) is driven by the live provider catalog and doesn't need a code change to surface new models — only the defaults / recommendations / labels are hardcoded.")
+            "The full searchable gateway picker (Admin → AI Provider → gateway) is NOT in this list — it's served live from \`getGatewayCatalog()\` (TTL-cached fetch of \`https://ai-gateway.vercel.sh/v1/models\`) and needs no code change for new models to appear. Only the curated/recommended subset and the offline fallback bundle are hardcoded (sites 6–7 above).")
           gh issue create -R "$GITHUB_REPOSITORY" \
             --title "$title" \
             --label "chore,area: api" \

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -31,7 +31,7 @@ On [app.useatlas.dev](https://app.useatlas.dev), billing is fully managed. View 
 | **Max seats** | 10 | 25 | Unlimited | Unlimited |
 | **Datasource connections** | 1 | 3 | Unlimited | Unlimited |
 | **Extra connections** | Upgrade plan | Upgrade plan | Included | N/A |
-| **Default model** | claude-haiku-4.5 | claude-sonnet-4.6 | claude-sonnet-4.6 | BYOK |
+| **Default model** | claude-haiku-4.5 | claude-sonnet-5 | claude-sonnet-5 | BYOK |
 | **Custom domain** | — | ✓ | ✓ | N/A |
 | **SSO / SCIM** | — | — | ✓ | N/A |
 | **Data residency (3 regions)** | ✓ | ✓ | ✓ | N/A |

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -76,7 +76,7 @@ Some providers need a **complete** credential set, not just one key, for chat to
 | `bedrock` | `anthropic.claude-opus-4-8` |
 | `ollama` | `llama3.1` |
 | `openai-compatible` | None — `ATLAS_MODEL` required |
-| `gateway` | `anthropic/claude-sonnet-4.6` |
+| `gateway` | `anthropic/claude-sonnet-5` |
 
 <Tabs items={["Anthropic", "OpenAI", "AWS Bedrock", "Ollama (local)", "OpenAI-compatible (vLLM, TGI)"]}>
 <Tab value="Anthropic">

--- a/create-atlas/index.ts
+++ b/create-atlas/index.ts
@@ -21,14 +21,14 @@ const PROVIDER_KEY_MAP: Record<string, { envVar: string; placeholder: string }> 
 };
 
 // Default models per provider. Keep in lockstep with PROVIDER_DEFAULTS in
-// packages/api/src/lib/providers.ts — gateway → Sonnet 4.6 (the hosted/SaaS
+// packages/api/src/lib/providers.ts — gateway → Sonnet 5 (the hosted/SaaS
 // default), the rest mirror the agent's per-provider defaults (#3098).
 const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
   bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
-  gateway: "anthropic/claude-sonnet-4.6",
+  gateway: "anthropic/claude-sonnet-5",
 };
 
 function copyDirRecursive(src: string, dest: string): void {

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -493,9 +493,9 @@ describe("billing routes", () => {
       expect(body.connections.count).toBe(0);
     });
 
-    it("reports the gateway provider default (Sonnet 4.6) when nothing is saved (#3098)", async () => {
+    it("reports the gateway provider default (Sonnet 5) when nothing is saved (#3098)", async () => {
       // The exact bug: on the SaaS gateway path with no saved model, the
-      // picker must show what actually runs — Sonnet 4.6 — not the plan's
+      // picker must show what actually runs — Sonnet 5 — not the plan's
       // recommended model and not a hardcoded UI fallback.
       const origProvider = process.env.ATLAS_PROVIDER;
       const origModel = process.env.ATLAS_MODEL;
@@ -515,7 +515,7 @@ describe("billing routes", () => {
         expect(res.status).toBe(200);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
         const body = await res.json() as any;
-        expect(body.currentModel).toBe("anthropic/claude-sonnet-4.6");
+        expect(body.currentModel).toBe("anthropic/claude-sonnet-5");
       } finally {
         if (origProvider !== undefined) process.env.ATLAS_PROVIDER = origProvider;
         else delete process.env.ATLAS_PROVIDER;

--- a/packages/api/src/lib/__tests__/providers.test.ts
+++ b/packages/api/src/lib/__tests__/providers.test.ts
@@ -202,12 +202,12 @@ describe("resolveModelId — SSOT default (#3098)", () => {
     expect(resolveModelId("gateway", undefined)).toBe(agentDefault);
   });
 
-  test("platform gateway default is Sonnet 4.6 (documented decision, #3098)", () => {
+  test("platform gateway default is Sonnet 5 (documented decision, #3098)", () => {
     delete process.env.ATLAS_MODEL;
     // Decision: the hosted/gateway default is the balanced, ~5x-cheaper Sonnet
-    // 4.6 — NOT Opus 4.8. Pinning it here so UI and runtime can't silently
+    // 5 — NOT Opus 4.8. Pinning it here so UI and runtime can't silently
     // diverge back to the expensive default.
-    expect(resolveModelId("gateway", undefined)).toBe("anthropic/claude-sonnet-4.6");
+    expect(resolveModelId("gateway", undefined)).toBe("anthropic/claude-sonnet-5");
   });
 
   test("an explicitly saved model overrides the default", () => {
@@ -226,7 +226,7 @@ describe("resolveModelId — SSOT default (#3098)", () => {
   });
 
   // The bug end-to-end: a SaaS deployment with nothing configured must resolve
-  // gateway → Sonnet 4.6, NOT anthropic → Opus. With no provider override and no
+  // gateway → Sonnet 5, NOT anthropic → Opus. With no provider override and no
   // ATLAS_PROVIDER, the provider falls through to getDefaultProvider() (gateway
   // on SaaS), then to PROVIDER_DEFAULTS.gateway. #3098.
   test("unset provider+model on SaaS resolves the gateway Sonnet default", () => {
@@ -234,7 +234,7 @@ describe("resolveModelId — SSOT default (#3098)", () => {
     delete process.env.ATLAS_MODEL;
     delete process.env.VERCEL;
     process.env.ATLAS_DEPLOY_MODE = "saas";
-    expect(resolveModelId(undefined, undefined)).toBe("anthropic/claude-sonnet-4.6");
+    expect(resolveModelId(undefined, undefined)).toBe("anthropic/claude-sonnet-5");
   });
 });
 

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -42,7 +42,7 @@ const FETCH_TIMEOUT_MS = 10_000;
  */
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
   "claude-opus-4-8",
-  "claude-sonnet-4-6",
+  "claude-sonnet-5",
   "claude-haiku-4-5",
 ]);
 

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -94,8 +94,8 @@ describe("billing/plans", () => {
       expect(getPlanDefinition("pro").pricePerSeat).toBe(69);
       expect(getPlanDefinition("business").pricePerSeat).toBe(149);
       expect(getPlanDefinition("starter").defaultModel).toBe("anthropic/claude-haiku-4.5");
-      expect(getPlanDefinition("pro").defaultModel).toBe("anthropic/claude-sonnet-4.6");
-      expect(getPlanDefinition("business").defaultModel).toBe("anthropic/claude-sonnet-4.6");
+      expect(getPlanDefinition("pro").defaultModel).toBe("anthropic/claude-sonnet-5");
+      expect(getPlanDefinition("business").defaultModel).toBe("anthropic/claude-sonnet-5");
     });
 
     it("plan features are tier-appropriate", () => {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -190,7 +190,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "pro",
     displayName: "Pro",
     pricePerSeat: 69,
-    defaultModel: "anthropic/claude-sonnet-4.6",
+    defaultModel: "anthropic/claude-sonnet-5",
     includedUsageDollarsPerSeat: 20,
     limits: {
       tokenBudgetPerSeat: 5_000_000,
@@ -230,7 +230,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
     name: "business",
     displayName: "Business",
     pricePerSeat: 149,
-    defaultModel: "anthropic/claude-sonnet-4.6",
+    defaultModel: "anthropic/claude-sonnet-5",
     includedUsageDollarsPerSeat: 20,
     limits: {
       tokenBudgetPerSeat: 15_000_000,

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -42,7 +42,7 @@ const FETCH_TIMEOUT_MS = 10_000;
  */
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
   "anthropic/claude-opus-4.8",
-  "anthropic/claude-sonnet-4.6",
+  "anthropic/claude-sonnet-5",
   "openai/gpt-4o",
   "openai/gpt-4o-mini",
   "google/gemini-2.0-flash",
@@ -66,12 +66,12 @@ const FALLBACK_MODELS: GatewayCatalogModel[] = [
     recommended: true,
   },
   {
-    id: "anthropic/claude-sonnet-4.6",
-    name: "Claude Sonnet 4.6",
+    id: "anthropic/claude-sonnet-5",
+    name: "Claude Sonnet 5",
     provider: "anthropic",
     type: "language",
-    contextWindow: 200_000,
-    maxOutputTokens: 64_000,
+    contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     inputPrice: null,
     outputPrice: null,
     recommended: true,

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -56,12 +56,12 @@ const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
   bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
   "openai-compatible": undefined,
-  // Hosted/gateway default: balanced Sonnet 4.6, NOT Opus 4.8. The gateway
+  // Hosted/gateway default: balanced Sonnet 5, NOT Opus 4.8. The gateway
   // path is the SaaS billing surface, where an unset workspace would otherwise
   // silently run (and be billed for) Opus 4.8 at ~5x the input cost while the
   // billing picker advertised Sonnet (#3098). Keep this in lockstep with the
   // billing page's displayed default — both flow through `resolveModelId()`.
-  gateway: "anthropic/claude-sonnet-4.6",
+  gateway: "anthropic/claude-sonnet-5",
 };
 
 /**

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -36,14 +36,14 @@ const PROVIDER_KEY_MAP: Record<string, string> = {
 };
 
 // Keep in lockstep with PROVIDER_DEFAULTS in packages/api/src/lib/providers.ts.
-// gateway → Sonnet 4.6 (the hosted/SaaS default, ~5x cheaper than Opus); the
+// gateway → Sonnet 5 (the hosted/SaaS default, ~5x cheaper than Opus); the
 // rest mirror the agent's per-provider defaults (#3098).
 const PROVIDER_DEFAULTS: Record<string, string> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
   bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
-  gateway: "anthropic/claude-sonnet-4.6",
+  gateway: "anthropic/claude-sonnet-5",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -141,7 +141,7 @@ function formatDollars(amount: number): string {
 // existing workspaces don't lose their selection on first load.
 const MODEL_OPTIONS = [
   { value: "anthropic/claude-haiku-4.5", label: "Haiku 4.5", hint: "fastest, lowest cost" },
-  { value: "anthropic/claude-sonnet-4.6", label: "Sonnet 4.6", hint: "balanced" },
+  { value: "anthropic/claude-sonnet-5", label: "Sonnet 5", hint: "balanced" },
   { value: "anthropic/claude-opus-4.8", label: "Opus 4.8", hint: "most capable" },
 ] as const;
 
@@ -153,14 +153,17 @@ const MODEL_OPTIONS = [
 //
 // Two kinds of migration live here:
 //   1. Format canonicalization — hyphen → slash+dot (e.g. `claude-sonnet-4-6`).
-//   2. Version roll-forward — a deprecated Opus version that no longer has its
-//      own picker row (4.6, the prior 4.7 default) is mapped to the current
-//      flagship `anthropic/claude-opus-4.8`. This is a version upgrade, not
-//      just a format change, so the Select highlights a valid option instead
-//      of rendering blank for workspaces still on the old default (#3076).
+//   2. Version roll-forward — a deprecated version that no longer has its own
+//      picker row (Opus 4.6/4.7, the prior Opus defaults; Sonnet 4.6, the
+//      prior Sonnet default) is mapped to the current flagship
+//      (`anthropic/claude-opus-4.8`, `anthropic/claude-sonnet-5`). This is a
+//      version upgrade, not just a format change, so the Select highlights a
+//      valid option instead of rendering blank for workspaces still on the
+//      old default (#3076).
 const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
-  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-5",
+  "anthropic/claude-sonnet-4.6": "anthropic/claude-sonnet-5",
   "claude-opus-4-6": "anthropic/claude-opus-4.8",
   "claude-opus-4-7": "anthropic/claude-opus-4.8",
   "anthropic/claude-opus-4.7": "anthropic/claude-opus-4.8",

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -20,11 +20,13 @@ import { ModelProviderSection } from "@/ui/components/admin/model-provider-secti
 const PLATFORM_MODEL_LABELS: Record<string, string> = {
   "claude-haiku-4-5": "Haiku 4.5",
   "claude-sonnet-4-6": "Sonnet 4.6",
+  "claude-sonnet-5": "Sonnet 5",
   "claude-opus-4-6": "Opus 4.6",
   "claude-opus-4-7": "Opus 4.7",
   "claude-opus-4-8": "Opus 4.8",
   "anthropic/claude-haiku-4.5": "Haiku 4.5",
   "anthropic/claude-sonnet-4.6": "Sonnet 4.6",
+  "anthropic/claude-sonnet-5": "Sonnet 5",
   "anthropic/claude-opus-4.6": "Opus 4.6",
   "anthropic/claude-opus-4.7": "Opus 4.7",
   "anthropic/claude-opus-4.8": "Opus 4.8",


### PR DESCRIPTION
… CI to 3 tiers

Anthropic shipped claude-sonnet-5 (gateway slug anthropic/claude-sonnet-5, verified live against the Vercel AI Gateway catalog). Bumps every site that currently pins Sonnet 4.6 as a *default* to Sonnet 5: gateway provider default, Pro/Business billing tiers, recommended-model sets (direct + gateway catalogs), the SaaS model picker (with a legacy-alias roll-forward for stored 4.6 settings), the admin label map, and the doctor/create-atlas mirrors of PROVIDER_DEFAULTS. Starter/Trial/Locked tiers stay on Haiku by design, per the Structure B billing ladder.

Also extends model-freshness.yml's monthly drift check from Opus-only to all three tiers (Opus/Sonnet/Haiku) — it never caught this Sonnet bump because pinned_opus was sourced from providers.ts's `gateway:` key, which holds the platform default (now Sonnet, not Opus) rather than an actual Opus pin. Re-sourced extraction from billing/page.tsx's MODEL_OPTIONS, which always carries one current gateway-format ID per tier.

## Summary

<!-- What does this PR do? Link related issues with "Closes #123". -->

## Test Plan

<!-- How was this tested? -->

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change)
