### PR TITLE
debug: surface claude-code-review error (throwaway, do not merge)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
Throwaway PR to capture the real error behind the silent claude-review failures (every run since #4171 dies in ~2s with is_error:true, $0 cost, and the message redacted). Adds show_full_output: true so the run log prints the actual error. Will be closed once captured.