### PR TITLE
fix(4167): make `atlas login` browser device-approval work end-to-end

### DIFF
--- a/packages/api/src/lib/auth/__tests__/device-authorization-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/device-authorization-plugin.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "bun:test";
 import { deviceAuthorization } from "better-auth/plugins";
 import { DEVICE_TOKEN_ENDPOINT_PATH } from "../server";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
+import { resolveDeviceVerificationUri } from "../device-verification-uri";
 
 /**
  * Contract-pinning tests for the better-auth deviceAuthorization plugin
@@ -31,5 +33,58 @@ describe("deviceAuthorization plugin contract (#4043)", () => {
     expect(Object.keys(plugin.endpoints ?? {})).toEqual(
       expect.arrayContaining(["deviceCode", "deviceToken", "deviceVerify", "deviceApprove", "deviceDeny"]),
     );
+  });
+});
+
+/**
+ * #4167 — the plugin's `verificationUri` is the URL `atlas login` prints for a
+ * human to approve at. server.ts wires it as
+ * `resolveDeviceVerificationUri(getWebOrigin())`; the bug was a hardcoded
+ * relative "/device" that Better Auth resolved against the API origin (→ 404).
+ * This pins the COMPOSITION the wiring depends on: given a web origin, it must
+ * produce an absolute URL on that (web) host, never a relative path or the API
+ * host. A regression to a literal relative verificationUri would go RED here.
+ * Self-contained: env is saved and restored, never mutated at module top level.
+ */
+describe("device verificationUri wiring (#4167)", () => {
+  const ORIGIN_KEYS = [
+    "ATLAS_CORS_ORIGIN",
+    "BETTER_AUTH_TRUSTED_ORIGINS",
+    "ATLAS_API_REGION",
+  ] as const;
+
+  function withEnv(overrides: Partial<Record<(typeof ORIGIN_KEYS)[number], string | undefined>>, run: () => void) {
+    const saved = Object.fromEntries(ORIGIN_KEYS.map((k) => [k, process.env[k]]));
+    try {
+      for (const k of ORIGIN_KEYS) {
+        const v = overrides[k];
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      run();
+    } finally {
+      for (const k of ORIGIN_KEYS) {
+        const v = saved[k];
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  }
+
+  it("composes getWebOrigin() into an ABSOLUTE web-origin /device URL (never the API host)", () => {
+    withEnv({ ATLAS_CORS_ORIGIN: "https://app.staging.useatlas.dev", BETTER_AUTH_TRUSTED_ORIGINS: undefined, ATLAS_API_REGION: undefined }, () => {
+      const uri = resolveDeviceVerificationUri(getWebOrigin());
+      expect(uri).toBe("https://app.staging.useatlas.dev/device");
+      // Absolute (parses standalone) so Better Auth won't re-resolve it against
+      // the API base — the crux of the 404 fix.
+      expect(() => new URL(uri)).not.toThrow();
+      expect(uri).not.toContain("api.");
+    });
+  });
+
+  it("falls back to relative /device only when no web origin resolves (single-origin embedded deploy)", () => {
+    withEnv({ ATLAS_CORS_ORIGIN: undefined, BETTER_AUTH_TRUSTED_ORIGINS: undefined, ATLAS_API_REGION: undefined }, () => {
+      expect(resolveDeviceVerificationUri(getWebOrigin())).toBe("/device");
+    });
   });
 });

--- a/packages/api/src/lib/auth/__tests__/device-verification-uri.test.ts
+++ b/packages/api/src/lib/auth/__tests__/device-verification-uri.test.ts
@@ -32,7 +32,18 @@ describe("resolveDeviceVerificationUri (#4167)", () => {
     expect(new URL(uri).pathname).toBe("/device");
   });
 
-  it("falls back to the relative /device when no web origin is configured (single-origin/off-SaaS dev)", () => {
+  it("falls back to the relative /device when no web origin is configured (single-origin embedded deploy)", () => {
     expect(resolveDeviceVerificationUri(null)).toBe("/device");
+  });
+
+  it("owns its no-trailing-slash precondition — never emits //device", () => {
+    // getWebOrigin() strips trailing slashes today, but the module enforces it
+    // itself so a future caller can't reintroduce a double slash.
+    expect(resolveDeviceVerificationUri("https://app.useatlas.dev/")).toBe(
+      "https://app.useatlas.dev/device",
+    );
+    expect(resolveDeviceVerificationUri("https://app.useatlas.dev///")).toBe(
+      "https://app.useatlas.dev/device",
+    );
   });
 });

--- a/packages/api/src/lib/auth/__tests__/device-verification-uri.test.ts
+++ b/packages/api/src/lib/auth/__tests__/device-verification-uri.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "bun:test";
+import { resolveDeviceVerificationUri } from "../device-verification-uri";
+
+/**
+ * #4167 — the RFC 8628 `verification_uri` the CLI prints must resolve to the
+ * WEB app's /device page (where the approval UI lives), never the API origin.
+ * Better Auth resolves a *relative* verificationUri against its own base URL
+ * (the API host), so a bare "/device" 404s. These pin the absolute-URL rule so
+ * a regression back to a relative path is RED, not a live dead-end.
+ */
+describe("resolveDeviceVerificationUri (#4167)", () => {
+  it("builds an absolute web-origin /device URL when a web origin is known", () => {
+    expect(resolveDeviceVerificationUri("https://app.staging.useatlas.dev")).toBe(
+      "https://app.staging.useatlas.dev/device",
+    );
+  });
+
+  it("points at the WEB origin, not the API origin", () => {
+    // The whole bug: the printed URL landed on api.* (404). Given the web
+    // origin, the result must be on app.* — never on an api.* host.
+    const uri = resolveDeviceVerificationUri("https://app.useatlas.dev");
+    expect(uri.startsWith("https://app.useatlas.dev/")).toBe(true);
+    expect(uri).not.toContain("api.");
+  });
+
+  it("is an absolute URL (has a scheme + host), so Better Auth won't re-resolve it against the API base", () => {
+    const uri = resolveDeviceVerificationUri("https://app.useatlas.dev");
+    // Absolute parse must succeed on its own (no base argument) — that's
+    // exactly what buildVerificationUris checks before falling back to the
+    // API base URL.
+    expect(() => new URL(uri)).not.toThrow();
+    expect(new URL(uri).pathname).toBe("/device");
+  });
+
+  it("falls back to the relative /device when no web origin is configured (single-origin/off-SaaS dev)", () => {
+    expect(resolveDeviceVerificationUri(null)).toBe("/device");
+  });
+});

--- a/packages/api/src/lib/auth/device-verification-uri.ts
+++ b/packages/api/src/lib/auth/device-verification-uri.ts
@@ -16,11 +16,20 @@
  * (api.*→app.* swap, #3706), so the device URL stays consistent with the
  * `/claim` URL across regions.
  *
- * When `getWebOrigin()` is null (single-origin / off-SaaS dev, where the API
- * and web app share a host) the relative `/device` still resolves correctly
- * against that shared origin, so we fall back to it — the device flow's browser
- * approval isn't a SaaS-only path.
+ * `getWebOrigin()` is null only when NONE of `ATLAS_CORS_ORIGIN`,
+ * `BETTER_AUTH_TRUSTED_ORIGINS`, or a region resolves — i.e. a genuinely
+ * single-origin embedded deploy (e.g. `nextjs-standalone` with the Hono API
+ * mounted on the web app's own origin), where the relative `/device` resolves
+ * correctly against that shared origin. Note the standard split-port
+ * `bun run dev` (API :3001, web :3000) is NOT that case: it ships
+ * `BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000`, so this returns the
+ * absolute `http://localhost:3000/device` there too — the relative fallback is
+ * for embedded single-origin deploys, not "any local dev".
+ *
+ * The `.replace(/\/+$/, "")` makes the module own its own no-trailing-slash
+ * precondition (avoids `//device`) rather than trusting every caller — even
+ * though `getWebOrigin()` already strips trailing slashes today.
  */
 export function resolveDeviceVerificationUri(webOrigin: string | null): string {
-  return webOrigin ? `${webOrigin}/device` : "/device";
+  return webOrigin ? `${webOrigin.replace(/\/+$/, "")}/device` : "/device";
 }

--- a/packages/api/src/lib/auth/device-verification-uri.ts
+++ b/packages/api/src/lib/auth/device-verification-uri.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve the `verificationUri` for the RFC 8628 device-authorization grant
+ * (#4043 / ADR-0026 / #4167).
+ *
+ * `atlas login` prints whatever the deviceAuthorization plugin returns here as
+ * the URL a human opens to approve the CLI. The approval page lives in
+ * `packages/web` at `src/app/device/page.tsx` — the WEB origin — but Better
+ * Auth resolves a *relative* `verificationUri` against its own base URL (the
+ * API origin), so a bare `"/device"` becomes `https://api.<env>.useatlas.dev
+ * /device`, which 404s (there is no `/device` route on the API host). Handing
+ * the plugin an ABSOLUTE web-app URL makes both `verification_uri` and
+ * `verification_uri_complete` (base + `?user_code=`) resolve to the page that
+ * actually renders.
+ *
+ * `getWebOrigin()` is the same region/env-aware source `buildClaimUrl` uses
+ * (api.*→app.* swap, #3706), so the device URL stays consistent with the
+ * `/claim` URL across regions.
+ *
+ * When `getWebOrigin()` is null (single-origin / off-SaaS dev, where the API
+ * and web app share a host) the relative `/device` still resolves correctly
+ * against that shared origin, so we fall back to it — the device flow's browser
+ * approval isn't a SaaS-only path.
+ */
+export function resolveDeviceVerificationUri(webOrigin: string | null): string {
+  return webOrigin ? `${webOrigin}/device` : "/device";
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2818,14 +2818,8 @@ export function buildPlugins() {
     deviceAuthorization({
       // The web page where a signed-in human enters the user code and
       // approves/denies. Lives in packages/web at src/app/device/page.tsx —
-      // the WEB origin. Better Auth resolves a *relative* verificationUri
-      // against its OWN base URL (the API origin), so a bare "/device" would
-      // 404 on `api.<env>.useatlas.dev` (there's no /device route there); the
-      // CLI prints that URL verbatim, dead-ending the human flow (#4167).
-      // resolveDeviceVerificationUri hands the plugin an ABSOLUTE web-app URL
-      // via getWebOrigin() (region/env-aware api.*→app.* swap — the same
-      // source buildClaimUrl uses), falling back to "/device" only off-SaaS
-      // where API and web share an origin.
+      // the WEB origin, so this MUST be absolute or the CLI-printed URL 404s on
+      // the API host (#4167). See `resolveDeviceVerificationUri` for why.
       verificationUri: resolveDeviceVerificationUri(getWebOrigin()),
       // `schema: {}` works around a better-auth 1.6.20 × zod 4.4.3
       // incompatibility: the plugin's options schema declares

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -57,6 +57,7 @@ import { deriveRegionApiUrl } from "@atlas/api/lib/residency/origins";
 // eagerly without importing better-auth (#3045). Re-exported here so the auth
 // surface (and its tests) keep a single import site.
 import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
+import { resolveDeviceVerificationUri } from "@atlas/api/lib/auth/device-verification-uri";
 import { resolveOAuthValidAudiences } from "@atlas/api/lib/auth/oauth-audiences";
 import { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
 export { resolvePasskeyRpId, DEFAULT_RP_ID } from "@atlas/api/lib/auth/rpid";
@@ -2816,8 +2817,16 @@ export function buildPlugins() {
   plugins.push(
     deviceAuthorization({
       // The web page where a signed-in human enters the user code and
-      // approves/denies. Lives in packages/web at src/app/device/page.tsx.
-      verificationUri: "/device",
+      // approves/denies. Lives in packages/web at src/app/device/page.tsx —
+      // the WEB origin. Better Auth resolves a *relative* verificationUri
+      // against its OWN base URL (the API origin), so a bare "/device" would
+      // 404 on `api.<env>.useatlas.dev` (there's no /device route there); the
+      // CLI prints that URL verbatim, dead-ending the human flow (#4167).
+      // resolveDeviceVerificationUri hands the plugin an ABSOLUTE web-app URL
+      // via getWebOrigin() (region/env-aware api.*→app.* swap — the same
+      // source buildClaimUrl uses), falling back to "/device" only off-SaaS
+      // where API and web share an origin.
+      verificationUri: resolveDeviceVerificationUri(getWebOrigin()),
       // `schema: {}` works around a better-auth 1.6.20 × zod 4.4.3
       // incompatibility: the plugin's options schema declares
       // `schema: z.custom(() => true)` WITHOUT `.optional()`, and zod v4

--- a/packages/web/src/app/device/page.test.tsx
+++ b/packages/web/src/app/device/page.test.tsx
@@ -115,6 +115,9 @@ describe("DevicePage — claim before approve (#4167)", () => {
       expect(deviceDenyMock).toHaveBeenCalledTimes(1);
     });
     expect(callLog).toEqual(["claim", "deny"]);
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Request denied");
+    });
   });
 
   test("a failed claim surfaces the error and never calls approve", async () => {
@@ -138,5 +141,47 @@ describe("DevicePage — claim before approve (#4167)", () => {
     // Approve must NOT fire when the claim failed.
     expect(deviceApproveMock).not.toHaveBeenCalled();
     expect(callLog).toEqual(["claim"]);
+  });
+
+  test("a failed claim on Deny surfaces the error and never calls deny (shared submit() path)", async () => {
+    deviceClaimMock.mockImplementation(async () => {
+      callLog.push("claim");
+      return { data: null, error: { error_description: "That code is invalid or has expired." } };
+    });
+
+    render(<DevicePage />);
+    const btn = await screen.findByRole("button", { name: /deny/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("That code is invalid or has expired.");
+    });
+    expect(deviceDenyMock).not.toHaveBeenCalled();
+    expect(callLog).toEqual(["claim"]);
+  });
+
+  test("a THROWN claim routes through catch, surfaces the error, and never approves", async () => {
+    deviceClaimMock.mockImplementation(async () => {
+      callLog.push("claim");
+      throw new TypeError("network down");
+    });
+
+    render(<DevicePage />);
+    const btn = await screen.findByRole("button", { name: /approve/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      // A thrown Error surfaces its .message through deviceErrorMessage — the
+      // catch path shows the real cause, it isn't swallowed.
+      expect(document.body.textContent).toContain("network down");
+    });
+    expect(deviceApproveMock).not.toHaveBeenCalled();
+    expect(callLog).toEqual(["claim"]);
+    // Buttons re-enabled after the throw (finally { setSubmitting(null) }).
+    expect((await screen.findByRole("button", { name: /approve/i })).hasAttribute("disabled")).toBe(false);
   });
 });

--- a/packages/web/src/app/device/page.test.tsx
+++ b/packages/web/src/app/device/page.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Coverage for the device-approval page — the claim-before-approve fix (#4167).
+ *
+ * Better Auth's device plugin rejects `/device/approve` (and `/device/deny`)
+ * until a verifying session has *claimed* the code via GET `/device`. The page
+ * must fire that claim (`authClient.device({ query: { user_code } })`) before
+ * the decision, or a signed-in human's first Approve always errors "Device code
+ * has not been claimed…". These tests pin the ordering and the error surfacing.
+ *
+ * `mock.module(...)` covers every named export it stubs (per repo rule) so a
+ * sibling test importing a different export doesn't trip a partial-mock error.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+// Ordered log so we can assert claim precedes the decision on the same click.
+const callLog: string[] = [];
+
+type Envelope = { data: unknown; error: { error_description?: string; message?: string } | null };
+
+const deviceClaimMock = mock(async (_opts: { query: { user_code: string } }): Promise<Envelope> => {
+  callLog.push("claim");
+  return { data: { user_code: _opts.query.user_code, status: "pending" }, error: null };
+});
+const deviceApproveMock = mock(async (_opts: { userCode: string }): Promise<Envelope> => {
+  callLog.push("approve");
+  return { data: { success: true }, error: null };
+});
+const deviceDenyMock = mock(async (_opts: { userCode: string }): Promise<Envelope> => {
+  callLog.push("deny");
+  return { data: { success: true }, error: null };
+});
+// `authClient.device` is the callable deviceVerify (GET /device) AND carries
+// `.approve`/`.deny` — mirror that shape by hanging the sub-actions off the fn.
+Object.assign(deviceClaimMock, { approve: deviceApproveMock, deny: deviceDenyMock });
+
+type Session = { isPending: boolean; data: { user: { email: string } } | null };
+const sessionStore: { value: Session } = {
+  value: { isPending: false, data: { user: { email: "dev@useatlas.dev" } } },
+};
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => sessionStore.value,
+    device: deviceClaimMock,
+  },
+}));
+
+const searchParamsStore: Record<string, string | null> = { user_code: "SRVPR7QG" };
+mock.module("next/navigation", () => ({
+  useSearchParams: () => ({ get: (k: string) => searchParamsStore[k] ?? null }),
+}));
+
+import DevicePage from "./page";
+
+beforeEach(() => {
+  callLog.length = 0;
+  deviceClaimMock.mockClear();
+  deviceApproveMock.mockClear();
+  deviceDenyMock.mockClear();
+  deviceClaimMock.mockImplementation(async (opts: { query: { user_code: string } }) => {
+    callLog.push("claim");
+    return { data: { user_code: opts.query.user_code, status: "pending" }, error: null };
+  });
+  deviceApproveMock.mockImplementation(async () => {
+    callLog.push("approve");
+    return { data: { success: true }, error: null };
+  });
+  deviceDenyMock.mockImplementation(async () => {
+    callLog.push("deny");
+    return { data: { success: true }, error: null };
+  });
+  sessionStore.value = { isPending: false, data: { user: { email: "dev@useatlas.dev" } } };
+  searchParamsStore.user_code = "SRVPR7QG";
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("DevicePage — claim before approve (#4167)", () => {
+  test("Approve first claims the code (GET /device), THEN approves", async () => {
+    render(<DevicePage />);
+    const btn = await screen.findByRole("button", { name: /approve/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(deviceApproveMock).toHaveBeenCalledTimes(1);
+    });
+    // The claim must precede the decision — that's the whole bug.
+    expect(callLog).toEqual(["claim", "approve"]);
+    expect(deviceClaimMock).toHaveBeenCalledWith({ query: { user_code: "SRVPR7QG" } });
+    expect(deviceApproveMock).toHaveBeenCalledWith({ userCode: "SRVPR7QG" });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Device approved");
+    });
+  });
+
+  test("Deny also claims first, then denies", async () => {
+    render(<DevicePage />);
+    const btn = await screen.findByRole("button", { name: /deny/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(deviceDenyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(callLog).toEqual(["claim", "deny"]);
+  });
+
+  test("a failed claim surfaces the error and never calls approve", async () => {
+    deviceClaimMock.mockImplementation(async () => {
+      callLog.push("claim");
+      return {
+        data: null,
+        error: { error_description: "That code is invalid or has expired." },
+      };
+    });
+
+    render(<DevicePage />);
+    const btn = await screen.findByRole("button", { name: /approve/i });
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("That code is invalid or has expired.");
+    });
+    // Approve must NOT fire when the claim failed.
+    expect(deviceApproveMock).not.toHaveBeenCalled();
+    expect(callLog).toEqual(["claim"]);
+  });
+});

--- a/packages/web/src/app/device/page.tsx
+++ b/packages/web/src/app/device/page.tsx
@@ -5,12 +5,11 @@
  *
  * `atlas login` runs the OAuth 2.0 device flow (RFC 8628): the CLI prints a
  * user code + this page's URL. A signed-in human lands here (the plugin's
- * `verificationUri`), confirms the code, and approves. Approving first *claims*
- * the code for the verifying session (GET `/device` via `authClient.device`) —
- * Better Auth requires that before it will accept `authClient.device.approve/
- * deny({ userCode })` (#4167) — then hands the decision to Better Auth. The
- * CLI, polling `/device/token`, then receives a workspace-scoped session bearer
- * stamped `origin='cli'`.
+ * `verificationUri`), confirms the code, then *claims* it (GET `/device` via
+ * `authClient.device`) and submits the decision. Better Auth requires the claim
+ * before it will accept EITHER `authClient.device.approve` or `.deny` (#4167).
+ * The CLI, polling `/device/token`, then receives a workspace-scoped session
+ * bearer stamped `origin='cli'`.
  *
  * Not signed in? We bounce to /login carrying a redirect back to this exact
  * URL (the user code rides in the query string), so the user returns here
@@ -76,6 +75,10 @@ function DeviceApproval() {
       // the same session on the same click, so there's no claim/approve race.
       const claim = await authClient.device?.({ query: { user_code: trimmedCode } });
       if (claim?.error) {
+        // Surfaced to the user below; also keep the raw cause in the console so
+        // a support case for THIS flow (the one #4167 fixes) is reconstructable
+        // when deviceErrorMessage degrades an unexpected shape to its default.
+        console.debug("device code claim failed", claim.error);
         setError(deviceErrorMessage(claim.error));
         return;
       }
@@ -86,6 +89,7 @@ function DeviceApproval() {
       }
       setOutcome(decision === "approve" ? "approved" : "denied");
     } catch (err) {
+      console.debug("device approval threw", err);
       setError(deviceErrorMessage(err));
     } finally {
       setSubmitting(null);

--- a/packages/web/src/app/device/page.tsx
+++ b/packages/web/src/app/device/page.tsx
@@ -5,10 +5,12 @@
  *
  * `atlas login` runs the OAuth 2.0 device flow (RFC 8628): the CLI prints a
  * user code + this page's URL. A signed-in human lands here (the plugin's
- * `verificationUri`), confirms the code, and approves — handing the decision to
- * Better Auth via `authClient.device.approve({ userCode })`. The CLI, polling
- * `/device/token`, then receives a workspace-scoped session bearer stamped
- * `origin='cli'`.
+ * `verificationUri`), confirms the code, and approves. Approving first *claims*
+ * the code for the verifying session (GET `/device` via `authClient.device`) —
+ * Better Auth requires that before it will accept `authClient.device.approve/
+ * deny({ userCode })` (#4167) — then hands the decision to Better Auth. The
+ * CLI, polling `/device/token`, then receives a workspace-scoped session bearer
+ * stamped `origin='cli'`.
  *
  * Not signed in? We bounce to /login carrying a redirect back to this exact
  * URL (the user code rides in the query string), so the user returns here
@@ -66,6 +68,17 @@ function DeviceApproval() {
     setSubmitting(decision);
     setError(null);
     try {
+      // Claim the code for THIS signed-in session first (GET /device via the
+      // base `authClient.device` call). Better Auth's device plugin rejects
+      // approve/deny until a verifying session has claimed the code — without
+      // this the human's first click always errors "Device code has not been
+      // claimed by a verifying session…" (#4167). Claiming and deciding ride
+      // the same session on the same click, so there's no claim/approve race.
+      const claim = await authClient.device?.({ query: { user_code: trimmedCode } });
+      if (claim?.error) {
+        setError(deviceErrorMessage(claim.error));
+        return;
+      }
       const res = await action({ userCode: trimmedCode });
       if (res?.error) {
         setError(deviceErrorMessage(res.error));


### PR DESCRIPTION
## Summary

Fixes #4167 — the RFC 8628 browser device-approval path for `atlas login` (#4043 / ADR-0026) was broken end-to-end: the URL the CLI printed 404'd, and even navigating to the right page, the first **Approve** errored. Two independent, compounding defects, both confirmed live on staging.

### Fix 1 — `verification_uri` 404 (server)
`deviceAuthorization({ verificationUri: "/device" })` was a **relative** path, so Better Auth resolved it against its own base URL (the **API** origin) → the CLI printed `https://api.<env>.useatlas.dev/device`, which 404s (the approval page lives in `packages/web`, the **web** origin).

Resolve it to an **absolute** web-app URL via `getWebOrigin()` (region/env-aware `api.*`→`app.*` swap — the same source `buildClaimUrl` uses), in a new pure `resolveDeviceVerificationUri()` module (mirrors the `resolvePasskeyRpId` pattern). Falls back to relative `/device` only for genuinely single-origin embedded deploys. No CLI change — `atlas login` echoes the server's `verification_uri` verbatim.

### Fix 2 — `/device` never claimed the code (web)
`app/device/page.tsx` called `authClient.device.approve/deny` with no prior `GET /device` claim. Better Auth's device plugin requires the verifying session to **claim** the code first (it stamps `userId` on the `deviceCode` row); both approve **and** deny reject an unclaimed code with *"Device code has not been claimed by a verifying session…"*.

Claim the code (`authClient.device({ query: { user_code } })`) inside `submit()` before the decision — same session, same click, race-free. A failed/thrown claim surfaces the error and never approves/denies.

## Regression coverage
- `resolveDeviceVerificationUri` unit test — absolute web-origin `/device`, never the API host; `//device` guard; null → relative fallback.
- Composition/wiring guard in `device-authorization-plugin.test.ts` — `getWebOrigin()` → absolute web-origin URI (the exact #4167 regression surface; a revert to a relative literal goes red).
- `/device` page test — claim strictly before approve **and** deny (exact payload shapes), failed-claim short-circuits the decision, thrown-claim routes through `catch` and surfaces the cause.

## Verification
- New/updated tests green; touched packages `tsgo` + `lint` clean.
- Local CI: 26/27 gates green; the lone `test` failure is the documented `VERCEL_*`-breaks-sandbox-tests local caveat (3 sandbox files this branch doesn't touch) — all three pass with `VERCEL_*` unset.
- Internal review-panel (silent-failure / type-design / test / comment): no must-fix defects; advisory findings applied inline.
- **Still to do** (per issue AC): re-run `/verify-mcp-cli` Phase C on staging **through the browser** (open the printed URL → renders 200 → Approve first-try → CLI `✓ Logged in`), after this deploys to staging.

Closes #4167