### PR TITLE
fix(v0.0.36): milestone-wide review-panel follow-ups

### DIFF
--- a/ee/src/onboarding/provision-trial.ts
+++ b/ee/src/onboarding/provision-trial.ts
@@ -9,7 +9,7 @@
  * `assignSaasTrial` / `claimTrialGrant` path verbatim: creating the
  * organization fires Better Auth's `afterCreateOrganization` hook, which runs
  * `assignSaasTrial` (atomic one-trial-per-user claim + tier assignment). This
- * provisioner then narrows `trial_ends_at` from the full {@link TRIAL_DAYS}
+ * provisioner then narrows `trial_ends_at` from the full `TRIAL_DAYS` (14-day)
  * window down to {@link TRIAL_GRACE_HOURS} — the 14-day clock only starts when
  * a human *claims* the account on the web.
  *

--- a/packages/cli/src/__tests__/datasource-command.test.ts
+++ b/packages/cli/src/__tests__/datasource-command.test.ts
@@ -379,6 +379,20 @@ describe("runDatasource — publish (#4126)", () => {
     expect(out.join("\n")).toContain("Nothing to publish");
   });
 
+  it("a deletion-only publish reports the prune, not a clean no-op", async () => {
+    // 0 promoted but >0 tombstoned entities is a real publish, not a no-op.
+    const { fetchImpl } = stubFetch(200, {
+      promoted: { connections: 0, entities: 0, prompts: 0, starterPrompts: 0 },
+      deleted: { entities: 2 },
+    });
+    const { io, out } = capture();
+    const code = await runDatasource(["datasource", "publish"], deps(fetchImpl), io);
+    expect(code).toBe(0);
+    const text = out.join("\n");
+    expect(text).not.toContain("Nothing to publish");
+    expect(text).toContain("Pruned 2 stale entities");
+  });
+
   it("--json emits the raw publish response", async () => {
     const body = { promoted: { connections: 1, entities: 0, prompts: 0, starterPrompts: 0 } };
     const { fetchImpl } = stubFetch(200, body);

--- a/packages/cli/src/commands/datasource.ts
+++ b/packages/cli/src/commands/datasource.ts
@@ -598,17 +598,32 @@ async function runPublish(
       prompts: typeof promoted.prompts === "number" ? promoted.prompts : 0,
       starterPrompts: typeof promoted.starterPrompts === "number" ? promoted.starterPrompts : 0,
     };
-    const total = counts.connections + counts.entities + counts.prompts + counts.starterPrompts;
-    if (total === 0) {
+    // The publish also tombstones stale entities superseded by the promotion
+    // (`deleted.entities`). Count it toward "did anything happen?" so a
+    // deletion-only publish isn't mislabeled a clean no-op.
+    const deletedEntities =
+      typeof asRecord(result.deleted).entities === "number"
+        ? (asRecord(result.deleted).entities as number)
+        : 0;
+    const promotedTotal =
+      counts.connections + counts.entities + counts.prompts + counts.starterPrompts;
+    if (promotedTotal === 0 && deletedEntities === 0) {
       io.out("Nothing to publish — no pending drafts in this workspace.");
       return 0;
     }
-    io.out(
-      `Published ${counts.connections} datasource${counts.connections === 1 ? "" : "s"}, ` +
-        `${counts.entities} entit${counts.entities === 1 ? "y" : "ies"}, ${counts.prompts} prompt ` +
-        `collection${counts.prompts === 1 ? "" : "s"}, and ${counts.starterPrompts} starter ` +
-        `prompt${counts.starterPrompts === 1 ? "" : "s"}.`,
-    );
+    if (promotedTotal > 0) {
+      io.out(
+        `Published ${counts.connections} datasource${counts.connections === 1 ? "" : "s"}, ` +
+          `${counts.entities} entit${counts.entities === 1 ? "y" : "ies"}, ${counts.prompts} prompt ` +
+          `collection${counts.prompts === 1 ? "" : "s"}, and ${counts.starterPrompts} starter ` +
+          `prompt${counts.starterPrompts === 1 ? "" : "s"}.`,
+      );
+    }
+    if (deletedEntities > 0) {
+      io.out(
+        `Pruned ${deletedEntities} stale entit${deletedEntities === 1 ? "y" : "ies"} superseded by this publish.`,
+      );
+    }
     io.out("  This is atomic and workspace-wide — every pending draft just went live, not only");
     io.out(`  ${id ? `"${id}"` : "the datasource you may have had in mind"}.`);
     return 0;

--- a/packages/cli/src/lib/credential.ts
+++ b/packages/cli/src/lib/credential.ts
@@ -1,8 +1,10 @@
 /**
  * The workspace credential the REST-backed CLI clients updated in #4112
- * (`sql`/`metric`/`explore`/`datasource`) authenticate with (ADR-0027 §5). The
- * legacy `query`/`import`/`init` commands route `ATLAS_API_KEY` through the
- * separate operator-Bearer path and do NOT use this type.
+ * (`sql`/`metric`/`explore`/`datasource`) authenticate with (ADR-0027 §5), plus
+ * `query`, which joined this XOR-credential path in #4124 (so `ATLAS_API_KEY`
+ * now rides as `x-api-key`, not the operator Bearer). The legacy `import`/`init`
+ * commands still route `ATLAS_API_KEY` through the separate operator-Bearer path
+ * and do NOT use this type.
  *
  * Authorization rides on exactly ONE of two mutually-exclusive credential
  * classes — never both:

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -46,11 +46,13 @@ mock.module("@atlas/api/lib/tools/sql", () => ({
 
 // --- Action-policy gate mock (gate 1, #4095) ---
 // executeSQL now declares actionCategory "raw_sql", so the dispatch gate
-// consults the per-workspace policy. Stub it all-allowed (these tests have no
-// real `mcp_action_policy` table) — mock ALL runtime exports so a sibling test
-// loading the real module doesn't inherit a partial mock (CLAUDE.md).
+// consults the per-workspace policy. Default all-allowed (these tests have no
+// real `mcp_action_policy` table); a test flips `blockedCategories` to exercise
+// the raw_sql kill-switch. Mock ALL runtime exports so a sibling test loading
+// the real module doesn't inherit a partial mock (CLAUDE.md).
+let blockedCategories = new Set<string>();
 mock.module("@atlas/api/lib/mcp/action-policy", () => ({
-  loadMcpActionPolicy: async () => ({ isBlocked: () => false }),
+  loadMcpActionPolicy: async () => ({ isBlocked: (c: string) => blockedCategories.has(c) }),
   mcpActionDenialCopy: (category: string) => ({
     message: `MCP '${category}' actions are disabled for this workspace by an administrator.`,
     hint: "A workspace admin can re-enable this category under Admin → MCP action policy.",
@@ -122,6 +124,7 @@ describe("MCP tools", () => {
     mockExploreExecute.mockClear();
     mockExecuteSQLExecute.mockClear();
     billingGateVerdict = { allowed: true };
+    blockedCategories = new Set();
     mockCheckAgentBillingGate.mockClear();
   });
 
@@ -261,6 +264,27 @@ describe("MCP tools", () => {
     expect(parsed.row_count).toBe(1);
     expect(parsed.rows).toEqual([{ count: 42 }]);
     expect(result.isError).toBeFalsy();
+  });
+
+  it("executeSQL is blocked (forbidden, pipeline never runs) when the workspace disables raw_sql (#4095)", async () => {
+    // The MCP half of the raw_sql kill-switch: executeSQL declares
+    // actionCategory "raw_sql", so a workspace that blocks the category must
+    // deny the tool at the dispatch gate BEFORE the SQL pipeline runs. Without
+    // this, dropping `actionCategory: "raw_sql"` from the tool registration
+    // would ship green while silently disabling the MCP enforcement surface.
+    blockedCategories = new Set(["raw_sql"]);
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "executeSQL",
+      arguments: { sql: "SELECT count(*) FROM users", explanation: "Count users" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = JSON.parse(getContentText(result.content));
+    expect(envelope.code).toBe("forbidden");
+    expect(envelope.message).toContain("raw_sql");
+    // The kill-switch short-circuits ahead of the SQL pipeline.
+    expect(mockExecuteSQLExecute).not.toHaveBeenCalled();
   });
 
   it("executeSQL returns structuredContent conforming to the declared outputSchema (#3498)", async () => {

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -2,8 +2,8 @@
  * Structured-output schemas for the MCP datasource-query tools (#3498,
  * spec 2025-11-25).
  *
- * `executeSQL` and `runMetric` declare an `outputSchema` and return
- * `structuredContent` so downstream clients/agents parse a typed result
+ * `executeSQL`, `runMetric`, and `query` (#4094) declare an `outputSchema` and
+ * return `structuredContent` so downstream clients/agents parse a typed result
  * instead of re-parsing the stringified text block (which is retained for
  * backward compatibility).
  *

--- a/packages/web/src/app/claim/page.test.tsx
+++ b/packages/web/src/app/claim/page.test.tsx
@@ -254,6 +254,19 @@ describe("ClaimPage — region routing", () => {
     expect(sendVerificationOtpMock).not.toHaveBeenCalled();
     expect(reloadMock).not.toHaveBeenCalled();
   });
+
+  test("a non-2xx resolve-region response surfaces a retryable error, never proceeds to OTP", async () => {
+    // Regression: a 500 whose JSON body has no `outcome` must not fall through
+    // to the exhaustive `default` and silently `proceed` on the default base —
+    // that would dispatch OTP for a home-region account against the wrong edge.
+    isCrossOriginMock.mockImplementation(() => true);
+    searchParamsStore.email = "owner@acme.com";
+    respondWith({ error: "internal_error" }, 500);
+    render(<ClaimPage />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /Try again/i })).toBeTruthy());
+    expect(sendVerificationOtpMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
 });
 
 // ── Credential step: passkey enrollment ─────────────────────────────────────

--- a/packages/web/src/app/claim/page.tsx
+++ b/packages/web/src/app/claim/page.tsx
@@ -197,6 +197,14 @@ export default function ClaimPage() {
         credentials: "same-origin",
         body: JSON.stringify({ email: targetEmail }),
       });
+      if (!res.ok) {
+        // A non-2xx (e.g. a 500 whose JSON body has no `outcome`) must NOT fall
+        // through to the exhaustive `default` and silently `proceed` on the
+        // default base — that mis-routes OTP for a home-region account. Surface
+        // it as the retryable `error` the code screen already renders.
+        console.warn("[claim] region resolution HTTP error:", res.status);
+        return { kind: "error", message: "We couldn't route your claim to the right region. Please try again." };
+      }
       const result = (await res.json()) as RegionResolution;
       switch (result.outcome) {
         case "single":
@@ -218,8 +226,11 @@ export default function ClaimPage() {
           return { kind: "proceed" };
         default: {
           const _exhaustive: never = result;
-          void _exhaustive;
-          return { kind: "proceed" };
+          // A 2xx with an unmodeled `outcome` is a server-contract violation;
+          // log it (never silently swallow) and surface a retryable error
+          // rather than proceeding on a possibly-wrong base.
+          console.warn("[claim] unexpected region resolution outcome:", JSON.stringify(_exhaustive));
+          return { kind: "error", message: "We couldn't route your claim to the right region. Please try again." };
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Fixes from the **v0.0.36 milestone-wide review panel** — a cross-PR review of the combined release diff (`v0.0.35..main`) run at closeout, which caught sibling drift that per-issue reviews missed. All four specialists (silent-failure, type-design, test-coverage, comment-accuracy) returned **ship-ready**; this folds the cheap/clear findings in **before the `v0.0.36` tag** rather than farming follow-ups.

| Fix | Finding | Severity |
|-----|---------|----------|
| **test(mcp)** pin the `raw_sql` kill-switch's MCP half | `executeSQL` declares `actionCategory: "raw_sql"` (#4095) but no test asserted the block path — dropping it would ship green while silently disabling MCP enforcement (REST/CLI stays covered) | test, sev 7 |
| **fix(web)** claim-page region resolve fail-loud | a non-2xx resolve-region response was swallowed into a silent `proceed` → an upstream 500 dispatches OTP against the default base, not the home region (launch-critical claim funnel) | silent-failure, LOW |
| **fix(cli)** deletion-only publish label | a publish with 0 promoted / >0 tombstoned entities was mislabeled "Nothing to publish" — `runPublish` ignored the server `deleted.entities` count | type-design, LOW |
| **docs(mcp)** `structured-output.ts` header | omitted `query` (#4094) as a third `outputSchema` consumer | comment, LOW |
| **docs(cli)** `CliCredential` docstring | said `query` doesn't use it; #4124 migrated `query` onto the XOR-credential (`x-api-key`) path | comment, LOW |
| **docs(ee)** `provision-trial` `{@link}` | dangling `{@link TRIAL_DAYS}` (only `TRIAL_GRACE_HOURS` imported) | comment, cosmetic |

Three new tests pin the two behavioral fixes + the enforcement gap.

## Deferred to #4156
The publish-result **wire-type unification** across REST/MCP/CLI (needs `@useatlas/types` release sequencing) and the `/regions` route→picker **wiring test** (needs non-trivial residency mocking; the picker logic itself is already exhaustively unit-tested). Both LOW, neither blocks the tag.

## Verification
- `bun test` — mcp `tools.test.ts` (44 pass), cli `datasource-command.test.ts` (53 pass), web `claim/page.test.tsx` (17 pass), all incl. the new tests.
- `bun run type` — clean (EXIT=0). `bun run lint` — clean (EXIT=0).

Closeout context: milestone #78 is CLOSED; the v0.0.36 tag is pending `/release`, so these land ahead of it.