### PR TITLE
refactor(agent): convert buildSystemParam to (providerType, options) form

### DIFF
--- a/packages/api/src/lib/__tests__/agent-cache.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cache.test.ts
@@ -412,6 +412,12 @@ describe("buildSystemParam", () => {
     expect(withEmpty).toBe(without);
     expect(withEmpty as string).not.toContain("## Working Memory");
   });
+
+  // #3819 — options-object form: an empty options bag must resolve every
+  // default exactly as omitting the argument does.
+  test("empty options object is byte-identical to omitting it", () => {
+    expect(buildSystemParam("openai", {})).toBe(buildSystemParam("openai"));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/__tests__/agent-cache.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cache.test.ts
@@ -321,19 +321,7 @@ describe("buildSystemParam", () => {
   // #3099 — gateway routing to an Anthropic model must cache the system prompt
   // exactly like the direct Anthropic provider (the gateway forwards the marker).
   test("returns SystemModelMessage with anthropic cacheControl for 'gateway' → Anthropic model", () => {
-    // modelId is the trailing positional arg; intermediate args default through.
-    const result = buildSystemParam(
-      "gateway",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "developer",
-      undefined,
-      "anthropic/claude-opus-4.8",
-    );
+    const result = buildSystemParam("gateway", { modelId: "anthropic/claude-opus-4.8" });
     expect(typeof result).toBe("object");
     const msg = result as { role: string; content: string; providerOptions: Record<string, unknown> };
     expect(msg.role).toBe("system");
@@ -344,18 +332,7 @@ describe("buildSystemParam", () => {
   });
 
   test("returns plain string for 'gateway' → non-Anthropic model", () => {
-    const result = buildSystemParam(
-      "gateway",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "developer",
-      undefined,
-      "openai/gpt-4o",
-    );
+    const result = buildSystemParam("gateway", { modelId: "openai/gpt-4o" });
     expect(typeof result).toBe("string");
   });
 
@@ -373,17 +350,16 @@ describe("buildSystemParam", () => {
       tool: { execute: async () => "ok" } as never,
     });
 
-    const result = buildSystemParam("openai", customRegistry);
+    const result = buildSystemParam("openai", { registry: customRegistry });
     expect(typeof result).toBe("string");
     expect(result as string).toContain("Custom Step");
     expect(result as string).not.toContain("Explore the Semantic Layer");
   });
 
   test("includes warnings section when warnings are provided", () => {
-    const result = buildSystemParam("openai", undefined, [
-      "Actions failed to initialize.",
-      "Python tool is unavailable.",
-    ]);
+    const result = buildSystemParam("openai", {
+      warnings: ["Actions failed to initialize.", "Python tool is unavailable."],
+    });
     expect(typeof result).toBe("string");
     const content = result as string;
     expect(content).toContain("## Warnings");
@@ -392,7 +368,7 @@ describe("buildSystemParam", () => {
   });
 
   test("omits warnings section when warnings array is empty", () => {
-    const result = buildSystemParam("openai", undefined, []);
+    const result = buildSystemParam("openai", { warnings: [] });
     expect(typeof result).toBe("string");
     expect(result as string).not.toContain("## Warnings");
   });
@@ -404,7 +380,7 @@ describe("buildSystemParam", () => {
   });
 
   test("warnings are included in SystemModelMessage content for anthropic", () => {
-    const result = buildSystemParam("anthropic", undefined, ["Test warning"]);
+    const result = buildSystemParam("anthropic", { warnings: ["Test warning"] });
     expect(typeof result).toBe("object");
     const msg = result as { content: string };
     expect(msg.content).toContain("## Warnings");
@@ -416,19 +392,10 @@ describe("buildSystemParam", () => {
   // The runAgent-seam tests assert the block is present/absent; these pin the
   // POSITION the acceptance criterion promises so a re-ordering can't slip past.
   test("durable memory block is appended LAST — after the warnings section", () => {
-    const result = buildSystemParam(
-      "openai",
-      undefined,
-      ["A warning"], // warnings
-      undefined, // orgSemanticIndex
-      undefined, // learnedPatternsSection
-      undefined, // routingContext
-      undefined, // boundDashboardContext
-      "developer", // presentationMode
-      undefined, // restRepresentation
-      undefined, // modelId
-      "## Working Memory\n\n- `note`: \"orders\"", // memoryBlock
-    );
+    const result = buildSystemParam("openai", {
+      warnings: ["A warning"],
+      memoryBlock: "## Working Memory\n\n- `note`: \"orders\"",
+    });
     expect(typeof result).toBe("string");
     const content = result as string;
     expect(content).toContain("## Working Memory");
@@ -439,10 +406,7 @@ describe("buildSystemParam", () => {
   });
 
   test("empty durable memory block threads nothing (no change vs today)", () => {
-    const withEmpty = buildSystemParam(
-      "openai", undefined, undefined, undefined, undefined,
-      undefined, undefined, "developer", undefined, undefined, "",
-    );
+    const withEmpty = buildSystemParam("openai", { memoryBlock: "" });
     const without = buildSystemParam("openai");
     // An empty memoryBlock is byte-identical to omitting it entirely.
     expect(withEmpty).toBe(without);

--- a/packages/api/src/lib/__tests__/agent-cross-source-composition.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-source-composition.test.ts
@@ -27,24 +27,9 @@ const MEMORY = "## Working memory\n\n- foo: bar";
 
 const COMPOSITION_HEADING = "## Cross-source composition";
 
-/** Build with the catalog at its positional slot, leaving the rest defaulted. */
+/** Build with just the catalog (and optionally memory), leaving the rest defaulted. */
 function withCatalog(sourceCatalog: string | undefined, memoryBlock?: string) {
-  return promptText(
-    buildSystemParam(
-      "openai",
-      undefined, // registry
-      undefined, // warnings
-      undefined, // orgSemanticIndex
-      undefined, // learnedPatternsSection
-      undefined, // routingContext
-      undefined, // boundDashboardContext
-      "developer",
-      undefined, // restRepresentation
-      undefined, // modelId
-      memoryBlock,
-      sourceCatalog,
-    ),
-  );
+  return promptText(buildSystemParam("openai", { memoryBlock, sourceCatalog }));
 }
 
 describe("buildSystemParam — cross-source composition guidance (#3909)", () => {
@@ -70,11 +55,7 @@ describe("buildSystemParam — cross-source composition guidance (#3909)", () =>
     // anthropic/bedrock providers return a SystemModelMessage rather than a bare
     // string; the guidance must live in that message's `content` (the SYSTEM
     // prompt), never in the message transcript (ADR-0020 / memory-LAST #3755).
-    const result = buildSystemParam(
-      "anthropic",
-      undefined, undefined, undefined, undefined, undefined,
-      undefined, "developer", undefined, undefined, undefined, CATALOG,
-    );
+    const result = buildSystemParam("anthropic", { sourceCatalog: CATALOG });
     expect(typeof result).not.toBe("string");
     // Narrow off the string branch — the cache providers return an object.
     if (typeof result === "string") {
@@ -124,11 +105,7 @@ describe("buildSystemParam — cross-source composition guidance (#3909)", () =>
     // the deep per-REST-datasource detail it routes into.
     const REST = "## REST datasource: acme\n\noperations...";
     const prompt = promptText(
-      buildSystemParam(
-        "openai",
-        undefined, undefined, undefined, undefined, undefined,
-        undefined, "developer", REST, undefined, undefined, CATALOG,
-      ),
+      buildSystemParam("openai", { restRepresentation: REST, sourceCatalog: CATALOG }),
     );
     expect(prompt).toContain(COMPOSITION_HEADING);
     expect(prompt).toContain("## REST datasource: acme");

--- a/packages/api/src/lib/__tests__/agent-presentation-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-presentation-mode.test.ts
@@ -32,16 +32,7 @@ function promptText(
 
 describe("buildSystemParam — presentation mode (#2705)", () => {
   it("appends the conversational addendum when mode is 'conversational'", () => {
-    const result = buildSystemParam(
-      "openai",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "conversational",
-    );
+    const result = buildSystemParam("openai", { presentationMode: "conversational" });
     const prompt = promptText(result);
     // The addendum heading is the canonical pin — guards a future
     // refactor that renames the section without updating callers.
@@ -55,16 +46,7 @@ describe("buildSystemParam — presentation mode (#2705)", () => {
   });
 
   it("omits the conversational addendum in 'developer' mode (the default)", () => {
-    const developer = buildSystemParam(
-      "openai",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "developer",
-    );
+    const developer = buildSystemParam("openai", { presentationMode: "developer" });
     const developerPrompt = promptText(developer);
     expect(developerPrompt).not.toContain("Presentation mode — conversational");
     expect(developerPrompt).not.toContain("Do NOT include SQL");
@@ -85,16 +67,7 @@ describe("buildSystemParam — presentation mode (#2705)", () => {
     // the addendum entirely) breaks this assertion.
     const developer = promptText(buildSystemParam("openai"));
     const conversational = promptText(
-      buildSystemParam(
-        "openai",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        "conversational",
-      ),
+      buildSystemParam("openai", { presentationMode: "conversational" }),
     );
     expect(conversational.length).toBeGreaterThan(developer.length);
     // The exact delta IS the addendum (modulo no other branches differ
@@ -110,16 +83,7 @@ describe("buildSystemParam — presentation mode (#2705)", () => {
     // Anthropic / Bedrock-Anthropic return a SystemModelMessage so the
     // adapter applies cache control. The addendum must live inside
     // `content`, not get stripped by the wrapping.
-    const wrapped = buildSystemParam(
-      "anthropic",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "conversational",
-    );
+    const wrapped = buildSystemParam("anthropic", { presentationMode: "conversational" });
     expect(typeof wrapped).toBe("object");
     if (typeof wrapped === "string") return; // unreachable, narrows TS
     expect(wrapped.role).toBe("system");

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -293,18 +293,13 @@ function findToolResults(
 
 describe("buildSystemParam — scope guidance section (slice 2)", () => {
   it("appends Cross-Environment Routing section when routingContext has >1 members", () => {
-    const result = buildSystemParam(
-      "openai",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    const result = buildSystemParam("openai", {
+      routingContext: {
         members: ["us-int", "eu", "apac"],
         currentMember: "us-int",
         groupId: "prod",
       },
-    );
+    });
     expect(typeof result).toBe("string");
     const prompt = result as string;
     expect(prompt).toContain("Cross-Environment Routing");
@@ -332,30 +327,20 @@ describe("buildSystemParam — scope guidance section (slice 2)", () => {
   });
 
   it("omits the scope guidance section when routingContext has a single member", () => {
-    const result = buildSystemParam(
-      "openai",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      { members: ["only"], currentMember: "only" },
-    );
+    const result = buildSystemParam("openai", {
+      routingContext: { members: ["only"], currentMember: "only" },
+    });
     const prompt = result as string;
     expect(prompt).not.toContain("Cross-Environment Routing");
   });
 
   it("renders the current member as the anchor for `scope: \"this\"`", () => {
-    const result = buildSystemParam(
-      "openai",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
+    const result = buildSystemParam("openai", {
+      routingContext: {
         members: ["us-int", "eu", "apac"],
         currentMember: "eu",
       },
-    );
+    });
     const prompt = result as string;
     expect(prompt).toMatch(/current member is `eu`/);
   });
@@ -391,17 +376,7 @@ describe("buildRestDatasourceScopeNote — REST env-scope framing (#3044)", () =
     // section; buildSystemParam appends the whole restRepresentation string.
     const scopeNote = buildRestDatasourceScopeNote({}, { boundToEnvironment: true });
     const rep = `${scopeNote}\n\n### REST Datasource\nuse executeRestOperation…`;
-    const result = buildSystemParam(
-      "openai",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "developer",
-      rep,
-    );
+    const result = buildSystemParam("openai", { restRepresentation: rep });
     const prompt = result as string;
     expect(prompt).toContain("workspace-global");
     expect(prompt).toContain("### REST Datasource");

--- a/packages/api/src/lib/__tests__/agent-source-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/agent-source-catalog.test.ts
@@ -20,48 +20,20 @@ const MEMORY = "## Working memory\n\n- foo: bar";
 
 describe("buildSystemParam — Source catalog (#3894)", () => {
   it("injects the catalog block when supplied", () => {
-    const prompt = promptText(
-      buildSystemParam(
-        "openai",
-        undefined, // registry
-        undefined, // warnings
-        undefined, // orgSemanticIndex
-        undefined, // learnedPatternsSection
-        undefined, // routingContext
-        undefined, // boundDashboardContext
-        "developer",
-        undefined, // restRepresentation
-        undefined, // modelId
-        undefined, // memoryBlock
-        CATALOG, // sourceCatalog
-      ),
-    );
+    const prompt = promptText(buildSystemParam("openai", { sourceCatalog: CATALOG }));
     expect(prompt).toContain("## Source catalog");
   });
 
   it("omits the catalog when empty (no behavior change vs. today)", () => {
-    const withCatalog = promptText(
-      buildSystemParam(
-        "openai", undefined, undefined, undefined, undefined, undefined,
-        undefined, "developer", undefined, undefined, undefined, "",
-      ),
-    );
-    const without = promptText(
-      buildSystemParam(
-        "openai", undefined, undefined, undefined, undefined, undefined,
-        undefined, "developer", undefined, undefined, undefined, undefined,
-      ),
-    );
+    const withCatalog = promptText(buildSystemParam("openai", { sourceCatalog: "" }));
+    const without = promptText(buildSystemParam("openai", { sourceCatalog: undefined }));
     expect(withCatalog).not.toContain("## Source catalog");
     expect(withCatalog).toBe(without);
   });
 
   it("keeps the durable memory block AFTER the catalog (memory-LAST invariant)", () => {
     const prompt = promptText(
-      buildSystemParam(
-        "openai", undefined, undefined, undefined, undefined, undefined,
-        undefined, "developer", undefined, undefined, MEMORY, CATALOG,
-      ),
+      buildSystemParam("openai", { memoryBlock: MEMORY, sourceCatalog: CATALOG }),
     );
     expect(prompt).toContain("## Source catalog");
     expect(prompt).toContain("## Working memory");

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -527,20 +527,6 @@ function buildSystemPrompt(
 }
 
 /**
- * Build the system prompt with provider-appropriate cache control.
- *
- * The prompt body is composed from the registry's tool descriptions via
- * `registry.describe()`, sandwiched between the standard prefix and suffix.
- *
- * - Anthropic / Bedrock-Anthropic: returns a SystemModelMessage with
- *   `providerOptions.anthropic.cacheControl` (~80% savings on steps 2+).
- * - Bedrock (non-Anthropic): returns a SystemModelMessage with
- *   `providerOptions.bedrock.cachePoint`.
- * - OpenAI / Ollama / OpenAI-compatible / Gateway: returns a plain string
- *   (OpenAI caches automatically for prompts >= 1024 tokens; others have
- *   no caching).
- */
-/**
  * #2705 — Conversational-mode addendum.
  *
  * Appended to the system prompt when the caller requests
@@ -601,33 +587,36 @@ When a question spans more than one source in the catalog above — several SQL 
 - **Report which source(s) you drew from** so the user can check provenance — e.g. "1,240 signups (Postgres), 180 of them paid (Stripe)".
 - **Never silently fall back to an unrelated source.** If the source that actually holds the answer is empty or errors, say so plainly and state the gap — do not answer from a different source and imply it is equivalent.`;
 
+/** Response-audience mode; `"conversational"` renders chat-platform-friendly answers (#2705). */
+export type PresentationMode = "developer" | "conversational";
+
 export interface BuildSystemParamOptions {
   /** Tool registry the prompt's tool-guidance sections are built from. Defaults to `defaultRegistry`. */
-  registry?: ToolRegistry;
+  readonly registry?: ToolRegistry;
   /** Startup/context warnings surfaced to the agent under a `## Warnings` section. */
-  warnings?: string[];
-  /** Org-level semantic index section (multi-source workspaces). */
-  orgSemanticIndex?: string;
-  /** Learned query-pattern section (pattern cache). */
-  learnedPatternsSection?: string;
-  /** Scope-routing context (connection-group routing guidance). */
-  routingContext?: ScopeRoutingContext;
+  readonly warnings?: readonly string[];
+  /** Org-scoped (DB-backed) semantic index section; preferred over the file-based index when present. */
+  readonly orgSemanticIndex?: string;
+  /** Org-knowledge section: learned query patterns + favorites + approved suggestions (#3633). */
+  readonly learnedPatternsSection?: string;
+  /** Scope-routing context; guidance renders only for >1-member connection groups. */
+  readonly routingContext?: ScopeRoutingContext;
   /** Bound dashboard context (dashboard-scoped chat). */
-  boundDashboardContext?: BoundDashboardAgentContext;
-  /** Response-audience mode; `"conversational"` appends the chat-surface addendum. Defaults to `"developer"`. */
-  presentationMode?: "developer" | "conversational";
+  readonly boundDashboardContext?: BoundDashboardAgentContext;
+  /** `"conversational"` appends the chat-surface addendum. Defaults to `"developer"`. */
+  readonly presentationMode?: PresentationMode;
   /**
    * #2924 — Path A REST representation. When a REST datasource resolves, the
    * trimmed operation-graph prompt context is appended so the agent can address
    * its operations with `executeRestOperation`. Absent for SQL-only workspaces.
    */
-  restRepresentation?: string;
+  readonly restRepresentation?: string;
   /**
    * #3099 — Resolved model id, used only to detect when the `gateway` provider
    * routes to an Anthropic-family model so the system prompt gets the same
    * cache breakpoint as the direct Anthropic provider. Ignored otherwise.
    */
-  modelId?: string;
+  readonly modelId?: string;
   /**
    * #3755 — pre-rendered durable working-memory block (the persisted slot values
    * for this session). Appended at a single deterministic position — LAST in the
@@ -638,7 +627,7 @@ export interface BuildSystemParamOptions {
    * it (the slice-2 invariant recorded in ADR-0020). Empty string / omitted ⇒
    * nothing appended (memory off / empty / no internal DB → no change vs. today).
    */
-  memoryBlock?: string;
+  readonly memoryBlock?: string;
   /**
    * #3894 — the Source catalog (ADR-0022 §4): the compact routing menu of SQL
    * Connection groups + REST datasources the agent reads to pick a source before
@@ -649,9 +638,25 @@ export interface BuildSystemParamOptions {
    * Empty string / omitted ⇒ nothing appended (single-source / no-internal-DB
    * workspaces are unchanged).
    */
-  sourceCatalog?: string;
+  readonly sourceCatalog?: string;
 }
 
+/**
+ * Build the system prompt with provider-appropriate cache control.
+ *
+ * The prompt body is composed from the registry's tool descriptions via
+ * `registry.describe()`, sandwiched between the standard prefix and suffix.
+ *
+ * - Anthropic / Bedrock-Anthropic: returns a SystemModelMessage with
+ *   `providerOptions.anthropic.cacheControl` (~80% savings on steps 2+).
+ * - Bedrock (non-Anthropic): returns a SystemModelMessage with
+ *   `providerOptions.bedrock.cachePoint`.
+ * - OpenAI / Ollama / OpenAI-compatible: returns a plain string (OpenAI
+ *   caches automatically for prompts >= 1024 tokens; others have no caching).
+ * - Gateway: plain string, EXCEPT when `options.modelId` resolves to an
+ *   Anthropic-family model — then it takes the Anthropic cacheControl branch
+ *   (#3099, see `cacheProviderFor`).
+ */
 export function buildSystemParam(
   providerType: ProviderType,
   options: BuildSystemParamOptions = {},
@@ -1011,7 +1016,7 @@ export async function runAgent({
    * Optional + defaulting to `"developer"` keeps every pre-#2705
    * caller's behavior unchanged.
    */
-  presentationMode?: "developer" | "conversational";
+  presentationMode?: PresentationMode;
   /**
    * #3747 — crash-resume re-entry (ADR-0020 phase 2). When supplied, the agent
    * RE-ENTERS an interrupted turn instead of starting a fresh one:

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -601,27 +601,33 @@ When a question spans more than one source in the catalog above — several SQL 
 - **Report which source(s) you drew from** so the user can check provenance — e.g. "1,240 signups (Postgres), 180 of them paid (Stripe)".
 - **Never silently fall back to an unrelated source.** If the source that actually holds the answer is empty or errors, say so plainly and state the gap — do not answer from a different source and imply it is equivalent.`;
 
-export function buildSystemParam(
-  providerType: ProviderType,
-  registry: ToolRegistry = defaultRegistry,
-  warnings?: string[],
-  orgSemanticIndex?: string,
-  learnedPatternsSection?: string,
-  routingContext?: ScopeRoutingContext,
-  boundDashboardContext?: BoundDashboardAgentContext,
-  presentationMode: "developer" | "conversational" = "developer",
+export interface BuildSystemParamOptions {
+  /** Tool registry the prompt's tool-guidance sections are built from. Defaults to `defaultRegistry`. */
+  registry?: ToolRegistry;
+  /** Startup/context warnings surfaced to the agent under a `## Warnings` section. */
+  warnings?: string[];
+  /** Org-level semantic index section (multi-source workspaces). */
+  orgSemanticIndex?: string;
+  /** Learned query-pattern section (pattern cache). */
+  learnedPatternsSection?: string;
+  /** Scope-routing context (connection-group routing guidance). */
+  routingContext?: ScopeRoutingContext;
+  /** Bound dashboard context (dashboard-scoped chat). */
+  boundDashboardContext?: BoundDashboardAgentContext;
+  /** Response-audience mode; `"conversational"` appends the chat-surface addendum. Defaults to `"developer"`. */
+  presentationMode?: "developer" | "conversational";
   /**
    * #2924 — Path A REST representation. When a REST datasource resolves, the
    * trimmed operation-graph prompt context is appended so the agent can address
    * its operations with `executeRestOperation`. Absent for SQL-only workspaces.
    */
-  restRepresentation?: string,
+  restRepresentation?: string;
   /**
    * #3099 — Resolved model id, used only to detect when the `gateway` provider
    * routes to an Anthropic-family model so the system prompt gets the same
    * cache breakpoint as the direct Anthropic provider. Ignored otherwise.
    */
-  modelId?: string,
+  modelId?: string;
   /**
    * #3755 — pre-rendered durable working-memory block (the persisted slot values
    * for this session). Appended at a single deterministic position — LAST in the
@@ -632,7 +638,7 @@ export function buildSystemParam(
    * it (the slice-2 invariant recorded in ADR-0020). Empty string / omitted ⇒
    * nothing appended (memory off / empty / no internal DB → no change vs. today).
    */
-  memoryBlock?: string,
+  memoryBlock?: string;
   /**
    * #3894 — the Source catalog (ADR-0022 §4): the compact routing menu of SQL
    * Connection groups + REST datasources the agent reads to pick a source before
@@ -643,8 +649,26 @@ export function buildSystemParam(
    * Empty string / omitted ⇒ nothing appended (single-source / no-internal-DB
    * workspaces are unchanged).
    */
-  sourceCatalog?: string,
+  sourceCatalog?: string;
+}
+
+export function buildSystemParam(
+  providerType: ProviderType,
+  options: BuildSystemParamOptions = {},
 ): string | SystemModelMessage {
+  const {
+    registry = defaultRegistry,
+    warnings,
+    orgSemanticIndex,
+    learnedPatternsSection,
+    routingContext,
+    boundDashboardContext,
+    presentationMode = "developer",
+    restRepresentation,
+    modelId,
+    memoryBlock,
+    sourceCatalog,
+  } = options;
   let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext);
 
   if (sourceCatalog) {
@@ -1514,7 +1538,19 @@ export async function runAgent({
   // glossary AND the durable memory block (#3755), and is passed to the model
   // separately, so neither ever enters the message array compaction rewrites
   // (#3759).
-  const systemParam = buildSystemParam(providerType, activeRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext, boundDashboardContext, presentationMode ?? "developer", restRepresentation, resolvedModelId, memoryBlock, sourceCatalog);
+  const systemParam = buildSystemParam(providerType, {
+    registry: activeRegistry,
+    warnings,
+    orgSemanticIndex,
+    learnedPatternsSection,
+    routingContext: scopeRoutingContext,
+    boundDashboardContext,
+    presentationMode: presentationMode ?? "developer",
+    restRepresentation,
+    modelId: resolvedModelId,
+    memoryBlock,
+    sourceCatalog,
+  });
 
   // #3759 — context compaction. Resolved once per turn (knobs hot-reload at the
   // next turn via the settings cache). Off by default ⇒ the prepareStep below


### PR DESCRIPTION
## Summary
- Converts `buildSystemParam` from 12 positional parameters (trailing six same-typed optional strings — transposition-prone, the debt flagged in #3819) to a `(providerType, options)` two-arg form with an exported `BuildSystemParamOptions` interface; per-field JSDoc (#2924/#3099/#3755/#3894) migrated intact
- Migrates every multi-arg positional call: 1 production site (`runAgent`) + 22 test sites across 5 test files; single-arg calls unchanged, no positional call remains
- Behavior-neutral by construction and by proof: system-prompt output verified **byte-identical** against a 17-combo input matrix captured before/after (incl. gateway→Anthropic cache branch, empty-string vs omitted semantics, memory-LAST ordering); all 69 `--affected` test files green
- Review-panel polish (all type/comment-level): corrected two mis-glossed field comments, adopted the orphaned cache-control JSDoc as the function doc with the #3099 gateway correction, extracted shared `PresentationMode` type, `readonly` options fields, added a `{}` ≡ omitted-arg test pin

## Test plan
- [x] Internal review panel (silent-failure, type-design, pr-test, comment): CLEAN, round 1
- [x] Byte-identical output probe before/after (deterministic, file-written to dodge pino stdout interleaving)
- [x] `bun run scripts/test-isolated.ts --affected` — 69/69 files pass
- [x] `scripts/ci-local.sh` — 26/27 gates green; `test` gate red only on the two known pre-existing WSL2 sandbox-env failures (`python.test.ts`, `explore-workspace-override.test.ts`), reproduced identically on `main`
- [ ] Required remote CI green on head SHA

Closes #3819