### PR TITLE
feat: OKF (Open Knowledge Format) interop spike — okf import/export + mapping findings

### DIFF
--- a/docs/research/okf-interop-spike.md
+++ b/docs/research/okf-interop-spike.md
@@ -1,0 +1,117 @@
+# OKF interop spike — mapping findings & recommendations
+
+**Issue:** #4140 · **Date:** 2026-07-02 · **Status:** spike complete; productionization is a follow-up
+
+Google's [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+(announced 2026-06-12) is a vendor-neutral bundle of markdown files with YAML
+frontmatter for the metadata/context AI agents need. Same "the semantic layer
+is a plain file" thesis as ours; the difference is stance: OKF is a
+**descriptive interchange format** (only `type` required, prose-first),
+Atlas's YAML is an **authoritative runtime** (pinned metric SQL runs verbatim,
+`status: ambiguous` gates the agent, the table whitelist enforces
+queryability). This spike prototyped both directions to measure how lossy the
+mapping actually is. Verdict up front: **worth speaking; the mapping is
+asymmetric** — export is easy and total, import is a useful but genuinely
+lossy draft generator.
+
+## What shipped in this spike
+
+- `packages/api/src/lib/semantic/okf/` — pure mapping engine, both directions,
+  operating on in-memory `{ path, content }` lists (no fs coupling — reusable
+  by a future ingest pipeline, see #4182).
+- `atlas okf import --bundle <dir>` / `atlas okf export --out <dir>` —
+  file↔file CLI prototypes (`packages/cli/src/commands/okf.ts`).
+- Tests incl. a GA4-shaped foreign-bundle fixture and a full round-trip
+  assertion (`packages/api/src/lib/semantic/okf/__tests__/`).
+
+## OKF in one paragraph (as verified against the spec + GA4 sample)
+
+A bundle is a directory tree of markdown concept docs. Frontmatter: `type`
+(required, free text — "BigQuery Table", "Reference", "Playbook"), plus
+recommended `title`/`description`/`resource`/`tags`/`timestamp`; **unknown
+keys are legal and consumers must preserve them** (this is load-bearing
+below). Reserved filenames: `index.md` (navigation, no frontmatter except
+root `okf_version`), `log.md` (history). Links are untyped edges; meaning
+lives in surrounding prose. In the GA4 sample, tables carry a `# Schema`
+bullet list (`- \`col\` (TYPE): description`; the launch blog uses a markdown
+table instead), metrics and joins are `type: Reference` docs tagged
+`metric`/`join` with a ```sql fence.
+
+## Mapping table
+
+### Import (OKF → Atlas draft)
+
+| OKF | Atlas | Fidelity |
+|---|---|---|
+| table/view concept (`type` contains "table"/"view") | `entities/<stem>.yml` (`name` ← `title`, `description` ← frontmatter + `# Overview`) | clean |
+| `# Schema` entries (bullet **and** table form) | `dimensions[]` with `sql: <name>`, types mapped onto `number/string/date/timestamp/boolean` | clean for scalars; **types coarsened** (INT64 and FLOAT both → `number`) |
+| RECORD/STRUCT/ARRAY/JSON columns | **skipped**, reported | lossy — no scalar dimension equivalent |
+| metric Reference (+```sql fence) | `metrics/okf-imported.yml` entry, **`okf.unverified_sql: true`** | lossy in *authority*: OKF metric SQL is illustrative prose (GA4's `new_user_count` SQL is a fragment with an explanatory comment, not runnable). Promoting it silently into pinned-metric status would be an integrity hole, so import never does |
+| join Reference (```sql equality) | `joins[]` entry on the source entity when **both** sides resolve to imported tables | partial — GA4's own join spec uses prose aliases (`GA_EVENTS`, `ADS_CLICKS`), which don't resolve; reported as unmapped. Cardinality is never expressed |
+| dataset concept | folded into `catalog.yml` description | clean (Atlas has no dataset object) |
+| glossary-ish concepts (tag `glossary`/`term`) | `terms` map, always `status: defined` | OKF has no ambiguity concept |
+| anything else (`Playbook`, `API Endpoint`, …) | reported unmapped | by design — but this is exactly the content a knowledge-connection store would want (#4182) |
+| entity type / grain / measures / virtual dims / sample stats | not inferable from prose | left for the existing scan → enrich → edit flow |
+
+Every import carries an `okf:` provenance block (source path, resource, tags,
+timestamp) — legal because `EntityShape` is passthrough.
+
+### Export (Atlas → OKF)
+
+Total: every entity, metric, and glossary term becomes a conformant concept
+doc with prose a foreign consumer can read (`# Schema` bullets, measures,
+joins, example queries) plus navigation `index.md`s and root `okf_version`.
+What foreign consumers **lose is semantics, not data**:
+
+- **Table whitelist** — entity existence survives; runtime enforcement has no
+  OKF equivalent. A consumer can see what's queryable, nothing stops it
+  querying anything else.
+- **Pinned-metric authority** — the SQL is in the doc, but to a non-Atlas
+  consumer it's illustrative prose, not a contract.
+- **Ambiguity gating** — `status: ambiguous` terms export with their
+  possible mappings and an "Atlas asks the user" prose note; no consumer will
+  actually ask.
+
+## Round-trip fidelity — the central finding
+
+**Prose alone does not round-trip.** Structured → prose → structured loses
+types (coarsened), measures, virtual-dimension SQL, join cardinality, and all
+profiler stats. **With an extension namespace it round-trips exactly:** the
+exporter writes the full source object under the `atlas:` frontmatter key
+(`atlas.entity` / `atlas.metric` / `atlas.term`+`entry`), which OKF v0.1
+explicitly permits and requires consumers to preserve. Re-import restores
+those objects verbatim — the round-trip test asserts deep equality, including
+`status: ambiguous` gating and metric authority (no `unverified_sql` flag on
+the native path).
+
+So the two paths through the importer are:
+1. **Atlas-produced bundle** → lossless restore from `atlas:` (identity).
+2. **Foreign bundle (GA4 etc.)** → heuristic prose parse, deterministic, no
+   LLM pass needed for the structural 80% (schema/descriptions/links);
+   an LLM pass would only add value for inferring grain/measures/types from
+   prose — exactly what the existing enrich step already is.
+
+## Decisions & recommendations
+
+1. **One-shot draft generator, not a maintained sync.** Import output is
+   drafts for scan → enrich → edit; a sync would need identity/merge rules
+   OKF can't express (it has no stable IDs beyond file paths). Re-run =
+   re-import with `--force`.
+2. **CLI surface: `atlas okf import|export`** subcommand group in the
+   published `atlas` binary. Bare `import`/`migrate-import` were taken;
+   file↔file means no tenant-DB access, so it doesn't belong in
+   `atlas-operator` (ADR-0025/0026).
+3. **Core, not plugin** — per triage decision on #4140; it targets the core
+   semantic SSOT directly.
+4. **Keep the `atlas:` extension namespace** as the compatibility contract.
+   If productionized, document the key shapes; consider trimming
+   `atlas.entity` duplication (frontmatter + prose carry the same info) if
+   bundle size matters.
+5. **No ADR yet.** The round-trip shape becomes load-bearing only if/when a
+   consumer beyond our own importer depends on `atlas:` — write the ADR at
+   productionization, cross-linking ADR-0012/0017/0025.
+6. **Follow-up (#4182):** the importer's bundle-parsing seam is deliberately
+   fs-free so an internally hosted per-workspace OKF document store
+   ("knowledge connections") can reuse it; the unmapped concept kinds
+   (playbooks, runbooks, API endpoints) that this importer rejects are that
+   feature's payload.

--- a/docs/research/okf-interop-spike.md
+++ b/docs/research/okf-interop-spike.md
@@ -53,8 +53,15 @@ table instead), metrics and joins are `type: Reference` docs tagged
 | anything else (`Playbook`, `API Endpoint`, …) | reported unmapped | by design — but this is exactly the content a knowledge-connection store would want (#4182) |
 | entity type / grain / measures / virtual dims / sample stats | not inferable from prose | left for the existing scan → enrich → edit flow |
 
-Every import carries an `okf:` provenance block (source path, resource, tags,
-timestamp) — legal because `EntityShape` is passthrough.
+Every *heuristically* imported artifact carries an `okf:` provenance block
+(source path, resource, tags, timestamp) — legal because `EntityShape` is
+passthrough. Native `atlas:` restores keep whatever the source object carried.
+
+**Trust boundary:** a bundle is third-party input, and the `atlas:` extension
+is trivially forgeable. Table names are validated via `safeSemanticRowName`
+on *both* import paths (a forged `atlas.entity.table: "../../x"` is reported
+and dropped, never written), the CLI's `writeFiles` independently refuses any
+path escaping `--out`, and metric authority never transfers (next section).
 
 ### Export (Atlas → OKF)
 
@@ -76,16 +83,24 @@ What foreign consumers **lose is semantics, not data**:
 
 **Prose alone does not round-trip.** Structured → prose → structured loses
 types (coarsened), measures, virtual-dimension SQL, join cardinality, and all
-profiler stats. **With an extension namespace it round-trips exactly:** the
+profiler stats. **With an extension namespace, objects round-trip:** the
 exporter writes the full source object under the `atlas:` frontmatter key
 (`atlas.entity` / `atlas.metric` / `atlas.term`+`entry`), which OKF v0.1
 explicitly permits and requires consumers to preserve. Re-import restores
-those objects verbatim — the round-trip test asserts deep equality, including
-`status: ambiguous` gating and metric authority (no `unverified_sql` flag on
-the native path).
+entity and glossary objects verbatim (deep-equality asserted, including
+`status: ambiguous` gating) and metric *fields* verbatim.
+
+Two deliberate exceptions keep the trip from being an identity:
+- **Metric authority never transfers.** The extension is forgeable, so even
+  `atlas.metric` restores are re-stamped `okf.unverified_sql: true` — Atlas
+  runs metric SQL verbatim at runtime, and authority belongs to the reviewed
+  file in your repo, not to data that arrived in a bundle.
+- **Catalog description and file layout are not preserved** (all metrics
+  land in `metrics/okf-imported.yml`; `catalog.yml` is rebuilt).
 
 So the two paths through the importer are:
-1. **Atlas-produced bundle** → lossless restore from `atlas:` (identity).
+1. **Atlas-produced bundle** → lossless object restore from `atlas:` (modulo
+   the unverified re-stamp above).
 2. **Foreign bundle (GA4 etc.)** → heuristic prose parse, deterministic, no
    LLM pass needed for the structural 80% (schema/descriptions/links);
    an LLM pass would only add value for inferring grain/measures/types from

--- a/docs/research/okf-interop-spike.md
+++ b/docs/research/okf-interop-spike.md
@@ -53,20 +53,23 @@ table instead), metrics and joins are `type: Reference` docs tagged
 | anything else (`Playbook`, `API Endpoint`, …) | reported unmapped | by design — but this is exactly the content a knowledge-connection store would want (#4182) |
 | entity type / grain / measures / virtual dims / sample stats | not inferable from prose | left for the existing scan → enrich → edit flow |
 
-Every *heuristically* imported artifact carries an `okf:` provenance block
-(source path, resource, tags, timestamp) — legal because `EntityShape` is
-passthrough. Native `atlas:` restores keep whatever the source object carried.
+Every *heuristically* imported entity/metric/term carries an `okf:`
+provenance block (source path, resource, tags, timestamp; joins carry
+`source_path` only) — legal because `EntityShape` is passthrough. Native
+`atlas:` restores keep whatever the source object carried.
 
 **Trust boundary:** a bundle is third-party input, and the `atlas:` extension
 is trivially forgeable. Table names are validated via `safeSemanticRowName`
 on *both* import paths (a forged `atlas.entity.table: "../../x"` is reported
 and dropped, never written), the CLI's `writeFiles` independently refuses any
-path escaping `--out`, and metric authority never transfers (next section).
+path escaping `--out`, and metric authority never transfers (see Round-trip
+fidelity below).
 
 ### Export (Atlas → OKF)
 
-Total: every entity, metric, and glossary term becomes a conformant concept
-doc with prose a foreign consumer can read (`# Schema` bullets, measures,
+Near-total: every well-formed entity, metric, and glossary term becomes a
+conformant concept doc (filename-stem collisions are first-wins, reported)
+with prose a foreign consumer can read (`# Schema` bullets, measures,
 joins, example queries) plus navigation `index.md`s and root `okf_version`.
 What foreign consumers **lose is semantics, not data**:
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,7 @@
     "./lib/semantic/expert": "./src/lib/semantic/expert/index.ts",
     "./lib/semantic/generate": "./src/lib/semantic/generate/index.ts",
     "./lib/semantic/enrich": "./src/lib/semantic/enrich/index.ts",
+    "./lib/semantic/okf": "./src/lib/semantic/okf/index.ts",
     "./lib/semantic/*": "./src/lib/semantic/*.ts",
     "./lib/*": "./src/lib/*.ts",
     "./lib/auth/*": "./src/lib/auth/*.ts",

--- a/packages/api/src/lib/semantic/okf/__tests__/fixtures.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/fixtures.ts
@@ -1,0 +1,323 @@
+/**
+ * In-memory fixtures for the OKF interop spike tests (#4140).
+ *
+ * FOREIGN_BUNDLE mirrors the shape of Google's GA4 e-commerce sample bundle
+ * (GoogleCloudPlatform/knowledge-catalog okf/bundles/ga4): table concepts
+ * with `# Schema` bullet lists, metric/join Reference concepts with sql
+ * fences, a dataset concept, and index.md navigation.
+ *
+ * SEMANTIC_LAYER is a compact Atlas layer (entity + glossary + metrics +
+ * catalog) modeled on the ecommerce seed fixtures.
+ */
+
+import type { InteropFile } from "../types";
+
+export const FOREIGN_BUNDLE: InteropFile[] = [
+  {
+    path: "index.md",
+    content: `---
+okf_version: "0.1"
+---
+
+# Shop analytics
+
+* [tables](tables/index.md) - Event export tables.
+* [references](references/index.md) - Metric and join definitions.
+`,
+  },
+  {
+    path: "datasets/shop_events.md",
+    content: `---
+type: BigQuery Dataset
+title: Shop events dataset
+description: Obfuscated e-commerce event export data covering three months.
+tags:
+- ecommerce
+timestamp: '2026-05-28T22:49:59+00:00'
+---
+
+# Overview
+Event export data for the demo shop.
+`,
+  },
+  {
+    path: "tables/events.md",
+    content: `---
+type: BigQuery Table
+resource: https://bigquery.googleapis.com/v2/projects/demo/datasets/shop/tables/events
+title: Events table
+description: Contains web event export data for the demo shop.
+tags:
+- events
+- ecommerce
+timestamp: '2026-05-28T22:53:05+00:00'
+---
+
+# Overview
+The \`events\` table contains web event export data for the demo shop.
+
+# Metrics
+- [Purchase Count](../references/metrics/purchase_count.md) - Total number of purchases.
+
+# Schema
+- \`event_date\` (STRING): The date when the event was logged (YYYYMMDD).
+- \`event_timestamp\` (INTEGER): Microseconds (UTC) when the event was received.
+- \`event_name\` (STRING): The name of the event.
+- \`event_value_in_usd\` (FLOAT): Currency-converted value of the event.
+- \`is_active_user\` (BOOLEAN): Whether the user was active in the session.
+- \`event_params\` (RECORD): Repeated record of event parameters.
+
+# Joins
+- [Events to users](../references/joins/events_users.md) - join on \`user_id\`.
+`,
+  },
+  {
+    path: "tables/users.md",
+    content: `---
+type: BigQuery Table
+title: Users table
+description: One row per known user.
+tags:
+- users
+timestamp: '2026-05-28T22:53:05+00:00'
+---
+
+# Overview
+The \`users\` table has one row per known user.
+
+# Schema
+
+| Column       | Type      | Description                     |
+|--------------|-----------|---------------------------------|
+| \`user_id\`  | STRING    | Unique user identifier.         |
+| \`signup_at\`| TIMESTAMP | When the user first signed up.  |
+| \`ltv_usd\`  | NUMERIC   | Lifetime value in USD.          |
+`,
+  },
+  {
+    path: "references/index.md",
+    content: `# References
+
+* [metrics](metrics/index.md) - Metric definitions.
+* [joins](joins/index.md) - Join specifications.
+`,
+  },
+  {
+    path: "references/metrics/purchase_count.md",
+    content: `---
+type: Reference
+resource: https://example.com/docs/basic-queries
+title: Purchase Count
+description: Total number of purchase events.
+tags:
+- metric
+timestamp: '2026-05-28T22:51:38+00:00'
+---
+
+Total number of purchase events.
+
+\`\`\`sql
+COUNT(*) -- filtered to event_name = 'purchase'
+\`\`\`
+
+# Citations
+- https://example.com/docs/basic-queries
+`,
+  },
+  {
+    path: "references/metrics/prose_only_metric.md",
+    content: `---
+type: Reference
+title: Engagement Rate
+description: Share of sessions with meaningful engagement.
+tags:
+- metric
+---
+
+Share of sessions with meaningful engagement. Computed upstream; no SQL published.
+`,
+  },
+  {
+    path: "references/joins/events_users.md",
+    content: `---
+type: Reference
+title: Join events to users
+description: Join event data with the users table.
+tags:
+- join
+---
+
+Join event data with the users table.
+
+\`\`\`sql
+events.user_id = users.user_id
+\`\`\`
+`,
+  },
+  {
+    path: "references/joins/events_ads.md",
+    content: `---
+type: Reference
+title: Join events to ads clicks
+description: Join event data with an external ads system.
+tags:
+- join
+---
+
+\`\`\`sql
+SHOP_EVENTS.collected.gclid = ADS_CLICKS.gclid
+\`\`\`
+`,
+  },
+  {
+    path: "references/runbook.md",
+    content: `---
+type: Playbook
+title: Backfill runbook
+description: How to backfill a missing day of events.
+---
+
+1. Re-run the export job.
+`,
+  },
+  {
+    path: "tables/broken.md",
+    content: `no frontmatter here at all
+`,
+  },
+];
+
+export const SEMANTIC_LAYER: InteropFile[] = [
+  {
+    path: "entities/orders.yml",
+    content: `name: Orders
+type: fact_table
+table: orders
+grain: one row per order
+description: |
+  Customer orders - the primary fact table for revenue analysis.
+dimensions:
+  - name: id
+    sql: id
+    type: number
+    description: Primary key - unique order identifier
+    primary_key: true
+  - name: status
+    sql: status
+    type: string
+    description: Order fulfillment status
+    sample_values: [pending, shipped, cancelled]
+  - name: total_cents
+    sql: total_cents
+    type: number
+    description: Order total in cents. Primary revenue field.
+  - name: created_at
+    sql: created_at
+    type: timestamp
+    description: When the order was placed
+  - name: order_month
+    sql: TO_CHAR(created_at, 'YYYY-MM')
+    type: string
+    description: Year-month the order was placed
+    virtual: true
+measures:
+  - name: order_count
+    sql: id
+    type: count_distinct
+    description: Number of unique orders
+  - name: total_gmv_cents
+    sql: total_cents
+    type: sum
+    description: Total GMV in cents
+joins:
+  - target_entity: Customers
+    relationship: many_to_one
+    join_columns:
+      from: customer_id
+      to: id
+    description: Each order belongs to one customer
+use_cases:
+  - GMV and revenue analysis
+query_patterns:
+  - name: monthly_gmv
+    description: Monthly GMV trend
+    sql: |-
+      SELECT TO_CHAR(created_at, 'YYYY-MM') AS order_month,
+             SUM(total_cents) / 100.0 AS gmv_dollars
+      FROM orders
+      WHERE status != 'cancelled'
+      GROUP BY TO_CHAR(created_at, 'YYYY-MM')
+`,
+  },
+  {
+    path: "entities/customers.yml",
+    content: `name: Customers
+type: fact_table
+table: customers
+description: One row per registered customer.
+dimensions:
+  - name: id
+    sql: id
+    type: number
+    primary_key: true
+  - name: email
+    sql: email
+    type: string
+`,
+  },
+  {
+    path: "glossary.yml",
+    content: `terms:
+  GMV:
+    status: defined
+    definition: >
+      Gross Merchandise Value. Total value of all orders before refunds.
+    tables:
+      - orders
+  revenue:
+    status: ambiguous
+    note: >
+      Could mean gross revenue, net revenue, or seller revenue. ASK the user
+      which definition they mean.
+    possible_mappings:
+      - orders.total_cents
+      - payments.amount_cents
+`,
+  },
+  {
+    path: "metrics/revenue.yml",
+    content: `metrics:
+  - id: total_gmv
+    label: Total GMV
+    description: >
+      Gross Merchandise Value - total value of all non-cancelled orders.
+    type: atomic
+    unit: USD
+    source:
+      entity: Orders
+      measure: total_gmv_cents
+    sql: |-
+      SELECT SUM(total_cents) / 100.0 AS total_gmv
+      FROM orders
+      WHERE status != 'cancelled'
+    aggregation: sum
+    objective: maximize
+`,
+  },
+  {
+    path: "catalog.yml",
+    content: `version: 1
+name: ecommerce
+description: Demo e-commerce semantic layer.
+entities:
+  - name: Orders
+    file: entities/orders.yml
+  - name: Customers
+    file: entities/customers.yml
+glossary: glossary.yml
+metrics:
+  - file: metrics/revenue.yml
+    description: Revenue metrics.
+`,
+  },
+];

--- a/packages/api/src/lib/semantic/okf/__tests__/fixtures.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/fixtures.ts
@@ -170,6 +170,19 @@ SHOP_EVENTS.collected.gclid = ADS_CLICKS.gclid
 `,
   },
   {
+    path: "references/glossary/mrr.md",
+    content: `---
+type: Reference
+title: MRR
+description: Monthly recurring revenue, net of refunds.
+tags:
+- glossary
+---
+
+Monthly recurring revenue, net of refunds. Computed monthly by finance.
+`,
+  },
+  {
     path: "references/runbook.md",
     content: `---
 type: Playbook

--- a/packages/api/src/lib/semantic/okf/__tests__/okf-export.test.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/okf-export.test.ts
@@ -127,19 +127,77 @@ describe("round-trip: Atlas -> OKF -> Atlas", () => {
     expect(roundTripped.terms).toEqual(original.terms);
   });
 
-  it("restores metrics verbatim (no unverified flag on the native path)", () => {
+  it("restores metric fields verbatim but re-stamps SQL as unverified (authority is trust, not data)", () => {
     const original = loadOriginal("metrics/revenue.yml") as {
       metrics: Array<Record<string, unknown>>;
     };
     const roundTripped = yaml.load(byPath.get("metrics/okf-imported.yml") ?? "") as {
       metrics: Array<Record<string, unknown>>;
     };
-    expect(roundTripped.metrics).toEqual(original.metrics);
+    expect(roundTripped.metrics).toEqual(
+      original.metrics.map((m) => ({ ...m, okf: { unverified_sql: true } })),
+    );
   });
 
   it("notes the lossless restores in the report", () => {
     expect(
       reimported.report.notes.filter((n) => n.includes("restored verbatim")).length,
     ).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("exportToOkf (malformed layer input)", () => {
+  it("reports malformed metrics/glossary/entity files instead of silently dropping them", () => {
+    const { files, report } = exportToOkf(
+      [
+        { path: "entities/no-table.yml", content: "name: NoTable\n" },
+        { path: "metrics/bad.yml", content: "metrics:\n  keyed: not-an-array\n" },
+        { path: "metrics/mixed.yml", content: "metrics:\n  - id: ok\n    label: OK\n  - just-a-string\n" },
+        { path: "glossary.yml", content: "definitions: wrong-key\n" },
+        { path: "entities/broken.yml", content: "table: [unclosed\n" },
+      ],
+      { timestamp: TIMESTAMP },
+    );
+    expect(report.unmapped.some((u) => u.includes("no-table.yml") && u.includes("table"))).toBe(
+      true,
+    );
+    expect(
+      report.unmapped.some((u) => u.includes("metrics/bad.yml") && u.includes("array")),
+    ).toBe(true);
+    expect(
+      report.unmapped.some((u) => u.includes("metrics/mixed.yml") && u.includes("non-mapping")),
+    ).toBe(true);
+    expect(
+      report.unmapped.some((u) => u.includes("glossary.yml") && u.includes("terms")),
+    ).toBe(true);
+    expect(
+      report.unmapped.some((u) => u.includes("entities/broken.yml") && u.includes("parse error")),
+    ).toBe(true);
+    // The one valid metric still exports.
+    expect(files.some((f) => f.path === "references/metrics/ok.md")).toBe(true);
+  });
+
+  it("renders map-form (name-keyed) dimensions", () => {
+    const { files } = exportToOkf(
+      [
+        {
+          path: "entities/legacy.yml",
+          content: `name: Legacy
+table: legacy
+dimensions:
+  id:
+    type: number
+    primary_key: true
+  label:
+    type: string
+    description: Display label
+`,
+        },
+      ],
+      { timestamp: TIMESTAMP },
+    );
+    const doc = files.find((f) => f.path === "tables/legacy.md")?.content ?? "";
+    expect(doc).toContain("- `id` (NUMBER): Primary key.");
+    expect(doc).toContain("- `label` (STRING): Display label");
   });
 });

--- a/packages/api/src/lib/semantic/okf/__tests__/okf-export.test.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/okf-export.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import * as yaml from "js-yaml";
+import { parseFrontmatter } from "../frontmatter";
+import { exportToOkf } from "../export";
+import { importOkfBundle } from "../import";
+import { SEMANTIC_LAYER } from "./fixtures";
+
+const TIMESTAMP = "2026-07-02T00:00:00+00:00";
+
+function fileMap(files: Array<{ path: string; content: string }>): Map<string, string> {
+  return new Map(files.map((f) => [f.path, f.content]));
+}
+
+describe("exportToOkf", () => {
+  const { files, report } = exportToOkf(SEMANTIC_LAYER, { timestamp: TIMESTAMP });
+  const byPath = fileMap(files);
+
+  it("emits one concept doc per entity, metric, and glossary term plus indexes", () => {
+    expect([...byPath.keys()].sort()).toEqual(
+      [
+        "index.md",
+        "references/glossary/gmv.md",
+        "references/glossary/index.md",
+        "references/glossary/revenue.md",
+        "references/index.md",
+        "references/metrics/index.md",
+        "references/metrics/total_gmv.md",
+        "tables/customers.md",
+        "tables/index.md",
+        "tables/orders.md",
+      ].sort(),
+    );
+  });
+
+  it("emits OKF-conformant concept docs (frontmatter with non-empty type)", () => {
+    for (const [path, content] of byPath) {
+      const base = path.split("/").pop() ?? path;
+      if (base === "index.md" || base === "log.md") continue;
+      const parsed = parseFrontmatter(content);
+      expect(parsed.ok).toBe(true);
+      if (!parsed.ok) throw new Error(`unparseable: ${path}: ${parsed.reason}`);
+      expect(parsed.doc.frontmatter.type.length).toBeGreaterThan(0);
+      expect(parsed.doc.frontmatter.timestamp).toBe(TIMESTAMP);
+    }
+  });
+
+  it("declares okf_version on the root index only", () => {
+    expect(byPath.get("index.md")).toContain('okf_version: "0.1"');
+    expect(byPath.get("tables/index.md")).not.toContain("okf_version");
+  });
+
+  it("renders a prose schema section with types, PK, samples, and virtual SQL", () => {
+    const orders = byPath.get("tables/orders.md") ?? "";
+    expect(orders).toContain("# Schema");
+    expect(orders).toContain("- `id` (NUMBER):");
+    expect(orders).toContain("Primary key.");
+    expect(orders).toContain("Sample values: pending, shipped, cancelled.");
+    expect(orders).toContain("Virtual dimension");
+    expect(orders).toContain("TO_CHAR(created_at, 'YYYY-MM')");
+  });
+
+  it("renders measures, joins, use cases, and query patterns as prose", () => {
+    const orders = byPath.get("tables/orders.md") ?? "";
+    expect(orders).toContain("# Measures");
+    expect(orders).toContain("`total_gmv_cents` (sum of `total_cents`)");
+    expect(orders).toContain("# Joins");
+    expect(orders).toContain("Customers on `orders.customer_id = id` (many to one)");
+    expect(orders).toContain("# Use cases");
+    expect(orders).toContain("# Example queries");
+    expect(orders).toContain("```sql");
+  });
+
+  it("links entity docs to the metrics sourced from them", () => {
+    const orders = byPath.get("tables/orders.md") ?? "";
+    expect(orders).toContain("# Metrics");
+    expect(orders).toContain("[Total GMV](../references/metrics/total_gmv.md)");
+  });
+
+  it("exports metrics as Reference concepts with the authoritative SQL", () => {
+    const metric = byPath.get("references/metrics/total_gmv.md") ?? "";
+    const parsed = parseFrontmatter(metric);
+    if (!parsed.ok) throw new Error(parsed.reason);
+    expect(parsed.doc.frontmatter.type).toBe("Reference");
+    expect(parsed.doc.frontmatter.tags).toContain("metric");
+    expect(metric).toContain("SELECT SUM(total_cents) / 100.0 AS total_gmv");
+    expect(metric).toContain("authoritative");
+  });
+
+  it("exports ambiguous glossary terms as prose and reports the dropped gating", () => {
+    const revenue = byPath.get("references/glossary/revenue.md") ?? "";
+    expect(revenue).toContain("Possible mappings:");
+    expect(revenue).toContain("`orders.total_cents`");
+    expect(revenue).toContain("asks the user");
+    expect(report.lossy.some((l) => l.includes('"revenue"') && l.includes("ask-first"))).toBe(
+      true,
+    );
+  });
+
+  it("reports the authoritative-runtime semantics OKF cannot express", () => {
+    expect(report.lossy.some((l) => l.includes("whitelist"))).toBe(true);
+    expect(report.lossy.some((l) => l.includes("pinned-metric"))).toBe(true);
+  });
+});
+
+describe("round-trip: Atlas -> OKF -> Atlas", () => {
+  const exported = exportToOkf(SEMANTIC_LAYER, { timestamp: TIMESTAMP });
+  const reimported = importOkfBundle(exported.files, { bundleName: "ecommerce" });
+  const byPath = fileMap(reimported.files);
+
+  function loadOriginal(path: string): unknown {
+    const file = SEMANTIC_LAYER.find((f) => f.path === path);
+    if (!file) throw new Error(`missing fixture ${path}`);
+    return yaml.load(file.content);
+  }
+
+  it("restores entities verbatim via the atlas extension", () => {
+    for (const path of ["entities/orders.yml", "entities/customers.yml"]) {
+      expect(yaml.load(byPath.get(path) ?? "")).toEqual(loadOriginal(path));
+    }
+  });
+
+  it("restores glossary terms verbatim, including ambiguity gating", () => {
+    const original = loadOriginal("glossary.yml") as { terms: Record<string, unknown> };
+    const roundTripped = yaml.load(byPath.get("glossary.yml") ?? "") as {
+      terms: Record<string, unknown>;
+    };
+    expect(roundTripped.terms).toEqual(original.terms);
+  });
+
+  it("restores metrics verbatim (no unverified flag on the native path)", () => {
+    const original = loadOriginal("metrics/revenue.yml") as {
+      metrics: Array<Record<string, unknown>>;
+    };
+    const roundTripped = yaml.load(byPath.get("metrics/okf-imported.yml") ?? "") as {
+      metrics: Array<Record<string, unknown>>;
+    };
+    expect(roundTripped.metrics).toEqual(original.metrics);
+  });
+
+  it("notes the lossless restores in the report", () => {
+    expect(
+      reimported.report.notes.filter((n) => n.includes("restored verbatim")).length,
+    ).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
@@ -327,7 +327,10 @@ title: Orders
     const glossary = yaml.load(files.find((f) => f.path === "glossary.yml")?.content ?? "") as {
       terms: Record<string, Record<string, unknown>>;
     };
-    expect(glossary.terms.constructor.status).toBe("defined");
+    // Map-based lookup: `.constructor` property access would resolve to the
+    // Object.prototype member in TS, which is the very trap under test.
+    const entry = new Map(Object.entries(glossary.terms)).get("constructor");
+    expect(entry?.status).toBe("defined");
     expect(report.unmapped.some((u) => u.includes("duplicate"))).toBe(false);
   });
 

--- a/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "bun:test";
+import * as yaml from "js-yaml";
+import { parseFrontmatter } from "../frontmatter";
+import { mapColumnType, parseSchemaColumns, splitSections } from "../parse";
+import { importOkfBundle } from "../import";
+import { FOREIGN_BUNDLE } from "./fixtures";
+
+function fileMap(files: Array<{ path: string; content: string }>): Map<string, string> {
+  return new Map(files.map((f) => [f.path, f.content]));
+}
+
+describe("parseFrontmatter", () => {
+  it("parses frontmatter and body", () => {
+    const result = parseFrontmatter(`---\ntype: Reference\ntitle: X\n---\n\nBody text.\n`);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.doc.frontmatter.type).toBe("Reference");
+    expect(result.doc.frontmatter.title).toBe("X");
+    expect(result.doc.body.trim()).toBe("Body text.");
+  });
+
+  it("rejects documents without frontmatter", () => {
+    const result = parseFrontmatter("just markdown\n");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toContain("no YAML frontmatter");
+  });
+
+  it("rejects frontmatter without the required type", () => {
+    const result = parseFrontmatter(`---\ntitle: X\n---\nBody\n`);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toContain("type");
+  });
+});
+
+describe("schema section parsing", () => {
+  it("parses bullet-form columns (GA4 style)", () => {
+    const cols = parseSchemaColumns(
+      "- `event_date` (STRING): The date.\n- `event_ts` (INTEGER): Micros.",
+    );
+    expect(cols).toEqual([
+      { name: "event_date", rawType: "STRING", description: "The date." },
+      { name: "event_ts", rawType: "INTEGER", description: "Micros." },
+    ]);
+  });
+
+  it("parses table-form columns (launch-blog style)", () => {
+    const cols = parseSchemaColumns(
+      [
+        "| Column | Type | Description |",
+        "|--------|------|-------------|",
+        "| `order_id` | STRING | Unique id. |",
+        "| `total` | NUMERIC | Order total. |",
+      ].join("\n"),
+    );
+    expect(cols).toEqual([
+      { name: "order_id", rawType: "STRING", description: "Unique id." },
+      { name: "total", rawType: "NUMERIC", description: "Order total." },
+    ]);
+  });
+
+  it("maps source types onto Atlas dimension types", () => {
+    expect(mapColumnType("STRING")).toBe("string");
+    expect(mapColumnType("INT64")).toBe("number");
+    expect(mapColumnType("FLOAT")).toBe("number");
+    expect(mapColumnType("TIMESTAMP")).toBe("timestamp");
+    expect(mapColumnType("DATE")).toBe("date");
+    expect(mapColumnType("BOOLEAN")).toBe("boolean");
+    expect(mapColumnType("RECORD")).toBeUndefined();
+    expect(mapColumnType("ARRAY<STRING>")).toBeUndefined();
+  });
+
+  it("splits bodies on top-level headings only", () => {
+    const sections = splitSections("intro\n\n# Schema\n- x\n\n## Group\n- y\n\n# Joins\nz");
+    expect(sections.get("")).toBe("intro");
+    expect(sections.get("schema")).toContain("## Group");
+    expect(sections.get("joins")).toBe("z");
+  });
+});
+
+describe("importOkfBundle (foreign bundle)", () => {
+  const { files, report } = importOkfBundle(FOREIGN_BUNDLE, { bundleName: "shop" });
+  const byPath = fileMap(files);
+
+  it("drafts one entity per table concept", () => {
+    expect([...byPath.keys()].filter((p) => p.startsWith("entities/")).sort()).toEqual([
+      "entities/events.yml",
+      "entities/users.yml",
+    ]);
+    const events = yaml.load(byPath.get("entities/events.yml") ?? "") as Record<string, unknown>;
+    expect(events.table).toBe("events");
+    expect(events.name).toBe("Events table");
+    expect(String(events.description)).toContain("web event export data");
+    const dims = events.dimensions as Array<Record<string, unknown>>;
+    expect(dims.map((d) => d.name)).toEqual([
+      "event_date",
+      "event_timestamp",
+      "event_name",
+      "event_value_in_usd",
+      "is_active_user",
+    ]);
+    expect(dims[1].type).toBe("number");
+    expect(dims[4].type).toBe("boolean");
+  });
+
+  it("parses table-form schemas too", () => {
+    const users = yaml.load(byPath.get("entities/users.yml") ?? "") as Record<string, unknown>;
+    const dims = users.dimensions as Array<Record<string, unknown>>;
+    expect(dims.map((d) => d.name)).toEqual(["user_id", "signup_at", "ltv_usd"]);
+    expect(dims[1].type).toBe("timestamp");
+    expect(dims[2].type).toBe("number");
+  });
+
+  it("reports nested RECORD columns as lossy instead of importing them", () => {
+    const events = yaml.load(byPath.get("entities/events.yml") ?? "") as Record<string, unknown>;
+    const dims = events.dimensions as Array<Record<string, unknown>>;
+    expect(dims.some((d) => d.name === "event_params")).toBe(false);
+    expect(report.lossy.some((l) => l.includes("event_params"))).toBe(true);
+  });
+
+  it("carries OKF provenance on imported entities", () => {
+    const events = yaml.load(byPath.get("entities/events.yml") ?? "") as Record<string, unknown>;
+    const okf = events.okf as Record<string, unknown>;
+    expect(okf.source_path).toBe("tables/events.md");
+    expect(String(okf.resource)).toContain("bigquery");
+  });
+
+  it("imports metrics as unverified drafts in a dedicated file", () => {
+    const content = byPath.get("metrics/okf-imported.yml") ?? "";
+    expect(content.startsWith("# Imported from OKF")).toBe(true);
+    const doc = yaml.load(content) as { metrics: Array<Record<string, unknown>> };
+    const purchase = doc.metrics.find((m) => m.id === "purchase_count");
+    expect(purchase).toBeDefined();
+    expect(String(purchase?.sql)).toContain("COUNT(*)");
+    expect((purchase?.okf as Record<string, unknown>).unverified_sql).toBe(true);
+    expect(
+      report.lossy.some((l) => l.includes("not an executable contract")),
+    ).toBe(true);
+  });
+
+  it("imports a metric with no sql fence as description-only", () => {
+    const doc = yaml.load(byPath.get("metrics/okf-imported.yml") ?? "") as {
+      metrics: Array<Record<string, unknown>>;
+    };
+    const prose = doc.metrics.find((m) => m.id === "prose_only_metric");
+    expect(prose).toBeDefined();
+    expect(prose?.sql).toBeUndefined();
+    expect(report.lossy.some((l) => l.includes("prose_only_metric"))).toBe(true);
+  });
+
+  it("attaches resolvable joins and reports unresolvable ones", () => {
+    const events = yaml.load(byPath.get("entities/events.yml") ?? "") as Record<string, unknown>;
+    const joins = events.joins as Array<Record<string, unknown>>;
+    expect(joins).toHaveLength(1);
+    expect(joins[0].target_entity).toBe("Users table");
+    expect(joins[0].join_columns).toEqual({ from: "user_id", to: "user_id" });
+    expect(
+      report.unmapped.some((u) => u.includes("events_ads") && u.includes("ADS_CLICKS")),
+    ).toBe(true);
+  });
+
+  it("folds dataset concepts into the catalog and reports unknown types", () => {
+    const catalog = yaml.load(byPath.get("catalog.yml") ?? "") as Record<string, unknown>;
+    expect(catalog.name).toBe("shop");
+    expect(String(catalog.description)).toContain("three months");
+    const entities = catalog.entities as Array<Record<string, unknown>>;
+    expect(entities.map((e) => e.file).sort()).toEqual([
+      "entities/events.yml",
+      "entities/users.yml",
+    ]);
+    expect(
+      report.unmapped.some((u) => u.includes("runbook.md") && u.includes("Playbook")),
+    ).toBe(true);
+  });
+
+  it("reports malformed concept files instead of silently skipping them", () => {
+    expect(report.unmapped.some((u) => u.includes("tables/broken.md"))).toBe(true);
+  });
+
+  it("does not emit a glossary when the bundle has no term concepts", () => {
+    expect(byPath.has("glossary.yml")).toBe(false);
+  });
+});

--- a/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
@@ -32,6 +32,27 @@ describe("parseFrontmatter", () => {
     if (result.ok) throw new Error("unreachable");
     expect(result.reason).toContain("type");
   });
+
+  it("rejects an unterminated frontmatter block", () => {
+    const result = parseFrontmatter(`---\ntype: Reference\nno closing fence`);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toContain("unterminated");
+  });
+
+  it("rejects non-mapping frontmatter (scalar or list)", () => {
+    const result = parseFrontmatter(`---\n- just\n- a list\n---\nBody\n`);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toContain("not a YAML mapping");
+  });
+
+  it("surfaces YAML parse errors with the parser message", () => {
+    const result = parseFrontmatter(`---\ntype: [unclosed\n---\nBody\n`);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toContain("parse error");
+  });
 });
 
 describe("schema section parsing", () => {
@@ -61,14 +82,18 @@ describe("schema section parsing", () => {
   });
 
   it("maps source types onto Atlas dimension types", () => {
-    expect(mapColumnType("STRING")).toBe("string");
-    expect(mapColumnType("INT64")).toBe("number");
-    expect(mapColumnType("FLOAT")).toBe("number");
-    expect(mapColumnType("TIMESTAMP")).toBe("timestamp");
-    expect(mapColumnType("DATE")).toBe("date");
-    expect(mapColumnType("BOOLEAN")).toBe("boolean");
+    expect(mapColumnType("STRING")).toEqual({ type: "string", guessed: false });
+    expect(mapColumnType("INT64")).toEqual({ type: "number", guessed: false });
+    expect(mapColumnType("FLOAT")).toEqual({ type: "number", guessed: false });
+    expect(mapColumnType("TIMESTAMP")).toEqual({ type: "timestamp", guessed: false });
+    expect(mapColumnType("DATE")).toEqual({ type: "date", guessed: false });
+    expect(mapColumnType("BOOLEAN")).toEqual({ type: "boolean", guessed: false });
     expect(mapColumnType("RECORD")).toBeUndefined();
     expect(mapColumnType("ARRAY<STRING>")).toBeUndefined();
+    expect(mapColumnType("JSON")).toBeUndefined();
+    // Substring traps: INTERVAL/POINT must not word-match INT.
+    expect(mapColumnType("INTERVAL")).toEqual({ type: "string", guessed: true });
+    expect(mapColumnType("GEOGRAPHY")).toEqual({ type: "string", guessed: true });
   });
 
   it("splits bodies on top-level headings only", () => {
@@ -135,7 +160,7 @@ describe("importOkfBundle (foreign bundle)", () => {
     expect(String(purchase?.sql)).toContain("COUNT(*)");
     expect((purchase?.okf as Record<string, unknown>).unverified_sql).toBe(true);
     expect(
-      report.lossy.some((l) => l.includes("not an executable contract")),
+      report.lossy.some((l) => l.includes("metric authority cannot travel through OKF")),
     ).toBe(true);
   });
 
@@ -178,7 +203,112 @@ describe("importOkfBundle (foreign bundle)", () => {
     expect(report.unmapped.some((u) => u.includes("tables/broken.md"))).toBe(true);
   });
 
-  it("does not emit a glossary when the bundle has no term concepts", () => {
-    expect(byPath.has("glossary.yml")).toBe(false);
+  it("imports foreign glossary concepts as defined terms and reports the ambiguity gap", () => {
+    const glossary = yaml.load(byPath.get("glossary.yml") ?? "") as {
+      terms: Record<string, Record<string, unknown>>;
+    };
+    const mrr = glossary.terms.MRR;
+    expect(mrr.status).toBe("defined");
+    expect(String(mrr.definition)).toContain("Monthly recurring revenue");
+    expect((mrr.okf as Record<string, unknown>).source_path).toBe("references/glossary/mrr.md");
+    expect(report.notes.some((n) => n.includes("ask-first gating"))).toBe(true);
+  });
+});
+
+describe("importOkfBundle (hostile/edge bundles)", () => {
+  it("rejects a forged atlas.entity.table containing path traversal", () => {
+    const { files, report } = importOkfBundle([
+      {
+        path: "tables/evil.md",
+        content: `---
+type: Table
+title: Evil
+atlas:
+  kind: table
+  entity:
+    table: ../../.github/workflows/evil
+    name: Evil
+---
+
+# Overview
+Nope.
+`,
+      },
+    ]);
+    expect(files.filter((f) => f.path.startsWith("entities/"))).toHaveLength(0);
+    expect(files.every((f) => !f.path.includes(".."))).toBe(true);
+    expect(
+      report.unmapped.some((u) => u.includes("evil.md") && u.includes("not a safe table name")),
+    ).toBe(true);
+  });
+
+  it("re-stamps forged atlas.metric extensions as unverified", () => {
+    const { files } = importOkfBundle([
+      {
+        path: "references/metrics/pwn.md",
+        content: `---
+type: Reference
+title: Pwn
+tags:
+- metric
+atlas:
+  kind: metric
+  metric:
+    id: pwn
+    label: Pwn
+    sql: SELECT * FROM secrets
+---
+
+Body.
+`,
+      },
+    ]);
+    const metricsFile = files.find((f) => f.path === "metrics/okf-imported.yml");
+    expect(metricsFile).toBeDefined();
+    const doc = yaml.load(metricsFile?.content ?? "") as {
+      metrics: Array<Record<string, unknown>>;
+    };
+    expect((doc.metrics[0].okf as Record<string, unknown>).unverified_sql).toBe(true);
+  });
+
+  it("reports duplicate table concepts instead of clobbering", () => {
+    const table = (p: string): { path: string; content: string } => ({
+      path: p,
+      content: `---
+type: Table
+title: Orders
+---
+
+# Schema
+- \`id\` (INTEGER): id.
+`,
+    });
+    const { files, report } = importOkfBundle([table("a/orders.md"), table("b/orders.md")]);
+    expect(files.filter((f) => f.path === "entities/orders.yml")).toHaveLength(1);
+    expect(report.unmapped.some((u) => u.includes('duplicate table "orders"'))).toBe(true);
+  });
+
+  it("notes columns whose type had to be guessed", () => {
+    const { files, report } = importOkfBundle([
+      {
+        path: "tables/geo.md",
+        content: `---
+type: Table
+title: Geo
+---
+
+# Schema
+- \`region\` (GEOGRAPHY): A shape.
+`,
+      },
+    ]);
+    const entity = yaml.load(
+      files.find((f) => f.path === "entities/geo.yml")?.content ?? "",
+    ) as Record<string, unknown>;
+    const dims = entity.dimensions as Array<Record<string, unknown>>;
+    expect(dims[0].type).toBe("string");
+    expect(report.notes.some((n) => n.includes("GEOGRAPHY") && n.includes("defaulted"))).toBe(
+      true,
+    );
   });
 });

--- a/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
+++ b/packages/api/src/lib/semantic/okf/__tests__/okf-import.test.ts
@@ -288,6 +288,49 @@ title: Orders
     expect(report.unmapped.some((u) => u.includes('duplicate table "orders"'))).toBe(true);
   });
 
+  it("reports duplicate tables case-insensitively (case-insensitive filesystems)", () => {
+    const table = (p: string, title: string): { path: string; content: string } => ({
+      path: p,
+      content: `---\ntype: Table\ntitle: ${title}\n---\n\n# Schema\n- \`id\` (INTEGER): id.\n`,
+    });
+    const { files, report } = importOkfBundle([
+      table("a/Orders.md", "Orders"),
+      table("b/orders.md", "orders"),
+    ]);
+    expect(files.filter((f) => f.path.startsWith("entities/"))).toHaveLength(1);
+    expect(report.unmapped.some((u) => u.includes("duplicate table"))).toBe(true);
+  });
+
+  it("reports duplicate metric ids instead of emitting ambiguous entries", () => {
+    const metric = (p: string): { path: string; content: string } => ({
+      path: p,
+      content: `---\ntype: Reference\ntitle: Total\ntags:\n- metric\n---\n\n\`\`\`sql\nCOUNT(*)\n\`\`\`\n`,
+    });
+    const { files, report } = importOkfBundle([
+      metric("references/metrics/total.md"),
+      metric("other/metrics/total.md"),
+    ]);
+    const doc = yaml.load(
+      files.find((f) => f.path === "metrics/okf-imported.yml")?.content ?? "",
+    ) as { metrics: Array<Record<string, unknown>> };
+    expect(doc.metrics).toHaveLength(1);
+    expect(report.unmapped.some((u) => u.includes('duplicate metric id "total"'))).toBe(true);
+  });
+
+  it("imports glossary terms named after Object.prototype members", () => {
+    const { files, report } = importOkfBundle([
+      {
+        path: "glossary/constructor.md",
+        content: `---\ntype: Reference\ntitle: constructor\ndescription: A business term, honestly.\ntags:\n- glossary\n---\n\nBody.\n`,
+      },
+    ]);
+    const glossary = yaml.load(files.find((f) => f.path === "glossary.yml")?.content ?? "") as {
+      terms: Record<string, Record<string, unknown>>;
+    };
+    expect(glossary.terms.constructor.status).toBe("defined");
+    expect(report.unmapped.some((u) => u.includes("duplicate"))).toBe(false);
+  });
+
   it("notes columns whose type had to be guessed", () => {
     const { files, report } = importOkfBundle([
       {

--- a/packages/api/src/lib/semantic/okf/export.ts
+++ b/packages/api/src/lib/semantic/okf/export.ts
@@ -1,0 +1,489 @@
+/**
+ * Atlas semantic layer -> OKF bundle (#4140 spike).
+ *
+ * Emits a conformant OKF v0.1 bundle: one concept doc per entity /
+ * metric / glossary term, index.md navigation files, and prose bodies an
+ * OKF consumer can read without knowing Atlas exists. Every concept also
+ * carries the full source object under the `atlas:` frontmatter extension
+ * (spec-legal — consumers must preserve unknown keys), which is what makes
+ * OKF -> Atlas -> OKF round-trips lossless for Atlas-produced bundles.
+ *
+ * What is semantically DROPPED for foreign consumers (data preserved in the
+ * extension, semantics not enforceable):
+ * - the table whitelist (entity existence survives; runtime enforcement doesn't)
+ * - pinned-metric authority (SQL becomes illustrative prose to other tools)
+ * - glossary `status: ambiguous` ask-first agent gating
+ * Each is recorded in the mapping report so `okf export` can print it.
+ */
+
+import * as yaml from "js-yaml";
+import { serializeDocument } from "./frontmatter";
+import {
+  emptyReport,
+  type MappingReport,
+  type InteropFile,
+  type OkfExportResult,
+  type OkfFrontmatter,
+} from "./types";
+
+export interface OkfExportOptions {
+  /** ISO-8601 timestamp stamped on every concept (caller supplies the clock). */
+  timestamp: string;
+  /** Bundle display name for the root index; defaults to the catalog name. */
+  bundleName?: string;
+}
+
+interface NormalizedDimension {
+  name: string;
+  sql?: string;
+  type?: string;
+  description?: string;
+  primary_key?: boolean;
+  virtual?: boolean;
+  sample_values?: unknown[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Narrow one raw dimension record onto the fields the renderer reads. */
+function toDimension(name: string, d: Record<string, unknown>): NormalizedDimension {
+  return {
+    name,
+    sql: asString(d.sql),
+    type: asString(d.type),
+    description: asString(d.description),
+    primary_key: d.primary_key === true,
+    virtual: d.virtual === true,
+    sample_values: Array.isArray(d.sample_values) ? d.sample_values : undefined,
+  };
+}
+
+/** Entity `dimensions` come in two on-disk forms: array-of-objects and name-keyed map. */
+function normalizeDimensions(entity: Record<string, unknown>): NormalizedDimension[] {
+  const dims = entity.dimensions;
+  const out: NormalizedDimension[] = [];
+  if (Array.isArray(dims)) {
+    for (const d of dims) {
+      if (isRecord(d) && typeof d.name === "string") out.push(toDimension(d.name, d));
+    }
+  } else if (isRecord(dims)) {
+    for (const [name, d] of Object.entries(dims)) {
+      if (isRecord(d)) out.push(toDimension(name, d));
+    }
+  }
+  return out;
+}
+
+/** Filesystem-safe concept filename from an arbitrary display name. */
+function safeFileStem(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9_.-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "unnamed"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Semantic-layer input parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedLayer {
+  entities: Record<string, unknown>[];
+  metrics: Record<string, unknown>[];
+  terms: Record<string, Record<string, unknown>>;
+  catalog: Record<string, unknown> | undefined;
+}
+
+function parseLayer(files: InteropFile[], report: MappingReport): ParsedLayer {
+  const layer: ParsedLayer = { entities: [], metrics: [], terms: {}, catalog: undefined };
+  for (const file of files) {
+    if (!/\.ya?ml$/.test(file.path)) continue;
+    let doc: unknown;
+    try {
+      doc = yaml.load(file.content);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      report.unmapped.push(`${file.path}: YAML parse error: ${msg}`);
+      continue;
+    }
+    if (!isRecord(doc)) {
+      report.unmapped.push(`${file.path}: not a YAML mapping`);
+      continue;
+    }
+    const base = file.path.split("/").pop() ?? file.path;
+    if (/(^|\/)entities\/[^/]+\.ya?ml$/.test(file.path)) {
+      if (typeof doc.table === "string" && doc.table !== "") {
+        layer.entities.push(doc);
+      } else {
+        report.unmapped.push(`${file.path}: entity file without a \`table\` field`);
+      }
+    } else if (/(^|\/)metrics\/[^/]+\.ya?ml$/.test(file.path)) {
+      if (Array.isArray(doc.metrics)) {
+        for (const m of doc.metrics) {
+          if (isRecord(m)) layer.metrics.push(m);
+        }
+      }
+    } else if (base === "glossary.yml" || base === "glossary.yaml") {
+      if (isRecord(doc.terms)) {
+        for (const [name, entry] of Object.entries(doc.terms)) {
+          if (isRecord(entry)) layer.terms[name] = entry;
+        }
+      }
+    } else if (base === "catalog.yml" || base === "catalog.yaml") {
+      layer.catalog = doc;
+    } else {
+      report.notes.push(`${file.path}: not an entity/glossary/metric/catalog file — skipped`);
+    }
+  }
+  return layer;
+}
+
+// ---------------------------------------------------------------------------
+// Concept rendering
+// ---------------------------------------------------------------------------
+
+function renderEntityDoc(
+  entity: Record<string, unknown>,
+  metricLinks: Array<{ file: string; label: string; description?: string }>,
+  options: OkfExportOptions,
+  report: MappingReport,
+): InteropFile {
+  const table = String(entity.table);
+  const name = asString(entity.name) ?? table;
+  const description = asString(entity.description) ?? "";
+  const tags = ["atlas"];
+  const entityType = asString(entity.type);
+  if (entityType) tags.push(entityType);
+  const group = asString(entity.group) ?? asString(entity.connection);
+  if (group) tags.push(group);
+
+  const frontmatter: OkfFrontmatter = {
+    type: "Table",
+    title: name,
+    ...(description !== "" ? { description: firstLine(description) } : {}),
+    tags,
+    timestamp: options.timestamp,
+    atlas: { kind: "table", entity },
+  };
+
+  const lines: string[] = [];
+  lines.push("# Overview");
+  const grain = asString(entity.grain);
+  const overviewParts = [description.trim(), grain ? `Grain: ${grain}.` : ""].filter(
+    (s) => s !== "",
+  );
+  lines.push(overviewParts.length > 0 ? overviewParts.join("\n\n") : `The \`${table}\` table.`);
+
+  const dims = normalizeDimensions(entity);
+  if (dims.length > 0) {
+    lines.push("", "# Schema");
+    for (const d of dims) {
+      const type = (d.type ?? "unknown").toUpperCase();
+      const parts: string[] = [];
+      if (d.description) parts.push(d.description.trim());
+      if (d.primary_key) parts.push("Primary key.");
+      if (d.virtual && d.sql) parts.push(`Virtual dimension — SQL: \`${flattenSql(d.sql)}\`.`);
+      if (Array.isArray(d.sample_values) && d.sample_values.length > 0) {
+        parts.push(`Sample values: ${d.sample_values.map((v) => String(v)).join(", ")}.`);
+      }
+      lines.push(`- \`${d.name}\` (${type}): ${parts.join(" ")}`.trimEnd());
+    }
+  }
+
+  const measures = Array.isArray(entity.measures) ? entity.measures.filter(isRecord) : [];
+  if (measures.length > 0) {
+    lines.push("", "# Measures");
+    for (const m of measures) {
+      const label = asString(m.name) ?? "measure";
+      const agg = asString(m.type) ?? "aggregation";
+      const sql = asString(m.sql) ?? "";
+      const desc = asString(m.description);
+      lines.push(`- \`${label}\` (${agg} of \`${sql}\`)${desc ? `: ${desc}` : ""}`);
+    }
+  }
+
+  if (metricLinks.length > 0) {
+    lines.push("", "# Metrics");
+    for (const link of metricLinks) {
+      lines.push(
+        `- [${link.label}](../references/metrics/${link.file})${
+          link.description ? ` — ${firstLine(link.description)}` : ""
+        }`,
+      );
+    }
+  }
+
+  const joins = Array.isArray(entity.joins) ? entity.joins.filter(isRecord) : [];
+  if (joins.length > 0) {
+    lines.push("", "# Joins");
+    for (const j of joins) {
+      const target = asString(j.target_entity) ?? "unknown";
+      const jc = isRecord(j.join_columns) ? j.join_columns : undefined;
+      const condition =
+        jc && typeof jc.from === "string" && typeof jc.to === "string"
+          ? ` on \`${table}.${jc.from} = ${jc.to}\``
+          : "";
+      const rel = asString(j.relationship);
+      const desc = asString(j.description);
+      lines.push(
+        `- ${target}${condition}${rel ? ` (${rel.replace(/_/g, " ")})` : ""}${desc ? ` — ${desc}` : ""}`,
+      );
+    }
+  }
+
+  const patterns = Array.isArray(entity.query_patterns)
+    ? entity.query_patterns.filter(isRecord)
+    : [];
+  if (patterns.length > 0) {
+    lines.push("", "# Example queries");
+    for (const p of patterns) {
+      const label = asString(p.name) ?? "query";
+      lines.push("", `## ${label}`);
+      const desc = asString(p.description);
+      if (desc) lines.push(desc);
+      const sql = asString(p.sql);
+      if (sql) lines.push("", "```sql", sql.trimEnd(), "```");
+    }
+  }
+
+  const useCases = Array.isArray(entity.use_cases) ? entity.use_cases : [];
+  if (useCases.length > 0) {
+    lines.push("", "# Use cases");
+    for (const u of useCases) lines.push(`- ${String(u)}`);
+  }
+
+  report.notes.push(
+    `entities/${table}.yml: measures/virtual-dimension SQL/query patterns exported as prose + atlas extension (no first-class OKF concepts)`,
+  );
+
+  return {
+    path: `tables/${safeFileStem(table)}.md`,
+    content: serializeDocument(frontmatter, lines.join("\n")),
+  };
+}
+
+function renderMetricDoc(
+  metric: Record<string, unknown>,
+  options: OkfExportOptions,
+): { file: InteropFile; stem: string; label: string; description?: string } {
+  const id = asString(metric.id) ?? asString(metric.label) ?? "metric";
+  const stem = safeFileStem(id);
+  const label = asString(metric.label) ?? id;
+  const description = asString(metric.description);
+
+  const frontmatter: OkfFrontmatter = {
+    type: "Reference",
+    title: label,
+    ...(description ? { description: firstLine(description) } : {}),
+    tags: ["metric", "atlas"],
+    timestamp: options.timestamp,
+    atlas: { kind: "metric", metric },
+  };
+
+  const lines: string[] = [];
+  if (description) lines.push(description.trim());
+  const sql = asString(metric.sql);
+  if (sql) {
+    lines.push("", "```sql", sql.trimEnd(), "```");
+    lines.push(
+      "",
+      "In Atlas this SQL is authoritative: the agent runs it verbatim when the metric is requested.",
+    );
+  }
+  return {
+    file: {
+      path: `references/metrics/${stem}.md`,
+      content: serializeDocument(frontmatter, lines.join("\n")),
+    },
+    stem,
+    label,
+    description,
+  };
+}
+
+function renderTermDoc(
+  name: string,
+  entry: Record<string, unknown>,
+  options: OkfExportOptions,
+  report: MappingReport,
+): InteropFile {
+  const status = asString(entry.status) ?? "defined";
+  const definition = asString(entry.definition);
+  const note = asString(entry.note);
+  const frontmatter: OkfFrontmatter = {
+    type: "Reference",
+    title: name,
+    ...(definition ? { description: firstLine(definition) } : {}),
+    tags: ["glossary-term", "atlas", ...(status === "ambiguous" ? ["ambiguous"] : [])],
+    timestamp: options.timestamp,
+    atlas: { kind: "glossary_term", term: name, entry },
+  };
+  const lines: string[] = [];
+  if (definition) lines.push(definition.trim());
+  if (note) lines.push(note.trim());
+  if (status === "ambiguous") {
+    const mappings = Array.isArray(entry.possible_mappings) ? entry.possible_mappings : [];
+    if (mappings.length > 0) {
+      lines.push("", "Possible mappings:");
+      for (const m of mappings) lines.push(`- \`${String(m)}\``);
+    }
+    lines.push(
+      "",
+      "Atlas treats this term as ambiguous and asks the user which definition they mean before querying.",
+    );
+    report.lossy.push(
+      `glossary term "${name}": status: ambiguous exported as prose — OKF consumers get no ask-first gating`,
+    );
+  }
+  return {
+    path: `references/glossary/${safeFileStem(name)}.md`,
+    content: serializeDocument(frontmatter, lines.join("\n")),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Index files
+// ---------------------------------------------------------------------------
+
+function indexFile(path: string, heading: string, items: Array<{ href: string; label: string; description?: string }>): InteropFile {
+  const lines = [`# ${heading}`];
+  for (const item of items) {
+    lines.push(`* [${item.label}](${item.href})${item.description ? ` - ${firstLine(item.description)}` : ""}`);
+  }
+  return { path, content: lines.join("\n") + "\n" };
+}
+
+function firstLine(text: string): string {
+  return text.trim().split("\n", 1)[0].trim();
+}
+
+function flattenSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/** Map a semantic layer (in-memory file list) onto an OKF v0.1 bundle. */
+export function exportToOkf(
+  files: InteropFile[],
+  options: OkfExportOptions,
+): OkfExportResult {
+  const report = emptyReport();
+  const layer = parseLayer(files, report);
+  const out: InteropFile[] = [];
+
+  // Metrics first so entity docs can link to them (source.entity -> entity name).
+  const renderedMetrics = layer.metrics.map((m) => renderMetricDoc(m, options));
+  const metricLinksByEntity = new Map<string, Array<{ file: string; label: string; description?: string }>>();
+  for (let i = 0; i < layer.metrics.length; i++) {
+    const source = layer.metrics[i].source;
+    const entityName = isRecord(source) ? asString(source.entity) : undefined;
+    if (!entityName) continue;
+    const link = renderedMetrics[i];
+    const list = metricLinksByEntity.get(entityName) ?? [];
+    list.push({ file: `${link.stem}.md`, label: link.label, description: link.description });
+    metricLinksByEntity.set(entityName, list);
+  }
+
+  const entityDocs = layer.entities.map((entity) =>
+    renderEntityDoc(
+      entity,
+      metricLinksByEntity.get(asString(entity.name) ?? String(entity.table)) ?? [],
+      options,
+      report,
+    ),
+  );
+  out.push(...entityDocs);
+  out.push(...renderedMetrics.map((r) => r.file));
+
+  const termDocs = Object.entries(layer.terms).map(([name, entry]) =>
+    renderTermDoc(name, entry, options, report),
+  );
+  out.push(...termDocs);
+
+  // --- index.md navigation ---
+  if (entityDocs.length > 0) {
+    out.push(
+      indexFile(
+        "tables/index.md",
+        "Tables",
+        layer.entities.map((e, i) => ({
+          href: entityDocs[i].path.replace(/^tables\//, ""),
+          label: asString(e.name) ?? String(e.table),
+          description: asString(e.description),
+        })),
+      ),
+    );
+  }
+  if (renderedMetrics.length > 0) {
+    out.push(
+      indexFile(
+        "references/metrics/index.md",
+        "Metrics",
+        renderedMetrics.map((r) => ({ href: `${r.stem}.md`, label: r.label, description: r.description })),
+      ),
+    );
+  }
+  if (termDocs.length > 0) {
+    out.push(
+      indexFile(
+        "references/glossary/index.md",
+        "Glossary",
+        Object.keys(layer.terms).map((name) => ({
+          href: `${safeFileStem(name)}.md`,
+          label: name,
+        })),
+      ),
+    );
+  }
+  if (renderedMetrics.length > 0 || termDocs.length > 0) {
+    const items: Array<{ href: string; label: string; description?: string }> = [];
+    if (renderedMetrics.length > 0) {
+      items.push({ href: "metrics/index.md", label: "metrics", description: "Metric definitions." });
+    }
+    if (termDocs.length > 0) {
+      items.push({ href: "glossary/index.md", label: "glossary", description: "Business term definitions." });
+    }
+    out.push(indexFile("references/index.md", "References", items));
+  }
+
+  const bundleName =
+    options.bundleName ?? (layer.catalog ? asString(layer.catalog.name) : undefined) ?? "atlas-export";
+  const catalogDescription = layer.catalog ? asString(layer.catalog.description) : undefined;
+  const rootItems: Array<{ href: string; label: string; description?: string }> = [];
+  if (entityDocs.length > 0) {
+    rootItems.push({ href: "tables/index.md", label: "tables", description: "Queryable tables." });
+  }
+  if (renderedMetrics.length > 0 || termDocs.length > 0) {
+    rootItems.push({
+      href: "references/index.md",
+      label: "references",
+      description: "Metric and glossary definitions.",
+    });
+  }
+  const rootBody = [
+    `# ${bundleName}`,
+    ...(catalogDescription ? [firstLine(catalogDescription)] : []),
+    ...rootItems.map(
+      (i) => `* [${i.label}](${i.href})${i.description ? ` - ${i.description}` : ""}`,
+    ),
+  ].join("\n");
+  // Root index.md is the one index allowed to carry frontmatter (okf_version).
+  out.push({ path: "index.md", content: `---\nokf_version: "0.1"\n---\n\n${rootBody}\n` });
+
+  report.lossy.push(
+    "table whitelist enforcement has no OKF equivalent — entity existence survives, runtime enforcement does not",
+    "pinned-metric authority has no OKF equivalent — exported SQL is illustrative prose to non-Atlas consumers",
+  );
+
+  return { files: out, report };
+}

--- a/packages/api/src/lib/semantic/okf/export.ts
+++ b/packages/api/src/lib/semantic/okf/export.ts
@@ -5,8 +5,11 @@
  * metric / glossary term, index.md navigation files, and prose bodies an
  * OKF consumer can read without knowing Atlas exists. Every concept also
  * carries the full source object under the `atlas:` frontmatter extension
- * (spec-legal — consumers must preserve unknown keys), which is what makes
- * OKF -> Atlas -> OKF round-trips lossless for Atlas-produced bundles.
+ * (spec-legal — consumers must preserve unknown keys), which makes an
+ * Atlas -> OKF -> Atlas re-import lossless for entity and glossary
+ * OBJECTS and for metric fields (the importer re-stamps metrics
+ * unverified — authority never travels through a bundle). Catalog
+ * description and metric file layout are NOT preserved across the trip.
  *
  * What is semantically DROPPED for foreign consumers (data preserved in the
  * extension, semantics not enforceable):
@@ -29,7 +32,7 @@ import {
 export interface OkfExportOptions {
   /** ISO-8601 timestamp stamped on every concept (caller supplies the clock). */
   timestamp: string;
-  /** Bundle display name for the root index; defaults to the catalog name. */
+  /** Bundle display name for the root index; defaults to the catalog name, then `atlas-export`. */
   bundleName?: string;
 }
 
@@ -95,7 +98,8 @@ function safeFileStem(name: string): string {
 // ---------------------------------------------------------------------------
 
 interface ParsedLayer {
-  entities: Record<string, unknown>[];
+  /** Only entities that passed the non-empty `table` gate in {@link parseLayer}. */
+  entities: Array<Record<string, unknown> & { table: string }>;
   metrics: Record<string, unknown>[];
   terms: Record<string, Record<string, unknown>>;
   catalog: Record<string, unknown> | undefined;
@@ -120,21 +124,33 @@ function parseLayer(files: InteropFile[], report: MappingReport): ParsedLayer {
     const base = file.path.split("/").pop() ?? file.path;
     if (/(^|\/)entities\/[^/]+\.ya?ml$/.test(file.path)) {
       if (typeof doc.table === "string" && doc.table !== "") {
-        layer.entities.push(doc);
+        layer.entities.push({ ...doc, table: doc.table });
       } else {
         report.unmapped.push(`${file.path}: entity file without a \`table\` field`);
       }
     } else if (/(^|\/)metrics\/[^/]+\.ya?ml$/.test(file.path)) {
       if (Array.isArray(doc.metrics)) {
         for (const m of doc.metrics) {
-          if (isRecord(m)) layer.metrics.push(m);
+          if (isRecord(m)) {
+            layer.metrics.push(m);
+          } else {
+            report.unmapped.push(`${file.path}: non-mapping entry in \`metrics\` array skipped`);
+          }
         }
+      } else {
+        report.unmapped.push(`${file.path}: metrics file without a \`metrics\` array`);
       }
     } else if (base === "glossary.yml" || base === "glossary.yaml") {
       if (isRecord(doc.terms)) {
         for (const [name, entry] of Object.entries(doc.terms)) {
-          if (isRecord(entry)) layer.terms[name] = entry;
+          if (isRecord(entry)) {
+            layer.terms[name] = entry;
+          } else {
+            report.unmapped.push(`${file.path}: glossary term "${name}" is not a mapping — skipped`);
+          }
         }
+      } else {
+        report.unmapped.push(`${file.path}: glossary file without a \`terms\` mapping`);
       }
     } else if (base === "catalog.yml" || base === "catalog.yaml") {
       layer.catalog = doc;
@@ -150,12 +166,12 @@ function parseLayer(files: InteropFile[], report: MappingReport): ParsedLayer {
 // ---------------------------------------------------------------------------
 
 function renderEntityDoc(
-  entity: Record<string, unknown>,
+  entity: Record<string, unknown> & { table: string },
   metricLinks: Array<{ file: string; label: string; description?: string }>,
   options: OkfExportOptions,
   report: MappingReport,
 ): InteropFile {
-  const table = String(entity.table);
+  const table = entity.table;
   const name = asString(entity.name) ?? table;
   const description = asString(entity.description) ?? "";
   const tags = ["atlas"];
@@ -259,9 +275,11 @@ function renderEntityDoc(
     for (const u of useCases) lines.push(`- ${String(u)}`);
   }
 
-  report.notes.push(
-    `entities/${table}.yml: measures/virtual-dimension SQL/query patterns exported as prose + atlas extension (no first-class OKF concepts)`,
-  );
+  if (measures.length > 0 || patterns.length > 0 || dims.some((d) => d.virtual)) {
+    report.notes.push(
+      `entities/${table}.yml: measures/virtual-dimension SQL/query patterns exported as prose + atlas extension (no first-class OKF concepts)`,
+    );
+  }
 
   return {
     path: `tables/${safeFileStem(table)}.md`,
@@ -485,5 +503,20 @@ export function exportToOkf(
     "pinned-metric authority has no OKF equivalent — exported SQL is illustrative prose to non-Atlas consumers",
   );
 
-  return { files: out, report };
+  // safeFileStem can collide ("Q1 Revenue" vs "Q1-Revenue", case-only diffs).
+  // First doc wins; the loser is reported, never silently clobbered on disk.
+  const seenPaths = new Set<string>();
+  const deduped: InteropFile[] = [];
+  for (const file of out) {
+    if (seenPaths.has(file.path)) {
+      report.unmapped.push(
+        `${file.path}: duplicate bundle path — a same-named concept was already emitted; this one dropped`,
+      );
+      continue;
+    }
+    seenPaths.add(file.path);
+    deduped.push(file);
+  }
+
+  return { files: deduped, report };
 }

--- a/packages/api/src/lib/semantic/okf/export.ts
+++ b/packages/api/src/lib/semantic/okf/export.ts
@@ -106,7 +106,14 @@ interface ParsedLayer {
 }
 
 function parseLayer(files: InteropFile[], report: MappingReport): ParsedLayer {
-  const layer: ParsedLayer = { entities: [], metrics: [], terms: {}, catalog: undefined };
+  const layer: ParsedLayer = {
+    entities: [],
+    metrics: [],
+    // Null prototype for the same reason as the importer: term names are
+    // arbitrary user vocabulary ("constructor" is a plausible business term).
+    terms: Object.create(null) as ParsedLayer["terms"],
+    catalog: undefined,
+  };
   for (const file of files) {
     if (!/\.ya?ml$/.test(file.path)) continue;
     let doc: unknown;
@@ -143,17 +150,26 @@ function parseLayer(files: InteropFile[], report: MappingReport): ParsedLayer {
     } else if (base === "glossary.yml" || base === "glossary.yaml") {
       if (isRecord(doc.terms)) {
         for (const [name, entry] of Object.entries(doc.terms)) {
-          if (isRecord(entry)) {
-            layer.terms[name] = entry;
-          } else {
+          if (!isRecord(entry)) {
             report.unmapped.push(`${file.path}: glossary term "${name}" is not a mapping — skipped`);
+          } else if (Object.hasOwn(layer.terms, name)) {
+            // Multi-source layers can carry several glossary.yml files.
+            report.unmapped.push(
+              `${file.path}: glossary term "${name}" already defined by an earlier file — skipped`,
+            );
+          } else {
+            layer.terms[name] = entry;
           }
         }
       } else {
         report.unmapped.push(`${file.path}: glossary file without a \`terms\` mapping`);
       }
     } else if (base === "catalog.yml" || base === "catalog.yaml") {
-      layer.catalog = doc;
+      if (layer.catalog !== undefined) {
+        report.unmapped.push(`${file.path}: a catalog file was already read — this one ignored`);
+      } else {
+        layer.catalog = doc;
+      }
     } else {
       report.notes.push(`${file.path}: not an entity/glossary/metric/catalog file — skipped`);
     }
@@ -415,7 +431,7 @@ export function exportToOkf(
   const entityDocs = layer.entities.map((entity) =>
     renderEntityDoc(
       entity,
-      metricLinksByEntity.get(asString(entity.name) ?? String(entity.table)) ?? [],
+      metricLinksByEntity.get(asString(entity.name) ?? entity.table) ?? [],
       options,
       report,
     ),
@@ -436,7 +452,7 @@ export function exportToOkf(
         "Tables",
         layer.entities.map((e, i) => ({
           href: entityDocs[i].path.replace(/^tables\//, ""),
-          label: asString(e.name) ?? String(e.table),
+          label: asString(e.name) ?? e.table,
           description: asString(e.description),
         })),
       ),

--- a/packages/api/src/lib/semantic/okf/frontmatter.ts
+++ b/packages/api/src/lib/semantic/okf/frontmatter.ts
@@ -1,0 +1,73 @@
+/**
+ * OKF frontmatter split/parse/serialize (#4140 spike).
+ *
+ * OKF conformance requires every non-reserved `.md` file to carry parseable
+ * YAML frontmatter with a non-empty `type`. Parsing failures are surfaced to
+ * the caller (never silently skipped) so a malformed bundle is reported, not
+ * partially imported.
+ */
+
+import * as yaml from "js-yaml";
+import type { OkfFrontmatter } from "./types";
+
+const FRONTMATTER_OPEN = /^---\r?\n/;
+
+export interface ParsedDocument {
+  frontmatter: OkfFrontmatter;
+  body: string;
+}
+
+export type FrontmatterResult =
+  | { ok: true; doc: ParsedDocument }
+  | { ok: false; reason: string };
+
+/**
+ * Split a markdown document into YAML frontmatter + body.
+ *
+ * Returns a typed failure (not a throw) for missing/unparseable frontmatter
+ * or a missing `type` — importers collect these into the mapping report.
+ */
+export function parseFrontmatter(content: string): FrontmatterResult {
+  if (!FRONTMATTER_OPEN.test(content)) {
+    return { ok: false, reason: "no YAML frontmatter block" };
+  }
+  const afterOpen = content.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = afterOpen.match(/^---\s*$/m);
+  if (!closeMatch || closeMatch.index === undefined) {
+    return { ok: false, reason: "unterminated frontmatter block" };
+  }
+  const rawYaml = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen
+    .slice(closeMatch.index + closeMatch[0].length)
+    .replace(/^\r?\n/, "");
+
+  let data: unknown;
+  try {
+    data = yaml.load(rawYaml);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: `frontmatter YAML parse error: ${msg}` };
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return { ok: false, reason: "frontmatter is not a YAML mapping" };
+  }
+  const record = data as Record<string, unknown>;
+  const type = record.type;
+  if (typeof type !== "string" || type.trim() === "") {
+    // OKF conformance: `type` is the one required key.
+    return { ok: false, reason: "frontmatter missing required non-empty `type`" };
+  }
+  return {
+    ok: true,
+    doc: { frontmatter: record as OkfFrontmatter, body },
+  };
+}
+
+/** Serialize frontmatter + body back into an OKF concept document. */
+export function serializeDocument(
+  frontmatter: OkfFrontmatter,
+  body: string,
+): string {
+  const fm = yaml.dump(frontmatter, { lineWidth: 120, noRefs: true });
+  return `---\n${fm}---\n\n${body.trimEnd()}\n`;
+}

--- a/packages/api/src/lib/semantic/okf/frontmatter.ts
+++ b/packages/api/src/lib/semantic/okf/frontmatter.ts
@@ -8,12 +8,12 @@
  */
 
 import * as yaml from "js-yaml";
-import type { OkfFrontmatter } from "./types";
+import type { OkfFrontmatter, ParsedFrontmatter } from "./types";
 
 const FRONTMATTER_OPEN = /^---\r?\n/;
 
 export interface ParsedDocument {
-  frontmatter: OkfFrontmatter;
+  frontmatter: ParsedFrontmatter;
   body: string;
 }
 
@@ -59,7 +59,7 @@ export function parseFrontmatter(content: string): FrontmatterResult {
   }
   return {
     ok: true,
-    doc: { frontmatter: record as OkfFrontmatter, body },
+    doc: { frontmatter: { ...record, type }, body },
   };
 }
 

--- a/packages/api/src/lib/semantic/okf/frontmatter.ts
+++ b/packages/api/src/lib/semantic/okf/frontmatter.ts
@@ -3,8 +3,8 @@
  *
  * OKF conformance requires every non-reserved `.md` file to carry parseable
  * YAML frontmatter with a non-empty `type`. Parsing failures are surfaced to
- * the caller (never silently skipped) so a malformed bundle is reported, not
- * partially imported.
+ * the caller as typed results, so malformed files land in the mapping report
+ * (never silently dropped) while the rest of the bundle still imports.
  */
 
 import * as yaml from "js-yaml";

--- a/packages/api/src/lib/semantic/okf/import.ts
+++ b/packages/api/src/lib/semantic/okf/import.ts
@@ -6,21 +6,27 @@
  *
  * - **Native round-trip** — Atlas-produced bundles carry the full source
  *   object under the `atlas:` frontmatter extension (spec-legal unknown key);
- *   we restore it verbatim. Lossless.
+ *   entity and glossary objects are restored verbatim.
  * - **Foreign bundle** — heuristic prose parsing of frontmatter + body
  *   sections (`# Schema` bullets/tables, sql code fences). Lossy by nature;
  *   every approximation lands in the {@link MappingReport}.
  *
- * Deliberately NOT restored/produced on import (no OKF equivalent):
- * whitelist membership beyond entity existence, metric authority (imported
- * SQL is marked unverified — Atlas runs metric SQL verbatim, so promoting
- * prose SQL silently would be an integrity hole), and glossary ambiguity
- * gating (OKF has no ask-first semantics).
+ * Trust boundary: a bundle is third-party input regardless of what its
+ * frontmatter claims, and the `atlas:` extension is trivially forgeable. So:
+ * - table names are validated via `safeSemanticRowName` on BOTH paths
+ *   (a native `atlas.entity.table` of `../../x` must never become a write path);
+ * - **metric authority is never imported** — even `atlas.metric` restores are
+ *   re-stamped `okf.unverified_sql: true`. Atlas runs metric SQL verbatim at
+ *   runtime; authority is a property of the reviewed file in your repo, not
+ *   of data that arrived in a bundle.
+ * For foreign bundles, additionally not producible (no OKF equivalent):
+ * glossary `status: ambiguous` ask-first gating, entity type/grain/measures.
  */
 
 import * as yaml from "js-yaml";
 import { safeSemanticRowName } from "../shapes";
 import {
+  atlasExtension,
   classifyConcept,
   conceptStem,
   extractSqlBlock,
@@ -40,7 +46,7 @@ import {
 
 const YAML_DUMP_OPTS = { lineWidth: 120, noRefs: true } as const;
 
-/** Provenance block attached to every imported artifact (passthrough-safe). */
+/** Provenance block attached to every heuristically imported artifact (passthrough-safe). */
 function provenance(concept: OkfConcept): Record<string, unknown> {
   const p: Record<string, unknown> = { source_path: concept.path };
   if (typeof concept.frontmatter.resource === "string") {
@@ -77,16 +83,27 @@ export function importOkfBundle(
   const concepts = parseBundle(files, report);
 
   const entities: DraftEntity[] = [];
+  const seenTables = new Set<string>();
   const metrics: Record<string, unknown>[] = [];
   const terms: Record<string, unknown> = {};
   const datasetNotes: string[] = [];
   const joinConcepts: OkfConcept[] = [];
+  let foreignTermCount = 0;
 
   for (const concept of concepts) {
-    switch (classifyConcept(concept)) {
+    const kind = classifyConcept(concept);
+    switch (kind) {
       case "table": {
         const entity = importTable(concept, report);
-        if (entity) entities.push(entity);
+        if (!entity) break;
+        if (seenTables.has(entity.table)) {
+          report.unmapped.push(
+            `${concept.path}: duplicate table "${entity.table}" — an earlier concept already produced entities/${entity.table}.yml; this one skipped`,
+          );
+          break;
+        }
+        seenTables.add(entity.table);
+        entities.push(entity);
         break;
       }
       case "metric":
@@ -96,7 +113,7 @@ export function importOkfBundle(
         joinConcepts.push(concept);
         break;
       case "glossary_term":
-        importTerm(concept, terms, report);
+        if (importTerm(concept, terms, report) === "foreign") foreignTermCount++;
         break;
       case "dataset": {
         const desc = concept.frontmatter.description;
@@ -111,6 +128,8 @@ export function importOkfBundle(
           `${concept.path}: unrecognized concept type "${concept.frontmatter.type}" — no Atlas equivalent`,
         );
         break;
+      default:
+        kind satisfies never;
     }
   }
 
@@ -128,21 +147,24 @@ export function importOkfBundle(
       path: "glossary.yml",
       content: yaml.dump({ terms }, YAML_DUMP_OPTS),
     });
-    report.notes.push(
-      "glossary terms imported as status: defined — OKF cannot express Atlas's `status: ambiguous` ask-first gating",
-    );
+    if (foreignTermCount > 0) {
+      report.notes.push(
+        `${foreignTermCount} foreign glossary term(s) imported as status: defined — OKF cannot express Atlas's \`status: ambiguous\` ask-first gating`,
+      );
+    }
   }
   if (metrics.length > 0) {
     const header =
-      "# Imported from OKF — metric SQL below is UNVERIFIED prose from the source\n" +
-      "# bundle. Atlas runs metric SQL verbatim (authoritative); review and edit each\n" +
-      "# entry before relying on it. Entries carry `okf.unverified_sql: true` until then.\n";
+      "# Imported from OKF. A bundle cannot confer metric authority: Atlas runs metric\n" +
+      "# SQL verbatim (authoritative), so every imported entry — including atlas.metric\n" +
+      "# extension restores — carries `okf.unverified_sql: true`. Review and edit each\n" +
+      "# entry, then remove the flag, before relying on it.\n";
     out.push({
       path: "metrics/okf-imported.yml",
       content: header + yaml.dump({ metrics }, YAML_DUMP_OPTS),
     });
     report.lossy.push(
-      "imported metric SQL is descriptive prose in OKF, not an executable contract — marked unverified, requires human review before use",
+      "metric authority cannot travel through OKF — every imported metric is marked unverified and requires human review before use",
     );
   }
   out.push({
@@ -157,11 +179,22 @@ export function importOkfBundle(
 }
 
 function importTable(concept: OkfConcept, report: MappingReport): DraftEntity | null {
-  // Native round-trip: full entity object under the atlas extension.
-  const native = concept.frontmatter.atlas?.entity;
+  // Native round-trip: full entity object under the atlas extension. The
+  // extension is untrusted input like the rest of the bundle, so the table
+  // name goes through the same safeSemanticRowName gate as the heuristic
+  // path — `entities/${table}.yml` becomes a write path downstream, and a
+  // forged `table: "../../x"` must die here, reported, not on disk.
+  const native = atlasExtension(concept)?.entity;
   if (isRecord(native) && typeof native.table === "string") {
+    const table = safeSemanticRowName(native.table);
+    if (table === null || table !== native.table) {
+      report.unmapped.push(
+        `${concept.path}: atlas.entity.table ${JSON.stringify(native.table)} is not a safe table name — extension ignored`,
+      );
+      return null;
+    }
     report.notes.push(`${concept.path}: restored verbatim from atlas.entity extension (lossless)`);
-    return { table: native.table, obj: native, concept };
+    return { table, obj: native, concept };
   }
 
   const stem = conceptStem(concept.path);
@@ -194,10 +227,15 @@ function importTable(concept: OkfConcept, report: MappingReport): DraftEntity | 
         );
         continue;
       }
+      if (mapped.guessed) {
+        report.notes.push(
+          `${concept.path}: column \`${col.name}\` type "${col.rawType}" not recognized — defaulted to string`,
+        );
+      }
       dimensions.push({
         name: col.name,
         sql: col.name,
-        type: mapped,
+        type: mapped.type,
         ...(col.description !== "" ? { description: col.description } : {}),
       });
     }
@@ -219,10 +257,15 @@ function importTable(concept: OkfConcept, report: MappingReport): DraftEntity | 
 }
 
 function importMetric(concept: OkfConcept, report: MappingReport): Record<string, unknown> {
-  const native = concept.frontmatter.atlas?.metric;
+  const native = atlasExtension(concept)?.metric;
   if (isRecord(native)) {
-    report.notes.push(`${concept.path}: restored verbatim from atlas.metric extension (lossless)`);
-    return native;
+    // Fields restore losslessly, but authority does not: the extension is
+    // forgeable, so the SQL is re-stamped unverified like any other import.
+    report.notes.push(
+      `${concept.path}: metric fields restored from atlas.metric extension; SQL re-marked unverified (authority is trust, not data)`,
+    );
+    const okf = isRecord(native.okf) ? native.okf : {};
+    return { ...native, okf: { ...okf, unverified_sql: true } };
   }
   const stem = conceptStem(concept.path);
   const sql = extractSqlBlock(concept.body);
@@ -244,19 +287,27 @@ function importTerm(
   concept: OkfConcept,
   terms: Record<string, unknown>,
   report: MappingReport,
-): void {
-  const atlasExt = concept.frontmatter.atlas;
-  const nativeName = atlasExt?.term;
-  const nativeEntry = atlasExt?.entry;
+): "native" | "foreign" | "skipped" {
+  const ext = atlasExtension(concept);
+  const nativeName = ext?.term;
+  const nativeEntry = ext?.entry;
   if (typeof nativeName === "string" && isRecord(nativeEntry)) {
+    if (nativeName in terms) {
+      report.unmapped.push(`${concept.path}: duplicate glossary term "${nativeName}" — skipped`);
+      return "skipped";
+    }
     terms[nativeName] = nativeEntry;
     report.notes.push(`${concept.path}: restored verbatim from atlas.term extension (lossless)`);
-    return;
+    return "native";
   }
   const name =
     typeof concept.frontmatter.title === "string"
       ? concept.frontmatter.title
       : conceptStem(concept.path);
+  if (name in terms) {
+    report.unmapped.push(`${concept.path}: duplicate glossary term "${name}" — skipped`);
+    return "skipped";
+  }
   const definition =
     typeof concept.frontmatter.description === "string" &&
     concept.frontmatter.description.trim() !== ""
@@ -267,6 +318,7 @@ function importTerm(
     definition,
     okf: provenance(concept),
   };
+  return "foreign";
 }
 
 /** Resolve join reference concepts against imported entities where possible. */

--- a/packages/api/src/lib/semantic/okf/import.ts
+++ b/packages/api/src/lib/semantic/okf/import.ts
@@ -1,0 +1,350 @@
+/**
+ * OKF bundle -> first-draft Atlas semantic layer (#4140 spike).
+ *
+ * One-shot draft generator: the output is entity/glossary/metric YAML that
+ * the existing scan -> enrich -> edit flow takes over. Two paths per concept:
+ *
+ * - **Native round-trip** — Atlas-produced bundles carry the full source
+ *   object under the `atlas:` frontmatter extension (spec-legal unknown key);
+ *   we restore it verbatim. Lossless.
+ * - **Foreign bundle** — heuristic prose parsing of frontmatter + body
+ *   sections (`# Schema` bullets/tables, sql code fences). Lossy by nature;
+ *   every approximation lands in the {@link MappingReport}.
+ *
+ * Deliberately NOT restored/produced on import (no OKF equivalent):
+ * whitelist membership beyond entity existence, metric authority (imported
+ * SQL is marked unverified — Atlas runs metric SQL verbatim, so promoting
+ * prose SQL silently would be an integrity hole), and glossary ambiguity
+ * gating (OKF has no ask-first semantics).
+ */
+
+import * as yaml from "js-yaml";
+import { safeSemanticRowName } from "../shapes";
+import {
+  classifyConcept,
+  conceptStem,
+  extractSqlBlock,
+  mapColumnType,
+  parseBundle,
+  parseJoinEquality,
+  parseSchemaColumns,
+  splitSections,
+} from "./parse";
+import {
+  emptyReport,
+  type MappingReport,
+  type InteropFile,
+  type OkfConcept,
+  type OkfImportResult,
+} from "./types";
+
+const YAML_DUMP_OPTS = { lineWidth: 120, noRefs: true } as const;
+
+/** Provenance block attached to every imported artifact (passthrough-safe). */
+function provenance(concept: OkfConcept): Record<string, unknown> {
+  const p: Record<string, unknown> = { source_path: concept.path };
+  if (typeof concept.frontmatter.resource === "string") {
+    p.resource = concept.frontmatter.resource;
+  }
+  if (Array.isArray(concept.frontmatter.tags)) p.tags = concept.frontmatter.tags;
+  if (typeof concept.frontmatter.timestamp === "string") {
+    p.timestamp = concept.frontmatter.timestamp;
+  }
+  return p;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface DraftEntity {
+  table: string;
+  obj: Record<string, unknown>;
+  concept: OkfConcept;
+}
+
+export interface OkfImportOptions {
+  /** Catalog display name; defaults to `okf-import`. */
+  bundleName?: string;
+}
+
+/** Map an OKF bundle onto a first-draft semantic layer. */
+export function importOkfBundle(
+  files: InteropFile[],
+  options: OkfImportOptions = {},
+): OkfImportResult {
+  const report = emptyReport();
+  const concepts = parseBundle(files, report);
+
+  const entities: DraftEntity[] = [];
+  const metrics: Record<string, unknown>[] = [];
+  const terms: Record<string, unknown> = {};
+  const datasetNotes: string[] = [];
+  const joinConcepts: OkfConcept[] = [];
+
+  for (const concept of concepts) {
+    switch (classifyConcept(concept)) {
+      case "table": {
+        const entity = importTable(concept, report);
+        if (entity) entities.push(entity);
+        break;
+      }
+      case "metric":
+        metrics.push(importMetric(concept, report));
+        break;
+      case "join":
+        joinConcepts.push(concept);
+        break;
+      case "glossary_term":
+        importTerm(concept, terms, report);
+        break;
+      case "dataset": {
+        const desc = concept.frontmatter.description;
+        if (typeof desc === "string" && desc.trim() !== "") datasetNotes.push(desc.trim());
+        report.notes.push(
+          `${concept.path}: dataset concept folded into catalog description (Atlas has no dataset object)`,
+        );
+        break;
+      }
+      case "unmapped":
+        report.unmapped.push(
+          `${concept.path}: unrecognized concept type "${concept.frontmatter.type}" — no Atlas equivalent`,
+        );
+        break;
+    }
+  }
+
+  attachJoins(joinConcepts, entities, report);
+
+  const out: InteropFile[] = [];
+  for (const entity of entities) {
+    out.push({
+      path: `entities/${entity.table}.yml`,
+      content: yaml.dump(entity.obj, YAML_DUMP_OPTS),
+    });
+  }
+  if (Object.keys(terms).length > 0) {
+    out.push({
+      path: "glossary.yml",
+      content: yaml.dump({ terms }, YAML_DUMP_OPTS),
+    });
+    report.notes.push(
+      "glossary terms imported as status: defined — OKF cannot express Atlas's `status: ambiguous` ask-first gating",
+    );
+  }
+  if (metrics.length > 0) {
+    const header =
+      "# Imported from OKF — metric SQL below is UNVERIFIED prose from the source\n" +
+      "# bundle. Atlas runs metric SQL verbatim (authoritative); review and edit each\n" +
+      "# entry before relying on it. Entries carry `okf.unverified_sql: true` until then.\n";
+    out.push({
+      path: "metrics/okf-imported.yml",
+      content: header + yaml.dump({ metrics }, YAML_DUMP_OPTS),
+    });
+    report.lossy.push(
+      "imported metric SQL is descriptive prose in OKF, not an executable contract — marked unverified, requires human review before use",
+    );
+  }
+  out.push({
+    path: "catalog.yml",
+    content: yaml.dump(
+      buildCatalog(options, entities, metrics, terms, datasetNotes),
+      YAML_DUMP_OPTS,
+    ),
+  });
+
+  return { files: out, report };
+}
+
+function importTable(concept: OkfConcept, report: MappingReport): DraftEntity | null {
+  // Native round-trip: full entity object under the atlas extension.
+  const native = concept.frontmatter.atlas?.entity;
+  if (isRecord(native) && typeof native.table === "string") {
+    report.notes.push(`${concept.path}: restored verbatim from atlas.entity extension (lossless)`);
+    return { table: native.table, obj: native, concept };
+  }
+
+  const stem = conceptStem(concept.path);
+  const table = safeSemanticRowName(stem);
+  if (table === null) {
+    report.unmapped.push(`${concept.path}: filename stem "${stem}" is not a safe table name`);
+    return null;
+  }
+
+  const sections = splitSections(concept.body);
+  const overview = (sections.get("overview") ?? sections.get("") ?? "").trim();
+  const fmDescription = (
+    typeof concept.frontmatter.description === "string" ? concept.frontmatter.description : ""
+  ).trim();
+  // The frontmatter description is often the overview's first sentence —
+  // don't duplicate it when the overview already covers it.
+  const description =
+    fmDescription !== "" && overview.includes(fmDescription)
+      ? overview
+      : [fmDescription, overview].filter((s) => s !== "").join("\n\n");
+
+  const dimensions: Record<string, unknown>[] = [];
+  const schemaSection = sections.get("schema");
+  if (schemaSection) {
+    for (const col of parseSchemaColumns(schemaSection)) {
+      const mapped = mapColumnType(col.rawType);
+      if (mapped === undefined) {
+        report.lossy.push(
+          `${concept.path}: column \`${col.name}\` (${col.rawType}) skipped — nested/repeated shapes have no scalar dimension equivalent`,
+        );
+        continue;
+      }
+      dimensions.push({
+        name: col.name,
+        sql: col.name,
+        type: mapped,
+        ...(col.description !== "" ? { description: col.description } : {}),
+      });
+    }
+  } else {
+    report.lossy.push(`${concept.path}: no # Schema section — entity drafted without dimensions`);
+  }
+
+  const obj: Record<string, unknown> = {
+    name: typeof concept.frontmatter.title === "string" ? concept.frontmatter.title : stem,
+    table,
+    ...(description !== "" ? { description } : {}),
+    dimensions,
+    okf: provenance(concept),
+  };
+  report.notes.push(
+    `${concept.path}: entity type/grain/measures not inferable from OKF prose — left for enrich/edit`,
+  );
+  return { table, obj, concept };
+}
+
+function importMetric(concept: OkfConcept, report: MappingReport): Record<string, unknown> {
+  const native = concept.frontmatter.atlas?.metric;
+  if (isRecord(native)) {
+    report.notes.push(`${concept.path}: restored verbatim from atlas.metric extension (lossless)`);
+    return native;
+  }
+  const stem = conceptStem(concept.path);
+  const sql = extractSqlBlock(concept.body);
+  if (sql === undefined) {
+    report.lossy.push(`${concept.path}: metric has no sql code fence — imported description-only`);
+  }
+  return {
+    id: stem,
+    label: typeof concept.frontmatter.title === "string" ? concept.frontmatter.title : stem,
+    ...(typeof concept.frontmatter.description === "string"
+      ? { description: concept.frontmatter.description }
+      : {}),
+    ...(sql !== undefined ? { sql } : {}),
+    okf: { ...provenance(concept), unverified_sql: true },
+  };
+}
+
+function importTerm(
+  concept: OkfConcept,
+  terms: Record<string, unknown>,
+  report: MappingReport,
+): void {
+  const atlasExt = concept.frontmatter.atlas;
+  const nativeName = atlasExt?.term;
+  const nativeEntry = atlasExt?.entry;
+  if (typeof nativeName === "string" && isRecord(nativeEntry)) {
+    terms[nativeName] = nativeEntry;
+    report.notes.push(`${concept.path}: restored verbatim from atlas.term extension (lossless)`);
+    return;
+  }
+  const name =
+    typeof concept.frontmatter.title === "string"
+      ? concept.frontmatter.title
+      : conceptStem(concept.path);
+  const definition =
+    typeof concept.frontmatter.description === "string" &&
+    concept.frontmatter.description.trim() !== ""
+      ? concept.frontmatter.description.trim()
+      : concept.body.trim();
+  terms[name] = {
+    status: "defined",
+    definition,
+    okf: provenance(concept),
+  };
+}
+
+/** Resolve join reference concepts against imported entities where possible. */
+function attachJoins(
+  joinConcepts: OkfConcept[],
+  entities: DraftEntity[],
+  report: MappingReport,
+): void {
+  const byTable = new Map(entities.map((e) => [e.table.toLowerCase(), e]));
+  for (const concept of joinConcepts) {
+    const sql = extractSqlBlock(concept.body);
+    const eq = sql !== undefined ? parseJoinEquality(sql) : undefined;
+    if (!eq) {
+      report.unmapped.push(
+        `${concept.path}: join has no parseable left.col = right.col condition`,
+      );
+      continue;
+    }
+    const from = byTable.get(eq.fromTable.toLowerCase());
+    const to = byTable.get(eq.toTable.toLowerCase());
+    if (!from || !to) {
+      // e.g. GA4's `GA_EVENTS.… = ADS_CLICKS.…` — prose aliases, not table names.
+      report.unmapped.push(
+        `${concept.path}: join condition references "${eq.fromTable}"/"${eq.toTable}" — not resolvable to imported entities (OKF join specs are prose, not typed references)`,
+      );
+      continue;
+    }
+    const joins = Array.isArray(from.obj.joins) ? (from.obj.joins as unknown[]) : [];
+    joins.push({
+      target_entity: String(to.obj.name ?? to.table),
+      join_columns: { from: eq.fromColumn, to: eq.toColumn },
+      ...(typeof concept.frontmatter.description === "string"
+        ? { description: concept.frontmatter.description }
+        : {}),
+      okf: { source_path: concept.path },
+    });
+    from.obj.joins = joins;
+    report.notes.push(
+      `${concept.path}: join attached to ${from.table} without relationship cardinality (not expressed in OKF)`,
+    );
+  }
+}
+
+function buildCatalog(
+  options: OkfImportOptions,
+  entities: DraftEntity[],
+  metrics: Record<string, unknown>[],
+  terms: Record<string, unknown>,
+  datasetNotes: string[],
+): Record<string, unknown> {
+  return {
+    version: 1,
+    name: options.bundleName ?? "okf-import",
+    description:
+      datasetNotes.length > 0
+        ? datasetNotes.join("\n\n")
+        : "First-draft semantic layer imported from an OKF bundle. Review via scan -> enrich -> edit.",
+    entities: entities.map((e) => ({
+      name: String(e.obj.name ?? e.table),
+      file: `entities/${e.table}.yml`,
+      ...(typeof e.obj.description === "string"
+        ? { description: firstLine(e.obj.description) }
+        : {}),
+    })),
+    ...(Object.keys(terms).length > 0 ? { glossary: "glossary.yml" } : {}),
+    ...(metrics.length > 0
+      ? {
+          metrics: [
+            {
+              file: "metrics/okf-imported.yml",
+              description: "Metrics imported from OKF (unverified SQL — review before use)",
+            },
+          ],
+        }
+      : {}),
+  };
+}
+
+function firstLine(text: string): string {
+  return text.split("\n", 1)[0].trim();
+}

--- a/packages/api/src/lib/semantic/okf/import.ts
+++ b/packages/api/src/lib/semantic/okf/import.ts
@@ -83,9 +83,17 @@ export function importOkfBundle(
   const concepts = parseBundle(files, report);
 
   const entities: DraftEntity[] = [];
+  // Case-insensitive: SAFE_TABLE_NAME admits uppercase, but entities/<t>.yml
+  // lands on possibly case-insensitive filesystems (APFS/NTFS), where
+  // `Orders.yml` and `orders.yml` would silently clobber. attachJoins already
+  // treats table identity case-insensitively — the dedup key must match.
   const seenTables = new Set<string>();
   const metrics: Record<string, unknown>[] = [];
-  const terms: Record<string, unknown> = {};
+  const seenMetricIds = new Set<string>();
+  // Null prototype: a glossary term legitimately named "constructor" or
+  // "toString" must not false-positive the duplicate check via the
+  // prototype chain (and `__proto__` must stay an ordinary key).
+  const terms: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   const datasetNotes: string[] = [];
   const joinConcepts: OkfConcept[] = [];
   let foreignTermCount = 0;
@@ -96,19 +104,31 @@ export function importOkfBundle(
       case "table": {
         const entity = importTable(concept, report);
         if (!entity) break;
-        if (seenTables.has(entity.table)) {
+        if (seenTables.has(entity.table.toLowerCase())) {
           report.unmapped.push(
-            `${concept.path}: duplicate table "${entity.table}" — an earlier concept already produced entities/${entity.table}.yml; this one skipped`,
+            `${concept.path}: duplicate table "${entity.table}" — an earlier concept already produced its entity file; this one skipped`,
           );
           break;
         }
-        seenTables.add(entity.table);
+        seenTables.add(entity.table.toLowerCase());
         entities.push(entity);
         break;
       }
-      case "metric":
-        metrics.push(importMetric(concept, report));
+      case "metric": {
+        const metric = importMetric(concept, report);
+        const id = typeof metric.id === "string" ? metric.id : undefined;
+        // Metric SQL is looked up by id downstream — an ambiguous id is the
+        // last-write-wins class this loop exists to prevent.
+        if (id !== undefined && seenMetricIds.has(id)) {
+          report.unmapped.push(
+            `${concept.path}: duplicate metric id "${id}" — an earlier concept already defined it; this one skipped`,
+          );
+          break;
+        }
+        if (id !== undefined) seenMetricIds.add(id);
+        metrics.push(metric);
         break;
+      }
       case "join":
         joinConcepts.push(concept);
         break;
@@ -292,7 +312,7 @@ function importTerm(
   const nativeName = ext?.term;
   const nativeEntry = ext?.entry;
   if (typeof nativeName === "string" && isRecord(nativeEntry)) {
-    if (nativeName in terms) {
+    if (Object.hasOwn(terms, nativeName)) {
       report.unmapped.push(`${concept.path}: duplicate glossary term "${nativeName}" — skipped`);
       return "skipped";
     }
@@ -304,7 +324,7 @@ function importTerm(
     typeof concept.frontmatter.title === "string"
       ? concept.frontmatter.title
       : conceptStem(concept.path);
-  if (name in terms) {
+  if (Object.hasOwn(terms, name)) {
     report.unmapped.push(`${concept.path}: duplicate glossary term "${name}" — skipped`);
     return "skipped";
   }

--- a/packages/api/src/lib/semantic/okf/index.ts
+++ b/packages/api/src/lib/semantic/okf/index.ts
@@ -1,0 +1,29 @@
+/**
+ * OKF (Open Knowledge Format) interop — spike for #4140.
+ *
+ * Import: OKF bundle -> first-draft semantic layer (one-shot; scan -> enrich
+ * -> edit takes over). Export: semantic layer -> conformant OKF v0.1 bundle
+ * with an `atlas:` frontmatter extension for lossless round-trips.
+ *
+ * Findings + mapping table: docs/research/okf-interop-spike.md
+ */
+
+export { importOkfBundle, type OkfImportOptions } from "./import";
+export { exportToOkf, type OkfExportOptions } from "./export";
+export { parseFrontmatter, serializeDocument } from "./frontmatter";
+export {
+  classifyConcept,
+  mapColumnType,
+  parseBundle,
+  parseSchemaColumns,
+  splitSections,
+} from "./parse";
+export type {
+  InteropFile,
+  MappingReport,
+  OkfConcept,
+  OkfConceptKind,
+  OkfExportResult,
+  OkfFrontmatter,
+  OkfImportResult,
+} from "./types";

--- a/packages/api/src/lib/semantic/okf/index.ts
+++ b/packages/api/src/lib/semantic/okf/index.ts
@@ -3,7 +3,9 @@
  *
  * Import: OKF bundle -> first-draft semantic layer (one-shot; scan -> enrich
  * -> edit takes over). Export: semantic layer -> conformant OKF v0.1 bundle
- * with an `atlas:` frontmatter extension for lossless round-trips.
+ * with an `atlas:` frontmatter extension that makes Atlas -> OKF -> Atlas
+ * re-import lossless for entity/glossary objects and metric fields (metric
+ * authority is deliberately re-stamped unverified on import).
  *
  * Findings + mapping table: docs/research/okf-interop-spike.md
  */
@@ -12,13 +14,16 @@ export { importOkfBundle, type OkfImportOptions } from "./import";
 export { exportToOkf, type OkfExportOptions } from "./export";
 export { parseFrontmatter, serializeDocument } from "./frontmatter";
 export {
+  atlasExtension,
   classifyConcept,
   mapColumnType,
   parseBundle,
   parseSchemaColumns,
   splitSections,
+  type MappedColumnType,
 } from "./parse";
 export type {
+  AtlasDimensionType,
   InteropFile,
   MappingReport,
   OkfConcept,
@@ -26,4 +31,5 @@ export type {
   OkfExportResult,
   OkfFrontmatter,
   OkfImportResult,
+  ParsedFrontmatter,
 } from "./types";

--- a/packages/api/src/lib/semantic/okf/parse.ts
+++ b/packages/api/src/lib/semantic/okf/parse.ts
@@ -1,0 +1,211 @@
+/**
+ * OKF bundle parsing + concept classification (#4140 spike).
+ *
+ * Walks an in-memory file list, parses every non-reserved `.md` into an
+ * {@link OkfConcept}, and classifies concepts for import using the signals
+ * OKF actually provides: the free-text `type`, `tags`, and directory
+ * placement. OKF is minimally opinionated (only `type` is required, and type
+ * values are producer-defined prose like "BigQuery Table" or "Reference"),
+ * so classification is necessarily heuristic — a headline lossiness finding
+ * for the spike doc.
+ */
+
+import { parseFrontmatter } from "./frontmatter";
+import type {
+  MappingReport,
+  OkfConcept,
+  OkfConceptKind,
+  OkfParsedColumn,
+  InteropFile,
+} from "./types";
+
+/** Reserved OKF filenames — navigation/history, never concepts. */
+const RESERVED_BASENAMES = new Set(["index.md", "log.md"]);
+
+function basename(p: string): string {
+  const idx = p.lastIndexOf("/");
+  return idx === -1 ? p : p.slice(idx + 1);
+}
+
+/** Parse every concept doc in a bundle; malformed files land in `report.unmapped`. */
+export function parseBundle(
+  files: InteropFile[],
+  report: MappingReport,
+): OkfConcept[] {
+  const concepts: OkfConcept[] = [];
+  for (const file of files) {
+    if (!file.path.endsWith(".md")) continue;
+    if (RESERVED_BASENAMES.has(basename(file.path))) continue;
+    const parsed = parseFrontmatter(file.content);
+    if (!parsed.ok) {
+      report.unmapped.push(`${file.path}: ${parsed.reason}`);
+      continue;
+    }
+    concepts.push({
+      path: file.path,
+      frontmatter: parsed.doc.frontmatter,
+      body: parsed.doc.body,
+    });
+  }
+  return concepts;
+}
+
+function tagsOf(concept: OkfConcept): string[] {
+  const tags = concept.frontmatter.tags;
+  if (!Array.isArray(tags)) return [];
+  return tags.filter((t): t is string => typeof t === "string").map((t) => t.toLowerCase());
+}
+
+/**
+ * Classify a concept for import. Signals in precedence order:
+ * 1. `atlas.kind` extension key (Atlas-produced bundles — unambiguous)
+ * 2. `type` substring match ("table", "dataset")
+ * 3. tags ("metric", "join", "glossary", "term")
+ * 4. directory placement (metrics/, joins/, glossary/)
+ */
+export function classifyConcept(concept: OkfConcept): OkfConceptKind {
+  const atlasKind = concept.frontmatter.atlas?.kind;
+  if (
+    atlasKind === "table" ||
+    atlasKind === "metric" ||
+    atlasKind === "glossary_term"
+  ) {
+    return atlasKind;
+  }
+  const type = concept.frontmatter.type.toLowerCase();
+  if (type.includes("table") || type.includes("view")) return "table";
+  if (type.includes("dataset")) return "dataset";
+
+  const tags = tagsOf(concept);
+  const dir = concept.path.toLowerCase();
+  if (tags.includes("metric") || /(^|\/)metrics\//.test(dir)) return "metric";
+  if (tags.includes("join") || /(^|\/)joins\//.test(dir)) return "join";
+  if (
+    tags.includes("glossary") ||
+    tags.includes("glossary-term") ||
+    tags.includes("term") ||
+    /(^|\/)glossary\//.test(dir)
+  ) {
+    return "glossary_term";
+  }
+  return "unmapped";
+}
+
+// ---------------------------------------------------------------------------
+// Body-section helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a markdown body into `# Heading` → section-text pairs (top-level
+ * headings only; `##` subsections stay inside their parent section). Text
+ * before the first heading is returned under the empty-string key.
+ */
+export function splitSections(body: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const lines = body.split("\n");
+  let current = "";
+  let buf: string[] = [];
+  for (const line of lines) {
+    const m = line.match(/^#\s+(.+?)\s*$/);
+    if (m) {
+      sections.set(current, buf.join("\n").trim());
+      current = m[1].toLowerCase();
+      buf = [];
+    } else {
+      buf.push(line);
+    }
+  }
+  sections.set(current, buf.join("\n").trim());
+  return sections;
+}
+
+/** First fenced ```sql block in a body, or undefined. */
+export function extractSqlBlock(text: string): string | undefined {
+  const m = text.match(/```sql\r?\n([\s\S]*?)```/);
+  return m ? m[1].trim() : undefined;
+}
+
+/**
+ * Parse column entries from a `# Schema` section. Two shapes seen in the
+ * wild (both in Google's own material):
+ *
+ * - bullet form (GA4 sample):  `- \`col\` (TYPE): description`
+ * - table form (launch blog):  `| \`col\` | TYPE | description |`
+ */
+export function parseSchemaColumns(section: string): OkfParsedColumn[] {
+  const columns: OkfParsedColumn[] = [];
+  for (const rawLine of section.split("\n")) {
+    const line = rawLine.trim();
+    const bullet = line.match(/^[-*]\s+`([^`]+)`\s*\(([^)]+)\)\s*:?\s*(.*)$/);
+    if (bullet) {
+      columns.push({
+        name: bullet[1].trim(),
+        rawType: bullet[2].trim(),
+        description: bullet[3].trim(),
+      });
+      continue;
+    }
+    if (line.startsWith("|")) {
+      const cells = line
+        .split("|")
+        .slice(1, -1)
+        .map((c) => c.trim());
+      if (cells.length < 2) continue;
+      const name = cells[0].replace(/^`|`$/g, "").trim();
+      // Skip the header row and the |---|---| separator row.
+      if (name === "" || /^-+$/.test(name.replace(/\s/g, "")) || /^column$/i.test(name)) {
+        continue;
+      }
+      columns.push({
+        name,
+        rawType: cells[1].replace(/^`|`$/g, "").trim(),
+        description: (cells[2] ?? "").trim(),
+      });
+    }
+  }
+  return columns;
+}
+
+/**
+ * Map a source column type string onto Atlas's dimension type vocabulary
+ * (`number` | `string` | `date` | `timestamp` | `boolean`). Returns
+ * undefined for shapes Atlas can't represent as a scalar dimension
+ * (RECORD/STRUCT/ARRAY) — callers report those as lossy.
+ */
+export function mapColumnType(rawType: string): string | undefined {
+  const t = rawType.toUpperCase();
+  if (/RECORD|STRUCT|ARRAY|REPEATED|JSON/.test(t)) return undefined;
+  if (/INT|NUMERIC|DECIMAL|FLOAT|DOUBLE|NUMBER|BIGNUM|MONEY|SERIAL/.test(t)) return "number";
+  if (/TIMESTAMP|DATETIME/.test(t)) return "timestamp";
+  if (/^DATE$/.test(t)) return "date";
+  if (/BOOL/.test(t)) return "boolean";
+  if (/STRING|TEXT|CHAR|UUID|BYTES/.test(t)) return "string";
+  return "string";
+}
+
+/** Equality pattern in a join spec's SQL: `left_table.col = right_table.col`. */
+export function parseJoinEquality(
+  sql: string,
+): { fromTable: string; fromColumn: string; toTable: string; toColumn: string } | undefined {
+  const m = sql.match(
+    /([A-Za-z_][\w.]*)\.(\w+)\s*=\s*([A-Za-z_][\w.]*)\.(\w+)/,
+  );
+  if (!m) return undefined;
+  // For dotted qualifiers keep only the trailing table token; the column is
+  // the final segment already captured separately.
+  const tableToken = (q: string): string => {
+    const parts = q.split(".");
+    return parts[parts.length - 1];
+  };
+  return {
+    fromTable: tableToken(m[1]),
+    fromColumn: m[2],
+    toTable: tableToken(m[3]),
+    toColumn: m[4],
+  };
+}
+
+/** Filename stem (`tables/events_.md` → `events_`). */
+export function conceptStem(path: string): string {
+  return basename(path).replace(/\.md$/, "");
+}

--- a/packages/api/src/lib/semantic/okf/parse.ts
+++ b/packages/api/src/lib/semantic/okf/parse.ts
@@ -12,6 +12,7 @@
 
 import { parseFrontmatter } from "./frontmatter";
 import type {
+  AtlasDimensionType,
   MappingReport,
   OkfConcept,
   OkfConceptKind,
@@ -56,15 +57,24 @@ function tagsOf(concept: OkfConcept): string[] {
   return tags.filter((t): t is string => typeof t === "string").map((t) => t.toLowerCase());
 }
 
+/** The `atlas:` extension block, when present and a mapping (narrowed from unknown). */
+export function atlasExtension(concept: OkfConcept): Record<string, unknown> | undefined {
+  const ext = concept.frontmatter.atlas;
+  return typeof ext === "object" && ext !== null && !Array.isArray(ext)
+    ? (ext as Record<string, unknown>)
+    : undefined;
+}
+
 /**
  * Classify a concept for import. Signals in precedence order:
  * 1. `atlas.kind` extension key (Atlas-produced bundles — unambiguous)
- * 2. `type` substring match ("table", "dataset")
- * 3. tags ("metric", "join", "glossary", "term")
- * 4. directory placement (metrics/, joins/, glossary/)
+ * 2. `type` substring match ("table"/"view", "dataset")
+ * 3. per-kind tag-or-directory signals, checked in kind order metric →
+ *    join → glossary_term (so a doc under `metrics/` tagged `join`
+ *    classifies as a metric — placement and tag rank equally within a kind)
  */
 export function classifyConcept(concept: OkfConcept): OkfConceptKind {
-  const atlasKind = concept.frontmatter.atlas?.kind;
+  const atlasKind = atlasExtension(concept)?.kind;
   if (
     atlasKind === "table" ||
     atlasKind === "metric" ||
@@ -98,24 +108,30 @@ export function classifyConcept(concept: OkfConcept): OkfConceptKind {
 /**
  * Split a markdown body into `# Heading` → section-text pairs (top-level
  * headings only; `##` subsections stay inside their parent section). Text
- * before the first heading is returned under the empty-string key.
+ * before the first heading is returned under the empty-string key. Repeated
+ * headings concatenate rather than overwrite.
  */
 export function splitSections(body: string): Map<string, string> {
   const sections = new Map<string, string>();
+  const flush = (key: string, buf: string[]): void => {
+    const text = buf.join("\n").trim();
+    const existing = sections.get(key);
+    sections.set(key, existing !== undefined && existing !== "" ? `${existing}\n\n${text}` : text);
+  };
   const lines = body.split("\n");
   let current = "";
   let buf: string[] = [];
   for (const line of lines) {
     const m = line.match(/^#\s+(.+?)\s*$/);
     if (m) {
-      sections.set(current, buf.join("\n").trim());
+      flush(current, buf);
       current = m[1].toLowerCase();
       buf = [];
     } else {
       buf.push(line);
     }
   }
-  sections.set(current, buf.join("\n").trim());
+  flush(current, buf);
   return sections;
 }
 
@@ -166,21 +182,36 @@ export function parseSchemaColumns(section: string): OkfParsedColumn[] {
   return columns;
 }
 
+/** A column type mapped onto Atlas's closed vocabulary; `guessed` marks the fallback. */
+export interface MappedColumnType {
+  type: AtlasDimensionType;
+  guessed: boolean;
+}
+
 /**
- * Map a source column type string onto Atlas's dimension type vocabulary
- * (`number` | `string` | `date` | `timestamp` | `boolean`). Returns
+ * Map a source column type string onto {@link AtlasDimensionType}. Returns
  * undefined for shapes Atlas can't represent as a scalar dimension
- * (RECORD/STRUCT/ARRAY) — callers report those as lossy.
+ * (RECORD/STRUCT/ARRAY/REPEATED/JSON) — callers report those as lossy.
+ * Unrecognized types fall back to `string` with `guessed: true` so callers
+ * can report the approximation instead of passing it off as a real match.
  */
-export function mapColumnType(rawType: string): string | undefined {
+export function mapColumnType(rawType: string): MappedColumnType | undefined {
   const t = rawType.toUpperCase();
-  if (/RECORD|STRUCT|ARRAY|REPEATED|JSON/.test(t)) return undefined;
-  if (/INT|NUMERIC|DECIMAL|FLOAT|DOUBLE|NUMBER|BIGNUM|MONEY|SERIAL/.test(t)) return "number";
-  if (/TIMESTAMP|DATETIME/.test(t)) return "timestamp";
-  if (/^DATE$/.test(t)) return "date";
-  if (/BOOL/.test(t)) return "boolean";
-  if (/STRING|TEXT|CHAR|UUID|BYTES/.test(t)) return "string";
-  return "string";
+  if (/\b(RECORD|STRUCT|ARRAY|REPEATED|JSON)\b/.test(t) || /ARRAY</.test(t)) return undefined;
+  if (
+    /\b(INT|INTEGER|INT64|BIGINT|SMALLINT|TINYINT|NUMERIC|DECIMAL|FLOAT|FLOAT64|DOUBLE|NUMBER|BIGNUMERIC|MONEY|SERIAL|REAL)\b/.test(
+      t,
+    )
+  ) {
+    return { type: "number", guessed: false };
+  }
+  if (/\b(TIMESTAMP|DATETIME)\b/.test(t)) return { type: "timestamp", guessed: false };
+  if (/^DATE$/.test(t)) return { type: "date", guessed: false };
+  if (/\bBOOL(EAN)?\b/.test(t)) return { type: "boolean", guessed: false };
+  if (/\b(STRING|TEXT|CHAR|VARCHAR|UUID|BYTES)\b/.test(t)) {
+    return { type: "string", guessed: false };
+  }
+  return { type: "string", guessed: true };
 }
 
 /** Equality pattern in a join spec's SQL: `left_table.col = right_table.col`. */
@@ -205,7 +236,11 @@ export function parseJoinEquality(
   };
 }
 
-/** Filename stem (`tables/events_.md` → `events_`). */
+/**
+ * Filename stem, NOT sanitized (`tables/events_.md` → `events_`, as in the
+ * GA4 sample's sharded-table doc) — importers validate it separately via
+ * `safeSemanticRowName`.
+ */
 export function conceptStem(path: string): string {
   return basename(path).replace(/\.md$/, "");
 }

--- a/packages/api/src/lib/semantic/okf/parse.ts
+++ b/packages/api/src/lib/semantic/okf/parse.ts
@@ -106,6 +106,19 @@ export function classifyConcept(concept: OkfConcept): OkfConceptKind {
 // ---------------------------------------------------------------------------
 
 /**
+ * A top-level `# Heading` line's text, or null. String ops instead of a
+ * regex: `/^#\s+(.+?)\s*$/` backtracks polynomially on hostile whitespace
+ * runs, and this runs on untrusted bundle content (CodeQL js/polynomial-redos).
+ */
+function topLevelHeading(line: string): string | null {
+  if (line.charAt(0) !== "#") return null;
+  const second = line.charAt(1);
+  if (second !== " " && second !== "\t") return null;
+  const text = line.slice(2).trim();
+  return text === "" ? null : text;
+}
+
+/**
  * Split a markdown body into `# Heading` → section-text pairs (top-level
  * headings only; `##` subsections stay inside their parent section). Text
  * before the first heading is returned under the empty-string key. Repeated
@@ -122,10 +135,10 @@ export function splitSections(body: string): Map<string, string> {
   let current = "";
   let buf: string[] = [];
   for (const line of lines) {
-    const m = line.match(/^#\s+(.+?)\s*$/);
-    if (m) {
+    const heading = topLevelHeading(line);
+    if (heading !== null) {
       flush(current, buf);
-      current = m[1].toLowerCase();
+      current = heading.toLowerCase();
       buf = [];
     } else {
       buf.push(line);
@@ -142,6 +155,41 @@ export function extractSqlBlock(text: string): string | undefined {
 }
 
 /**
+ * One bullet-form schema entry — `- \`col\` (TYPE): description` — or null.
+ * Hand-parsed with indexOf/slice: the equivalent regex's adjacent optional
+ * whitespace runs backtrack polynomially on hostile input (CodeQL
+ * js/polynomial-redos), and schema sections are untrusted bundle content.
+ * Expects a pre-trimmed line.
+ */
+function parseBulletColumn(line: string): OkfParsedColumn | null {
+  const marker = line.charAt(0);
+  if (marker !== "-" && marker !== "*") return null;
+  const afterMarker = line.slice(1);
+  const second = afterMarker.charAt(0);
+  if (second !== " " && second !== "\t") return null;
+
+  const tickStart = afterMarker.indexOf("`");
+  if (tickStart === -1) return null;
+  // Only whitespace may sit between the list marker and the backtick.
+  if (afterMarker.slice(0, tickStart).trim() !== "") return null;
+  const tickEnd = afterMarker.indexOf("`", tickStart + 1);
+  if (tickEnd === -1) return null;
+  const name = afterMarker.slice(tickStart + 1, tickEnd).trim();
+  if (name === "") return null;
+
+  let rest = afterMarker.slice(tickEnd + 1).trimStart();
+  if (rest.charAt(0) !== "(") return null;
+  const closeParen = rest.indexOf(")");
+  if (closeParen === -1) return null;
+  const rawType = rest.slice(1, closeParen).trim();
+  if (rawType === "") return null;
+
+  rest = rest.slice(closeParen + 1).trimStart();
+  if (rest.startsWith(":")) rest = rest.slice(1);
+  return { name, rawType, description: rest.trim() };
+}
+
+/**
  * Parse column entries from a `# Schema` section. Two shapes seen in the
  * wild (both in Google's own material):
  *
@@ -152,13 +200,9 @@ export function parseSchemaColumns(section: string): OkfParsedColumn[] {
   const columns: OkfParsedColumn[] = [];
   for (const rawLine of section.split("\n")) {
     const line = rawLine.trim();
-    const bullet = line.match(/^[-*]\s+`([^`]+)`\s*\(([^)]+)\)\s*:?\s*(.*)$/);
+    const bullet = parseBulletColumn(line);
     if (bullet) {
-      columns.push({
-        name: bullet[1].trim(),
-        rawType: bullet[2].trim(),
-        description: bullet[3].trim(),
-      });
+      columns.push(bullet);
       continue;
     }
     if (line.startsWith("|")) {
@@ -214,25 +258,32 @@ export function mapColumnType(rawType: string): MappedColumnType | undefined {
   return { type: "string", guessed: true };
 }
 
-/** Equality pattern in a join spec's SQL: `left_table.col = right_table.col`. */
+/**
+ * Equality pattern in a join spec's SQL: `left_table.col = right_table.col`.
+ * The dotted-chain alternation `(?:\.\w+)+` is deliberately unambiguous
+ * (each hop starts with a literal dot, and `\w`/`.`/`\s` are disjoint) so
+ * the regex stays linear on untrusted sql fences — the naive
+ * `[\w.]*\.\w+` form backtracks polynomially (same CodeQL class as the
+ * schema/heading parsers above).
+ */
 export function parseJoinEquality(
   sql: string,
 ): { fromTable: string; fromColumn: string; toTable: string; toColumn: string } | undefined {
-  const m = sql.match(
-    /([A-Za-z_][\w.]*)\.(\w+)\s*=\s*([A-Za-z_][\w.]*)\.(\w+)/,
-  );
+  const m = sql.match(/([A-Za-z_]\w*(?:\.\w+)+)\s*=\s*([A-Za-z_]\w*(?:\.\w+)+)/);
   if (!m) return undefined;
-  // For dotted qualifiers keep only the trailing table token; the column is
-  // the final segment already captured separately.
-  const tableToken = (q: string): string => {
-    const parts = q.split(".");
-    return parts[parts.length - 1];
+  // For dotted qualifiers the column is the last segment and the table the
+  // one before it (`db.schema.table.col` -> table `table`, column `col`).
+  const split = (chain: string): { table: string; column: string } => {
+    const parts = chain.split(".");
+    return { table: parts[parts.length - 2], column: parts[parts.length - 1] };
   };
+  const from = split(m[1]);
+  const to = split(m[2]);
   return {
-    fromTable: tableToken(m[1]),
-    fromColumn: m[2],
-    toTable: tableToken(m[3]),
-    toColumn: m[4],
+    fromTable: from.table,
+    fromColumn: from.column,
+    toTable: to.table,
+    toColumn: to.column,
   };
 }
 

--- a/packages/api/src/lib/semantic/okf/types.ts
+++ b/packages/api/src/lib/semantic/okf/types.ts
@@ -1,0 +1,86 @@
+/**
+ * OKF (Open Knowledge Format) interop types — spike for #4140.
+ *
+ * OKF v0.1 (GoogleCloudPlatform/knowledge-catalog) represents knowledge as a
+ * directory of markdown files with YAML frontmatter. Only `type` is required;
+ * `title` / `description` / `resource` / `tags` / `timestamp` are recommended;
+ * unknown keys are legal and consumers must preserve them.
+ *
+ * Both mapping directions operate on in-memory `{ path, content }` file lists
+ * so the module has no filesystem coupling — the CLI walks/writes disk, and a
+ * future ingest pipeline (#4182) can feed DB-sourced documents through the
+ * same seam.
+ */
+
+/** One file in a bundle (OKF) or semantic layer (Atlas), path bundle-relative POSIX. */
+export interface InteropFile {
+  path: string;
+  content: string;
+}
+
+/** Parsed OKF frontmatter — the spec's recommended keys plus passthrough extras. */
+export interface OkfFrontmatter {
+  type: string;
+  title?: string;
+  description?: string;
+  resource?: string;
+  tags?: string[];
+  timestamp?: string;
+  /** Atlas extension namespace (spec-legal unknown key) enabling lossless round-trip. */
+  atlas?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** A parsed OKF concept document (any non-reserved `.md` file). */
+export interface OkfConcept {
+  /** Bundle-relative path, e.g. `tables/orders.md`. */
+  path: string;
+  frontmatter: OkfFrontmatter;
+  /** Markdown body after the frontmatter block. */
+  body: string;
+}
+
+/** How a concept was classified for import. */
+export type OkfConceptKind =
+  | "table"
+  | "dataset"
+  | "metric"
+  | "join"
+  | "glossary_term"
+  | "unmapped";
+
+/** A column parsed from an OKF `# Schema` section (bullet or table form). */
+export interface OkfParsedColumn {
+  name: string;
+  /** Raw source type string, e.g. `INTEGER`, `RECORD`. */
+  rawType: string;
+  description: string;
+}
+
+/** Result of mapping in either direction. */
+export interface MappingReport {
+  /** Human-readable notes about information lost or approximated. */
+  lossy: string[];
+  /** Inputs that could not be mapped at all (path + reason). */
+  unmapped: string[];
+  /** Non-fatal observations (e.g. defaults applied). */
+  notes: string[];
+}
+
+/** Output of an OKF → semantic-layer import. */
+export interface OkfImportResult {
+  /** Semantic-layer files to write (entities/*.yml, glossary.yml, metrics/*.yml, catalog.yml). */
+  files: InteropFile[];
+  report: MappingReport;
+}
+
+/** Output of a semantic-layer → OKF export. */
+export interface OkfExportResult {
+  /** OKF bundle files to write (concept docs + index.md files). */
+  files: InteropFile[];
+  report: MappingReport;
+}
+
+export function emptyReport(): MappingReport {
+  return { lossy: [], unmapped: [], notes: [] };
+}

--- a/packages/api/src/lib/semantic/okf/types.ts
+++ b/packages/api/src/lib/semantic/okf/types.ts
@@ -18,7 +18,23 @@ export interface InteropFile {
   content: string;
 }
 
-/** Parsed OKF frontmatter — the spec's recommended keys plus passthrough extras. */
+/**
+ * Frontmatter as parsed from an untrusted bundle. Only `type` is verified at
+ * the parse boundary — every other key is `unknown` and consumers MUST narrow
+ * before use (the compiler enforces it). Do not widen this to the richer
+ * {@link OkfFrontmatter}: that type is for documents *we construct* on export,
+ * where the field shapes are true by construction.
+ */
+export interface ParsedFrontmatter {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Frontmatter Atlas constructs on export — the spec's recommended keys plus
+ * the `atlas:` extension. Sound only on the write side; parsed input uses
+ * {@link ParsedFrontmatter}.
+ */
 export interface OkfFrontmatter {
   type: string;
   title?: string;
@@ -26,7 +42,7 @@ export interface OkfFrontmatter {
   resource?: string;
   tags?: string[];
   timestamp?: string;
-  /** Atlas extension namespace (spec-legal unknown key) enabling lossless round-trip. */
+  /** Atlas extension namespace (spec-legal unknown key) enabling near-lossless round-trip. */
   atlas?: Record<string, unknown>;
   [key: string]: unknown;
 }
@@ -35,10 +51,13 @@ export interface OkfFrontmatter {
 export interface OkfConcept {
   /** Bundle-relative path, e.g. `tables/orders.md`. */
   path: string;
-  frontmatter: OkfFrontmatter;
+  frontmatter: ParsedFrontmatter;
   /** Markdown body after the frontmatter block. */
   body: string;
 }
+
+/** Atlas's closed dimension-type vocabulary — what imported columns map onto. */
+export type AtlasDimensionType = "number" | "string" | "date" | "timestamp" | "boolean";
 
 /** How a concept was classified for import. */
 export type OkfConceptKind =

--- a/packages/cli/bin/atlas.ts
+++ b/packages/cli/bin/atlas.ts
@@ -242,6 +242,14 @@ async function main() {
     return handleMetric(args);
   }
 
+  // #4140 — OKF (Open Knowledge Format) interop spike. File <-> file only
+  // (no REST, no DB), so it lives in the published binary; named `okf` because
+  // bare `import` already means "sync semantic YAML -> internal DB".
+  if (command === "okf") {
+    const { handleOkf } = await import("../src/commands/okf");
+    return handleOkf(args);
+  }
+
   if (command === "eval") {
     const { handleEval } = await import("./eval");
     return handleEval(args);

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -696,6 +696,52 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       "atlas completions fish > ~/.config/fish/completions/atlas.fish",
     ],
   },
+  okf: {
+    description:
+      "OKF (Open Knowledge Format) interop — import a bundle as a draft semantic layer, or export the semantic layer as an OKF bundle.",
+    usage: "okf <import|export> [options]",
+    subcommands: [
+      {
+        name: "import",
+        description: "OKF bundle directory -> first-draft semantic layer YAML",
+      },
+      {
+        name: "export",
+        description: "Semantic layer directory -> OKF v0.1 bundle",
+      },
+    ],
+    flags: [
+      {
+        flag: "--bundle <dir>",
+        description: "(import) OKF bundle to read (required)",
+      },
+      {
+        flag: "--out <dir>",
+        description:
+          "Output directory (import default: ./semantic; export: required)",
+      },
+      {
+        flag: "--name <name>",
+        description: "(import) Catalog name for the draft",
+      },
+      {
+        flag: "--semantic <dir>",
+        description: "(export) Semantic layer to read (default: ./semantic)",
+      },
+      {
+        flag: "--force",
+        description: "Overwrite existing/non-empty output",
+      },
+    ],
+    examples: [
+      "atlas okf import --bundle ./ga4-bundle --out ./semantic",
+      "atlas okf export --semantic ./semantic --out ./okf-bundle",
+    ],
+    notes: [
+      "Import produces DRAFTS: metric SQL from a bundle is unverified prose until reviewed.",
+      "Spike findings + mapping table: docs/research/okf-interop-spike.md (#4140).",
+    ],
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -728,6 +774,7 @@ export function printOverviewHelp(): void {
       "  canonical-eval   Run canonical-question harness against the demo dataset (no LLM by default)\n" +
       "  smoke            Run E2E smoke tests against a running Atlas deployment\n" +
       "  migrate          Semantic layer versioning (snapshot, diff, rollback)\n" +
+      "  okf              OKF interop — import/export Open Knowledge Format bundles\n" +
       "  plugin           Manage plugins (list, create, add)\n" +
       "  benchmark        Run BIRD benchmark for text-to-SQL accuracy\n" +
       "  mcp              Start MCP server (stdio or SSE transport)\n" +

--- a/packages/cli/src/__tests__/okf-command.test.ts
+++ b/packages/cli/src/__tests__/okf-command.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { runOkf, type OkfIO } from "../commands/okf";
+
+interface CapturedIO extends OkfIO {
+  readonly outLines: string[];
+  readonly errLines: string[];
+}
+
+function captureIO(): CapturedIO {
+  const outLines: string[] = [];
+  const errLines: string[] = [];
+  return {
+    outLines,
+    errLines,
+    out: (line) => outLines.push(line),
+    err: (line) => errLines.push(line),
+  };
+}
+
+const TABLE_DOC = `---
+type: BigQuery Table
+title: Events table
+description: Contains web event export data.
+tags:
+- events
+timestamp: '2026-05-28T22:53:05+00:00'
+---
+
+# Overview
+The events table.
+
+# Schema
+- \`event_name\` (STRING): The name of the event.
+- \`event_count\` (INTEGER): How many times it fired.
+`;
+
+const METRIC_DOC = `---
+type: Reference
+title: Event Count
+description: Total number of events.
+tags:
+- metric
+---
+
+\`\`\`sql
+COUNT(*)
+\`\`\`
+`;
+
+const ENTITY_YAML = `name: Orders
+type: fact_table
+table: orders
+description: Customer orders.
+dimensions:
+  - name: id
+    sql: id
+    type: number
+    primary_key: true
+`;
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), "okf-cli-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeBundle(): string {
+  const bundle = path.join(workDir, "bundle");
+  fs.mkdirSync(path.join(bundle, "tables"), { recursive: true });
+  fs.mkdirSync(path.join(bundle, "references", "metrics"), { recursive: true });
+  fs.writeFileSync(path.join(bundle, "index.md"), "# Bundle\n");
+  fs.writeFileSync(path.join(bundle, "tables", "events.md"), TABLE_DOC);
+  fs.writeFileSync(path.join(bundle, "references", "metrics", "event_count.md"), METRIC_DOC);
+  return bundle;
+}
+
+function writeSemanticLayer(): string {
+  const layer = path.join(workDir, "semantic");
+  fs.mkdirSync(path.join(layer, "entities"), { recursive: true });
+  fs.writeFileSync(path.join(layer, "entities", "orders.yml"), ENTITY_YAML);
+  return layer;
+}
+
+describe("okf command dispatch", () => {
+  it("prints usage and exits 1 with no subcommand", () => {
+    const io = captureIO();
+    expect(runOkf(["okf"], io)).toBe(1);
+    expect(io.outLines.join("\n")).toContain("Usage: atlas okf");
+  });
+
+  it("prints usage and exits 0 for --help", () => {
+    const io = captureIO();
+    expect(runOkf(["okf", "--help"], io)).toBe(0);
+  });
+
+  it("rejects unknown subcommands", () => {
+    const io = captureIO();
+    expect(runOkf(["okf", "sync"], io)).toBe(1);
+    expect(io.errLines.join("\n")).toContain("Unknown okf subcommand: sync");
+  });
+});
+
+describe("okf import", () => {
+  it("requires --bundle", () => {
+    const io = captureIO();
+    expect(runOkf(["okf", "import"], io)).toBe(1);
+    expect(io.errLines.join("\n")).toContain("--bundle");
+  });
+
+  it("fails on a missing bundle directory", () => {
+    const io = captureIO();
+    expect(runOkf(["okf", "import", "--bundle", path.join(workDir, "nope")], io)).toBe(1);
+    expect(io.errLines.join("\n")).toContain("not found");
+  });
+
+  it("writes a draft semantic layer from a bundle", () => {
+    const bundle = writeBundle();
+    const out = path.join(workDir, "out");
+    const io = captureIO();
+    expect(runOkf(["okf", "import", "--bundle", bundle, "--out", out], io)).toBe(0);
+
+    const entity = fs.readFileSync(path.join(out, "entities", "events.yml"), "utf8");
+    expect(entity).toContain("table: events");
+    expect(entity).toContain("name: Events table");
+    const metrics = fs.readFileSync(path.join(out, "metrics", "okf-imported.yml"), "utf8");
+    expect(metrics).toContain("unverified_sql: true");
+    expect(fs.existsSync(path.join(out, "catalog.yml"))).toBe(true);
+    expect(io.outLines.join("\n")).toContain("1 entities");
+  });
+
+  it("refuses to overwrite existing files without --force", () => {
+    const bundle = writeBundle();
+    const out = path.join(workDir, "out");
+    fs.mkdirSync(path.join(out, "entities"), { recursive: true });
+    fs.writeFileSync(path.join(out, "entities", "events.yml"), "table: events\n");
+
+    const io = captureIO();
+    expect(runOkf(["okf", "import", "--bundle", bundle, "--out", out], io)).toBe(1);
+    expect(io.errLines.join("\n")).toContain("--force");
+    // Existing file untouched.
+    expect(fs.readFileSync(path.join(out, "entities", "events.yml"), "utf8")).toBe(
+      "table: events\n",
+    );
+
+    const forced = captureIO();
+    expect(
+      runOkf(["okf", "import", "--bundle", bundle, "--out", out, "--force"], forced),
+    ).toBe(0);
+    expect(
+      fs.readFileSync(path.join(out, "entities", "events.yml"), "utf8"),
+    ).toContain("name: Events table");
+  });
+});
+
+describe("okf export", () => {
+  it("requires --out", () => {
+    const io = captureIO();
+    expect(runOkf(["okf", "export"], io)).toBe(1);
+    expect(io.errLines.join("\n")).toContain("--out");
+  });
+
+  it("writes an OKF bundle from a semantic layer", () => {
+    const layer = writeSemanticLayer();
+    const out = path.join(workDir, "bundle-out");
+    const io = captureIO();
+    expect(runOkf(["okf", "export", "--semantic", layer, "--out", out], io)).toBe(0);
+
+    const doc = fs.readFileSync(path.join(out, "tables", "orders.md"), "utf8");
+    expect(doc).toContain("type: Table");
+    expect(doc).toContain("# Schema");
+    expect(doc).toContain("atlas:");
+    const rootIndex = fs.readFileSync(path.join(out, "index.md"), "utf8");
+    expect(rootIndex).toContain('okf_version: "0.1"');
+    expect(io.outLines.join("\n")).toContain("concept docs");
+  });
+
+  it("refuses a non-empty output directory without --force", () => {
+    const layer = writeSemanticLayer();
+    const out = path.join(workDir, "bundle-out");
+    fs.mkdirSync(out, { recursive: true });
+    fs.writeFileSync(path.join(out, "keep.txt"), "x");
+
+    const io = captureIO();
+    expect(runOkf(["okf", "export", "--semantic", layer, "--out", out], io)).toBe(1);
+    expect(io.errLines.join("\n")).toContain("--force");
+  });
+});

--- a/packages/cli/src/__tests__/okf-command.test.ts
+++ b/packages/cli/src/__tests__/okf-command.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { runOkf, type OkfIO } from "../commands/okf";
+import { resolveInside, runOkf, type OkfIO } from "../commands/okf";
 
 interface CapturedIO extends OkfIO {
   readonly outLines: string[];
@@ -87,6 +87,27 @@ function writeSemanticLayer(): string {
   fs.writeFileSync(path.join(layer, "entities", "orders.yml"), ENTITY_YAML);
   return layer;
 }
+
+describe("resolveInside (defense-in-depth sink guard)", () => {
+  it("resolves normal nested paths under the output root", () => {
+    const out = path.join(workDir, "out");
+    expect(resolveInside(out, "entities/orders.yml")).toBe(
+      path.join(out, "entities", "orders.yml"),
+    );
+  });
+
+  it("throws on traversal segments", () => {
+    const out = path.join(workDir, "out");
+    expect(() => resolveInside(out, "entities/../../escaped.yml")).toThrow(
+      "refusing to write outside",
+    );
+  });
+
+  it("throws on prefix-sibling escapes (out vs out-evil)", () => {
+    const out = path.join(workDir, "out");
+    expect(() => resolveInside(out, "../out-evil/x.yml")).toThrow("refusing to write outside");
+  });
+});
 
 describe("okf command dispatch", () => {
   it("prints usage and exits 1 with no subcommand", () => {

--- a/packages/cli/src/__tests__/okf-command.test.ts
+++ b/packages/cli/src/__tests__/okf-command.test.ts
@@ -159,11 +159,52 @@ describe("okf import", () => {
   });
 });
 
+describe("okf import (hostile bundle)", () => {
+  it("never writes outside --out for a forged atlas.entity.table", () => {
+    const bundle = path.join(workDir, "bundle");
+    fs.mkdirSync(path.join(bundle, "tables"), { recursive: true });
+    fs.writeFileSync(
+      path.join(bundle, "tables", "evil.md"),
+      `---
+type: Table
+title: Evil
+atlas:
+  kind: table
+  entity:
+    table: ../../escaped
+---
+
+# Overview
+Nope.
+`,
+    );
+    const out = path.join(workDir, "out");
+    const io = captureIO();
+    expect(runOkf(["okf", "import", "--bundle", bundle, "--out", out], io)).toBe(0);
+    // The engine rejects the forged name; nothing may exist above --out.
+    expect(fs.existsSync(path.join(workDir, "escaped.yml"))).toBe(false);
+    expect(fs.existsSync(path.join(out, "entities"))).toBe(false);
+    expect(io.errLines.join("\n")).toContain("not a safe table name");
+    expect(io.errLines.join("\n")).toContain("no entities were imported");
+  });
+});
+
 describe("okf export", () => {
   it("requires --out", () => {
     const io = captureIO();
     expect(runOkf(["okf", "export"], io)).toBe(1);
     expect(io.errLines.join("\n")).toContain("--out");
+  });
+
+  it("fails on a missing semantic layer directory", () => {
+    const io = captureIO();
+    expect(
+      runOkf(
+        ["okf", "export", "--semantic", path.join(workDir, "nope"), "--out", path.join(workDir, "b")],
+        io,
+      ),
+    ).toBe(1);
+    expect(io.errLines.join("\n")).toContain("not found");
   });
 
   it("writes an OKF bundle from a semantic layer", () => {

--- a/packages/cli/src/commands/okf.ts
+++ b/packages/cli/src/commands/okf.ts
@@ -16,9 +16,10 @@
  * means "import an Atlas export bundle" — see the #4140 triage note.
  *
  * Pure file <-> file: no REST, no DB, so it lives in the published `atlas`
- * binary (per ADR-0025/0026 only direct-DB tenant tooling is operator-only).
- * The mapping engine is `@atlas/api/lib/semantic/okf`; this file only walks
- * and writes directories. Findings: docs/research/okf-interop-spike.md.
+ * binary (per ADR-0025 §Sequencing / #4045, only tenant-destructive
+ * direct-DB tooling is operator-only). The mapping engine is
+ * `@atlas/api/lib/semantic/okf`; this file only walks and writes
+ * directories. Findings: docs/research/okf-interop-spike.md.
  */
 
 import * as fs from "fs";
@@ -79,6 +80,9 @@ function collectFiles(root: string, extensions: RegExp): InteropFile[] {
       // Skip dotfiles/dirs (.git, .orgs mirrors) — never part of a bundle or layer.
       if (entry.name.startsWith(".")) continue;
       const full = path.join(dir, entry.name);
+      // Symlinks fail both isDirectory() and isFile() and are intentionally
+      // excluded: a bundle should be self-contained, and following links
+      // would let it read outside its own tree.
       if (entry.isDirectory()) {
         walk(full);
       } else if (entry.isFile() && extensions.test(entry.name)) {
@@ -93,29 +97,45 @@ function collectFiles(root: string, extensions: RegExp): InteropFile[] {
   return files;
 }
 
+/**
+ * Resolve a bundle-relative POSIX path under `outDir`, refusing anything
+ * that escapes it. The mapping engine validates names on its side; this is
+ * the defense-in-depth sink guard (CLAUDE.md path-traversal rule) so no
+ * future engine bug can turn an import into an arbitrary file write.
+ */
+function resolveInside(outDir: string, relPath: string): string {
+  const root = path.resolve(outDir);
+  const target = path.resolve(root, ...relPath.split("/"));
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    throw new Error(`refusing to write outside ${outDir}: ${relPath}`);
+  }
+  return target;
+}
+
 function writeFiles(outDir: string, files: InteropFile[]): void {
   for (const file of files) {
-    const target = path.join(outDir, ...file.path.split("/"));
+    const target = resolveInside(outDir, file.path);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, file.content, "utf8");
   }
 }
 
+/** Warnings go to stderr so stdout stays pipeable. */
 function printReport(io: OkfIO, report: MappingReport): void {
   if (report.lossy.length > 0) {
-    io.out("");
-    io.out(`Lossy mappings (${report.lossy.length}):`);
-    for (const l of report.lossy) io.out(`  ! ${l}`);
+    io.err("");
+    io.err(`Lossy mappings (${report.lossy.length}):`);
+    for (const l of report.lossy) io.err(`  ! ${l}`);
   }
   if (report.unmapped.length > 0) {
-    io.out("");
-    io.out(`Unmapped (${report.unmapped.length}):`);
-    for (const u of report.unmapped) io.out(`  x ${u}`);
+    io.err("");
+    io.err(`Unmapped (${report.unmapped.length}):`);
+    for (const u of report.unmapped) io.err(`  x ${u}`);
   }
   if (report.notes.length > 0) {
-    io.out("");
-    io.out(`Notes (${report.notes.length}):`);
-    for (const n of report.notes) io.out(`  - ${n}`);
+    io.err("");
+    io.err(`Notes (${report.notes.length}):`);
+    for (const n of report.notes) io.err(`  - ${n}`);
   }
 }
 
@@ -142,9 +162,7 @@ function runImport(args: string[], io: OkfIO): number {
   const { files, report } = importOkfBundle(bundleFiles, { bundleName });
 
   if (!force) {
-    const collisions = files.filter((f) =>
-      fs.existsSync(path.join(outDir, ...f.path.split("/"))),
-    );
+    const collisions = files.filter((f) => fs.existsSync(resolveInside(outDir, f.path)));
     if (collisions.length > 0) {
       io.err(
         `Refusing to overwrite ${collisions.length} existing file(s) in ${outDir} ` +
@@ -161,6 +179,11 @@ function runImport(args: string[], io: OkfIO): number {
     `  ${entityCount} entities, ${files.length} files total. ` +
       "Drafts only - review via scan -> enrich -> edit before publishing.",
   );
+  if (entityCount === 0) {
+    io.err(
+      "Warning: no entities were imported - every table concept was unmapped or the bundle has none. See the report below.",
+    );
+  }
   printReport(io, report);
   return 0;
 }
@@ -199,12 +222,25 @@ function runExport(args: string[], io: OkfIO): number {
   return 0;
 }
 
+/** Run a subcommand with foreseeable fs failures turned into actionable messages. */
+function guarded(label: string, io: OkfIO, fn: () => number): number {
+  try {
+    return fn();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    io.err(
+      `okf ${label} failed: ${msg}. Check that the input path is a readable directory and the output path is writable, then re-run.`,
+    );
+    return 1;
+  }
+}
+
 /** Testable core — dispatches subcommands, returns the exit code. */
 export function runOkf(args: string[], io: OkfIO = defaultIO): number {
   // args[0] is the command name ("okf"); the subcommand follows.
   const sub = args[1];
-  if (sub === "import") return runImport(args, io);
-  if (sub === "export") return runExport(args, io);
+  if (sub === "import") return guarded("import", io, () => runImport(args, io));
+  if (sub === "export") return guarded("export", io, () => runExport(args, io));
   if (sub === undefined || sub === "--help" || sub === "-h") {
     io.out(USAGE);
     return sub === undefined ? 1 : 0;

--- a/packages/cli/src/commands/okf.ts
+++ b/packages/cli/src/commands/okf.ts
@@ -1,0 +1,221 @@
+/**
+ * `atlas okf import|export` — OKF (Open Knowledge Format) interop spike (#4140).
+ *
+ * OKF v0.1 (GoogleCloudPlatform/knowledge-catalog) is a vendor-neutral bundle
+ * of markdown files with YAML frontmatter. This command group is the
+ * file-to-file prototype of both mapping directions:
+ *
+ * - `okf import`  — OKF bundle directory -> first-draft semantic layer
+ *   (entities/glossary/metrics YAML); the scan -> enrich -> edit flow takes
+ *   over from there. One-shot draft generator, NOT a maintained sync.
+ * - `okf export`  — semantic layer directory -> conformant OKF bundle, with
+ *   an `atlas:` frontmatter extension that makes re-import lossless.
+ *
+ * Named `okf` (subcommand group) because bare `import` already means
+ * "sync on-disk semantic YAML -> internal DB" (import.ts) and `migrate-import`
+ * means "import an Atlas export bundle" — see the #4140 triage note.
+ *
+ * Pure file <-> file: no REST, no DB, so it lives in the published `atlas`
+ * binary (per ADR-0025/0026 only direct-DB tenant tooling is operator-only).
+ * The mapping engine is `@atlas/api/lib/semantic/okf`; this file only walks
+ * and writes directories. Findings: docs/research/okf-interop-spike.md.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import {
+  exportToOkf,
+  importOkfBundle,
+  type InteropFile,
+  type MappingReport,
+} from "@atlas/api/lib/semantic/okf";
+import { getFlag } from "../../lib/cli-utils";
+
+const USAGE = `OKF (Open Knowledge Format) interop - import a bundle as a draft semantic layer, or export the semantic layer as an OKF bundle.
+
+Usage: atlas okf <command> [options]
+
+Commands:
+  import              OKF bundle directory -> first-draft semantic layer YAML
+  export              Semantic layer directory -> OKF v0.1 bundle
+
+Options (import):
+  --bundle <dir>      OKF bundle to read (required)
+  --out <dir>         Semantic layer output directory (default: ./semantic)
+  --name <name>       Catalog name for the draft (default: bundle directory name)
+  --force             Overwrite existing files in --out
+
+Options (export):
+  --semantic <dir>    Semantic layer to read (default: ./semantic)
+  --out <dir>         Bundle output directory (required)
+  --force             Write into a non-empty --out directory
+
+Examples:
+  atlas okf import --bundle ./ga4-bundle --out ./semantic
+  atlas okf export --semantic ./semantic --out ./okf-bundle
+
+Import produces DRAFTS: imported metric SQL is unverified prose until a human
+reviews it, and entity type/grain/measures are left for enrich/edit. Export
+notes what OKF cannot express (whitelist enforcement, pinned-metric authority,
+glossary ambiguity gating) - the data survives under the \`atlas:\` frontmatter
+extension, the runtime semantics do not.`;
+
+/** stdout/stderr sink — injected so tests can capture output. */
+export interface OkfIO {
+  readonly out: (line: string) => void;
+  readonly err: (line: string) => void;
+}
+
+const defaultIO: OkfIO = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+/** Recursively collect files under `root` (relative POSIX paths) with an extension filter. */
+function collectFiles(root: string, extensions: RegExp): InteropFile[] {
+  const files: InteropFile[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      // Skip dotfiles/dirs (.git, .orgs mirrors) — never part of a bundle or layer.
+      if (entry.name.startsWith(".")) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && extensions.test(entry.name)) {
+        files.push({
+          path: path.relative(root, full).split(path.sep).join("/"),
+          content: fs.readFileSync(full, "utf8"),
+        });
+      }
+    }
+  };
+  walk(root);
+  return files;
+}
+
+function writeFiles(outDir: string, files: InteropFile[]): void {
+  for (const file of files) {
+    const target = path.join(outDir, ...file.path.split("/"));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, file.content, "utf8");
+  }
+}
+
+function printReport(io: OkfIO, report: MappingReport): void {
+  if (report.lossy.length > 0) {
+    io.out("");
+    io.out(`Lossy mappings (${report.lossy.length}):`);
+    for (const l of report.lossy) io.out(`  ! ${l}`);
+  }
+  if (report.unmapped.length > 0) {
+    io.out("");
+    io.out(`Unmapped (${report.unmapped.length}):`);
+    for (const u of report.unmapped) io.out(`  x ${u}`);
+  }
+  if (report.notes.length > 0) {
+    io.out("");
+    io.out(`Notes (${report.notes.length}):`);
+    for (const n of report.notes) io.out(`  - ${n}`);
+  }
+}
+
+function runImport(args: string[], io: OkfIO): number {
+  const bundleDir = getFlag(args, "--bundle");
+  if (!bundleDir) {
+    io.err("Missing required --bundle <dir> (the OKF bundle to import).");
+    return 1;
+  }
+  if (!fs.existsSync(bundleDir) || !fs.statSync(bundleDir).isDirectory()) {
+    io.err(`Bundle directory not found: ${bundleDir}`);
+    return 1;
+  }
+  const outDir = getFlag(args, "--out") ?? "./semantic";
+  const force = args.includes("--force");
+  const bundleName = getFlag(args, "--name") ?? path.basename(path.resolve(bundleDir));
+
+  const bundleFiles = collectFiles(bundleDir, /\.md$/);
+  if (bundleFiles.length === 0) {
+    io.err(`No markdown files found in ${bundleDir} - not an OKF bundle.`);
+    return 1;
+  }
+
+  const { files, report } = importOkfBundle(bundleFiles, { bundleName });
+
+  if (!force) {
+    const collisions = files.filter((f) =>
+      fs.existsSync(path.join(outDir, ...f.path.split("/"))),
+    );
+    if (collisions.length > 0) {
+      io.err(
+        `Refusing to overwrite ${collisions.length} existing file(s) in ${outDir} ` +
+          `(first: ${collisions[0].path}). Re-run with --force to overwrite.`,
+      );
+      return 1;
+    }
+  }
+
+  writeFiles(outDir, files);
+  const entityCount = files.filter((f) => f.path.startsWith("entities/")).length;
+  io.out(`Imported OKF bundle ${bundleDir} -> ${outDir}`);
+  io.out(
+    `  ${entityCount} entities, ${files.length} files total. ` +
+      "Drafts only - review via scan -> enrich -> edit before publishing.",
+  );
+  printReport(io, report);
+  return 0;
+}
+
+function runExport(args: string[], io: OkfIO): number {
+  const outDir = getFlag(args, "--out");
+  if (!outDir) {
+    io.err("Missing required --out <dir> (where to write the OKF bundle).");
+    return 1;
+  }
+  const semanticDir = getFlag(args, "--semantic") ?? "./semantic";
+  if (!fs.existsSync(semanticDir) || !fs.statSync(semanticDir).isDirectory()) {
+    io.err(`Semantic layer directory not found: ${semanticDir}`);
+    return 1;
+  }
+  const force = args.includes("--force");
+  if (!force && fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
+    io.err(`Output directory ${outDir} is not empty. Re-run with --force to write anyway.`);
+    return 1;
+  }
+
+  const layerFiles = collectFiles(semanticDir, /\.ya?ml$/);
+  if (layerFiles.length === 0) {
+    io.err(`No YAML files found in ${semanticDir} - nothing to export.`);
+    return 1;
+  }
+
+  const { files, report } = exportToOkf(layerFiles, {
+    timestamp: new Date().toISOString(),
+  });
+  writeFiles(outDir, files);
+  const conceptCount = files.filter((f) => !f.path.endsWith("index.md")).length;
+  io.out(`Exported ${semanticDir} -> OKF bundle at ${outDir}`);
+  io.out(`  ${conceptCount} concept docs, ${files.length} files total.`);
+  printReport(io, report);
+  return 0;
+}
+
+/** Testable core — dispatches subcommands, returns the exit code. */
+export function runOkf(args: string[], io: OkfIO = defaultIO): number {
+  // args[0] is the command name ("okf"); the subcommand follows.
+  const sub = args[1];
+  if (sub === "import") return runImport(args, io);
+  if (sub === "export") return runExport(args, io);
+  if (sub === undefined || sub === "--help" || sub === "-h") {
+    io.out(USAGE);
+    return sub === undefined ? 1 : 0;
+  }
+  io.err(`Unknown okf subcommand: ${sub}\n`);
+  io.err(USAGE);
+  return 1;
+}
+
+/** Thin shell for bin/atlas.ts. */
+export async function handleOkf(args: string[]): Promise<void> {
+  const code = runOkf(args);
+  if (code !== 0) process.exit(code);
+}

--- a/packages/cli/src/commands/okf.ts
+++ b/packages/cli/src/commands/okf.ts
@@ -9,7 +9,9 @@
  *   (entities/glossary/metrics YAML); the scan -> enrich -> edit flow takes
  *   over from there. One-shot draft generator, NOT a maintained sync.
  * - `okf export`  — semantic layer directory -> conformant OKF bundle, with
- *   an `atlas:` frontmatter extension that makes re-import lossless.
+ *   an `atlas:` frontmatter extension that makes re-import lossless for
+ *   entity/glossary objects and metric fields (metric SQL is re-stamped
+ *   unverified on import — authority never travels through a bundle).
  *
  * Named `okf` (subcommand group) because bare `import` already means
  * "sync on-disk semantic YAML -> internal DB" (import.ts) and `migrate-import`
@@ -102,8 +104,10 @@ function collectFiles(root: string, extensions: RegExp): InteropFile[] {
  * that escapes it. The mapping engine validates names on its side; this is
  * the defense-in-depth sink guard (CLAUDE.md path-traversal rule) so no
  * future engine bug can turn an import into an arbitrary file write.
+ * Exported for direct tests — this layer only matters when the engine gate
+ * has regressed, a scenario end-to-end tests can't reach.
  */
-function resolveInside(outDir: string, relPath: string): string {
+export function resolveInside(outDir: string, relPath: string): string {
   const root = path.resolve(outDir);
   const target = path.resolve(root, ...relPath.split("/"));
   if (target !== root && !target.startsWith(root + path.sep)) {


### PR DESCRIPTION
## Summary

- **Mapping engine** (`packages/api/src/lib/semantic/okf/`): both directions of OKF v0.1 interop as pure functions over in-memory `{path, content}` file lists (fs-free, reusable by the future knowledge-connections ingest, #4182). Import: OKF bundle → first-draft entities/glossary/metrics YAML with `okf:` provenance. Export: semantic layer → conformant OKF bundle (prose bodies + `index.md` navigation) with an `atlas:` frontmatter extension that makes Atlas → OKF → Atlas re-import lossless for entity/glossary objects and metric fields.
- **CLI**: `atlas okf import --bundle <dir>` / `atlas okf export --out <dir>` subcommand group (bare `import` was taken per the triage note); file↔file only, so it stays in the published binary per ADR-0025.
- **Spike findings** (`docs/research/okf-interop-spike.md`): mapping table (clean vs lossy each way), round-trip fidelity, and the decisions — one-shot draft generator (not a maintained sync), core not plugin, no ADR until the `atlas:` extension becomes load-bearing.
- **Trust boundary** (from the internal review panel): bundles are third-party input — table names gate through `safeSemanticRowName` on both import paths plus a defense-in-depth sink guard in the CLI; **metric authority never transfers** (even forged `atlas.metric` restores are re-stamped `okf.unverified_sql: true`); every lossy/unmapped/duplicate drop lands in the printed mapping report, never silently.

Answers all six acceptance criteria on #4140; internal review panel ran 2 rounds → clean.

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — 57 tests: GA4-shaped foreign-bundle fixture, hostile-bundle traversal (engine + CLI sink guard), forged `atlas.metric`, round-trip deep-equality suite, malformed-input reporting, CLI command tests (temp-dir, injected IO)
- [ ] E2E tests added/updated — not applicable (spike; no server surface)

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — via `scripts/ci-local.sh`, all 27 gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — exploratory spike, not user-facing until productionized

Closes #4140

https://claude.ai/code/session_017aZKxHtWtbrpNubFywiq3f

---
_Generated by [Claude Code](https://claude.ai/code/session_017aZKxHtWtbrpNubFywiq3f)_