### PR TITLE
refactor(api): mountBoth helper replaces 50 trailing-slash route-mount pairs (#4202)

### DIFF
--- a/packages/api/src/api/__tests__/admin-trailing-slash.test.ts
+++ b/packages/api/src/api/__tests__/admin-trailing-slash.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Behavioral pin for #4202 — every admin sub-router mount answers identically
+ * with and without a trailing slash.
+ *
+ * The mount list is extracted from admin.ts source (the mountBoth call sites)
+ * rather than hardcoded, so a newly added sub-router is covered automatically.
+ * For each mount path the real admin router is driven twice — `GET <path>` and
+ * `GET <path>/` — and the two responses must carry the same status. The
+ * assertion is equality (not a specific code): some sub-router roots have no
+ * GET route (404 on both), others answer 200/4xx under the unified mocks —
+ * either way the slash variant may never diverge, which is exactly the bug
+ * class the old hand-written pairs allowed (`/organizations` shipped bare-only
+ * before this refactor).
+ */
+
+import { describe, it, expect, afterAll } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+  },
+});
+
+// --- Import the router AFTER mocks ---
+
+const { admin } = await import("../routes/admin");
+const { Hono } = await import("hono");
+
+const app = new Hono();
+app.route("/api/v1/admin", admin);
+
+function request(p: string) {
+  return app.request(`http://localhost${p}`);
+}
+
+const adminSource = fs.readFileSync(
+  path.resolve(import.meta.dir, "..", "routes", "admin.ts"),
+  "utf-8",
+);
+const mountPaths = [...adminSource.matchAll(/mountBoth\(admin, "([^"]+)"/g)].map(
+  (m) => m[1]!,
+);
+
+afterAll(() => {
+  mocks.cleanup();
+});
+
+describe("admin sub-router mounts — trailing-slash parity (#4202)", () => {
+  it("extracts the mount list from admin.ts (guards against a rotted regex)", () => {
+    expect(mountPaths.length).toBeGreaterThanOrEqual(45);
+    expect(mountPaths).toContain("/organizations");
+    expect(mountPaths).toContain("/audit");
+  });
+
+  it("every mount answers with the same status with and without a trailing slash", async () => {
+    for (const mountPath of mountPaths) {
+      const bare = await request(`/api/v1/admin${mountPath}`);
+      const slash = await request(`/api/v1/admin${mountPath}/`);
+      expect({ path: mountPath, status: slash.status }).toEqual({
+        path: mountPath,
+        status: bare.status,
+      });
+    }
+  });
+
+  it("/organizations (the previously half-registered mount) resolves on both variants", async () => {
+    // Before #4202 the trailing-slash variant was never registered, so
+    // GET /organizations/ 404'd while GET /organizations resolved.
+    const bare = await request("/api/v1/admin/organizations");
+    const slash = await request("/api/v1/admin/organizations/");
+    expect(bare.status).not.toBe(404);
+    expect(slash.status).toBe(bare.status);
+  });
+});

--- a/packages/api/src/api/__tests__/admin-trailing-slash.test.ts
+++ b/packages/api/src/api/__tests__/admin-trailing-slash.test.ts
@@ -4,13 +4,21 @@
  *
  * The mount list is extracted from admin.ts source (the mountBoth call sites)
  * rather than hardcoded, so a newly added sub-router is covered automatically.
- * For each mount path the real admin router is driven twice — `GET <path>` and
- * `GET <path>/` — and the two responses must carry the same status. The
- * assertion is equality (not a specific code): some sub-router roots have no
- * GET route (404 on both), others answer 200/4xx under the unified mocks —
- * either way the slash variant may never diverge, which is exactly the bug
- * class the old hand-written pairs allowed (`/organizations` shipped bare-only
- * before this refactor).
+ * For each mount path the real admin router is driven with several methods, at
+ * both `<path>` and `<path>/`, and the two responses must carry the same status
+ * per method. The assertion is equality (not a specific code): some roots have
+ * no root route (404 on both), so a GET-only probe would pass vacuously as
+ * `404 === 404` for the POST-style action roots (`/archive-connection`,
+ * `/restore-connection`, …). Probing GET **and** POST means each such root is
+ * exercised by a method its handler actually answers, so the parity assertion
+ * observes a real (non-404) response rather than the trivial 404 pair — which
+ * is exactly the divergence the old hand-written pairs allowed (`/organizations`
+ * shipped bare-only before this refactor).
+ *
+ * Structural completeness — that a mount can never be *half*-registered in the
+ * first place — is enforced separately by the source-scan guard in
+ * routes/__tests__/mount.test.ts (no bare `admin.route(`); this file pins the
+ * runtime behavior for the roots that answer at `/`.
  */
 
 import { describe, it, expect, afterAll } from "bun:test";
@@ -35,8 +43,8 @@ const { Hono } = await import("hono");
 const app = new Hono();
 app.route("/api/v1/admin", admin);
 
-function request(p: string) {
-  return app.request(`http://localhost${p}`);
+function request(p: string, method = "GET") {
+  return app.request(`http://localhost${p}`, { method });
 }
 
 const adminSource = fs.readFileSync(
@@ -59,13 +67,19 @@ describe("admin sub-router mounts — trailing-slash parity (#4202)", () => {
   });
 
   it("every mount answers with the same status with and without a trailing slash", async () => {
+    // Probe GET and POST: a GET-only probe passes vacuously (404 === 404) for
+    // the POST-style action roots, which have no root GET handler. POST hits
+    // their real handler, so the parity assertion observes a non-404 response.
     for (const mountPath of mountPaths) {
-      const bare = await request(`/api/v1/admin${mountPath}`);
-      const slash = await request(`/api/v1/admin${mountPath}/`);
-      expect({ path: mountPath, status: slash.status }).toEqual({
-        path: mountPath,
-        status: bare.status,
-      });
+      for (const method of ["GET", "POST"]) {
+        const bare = await request(`/api/v1/admin${mountPath}`, method);
+        const slash = await request(`/api/v1/admin${mountPath}/`, method);
+        expect({ path: mountPath, method, status: slash.status }).toEqual({
+          path: mountPath,
+          method,
+          status: bare.status,
+        });
+      }
     }
   });
 

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -48,6 +48,7 @@ import { subProcessorSubscriptions } from "./routes/sub-processor-subscriptions"
 import { contact } from "./routes/contact";
 import { wellKnown } from "./routes/well-known";
 import { authMd } from "./routes/auth-md";
+import { mountBoth } from "./routes/mount";
 
 const log = createLogger("api");
 const tracer = trace.getTracer("atlas");
@@ -267,9 +268,9 @@ try {
 // Suggestions routes — user-facing query suggestions.
 try {
   const { suggestions } = await import("./routes/suggestions");
-  app.route("/api/v1/suggestions", suggestions);
-  // Also register trailing-slash variant so ?table=orders and GET / both match.
-  app.route("/api/v1/suggestions/", suggestions);
+  // mountBoth registers the trailing-slash variant too, so ?table=orders and
+  // GET / both match (#4202).
+  mountBoth(app, "/api/v1/suggestions", suggestions);
 } catch (err) {
   log.error(
     { err: err instanceof Error ? err : new Error(String(err)) },

--- a/packages/api/src/api/routes/__tests__/mount.test.ts
+++ b/packages/api/src/api/routes/__tests__/mount.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for mountBoth (#4202) — the single registration seam that replaces
+ * the hand-written trailing-slash mount pairs in admin.ts / index.ts.
+ *
+ * Two layers:
+ *   1. Unit — mountBoth registers a child at both `path` and `path + "/"`,
+ *      with identical dispatch for every method, and rejects a path that
+ *      already carries a trailing slash.
+ *   2. Source-scan guard — the paired duplicates must not creep back: no
+ *      trailing-slash mount paths remain in admin.ts / index.ts, and admin.ts
+ *      registers sub-routers exclusively through mountBoth (a direct
+ *      `admin.route(...)` is the half-registration footgun the helper exists
+ *      to close).
+ */
+
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { Hono } from "hono";
+import { mountBoth } from "../mount";
+
+function buildParent(): Hono {
+  const child = new Hono();
+  child.get("/", (c) => c.json({ hit: "root-get" }));
+  child.post("/", (c) => c.json({ hit: "root-post" }));
+  child.get("/items/:id", (c) => c.json({ hit: `item-${c.req.param("id")}` }));
+
+  const parent = new Hono();
+  mountBoth(parent, "/audit", child);
+  return parent;
+}
+
+describe("mountBoth", () => {
+  it("serves the child's root routes at both the bare path and the trailing-slash variant", async () => {
+    const parent = buildParent();
+
+    const bareGet = await parent.request("/audit");
+    const slashGet = await parent.request("/audit/");
+    expect(bareGet.status).toBe(200);
+    expect(slashGet.status).toBe(200);
+    expect(await bareGet.json()).toEqual(await slashGet.json());
+
+    const barePost = await parent.request("/audit", { method: "POST" });
+    const slashPost = await parent.request("/audit/", { method: "POST" });
+    expect(barePost.status).toBe(200);
+    expect(slashPost.status).toBe(200);
+    expect(await barePost.json()).toEqual(await slashPost.json());
+  });
+
+  it("serves child sub-paths (unaffected by the pairing)", async () => {
+    const parent = buildParent();
+    const res = await parent.request("/audit/items/7");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ hit: "item-7" });
+  });
+
+  it("does not leak matches onto sibling prefixes", async () => {
+    const parent = buildParent();
+    expect((await parent.request("/auditx")).status).toBe(404);
+    expect((await parent.request("/audi")).status).toBe(404);
+  });
+
+  it("rejects methods the child does not define, identically on both variants", async () => {
+    const parent = buildParent();
+    const bare = await parent.request("/audit", { method: "DELETE" });
+    const slash = await parent.request("/audit/", { method: "DELETE" });
+    expect(bare.status).toBe(404);
+    expect(slash.status).toBe(bare.status);
+  });
+
+  it("throws at registration time when the path already ends with a trailing slash", () => {
+    const parent = new Hono();
+    const child = new Hono();
+    expect(() => mountBoth(parent, "/audit/", child)).toThrow(/must not end with "\/"/);
+    expect(() => mountBoth(parent, "/", child)).toThrow(/must not end with "\/"/);
+  });
+});
+
+describe("trailing-slash mount pairs stay retired (#4202 source guard)", () => {
+  const routesDir = path.resolve(import.meta.dir, "..");
+  const adminSource = fs.readFileSync(path.join(routesDir, "admin.ts"), "utf-8");
+  const indexSource = fs.readFileSync(
+    path.resolve(routesDir, "..", "index.ts"),
+    "utf-8",
+  );
+
+  // A mount whose quoted path ends with "/" (beyond a bare "/") is one half
+  // of the old duplicate pattern — mountBoth registers that variant itself.
+  const trailingSlashMount = /\.route\(\s*"[^"]+\/"/;
+
+  it("admin.ts has no trailing-slash .route() mounts", () => {
+    expect(adminSource).not.toMatch(trailingSlashMount);
+  });
+
+  it("index.ts has no trailing-slash .route() mounts", () => {
+    expect(indexSource).not.toMatch(trailingSlashMount);
+  });
+
+  it("admin.ts registers sub-routers only via mountBoth — a direct admin.route() can be half-registered with no signal", () => {
+    expect(adminSource).not.toMatch(/admin\.route\(/);
+  });
+
+  it("mountBoth call sites in admin.ts cover the full sub-router surface", () => {
+    const count = (adminSource.match(/mountBoth\(admin, "/g) ?? []).length;
+    // 49 static mounts + marketplace + semantic-improve. A drop below the
+    // floor means mounts were converted back to raw .route() calls (or the
+    // registration seam moved) — update this test alongside such a change.
+    expect(count).toBeGreaterThanOrEqual(45);
+  });
+});

--- a/packages/api/src/api/routes/__tests__/mount.test.ts
+++ b/packages/api/src/api/routes/__tests__/mount.test.ts
@@ -102,9 +102,9 @@ describe("trailing-slash mount pairs stay retired (#4202 source guard)", () => {
 
   it("mountBoth call sites in admin.ts cover the full sub-router surface", () => {
     const count = (adminSource.match(/mountBoth\(admin, "/g) ?? []).length;
-    // 49 static mounts + marketplace + semantic-improve. A drop below the
-    // floor means mounts were converted back to raw .route() calls (or the
-    // registration seam moved) — update this test alongside such a change.
+    // 50 static mounts + marketplace + semantic-improve (52 total). A drop
+    // below the floor means mounts were converted back to raw .route() calls
+    // (or the registration seam moved) — update this test alongside such a change.
     expect(count).toBeGreaterThanOrEqual(45);
   });
 });

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -101,6 +101,7 @@ import { adminRoles } from "./admin-roles";
 import { adminModelConfig } from "./admin-model-config";
 import { adminEmailProvider } from "./admin-email-provider";
 import { adminAuthPreamble, authErrorCode, requireAdminAuth } from "./admin-auth";
+import { mountBoth } from "./mount";
 import { enforcePermission } from "./admin-router";
 import type { Permission } from "@atlas/api/lib/auth/permissions";
 import { adminUsage } from "./admin-usage";
@@ -390,74 +391,44 @@ admin.onError(eeOnError);
 
 admin.use(withRequestId);
 
-// Mount organization management sub-router
-admin.route("/organizations", adminOrgs);
-admin.route("/learned-patterns", adminLearnedPatterns);
-admin.route("/learned-patterns/", adminLearnedPatterns);
-admin.route("/sessions", adminSessions);
-admin.route("/sessions/", adminSessions);
-admin.route("/audit", adminAudit);
-admin.route("/audit/", adminAudit);
-admin.route("/prompts", adminPrompts);
-admin.route("/prompts/", adminPrompts);
-admin.route("/suggestions", adminSuggestions);
-admin.route("/suggestions/", adminSuggestions);
-admin.route("/starter-prompts", adminStarterPrompts);
-admin.route("/starter-prompts/", adminStarterPrompts);
-admin.route("/usage", adminUsage);
-admin.route("/usage/", adminUsage);
-admin.route("/sso", adminSso);
-admin.route("/sso/", adminSso);
-admin.route("/scim", adminScim);
-admin.route("/scim/", adminScim);
-admin.route("/ip-allowlist", adminIPAllowlist);
-admin.route("/ip-allowlist/", adminIPAllowlist);
-admin.route("/roles", adminRoles);
-admin.route("/roles/", adminRoles);
-admin.route("/audit/retention", adminAuditRetention);
-admin.route("/audit/retention/", adminAuditRetention);
-admin.route("/mcp/action-policy", adminMcpActionPolicy);
-admin.route("/mcp/action-policy/", adminMcpActionPolicy);
-admin.route("/audit/admin-action-retention", adminActionRetention);
-admin.route("/audit/admin-action-retention/", adminActionRetention);
-admin.route("/audit/erase-user", adminEraseUser);
-admin.route("/audit/erase-user/", adminEraseUser);
-admin.route("/model-config", adminModelConfig);
-admin.route("/model-config/", adminModelConfig);
-admin.route("/email-provider", adminEmailProvider);
-admin.route("/email-provider/", adminEmailProvider);
-admin.route("/approval", adminApproval);
-admin.route("/approval/", adminApproval);
-admin.route("/session-memory", adminSessionMemory);
-admin.route("/session-memory/", adminSessionMemory);
-admin.route("/compliance", adminCompliance);
-admin.route("/compliance/", adminCompliance);
-admin.route("/branding", adminBranding);
-admin.route("/branding/", adminBranding);
-admin.route("/domain", adminDomains);
-admin.route("/domain/", adminDomains);
-admin.route("/proactive/analytics", adminProactiveAnalytics);
-admin.route("/proactive/analytics/", adminProactiveAnalytics);
-admin.route("/onboarding-emails", adminOnboardingEmails);
-admin.route("/onboarding-emails/", adminOnboardingEmails);
-admin.route("/abuse", adminAbuse);
-admin.route("/abuse/", adminAbuse);
-admin.route("/integrations", adminIntegrations);
-admin.route("/integrations/", adminIntegrations);
-admin.route("/sandbox", adminSandbox);
-admin.route("/sandbox/", adminSandbox);
-admin.route("/scheduler", adminScheduler);
-admin.route("/scheduler/", adminScheduler);
-admin.route("/residency", adminResidency);
-admin.route("/residency/", adminResidency);
-admin.route("/migrate", adminMigrate);
-admin.route("/migrate/", adminMigrate);
-admin.route("/tokens", adminTokens);
-admin.route("/tokens/", adminTokens);
-admin.route("/oauth-clients", adminOauthClients);
-admin.route("/oauth-clients/", adminOauthClients);
-admin.route("/workspace-keys", adminWorkspaceKeys);
-admin.route("/workspace-keys/", adminWorkspaceKeys);
+// Mount domain sub-routers. mountBoth registers each at both the bare path
+// and its trailing-slash variant (#4202) — Hono matches trailing slashes
+// strictly, so a single .route() call would leave the child's root routes
+// 404ing on `GET <path>/`. See ./mount.ts.
+mountBoth(admin, "/organizations", adminOrgs);
+mountBoth(admin, "/learned-patterns", adminLearnedPatterns);
+mountBoth(admin, "/sessions", adminSessions);
+mountBoth(admin, "/audit", adminAudit);
+mountBoth(admin, "/prompts", adminPrompts);
+mountBoth(admin, "/suggestions", adminSuggestions);
+mountBoth(admin, "/starter-prompts", adminStarterPrompts);
+mountBoth(admin, "/usage", adminUsage);
+mountBoth(admin, "/sso", adminSso);
+mountBoth(admin, "/scim", adminScim);
+mountBoth(admin, "/ip-allowlist", adminIPAllowlist);
+mountBoth(admin, "/roles", adminRoles);
+mountBoth(admin, "/audit/retention", adminAuditRetention);
+mountBoth(admin, "/mcp/action-policy", adminMcpActionPolicy);
+mountBoth(admin, "/audit/admin-action-retention", adminActionRetention);
+mountBoth(admin, "/audit/erase-user", adminEraseUser);
+mountBoth(admin, "/model-config", adminModelConfig);
+mountBoth(admin, "/email-provider", adminEmailProvider);
+mountBoth(admin, "/approval", adminApproval);
+mountBoth(admin, "/session-memory", adminSessionMemory);
+mountBoth(admin, "/compliance", adminCompliance);
+mountBoth(admin, "/branding", adminBranding);
+mountBoth(admin, "/domain", adminDomains);
+mountBoth(admin, "/proactive/analytics", adminProactiveAnalytics);
+mountBoth(admin, "/onboarding-emails", adminOnboardingEmails);
+mountBoth(admin, "/abuse", adminAbuse);
+mountBoth(admin, "/integrations", adminIntegrations);
+mountBoth(admin, "/sandbox", adminSandbox);
+mountBoth(admin, "/scheduler", adminScheduler);
+mountBoth(admin, "/residency", adminResidency);
+mountBoth(admin, "/migrate", adminMigrate);
+mountBoth(admin, "/tokens", adminTokens);
+mountBoth(admin, "/oauth-clients", adminOauthClients);
+mountBoth(admin, "/workspace-keys", adminWorkspaceKeys);
 // Per-user trusted-browsers — see me-trusted-devices.ts header.
 import { registerTrustedDeviceRoutes } from "./me-trusted-devices";
 registerTrustedDeviceRoutes(admin, reqId);
@@ -471,47 +442,30 @@ registerRevokeRoutes(admin, adminAuthAndContext, verifyOrgMembership);
 // the same module — that route uses light auth (no adminAuthAndContext gate).
 import { registerMfaResetRoutes } from "./admin-mfa-reset";
 registerMfaResetRoutes(admin, adminAuthAndContext, verifyOrgMembership, reqId);
-admin.route("/connections", adminConnections);
-admin.route("/connections/", adminConnections);
+mountBoth(admin, "/connections", adminConnections);
 // #3894 — per-Connection-group Source-catalog descriptions (ADR-0022 §4).
-admin.route("/connection-groups", adminConnectionGroupDescriptions);
-admin.route("/connection-groups/", adminConnectionGroupDescriptions);
-admin.route("/openapi-datasources", adminOpenApiDatasources);
-admin.route("/openapi-datasources/", adminOpenApiDatasources);
-admin.route("/knowledge", adminKnowledge);
-admin.route("/knowledge/", adminKnowledge);
-admin.route("/proactive", adminProactive);
-admin.route("/proactive/", adminProactive);
-admin.route("/publish", adminPublish);
-admin.route("/publish/", adminPublish);
-admin.route("/publish-preview", adminPublishPreview);
-admin.route("/publish-preview/", adminPublishPreview);
-admin.route("/archive-connection", adminArchive);
-admin.route("/archive-connection/", adminArchive);
-admin.route("/restore-connection", adminRestore);
-admin.route("/restore-connection/", adminRestore);
-admin.route("/plugins", adminPlugins);
-admin.route("/plugins/", adminPlugins);
-admin.route("/cache", adminCache);
-admin.route("/cache/", adminCache);
-admin.route("/proactive/pause", adminProactivePauses);
-admin.route("/proactive/pause/", adminProactivePauses);
-admin.route("/proactive/public-dataset", adminProactivePublicDataset);
-admin.route("/proactive/public-dataset/", adminProactivePublicDataset);
-admin.route("/proactive/events", adminProactiveEvents);
-admin.route("/proactive/events/", adminProactiveEvents);
-admin.route("/admin-actions", adminActions);
-admin.route("/admin-actions/", adminActions);
-admin.route("/security", adminSecurityMetrics);
-admin.route("/security/", adminSecurityMetrics);
+mountBoth(admin, "/connection-groups", adminConnectionGroupDescriptions);
+mountBoth(admin, "/openapi-datasources", adminOpenApiDatasources);
+mountBoth(admin, "/knowledge", adminKnowledge);
+mountBoth(admin, "/proactive", adminProactive);
+mountBoth(admin, "/publish", adminPublish);
+mountBoth(admin, "/publish-preview", adminPublishPreview);
+mountBoth(admin, "/archive-connection", adminArchive);
+mountBoth(admin, "/restore-connection", adminRestore);
+mountBoth(admin, "/plugins", adminPlugins);
+mountBoth(admin, "/cache", adminCache);
+mountBoth(admin, "/proactive/pause", adminProactivePauses);
+mountBoth(admin, "/proactive/public-dataset", adminProactivePublicDataset);
+mountBoth(admin, "/proactive/events", adminProactiveEvents);
+mountBoth(admin, "/admin-actions", adminActions);
+mountBoth(admin, "/security", adminSecurityMetrics);
 // Plugin marketplace — dynamic import defers loading the marketplace module
 // (and its dependency graph) until admin routes register. Import failure is a
 // build/test bug, not a runtime-recoverable condition: log then re-throw so it
 // fails loudly instead of serving silent 404s on marketplace endpoints.
 try {
   const { workspaceMarketplace } = await import("./admin-marketplace");
-  admin.route("/plugins/marketplace", workspaceMarketplace);
-  admin.route("/plugins/marketplace/", workspaceMarketplace);
+  mountBoth(admin, "/plugins/marketplace", workspaceMarketplace);
 } catch (err) {
   log.error(
     { err: err instanceof Error ? err : new Error(String(err)) },
@@ -525,8 +479,7 @@ try {
 // reason as the marketplace import above.
 try {
   const { adminSemanticImprove } = await import("./admin-semantic-improve");
-  admin.route("/semantic-improve", adminSemanticImprove);
-  admin.route("/semantic-improve/", adminSemanticImprove);
+  mountBoth(admin, "/semantic-improve", adminSemanticImprove);
 } catch (err) {
   log.error(
     { err: err instanceof Error ? err : new Error(String(err)) },

--- a/packages/api/src/api/routes/mount.ts
+++ b/packages/api/src/api/routes/mount.ts
@@ -1,0 +1,52 @@
+/**
+ * Trailing-slash-tolerant sub-router mounting.
+ *
+ * Hono matches trailing slashes strictly: mounting a child at "/audit" makes
+ * its root route answer `GET /audit` but NOT `GET /audit/` (and vice versa),
+ * so every mount historically needed a hand-written pair —
+ * `admin.route("/audit", x)` + `admin.route("/audit/", x)`. With ~50 such
+ * pairs a new sub-router could be half-registered (one variant only) with no
+ * signal (#4202 — `/organizations` shipped exactly that way).
+ *
+ * `mountBoth` is the single registration seam: one call registers both
+ * variants, so the invariant "route behavior is identical with and without a
+ * trailing slash" holds by construction. Sub-paths are unaffected either way
+ * (Hono's mergePath collapses the double slash), so the pair only matters for
+ * the child's root ("/") routes.
+ */
+
+import type { Env, Hono, Schema } from "hono";
+
+/**
+ * Mount `child` on `parent` at both `path` and `path + "/"`.
+ *
+ * Registration order is preserved relative to other mounts — the bare path is
+ * registered first, then the trailing-slash variant, exactly like the manual
+ * pairs this replaces. When `parent` is an `OpenAPIHono`, its `.route()`
+ * override still runs (runtime dispatch), so OpenAPI registry merging is
+ * unchanged.
+ *
+ * @throws Error at registration (boot) time when `path` ends with "/" — the
+ * variant is added automatically, and accepting one would silently register
+ * `path` and `path + "//"` instead of the intended pair.
+ */
+export function mountBoth<
+  E extends Env,
+  S extends Schema,
+  BasePath extends string,
+  SubEnv extends Env,
+  SubSchema extends Schema,
+  SubBasePath extends string,
+>(
+  parent: Hono<E, S, BasePath>,
+  path: string,
+  child: Hono<SubEnv, SubSchema, SubBasePath>,
+): void {
+  if (path.endsWith("/")) {
+    throw new Error(
+      `mountBoth: path must not end with "/" (got "${path}") — the trailing-slash variant is registered automatically`,
+    );
+  }
+  parent.route(path, child);
+  parent.route(`${path}/`, child);
+}


### PR DESCRIPTION
## Summary

Replaces the 50 trailing-slash-paired `admin.route(...)` duplicates in `api/routes/admin.ts` (and the same doubling in `api/index.ts`) with a single `mountBoth(parent, path, child)` helper, so a sub-router can no longer be half-registered with only one variant.

Closes #4202

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — pins that route behavior is identical with and without the trailing slash
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area) — inherited from issue (refactor, area: api)
- [ ] CHANGELOG.md updated (if user-facing change)

> ⚠️ **Draft:** authored by an autonomous ship-issue worker that was interrupted (session limit) before the `/ci` gate ran. CI checks below have not been locally verified — do not merge until green.

https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c)_