### PR TITLE
refactor(mcp): approvalRequiredResult — one validated approval payload builder (#4199)

### DIFF
--- a/packages/mcp/src/__tests__/approval-required-result.test.ts
+++ b/packages/mcp/src/__tests__/approval-required-result.test.ts
@@ -1,0 +1,178 @@
+/**
+ * #4199 — `approvalRequiredResult` (the ONE validated MCP approval payload
+ * builder).
+ *
+ * Contract test for the approval-resume payload every governance surface
+ * emits — `executeSQL`, `runMetric`, `query`, and dispatch-gate gate-4 all
+ * consume this builder, so this file pins the shared contract:
+ *
+ *   1. the payload carries `approval_required: true`, the request id, the
+ *      matched rules, and a `message` that always ends with the resume hint
+ *      (#3750 — re-call the identical tool once approved);
+ *   2. text block and `structuredContent` are built from the same object so
+ *      they can never drift (#3498);
+ *   3. malformed internal fields (non-string id, non-array rules) are
+ *      stripped rather than thrown (#3584 — SDK output-schema validation must
+ *      never break the dispatch and lose the approval signal);
+ *   4. a null/undefined request id is OMITTED (never `approval_request_id:
+ *      null`, which would fail the declared output schemas);
+ *   5. the payload validates against every consuming tool's declared
+ *      output schema (executeSQL / runMetric / query approval branch).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  approvalRequiredResult,
+  MCP_APPROVAL_RESUME_HINT,
+  executeSqlOutputSchema,
+  runMetricOutputSchema,
+  queryOutputSchema,
+} from "../structured-output.js";
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const first = result.content[0];
+  if (!first || first.type !== "text" || typeof first.text !== "string") {
+    throw new Error("expected a text content block");
+  }
+  return first.text;
+}
+
+describe("approvalRequiredResult (#4199)", () => {
+  it("builds the full non-error approval payload with the resume hint appended", () => {
+    const result = approvalRequiredResult({
+      approvalRequestId: "appr_abc123",
+      matchedRules: ["PII rule"],
+      message: "Approval required. Rule: PII rule.",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const body = result.structuredContent as Record<string, unknown>;
+    expect(body.approval_required).toBe(true);
+    expect(body.approval_request_id).toBe("appr_abc123");
+    expect(body.matched_rules).toEqual(["PII rule"]);
+    expect(body.message).toBe(
+      `Approval required. Rule: PII rule. ${MCP_APPROVAL_RESUME_HINT}`,
+    );
+  });
+
+  it("text block and structuredContent are the same object serialized (#3498)", () => {
+    const result = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      matchedRules: ["r"],
+      message: "m",
+    });
+    expect(JSON.parse(textOf(result))).toEqual(result.structuredContent);
+  });
+
+  it("omits approval_request_id entirely when null/undefined (never a null field)", () => {
+    for (const id of [null, undefined]) {
+      const result = approvalRequiredResult({
+        approvalRequestId: id,
+        matchedRules: ["r"],
+        message: "m",
+      });
+      const body = result.structuredContent as Record<string, unknown>;
+      expect(body.approval_required).toBe(true);
+      expect("approval_request_id" in body).toBe(false);
+      expect(textOf(result)).not.toContain("approval_request_id");
+    }
+  });
+
+  it("strips malformed fields (#3584) instead of throwing, keeping the valid ones", () => {
+    const result = approvalRequiredResult({
+      // Non-string id — a malformed internal payload from an older gateway.
+      approvalRequestId: 12345,
+      matchedRules: ["still-valid rule"],
+      message: "approval needed",
+    });
+    const body = result.structuredContent as Record<string, unknown>;
+    expect(body.approval_required).toBe(true);
+    expect("approval_request_id" in body).toBe(false);
+    // The valid matched_rules survive (better than the old per-site fallback,
+    // which dropped them wholesale).
+    expect(body.matched_rules).toEqual(["still-valid rule"]);
+    expect(String(body.message)).toContain(MCP_APPROVAL_RESUME_HINT);
+
+    const nonArrayRules = approvalRequiredResult({
+      approvalRequestId: "appr_ok",
+      matchedRules: "not-an-array",
+      message: "approval needed",
+    });
+    const body2 = nonArrayRules.structuredContent as Record<string, unknown>;
+    expect(body2.approval_required).toBe(true);
+    expect(body2.approval_request_id).toBe("appr_ok");
+    expect("matched_rules" in body2).toBe(false);
+  });
+
+  it("tolerates a missing upstream message — the resume hint is always present", () => {
+    const result = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      matchedRules: [],
+      message: undefined,
+    });
+    const body = result.structuredContent as Record<string, unknown>;
+    expect(body.message).toBe(MCP_APPROVAL_RESUME_HINT);
+  });
+
+  it("never double-appends the hint when the upstream message already carries it", () => {
+    const already = `parked ${MCP_APPROVAL_RESUME_HINT}`;
+    const result = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      message: already,
+    });
+    const body = result.structuredContent as Record<string, unknown>;
+    expect(body.message).toBe(already);
+  });
+
+  it("carries tool-specific leading fields via `extra` (runMetric id / query answer+sql)", () => {
+    const result = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      matchedRules: ["r"],
+      message: "m",
+      extra: { id: "revenue_mtd" },
+    });
+    const body = result.structuredContent as Record<string, unknown>;
+    expect(body.id).toBe("revenue_mtd");
+    expect(body.approval_required).toBe(true);
+  });
+
+  it("structured: false returns a text-only result (gate-4 tools declare no outputSchema)", () => {
+    const result = approvalRequiredResult({
+      approvalRequestId: "req_stub",
+      matchedRules: ["MCP destructive"],
+      message: "This action requires approval before execution.",
+      structured: false,
+    });
+    expect("structuredContent" in result).toBe(false);
+    const body = JSON.parse(textOf(result)) as Record<string, unknown>;
+    expect(body.approval_required).toBe(true);
+    expect(body.approval_request_id).toBe("req_stub");
+    expect(String(body.message)).toContain(MCP_APPROVAL_RESUME_HINT);
+  });
+
+  it("the payload validates against every consuming tool's declared output schema", () => {
+    const base = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      matchedRules: ["r"],
+      message: "m",
+    }).structuredContent;
+    expect(executeSqlOutputSchema.safeParse(base).success).toBe(true);
+    expect(queryOutputSchema.safeParse(base).success).toBe(true);
+
+    const metric = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      matchedRules: ["r"],
+      message: "m",
+      extra: { id: "revenue_mtd" },
+    }).structuredContent;
+    expect(runMetricOutputSchema.safeParse(metric).success).toBe(true);
+
+    const query = approvalRequiredResult({
+      approvalRequestId: "appr_1",
+      matchedRules: ["r"],
+      message: "m",
+      extra: { answer: "parked", sql: ["SELECT 1"] },
+    }).structuredContent;
+    expect(queryOutputSchema.safeParse(query).success).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/approval-required-result.test.ts
+++ b/packages/mcp/src/__tests__/approval-required-result.test.ts
@@ -102,6 +102,12 @@ describe("approvalRequiredResult (#4199)", () => {
     expect(body2.approval_required).toBe(true);
     expect(body2.approval_request_id).toBe("appr_ok");
     expect("matched_rules" in body2).toBe(false);
+
+    // The whole point of stripping (not throwing) is that the RECOVERED payload
+    // is still representable by the consuming output schema — otherwise SDK
+    // validation would throw at dispatch and lose the approval signal (#3584).
+    expect(executeSqlOutputSchema.safeParse(body).success).toBe(true);
+    expect(executeSqlOutputSchema.safeParse(body2).success).toBe(true);
   });
 
   it("tolerates a missing upstream message — the resume hint is always present", () => {
@@ -174,5 +180,32 @@ describe("approvalRequiredResult (#4199)", () => {
       extra: { answer: "parked", sql: ["SELECT 1"] },
     }).structuredContent;
     expect(queryOutputSchema.safeParse(query).success).toBe(true);
+  });
+
+  it("strips reserved keys from `extra` so a caller cannot inject the approval signal (#4199)", () => {
+    const result = approvalRequiredResult({
+      approvalRequestId: undefined,
+      matchedRules: ["real rule"],
+      message: "m",
+      // A caller must not be able to smuggle a request id through `extra` and
+      // defeat the null-omission invariant, nor override approval_required /
+      // matched_rules / message from the passthrough.
+      extra: {
+        approval_request_id: "leaked",
+        approval_required: false,
+        matched_rules: ["hijacked"],
+        message: "spoofed",
+        answer: "kept",
+      },
+    });
+    const body = result.structuredContent as Record<string, unknown>;
+    // Reserved keys reflect the real builder inputs, not the `extra` injection.
+    expect("approval_request_id" in body).toBe(false); // undefined id → omitted
+    expect(body.approval_required).toBe(true);
+    expect(body.matched_rules).toEqual(["real rule"]);
+    expect(body.message).not.toBe("spoofed");
+    expect(String(body.message)).toContain(MCP_APPROVAL_RESUME_HINT);
+    // A non-reserved `extra` field still passes through.
+    expect(body.answer).toBe("kept");
   });
 });

--- a/packages/mcp/src/dispatch-gate.ts
+++ b/packages/mcp/src/dispatch-gate.ts
@@ -71,6 +71,7 @@ import {
 import { writeScopeOrNull } from "./tools.js";
 import { billingGateOrNull } from "./billing-gate.js";
 import { envelope, toEnvelopeResult } from "./error-envelope.js";
+import { approvalRequiredResult } from "./structured-output.js";
 import { getLiveActor } from "./live-actor-store.js";
 
 // Re-export the gate CONTRACT shapes (#3599) so existing consumers that
@@ -354,25 +355,20 @@ async function runApprovalGate(
       }),
     );
 
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              approval_required: true,
-              approval_request_id: req.id,
-              matched_rules: match.matchedRules.map((r) => r.name),
-              message:
-                `This action requires approval before execution. Rule: "${firstRule.name}". ` +
-                `An approval request has been submitted (ID: ${req.id}).`,
-            },
-            null,
-            2,
-          ),
-        },
-      ],
-    };
+    // #4199 — shared validated builder (one contract with the executeSQL /
+    // runMetric / query approval branches, so agents/SDK parse one shape).
+    // The #3750 resume hint applies here too: re-calling the identical tool
+    // once approved passes gate-4 via the hasApprovedRequest dedup above.
+    // `structured: false` — the destructive tools this gate guards declare no
+    // outputSchema, and the MCP SDK rejects structuredContent without one.
+    return approvalRequiredResult({
+      approvalRequestId: req.id,
+      matchedRules: match.matchedRules.map((r) => r.name),
+      message:
+        `This action requires approval before execution. Rule: "${firstRule.name}". ` +
+        `An approval request has been submitted (ID: ${req.id}).`,
+      structured: false,
+    });
   } catch (err) {
     log.error(
       {

--- a/packages/mcp/src/query-tool.ts
+++ b/packages/mcp/src/query-tool.ts
@@ -45,7 +45,7 @@ import {
 import { type McpTransport, type McpDeployMode } from "./telemetry.js";
 import { envelope, toEnvelopeResult, toStructuredContent } from "./error-envelope.js";
 import { createMcpDispatch } from "./mcp-dispatch.js";
-import { queryOutputShape, withResumeHint } from "./structured-output.js";
+import { approvalRequiredResult, queryOutputShape } from "./structured-output.js";
 import { withProgressAndCancellation } from "./progress.js";
 
 // The question is free text the customer's LLM composed. Cap it so a hostile
@@ -227,14 +227,18 @@ export function registerQueryTool(
           // governance signal (NOT an error) so the client re-runs the identical
           // call once approved, mirroring executeSQL/runMetric.
           if (result.pendingApproval) {
+            // #4199 — shared validated builder: #3584 safeParse guard (a null
+            // approvalId is omitted, never emitted as `approval_request_id:
+            // null`) + #3750 resume hint.
             const { requestId: approvalId, matchedRules, message } = result.pendingApproval;
-            return toStructuredContent({
-              answer: result.answer,
-              ...(result.sql.length > 0 ? { sql: result.sql } : {}),
-              approval_required: true,
-              ...(approvalId ? { approval_request_id: approvalId } : {}),
-              matched_rules: matchedRules,
-              message: withResumeHint(message),
+            return approvalRequiredResult({
+              approvalRequestId: approvalId,
+              matchedRules,
+              message,
+              extra: {
+                answer: result.answer,
+                ...(result.sql.length > 0 ? { sql: result.sql } : {}),
+              },
             });
           }
 

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -56,7 +56,7 @@ import {
   toStructuredContent,
 } from "./error-envelope.js";
 import { createMcpDispatch } from "./mcp-dispatch.js";
-import { runMetricOutputShape, withResumeHint } from "./structured-output.js";
+import { approvalRequiredResult, runMetricOutputShape } from "./structured-output.js";
 import { withProgressAndCancellation } from "./progress.js";
 
 // Modest input bounds — MCP clients (including hostile ones in BYOC
@@ -520,14 +520,13 @@ export function registerSemanticTools(
             // doesn't retry and silently duplicate the request. Mirrors the
             // same branch in tools.ts:executeSQL.
             if (result.approval_required === true) {
-              return toStructuredContent({
-                id: metric.id,
-                approval_required: true,
-                approval_request_id: result.approval_request_id,
-                matched_rules: result.matched_rules,
-                // #3750 — resume hint: re-run this exact runMetric call once
-                // approved (parity with executeSQL's approval branch).
-                message: withResumeHint(result.message),
+              // #4199 — shared validated builder (parity with executeSQL's
+              // approval branch): #3584 safeParse guard + #3750 resume hint.
+              return approvalRequiredResult({
+                approvalRequestId: result.approval_request_id,
+                matchedRules: result.matched_rules,
+                message: result.message,
+                extra: { id: metric.id },
               });
             }
 

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -80,12 +80,38 @@ export function withResumeHint(message: unknown): string {
  */
 const approvalPayloadSchema = z
   .object({
+    // Derived from the `approvalFields` SSOT so a loosen/rename there can't
+    // drift the guard out of sync with the consuming output schemas; only the
+    // two invariants this builder enforces are tightened on top.
+    ...approvalFields,
     approval_required: z.literal(true),
-    approval_request_id: z.string().optional(),
-    matched_rules: z.array(z.unknown()).optional(),
     message: z.string(),
   })
   .catchall(z.unknown());
+
+/**
+ * Reserved keys the builder owns; stripped from caller-supplied `extra` before
+ * the spread so a caller can't inject e.g. `approval_request_id` through the
+ * passthrough and defeat the null-omission / `approval_required: true`
+ * invariants this builder exists to enforce (#4199).
+ */
+const RESERVED_APPROVAL_KEYS: ReadonlySet<string> = new Set([
+  "approval_required",
+  "approval_request_id",
+  "matched_rules",
+  "message",
+]);
+
+function sanitizeExtra(
+  extra: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!extra) return {};
+  const clean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(extra)) {
+    if (!RESERVED_APPROVAL_KEYS.has(key)) clean[key] = value;
+  }
+  return clean;
+}
 
 /**
  * #4199 — the ONE validated builder for the non-error `approval_required`
@@ -126,8 +152,9 @@ export function approvalRequiredResult({
   structured?: boolean;
 }): CallToolResult {
   const hinted = withResumeHint(message);
+  const safeExtra = sanitizeExtra(extra);
   const raw: Record<string, unknown> = {
-    ...(extra ?? {}),
+    ...safeExtra,
     approval_required: true,
     ...(approvalRequestId !== undefined && approvalRequestId !== null
       ? { approval_request_id: approvalRequestId }
@@ -141,7 +168,7 @@ export function approvalRequiredResult({
   const payload = approvalPayloadSchema.safeParse(raw).success
     ? raw
     : {
-        ...(extra ?? {}),
+        ...safeExtra,
         approval_required: true as const,
         ...(typeof approvalRequestId === "string"
           ? { approval_request_id: approvalRequestId }

--- a/packages/mcp/src/structured-output.ts
+++ b/packages/mcp/src/structured-output.ts
@@ -24,6 +24,7 @@
  */
 
 import { z } from "zod/v4";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { PublishResult } from "@useatlas/types";
 
 /** A result row: a flat map of column name → cell value. */
@@ -68,6 +69,90 @@ export function withResumeHint(message: unknown): string {
   const base = typeof message === "string" && message.length > 0 ? message : "";
   if (base.includes(MCP_APPROVAL_RESUME_HINT)) return base;
   return base ? `${base} ${MCP_APPROVAL_RESUME_HINT}` : MCP_APPROVAL_RESUME_HINT;
+}
+
+/**
+ * Validation guard for the payload {@link approvalRequiredResult} emits:
+ * the approval branch of every declared tool output schema, with
+ * `approval_required` pinned to `true`, `message` required (the resume hint
+ * guarantees one), and tool-specific leading fields (`id`, `answer`, `sql`)
+ * passed through via catchall.
+ */
+const approvalPayloadSchema = z
+  .object({
+    approval_required: z.literal(true),
+    approval_request_id: z.string().optional(),
+    matched_rules: z.array(z.unknown()).optional(),
+    message: z.string(),
+  })
+  .catchall(z.unknown());
+
+/**
+ * #4199 — the ONE validated builder for the non-error `approval_required`
+ * governance payload. `executeSQL`, `runMetric`, `query`, and dispatch-gate
+ * gate-4 all emit this shape; before this builder each site re-derived the
+ * object and validation rigor had drifted (safeParse in tools.ts, none in
+ * query-tool/semantic-tools, raw JSON.stringify in gate-4).
+ *
+ * Folds in:
+ * - {@link withResumeHint} (#3750) — `message` always tells the MCP client
+ *   to re-call the identical tool once approved (all consumers dedup the
+ *   re-call via `hasApprovedRequest`, so the hint is accurate everywhere);
+ * - the #3584 safeParse guard — malformed internal fields (non-string
+ *   `approval_request_id`, non-array `matched_rules`) are stripped rather
+ *   than allowed to throw in SDK output-schema validation, which would break
+ *   the dispatch and lose the approval signal entirely. Valid fields survive;
+ * - null/undefined request-id omission — a parked approval with no queued
+ *   row must not emit `approval_request_id: null` (fails the declared
+ *   output schemas).
+ *
+ * `extra` carries the tool-specific leading fields (`{ id }` for runMetric,
+ * `{ answer, sql }` for query). `structured: false` drops
+ * `structuredContent` for tools that declare no `outputSchema` (the
+ * destructive tools gate-4 guards) — the MCP SDK rejects structuredContent
+ * from a tool without one.
+ */
+export function approvalRequiredResult({
+  approvalRequestId,
+  matchedRules,
+  message,
+  extra,
+  structured = true,
+}: {
+  approvalRequestId?: unknown;
+  matchedRules?: unknown;
+  message?: unknown;
+  extra?: Record<string, unknown>;
+  structured?: boolean;
+}): CallToolResult {
+  const hinted = withResumeHint(message);
+  const raw: Record<string, unknown> = {
+    ...(extra ?? {}),
+    approval_required: true,
+    ...(approvalRequestId !== undefined && approvalRequestId !== null
+      ? { approval_request_id: approvalRequestId }
+      : {}),
+    ...(matchedRules !== undefined ? { matched_rules: matchedRules } : {}),
+    message: hinted,
+  };
+  // Serialize `raw` itself when it validates (preserves the caller's field
+  // order in the text block); rebuild field-by-field when it doesn't,
+  // keeping every field whose runtime type matches the declared schema.
+  const payload = approvalPayloadSchema.safeParse(raw).success
+    ? raw
+    : {
+        ...(extra ?? {}),
+        approval_required: true as const,
+        ...(typeof approvalRequestId === "string"
+          ? { approval_request_id: approvalRequestId }
+          : {}),
+        ...(Array.isArray(matchedRules) ? { matched_rules: matchedRules } : {}),
+        message: hinted,
+      };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    ...(structured ? { structuredContent: payload } : {}),
+  };
 }
 
 /**

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -44,7 +44,7 @@ import {
   toEnvelopeResult,
 } from "./error-envelope.js";
 import { createMcpDispatch } from "./mcp-dispatch.js";
-import { executeSqlOutputShape } from "./structured-output.js";
+import { approvalRequiredResult, executeSqlOutputShape } from "./structured-output.js";
 import { withProgressAndCancellation } from "./progress.js";
 
 export interface RegisterToolsOptions {
@@ -284,40 +284,17 @@ export function registerTools(server: McpServer, opts: RegisterToolsOptions): vo
             // + user see the full payload.
             if (obj.approval_required === true) {
               // Non-error governance branch — still carries structuredContent
-              // (#3498) since the declared outputSchema makes the SDK require it
-              // on every non-error result. #3584 — narrow each field against the
-              // declared outputSchema types before assigning to structuredContent
-              // so SDK output-schema validation can't throw on a malformed
-              // internal payload (e.g. non-string approval_request_id).
-              const { executeSqlOutputSchema: schema, withResumeHint } = await import(
-                "./structured-output.js"
-              );
-              const raw = {
-                approval_required: true,
-                approval_request_id: obj.approval_request_id,
-                matched_rules: obj.matched_rules,
-                // #3750 — tell the MCP client how to resume: re-call the
-                // identical tool once approved (the executeSQL gate's
-                // hasApprovedRequest dedup lets the re-call through).
-                message: withResumeHint(obj.message),
-              };
-              const parsed = schema.safeParse(raw);
-              const approval = parsed.success ? parsed.data : {
-                approval_required: true as const,
-                ...(typeof obj.approval_request_id === "string"
-                  ? { approval_request_id: obj.approval_request_id }
-                  : {}),
-                // Resume hint is always present (withResumeHint tolerates a
-                // missing upstream message) so even the fallback shape tells
-                // the client how to continue.
-                message: withResumeHint(obj.message),
-              };
-              return {
-                content: [
-                  { type: "text" as const, text: JSON.stringify(approval, null, 2) },
-                ],
-                structuredContent: approval,
-              };
+              // (#3498) since the declared outputSchema makes the SDK require
+              // it on every non-error result. #4199 — the shared builder folds
+              // in the #3584 safeParse guard (malformed internal fields are
+              // stripped, never thrown) and the #3750 resume hint (re-call the
+              // identical tool once approved; the executeSQL gate's
+              // hasApprovedRequest dedup lets the re-call through).
+              return approvalRequiredResult({
+                approvalRequestId: obj.approval_request_id,
+                matchedRules: obj.matched_rules,
+                message: obj.message,
+              });
             }
 
             const rawError = String(obj.error ?? obj.message ?? "");


### PR DESCRIPTION
## Summary

Adds `approvalRequiredResult({approvalRequestId, matchedRules, message, extra})` to `packages/mcp/src/structured-output.ts`, folding in `withResumeHint` + the `safeParse` guard, and routes the five sites that assembled the MCP governance approval payload by hand (executeSQL ×2, query-tool, semantic-tools runMetric, dispatch-gate gate-4) through it — removing the validation-rigor drift. ADR-0016 gate-order semantics unchanged.

Closes #4199

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — one contract test for the approval-resume payload
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area) — inherited from issue (refactor, area: mcp)
- [ ] CHANGELOG.md updated (if user-facing change)

> ⚠️ **Draft:** authored by an autonomous ship-issue worker that was interrupted (session limit) before the `/ci` gate ran. CI checks below have not been locally verified — do not merge until green.

https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c)_