### PR TITLE
fix(4159): allow the Cloudflare Turnstile iframe in the web CSP frame-src

### DIFF
--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -36,12 +36,12 @@ const nextConfig: NextConfig = {
   async headers() {
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
       "connect-src 'self' https: wss:",
-      "frame-src 'self'",
+      "frame-src 'self' https://challenges.cloudflare.com",
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -34,12 +34,12 @@ const nextConfig: NextConfig = {
   async headers() {
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
       "connect-src 'self' https: wss:",
-      "frame-src 'self'",
+      "frame-src 'self' https://challenges.cloudflare.com",
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -43,12 +43,12 @@ const nextConfig: NextConfig = {
   async headers() {
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
       "connect-src 'self' https: wss:",
-      "frame-src 'self'",
+      "frame-src 'self' https://challenges.cloudflare.com",
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -94,12 +94,12 @@ const nextConfig: NextConfig = {
   async headers() {
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
       "font-src 'self' data:",
       "connect-src 'self' https: wss:",
-      "frame-src 'self'",
+      "frame-src 'self' https://challenges.cloudflare.com",
       "frame-ancestors 'self'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/packages/web/src/lib/csp.test.ts
+++ b/packages/web/src/lib/csp.test.ts
@@ -53,6 +53,15 @@ describe("buildCsp", () => {
       "'self' 'unsafe-inline'",
     );
   });
+
+  it("frame-src admits the Cloudflare Turnstile challenge iframe (#4159)", () => {
+    // The signup Turnstile widget renders its challenge in an iframe from
+    // challenges.cloudflare.com; without this host, `frame-src 'self'` blocks it
+    // and the widget never renders (the button stays permanently disabled).
+    const frame = directive(buildCsp(NONCE, "'self'", "prod"), "frame-src")!;
+    expect(frame).toContain("'self'");
+    expect(frame).toContain("https://challenges.cloudflare.com");
+  });
 });
 
 describe("frameAncestorsFor", () => {

--- a/packages/web/src/lib/csp.ts
+++ b/packages/web/src/lib/csp.ts
@@ -53,7 +53,12 @@ export function buildCsp(
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
     "connect-src 'self' https: wss:",
-    "frame-src 'self'",
+    // `https://challenges.cloudflare.com` frames the Cloudflare Turnstile
+    // challenge on the web signup (#4159). Only `frame-src` needs the host here:
+    // the Turnstile api.js rides `script-src`'s `'strict-dynamic'` (a nonce'd
+    // bundle script injects it), but the challenge iframe is a plain frame the
+    // host allowlist must admit — `frame-src 'self'` alone blocks it.
+    "frame-src 'self' https://challenges.cloudflare.com",
     `frame-ancestors ${frameAncestors}`,
     "base-uri 'self'",
     "form-action 'self'",


### PR DESCRIPTION
Follow-up to #4159 / #4162 — the signup Turnstile widget **still** didn't render even after the site key was baked into the bundle.

## Root cause (verified in-browser on staging)
The web app's Content-Security-Policy sets `frame-src 'self'`, which **blocks the Cloudflare Turnstile challenge iframe** (`https://challenges.cloudflare.com`). Console on `app.staging.useatlas.dev/signup/account`:

```
Framing 'https://challenges.cloudflare.com/' violates the CSP directive: "frame-src 'self'". The request has been blocked.
```

The `api.js` script loaded fine (`window.turnstile` was defined) because `script-src` uses `'strict-dynamic'` — a nonce'd bundle script injects the tag, which strict-dynamic trusts regardless of host. But the **challenge iframe** is a plain frame, and `frame-src` has no strict-dynamic semantics — so `render()` painted nothing and the "Create account" button stayed permanently disabled.

## Fix
- **`packages/web/src/lib/csp.ts`** — the runtime nonce CSP the proxy applies on staging/prod (it overwrites the static header). Add `https://challenges.cloudflare.com` to `frame-src`. Only `frame-src` needs it here; strict-dynamic already admits the script.
- **`packages/web/next.config.ts` + 3 scaffold mirrors** — the self-hosted fallback CSP (no strict-dynamic). Add the host to **both** `script-src` and `frame-src` so self-hosted Turnstile isn't left broken. Kept byte-identical per the `security-headers-drift` gate.
- **`csp.test.ts`** — regression test that `frame-src` admits the Turnstile host.

## Testing
- `security-headers-drift` ✅ (3 mirrors match), `csp.test.ts` 12 pass (incl. new #4159 case), full local gate suite green (24/24).
- Verified the failure live in a browser before the fix; will re-verify the widget renders on staging after this merges + `web-staging` redeploys.