### PR TITLE
docs(adr): ADR-0028 — Knowledge Base is a fourth pillar (hosted OKF collections)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,7 +6,7 @@ When you find yourself reaching for one of these words, use the canonical form. 
 
 ## Pillars
 
-Atlas reaches the outside world in three distinct ways. A given **catalog row** fits in exactly one pillar; the split matters because the install lifecycle, credential storage, and admin UX differ across them. Some third-party *systems* span pillars by carrying multiple catalog rows — see "Multi-pillar systems" below.
+Atlas reaches the outside world in four distinct ways. A given **catalog row** fits in exactly one pillar; the split matters because the install lifecycle, credential storage, and admin UX differ across them. Some third-party *systems* span pillars by carrying multiple catalog rows — see "Multi-pillar systems" below.
 
 - **Datasource** — a third-party system Atlas *reads* tabular data from to answer questions. Configured in `/admin/connections`, queried by the agent via the `executeSQL` tool, backed by `semantic/entities/*.yml`. Examples: Postgres, MySQL, Snowflake, ClickHouse, BigQuery, DuckDB, Salesforce (SOQL).
   _Avoid_: Connector, "data source" (two words), "DB connection" (means the pool, not the third-party system).
@@ -17,6 +17,9 @@ Atlas reaches the outside world in three distinct ways. A given **catalog row** 
 - **Action Target** — a third-party system Atlas *writes to or acts on* (creates issues, sends emails, fires webhooks). The customer doesn't talk to Atlas through these; Atlas reaches out. Examples: GitHub, Linear, Email (SMTP), Webhooks.
   _Avoid_: "Outbound integration", "Action Integration". Bare "Integration" is ambiguous — it can mean a Chat Platform, an Action Target, or the umbrella over the latter two.
 
+- **Knowledge Base** — a third-party knowledge corpus Atlas *ingests descriptive context* from (business rules, runbooks, product definitions) to inform its answers. Content lands per-Workspace as **knowledge documents**, each owned by exactly one Knowledge Base install; it is descriptive only — never queried as data, never authoritative (see anti-confusions below). Knowledge documents scope to the Workspace, never to a Connection group — an entity describes a group's *schema*, a knowledge document describes the *business*. Examples: OKF bundle upload, Notion, Confluence.
+  _Avoid_: "knowledge connection" ("connection" is overloaded — see anti-confusions), "context source" ("source" is a deprecated alias for Connection group), "docs integration"; group-scoping knowledge documents (affinity is a `tags` concern).
+
 ### One user-facing surface per pillar
 
 A given third-party system appears on **exactly one** admin page, determined by its pillar:
@@ -24,6 +27,7 @@ A given third-party system appears on **exactly one** admin page, determined by 
 - Datasource → `/admin/connections`
 - Chat Platform → `/admin/integrations` (chat section)
 - Action Target → `/admin/integrations` (actions section)
+- Knowledge Base → `/admin/knowledge`
 
 The install **handler** it uses (OAuth, Form, Static-bot per "Install models" below) is orthogonal to the pillar. A Datasource can use OAuth (Salesforce), a Chat Platform can use Static-bot (Telegram), an Action Target can use Form (Webhook). Pillar determines *where it appears*; install handler determines *how credentials are obtained*. Conflating the two would put OAuth-installed Datasources on the integrations page just because OAuth is "where catalog cards live today" — that's an install-mechanism leak into user-facing taxonomy.
 
@@ -32,6 +36,8 @@ The install **handler** it uses (OAuth, Form, Static-bot per "Install models" be
 - "Salesforce integration" is ambiguous — Salesforce is a **Datasource** (read via SOQL), not an Action Target, even though it has an OAuth install dance that looks superficially like GitHub's. Its UI home is `/admin/connections`.
 - "GitHub integration" is ambiguous — GitHub is an **Action Target** (Atlas creates issues, comments). It is *not* a Chat Platform, even though CONTEXT.md historically lumped it in alongside Slack.
 - "Connection" is overloaded — say **Datasource** (the third-party system) or **Workspace Connection** (the chat OAuth handshake, defined below). Never just "connection" in glossary-relevant prose.
+- The **Knowledge Base** pillar is *descriptive*; the **semantic layer** is *authoritative*. Both are "context the agent reads," but a knowledge document never runs verbatim, never extends the table whitelist, and never gates the agent — the semantic layer (pinned metrics, glossary gating, whitelist) stays the sole authoritative context surface. This moat boundary is a property of the taxonomy, not a discipline of any one implementation.
+- "Notion/Confluence integration" is ambiguous and genuinely dual — the same system can be a **REST Datasource** (live `executeRestOperation` calls against the vendor API: always-current, but slow, rate-limited, and shaped by the vendor's API) or a **Knowledge Base** (content ingested as knowledge documents: indexed, searchable, review-gated — faster and more accurate for informing answers). Per the multi-pillar rule, that's one catalog row per (system, pillar); a customer can install both.
 
 ## Chat Platform mechanics
 
@@ -52,6 +58,16 @@ These four terms are distinct and frequently confused. Pin them.
 
 - "Slack integration" is ambiguous — disambiguate to App Registration (operator-side), Adapter (code), or Workspace Connection (customer-side).
 - "Adapter is enabled" is ambiguous — say either "Adapter has credentials wired" (deploy-level, operator-controlled) or "Workspace Connection exists" (workspace-level, customer-controlled).
+
+## Knowledge Base mechanics
+
+- **Collection** — the customer-facing unit of knowledge organization: a named, independently-searchable **hosted OKF bundle** (one tree, one root `index.md`). Realized as one Knowledge Base **Workspace Install** — the install id is the collection's slug (the datasource pillar's multi-instance pattern, not the chat/action singleton). A **knowledge document** belongs to exactly one collection; uploads upsert into the collection's tree by path. Typical split: one collection per product or corpus, so search can scope to one without wading through the others.
+  _Avoid_: "bundle" for the hosted thing (a bundle is the *interchange artifact* uploaded or exported; the collection is what Atlas hosts); conflating with **Connection group** (a SQL-only concept — collections never route queries).
+
+### Cardinality
+
+- Collections: `(Workspace, Knowledge Base catalog row) → many` (multi-instance, like datasource installs)
+- Knowledge documents: `document → 1 collection`
 
 ## Plugin lifecycle
 

--- a/docs/adr/0028-knowledge-base-fourth-pillar.md
+++ b/docs/adr/0028-knowledge-base-fourth-pillar.md
@@ -1,0 +1,61 @@
+# ADR-0028: Knowledge Base is a fourth pillar (hosted OKF collections)
+
+**Status:** Accepted
+**Date:** 2026-07-01
+**Context milestone:** v0.0.41 — Knowledge Base Pillar
+**Depends on:** [ADR-0006](./0006-three-pillar-integration-taxonomy.md), [ADR-0007](./0007-unified-install-pipeline.md)
+**Issues:** #4182 (design), #4140 (OKF interop spike, findings in [docs/research/okf-interop-spike.md](../research/okf-interop-spike.md))
+
+## Context
+
+Customers hold knowledge that informs data answers but isn't schema: business rules, runbooks, product definitions, deprecation notices. The OKF interop spike (#4140) made Atlas *speak* Google's [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog) at the file boundary; #4182 makes Atlas *host* it — ingesting a customer's knowledge base per SaaS Workspace as first-class agent context.
+
+Where does that live in the taxonomy? ADR-0006 established three mutually-exclusive pillars (Datasource / Chat Platform / Action Target), enforced by `plugin_catalog`'s pillar CHECK. A knowledge corpus is none of them: Atlas reads from it, but not tabular data via `executeSQL`; it is descriptive context only. Meanwhile the plugin SDK already carried a latent fourth kind — `PluginType` includes `"context"` with a `contextProvider` seam (used by `plugins/yaml-context`) — but that type predates the pillar taxonomy and has no pillar value, no admin surface, and no install lifecycle.
+
+A second question rode along: what does "hosting OKF" mean for the documents themselves? OKF's design principles are *just markdown, just files, indexable by any search tool, the same file with no translation layer*. Any hosting design that rewrites documents (wrapping them in trust envelopes, transforming them into a proprietary at-rest shape) forfeits those properties and the portability story with them.
+
+## Decision
+
+**1. Knowledge Base is a fourth pillar.** Catalog rows of type `context`, pillar `knowledge`, admin surface `/admin/knowledge` (one-surface-per-pillar rule). Definition: *a third-party knowledge corpus Atlas ingests descriptive context from — never queried as data, never authoritative*. The moat boundary — the semantic layer (whitelist, pinned metrics, glossary gating) is the **sole authoritative** context surface; Knowledge Base content is **descriptive only** — is now a property of the taxonomy rather than a discipline any one implementation must maintain. Nothing in a knowledge document ever runs verbatim, extends the table whitelist, or gates the agent.
+
+**2. Collection = Knowledge Base install = Atlas's hosted OKF bundle.** The knowledge pillar joins the *multi-instance* side of `workspace_plugins` (the datasource-pillar pattern: composite PK `(workspace_id, catalog_id, install_id)`, excluded from the `workspace_plugins_singleton` partial unique). Each install is a named **collection** (`install_id` is the slug): one hosted tree, one root `index.md`, independently searchable — one per product or corpus so the agent needn't wade through unrelated knowledge. Knowledge documents belong to exactly one collection; uploads upsert into the tree by path. Collections are **workspace-global, never group-scoped** — an entity describes a Connection group's *schema*; a knowledge document describes the *business*. Affinity ("this runbook concerns the EU replica") is a `tags` concern, not a structural FK.
+
+**3. Atlas hosts OKF verbatim.** Document bodies are stored and mirrored byte-identical to what was reviewed; the only Atlas addition is provenance under the `atlas:` frontmatter extension key (collection, ingest time, source) — spec-legal (OKF requires consumers to preserve unknown keys) and the same namespace the spike established for export. The agent reads collections with the base tools it already has — the sandboxed explore tool (`ls`/`cat`/`grep`) over the per-org, per-mode mirror (`.orgs/{orgId}/modes/{mode}/knowledge/<collection>/…`, the `semantic/sync.ts` dual-write pattern generalized) — walking `index.md` hierarchies as OKF intends. No `readDocument` tool, no viewer, no translation layer. Exporting a collection back to a bundle is the tree itself.
+
+**4. Injection hardening lives at the boundaries, not in the files.** Ingested third-party content is defended by: (a) the content-mode **draft→published review gate** — every ingest lands `draft`; a human saw the content before the non-admin agent path ever can; promotion happens only through the atomic publish endpoint (an "upload & publish" convenience runs that same endpoint in the same admin action; connector-synced content gets no such option and always queues for review); re-ingests that change a published document demote it to `draft`; (b) prompt framing — the explore tool description and system prompt declare the `knowledge/` subtree third-party descriptive content, never instructions, once; (c) structure — the read-only sandbox, and hard-boundary tests proving Knowledge Base content cannot reach the SQL whitelist, pinned metrics, or glossary gating.
+
+**5. v0 lifecycle.** One built-in catalog row, `okf-upload`: an **explicit, degenerate form install** — no credentials, minimal `config_schema`; installing creates the collection, ingest is a separate admin act (bundle upload → the spike's fs-free parser → `knowledge_documents` + `knowledge_links` rows, frontmatter and links extracted at ingest, caps via the settings registry). Uninstall archives the collection's documents (content-mode `archived`), never hard-deletes. Notion/Confluence connectors (OAuth installs, `INTEGRATION_TABLES` credentials, Scheduler sync), `searchKnowledge` (frontmatter filter / Postgres FTS / 1-hop link-graph), and embeddings are deliberate follow-ups; v0 search is grep-native, per the format.
+
+## Alternatives considered
+
+### Shoehorn into the Datasource pillar (rejected)
+
+`ConnectionRegistry` treats every `pillar = 'datasource'` install as a query-execution target; a Knowledge Base must never be one — that's the moat boundary. It would also put knowledge rows on `/admin/connections` under the wrong verb and force carve-outs at every site that filters on the pillar.
+
+### Extend the semantic layer instead of a new pillar (rejected)
+
+Blurs descriptive into authoritative. The semantic layer's value is precisely that everything in it is enforced (whitelist, pinned SQL, gating); mixing in unenforced third-party prose would make "is this authoritative?" a per-file question. Kept crisp by construction: separate pillar, separate tables, agent-visible as a separate subtree.
+
+### Skip the catalog for v0 — plain tables + an upload endpoint (rejected)
+
+v0's only ingest is a credential-less file upload, so the install machinery looks like ceremony. But it defers exactly the decision this ADR exists to make, and the Notion/Confluence follow-ups would retrofit lifecycle, credentials, and sync state onto an unregistered feature. The degenerate form install costs almost nothing and makes collections nameable from day one.
+
+### A new "upload" install model (rejected)
+
+The install-model enum is load-bearing across handler dispatch and admin UI. Static-bot is already documented as "a degenerate form-install"; an upload install is one step further along the same line. If connectors later reveal a real content-push pattern, name it when there's a second example.
+
+### Per-file provenance envelopes baked into the mirror (rejected)
+
+Wrapping mirrored documents in trust-boundary text breaks OKF's "same file, no translation layer" principle, invites delimiter-forgery (a document containing a fake end-of-envelope marker), and is theater next to the review gate — a determined injection mimics whatever framing wraps it. Provenance rides in `atlas:` frontmatter; trust posture rides in the tool/prompt framing and the review gate.
+
+### Group-scoped knowledge documents (rejected)
+
+The issue's "per-workspace group scoping (ADR-0012)" phrasing read two ways. Entities bind to Connection groups because members share a schema the entity describes; knowledge documents describe the business. ADR-0012 is reused for the *per-org mirror mechanics* only. A nullable group column is an easy additive migration if a real need emerges; unwinding a baked-in group FK is not.
+
+## Consequences
+
+- Migrations widen the `plugin_catalog` / `workspace_plugins` pillar CHECKs to admit `'knowledge'`; the knowledge pillar must stay out of the `workspace_plugins_singleton` partial unique (multi-instance is what makes collections possible).
+- `knowledge_documents` mirrors OKF frontmatter as real columns (`type`, `title`, `description`, `tags` jsonb, `timestamp`, `resource`) plus body, collection ownership, `atlas:` provenance, and a content-mode `status` column; `knowledge_links` holds the link graph extracted at ingest. Both are content-mode participants (draft counts, publish endpoint, dev-mode overlay — drafts are previewable through the agent in developer mode via the existing per-mode mirror).
+- The layered search roadmap (structured frontmatter filter → Postgres FTS → 1-hop graph expansion → embeddings) lands on these same rows later without re-ingestion; adopting it is a tool addition, not a storage change.
+- A multi-pillar anti-confusion enters the glossary: Notion/Confluence can be a **REST Datasource** (live vendor-API queries) *or* a **Knowledge Base** (ingested, indexed, review-gated context) — one catalog row per (system, pillar), a customer can install both.
+- CONTEXT.md gains the pillar entry, the Collection term, and the descriptive-vs-authoritative anti-confusion (updated alongside this ADR).


### PR DESCRIPTION
> *This was generated by AI during triage.*

Design resolution for #4182, produced by a triage + grill-with-docs session. Extends ADR-0006's three-pillar taxonomy with a fourth pillar.

## What's in here

- **docs/adr/0028-knowledge-base-fourth-pillar.md** — the decision record: Knowledge Base pillar (`type='context'`, pillar `'knowledge'`, `/admin/knowledge`), Collection = multi-instance install = hosted OKF bundle, workspace-global scoping, OKF-verbatim hosting (`atlas:` frontmatter is the only Atlas addition), boundary-level injection hardening (content-mode draft→published review gate as the primary defense), degenerate form install for the v0 `okf-upload` row. Six rejected alternatives recorded.
- **CONTEXT.md** — glossary updates: Knowledge Base pillar entry, `/admin/knowledge` in the one-surface-per-pillar list, new Knowledge Base mechanics section (Collection term + cardinality), two anti-confusions (descriptive-vs-authoritative moat boundary; Notion/Confluence as dual-pillar REST-Datasource-or-Knowledge-Base).

Satisfies the design-doc/ADR acceptance criterion of #4182. Implementation slices live in milestone v0.0.41 — Knowledge Base Pillar.

Refs #4182, #4140.