### PR TITLE
refactor(plugin-sdk): measuredHealthCheck primitive adopted across 18 plugins (#4191)

### DIFF
--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/plugin-sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Type definitions and helpers for authoring Atlas plugins",
   "type": "module",
   "scripts": {

--- a/packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts
+++ b/packages/plugin-sdk/src/__tests__/sandbox-helpers.test.ts
@@ -1,18 +1,22 @@
 /**
- * Tests for the shared sandbox helpers (#3373) — `collectSemanticFiles` and
+ * Tests for the shared health-check + sandbox helpers (#3373, #4191) —
+ * `collectSemanticFiles`, `measuredHealthCheck`, and
  * `runHealthCheckWithTimeout`.
  *
- * These single-source two blocks that were copy-pasted across the four sandbox
- * plugins (vercel-sandbox, e2b, daytona, railway-sandbox). The symlink-escape
- * guard in `collectSemanticFiles` is a SECURITY property — a symlink that
- * resolves outside the semantic root must never be uploaded into a sandbox.
+ * These single-source blocks that were copy-pasted across plugins: the
+ * measured-health-check bracket (latency + error narrowing) hand-rolled by 18
+ * non-sandbox plugins, and the sandbox-shaped timeout/cleanup variant from the
+ * four sandbox plugins (vercel-sandbox, e2b, daytona, railway-sandbox). The
+ * symlink-escape guard in `collectSemanticFiles` is a SECURITY property — a
+ * symlink that resolves outside the semantic root must never be uploaded into
+ * a sandbox.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { collectSemanticFiles, runHealthCheckWithTimeout } from "../helpers";
+import { collectSemanticFiles, measuredHealthCheck, runHealthCheckWithTimeout } from "../helpers";
 
 function makeLogger() {
   const warnings: string[] = [];
@@ -247,6 +251,80 @@ describe("collectSemanticFiles", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// measuredHealthCheck
+// ---------------------------------------------------------------------------
+
+describe("measuredHealthCheck", () => {
+  test("stamps latencyMs onto a healthy probe result", async () => {
+    const result = await measuredHealthCheck(async () => ({ healthy: true }));
+    expect(result.healthy).toBe(true);
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("passes through the probe's message on healthy and unhealthy results", async () => {
+    const healthy = await measuredHealthCheck(async () => ({
+      healthy: true,
+      message: "3 entity file(s) found",
+    }));
+    expect(healthy.message).toBe("3 entity file(s) found");
+
+    const unhealthy = await measuredHealthCheck(async () => ({
+      healthy: false,
+      message: "not initialized",
+    }));
+    expect(unhealthy.healthy).toBe(false);
+    expect(unhealthy.message).toBe("not initialized");
+    // The unhealthy-return branch is stamped too — it is the probe's own
+    // verdict, not a throw, and callers rely on latency either way.
+    expect(typeof unhealthy.latencyMs).toBe("number");
+  });
+
+  test("accepts a synchronous (non-promise-returning) probe", async () => {
+    const result = await measuredHealthCheck(() => ({ healthy: true }));
+    expect(result.healthy).toBe(true);
+    expect(typeof result.latencyMs).toBe("number");
+  });
+
+  test("narrows a thrown Error into { healthy: false, message }", async () => {
+    const result = await measuredHealthCheck(async () => {
+      throw new Error("connection refused");
+    });
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("connection refused");
+    expect(typeof result.latencyMs).toBe("number");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("normalizes a non-Error throw via String(err)", async () => {
+    const result = await measuredHealthCheck(async () => {
+      throw "plain string failure";
+    });
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("plain string failure");
+  });
+
+  test("handles a synchronously-throwing probe", async () => {
+    const result = await measuredHealthCheck(() => {
+      throw new Error("sync boom");
+    });
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("sync boom");
+    expect(typeof result.latencyMs).toBe("number");
+  });
+
+  test("measures elapsed time across the probe's await", async () => {
+    const result = await measuredHealthCheck(async () => {
+      await new Promise((r) => setTimeout(r, 25));
+      return { healthy: true };
+    });
+    // Rounded wall-clock; allow generous slack below the nominal 25ms since
+    // timers can fire marginally early under load.
+    expect(result.latencyMs).toBeGreaterThanOrEqual(15);
   });
 });
 

--- a/packages/plugin-sdk/src/helpers.ts
+++ b/packages/plugin-sdk/src/helpers.ts
@@ -419,6 +419,49 @@ export function collectSemanticFiles(
   return results;
 }
 
+/**
+ * Wrap a health probe with the measured-health-check bracket every plugin
+ * otherwise hand-rolls: `performance.now()` latency measurement,
+ * instanceof-Error narrowing, and `latencyMs` stamping — nothing else (no
+ * cleanup or timeout ceremony; see {@link runHealthCheckWithTimeout} for the
+ * sandbox-shaped variant, which composes this).
+ *
+ * The probe returns a `PluginHealthResult` without `latencyMs` (stamped here,
+ * measured from probe start to settle) — healthy or unhealthy, with whatever
+ * `message` it wants. A thrown error (or rejected promise) becomes
+ * `{ healthy: false, message }` with the message narrowed via
+ * `err instanceof Error ? err.message : String(err)`. Probes that need a
+ * custom failure message or a `logger.warn` on failure keep their own inner
+ * `catch` and return an unhealthy result instead of throwing.
+ *
+ * @example
+ * ```typescript
+ * async healthCheck(): Promise<PluginHealthResult> {
+ *   return measuredHealthCheck(async () => {
+ *     await conn.query("SELECT 1", 5000);
+ *     return { healthy: true };
+ *   });
+ * }
+ * ```
+ */
+export async function measuredHealthCheck(
+  fn: () =>
+    | (Omit<PluginHealthResult, "latencyMs"> & { latencyMs?: never })
+    | Promise<Omit<PluginHealthResult, "latencyMs"> & { latencyMs?: never }>,
+): Promise<PluginHealthResult> {
+  const start = performance.now();
+  try {
+    const result = await fn();
+    return { ...result, latencyMs: Math.round(performance.now() - start) };
+  } catch (err) {
+    return {
+      healthy: false,
+      message: err instanceof Error ? err.message : String(err),
+      latencyMs: Math.round(performance.now() - start),
+    };
+  }
+}
+
 /** Options for {@link runHealthCheckWithTimeout}. */
 export interface HealthCheckTimeoutOptions {
   /** Milliseconds before the probe is abandoned and reported as timed out. */
@@ -447,13 +490,16 @@ const HEALTH_CHECK_TIMEOUT = Symbol("plugin-sdk:health-check-timeout");
 /**
  * Run a sandbox `healthCheck()` probe under a timeout, attaching a measured
  * `latencyMs` and running cleanup-in-every-failing-branch (single-sourced,
- * #3373).
+ * #3373). Composes {@link measuredHealthCheck} for the latency bracket +
+ * error narrowing, adding the `Promise.race` timeout and safety-net cleanup
+ * on top.
  *
  * The probe (`fn`) creates whatever it needs, performs the check, tears down
  * its own resources on the happy path, and returns a `PluginHealthResult`
  * without `latencyMs` (added here). When the `Promise.race` timeout wins — or
  * the probe throws — `cleanup` runs to reap any resource the probe captured but
- * could not release.
+ * could not release. `latencyMs` measures the probe only, stamped when it
+ * settles (or times out) — cleanup time is never included.
  *
  * **Why not `await using`?** The timeout can win while the probe is still
  * mid-create/exec, and the sandbox SDKs expose no `AbortSignal` on create — a
@@ -473,10 +519,40 @@ export async function runHealthCheckWithTimeout(
       `runHealthCheckWithTimeout: timeoutMs must be a positive, finite number (got ${timeoutMs})`,
     );
   }
-  const start = performance.now();
   let timer: ReturnType<typeof setTimeout>;
+  // Tracks how the probe settled so the failing branches (timeout / throw) —
+  // and ONLY those — trigger the warn + cleanup after measuredHealthCheck has
+  // narrowed the error and stamped latency. A probe that RETURNS an unhealthy
+  // result owns its own teardown and logging, so it is not a failing branch.
+  // (The assertion defeats CFA literal-narrowing: the reassignments happen
+  // inside the probe closure, which TS does not track across the await.)
+  type ProbeOutcome = "returned" | "timeout" | "threw";
+  let outcome = "threw" as ProbeOutcome;
 
-  const runCleanup = async (): Promise<void> => {
+  const result = await measuredHealthCheck(async () => {
+    const raced = await Promise.race([
+      fn(),
+      new Promise<typeof HEALTH_CHECK_TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(HEALTH_CHECK_TIMEOUT), timeoutMs);
+      }),
+    ]).finally(() => clearTimeout(timer!));
+
+    if (raced === HEALTH_CHECK_TIMEOUT) {
+      outcome = "timeout";
+      // Thrown so measuredHealthCheck stamps latency at the moment the
+      // timeout fired; its narrowing turns this into the result message.
+      throw new Error(`Health check timed out after ${timeoutMs}ms`);
+    }
+    outcome = "returned";
+    return raced;
+  });
+
+  if (outcome !== "returned") {
+    logger?.warn(
+      outcome === "timeout"
+        ? `[plugin-sdk] Health check timed out after ${timeoutMs}ms`
+        : `[plugin-sdk] Health check probe failed: ${result.message}`,
+    );
     try {
       await cleanup();
     } catch (err) {
@@ -484,35 +560,6 @@ export async function runHealthCheckWithTimeout(
         `[plugin-sdk] Health-check cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-  };
-
-  try {
-    const result = await Promise.race([
-      fn(),
-      new Promise<typeof HEALTH_CHECK_TIMEOUT>((resolve) => {
-        timer = setTimeout(() => resolve(HEALTH_CHECK_TIMEOUT), timeoutMs);
-      }),
-    ]).finally(() => clearTimeout(timer!));
-
-    const latencyMs = Math.round(performance.now() - start);
-    if (result === HEALTH_CHECK_TIMEOUT) {
-      logger?.warn(`[plugin-sdk] Health check timed out after ${timeoutMs}ms`);
-      await runCleanup();
-      return {
-        healthy: false,
-        message: `Health check timed out after ${timeoutMs}ms`,
-        latencyMs,
-      };
-    }
-    return { ...result, latencyMs };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger?.warn(`[plugin-sdk] Health check probe failed: ${message}`);
-    await runCleanup();
-    return {
-      healthy: false,
-      message,
-      latencyMs: Math.round(performance.now() - start),
-    };
   }
+  return result;
 }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -83,6 +83,7 @@ export {
   isActionPlugin,
   isSandboxPlugin,
   collectSemanticFiles,
+  measuredHealthCheck,
   runHealthCheckWithTimeout,
 } from "./helpers";
 

--- a/plugins/bigquery/src/index.ts
+++ b/plugins/bigquery/src/index.ts
@@ -36,7 +36,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult, PluginLogger, PluginHooks, QueryHookContext, QueryHookMutation } from "@useatlas/plugin-sdk";
 import {
   createBigQueryConnection,
@@ -263,33 +263,25 @@ export function buildBigQueryPlugin(
       if (!hasStaticConfig) {
         return { healthy: true, message: "adapter-only: no static datasource configured" };
       }
-      const start = performance.now();
-      let conn: PluginDBConnection | undefined;
-      try {
-        conn = createBigQueryConnection({
-          projectId: config.projectId,
-          dataset: config.dataset,
-          keyFilename: config.keyFilename,
-          credentials: config.credentials,
-          location: config.location,
-        });
-        // SELECT 1 processes 0 bytes in BigQuery — effectively free.
-        await conn.query("SELECT 1", 5000);
-        return {
-          healthy: true,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } catch (err) {
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } finally {
-        if (conn) {
-          await conn.close();
+      return measuredHealthCheck(async () => {
+        let conn: PluginDBConnection | undefined;
+        try {
+          conn = createBigQueryConnection({
+            projectId: config.projectId,
+            dataset: config.dataset,
+            keyFilename: config.keyFilename,
+            credentials: config.credentials,
+            location: config.location,
+          });
+          // SELECT 1 processes 0 bytes in BigQuery — effectively free.
+          await conn.query("SELECT 1", 5000);
+          return { healthy: true };
+        } finally {
+          if (conn) {
+            await conn.close();
+          }
         }
-      }
+      });
     },
   };
 }

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -45,7 +45,7 @@
 
 import type { Adapter, StateAdapter } from "chat";
 import type { SlackAdapter } from "@chat-adapter/slack";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasInteractionPlugin,
   AtlasPluginContext,
@@ -918,74 +918,65 @@ function buildChatPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
+      return measuredHealthCheck(async () => {
+        if (!initialized || !bridge) {
+          return { healthy: false, message: "Chat plugin not initialized" };
+        }
 
-      if (!initialized || !bridge) {
+        const enabledAdapters: string[] = [];
+        if (slackAdapterInstance) enabledAdapters.push("slack");
+        if (telegramAdapterInstance) enabledAdapters.push("telegram");
+        if (discordAdapterInstance) enabledAdapters.push("discord");
+        if (whatsappAdapterInstance) enabledAdapters.push("whatsapp");
+        if (gchatAdapterInstance) enabledAdapters.push("gchat");
+        if (teamsAdapterInstance) enabledAdapters.push("teams");
+
+        if (enabledAdapters.length === 0) {
+          // Use the diagnostics captured at init to point operators at the
+          // actual cause: a catalog row referencing an unknown slug, or a
+          // recognized slug whose env vars are missing.
+          const parts = [
+            "No chat adapters registered.",
+          ];
+          if (adapterDiagnostics.missingCredSlugs.length > 0) {
+            parts.push(
+              `Missing env vars for: ${adapterDiagnostics.missingCredSlugs.join(", ")}.`,
+            );
+          }
+          if (adapterDiagnostics.unrecognizedSlugs.length > 0) {
+            parts.push(
+              `Unknown slugs in catalog: ${adapterDiagnostics.unrecognizedSlugs.join(", ")}.`,
+            );
+          }
+          if (
+            adapterDiagnostics.missingCredSlugs.length === 0 &&
+            adapterDiagnostics.unrecognizedSlugs.length === 0
+          ) {
+            parts.push(
+              "No chat-type catalog entries declared in atlas.config.ts (or all are disabled / form-based).",
+            );
+          }
+          return { healthy: false, message: parts.join(" ") };
+        }
+
+        // Probe state adapter health (lightweight get on a non-existent key)
+        if (stateAdapter) {
+          try {
+            await stateAdapter.get("_healthcheck");
+          } catch (stateErr) {
+            // Returned (not rethrown) to keep the "State backend error" prefix.
+            return {
+              healthy: false,
+              message: `State backend error: ${stateErr instanceof Error ? stateErr.message : String(stateErr)}`,
+            };
+          }
+        }
+
         return {
-          healthy: false,
-          message: "Chat plugin not initialized",
-          latencyMs: Math.round(performance.now() - start),
+          healthy: true,
+          message: `Adapters: ${enabledAdapters.join(", ")}`,
         };
-      }
-
-      const enabledAdapters: string[] = [];
-      if (slackAdapterInstance) enabledAdapters.push("slack");
-      if (telegramAdapterInstance) enabledAdapters.push("telegram");
-      if (discordAdapterInstance) enabledAdapters.push("discord");
-      if (whatsappAdapterInstance) enabledAdapters.push("whatsapp");
-      if (gchatAdapterInstance) enabledAdapters.push("gchat");
-      if (teamsAdapterInstance) enabledAdapters.push("teams");
-
-      if (enabledAdapters.length === 0) {
-        // Use the diagnostics captured at init to point operators at the
-        // actual cause: a catalog row referencing an unknown slug, or a
-        // recognized slug whose env vars are missing.
-        const parts = [
-          "No chat adapters registered.",
-        ];
-        if (adapterDiagnostics.missingCredSlugs.length > 0) {
-          parts.push(
-            `Missing env vars for: ${adapterDiagnostics.missingCredSlugs.join(", ")}.`,
-          );
-        }
-        if (adapterDiagnostics.unrecognizedSlugs.length > 0) {
-          parts.push(
-            `Unknown slugs in catalog: ${adapterDiagnostics.unrecognizedSlugs.join(", ")}.`,
-          );
-        }
-        if (
-          adapterDiagnostics.missingCredSlugs.length === 0 &&
-          adapterDiagnostics.unrecognizedSlugs.length === 0
-        ) {
-          parts.push(
-            "No chat-type catalog entries declared in atlas.config.ts (or all are disabled / form-based).",
-          );
-        }
-        return {
-          healthy: false,
-          message: parts.join(" "),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
-
-      // Probe state adapter health (lightweight get on a non-existent key)
-      if (stateAdapter) {
-        try {
-          await stateAdapter.get("_healthcheck");
-        } catch (stateErr) {
-          return {
-            healthy: false,
-            message: `State backend error: ${stateErr instanceof Error ? stateErr.message : String(stateErr)}`,
-            latencyMs: Math.round(performance.now() - start),
-          };
-        }
-      }
-
-      return {
-        healthy: true,
-        message: `Adapters: ${enabledAdapters.join(", ")}`,
-        latencyMs: Math.round(performance.now() - start),
-      };
+      });
     },
 
     async teardown() {

--- a/plugins/clickhouse/src/index.ts
+++ b/plugins/clickhouse/src/index.ts
@@ -29,7 +29,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult, PluginLogger } from "@useatlas/plugin-sdk";
 import {
   createClickHouseConnection,
@@ -167,26 +167,18 @@ export function buildClickHousePlugin(
       if (!staticUrl) {
         return { healthy: true, message: "adapter-only: no static datasource configured" };
       }
-      const start = performance.now();
-      let conn: PluginDBConnection | undefined;
-      try {
-        conn = createClickHouseConnection({ url: staticUrl, database: config.database });
-        await conn.query("SELECT 1", 5000);
-        return {
-          healthy: true,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } catch (err) {
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } finally {
-        if (conn) {
-          await conn.close();
+      return measuredHealthCheck(async () => {
+        let conn: PluginDBConnection | undefined;
+        try {
+          conn = createClickHouseConnection({ url: staticUrl, database: config.database });
+          await conn.query("SELECT 1", 5000);
+          return { healthy: true };
+        } finally {
+          if (conn) {
+            await conn.close();
+          }
         }
-      }
+      });
     },
   };
 }

--- a/plugins/duckdb/src/index.ts
+++ b/plugins/duckdb/src/index.ts
@@ -31,7 +31,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult } from "@useatlas/plugin-sdk";
 import { createDuckDBConnection, parseDuckDBUrl } from "./connection";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
@@ -214,28 +214,22 @@ export function buildDuckDBPlugin(
         path: staticPath,
         readOnly: staticReadOnly,
       });
-      const start = performance.now();
-      let conn: PluginDBConnection | undefined;
-      try {
-        conn = createDuckDBConnection(dbConfig);
-        await conn.query("SELECT 1", 5000);
-        return {
-          healthy: true,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log?.warn(`Health check failed: ${message}`);
-        return {
-          healthy: false,
-          message,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } finally {
-        if (conn) {
-          await conn.close();
+      return measuredHealthCheck(async () => {
+        let conn: PluginDBConnection | undefined;
+        try {
+          conn = createDuckDBConnection(dbConfig);
+          await conn.query("SELECT 1", 5000);
+          return { healthy: true };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          log?.warn(`Health check failed: ${message}`);
+          return { healthy: false, message };
+        } finally {
+          if (conn) {
+            await conn.close();
+          }
         }
-      }
+      });
     },
   };
 }

--- a/plugins/elasticsearch/src/index.ts
+++ b/plugins/elasticsearch/src/index.ts
@@ -29,7 +29,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin, warnIfStructuralOnly } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck, warnIfStructuralOnly } from "@useatlas/plugin-sdk";
 import type {
   AtlasDatasourcePlugin,
   ConfigSchemaField,
@@ -515,22 +515,21 @@ export function buildElasticsearchPlugin(
       if (!staticConfig) {
         return { healthy: true, message: "adapter-only: no static datasource configured" };
       }
-      const start = performance.now();
-      try {
-        // The client owns the timeout/abort (it rejects with a clear "timed out"
-        // message at 5000ms), so awaiting it directly avoids the orphaned-promise
-        // / unhandled-rejection hazard of racing it against an outer setTimeout.
-        await getOrCreateConnection().ping(5000);
-        return { healthy: true, latencyMs: Math.round(performance.now() - start) };
-      } catch (err) {
-        const message = scrubElasticsearchError(err, collectConfigSecrets(staticConfig));
-        log?.warn(`Elasticsearch health check failed: ${message}`);
-        return {
-          healthy: false,
-          message,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+      return measuredHealthCheck(async () => {
+        try {
+          // The client owns the timeout/abort (it rejects with a clear "timed out"
+          // message at 5000ms), so awaiting it directly avoids the orphaned-promise
+          // / unhandled-rejection hazard of racing it against an outer setTimeout.
+          await getOrCreateConnection().ping(5000);
+          return { healthy: true };
+        } catch (err) {
+          // Returned (not rethrown) so the scrubbed message — never the raw
+          // error, which can embed credentials — is what surfaces.
+          const message = scrubElasticsearchError(err, collectConfigSecrets(staticConfig));
+          log?.warn(`Elasticsearch health check failed: ${message}`);
+          return { healthy: false, message };
+        }
+      });
     },
 
     async teardown(): Promise<void> {

--- a/plugins/email-digest/src/index.ts
+++ b/plugins/email-digest/src/index.ts
@@ -31,7 +31,7 @@
  */
 
 import { Hono } from "hono";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasInteractionPlugin,
   AtlasPluginContext,
@@ -452,42 +452,36 @@ function buildEmailDigestPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
+      return measuredHealthCheck(async () => {
+        if (!initialized) {
+          return { healthy: false, message: "Email digest plugin not initialized" };
+        }
 
-      if (!initialized) {
-        return {
-          healthy: false,
-          message: "Email digest plugin not initialized",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        if (!pluginDb) {
+          return {
+            healthy: false,
+            message: "Internal database not available — subscriptions cannot be managed",
+          };
+        }
 
-      if (!pluginDb) {
-        return {
-          healthy: false,
-          message: "Internal database not available — subscriptions cannot be managed",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        if (!schemaReady) {
+          return {
+            healthy: false,
+            message: "Database schema not ready — table creation may have failed",
+          };
+        }
 
-      if (!schemaReady) {
-        return {
-          healthy: false,
-          message: "Database schema not ready — table creation may have failed",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
-
-      try {
-        await pluginDb.query("SELECT 1 FROM digest_subscriptions LIMIT 0", []);
-        return { healthy: true, latencyMs: Math.round(performance.now() - start) };
-      } catch (err) {
-        return {
-          healthy: false,
-          message: `Table probe failed: ${err instanceof Error ? err.message : String(err)}`,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        try {
+          await pluginDb.query("SELECT 1 FROM digest_subscriptions LIMIT 0", []);
+          return { healthy: true };
+        } catch (err) {
+          // Returned (not rethrown) to keep the "Table probe failed" prefix.
+          return {
+            healthy: false,
+            message: `Table probe failed: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      });
     },
 
     async teardown() {

--- a/plugins/email/src/index.ts
+++ b/plugins/email/src/index.ts
@@ -23,7 +23,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasActionPlugin, PluginAction } from "@useatlas/plugin-sdk";
 import { createEmailTool } from "./tool";
 import type { EmailPluginConfig } from "./tool";
@@ -93,30 +93,20 @@ export const emailPlugin = createPlugin<EmailPluginConfig, AtlasActionPlugin<Ema
       },
 
       async healthCheck() {
-        const start = performance.now();
-        try {
+        return measuredHealthCheck(async () => {
           const response = await fetch("https://api.resend.com/domains", {
             method: "GET",
             headers: { Authorization: `Bearer ${config.resendApiKey}` },
             signal: AbortSignal.timeout(5000),
           });
-          const latencyMs = Math.round(performance.now() - start);
-
           if (response.ok) {
-            return { healthy: true, latencyMs };
+            return { healthy: true };
           }
           return {
             healthy: false,
             message: `Resend API returned ${response.status}`,
-            latencyMs,
           };
-        } catch (err) {
-          return {
-            healthy: false,
-            message: err instanceof Error ? err.message : String(err),
-            latencyMs: Math.round(performance.now() - start),
-          };
-        }
+        });
       },
     };
   },

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -23,7 +23,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasActionPlugin, PluginAction, PluginLogger } from "@useatlas/plugin-sdk";
 import { createJiraTool } from "./tool";
 import type { JiraPluginConfig } from "./tool";
@@ -137,11 +137,10 @@ export const jiraPlugin = createPlugin<JiraPluginConfig, AtlasActionPlugin<JiraP
       },
 
       async healthCheck() {
-        const start = performance.now();
-        const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
-        const url = `${config.host.replace(/\/$/, "")}/rest/api/3/myself`;
+        return measuredHealthCheck(async () => {
+          const auth = Buffer.from(`${config.email}:${config.apiToken}`).toString("base64");
+          const url = `${config.host.replace(/\/$/, "")}/rest/api/3/myself`;
 
-        try {
           const response = await fetch(url, {
             method: "GET",
             headers: {
@@ -150,24 +149,15 @@ export const jiraPlugin = createPlugin<JiraPluginConfig, AtlasActionPlugin<JiraP
             },
             signal: AbortSignal.timeout(5000),
           });
-          const latencyMs = Math.round(performance.now() - start);
-
           if (response.ok) {
-            return { healthy: true, latencyMs };
+            return { healthy: true };
           }
 
           return {
             healthy: false,
             message: `JIRA API returned ${response.status}`,
-            latencyMs,
           };
-        } catch (err) {
-          return {
-            healthy: false,
-            message: err instanceof Error ? err.message : String(err),
-            latencyMs: Math.round(performance.now() - start),
-          };
-        }
+        });
       },
     };
   },

--- a/plugins/mcp/src/index.ts
+++ b/plugins/mcp/src/index.ts
@@ -22,7 +22,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasInteractionPlugin, PluginHealthResult } from "@useatlas/plugin-sdk";
 
 const McpConfigSchema = z.object({
@@ -104,22 +104,15 @@ export function buildMcpPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      if (!connected) {
-        return {
-          healthy: false,
-          message: "MCP server not initialized or not connected",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
-      if (config.transport === "sse" && !sseHandle) {
-        return {
-          healthy: false,
-          message: "SSE handle missing — server may have crashed",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
-      return { healthy: true, latencyMs: Math.round(performance.now() - start) };
+      return measuredHealthCheck(() => {
+        if (!connected) {
+          return { healthy: false, message: "MCP server not initialized or not connected" };
+        }
+        if (config.transport === "sse" && !sseHandle) {
+          return { healthy: false, message: "SSE handle missing — server may have crashed" };
+        }
+        return { healthy: true };
+      });
     },
 
     async teardown() {

--- a/plugins/mysql/src/index.ts
+++ b/plugins/mysql/src/index.ts
@@ -18,7 +18,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult, PluginLogger } from "@useatlas/plugin-sdk";
 import { createMySQLConnection, extractHost } from "./connection";
 
@@ -95,30 +95,22 @@ export function buildMySQLPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      let conn: PluginDBConnection | undefined;
-      try {
-        conn = createMySQLConnection({
-          url: config.url,
-          poolSize: config.poolSize,
-          idleTimeoutMs: config.idleTimeoutMs,
-        });
-        await conn.query("SELECT 1", 5000);
-        return {
-          healthy: true,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } catch (err) {
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } finally {
-        if (conn) {
-          await conn.close();
+      return measuredHealthCheck(async () => {
+        let conn: PluginDBConnection | undefined;
+        try {
+          conn = createMySQLConnection({
+            url: config.url,
+            poolSize: config.poolSize,
+            idleTimeoutMs: config.idleTimeoutMs,
+          });
+          await conn.query("SELECT 1", 5000);
+          return { healthy: true };
+        } finally {
+          if (conn) {
+            await conn.close();
+          }
         }
-      }
+      });
     },
   };
 }

--- a/plugins/nsjail/src/index.ts
+++ b/plugins/nsjail/src/index.ts
@@ -24,7 +24,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasSandboxPlugin,
   PluginExploreBackend,
@@ -256,12 +256,11 @@ export function buildNsjailSandboxPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      const nsjailPath = findNsjailBinary(config.nsjailPath);
-      if (!nsjailPath) {
-        return { healthy: false, message: "nsjail binary not found", latencyMs: Math.round(performance.now() - start) };
-      }
-      try {
+      return measuredHealthCheck(async () => {
+        const nsjailPath = findNsjailBinary(config.nsjailPath);
+        if (!nsjailPath) {
+          return { healthy: false, message: "nsjail binary not found" };
+        }
         const args = buildNsjailArgs(nsjailPath, "/tmp", "echo nsjail-ok", config);
         const proc = Bun.spawn(args, {
           env: JAIL_ENV,
@@ -276,31 +275,19 @@ export function buildNsjailSandboxPlugin(
             readLimited(proc.stderr, MAX_OUTPUT),
           ]);
           const exitCode = await proc.exited;
-          clearTimeout(timer);
 
           if (exitCode === 0 && stdout.includes("nsjail-ok")) {
-            return {
-              healthy: true,
-              latencyMs: Math.round(performance.now() - start),
-            };
+            return { healthy: true };
           }
 
           return {
             healthy: false,
             message: `nsjail test command failed (exit ${exitCode})`,
-            latencyMs: Math.round(performance.now() - start),
           };
-        } catch (err) {
+        } finally {
           clearTimeout(timer);
-          throw err;
         }
-      } catch (err) {
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+      });
     },
   };
 }

--- a/plugins/obsidian-reader/src/index.ts
+++ b/plugins/obsidian-reader/src/index.ts
@@ -19,7 +19,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasActionPlugin, PluginAction } from "@useatlas/plugin-sdk";
 import { createObsidianTool, stripTrailingSlashes } from "./tool";
 import type { ObsidianReaderPluginConfig } from "./tool";
@@ -72,15 +72,13 @@ export const obsidianReaderPlugin = createPlugin<
       },
 
       async healthCheck() {
-        const start = performance.now();
         const base = stripTrailingSlashes(config.api_url ?? "http://127.0.0.1:27123");
-        try {
+        return measuredHealthCheck(async () => {
           const response = await fetch(`${base}/`, {
             method: "GET",
             headers: { Authorization: `Bearer ${config.api_key}` },
             signal: AbortSignal.timeout(5000),
           });
-          const latencyMs = Math.round(performance.now() - start);
           if (response.ok || response.status === 401) {
             // 401 means the plugin is running but the key is wrong — still
             // a "reachable" signal. The agent will surface the auth error
@@ -92,21 +90,14 @@ export const obsidianReaderPlugin = createPlugin<
               console.warn("[obsidian-reader] healthCheck: REST API rejected the API key (401)");
             }
             return response.ok
-              ? { healthy: true, latencyMs }
-              : { healthy: false, message: "Obsidian REST API rejected the API key", latencyMs };
+              ? { healthy: true }
+              : { healthy: false, message: "Obsidian REST API rejected the API key" };
           }
           return {
             healthy: false,
             message: `Obsidian REST API returned ${response.status}`,
-            latencyMs,
           };
-        } catch (err) {
-          return {
-            healthy: false,
-            message: err instanceof Error ? err.message : String(err),
-            latencyMs: Math.round(performance.now() - start),
-          };
-        }
+        });
       },
     };
   },

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -41,7 +41,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin, warnIfStructuralOnly } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck, warnIfStructuralOnly } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginHealthResult, PluginLogger, QueryValidationResult } from "@useatlas/plugin-sdk";
 import {
   createSalesforceConnection,
@@ -280,30 +280,27 @@ export function buildSalesforcePlugin(
       if (!staticUrl) {
         return { healthy: true, message: "adapter-only: no static datasource configured" };
       }
-      const start = performance.now();
-      try {
-        const conn = getOrCreateConnection();
-        let timer: ReturnType<typeof setTimeout>;
-        const result = await Promise.race([
-          conn.listSObjects().then(() => "ok" as const),
-          new Promise<"timeout">((resolve) => {
-            timer = setTimeout(() => resolve("timeout"), 5000);
-          }),
-        ]).finally(() => clearTimeout(timer!));
-        const latencyMs = Math.round(performance.now() - start);
-        if (result === "timeout") {
-          return { healthy: false, message: "Health check timed out after 5000ms", latencyMs };
+      return measuredHealthCheck(async () => {
+        try {
+          const conn = getOrCreateConnection();
+          let timer: ReturnType<typeof setTimeout>;
+          const result = await Promise.race([
+            conn.listSObjects().then(() => "ok" as const),
+            new Promise<"timeout">((resolve) => {
+              timer = setTimeout(() => resolve("timeout"), 5000);
+            }),
+          ]).finally(() => clearTimeout(timer!));
+          if (result === "timeout") {
+            return { healthy: false, message: "Health check timed out after 5000ms" };
+          }
+          return { healthy: true };
+        } catch (err) {
+          // Returned (not rethrown) to keep the operator log line on failure.
+          const message = err instanceof Error ? err.message : String(err);
+          log?.warn(`Health check failed: ${message}`);
+          return { healthy: false, message };
         }
-        return { healthy: true, latencyMs };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        log?.warn(`Health check failed: ${message}`);
-        return {
-          healthy: false,
-          message,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+      });
     },
 
     async teardown(): Promise<void> {

--- a/plugins/sidecar/src/index.ts
+++ b/plugins/sidecar/src/index.ts
@@ -23,7 +23,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasSandboxPlugin,
   PluginExploreBackend,
@@ -239,32 +239,20 @@ export function buildSidecarSandboxPlugin(
 
     async healthCheck(): Promise<PluginHealthResult> {
       const healthUrl = `${baseUrl.origin}/health`;
-      const start = performance.now();
-
-      try {
+      return measuredHealthCheck(async () => {
         const response = await fetch(healthUrl, {
           signal: AbortSignal.timeout(5000),
         });
 
-        const latencyMs = Math.round(performance.now() - start);
-
         if (response.ok) {
-          return { healthy: true, latencyMs };
+          return { healthy: true };
         }
 
         return {
           healthy: false,
           message: `Sidecar returned HTTP ${response.status}`,
-          latencyMs,
         };
-      } catch (err) {
-        const latencyMs = Math.round(performance.now() - start);
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs,
-        };
-      }
+      });
     },
   };
 }

--- a/plugins/snowflake/src/index.ts
+++ b/plugins/snowflake/src/index.ts
@@ -31,7 +31,7 @@
  */
 
 import { z } from "zod";
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type { AtlasDatasourcePlugin, PluginDBConnection, PluginHealthResult, PluginLogger } from "@useatlas/plugin-sdk";
 import {
   createSnowflakeConnection,
@@ -184,30 +184,22 @@ export function buildSnowflakePlugin(
       if (!staticUrl) {
         return { healthy: true, message: "adapter-only: no static datasource configured" };
       }
-      const start = performance.now();
-      let conn: PluginDBConnection | undefined;
-      try {
-        conn = createSnowflakeConnection({ url: staticUrl, maxConnections: config.maxConnections });
-        await conn.query("SELECT 1", 5000);
-        return {
-          healthy: true,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } catch (err) {
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      } finally {
-        if (conn) {
-          try {
-            await conn.close();
-          } catch (closeErr) {
-            (log ?? console).warn(`[snowflake-datasource] Failed to close health-check connection: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`);
+      return measuredHealthCheck(async () => {
+        let conn: PluginDBConnection | undefined;
+        try {
+          conn = createSnowflakeConnection({ url: staticUrl, maxConnections: config.maxConnections });
+          await conn.query("SELECT 1", 5000);
+          return { healthy: true };
+        } finally {
+          if (conn) {
+            try {
+              await conn.close();
+            } catch (closeErr) {
+              (log ?? console).warn(`[snowflake-datasource] Failed to close health-check connection: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`);
+            }
           }
         }
-      }
+      });
     },
   };
 }

--- a/plugins/teams/src/index.ts
+++ b/plugins/teams/src/index.ts
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasInteractionPlugin,
   AtlasPluginContext,
@@ -130,25 +130,17 @@ function buildTeamsPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
+      return measuredHealthCheck(() => {
+        if (!initialized) {
+          return { healthy: false, message: "Teams plugin not initialized" };
+        }
 
-      if (!initialized) {
-        return {
-          healthy: false,
-          message: "Teams plugin not initialized",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        if (!config.appId || !config.appPassword) {
+          return { healthy: false, message: "Missing app credentials" };
+        }
 
-      if (!config.appId || !config.appPassword) {
-        return {
-          healthy: false,
-          message: "Missing app credentials",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
-
-      return { healthy: true, latencyMs: Math.round(performance.now() - start) };
+        return { healthy: true };
+      });
     },
 
     async teardown() {

--- a/plugins/webhook/src/index.ts
+++ b/plugins/webhook/src/index.ts
@@ -31,7 +31,7 @@
  * ```
  */
 
-import { createPlugin } from "@useatlas/plugin-sdk";
+import { createPlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasInteractionPlugin,
   AtlasPluginContext,
@@ -104,25 +104,17 @@ function buildWebhookPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
+      return measuredHealthCheck(() => {
+        if (!initialized) {
+          return { healthy: false, message: "Webhook plugin not initialized" };
+        }
 
-      if (!initialized) {
-        return {
-          healthy: false,
-          message: "Webhook plugin not initialized",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        if (channelMap.size === 0) {
+          return { healthy: false, message: "No webhook channels configured" };
+        }
 
-      if (channelMap.size === 0) {
-        return {
-          healthy: false,
-          message: "No webhook channels configured",
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
-
-      return { healthy: true, latencyMs: Math.round(performance.now() - start) };
+        return { healthy: true };
+      });
     },
 
     async teardown() {

--- a/plugins/yaml-context/src/index.ts
+++ b/plugins/yaml-context/src/index.ts
@@ -21,7 +21,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
 import { z } from "zod";
-import { definePlugin } from "@useatlas/plugin-sdk";
+import { definePlugin, measuredHealthCheck } from "@useatlas/plugin-sdk";
 import type {
   AtlasContextPlugin,
   AtlasMcpTool,
@@ -380,45 +380,34 @@ export function buildContextYamlPlugin(
     },
 
     async healthCheck(): Promise<PluginHealthResult> {
-      const start = performance.now();
-      const entitiesDir = path.join(semanticDir, "entities");
+      return measuredHealthCheck(() => {
+        const entitiesDir = path.join(semanticDir, "entities");
 
-      if (!fs.existsSync(semanticDir)) {
-        return {
-          healthy: false,
-          message: `Semantic directory not found: ${semanticDir}`,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        if (!fs.existsSync(semanticDir)) {
+          return {
+            healthy: false,
+            message: `Semantic directory not found: ${semanticDir}`,
+          };
+        }
 
-      if (!fs.existsSync(entitiesDir)) {
-        return {
-          healthy: false,
-          message: `Entities directory not found: ${entitiesDir}`,
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        if (!fs.existsSync(entitiesDir)) {
+          return {
+            healthy: false,
+            message: `Entities directory not found: ${entitiesDir}`,
+          };
+        }
 
-      try {
         const files = fs
           .readdirSync(entitiesDir)
           .filter((f) => f.endsWith(".yml"));
-        const latencyMs = Math.round(performance.now() - start);
         if (files.length === 0) {
           return {
             healthy: false,
             message: "No entity YAML files found in entities directory",
-            latencyMs,
           };
         }
-        return { healthy: true, message: `${files.length} entity file(s) found`, latencyMs };
-      } catch (err) {
-        return {
-          healthy: false,
-          message: err instanceof Error ? err.message : String(err),
-          latencyMs: Math.round(performance.now() - start),
-        };
-      }
+        return { healthy: true, message: `${files.length} entity file(s) found` };
+      });
     },
   } satisfies AtlasContextPlugin<ContextYamlConfig>);
 }


### PR DESCRIPTION
## Summary

Adds a thin `measuredHealthCheck(fn)` helper to the plugin SDK — `performance.now()` latency bracketing + `instanceof Error` narrowing + `latencyMs` stamping — and composes `runHealthCheckWithTimeout` on top of it. Adopts it across the 18 plugins that hand-rolled the identical measured health probe, so a future plugin health-check is one line.

Closes #4191

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — error-narrowing + latency stamping tested once in plugin-sdk
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area) — inherited from issue (refactor, area: plugins)
- [ ] CHANGELOG.md updated (if user-facing change)

> ⚠️ **Draft:** authored by an autonomous ship-issue worker that was interrupted (session limit) before the `/ci` gate ran. Note `plugin-sdk/package.json` changed — verify `bun run deps:lint`. CI checks below have not been locally verified — do not merge until green.

https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c)_