### PR TITLE
refactor: one delivery-transport seam behind email/slack/webhook channels (#4198)

### DIFF
--- a/packages/api/src/lib/scheduler/__tests__/delivery-transports.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/delivery-transports.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Permanence-classification policy unit tests for the delivery-transport
+ * seam (#4198) — one suite per channel descriptor.
+ *
+ * The shared {@link deliverVia} wrapper owns the load → send → classify →
+ * log → DeliveryError skeleton; the ONLY per-channel policy is what counts
+ * as a permanent failure. These tests pin that policy per channel:
+ *   - email:   `provider === "log"` (no sender configured)
+ *   - slack:   missing bot token; API `ok: false` stays transient
+ *   - webhook: blocked URL (pre-flight + egress guard) and HTTP 4xx
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
+import type { FormattedResult } from "../shape-result";
+import {
+  emailTransport,
+  slackTransport,
+  webhookTransport,
+  isHttpPermanent,
+  MissingSlackTokenError,
+  BlockedWebhookUrlError,
+} from "../delivery";
+
+const shaped: FormattedResult = {
+  taskId: "task-123",
+  taskName: "Daily Revenue",
+  question: "What was yesterday's revenue?",
+  answer: "Revenue was $1M",
+  sql: [],
+  datasets: [],
+  steps: 1,
+  totalTokens: 10,
+  generatedAt: "2024-01-01T00:00:00Z",
+  orgId: null,
+};
+
+describe("email transport permanence policy", () => {
+  const transport = emailTransport({ type: "email", address: "a@example.com" }, shaped);
+
+  it("classifies the log-provider fallback as permanent (#3379)", async () => {
+    const failure = await transport.inspect({
+      success: false,
+      provider: "log",
+      error: "No email delivery backend configured — set RESEND_API_KEY",
+    });
+    expect(failure).toMatchObject({
+      permanent: true,
+      message: "No email delivery backend configured — set RESEND_API_KEY",
+    });
+  });
+
+  it("classifies a real-provider failure as transient", async () => {
+    const failure = await transport.inspect({ success: false, provider: "resend", error: "rate limited" });
+    expect(failure).toMatchObject({ permanent: false, message: "rate limited" });
+  });
+
+  it("falls back to a generic message when the provider reports none", async () => {
+    const failure = await transport.inspect({ success: false, provider: "resend" });
+    expect(failure?.message).toBe("Email delivery failed");
+  });
+
+  it("treats a successful outcome as no failure", async () => {
+    expect(await transport.inspect({ success: true, provider: "resend" })).toBeNull();
+  });
+});
+
+describe("slack transport permanence policy", () => {
+  const transport = slackTransport({ type: "slack", channel: "#reports" }, shaped);
+
+  it("rejects with the missing-token sentinel before calling the API", async () => {
+    const postMessage = mock(() => Promise.resolve({ ok: true as const }));
+    await expect(
+      transport.send({ token: null, postMessage: postMessage as never }),
+    ).rejects.toBeInstanceOf(MissingSlackTokenError);
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("classifies a missing bot token as permanent with a warn-level log", () => {
+    const failure = transport.classifyThrown?.(new MissingSlackTokenError());
+    expect(failure).toMatchObject({ permanent: true, message: "No Slack bot token" });
+    expect(failure?.log?.level).toBe("warn");
+  });
+
+  it("leaves other thrown errors to the default transient classification", () => {
+    expect(transport.classifyThrown?.(new Error("ECONNRESET"))).toBeNull();
+  });
+
+  it("classifies an API-level error as transient", async () => {
+    const failure = await transport.inspect({ ok: false, error: "channel_not_found" });
+    expect(failure).toMatchObject({ permanent: false, message: "channel_not_found" });
+  });
+
+  it("treats an ok response as no failure", async () => {
+    expect(await transport.inspect({ ok: true })).toBeNull();
+  });
+});
+
+describe("webhook transport permanence policy", () => {
+  const transport = webhookTransport({ type: "webhook", url: "https://hook.example.com" }, shaped);
+
+  it("rejects a blocked URL with the sentinel before any fetch", async () => {
+    const blocked = webhookTransport({ type: "webhook", url: "http://10.0.0.1/internal" }, shaped);
+    const fetchImpl = mock(() => Promise.resolve(new Response("ok")));
+    await expect(blocked.send(fetchImpl as never)).rejects.toBeInstanceOf(BlockedWebhookUrlError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("classifies a pre-flight blocked URL as permanent", () => {
+    const failure = transport.classifyThrown?.(new BlockedWebhookUrlError());
+    expect(failure).toMatchObject({ permanent: true, message: "Blocked URL" });
+  });
+
+  it("classifies an egress-guard rejection (redirect hop) as permanent (#3340)", () => {
+    const failure = transport.classifyThrown?.(new EgressBlockedError("http://169.254.169.254/latest"));
+    expect(failure?.permanent).toBe(true);
+    expect(failure?.message).toContain("Blocked URL (egress guard)");
+  });
+
+  it("leaves network errors to the default transient classification", () => {
+    expect(transport.classifyThrown?.(new Error("network error"))).toBeNull();
+  });
+
+  it("classifies HTTP 4xx as permanent and 5xx as transient", async () => {
+    const notFound = await transport.inspect(new Response("nope", { status: 404 }));
+    expect(notFound).toMatchObject({ permanent: true, message: "HTTP 404" });
+
+    const serverError = await transport.inspect(new Response("boom", { status: 500 }));
+    expect(serverError).toMatchObject({ permanent: false, message: "HTTP 500" });
+  });
+
+  it("treats a 2xx response as no failure", async () => {
+    expect(await transport.inspect(new Response("ok", { status: 200 }))).toBeNull();
+  });
+});
+
+describe("isHttpPermanent", () => {
+  it("marks exactly the 4xx range permanent", () => {
+    expect(isHttpPermanent(399)).toBe(false);
+    expect(isHttpPermanent(400)).toBe(true);
+    expect(isHttpPermanent(499)).toBe(true);
+    expect(isHttpPermanent(500)).toBe(false);
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/delivery-transports.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/delivery-transports.test.ts
@@ -10,9 +10,11 @@
  *   - webhook: blocked URL (pre-flight + egress guard) and HTTP 4xx
  */
 import { describe, it, expect, mock } from "bun:test";
+import { Effect } from "effect";
 import { EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
 import type { FormattedResult } from "../shape-result";
 import {
+  deliverVia,
   emailTransport,
   slackTransport,
   webhookTransport,
@@ -139,5 +141,45 @@ describe("isHttpPermanent", () => {
     expect(isHttpPermanent(400)).toBe(true);
     expect(isHttpPermanent(499)).toBe(true);
     expect(isHttpPermanent(500)).toBe(false);
+  });
+});
+
+describe("deliverVia wrapper failure policy (#4198)", () => {
+  // A minimal stub transport; individual cases override load/inspect to fail.
+  const baseStub = {
+    channel: "webhook" as const,
+    recipient: "https://example.com/hook",
+    send: async () => ({ ok: true }),
+    inspect: () => null,
+    success: () => ({ fields: {}, message: "delivered" }),
+  };
+
+  // `Effect.flip` turns the DeliveryError channel into the success channel so
+  // runPromise resolves with the error for inspection.
+  const failureOf = (transport: Parameters<typeof deliverVia>[0]) =>
+    Effect.runPromise(Effect.flip(deliverVia(transport, shaped)));
+
+  it("maps a rejecting load to a transient DeliveryError (retryable)", async () => {
+    const err = await failureOf({
+      ...baseStub,
+      load: async () => {
+        throw new Error("dynamic import blew up");
+      },
+    });
+    expect(err.permanent).toBe(false);
+    expect(err.message).toContain("dynamic import blew up");
+    expect(err.channel).toBe("webhook");
+  });
+
+  it("maps a rejecting inspect to a transient DeliveryError, not a batch-killing defect", async () => {
+    const err = await failureOf({
+      ...baseStub,
+      load: async () => ({}),
+      inspect: async () => {
+        throw new Error("response read failed");
+      },
+    });
+    expect(err.permanent).toBe(false);
+    expect(err.message).toContain("response read failed");
   });
 });

--- a/packages/api/src/lib/scheduler/delivery.ts
+++ b/packages/api/src/lib/scheduler/delivery.ts
@@ -3,7 +3,12 @@
  *
  * Effect migration (P3): sequential for-loops replaced with Effect.forEach.
  * Transient failures get exponential backoff retry (3 attempts, 1s base).
- * Channel-specific logic is parameterized via a handler map.
+ *
+ * One delivery-transport seam (#4198): the load → send → classify → log →
+ * DeliveryError skeleton lives once in {@link deliverVia}; each channel
+ * supplies a small {@link ChannelTransport} descriptor whose only real policy
+ * is permanence classification (email `provider === "log"`, slack missing
+ * token, webhook blocked URL / HTTP 4xx).
  */
 
 import { Effect, Schedule, Duration } from "effect";
@@ -111,187 +116,302 @@ const retryPolicy = Schedule.intersect(
 );
 
 /** HTTP 4xx errors are client errors that will never succeed on retry. */
-function isHttpPermanent(status: number): boolean {
+export function isHttpPermanent(status: number): boolean {
   return status >= 400 && status < 500;
 }
 
-// ── Per-recipient delivery Effects ────────────────────────────────
+// ── Delivery transport seam (#4198) ───────────────────────────────
 
-function deliverToEmail(
-  recipient: EmailRecipient,
+/**
+ * A classified delivery failure: the `DeliveryError` fields plus the log line
+ * that should accompany it. `permanent` is the channel's permanence policy —
+ * it decides whether the executor retries (transient) or records
+ * `failed_permanent` (misconfiguration; see {@link DeliverySummary}).
+ */
+export interface DeliveryFailure {
+  readonly message: string;
+  readonly permanent: boolean;
+  readonly log?: {
+    /** Defaults to `"error"`. */
+    readonly level?: "warn" | "error";
+    readonly fields: Record<string, unknown>;
+    readonly message: string;
+  };
+}
+
+/**
+ * Channel descriptor consumed by {@link deliverVia}. The shared wrapper owns
+ * the skeleton (dynamic import → transport call → response inspection →
+ * logging → `DeliveryError` construction); a channel supplies only:
+ *
+ * - `load` — backend acquisition (dynamic import + credential resolution).
+ *   A rejection is always a **transient** failure; contextualize the message
+ *   inside `load` itself (see {@link rethrowWith}).
+ * - `send` — the transport call. May throw a channel sentinel (e.g.
+ *   {@link MissingSlackTokenError}) for pre-send preconditions.
+ * - `classifyThrown` — the permanence policy for errors thrown by `send`.
+ *   Returning `null` falls back to the default: transient, raw message.
+ * - `inspect` — the permanence policy for a resolved response. Returning
+ *   `null` means the delivery succeeded.
+ */
+interface ChannelTransport<Backend, Resp> {
+  readonly channel: Recipient["type"];
+  /** Recipient identity for `DeliveryError` (address / channel / URL). */
+  readonly recipient: string;
+  readonly load: () => Promise<Backend>;
+  readonly send: (backend: Backend) => Promise<Resp>;
+  readonly classifyThrown?: (err: unknown) => DeliveryFailure | null;
+  readonly inspect: (resp: Resp) => DeliveryFailure | null | Promise<DeliveryFailure | null>;
+  readonly success: (resp: Resp) => { readonly fields: Record<string, unknown>; readonly message: string };
+}
+
+const errMsg = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/**
+ * Rethrow with a contextual prefix so `load` failures keep their historical
+ * per-step messages ("Failed to load Slack API: …") without the wrapper
+ * needing per-channel knowledge.
+ */
+const rethrowWith =
+  (prefix: string) =>
+  (err: unknown): never => {
+    throw new Error(`${prefix}: ${errMsg(err)}`);
+  };
+
+/**
+ * The single transport wrapper: load → send → classify → log → DeliveryError.
+ * Every `DeliveryError` a channel can produce is constructed here.
+ */
+function deliverVia<Backend, Resp>(
+  transport: ChannelTransport<Backend, Resp>,
   shaped: FormattedResult,
 ): Effect.Effect<void, DeliveryError> {
-  return Effect.gen(function* () {
-    const { subject, body } = formatEmailReport(shaped);
-
-    const { sendEmail } = yield* Effect.tryPromise({
-      try: () => import("@atlas/api/lib/email/delivery"),
-      catch: (err) =>
-        new DeliveryError({
-          message: `Failed to load email delivery: ${err instanceof Error ? err.message : String(err)}`,
-          channel: "email",
-          recipient: recipient.address,
-          permanent: false,
-        }),
+  const toError = (failure: { message: string; permanent: boolean }) =>
+    new DeliveryError({
+      message: failure.message,
+      channel: transport.channel,
+      recipient: transport.recipient,
+      permanent: failure.permanent,
     });
 
-    const deliveryResult = yield* Effect.tryPromise({
+  /** Emit the failure's log line (once per attempt) and build its error. */
+  const failWith = (failure: DeliveryFailure): DeliveryError => {
+    if (failure.log) {
+      const fields = { taskId: shaped.taskId, ...failure.log.fields };
+      if (failure.log.level === "warn") log.warn(fields, failure.log.message);
+      else log.error(fields, failure.log.message);
+    }
+    return toError(failure);
+  };
+
+  return Effect.gen(function* () {
+    const backend = yield* Effect.tryPromise({
+      try: transport.load,
+      catch: (err) => toError({ message: errMsg(err), permanent: false }),
+    });
+
+    const resp = yield* Effect.tryPromise({
+      try: () => transport.send(backend),
+      catch: (err) => {
+        const classified = transport.classifyThrown?.(err) ?? null;
+        return classified ? failWith(classified) : toError({ message: errMsg(err), permanent: false });
+      },
+    });
+
+    const failure = yield* Effect.promise(async () => transport.inspect(resp));
+    if (failure) {
+      return yield* Effect.fail(failWith(failure));
+    }
+
+    const success = transport.success(resp);
+    log.info({ taskId: shaped.taskId, ...success.fields }, success.message);
+  });
+}
+
+// ── Channel descriptors ───────────────────────────────────────────
+
+type EmailModule = typeof import("@atlas/api/lib/email/delivery");
+type EmailOutcome = Awaited<ReturnType<EmailModule["sendEmail"]>>;
+
+/** Exported for permanence-policy unit tests (#4198). */
+export function emailTransport(
+  recipient: EmailRecipient,
+  shaped: FormattedResult,
+): ChannelTransport<EmailModule, EmailOutcome> {
+  return {
+    channel: "email",
+    recipient: recipient.address,
+    load: () => import("@atlas/api/lib/email/delivery").catch(rethrowWith("Failed to load email delivery")),
+    send: async ({ sendEmail }) => {
+      const { subject, body } = formatEmailReport(shaped);
       // Threading shaped.orgId keeps the send on the SAME chain link the
       // #3379 preflight resolved (per-org transport first) — without it,
       // an org-transport-only deployment preflights clean and then falls
       // through to platform/env/log at delivery time (#3386).
-      try: () => sendEmail({ to: recipient.address, subject, html: body }, shaped.orgId ?? undefined),
-      catch: (err) =>
-        new DeliveryError({
-          message: err instanceof Error ? err.message : String(err),
-          channel: "email",
-          recipient: recipient.address,
-          permanent: false,
-        }),
-    });
-
-    if (!deliveryResult.success) {
-      log.error(
-        { taskId: shaped.taskId, recipient: recipient.address, provider: deliveryResult.provider, error: deliveryResult.error },
-        "Email delivery failed",
-      );
-      return yield* Effect.fail(
-        new DeliveryError({
-          message: deliveryResult.error ?? "Email delivery failed",
-          channel: "email",
-          recipient: recipient.address,
-          permanent: deliveryResult.provider === "log",
-        }),
-      );
-    }
-
-    log.info({ taskId: shaped.taskId, recipient: recipient.address, provider: deliveryResult.provider }, "Email delivered");
-  });
+      return sendEmail({ to: recipient.address, subject, html: body }, shaped.orgId ?? undefined);
+    },
+    inspect: (outcome) =>
+      outcome.success
+        ? null
+        : {
+            message: outcome.error ?? "Email delivery failed",
+            // The "log" provider is the configured-nothing fallback — no
+            // sender exists, so retrying can never succeed (#3379).
+            permanent: outcome.provider === "log",
+            log: {
+              fields: { recipient: recipient.address, provider: outcome.provider, error: outcome.error },
+              message: "Email delivery failed",
+            },
+          },
+    success: (outcome) => ({
+      fields: { recipient: recipient.address, provider: outcome.provider },
+      message: "Email delivered",
+    }),
+  };
 }
 
-function deliverToSlack(
+/**
+ * Pre-send sentinel: no Slack bot token is resolvable for the recipient's
+ * team. Thrown by the slack transport's `send` and classified permanent by
+ * its `classifyThrown` — missing credentials never heal on retry.
+ */
+export class MissingSlackTokenError extends Error {
+  constructor() {
+    super("No Slack bot token");
+    this.name = "MissingSlackTokenError";
+  }
+}
+
+type SlackModule = typeof import("@atlas/api/lib/slack/api");
+interface SlackBackend {
+  readonly token: string | null;
+  readonly postMessage: SlackModule["postMessage"];
+}
+type SlackResponse = Awaited<ReturnType<SlackModule["postMessage"]>>;
+
+/** Exported for permanence-policy unit tests (#4198). */
+export function slackTransport(
   recipient: SlackRecipient,
   shaped: FormattedResult,
-): Effect.Effect<void, DeliveryError> {
-  return Effect.gen(function* () {
-    const { text, blocks } = formatSlackReport(shaped);
-
-    // Per-team token, then SLACK_BOT_TOKEN env — via the shared resolver the
-    // sender preflight also uses (#3379), so the two can never disagree.
-    const token = yield* Effect.tryPromise({
-      try: () => resolveSlackBotToken(recipient.teamId),
-      catch: (err) =>
-        new DeliveryError({
-          message: `Failed to resolve Slack bot token: ${err instanceof Error ? err.message : String(err)}`,
-          channel: "slack",
-          recipient: recipient.channel,
-          permanent: false,
-        }),
-    });
-    if (!token) {
-      log.warn({ taskId: shaped.taskId, channel: recipient.channel }, "No Slack bot token available — delivery skipped");
-      return yield* Effect.fail(
-        new DeliveryError({ message: "No Slack bot token", channel: "slack", recipient: recipient.channel, permanent: true }),
+): ChannelTransport<SlackBackend, SlackResponse> {
+  return {
+    channel: "slack",
+    recipient: recipient.channel,
+    load: async () => {
+      // Per-team token, then SLACK_BOT_TOKEN env — via the shared resolver the
+      // sender preflight also uses (#3379), so the two can never disagree.
+      const token = await resolveSlackBotToken(recipient.teamId).catch(
+        rethrowWith("Failed to resolve Slack bot token"),
       );
-    }
-
-    const { postMessage } = yield* Effect.tryPromise({
-      try: () => import("@atlas/api/lib/slack/api"),
-      catch: (err) =>
-        new DeliveryError({
-          message: `Failed to load Slack API: ${err instanceof Error ? err.message : String(err)}`,
-          channel: "slack",
-          recipient: recipient.channel,
-          permanent: false,
-        }),
-    });
-    const resp = yield* Effect.tryPromise({
-      try: () => postMessage(token, { channel: recipient.channel, text, blocks }),
-      catch: (err) =>
-        new DeliveryError({
-          message: err instanceof Error ? err.message : String(err),
-          channel: "slack",
-          recipient: recipient.channel,
-          permanent: false,
-        }),
-    });
-
-    if (!resp.ok) {
-      log.error({ taskId: shaped.taskId, channel: recipient.channel, error: resp.error }, "Slack delivery failed");
-      return yield* Effect.fail(
-        new DeliveryError({ message: resp.error ?? "Slack API error", channel: "slack", recipient: recipient.channel, permanent: false }),
+      const { postMessage } = await import("@atlas/api/lib/slack/api").catch(
+        rethrowWith("Failed to load Slack API"),
       );
-    }
-
-    log.info({ taskId: shaped.taskId, channel: recipient.channel }, "Slack message delivered");
-  });
+      return { token, postMessage };
+    },
+    send: async ({ token, postMessage }) => {
+      if (!token) throw new MissingSlackTokenError();
+      const { text, blocks } = formatSlackReport(shaped);
+      return postMessage(token, { channel: recipient.channel, text, blocks });
+    },
+    classifyThrown: (err) =>
+      err instanceof MissingSlackTokenError
+        ? {
+            message: "No Slack bot token",
+            permanent: true,
+            log: {
+              level: "warn",
+              fields: { channel: recipient.channel },
+              message: "No Slack bot token available — delivery skipped",
+            },
+          }
+        : null,
+    inspect: (resp) =>
+      resp.ok
+        ? null
+        : {
+            message: resp.error ?? "Slack API error",
+            permanent: false,
+            log: {
+              fields: { channel: recipient.channel, error: resp.error },
+              message: "Slack delivery failed",
+            },
+          },
+    success: () => ({ fields: { channel: recipient.channel }, message: "Slack message delivered" }),
+  };
 }
 
-function deliverToWebhook(
+/**
+ * Pre-send sentinel: the webhook URL targets a private/internal address
+ * ({@link isBlockedUrl}). Thrown by the webhook transport's `send` and
+ * classified permanent by its `classifyThrown`.
+ */
+export class BlockedWebhookUrlError extends Error {
+  constructor() {
+    super("Blocked URL");
+    this.name = "BlockedWebhookUrlError";
+  }
+}
+
+/** Exported for permanence-policy unit tests (#4198). */
+export function webhookTransport(
   recipient: WebhookRecipient,
   shaped: FormattedResult,
-): Effect.Effect<void, DeliveryError> {
-  return Effect.gen(function* () {
-    if (isBlockedUrl(recipient.url)) {
-      log.error({ taskId: shaped.taskId, url: recipient.url }, "Webhook URL blocked — targets private/internal address");
-      return yield* Effect.fail(
-        new DeliveryError({ message: "Blocked URL", channel: "webhook", recipient: recipient.url, permanent: true }),
-      );
-    }
-
-    const payload = formatWebhookPayload(shaped);
-    const safeHeaders = sanitizeHeaders(recipient.headers ?? {});
-
-    // guardedFetch re-validates the target before the request leaves the box
-    // and on every redirect hop (manual redirects) — a public recipient that
-    // 302-redirects to an internal address is rejected, not followed (#3340).
-    const resp = yield* Effect.tryPromise({
-      try: () =>
-        guardedFetch(recipient.url, {
-          method: "POST",
-          headers: { ...safeHeaders, "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        }),
-      catch: (err) => {
-        if (err instanceof EgressBlockedError) {
-          log.error(
-            { taskId: shaped.taskId, host: err.host },
-            "Webhook delivery blocked by egress guard",
-          );
-          return new DeliveryError({
-            message: `Blocked URL (egress guard): ${hostForLog(recipient.url)}`,
-            channel: "webhook",
-            recipient: recipient.url,
-            permanent: true,
-          });
-        }
-        return new DeliveryError({
-          message: err instanceof Error ? err.message : String(err),
-          channel: "webhook",
-          recipient: recipient.url,
-          permanent: false,
-        });
-      },
-    });
-
-    if (!resp.ok) {
-      const text = yield* Effect.promise(() => resp.text().catch(() => ""));
-      log.error(
-        { taskId: shaped.taskId, url: recipient.url, status: resp.status, body: text.slice(0, 200) },
-        "Webhook delivery failed",
-      );
-      return yield* Effect.fail(
-        new DeliveryError({
-          message: `HTTP ${resp.status}`,
-          channel: "webhook",
-          recipient: recipient.url,
-          permanent: isHttpPermanent(resp.status),
-        }),
-      );
-    }
-
-    log.info({ taskId: shaped.taskId, url: recipient.url }, "Webhook delivered");
-  });
+): ChannelTransport<typeof guardedFetch, Response> {
+  return {
+    channel: "webhook",
+    recipient: recipient.url,
+    load: async () => guardedFetch,
+    send: async (fetchImpl) => {
+      if (isBlockedUrl(recipient.url)) throw new BlockedWebhookUrlError();
+      const payload = formatWebhookPayload(shaped);
+      const safeHeaders = sanitizeHeaders(recipient.headers ?? {});
+      // guardedFetch re-validates the target before the request leaves the box
+      // and on every redirect hop (manual redirects) — a public recipient that
+      // 302-redirects to an internal address is rejected, not followed (#3340).
+      return fetchImpl(recipient.url, {
+        method: "POST",
+        headers: { ...safeHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    },
+    classifyThrown: (err) => {
+      if (err instanceof BlockedWebhookUrlError) {
+        return {
+          message: "Blocked URL",
+          permanent: true,
+          log: {
+            fields: { url: recipient.url },
+            message: "Webhook URL blocked — targets private/internal address",
+          },
+        };
+      }
+      if (err instanceof EgressBlockedError) {
+        return {
+          message: `Blocked URL (egress guard): ${hostForLog(recipient.url)}`,
+          permanent: true,
+          log: {
+            fields: { host: err.host },
+            message: "Webhook delivery blocked by egress guard",
+          },
+        };
+      }
+      return null;
+    },
+    inspect: async (resp) => {
+      if (resp.ok) return null;
+      // intentionally ignored: the body is best-effort log context only.
+      const text = await resp.text().catch(() => "");
+      return {
+        message: `HTTP ${resp.status}`,
+        permanent: isHttpPermanent(resp.status),
+        log: {
+          fields: { url: recipient.url, status: resp.status, body: text.slice(0, 200) },
+          message: "Webhook delivery failed",
+        },
+      };
+    },
+    success: () => ({ fields: { url: recipient.url }, message: "Webhook delivered" }),
+  };
 }
 
 // ── Channel routing ───────────────────────────────────────────────
@@ -303,11 +423,11 @@ function deliverySingle(
   const inner = (() => {
     switch (recipient.type) {
       case "email":
-        return deliverToEmail(recipient, shaped);
+        return deliverVia(emailTransport(recipient, shaped), shaped);
       case "slack":
-        return deliverToSlack(recipient, shaped);
+        return deliverVia(slackTransport(recipient, shaped), shaped);
       case "webhook":
-        return deliverToWebhook(recipient, shaped);
+        return deliverVia(webhookTransport(recipient, shaped), shaped);
     }
   })();
   return withEffectSpan(

--- a/packages/api/src/lib/scheduler/delivery.ts
+++ b/packages/api/src/lib/scheduler/delivery.ts
@@ -125,8 +125,9 @@ export function isHttpPermanent(status: number): boolean {
 /**
  * A classified delivery failure: the `DeliveryError` fields plus the log line
  * that should accompany it. `permanent` is the channel's permanence policy —
- * it decides whether the executor retries (transient) or records
- * `failed_permanent` (misconfiguration; see {@link DeliverySummary}).
+ * it decides whether `deliverResult`'s retry loop retries it (transient) or
+ * the run is recorded as `failed_permanent` (misconfiguration; see
+ * {@link DeliverySummary}).
  */
 export interface DeliveryFailure {
   readonly message: string;
@@ -142,7 +143,7 @@ export interface DeliveryFailure {
 /**
  * Channel descriptor consumed by {@link deliverVia}. The shared wrapper owns
  * the skeleton (dynamic import → transport call → response inspection →
- * logging → `DeliveryError` construction); a channel supplies only:
+ * logging → `DeliveryError` construction); a channel supplies:
  *
  * - `load` — backend acquisition (dynamic import + credential resolution).
  *   A rejection is always a **transient** failure; contextualize the message
@@ -152,7 +153,9 @@ export interface DeliveryFailure {
  * - `classifyThrown` — the permanence policy for errors thrown by `send`.
  *   Returning `null` falls back to the default: transient, raw message.
  * - `inspect` — the permanence policy for a resolved response. Returning
- *   `null` means the delivery succeeded.
+ *   `null` means the delivery succeeded. Must be total (never reject): the
+ *   wrapper maps a rejection to a transient failure, not a defect.
+ * - `success` — the fields + message for the success log line.
  */
 interface ChannelTransport<Backend, Resp> {
   readonly channel: Recipient["type"];
@@ -181,8 +184,11 @@ const rethrowWith =
 /**
  * The single transport wrapper: load → send → classify → log → DeliveryError.
  * Every `DeliveryError` a channel can produce is constructed here.
+ *
+ * Exported for wrapper-policy unit tests (#4198) — the load/inspect
+ * failure-to-transient mapping is exercised via a stub transport.
  */
-function deliverVia<Backend, Resp>(
+export function deliverVia<Backend, Resp>(
   transport: ChannelTransport<Backend, Resp>,
   shaped: FormattedResult,
 ): Effect.Effect<void, DeliveryError> {
@@ -197,7 +203,7 @@ function deliverVia<Backend, Resp>(
   /** Emit the failure's log line (once per attempt) and build its error. */
   const failWith = (failure: DeliveryFailure): DeliveryError => {
     if (failure.log) {
-      const fields = { taskId: shaped.taskId, ...failure.log.fields };
+      const fields = { ...failure.log.fields, taskId: shaped.taskId };
       if (failure.log.level === "warn") log.warn(fields, failure.log.message);
       else log.error(fields, failure.log.message);
     }
@@ -218,13 +224,20 @@ function deliverVia<Backend, Resp>(
       },
     });
 
-    const failure = yield* Effect.promise(async () => transport.inspect(resp));
+    const failure = yield* Effect.tryPromise({
+      try: async () => transport.inspect(resp),
+      // A rejecting `inspect` degrades to a transient failure for THIS
+      // recipient — consistent with the load/send catches. Using Effect.promise
+      // here would turn a rejection into a defect (die) that escapes the
+      // per-recipient catchTag and aborts the whole batch (see #4198 review).
+      catch: (err) => toError({ message: errMsg(err), permanent: false }),
+    });
     if (failure) {
       return yield* Effect.fail(failWith(failure));
     }
 
     const success = transport.success(resp);
-    log.info({ taskId: shaped.taskId, ...success.fields }, success.message);
+    log.info({ ...success.fields, taskId: shaped.taskId }, success.message);
   });
 }
 


### PR DESCRIPTION
## Summary

Collapses the three copies of the delivery skeleton in `scheduler/delivery.ts` (`deliverToEmail`/`deliverToSlack`/`deliverToWebhook`) into one `deliverVia(channel, shaped)` seam where each channel supplies `{import, call, isPermanent(err)}` and the import → call → classify → log → `DeliveryError` wrapper lives once. The 12 `DeliveryError` construction sites collapse; retry/permanent semantics unchanged.

Closes #4198

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — permanence classification policy unit-tested per channel
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area) — inherited from issue (refactor, area: api)
- [ ] CHANGELOG.md updated (if user-facing change)

> ⚠️ **Draft:** authored by an autonomous ship-issue worker that was interrupted (session limit) before the `/ci` gate ran. CI checks below have not been locally verified — do not merge until green.

https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhrhtmFSLzZeEJbAHRnL4c)_