### PR TITLE
feat(knowledge): searchKnowledge tool — frontmatter filter + Postgres FTS + 1-hop graph expansion

### DIFF
--- a/packages/api/src/lib/tools/__tests__/knowledge-search-pg.test.ts
+++ b/packages/api/src/lib/tools/__tests__/knowledge-search-pg.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Real-Postgres coverage for `searchKnowledge` (#4210). Mirrors the
+ * `knowledge-lifecycle-pg.test.ts` harness: skips when `TEST_DATABASE_URL` is
+ * unset, runs every migration into a unique per-test schema, ingests real OKF
+ * bundles, and executes the REAL search + 1-hop expansion SQL against the live
+ * `knowledge_documents` / `knowledge_links` schema.
+ *
+ * Catches the drift a mock-exec unit test can't: `websearch_to_tsquery` /
+ * `to_tsvector` / `ts_headline`, `tags @> …::jsonb` against the GIN index, the
+ * quoted `"timestamp"` column, the `array_agg` edge aggregation, and content-mode
+ * status gating in both directions.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { zipSync, strToU8 } from "fflate";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { extractBundle } from "@atlas/api/lib/knowledge/bundle-archive";
+import { parseLenientBundle } from "@atlas/api/lib/knowledge/parse-lenient";
+import { ingestBundleIntoCollection, type IngestClient } from "@atlas/api/lib/knowledge/ingest";
+import {
+  searchKnowledgeCore,
+  type KnowledgeQueryExec,
+} from "@atlas/api/lib/tools/search-knowledge";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 30_000;
+const LIMITS = { maxDocBytes: 1_000_000, maxTotalBytes: 25_000_000 };
+
+function docsFrom(files: Record<string, string>) {
+  const zip = zipSync(Object.fromEntries(Object.entries(files).map(([p, c]) => [p, strToU8(c)])));
+  const extracted = extractBundle(zip, LIMITS);
+  return parseLenientBundle(extracted.files).docs;
+}
+
+describeIfPg("searchKnowledge against the live schema", () => {
+  let pool: Pool;
+  let client: IngestClient;
+  let exec: KnowledgeQueryExec;
+  const schemaName = `knowledge_search_pg_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ws = `ws-search-${Date.now()}`;
+
+  async function publish(collectionId: string, path: string) {
+    await pool.query(
+      `UPDATE knowledge_documents SET status = 'published'
+        WHERE workspace_id = $1 AND collection_id = $2 AND path = $3`,
+      [ws, collectionId, path],
+    );
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (c) => {
+      void c.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(`knowledge-search-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:okf-upload', 'Knowledge Base (Upload)', 'okf-upload', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    client = pool as unknown as IngestClient;
+    exec = async (sql, params) => (await pool.query(sql, params)).rows as never;
+
+    // A runbooks collection: eu.md links to replica.md; a draft doc stays hidden.
+    const docs = docsFrom({
+      "runbooks/eu.md":
+        "---\ntype: Runbook\ntitle: EU Failover\ntags: [ops, eu]\ntimestamp: '2026-05-28T00:00:00Z'\n---\n# EU Failover\n\nWhen replica lag exceeds threshold, promote the standby. See [replica notes](../glossary/replica.md).",
+      "glossary/replica.md":
+        "---\ntype: Document\ntitle: Replica Lag\ntags: [ops]\n---\n# Replica Lag\n\nReplica lag is the delay between primary and standby.",
+      "runbooks/secret.md":
+        "---\ntype: Runbook\ntitle: Secret Draft\ntags: [ops]\n---\n# Secret Draft\n\nUnpublished replica content that must stay hidden.",
+    });
+    await ingestBundleIntoCollection({
+      client,
+      workspaceId: ws,
+      collectionId: "runbooks",
+      source: "upload",
+      docs,
+    });
+    // Publish two of three; secret.md stays draft.
+    await publish("runbooks", "runbooks/eu.md");
+    await publish("runbooks", "glossary/replica.md");
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      console.error(`knowledge-search-pg: cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+    await pool.end();
+  });
+
+  it("full-text search returns matches with a highlighted snippet and provenance", async () => {
+    const res = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { query: "replica lag", limit: 10, expand: false },
+      exec,
+    });
+    const eu = res.results.find((r) => r.path === "runbooks/eu.md");
+    expect(eu).toBeDefined();
+    expect(eu!.provenance.type).toBe("Runbook");
+    expect(eu!.provenance.status).toBe("published");
+    expect(eu!.snippet).toContain("**");
+    expect(eu!.snippet?.toLowerCase()).toContain("replica");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("published mode hides draft documents; developer mode surfaces them", async () => {
+    const published = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { query: "replica", limit: 10, expand: false },
+      exec,
+    });
+    expect(published.results.some((r) => r.path === "runbooks/secret.md")).toBe(false);
+
+    const developer = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "developer",
+      filters: { query: "replica", limit: 10, expand: false },
+      exec,
+    });
+    const secret = developer.results.find((r) => r.path === "runbooks/secret.md");
+    expect(secret).toBeDefined();
+    expect(secret!.provenance.status).toBe("draft");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("frontmatter filters narrow by type and tag (GIN jsonb containment)", async () => {
+    const byTag = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { tags: ["eu"], limit: 10, expand: false },
+      exec,
+    });
+    expect(byTag.results.map((r) => r.path)).toEqual(["runbooks/eu.md"]);
+
+    const byType = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { type: "Document", limit: 10, expand: false },
+      exec,
+    });
+    expect(byType.results.map((r) => r.path)).toEqual(["glossary/replica.md"]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("1-hop expansion returns outbound neighbors of the matched seed", async () => {
+    const res = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { query: "failover", limit: 10, expand: true },
+      exec,
+    });
+    expect(res.results.map((r) => r.path)).toContain("runbooks/eu.md");
+    const neighbor = res.neighbors.find((n) => n.path === "glossary/replica.md");
+    expect(neighbor).toBeDefined();
+    expect(neighbor!.direction).toContain("outbound");
+    expect(neighbor!.via).toContain("runbooks/eu.md");
+    expect(neighbor!.anchors).toContain("replica notes");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("1-hop expansion returns inbound neighbors (the doc that links to the seed)", async () => {
+    const res = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      // Match only replica.md by a term unique to it.
+      filters: { query: "delay between primary", limit: 10, expand: true },
+      exec,
+    });
+    expect(res.results.map((r) => r.path)).toContain("glossary/replica.md");
+    const neighbor = res.neighbors.find((n) => n.path === "runbooks/eu.md");
+    expect(neighbor).toBeDefined();
+    expect(neighbor!.direction).toContain("inbound");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("recency ordering (no query) returns the newest document first", async () => {
+    const res = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { limit: 10, expand: false },
+      exec,
+    });
+    // Only eu.md and replica.md are published. eu.md carries an explicit
+    // 2026-05-28 frontmatter timestamp; replica.md has none and falls back to
+    // its ingest time (the same-run ingest, ~now = 2026-07+), so replica.md is
+    // the newer of the two and must sort first — this asserts the ORDER BY DESC.
+    expect(res.results.length).toBe(2);
+    expect(res.results[0].path).toBe("glossary/replica.md");
+    expect(res.results[1].path).toBe("runbooks/eu.md");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("dedupes a neighbor linked from two seeds into one row with merged `via`", async () => {
+    // A separate collection where two published seeds both link to the same doc.
+    const docs = docsFrom({
+      "hub/a.md": "---\ntype: Runbook\ntitle: Alpha Hub\n---\n# Alpha Hub\n\nunique-alpha-token → [shared](./shared.md).",
+      "hub/b.md": "---\ntype: Runbook\ntitle: Beta Hub\n---\n# Beta Hub\n\nunique-alpha-token → [shared](./shared.md).",
+      "hub/shared.md": "---\ntype: Document\ntitle: Shared\n---\n# Shared\n\ncommon target",
+    });
+    await ingestBundleIntoCollection({
+      client, workspaceId: ws, collectionId: "hub", source: "upload", docs,
+    });
+    for (const p of ["hub/a.md", "hub/b.md", "hub/shared.md"]) await publish("hub", p);
+
+    const res = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { query: "unique-alpha-token", limit: 10, expand: true },
+      exec,
+    });
+    // Both hubs match the seed query; the shared doc is a single neighbor row
+    // whose `via` names both seeds (array_agg DISTINCT dedup).
+    expect(res.results.map((r) => r.path).sort()).toEqual(["hub/a.md", "hub/b.md"]);
+    const shared = res.neighbors.filter((n) => n.path === "hub/shared.md");
+    expect(shared).toHaveLength(1);
+    expect([...shared[0].via].sort()).toEqual(["hub/a.md", "hub/b.md"]);
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -177,6 +177,7 @@ describe("defaultRegistry", () => {
     expect(defaultRegistry.get("explore")).toBeDefined();
     expect(defaultRegistry.get("executeSQL")).toBeDefined();
     expect(defaultRegistry.get("createDashboard")).toBeDefined();
+    expect(defaultRegistry.get("searchKnowledge")).toBeDefined();
   });
 
   it("getAll returns exactly the core tools", () => {
@@ -186,6 +187,7 @@ describe("defaultRegistry", () => {
       "createLinearIssue",
       "executeSQL",
       "explore",
+      "searchKnowledge",
       "sendEmail",
     ]);
   });
@@ -195,6 +197,7 @@ describe("defaultRegistry", () => {
     expect(text).toContain("### 2. Explore the Semantic Layer");
     expect(text).toContain("### 3. Write and Execute SQL");
     expect(text).toContain("### Create a Dashboard");
+    expect(text).toContain("### Search the Knowledge Base");
   });
 
   it("is frozen — cannot register additional tools", () => {
@@ -238,6 +241,7 @@ describe("buildRegistry", () => {
         "executePython",
         "executeSQL",
         "explore",
+        "searchKnowledge",
         "sendEmail",
       ]);
       expect(registry.describe()).toContain("### 4. Analyze Data with Python");
@@ -257,6 +261,7 @@ describe("buildRegistry", () => {
       "createLinearIssue",
       "executeSQL",
       "explore",
+      "searchKnowledge",
       "sendEmail",
     ]);
   });
@@ -270,6 +275,7 @@ describe("buildRegistry", () => {
       "createLinearIssue",
       "executeSQL",
       "explore",
+      "searchKnowledge",
       "sendEmail",
       "sendEmailReport",
     ]);

--- a/packages/api/src/lib/tools/__tests__/search-knowledge-tool.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-knowledge-tool.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Execute-wrapper coverage for the `searchKnowledge` tool (#4210) — the guards
+ * and context wiring that live OUTSIDE the pure `searchKnowledgeCore`
+ * (unit-tested with an injected exec in `search-knowledge.test.ts`):
+ *   - the no-internal-DB and no-workspace degraded paths (distinct shapes),
+ *   - the fail-closed `mode` default (missing context ⇒ published, never leaks drafts),
+ *   - `normalizeFilters` applied end-to-end (limit clamp),
+ *   - the error catch: a thrown query is logged and mapped to a generic,
+ *     secret-free `{ error }` (CLAUDE.md: no stack/connection-string in responses).
+ *
+ * Kept in its own file (mock.module is file-global under the isolated runner) so
+ * the mock-free pure-builder tests in `search-knowledge.test.ts` stay clean.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+
+// Mutable mock state — set per test before invoking the tool.
+let mockRequestContext:
+  | { user?: { activeOrganizationId?: string }; atlasMode?: "developer" | "published" }
+  | undefined;
+let mockHasInternalDB = true;
+const queryCalls: { sql: string; params: unknown[] }[] = [];
+let queryImpl: (sql: string, params?: unknown[]) => Promise<unknown[]> = async () => [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params: params ?? [] });
+    return queryImpl(sql, params);
+  },
+}));
+
+let loggedError: unknown;
+// Mock all value exports of the logger module (mock.module is file-global; a
+// partial stub would hand `undefined` to any importer reaching an unmocked one).
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  debug: () => {},
+  error: (obj: unknown) => {
+    loggedError = obj;
+  },
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  createLogger: () => noopLogger,
+  getLogger: () => noopLogger,
+  getRequestContext: () => mockRequestContext,
+  withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (o: unknown) => o,
+  hashShareToken: (t: string) => t,
+  setLogLevel: () => true,
+}));
+
+const { searchKnowledge } = await import("@atlas/api/lib/tools/search-knowledge");
+
+function run(input: Record<string, unknown> = {}) {
+  // AI SDK tool.execute(args, ToolCallOptions). Cast through unknown: the tool's
+  // arg/return types are internal to this test and we only assert on the shape.
+  return searchKnowledge.execute!(
+    input as never,
+    { toolCallId: "t1", messages: [] } as never,
+  ) as unknown as Promise<Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  mockRequestContext = { user: { activeOrganizationId: "ws-1" }, atlasMode: "published" };
+  mockHasInternalDB = true;
+  queryCalls.length = 0;
+  queryImpl = async () => [];
+  loggedError = undefined;
+});
+
+describe("searchKnowledge tool.execute", () => {
+  it("returns an error (not empty results) when no internal DB is configured", async () => {
+    mockHasInternalDB = false;
+    const res = await run({ query: "x" });
+    expect(res.error).toContain("internal database");
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("returns empty results (not an error) when there is no active workspace", async () => {
+    mockRequestContext = { user: {} };
+    const res = await run({ query: "x" });
+    expect(res).toEqual({ results: [], neighbors: [] });
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("defaults to published mode when request context carries no atlasMode", async () => {
+    mockRequestContext = { user: { activeOrganizationId: "ws-1" } };
+    await run({ query: "x", expand: false });
+    expect(queryCalls).toHaveLength(1);
+    // Fail-closed: the published-only clause, never the draft overlay.
+    expect(queryCalls[0].sql).toContain("kd.status = 'published'");
+    expect(queryCalls[0].sql).not.toContain("'draft'");
+  });
+
+  it("uses the developer draft overlay when atlasMode is developer", async () => {
+    mockRequestContext = { user: { activeOrganizationId: "ws-1" }, atlasMode: "developer" };
+    await run({ query: "x", expand: false });
+    expect(queryCalls[0].sql).toContain("kd.status IN ('published', 'draft')");
+  });
+
+  it("clamps an over-large limit through normalizeFilters before querying", async () => {
+    await run({ query: "x", limit: 999, expand: false });
+    const params = queryCalls[0].params;
+    // The LIMIT is the last bind param.
+    expect(params[params.length - 1]).toBe(50);
+  });
+
+  it("logs and returns a generic, secret-free error when the query throws", async () => {
+    queryImpl = async () => {
+      throw new Error("connection to postgres://user:pw@host failed");
+    };
+    const res = await run({ query: "x" });
+    expect(res.error).toContain("Knowledge search failed");
+    // The raw exception (which carries a connection string) must not leak.
+    expect(JSON.stringify(res)).not.toContain("postgres://");
+    expect(loggedError).toBeDefined();
+  });
+
+  it("returns the mapped results on success", async () => {
+    queryImpl = async () => [
+      {
+        id: "d1",
+        path: "a.md",
+        collection_id: "c",
+        title: "A",
+        description: null,
+        type: "Document",
+        tags: [],
+        resource: null,
+        atlas_source: "upload",
+        atlas_ingested_at: null,
+        timestamp: null,
+        status: "published",
+        snippet: null,
+        rank: null,
+      },
+    ];
+    const res = await run({ query: "a", expand: false });
+    expect(res.results).toEqual([
+      {
+        path: "a.md",
+        collection: "c",
+        title: "A",
+        snippet: null,
+        provenance: {
+          type: "Document",
+          tags: [],
+          resource: null,
+          source: "upload",
+          ingestedAt: null,
+          timestamp: null,
+          status: "published",
+        },
+      },
+    ]);
+    expect(res.neighbors).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/search-knowledge.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-knowledge.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit coverage for `searchKnowledge` (#4210) — the pure query builders and the
+ * injected-executor core. The real FTS + graph SQL is exercised against live
+ * Postgres in `knowledge-search-pg.test.ts`; here we assert the SQL shape
+ * (parameterization, status gating, FTS vs recency branch) and the row → result
+ * mapping without a database.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  buildSearchQuery,
+  buildNeighborQuery,
+  searchKnowledgeCore,
+  normalizeFilters,
+  type KnowledgeQueryExec,
+  type KnowledgeSearchFilters,
+} from "@atlas/api/lib/tools/search-knowledge";
+
+const WS = "ws-1";
+
+function filters(overrides: Partial<KnowledgeSearchFilters> = {}): KnowledgeSearchFilters {
+  return { limit: 10, expand: true, ...overrides };
+}
+
+describe("buildSearchQuery", () => {
+  it("published mode gates on status = 'published' and scopes to the workspace", () => {
+    const { sql, params } = buildSearchQuery(WS, "published", filters());
+    expect(sql).toContain("kd.workspace_id = $1");
+    expect(sql).toContain("kd.status = 'published'");
+    expect(sql).not.toContain("draft");
+    expect(params[0]).toBe(WS);
+  });
+
+  it("developer mode overlays drafts via the shared status clause", () => {
+    const { sql } = buildSearchQuery(WS, "developer", filters());
+    expect(sql).toContain("kd.status IN ('published', 'draft')");
+  });
+
+  it("with a query, emits FTS match, ts_headline snippet, ts_rank, and rank-first ordering", () => {
+    const { sql, params } = buildSearchQuery(WS, "published", filters({ query: "replica lag" }));
+    expect(sql).toContain("websearch_to_tsquery('english', $2)");
+    expect(sql).toContain("@@");
+    expect(sql).toContain("ts_headline('english', kd.body");
+    expect(sql).toContain("ts_rank(");
+    expect(sql).toMatch(/ORDER BY\s+rank DESC NULLS LAST/);
+    expect(params).toContain("replica lag");
+  });
+
+  it("without a query, snippet + rank are NULL and ordering is recency-only", () => {
+    const { sql } = buildSearchQuery(WS, "published", filters());
+    expect(sql).toContain("NULL AS snippet");
+    expect(sql).toContain("NULL AS rank");
+    expect(sql).not.toContain("websearch_to_tsquery");
+    expect(sql).toMatch(/ORDER BY\s+coalesce\(kd\."timestamp", kd\.atlas_ingested_at\) DESC/);
+  });
+
+  it("blank/whitespace query is treated as no query (structured filter only)", () => {
+    const { sql } = buildSearchQuery(WS, "published", filters({ query: "   " }));
+    expect(sql).not.toContain("websearch_to_tsquery");
+    expect(sql).toContain("NULL AS snippet");
+  });
+
+  it("adds a bound clause for each frontmatter filter (type, collection, tags, since)", () => {
+    const { sql, params } = buildSearchQuery(
+      WS,
+      "published",
+      filters({ type: "Runbook", collection: "runbooks", tags: ["ops", "eu"], since: "2026-01-01" }),
+    );
+    expect(sql).toContain("kd.type = $");
+    expect(sql).toContain("kd.collection_id = $");
+    expect(sql).toContain("kd.tags @> $");
+    expect(sql).toContain("::jsonb");
+    expect(sql).toContain('coalesce(kd."timestamp", kd.atlas_ingested_at) >= $');
+    expect(sql).toContain("::timestamptz");
+    expect(params).toContain("Runbook");
+    expect(params).toContain("runbooks");
+    expect(params).toContain(JSON.stringify(["ops", "eu"]));
+    expect(params).toContain("2026-01-01");
+    // Last param is always the LIMIT.
+    expect(params[params.length - 1]).toBe(10);
+  });
+
+  it("reuses the same tsquery placeholder across match, snippet, and rank (single bind)", () => {
+    const { sql, params } = buildSearchQuery(WS, "published", filters({ query: "x", type: "Runbook" }));
+    // Query text is $2; it must appear exactly once in params.
+    expect(params.filter((p) => p === "x")).toHaveLength(1);
+    expect(sql.match(/\$2/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("normalizeFilters", () => {
+  it("defaults limit to 10 and expand to true", () => {
+    const f = normalizeFilters({});
+    expect(f.limit).toBe(10);
+    expect(f.expand).toBe(true);
+  });
+
+  it("clamps limit to [1, 50] and floors fractional values", () => {
+    expect(normalizeFilters({ limit: 999 }).limit).toBe(50);
+    expect(normalizeFilters({ limit: 0 }).limit).toBe(1);
+    expect(normalizeFilters({ limit: 2.7 }).limit).toBe(2);
+  });
+
+  it("trims tags, drops blanks, and collapses an all-blank list to undefined", () => {
+    expect(normalizeFilters({ tags: [" ops ", "", "  "] }).tags).toEqual(["ops"]);
+    expect(normalizeFilters({ tags: ["", "   "] }).tags).toBeUndefined();
+  });
+
+  it("coerces blank string filters to undefined", () => {
+    const f = normalizeFilters({ type: "  ", collection: "", since: "   " });
+    expect(f.type).toBeUndefined();
+    expect(f.collection).toBeUndefined();
+    expect(f.since).toBeUndefined();
+  });
+
+  it("respects an explicit expand: false", () => {
+    expect(normalizeFilters({ expand: false }).expand).toBe(false);
+  });
+});
+
+describe("buildNeighborQuery", () => {
+  it("expands outbound + inbound edges, re-applies the status clause to the neighbor, excludes seeds", () => {
+    const { sql, params } = buildNeighborQuery(WS, "published", ["a", "b"]);
+    expect(sql).toContain("'outbound' AS direction");
+    expect(sql).toContain("'inbound' AS direction");
+    expect(sql).toContain("kd.status = 'published'");
+    expect(sql).toContain("kd.id <> ALL($2::uuid[])");
+    expect(sql).toContain("array_agg(DISTINCT e.via)");
+    expect(sql).toContain("LIMIT $3");
+    expect(params[0]).toBe(WS);
+    expect(params[1]).toEqual(["a", "b"]);
+    // Third bind is the neighbor cap.
+    expect(params[2]).toBe(25);
+  });
+
+  it("developer mode surfaces draft neighbors too", () => {
+    const { sql } = buildNeighborQuery(WS, "developer", ["a"]);
+    expect(sql).toContain("kd.status IN ('published', 'draft')");
+  });
+});
+
+// A recording fake executor that returns queued result batches in order.
+function fakeExec(batches: Record<string, unknown>[][]): {
+  exec: KnowledgeQueryExec;
+  calls: { sql: string; params: unknown[] }[];
+} {
+  const calls: { sql: string; params: unknown[] }[] = [];
+  let i = 0;
+  const exec: KnowledgeQueryExec = async (sql, params) => {
+    calls.push({ sql, params });
+    return (batches[i++] ?? []) as never;
+  };
+  return { exec, calls };
+}
+
+describe("searchKnowledgeCore", () => {
+  const seedRow = {
+    id: "doc-1",
+    path: "runbooks/eu.md",
+    collection_id: "runbooks",
+    title: "EU",
+    description: "European runbook",
+    type: "Runbook",
+    tags: ["eu", "ops"],
+    resource: "https://example.com",
+    atlas_source: "upload",
+    atlas_ingested_at: new Date("2026-05-01T00:00:00Z"),
+    timestamp: "2026-04-28T22:49:59Z",
+    status: "published",
+    snippet: "…**replica** lag…",
+    rank: 0.5,
+  };
+
+  it("maps rows into provenance-carrying results", async () => {
+    const { exec } = fakeExec([[seedRow]]);
+    const res = await searchKnowledgeCore({
+      workspaceId: WS,
+      mode: "published",
+      filters: filters({ query: "replica", expand: false }),
+      exec,
+    });
+    expect(res.results).toHaveLength(1);
+    expect(res.results[0]).toEqual({
+      path: "runbooks/eu.md",
+      collection: "runbooks",
+      title: "EU",
+      snippet: "…**replica** lag…",
+      provenance: {
+        type: "Runbook",
+        tags: ["eu", "ops"],
+        resource: "https://example.com",
+        source: "upload",
+        ingestedAt: "2026-05-01T00:00:00.000Z",
+        timestamp: "2026-04-28T22:49:59.000Z",
+        status: "published",
+      },
+    });
+    expect(res.neighbors).toEqual([]);
+  });
+
+  it("parses jsonb tags handed back as a raw string", async () => {
+    const { exec } = fakeExec([[{ ...seedRow, tags: '["eu","ops"]' }]]);
+    const res = await searchKnowledgeCore({
+      workspaceId: WS,
+      mode: "published",
+      filters: filters({ expand: false }),
+      exec,
+    });
+    expect(res.results[0].provenance.tags).toEqual(["eu", "ops"]);
+  });
+
+  it("does NOT run the expansion query when expand is false", async () => {
+    const { exec, calls } = fakeExec([[seedRow]]);
+    await searchKnowledgeCore({
+      workspaceId: WS,
+      mode: "published",
+      filters: filters({ expand: false }),
+      exec,
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("skips the expansion query when there are no seed documents", async () => {
+    const { exec, calls } = fakeExec([[]]);
+    const res = await searchKnowledgeCore({
+      workspaceId: WS,
+      mode: "published",
+      filters: filters({ expand: true }),
+      exec,
+    });
+    expect(calls).toHaveLength(1);
+    expect(res.results).toEqual([]);
+    expect(res.neighbors).toEqual([]);
+  });
+
+  it("runs expansion with the seed ids and maps neighbor edge aggregates", async () => {
+    const neighborRow = {
+      id: "doc-2",
+      path: "glossary/replica.md",
+      collection_id: "runbooks",
+      title: "Replica",
+      description: null,
+      type: "Document",
+      tags: [],
+      resource: null,
+      atlas_source: "upload",
+      atlas_ingested_at: new Date("2026-05-02T00:00:00Z"),
+      timestamp: null,
+      status: "published",
+      snippet: null,
+      rank: null,
+      via: ["runbooks/eu.md"],
+      direction: ["outbound"],
+      anchors: ["glossary"],
+    };
+    const { exec, calls } = fakeExec([[seedRow], [neighborRow]]);
+    const res = await searchKnowledgeCore({
+      workspaceId: WS,
+      mode: "published",
+      filters: filters({ query: "replica", expand: true }),
+      exec,
+    });
+    expect(calls).toHaveLength(2);
+    // Seed ids threaded into the expansion query's $2 param.
+    expect(calls[1].params[1]).toEqual(["doc-1"]);
+    expect(res.neighbors).toHaveLength(1);
+    expect(res.neighbors[0]).toMatchObject({
+      path: "glossary/replica.md",
+      collection: "runbooks",
+      title: "Replica",
+      via: ["runbooks/eu.md"],
+      direction: ["outbound"],
+      anchors: ["glossary"],
+    });
+  });
+
+  it("normalizes a null anchors aggregate to an empty array", async () => {
+    const neighborRow = {
+      ...seedRow,
+      id: "doc-3",
+      path: "n.md",
+      via: ["runbooks/eu.md"],
+      direction: ["inbound"],
+      anchors: null,
+    };
+    const { exec } = fakeExec([[seedRow], [neighborRow]]);
+    const res = await searchKnowledgeCore({
+      workspaceId: WS,
+      mode: "published",
+      filters: filters({ expand: true }),
+      exec,
+    });
+    expect(res.neighbors[0].anchors).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -13,6 +13,7 @@ import {
   QUERY_SALESFORCE_DESCRIPTION,
   isSalesforceOAuthConfigured,
 } from "@atlas/api/lib/integrations/salesforce-tool";
+import { searchKnowledge, SEARCH_KNOWLEDGE_DESCRIPTION } from "./search-knowledge";
 
 export type { AtlasAction };
 export { isAction };
@@ -198,6 +199,19 @@ defaultRegistry.register({
   tool: createDashboard,
 });
 
+// #4210 — layered knowledge-base search (frontmatter filter + Postgres FTS +
+// 1-hop graph expansion). Registered globally like the other execute-time-gated
+// tools: it reads the workspace + mode from request context inside execute — so
+// it stays discoverable everywhere without a boot-time gate. The two degraded
+// paths have deliberately different shapes: no active workspace returns an empty
+// result set (`{ results: [], neighbors: [] }`), while a deployment with no
+// internal DB returns a user-facing `{ error }`.
+defaultRegistry.register({
+  name: "searchKnowledge",
+  description: SEARCH_KNOWLEDGE_DESCRIPTION,
+  tool: searchKnowledge,
+});
+
 // First per-Workspace lazy-plugin tool (#2698). Registered globally
 // because the workspace + install check happens at execute time inside
 // the tool — keeping the tool discoverable across all Workspaces while
@@ -312,6 +326,12 @@ export async function buildRegistry(options?: {
     name: "createDashboard",
     description: CREATE_DASHBOARD_DESCRIPTION,
     tool: createDashboard,
+  });
+
+  registry.register({
+    name: "searchKnowledge",
+    description: SEARCH_KNOWLEDGE_DESCRIPTION,
+    tool: searchKnowledge,
   });
 
   registry.register({

--- a/packages/api/src/lib/tools/search-knowledge.ts
+++ b/packages/api/src/lib/tools/search-knowledge.ts
@@ -1,0 +1,461 @@
+/**
+ * `searchKnowledge` — the deferred scale-search layer over hosted OKF knowledge
+ * documents (#4210, ADR-0028). Navigation (explore over the mirror) stays the
+ * OKF-native primary path; this adds a layered search tool on the SAME rows the
+ * ingest slice (#4207) wrote — a tool addition, not a storage change.
+ *
+ * Three tiers, all against the internal Postgres (`knowledge_documents` /
+ * `knowledge_links`) — never the analytics datasource, the semantic whitelist,
+ * metrics, or the glossary (the hard-boundary invariant, ADR-0028):
+ *
+ *   1. Structured frontmatter filter — `type`, `tags` (GIN-backed jsonb
+ *      containment), `collection`, and a `since` recency bound.
+ *   2. Lexical FTS — Postgres `to_tsvector` over title + description + body with
+ *      `websearch_to_tsquery` (user-friendly, never throws on arbitrary agent
+ *      input) and `ts_headline` snippets, ranked by `ts_rank`.
+ *   3. 1-hop graph expansion — the seed docs' neighbors via `knowledge_links`
+ *      (outbound targets + inbound sources, intra-collection), the context shape
+ *      text-to-SQL wants.
+ *
+ * Content-mode: every read gates on `status` through the SAME `resolveStatusClause`
+ * SSOT the rest of Atlas uses — published-only outside developer mode; developer
+ * mode overlays drafts. `knowledge_links` is content-mode-exempt derived data, so
+ * expansion re-applies the status clause to the NEIGHBOR document (a draft
+ * neighbor never leaks into a published-mode answer).
+ *
+ * Read-only: no INSERT/UPDATE/DELETE path exists here. The SQL is fully
+ * parameterized; the only interpolated fragments are the fixed-alias status
+ * clause (no user input) and the FTS expressions.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { resolveStatusClause } from "@atlas/api/lib/content-mode/port";
+import type { AtlasMode } from "@useatlas/types/auth";
+
+const log = createLogger("search-knowledge");
+
+/** Content-mode segment key for `knowledge_documents` (see content-mode/tables.ts). */
+const KNOWLEDGE_TABLE_KEY = "knowledgeDocuments";
+
+/** The content-mode lifecycle states a knowledge document can carry (DB CHECK). */
+export const KNOWLEDGE_DOCUMENT_STATUSES = ["draft", "published", "archived"] as const;
+export type KnowledgeDocumentStatus = (typeof KNOWLEDGE_DOCUMENT_STATUSES)[number];
+
+/** Default page size when the caller omits `limit`. */
+const DEFAULT_LIMIT = 10;
+/** Hard cap on returned seed documents. */
+const MAX_LIMIT = 50;
+/** Hard cap on distinct 1-hop neighbors returned across the whole seed set. */
+const NEIGHBOR_LIMIT = 25;
+
+// ── Public shapes ────────────────────────────────────────────────────
+
+/** Normalized, validated filter set the core operates on. */
+export interface KnowledgeSearchFilters {
+  /** Free-text lexical query. Absent/blank ⇒ pure structured filter, ordered by recency. */
+  readonly query?: string;
+  readonly type?: string;
+  readonly tags?: readonly string[];
+  /** Restrict to a single collection (`workspace_plugins.install_id` slug). */
+  readonly collection?: string;
+  /** ISO-8601 lower bound on the document's own timestamp (falls back to ingest time). */
+  readonly since?: string;
+  readonly limit: number;
+  readonly expand: boolean;
+}
+
+/** Provenance carried on every result — where the document came from. */
+export interface KnowledgeProvenance {
+  readonly type: string | null;
+  readonly tags: readonly string[];
+  readonly resource: string | null;
+  /** `atlas_source` — how the document arrived (`upload`, future connectors). */
+  readonly source: string | null;
+  readonly ingestedAt: string | null;
+  readonly timestamp: string | null;
+  /** Content-mode status: `published` normally; `draft` only surfaces in developer mode. */
+  readonly status: KnowledgeDocumentStatus;
+}
+
+export interface KnowledgeSearchResult {
+  readonly path: string;
+  readonly collection: string;
+  readonly title: string | null;
+  /** `ts_headline` snippet when a lexical query ran, else null. */
+  readonly snippet: string | null;
+  readonly provenance: KnowledgeProvenance;
+}
+
+/** A 1-hop neighbor of one or more seed documents. */
+export interface KnowledgeNeighbor extends KnowledgeSearchResult {
+  /** Seed document path(s) this neighbor is linked to/from. */
+  readonly via: readonly string[];
+  /** `outbound` (seed → neighbor) and/or `inbound` (neighbor → seed). */
+  readonly direction: readonly string[];
+  /** Anchor text(s) of the connecting link(s). */
+  readonly anchors: readonly string[];
+}
+
+export interface KnowledgeSearchResponse {
+  readonly results: readonly KnowledgeSearchResult[];
+  readonly neighbors: readonly KnowledgeNeighbor[];
+}
+
+/** Injected query runner — `internalQuery` in production, a fake in tests. */
+export type KnowledgeQueryExec = <T extends Record<string, unknown>>(
+  sql: string,
+  params: unknown[],
+) => Promise<T[]>;
+
+// ── DB row shapes ────────────────────────────────────────────────────
+
+interface DocRow extends Record<string, unknown> {
+  id: string;
+  path: string;
+  collection_id: string;
+  title: string | null;
+  description: string | null;
+  type: string | null;
+  tags: unknown;
+  resource: string | null;
+  atlas_source: string | null;
+  atlas_ingested_at: Date | string | null;
+  timestamp: Date | string | null;
+  status: string;
+  snippet: string | null;
+  rank: number | string | null;
+}
+
+interface NeighborRow extends DocRow {
+  via: unknown;
+  direction: unknown;
+  anchors: unknown;
+}
+
+// ── Normalizers ──────────────────────────────────────────────────────
+
+/** timestamptz read-back (Date | ISO string | null) → ISO string | null. */
+function toIso(value: unknown): string | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/** jsonb `tags` → clean `string[]` (pg may hand back a parsed array or raw string). */
+function toTags(value: unknown): string[] {
+  let arr: unknown = value;
+  if (typeof value === "string") {
+    try {
+      arr = JSON.parse(value);
+    } catch {
+      // intentionally ignored: pg normally returns already-parsed jsonb; a
+      // non-JSON string here is malformed provenance metadata, not query-fatal.
+      // Tags are display-only (never a gate), so degrade to none but surface it.
+      log.debug({ raw: value }, "toTags: unparseable jsonb tags — defaulting to []");
+      return [];
+    }
+  }
+  return Array.isArray(arr) ? arr.filter((t): t is string => typeof t === "string") : [];
+}
+
+/** Postgres text[] (or null) → `string[]`, dropping non-strings and nulls. */
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((x): x is string => typeof x === "string");
+}
+
+function toResult(row: DocRow): KnowledgeSearchResult {
+  return {
+    path: row.path,
+    collection: row.collection_id,
+    title: row.title,
+    snippet: row.snippet ?? null,
+    provenance: {
+      type: row.type,
+      tags: toTags(row.tags),
+      resource: row.resource,
+      source: row.atlas_source,
+      ingestedAt: toIso(row.atlas_ingested_at),
+      timestamp: toIso(row.timestamp),
+      // `status` is CHECK-constrained in `knowledge_documents` to exactly these
+      // three values, so this DB-boundary narrowing cannot represent an illegal state.
+      status: row.status as KnowledgeDocumentStatus,
+    },
+  };
+}
+
+// ── Query builders (pure, unit-tested) ───────────────────────────────
+
+/** Shared projection column list — same shape drives seed + neighbor mapping. */
+const DOC_COLUMNS = `kd.id, kd.path, kd.collection_id, kd.title, kd.description,
+  kd.type, kd.tags, kd.resource, kd.atlas_source, kd.atlas_ingested_at,
+  kd."timestamp", kd.status`;
+
+// Full-text vector over the human-readable fields (title + description + body),
+// all terms equally weighted — no setweight()/A-B-C ranking, so ts_rank treats a
+// title hit and a body hit the same. (Field weighting is a possible follow-up.)
+const TS_VECTOR = `to_tsvector('english',
+  coalesce(kd.title, '') || ' ' || coalesce(kd.description, '') || ' ' || coalesce(kd.body, ''))`;
+
+/**
+ * Build the seed-search query. Every dynamic value is a bind parameter; the
+ * only interpolated fragments are the status clause (fixed alias, no user
+ * input) and the FTS expressions. Returns the SQL and its ordered params.
+ */
+export function buildSearchQuery(
+  workspaceId: string,
+  mode: AtlasMode,
+  filters: KnowledgeSearchFilters,
+): { sql: string; params: unknown[] } {
+  const params: unknown[] = [workspaceId];
+  const where: string[] = [
+    `kd.workspace_id = $1`,
+    resolveStatusClause(KNOWLEDGE_TABLE_KEY, mode, "kd"),
+  ];
+
+  const trimmedQuery = filters.query?.trim();
+  let tsQueryExpr: string | null = null;
+  if (trimmedQuery) {
+    params.push(trimmedQuery);
+    tsQueryExpr = `websearch_to_tsquery('english', $${params.length})`;
+  }
+
+  if (filters.type) {
+    params.push(filters.type);
+    where.push(`kd.type = $${params.length}`);
+  }
+  if (filters.collection) {
+    params.push(filters.collection);
+    where.push(`kd.collection_id = $${params.length}`);
+  }
+  if (filters.tags && filters.tags.length > 0) {
+    params.push(JSON.stringify(filters.tags));
+    where.push(`kd.tags @> $${params.length}::jsonb`);
+  }
+  if (filters.since) {
+    params.push(filters.since);
+    where.push(`coalesce(kd."timestamp", kd.atlas_ingested_at) >= $${params.length}::timestamptz`);
+  }
+  if (tsQueryExpr) {
+    where.push(`${TS_VECTOR} @@ ${tsQueryExpr}`);
+  }
+
+  const snippetExpr = tsQueryExpr
+    ? `ts_headline('english', kd.body, ${tsQueryExpr},
+        'StartSel=**, StopSel=**, MaxFragments=2, MaxWords=28, MinWords=8')`
+    : `NULL`;
+  const rankExpr = tsQueryExpr ? `ts_rank(${TS_VECTOR}, ${tsQueryExpr})` : `NULL`;
+  // Relevance first when there's a lexical query; recency is the tiebreaker
+  // (and the sole order when the query is a pure structured filter).
+  const orderBy = tsQueryExpr
+    ? `rank DESC NULLS LAST, coalesce(kd."timestamp", kd.atlas_ingested_at) DESC NULLS LAST`
+    : `coalesce(kd."timestamp", kd.atlas_ingested_at) DESC NULLS LAST`;
+
+  params.push(filters.limit);
+  const limitPlaceholder = `$${params.length}`;
+
+  const sql = `
+    SELECT ${DOC_COLUMNS},
+           ${snippetExpr} AS snippet,
+           ${rankExpr} AS rank
+      FROM knowledge_documents kd
+     WHERE ${where.join(" AND ")}
+     ORDER BY ${orderBy}
+     LIMIT ${limitPlaceholder}`;
+
+  return { sql, params };
+}
+
+/**
+ * Build the 1-hop expansion query for a set of seed document ids. Neighbors are
+ * the seeds' outbound link targets AND their inbound link sources, intra-
+ * collection, with the status clause re-applied to the neighbor document. Seeds
+ * themselves are excluded (they're already in `results`).
+ *
+ * Params: `$1` workspaceId, `$2` seed id array, `$3` neighbor limit.
+ */
+export function buildNeighborQuery(
+  workspaceId: string,
+  mode: AtlasMode,
+  seedIds: readonly string[],
+): { sql: string; params: unknown[] } {
+  const statusClause = resolveStatusClause(KNOWLEDGE_TABLE_KEY, mode, "kd");
+  const sql = `
+    WITH seeds AS (
+      SELECT id, collection_id, path
+        FROM knowledge_documents
+       WHERE workspace_id = $1 AND id = ANY($2::uuid[])
+    ),
+    edges AS (
+      -- outbound: neighbor is the doc the seed links to
+      SELECT tgt.id AS neighbor_id, s.path AS via, l.anchor_text AS anchor_text,
+             'outbound' AS direction
+        FROM seeds s
+        JOIN knowledge_links l ON l.source_document_id = s.id
+        JOIN knowledge_documents tgt
+          ON tgt.workspace_id = $1
+         AND tgt.collection_id = s.collection_id
+         AND tgt.path = l.target_path
+         AND tgt.id <> s.id
+      UNION ALL
+      -- inbound: neighbor is the doc that links to the seed
+      SELECT src.id AS neighbor_id, s.path AS via, l.anchor_text AS anchor_text,
+             'inbound' AS direction
+        FROM seeds s
+        JOIN knowledge_links l ON l.target_path = s.path
+        JOIN knowledge_documents src
+          ON src.id = l.source_document_id
+         AND src.workspace_id = $1
+         AND src.collection_id = s.collection_id
+         AND src.id <> s.id
+    )
+    SELECT ${DOC_COLUMNS},
+           NULL AS snippet,
+           NULL AS rank,
+           array_agg(DISTINCT e.via) AS via,
+           array_agg(DISTINCT e.direction) AS direction,
+           array_agg(DISTINCT e.anchor_text)
+             FILTER (WHERE e.anchor_text IS NOT NULL) AS anchors
+      FROM edges e
+      JOIN knowledge_documents kd ON kd.id = e.neighbor_id
+     WHERE ${statusClause}
+       AND kd.id <> ALL($2::uuid[])
+     GROUP BY ${DOC_COLUMNS}
+     ORDER BY kd.path
+     LIMIT $3`;
+
+  return { sql, params: [workspaceId, [...seedIds], NEIGHBOR_LIMIT] };
+}
+
+// ── Core ─────────────────────────────────────────────────────────────
+
+/**
+ * Run the layered search against the injected executor. Pure of request context
+ * and the AI SDK so it's directly unit-testable; the tool wrapper resolves the
+ * workspace + mode and hands in `internalQuery`.
+ */
+export async function searchKnowledgeCore(opts: {
+  workspaceId: string;
+  mode: AtlasMode;
+  filters: KnowledgeSearchFilters;
+  exec: KnowledgeQueryExec;
+}): Promise<KnowledgeSearchResponse> {
+  const { workspaceId, mode, filters, exec } = opts;
+
+  const search = buildSearchQuery(workspaceId, mode, filters);
+  const seedRows = await exec<DocRow>(search.sql, search.params);
+  const results = seedRows.map(toResult);
+
+  if (!filters.expand || seedRows.length === 0) {
+    return { results, neighbors: [] };
+  }
+
+  const seedIds = seedRows.map((r) => r.id);
+  const neighbor = buildNeighborQuery(workspaceId, mode, seedIds);
+  const neighborRows = await exec<NeighborRow>(neighbor.sql, neighbor.params);
+  const neighbors: KnowledgeNeighbor[] = neighborRows.map((row) => ({
+    ...toResult(row),
+    via: toStringArray(row.via),
+    direction: toStringArray(row.direction),
+    anchors: toStringArray(row.anchors),
+  }));
+
+  return { results, neighbors };
+}
+
+// ── Tool definition ──────────────────────────────────────────────────
+
+/** LLM-facing description for the `searchKnowledge` tool. */
+export const SEARCH_KNOWLEDGE_TOOL_DESCRIPTION = `Search the workspace's hosted knowledge base (uploaded OKF/markdown documents) with a layered filter → full-text → 1-hop graph expansion. Combine a lexical \`query\` with structured frontmatter filters (\`type\`, \`tags\`, \`collection\`, \`since\`); each result carries \`{ path, collection, title, snippet, provenance }\` and, when \`expand\` is on (default), the linked \`neighbors\` of the matched documents. Reads published documents only (drafts surface in developer mode). Example call: \`{ "query": "replica lag runbook", "tags": ["ops"] }\`. Example response: \`{ "results": [{ "path": "runbooks/eu.md", "collection": "runbooks", "title": "EU", "snippet": "...", "provenance": { "type": "Runbook", "status": "published" } }], "neighbors": [] }\`.
+
+Use this when the user's question is about narrative/reference knowledge (runbooks, playbooks, docs, policies, glossaries) rather than tabular data, or when you need the linked context around a document. Don't use this for querying business data — that's \`executeSQL\`; and don't use it for the on-disk semantic layer — that's \`explore\`. It never touches the SQL table whitelist, metrics, or the business glossary.`;
+
+/** Workflow-guidance block injected into the agent system prompt via `describe()`. */
+export const SEARCH_KNOWLEDGE_DESCRIPTION = `### Search the Knowledge Base
+Use the searchKnowledge tool to find hosted knowledge documents (uploaded OKF/markdown):
+- Pass a natural-language \`query\` for full-text search; add \`type\`, \`tags\`, \`collection\`, or \`since\` to narrow by frontmatter
+- Results carry provenance (\`{ path, collection, title, snippet, provenance }\`); \`neighbors\` are the 1-hop linked documents (on by default — set \`expand: false\` to skip)
+- Read-only over published documents; this never reaches the SQL whitelist, metrics, or glossary
+- Prefer this over \`explore\` for uploaded knowledge, and over \`executeSQL\` for narrative/reference questions`;
+
+/** Clamp + normalize raw tool input into the validated filter set. Exported for tests. */
+export function normalizeFilters(input: {
+  query?: string;
+  type?: string;
+  tags?: string[];
+  collection?: string;
+  since?: string;
+  limit?: number;
+  expand?: boolean;
+}): KnowledgeSearchFilters {
+  const rawLimit = input.limit ?? DEFAULT_LIMIT;
+  const limit = Math.max(1, Math.min(MAX_LIMIT, Math.floor(rawLimit)));
+  const tags = input.tags?.map((t) => t.trim()).filter((t) => t !== "");
+  return {
+    query: input.query,
+    type: input.type?.trim() || undefined,
+    tags: tags && tags.length > 0 ? tags : undefined,
+    collection: input.collection?.trim() || undefined,
+    since: input.since?.trim() || undefined,
+    limit,
+    expand: input.expand ?? true,
+  };
+}
+
+export const searchKnowledge = tool({
+  description: SEARCH_KNOWLEDGE_TOOL_DESCRIPTION,
+
+  inputSchema: z.object({
+    query: z
+      .string()
+      .optional()
+      .describe("Free-text lexical search over title, description, and body. Omit for a pure frontmatter filter (ordered by recency)."),
+    type: z.string().optional().describe("Filter to one OKF document type, e.g. 'Runbook'."),
+    tags: z.array(z.string()).optional().describe("Filter to documents carrying ALL of these OKF tags."),
+    collection: z.string().optional().describe("Restrict to a single knowledge collection (install slug)."),
+    since: z.string().optional().describe("ISO-8601 date; only documents at or after this timestamp."),
+    limit: z.number().int().min(1).max(MAX_LIMIT).optional().describe(`Max seed documents to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
+    expand: z.boolean().optional().describe("Include 1-hop linked neighbors of the matched documents (default true)."),
+  }),
+
+  execute: async (input) => {
+    const reqCtx = getRequestContext();
+    const workspaceId = reqCtx?.user?.activeOrganizationId;
+    const mode: AtlasMode = reqCtx?.atlasMode ?? "published";
+
+    if (!hasInternalDB()) {
+      return {
+        error:
+          "Knowledge search is unavailable — this deployment has no internal database configured.",
+      };
+    }
+    if (!workspaceId) {
+      // The knowledge base is workspace-scoped; without a workspace there are no
+      // documents to search. Return an empty result set (not an error) so the
+      // agent moves on rather than retrying.
+      return { results: [], neighbors: [] } satisfies KnowledgeSearchResponse;
+    }
+
+    try {
+      return await searchKnowledgeCore({
+        workspaceId,
+        mode,
+        filters: normalizeFilters(input),
+        exec: internalQuery,
+      });
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), workspaceId },
+        "searchKnowledge failed",
+      );
+      return {
+        error:
+          "Knowledge search failed. Retry with a simpler query or fewer filters; " +
+          "if it persists, the knowledge base may be temporarily unavailable.",
+      };
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Adds the deferred scale-search layer over hosted OKF knowledge documents (#4210, ADR-0028). Navigation via `explore` stays the OKF-native primary path; this is a layered `searchKnowledge` agent tool on the **same rows** the ingest slice (#4207) wrote — a tool addition, no storage change, no re-ingestion.

- **Three tiers over the internal Postgres** (never the analytics datasource, SQL whitelist, metrics, or glossary — the ADR-0028 hard boundary):
  1. Structured frontmatter filter — `type`, `tags` (GIN-backed jsonb containment), `collection`, and a `since` recency bound.
  2. Lexical FTS — `to_tsvector` over title + description + body with `websearch_to_tsquery` (never throws on arbitrary agent input) and `ts_headline` snippets, ranked by `ts_rank`.
  3. 1-hop graph expansion via `knowledge_links` — outbound targets + inbound sources, intra-collection.
- Results carry provenance: `{ path, collection, title, snippet, provenance }`, plus `neighbors` (each with `via` / `direction` / `anchors`) when `expand` is on (default).
- **Content-mode gated** through the shared `resolveStatusClause` SSOT — published-only outside developer mode; the neighbor read re-applies the status clause to the *neighbor* document so a draft neighbor never leaks into a published-mode answer. Read-only, fully parameterized SQL.
- Registered globally in `defaultRegistry` + `buildRegistry`; execute-time gates on workspace + internal DB (empty results when no workspace; `{ error }` when no internal DB).

## Test Plan

- [x] Manual testing — real-Postgres `-pg` test run locally against a live DB (FTS, `ts_headline` highlighting, GIN jsonb tag filter, status gating both directions, outbound/inbound/dedup graph expansion, recency ordering)
- [x] Unit tests added/updated — pure query builders + injected-exec core (`search-knowledge.test.ts`), `normalizeFilters` clamping, and an execute-wrapper suite (`search-knowledge-tool.test.ts`) covering the no-DB / no-workspace guards, the fail-closed `mode` default, and the secret-free error path
- [x] E2E tests added/updated — `knowledge-search-pg.test.ts` (TEST_DATABASE_URL-gated, runs real migrations + real ingest)

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — 26/27 local gates green; the one red is `admin-model-config.test.ts`, an unrelated network-dependent gateway-catalog fetch that times out in the sandbox and passes on retry / in CI
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes (uses existing `pg` / `ai` / `zod`; no scaffold `package.json` change needed)
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — deferred to the milestone changelog per the per-tag feed convention

Closes #4210

https://claude.ai/code/session_016uGWKpbigsCSCEoSUMob7b

---
_Generated by [Claude Code](https://claude.ai/code/session_016uGWKpbigsCSCEoSUMob7b)_