### PR TITLE
refactor(api): swappable-store sliding-window rate limiter (#4129)

### DIFF
--- a/packages/api/src/__tests__/demo.test.ts
+++ b/packages/api/src/__tests__/demo.test.ts
@@ -172,46 +172,47 @@ describe("demoUserId", () => {
 describe("checkDemoRateLimit", () => {
   const originalRpm = process.env.ATLAS_DEMO_RATE_LIMIT_RPM;
 
-  beforeEach(() => {
-    resetDemoRateLimits();
+  beforeEach(async () => {
+    await resetDemoRateLimits();
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     if (originalRpm !== undefined) process.env.ATLAS_DEMO_RATE_LIMIT_RPM = originalRpm;
     else delete process.env.ATLAS_DEMO_RATE_LIMIT_RPM;
-    resetDemoRateLimits();
+    await resetDemoRateLimits();
   });
 
-  it("allows requests under limit", () => {
+  it("allows requests under limit", async () => {
     process.env.ATLAS_DEMO_RATE_LIMIT_RPM = "5";
     for (let i = 0; i < 5; i++) {
-      expect(checkDemoRateLimit("test@example.com").allowed).toBe(true);
+      expect((await checkDemoRateLimit("test@example.com")).allowed).toBe(true);
     }
   });
 
-  it("blocks at limit", () => {
+  it("blocks at limit", async () => {
     process.env.ATLAS_DEMO_RATE_LIMIT_RPM = "3";
     for (let i = 0; i < 3; i++) {
-      expect(checkDemoRateLimit("test@example.com").allowed).toBe(true);
+      expect((await checkDemoRateLimit("test@example.com")).allowed).toBe(true);
     }
-    const result = checkDemoRateLimit("test@example.com");
+    const result = await checkDemoRateLimit("test@example.com");
     expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("unreachable: expected a blocked decision");
     expect(result.retryAfterMs).toBeGreaterThan(0);
   });
 
-  it("allows all when limit is 0 (disabled)", () => {
+  it("allows all when limit is 0 (disabled)", async () => {
     process.env.ATLAS_DEMO_RATE_LIMIT_RPM = "0";
     for (let i = 0; i < 100; i++) {
-      expect(checkDemoRateLimit("test@example.com").allowed).toBe(true);
+      expect((await checkDemoRateLimit("test@example.com")).allowed).toBe(true);
     }
   });
 
-  it("tracks different emails separately", () => {
+  it("tracks different emails separately", async () => {
     process.env.ATLAS_DEMO_RATE_LIMIT_RPM = "2";
-    expect(checkDemoRateLimit("a@b.com").allowed).toBe(true);
-    expect(checkDemoRateLimit("a@b.com").allowed).toBe(true);
-    expect(checkDemoRateLimit("a@b.com").allowed).toBe(false);
+    expect((await checkDemoRateLimit("a@b.com")).allowed).toBe(true);
+    expect((await checkDemoRateLimit("a@b.com")).allowed).toBe(true);
+    expect((await checkDemoRateLimit("a@b.com")).allowed).toBe(false);
     // Different email still has quota
-    expect(checkDemoRateLimit("c@d.com").allowed).toBe(true);
+    expect((await checkDemoRateLimit("c@d.com")).allowed).toBe(true);
   });
 });

--- a/packages/api/src/api/__tests__/starter-prompts.test.ts
+++ b/packages/api/src/api/__tests__/starter-prompts.test.ts
@@ -153,7 +153,7 @@ afterAll(() => {
   }
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   // Clear call history so per-test "was/wasn't called" assertions are
   // honest (the mock accumulates across the whole file otherwise).
   mocks.mockAuthenticateRequest.mockClear();
@@ -176,7 +176,7 @@ beforeEach(() => {
   mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
   // Demo rate limiter is keyed by demoUserId(email) and persists across
   // tests in module-level state — clear it so per-test budgets are reset.
-  resetDemoRateLimits();
+  await resetDemoRateLimits();
   demoIndustryFixture = undefined;
   mockListFavorites.mockReset();
   mockListFavorites.mockImplementation(async () => []);

--- a/packages/api/src/api/routes/__tests__/contact.test.ts
+++ b/packages/api/src/api/routes/__tests__/contact.test.ts
@@ -36,7 +36,7 @@ let upsertLeadShouldFail = false;
 // ── Mock the side modules BEFORE importing the route ─────────────────
 
 mock.module("@atlas/api/lib/contact", () => ({
-  checkContactRateLimit: () => ({
+  checkContactRateLimit: async () => ({
     allowed: rateLimitAllowed,
     retryAfterMs: rateLimitAllowed ? undefined : rateLimitRetryAfterMs,
   }),

--- a/packages/api/src/api/routes/__tests__/platform-demo.test.ts
+++ b/packages/api/src/api/routes/__tests__/platform-demo.test.ts
@@ -146,10 +146,10 @@ mock.module("@atlas/api/lib/demo", () => ({
   demoRunAgentModelParams: () => ({}),
   signDemoToken: () => "",
   verifyDemoToken: () => null,
-  checkDemoRateLimit: () => ({ allowed: true }),
-  resetDemoRateLimits: () => {},
+  checkDemoRateLimit: async () => ({ allowed: true }),
+  resetDemoRateLimits: async () => {},
   DEMO_CLEANUP_INTERVAL_MS: 60_000,
-  demoCleanupTick: () => {},
+  demoCleanupTick: async () => {},
   captureDemoLead: async () => ({}),
   countDemoConversations: async () => 0,
 }));

--- a/packages/api/src/api/routes/contact.ts
+++ b/packages/api/src/api/routes/contact.ts
@@ -179,9 +179,9 @@ contact.openapi(contactRoute, async (c) => {
           "ATLAS_TRUST_PROXY is not set — contact-form per-IP rate-limit collapses to one global bucket. Set ATLAS_TRUST_PROXY=true behind a trusted proxy (Cloudflare, Railway edge) to enable per-IP enforcement.",
         );
       }
-      const rateCheck = checkContactRateLimit(ip ?? "anon-contact");
+      const rateCheck = yield* Effect.promise(() => checkContactRateLimit(ip ?? "anon-contact"));
       if (!rateCheck.allowed) {
-        const retryAfterSeconds = Math.ceil((rateCheck.retryAfterMs ?? 60000) / 1000);
+        const retryAfterSeconds = Math.ceil(rateCheck.retryAfterMs / 1000);
         return c.json(
           {
             error: "rate_limited",

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -432,9 +432,9 @@ demo.openapi(demoStartRoute, async (c) => {
 
     // IP-based rate limit to prevent abuse (email enumeration, DB flooding)
     const ip = getClientIP(c.req.raw);
-    const startRateCheck = checkDemoRateLimit(ip ?? "anon-start");
+    const startRateCheck = yield* Effect.promise(() => checkDemoRateLimit(ip ?? "anon-start"));
     if (!startRateCheck.allowed) {
-      const retryAfterSeconds = Math.ceil((startRateCheck.retryAfterMs ?? 60000) / 1000);
+      const retryAfterSeconds = Math.ceil(startRateCheck.retryAfterMs / 1000);
       return c.json(
         { error: "rate_limited", message: "Too many requests. Please wait.", retryAfterSeconds, requestId },
         { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } },
@@ -516,9 +516,9 @@ demo.openapi(demoChatRoute, async (c) => {
   const userId = demoUserId(email);
 
   // Demo rate limit
-  const rateCheck = checkDemoRateLimit(email);
+  const rateCheck = await checkDemoRateLimit(email);
   if (!rateCheck.allowed) {
-    const retryAfterSeconds = Math.ceil((rateCheck.retryAfterMs ?? 60000) / 1000);
+    const retryAfterSeconds = Math.ceil(rateCheck.retryAfterMs / 1000);
     return c.json(
       {
         error: "rate_limited",

--- a/packages/api/src/api/routes/starter-prompts.ts
+++ b/packages/api/src/api/routes/starter-prompts.ts
@@ -266,9 +266,9 @@ const demoOrStandardAuth = createMiddleware<AuthEnv>(async (c, next) => {
     // Same per-email throttle the rest of the demo surface uses. Returning
     // 429 with Retry-After mirrors `/api/v1/demo/chat` so the widget can
     // back off without bespoke handling.
-    const rateCheck = checkDemoRateLimit(demoEmail);
+    const rateCheck = await checkDemoRateLimit(demoEmail);
     if (!rateCheck.allowed) {
-      const retryAfterSeconds = Math.ceil((rateCheck.retryAfterMs ?? 60_000) / 1000);
+      const retryAfterSeconds = Math.ceil(rateCheck.retryAfterMs / 1000);
       return c.json(
         {
           error: "rate_limited",

--- a/packages/api/src/lib/__tests__/contact.test.ts
+++ b/packages/api/src/lib/__tests__/contact.test.ts
@@ -19,8 +19,8 @@ afterAll(() => {
   else process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = ORIGINAL_ENV;
 });
 
-beforeEach(() => {
-  resetContactRateLimits();
+beforeEach(async () => {
+  await resetContactRateLimits();
 });
 
 describe("getContactRpmLimit", () => {
@@ -39,44 +39,45 @@ describe("getContactRpmLimit", () => {
     expect(getContactRpmLimit()).toBe(5);
   });
 
-  test("0 disables the limit", () => {
+  test("0 disables the limit", async () => {
     process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = "0";
     expect(getContactRpmLimit()).toBe(0);
-    expect(checkContactRateLimit("1.2.3.4").allowed).toBe(true);
+    expect((await checkContactRateLimit("1.2.3.4")).allowed).toBe(true);
   });
 });
 
 describe("checkContactRateLimit", () => {
-  test("allows up to limit submissions per IP per minute", () => {
+  test("allows up to limit submissions per IP per minute", async () => {
     process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = "3";
-    expect(checkContactRateLimit("ip-a").allowed).toBe(true);
-    expect(checkContactRateLimit("ip-a").allowed).toBe(true);
-    expect(checkContactRateLimit("ip-a").allowed).toBe(true);
-    const blocked = checkContactRateLimit("ip-a");
+    expect((await checkContactRateLimit("ip-a")).allowed).toBe(true);
+    expect((await checkContactRateLimit("ip-a")).allowed).toBe(true);
+    expect((await checkContactRateLimit("ip-a")).allowed).toBe(true);
+    const blocked = await checkContactRateLimit("ip-a");
     expect(blocked.allowed).toBe(false);
+    if (blocked.allowed) throw new Error("unreachable: expected a blocked decision");
     expect(blocked.retryAfterMs).toBeGreaterThan(0);
   });
 
-  test("separate IPs do not share the window", () => {
+  test("separate IPs do not share the window", async () => {
     process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = "1";
-    expect(checkContactRateLimit("ip-x").allowed).toBe(true);
-    expect(checkContactRateLimit("ip-x").allowed).toBe(false);
+    expect((await checkContactRateLimit("ip-x")).allowed).toBe(true);
+    expect((await checkContactRateLimit("ip-x")).allowed).toBe(false);
     // Different IP — fresh budget.
-    expect(checkContactRateLimit("ip-y").allowed).toBe(true);
+    expect((await checkContactRateLimit("ip-y")).allowed).toBe(true);
   });
 });
 
 describe("contactCleanupTick", () => {
   test("evicts entries whose newest timestamp is older than the window", async () => {
     process.env.ATLAS_CONTACT_RATE_LIMIT_RPM = "2";
-    checkContactRateLimit("ip-evict");
+    await checkContactRateLimit("ip-evict");
     // Drop the timestamps to expired (simulate the passage of >60s).
-    // Implementation detail: contactCleanupTick walks the same map, so
+    // Implementation detail: contactCleanupTick walks the same store, so
     // we just call it after manually fast-forwarding via reset.
-    resetContactRateLimits();
-    checkContactRateLimit("ip-recent");
-    contactCleanupTick();
+    await resetContactRateLimits();
+    await checkContactRateLimit("ip-recent");
+    await contactCleanupTick();
     // ip-evict is gone (reset cleared everything); ip-recent stays.
-    expect(checkContactRateLimit("ip-recent").allowed).toBe(true);
+    expect((await checkContactRateLimit("ip-recent")).allowed).toBe(true);
   });
 });

--- a/packages/api/src/lib/__tests__/sliding-window-rate-limit.test.ts
+++ b/packages/api/src/lib/__tests__/sliding-window-rate-limit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Sliding-window limiter tests (#4129).
+ *
+ * The window logic is asserted against the {@link SlidingWindowStore}
+ * INTERFACE, not the concrete in-memory `Map`: every case runs over two
+ * conforming stores — the shipped in-memory adapter and a second, deliberately
+ * Map-free `Record`-backed store defined here. If the limiter ever reached
+ * past the interface into Map internals, the second store would fail. This is
+ * the executable proof that the Redis adapter (the follow-up) is a drop-in.
+ *
+ * Scope note: both stores here resolve their `await`s synchronously, so this
+ * suite proves STRUCTURAL swappability, not behavior under interleaved
+ * concurrent awaits. The in-memory adapter is effectively atomic per process
+ * (see the module's atomicity note); a networked adapter has a read/record
+ * race. When the Redis adapter lands (#3801), it must ship with a test that
+ * interleaves two concurrent `check()`s on one key — the suite below would pass
+ * a racy adapter.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  createSlidingWindowLimiter,
+  createInMemorySlidingWindowStore,
+  type SlidingWindowStore,
+  type WindowSnapshot,
+} from "../sliding-window-rate-limit";
+
+/**
+ * A second conforming store with NO `Map` — keyed by a plain object — so the
+ * suite proves the limiter speaks only the interface. Mirrors the in-memory
+ * adapter's eviction semantics.
+ */
+function createRecordSlidingWindowStore(): SlidingWindowStore {
+  const windows: Record<string, number[]> = Object.create(null);
+  const bucket = (key: string): number[] => (windows[key] ??= []);
+  return {
+    async read(key, windowMs, now): Promise<WindowSnapshot> {
+      const cutoff = now - windowMs;
+      const live = bucket(key).filter((t) => t > cutoff);
+      windows[key] = live;
+      return { count: live.length, oldest: live[0] };
+    },
+    async append(key, timestamp) {
+      bucket(key).push(timestamp);
+    },
+    async evictStale(windowMs, now) {
+      const cutoff = now - windowMs;
+      for (const key of Object.keys(windows)) {
+        const ts = windows[key]!;
+        if (ts.length === 0 || ts[ts.length - 1]! <= cutoff) delete windows[key];
+      }
+    },
+    async clear() {
+      for (const key of Object.keys(windows)) delete windows[key];
+    },
+  };
+}
+
+const STORES: ReadonlyArray<readonly [string, () => SlidingWindowStore]> = [
+  ["in-memory (shipped)", createInMemorySlidingWindowStore],
+  ["record-backed (interface proof)", createRecordSlidingWindowStore],
+];
+
+const WINDOW = 60_000;
+
+for (const [name, makeStore] of STORES) {
+  describe(`SlidingWindowLimiter over ${name}`, () => {
+    const make = () => createSlidingWindowLimiter({ store: makeStore(), windowMs: WINDOW });
+
+    test("allows up to the limit, then blocks with retry guidance", async () => {
+      const limiter = make();
+      const t0 = 1_000_000;
+      expect((await limiter.check("k", 3, t0)).allowed).toBe(true);
+      expect((await limiter.check("k", 3, t0 + 1)).allowed).toBe(true);
+      expect((await limiter.check("k", 3, t0 + 2)).allowed).toBe(true);
+      const blocked = await limiter.check("k", 3, t0 + 3);
+      expect(blocked.allowed).toBe(false);
+      if (blocked.allowed) throw new Error("unreachable: expected a blocked decision");
+      // First of three timestamps was at t0; it frees one window later.
+      expect(blocked.retryAfterMs).toBe(t0 + WINDOW - (t0 + 3));
+    });
+
+    test("retryAfterMs floors at 1ms at the last instant of the window", async () => {
+      const limiter = make();
+      const t0 = 1_500_000;
+      expect((await limiter.check("k", 1, t0)).allowed).toBe(true);
+      // One ms before the recorded attempt ages out: still blocked, retry = 1ms
+      // (the Math.max(1, …) floor — the smallest non-zero retry the window emits).
+      const blocked = await limiter.check("k", 1, t0 + WINDOW - 1);
+      expect(blocked.allowed).toBe(false);
+      if (blocked.allowed) throw new Error("unreachable: expected a blocked decision");
+      expect(blocked.retryAfterMs).toBe(1);
+    });
+
+    test("peek is non-recording — it never consumes budget", async () => {
+      const limiter = make();
+      const t0 = 2_000_000;
+      // Peek many times under a limit of 1; none of them record.
+      for (let i = 0; i < 5; i++) {
+        expect((await limiter.peek("k", 1, t0)).allowed).toBe(true);
+      }
+      // The single real slot is still free.
+      expect((await limiter.check("k", 1, t0)).allowed).toBe(true);
+      expect((await limiter.check("k", 1, t0)).allowed).toBe(false);
+    });
+
+    test("a blocked check does not record (caller recovers on schedule)", async () => {
+      const limiter = make();
+      const t0 = 3_000_000;
+      expect((await limiter.check("k", 1, t0)).allowed).toBe(true);
+      // Blocked — must not extend the window by recording itself.
+      expect((await limiter.check("k", 1, t0 + 10)).allowed).toBe(false);
+      // One window after the FIRST (only) recorded attempt, the slot frees.
+      expect((await limiter.check("k", 1, t0 + WINDOW)).allowed).toBe(true);
+    });
+
+    test("sliding window: stale timestamps free slots", async () => {
+      const limiter = make();
+      const t0 = 4_000_000;
+      expect((await limiter.check("k", 1, t0)).allowed).toBe(true);
+      expect((await limiter.check("k", 1, t0 + 1)).allowed).toBe(false);
+      // The first attempt ages out exactly one window later.
+      expect((await limiter.check("k", 1, t0 + WINDOW + 1)).allowed).toBe(true);
+    });
+
+    test("distinct keys keep independent budgets", async () => {
+      const limiter = make();
+      const t0 = 5_000_000;
+      expect((await limiter.check("a", 1, t0)).allowed).toBe(true);
+      expect((await limiter.check("a", 1, t0)).allowed).toBe(false);
+      expect((await limiter.check("b", 1, t0)).allowed).toBe(true);
+    });
+
+    test("limit 0 disables the bucket and never records", async () => {
+      const store = makeStore();
+      const limiter = createSlidingWindowLimiter({ store, windowMs: WINDOW });
+      const t0 = 6_000_000;
+      for (let i = 0; i < 50; i++) {
+        expect((await limiter.check("k", 0, t0)).allowed).toBe(true);
+      }
+      // Nothing was recorded — the store still reports an empty window.
+      expect((await store.read("k", WINDOW, t0)).count).toBe(0);
+    });
+
+    test("cleanup evicts fully-stale keys; reset frees everything", async () => {
+      const limiter = make();
+      const t0 = 7_000_000;
+      await limiter.check("stale", 5, t0);
+      await limiter.check("fresh", 5, t0 + WINDOW);
+      // One window past `stale`'s only attempt → it is fully stale; `fresh` isn't.
+      await limiter.cleanup(t0 + WINDOW);
+      // (Eviction is a memory-reclaim concern; behavior is unchanged either way,
+      //  but a fresh key keeps its budget and a stale key is reclaimable.)
+      expect((await limiter.check("fresh", 1, t0 + WINDOW)).allowed).toBe(false);
+
+      await limiter.reset();
+      expect((await limiter.check("fresh", 1, t0 + WINDOW)).allowed).toBe(true);
+    });
+  });
+}

--- a/packages/api/src/lib/__tests__/trial-abuse.test.ts
+++ b/packages/api/src/lib/__tests__/trial-abuse.test.ts
@@ -43,8 +43,8 @@ afterAll(() => {
   restore("ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM", ORIG_EMAIL);
 });
 
-beforeEach(() => {
-  resetTrialAttemptRateLimits();
+beforeEach(async () => {
+  await resetTrialAttemptRateLimits();
   // High IP ceiling by default so per-email tests aren't shadowed by the IP
   // bucket, and vice versa. Individual tests narrow the relevant knob.
   process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1000";
@@ -75,105 +75,105 @@ describe("limit resolution", () => {
 });
 
 describe("per-IP attempt window", () => {
-  test("allows up to the IP limit, then blocks with retry guidance", () => {
+  test("allows up to the IP limit, then blocks with retry guidance", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "3";
     // Distinct emails so only the IP bucket can trip.
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" }).allowed).toBe(true);
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" }).allowed).toBe(true);
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "c@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" })).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" })).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "c@x.com" })).allowed).toBe(true);
     const blocked = expectBlocked(
-      checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "d@x.com" }),
+      await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "d@x.com" }),
     );
     expect(blocked.bucket).toBe("ip");
     expect(blocked.retryAfterMs).toBeGreaterThan(0);
   });
 
-  test("distinct IPs do not share the window (shared-NAT attempts are not capped per trial)", () => {
+  test("distinct IPs do not share the window (shared-NAT attempts are not capped per trial)", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1";
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" }).allowed).toBe(true);
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" }).allowed).toBe(false);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" })).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" })).allowed).toBe(false);
     // Different IP — fresh budget.
-    expect(checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "c@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "c@x.com" })).allowed).toBe(true);
   });
 
-  test("null IP collapses to a single shared bucket", () => {
+  test("null IP collapses to a single shared bucket", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1";
-    expect(checkTrialAttemptRateLimit({ ip: null, email: "a@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: null, email: "a@x.com" })).allowed).toBe(true);
     const blocked = expectBlocked(
-      checkTrialAttemptRateLimit({ ip: null, email: "b@x.com" }),
+      await checkTrialAttemptRateLimit({ ip: null, email: "b@x.com" }),
     );
     expect(blocked.bucket).toBe("ip");
   });
 });
 
 describe("per-email attempt window", () => {
-  test("allows up to the email limit, then blocks", () => {
+  test("allows up to the email limit, then blocks", async () => {
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "2";
     // Distinct IPs so only the email bucket can trip.
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "spam@x.com" }).allowed).toBe(true);
-    expect(checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "spam@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "spam@x.com" })).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "spam@x.com" })).allowed).toBe(true);
     const blocked = expectBlocked(
-      checkTrialAttemptRateLimit({ ip: "3.3.3.3", email: "spam@x.com" }),
+      await checkTrialAttemptRateLimit({ ip: "3.3.3.3", email: "spam@x.com" }),
     );
     expect(blocked.bucket).toBe("email");
     expect(blocked.retryAfterMs).toBeGreaterThan(0);
   });
 
-  test("email matching is case-insensitive + trimmed", () => {
+  test("email matching is case-insensitive + trimmed", async () => {
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "1";
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "Spam@X.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "Spam@X.com" })).allowed).toBe(true);
     const blocked = expectBlocked(
-      checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "  spam@x.com " }),
+      await checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "  spam@x.com " }),
     );
     expect(blocked.bucket).toBe("email");
   });
 });
 
 describe("blocked attempts are not recorded", () => {
-  test("a blocked attempt does not consume the OTHER bucket's budget", () => {
+  test("a blocked attempt does not consume the OTHER bucket's budget", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1";
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "5";
     // Burn the IP bucket.
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "e@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "e@x.com" })).allowed).toBe(true);
     // This trips on IP — must NOT charge the email bucket for "e2@x.com".
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "e2@x.com" }).allowed).toBe(false);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "e2@x.com" })).allowed).toBe(false);
     // A fresh IP with that same email still has its full email budget.
-    expect(checkTrialAttemptRateLimit({ ip: "9.9.9.9", email: "e2@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "9.9.9.9", email: "e2@x.com" })).allowed).toBe(true);
   });
 });
 
 describe("disabled limits", () => {
-  test("0 disables a bucket", () => {
+  test("0 disables a bucket", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "0";
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "0";
     expect(getTrialIpRpmLimit()).toBe(0);
     for (let i = 0; i < 50; i++) {
-      expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "x@x.com" }).allowed).toBe(true);
+      expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "x@x.com" })).allowed).toBe(true);
     }
   });
 });
 
 describe("recovery after reset", () => {
-  test("resetTrialAttemptRateLimits frees both windows", () => {
+  test("resetTrialAttemptRateLimits frees both windows", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1";
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" }).allowed).toBe(true);
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" }).allowed).toBe(false);
-    resetTrialAttemptRateLimits();
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "a@x.com" })).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "b@x.com" })).allowed).toBe(false);
+    await resetTrialAttemptRateLimits();
     // Window cleared — the IP recovers a full budget (simulates the passage
     // of the window, as in contact.test.ts).
-    expect(checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "c@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "c@x.com" })).allowed).toBe(true);
   });
 });
 
 describe("trialAttemptCleanupTick", () => {
-  test("evicts fully-stale buckets", () => {
+  test("evicts fully-stale buckets", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "2";
-    checkTrialAttemptRateLimit({ ip: "ip-evict", email: "a@x.com" });
-    resetTrialAttemptRateLimits();
-    checkTrialAttemptRateLimit({ ip: "ip-recent", email: "b@x.com" });
-    trialAttemptCleanupTick();
+    await checkTrialAttemptRateLimit({ ip: "ip-evict", email: "a@x.com" });
+    await resetTrialAttemptRateLimits();
+    await checkTrialAttemptRateLimit({ ip: "ip-recent", email: "b@x.com" });
+    await trialAttemptCleanupTick();
     // ip-evict is gone (reset cleared it); ip-recent still has budget.
-    expect(checkTrialAttemptRateLimit({ ip: "ip-recent", email: "c@x.com" }).allowed).toBe(true);
+    expect((await checkTrialAttemptRateLimit({ ip: "ip-recent", email: "c@x.com" })).allowed).toBe(true);
   });
 });
 
@@ -181,38 +181,38 @@ describe("trialAttemptCleanupTick", () => {
 // just a per-replica log. Spy on the singleton counter's `.add` (works under
 // the no-op meter, which exposes no value).
 describe("rejection metric (#3796)", () => {
-  test("increments the counter with limiter=ip when the IP window trips", () => {
+  test("increments the counter with limiter=ip when the IP window trips", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1";
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "1000";
     const add = spyOn(trialAbuseRejections, "add");
     try {
-      checkTrialAttemptRateLimit({ ip: "9.9.9.9", email: "a@x.com" }); // allowed
-      checkTrialAttemptRateLimit({ ip: "9.9.9.9", email: "b@x.com" }); // IP trips
+      await checkTrialAttemptRateLimit({ ip: "9.9.9.9", email: "a@x.com" }); // allowed
+      await checkTrialAttemptRateLimit({ ip: "9.9.9.9", email: "b@x.com" }); // IP trips
       expect(add).toHaveBeenCalledWith(1, { limiter: "ip" });
     } finally {
       add.mockRestore();
     }
   });
 
-  test("increments the counter with limiter=email when the email window trips", () => {
+  test("increments the counter with limiter=email when the email window trips", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1000";
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "1";
     const add = spyOn(trialAbuseRejections, "add");
     try {
-      checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "same@x.com" }); // allowed
-      checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "same@x.com" }); // email trips
+      await checkTrialAttemptRateLimit({ ip: "1.1.1.1", email: "same@x.com" }); // allowed
+      await checkTrialAttemptRateLimit({ ip: "2.2.2.2", email: "same@x.com" }); // email trips
       expect(add).toHaveBeenCalledWith(1, { limiter: "email" });
     } finally {
       add.mockRestore();
     }
   });
 
-  test("does not increment when the attempt is allowed", () => {
+  test("does not increment when the attempt is allowed", async () => {
     process.env.ATLAS_TRIAL_IP_RATE_LIMIT_RPM = "1000";
     process.env.ATLAS_TRIAL_EMAIL_RATE_LIMIT_RPM = "1000";
     const add = spyOn(trialAbuseRejections, "add");
     try {
-      checkTrialAttemptRateLimit({ ip: "3.3.3.3", email: "ok@x.com" });
+      await checkTrialAttemptRateLimit({ ip: "3.3.3.3", email: "ok@x.com" });
       expect(add).not.toHaveBeenCalled();
     } finally {
       add.mockRestore();

--- a/packages/api/src/lib/contact.ts
+++ b/packages/api/src/lib/contact.ts
@@ -5,18 +5,23 @@
  * contact form should be a rare event per visitor (5 submissions per
  * minute is plenty for a sales conversation; 30+ is abuse).
  *
- * The map-of-arrays implementation matches the demo limiter so an
- * operator who looks at one understands the other. A future Redis
- * backend would replace both call sites uniformly.
+ * Storage is the shared {@link createSlidingWindowLimiter} seam (#4129) — the same
+ * limiter `lib/demo.ts` / `lib/trial-abuse.ts` use, so the Redis adapter that
+ * makes this window shared across replicas/regions lands once (at the store)
+ * without touching this call site. The per-process limitation is documented at
+ * that seam (`lib/sliding-window-rate-limit.ts`).
  */
 
 import { createLogger } from "./logger";
 import { getSettingAuto } from "@atlas/api/lib/settings";
+import {
+  createSlidingWindowLimiter,
+  type RateLimitDecision,
+} from "@atlas/api/lib/sliding-window-rate-limit";
 
 const log = createLogger("contact");
 
 const CONTACT_DEFAULT_RPM = 5;
-const WINDOW_MS = 60_000;
 
 let lastWarnedRpm: string | undefined;
 
@@ -38,57 +43,26 @@ export function getContactRpmLimit(): number {
   return Math.floor(n);
 }
 
-const contactWindows = new Map<string, number[]>();
+const contactLimiter = createSlidingWindowLimiter();
 
 /**
- * Sliding-window rate limit keyed by IP.
- * Returns `{ allowed: true }` or `{ allowed: false, retryAfterMs }`.
+ * Sliding-window rate limit keyed by IP. The discriminated `RateLimitDecision`
+ * carries `retryAfterMs` IFF blocked, so callers read it after `!allowed`
+ * without a fallback.
  */
-export function checkContactRateLimit(ip: string): {
-  allowed: boolean;
-  retryAfterMs?: number;
-} {
-  const limit = getContactRpmLimit();
-  if (limit === 0) return { allowed: true };
-
-  const now = Date.now();
-  const cutoff = now - WINDOW_MS;
-  const key = ip;
-
-  let timestamps = contactWindows.get(key);
-  if (!timestamps) {
-    timestamps = [];
-    contactWindows.set(key, timestamps);
-  }
-
-  // Evict stale entries (matches demo limiter — single-pass, in-place).
-  const firstValid = timestamps.findIndex((t) => t > cutoff);
-  if (firstValid > 0) timestamps.splice(0, firstValid);
-  else if (firstValid === -1) timestamps.length = 0;
-
-  if (timestamps.length < limit) {
-    timestamps.push(now);
-    return { allowed: true };
-  }
-
-  const retryAfterMs = Math.max(1, timestamps[0] + WINDOW_MS - now);
-  return { allowed: false, retryAfterMs };
+export function checkContactRateLimit(ip: string): Promise<RateLimitDecision> {
+  return contactLimiter.check(ip, getContactRpmLimit());
 }
 
 /** Clear rate limit state. For tests. */
-export function resetContactRateLimits(): void {
-  contactWindows.clear();
+export function resetContactRateLimits(): Promise<void> {
+  return contactLimiter.reset();
 }
 
 /**
  * Evict stale entries — matches `demoCleanupTick` shape so the
  * SchedulerLayer can call it on the same cadence.
  */
-export function contactCleanupTick(): void {
-  const cutoff = Date.now() - WINDOW_MS;
-  for (const [key, timestamps] of contactWindows) {
-    if (timestamps.length === 0 || timestamps[timestamps.length - 1] <= cutoff) {
-      contactWindows.delete(key);
-    }
-  }
+export function contactCleanupTick(): Promise<void> {
+  return contactLimiter.cleanup();
 }

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -14,6 +14,11 @@ import { SaasCrm } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { getDefaultProvider, getModelForConfig } from "@atlas/api/lib/providers";
+import {
+  createSlidingWindowLimiter,
+  RATE_LIMIT_WINDOW_MS,
+  type RateLimitDecision,
+} from "@atlas/api/lib/sliding-window-rate-limit";
 import type { AtlasAiModelShape } from "@atlas/api/lib/effect/ai";
 
 const log = createLogger("demo");
@@ -268,63 +273,31 @@ export function demoUserId(email: string): string {
 // Demo rate limiter (separate from main rate limiter)
 // ---------------------------------------------------------------------------
 
-const WINDOW_MS = 60_000;
-const demoWindows = new Map<string, number[]>();
+const demoLimiter = createSlidingWindowLimiter();
 
 /**
- * Sliding-window rate limit for demo users.
- * Returns `{ allowed: true }` or `{ allowed: false, retryAfterMs }`.
+ * Sliding-window rate limit for demo users. The discriminated `RateLimitDecision`
+ * carries `retryAfterMs` IFF blocked, so callers read it after `!allowed`
+ * without a fallback.
  */
-export function checkDemoRateLimit(email: string): {
-  allowed: boolean;
-  retryAfterMs?: number;
-} {
-  const limit = getDemoRpmLimit();
-  if (limit === 0) return { allowed: true };
-
-  const now = Date.now();
-  const cutoff = now - WINDOW_MS;
-  const key = demoUserId(email);
-
-  let timestamps = demoWindows.get(key);
-  if (!timestamps) {
-    timestamps = [];
-    demoWindows.set(key, timestamps);
-  }
-
-  // Evict stale entries
-  const firstValid = timestamps.findIndex((t) => t > cutoff);
-  if (firstValid > 0) timestamps.splice(0, firstValid);
-  else if (firstValid === -1) timestamps.length = 0;
-
-  if (timestamps.length < limit) {
-    timestamps.push(now);
-    return { allowed: true };
-  }
-
-  const retryAfterMs = Math.max(1, timestamps[0] + WINDOW_MS - now);
-  return { allowed: false, retryAfterMs };
+export function checkDemoRateLimit(email: string): Promise<RateLimitDecision> {
+  return demoLimiter.check(demoUserId(email), getDemoRpmLimit());
 }
 
 /** Clear demo rate limit state. For tests. */
-export function resetDemoRateLimits(): void {
-  demoWindows.clear();
+export function resetDemoRateLimits(): Promise<void> {
+  return demoLimiter.reset();
 }
 
 /** Interval for demo rate-limit cleanup. Exported for SchedulerLayer. */
-export const DEMO_CLEANUP_INTERVAL_MS = WINDOW_MS;
+export const DEMO_CLEANUP_INTERVAL_MS = RATE_LIMIT_WINDOW_MS;
 
 /**
  * Evict stale demo rate-limit entries. Called periodically by the
  * SchedulerLayer fiber in lib/effect/layers.ts.
  */
-export function demoCleanupTick(): void {
-  const cutoff = Date.now() - WINDOW_MS;
-  for (const [key, timestamps] of demoWindows) {
-    if (timestamps.length === 0 || timestamps[timestamps.length - 1] <= cutoff) {
-      demoWindows.delete(key);
-    }
-  }
+export function demoCleanupTick(): Promise<void> {
+  return demoLimiter.cleanup();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -2110,13 +2110,13 @@ export function makeSchedulerLive(
       );
 
       // ── Periodic fiber: demo rate-limit cleanup — interval from DEMO_CLEANUP_INTERVAL_MS ──
-      const demoTick = Effect.try({
-        try: () => {
+      const demoTick = Effect.tryPromise({
+        try: async () => {
           // eslint-disable-next-line @typescript-eslint/no-require-imports
           const { demoCleanupTick } = require("@atlas/api/lib/demo") as {
-            demoCleanupTick: () => void;
+            demoCleanupTick: () => Promise<void>;
           };
-          demoCleanupTick();
+          await demoCleanupTick();
         },
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(
@@ -2147,13 +2147,13 @@ export function makeSchedulerLive(
       // Unauthenticated public endpoint with a per-IP map; without
       // periodic eviction the map leaks one entry per distinct source IP
       // until process restart.
-      const contactTick = Effect.try({
-        try: () => {
+      const contactTick = Effect.tryPromise({
+        try: async () => {
           // eslint-disable-next-line @typescript-eslint/no-require-imports
           const { contactCleanupTick } = require("@atlas/api/lib/contact") as {
-            contactCleanupTick: () => void;
+            contactCleanupTick: () => Promise<void>;
           };
-          contactCleanupTick();
+          await contactCleanupTick();
         },
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(
@@ -2182,13 +2182,13 @@ export function makeSchedulerLive(
       // trims timestamps WITHIN a live entry, never removes the key, so
       // without this sweep a spammer cycling distinct IPs/emails grows the
       // maps until restart. `trialAttemptCleanupTick` evicts fully-stale keys.
-      const trialTick = Effect.try({
-        try: () => {
+      const trialTick = Effect.tryPromise({
+        try: async () => {
           // eslint-disable-next-line @typescript-eslint/no-require-imports
           const { trialAttemptCleanupTick } = require("@atlas/api/lib/trial-abuse") as {
-            trialAttemptCleanupTick: () => void;
+            trialAttemptCleanupTick: () => Promise<void>;
           };
-          trialAttemptCleanupTick();
+          await trialAttemptCleanupTick();
         },
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(

--- a/packages/api/src/lib/sliding-window-rate-limit.ts
+++ b/packages/api/src/lib/sliding-window-rate-limit.ts
@@ -1,0 +1,203 @@
+/**
+ * Sliding-window rate limiter with a swappable store (#4129).
+ *
+ * Consolidates the three byte-for-byte-identical Map-of-timestamps sliding
+ * windows that v0.0.19 grew on the unauthenticated public surface
+ * (`lib/trial-abuse.ts` per-IP + per-email, `lib/contact.ts` per-IP,
+ * `lib/demo.ts` per-email) into ONE limiter behind a store interface.
+ *
+ * The window *algorithm* lives here once; the *storage* is pluggable via
+ * {@link SlidingWindowStore}. The only adapter that ships today is the
+ * per-process {@link createInMemorySlidingWindowStore}; a Redis adapter is a
+ * drop-in follow-up (see the seam note below).
+ *
+ * ── The multi-instance limitation (the reason this seam exists) ──────────────
+ * The in-memory adapter holds its window in a per-process `Map`, and each
+ * regional API service is an independent process that scales to N replicas
+ * under load (today the regions are US / EU / APAC). So a per-IP cap of R RPM
+ * is really enforced as `R × replicas-per-region` within a region and is
+ * fragmented across regions entirely — the effective ceiling on exactly the
+ * unauthenticated trial / demo / contact surface you'd scale under launch load
+ * is `R × (total replicas across all regions)`. This is LATENT at one replica
+ * per region but activates on any horizontal scale-up.
+ *
+ * The fix is a process-external store. Because every {@link SlidingWindowStore}
+ * method is async, a Redis adapter (a sorted set per key: `ZADD` to record,
+ * `ZREMRANGEBYSCORE` + `ZCARD` to read, per-key TTL for eviction) is a drop-in
+ * that makes the window shared across replicas AND regions WITHOUT touching any
+ * call site — the limiter, `trial-abuse.ts`, `contact.ts`, `demo.ts`, and their
+ * routes already `await`. That Redis adapter is a not-yet-filed follow-up
+ * (parent umbrella #3801; this seam landed in #4129); until it lands, the
+ * fragmentation above stands.
+ *
+ * Note on atomicity: a check spans `await`s (read, then record). With the
+ * in-memory adapter those awaits do NO real I/O and resolve on the microtask
+ * queue, which drains fully before the next request's macrotask — so one
+ * request's read→record pair completes before another request's check begins.
+ * The pair is therefore effectively atomic per process, preserving the
+ * synchronous originals' behavior (single-threaded-ness alone would NOT
+ * guarantee this — the load-bearing property is the absence of a real I/O
+ * suspension between read and record). A networked adapter (Redis) introduces
+ * exactly that suspension, so concurrent same-key requests can interleave and
+ * admit a few past the cap. That race is acceptable for abuse control (a
+ * handful of extra requests slipping a burst window is not a security boundary)
+ * and can be tightened later with a Lua script — it is NOT a reason to keep the
+ * store in-process.
+ */
+
+/** The window every public-surface limiter uses: one minute. */
+export const RATE_LIMIT_WINDOW_MS = 60_000;
+
+/** A non-recording snapshot of a key's live window. */
+export interface WindowSnapshot {
+  /** Count of attempts still within `[now - windowMs, now]` after eviction. */
+  readonly count: number;
+  /** Oldest surviving timestamp (ms), or `undefined` when the window is empty. */
+  readonly oldest: number | undefined;
+}
+
+/**
+ * Storage backing a sliding window. Every method is async so a process-external
+ * adapter (Redis) is a drop-in for {@link createInMemorySlidingWindowStore}
+ * without changing the limiter or any call site.
+ *
+ * Keys are opaque strings — the caller owns key derivation (IP, lowercased
+ * email, hashed user id) so distinct logical buckets never collide.
+ */
+export interface SlidingWindowStore {
+  /**
+   * Evict timestamps older than `now - windowMs` for `key`, then return the
+   * surviving {@link WindowSnapshot}. Non-recording: it never adds the current
+   * attempt, so a caller can check several windows and commit to none.
+   */
+  read(key: string, windowMs: number, now: number): Promise<WindowSnapshot>;
+  /** Record an attempt timestamp for `key`. */
+  append(key: string, timestamp: number): Promise<void>;
+  /** Evict every key whose window is fully stale (periodic memory reclaim). */
+  evictStale(windowMs: number, now: number): Promise<void>;
+  /** Drop all state. Test helper / window-reset simulation. */
+  clear(): Promise<void>;
+}
+
+/**
+ * Outcome of a window check. Discriminated on `allowed` so `retryAfterMs` is
+ * present IFF blocked — a `{ allowed: true }` can't carry a stray retry, and a
+ * consumer that branches on `!allowed` reads `retryAfterMs` without a fallback
+ * or a non-null assertion.
+ */
+export type RateLimitDecision =
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      /** Milliseconds until the window frees a slot. */
+      readonly retryAfterMs: number;
+    };
+
+/**
+ * A sliding-window limiter over a {@link SlidingWindowStore}. `limit` is passed
+ * per call (not fixed at construction) so a hot-reloadable, settings-backed RPM
+ * is read fresh by the caller each time. `limit === 0` disables the bucket:
+ * always allowed, never recorded, never touches the store.
+ */
+export interface SlidingWindowLimiter {
+  /**
+   * Non-mutating check — evicts stale entries and reports the decision but does
+   * NOT record. Lets a caller gate on several windows and record only once all
+   * pass (the per-IP + per-email trial pattern), so a bucket that passes is not
+   * charged for an attempt a later bucket blocks. Pass an explicit shared `now`
+   * across a multi-window check.
+   */
+  peek(key: string, limit: number, now?: number): Promise<RateLimitDecision>;
+  /** Record an attempt. No-op when `limit === 0`. */
+  record(key: string, limit: number, now?: number): Promise<void>;
+  /** {@link peek} then {@link record} iff allowed — the single-bucket path. */
+  check(key: string, limit: number, now?: number): Promise<RateLimitDecision>;
+  /** Evict fully-stale keys. Called periodically by the SchedulerLayer fiber. */
+  cleanup(now?: number): Promise<void>;
+  /** Drop all state. Test helper / window-reset simulation. */
+  reset(): Promise<void>;
+}
+
+/**
+ * Per-process in-memory store: a `Map` of key → ascending attempt timestamps.
+ * Eviction is a single in-place pass (the shape every call site already used).
+ * This is the only adapter that ships today — see the multi-instance note at
+ * the top of the file for why a Redis adapter is the eventual replacement.
+ */
+export function createInMemorySlidingWindowStore(): SlidingWindowStore {
+  const windows = new Map<string, number[]>();
+
+  function bucket(key: string): number[] {
+    let timestamps = windows.get(key);
+    if (!timestamps) {
+      timestamps = [];
+      windows.set(key, timestamps);
+    }
+    return timestamps;
+  }
+
+  return {
+    async read(key, windowMs, now) {
+      const cutoff = now - windowMs;
+      const timestamps = bucket(key);
+      // Evict stale entries in place (single pass — they're ascending).
+      const firstValid = timestamps.findIndex((t) => t > cutoff);
+      if (firstValid > 0) timestamps.splice(0, firstValid);
+      else if (firstValid === -1) timestamps.length = 0;
+      return { count: timestamps.length, oldest: timestamps[0] };
+    },
+    async append(key, timestamp) {
+      bucket(key).push(timestamp);
+    },
+    async evictStale(windowMs, now) {
+      const cutoff = now - windowMs;
+      for (const [key, timestamps] of windows) {
+        if (timestamps.length === 0 || timestamps[timestamps.length - 1]! <= cutoff) {
+          windows.delete(key);
+        }
+      }
+    },
+    async clear() {
+      windows.clear();
+    },
+  } satisfies SlidingWindowStore;
+}
+
+/**
+ * Build a {@link SlidingWindowLimiter}. Defaults to a fresh in-memory store and
+ * the one-minute {@link RATE_LIMIT_WINDOW_MS} window; pass `store` to swap in a
+ * process-external adapter (the Redis follow-up) with no other change.
+ */
+export function createSlidingWindowLimiter(opts?: {
+  store?: SlidingWindowStore;
+  windowMs?: number;
+}): SlidingWindowLimiter {
+  const store = opts?.store ?? createInMemorySlidingWindowStore();
+  const windowMs = opts?.windowMs ?? RATE_LIMIT_WINDOW_MS;
+
+  async function peek(key: string, limit: number, now = Date.now()): Promise<RateLimitDecision> {
+    if (limit === 0) return { allowed: true };
+    const { count, oldest } = await store.read(key, windowMs, now);
+    if (count < limit) return { allowed: true };
+    // count >= limit >= 1 here, so `oldest` is defined; `?? now` is defensive.
+    const retryAfterMs = Math.max(1, (oldest ?? now) + windowMs - now);
+    return { allowed: false, retryAfterMs };
+  }
+
+  async function record(key: string, limit: number, now = Date.now()): Promise<void> {
+    if (limit === 0) return;
+    await store.append(key, now);
+  }
+
+  return {
+    peek,
+    record,
+    async check(key, limit, now = Date.now()) {
+      const decision = await peek(key, limit, now);
+      if (decision.allowed) await record(key, limit, now);
+      return decision;
+    },
+    cleanup: (now = Date.now()) => store.evictStale(windowMs, now),
+    reset: () => store.clear(),
+  } satisfies SlidingWindowLimiter;
+}

--- a/packages/api/src/lib/trial-abuse.ts
+++ b/packages/api/src/lib/trial-abuse.ts
@@ -17,9 +17,12 @@
  * burst from one source is throttled while a steady trickle of distinct
  * legitimate signups behind the same NAT is not.
  *
- * Map-of-arrays implementation deliberately matches `lib/contact.ts` /
- * `lib/demo.ts` so an operator who understands one understands all three; a
- * future Redis backend would replace every call site uniformly.
+ * Storage is the shared {@link createSlidingWindowLimiter} seam (#4129) — the same
+ * limiter `lib/contact.ts` / `lib/demo.ts` use, so an operator who understands
+ * one understands all three, and the Redis adapter that makes these windows
+ * shared across replicas/regions lands once (at the store) without touching any
+ * of these three call sites. The per-process limitation is documented at that
+ * seam (`lib/sliding-window-rate-limit.ts`).
  *
  * Per-IP windows degrade gracefully: when the client IP is unknown (no
  * `ATLAS_TRUST_PROXY` behind the proxy), the caller passes `null` and every
@@ -31,6 +34,10 @@
 import { createLogger } from "./logger";
 import { getSettingAuto } from "@atlas/api/lib/settings";
 import { trialAbuseRejections } from "@atlas/api/lib/metrics";
+import {
+  createSlidingWindowLimiter,
+  RATE_LIMIT_WINDOW_MS,
+} from "@atlas/api/lib/sliding-window-rate-limit";
 
 const log = createLogger("trial-abuse");
 
@@ -38,7 +45,6 @@ const log = createLogger("trial-abuse");
 const TRIAL_IP_DEFAULT_RPM = 5;
 /** Per-email attempts/minute. Tighter — one mailbox retrying many times is abuse. */
 const TRIAL_EMAIL_DEFAULT_RPM = 3;
-const WINDOW_MS = 60_000;
 
 /** Fallback bucket when the client IP is unknown (no trusted proxy). */
 const ANON_IP_KEY = "anon-trial";
@@ -92,51 +98,11 @@ export function getTrialEmailRpmLimit(): number {
   return v;
 }
 
-const ipWindows = new Map<string, number[]>();
-const emailWindows = new Map<string, number[]>();
-
-/**
- * Non-mutating sliding-window check. Evicts stale timestamps in place (so the
- * window self-trims) but does NOT record the current attempt — the caller
- * records only once BOTH buckets pass, so a request blocked on the second
- * bucket never inflates the first bucket's count.
- *
- * `limit === 0` disables the bucket (always allowed, never recorded).
- */
-function peek(
-  windows: Map<string, number[]>,
-  key: string,
-  limit: number,
-  now: number,
-): { allowed: true } | { allowed: false; retryAfterMs: number } {
-  if (limit === 0) return { allowed: true };
-
-  const cutoff = now - WINDOW_MS;
-  let timestamps = windows.get(key);
-  if (!timestamps) {
-    timestamps = [];
-    windows.set(key, timestamps);
-  }
-
-  // Evict stale entries (single-pass, in-place — matches the contact limiter).
-  const firstValid = timestamps.findIndex((t) => t > cutoff);
-  if (firstValid > 0) timestamps.splice(0, firstValid);
-  else if (firstValid === -1) timestamps.length = 0;
-
-  if (timestamps.length < limit) return { allowed: true };
-  const retryAfterMs = Math.max(1, timestamps[0]! + WINDOW_MS - now);
-  return { allowed: false, retryAfterMs };
-}
-
-function record(windows: Map<string, number[]>, key: string, limit: number, now: number): void {
-  if (limit === 0) return;
-  let timestamps = windows.get(key);
-  if (!timestamps) {
-    timestamps = [];
-    windows.set(key, timestamps);
-  }
-  timestamps.push(now);
-}
+// Two independent windows over the shared limiter seam: one keyed by IP, one by
+// email. Separate limiters (separate stores) keep the key spaces from colliding
+// — the same isolation the previous two-Map implementation gave.
+const ipLimiter = createSlidingWindowLimiter({ windowMs: RATE_LIMIT_WINDOW_MS });
+const emailLimiter = createSlidingWindowLimiter({ windowMs: RATE_LIMIT_WINDOW_MS });
 
 /** Which bucket tripped — surfaced for structured logging, never to the caller's user. */
 export type TrialAttemptBucket = "ip" | "email";
@@ -168,10 +134,10 @@ export type TrialAttemptRateLimitResult =
  * `ip` may be `null` (unknown client IP) — it collapses to a shared bucket.
  * `email` is lower-cased + trimmed so case variants share a window.
  */
-export function checkTrialAttemptRateLimit(input: {
+export async function checkTrialAttemptRateLimit(input: {
   ip: string | null;
   email: string;
-}): TrialAttemptRateLimitResult {
+}): Promise<TrialAttemptRateLimitResult> {
   const ipLimit = getTrialIpRpmLimit();
   const emailLimit = getTrialEmailRpmLimit();
 
@@ -181,7 +147,7 @@ export function checkTrialAttemptRateLimit(input: {
 
   // Check IP first, then email. Record in NEITHER until both pass so the
   // first-checked bucket isn't charged for an attempt the second bucket blocks.
-  const ipCheck = peek(ipWindows, ipKey, ipLimit, now);
+  const ipCheck = await ipLimiter.peek(ipKey, ipLimit, now);
   if (!ipCheck.allowed) {
     // Observability (#3796): aggregate per-replica in-memory rejections at the
     // collector so a fleet-wide attack is a graphable/alertable series, not
@@ -189,34 +155,29 @@ export function checkTrialAttemptRateLimit(input: {
     trialAbuseRejections.add(1, { limiter: "ip" });
     return { allowed: false, bucket: "ip", retryAfterMs: ipCheck.retryAfterMs };
   }
-  const emailCheck = peek(emailWindows, emailKey, emailLimit, now);
+  const emailCheck = await emailLimiter.peek(emailKey, emailLimit, now);
   if (!emailCheck.allowed) {
     trialAbuseRejections.add(1, { limiter: "email" });
     return { allowed: false, bucket: "email", retryAfterMs: emailCheck.retryAfterMs };
   }
 
-  record(ipWindows, ipKey, ipLimit, now);
-  record(emailWindows, emailKey, emailLimit, now);
+  await ipLimiter.record(ipKey, ipLimit, now);
+  await emailLimiter.record(emailKey, emailLimit, now);
   return { allowed: true };
 }
 
 /** Clear all rate-limit state. For tests. */
-export function resetTrialAttemptRateLimits(): void {
-  ipWindows.clear();
-  emailWindows.clear();
+export async function resetTrialAttemptRateLimits(): Promise<void> {
+  await ipLimiter.reset();
+  await emailLimiter.reset();
 }
 
 /**
  * Evict fully-stale buckets — matches `contactCleanupTick` shape so the
  * SchedulerLayer can sweep all the public limiters on one cadence.
  */
-export function trialAttemptCleanupTick(): void {
-  const cutoff = Date.now() - WINDOW_MS;
-  for (const windows of [ipWindows, emailWindows]) {
-    for (const [key, timestamps] of windows) {
-      if (timestamps.length === 0 || timestamps[timestamps.length - 1]! <= cutoff) {
-        windows.delete(key);
-      }
-    }
-  }
+export async function trialAttemptCleanupTick(): Promise<void> {
+  const now = Date.now();
+  await ipLimiter.cleanup(now);
+  await emailLimiter.cleanup(now);
 }

--- a/packages/mcp/src/__tests__/onboarding.test.ts
+++ b/packages/mcp/src/__tests__/onboarding.test.ts
@@ -50,7 +50,7 @@ import {
 const OK_TOKEN = "tok-ok";
 /** Default test stubs: Turnstile passes, rate limit allows. */
 const passTurnstile: VerifyTurnstileFn = async () => ({ ok: true });
-const allowRate: TrialAttemptLimiter = () => ({ allowed: true });
+const allowRate: TrialAttemptLimiter = async () => ({ allowed: true });
 
 // The elicitation requestState is HMAC'd from BETTER_AUTH_SECRET; set one for
 // the round-trip test and restore after (self-contained, no top-level mutation).
@@ -439,7 +439,7 @@ describe("start_trial abuse controls (#3654)", () => {
       verifyCalled = true;
       return { ok: true };
     };
-    const checkRateLimit: TrialAttemptLimiter = () => ({
+    const checkRateLimit: TrialAttemptLimiter = async () => ({
       allowed: false,
       bucket: "email",
       retryAfterMs: 42_000,
@@ -464,7 +464,7 @@ describe("start_trial abuse controls (#3654)", () => {
   it("passes the resolved email to the rate limiter and recovers once it clears", async () => {
     const seen: Array<{ ip: string | null; email: string }> = [];
     let trip = true;
-    const checkRateLimit: TrialAttemptLimiter = (input) => {
+    const checkRateLimit: TrialAttemptLimiter = async (input) => {
       seen.push(input);
       return trip
         ? { allowed: false, bucket: "ip", retryAfterMs: 1000 }

--- a/packages/mcp/src/onboarding.ts
+++ b/packages/mcp/src/onboarding.ts
@@ -80,7 +80,7 @@ export type VerifyTurnstileFn = (opts: {
 export type TrialAttemptLimiter = (input: {
   ip: string | null;
   email: string;
-}) => TrialAttemptRateLimitResult;
+}) => Promise<TrialAttemptRateLimitResult>;
 
 export interface RegisterStartTrialOptions {
   /** Override the provisioner (tests inject a stub). */
@@ -270,7 +270,7 @@ export function registerStartTrialTool(
         // spam before it can burn a Turnstile round-trip or a DB write), then
         // Turnstile. The limiter bounds creation ATTEMPTS per-IP/per-email —
         // NOT trials per IP (shared NATs must keep signing up).
-        const rate = checkRateLimit({ ip: clientIp, email: input.email });
+        const rate = await checkRateLimit({ ip: clientIp, email: input.email });
         if (!rate.allowed) {
           const retryAfter = Math.ceil(rate.retryAfterMs / 1000);
           log.warn(


### PR DESCRIPTION
Closes #4129.

## What

Consolidates the three byte-identical in-process `Map`-of-timestamps sliding-window rate limiters on the **unauthenticated public surface** — `trial-abuse.ts` (per-IP + per-email), `contact.ts` (per-IP), `demo.ts` (per-email) — into **one async limiter behind a swappable `SlidingWindowStore` interface** (`packages/api/src/lib/sliding-window-rate-limit.ts`).

## Why (correctness, not just cleanliness)

The limiter guards the unauthenticated trial-signup / demo / contact surface. Each regional API service (US / EU / APAC) is an independent process holding its **own** in-process window, and each scales to N replicas under load — so the per-IP cap is effectively `R × (total replicas across all regions)`. Latent at one replica per region, it **activates on exactly the horizontal scale-up you'd do under launch load**. The seam makes the eventual fix (a process-external Redis store) a drop-in.

## How

- **New `lib/sliding-window-rate-limit.ts`** — async `SlidingWindowStore` interface + `InMemorySlidingWindowStore` adapter + `SlidingWindowLimiter`. Because every store method is async, a Redis adapter (sorted set per key) shares the window across replicas/regions **without touching any call site**. The multi-instance limitation is documented at the seam (and the atomicity note is precise: the in-memory adapter is effectively atomic per process via microtask draining; the read/record race appears only with a networked adapter).
- `RateLimitDecision` is a **discriminated union** — `retryAfterMs` present IFF blocked — so consumers read it after `!allowed` with no fallback or non-null assertion.
- `trial-abuse` / `contact` / `demo` refactored onto it; `check` / `reset` / `cleanup` are now async.
- Call sites awaited: contact / demo / starter-prompts routes (`Effect.gen` handlers via `yield* Effect.promise`, plain async handlers via `await`) and the MCP onboarding limiter; the three scheduler cleanup ticks switched `Effect.try` → `Effect.tryPromise`.

## Behavior preserved (in-memory adapter)

Same per-IP / per-email RPM, same anon-IP graceful degradation, same two-phase **record-in-neither-bucket-until-both-pass** semantics, same settings-backed limits (`ATLAS_*_RATE_LIMIT_RPM`) and `trialAbuseRejections` metrics. A store rejection (impossible in-memory; relevant for the Redis follow-up) fails **closed** — `runEffect` maps it to a 500 with `requestId`.

## Acceptance criteria

- [x] One `rate-limiter` module with a swappable store interface, consumed by all three call sites (no per-call-site `Map`)
- [x] Store interface is process-external-ready — a Redis adapter shares the window across replicas/regions without touching any call site
- [x] Behavior preserved under the in-memory adapter
- [x] Multi-instance limitation documented at the seam; a test covers the window logic against the store **interface** (parametrized over two distinct stores), not a concrete `Map`

## Tests

New `sliding-window-rate-limit.test.ts` runs every window-logic case over **two conforming stores** — the shipped in-memory adapter and a deliberately `Map`-free `Record`-backed one — proving the limiter speaks only the interface. The three existing unit suites migrated sync→async with no assertions dropped.

## Review

Internal review panel run on the diff (type-design, silent-failure, comment-accuracy, test-coverage) — converged CLEAN over 2 rounds. Notable: the discriminated union surfaced two previously-unguarded `.retryAfterMs` test reads, now narrowed.

## Notes

- The Redis adapter is a **not-yet-filed follow-up** (parent umbrella #3801; this PR lands the seam).
- Out of scope: the separate fixed-window `public-rate-limit.ts` / `source-rate-limit.ts` limiters (different algorithm/domain).
