### PR TITLE
feat(governance): workspace-admin off-switch for raw executeSQL over CLI/MCP (#4095)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -2635,7 +2635,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — billing block or RLS-denied",
+            "description": "Forbidden — billing block, RLS-denied, or raw SQL disabled for this workspace by an admin (#4095)",
             "content": {
               "application/json": {
                 "schema": {
@@ -2733,7 +2733,7 @@
             }
           },
           "503": {
-            "description": "Datasource or enterprise subsystem unavailable",
+            "description": "Datasource or enterprise subsystem unavailable, or the raw-SQL policy could not be read (fail-closed, #4095)",
             "content": {
               "application/json": {
                 "schema": {
@@ -35931,7 +35931,8 @@
                     "enum": [
                       "datasource",
                       "integration",
-                      "policy"
+                      "policy",
+                      "raw_sql"
                     ],
                     "example": "datasource",
                     "description": "MCP action category to toggle"

--- a/packages/api/src/api/__tests__/admin-mcp-action-policy.test.ts
+++ b/packages/api/src/api/__tests__/admin-mcp-action-policy.test.ts
@@ -137,7 +137,7 @@ describe("admin MCP action policy route (#3509)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { entries: { category: string; status: string }[] };
     expect(body.entries.map((e) => e.category).sort()).toEqual(
-      ["datasource", "integration", "policy"],
+      ["datasource", "integration", "policy", "raw_sql"],
     );
     expect(body.entries.every((e) => e.status === "allowed")).toBe(true);
   });
@@ -151,6 +151,13 @@ describe("admin MCP action policy route (#3509)", () => {
     const get = await request("GET");
     const getBody = (await get.json()) as { entries: { category: string; status: string }[] };
     expect(getBody.entries.find((e) => e.category === "datasource")?.status).toBe("blocked");
+  });
+
+  it("PUT can disable raw_sql — the admin off-switch for raw executeSQL over CLI/MCP (#4095)", async () => {
+    const put = await request("PUT", { category: "raw_sql", status: "blocked" });
+    expect(put.status).toBe(200);
+    const putBody = (await put.json()) as { entries: { category: string; status: string }[] };
+    expect(putBody.entries.find((e) => e.category === "raw_sql")?.status).toBe("blocked");
   });
 
   it("PUT audit-attributes the toggle with the category + status delta", async () => {

--- a/packages/api/src/api/routes/__tests__/execute-sql.test.ts
+++ b/packages/api/src/api/routes/__tests__/execute-sql.test.ts
@@ -104,6 +104,35 @@ mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   },
 }));
 
+// ── MCP action policy mock (gate 1 — raw-SQL kill-switch, #4095) ──────────────
+//
+// The route now consults `loadMcpActionPolicy` for the `raw_sql` category before
+// the pipeline (parity with the MCP `executeSQL` tool). Swap per-test to exercise
+// allow / block / read-throw (fail-closed). Sentinel denial copy asserts the
+// route surfaces the CENTRALIZED `mcpActionDenialCopy` (the real wording is pinned
+// in action-policy.test.ts); mock ALL runtime exports so a sibling test loading the
+// real module doesn't inherit a partial mock (CLAUDE.md mock-all-exports).
+let rawSqlPolicy: "allow" | "block" | "throw" = "allow";
+let policyCalls: Array<string> = [];
+const ALL_CATEGORIES = ["datasource", "integration", "policy", "raw_sql"];
+
+mock.module("@atlas/api/lib/mcp/action-policy", () => ({
+  loadMcpActionPolicy: async (orgId: string) => {
+    policyCalls.push(orgId);
+    if (rawSqlPolicy === "throw") throw new Error("policy read boom");
+    return { isBlocked: (c: string) => c === "raw_sql" && rawSqlPolicy === "block" };
+  },
+  mcpActionDenialCopy: (category: string) => ({
+    message: `denied:${category}`,
+    hint: `hint:${category}`,
+  }),
+  MCP_ACTION_CATEGORIES: ALL_CATEGORIES,
+  MCP_ACTION_CATEGORY_META: [],
+  isMcpActionCategory: (v: string) => ALL_CATEGORIES.includes(v),
+  getMcpActionPolicyEntries: async () => [],
+  setMcpActionCategoryStatus: async () => {},
+}));
+
 // ── runUserQueryPipeline mock ─────────────────────────────────────────────────
 //
 // Replace the shared pipeline so the route is tested without a live datasource.
@@ -182,6 +211,8 @@ beforeEach(() => {
   capturedContexts = [];
   gateCalls = [];
   pipelineCalls = [];
+  rawSqlPolicy = "allow";
+  policyCalls = [];
   gateImpl = async () => ({ allowed: true });
   pipelineImpl = async () => ({
     kind: "ok",
@@ -224,6 +255,64 @@ describe("POST /api/v1/execute-sql — auth + member floor (ADR-0027 §2)", () =
     expect(pipelineCalls[0]).toEqual(pipelineCalls[1]);
     // Neither was rejected for role.
     expect(pipelineCalls[0]).toMatchObject({ sql: "SELECT id FROM users" });
+  });
+});
+
+describe("POST /api/v1/execute-sql — raw-SQL kill-switch (gate 1, #4095)", () => {
+  it("allows raw SQL through to the pipeline when the policy permits it (default enabled)", async () => {
+    fakeAuth = userAuth();
+    rawSqlPolicy = "allow";
+    const res = await post({ sql: "SELECT 1" });
+    expect(res.status).toBe(200);
+    expect(policyCalls).toEqual(["org-1"]);
+    expect(pipelineCalls).toHaveLength(1);
+  });
+
+  it("blocks with 403 raw_sql_disabled (and never runs the pipeline) when an admin disabled raw SQL", async () => {
+    fakeAuth = userAuth();
+    rawSqlPolicy = "block";
+    const res = await post({ sql: "SELECT 1" });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; message: string; hint: string; requestId?: string };
+    expect(body.error).toBe("raw_sql_disabled");
+    // The route surfaces the centralized `mcpActionDenialCopy` (sentinel here;
+    // real "use `atlas query`" wording pinned in action-policy.test.ts).
+    expect(body.message).toBe("denied:raw_sql");
+    expect(body.hint).toBe("hint:raw_sql");
+    expect(body.requestId).toBeDefined();
+    expect(pipelineCalls).toHaveLength(0);
+  });
+
+  it("fails closed to 503 action_policy_unavailable when the policy read throws", async () => {
+    fakeAuth = userAuth();
+    rawSqlPolicy = "throw";
+    const res = await post({ sql: "SELECT 1" });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string; retryable?: boolean; requestId?: string };
+    expect(body.error).toBe("action_policy_unavailable");
+    expect(body.retryable).toBe(true);
+    expect(body.requestId).toBeDefined();
+    expect(pipelineCalls).toHaveLength(0);
+  });
+
+  it("runs the policy gate AFTER billing — a billing block short-circuits before the policy check", async () => {
+    fakeAuth = userAuth();
+    rawSqlPolicy = "block";
+    gateImpl = async () => ({
+      allowed: false,
+      errorCode: "trial_expired",
+      errorMessage: "Trial expired.",
+      httpStatus: 403,
+      retryable: false,
+    });
+    const res = await post({ sql: "SELECT 1" });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    // Billing wins the ordering — the raw_sql block never fires, the policy is
+    // never consulted, and the pipeline never runs.
+    expect(body.error).toBe("trial_expired");
+    expect(policyCalls).toHaveLength(0);
+    expect(pipelineCalls).toHaveLength(0);
   });
 });
 

--- a/packages/api/src/api/routes/execute-sql.ts
+++ b/packages/api/src/api/routes/execute-sql.ts
@@ -28,6 +28,14 @@
  *    suspended / trial-expired / plan-exhausted workspace is blocked before the
  *    pipeline runs. Solvency-only — Shape B runs no LLM. A throw from the gate
  *    fails closed to a 503 (never an allow).
+ *  - Action-policy gate-1 (raw-SQL kill-switch) via `loadMcpActionPolicy`, parity
+ *    with the MCP `executeSQL` tool's `actionCategory: "raw_sql"` (#4095, ADR-0016
+ *    gate 1). A workspace admin can disable raw SQL over the programmatic surfaces
+ *    (this route + the MCP tool), restricting members to the NL `atlas query`
+ *    path; both transports consult the SAME store + category so they can't drift.
+ *    Default enabled (no `blocked` row ⇒ allow), tighten-only, and fails closed
+ *    to a 503 on a policy read error. The agent loop / chat / `atlas query` never
+ *    reach this route, so they are never gated by it.
  *  - Member floor (any authenticated member; inherited from `standardAuth`) and
  *    no escalation: raw-SQL reach ≡ agent-loop reach for the same member —
  *    identical whitelist, RLS, and approval classification (the pipeline derives
@@ -65,6 +73,10 @@ import {
 } from "@atlas/api/lib/billing/agent-gate";
 import { isRequestOrigin } from "@atlas/api/lib/approvals/types";
 import { resolveActorKind } from "@atlas/api/lib/auth/api-key-metadata";
+import {
+  loadMcpActionPolicy,
+  mcpActionDenialCopy,
+} from "@atlas/api/lib/mcp/action-policy";
 import type { ExecuteSqlRestResponse } from "@useatlas/types";
 import type { UserQueryOutcome } from "@atlas/api/lib/tools/sql";
 import { validationHook } from "./validation-hook";
@@ -146,7 +158,8 @@ const executeSqlRoute = createRoute({
       content: { "application/json": { schema: z.record(z.string(), z.unknown()) } },
     },
     403: {
-      description: "Forbidden — billing block or RLS-denied",
+      description:
+        "Forbidden — billing block, RLS-denied, or raw SQL disabled for this workspace by an admin (#4095)",
       content: { "application/json": { schema: z.record(z.string(), z.unknown()) } },
     },
     404: {
@@ -174,7 +187,8 @@ const executeSqlRoute = createRoute({
       content: { "application/json": { schema: ErrorSchema } },
     },
     503: {
-      description: "Datasource or enterprise subsystem unavailable",
+      description:
+        "Datasource or enterprise subsystem unavailable, or the raw-SQL policy could not be read (fail-closed, #4095)",
       content: { "application/json": { schema: ErrorSchema } },
     },
   },
@@ -328,7 +342,7 @@ executeSql.openapi(executeSqlRoute, async (c) => {
       // the billing surface's "try again" signal instead of an opaque 500. ---
       const gate = yield* Effect.tryPromise({
         try: () => checkAgentBillingGate(orgId),
-        catch: (err) => new Error(err instanceof Error ? err.message : String(err)),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(
         Effect.catchAll((err) => {
           log.error(
@@ -366,6 +380,79 @@ executeSql.openapi(executeSqlRoute, async (c) => {
           // the gate's own.
           (gate.httpStatus ?? 403) as 403,
         );
+      }
+
+      // --- Gate 1 (parity with the MCP `executeSQL` tool): the per-workspace
+      // raw-SQL kill-switch (#4095, ADR-0016 gate 1). A workspace admin can
+      // disable raw `executeSQL` over the programmatic surfaces — this route
+      // (the `atlas sql` transport) and the MCP tool. Both consult the SAME
+      // `loadMcpActionPolicy` store + `raw_sql` category, so the two transports
+      // cannot drift (no per-surface enforcement). Tighten-only: an admin toggle
+      // can only restrict reach (add a block), never grant access below the
+      // member floor — ADR-0016's tighten-only invariant.
+      //
+      // Fails closed: a policy READ error blocks (503, retryable) rather than
+      // proceeds — a security decision must not fall through on infra failure,
+      // matching the billing gate above and the MCP dispatch gate. Absence of a
+      // `blocked` row (the default) and a DB-less deploy both resolve to allow
+      // inside `loadMcpActionPolicy`, so this is transparent until an admin
+      // flips it. The agent loop / chat / NL `atlas query` never reach this
+      // route, so they are structurally unaffected. ---
+      const rawSqlPolicy = yield* Effect.tryPromise({
+        try: async (): Promise<"allow" | "block"> =>
+          (await loadMcpActionPolicy(orgId)).isBlocked("raw_sql") ? "block" : "allow",
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => {
+          log.error(
+            { requestId, orgId, err, category: "action_policy_check_error" },
+            "MCP action policy read threw — failing closed (blocking raw SQL)",
+          );
+          return Effect.succeed<"unavailable">("unavailable");
+        }),
+      );
+      // Exhaustive on the tri-state so `allow` is explicit and any future state
+      // fails CLOSED (a security gate must never implicitly fall through to
+      // allow): the `never` default is both a compile guard and a 503 at runtime.
+      switch (rawSqlPolicy) {
+        case "allow":
+          break;
+        case "unavailable":
+          return c.json(
+            {
+              error: "action_policy_unavailable",
+              message:
+                "Unable to verify the raw-SQL policy for this workspace. Please try again shortly.",
+              retryable: true,
+              requestId,
+            } as never,
+            503,
+          );
+        case "block": {
+          log.warn(
+            { requestId, orgId, category: "raw_sql_disabled" },
+            "Execute-SQL blocked by workspace action policy (raw_sql disabled)",
+          );
+          const { message, hint } = mcpActionDenialCopy("raw_sql");
+          return c.json({ error: "raw_sql_disabled", message, hint, requestId } as never, 403);
+        }
+        default: {
+          const _exhaustive: never = rawSqlPolicy;
+          log.error(
+            { requestId, orgId, state: String(_exhaustive), category: "action_policy_unhandled_state" },
+            "Unhandled raw-SQL policy state — failing closed",
+          );
+          return c.json(
+            {
+              error: "action_policy_unavailable",
+              message:
+                "Unable to verify the raw-SQL policy for this workspace. Please try again shortly.",
+              retryable: true,
+              requestId,
+            } as never,
+            503,
+          );
+        }
       }
 
       // Audit origin derives from the credential's claim, never hardcoded — a

--- a/packages/api/src/lib/mcp/__tests__/action-policy.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/action-policy.test.ts
@@ -7,11 +7,14 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   loadMcpActionPolicy,
   getMcpActionPolicyEntries,
   setMcpActionCategoryStatus,
   isMcpActionCategory,
+  mcpActionDenialCopy,
   MCP_ACTION_CATEGORIES,
   MCP_ACTION_CATEGORY_META,
   type ActionPolicyQuery,
@@ -120,6 +123,50 @@ describe("setMcpActionCategoryStatus", () => {
 describe("isMcpActionCategory", () => {
   it("accepts canonical categories and rejects others", () => {
     expect(isMcpActionCategory("datasource")).toBe(true);
+    expect(isMcpActionCategory("raw_sql")).toBe(true);
     expect(isMcpActionCategory("nope")).toBe(false);
+  });
+});
+
+describe("raw_sql category (#4095)", () => {
+  it("is a canonical category with server-authoritative dashboard copy", () => {
+    expect(MCP_ACTION_CATEGORIES).toContain("raw_sql");
+    const meta = MCP_ACTION_CATEGORY_META.find((m) => m.category === "raw_sql");
+    expect(meta).toBeDefined();
+    expect(meta?.label).toBe("Raw SQL execution");
+    // The description must point members at the NL happy path and reassure that
+    // the agent/chat are untouched — the whole framing of the off-switch.
+    expect(meta?.description).toContain("atlas query");
+  });
+});
+
+describe("raw_sql gate scope (#4095 AC2b — the agent/chat path is never gated)", () => {
+  it("the shared runUserQueryPipeline (lib/tools/sql.ts) never consults the raw_sql kill-switch", () => {
+    // AC2(b): disabling raw_sql must NOT gate the Atlas agent loop / chat / NL
+    // `atlas query` — those bottom out in `runUserQueryPipeline`, while the gate
+    // lives ONLY in the REST route (`api/routes/execute-sql.ts`) and the MCP tool
+    // (`mcp/tools.ts`). This grep-guard (per the #4095 review panel) locks the
+    // seam: a future refactor that moved the policy check into the shared pipeline
+    // would fail here rather than silently gating the agent with no failing test.
+    const sqlSource = readFileSync(join(import.meta.dir, "../../tools/sql.ts"), "utf8");
+    expect(sqlSource).not.toContain("loadMcpActionPolicy");
+    expect(sqlSource).not.toContain("mcpActionDenialCopy");
+    expect(sqlSource).not.toContain("mcp/action-policy");
+  });
+});
+
+describe("mcpActionDenialCopy", () => {
+  it("gives raw_sql tailored copy that points members at `atlas query`", () => {
+    const { message, hint } = mcpActionDenialCopy("raw_sql");
+    expect(message).toContain("Raw SQL execution is disabled");
+    expect(message).toContain("atlas query");
+    expect(hint).toContain("re-enable raw SQL");
+  });
+
+  it("gives the mutation categories the generic per-category copy", () => {
+    const { message } = mcpActionDenialCopy("datasource");
+    expect(message).toBe(
+      "MCP 'datasource' actions are disabled for this workspace by an administrator.",
+    );
   });
 });

--- a/packages/api/src/lib/mcp/action-policy.ts
+++ b/packages/api/src/lib/mcp/action-policy.ts
@@ -35,14 +35,29 @@ const log = createLogger("mcp:action-policy");
  * `McpActionCategory` union in `@useatlas/types/mcp` — the value tuple lives
  * here (not exported from `@useatlas/types`) so adding a category never breaks
  * the scaffold smoke tests that pull the published `@useatlas/types`. The
- * `satisfies` keeps the two in lockstep: a category added to the union but not
- * here (or vice-versa) is a compile error.
+ * `satisfies` catches tuple→union drift (a bogus tuple element); the
+ * `_AssertCategoriesComplete` check below catches union→tuple drift (a category
+ * added to the wire union but forgotten here). Together they keep the two in
+ * lockstep in BOTH directions, so a security-relevant kill-switch category can't
+ * silently exist in the wire type without runtime enforcement.
  */
 export const MCP_ACTION_CATEGORIES = [
   "datasource",
   "integration",
   "policy",
+  "raw_sql",
 ] as const satisfies readonly McpActionCategory[];
+
+// Compile-time check: every `McpActionCategory` must appear in the tuple above.
+// `satisfies` alone only proves tuple ⊆ union; this proves union ⊆ tuple. If a
+// category is added to `McpActionCategory` but not appended here, this resolves
+// to `never` and the assignment fails to compile. Mirrors the
+// `ATLAS_ERROR_TAG_LIST` precedent in `lib/effect/errors.ts`.
+type _AssertCategoriesComplete = McpActionCategory extends (typeof MCP_ACTION_CATEGORIES)[number]
+  ? true
+  : never;
+const _assertCategoriesComplete: _AssertCategoriesComplete = true;
+void _assertCategoriesComplete;
 
 /** Server-authoritative label + description per category for the dashboard. */
 export interface McpActionCategoryMeta {
@@ -75,7 +90,37 @@ export const MCP_ACTION_CATEGORY_META: readonly McpActionCategoryMeta[] = [
     description:
       "Raising governance via MCP — adding approval rules and PII classifications. MCP can only tighten controls, never loosen them (the origin ceiling).",
   },
+  {
+    category: "raw_sql",
+    label: "Raw SQL execution",
+    description:
+      "Running caller-authored SQL directly over the programmatic surfaces — the CLI (`atlas sql`) and the MCP `executeSQL` tool. Disable to restrict members to the natural-language `atlas query` path. The Atlas agent, chat, and `atlas query` are never affected.",
+  },
 ];
+
+/**
+ * Denial copy for a blocked category, transport-neutral so the CLI/REST and MCP
+ * enforcement points surface identical wording (no per-surface drift, #4095).
+ * `raw_sql` points members at the NL `atlas query` path; the mutation categories
+ * share the generic copy the gate has always used. Single-sourced here alongside
+ * the category labels rather than inlined at each gate.
+ */
+export function mcpActionDenialCopy(category: McpActionCategory): {
+  message: string;
+  hint: string;
+} {
+  if (category === "raw_sql") {
+    return {
+      message:
+        "Raw SQL execution is disabled for this workspace by an administrator. Use the natural-language `atlas query` command instead.",
+      hint: "A workspace admin can re-enable raw SQL under Admin → MCP action policy.",
+    };
+  }
+  return {
+    message: `MCP '${category}' actions are disabled for this workspace by an administrator.`,
+    hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
+  };
+}
 
 /** Type guard — narrows an arbitrary string to a known category. */
 export function isMcpActionCategory(value: string): value is McpActionCategory {

--- a/packages/cli/src/lib/sql-client.ts
+++ b/packages/cli/src/lib/sql-client.ts
@@ -42,7 +42,7 @@ const ERR = {
 /** The kinds of failure a raw-SQL call can surface, each with an actionable message. */
 export type SqlErrorKind =
   | "unauthorized" // 401 — bearer missing/expired
-  | "forbidden" // 403 — billing block or RLS-denied
+  | "forbidden" // 403 — billing block, RLS-denied, or raw SQL disabled by a workspace admin (#4095)
   | "no_workspace" // 400 — credential has no bound workspace
   | "workspace_not_found" // 404 — billing block: the workspace was deleted
   | "invalid_sql" // 400 — rejected by the validation pipeline (DML/whitelist/unparseable)
@@ -154,8 +154,10 @@ export async function runSql(opts: SqlClientOptions, args: RunSqlArgs): Promise<
         "Your session is no longer valid. Run `atlas login` again.",
       );
     case 403:
-      // Billing block or RLS-denied — surface the server's message (it carries
-      // the actionable remedy, e.g. trial-expired guidance or the RLS reason).
+      // Billing block, RLS-denied, or raw SQL disabled for the workspace by an
+      // admin (#4095) — surface the server's message (it carries the actionable
+      // remedy, e.g. trial-expired guidance, the RLS reason, or "use `atlas
+      // query`").
       throw new SqlCliError("forbidden", serverMessage(body, res.status));
     case 404:
       // The ONLY 404 this route emits is a billing-gate block for a deleted

--- a/packages/mcp/src/__tests__/dispatch-gate.test.ts
+++ b/packages/mcp/src/__tests__/dispatch-gate.test.ts
@@ -148,6 +148,18 @@ const datasourceReqs: McpDispatchGateRequirements = {
   actionCategory: "datasource",
 };
 
+/**
+ * Member-floor, read-only reqs carrying the `raw_sql` read category — based on
+ * the real `executeSQL` tool (#4095), minus `checksBilling`/`requiresBoundOrg`
+ * so the test isolates gate 1 (no write scope, no billing).
+ */
+const rawSqlReqs: McpDispatchGateRequirements = {
+  toolName: "executeSQL",
+  requiresWrite: false,
+  minRole: "member",
+  actionCategory: "raw_sql",
+};
+
 describe("runMcpDispatchGate — gate order + branches (#3508)", () => {
   it("gate 2: denies a hosted mcp:read-only caller (forbidden)", async () => {
     const res = await runMcpDispatchGate(baseCtx({ scopes: ["mcp:read"] }), adminReqs);
@@ -402,6 +414,28 @@ describe("runMcpDispatchGate — gate 1: MCP action policy kill-switch (#3509)",
     });
     expect(res).toBeNull();
     expect(consulted).toBe(false); // no category ⇒ gate 1 skipped entirely
+  });
+
+  it("blocks the raw_sql read category with copy pointing members at `atlas query` (#4095)", async () => {
+    const res = await runMcpDispatchGate(baseCtx(), rawSqlReqs, {
+      loadActionPolicy: async () => stubActionPolicy(["raw_sql"]),
+    });
+    expect(res?.isError).toBe(true);
+    const env = parseAtlasMcpToolError(getContentText(res?.content));
+    expect(env?.code).toBe("forbidden");
+    // The tailored, transport-neutral copy from `mcpActionDenialCopy` — NOT the
+    // generic "MCP 'raw_sql' actions" wording (this is a read surface, and the
+    // remedy is the NL path).
+    expect(env?.message).toContain("Raw SQL execution is disabled");
+    expect(env?.message).toContain("atlas query");
+    expect(env?.message).not.toContain("MCP 'raw_sql'");
+  });
+
+  it("lets raw_sql through when the workspace has not disabled it (default enabled)", async () => {
+    const res = await runMcpDispatchGate(baseCtx(), rawSqlReqs, {
+      loadActionPolicy: async () => stubActionPolicy([]),
+    });
+    expect(res).toBeNull();
   });
 
   it("is a no-op (skipped) when there is no bound workspace (orgId undefined)", async () => {

--- a/packages/mcp/src/__tests__/mcp-approval-resume.test.ts
+++ b/packages/mcp/src/__tests__/mcp-approval-resume.test.ts
@@ -55,6 +55,24 @@ mock.module("@atlas/api/lib/config", () => ({
   _warnPoolDefaultsInSaaS: mock(() => undefined),
 }));
 
+// Gate-1 action policy (#4095): executeSQL declares actionCategory "raw_sql",
+// so the dispatch gate consults the per-workspace policy. Stub it all-allowed
+// (no real `mcp_action_policy` table here) — mock ALL runtime exports so a
+// sibling test loading the real module doesn't inherit a partial mock (CLAUDE.md).
+mock.module("@atlas/api/lib/mcp/action-policy", () => ({
+  loadMcpActionPolicy: async () => ({ isBlocked: () => false }),
+  mcpActionDenialCopy: (category: string) => ({
+    message: `MCP '${category}' actions are disabled for this workspace by an administrator.`,
+    hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
+  }),
+  MCP_ACTION_CATEGORIES: ["datasource", "integration", "policy", "raw_sql"],
+  MCP_ACTION_CATEGORY_META: [],
+  isMcpActionCategory: (v: string) =>
+    ["datasource", "integration", "policy", "raw_sql"].includes(v),
+  getMcpActionPolicyEntries: async () => [],
+  setMcpActionCategoryStatus: async () => {},
+}));
+
 mock.module("@atlas/api/lib/tools/explore", () => ({
   explore: {
     description: "Explore the semantic layer",

--- a/packages/mcp/src/__tests__/plugin-tools.test.ts
+++ b/packages/mcp/src/__tests__/plugin-tools.test.ts
@@ -47,6 +47,24 @@ mock.module("@atlas/api/lib/config", () => ({
   _warnPoolDefaultsInSaaS: mock(() => undefined),
 }));
 
+// Gate-1 action policy (#4095): executeSQL declares actionCategory "raw_sql",
+// so the dispatch gate consults the per-workspace policy. Stub it all-allowed
+// (no real `mcp_action_policy` table here) — mock ALL runtime exports so a
+// sibling test loading the real module doesn't inherit a partial mock (CLAUDE.md).
+mock.module("@atlas/api/lib/mcp/action-policy", () => ({
+  loadMcpActionPolicy: async () => ({ isBlocked: () => false }),
+  mcpActionDenialCopy: (category: string) => ({
+    message: `MCP '${category}' actions are disabled for this workspace by an administrator.`,
+    hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
+  }),
+  MCP_ACTION_CATEGORIES: ["datasource", "integration", "policy", "raw_sql"],
+  MCP_ACTION_CATEGORY_META: [],
+  isMcpActionCategory: (v: string) =>
+    ["datasource", "integration", "policy", "raw_sql"].includes(v),
+  getMcpActionPolicyEntries: async () => [],
+  setMcpActionCategoryStatus: async () => {},
+}));
+
 mock.module("@atlas/api/lib/tools/explore", () => ({
   explore: {
     description: "Explore the semantic layer",

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -46,6 +46,24 @@ mock.module("@atlas/api/lib/config", () => ({
   _warnPoolDefaultsInSaaS: mock(() => undefined),
 }));
 
+// Gate-1 action policy (#4095): executeSQL declares actionCategory "raw_sql",
+// so the dispatch gate consults the per-workspace policy. Stub it all-allowed
+// (no real `mcp_action_policy` table here) — mock ALL runtime exports so a
+// sibling test loading the real module doesn't inherit a partial mock (CLAUDE.md).
+mock.module("@atlas/api/lib/mcp/action-policy", () => ({
+  loadMcpActionPolicy: async () => ({ isBlocked: () => false }),
+  mcpActionDenialCopy: (category: string) => ({
+    message: `MCP '${category}' actions are disabled for this workspace by an administrator.`,
+    hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
+  }),
+  MCP_ACTION_CATEGORIES: ["datasource", "integration", "policy", "raw_sql"],
+  MCP_ACTION_CATEGORY_META: [],
+  isMcpActionCategory: (v: string) =>
+    ["datasource", "integration", "policy", "raw_sql"].includes(v),
+  getMcpActionPolicyEntries: async () => [],
+  setMcpActionCategoryStatus: async () => {},
+}));
+
 mock.module("@atlas/api/lib/tools/explore", () => ({
   explore: {
     description: "Explore the semantic layer",

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -44,6 +44,25 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
   },
 }));
 
+// --- Action-policy gate mock (gate 1, #4095) ---
+// executeSQL now declares actionCategory "raw_sql", so the dispatch gate
+// consults the per-workspace policy. Stub it all-allowed (these tests have no
+// real `mcp_action_policy` table) — mock ALL runtime exports so a sibling test
+// loading the real module doesn't inherit a partial mock (CLAUDE.md).
+mock.module("@atlas/api/lib/mcp/action-policy", () => ({
+  loadMcpActionPolicy: async () => ({ isBlocked: () => false }),
+  mcpActionDenialCopy: (category: string) => ({
+    message: `MCP '${category}' actions are disabled for this workspace by an administrator.`,
+    hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
+  }),
+  MCP_ACTION_CATEGORIES: ["datasource", "integration", "policy", "raw_sql"],
+  MCP_ACTION_CATEGORY_META: [],
+  isMcpActionCategory: (v: string) =>
+    ["datasource", "integration", "policy", "raw_sql"].includes(v),
+  getMcpActionPolicyEntries: async () => [],
+  setMcpActionCategoryStatus: async () => {},
+}));
+
 // --- Billing gate mock (#3437) ---
 // The MCP layer consults `checkAgentBillingGate` before any datasource
 // query (executeSQL / runMetric). Tests flip `billingGateVerdict` to

--- a/packages/mcp/src/dispatch-gate.ts
+++ b/packages/mcp/src/dispatch-gate.ts
@@ -53,6 +53,7 @@ import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { meetsRoleRequirement, getUserRole } from "@atlas/api/lib/auth/permissions";
 import {
   loadMcpActionPolicy,
+  mcpActionDenialCopy,
   type McpActionPolicy,
 } from "@atlas/api/lib/mcp/action-policy";
 import {
@@ -252,15 +253,10 @@ async function runActionPolicyGate(
       },
       "MCP tool denied at gate 1 — action category blocked by workspace policy",
     );
-    return toEnvelopeResult(
-      envelope(
-        "forbidden",
-        `MCP '${actionCategory}' actions are disabled for this workspace by an administrator.`,
-        {
-          hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
-        },
-      ),
-    );
+    // Denial copy is single-sourced in `mcpActionDenialCopy` so the MCP and
+    // CLI/REST enforcement points can't drift (#4095).
+    const { message, hint } = mcpActionDenialCopy(actionCategory);
+    return toEnvelopeResult(envelope("forbidden", message, { hint }));
   } catch (err) {
     log.error(
       {

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -236,8 +236,19 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
         "executeSQL",
         // Reaches a datasource → gate-0 billing (#3437/#3601). SELECT-only
         // (the 4-layer validator rejects DML/DDL) so it is read-only — no
-        // mcp:write — and member-callable.
-        { requiresWrite: false, requiresBoundOrg: false, minRole: "member", checksBilling: true },
+        // mcp:write — and member-callable. `actionCategory: "raw_sql"` opts it
+        // into the gate-1 per-workspace kill-switch (#4095): a workspace admin
+        // can disable raw SQL over MCP/CLI, restricting members to the NL
+        // `atlas query` path. Default is enabled (no `blocked` row), so this is
+        // a no-op until an admin flips it — the agent loop / chat are unaffected
+        // (they never route through this tool).
+        {
+          requiresWrite: false,
+          requiresBoundOrg: false,
+          minRole: "member",
+          checksBilling: true,
+          actionCategory: "raw_sql",
+        },
         async (requestId) => {
           // #3500 — progress + cancellation around the query work.
           // #3575 — `executeSQL.execute` does not read `abortSignal` from the

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -219,6 +219,11 @@ export type CanonicalToggle = "auto" | "always" | "never";
  *   - `datasource`  — datasource create / test / profile / delete (Tier-2 flagship)
  *   - `integration` — BYOT integration connections (Slack/GitHub/Linear/Email, Phase 4)
  *   - `policy`      — governance-*raising* tools (approval rules, PII classes, Phase 4)
+ *   - `raw_sql`     — caller-authored raw SQL over the programmatic surfaces
+ *     (CLI `atlas sql`, MCP `executeSQL`). The *read/query* category (#4095):
+ *     the mutation categories above govern writes, this governs the advanced
+ *     read surface. Disabling it restricts members to the NL `atlas query`
+ *     path; the Atlas agent / chat / `atlas query` are never gated by it.
  *
  * Type-only here (no value tuple) so `@atlas/web` shares the union without
  * reaching into `@atlas/api`; the runtime tuple + per-category labels live in
@@ -226,7 +231,7 @@ export type CanonicalToggle = "auto" | "always" | "never";
  * categories straight off the policy API response — same no-value-export
  * discipline as `CanonicalToggle` above.
  */
-export type McpActionCategory = "datasource" | "integration" | "policy";
+export type McpActionCategory = "datasource" | "integration" | "policy" | "raw_sql";
 
 /**
  * Stored state of one category for a workspace. The default posture is


### PR DESCRIPTION
Closes #4095.

Lets a **workspace admin** disable raw `executeSQL` over the programmatic surfaces — the CLI (`atlas sql`) and the MCP `executeSQL` tool — restricting members to the safe NL **`atlas query`** (Shape A) path, **without affecting the agent loop / chat / `atlas query`**. This is the gate-1 analog governance lever shaped during the #4047 security grill (ADR-0025 surface).

## What changed

- **New `raw_sql` action-policy category** (`packages/api/src/lib/mcp/action-policy.ts` + `packages/types/src/mcp.ts`). It's the first *read/query* category — the existing `datasource`/`integration`/`policy` categories govern mutations. Default **enabled** (no `blocked` row ⇒ allow), so rollout is a no-op until an admin flips it. The union↔runtime-tuple lockstep is now enforced in **both** directions (a compile-time exhaustiveness assert catches union→tuple drift that `satisfies` alone missed).
- **Enforced at the same store + category for both transports** (no per-surface drift, tighten-only):
  - **MCP** — the `executeSQL` tool declares `actionCategory: "raw_sql"`, so dispatch gate-1 consults the policy.
  - **CLI/REST** — the `/api/v1/execute-sql` route (which `atlas sql` calls) consults `loadMcpActionPolicy` after billing gate-0, **fails closed** on a read error (503 retryable), and returns a 403 `raw_sql_disabled` when blocked.
- **Single-sourced denial copy** (`mcpActionDenialCopy`) so the MCP `forbidden` envelope and the REST 403 can't drift; members get a clear *"Raw SQL execution is disabled … Use the natural-language `atlas query` command instead."*
- **Admin toggle** surfaces automatically — the admin MCP-action-policy UI is data-driven and the PUT enum derives from the category tuple, so no per-category UI code was needed.

## Acceptance criteria
- [x] A workspace admin can disable raw `executeSQL` over CLI + MCP; members get a clear "use `atlas query`" error.
- [x] Default **enabled** (no behavior change on rollout); the agent loop / chat / NL `atlas query` are never gated — locked by a grep-guard test asserting the shared `runUserQueryPipeline` never imports the policy loader.
- [x] Enforced at the same gate seam (same store + category) for both transports; `origin`-ceiling preserved (tighten-only).

## Testing
- New/updated tests: `action-policy.test.ts` (category presence, denial copy, AC2b scope-guard), `dispatch-gate.test.ts` (raw_sql block/allow + tailored copy), `execute-sql.test.ts` (403 block, 503 fail-closed, allow, billing-before-policy ordering), `admin-mcp-action-policy.test.ts` (raw_sql toggle). The 4 MCP integration tests gained an all-allowed `action-policy` mock (mock-all-exports).
- Deterministic gates green locally: type ✓, lint ✓, syncpack ✓, schema-drift ✓, template-drift ✓, openapi-drift regenerated. Full suite runs in CI.

## Review
Ran the internal **4-specialist review panel** pre-PR (silent-failure, type-design, test-coverage, comment-accuracy): **0 must-fix**. All MEDIUM/LOW findings addressed and verified — bidirectional exhaustiveness assert (empirically proven to catch drift via `tsc`), fail-closed exhaustive `switch`, `catch` normalization to the CLAUDE.md form, the AC2b grep-guard test, and comment clarity.

## Dependencies
Depends on #4047 (merged — the raw-SQL surface this governs). ADR-0016 (gate chain), ADR-0025 (self-service surfaces).
