### PR TITLE
feat(mcp): high-level NL-agent `query` tool (#4094)

### DIFF
--- a/apps/docs/content/docs/architecture/mcp-tools.mdx
+++ b/apps/docs/content/docs/architecture/mcp-tools.mdx
@@ -25,7 +25,16 @@ Every typed MCP tool description must:
 - Include at least one **inline JSON example** showing call shape (preferred) or response shape. LLMs trained on tool use produce better-shaped calls when the description shows the call shape verbatim.
 - End with the structured **`Error contract:`** section. Appended at the MCP layer by `withErrorContract(BASE, CODES)` — the LLM reads purpose → recovery in one continuous block. Codes must match what the dispatch path actually returns.
 
-The base description bodies live in [`packages/api/src/lib/tools/descriptions.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/descriptions.ts) — the single source of truth that both `explore` / `executeSQL` (legacy AI SDK tool wrappers) and `listEntities` / `describeEntity` / `searchGlossary` / `runMetric` (typed semantic tools) read from.
+The base description bodies live in [`packages/api/src/lib/tools/descriptions.ts`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/tools/descriptions.ts) — the single source of truth that both `explore` / `executeSQL` (legacy AI SDK tool wrappers), `listEntities` / `describeEntity` / `searchGlossary` / `runMetric` (typed semantic tools), and `query` (the NL-agent tool) read from.
+
+### `query` vs `executeSQL` — two shapes of data access
+
+The MCP exposes two ways to answer a data question, and the routing directives in their descriptions steer the client's LLM to the right one:
+
+- **`query` (Shape A, recommended)** — the caller sends a *question*; Atlas's own server-side agent explores the semantic layer, writes and runs the SQL, and returns the answer plus the SQL it ran. It dispatches into `executeAgentQuery` **in-process** (not a loopback HTTP call, per ADR-0016). Like every datasource-reaching tool it declares `checksBilling` for the gate-0 workspace-solvency check; *additionally*, because it spends Atlas plan tokens (a second, server-side LLM — the caller pays twice), `executeAgentQuery` layers on the claim gate + token metering.
+- **`executeSQL` (Shape B, advanced/raw escape hatch)** — the caller's own LLM wrote the `SELECT`; Atlas validates + runs it, spending no Atlas-agent tokens.
+
+Both clear the same dispatch gate chain and land the same `origin=mcp` audit trail. Position `query` as the default for question-answering; `executeSQL` for callers that want full control over the query.
 
 ## Template
 

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -330,6 +330,15 @@ Atlas ships with a NovaMart demo dataset (orders, customers, sellers, returns) �
 
 If your agent doesn't see the Atlas tools at all, **restart the client** — most MCP clients only re-read their config at startup.
 
+### Two ways to ask: `query` vs `executeSQL`
+
+There are two shapes of data access over MCP, and the **recommended** one is the high-level `query` tool:
+
+- **`query` (recommended)** — hand Atlas a **natural-language question** and let *Atlas's own server-side agent* answer it. Atlas explores its semantic layer, picks the right entities and canonical metrics, writes and runs the SQL, and returns a prose `answer` plus the exact SQL it ran and the result rows. Because it knows your catalog, glossary, joins, and RLS, it composes better SQL than a generic client writing raw SQL blind. Example: `{ "question": "top 5 customers by revenue last quarter" }`. Note it runs a second, server-side LLM and **spends your Atlas plan tokens** (your client's model already paid once), so reach for it when answer quality on a complex schema matters most.
+- **`executeSQL` (advanced / raw escape hatch)** — you (or your client's model) already wrote the exact `SELECT`; Atlas validates it through the [SQL pipeline](/security/sql-validation) and runs it. No Atlas-agent tokens are spent — your client's model did the SQL authoring. Use it when you want full control over the query, or when the question is simple enough that your client's own model writes correct SQL against the semantic layer's `describeEntity` output.
+
+Both clear the same dispatch gate (billing solvency → action policy → `mcp:write` → RBAC → approval) and land the same `origin=mcp` audit trail; `query` additionally runs the **claim gate** (unclaimed-trial metering) because it spends Atlas plan tokens.
+
 ---
 
 ## Client status

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -106,8 +106,11 @@ export interface ExecuteAgentQueryOptions {
    * (e.g. `scheduler`). When omitted, the actor is propagated from the
    * parent RequestContext (e.g. the `/query` route stamps `human`); when
    * neither is present, `logQueryAudit` defaults the row to `agent`.
-   * Excludes `mcp` because the MCP dispatchers set their own actor (with
-   * `clientId` / `toolName`) and never route through `executeAgentQuery`.
+   * Excludes `mcp` because the MCP path binds its actor via the inherited
+   * RequestContext (the `mcpActor` set in `mcp-dispatch.ts`, carrying
+   * `clientId` / `toolName`), never via this option — even the NL-agent `query`
+   * MCP tool (#4094), which DOES route through `executeAgentQuery`, inherits
+   * that actor rather than passing `actorKind`.
    */
   actorKind?: Exclude<ActorKind, "mcp">;
   /**

--- a/packages/api/src/lib/tools/__tests__/description-rubric.test.ts
+++ b/packages/api/src/lib/tools/__tests__/description-rubric.test.ts
@@ -36,6 +36,8 @@ import {
   EXPLORE_TOOL_DESCRIPTION,
   LIST_ENTITIES_ERROR_CODES,
   LIST_ENTITIES_TOOL_DESCRIPTION,
+  QUERY_ERROR_CODES,
+  QUERY_TOOL_DESCRIPTION,
   RUN_METRIC_ERROR_CODES,
   RUN_METRIC_TOOL_DESCRIPTION,
   SEARCH_GLOSSARY_ERROR_CODES,
@@ -65,6 +67,8 @@ const RECOGNIZED_EXAMPLE_KEYS = [
   "matches", // searchGlossary response
   "entities", // listEntities response
   "count", // listEntities / searchGlossary response
+  "question", // query
+  "answer", // query response
 ] as const;
 const JSON_EXAMPLE_RE = new RegExp(
   `\\{[^{}]*"(?:${RECOGNIZED_EXAMPLE_KEYS.join("|")})"\\s*:[^{}]+\\}`,
@@ -83,6 +87,7 @@ const TOOLS: readonly ToolUnderRubric[] = [
   { name: "describeEntity", base: DESCRIBE_ENTITY_TOOL_DESCRIPTION, codes: DESCRIBE_ENTITY_ERROR_CODES },
   { name: "searchGlossary", base: SEARCH_GLOSSARY_TOOL_DESCRIPTION, codes: SEARCH_GLOSSARY_ERROR_CODES },
   { name: "runMetric", base: RUN_METRIC_TOOL_DESCRIPTION, codes: RUN_METRIC_ERROR_CODES },
+  { name: "query", base: QUERY_TOOL_DESCRIPTION, codes: QUERY_ERROR_CODES },
 ];
 
 function wordCount(text: string): number {
@@ -96,6 +101,7 @@ describe("MCP tool description rubric", () => {
       "executeSQL",
       "explore",
       "listEntities",
+      "query",
       "runMetric",
       "searchGlossary",
     ]);

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -59,6 +59,12 @@ Use this whenever a metric exists for what the user asked — never re-derive me
 
 Don't use this when no metric id matches; fall back to \`executeSQL\` with a query pattern from \`describeEntity\`. Avoid passing \`filters\` — pass-through is reserved for future work and is rejected today.`;
 
+export const QUERY_TOOL_DESCRIPTION = `Ask Atlas's server-side analyst agent a natural-language question; it explores the semantic layer, writes and runs the SELECTs itself, and returns a prose \`answer\` plus every SQL statement it ran and the result rows. This is the recommended path for question-answering — the agent knows the catalog, glossary, canonical metrics, joins, and RLS, so it composes better SQL than a generic client writing raw SQL blind. It runs a second server-side LLM and spends Atlas plan tokens; prefer it when answer quality matters. Example call: \`{ "question": "top 5 products by revenue last quarter" }\`. Example response: \`{ "answer": "...", "sql": ["SELECT ..."], "data": [...] }\`.
+
+Use this when the user asks a data question in words and you want a high-quality answer without hand-writing SQL.
+
+Don't use this when you already have exact SQL — call \`executeSQL\`, the raw escape hatch — or for catalog discovery (\`listEntities\` / \`describeEntity\`).`;
+
 // ── Per-tool error catalogs ───────────────────────────────────────────
 //
 // Surfaced in tool descriptions via `withErrorContract` so an agent can
@@ -115,6 +121,19 @@ export const RUN_METRIC_ERROR_CODES = [
   "query_timeout",
   "rate_limited",
   "billing_blocked",
+  "internal_error",
+] as const satisfies readonly AtlasMcpToolErrorCode[];
+// #4094 — the NL-agent `query` tool. Its datasource work happens inside the
+// agent loop (executeSQL swallows per-query SQL failures into the answer, so
+// no validation/rls/timeout code surfaces at the tool boundary). What DOES
+// surface: the gate-0 billing block (`billing_blocked`), the abuse-throttle /
+// per-client rate limit (`rate_limited`), and the catch-all (`internal_error`,
+// which also carries the fail-closed claim-check-unverifiable case). The
+// unclaimed-trial claim gate maps to `billing_blocked` (resolve on the web),
+// reusing the closed catalog rather than minting a new code.
+export const QUERY_ERROR_CODES = [
+  "billing_blocked",
+  "rate_limited",
   "internal_error",
 ] as const satisfies readonly AtlasMcpToolErrorCode[];
 

--- a/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
+++ b/packages/mcp/src/__tests__/canonical-mcp-eval.evalspec.ts
@@ -599,6 +599,8 @@ describe("MCP path canonical eval (#2074)", () => {
         "listEntities",
         "list_datasources",
         "profile_datasource",
+        "publish_datasources",
+        "query",
         "restore_datasource",
         "runMetric",
         "searchGlossary",

--- a/packages/mcp/src/__tests__/query-tool.test.ts
+++ b/packages/mcp/src/__tests__/query-tool.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import { getRequestContext } from "@atlas/api/lib/logger";
+import { parseAtlasMcpToolError } from "@useatlas/types/mcp";
+import { queryOutputSchema } from "../structured-output.js";
+import { MCP_APPROVAL_RESUME_HINT } from "../structured-output.js";
+
+const TEST_ACTOR = createAtlasUser("u_test", "managed", "test@example.com", {
+  role: "admin",
+  activeOrganizationId: "org_test",
+});
+
+// --- executeAgentQuery mock (#4094) ---
+// The query tool dispatches into `executeAgentQuery` in-process. Tests drive
+// its return value (or make it throw a typed gate error) to exercise every
+// branch. Default: a plain successful agent answer.
+type AgentResult = {
+  answer: string;
+  sql: string[];
+  data: { columns: string[]; rows: Record<string, unknown>[] }[];
+  steps: number;
+  usage: { totalTokens: number };
+  pendingApproval?: {
+    requestId: string | null;
+    ruleName: string;
+    matchedRules: string[];
+    message: string;
+  };
+};
+
+const DEFAULT_RESULT: AgentResult = {
+  answer: "Revenue was $1.2M last quarter.",
+  sql: ["SELECT sum(amount) FROM orders WHERE quarter = 'Q1'"],
+  data: [{ columns: ["sum"], rows: [{ sum: 1_200_000 }] }],
+  steps: 3,
+  usage: { totalTokens: 4210 },
+};
+
+const mockExecuteAgentQuery = mock<(...args: unknown[]) => Promise<AgentResult>>(
+  async () => DEFAULT_RESULT,
+);
+
+mock.module("@atlas/api/lib/agent-query", () => ({
+  executeAgentQuery: mockExecuteAgentQuery,
+}));
+
+// --- Typed gate error classes ---
+// Mirror the real shapes just enough for the query tool's `instanceof` mapping.
+// Both the tool body (lazy import) and this test get the SAME class reference
+// from the mocked module, so `instanceof` works.
+class BillingBlockedError extends Error {
+  override readonly name = "BillingBlockedError";
+  readonly errorCode: string;
+  readonly httpStatus: 403 | 404 | 429 | 503;
+  readonly retryable: boolean;
+  readonly retryAfterSeconds: number | undefined;
+  readonly usage: undefined;
+  constructor(block: {
+    errorCode: string;
+    errorMessage: string;
+    httpStatus: 403 | 404 | 429 | 503;
+    retryable: boolean;
+    retryAfterSeconds?: number;
+  }) {
+    super(block.errorMessage);
+    this.errorCode = block.errorCode;
+    this.httpStatus = block.httpStatus;
+    this.retryable = block.retryable;
+    this.retryAfterSeconds = block.retryAfterSeconds;
+    this.usage = undefined;
+  }
+}
+
+class ClaimRequiredError extends Error {
+  override readonly name = "ClaimRequiredError";
+  readonly claimUrl: string;
+  readonly errorCode = "claim_required" as const;
+  readonly httpStatus = 403 as const;
+  constructor(claimUrl: string) {
+    super(`Verify your email and finish setup on the web to continue: ${claimUrl}`);
+    this.claimUrl = claimUrl;
+  }
+}
+
+class ClaimCheckFailedError extends Error {
+  override readonly name = "ClaimCheckFailedError";
+  readonly errorCode = "claim_check_failed" as const;
+  readonly httpStatus = 503 as const;
+  readonly retryable = true as const;
+  constructor() {
+    super("Unable to verify your workspace's claim status. Please try again.");
+  }
+}
+
+// --- Billing gate-0 mock (#3437) ---
+// The `query` tool declares `checksBilling`, so the ADR-0016 gate-0 solvency
+// check (`checkAgentBillingGate`, via `billing-gate.ts`) runs before the agent.
+type GateVerdict =
+  | { allowed: true }
+  | {
+      allowed: false;
+      errorCode: string;
+      errorMessage: string;
+      httpStatus: 403 | 404 | 429 | 503;
+      retryable: boolean;
+      retryAfterSeconds?: number;
+    };
+let billingGateVerdict: GateVerdict = { allowed: true };
+const mockCheckAgentBillingGate = mock(async (_orgId: string | undefined) => billingGateVerdict);
+
+mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError,
+}));
+
+mock.module("@atlas/api/lib/billing/claim-gate", () => ({
+  buildClaimUrl: (email?: string) => `https://app.useatlas.dev/claim?email=${email ?? ""}`,
+  ClaimRequiredError,
+  ClaimCheckFailedError,
+  checkClaimGate: mock(async () => ({ allowed: true })),
+}));
+
+// Import after mocks are set up.
+const { registerQueryTool } = await import("../query-tool.js");
+
+function getContentText(content: unknown): string {
+  const arr = content as Array<{ type: string; text: string }>;
+  return arr[0]?.text ?? "";
+}
+
+async function createTestClient(
+  actor = TEST_ACTOR,
+  clientId?: string,
+  scopes?: readonly string[],
+) {
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerQueryTool(server, {
+    actor,
+    transport: "stdio",
+    workspaceId: actor.activeOrganizationId ?? actor.id,
+    deployMode: "saas",
+    ...(clientId ? { clientId } : {}),
+    ...(scopes ? { scopes } : {}),
+  });
+
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, server };
+}
+
+describe("MCP query tool (#4094)", () => {
+  beforeEach(() => {
+    mockExecuteAgentQuery.mockClear();
+    mockExecuteAgentQuery.mockImplementation(async () => DEFAULT_RESULT);
+    billingGateVerdict = { allowed: true };
+    mockCheckAgentBillingGate.mockClear();
+  });
+
+  it("is registered as a read-only, open-world tool advertising the error contract", async () => {
+    const { client } = await createTestClient();
+    const { tools } = await client.listTools();
+    const query = tools.find((t) => t.name === "query");
+
+    expect(query).toBeDefined();
+    expect(query?.annotations?.readOnlyHint).toBe(true);
+    expect(query?.annotations?.openWorldHint).toBe(true);
+    expect(query?.outputSchema).toBeDefined();
+    // The LLM-facing description must advertise the codes it can branch on.
+    expect(query?.description).toContain("Error contract");
+    expect(query?.description).toContain("`billing_blocked`");
+    expect(query?.description).toContain("recommended path");
+  });
+
+  it("returns the agent's answer + SQL + data as schema-valid structured output", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "How much revenue last quarter?" },
+    });
+
+    expect(mockExecuteAgentQuery).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeFalsy();
+
+    // Structured output present + schema-valid.
+    expect(result.structuredContent).toBeDefined();
+    const validated = queryOutputSchema.parse(result.structuredContent);
+    expect(validated.answer).toBe(DEFAULT_RESULT.answer);
+    expect(validated.sql).toEqual(DEFAULT_RESULT.sql);
+    expect(validated.data).toEqual(DEFAULT_RESULT.data);
+    expect(validated.steps).toBe(3);
+    // The double-billing cost is surfaced back to the caller.
+    expect(validated.usage?.total_tokens).toBe(4210);
+
+    // Retained text block mirrors the structured payload.
+    expect(JSON.parse(getContentText(result.content))).toEqual(result.structuredContent);
+  });
+
+  it("threads the question + connectionId into executeAgentQuery", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({
+      name: "query",
+      arguments: { question: "top products", connectionId: "warehouse" },
+    });
+
+    const calls = mockExecuteAgentQuery.mock.calls;
+    const [question, _requestId, options] = calls[calls.length - 1] as [
+      string,
+      string,
+      { connectionId?: string },
+    ];
+    expect(question).toBe("top products");
+    expect(options.connectionId).toBe("warehouse");
+  });
+
+  it("omits connectionId when the caller doesn't supply one (default connection)", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "query", arguments: { question: "anything" } });
+
+    const calls = mockExecuteAgentQuery.mock.calls;
+    const options = (calls[calls.length - 1] as unknown[])[2] as Record<string, unknown>;
+    expect("connectionId" in options).toBe(false);
+  });
+
+  it("dispatches with a bound mcp actor + origin=mcp so audit + approval rules see the caller", async () => {
+    let observed: ReturnType<typeof getRequestContext>;
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      observed = getRequestContext();
+      return DEFAULT_RESULT;
+    });
+
+    const { client } = await createTestClient(TEST_ACTOR, "claude-desktop");
+    await client.callTool({ name: "query", arguments: { question: "probe" } });
+
+    expect(observed!.user?.id).toBe(TEST_ACTOR.id);
+    expect(observed!.user?.activeOrganizationId).toBe("org_test");
+    expect(observed!.actor).toEqual({
+      kind: "mcp",
+      clientId: "claude-desktop",
+      toolName: "query",
+    });
+    expect(observed!.agentOrigin).toBe("mcp");
+  });
+
+  it("surfaces a parked approval as approval_required (not an error) with a resume hint", async () => {
+    mockExecuteAgentQuery.mockImplementationOnce(async () => ({
+      ...DEFAULT_RESULT,
+      answer: "This query needs approval before it can run.",
+      pendingApproval: {
+        requestId: "appr_xyz789",
+        ruleName: "pii-tables",
+        matchedRules: ["pii-tables"],
+        message: 'This query requires approval before execution. Rule: "pii-tables".',
+      },
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "show me every customer's email" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = queryOutputSchema.parse(result.structuredContent);
+    expect(parsed.approval_required).toBe(true);
+    expect(parsed.approval_request_id).toBe("appr_xyz789");
+    expect(parsed.matched_rules).toEqual(["pii-tables"]);
+    // The resume protocol must be spelled out for the MCP client.
+    expect(parsed.message).toContain(MCP_APPROVAL_RESUME_HINT);
+  });
+
+  it("omits approval_request_id when the parked approval has no queued row (null id)", async () => {
+    // PendingApproval.requestId is `string | null` — null on the no-org /
+    // identityMissing path (agent-query.ts), i.e. the stdio self-hosted shape.
+    // The tool must NOT emit `approval_request_id: null` (which fails the
+    // z.string() output-schema field); the field is simply absent.
+    mockExecuteAgentQuery.mockImplementationOnce(async () => ({
+      ...DEFAULT_RESULT,
+      pendingApproval: {
+        requestId: null,
+        ruleName: "approval-required",
+        matchedRules: [],
+        message: "This query requires approval before execution.",
+      },
+    }));
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "show me customer PII" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    // Schema-valid despite the null id (would throw if `null` leaked through).
+    const parsed = queryOutputSchema.parse(result.structuredContent);
+    expect(parsed.approval_required).toBe(true);
+    expect(parsed.approval_request_id).toBeUndefined();
+    expect("approval_request_id" in (result.structuredContent as object)).toBe(false);
+  });
+
+  it("rejects an empty question before dispatching (input bound)", async () => {
+    const { client } = await createTestClient();
+    // The MCP SDK enforces the input schema (`.trim().min(1)`) before dispatch.
+    // A whitespace-only question must not reach the agent — no wasted Atlas
+    // tokens on a malformed call. The SDK surfaces the schema violation either
+    // as a rejection or an `isError` result depending on version; the invariant
+    // we pin is that the agent never ran.
+    let rejected = false;
+    let result: Awaited<ReturnType<typeof client.callTool>> | undefined;
+    try {
+      result = await client.callTool({ name: "query", arguments: { question: "   " } });
+    } catch {
+      rejected = true;
+    }
+    expect(rejected || result?.isError === true).toBe(true);
+    expect(mockExecuteAgentQuery).not.toHaveBeenCalled();
+  });
+
+  it("maps an unclaimed-trial ClaimRequiredError to billing_blocked carrying the claim URL", async () => {
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      throw new ClaimRequiredError("https://app.useatlas.dev/claim?email=a@b.co");
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "revenue?" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("billing_blocked");
+    expect(envelope!.hint).toContain("https://app.useatlas.dev/claim");
+  });
+
+  it("fails closed as retryable internal_error when claim status is unverifiable", async () => {
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      throw new ClaimCheckFailedError();
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "revenue?" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.request_id).toMatch(/^mcp-query-/);
+    expect(envelope!.retry_after).toBe(2);
+  });
+
+  it("maps a mid-run BillingBlockedError throttle to rate_limited with retry_after", async () => {
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      throw new BillingBlockedError({
+        errorCode: "workspace_throttled",
+        errorMessage: "Workspace is temporarily throttled. Retry shortly.",
+        httpStatus: 429,
+        retryable: true,
+        retryAfterSeconds: 7,
+      });
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "revenue?" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("rate_limited");
+    expect(envelope!.retry_after).toBe(7);
+  });
+
+  it("maps a mid-run BillingBlockedError suspension to billing_blocked", async () => {
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      throw new BillingBlockedError({
+        errorCode: "workspace_suspended",
+        errorMessage: "Workspace suspended. Contact your administrator.",
+        httpStatus: 403,
+        retryable: false,
+      });
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "revenue?" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("billing_blocked");
+    expect(envelope!.hint).toBeDefined();
+  });
+
+  it("maps a mid-run BillingBlockedError 503 (check failure) to a retryable internal_error", async () => {
+    // The distinct third arm: a 503 infra fault must surface as internal_error
+    // (retryable, quote the request id), NOT billing_blocked — mis-signalling
+    // "upgrade your plan" for what is an operator-side blip.
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      throw new BillingBlockedError({
+        errorCode: "workspace_check_failed",
+        errorMessage: "Unable to verify workspace status. Please try again.",
+        httpStatus: 503,
+        retryable: true,
+      });
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "revenue?" },
+    });
+
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.request_id).toMatch(/^mcp-query-/);
+  });
+
+  it("falls back to internal_error with request_id on an unexpected throw", async () => {
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      throw new Error("provider exploded");
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "revenue?" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("internal_error");
+    expect(envelope!.message).toContain("provider exploded");
+    expect(envelope!.request_id).toMatch(/^mcp-query-/);
+  });
+
+  describe("gate-0 billing (#3437)", () => {
+    it("returns billing_blocked and never runs the agent when the workspace is suspended", async () => {
+      billingGateVerdict = {
+        allowed: false,
+        errorCode: "workspace_suspended",
+        errorMessage: "Workspace suspended due to unusual activity.",
+        httpStatus: 403,
+        retryable: false,
+      };
+
+      const { client } = await createTestClient();
+      const result = await client.callTool({
+        name: "query",
+        arguments: { question: "revenue?" },
+      });
+
+      expect(result.isError).toBe(true);
+      const envelope = parseAtlasMcpToolError(getContentText(result.content));
+      expect(envelope!.code).toBe("billing_blocked");
+      // Agent never ran — zero Atlas-token spend on a blocked workspace.
+      expect(mockExecuteAgentQuery).not.toHaveBeenCalled();
+      // Gate-0 consulted the actor's workspace (the org-vs-actor.id distinction
+      // is the dispatch-gate's concern and is pinned there; here both happen to
+      // equal "org_test").
+      expect(mockCheckAgentBillingGate).toHaveBeenCalledWith("org_test");
+    });
+
+    it("proceeds and runs the agent once when the gate allows", async () => {
+      const { client } = await createTestClient();
+      const result = await client.callTool({
+        name: "query",
+        arguments: { question: "revenue?" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mockCheckAgentBillingGate).toHaveBeenCalledWith("org_test");
+      expect(mockExecuteAgentQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/mcp/src/__tests__/server.test.ts
+++ b/packages/mcp/src/__tests__/server.test.ts
@@ -60,7 +60,7 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
 const { createAtlasMcpServer } = await import("../server.js");
 
 describe("MCP server integration", () => {
-  it("creates a server and lists explore + executeSQL + the four typed semantic tools", async () => {
+  it("creates a server and lists explore + executeSQL + query + the four typed semantic tools", async () => {
     const server = await createAtlasMcpServer({ actor: TEST_ACTOR });
     const client = new Client({ name: "test-client", version: "0.0.1" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -82,6 +82,7 @@ describe("MCP server integration", () => {
       "list_datasources",
       "profile_datasource",
       "publish_datasources",
+      "query",
       "restore_datasource",
       "runMetric",
       "searchGlossary",

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -132,6 +132,7 @@ describe("MCP smoke — tool listing", () => {
       "list_datasources",
       "profile_datasource",
       "publish_datasources",
+      "query",
       "restore_datasource",
       "runMetric",
       "searchGlossary",
@@ -223,11 +224,11 @@ describe("MCP smoke — server lifecycle", () => {
     await server.connect(serverTransport);
     await client.connect(clientTransport);
 
-    // Verify the server is operational — explore + executeSQL + the four
-    // typed semantic tools (#2020) + the nine datasource lifecycle tools
-    // (#3511–#3514, #3547, #4126) = 15.
+    // Verify the server is operational — explore + executeSQL + the NL-agent
+    // query tool (#4094) + the four typed semantic tools (#2020) + the nine
+    // datasource lifecycle tools (#3511–#3514, #3547, #4126) = 16.
     const tools = await client.listTools();
-    expect(tools.tools.length).toBe(15);
+    expect(tools.tools.length).toBe(16);
 
     // Clean shutdown — should not throw
     await client.close();

--- a/packages/mcp/src/__tests__/sse.test.ts
+++ b/packages/mcp/src/__tests__/sse.test.ts
@@ -176,6 +176,7 @@ describe("SSE server — MCP client integration", () => {
       "list_datasources",
       "profile_datasource",
       "publish_datasources",
+      "query",
       "restore_datasource",
       "runMetric",
       "searchGlossary",
@@ -272,12 +273,12 @@ describe("SSE server — MCP client integration", () => {
     await client2.connect(transport2);
 
     // Both clients can list tools independently — explore + executeSQL +
-    // the four typed semantic tools (#2020) + the nine datasource lifecycle
-    // tools (#3511–#3514, #3547, #4126) = 15.
+    // the NL-agent query tool (#4094) + the four typed semantic tools (#2020)
+    // + the nine datasource lifecycle tools (#3511–#3514, #3547, #4126) = 16.
     const result1 = await client1.listTools();
     const result2 = await client2.listTools();
-    expect(result1.tools.length).toBe(15);
-    expect(result2.tools.length).toBe(15);
+    expect(result1.tools.length).toBe(16);
+    expect(result2.tools.length).toBe(16);
 
     // Health shows 2+ sessions
     const res = await fetch(`http://localhost:${handle.server.port}/health`);

--- a/packages/mcp/src/query-tool.ts
+++ b/packages/mcp/src/query-tool.ts
@@ -1,0 +1,254 @@
+/**
+ * High-level natural-language `query` MCP tool (#4094) — the **Shape A**
+ * counterpart to the raw-SQL `executeSQL` MCP tool (Shape B). The related
+ * #4047 / ADR-0027 is the raw-SQL-over-REST sibling (`POST /api/v1/execute-sql`
+ * + `atlas sql`) that this complements — NOT the MCP `executeSQL` tool, which
+ * predates it.
+ *
+ * `executeSQL` is Shape B: the caller's own LLM writes the SQL, Atlas
+ * validates + runs it. `query` is Shape A: the caller sends a *question* and
+ * Atlas's own server-side, semantic-layer-aware agent explores the catalog,
+ * writes + runs the SELECTs, and hands back the answer plus the SQL it ran.
+ * It is the *recommended* MCP path for question-answering; `executeSQL` is
+ * documented as the advanced/raw escape hatch (see
+ * `apps/docs/content/docs/architecture/mcp-tools.mdx`).
+ *
+ * **Agent-in-agent, token-metered.** The customer's LLM calls this tool, which
+ * runs Atlas's agent (a second LLM) in-process — NOT a loopback HTTP call to
+ * `/api/v1/query` (ADR-0016: MCP dispatches into the same `executeAgentQuery`
+ * lib seam directly). Like every datasource-reaching tool it declares
+ * `checksBilling`, so the ADR-0016 gate-0 workspace-*solvency* check runs
+ * before any datasource/LLM work (the metadata-read tools omit it; `executeSQL`
+ * declares it too while spending zero Atlas tokens). What makes this an
+ * agent-in-agent double-bill is the token spend, not `checksBilling`: because
+ * it *additionally* burns Atlas plan tokens, `executeAgentQuery` layers on the
+ * claim gate + token metering internally.
+ *
+ * Registration stays off the agent graph: `executeAgentQuery` (and the billing
+ * error classes) are lazy-imported inside the dispatch body, the same deferral
+ * the shared dispatch gate + trial footer use. Importing them at module load
+ * would couple MCP tool *registration* to the whole `runAgent` graph.
+ */
+
+import { z } from "zod/v4";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AtlasUser } from "@atlas/api/lib/auth/types";
+// Type-only — erased at compile time, so it does NOT pull the `runAgent` graph
+// into registration (the reason `executeAgentQuery` itself is lazy-imported).
+import type { AgentQueryResult } from "@atlas/api/lib/agent-query";
+import {
+  QUERY_TOOL_DESCRIPTION,
+  QUERY_ERROR_CODES,
+  withErrorContract,
+} from "@atlas/api/lib/tools/descriptions";
+import { type McpTransport, type McpDeployMode } from "./telemetry.js";
+import { envelope, toEnvelopeResult, toStructuredContent } from "./error-envelope.js";
+import { createMcpDispatch } from "./mcp-dispatch.js";
+import { queryOutputShape, withResumeHint } from "./structured-output.js";
+import { withProgressAndCancellation } from "./progress.js";
+
+// The question is free text the customer's LLM composed. Cap it so a hostile
+// client can't drive a megabyte prompt into the agent loop; generous enough
+// for a rich multi-sentence question (the semantic tools cap free text at
+// 1024, but a question legitimately carries more context than a filter term).
+const MAX_QUESTION_LEN = 4096;
+const MAX_CONNECTION_ID_LEN = 256;
+
+/**
+ * The hint attached to a `billing_blocked` envelope — adapts the wording of
+ * billing-gate.ts (claim/setup framing for the agent path; the mapping *logic*
+ * below is byte-for-byte identical to billing-gate.ts).
+ */
+const BILLING_BLOCKED_HINT =
+  "Retrying will not help. The workspace owner must resolve the workspace's billing or claim/setup status in Atlas before the agent can run.";
+
+export interface RegisterQueryToolOptions {
+  /** Actor bound on every tool dispatch — see tools.ts. */
+  actor: AtlasUser;
+  /** OTel transport tag (#2029) — threaded from `bin/serve.ts` via `server.ts`. */
+  transport: McpTransport;
+  /** Resolved workspace id for OTel attribution (`actor.activeOrganizationId` or `actor.id`). */
+  workspaceId: string;
+  /** Resolved `deployMode` for OTel attribution (`self-hosted` / `saas`). */
+  deployMode: McpDeployMode;
+  /** Hosted-MCP OAuth client_id, surfaced into `audit_log.client_id` (#2067). */
+  clientId?: string;
+  /** #3504 — OAuth token scopes, threaded onto each dispatch's RequestContext. */
+  scopes?: readonly string[];
+}
+
+export function registerQueryTool(
+  server: McpServer,
+  opts: RegisterQueryToolOptions,
+): void {
+  const { actor, transport, workspaceId, deployMode, clientId, scopes } = opts;
+
+  // Shared dispatch wrapper (#3602) — identical contract to tools.ts /
+  // semantic-tools.ts (OTel → actor bind → rate-limit → ADR-0016 gate order →
+  // body → typed error envelope). `checksBilling` runs the gate-0 solvency
+  // check; the claim gate + token metering live inside `executeAgentQuery`.
+  const { dispatch } = createMcpDispatch({
+    actor,
+    transport,
+    workspaceId,
+    deployMode,
+    ...(clientId ? { clientId } : {}),
+    ...(scopes ? { scopes } : {}),
+  });
+
+  server.registerTool(
+    "query",
+    {
+      title: "Ask Atlas (NL Data Question)",
+      description: withErrorContract(QUERY_TOOL_DESCRIPTION, QUERY_ERROR_CODES),
+      inputSchema: {
+        question: z
+          .string()
+          .trim()
+          .min(1)
+          .max(MAX_QUESTION_LEN)
+          .describe(
+            "The natural-language data question for Atlas's agent to answer, e.g. \"What were the top 5 products by revenue last quarter?\"",
+          ),
+        connectionId: z
+          .string()
+          .min(1)
+          .max(MAX_CONNECTION_ID_LEN)
+          .optional()
+          .describe(
+            "Target connection id. Omit to run against the workspace's default (published) connection.",
+          ),
+      },
+      // The agent only runs SELECTs (executeSQL is SELECT-only, validated); any
+      // action tool it reaches is approval-gated and returns `pending` rather
+      // than mutating — nothing changes synchronously, so read-only. It reaches
+      // an external datasource + LLM, so the world is open.
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
+      // #3498 — typed result so the client agent parses answer/sql/data instead
+      // of re-parsing the text block (which is retained below).
+      outputSchema: queryOutputShape,
+    },
+    async ({ question, connectionId }, extra): Promise<CallToolResult> =>
+      dispatch(
+        "query",
+        // Runs Atlas's agent → burns Atlas plan tokens → gate-0 billing
+        // (#3437/#3601), like every datasource-reaching tool. Member-callable
+        // read; no bound-org precondition (stdio self-hosted has no org and
+        // runs against ATLAS_DATASOURCE_URL).
+        { requiresWrite: false, requiresBoundOrg: false, minRole: "member", checksBilling: true },
+        async (requestId) => {
+          // Lazy-import to keep MCP tool registration off the `runAgent` graph
+          // (see module header). ESM caches, so the error classes we import
+          // here share identity with the ones `executeAgentQuery` throws.
+          const { executeAgentQuery } = await import("@atlas/api/lib/agent-query");
+          const { BillingBlockedError } = await import("@atlas/api/lib/billing/agent-gate");
+          const { ClaimRequiredError, ClaimCheckFailedError } = await import(
+            "@atlas/api/lib/billing/claim-gate"
+          );
+
+          let result: AgentQueryResult;
+          try {
+            // #3500 — progress start/end around the (potentially long) agent
+            // run. #3575 — `executeAgentQuery` takes no abort signal, so the
+            // client-cancel path cuts the dispatch loose at the MCP boundary
+            // (the shared dispatch re-throws OperationCancelledError); the agent
+            // drains server-side. The signal is intentionally not threaded.
+            result = await withProgressAndCancellation(
+              extra,
+              { startMessage: "Running Atlas agent", endMessage: "Answer ready" },
+              async (_reporter, _signal) =>
+                executeAgentQuery(question, requestId, {
+                  // The dispatch RequestContext already carries user + actor
+                  // (kind:mcp, toolName) + agentOrigin:"mcp" (#1858/#2067/#2072),
+                  // which `executeAgentQuery` inherits — so executeSQL audit rows
+                  // record actor_kind='mcp' and origin-scoped approval rules fire
+                  // for origin=mcp. Only connectionId isn't on the context, so
+                  // thread it explicitly (#4124).
+                  ...(connectionId ? { connectionId } : {}),
+                }),
+            );
+          } catch (err) {
+            // The billing/claim gates inside `executeAgentQuery` throw typed
+            // errors (mirroring the `/api/v1/query` route). Map each onto the
+            // closed MCP envelope catalog rather than letting the shared
+            // dispatch demote it to a bare `internal_error`.
+
+            // Unclaimed metered trial (ADR-0018 / #3651): claim on the web to
+            // run Atlas-token Q&A. Reuse `billing_blocked` (an account-standing
+            // block the owner resolves on the web) — the closed catalog has no
+            // `claim_required` code, and the recovery is the same.
+            if (err instanceof ClaimRequiredError) {
+              return toEnvelopeResult(
+                envelope("billing_blocked", err.message, {
+                  hint: `Finish setup on the web to continue: ${err.claimUrl}`,
+                }),
+              );
+            }
+            // Claim status unverifiable — fail closed as a retryable
+            // internal_error (an infra fault), NOT a claim prompt and NOT a
+            // token-spending allow. Mirrors the route's 503.
+            if (err instanceof ClaimCheckFailedError) {
+              return toEnvelopeResult(
+                envelope("internal_error", err.message, { request_id: requestId, retry_after: 2 }),
+              );
+            }
+            // Billing block. Gate-0 (`checksBilling`) normally catches a blocked
+            // workspace first, so this is a defensive fallback for a state that
+            // changed mid-run. Map exactly like billing-gate.ts: throttle →
+            // rate_limited, 503 → internal_error, else → billing_blocked.
+            if (err instanceof BillingBlockedError) {
+              if (err.errorCode === "workspace_throttled") {
+                return toEnvelopeResult(
+                  envelope("rate_limited", err.message, {
+                    ...(err.retryAfterSeconds !== undefined && { retry_after: err.retryAfterSeconds }),
+                  }),
+                );
+              }
+              if (err.httpStatus === 503) {
+                return toEnvelopeResult(
+                  envelope("internal_error", err.message, { request_id: requestId }),
+                );
+              }
+              return toEnvelopeResult(
+                envelope("billing_blocked", err.message, { hint: BILLING_BLOCKED_HINT }),
+              );
+            }
+            // Anything else (provider/LLM errors, unexpected throws) → let the
+            // shared dispatch surface a typed `internal_error` with request_id.
+            throw err;
+          }
+
+          // Approval branch: one of the agent's SELECTs hit an approval rule and
+          // was parked (origin=mcp). Surface it as the `approval_required`
+          // governance signal (NOT an error) so the client re-runs the identical
+          // call once approved, mirroring executeSQL/runMetric.
+          if (result.pendingApproval) {
+            const { requestId: approvalId, matchedRules, message } = result.pendingApproval;
+            return toStructuredContent({
+              answer: result.answer,
+              ...(result.sql.length > 0 ? { sql: result.sql } : {}),
+              approval_required: true,
+              ...(approvalId ? { approval_request_id: approvalId } : {}),
+              matched_rules: matchedRules,
+              message: withResumeHint(message),
+            });
+          }
+
+          // Data branch: the prose answer, the SQL the agent ran, the result
+          // sets, the step count, and Atlas-plan token spend (the double-billing
+          // cost surfaced back — the client already paid its own LLM).
+          return toStructuredContent({
+            answer: result.answer,
+            sql: result.sql,
+            data: result.data,
+            steps: result.steps,
+            usage: { total_tokens: result.usage.totalTokens },
+          });
+        },
+      ),
+  );
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,6 +16,7 @@ import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { loadSettings } from "@atlas/api/lib/settings";
 import { registerTools } from "./tools.js";
+import { registerQueryTool } from "./query-tool.js";
 import { registerDatasourceTools } from "./datasource-tools.js";
 import { registerPluginTools } from "./plugin-tools.js";
 import { bootPluginsForMcp } from "@atlas/api/lib/plugins";
@@ -147,6 +148,19 @@ export async function createAtlasMcpServer(
   );
 
   registerTools(server, { actor, transport, clientId, ...(scopes && { scopes }) });
+
+  // #4094 — the high-level NL-agent `query` tool (Shape A). Separate file
+  // because it dispatches into the whole `runAgent` graph (lazy-imported), so
+  // isolating it keeps that coupling out of the raw-tool file. Wired here like
+  // the datasource tools rather than from within `registerTools`.
+  registerQueryTool(server, {
+    actor,
+    transport,
+    ...(clientId && { clientId }),
+    ...(scopes && { scopes }),
+    workspaceId: actor.activeOrganizationId ?? actor.id,
+    deployMode: getConfig()?.deployMode ?? "self-hosted",
+  });
 
   // Datasource lifecycle admin tools (Tier 2 — list/test/archive/restore/
   // delete/create/profile). Self-contained in `datasource-tools.ts`; this is

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -102,6 +102,32 @@ export const runMetricOutputShape = {
   ...approvalFields,
 } as const;
 
+/**
+ * A single agent result set — the `{ columns, rows }` pair the NL-agent
+ * `query` tool surfaces once per SELECT the agent ran. The agent can run
+ * several queries per turn, so `query`'s `data` is an ARRAY of these (one
+ * per `executeSQL` step), unlike `executeSQL`/`runMetric` which return one.
+ */
+const dataSetField = z.array(z.object({ columns: columnsField, rows: rowsField }));
+
+/**
+ * `query` (Shape-A NL agent) output — #4094. Data branch: the agent's prose
+ * `answer`, the `sql` statements it ran, the `data` result sets, the agent
+ * `steps` count, and Atlas-plan token `usage` (Shape A burns Atlas tokens, so
+ * the double-billing cost is surfaced back). Plus the same `approval_required`
+ * governance branch every datasource tool carries — a SELECT the agent tried
+ * hit an approval rule and was parked rather than run.
+ */
+export const queryOutputShape = {
+  answer: z.string().optional(),
+  sql: z.array(z.string()).optional(),
+  data: dataSetField.optional(),
+  steps: z.number().int().nonnegative().optional(),
+  usage: z.object({ total_tokens: z.number().int().nonnegative() }).optional(),
+  ...approvalFields,
+} as const;
+
 /** Zod objects for validating a result against the declared output schema. */
 export const executeSqlOutputSchema = z.object(executeSqlOutputShape);
 export const runMetricOutputSchema = z.object(runMetricOutputShape);
+export const queryOutputSchema = z.object(queryOutputShape);


### PR DESCRIPTION
## What

Adds a high-level **Shape A** natural-language `query` MCP tool (#4094): a customer's LLM hands Atlas a *question* and Atlas's own server-side, semantic-layer-aware agent (`executeAgentQuery`, in-process per ADR-0016) explores the catalog, writes + runs the SQL, and returns the prose answer plus the exact SQL it ran and the result rows.

This is the **recommended** MCP path for question-answering; the raw-SQL `executeSQL` MCP tool (Shape B) stays as the advanced/raw escape hatch.

## Acceptance criteria (all met)

- [x] MCP exposes a high-level `query` tool whose input is a natural-language `question` (+ optional `connectionId`).
- [x] Runs Atlas's server-side agent (`executeAgentQuery`) **in-process** (not a loopback HTTP call, ADR-0016), semantic-layer-aware; returns the structured `answer` + `sql[]` + `data[]` + `steps` + `usage`.
- [x] **Token-metered** — declares `checksBilling` so ADR-0016 gate-0 solvency runs before any LLM work; `executeAgentQuery` layers on the claim gate + Atlas-plan token metering (Shape A burns Atlas tokens; the caller pays twice).
- [x] Clears the same dispatch gate chain + `origin=mcp` audit as every other MCP tool (verified end-to-end: the agent's inner `executeSQL` audit rows record `actor_kind=mcp`, `tool_name=query`).
- [x] Docs position it as the recommended path; `executeSQL` documented as the advanced/raw escape hatch.

## How

- **`packages/mcp/src/query-tool.ts`** — new `registerQueryTool`, wired from `server.ts`. Lazy-imports `executeAgentQuery` (keeps the `runAgent` graph off MCP registration). Structured output (`answer`/`sql`/`data`/`steps`/`usage`) + the `approval_required` governance branch. Typed billing/claim gate throws (`ClaimRequiredError` → `billing_blocked` w/ claim URL, `ClaimCheckFailedError` → retryable `internal_error`, `BillingBlockedError` throttle→`rate_limited`/503→`internal_error`/else→`billing_blocked`) mapped onto the closed MCP envelope catalog; everything else falls through to the shared dispatch `internal_error`.
- **`structured-output.ts`** — `queryOutputShape`/`queryOutputSchema` (data branch + approval branch as one optional-member object, per the MCP single-object outputSchema constraint).
- **`descriptions.ts`** — `QUERY_TOOL_DESCRIPTION` (rubric-compliant) + `QUERY_ERROR_CODES`.
- **Docs** — `guides/mcp.mdx` ("Two ways to ask: `query` vs `executeSQL`") + `architecture/mcp-tools.mdx`.

## Dependency

Built on **#4124 / #4145** (merged) — the Shape-A connection-resolution fix (`/api/v1/query` honoring `connectionId`), which this tool needs to resolve a workspace datasource on SaaS.

## Tests

New `query-tool.test.ts` (16 cases): success + schema-valid structured output, `connectionId` passthrough/omission, bound `mcp` actor + `origin=mcp`, approval branch (incl. `requestId===null`), claim/billing gate mappings (incl. 503 arm), gate-0 block (agent never runs → zero token spend), empty-question input bound. Tool-set/count assertions updated across `server`/`smoke`/`sse`/`canonical-mcp-eval`.

## Review

Internal `/review-panel` (4 specialists) — **CLEAN** on all four axes in 1 round. Addressed inline: 2 MEDIUM comment-accuracy fixes (a wrong `#4047` attribution; comment-rot the PR introduced in `agent-query.ts`'s `actorKind` doc), precision fixes to the `checksBilling` framing, and 2 severity-5 test-branch additions.

Closes #4094
