### PR TITLE
docs(v0.0.36): close CLI/MCP hardening doc gaps

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -394,7 +394,7 @@ It returns:
 
 `state` is one of `grace` (a fresh trial in its unclaimed-grace window) or `locked` (this account has already used its one trial — the workspace is created but starts blocked, and you must subscribe on the web to use it).
 
-Point your agent's MCP client at `connectUrl` to run the normal OAuth 2.1 + DCR + PKCE [connect flow](#path-a--in-product-wizard-recommended) and attach a hosted actor to the new workspace. The workspace starts in a short **unclaimed grace period** (`state: "grace"`) — setup (connect a datasource, build the semantic layer) and client-paid MCP querying work immediately; the full 14-day trial clock starts when you **claim** the account on the web (verify email → set a credential → accept ToS).
+Point your agent's MCP client at `connectUrl` to run the normal OAuth 2.1 + DCR + PKCE [connect flow](#path-a--in-product-wizard-recommended) and attach a hosted actor to the new workspace. The workspace starts in a short **unclaimed grace period** (`state: "grace"`) — setup (connect a datasource, build the semantic layer) and client-paid MCP querying work immediately; the full 14-day trial clock starts when you **claim** the account on the web (verify email by OTP → enroll a passkey → accept ToS — no password).
 
 #### Metered until claimed
 
@@ -403,13 +403,23 @@ While the workspace is unclaimed, it is **metered**: everything you do over MCP 
 - **Open pre-claim:** `start_trial`, the datasource setup/lifecycle tools, `executeSQL`, `runMetric`, and the rest of the MCP surface. The client model pays for MCP querying, so it costs Atlas nothing.
 - **Withheld pre-claim:** Atlas-token Q&A on the web `/api/v1/query` endpoint, chat platforms, and the scheduler. These return a typed `claim_required` response carrying the claim URL (the web OTP interstitial) instead of an answer.
 
-**Claim the account on the web** — open the claim URL, enter the emailed one-time code to verify your email (never a magic link), set a credential or passkey, and accept the Terms. Verifying your email **is** the claim: it flips the workspace metered → full and starts the full 14-day trial clock. No payment is required. Once claimed, Atlas-token Q&A runs within the normal trial budget, and `checksBilling` MCP tool responses include the number of **trial days remaining**.
+**Claim the account on the web** — open the claim URL (the `/claim` interstitial), enter the emailed one-time code to verify your email (never a magic link), enroll a passkey (password-free — this also clears the admin-MFA requirement), and accept the Terms. Verifying your email **is** the claim: it flips the workspace metered → full and starts the full 14-day trial clock. No payment is required. Once claimed, Atlas-token Q&A runs within the normal trial budget, and `checksBilling` MCP tool responses include the number of **trial days remaining**.
 
 See [Claiming a Self-Serve (MCP) Trial](/guides/signup#claiming-a-self-serve-mcp-trial) for the full claim flow. Note this is distinct from trial **expiry**: once a trial expires, every surface — MCP included — is blocked with `billing_blocked` until a paid subscription is added.
 
 ## Available tools
 
-The MCP server exposes six core semantic tools — two general-purpose and four typed accessors over the semantic layer — plus a set of admin [datasource lifecycle tools](#datasource-lifecycle-tools) covered below. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
+The MCP server exposes seven core semantic tools — three general-purpose and four typed accessors over the semantic layer — plus a set of admin [datasource lifecycle tools](#datasource-lifecycle-tools) covered below. Prefer the typed tools when you only need catalog/glossary/metric data; reach for `explore` only when you need raw file access.
+
+### query
+
+Hand Atlas a **natural-language question** and let its server-side agent answer it — the recommended, highest-quality path. See [Two ways to ask: `query` vs `executeSQL`](#two-ways-to-ask-query-vs-executesql) for when to reach for it versus the raw `executeSQL` escape hatch.
+
+```
+question: "top 5 customers by revenue last quarter"
+```
+
+It returns a prose `answer` plus the exact SQL it ran and the result rows. Because it runs a second, server-side LLM it **spends your Atlas plan tokens** and additionally clears the claim gate (unclaimed-trial metering).
 
 ### explore
 
@@ -528,9 +538,9 @@ The `filters` parameter is reserved for future pre-aggregation filter pass-throu
 
 ## Datasource lifecycle tools
 
-Beyond the read-only semantic tools above, the server exposes a set of **admin, write-scoped** tools for managing datasources from an agent: `list_datasources`, `test_datasource`, `create_datasource`, `create_rest_datasource`, `profile_datasource`, `archive_datasource`, `restore_datasource`, and `delete_datasource`. They require the `admin` role and (for the mutating tools) the `mcp:write` scope, and route through RBAC plus the per-workspace MCP action policy; the `destructive` `delete_datasource` additionally routes through the approval gate. None of them ever return a connection URL or any secret — `create_datasource` collects the credential via a separate masked prompt that is never shared with the agent.
+Beyond the read-only semantic tools above, the server exposes a set of **admin, write-scoped** tools for managing datasources from an agent: `list_datasources`, `test_datasource`, `create_datasource`, `create_rest_datasource`, `profile_datasource`, `publish_datasources`, `archive_datasource`, `restore_datasource`, and `delete_datasource`. They require the `admin` role and (for the mutating tools) the `mcp:write` scope, and route through RBAC plus the per-workspace MCP action policy; the `destructive` `delete_datasource` additionally routes through the approval gate. None of them ever return a connection URL or any secret — `create_datasource` collects the credential via a separate masked prompt that is never shared with the agent.
 
-The two-step path to make a new datasource queryable is **create → profile**:
+The path to make a new datasource queryable on the published `/chat` surface is **create → profile → publish**:
 
 ### create_datasource
 
@@ -560,9 +570,19 @@ Profiling does two things with the generated layer:
 }
 ```
 
-Because the persisted rows land as **drafts**, they follow the standard [content-mode](/security/sql-validation) status discipline: queryable immediately in **developer mode** (the draft overlay), but **not** on the published `/chat` surface until an admin promotes them through the atomic publish endpoint (`/api/v1/admin/publish`). This keeps machine-generated, unreviewed entities out of the published whitelist until a human signs off. Profiling fails loud (a `validation_failed` envelope) rather than report success if any generated table cannot be persisted — a partially-persisted layer would silently leave some tables unqueryable.
+Because the persisted rows land as **drafts**, they follow the standard [content-mode](/security/sql-validation) status discipline: queryable immediately in **developer mode** (the draft overlay), but **not** on the published `/chat` surface until an admin promotes them through the atomic publish endpoint (`/api/v1/admin/publish`) — reachable from an agent via the [`publish_datasources`](#publish_datasources) tool below, from a shell via [`atlas datasource publish`](/reference/cli#datasource-publish), or from the admin console. This keeps machine-generated, unreviewed entities out of the published whitelist until a human signs off. Profiling fails loud (a `validation_failed` envelope) rather than report success if any generated table cannot be persisted — a partially-persisted layer would silently leave some tables unqueryable.
 
 If profiling persists fewer rows than it generated, or the workspace has no internal database configured (a self-hosted stdio server with no `DATABASE_URL`), `persisted` is `false` and only the in-process whitelist is populated for the current session.
+
+### publish_datasources
+
+Promote **every** pending datasource draft in the workspace to `published` in one atomic transaction, so the entities and metrics `profile_datasource` generated become queryable from the published `/chat` surface (not just in developer mode). It is the agent-facing client for the same atomic publish endpoint (`/api/v1/admin/publish`) as [`atlas datasource publish`](/reference/cli#datasource-publish); it is **workspace-wide**, not per-datasource. Requires the `admin` role and the `mcp:write` scope, and routes through the per-workspace action policy.
+
+```jsonc
+// Example publish_datasources success
+// `promoted` = draft rows flipped to published; `deleted_entities` = stale rows pruned by the publish
+{ "published": true, "promoted": 16, "deleted_entities": 0 }
+```
 
 ---
 
@@ -575,7 +595,16 @@ Each workspace has a **per-workspace MCP action policy** — a customer-admin ki
 - **Governance is raise-only** (ADR-0016): the policy can only ever *tighten* what MCP clients may do. It never lowers the non-configurable origin ceiling — MCP can restrict, but never broaden, the workspace's configured permissions.
 - Policy changes and gated dispatches carry audit-trail attribution.
 
-This is the kill-switch to reach for when you want to keep, say, datasource mutation or destructive actions off the MCP surface for a workspace while leaving the read-only analyst tools available.
+The categories are:
+
+| Category | Governs |
+|----------|---------|
+| `datasource` | Creating, testing, profiling, publishing, and deleting datasources via MCP |
+| `integration` | Connecting delivery integrations (Slack, GitHub, Linear, Email) via MCP |
+| `policy` | Raising governance via MCP — approval rules and PII classifications (tighten-only) |
+| `raw_sql` | Running caller-authored SQL over the **programmatic** surfaces — the MCP `executeSQL` tool **and** the CLI's [`atlas sql`](/reference/cli#sql) |
+
+Most categories are the kill-switch to reach for when you want to keep, say, datasource mutation or destructive actions off the MCP surface for a workspace while leaving the read-only analyst tools available. The `raw_sql` category is broader than MCP alone: blocking it disables raw `executeSQL` over **both** MCP and the CLI, restricting members to the natural-language [`atlas query`](/reference/cli#query) path. The Atlas analyst agent, chat, and `atlas query` itself are **never** gated by it — it restricts only the raw pass-through, not the agent.
 
 ---
 

--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -243,12 +243,12 @@ A workspace created over MCP starts **unclaimed (metered)**. In that state:
 {
   "error": "claim_required",
   "message": "Asking Atlas questions of your data is paused until you claim this workspace…",
-  "claimUrl": "https://app.useatlas.dev/signup?email=you@acme.com",
+  "claimUrl": "https://app.useatlas.dev/claim?email=you@acme.com",
   "retryable": false
 }
 ```
 
-**Claiming** = completing the post-signup OTP interstitial on the web: enter the emailed one-time code to verify your email (Atlas never uses magic links), set a credential or passkey, and accept the Terms. Verifying your email **is** the claim. On claim, Atlas:
+**Claiming** = completing the dedicated `/claim` interstitial on the web: enter the emailed one-time code to verify your email (Atlas never uses magic links), enroll a passkey (password-free — this also satisfies the admin-MFA requirement, so the trial owner can immediately reach admin surfaces and mint an API key), and accept the Terms. Verifying your email **is** the claim. On claim, Atlas:
 
 1. Flips the workspace from metered → full (Atlas-token Q&A is no longer withheld).
 2. Records the owner's `emailVerified` bit — the single signal the claim-gate keys on.

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -177,7 +177,7 @@ The commands in this group act on a **workspace** through a running Atlas API �
 **Authentication** rides on exactly one of two mutually exclusive credentials — never both:
 
 - **Ambient `atlas login` session (recommended).** Run [`atlas login`](#login) once; the OAuth device flow stores a session in `~/.atlas/credentials` and every later `atlas` command (and any agent running in that logged-in shell) reuses it automatically — the `gh auth login` / `railway login` model. No key to provision.
-- **Workspace API key (unattended CI).** Mint a workspace-scoped key on the `/admin/api-keys` page and pass it via the `ATLAS_API_KEY` environment variable or `--api-key <key>` (the flag overrides the env var). Honored by the four REST-backed commands — `sql`, `metric run`, `explore`, and `datasource`. A key is pinned to one workspace, so the `--workspace` override does not apply to it. Commands that need an interactive session (`switch`, `entities`) still require `atlas login`.
+- **Workspace API key (unattended CI).** Mint a workspace-scoped key on the `/admin/api-keys` page and pass it via the `ATLAS_API_KEY` environment variable or `--api-key <key>` (the flag overrides the env var). Honored by the REST-backed commands — [`query`](#query), `sql`, `metric run`, `explore`, and `datasource`. A key is pinned to one workspace, so the `--workspace` override does not apply to it. Commands that need an interactive session (`switch`, `entities`) still require `atlas login`.
 
 Set `ATLAS_API_URL` (default `http://localhost:3001`) to target a non-local API. See [API Key Management](/guides/api-keys) for the full credential model — ambient login vs. workspace key, scope, and RLS-claim bounds — and [Environment Variables](/reference/environment-variables#workspace-cli-credentials) for `ATLAS_API_URL` / `ATLAS_API_KEY` / `ATLAS_DATASOURCE_SECRET`.
 
@@ -253,6 +253,10 @@ bun run atlas -- sql "SELECT ..." [options]
 | `--csv` | CSV output (headers + rows, pipe-friendly). Mutually exclusive with `--json` |
 
 DML/DDL, multi-statement (`;`-chained), non-whitelisted-table, and unparseable SQL are all rejected by the server. Human output is a table (`(no rows)` when empty); a row-limited result prints a truncation note.
+
+<Callout title="A workspace admin can disable raw SQL">
+Raw caller-authored SQL over the programmatic surfaces is a governance category. A workspace admin can turn it off under **Admin → MCP action policy** (the `raw_sql` category); when disabled, both `atlas sql` and the MCP `executeSQL` tool are blocked and members are pointed at the natural-language [`atlas query`](#query) path instead. The Atlas agent, chat, and `atlas query` are **never** affected — this restricts only the raw pass-through, not the analyst agent.
+</Callout>
 
 **Examples:**
 
@@ -337,6 +341,7 @@ bun run atlas -- datasource <command> [id] [options]
 | [`test <id>`](#datasource-test) | Health-check a datasource connection |
 | [`create <id>`](#datasource-create) | Provision a new datasource (connection URL captured on stdin / env, never a flag) |
 | [`profile <id>`](#datasource-profile) | Profile a datasource and generate its semantic layer as drafts (long-running, cancellable) |
+| [`publish [id]`](#datasource-publish) | Publish every pending draft in the workspace (atomic, workspace-wide — the optional `id` is only for confirmation messaging) |
 | [`archive <id>`](#datasource-archive) | Archive a datasource (reversible via `restore`) |
 | [`restore <id>`](#datasource-restore) | Restore an archived datasource (republishes it) |
 | [`delete <id>`](#datasource-delete) | Delete a datasource (soft — recoverable via `restore`) |
@@ -395,7 +400,7 @@ ATLAS_DATASOURCE_SECRET="postgres://user:pass@host:5432/db" bun run atlas -- dat
 The connection URL is captured by exactly one of two paths, in priority order: (1) the `ATLAS_DATASOURCE_SECRET` environment variable (the headless-agent path — read at request time, never lands in argv), or (2) a masked stdin prompt (the interactive path — keystrokes don't echo and don't enter shell history). With **no TTY and no env var** (a CI runner), `create` fails closed and defers datasource creation to the dashboard or the [Atlas MCP](/guides/mcp); a set-but-empty `ATLAS_DATASOURCE_SECRET` is treated as a misconfiguration and fails loudly rather than silently prompting.
 </Callout>
 
-The new datasource lands as a **draft** — publish it in the Atlas console (or it stays developer-mode-only). The command suggests `atlas datasource test <id>` to verify connectivity.
+The new datasource lands as a **draft** — run [`atlas datasource publish`](#datasource-publish) (or publish it in the Atlas console), or it stays developer-mode-only. The command suggests `atlas datasource test <id>` to verify connectivity.
 
 ### datasource profile
 
@@ -406,7 +411,21 @@ bun run atlas -- datasource profile <id>
 bun run atlas -- datasource profile <id> --json
 ```
 
-Generated entities and metrics are persisted as **drafts** — they are **not** auto-published. They are queryable immediately in developer mode; publish them from the admin console to make them queryable from the published `/chat` surface. If some tables fail introspection, the result is reported as incomplete and names the absent tables.
+Generated entities and metrics are persisted as **drafts** — they are **not** auto-published. They are queryable immediately in developer mode; run [`atlas datasource publish`](#datasource-publish) (or publish from the admin console) to make them queryable from the published `/chat` surface. If some tables fail introspection, the result is reported as incomplete and names the absent tables.
+
+### datasource publish
+
+Publish every pending datasource draft in the workspace, making CLI/MCP-generated datasources — and the entities/metrics `profile` generated for them — queryable from the published `/chat` surface. It is a thin client over the atomic workspace-wide publish endpoint (`POST /api/v1/admin/publish`): it promotes **all** pending drafts in one transaction, **not** a single datasource, so the `id` positional is **optional** and used only to phrase the confirmation. Requires the workspace admin role.
+
+```bash
+# Publish every pending draft in the workspace
+bun run atlas -- datasource publish
+
+# The id is accepted but only for confirmation messaging — the publish is still workspace-wide
+bun run atlas -- datasource publish <id>
+```
+
+The MCP equivalent is the [`publish_datasources`](/guides/mcp#publish_datasources) tool. Drafts created by the CLI/MCP are already queryable in developer mode before publishing; `publish` is what exposes them on the published `/chat` surface.
 
 ### datasource archive
 

--- a/apps/docs/content/docs/reference/error-codes.mdx
+++ b/apps/docs/content/docs/reference/error-codes.mdx
@@ -165,7 +165,7 @@ A workspace provisioned over MCP by `start_trial` starts **unclaimed (metered)**
 
 | Code | Class | HTTP Status | Trigger | Fix | Retryable |
 |------|-------|-------------|---------|-----|-----------|
-| `claim_required` | `ClaimRequiredError` | 403 | Atlas-token Q&A was attempted on an unclaimed (metered) trial workspace. The response body carries `claimUrl` (the web OTP interstitial) alongside `message` | Open `claimUrl`, verify the owner's email (enter the emailed one-time code), set a credential, and accept the Terms. Verifying email **is** the claim — it flips the workspace metered → full | No |
+| `claim_required` | `ClaimRequiredError` | 403 | Atlas-token Q&A was attempted on an unclaimed (metered) trial workspace. The response body carries `claimUrl` (the web OTP interstitial) alongside `message` | Open `claimUrl` (the `/claim` interstitial), verify the owner's email (enter the emailed one-time code), enroll a passkey (password-free), and accept the Terms. Verifying email **is** the claim — it flips the workspace metered → full | No |
 | `claim_check_failed` | `ClaimCheckFailedError` | 503 | The claim-gate could not read the owner's `emailVerified` state (e.g. internal DB transiently unavailable). Surfaced as a retryable 503 rather than spending Atlas tokens on an unverifiable request | Retry after a short backoff. If it persists, check internal-DB (`DATABASE_URL`) health | Yes |
 
 ### Self-serve trial signup over MCP (`start_trial`)


### PR DESCRIPTION
## Summary

Milestone **v0.0.36 — CLI & MCP Hardening** ([#78](https://github.com/AtlasDevHQ/atlas/milestone/78)) closeout docs audit. Four user-facing behaviors shipped without matching docs (or against now-stale docs); fixed inline per the closeout doc-audit step.

| Gap | Feature | Files |
|-----|---------|-------|
| `atlas datasource publish` + MCP `publish_datasources` undocumented; stale "publish via console" lines | #4126 | `reference/cli.mdx`, `guides/mcp.mdx` |
| `raw_sql` action-policy category + cross-surface scope undocumented | #4095 | `guides/mcp.mdx`, `reference/cli.mdx` |
| Claim flow still referenced `/signup` + "set a credential"; now `/claim` + password-free passkey | #4125 / #4135 | `guides/signup.mdx`, `guides/mcp.mdx`, `reference/error-codes.mdx` |
| MCP `query` tool missing from the Available-tools list (count said 6, is 7) | #4094 | `guides/mcp.mdx` |

Also cross-links `atlas query` into the workspace-key command list (#4124).

## Verification

- Ground-truth checked against code before editing: `buildClaimUrl` (`/claim?email=`), MCP tool name `publish_datasources` + its real `{ published, promoted, deleted_entities }` response shape, the `raw_sql` category meta/scope in `lib/mcp/action-policy.ts`, and the CLI `datasource publish [id]` (workspace-wide, `id` for messaging only).
- New headings resolve; `<Callout>` tags balanced (cli.mdx 8/8, mcp.mdx 7/7); no stale `/signup` claim refs remain.

Docs-only. No `apps/www` changes needed (verified: every surface this milestone touched — CLI/MCP/NL query — is already framed as first-class on the landing page; hardening, not net-new capability).