### PR TITLE
feat(knowledge): pillar foundation — knowledge pillar, okf-upload catalog, knowledge_documents/knowledge_links (#4206)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -13055,6 +13055,10 @@
                         "starterPrompts": {
                           "type": "integer",
                           "minimum": 0
+                        },
+                        "knowledgeDocuments": {
+                          "type": "integer",
+                          "minimum": 0
                         }
                       },
                       "required": [
@@ -13063,7 +13067,8 @@
                         "entityEdits",
                         "entityDeletes",
                         "prompts",
-                        "starterPrompts"
+                        "starterPrompts",
+                        "knowledgeDocuments"
                       ]
                     },
                     "draftActivity": {
@@ -13161,6 +13166,21 @@
                           "required": [
                             "lastEditedAt"
                           ]
+                        },
+                        "knowledgeDocuments": {
+                          "type": "object",
+                          "properties": {
+                            "lastEditedAt": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "format": "date-time"
+                            }
+                          },
+                          "required": [
+                            "lastEditedAt"
+                          ]
                         }
                       },
                       "required": [
@@ -13169,7 +13189,8 @@
                         "entityEdits",
                         "entityDeletes",
                         "prompts",
-                        "starterPrompts"
+                        "starterPrompts",
+                        "knowledgeDocuments"
                       ]
                     }
                   },

--- a/packages/api/src/api/routes/__tests__/mode.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode.test.ts
@@ -454,6 +454,24 @@ describe("GET /api/v1/mode — draft counts", () => {
     expect(unionCall).toContain("status = 'draft'");
   });
 
+  it("scopes the knowledge_documents activity segment by workspace_id, not org_id (#4206)", async () => {
+    // DRAFT_ACTIVITY_SQL is a hand-written route constant. The knowledge
+    // segment is the ONLY one keyed on `workspace_id` (every sibling uses
+    // `org_id`), so a copy-paste typo to `org_id` would 500 the endpoint at
+    // runtime (`column "org_id" does not exist`) while passing every
+    // registry-driven count assertion. Pin the segment's table + scope column.
+    await request("/api/v1/mode");
+    const calls = mockInternalQuery.mock.calls.map(([sql]) => String(sql));
+    // The activity query is the UNION that reports MAX(updated_at) per surface.
+    const activityCall = calls.find(
+      (sql) =>
+        sql.includes("MAX(updated_at)") && sql.includes("'knowledgeDocuments'"),
+    );
+    expect(activityCall).toBeDefined();
+    expect(activityCall).toContain("FROM knowledge_documents");
+    expect(activityCall).toContain("workspace_id = $1");
+  });
+
   it("returns draftCounts=null when no orgId is available", async () => {
     authenticated = true;
     currentAuthMode = "managed";

--- a/packages/api/src/api/routes/mode.ts
+++ b/packages/api/src/api/routes/mode.ts
@@ -64,6 +64,7 @@ const DraftCountsSchema = z.object({
   entityDeletes: z.number().int().nonnegative(),
   prompts: z.number().int().nonnegative(),
   starterPrompts: z.number().int().nonnegative(),
+  knowledgeDocuments: z.number().int().nonnegative(),
 });
 
 const DraftSurfaceActivitySchema = z.object({
@@ -77,6 +78,7 @@ const DraftActivitySchema = z.object({
   entityDeletes: DraftSurfaceActivitySchema,
   prompts: DraftSurfaceActivitySchema,
   starterPrompts: DraftSurfaceActivitySchema,
+  knowledgeDocuments: DraftSurfaceActivitySchema,
 });
 
 const ModeStatusSchema = z.object({
@@ -141,7 +143,8 @@ function totalDrafts(counts: ModeDraftCounts): number {
     counts.entityEdits +
     counts.entityDeletes +
     counts.prompts +
-    counts.starterPrompts
+    counts.starterPrompts +
+    counts.knowledgeDocuments
   );
 }
 
@@ -178,6 +181,9 @@ const DRAFT_ACTIVITY_SQL = `
   UNION ALL
   SELECT 'starterPrompts' AS key, MAX(updated_at) AS at FROM query_suggestions
    WHERE org_id = $1 AND status = 'draft'
+  UNION ALL
+  SELECT 'knowledgeDocuments' AS key, MAX(updated_at) AS at FROM knowledge_documents
+   WHERE workspace_id = $1 AND status = 'draft'
 `;
 
 /**
@@ -205,6 +211,7 @@ const ACTIVITY_SURFACE_KEYS = [
   "entityDeletes",
   "prompts",
   "starterPrompts",
+  "knowledgeDocuments",
 ] as const satisfies ReadonlyArray<keyof ModeDraftActivity>;
 
 function buildDraftActivity(

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -449,6 +449,12 @@ describe("migrateAuthTables", () => {
             // (ADR-0027 §6, #4046); ALTERs the Atlas-internal audit_log, no FK to
             // a Better Auth table, so it runs in every auth mode — must be listed.
             { name: "0160_audit_log_actor_kind_api_key.sql" },
+            // 0161–0163 (#4206, ADR-0028) — pillar CHECK widen +
+            // knowledge_documents / knowledge_links. Atlas-internal tables, no
+            // FK to a Better Auth table, so they run in every auth mode.
+            { name: "0161_knowledge_pillar_check.sql" },
+            { name: "0162_knowledge_documents.sql" },
+            { name: "0163_knowledge_links.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/content-mode/__tests__/registry.test.ts
+++ b/packages/api/src/lib/content-mode/__tests__/registry.test.ts
@@ -276,6 +276,7 @@ describe("ContentModeRegistry.countAllDrafts", () => {
       entities: 0,
       entityEdits: 0,
       entityDeletes: 0,
+      knowledgeDocuments: 0,
     });
     // Every `$N` token in the query must be `$1` — the registry passes a
     // single orgId param; a future exotic segment that introduces `$2`
@@ -410,14 +411,16 @@ describe("ContentModeRegistry.countAllDrafts", () => {
 describe("ContentModeRegistry.runPublishPhases", () => {
   it("invokes simple adapters in tuple order followed by semantic_entities tombstone+promote", async () => {
     // Production tuple flow (phase 2d of #1515):
-    // 1. connections       → UPDATE (1 SQL)
-    // 2. prompt_collections → UPDATE (1 SQL)
-    // 3. query_suggestions  → UPDATE (1 SQL)
-    // 4. semantic_entities  → applyTombstones (2 SQL) + promoteDraftEntities (2 SQL)
+    // 1. connections         → UPDATE (1 SQL)
+    // 2. prompt_collections  → UPDATE (1 SQL)
+    // 3. query_suggestions   → UPDATE (1 SQL)
+    // 4. knowledge_documents → UPDATE (1 SQL)  [#4206]
+    // 5. semantic_entities   → applyTombstones (2 SQL) + promoteDraftEntities (2 SQL)
     const { client, calls } = makeMockPoolClient([
       { rowCount: 3 }, // connections
       { rowCount: 2 }, // prompt_collections
       { rowCount: 1 }, // query_suggestions
+      { rowCount: 0 }, // knowledge_documents (#4206 — no ingest yet, promotes 0)
       // semantic_entities.applyTombstones:
       { rows: [{ id: "e1" }, { id: "e2" }], rowCount: 2 }, //   DELETE published via tombstone join
       { rowCount: 2 }, //                                        DELETE tombstones
@@ -443,24 +446,27 @@ describe("ContentModeRegistry.runPublishPhases", () => {
       "workspace_plugins",
       "prompt_collections",
       "query_suggestions",
+      "knowledge_documents",
       "semantic_entities",
     ]);
     expect(reports[0].promoted).toBe(3);
     expect(reports[1].promoted).toBe(2);
     expect(reports[2].promoted).toBe(1);
+    expect(reports[3].promoted).toBe(0); // knowledge_documents (#4206)
     // semantic_entities report composes both phases' counts.
-    expect(reports[3].promoted).toBe(3);
-    expect(reports[3].tombstonesApplied).toBe(2);
+    expect(reports[4].promoted).toBe(3);
+    expect(reports[4].tombstonesApplied).toBe(2);
 
-    expect(calls).toHaveLength(7);
+    expect(calls).toHaveLength(8);
     expect(calls[0].sql).toContain("UPDATE workspace_plugins");
     expect(calls[1].sql).toContain("UPDATE prompt_collections");
     expect(calls[2].sql).toContain("UPDATE query_suggestions");
+    expect(calls[3].sql).toContain("UPDATE knowledge_documents");
     // Tombstones before promote.
-    expect(calls[3].sql).toContain("draft_delete");
     expect(calls[4].sql).toContain("draft_delete");
-    expect(calls[5].sql).toMatch(/DELETE FROM semantic_entities/);
-    expect(calls[6].sql).toContain("UPDATE semantic_entities");
+    expect(calls[5].sql).toContain("draft_delete");
+    expect(calls[6].sql).toMatch(/DELETE FROM semantic_entities/);
+    expect(calls[7].sql).toContain("UPDATE semantic_entities");
     for (const c of calls) expect(c.params).toEqual(["org-1"]);
   });
 

--- a/packages/api/src/lib/content-mode/tables.ts
+++ b/packages/api/src/lib/content-mode/tables.ts
@@ -43,6 +43,18 @@ export const CONTENT_MODE_TABLES = [
   },
   { kind: "simple", key: "prompts", table: "prompt_collections" },
   { kind: "simple", key: "starterPrompts", table: "query_suggestions" },
+  // #4206 / ADR-0028 — hosted OKF knowledge documents. Every ingest lands
+  // `draft` (the review gate); the atomic publish endpoint promotes them and
+  // the non-admin agent read gates on `status='published'`. `workspace_id` is
+  // the org scope (workspace-global, never group-scoped). `knowledge_links` is
+  // NOT registered — a link's visibility follows its source document, so it is
+  // content-mode-exempt derived data (see migration 0163).
+  {
+    kind: "simple",
+    key: "knowledgeDocuments",
+    table: "knowledge_documents",
+    orgColumn: "workspace_id",
+  },
   {
     kind: "exotic",
     key: "semantic_entities",

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3045,6 +3045,157 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     );
     expect(remaining.rowCount).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
+
+  // ─────────────────────────────────────────────────────────────────────
+  // 0161–0163 — Knowledge Base pillar foundation (#4206, ADR-0028)
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("0161: plugin_catalog + workspace_plugins pillar CHECKs admit 'knowledge' (#4206)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const catalogId = `catalog:kb-${stamp}`;
+    const slug = `kb-${stamp}`;
+    // A knowledge-pillar catalog row is now legal.
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, install_model, pillar)
+       VALUES ($1, 'KB test', $2, 'context', 'form', 'knowledge')`,
+      [catalogId, slug],
+    );
+    // …and a knowledge-pillar install of it.
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar)
+       VALUES ($1, $2, $3, 'my-collection', 'knowledge')`,
+      [`wp-${stamp}`, `ws-${stamp}`, catalogId],
+    );
+    const { rows } = await pool.query<{ pillar: string }>(
+      `SELECT pillar FROM workspace_plugins WHERE catalog_id = $1`,
+      [catalogId],
+    );
+    expect(rows[0]?.pillar).toBe("knowledge");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0161: an unknown pillar is still rejected by the widened CHECK (#4206)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    let err: Error | null = null;
+    try {
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, install_model, pillar)
+         VALUES ($1, 'bad pillar', $2, 'context', 'form', 'nonsense')`,
+        [`catalog:bad-${stamp}`, `bad-${stamp}`],
+      );
+    } catch (e) {
+      err = e instanceof Error ? e : new Error(String(e));
+    }
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/chk_plugin_catalog_pillar|23514|check constraint/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0161: workspace_plugins_singleton does NOT cover 'knowledge' — collections are multi-instance (#4206)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const catalogId = `catalog:kbmulti-${stamp}`;
+    const workspaceId = `ws-multi-${stamp}`;
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, install_model, pillar)
+       VALUES ($1, 'KB multi', $2, 'context', 'form', 'knowledge')`,
+      [catalogId, `kbmulti-${stamp}`],
+    );
+    // Two installs of the SAME (workspace, catalog) with distinct install_ids —
+    // the datasource-pillar pattern. This is what makes multiple collections
+    // per workspace possible; the singleton partial unique must not reject it.
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar) VALUES
+         ($1, $3, $4, 'runbooks', 'knowledge'),
+         ($2, $3, $4, 'product-docs', 'knowledge')`,
+      [`wp-a-${stamp}`, `wp-b-${stamp}`, workspaceId, catalogId],
+    );
+    const { rows } = await pool.query<{ n: string }>(
+      `SELECT COUNT(*)::text AS n FROM workspace_plugins
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, catalogId],
+    );
+    expect(rows[0]?.n).toBe("2");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0162: knowledge_documents defaults status to 'draft' and enforces the status CHECK (#4206)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-doc-${stamp}`;
+    const { rows } = await pool.query<{ status: string; tags: unknown }>(
+      `INSERT INTO knowledge_documents (workspace_id, collection_id, path, body)
+       VALUES ($1, 'runbooks', 'index.md', '# Index')
+       RETURNING status, tags`,
+      [ws],
+    );
+    // Content-mode default: every ingest lands draft (the review gate).
+    expect(rows[0]?.status).toBe("draft");
+    // tags defaults to an empty JSON array.
+    expect(rows[0]?.tags).toEqual([]);
+
+    let err: Error | null = null;
+    try {
+      await pool.query(
+        `INSERT INTO knowledge_documents (workspace_id, collection_id, path, body, status)
+         VALUES ($1, 'runbooks', 'other.md', 'x', 'live')`,
+        [ws],
+      );
+    } catch (e) {
+      err = e instanceof Error ? e : new Error(String(e));
+    }
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/chk_knowledge_documents_status|23514|check constraint/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0162: knowledge_documents path is unique per collection, not per workspace (#4206)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-uniq-${stamp}`;
+    // Same path in two DIFFERENT collections of the same workspace is allowed.
+    await pool.query(
+      `INSERT INTO knowledge_documents (workspace_id, collection_id, path, body) VALUES
+         ($1, 'coll-a', 'index.md', 'A'),
+         ($1, 'coll-b', 'index.md', 'B')`,
+      [ws],
+    );
+    // Re-inserting the same (workspace, collection, path) collides.
+    let err: Error | null = null;
+    try {
+      await pool.query(
+        `INSERT INTO knowledge_documents (workspace_id, collection_id, path, body)
+         VALUES ($1, 'coll-a', 'index.md', 'dupe')`,
+        [ws],
+      );
+    } catch (e) {
+      err = e instanceof Error ? e : new Error(String(e));
+    }
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(/uq_knowledge_documents_collection_path|23505|unique/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0163: knowledge_links cascade-delete with the source document; target_path is not a FK (#4206)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-link-${stamp}`;
+    const doc = await pool.query<{ id: string }>(
+      `INSERT INTO knowledge_documents (workspace_id, collection_id, path, body)
+       VALUES ($1, 'runbooks', 'a.md', 'A') RETURNING id`,
+      [ws],
+    );
+    const sourceId = doc.rows[0]?.id as string;
+    // target_path may point at a not-yet-ingested path — no FK enforcement.
+    await pool.query(
+      `INSERT INTO knowledge_links (source_document_id, target_path, anchor_text)
+       VALUES ($1, 'not/ingested/yet.md', 'see also')`,
+      [sourceId],
+    );
+    const before = await pool.query(
+      `SELECT 1 FROM knowledge_links WHERE source_document_id = $1`,
+      [sourceId],
+    );
+    expect(before.rowCount).toBe(1);
+    // Deleting the source document cascades its edges away.
+    await pool.query(`DELETE FROM knowledge_documents WHERE id = $1`, [sourceId]);
+    const after = await pool.query(
+      `SELECT 1 FROM knowledge_links WHERE source_document_id = $1`,
+      [sourceId],
+    );
+    expect(after.rowCount).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
 });
 
 // #2606 — source-level revert guard for the integration-store SQL formatter.

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -196,7 +196,13 @@ describe("runMigrations", () => {
     //   phase-2 two-phase drop, #4013) = 160.
     //   Plus 0160 (audit_log.actor_kind CHECK gains 'api_key' for the
     //   workspace-scoped API key, ADR-0027 §6, #4046) = 161.
-    expect(count).toBe(161);
+    //   Plus 0161 (widen plugin_catalog + workspace_plugins pillar CHECKs to
+    //   admit the fourth pillar 'knowledge', ADR-0028, #4206) = 162.
+    //   Plus 0162 (knowledge_documents hosted-OKF document store, ADR-0028,
+    //   #4206) = 163.
+    //   Plus 0163 (knowledge_links intra-collection link graph, ADR-0028,
+    //   #4206) = 164.
+    expect(count).toBe(164);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -386,6 +392,9 @@ describe("runMigrations", () => {
         "0158_session_origin_column.sql",
         "0159_drop_user_stripe_customer_id.sql",
         "0160_audit_log_actor_kind_api_key.sql",
+        "0161_knowledge_pillar_check.sql",
+        "0162_knowledge_documents.sql",
+        "0163_knowledge_links.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the built-in Knowledge Base catalog seed pass (#4206, ADR-0028).
+ *
+ * Two surfaces under test:
+ *
+ *  1. `seedBuiltinKnowledgeCatalog(db)` — the runtime seeder. Asserts the single
+ *     `okf-upload` row is inserted with `ON CONFLICT DO NOTHING` semantics
+ *     through the operator-curated seam, with the ADR-0028 §5 shape (type
+ *     `context`, pillar `knowledge`, install_model `form`, no credentials).
+ *
+ *  2. `BUILTIN_KNOWLEDGE_CATALOG_ROW` — the in-process source of truth. Asserts
+ *     content-level invariants.
+ *
+ * The migration/CHECK interaction is checked end-to-end by `migrate-pg.test.ts`
+ * against a real Postgres; here we exercise the boot-time seed against an
+ * in-memory mock pool.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+  seedBuiltinKnowledgeCatalog,
+  BUILTIN_KNOWLEDGE_CATALOG_ROW,
+  type BuiltinKnowledgeCatalogSeedDb,
+} from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const captureDb = (
+  insertedSlugs: ReadonlyArray<string> = [BUILTIN_KNOWLEDGE_CATALOG_ROW.slug],
+): { db: BuiltinKnowledgeCatalogSeedDb; captured: CapturedQuery[] } => {
+  const captured: CapturedQuery[] = [];
+  const db: BuiltinKnowledgeCatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      captured.push({ sql, params: params ?? [] });
+      return { rows: insertedSlugs.map((slug) => ({ slug })) as T[] };
+    },
+  };
+  return { db, captured };
+};
+
+describe("BUILTIN_KNOWLEDGE_CATALOG_ROW", () => {
+  it("is the credential-less `okf-upload` form install (ADR-0028 §5)", () => {
+    const row = BUILTIN_KNOWLEDGE_CATALOG_ROW;
+    expect(row.slug).toBe("okf-upload");
+    expect(row.id).toBe("catalog:okf-upload");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    // No credentials: no field is flagged secret.
+    expect(row.configSchema.every((f) => f.secret !== true)).toBe(true);
+  });
+
+  it("uses the `catalog:<slug>` id convention", () => {
+    expect(BUILTIN_KNOWLEDGE_CATALOG_ROW.id).toBe(
+      `catalog:${BUILTIN_KNOWLEDGE_CATALOG_ROW.slug}`,
+    );
+  });
+});
+
+describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
+  it("issues a single INSERT with type 'context' and pillar 'knowledge'", async () => {
+    const { db, captured } = captureDb();
+    await seedBuiltinKnowledgeCatalog(db);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("INSERT INTO plugin_catalog");
+    expect(captured[0]!.sql).toContain("'context'");
+    expect(captured[0]!.sql).toContain("'knowledge'");
+    // Unqualified ON CONFLICT DO NOTHING covers both the slug unique index
+    // AND the id PK (mirrors the datasource seed's edge-case handling).
+    expect(captured[0]!.sql).toContain("ON CONFLICT DO NOTHING");
+    expect(captured[0]!.sql).not.toContain("ON CONFLICT (slug)");
+    expect(captured[0]!.sql).toContain("RETURNING slug");
+  });
+
+  it("binds the row's 8 params and serializes config_schema as JSON", async () => {
+    const { db, captured } = captureDb();
+    await seedBuiltinKnowledgeCatalog(db);
+    expect(captured[0]!.params).toHaveLength(8);
+    const configParam = captured[0]!.params[7];
+    expect(typeof configParam).toBe("string");
+    expect(JSON.parse(configParam as string)).toEqual(
+      BUILTIN_KNOWLEDGE_CATALOG_ROW.configSchema,
+    );
+  });
+
+  it("reports inserted on a fresh catalog and preserved on a re-boot", async () => {
+    const fresh = await seedBuiltinKnowledgeCatalog(captureDb().db);
+    expect(fresh.inserted).toBe(true);
+    // Empty RETURNING = row already existed (ON CONFLICT DO NOTHING path).
+    const reboot = await seedBuiltinKnowledgeCatalog(captureDb([]).db);
+    expect(reboot.inserted).toBe(false);
+  });
+
+  it("propagates DB errors instead of swallowing them", async () => {
+    const failing: BuiltinKnowledgeCatalogSeedDb = {
+      async query() {
+        throw new Error("simulated pg error");
+      },
+    };
+    await expect(seedBuiltinKnowledgeCatalog(failing)).rejects.toThrow(
+      /simulated pg error/,
+    );
+  });
+});
+
+describe("runBuiltinKnowledgeCatalogSeedBoot (discriminated outcomes)", () => {
+  const mockQuery = mock<
+    (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+  >(() => Promise.resolve({ rows: [{ slug: "okf-upload" }] }));
+
+  let hasInternalDBReturns = true;
+
+  mock.module("@atlas/api/lib/db/internal", () => ({
+    hasInternalDB: () => hasInternalDBReturns,
+    getInternalDB: () => ({ query: mockQuery }),
+    _resetEncryptionKeyCache: () => {},
+  }));
+
+  afterEach(() => {
+    mockQuery.mockClear();
+    hasInternalDBReturns = true;
+  });
+
+  it("returns `{ kind: 'skipped' }` when no internal DB is configured", async () => {
+    hasInternalDBReturns = false;
+    const { runBuiltinKnowledgeCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-knowledge-catalog"
+    );
+    const result = await runBuiltinKnowledgeCatalogSeedBoot();
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") expect(result.reason).toBe("no-internal-db");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns `{ kind: 'seeded', inserted: true }` on a successful insert", async () => {
+    hasInternalDBReturns = true;
+    mockQuery.mockImplementation(() =>
+      Promise.resolve({ rows: [{ slug: "okf-upload" }] }),
+    );
+    const { runBuiltinKnowledgeCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-knowledge-catalog"
+    );
+    const result = await runBuiltinKnowledgeCatalogSeedBoot();
+    expect(result.kind).toBe("seeded");
+    if (result.kind === "seeded") expect(result.inserted).toBe(true);
+  });
+
+  it("returns `{ kind: 'error' }` when the pool query throws", async () => {
+    hasInternalDBReturns = true;
+    mockQuery.mockImplementation(() =>
+      Promise.reject(new Error("simulated pg failure")),
+    );
+    const { runBuiltinKnowledgeCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-knowledge-catalog"
+    );
+    const result = await runBuiltinKnowledgeCatalogSeedBoot();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("simulated pg failure");
+    }
+  });
+});

--- a/packages/api/src/lib/db/migrations/0161_knowledge_pillar_check.sql
+++ b/packages/api/src/lib/db/migrations/0161_knowledge_pillar_check.sql
@@ -1,0 +1,35 @@
+-- Migration 0161: admit 'knowledge' to the pillar taxonomy (#4206, ADR-0028).
+--
+-- The Knowledge Base is Atlas's fourth pillar (ADR-0028): catalog rows of type
+-- `context`, pillar `knowledge`, hosting review-gated OKF collections as
+-- descriptive agent context. This migration widens the two pillar CHECKs that
+-- ADR-0006's three-pillar taxonomy pinned in migration 0092 so
+-- `plugin_catalog` and `workspace_plugins` rows may carry `pillar = 'knowledge'`.
+--
+-- Widening a CHECK with one more allowed value is expand-only —
+-- backward-compatible and single-release safe (old code never writes
+-- `knowledge`; new code does; a reader sees a plain string either way). Same
+-- idempotent DROP-IF-EXISTS-then-re-ADD shape as 0092 (which created these
+-- constraints) and 0160 (the most recent CHECK widen).
+--
+-- Deliberately NOT touched: the `workspace_plugins_singleton` partial unique
+-- from 0092 is `WHERE pillar IN ('chat', 'action')`, so it already excludes
+-- `knowledge` — exactly like `datasource`. That exclusion is what makes
+-- collections possible: multiple knowledge installs per (workspace, catalog),
+-- one per corpus (ADR-0028 §2). Adding `knowledge` to the singleton would break
+-- the multi-instance invariant, so it stays out.
+--
+-- Mirrored in db/schema.ts (`chk_plugin_catalog_pillar` /
+-- `chk_workspace_plugins_pillar`) in the same commit.
+
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS chk_plugin_catalog_pillar;
+ALTER TABLE plugin_catalog
+  ADD CONSTRAINT chk_plugin_catalog_pillar
+  CHECK (pillar IN ('datasource', 'chat', 'action', 'knowledge'));
+
+ALTER TABLE workspace_plugins
+  DROP CONSTRAINT IF EXISTS chk_workspace_plugins_pillar;
+ALTER TABLE workspace_plugins
+  ADD CONSTRAINT chk_workspace_plugins_pillar
+  CHECK (pillar IN ('datasource', 'chat', 'action', 'knowledge'));

--- a/packages/api/src/lib/db/migrations/0162_knowledge_documents.sql
+++ b/packages/api/src/lib/db/migrations/0162_knowledge_documents.sql
@@ -1,0 +1,92 @@
+-- 0162: knowledge_documents — hosted OKF documents, one row per file in a
+-- collection's bundle tree (#4206, ADR-0028).
+--
+-- A *collection* is a Knowledge Base install (a `workspace_plugins` row,
+-- pillar `knowledge`, whose `install_id` is the collection slug). Each document
+-- belongs to exactly one collection and is addressed by its bundle `path`
+-- (e.g. `runbooks/eu-replica.md`). Documents are WORKSPACE-GLOBAL, never
+-- group-scoped: an entity describes a Connection group's schema; a knowledge
+-- document describes the business (ADR-0028 §2, "Group-scoped … rejected").
+--
+-- Atlas hosts OKF verbatim (ADR-0028 §3): the OKF frontmatter fields land as
+-- real columns (`type`, `title`, `description`, `tags`, `timestamp`, `resource`)
+-- and the markdown lands byte-identical in `body`. The only Atlas addition is
+-- provenance under the `atlas:` frontmatter extension key — the collection
+-- (already `collection_id`), the ingest source, and the ingest time
+-- (`atlas_source` / `atlas_ingested_at`).
+--
+-- CONTENT-MODE PARTICIPANT (ADR-0028 §4): every ingest lands `draft` so a human
+-- reviews third-party content before the non-admin agent path can read it;
+-- promotion happens only through the atomic publish endpoint. The `status`
+-- column + CHECK + default `draft` opt this table into the ContentModeRegistry
+-- (see docs/development/content-mode.md); `updated_at` is required by the
+-- registry's simple promote UPDATE. Ingest, serving, and search are follow-up
+-- slices — this migration is schema only.
+--
+-- No credentials / no INTEGRATION_TABLES entry: the v0 `okf-upload` install is
+-- a credential-less form install (ADR-0028 §5); connectors arrive later.
+--
+-- Drizzle-managed (mirrored in db/schema.ts as `knowledgeDocuments`, same
+-- commit). Additive CREATE only — no DROP, so no two-phase-drop discipline
+-- applies; the mirror lands in the same commit so a later `drizzle-kit
+-- generate` can't emit a DROP. `workspace_id` / `collection_id` are TEXT with
+-- no FK, matching the org-scoped Atlas tables (conversations / settings /
+-- semantic_entities) and the composite-PK `workspace_plugins` install ref.
+
+CREATE TABLE IF NOT EXISTS knowledge_documents (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Better-Auth organization id. Workspace-global scope (never a group FK).
+  workspace_id   TEXT NOT NULL,
+  -- The owning collection = the `workspace_plugins.install_id` slug of the
+  -- knowledge install. No composite FK: workspace_plugins' PK carries a
+  -- `catalog_id` this table doesn't need to name, and the singleton unique
+  -- excludes the knowledge pillar. Referential integrity is the ingest slice's
+  -- job; this is the install ref (ADR-0028 §2).
+  collection_id  TEXT NOT NULL,
+  -- Bundle path within the collection tree, unique PER COLLECTION (not per
+  -- workspace) — the same `index.md` may exist in two collections. Uploads
+  -- upsert into the tree by this path.
+  path           TEXT NOT NULL,
+  -- OKF frontmatter, stored verbatim as real columns.
+  type           TEXT,
+  title          TEXT,
+  description    TEXT,
+  tags           JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- OKF `timestamp` frontmatter field (the document's own timestamp), distinct
+  -- from Atlas's ingest bookkeeping below. Quoted because `timestamp` is a
+  -- Postgres type keyword.
+  "timestamp"    TIMESTAMPTZ,
+  resource       TEXT,
+  -- The markdown body, byte-identical to what was reviewed (ADR-0028 §3).
+  body           TEXT NOT NULL,
+  -- `atlas:` frontmatter provenance extension (spec-legal unknown key).
+  atlas_source   TEXT,
+  atlas_ingested_at TIMESTAMPTZ,
+  -- Content-mode lifecycle. Defaults `draft` — the review gate (ADR-0028 §4).
+  status         TEXT NOT NULL DEFAULT 'draft',
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT chk_knowledge_documents_status
+    CHECK (status IN ('draft', 'published', 'archived')),
+  -- `path` is unique per collection, not per workspace (ADR-0028 §2).
+  CONSTRAINT uq_knowledge_documents_collection_path
+    UNIQUE (workspace_id, collection_id, path)
+);
+
+COMMENT ON TABLE knowledge_documents IS
+  'Hosted OKF documents (ADR-0028). One row per file in a collection bundle tree; workspace-global, owned by one collection via collection_id. Content-mode participant — every ingest lands draft, promoted only via the atomic publish endpoint.';
+
+-- Per-collection tree walks (a collection's documents) and per-tenant scans.
+CREATE INDEX IF NOT EXISTS idx_knowledge_documents_collection
+  ON knowledge_documents (workspace_id, collection_id);
+
+-- Content-mode status filter (mirrors idx_workspace_plugins_status): the
+-- non-admin published-only read and the developer-mode overlay both scope by
+-- (workspace_id, status).
+CREATE INDEX IF NOT EXISTS idx_knowledge_documents_status
+  ON knowledge_documents (workspace_id, status);
+
+-- GIN over the OKF `tags` array for the frontmatter-filter search layer
+-- (ADR-0028 §5 — "structured frontmatter filter" is the first search tier).
+CREATE INDEX IF NOT EXISTS idx_knowledge_documents_tags
+  ON knowledge_documents USING gin (tags);

--- a/packages/api/src/lib/db/migrations/0163_knowledge_links.sql
+++ b/packages/api/src/lib/db/migrations/0163_knowledge_links.sql
@@ -1,0 +1,48 @@
+-- 0163: knowledge_links — the intra-collection link graph extracted at ingest
+-- (#4206, ADR-0028).
+--
+-- One row per markdown link found in a source document: (source document,
+-- target path, anchor text). Populated by the ingest slice — the frontmatter
+-- and links are extracted once, at ingest, from the fs-free OKF parser (ADR-0028
+-- §5). The graph backs the layered-search roadmap's "1-hop link-graph
+-- expansion" tier without re-ingestion (ADR-0028 §Consequences); v0 search is
+-- grep-native and does not read this table yet. This migration is schema only.
+--
+-- `target_path` is a bundle path string, NOT a FK to knowledge_documents.id: a
+-- link may point at a path that isn't ingested yet (or a broken link), so the
+-- edge is resolved lazily at query time, never enforced at write time.
+--
+-- CONTENT-MODE EXEMPT: a link is derived data, not user-authored content. Its
+-- visibility follows its source document (the content-mode participant); a link
+-- has nothing of its own to draft/publish/archive. So it deliberately omits the
+-- `status` column + ContentModeRegistry filtering — see
+-- docs/development/content-mode.md "Carve-outs must be explicit and justified".
+-- Cascade-deleting with the source document keeps the graph consistent when a
+-- document is re-ingested (the ingest slice deletes-then-reinserts a document's
+-- edges).
+--
+-- Drizzle-managed (mirrored in db/schema.ts as `knowledgeLinks`, same commit).
+-- Additive CREATE only — no DROP, so no two-phase-drop discipline applies.
+
+CREATE TABLE IF NOT EXISTS knowledge_links (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- The document the link was found in. Cascade so a document's edges vanish
+  -- with it (re-ingest = delete document → its links go too).
+  source_document_id UUID NOT NULL REFERENCES knowledge_documents(id) ON DELETE CASCADE,
+  -- The bundle path the link points at — a plain string, resolved lazily. Not a
+  -- FK: the target may not be ingested (yet) or may be a dangling link.
+  target_path        TEXT NOT NULL,
+  -- The link's anchor text, if any.
+  anchor_text        TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE knowledge_links IS
+  'Intra-collection link graph extracted at ingest (ADR-0028). Edges of (source_document_id, target_path, anchor_text). Content-mode-exempt: derived data whose visibility follows its source document. target_path is a lazily-resolved path string, not a FK.';
+
+-- Outbound edges of a document (the common walk direction) and inbound
+-- resolution by path (which documents link to this path).
+CREATE INDEX IF NOT EXISTS idx_knowledge_links_source
+  ON knowledge_links (source_document_id);
+CREATE INDEX IF NOT EXISTS idx_knowledge_links_target
+  ON knowledge_links (target_path);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1631,7 +1631,9 @@ export const pluginCatalog = pgTable(
       .where(sql`enabled = true`),
     check("chk_plugin_catalog_type", sql`type IN ('datasource', 'context', 'interaction', 'action', 'sandbox', 'chat', 'integration')`),
     check("chk_plugin_catalog_install_model", sql`install_model IN ('oauth', 'form', 'static-bot', 'oauth-datasource')`),
-    check("chk_plugin_catalog_pillar", sql`pillar IN ('datasource', 'chat', 'action')`),
+    // 0161 / #4206 / ADR-0028 — widened to admit the fourth pillar `knowledge`
+    // (hosted OKF collections). Kept in lockstep with migration 0161.
+    check("chk_plugin_catalog_pillar", sql`pillar IN ('datasource', 'chat', 'action', 'knowledge')`),
     check("chk_plugin_catalog_implementation_status", sql`implementation_status IN ('available', 'coming_soon')`),
   ],
 );
@@ -1732,8 +1734,103 @@ export const workspacePlugins = pgTable(
     index("idx_workspace_plugins_workspace").on(t.workspaceId),
     index("idx_workspace_plugins_catalog").on(t.catalogId),
     index("idx_workspace_plugins_status").on(t.workspaceId, t.status),
-    check("chk_workspace_plugins_pillar", sql`pillar IN ('datasource', 'chat', 'action')`),
+    // 0161 / #4206 / ADR-0028 — widened to admit the fourth pillar `knowledge`.
+    // The `workspace_plugins_singleton` partial unique above stays
+    // `WHERE pillar IN ('chat', 'action')`, so knowledge (like datasource) is
+    // multi-instance per (workspace, catalog) — that exclusion is what makes
+    // collections possible.
+    check("chk_workspace_plugins_pillar", sql`pillar IN ('datasource', 'chat', 'action', 'knowledge')`),
     check("chk_workspace_plugins_status", sql`status IN ('published', 'draft', 'archived')`),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Knowledge Base pillar (0162 / 0163 — #4206, ADR-0028)
+// ---------------------------------------------------------------------------
+
+// knowledge_documents — hosted OKF documents, one row per file in a
+// collection's bundle tree. A collection is a `workspace_plugins` install
+// (pillar `knowledge`, `install_id` = collection slug). Workspace-global,
+// never group-scoped; owned by exactly one collection via `collectionId`.
+// OKF frontmatter is stored as real columns; the body byte-identical.
+// Content-mode participant — every ingest lands `draft` (the ADR-0028 §4
+// review gate), promoted only via the atomic publish endpoint. Mirrors
+// migration 0162.
+export const knowledgeDocuments = pgTable(
+  "knowledge_documents",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // Better-Auth organization id. Workspace-global (no group FK), TEXT/no-FK
+    // like the other org-scoped Atlas tables.
+    workspaceId: text("workspace_id").notNull(),
+    // The owning collection = `workspace_plugins.install_id` slug. No composite
+    // FK (see migration 0162); referential integrity is the ingest slice's job.
+    collectionId: text("collection_id").notNull(),
+    // Bundle path within the collection tree, unique PER COLLECTION.
+    path: text("path").notNull(),
+    // OKF frontmatter, stored verbatim.
+    type: text("type"),
+    title: text("title"),
+    description: text("description"),
+    tags: jsonb("tags").notNull().default(sql`'[]'::jsonb`),
+    // OKF `timestamp` frontmatter field (the document's own timestamp),
+    // distinct from Atlas ingest bookkeeping. Column is `"timestamp"` (a
+    // Postgres type keyword) — JS field renamed to avoid shadowing the
+    // imported `timestamp` column helper.
+    docTimestamp: timestamp("timestamp", { withTimezone: true }),
+    resource: text("resource"),
+    // Markdown body, byte-identical to what was reviewed (ADR-0028 §3).
+    body: text("body").notNull(),
+    // `atlas:` frontmatter provenance extension.
+    atlasSource: text("atlas_source"),
+    atlasIngestedAt: timestamp("atlas_ingested_at", { withTimezone: true }),
+    // Content-mode lifecycle — defaults `draft` (the review gate).
+    status: text("status").notNull().default("draft"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // Per-collection tree walks and per-tenant scans.
+    index("idx_knowledge_documents_collection").on(t.workspaceId, t.collectionId),
+    // Content-mode status filter (published-only read + developer overlay).
+    index("idx_knowledge_documents_status").on(t.workspaceId, t.status),
+    // GIN over the OKF `tags` array for the frontmatter-filter search tier.
+    index("idx_knowledge_documents_tags").using("gin", t.tags),
+    // `path` unique per collection, not per workspace (ADR-0028 §2).
+    uniqueIndex("uq_knowledge_documents_collection_path").on(
+      t.workspaceId,
+      t.collectionId,
+      t.path,
+    ),
+    check(
+      "chk_knowledge_documents_status",
+      sql`status IN ('draft', 'published', 'archived')`,
+    ),
+  ],
+);
+
+// knowledge_links — the intra-collection link graph extracted at ingest.
+// One row per markdown link: (source document, target path, anchor text).
+// Content-mode-exempt (derived data whose visibility follows its source
+// document — see migration 0163). `targetPath` is a lazily-resolved path
+// string, not a FK. Mirrors migration 0163.
+export const knowledgeLinks = pgTable(
+  "knowledge_links",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // The document the link was found in. Cascade so a document's edges vanish
+    // with it (re-ingest deletes the document, its links follow).
+    sourceDocumentId: uuid("source_document_id")
+      .notNull()
+      .references(() => knowledgeDocuments.id, { onDelete: "cascade" }),
+    // The bundle path the link points at — resolved lazily, not a FK.
+    targetPath: text("target_path").notNull(),
+    anchorText: text("anchor_text"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("idx_knowledge_links_source").on(t.sourceDocumentId),
+    index("idx_knowledge_links_target").on(t.targetPath),
   ],
 );
 

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -1,0 +1,180 @@
+/**
+ * Boot-time idempotent seed pass for the single built-in Knowledge Base
+ * catalog row, `okf-upload` (#4206, ADR-0028).
+ *
+ * The v0 Knowledge Base lifecycle (ADR-0028 §5) is one built-in catalog row:
+ * an **explicit, degenerate form install** — no credentials, minimal
+ * `config_schema`. Installing it creates a *collection* (a `workspace_plugins`
+ * row, pillar `knowledge`); ingest is a separate admin act. Per ADR-0028 §5 the
+ * row ships inside Atlas and is operator-curated — not declared in
+ * `atlas.config.ts` — so it is seeded here at boot through the operator-curated
+ * seam (`assertOperatorCatalogWrite`, `lib/plugins/catalog-provenance.ts`),
+ * exactly mirroring the built-in Datasource catalog seed.
+ *
+ * Unlike the Datasource rows, `okf-upload` carries **no credentials and no
+ * `INTEGRATION_TABLES` entry** — connectors (Notion/Confluence OAuth installs
+ * with credentials + Scheduler sync) are deliberate follow-ups. The row's
+ * `pillar = 'knowledge'` is admitted by migration 0161's widened CHECK, which
+ * `Migration` guarantees has run before this seed (the Layer's `Migration`
+ * dependency).
+ *
+ * Idempotency: unqualified `ON CONFLICT DO NOTHING` covers both the `slug`
+ * unique index and the `id` primary key, so re-running on a populated catalog
+ * is a no-op. A seed-time failure logs at error and the API keeps booting —
+ * the row from a prior boot answers admin-UI reads.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
+import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
+
+const log = createLogger("db.seed-builtin-knowledge-catalog");
+
+/**
+ * Declarative description of the built-in Knowledge Base catalog row.
+ * Mirrors `plugin_catalog`'s column shape for the columns the seed sets.
+ * `type` (`context`), `pillar` (`knowledge`), `implementation_status`
+ * (`available`), `min_plan` (`starter`), and `enabled` (`true`) are pinned
+ * as SQL literals in the INSERT.
+ */
+export interface BuiltinKnowledgeCatalogRow {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly installModel: "form";
+  readonly autoInstall: boolean;
+  readonly saasEligible: boolean;
+  readonly configSchema: ReadonlyArray<ConfigSchemaField>;
+}
+
+/**
+ * The single built-in Knowledge Base catalog row (ADR-0028 §5). A
+ * credential-less form install: the only config field is an optional
+ * human description of the collection. The collection's identity is the
+ * install slug chosen at install time, not a config field.
+ */
+export const BUILTIN_KNOWLEDGE_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: "catalog:okf-upload",
+  slug: "okf-upload",
+  name: "Knowledge Base (Upload)",
+  description:
+    "Upload an Open Knowledge Format bundle as a review-gated knowledge collection.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
+/**
+ * Narrow shape of the DB client the seeder needs. Mirrors
+ * `BuiltinDatasourceCatalogSeedDb` so a single mock pool serves both
+ * seeders in tests.
+ */
+export interface BuiltinKnowledgeCatalogSeedDb {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export interface BuiltinKnowledgeCatalogSeedResult {
+  /** True when the `ON CONFLICT DO NOTHING` ran an insert (row didn't exist). */
+  readonly inserted: boolean;
+}
+
+/**
+ * Idempotently seed the built-in `okf-upload` Knowledge Base catalog row.
+ *
+ * Column order matches the built-in Datasource seed's VALUES block so the two
+ * seeds stay structurally recognizable; `type` and `pillar` differ (`context` /
+ * `knowledge`). `RETURNING slug` reports whether the row was inserted vs
+ * preserved.
+ */
+export async function seedBuiltinKnowledgeCatalog(
+  db: BuiltinKnowledgeCatalogSeedDb,
+): Promise<BuiltinKnowledgeCatalogSeedResult> {
+  const row = BUILTIN_KNOWLEDGE_CATALOG_ROW;
+
+  // Operator-curated-only gate (#4174/#4099): this row ships inside Atlas.
+  assertOperatorCatalogWrite("builtin-knowledge-seed");
+  const { rows } = await db.query<{ slug: string }>(
+    `INSERT INTO plugin_catalog
+       (id, name, slug, description, type, install_model, pillar,
+        implementation_status, auto_install, min_plan, enabled, saas_eligible,
+        config_schema, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, 'context', $5, 'knowledge', 'available', $6,
+             'starter', true, $7, $8::jsonb, NOW(), NOW())
+     ON CONFLICT DO NOTHING
+     RETURNING slug`,
+    [
+      row.id,
+      row.name,
+      row.slug,
+      row.description,
+      row.installModel,
+      row.autoInstall,
+      row.saasEligible,
+      JSON.stringify(row.configSchema),
+    ],
+  );
+
+  const inserted = rows.length > 0;
+  log.info(
+    { inserted, slug: row.slug },
+    "Built-in Knowledge Base catalog seed complete",
+  );
+  return { inserted };
+}
+
+/**
+ * Discriminated outcome of {@link runBuiltinKnowledgeCatalogSeedBoot}.
+ * Mirrors the Datasource seed's boot result so the Effect Layer can surface
+ * skip vs error to health consumers without conflating them.
+ */
+export type BuiltinKnowledgeCatalogSeedBootResult =
+  | { readonly kind: "skipped"; readonly reason: "no-internal-db" }
+  | { readonly kind: "seeded"; readonly inserted: boolean }
+  | { readonly kind: "error"; readonly message: string };
+
+/**
+ * Boot-pass wrapper. Log-and-continue posture (mirrors
+ * `runBuiltinDatasourceCatalogSeedBoot`): a seed failure leaves the
+ * pre-existing row authoritative rather than crashing the API.
+ */
+export async function runBuiltinKnowledgeCatalogSeedBoot(): Promise<BuiltinKnowledgeCatalogSeedBootResult> {
+  const { hasInternalDB, getInternalDB } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+
+  if (!hasInternalDB()) {
+    log.info(
+      "Built-in Knowledge Base catalog seed: no internal DB configured, skipping",
+    );
+    return { kind: "skipped", reason: "no-internal-db" };
+  }
+
+  const pool = getInternalDB();
+  const db: BuiltinKnowledgeCatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const result = await pool.query(sql, params);
+      return { rows: result.rows as T[] };
+    },
+  };
+
+  try {
+    const result = await seedBuiltinKnowledgeCatalog(db);
+    return { kind: "seeded", inserted: result.inserted };
+  } catch (err) {
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      { err: normalized },
+      "Built-in Knowledge Base catalog seed failed — okf-upload row from prior boot remains authoritative",
+    );
+    return { kind: "error", message: normalized.message };
+  }
+}

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -916,6 +916,107 @@ export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
 );
 
 // ══════════════════════════════════════════════════════════════════════
+// ██  Built-in Knowledge Base Catalog Seed Layer (#4206 — ADR-0028)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Discriminated outcome of the boot-time built-in Knowledge Base catalog
+ * seed (the single `okf-upload` row, ADR-0028 §5). Mirrors
+ * {@link BuiltinDatasourceCatalogSeedOutcome}.
+ *
+ * - `skipped-gate`  — InternalDB or Migration upstream not satisfied
+ * - `seeded`        — seed ran (`inserted` false on re-boot with the row present)
+ * - `error`         — the boot wrapper or its dynamic import threw;
+ *                     the pre-existing row answers admin-UI reads
+ */
+export type BuiltinKnowledgeCatalogSeedOutcome =
+  | "skipped-gate"
+  | "seeded"
+  | "error";
+
+export interface BuiltinKnowledgeCatalogSeedShape {
+  /** True when the `okf-upload` row was newly inserted this boot. */
+  readonly inserted: boolean;
+  readonly outcome: BuiltinKnowledgeCatalogSeedOutcome;
+  /** Scrubbed error message when `outcome === "error"`. */
+  readonly error?: string;
+}
+
+export class BuiltinKnowledgeCatalogSeed extends Context.Tag(
+  "BuiltinKnowledgeCatalogSeed",
+)<BuiltinKnowledgeCatalogSeed, BuiltinKnowledgeCatalogSeedShape>() {}
+
+/**
+ * Idempotent boot-time seed of the built-in `okf-upload` Knowledge Base
+ * catalog row (#4206, ADR-0028). Code-seeded through the operator-curated
+ * seam and re-asserted on every boot via `ON CONFLICT DO NOTHING`.
+ *
+ * Depends on `Migration` so migration 0161's widened pillar CHECK (which
+ * admits `pillar = 'knowledge'`) is guaranteed before the INSERT; depends on
+ * `InternalDB` for the pool. Non-fatal: the boot wrapper swallows errors and
+ * logs at error so a failed seed leaves the pre-existing row authoritative.
+ */
+export const BuiltinKnowledgeCatalogSeedLive: Layer.Layer<
+  BuiltinKnowledgeCatalogSeed,
+  never,
+  InternalDB | Migration
+> = Layer.effect(
+  BuiltinKnowledgeCatalogSeed,
+  Effect.gen(function* () {
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+
+    if (!db.available || !migration.migrated) {
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "Built-in Knowledge Base catalog seed skipped — upstream gate not satisfied",
+      );
+      return {
+        inserted: false,
+        outcome: "skipped-gate",
+      } satisfies BuiltinKnowledgeCatalogSeedShape;
+    }
+
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const { runBuiltinKnowledgeCatalogSeedBoot } = await import(
+          "@atlas/api/lib/db/seed-builtin-knowledge-catalog"
+        );
+        const result = await runBuiltinKnowledgeCatalogSeedBoot();
+        switch (result.kind) {
+          case "skipped":
+            return {
+              inserted: false,
+              outcome: "skipped-gate",
+            } satisfies BuiltinKnowledgeCatalogSeedShape;
+          case "seeded":
+            return {
+              inserted: result.inserted,
+              outcome: "seeded",
+            } satisfies BuiltinKnowledgeCatalogSeedShape;
+          case "error":
+            return {
+              inserted: false,
+              outcome: "error",
+              error: result.message,
+            } satisfies BuiltinKnowledgeCatalogSeedShape;
+        }
+      },
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.catchAll((err) => {
+        log.error({ err }, "Built-in Knowledge Base catalog seed boot wrapper threw");
+        return Effect.succeed({
+          inserted: false,
+          outcome: "error",
+          error: errorMessage(err),
+        } satisfies BuiltinKnowledgeCatalogSeedShape);
+      }),
+    );
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
 // ██  OpenAPI Generic Datasource Catalog Seed (#2926 — v0.0.2 slice 2)
 // ══════════════════════════════════════════════════════════════════════
 
@@ -3301,6 +3402,15 @@ export function buildAppLayer(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );
 
+  // BuiltinKnowledgeCatalogSeedLive (#4206, ADR-0028) — the built-in
+  // `okf-upload` Knowledge Base row, code-seeded through the operator-curated
+  // seam. Depends on Migration so 0161's widened pillar CHECK (admitting
+  // `pillar='knowledge'`) is guaranteed before the INSERT. Independent peer of
+  // the other seeds; disjoint slug so ordering doesn't matter.
+  const builtinKnowledgeCatalogSeedLayer = BuiltinKnowledgeCatalogSeedLive.pipe(
+    Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+  );
+
   // OpenApiDatasourceCatalogSeedLive (#2926, slice 2) — the built-in
   // `openapi-generic` REST datasource row, code-seeded per ADR-0007.
   // Independent peer of the two seeds above; disjoint slug so ordering
@@ -3496,6 +3606,7 @@ export function buildAppLayer(
     backfillSaasTrialLayer,
     catalogSeedLayer,
     builtinDatasourceCatalogSeedLayer,
+    builtinKnowledgeCatalogSeedLayer,
     openApiDatasourceCatalogSeedLayer,
     implementationStatusOverrideLayer,
     connectionsHydrateLayer,

--- a/packages/api/src/lib/plugins/__tests__/catalog-provenance.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/catalog-provenance.test.ts
@@ -55,6 +55,8 @@ const KNOWN_CATALOG_WRITE_SITES = {
   "packages/api/src/api/routes/admin-marketplace.ts": "platform-admin-crud",
   "packages/api/src/lib/db/seed-builtin-datasource-catalog.ts":
     "builtin-datasource-seed",
+  "packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts":
+    "builtin-knowledge-seed",
   "packages/api/src/lib/integrations/catalog-seeder.ts": "config-catalog-seed",
   "packages/api/src/lib/integrations/implementation-status-override.ts":
     "implementation-status-override",

--- a/packages/api/src/lib/plugins/catalog-provenance.ts
+++ b/packages/api/src/lib/plugins/catalog-provenance.ts
@@ -63,6 +63,8 @@ export const OPERATOR_CATALOG_WRITE_SOURCES = [
   "openapi-generic-seed",
   /** OpenAPI data-candidate rows (`openapi/data-candidate-seed.ts`). */
   "openapi-data-candidate-seed",
+  /** The built-in `okf-upload` Knowledge Base row (`db/seed-builtin-knowledge-catalog.ts`, #4206). */
+  "builtin-knowledge-seed",
 ] as const;
 
 export type OperatorCatalogWriteSource =

--- a/packages/types/src/mode.ts
+++ b/packages/types/src/mode.ts
@@ -24,6 +24,8 @@ export interface ModeDraftCounts {
   readonly prompts: number;
   /** Draft starter-prompt suggestions (status = 'draft'). */
   readonly starterPrompts: number;
+  /** Draft hosted-OKF knowledge documents (status = 'draft'), #4206 / ADR-0028. */
+  readonly knowledgeDocuments: number;
 }
 
 /**
@@ -44,6 +46,7 @@ export interface ModeDraftActivity {
   readonly entityDeletes: { readonly lastEditedAt: string | null };
   readonly prompts: { readonly lastEditedAt: string | null };
   readonly starterPrompts: { readonly lastEditedAt: string | null };
+  readonly knowledgeDocuments: { readonly lastEditedAt: string | null };
 }
 
 /**


### PR DESCRIPTION
## Summary

First slice of the Knowledge Base pillar (#4182, [ADR-0028](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0028-knowledge-base-fourth-pillar.md)). Lays the pillar + storage foundation only — **no ingest, serving, or UI**: schema, seeds, and invariant tests.

- **Migration 0161** widens the `plugin_catalog` + `workspace_plugins` pillar CHECKs to admit the fourth pillar `knowledge`. The `workspace_plugins_singleton` partial unique stays `chat`/`action`-only, so `knowledge` (like `datasource`) is **multi-instance per (workspace, catalog)** — the exclusion that makes collections possible.
- **Migrations 0162/0163** create `knowledge_documents` (hosted OKF documents; content-mode participant — `status` draft/published/archived + CHECK default `draft`, `path` unique **per collection**, OKF frontmatter columns + `tags` GIN, `atlas:` provenance) and `knowledge_links` (intra-collection link graph; content-mode-**exempt** derived data, `target_path` lazily-resolved, cascade on source document). `schema.ts` mirrors land in the same commit (check-schema-drift).
- **Built-in `okf-upload` catalog row** (type `context`, pillar `knowledge`, install_model `form`, **no credentials / no `INTEGRATION_TABLES`**) seeded at boot through the operator-curated seam (`assertOperatorCatalogWrite`), mirroring the built-in datasource seed. New `BuiltinKnowledgeCatalogSeed` layer.
- **Content-mode opt-in:** `ContentModeRegistry` entry gives readFilter + draftCounts + atomic-publish promotion; `ModeDraftCounts`/`ModeDraftActivity` wire types + `/api/v1/mode` surface `knowledgeDocuments`.

## Test plan
- [x] `bun run type` green; schema-drift green
- [x] Both migration count/list tests bumped (db 161→164 + auth filename list)
- [x] Real-PG invariant tests for 0161–0163: pillar CHECK admits `knowledge` / rejects unknown, singleton multi-instance, `knowledge_documents` draft default + status CHECK + unique-per-collection path, `knowledge_links` cascade + non-FK `target_path`
- [x] Unit test for the `okf-upload` boot seed (idempotency + discriminated outcomes)
- [x] Internal review panel: clean (2 cosmetic comment fixes applied)
- [ ] Remote CI incl. `migrate-pg` shards (couldn't run locally without a DB)

Closes #4206

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrryMcPix2ouTNrj3qMans)_