### PR TITLE
chore: refresh bun.lock for @useatlas/plugin-sdk 0.0.16 version bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -324,7 +324,7 @@
     },
     "packages/plugin-sdk": {
       "name": "@useatlas/plugin-sdk",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "devDependencies": {
         "@types/node": "^25.9.4",
         "ai": "^6.0.208",


### PR DESCRIPTION
One-line lockfile sync: main's committed `bun.lock` still records the `@useatlas/plugin-sdk` workspace at `0.0.15`, but the package's `package.json` was bumped to `0.0.16` without the lock refresh — so every `bun install` on a clean main regenerates this diff. No dependency changes.