### PR TITLE
fix(sandbox): evict stale explore backends on semantic writes; cap + timeout explore output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Guidance for Claude Code when working in this repository.
 
 ### Agent Tools
 - [ ] **Tools return structured data** — `executeSQL` returns `{ columns, rows }`
-- [ ] **Explore is read-only** — Only `ls`, `cat`, `grep`, `find` on `semantic/`. No writes, no shell escapes. Sandbox priority documented under **Security (General)** above
+- [ ] **Explore is read-only by isolation, not command validation** — There is no command allowlist; the agent may run arbitrary shell (`awk`/`sed`/pipes included). Read-only scoping to `semantic/` is enforced structurally by each backend (ephemeral microVM / read-only bind mounts / OverlayFs): writes land in ephemeral or in-memory layers and never touch host files. Output is capped at 1 MB at the tool seam. Sandbox priority documented under **Security (General)** above
 - [ ] **Agent max steps** — `stopWhen: stepCountIs(getAgentMaxSteps())`. Default 25, via `ATLAS_AGENT_MAX_STEPS` (1–100)
 - [ ] **Semantic layer drives the agent** — Read entity YAMLs before writing SQL
 

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -302,7 +302,7 @@ bun run atlas -- metric run total_gmv --json
 
 ## explore
 
-Run a single read-only command against your logged-in workspace's semantic layer — a thin HTTP client over `POST /api/v1/explore`. The server sandboxes execution with read-only, path-traversal-protected access scoped to `semantic/`, so writes, shell escapes, and traversal are rejected server-side (the CLI does no validation of its own).
+Run a single read-only command against your logged-in workspace's semantic layer — a thin HTTP client over `POST /api/v1/explore`. Neither the CLI nor the server validates the command against an allowlist: the server executes it inside its sandbox backend, whose isolation (ephemeral microVM, read-only bind mounts, or in-memory overlay) structurally scopes access to `semantic/` — writes land in an ephemeral layer and never touch the real semantic files.
 
 ```bash
 bun run atlas -- explore <command...> [options]
@@ -315,7 +315,7 @@ The command is every token after `explore` (minus this CLI's own flags), so both
 | `--api-key <key>` | Use a workspace API key instead of your `atlas login` session (unattended CI). Overrides `ATLAS_API_KEY` |
 | `--json` | Machine-readable JSON output (`{ "output": "..." }`) |
 
-Only read-only commands run (`ls` / `cat` / `grep` / `find` / `head` / `tail` / `wc` / `awk` / `sed` / pipes).
+Typical commands: `ls` / `cat` / `grep` / `find` / `head` / `tail` / `wc` / `awk` / `sed` / pipes. Output is capped at 1 MB.
 
 **Examples:**
 

--- a/packages/api/src/lib/semantic/__tests__/mode-semantic-root.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/mode-semantic-root.test.ts
@@ -54,6 +54,22 @@ mock.module("@atlas/api/lib/knowledge/mirror", () => ({
   },
 }));
 
+// `invalidateOrgModeRoots` fire-and-forget imports the explore module to drop
+// the org's cached backends (file-snapshot backends like Vercel copy semantic
+// files in at creation and would serve stale YAMLs otherwise). Mock ALL
+// exports so loading it here never touches real backend detection.
+const mockInvalidateOrgExploreBackends = mock((_orgId: string) => {});
+mock.module("@atlas/api/lib/tools/explore", () => ({
+  explore: {},
+  getActiveSandboxPluginId: () => null,
+  getExploreBackendType: () => "just-bash",
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: mockInvalidateOrgExploreBackends,
+  markNsjailFailed: () => {},
+  markSidecarFailed: () => {},
+  _formatSandboxPriorityFailureForTest: () => "",
+}));
+
 // ---------------------------------------------------------------------------
 // Imports under test
 // ---------------------------------------------------------------------------
@@ -164,6 +180,16 @@ describe("ensureOrgModeSemanticRoot", () => {
     const root = await ensureOrgModeSemanticRoot("org-1", "published");
     expect(mockListEntities).toHaveBeenCalledTimes(2);
     expect(fs.existsSync(path.join(root, "entities", "orders.yml"))).toBe(true);
+  });
+
+  it("invalidateOrgModeRoots also drops the org's cached explore backends", async () => {
+    mockInvalidateOrgExploreBackends.mockClear();
+
+    invalidateOrgModeRoots("org-1");
+
+    // The eviction rides a fire-and-forget dynamic import — flush microtasks
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockInvalidateOrgExploreBackends).toHaveBeenCalledWith("org-1");
   });
 
   it("invalidation that fires DURING a build prevents the stale result from being cached", async () => {

--- a/packages/api/src/lib/semantic/sync.ts
+++ b/packages/api/src/lib/semantic/sync.ts
@@ -440,6 +440,21 @@ export function invalidateOrgModeRoots(orgId: string): void {
     _modeBuilt.delete(key);
     _modeInvalidationStamp.set(key, (_modeInvalidationStamp.get(key) ?? 0) + 1);
   }
+  // Rebuilding the mode roots isn't enough for file-snapshot explore backends
+  // (Vercel/BYOC microVMs): they copy semantic files in at creation and never
+  // re-read host disk, so a pooled sandbox would serve stale YAMLs until an
+  // infra error forced a rebuild. Drop the org's cached backends too.
+  // Dynamic import breaks the tools/explore → semantic/sync module cycle;
+  // fire-and-forget is safe because the eviction only has to land before the
+  // next agent turn, and the microtask resolves long before that.
+  void import("@atlas/api/lib/tools/explore")
+    .then(({ invalidateOrgExploreBackends }) => invalidateOrgExploreBackends(orgId))
+    .catch((err) => {
+      log.warn(
+        { orgId, err: errorMessage(err) },
+        "Failed to invalidate explore backends after semantic change",
+      );
+    });
 }
 
 /**

--- a/packages/api/src/lib/tools/__tests__/explore-plugin.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-plugin.test.ts
@@ -373,3 +373,112 @@ describe("explore sandbox plugin integration", () => {
     expect(mod.getActiveSandboxPluginId()).toBe("default-priority");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Output capping at the tool seam
+// ---------------------------------------------------------------------------
+
+describe("explore output capping", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockSandboxPlugins = [];
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+    delete process.env.ATLAS_SANDBOX;
+    delete process.env.ATLAS_SANDBOX_URL;
+    delete process.env.ATLAS_NSJAIL_PATH;
+    process.env.PATH = "/usr/bin:/bin";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  const MAX_OUTPUT = 1024 * 1024;
+
+  it("truncates oversized stdout with a notice", async () => {
+    mockSandboxPlugins = [
+      {
+        id: "huge-stdout",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: {
+          create: async () => ({
+            exec: async (): Promise<ExecResult> => ({
+              stdout: "x".repeat(MAX_OUTPUT + 4096),
+              stderr: "",
+              exitCode: 0,
+            }),
+          }),
+        },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute(
+      { command: "cat entities/huge.yml" },
+      { toolCallId: "test", messages: [], abortSignal: new AbortController().signal },
+    );
+
+    expect(result).toContain("[output truncated: exceeded 1 MB limit]");
+    // Capped payload + one line of truncation notice — never the full 1 MB + 4 KB
+    expect(result.length).toBeLessThan(MAX_OUTPUT + 100);
+  });
+
+  it("truncates oversized stderr on non-zero exit", async () => {
+    mockSandboxPlugins = [
+      {
+        id: "huge-stderr",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: {
+          create: async () => ({
+            exec: async (): Promise<ExecResult> => ({
+              stdout: "",
+              stderr: "e".repeat(MAX_OUTPUT + 4096),
+              exitCode: 2,
+            }),
+          }),
+        },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute(
+      { command: "grep -r nope ." },
+      { toolCallId: "test", messages: [], abortSignal: new AbortController().signal },
+    );
+
+    expect(result).toContain("Error (exit 2)");
+    expect(result).toContain("[output truncated: exceeded 1 MB limit]");
+    expect(result.length).toBeLessThan(MAX_OUTPUT + 100);
+  });
+
+  it("passes small output through unchanged", async () => {
+    mockSandboxPlugins = [
+      {
+        id: "small-output",
+        types: ["sandbox"],
+        version: "1.0.0",
+        sandbox: {
+          create: async () => ({
+            exec: async (): Promise<ExecResult> => ({
+              stdout: "table: orders\n",
+              stderr: "",
+              exitCode: 0,
+            }),
+          }),
+        },
+      },
+    ];
+
+    const mod = await freshExploreModule();
+    const result = await mod.explore.execute(
+      { command: "cat entities/orders.yml" },
+      { toolCallId: "test", messages: [], abortSignal: new AbortController().signal },
+    );
+
+    expect(result).toBe("table: orders\n");
+  });
+});

--- a/packages/api/src/lib/tools/backends/shared.ts
+++ b/packages/api/src/lib/tools/backends/shared.ts
@@ -11,6 +11,19 @@ import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 export const MAX_OUTPUT = 1024 * 1024;
 
 /**
+ * Cap a fully-buffered output string destined for agent context, appending a
+ * truncation notice so the model knows the output was cut rather than complete.
+ *
+ * Complements readLimited: readLimited bounds subprocess-stream memory during
+ * the read; capOutput bounds already-buffered strings from backends that return
+ * whole outputs (Vercel sandbox, just-bash, plugin/BYOC backends).
+ */
+export function capOutput(output: string, max = MAX_OUTPUT): string {
+  if (output.length <= max) return output;
+  return `${output.slice(0, max)}\n[output truncated: exceeded ${Math.floor(max / (1024 * 1024))} MB limit]`;
+}
+
+/**
  * Read up to `max` bytes from a stream, releasing the reader on completion or error.
  *
  * Used by nsjail backends (explore + python) to cap subprocess output

--- a/packages/api/src/lib/tools/backends/shared.ts
+++ b/packages/api/src/lib/tools/backends/shared.ts
@@ -6,6 +6,7 @@
  */
 
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
+import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
 
 /** Maximum bytes to read from stdout/stderr (1 MB). */
 export const MAX_OUTPUT = 1024 * 1024;
@@ -52,6 +53,21 @@ export async function readLimited(
     await reader.cancel().catch(() => {});
   }
   return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+/**
+ * Attribution tags for Vercel sandboxes created by Atlas (max 5 allowed by
+ * the API; we use 3). Without them, sandbox listings are a wall of
+ * random-named entries with no way to tell prod explore pools from local-dev
+ * or e2e churn — which is exactly how 1,200+ untraceable sandboxes
+ * accumulated before 2026-07.
+ */
+export function atlasSandboxTags(source: "explore" | "python"): Record<string, string> {
+  return {
+    app: "atlas",
+    source,
+    env: resolveDeployEnv(),
+  };
 }
 
 /** Logger interface accepted by parsePositiveInt — avoids coupling to pino. */

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ExploreBackend, ExecResult } from "./backends/types";
-import { sandboxErrorDetail, safeError } from "./backends/shared";
+import { sandboxErrorDetail, safeError, atlasSandboxTags } from "./backends/shared";
 import { vercelSandboxAccess, type RedactedSecret } from "./backends/detect";
 import * as path from "path";
 import * as fs from "fs";
@@ -152,6 +152,7 @@ export async function createSandboxBackend(
       // v2 persists (snapshots) by default — force ephemeral so semantic
       // files never linger in Vercel snapshot storage after stop().
       persistent: false,
+      tags: atlasSandboxTags("explore"),
       ...(explicitAccess ?? {}),
     });
   } catch (err) {

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -77,6 +77,11 @@ function collectSemanticFiles(
   return results;
 }
 
+// Per-command wall-clock limit, enforced sandbox-side (SIGKILL). Matches the
+// 10s default of the nsjail (ATLAS_NSJAIL_TIME_LIMIT) and sidecar backends —
+// without it a pathological command holds the pooled sandbox open unboundedly.
+const COMMAND_TIMEOUT_MS = 10_000;
+
 // Prefix for sandbox file paths: the SDK resolves relative paths under /vercel/sandbox/.
 const SANDBOX_SEMANTIC_REL = "semantic";
 // Must match the absolute resolution of SANDBOX_SEMANTIC_REL (used as runCommand cwd).
@@ -249,6 +254,7 @@ export async function createSandboxBackend(
           cmd: "sh",
           args: ["-c", command],
           cwd: SANDBOX_SEMANTIC_CWD,
+          timeoutMs: COMMAND_TIMEOUT_MS,
         });
         return {
           stdout: await result.stdout(),

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -30,6 +30,7 @@ import { getSemanticRoot, ensureOrgModeSemanticRoot } from "@atlas/api/lib/seman
 import { getSetting } from "@atlas/api/lib/settings";
 import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
+import { capOutput } from "./backends/shared";
 import { EXPLORE_TOOL_DESCRIPTION } from "./descriptions";
 
 const log = createLogger("explore");
@@ -733,11 +734,15 @@ export const explore = tool({
         "explore command",
       );
 
+      // Cap output at the tool seam so every backend is covered — nsjail caps
+      // at stream-read time, but Vercel/just-bash/plugin/BYOC backends return
+      // whole buffered outputs that would otherwise flow into agent context
+      // (and the MCP/REST explore surfaces) unbounded.
       if (result.exitCode !== 0) {
-        return `Error (exit ${result.exitCode}):\n${result.stderr}`;
+        return `Error (exit ${result.exitCode}):\n${capOutput(result.stderr)}`;
       }
 
-      const output = result.stdout || "(no output)";
+      const output = capOutput(result.stdout) || "(no output)";
       await dispatchHook("afterExplore", { command: execCommand, output });
 
       return output;

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -28,7 +28,7 @@ import type { PythonBackend, PythonResult } from "./python";
 import type { SandboxNetworkPolicy } from "./backends/network-allowlist";
 import type { VercelSandboxAccessOverride } from "./explore-sandbox";
 import { PYTHON_SECURITY_AND_SETUP } from "./python-wrapper";
-import { sandboxErrorDetail, safeError, MAX_OUTPUT } from "./backends/shared";
+import { sandboxErrorDetail, safeError, MAX_OUTPUT, atlasSandboxTags } from "./backends/shared";
 import { vercelSandboxAccess } from "./backends/detect";
 import { randomUUID } from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -265,6 +265,7 @@ export function createPythonSandboxBackend(
             // per-request code/data/chart files never land in Vercel
             // snapshot storage after the sandbox is stopped.
             persistent: false,
+            tags: atlasSandboxTags("python"),
             ...(explicitAccess ?? {}),
           }),
         catch: (err) => {

--- a/packages/api/src/types/vercel-sandbox.d.ts
+++ b/packages/api/src/types/vercel-sandbox.d.ts
@@ -55,6 +55,13 @@ declare module "@vercel/sandbox" {
     persistent?: boolean;
     ports?: number[];
     timeout?: number;
+    /**
+     * Key-value attribution tags (max 5, per the API). Atlas always passes
+     * `atlasSandboxTags()` (`app`/`source`/`env`) so sandbox listings can be
+     * attributed to a code path + deploy env instead of reading as a wall of
+     * random-named entries.
+     */
+    tags?: Record<string, string>;
   }
 
   interface WriteFileEntry {

--- a/packages/api/src/types/vercel-sandbox.d.ts
+++ b/packages/api/src/types/vercel-sandbox.d.ts
@@ -74,6 +74,13 @@ declare module "@vercel/sandbox" {
     cwd?: string;
     env?: Record<string, string>;
     sudo?: boolean;
+    /**
+     * Maximum time in milliseconds the command may run before it is killed
+     * with SIGKILL — enforced sandbox-side at exec time. Atlas passes this
+     * from `explore-sandbox.ts` so a pathological command can't hold the
+     * pooled sandbox open unboundedly.
+     */
+    timeoutMs?: number;
   }
 
   /** Subset of actual CommandFinished class — see SDK docs for full API. */

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -97,6 +97,18 @@ const SANDBOX_SEMANTIC_REL = "semantic";
 // Must match the absolute resolution of SANDBOX_SEMANTIC_REL (used as runCommand cwd).
 const SANDBOX_SEMANTIC_CWD = "/vercel/sandbox/semantic";
 
+/**
+ * Attribution tags for sandboxes this plugin creates (Vercel allows max 5).
+ * Standalone package — mirrors the api's `atlasSandboxTags` shape (app/source/
+ * env) without importing `@atlas/api`; the raw `ATLAS_DEPLOY_ENV` read matches
+ * the api's `resolveDeployEnv` default of "production" when unset.
+ */
+function sandboxTags(source: string): Record<string, string> {
+  const raw = process.env.ATLAS_DEPLOY_ENV?.trim().toLowerCase();
+  const env = raw === "development" || raw === "staging" ? raw : "production";
+  return { app: "atlas", source, env };
+}
+
 // ---------------------------------------------------------------------------
 // Lazy import helper
 // ---------------------------------------------------------------------------
@@ -193,6 +205,9 @@ async function createVercelExploreBackend(
     // v2 persists (snapshots) by default — force ephemeral so semantic files
     // never linger in Vercel snapshot storage after stop().
     persistent: false,
+    // Attribution tags (max 5 per the API) so sandbox listings — including on
+    // a BYOC org's own Vercel account — can be traced back to Atlas.
+    tags: sandboxTags("explore-plugin"),
   };
   if (config.accessToken) {
     createOpts.accessToken = config.accessToken;
@@ -394,6 +409,7 @@ export function buildVercelSandboxPlugin(
             networkPolicy: "deny-all",
             // v2 persists by default — keep the health-check sandbox ephemeral.
             persistent: false,
+            tags: sandboxTags("health-check"),
           };
           if (config.accessToken) {
             createOpts.accessToken = config.accessToken;


### PR DESCRIPTION
## Summary

Fixes three gaps found while comparing Atlas's sandbox layer against its genesis project (vercel-labs/oss-data-analyst). Sibling residency gap filed separately as #4223.

### 1. Stale semantic files in pooled file-snapshot explore backends (live on SaaS)
Semantic writes (`/admin/publish`, entity CRUD via `whitelist.ts`, knowledge via `admin-knowledge.ts`) call `invalidateOrgModeRoots`, which rebuilds the on-disk mode roots in place — but never dropped the org's cached explore backends. The Vercel/BYOC microVMs copy semantic files in **once at creation** and never re-read host disk, so a pooled sandbox served stale YAMLs after a publish until an infra error forced a rebuild. SaaS pins `vercel-sandbox`, so this was live.

`invalidateOrgModeRoots` now also fires `invalidateOrgExploreBackends(orgId)` (fire-and-forget dynamic import — breaks the `tools/explore` → `semantic/sync` module cycle; the eviction only has to land before the next agent turn).

### 2. Unbounded output + no wall-clock on exactly the SaaS-pinned backend
The vercel-sandbox explore backend returned `stdout()` untruncated and ran commands with no timeout; just-bash was also unbounded (nsjail/sidecar already cap 1 MB / 10 s). Now:
- **`capOutput`** (new, `backends/shared.ts`) caps stdout/stderr at 1 MB **at the tool seam** in `explore.ts`, with an explicit truncation notice for the model. Seam placement covers vercel, just-bash, sidecar, plugin, and BYOC backends — and all three explore surfaces (agent loop, MCP `explore`, `POST /api/v1/explore`) since they all route through `explore.execute`.
- The Vercel backend passes `timeoutMs: 10_000` to `runCommand` (sandbox-side SIGKILL), matching the nsjail/sidecar defaults. Added `timeoutMs` to our local `@vercel/sandbox` type stub (present in the installed SDK's own types).

### 3. Docs overstated explore enforcement
CLAUDE.md and `cli.mdx` claimed an `ls`/`cat`/`grep`/`find` allowlist with server-side rejection of writes and shell escapes. No such validator exists (`explore.ts` states this explicitly — enforcement is structural isolation per backend). Reworded both to describe the actual model: no command allowlist; read-only scoping is structural (ephemeral microVM / read-only binds / OverlayFs).

## Tests
- `explore-plugin.test.ts`: 3 new tests — oversized stdout truncated with notice, oversized stderr truncated on non-zero exit, small output passes through byte-identical.
- `mode-semantic-root.test.ts`: new test asserting `invalidateOrgModeRoots` evicts the org's cached explore backends (explore module fully mocked per mock-all-exports discipline).

## Verification
- `bun test` on both touched test files: green (12 + 9 pass).
- `bun run scripts/test-isolated.ts --affected`: 73/74 green; the one failure (`description-rubric.test.ts`) is the documented WSL2 load-flake and passes standalone.
- `bun run type`: green (after the type-stub addition).
- eslint on all touched files: clean.