### PR TITLE
fix(web): make /claim public so MCP/CLI trials can claim (#4164)

### DIFF
--- a/packages/web/src/lib/public-routes.ts
+++ b/packages/web/src/lib/public-routes.ts
@@ -16,4 +16,10 @@ export const PUBLIC_ROUTE_PREFIXES = [
   "/shared",
   "/report",
   "/accept-invitation",
+  // The MCP/CLI trial-claim interstitial (`start_trial`'s `claimUrl`, ADR-0018 /
+  // #4125). A brand-new trial user arrives here with NO session, so it MUST be
+  // public — otherwise on cross-origin SaaS the proxy defers to AuthGuard, which
+  // treats the sessionless visitor as a stale-session case and bounces them to
+  // /login (the page never renders). See #4164.
+  "/claim",
 ] as const;

--- a/packages/web/src/ui/__tests__/auth-guard.test.tsx
+++ b/packages/web/src/ui/__tests__/auth-guard.test.tsx
@@ -164,6 +164,26 @@ describe("AuthGuard stale-session recovery", () => {
     expect(assignMock).not.toHaveBeenCalled();
   });
 
+  test("does NOT sign out or redirect a sessionless visitor on /claim — the MCP/CLI trial claim page is public (#4164)", async () => {
+    // A brand-new MCP/CLI trial user lands on /claim with NO session. Before the
+    // fix, /claim was missing from PUBLIC_ROUTE_PREFIXES, so this exact state
+    // (managed mode, clean "no session", non-public route) ran the stale-session
+    // recovery — signOut + hard-nav to /login — and the claim page never
+    // rendered (the page's own cold-start OTP flow was pre-empted).
+    pathname = "/claim";
+    sessionState = { data: null, isPending: false, error: null };
+
+    renderGuard();
+
+    // Flush the mount effect; the public-route early-return is synchronous, so a
+    // microtask turn is enough to prove recovery did NOT fire.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
   test("recovers exactly once even when the effect re-fires (one-shot guard)", async () => {
     pathname = "/";
     sessionState = { data: null, isPending: false, error: null };


### PR DESCRIPTION
Fixes **#4164** — the one-line fix found during `/verify-mcp-cli in prod`.

## Problem
`/claim` (the interstitial that `start_trial`'s `claimUrl` points at) was missing from `PUBLIC_ROUTE_PREFIXES`. On cross-origin SaaS (prod: `app.` ≠ `api.useatlas.dev`), the edge proxy (`proxy.ts:179`) returns `200` and **defers auth to the client `AuthGuard`**, whose public list is `[...PUBLIC_ROUTE_PREFIXES, "/login", "/signup", "/wizard"]` — also no `/claim`. So a brand-new MCP/CLI trial user, arriving with **no session**, was treated as a stale-session case: `authClient.signOut()` + hard-nav to `/login`. The claim page never rendered, and the "Claim your account" link on `/login` looped back.

**Impact:** blocked *all* MCP/CLI trial onboarding on prod — no `/claim` → no passkey-at-claim → the admin-MFA gate never clears → API-key mint + `atlas datasource create` return `403` → the workspace is stuck at 0 entities / no queryable connection.

## Fix
Add `"/claim"` to `PUBLIC_ROUTE_PREFIXES` (`packages/web/src/lib/public-routes.ts`). Both the proxy and AuthGuard derive their public lists from this shared array, so one entry fixes both layers.

## Test
`auth-guard.test.tsx` regression: a sessionless visitor on `/claim` must NOT be signed out or redirected. Verified **red before / green after** (12 pass / 1 fail without the fix; all pass with it). Sibling `proxy.test.ts` and `bun run type` also green.

Found on the v0.0.37 (`c46cc263e`) prod build; runbook hardened in #4165 to walk `/claim` cold so this class of bug can't slip past staging again.