### PR TITLE
fix(web): adopt useConfigForm across email-provider, sandbox, branding (#4204)

### DIFF
--- a/packages/web/src/app/admin/branding/__tests__/config-form.test.tsx
+++ b/packages/web/src/app/admin/branding/__tests__/config-form.test.tsx
@@ -1,0 +1,194 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import BrandingPage from "../page";
+
+/**
+ * Behavior lock for the branding page's `useConfigForm` migration (#4204):
+ *
+ *  - the save is dirty-gated (disabled "Saved" on an unchanged form, enabled
+ *    "Save changes" after an edit);
+ *  - `toPayload` maps empty strings to null on the wire;
+ *  - reset-to-defaults re-baselines the form to EMPTY via the refetched
+ *    `{ branding: null }` — the old hand-rolled `form.reset(EMPTY)` call and
+ *    reset-on-refetch effect are gone.
+ */
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SAVED_BRANDING = {
+  id: "brand_1",
+  orgId: "org_1",
+  logoUrl: null,
+  logoText: "Acme Corp",
+  primaryColor: null,
+  faviconUrl: null,
+  hideAtlasBranding: false,
+  createdAt: "2026-06-01T00:00:00.000Z",
+  updatedAt: "2026-06-01T00:00:00.000Z",
+};
+
+/**
+ * Route GET to a mutable branding value; capture PUT bodies; let DELETE flip
+ * the GET to `{ branding: null }`. Unrecognized traffic throws loudly.
+ */
+function mockBrandingApi(initial: unknown) {
+  const state = { branding: initial, putBodies: [] as unknown[] };
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    if (!url.endsWith("/api/v1/admin/branding")) {
+      throw new Error(`unexpected ${method} ${url}`);
+    }
+    if (method === "GET") {
+      return jsonResponse({ branding: state.branding });
+    }
+    if (method === "PUT") {
+      state.putBodies.push(JSON.parse(String(init?.body)));
+      return jsonResponse({ branding: state.branding });
+    }
+    if (method === "DELETE") {
+      state.branding = null;
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected ${method} ${url}`);
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  expect(button).toBeDefined();
+  return button as HTMLButtonElement;
+}
+
+async function waitForButton(label: string): Promise<HTMLButtonElement> {
+  return waitFor(() => findButton(label));
+}
+
+describe("/admin/branding useConfigForm loop (#4204)", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("save is dirty-gated: disabled on an unchanged form, enabled after an edit", async () => {
+    mockBrandingApi(SAVED_BRANDING);
+    render(<BrandingPage />, { wrapper: Wrapper });
+
+    const saveButton = await waitForButton("Saved");
+    expect(saveButton.disabled).toBe(true);
+
+    const toggle = document.querySelector<HTMLButtonElement>(
+      'button[role="switch"]',
+    );
+    expect(toggle).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(toggle!);
+    });
+
+    expect(findButton("Save changes").disabled).toBe(false);
+  });
+
+  test("toPayload maps empty strings to null on the wire", async () => {
+    const state = mockBrandingApi(SAVED_BRANDING);
+    render(<BrandingPage />, { wrapper: Wrapper });
+
+    await waitForButton("Saved");
+    // Expand the Logo text row (pre-filled "Acme Corp") and clear it.
+    await act(async () => {
+      fireEvent.click(findButton("Edit"));
+    });
+    const input = document.querySelector<HTMLInputElement>(
+      "input#branding-logo-text",
+    );
+    expect(input).not.toBeNull();
+    await act(async () => {
+      fireEvent.change(input!, { target: { value: "" } });
+    });
+    await act(async () => {
+      fireEvent.click(findButton("Save changes"));
+    });
+
+    await waitFor(() => {
+      expect(state.putBodies).toHaveLength(1);
+    });
+    expect(state.putBodies[0]).toEqual({
+      logoUrl: null,
+      logoText: null,
+      primaryColor: null,
+      faviconUrl: null,
+      hideAtlasBranding: false,
+    });
+  });
+
+  test("reset-to-defaults re-baselines the form to EMPTY from the refetched null", async () => {
+    mockBrandingApi(SAVED_BRANDING);
+    const { getByText, queryByText } = render(<BrandingPage />, {
+      wrapper: Wrapper,
+    });
+
+    const resetButton = await waitForButton("Reset to defaults");
+    getByText("1 of 5 customized");
+
+    await act(async () => {
+      fireEvent.click(resetButton);
+    });
+
+    await waitFor(() => {
+      getByText("Using Atlas defaults");
+    });
+    // The reset affordance disappears with the branding row, and the form is
+    // back to a clean (non-dirty) baseline.
+    expect(queryByText("Reset to defaults")).toBeNull();
+    expect(findButton("Saved").disabled).toBe(true);
+  });
+});

--- a/packages/web/src/app/admin/branding/page.tsx
+++ b/packages/web/src/app/admin/branding/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useForm, useWatch } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import {
   AlertCircle,
@@ -16,8 +14,11 @@ import {
   ShieldOff,
   Type,
 } from "lucide-react";
-import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import {
+  useConfigForm,
+  type ConfigFormFields,
+} from "@/ui/hooks/use-config-form";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
@@ -31,35 +32,34 @@ import {
 } from "@/ui/components/admin/compact";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import {
-  Form,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormControl,
-  FormDescription,
-  FormMessage,
-} from "@/components/ui/form";
 import { WorkspaceBrandingSchema } from "@/ui/lib/admin-schemas";
 
-const BrandingResponseSchema = z
-  .object({ branding: WorkspaceBrandingSchema.nullable() })
-  .transform((r) => r.branding);
+// The nullable `branding` stays wrapped (no `.transform` unwrap): useConfigForm
+// re-baselines only when the fetched object changes, and a bare `null` data
+// value would read as "not loaded" — the wrapper keeps "loaded, but no
+// branding row" representable so a reset-to-defaults refetch still
+// re-baselines the form to EMPTY.
+const BrandingResponseSchema = z.object({
+  branding: WorkspaceBrandingSchema.nullable(),
+});
+
+type BrandingResponse = z.infer<typeof BrandingResponseSchema>;
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
-const brandingSchema = z.object({
-  logoUrl: z.string(),
-  logoText: z.string(),
-  primaryColor: z.string().refine((v) => !v || HEX_RE.test(v), {
-    message: "Must be a 6-digit hex color (e.g. #FF5500)",
-  }),
-  faviconUrl: z.string(),
-  hideAtlasBranding: z.boolean(),
-});
+/** Editable field set — `toForm` below is its single statement (#4204). */
+type BrandingValues = {
+  logoUrl: string;
+  logoText: string;
+  primaryColor: string;
+  faviconUrl: string;
+  hideAtlasBranding: boolean;
+};
 
-type BrandingValues = z.infer<typeof brandingSchema>;
+type BrandingField<K extends keyof BrandingValues> =
+  ConfigFormFields<BrandingValues>[K];
 
 const EMPTY: BrandingValues = {
   logoUrl: "",
@@ -103,66 +103,53 @@ function countCustomized(v: BrandingValues): number {
 // ── Page ──────────────────────────────────────────────────────────
 
 export default function BrandingPage() {
-  const { data, loading, error, refetch } = useAdminFetch(
-    "/api/v1/admin/branding",
-    { schema: BrandingResponseSchema },
-  );
-  const save = useAdminMutation({
+  // Load → edit → dirty-gated save → re-baseline ride `useConfigForm` — the
+  // former react-hook-form wiring hand-rolled its own reset-on-refetch
+  // effect; here the re-baseline derives from `toForm` (#4204).
+  const form = useConfigForm<BrandingResponse, BrandingValues>({
     path: "/api/v1/admin/branding",
-    invalidates: refetch,
+    schema: BrandingResponseSchema,
+    saveMethod: "PUT",
+    toForm: (d) => ({
+      logoUrl: d.branding?.logoUrl ?? "",
+      logoText: d.branding?.logoText ?? "",
+      primaryColor: d.branding?.primaryColor ?? "",
+      faviconUrl: d.branding?.faviconUrl ?? "",
+      hideAtlasBranding: d.branding?.hideAtlasBranding ?? false,
+    }),
+    toPayload: (v) => ({
+      logoUrl: v.logoUrl || null,
+      logoText: v.logoText || null,
+      primaryColor: v.primaryColor || null,
+      faviconUrl: v.faviconUrl || null,
+      hideAtlasBranding: v.hideAtlasBranding,
+    }),
   });
   const reset = useAdminMutation({
     path: "/api/v1/admin/branding",
-    invalidates: refetch,
+    method: "DELETE",
   });
 
-  const form = useForm<BrandingValues>({
-    resolver: zodResolver(brandingSchema),
-    defaultValues: EMPTY,
-  });
-
-  // Reset form to server state whenever the fetched `data` changes — e.g.
-  // after save/reset refetches. `form.reset` has a stable identity per RHF,
-  // so it's omitted from deps deliberately; adding it would loop.
-  useEffect(() => {
-    if (loading) return;
-    if (data) {
-      form.reset({
-        logoUrl: data.logoUrl ?? "",
-        logoText: data.logoText ?? "",
-        primaryColor: data.primaryColor ?? "",
-        faviconUrl: data.faviconUrl ?? "",
-        hideAtlasBranding: data.hideAtlasBranding,
-      });
-    } else {
-      form.reset(EMPTY);
-    }
-  }, [data, loading]);
-
-  const values = form.watch();
+  // Hero + preview render from EMPTY until the first load lands — same as the
+  // old react-hook-form defaultValues.
+  const values = form.values ?? EMPTY;
   const customized = countCustomized(values);
   const colorValid = !values.primaryColor || HEX_RE.test(values.primaryColor);
-  const isDirty = form.formState.isDirty;
-  const busy = save.saving || reset.saving;
+  const busy = form.saving || reset.saving;
 
-  async function handleSave(v: BrandingValues) {
-    // saveError is surfaced by <MutationErrorSurface> below — no throw
-    // needed; react-hook-form's handleSubmit would swallow it anyway.
-    await save.mutate({
-      method: "PUT",
-      body: {
-        logoUrl: v.logoUrl || null,
-        logoText: v.logoText || null,
-        primaryColor: v.primaryColor || null,
-        faviconUrl: v.faviconUrl || null,
-        hideAtlasBranding: v.hideAtlasBranding,
-      },
-    });
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    // Save error is surfaced by <MutationErrorSurface> below; the invalid-hex
+    // case is gated here AND on the button so an Enter-key submit can't
+    // slip an invalid color past a disabled button.
+    if (!colorValid) return;
+    await form.save();
   }
 
   async function handleReset() {
-    const result = await reset.mutate({ method: "DELETE" });
-    if (result.ok) form.reset(EMPTY);
+    // No manual field reset: the DELETE's invalidation refetch returns
+    // `{ branding: null }`, and `toForm` re-baselines the form to EMPTY.
+    await reset.mutate();
   }
 
   return (
@@ -171,27 +158,24 @@ export default function BrandingPage() {
         <Hero customized={customized} />
 
         <AdminContentWrapper
-          loading={loading}
-          error={error}
+          loading={form.loading}
+          error={form.loadError}
           feature="Branding"
-          onRetry={refetch}
+          onRetry={form.refetch}
           loadingMessage="Loading branding settings..."
         >
-          <Form {...form}>
-            <form
-              onSubmit={form.handleSubmit(handleSave)}
-              className="space-y-10"
-            >
+          {form.fields && (
+            <form onSubmit={handleSave} className="space-y-10">
               <section>
                 <SectionHeading
                   title="Identity"
                   description="Replace Atlas defaults with your own logo, type, and color"
                 />
                 <div className="space-y-2">
-                  <LogoUrlRow />
-                  <LogoTextRow />
-                  <PrimaryColorRow />
-                  <FaviconRow />
+                  <LogoUrlRow field={form.fields.logoUrl} />
+                  <LogoTextRow field={form.fields.logoText} />
+                  <PrimaryColorRow field={form.fields.primaryColor} />
+                  <FaviconRow field={form.fields.faviconUrl} />
                 </div>
               </section>
 
@@ -200,7 +184,7 @@ export default function BrandingPage() {
                   title="Attribution"
                   description="Control how Atlas is credited across the UI"
                 />
-                <AttributionRow />
+                <AttributionRow field={form.fields.hideAtlasBranding} />
               </section>
 
               <section>
@@ -212,7 +196,7 @@ export default function BrandingPage() {
               </section>
 
               <MutationErrorSurface
-                error={save.error}
+                error={form.error}
                 feature="Branding"
                 variant="inline"
                 inlinePrefix="Save failed."
@@ -233,15 +217,15 @@ export default function BrandingPage() {
               <footer className="flex items-center gap-2 border-t border-border/50 pt-5">
                 <Button
                   type="submit"
-                  disabled={busy || !colorValid || !isDirty}
+                  disabled={busy || !colorValid || !form.dirty}
                   size="sm"
                 >
-                  {save.saving && (
+                  {form.saving && (
                     <Loader2 className="mr-1.5 size-3 animate-spin" />
                   )}
-                  {isDirty ? "Save changes" : "Saved"}
+                  {form.dirty ? "Save changes" : "Saved"}
                 </Button>
-                {data && (
+                {form.data?.branding && (
                   <Button
                     type="button"
                     variant="outline"
@@ -264,7 +248,7 @@ export default function BrandingPage() {
                 </span>
               </footer>
             </form>
-          </Form>
+          )}
         </AdminContentWrapper>
       </div>
     </ErrorBoundary>
@@ -297,18 +281,17 @@ function Hero({ customized }: { customized: number }) {
 
 // ── Rows ──────────────────────────────────────────────────────────
 
-function LogoUrlRow() {
+function LogoUrlRow({ field }: { field: BrandingField<"logoUrl"> }) {
   const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
     useDisclosure();
-  const value = useWatchField("logoUrl");
-  const status: StatusKind = value ? "connected" : "disconnected";
+  const status: StatusKind = field.value ? "connected" : "disconnected";
 
   if (!expanded) {
     return (
       <CompactRow
         icon={ImageIcon}
         title="Logo image"
-        description={value || "Replace the Atlas logo with your own image"}
+        description={field.value || "Replace the Atlas logo with your own image"}
         status={status}
         statusLabel={BRANDING_STATUS_LABEL[status]}
         action={
@@ -320,7 +303,7 @@ function LogoUrlRow() {
             aria-expanded={false}
             onClick={() => setExpanded(true)}
           >
-            {value ? (
+            {field.value ? (
               "Edit"
             ) : (
               <>
@@ -344,38 +327,33 @@ function LogoUrlRow() {
       status="disconnected"
       onCollapse={collapse}
     >
-      <FormField
-        name="logoUrl"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel className="sr-only">Logo URL</FormLabel>
-            <FormControl>
-              <Input
-                placeholder="https://example.com/logo.png"
-                className="font-mono text-sm"
-                {...field}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      <div className="space-y-1">
+        <Label htmlFor="branding-logo-url" className="sr-only">
+          Logo URL
+        </Label>
+        <Input
+          id="branding-logo-url"
+          placeholder="https://example.com/logo.png"
+          className="font-mono text-sm"
+          value={field.value}
+          onChange={(e) => field.set(e.target.value)}
+        />
+      </div>
     </Shell>
   );
 }
 
-function LogoTextRow() {
+function LogoTextRow({ field }: { field: BrandingField<"logoText"> }) {
   const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
     useDisclosure();
-  const value = useWatchField("logoText");
-  const status: StatusKind = value ? "connected" : "disconnected";
+  const status: StatusKind = field.value ? "connected" : "disconnected";
 
   if (!expanded) {
     return (
       <CompactRow
         icon={Type}
         title="Logo text"
-        description={value || "Displayed next to or instead of the logo"}
+        description={field.value || "Displayed next to or instead of the logo"}
         status={status}
         statusLabel={BRANDING_STATUS_LABEL[status]}
         action={
@@ -387,7 +365,7 @@ function LogoTextRow() {
             aria-expanded={false}
             onClick={() => setExpanded(true)}
           >
-            {value ? (
+            {field.value ? (
               "Edit"
             ) : (
               <>
@@ -411,26 +389,25 @@ function LogoTextRow() {
       status="disconnected"
       onCollapse={collapse}
     >
-      <FormField
-        name="logoText"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel className="sr-only">Logo text</FormLabel>
-            <FormControl>
-              <Input placeholder="Acme Corp" {...field} />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      <div className="space-y-1">
+        <Label htmlFor="branding-logo-text" className="sr-only">
+          Logo text
+        </Label>
+        <Input
+          id="branding-logo-text"
+          placeholder="Acme Corp"
+          value={field.value}
+          onChange={(e) => field.set(e.target.value)}
+        />
+      </div>
     </Shell>
   );
 }
 
-function PrimaryColorRow() {
+function PrimaryColorRow({ field }: { field: BrandingField<"primaryColor"> }) {
   const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
     useDisclosure();
-  const value = useWatchField("primaryColor");
+  const value = field.value;
   const valid = !value || HEX_RE.test(value);
   const swatchColor = valid && value ? value : null;
   const invalid = Boolean(value) && !valid;
@@ -505,47 +482,49 @@ function PrimaryColorRow() {
       status="disconnected"
       onCollapse={collapse}
     >
-      <FormField
-        name="primaryColor"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel className="sr-only">Primary color</FormLabel>
-            <div className="flex items-center gap-3">
-              <span
-                aria-hidden
-                className="size-10 shrink-0 rounded-md border"
-                style={{
-                  backgroundColor: swatchColor ?? "var(--muted)",
-                }}
-              />
-              <FormControl>
-                <Input
-                  placeholder="#FF5500"
-                  className="font-mono text-sm"
-                  {...field}
-                />
-              </FormControl>
-            </div>
-            <FormMessage />
-          </FormItem>
+      <div className="space-y-1">
+        <Label htmlFor="branding-primary-color" className="sr-only">
+          Primary color
+        </Label>
+        <div className="flex items-center gap-3">
+          <span
+            aria-hidden
+            className="size-10 shrink-0 rounded-md border"
+            style={{
+              backgroundColor: swatchColor ?? "var(--muted)",
+            }}
+          />
+          <Input
+            id="branding-primary-color"
+            placeholder="#FF5500"
+            className="font-mono text-sm"
+            value={value}
+            onChange={(e) => field.set(e.target.value)}
+          />
+        </div>
+        {invalid && (
+          <InlineError>
+            Must be a 6-digit hex color (e.g. #FF5500)
+          </InlineError>
         )}
-      />
+      </div>
     </Shell>
   );
 }
 
-function FaviconRow() {
+function FaviconRow({ field }: { field: BrandingField<"faviconUrl"> }) {
   const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } =
     useDisclosure();
-  const value = useWatchField("faviconUrl");
-  const status: StatusKind = value ? "connected" : "disconnected";
+  const status: StatusKind = field.value ? "connected" : "disconnected";
 
   if (!expanded) {
     return (
       <CompactRow
         icon={Globe}
         title="Favicon"
-        description={value ? truncateUrl(value) : "Shown in browser tabs and bookmarks"}
+        description={
+          field.value ? truncateUrl(field.value) : "Shown in browser tabs and bookmarks"
+        }
         status={status}
         statusLabel={BRANDING_STATUS_LABEL[status]}
         action={
@@ -557,7 +536,7 @@ function FaviconRow() {
             aria-expanded={false}
             onClick={() => setExpanded(true)}
           >
-            {value ? (
+            {field.value ? (
               "Edit"
             ) : (
               <>
@@ -581,60 +560,49 @@ function FaviconRow() {
       status="disconnected"
       onCollapse={collapse}
     >
-      <FormField
-        name="faviconUrl"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel className="sr-only">Favicon URL</FormLabel>
-            <FormControl>
-              <Input
-                placeholder="https://example.com/favicon.ico"
-                className="font-mono text-sm"
-                {...field}
-              />
-            </FormControl>
-            <FormDescription className="text-[11px]">
-              Browsers cache favicons aggressively; clear site data to verify.
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      <div className="space-y-1">
+        <Label htmlFor="branding-favicon-url" className="sr-only">
+          Favicon URL
+        </Label>
+        <Input
+          id="branding-favicon-url"
+          placeholder="https://example.com/favicon.ico"
+          className="font-mono text-sm"
+          value={field.value}
+          onChange={(e) => field.set(e.target.value)}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Browsers cache favicons aggressively; clear site data to verify.
+        </p>
+      </div>
     </Shell>
   );
 }
 
-function AttributionRow() {
+function AttributionRow({
+  field,
+}: {
+  field: BrandingField<"hideAtlasBranding">;
+}) {
+  const status: StatusKind = field.value ? "connected" : "disconnected";
   return (
-    <FormField
-      name="hideAtlasBranding"
-      render={({ field }) => {
-        const status: StatusKind = field.value ? "connected" : "disconnected";
-        return (
-          <FormItem className="space-y-0">
-            <CompactRow
-              icon={ShieldOff}
-              title="Hide Atlas branding"
-              description={
-                field.value
-                  ? "“Atlas” and “Powered by Atlas” text are hidden"
-                  : "Default — Atlas attribution remains visible"
-              }
-              status={status}
-              statusLabel={BRANDING_STATUS_LABEL[status]}
-              action={
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    aria-label="Hide Atlas branding"
-                  />
-                </FormControl>
-              }
-            />
-          </FormItem>
-        );
-      }}
+    <CompactRow
+      icon={ShieldOff}
+      title="Hide Atlas branding"
+      description={
+        field.value
+          ? "“Atlas” and “Powered by Atlas” text are hidden"
+          : "Default — Atlas attribution remains visible"
+      }
+      status={status}
+      statusLabel={BRANDING_STATUS_LABEL[status]}
+      action={
+        <Switch
+          checked={field.value}
+          onCheckedChange={field.set}
+          aria-label="Hide Atlas branding"
+        />
+      }
     />
   );
 }
@@ -731,12 +699,4 @@ function PreviewShell({
       )}
     </Shell>
   );
-}
-
-// ── Internal hook ─────────────────────────────────────────────────
-
-function useWatchField<K extends keyof BrandingValues>(
-  name: K,
-): BrandingValues[K] {
-  return useWatch({ name }) as BrandingValues[K];
 }

--- a/packages/web/src/app/admin/email-provider/__tests__/dirty-gate.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/dirty-gate.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, fireEvent, waitFor, cleanup, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import EmailProviderPage from "../page";
+
+/**
+ * Regression guard for #4204: the email-provider save had no dirty gate —
+ * Save always fired, even on an untouched form. The page now rides
+ * `useConfigForm`, whose `dirty` compare derives from `toForm`, so:
+ *
+ *  - with a saved override and no edits, "Replace" is disabled and no PUT
+ *    can fire;
+ *  - with no override, "Save" is disabled until the admin types something;
+ *  - any edit (credentials or from-address) enables the button.
+ */
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    QueryClientProvider,
+    { client: testQueryClient },
+    createElement(
+      AtlasProvider,
+      {
+        config: {
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const NO_OVERRIDE_CONFIG = {
+  config: {
+    baseline: { provider: "resend", fromAddress: "noreply@atlas.dev" },
+    override: null,
+  },
+};
+
+const OVERRIDE_CONFIG = {
+  config: {
+    baseline: { provider: "resend", fromAddress: "noreply@atlas.dev" },
+    override: {
+      provider: "resend",
+      fromAddress: "sender@acme.com",
+      secretLabel: "API key",
+      secretMasked: "re_****abcd",
+      hints: {},
+      installedAt: "2026-06-01T00:00:00.000Z",
+    },
+  },
+};
+
+/**
+ * Route GET to the given config. Any write throws — these tests assert the
+ * dirty gate keeps writes from firing, so a PUT reaching the mock is itself
+ * the failure.
+ */
+function mockReadOnlyApi(config: unknown) {
+  globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    if (method === "GET" && url.endsWith("/api/v1/admin/email-provider")) {
+      return Promise.resolve(jsonResponse(config));
+    }
+    throw new Error(`unexpected ${method} ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  expect(button).toBeDefined();
+  return button as HTMLButtonElement;
+}
+
+async function openEditor() {
+  const addButton = await waitFor(() => {
+    const b = Array.from(document.querySelectorAll("button")).find((btn) =>
+      btn.textContent?.includes("+ Add credentials"),
+    );
+    if (!b) throw new Error("+ Add credentials button not found");
+    return b;
+  });
+  await act(async () => {
+    fireEvent.click(addButton);
+  });
+}
+
+function typeIntoInput(id: string, value: string) {
+  const el = document.querySelector<HTMLInputElement>(`input#${id}`);
+  expect(el).not.toBeNull();
+  fireEvent.change(el!, { target: { value } });
+}
+
+describe("/admin/email-provider dirty gate (#4204)", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("with a saved override and no edits, Replace is disabled (no save can fire)", async () => {
+    mockReadOnlyApi(OVERRIDE_CONFIG);
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    const replaceButton = await waitFor(() => findButton("Replace"));
+    expect(replaceButton.disabled).toBe(true);
+
+    // Clicking the unchanged form must not fire a PUT — the read-only mock
+    // throws on any write, so reaching it would fail the test loudly.
+    await act(async () => {
+      fireEvent.click(replaceButton);
+    });
+    expect(findButton("Replace").disabled).toBe(true);
+  });
+
+  test("editing the from-address on a saved override enables Replace", async () => {
+    mockReadOnlyApi(OVERRIDE_CONFIG);
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    await waitFor(() => findButton("Replace"));
+    await act(async () => {
+      typeIntoInput("fromAddress", "new-sender@acme.com");
+    });
+    expect(findButton("Replace").disabled).toBe(false);
+  });
+
+  test("with no override, Save is disabled until a credential is typed", async () => {
+    mockReadOnlyApi(NO_OVERRIDE_CONFIG);
+
+    render(<EmailProviderPage />, { wrapper: Wrapper });
+
+    await openEditor();
+    expect(findButton("Save").disabled).toBe(true);
+
+    await act(async () => {
+      typeIntoInput("resendApiKey", "re_freshkey");
+    });
+    expect(findButton("Save").disabled).toBe(false);
+  });
+});

--- a/packages/web/src/app/admin/email-provider/page.tsx
+++ b/packages/web/src/app/admin/email-provider/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type ComponentType, type ReactNode } from "react";
+import { useState, type ComponentType, type ReactNode } from "react";
 import { z } from "zod";
 import {
   buildProviderConfig,
@@ -26,8 +26,8 @@ import {
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
-import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { useConfigForm } from "@/ui/hooks/use-config-form";
 import { combineMutationErrors } from "@/ui/lib/mutation-errors";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
@@ -79,6 +79,20 @@ const EmailProviderConfigResponseSchema = z.object({
     override: OverrideSchema.nullable(),
   }),
 });
+
+type EmailProviderConfigResponse = z.infer<typeof EmailProviderConfigResponseSchema>;
+
+/**
+ * Editable field set for `useConfigForm` — the single statement of what this
+ * page edits (#4204). `creds` re-baselines to `INITIAL_FIELD_VALUES` on every
+ * refetch because secrets are write-only: the server never echoes them back,
+ * so "dirty" means "the admin typed something new since the last load".
+ */
+type EmailFormValues = {
+  provider: EmailProvider;
+  fromAddress: string;
+  creds: ProviderFieldValues;
+};
 
 interface TestResult {
   success: boolean;
@@ -440,28 +454,47 @@ function ProviderFields({ provider, values, onChange, showSecrets, onToggleSecre
 export default function EmailProviderPage() {
   const [expanded, setExpanded] = useState(false);
   const [showSecrets, setShowSecrets] = useState(false);
-  const [provider, setProvider] = useState<EmailProvider>("resend");
-  const [fromAddress, setFromAddress] = useState("");
   const [recipientEmail, setRecipientEmail] = useState("");
-  const [fields, setFields] = useState<ProviderFieldValues>(INITIAL_FIELD_VALUES);
   const [formError, setFormError] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
 
-  const { data, loading, error, refetch } = useAdminFetch("/api/v1/admin/email-provider", {
+  // Load → edit → dirty-gated save → re-baseline ride `useConfigForm`
+  // (#4204). The dirty compare derives from `toForm`, so Save/Replace stays
+  // disabled on an unchanged form — the always-fires save this page used to
+  // hand-roll is structurally gone. The post-save invalidation refetch
+  // re-baselines the form (credentials back to empty, from-address to the
+  // saved override), replacing the old `lastSyncedKey` sync effect.
+  const form = useConfigForm<EmailProviderConfigResponse, EmailFormValues>({
+    path: "/api/v1/admin/email-provider",
     schema: EmailProviderConfigResponseSchema,
+    saveMethod: "PUT",
+    toForm: (d) => ({
+      provider: d.config.override?.provider ?? "resend",
+      fromAddress: d.config.override?.fromAddress ?? "",
+      creds: INITIAL_FIELD_VALUES,
+    }),
+    toPayload: (v) => {
+      // `handleSave` validates before calling `save()`, so `ok` holds here.
+      // The empty-config arm exists only to keep `toPayload` total; if a
+      // future caller skips that validation the server rejects the payload
+      // with a 400 rather than storing a half-built config.
+      const configResult = buildProviderConfig(v.provider, v.creds);
+      return {
+        provider: v.provider,
+        fromAddress: v.fromAddress.trim(),
+        config: configResult.ok ? configResult.config : {},
+      };
+    },
   });
 
-  const { mutate: saveMutate, saving, error: saveError, clearError: clearSaveError } =
-    useAdminMutation({
-      path: "/api/v1/admin/email-provider",
-      method: "PUT",
-      invalidates: refetch,
-    });
+  // Remove/test stay hand-wired mutations: DELETE and POST /test are actions,
+  // not part of the config-form save loop. No explicit `invalidates` —
+  // useAdminMutation's onSuccess already invalidates every admin-fetch query,
+  // which refetches the GET above and drives the re-baseline.
   const { mutate: deleteMutate, saving: deleting, error: deleteError, clearError: clearDeleteError } =
     useAdminMutation({
       path: "/api/v1/admin/email-provider",
       method: "DELETE",
-      invalidates: refetch,
     });
   const { mutate: testMutate, saving: testing, error: testError, clearError: clearTestError } =
     useAdminMutation<TestResult>({
@@ -469,42 +502,17 @@ export default function EmailProviderPage() {
       method: "POST",
     });
 
-  const structuredError = combineMutationErrors([saveError, deleteError, testError]);
-  const baseline = data?.config.baseline;
-  const override = data?.config.override ?? null;
+  const structuredError = combineMutationErrors([form.error, deleteError, testError]);
+  const baseline = form.data?.config.baseline;
+  const override = form.data?.config.override ?? null;
   const hasOverride = override !== null;
   const showEditor = hasOverride || expanded;
-
-  // Sync form state from the server only when the override's identity actually
-  // changes — not on every background refetch (window-focus, 30s stale revalidation,
-  // mutation invalidation). An unconditional reset clobbers in-flight edits and
-  // silently dismisses mutation errors the user hasn't seen yet.
-  //
-  // The `clear*Error` callbacks are stable references returned by `useAdminMutation`
-  // (see hook docs), so omitting them from the dep array is safe — otherwise the
-  // effect would re-run on every render and defeat the identity gate.
-  const lastSyncedKey = useRef<string | null>(null);
-  useEffect(() => {
-    if (loading) return;
-    const key = override
-      ? `${override.provider}|${override.fromAddress}|${override.installedAt}`
-      : "none";
-    if (lastSyncedKey.current === key) return;
-    lastSyncedKey.current = key;
-    setProvider(override?.provider ?? "resend");
-    setFromAddress(override?.fromAddress ?? "");
-    setFields(INITIAL_FIELD_VALUES);
-    setRecipientEmail("");
-    setTestResult(null);
-    setFormError(null);
-    clearSaveError();
-    clearDeleteError();
-    clearTestError();
-  }, [data, loading]);
+  const values = form.values;
+  const fields = form.fields;
 
   function clearAllErrors() {
     setFormError(null);
-    clearSaveError();
+    form.clearError();
     clearDeleteError();
     clearTestError();
   }
@@ -512,26 +520,24 @@ export default function EmailProviderPage() {
   async function handleSave() {
     setTestResult(null);
     clearAllErrors();
+    if (!values) return;
 
-    const configResult = buildProviderConfig(provider, fields);
+    const configResult = buildProviderConfig(values.provider, values.creds);
     if (!configResult.ok) {
       setFormError(configResult.error);
       return;
     }
-    if (!fromAddress.trim()) {
+    if (!values.fromAddress.trim()) {
       setFormError("From address is required.");
       return;
     }
 
-    const result = await saveMutate({
-      body: {
-        provider,
-        fromAddress: fromAddress.trim(),
-        config: configResult.config,
-      },
-    });
+    const result = await form.save();
     if (result.ok) {
-      setFields(INITIAL_FIELD_VALUES);
+      // Transient test-flow state isn't part of the form baseline, so the
+      // refetch re-baseline doesn't touch it — clear it here like the old
+      // sync effect did.
+      setRecipientEmail("");
     }
   }
 
@@ -540,16 +546,17 @@ export default function EmailProviderPage() {
     clearAllErrors();
     const result = await deleteMutate();
     if (result.ok) {
+      // The invalidation refetch re-baselines the form to the baseline-only
+      // state; only the transient UI state needs clearing by hand.
       setExpanded(false);
-      setProvider("resend");
-      setFromAddress("");
-      setFields(INITIAL_FIELD_VALUES);
+      setRecipientEmail("");
     }
   }
 
   async function handleTest() {
     setTestResult(null);
     clearAllErrors();
+    if (!values) return;
 
     if (!recipientEmail.trim()) {
       setFormError("Enter a recipient email to send a test.");
@@ -560,8 +567,8 @@ export default function EmailProviderPage() {
     // override" by checking whether any provider-specific field was touched.
     // If anything is typed we MUST test exactly that — otherwise we'd silently
     // fall through to the saved/platform config and mislead the admin.
-    const hasTypedCreds = hasAnyProviderFieldFilled(provider, fields);
-    const configResult = buildProviderConfig(provider, fields);
+    const hasTypedCreds = hasAnyProviderFieldFilled(values.provider, values.creds);
+    const configResult = buildProviderConfig(values.provider, values.creds);
 
     const body: Record<string, unknown> = { recipientEmail: recipientEmail.trim() };
 
@@ -570,8 +577,9 @@ export default function EmailProviderPage() {
         setFormError(configResult.error);
         return;
       }
-      body.provider = provider;
-      body.fromAddress = fromAddress.trim() || override?.fromAddress || baseline?.fromAddress;
+      body.provider = values.provider;
+      body.fromAddress =
+        values.fromAddress.trim() || override?.fromAddress || baseline?.fromAddress;
       body.config = configResult.config;
     } else if (!hasOverride) {
       setFormError("Enter credentials to test, or save an override first.");
@@ -586,10 +594,8 @@ export default function EmailProviderPage() {
   function handleCollapse() {
     setExpanded(false);
     setTestResult(null);
-    setProvider("resend");
-    setFromAddress("");
     setRecipientEmail("");
-    setFields(INITIAL_FIELD_VALUES);
+    form.reset();
     clearAllErrors();
   }
 
@@ -618,10 +624,10 @@ export default function EmailProviderPage() {
         )}
 
         <AdminContentWrapper
-          loading={loading}
-          error={error}
+          loading={form.loading}
+          error={form.loadError}
           feature="Email Provider"
-          onRetry={refetch}
+          onRetry={form.refetch}
           loadingMessage="Loading email configuration..."
         >
           <div className="mx-auto max-w-3xl space-y-8">
@@ -668,7 +674,7 @@ export default function EmailProviderPage() {
                 />
               )}
 
-              {showEditor && (
+              {showEditor && values && fields && (
                 <OverrideShell
                   status={hasOverride ? "connected" : "disconnected"}
                   title={
@@ -705,8 +711,12 @@ export default function EmailProviderPage() {
                           Remove override
                         </Button>
                       )}
-                      <Button type="button" onClick={handleSave} disabled={saving}>
-                        {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+                      <Button
+                        type="button"
+                        onClick={handleSave}
+                        disabled={form.saving || !form.dirty}
+                      >
+                        {form.saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
                         {hasOverride ? "Replace" : "Save"}
                       </Button>
                     </>
@@ -729,7 +739,10 @@ export default function EmailProviderPage() {
                   <div className="space-y-4">
                     <div className="space-y-1">
                       <Label htmlFor="providerSelect">Provider</Label>
-                      <Select value={provider} onValueChange={(v) => setProvider(v as EmailProvider)}>
+                      <Select
+                        value={values.provider}
+                        onValueChange={(v) => fields.provider.set(v as EmailProvider)}
+                      >
                         <SelectTrigger id="providerSelect">
                           <SelectValue />
                         </SelectTrigger>
@@ -752,9 +765,9 @@ export default function EmailProviderPage() {
                     </div>
 
                     <ProviderFields
-                      provider={provider}
-                      values={fields}
-                      onChange={setFields}
+                      provider={values.provider}
+                      values={values.creds}
+                      onChange={fields.creds.set}
                       showSecrets={showSecrets}
                       onToggleSecrets={() => setShowSecrets((v) => !v)}
                     />
@@ -765,8 +778,8 @@ export default function EmailProviderPage() {
                         id="fromAddress"
                         placeholder={override?.fromAddress ?? "Acme <noreply@acme.com>"}
                         className="font-mono text-sm"
-                        value={fromAddress}
-                        onChange={(e) => setFromAddress(e.target.value)}
+                        value={values.fromAddress}
+                        onChange={(e) => fields.fromAddress.set(e.target.value)}
                       />
                       <p className="text-xs text-muted-foreground">
                         Must be a sender verified with the chosen provider.

--- a/packages/web/src/app/admin/sandbox/__tests__/mode-gating.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/mode-gating.test.tsx
@@ -51,10 +51,15 @@ function makeStatus(overrides: Partial<SandboxStatus> = {}): SandboxStatus {
 
 // The sandbox-status fetch always succeeds in these tests — the point is
 // that a healthy status payload alone must NOT be enough to render a view
-// while the deploy mode is still a guess.
+// while the deploy mode is still a guess. The payload is hoisted to a stable
+// reference to match the real hook's contract: TanStack Query returns a
+// referentially stable `data` across renders (structural sharing), and
+// `useConfigForm`'s render-time re-baseline relies on that — a fresh object
+// per render would re-baseline forever.
+const stableStatus = makeStatus();
 mock.module("@/ui/hooks/use-admin-fetch", () => ({
   useAdminFetch: () => ({
-    data: makeStatus(),
+    data: stableStatus,
     loading: false,
     error: null,
     setError: () => {},

--- a/packages/web/src/app/admin/sandbox/page.tsx
+++ b/packages/web/src/app/admin/sandbox/page.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/ui/components/admin/compact";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { useConfigForm } from "@/ui/hooks/use-config-form";
 // Provider-key vocabulary and status wire schemas are shared with the
 // API route layer via `@useatlas/schemas` (#3371).
 import {
@@ -251,7 +252,6 @@ export default function SandboxPage() {
                 />
               ) : (
                 <SelfHostedSandboxView
-                  status={data}
                   onSelectBackend={(backendId) =>
                     saveMutation.mutate({ body: { value: backendId } })
                   }
@@ -692,31 +692,52 @@ function ProviderRow({
 
 // ── Self-hosted view ──────────────────────────────────────────────
 
+/** Editable field set for the self-hosted backend form (#4204). */
+type SelfHostedFormValues = {
+  backend: string;
+  sidecarUrl: string;
+};
+
 function SelfHostedSandboxView({
-  status,
   onSelectBackend,
   onSetSidecarUrl,
   onReset,
   saving,
 }: {
-  status: SandboxStatus;
   onSelectBackend: (backendId: string) => Promise<unknown>;
   onSetSidecarUrl: (url: string) => Promise<unknown>;
   onReset: () => Promise<void>;
   saving: boolean;
 }) {
-  const [selectedBackend, setSelectedBackend] = useState(
-    status.workspaceOverride ?? "",
-  );
-  const [sidecarUrl, setSidecarUrl] = useState(status.workspaceSidecarUrl ?? "");
+  // Load / dirty gate / reset-on-refetch ride `useConfigForm` on the same
+  // status query the page already fetches (TanStack dedupes on the path key),
+  // replacing the hand-rolled useState pair + `hasChanges` compare (#4204).
+  // The save itself deliberately does NOT go through `form.save()`: it fans
+  // out to two settings endpoints (ATLAS_SANDBOX_BACKEND / ATLAS_SANDBOX_URL,
+  // PUT or DELETE depending on the value) via the parent's mutations, and
+  // multi-endpoint saves are out of useConfigForm's scope by design (see the
+  // hook docs). The mutations' invalidation refetch still drives the
+  // re-baseline, so a successful save flips `dirty` back to false.
+  const form = useConfigForm<SandboxStatus, SelfHostedFormValues>({
+    path: "/api/v1/admin/sandbox/status",
+    schema: SandboxStatusSchema,
+    toForm: (s) => ({
+      backend: s.workspaceOverride ?? "",
+      sidecarUrl: s.workspaceSidecarUrl ?? "",
+    }),
+  });
+
+  const status = form.data;
+  const fields = form.fields;
+  const values = form.values;
+  // The parent only renders this view once the status query has data, so
+  // this guard closes the single pre-baseline render pass, not a real state.
+  if (!status || !fields || !values) return null;
 
   const availableBackends = status.availableBackends.filter((b) => b.available);
   const showSidecarUrl =
-    selectedBackend === "sidecar" ||
-    (!selectedBackend && status.activeBackend === "sidecar");
-  const hasChanges =
-    (selectedBackend && selectedBackend !== (status.workspaceOverride ?? "")) ||
-    sidecarUrl !== (status.workspaceSidecarUrl ?? "");
+    values.backend === "sidecar" ||
+    (!values.backend && status.activeBackend === "sidecar");
   const hasOverride = Boolean(status.workspaceOverride);
   const shellStatus: StatusKind = hasOverride ? "connected" : "ready";
 
@@ -749,9 +770,9 @@ function SelfHostedSandboxView({
                 size="sm"
                 className="text-muted-foreground"
                 onClick={async () => {
+                  // The DELETEs' invalidation refetch re-baselines the form
+                  // to the cleared override — no manual field reset needed.
                   await onReset();
-                  setSelectedBackend("");
-                  setSidecarUrl("");
                 }}
                 disabled={saving}
               >
@@ -765,17 +786,17 @@ function SelfHostedSandboxView({
                 // `"__default__"` is a Select sentinel: picking it clears the
                 // workspace override so the platform default takes over.
                 const effectiveBackend =
-                  selectedBackend === "__default__" ? "" : selectedBackend;
+                  values.backend === "__default__" ? "" : values.backend;
                 if (effectiveBackend) {
                   await onSelectBackend(effectiveBackend);
                 } else {
                   await onReset();
                 }
-                if (sidecarUrl && showSidecarUrl && effectiveBackend) {
-                  await onSetSidecarUrl(sidecarUrl);
+                if (values.sidecarUrl && showSidecarUrl && effectiveBackend) {
+                  await onSetSidecarUrl(values.sidecarUrl);
                 }
               }}
-              disabled={saving || !hasChanges}
+              disabled={saving || !form.dirty}
             >
               {saving ? (
                 <Loader2 className="mr-1.5 size-3.5 animate-spin" />
@@ -801,7 +822,7 @@ function SelfHostedSandboxView({
 
         <div className="space-y-1.5">
           <Label htmlFor="sandbox-backend">Backend</Label>
-          <Select value={selectedBackend} onValueChange={setSelectedBackend}>
+          <Select value={values.backend} onValueChange={fields.backend.set}>
             <SelectTrigger id="sandbox-backend" aria-label="Sandbox backend">
               <SelectValue placeholder="Use platform default" />
             </SelectTrigger>
@@ -832,8 +853,8 @@ function SelfHostedSandboxView({
               type="url"
               placeholder="https://sandbox.example.com"
               className="font-mono text-sm"
-              value={sidecarUrl}
-              onChange={(e) => setSidecarUrl(e.target.value)}
+              value={values.sidecarUrl}
+              onChange={(e) => fields.sidecarUrl.set(e.target.value)}
             />
             <p className="text-[11px] text-muted-foreground">
               Override the sidecar service URL. Leave empty to use the platform default.


### PR DESCRIPTION
## Summary

Fixes the email-provider admin form's missing dirty gate (Save always fired, even on an unchanged form) by migrating it — plus the sandbox page (2 sub-forms) and the branding page (react-hook-form + a hand-rolled reset-on-refetch effect) — onto `useConfigForm`. The dirty gate and reset-on-refetch now derive from a single `toForm` field-set statement.

Closes #4204

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — `email-provider/__tests__/dirty-gate.test.tsx`, `branding/__tests__/config-form.test.tsx`, updated `sandbox` mode-gating test
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area) — inherited from issue (bug, area: web)
- [ ] CHANGELOG.md updated (if user-facing change)

> ⚠️ **Draft:** authored by an autonomous ship-issue worker that was interrupted (session limit) before the `/ci` gate ran. CI checks below have not been locally verified — do not merge until green.

https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c)_