### PR TITLE
refactor(4156): unify publish-result wire type across REST/MCP/CLI + pin /regions apiRegion test

### DIFF
--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -11,9 +11,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock, type Mock } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
 import { makeQueryEffectMock } from "@atlas/api/testing/api-test-mocks";
+import { ResidencyResolver, type ResidencyResolverShape } from "@atlas/api/lib/effect/services";
 
 // --- Mocks ---
 
@@ -223,6 +224,41 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
   isIPAllowed: mock(() => true),
 }));
 
+// Residency resolver injection (#4156). The `/regions` route yields
+// `ResidencyResolver` (the ONLY enterprise Tag onboarding uses) from the
+// enterprise runtime; the real runtime resolves it to the no-op (available:
+// false) in a self-hosted test build. Override `getEnterpriseRuntime` to a
+// runtime whose ResidencyResolver reads mutable per-test vars via getters, so a
+// test can drive the configured multi-region path without the heavier
+// effect-module shim `admin-residency.test.ts` uses. Default = unavailable, so
+// the pre-existing `configured:false` regions test is unaffected.
+let mockResidencyAvailable = false;
+let mockResidencyDefaultRegion = "us";
+let mockResidencyRegions: Record<
+  string,
+  { label: string; apiUrl?: string; selectable?: boolean }
+> = {};
+const fakeResidencyResolver = {
+  get available() {
+    return mockResidencyAvailable;
+  },
+  listRegions: () => Effect.succeed([]),
+  getDefaultRegion: () => mockResidencyDefaultRegion,
+  getConfiguredRegions: () => mockResidencyRegions,
+  assignWorkspaceRegion: () => Effect.succeed(null),
+  getWorkspaceRegionAssignment: () => Effect.succeed(null),
+  listWorkspaceRegions: () => Effect.succeed([]),
+  isConfiguredRegion: (r: string) => r in mockResidencyRegions,
+} as unknown as ResidencyResolverShape;
+const testEnterpriseRuntime = ManagedRuntime.make(
+  Layer.succeed(ResidencyResolver, fakeResidencyResolver),
+);
+const realEnterpriseLayer = await import("@atlas/api/lib/effect/enterprise-layer");
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  ...realEnterpriseLayer,
+  getEnterpriseRuntime: () => testEnterpriseRuntime,
+}));
+
 // --- Import the route after mocks are set up ---
 
 const { onboarding } = await import("../routes/onboarding");
@@ -305,6 +341,54 @@ describe("GET /api/v1/onboarding/regions (public — pre-auth, ADR-0024 §4)", (
     } finally {
       // Restore even if the assertion throws, so the mode can't leak forward.
       mockAuthMode = "managed";
+    }
+  });
+
+  it("collapses the picker to this deploy's own (non-selectable staging) home arm — the { apiRegion } wiring (#4131/#4156)", async () => {
+    // The staging deploy claims ATLAS_API_REGION=staging while building from the
+    // shared prod config, so its home arm is the non-selectable `staging` entry.
+    // The route MUST thread `{ apiRegion: getApiRegion() }` into
+    // buildSignupRegions so the picker collapses to ONLY that home arm — every
+    // public arm's apiUrl points at a DIFFERENT deploy, so offering them would
+    // cross-origin the signup POST and dead-end (#4131). Dropping the
+    // `{ apiRegion }` argument (a plausible refactor) would offer the selectable
+    // prod arms (us, eu) instead and this assertion fails — the regression this
+    // route test exists to catch.
+    mockAuthMode = "managed";
+    mockResidencyAvailable = true;
+    mockResidencyDefaultRegion = "us";
+    mockResidencyRegions = {
+      us: { label: "US", apiUrl: "https://api.useatlas.dev", selectable: true },
+      eu: { label: "EU", apiUrl: "https://eu.api.useatlas.dev", selectable: true },
+      staging: {
+        label: "Staging",
+        apiUrl: "https://api-staging.useatlas.dev",
+        selectable: false,
+      },
+    };
+    const prevApiRegion = process.env.ATLAS_API_REGION;
+    process.env.ATLAS_API_REGION = "staging";
+    try {
+      const res = await request("/api/v1/onboarding/regions");
+      expect(res.status).toBe(200);
+      const data = await json(res);
+      expect(data.configured).toBe(true);
+      // Collapsed to the home arm only — NOT the selectable prod arms.
+      expect(data.defaultRegion).toBe("staging");
+      expect(data.availableRegions).toEqual([
+        {
+          id: "staging",
+          label: "Staging",
+          isDefault: true,
+          apiUrl: "https://api-staging.useatlas.dev",
+        },
+      ]);
+    } finally {
+      if (prevApiRegion === undefined) delete process.env.ATLAS_API_REGION;
+      else process.env.ATLAS_API_REGION = prevApiRegion;
+      mockResidencyAvailable = false;
+      mockResidencyRegions = {};
+      mockResidencyDefaultRegion = "us";
     }
   });
 });

--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -121,13 +121,13 @@ export type PublishResponse = z.infer<typeof PublishResponseSchema>;
 // #4156 drift guard: the REST response must stay a structural superset of the
 // shared `PublishResult` core (promoted counts + `deleted.entities`) so the
 // REST / MCP / CLI publish surfaces can't diverge on the delete-count field
-// name. Reshaping the core here (e.g. `deleted` → `deleted_entities`, or a
-// promoted-count rename) fails this assignment at compile time. The REST schema
-// itself stays local hono-`z` because `@useatlas/schemas` carries no
-// `.openapi()` metadata and this response adds the REST-only `archived` +
-// `warnings` blocks on top of the shared core.
-const _publishResponseConformsToShared: PublishResult =
-  undefined as unknown as PublishResponse;
+// name. This never-called function fails to compile if the REST core reshapes
+// (e.g. `deleted` → `deleted_entities`, or a promoted-count rename); the
+// `archived` + `warnings` extras don't break it (a superset is assignable to
+// the core). The REST schema itself stays local hono-`z` because
+// `@useatlas/schemas` carries no `.openapi()` metadata. Mirrors the guard idiom
+// in `packages/mcp/src/structured-output.ts`.
+const _assertPublishResponseIsShared = (r: PublishResponse): PublishResult => r;
 
 // ---------------------------------------------------------------------------
 // Route definition

--- a/packages/api/src/api/routes/admin-publish.ts
+++ b/packages/api/src/api/routes/admin-publish.ts
@@ -22,6 +22,7 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
+import type { PublishResult } from "@useatlas/types";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { getInternalDB } from "@atlas/api/lib/db/internal";
@@ -116,6 +117,17 @@ const PublishResponseSchema = z.object({
 });
 
 export type PublishResponse = z.infer<typeof PublishResponseSchema>;
+
+// #4156 drift guard: the REST response must stay a structural superset of the
+// shared `PublishResult` core (promoted counts + `deleted.entities`) so the
+// REST / MCP / CLI publish surfaces can't diverge on the delete-count field
+// name. Reshaping the core here (e.g. `deleted` → `deleted_entities`, or a
+// promoted-count rename) fails this assignment at compile time. The REST schema
+// itself stays local hono-`z` because `@useatlas/schemas` carries no
+// `.openapi()` metadata and this response adds the REST-only `archived` +
+// `warnings` blocks on top of the shared core.
+const _publishResponseConformsToShared: PublishResult =
+  undefined as unknown as PublishResponse;
 
 // ---------------------------------------------------------------------------
 // Route definition

--- a/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/mcp-lifecycle.test.ts
@@ -811,9 +811,11 @@ describe("publishWorkspaceDrafts (#4126)", () => {
 
     const result = await publishWorkspaceDrafts("org_1");
 
+    // #4156 — shared PublishResult core: nested `deleted: { entities }`, not the
+    // old flat `deletedEntities`.
     expect(result).toEqual({
       promoted: { connections: 1, entities: 2, prompts: 0, starterPrompts: 3 },
-      deletedEntities: 1,
+      deleted: { entities: 1 },
     });
     const sqlLog = publishClientQueries.map((q) => q.sql.trim().toUpperCase());
     expect(sqlLog[0]).toBe("BEGIN");

--- a/packages/api/src/lib/datasources/mcp-lifecycle.ts
+++ b/packages/api/src/lib/datasources/mcp-lifecycle.ts
@@ -27,7 +27,7 @@
 
 import { Cause, Effect, ManagedRuntime } from "effect";
 import type { AtlasMode } from "@useatlas/types/auth";
-import type { WorkspaceId } from "@useatlas/types";
+import type { PublishResult, WorkspaceId } from "@useatlas/types";
 import { CONTENT_MODE_TABLES, makeService } from "@atlas/api/lib/content-mode";
 import { connections } from "@atlas/api/lib/db/connection";
 import type { HealthCheckResult, DBType } from "@atlas/api/lib/db/connection";
@@ -245,16 +245,14 @@ function safeDbType(catalogSlug: string): string {
 
 // ── Publish (#4126) ─────────────────────────────────────────────────────
 
-/** Promotion counts returned by {@link publishWorkspaceDrafts}. */
-export interface PublishWorkspaceDraftsResult {
-  readonly promoted: {
-    readonly connections: number;
-    readonly entities: number;
-    readonly prompts: number;
-    readonly starterPrompts: number;
-  };
-  readonly deletedEntities: number;
-}
+/**
+ * Result of {@link publishWorkspaceDrafts} — the shared {@link PublishResult}
+ * wire type (#4156). The lib returns exactly the shared core (`promoted` +
+ * `deleted.entities`); the REST route and MCP tool extend it with their
+ * surface-specific extras (see {@link PublishResult}). Kept as a named alias so
+ * this module's callers keep a domain-local name.
+ */
+export type PublishWorkspaceDraftsResult = PublishResult;
 
 /**
  * Atomically promote every pending `draft` (and apply every `draft_delete`
@@ -297,7 +295,9 @@ export async function publishWorkspaceDrafts(orgId: string): Promise<PublishWork
         prompts: find("prompt_collections")?.promoted ?? 0,
         starterPrompts: find("query_suggestions")?.promoted ?? 0,
       },
-      deletedEntities: entitiesReport?.tombstonesApplied ?? 0,
+      // #4156 — `deleted.entities` (shared shape), NOT the old flat
+      // `deletedEntities`; mirrors the REST route's `deleted: { entities }`.
+      deleted: { entities: entitiesReport?.tombstonesApplied ?? 0 },
     };
 
     // Best-effort hot-register into the live ConnectionRegistry — same

--- a/packages/cli/src/__tests__/datasource-client.test.ts
+++ b/packages/cli/src/__tests__/datasource-client.test.ts
@@ -152,6 +152,20 @@ describe("datasource-client route mapping (#4044)", () => {
     expect(calls[0].url).toBe(`${BASE}/api/v1/admin/publish`);
     expect(JSON.parse(calls[0].body!)).toEqual({});
     expect(out.promoted).toEqual({ connections: 1, entities: 2, prompts: 0, starterPrompts: 0 });
+    // Lock the delete-count pass-through at the client boundary too (#4156).
+    expect(out.deleted).toEqual({ entities: 0 });
+  });
+
+  it("publish surfaces a typed error on an unexpected 200 shape, not a silent no-op (#4156)", async () => {
+    // A 200 whose body isn't a real PublishResult — version skew, or a proxy /
+    // captive portal answering 200 with HTML. Must throw (so the operator sees
+    // it) rather than pass an empty shape that `runPublish` degrades to
+    // "Nothing to publish".
+    const { fetchImpl } = stubFetch(200, { promoted: { connections: 1 } });
+    const err = await publishDatasources(opts(fetchImpl)).catch((e) => e);
+    expect(err).toBeInstanceOf(DatasourceCliError);
+    expect((err as DatasourceCliError).kind).toBe("request_failed");
+    expect((err as DatasourceCliError).message).toContain("unexpected response shape");
   });
 
   it("create → POST /api/v1/admin/connections with the secret url in the body", async () => {

--- a/packages/cli/src/__tests__/datasource-command.test.ts
+++ b/packages/cli/src/__tests__/datasource-command.test.ts
@@ -362,6 +362,7 @@ describe("runDatasource — publish (#4126)", () => {
   it("does not require an id, but echoes it in the confirmation when given", async () => {
     const { fetchImpl } = stubFetch(200, {
       promoted: { connections: 1, entities: 0, prompts: 0, starterPrompts: 0 },
+      deleted: { entities: 0 },
     });
     const { io, out } = capture();
     const code = await runDatasource(["datasource", "publish", "fresh-pg"], deps(fetchImpl), io);
@@ -372,6 +373,7 @@ describe("runDatasource — publish (#4126)", () => {
   it("reports a clean no-op when there is nothing to publish", async () => {
     const { fetchImpl } = stubFetch(200, {
       promoted: { connections: 0, entities: 0, prompts: 0, starterPrompts: 0 },
+      deleted: { entities: 0 },
     });
     const { io, out } = capture();
     const code = await runDatasource(["datasource", "publish"], deps(fetchImpl), io);
@@ -394,7 +396,12 @@ describe("runDatasource — publish (#4126)", () => {
   });
 
   it("--json emits the raw publish response", async () => {
-    const body = { promoted: { connections: 1, entities: 0, prompts: 0, starterPrompts: 0 } };
+    // A realistic REST response — always includes the `deleted` core (the client
+    // validates the shape before emitting); `--json` echoes it verbatim.
+    const body = {
+      promoted: { connections: 1, entities: 0, prompts: 0, starterPrompts: 0 },
+      deleted: { entities: 0 },
+    };
     const { fetchImpl } = stubFetch(200, body);
     const { io, out } = capture();
     const code = await runDatasource(["datasource", "publish", "--json"], deps(fetchImpl), io);

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -35,6 +35,7 @@ import type {
   ConnectionInfo,
   DatasourceProfileResult,
   DatasourceProfileTableEvent,
+  PublishResult,
 } from "@useatlas/types";
 import {
   ConnectionDetailSchema,
@@ -418,15 +419,21 @@ export async function deleteDatasource(
  */
 export async function publishDatasources(
   opts: DatasourceClientOptions,
-): Promise<Record<string, unknown>> {
-  return asRecord(
-    await request(opts, {
-      method: "POST",
-      path: "/api/v1/admin/publish",
-      body: {},
-      operation: "publish datasources",
-    }),
-  );
+): Promise<PublishResult> {
+  // Typed pass-through of the shared PublishResult core (#4156 — the SSOT in
+  // `@useatlas/types`). Deliberately NOT `.safeParse()`d + thrown like the
+  // `atlas sql` / `atlas metric` clients: those render structured column/row
+  // data a shape skew would mangle, whereas the publish command reads only a few
+  // counts and degrades a missing count to 0 (`runPublish`), so this client
+  // stays tolerant. The raw body is returned verbatim, so `--json` still emits
+  // the REST-only `archived` / `warnings` blocks the command layer ignores.
+  const raw = await request(opts, {
+    method: "POST",
+    path: "/api/v1/admin/publish",
+    body: {},
+    operation: "publish datasources",
+  });
+  return raw as PublishResult;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -40,6 +40,7 @@ import type {
 import {
   ConnectionDetailSchema,
   ConnectionsResponseSchema,
+  PublishResultSchema,
   parseDatasourceProfileStreamEvent,
 } from "@useatlas/schemas";
 import { credentialHeaders, type CliCredential } from "./credential";
@@ -420,19 +421,27 @@ export async function deleteDatasource(
 export async function publishDatasources(
   opts: DatasourceClientOptions,
 ): Promise<PublishResult> {
-  // Typed pass-through of the shared PublishResult core (#4156 — the SSOT in
-  // `@useatlas/types`). Deliberately NOT `.safeParse()`d + thrown like the
-  // `atlas sql` / `atlas metric` clients: those render structured column/row
-  // data a shape skew would mangle, whereas the publish command reads only a few
-  // counts and degrades a missing count to 0 (`runPublish`), so this client
-  // stays tolerant. The raw body is returned verbatim, so `--json` still emits
-  // the REST-only `archived` / `warnings` blocks the command layer ignores.
   const raw = await request(opts, {
     method: "POST",
     path: "/api/v1/admin/publish",
     body: {},
     operation: "publish datasources",
   });
+  // Validate the shared PublishResult core (the SSOT in `@useatlas/types`) — a
+  // shape mismatch is a server bug / version skew. Returning it unchecked would
+  // let `runPublish`'s degrade-a-missing-count-to-0 reads misreport a real
+  // publish (or a 200 from a misrouted proxy / captive portal) as a clean
+  // "Nothing to publish" no-op — the worst failure mode for a mutation command.
+  // Surface it as a typed error instead, like the sibling `atlas sql` /
+  // `atlas metric` clients. VALIDATE only: return the RAW body (NOT
+  // `parsed.data`, which would strip the REST-only `archived` / `warnings`
+  // blocks `--json` surfaces); the command layer reads only the validated core.
+  if (!PublishResultSchema.safeParse(raw).success) {
+    throw new DatasourceCliError(
+      "request_failed",
+      "The Atlas API returned an unexpected response shape for publish datasources. Update the CLI, or check the server logs.",
+    );
+  }
   return raw as PublishResult;
 }
 

--- a/packages/mcp/src/__tests__/datasource-tools.test.ts
+++ b/packages/mcp/src/__tests__/datasource-tools.test.ts
@@ -28,6 +28,7 @@ import {
   mcpToolMutates,
   type McpToolAnnotationsShape,
 } from "@atlas/api/lib/mcp/dispatch-gate-contract";
+import { publishDatasourcesOutputSchema } from "../structured-output.js";
 
 const TEST_ACTOR = createAtlasUser("u_ds", "managed", "ds@test", {
   role: "admin",
@@ -195,10 +196,11 @@ const mockProfileLive = mock<(...a: unknown[]) => Promise<unknown>>(async (...a:
   return profileResult;
 });
 
-// #4126 — publish_datasources' lib call. Default: nothing pending.
+// #4126 — publish_datasources' lib call. Default: nothing pending. The lib
+// returns the shared PublishResult core (#4156 — `deleted: { entities }`).
 let publishResult: unknown = {
   promoted: { connections: 0, entities: 0, prompts: 0, starterPrompts: 0 },
-  deletedEntities: 0,
+  deleted: { entities: 0 },
 };
 const mockPublishWorkspaceDrafts = mock<(...a: unknown[]) => Promise<unknown>>(
   async () => publishResult,
@@ -323,7 +325,7 @@ beforeEach(() => {
   mockPublishWorkspaceDrafts.mockClear();
   publishResult = {
     promoted: { connections: 0, entities: 0, prompts: 0, starterPrompts: 0 },
-    deletedEntities: 0,
+    deleted: { entities: 0 },
   };
   gateCalls = [];
   installerCalls = [];
@@ -841,17 +843,25 @@ describe("publish_datasources (#4126)", () => {
   it("calls the lib seam with the bound org and shapes the promoted/deleted counts", async () => {
     publishResult = {
       promoted: { connections: 1, entities: 3, prompts: 0, starterPrompts: 0 },
-      deletedEntities: 1,
+      deleted: { entities: 1 },
     };
     const client = await createTestClient();
     const res = await client.callTool({ name: "publish_datasources", arguments: {} });
     expect(mockPublishWorkspaceDrafts).toHaveBeenCalledWith("org_ds");
-    const body = JSON.parse(getContentText(res.content));
-    expect(body).toEqual({
+    // #4156 — single-cased (all camelCase) output keyed off the shared
+    // PublishResult core: nested `deleted: { entities }`, NOT snake
+    // `deleted_entities`.
+    const expected = {
       published: true,
       promoted: { connections: 1, entities: 3, prompts: 0, starterPrompts: 0 },
-      deleted_entities: 1,
-    });
+      deleted: { entities: 1 },
+    };
+    const body = JSON.parse(getContentText(res.content));
+    expect(body).toEqual(expected);
+    // #3498 — the declared outputSchema makes structuredContent mandatory; it
+    // mirrors the text block and conforms to publishDatasourcesOutputSchema.
+    expect(res.structuredContent).toEqual(expected);
+    expect(publishDatasourcesOutputSchema.safeParse(res.structuredContent).success).toBe(true);
   });
 
   it("is a clean no-op (zero counts) when nothing is pending", async () => {
@@ -859,7 +869,7 @@ describe("publish_datasources (#4126)", () => {
     const res = await client.callTool({ name: "publish_datasources", arguments: {} });
     const body = JSON.parse(getContentText(res.content));
     expect(body.promoted).toEqual({ connections: 0, entities: 0, prompts: 0, starterPrompts: 0 });
-    expect(body.deleted_entities).toBe(0);
+    expect(body.deleted).toEqual({ entities: 0 });
   });
 
   it("requires a bound workspace — refused before the lib call", async () => {

--- a/packages/mcp/src/datasource-tools.ts
+++ b/packages/mcp/src/datasource-tools.ts
@@ -61,6 +61,7 @@ import { envelope, toEnvelopeResult, toJsonContent } from "./error-envelope.js";
 import { createMcpDispatch, errorMessage } from "./mcp-dispatch.js";
 import { elicitMaskedForm } from "./elicitation.js";
 import { withProgressAndCancellation, OperationCancelledError } from "./progress.js";
+import { publishDatasourcesOutputShape } from "./structured-output.js";
 
 // ── Lazy heavy-module loaders ─────────────────────────────────────────
 //
@@ -932,6 +933,10 @@ export function registerDatasourceTools(
       description: withErrorContract(PUBLISH_DATASOURCES_DESCRIPTION, DATASOURCE_WRITE_ERROR_CODES),
       annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
       inputSchema: {},
+      // #4156 — typed result keyed off the shared PublishResult core, so an MCP
+      // client parses `{ published, promoted, deleted: { entities } }` instead of
+      // re-parsing the text block (retained below for back-compat).
+      outputSchema: publishDatasourcesOutputShape,
     },
     async (): Promise<CallToolResult> =>
       dispatch(
@@ -946,11 +951,22 @@ export function registerDatasourceTools(
         async () => {
           const orgId = boundOrg();
           const result = await (await lifecycle()).publishWorkspaceDrafts(orgId);
-          return toJsonContent({
+          // #4156 — single-cased (all camelCase) output keyed off the shared
+          // PublishResult core: `deleted: { entities }`, never snake
+          // `deleted_entities`. `published: true` is the MCP success sentinel.
+          // The declared outputSchema makes `structuredContent` required (#3498);
+          // the text block is retained for clients that read it.
+          const structured = {
             published: true,
             promoted: result.promoted,
-            deleted_entities: result.deletedEntities,
-          });
+            deleted: { entities: result.deleted.entities },
+          };
+          return {
+            content: [
+              { type: "text" as const, text: JSON.stringify(structured, null, 2) },
+            ],
+            structuredContent: structured,
+          };
         },
       ),
   );
@@ -1038,7 +1054,7 @@ const CREATE_REST_DATASOURCE_DESCRIPTION = `Provision a NEW generic REST datasou
 
 const PROFILE_DATASOURCE_DESCRIPTION = `Profile a datasource (introspect its tables) and generate its semantic layer — entities + the table whitelist — so the agent can query it with executeSQL. Long-running: emits progress per table and is cancellable. Typically run right after create_datasource; follow up with publish_datasources to make the result queryable from the published /chat surface. Requires the \`mcp:write\` scope and the admin role. Example call: \`{ "id": "prod-us" }\`. Example success: \`{ "id": "prod-us", "queryable": true, "entities_generated": 12, "tables": ["orders", "users"], "elapsed_ms": 1840 }\`.`;
 
-const PUBLISH_DATASOURCES_DESCRIPTION = `Atomically promote EVERY pending draft in this workspace — every datasource, semantic entity, prompt collection, and starter prompt created/edited but not yet live — to published, making them queryable from the published /chat surface. This is the SAME atomic, workspace-wide operation as the admin console's single "Publish" button (NOT a per-datasource action — there is no \`id\` argument, and it is not scoped to one datasource even if you just created or profiled only one). Typically the last step after create_datasource → profile_datasource. A no-op (zero counts) when nothing is pending. Requires the \`mcp:write\` scope and the admin role. Example success: \`{ "published": true, "promoted": { "connections": 1, "entities": 12, "prompts": 0, "starterPrompts": 0 }, "deleted_entities": 0 }\`.`;
+const PUBLISH_DATASOURCES_DESCRIPTION = `Atomically promote EVERY pending draft in this workspace — every datasource, semantic entity, prompt collection, and starter prompt created/edited but not yet live — to published, making them queryable from the published /chat surface. This is the SAME atomic, workspace-wide operation as the admin console's single "Publish" button (NOT a per-datasource action — there is no \`id\` argument, and it is not scoped to one datasource even if you just created or profiled only one). Typically the last step after create_datasource → profile_datasource. A no-op (zero counts) when nothing is pending. Requires the \`mcp:write\` scope and the admin role. Example success: \`{ "published": true, "promoted": { "connections": 1, "entities": 12, "prompts": 0, "starterPrompts": 0 }, "deleted": { "entities": 0 } }\`.`;
 
 // Read tools: not-found surfaces as `unknown_entity`; everything else as
 // `internal_error`. RBAC denial (gate 3) surfaces as `forbidden`.

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -24,6 +24,7 @@
  */
 
 import { z } from "zod/v4";
+import type { PublishResult } from "@useatlas/types";
 
 /** A result row: a flat map of column name → cell value. */
 const rowsField = z.array(z.record(z.string(), z.unknown()));
@@ -127,7 +128,36 @@ export const queryOutputShape = {
   ...approvalFields,
 } as const;
 
+/**
+ * `publish_datasources` output (#4126 / #4156). Unlike the query tools, publish
+ * has a SINGLE non-error result — the atomic promotion always returns the same
+ * shape (it is additive, never approval-gated, so there is no `approval_required`
+ * branch) — so every field is required, not optional. `published` is the success
+ * sentinel; `promoted` + `deleted` are the shared {@link PublishResult} core,
+ * single-cased camelCase throughout (`deleted: { entities }`, never a snake
+ * `deleted_entities`).
+ */
+export const publishDatasourcesOutputShape = {
+  published: z.boolean(),
+  promoted: z.object({
+    connections: z.number().int().nonnegative(),
+    entities: z.number().int().nonnegative(),
+    prompts: z.number().int().nonnegative(),
+    starterPrompts: z.number().int().nonnegative(),
+  }),
+  deleted: z.object({ entities: z.number().int().nonnegative() }),
+} as const;
+
 /** Zod objects for validating a result against the declared output schema. */
 export const executeSqlOutputSchema = z.object(executeSqlOutputShape);
 export const runMetricOutputSchema = z.object(runMetricOutputShape);
 export const queryOutputSchema = z.object(queryOutputShape);
+export const publishDatasourcesOutputSchema = z.object(publishDatasourcesOutputShape);
+
+// #4156 drift guard: the publish output's data fields conform to the shared
+// PublishResult core (the `published` sentinel is MCP-only, alongside it). A
+// rename/reshape of `promoted`/`deleted` here fails to compile against the SSOT
+// type in `@useatlas/types`.
+const _publishOutputConformsToShared = (
+  o: z.infer<typeof publishDatasourcesOutputSchema>,
+): PublishResult => ({ promoted: o.promoted, deleted: o.deleted });

--- a/packages/schemas/src/__tests__/rest-suite.test.ts
+++ b/packages/schemas/src/__tests__/rest-suite.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { ExecuteSqlRestResponseSchema } from "../execute-sql";
 import { RunMetricRestResponseSchema } from "../metric-run";
+import { PublishResultSchema } from "../mode";
 
 // These schemas validate untrusted server JSON, so fixtures cross the boundary
 // as `unknown` and are checked with `.safeParse()` (how the CLI consumes them).
@@ -59,5 +60,49 @@ describe("RunMetricRestResponseSchema (#4111)", () => {
   test("rejects a body missing the sql field", () => {
     const { sql: _sql, ...noSql } = scalar;
     expect(RunMetricRestResponseSchema.safeParse(noSql).success).toBe(false);
+  });
+});
+
+describe("PublishResultSchema (#4156)", () => {
+  const ok = {
+    promoted: { connections: 1, entities: 12, prompts: 0, starterPrompts: 2 },
+    deleted: { entities: 3 },
+  };
+
+  test("parses the shared publish-result core", () => {
+    const r = PublishResultSchema.safeParse(ok);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual(ok);
+  });
+
+  test("strips REST-only extras (archived / warnings) to the shared core", () => {
+    const withExtras = {
+      ...ok,
+      archived: { connections: 0, entities: 0, prompts: 0 },
+      warnings: { incompleteLayers: [] },
+    };
+    const r = PublishResultSchema.safeParse(withExtras);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual(ok);
+  });
+
+  test("rejects the pre-#4156 flat delete-count shapes", () => {
+    // `deleted_entities` (MCP) / `deletedEntities` (lib) are the drifted shapes
+    // this unification retired — the canonical field is nested `deleted.entities`.
+    expect(
+      PublishResultSchema.safeParse({ promoted: ok.promoted, deleted_entities: 3 }).success,
+    ).toBe(false);
+    expect(
+      PublishResultSchema.safeParse({ promoted: ok.promoted, deletedEntities: 3 }).success,
+    ).toBe(false);
+  });
+
+  test("rejects a negative count", () => {
+    expect(
+      PublishResultSchema.safeParse({
+        promoted: { ...ok.promoted, connections: -1 },
+        deleted: { entities: 0 },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -12,6 +12,7 @@ export * from "./dashboard";
 export * from "./datasource-profile";
 export * from "./execute-sql";
 export * from "./metric-run";
+export * from "./mode";
 export * from "./integrations";
 export * from "./mcp-prompts";
 export * from "./mcp-usage";

--- a/packages/schemas/src/mode.ts
+++ b/packages/schemas/src/mode.ts
@@ -1,0 +1,25 @@
+/**
+ * Zod schemas for the content-mode publish operation.
+ *
+ * SSOT Zod mirror of the {@link PublishResult} wire type in `@useatlas/types`
+ * (#4156). `satisfies z.ZodType<…>` keeps each schema locked to its type, so the
+ * two cannot drift in shape. The `atlas datasource publish` CLI client
+ * `.safeParse()`s the `POST /api/v1/admin/publish` response through
+ * {@link PublishResultSchema}; the admin route keeps its own local hono-`z`
+ * mirror (which additionally carries the REST-only `archived`/`warnings` blocks
+ * and the `.openapi()` metadata `@useatlas/schemas` does not).
+ */
+import { z } from "zod";
+import type { PublishPromotedCounts, PublishResult } from "@useatlas/types";
+
+export const PublishPromotedCountsSchema = z.object({
+  connections: z.number().int().nonnegative(),
+  entities: z.number().int().nonnegative(),
+  prompts: z.number().int().nonnegative(),
+  starterPrompts: z.number().int().nonnegative(),
+}) satisfies z.ZodType<PublishPromotedCounts, unknown>;
+
+export const PublishResultSchema = z.object({
+  promoted: PublishPromotedCountsSchema,
+  deleted: z.object({ entities: z.number().int().nonnegative() }),
+}) satisfies z.ZodType<PublishResult, unknown>;

--- a/packages/types/src/mode.ts
+++ b/packages/types/src/mode.ts
@@ -69,3 +69,43 @@ export interface ModeStatusResponse {
    */
   readonly draftActivity: ModeDraftActivity | null;
 }
+
+/**
+ * Per-content-type promotion counts returned by the atomic publish operation
+ * (#4126) — one number per promotable content surface. Keys mirror the
+ * `promoted` block of {@link ModeStatusResponse}'s draft summary.
+ */
+export interface PublishPromotedCounts {
+  /** Datasource connections promoted `draft` → `published`. */
+  readonly connections: number;
+  /** Semantic entities promoted. */
+  readonly entities: number;
+  /** Prompt collections promoted. */
+  readonly prompts: number;
+  /** Starter-prompt suggestions promoted. */
+  readonly starterPrompts: number;
+}
+
+/**
+ * Shared wire type for the atomic publish operation's result — the single
+ * shape every publish surface keys off (#4156). Returned by the atomic publish
+ * endpoint (`POST /api/v1/admin/publish`), the MCP `publish_datasources` tool,
+ * and `atlas datasource publish` — all of which promote the same workspace-wide
+ * drafts and so must report the same counts.
+ *
+ * The delete-count field is `deleted.entities` on EVERY surface (this closes the
+ * pre-#4156 drift where REST used `deleted.entities`, MCP `deleted_entities`, and
+ * the lib `deletedEntities`). Surfaces that carry MORE than the shared core
+ * extend this type rather than reshaping it: the REST response adds `archived`
+ * (its phase-4 connection cascade) + `warnings` (partial-profile markers); the
+ * MCP tool adds `published: true`; the lib returns exactly this core.
+ */
+export interface PublishResult {
+  /** Per-content-type counts promoted `draft` → `published`. */
+  readonly promoted: PublishPromotedCounts;
+  /** Published rows removed by applying `draft_delete` tombstones. */
+  readonly deleted: {
+    /** Published entities superseded/removed by the promotion's tombstones. */
+    readonly entities: number;
+  };
+}

--- a/packages/types/src/mode.ts
+++ b/packages/types/src/mode.ts
@@ -72,8 +72,10 @@ export interface ModeStatusResponse {
 
 /**
  * Per-content-type promotion counts returned by the atomic publish operation
- * (#4126) — one number per promotable content surface. Keys mirror the
- * `promoted` block of {@link ModeStatusResponse}'s draft summary.
+ * (#4126) — one number per promotable content surface. These are the four
+ * surfaces the publish flow promotes, a subset of {@link ModeDraftCounts}: that
+ * type's `entityEdits` fold into `entities`, and its `entityDeletes` become the
+ * separate {@link PublishResult.deleted} `entities` count.
  */
 export interface PublishPromotedCounts {
   /** Datasource connections promoted `draft` → `published`. */


### PR DESCRIPTION
Closes #4156

Deferred follow-ups from the v0.0.36 milestone-wide review panel. Two LOW-severity but genuine cross-PR sibling-drift items — landed **before** `/release` so the tag ships with consistent types (clean on release, not fixed later).

## 1. Publish-result wire type unified across REST / MCP / CLI (#4126)

The atomic publish operation (`POST /api/v1/admin/publish`, backing both `atlas datasource publish` and the MCP `publish_datasources` tool) returned the same logical result in **three inconsistent shapes**. This PR lifts one shared wire type and keys every surface off it.

| Surface | Before | After |
|---------|--------|-------|
| REST route | `deleted: { entities }` (nested) | unchanged (canonical) |
| MCP `publish_datasources` | `deleted_entities` (flat snake) + no `outputSchema` | `deleted: { entities }` + declares `outputSchema` |
| lib `PublishWorkspaceDraftsResult` | `deletedEntities` (flat camel) | `deleted: { entities }` |

- **`@useatlas/types`**: new `PublishResult` + `PublishPromotedCounts` (the SSOT). **`@useatlas/schemas`**: `PublishResultSchema` Zod mirror (`satisfies z.ZodType<PublishResult>`), consumed by the CLI.
- **Canonical shape = the REST shape** (nested camelCase `deleted: { entities }`). The issue *recommended* flat snake_case, but canonicalizing there would have reshaped the already-consumed REST endpoint + web publish-modal + CLI for no benefit and made the `@useatlas/types` entry inconsistent with every sibling. REST is unchanged; only MCP + lib move onto the shared shape. The MCP output is now single-cased (all camelCase).
- **REST** keeps its local hono-`z` schema (needs `.openapi()` + the REST-only `archived`/`warnings` blocks) with a compile-time superset drift-guard against `PublishResult`. **MCP** gets a local `publishDatasourcesOutputShape` in `structured-output.ts` (matching the `executeSQL`/`runMetric`/`query` pattern) with its own drift guard. **CLI** validates the 200 via `PublishResultSchema.safeParse` (validate-only, returns raw to keep `--json` fidelity) and surfaces a typed error instead of silently degrading a skewed/misrouted response to "Nothing to publish".

**Release sequencing:** all new-symbol imports are `import type` (or in the non-scaffold `@atlas/mcp`), so the scaffold `check-published-symbols` gate is satisfied and the tag builds with **no `@useatlas/*` publish-first dance**.

## 2. `/regions` route → picker `{ apiRegion }` wiring test (#4131)

`buildSignupRegions`/`buildAvailableRegions` were exhaustively unit-tested, but the **route call** threading `{ apiRegion: getApiRegion() }` had no coverage — dropping that arg would re-introduce the staging-signup dead-end (#4131) with green CI. Added a route test with a configured multi-region residency + `getApiRegion()` mocked to `"staging"` (non-selectable), asserting the picker collapses to **only** the staging home arm. Dropping `{ apiRegion }` fails the assertion.

## Review
Internal review-panel (silent-failure / type-design / test-coverage / comment-accuracy) run pre-PR — converged **CLEAN in 2 rounds**. Round 1 flagged the CLI's unchecked cast (fixed: now validates via `PublishResultSchema`) and two comment issues (fixed).

## Test plan
- `bun run test` for `@atlas/api`, `@atlas/mcp`, `@atlas/cli`, `@useatlas/schemas` — green (new: CLI negative-shape test, MCP `structuredContent`/`outputSchema` conformance, `PublishResultSchema` suite, `/regions` staging-collapse route test).
- `bun run type` + `bun run lint` — clean across the monorepo. Scaffold `check-published-symbols` gate — pass.
- Local `ci-local.sh`: 26/27 gates green; the one `test`-gate failure is the documented `VERCEL_*`-set sandbox-env flake on unrelated tests (66/66 pass with the vars unset).