### PR TITLE
fix(marketplace): route POST /install through the Form-install persistence spine (#4186)

### DIFF
--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -441,6 +441,20 @@ function findCapturedQuery(pattern: string): { sql: string; params: unknown[] } 
 // confirm the `enc:v1:` prefix; tests that only care about the semantic
 // restore/passthrough behavior assert the decrypted plaintext.
 const testEncryptionKey = Buffer.alloc(32, 0x42);
+// #4186 — the SaaS keyset-gate test flips this off to simulate a SaaS deploy
+// with no encryption keys configured; every other test runs with keys.
+// Declared before BOTH keyset-bearing mocks so the two module views can
+// never split-brain (db/internal keyed on, encryption-keys keyed off).
+let mockKeysetAvailable = true;
+const mockKeyset = () =>
+  mockKeysetAvailable
+    ? {
+        active: { version: 1, key: testEncryptionKey },
+        byVersion: new Map([[1, testEncryptionKey]]),
+        decrypt: [{ version: 1, key: testEncryptionKey }],
+        source: "ATLAS_ENCRYPTION_KEY",
+      }
+    : null;
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   getInternalDB: () => ({
@@ -461,13 +475,8 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   setWorkspaceRegion: mock(async () => {}),
   insertSemanticAmendment: mock(async () => "mock-amendment-id"),
   getPendingAmendmentCount: mock(async () => 0),
-  getEncryptionKey: () => testEncryptionKey,
-  getEncryptionKeyset: () => ({
-    active: { version: 1, key: testEncryptionKey },
-    byVersion: new Map([[1, testEncryptionKey]]),
-    decrypt: [{ version: 1, key: testEncryptionKey }],
-    source: "ATLAS_ENCRYPTION_KEY",
-  }),
+  getEncryptionKey: () => (mockKeysetAvailable ? testEncryptionKey : null),
+  getEncryptionKeyset: mockKeyset,
   _resetEncryptionKeyCache: () => {},
 }));
 
@@ -477,20 +486,9 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 // needs a mock. Without this, `getEncryptionKeyset()` returns null, the
 // encrypt helpers degrade to plaintext passthrough, and the F-42
 // "encrypted at rest" assertions fail.
-// #4186 — the SaaS keyset-gate test flips this off to simulate a SaaS deploy
-// with no encryption keys configured; every other test runs with keys.
-let mockKeysetAvailable = true;
 mock.module("@atlas/api/lib/db/encryption-keys", () => ({
   getEncryptionKey: () => (mockKeysetAvailable ? testEncryptionKey : null),
-  getEncryptionKeyset: () =>
-    mockKeysetAvailable
-      ? {
-          active: { version: 1, key: testEncryptionKey },
-          byVersion: new Map([[1, testEncryptionKey]]),
-          decrypt: [{ version: 1, key: testEncryptionKey }],
-          source: "ATLAS_ENCRYPTION_KEY",
-        }
-      : null,
+  getEncryptionKeyset: mockKeyset,
   activeKeyVersion: () => 1,
   _resetEncryptionKeyCache: () => {},
 }));
@@ -1129,6 +1127,74 @@ describe("Workspace Plugin Marketplace", () => {
       expect(insertCall!.params[1]).toBe("org-1");
       expect(insertCall!.params[2]).toBe("cat-1");
       expect(insertCall!.params[4]).toBe("admin-1");
+
+      // The PERSISTED id (the upsert's RETURNING, not the candidate UUID)
+      // threads through the read-back, the success audit, and the response.
+      const readback = findCapturedQuery("FROM workspace_plugins wp");
+      expect(readback).toBeDefined();
+      expect(readback!.params[0]).toBe("inst-1");
+      expect(readback!.params[1]).toBe("org-1");
+      const success = mockLogAdminAction.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.actionType === "plugin.install" && e.status !== "failure");
+      expect(success?.targetId).toBe("inst-1");
+      const body = await json(res);
+      expect(body.id).toBe("inst-1");
+    });
+
+    it("threads the catalog row's chat pillar into the spine SQL (#4186)", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [
+        { ...sampleCatalogRow, pillar: "chat" },
+      ]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setInstallPersistResults({
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "BigQuery",
+        slug: "bigquery",
+        type: "datasource",
+        description: null,
+      });
+
+      const res = await buildWorkspaceApp().request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(201);
+      const insertCall = findCapturedQuery("INSERT INTO workspace_plugins");
+      expect(insertCall!.sql).toBe(buildFormInstallUpsertSql(true, "chat"));
+    });
+
+    it("500s truthfully when the read-back finds no row — install already audited as success (#4186)", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setQueryResult("INSERT INTO workspace_plugins", [{ id: "inst-1" }]);
+      // Concurrent uninstall between the upsert and the read-back.
+      setQueryResult("FROM workspace_plugins wp", []);
+
+      const res = await buildWorkspaceApp().request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(500);
+      const body = await json(res);
+      expect(body.error).toBe("internal_error");
+      // The install DID complete — the success audit fires before the
+      // read-back so a response-shaping failure never hides the write.
+      const success = mockLogAdminAction.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.actionType === "plugin.install" && e.status !== "failure");
+      expect(success?.targetId).toBe("inst-1");
+      expect(evictCalls).toEqual([{ workspaceId: "org-1", catalogId: "cat-1" }]);
     });
 
     it("evicts the lazy plugin cache after the persist — spine step 4 (#4186)", async () => {
@@ -1162,7 +1228,7 @@ describe("Workspace Plugin Marketplace", () => {
     // datasource (multi-instance drafts via /admin/connections) and knowledge
     // (ingest flow) rows must be refused even when their install_model is
     // `form`, mirroring the #3681 install-model gate.
-    it.each(["datasource", "knowledge"])(
+    it.each(["datasource", "knowledge", null])(
       "rejects a form-model row on the %s pillar and persists nothing (#4186)",
       async (pillar) => {
         setQueryResult("SELECT * FROM plugin_catalog WHERE id", [
@@ -1183,7 +1249,11 @@ describe("Workspace Plugin Marketplace", () => {
         const failure = mockLogAdminAction.mock.calls
           .map((c) => c[0])
           .find((e) => e.actionType === "plugin.install" && e.status === "failure");
-        expect(failure?.metadata).toMatchObject({ pillarRejected: pillar, orgId: "org-1" });
+        // A drifted row with no pillar fails closed and audits "unknown".
+        expect(failure?.metadata).toMatchObject({
+          pillarRejected: pillar ?? "unknown",
+          orgId: "org-1",
+        });
       },
     );
 

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -184,6 +184,22 @@ mock.module("effect", () => {
       const effectValue: TestEffectPromise = { _tag: "EffectPromise", fn, errorTaps: [] };
       return makePipeable(effectValue);
     },
+    // #4186 — the install route wraps persistInstallRecord in
+    // Effect.tryPromise so persist failures surface in the error channel
+    // (audited via tapError, mapped to 500 by runEffect). The shim maps a
+    // rejection through the caller's `catch` normalizer, then rethrows so
+    // the runEffect shim below runs the error taps.
+    tryPromise: (opts: { try: () => Promise<unknown>; catch: (err: unknown) => unknown }) => {
+      const effectValue: TestEffectPromise = {
+        _tag: "EffectPromise",
+        fn: () =>
+          opts.try().catch((err) => {
+            throw opts.catch(err);
+          }),
+        errorTaps: [],
+      };
+      return makePipeable(effectValue);
+    },
     // Support Effect.runPromise for routes that unwrap Effect-returning EE functions
     runPromise: (value: unknown) => {
       return Promise.resolve(value);
@@ -365,6 +381,22 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
   IPAllowlistError: class extends Error { constructor(message: string, public readonly code: string) { super(message); this.name = "IPAllowlistError"; } },
 }));
 
+// #4186 — the install route persists through the form-install spine
+// (persistInstallRecord), whose step 4 evicts the lazy plugin cache so a
+// re-install never keeps serving a stale cached PluginLike. Captured here so
+// tests can assert the evict; mock ALL value exports (CLAUDE.md rule).
+const evictCalls: Array<{ workspaceId: string; catalogId: string }> = [];
+const mockLazyEvict = mock(async (workspaceId: string, catalogId: string) => {
+  evictCalls.push({ workspaceId, catalogId });
+  return true;
+});
+mock.module("@atlas/api/lib/plugins/lazy-loader", () => ({
+  lazyPluginLoader: { evict: mockLazyEvict },
+  LazyPluginLoader: class {},
+  LazyPluginBuilderMissingError: class extends Error {},
+  LazyPluginInstallNotFoundError: class extends Error {},
+}));
+
 // --- Internal DB mock ---
 
 let mockHasInternalDB = true;
@@ -445,14 +477,20 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 // needs a mock. Without this, `getEncryptionKeyset()` returns null, the
 // encrypt helpers degrade to plaintext passthrough, and the F-42
 // "encrypted at rest" assertions fail.
+// #4186 — the SaaS keyset-gate test flips this off to simulate a SaaS deploy
+// with no encryption keys configured; every other test runs with keys.
+let mockKeysetAvailable = true;
 mock.module("@atlas/api/lib/db/encryption-keys", () => ({
-  getEncryptionKey: () => testEncryptionKey,
-  getEncryptionKeyset: () => ({
-    active: { version: 1, key: testEncryptionKey },
-    byVersion: new Map([[1, testEncryptionKey]]),
-    decrypt: [{ version: 1, key: testEncryptionKey }],
-    source: "ATLAS_ENCRYPTION_KEY",
-  }),
+  getEncryptionKey: () => (mockKeysetAvailable ? testEncryptionKey : null),
+  getEncryptionKeyset: () =>
+    mockKeysetAvailable
+      ? {
+          active: { version: 1, key: testEncryptionKey },
+          byVersion: new Map([[1, testEncryptionKey]]),
+          decrypt: [{ version: 1, key: testEncryptionKey }],
+          source: "ATLAS_ENCRYPTION_KEY",
+        }
+      : null,
   activeKeyVersion: () => 1,
   _resetEncryptionKeyCache: () => {},
 }));
@@ -492,6 +530,12 @@ const { OpenAPIHono } = await import("@hono/zod-openapi");
 // the same key.
 const { decryptSecret } = await import("@atlas/api/lib/db/secret-encryption");
 const { isEncryptedSecret } = await import("@atlas/api/lib/plugins/secrets");
+// #4186: the install route must persist through the form-install spine —
+// the regression pin compares the captured INSERT byte-for-byte against
+// the spine's canonical builder output.
+const { buildFormInstallUpsertSql } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -548,9 +592,23 @@ const sampleCatalogRow = {
   enabled: true,
   // #3681 — the marketplace install path is gated to the `form` install model.
   install_model: "form",
+  // #4186 — and to the chat/action pillars (the form-install spine's
+  // singleton upsert only arbitrates those).
+  pillar: "action",
   created_at: now,
   updated_at: now,
 };
+
+/**
+ * #4186 — the two query results every successful install now produces:
+ * the spine's upsert (`INSERT INTO workspace_plugins … RETURNING id`) and
+ * the route's follow-up row fetch (`SELECT wp.*, pc.name … JOIN`), replacing
+ * the pre-#4186 single hand-rolled `INSERT … RETURNING *`.
+ */
+function setInstallPersistResults(row: Record<string, unknown>) {
+  setQueryResult("INSERT INTO workspace_plugins", [{ id: row.id }]);
+  setQueryResult("FROM workspace_plugins wp", [row]);
+}
 
 // ---------------------------------------------------------------------------
 // Platform Catalog CRUD
@@ -793,6 +851,10 @@ describe("Workspace Plugin Marketplace", () => {
     // #3681 — reset dedicated-credential teardown capture.
     credStoreCalls.length = 0;
     mockDeleteDedicatedCredentialStore.mockClear();
+    // #4186 — reset spine-evict capture + keyset availability.
+    evictCalls.length = 0;
+    mockLazyEvict.mockClear();
+    mockKeysetAvailable = true;
   });
 
   describe("GET /marketplace/available", () => {
@@ -999,7 +1061,7 @@ describe("Workspace Plugin Marketplace", () => {
       setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
       setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
       setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
-      setQueryResult("INSERT INTO workspace_plugins", [{
+      setInstallPersistResults({
         id: "inst-1",
         workspace_id: "org-1",
         catalog_id: "cat-1",
@@ -1011,7 +1073,7 @@ describe("Workspace Plugin Marketplace", () => {
         slug: "bigquery",
         type: "datasource",
         description: "Google BigQuery datasource",
-      }]);
+      });
 
       const app = buildWorkspaceApp();
       const res = await app.request("/marketplace/install", {
@@ -1023,6 +1085,160 @@ describe("Workspace Plugin Marketplace", () => {
       const body = await json(res);
       expect(body.catalogId).toBe("cat-1");
       expect(body.name).toBe("BigQuery");
+    });
+
+    // #4186 — the route must persist through the form-install spine's
+    // canonical upsert, not a hand-rolled INSERT. The pre-#4186 copy omitted
+    // `install_id` + `pillar` (both NOT NULL post-0096, filler trigger
+    // dropped) so every marketplace install 23502'd against the live schema,
+    // and it skipped the lazy-loader evict + SaaS keyset gate. Pinning the
+    // captured SQL to the builder's exact output means a re-hand-rolled copy
+    // can't drift back in unnoticed.
+    it("persists via the form-install spine SQL verbatim, attributing installed_by (#4186)", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setInstallPersistResults({
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "BigQuery",
+        slug: "bigquery",
+        type: "datasource",
+        description: "Google BigQuery datasource",
+      });
+
+      const res = await buildWorkspaceApp().request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(201);
+
+      const insertCall = findCapturedQuery("INSERT INTO workspace_plugins");
+      expect(insertCall).toBeDefined();
+      // Byte-for-byte the spine's canonical singleton upsert — install_id +
+      // pillar named, partial-index conflict target, RETURNING id.
+      expect(insertCall!.sql).toBe(buildFormInstallUpsertSql(true, "action"));
+      // ($1 candidate id, $2 workspace, $3 FULL catalog id, $4 config,
+      //  $5 the authenticated admin as installed_by)
+      expect(insertCall!.params[1]).toBe("org-1");
+      expect(insertCall!.params[2]).toBe("cat-1");
+      expect(insertCall!.params[4]).toBe("admin-1");
+    });
+
+    it("evicts the lazy plugin cache after the persist — spine step 4 (#4186)", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setInstallPersistResults({
+        id: "inst-1",
+        workspace_id: "org-1",
+        catalog_id: "cat-1",
+        config: {},
+        enabled: true,
+        installed_at: now,
+        installed_by: "admin-1",
+        name: "BigQuery",
+        slug: "bigquery",
+        type: "datasource",
+        description: "Google BigQuery datasource",
+      });
+
+      const res = await buildWorkspaceApp().request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(201);
+      expect(evictCalls).toEqual([{ workspaceId: "org-1", catalogId: "cat-1" }]);
+    });
+
+    // #4186 — the spine's singleton upsert only serves chat/action pillars;
+    // datasource (multi-instance drafts via /admin/connections) and knowledge
+    // (ingest flow) rows must be refused even when their install_model is
+    // `form`, mirroring the #3681 install-model gate.
+    it.each(["datasource", "knowledge"])(
+      "rejects a form-model row on the %s pillar and persists nothing (#4186)",
+      async (pillar) => {
+        setQueryResult("SELECT * FROM plugin_catalog WHERE id", [
+          { ...sampleCatalogRow, pillar },
+        ]);
+        setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+        setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+
+        const res = await buildWorkspaceApp().request("/marketplace/install", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ catalogId: "cat-1" }),
+        });
+        expect(res.status).toBe(400);
+        const body = await json(res);
+        expect(body.error).toBe("pillar_unsupported");
+        expect(findCapturedQuery("INSERT INTO workspace_plugins")).toBeUndefined();
+        const failure = mockLogAdminAction.mock.calls
+          .map((c) => c[0])
+          .find((e) => e.actionType === "plugin.install" && e.status === "failure");
+        expect(failure?.metadata).toMatchObject({ pillarRejected: pillar, orgId: "org-1" });
+      },
+    );
+
+    // #4186 — spine step 1: on a SaaS deploy with no encryption keyset,
+    // `encryptSecretFields` would silently degrade to plaintext passthrough.
+    // The install must refuse (500 + failure audit) before anything persists.
+    it("fails closed when SaaS has no encryption keyset — nothing persists (#4186)", async () => {
+      const originalDeployMode = process.env.ATLAS_DEPLOY_MODE;
+      process.env.ATLAS_DEPLOY_MODE = "saas";
+      mockKeysetAvailable = false;
+      try {
+        setQueryResult("SELECT * FROM plugin_catalog WHERE id", [{
+          ...sampleCatalogRow,
+          config_schema: [{ key: "apiKey", type: "string", secret: true }],
+        }]);
+        setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+        setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+
+        const res = await buildWorkspaceApp().request("/marketplace/install", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ catalogId: "cat-1", config: { apiKey: "sk-live-secret" } }),
+        });
+        expect(res.status).toBe(500);
+        const body = await json(res);
+        expect(body.error).toBe("encryption_unavailable");
+        expect(findCapturedQuery("INSERT INTO workspace_plugins")).toBeUndefined();
+        const failure = mockLogAdminAction.mock.calls
+          .map((c) => c[0])
+          .find((e) => e.actionType === "plugin.install" && e.status === "failure");
+        expect(failure?.metadata).toMatchObject({ keysetUnavailable: true, orgId: "org-1" });
+      } finally {
+        if (originalDeployMode === undefined) delete process.env.ATLAS_DEPLOY_MODE;
+        else process.env.ATLAS_DEPLOY_MODE = originalDeployMode;
+      }
+    });
+
+    it("emits a failure audit and 500 when the spine persist rejects (#4186)", async () => {
+      setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
+      setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
+      setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
+      setQueryResult("INSERT INTO workspace_plugins", new Error("pg pool exhausted"));
+
+      const res = await buildWorkspaceApp().request("/marketplace/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ catalogId: "cat-1" }),
+      });
+      expect(res.status).toBe(500);
+      const failure = mockLogAdminAction.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.actionType === "plugin.install" && e.status === "failure");
+      expect(failure?.metadata).toMatchObject({ orgId: "org-1", error: "pg pool exhausted" });
+      // Persist failed → the cache must not have been evicted.
+      expect(evictCalls).toEqual([]);
     });
 
     it("rejects when plan is insufficient", async () => {
@@ -1135,7 +1351,7 @@ describe("Workspace Plugin Marketplace", () => {
       ]);
       setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
       setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
-      setQueryResult("INSERT INTO workspace_plugins", [{
+      setInstallPersistResults({
         id: "inst-1",
         workspace_id: "org-1",
         catalog_id: "cat-1",
@@ -1146,7 +1362,7 @@ describe("Workspace Plugin Marketplace", () => {
         name: "DuckDB",
         slug: "duckdb",
         type: "datasource",
-      }]);
+      });
 
       const res = await buildWorkspaceApp().request("/marketplace/install", {
         method: "POST",
@@ -1169,7 +1385,7 @@ describe("Workspace Plugin Marketplace", () => {
       ]);
       setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
       setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
-      setQueryResult("INSERT INTO workspace_plugins", [{
+      setInstallPersistResults({
         id: "inst-1",
         workspace_id: "org-1",
         catalog_id: "cat-1",
@@ -1180,7 +1396,7 @@ describe("Workspace Plugin Marketplace", () => {
         name: "Obsidian",
         slug: "obsidian",
         type: "context",
-      }]);
+      });
 
       const res = await buildWorkspaceApp().request("/marketplace/install", {
         method: "POST",
@@ -1707,12 +1923,12 @@ describe("Workspace Plugin Marketplace", () => {
       }]);
       setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
       setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
-      setQueryResult("INSERT INTO workspace_plugins", [{
+      setInstallPersistResults({
         id: "inst-new",
         workspace_id: "org-1",
         catalog_id: "cat-1",
-        // Returned row carries the encrypted config the INSERT wrote; the
-        // route must mask before responding.
+        // The row fetch returns the encrypted config the spine upsert wrote;
+        // the route must mask before responding.
         config: { apiKey: "enc:v1:fake:fake:fake" },
         enabled: true,
         installed_at: now,
@@ -1720,7 +1936,7 @@ describe("Workspace Plugin Marketplace", () => {
         name: "BigQuery",
         slug: "bigquery",
         type: "datasource",
-      }]);
+      });
 
       const res = await buildWorkspaceApp().request("/marketplace/install", {
         method: "POST",
@@ -2121,7 +2337,7 @@ describe("audit emission — Workspace marketplace", () => {
       setQueryResult("SELECT * FROM plugin_catalog WHERE id", [sampleCatalogRow]);
       setQueryResult("SELECT plan_tier FROM organization", [{ plan_tier: "starter" }]);
       setQueryResult("SELECT id FROM workspace_plugins WHERE workspace_id", []);
-      setQueryResult("INSERT INTO workspace_plugins", [{
+      setInstallPersistResults({
         id: "inst-1",
         workspace_id: "org-1",
         catalog_id: "cat-1",
@@ -2133,7 +2349,7 @@ describe("audit emission — Workspace marketplace", () => {
         slug: "bigquery",
         type: "datasource",
         description: null,
-      }]);
+      });
 
       const app = buildWorkspaceApp();
       const res = await app.request("/marketplace/install", {

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -1175,8 +1175,9 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       // #4186 — spine steps 3+4: the canonical post-0092 singleton upsert
       // (explicit `install_id` + `pillar`, partial-index conflict target,
       // returned-id invariant) + the unconditional lazy-loader evict, via
-      // `persistInstallRecord` — the same tested artifact every form/OAuth
-      // install handler persists through. The pre-#4186 hand-rolled INSERT
+      // `persistInstallRecord` — the same tested artifact the form-install
+      // spine and OAuth install handlers persist through. The pre-#4186
+      // hand-rolled INSERT
       // here omitted `install_id`/`pillar` (both NOT NULL since 0092; the
       // filler trigger that papered over the omission was dropped by 0096,
       // so every marketplace install 23502'd against the live schema) and

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -41,6 +41,8 @@ import {
   assertSaasEncryptionKeyset,
   deriveSecretLabel,
   persistInstallRecord,
+  EncryptionKeysetUnavailableError,
+  MARKETPLACE_INSTALL_READBACK_SQL,
 } from "@atlas/api/lib/integrations/install/persist-form-install";
 import type { WorkspaceId } from "@useatlas/types";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
@@ -173,10 +175,12 @@ interface CatalogRow extends Record<string, unknown> {
   enabled: boolean;
   // 0092 / #2739 — three-pillar taxonomy, NOT NULL in the DB. Typed here
   // because the install route narrows it (`chat`/`action` only) before
-  // handing the persist to the form-install spine (#4186). This is still
-  // an unvalidated `SELECT *` cast, so the narrow fails closed on any
-  // unexpected value rather than trusting the type.
-  pillar: string;
+  // handing the persist to the form-install spine (#4186). Declared
+  // optional+nullable ON PURPOSE: this is an unvalidated `SELECT *` cast,
+  // so the type must not promise more than the driver does — the install
+  // route's narrow fails closed on any missing/unexpected value rather
+  // than trusting the type (a drifted row is refused, never coerced).
+  pillar?: string | null;
   // #3301 — false rows are hidden from the marketplace on SaaS deploys
   // (e.g. DuckDB, which is file-path based and not multi-tenant safe).
   // `NOT NULL DEFAULT true` in the DB; the filter still treats only an
@@ -1110,6 +1114,11 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       try {
         assertSaasEncryptionKeyset(log, orgId as WorkspaceId, deriveSecretLabel(installSchema));
       } catch (err) {
+        // Only the gate's own refusal is shaped here; anything else (e.g.
+        // a malformed-keyset parse error out of getEncryptionKeyset)
+        // rethrows to runEffect's generic 500 mapper rather than being
+        // mislabeled "keyset unavailable" with its raw message echoed.
+        if (!(err instanceof EncryptionKeysetUnavailableError)) throw err;
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.install,
           targetType: "plugin",
@@ -1125,9 +1134,7 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
         });
         return c.json({
           error: "encryption_unavailable",
-          message: err instanceof Error
-            ? err.message
-            : "Encryption keyset unavailable — refusing to persist plaintext credentials.",
+          message: err.message,
           requestId,
         }, 500);
       }
@@ -1170,9 +1177,11 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
       // returned-id invariant) + the unconditional lazy-loader evict, via
       // `persistInstallRecord` — the same tested artifact every form/OAuth
       // install handler persists through. The pre-#4186 hand-rolled INSERT
-      // here omitted `install_id`/`pillar` (both NOT NULL post-0096) and
-      // skipped the evict, so a re-install kept serving a stale cached
-      // PluginLike. Entered at `persistInstallRecord` rather than
+      // here omitted `install_id`/`pillar` (both NOT NULL since 0092; the
+      // filler trigger that papered over the omission was dropped by 0096,
+      // so every marketplace install 23502'd against the live schema) and
+      // skipped the evict, so a re-install would keep serving a stale
+      // cached PluginLike. Entered at `persistInstallRecord` rather than
       // `persistFormInstall` because platform-admin-CRUD catalog rows carry
       // a bare-UUID id, not the seeder's `catalog:<slug>` (so the slug-
       // derived FK would miss); encryption ran above with the route's own
@@ -1208,19 +1217,10 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
         });
       })));
 
-      // Fetch the persisted row + joined catalog fields for the response —
-      // the spine's upsert only RETURNs the id.
-      const rows = yield* queryEffect<WorkspacePluginRow>(
-        `SELECT wp.*, pc.name, pc.slug, pc.type, pc.description
-           FROM workspace_plugins wp
-           JOIN plugin_catalog pc ON pc.id = wp.catalog_id
-          WHERE wp.id = $1 AND wp.workspace_id = $2`,
-        [persistedId, orgId],
-      );
-
-      if (rows.length === 0) {
-        return c.json({ error: "internal_error", message: "Failed to install plugin — no row returned.", requestId }, 500);
-      }
+      // The state change is complete here (row persisted, cache evicted) —
+      // audit success NOW, before the response read-back, so a read-back
+      // failure can never leave a completed credential write unaudited
+      // (#4186 review).
       logAdminAction({
         actionType: ADMIN_ACTIONS.plugin.install,
         targetType: "plugin",
@@ -1233,6 +1233,38 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
         },
       });
       log.info({ orgId, catalogId: body.catalogId, installationId: persistedId }, "Plugin installed in workspace");
+
+      // Fetch the persisted row + joined catalog fields for the response —
+      // the spine's upsert only RETURNs the id. Failures past this point
+      // are response-shaping failures of a SUCCEEDED install: log them as
+      // such so the operator doesn't misread the 500 as "nothing happened".
+      const rows = yield* queryEffect<WorkspacePluginRow>(
+        MARKETPLACE_INSTALL_READBACK_SQL,
+        [persistedId, orgId],
+      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+        log.error(
+          {
+            orgId,
+            catalogId: body.catalogId,
+            installationId: persistedId,
+            err: err instanceof Error ? err.message : String(err),
+            requestId,
+          },
+          "Plugin install persisted but the response read-back failed — install is live despite the 500",
+        );
+      })));
+
+      if (rows.length === 0) {
+        log.error(
+          { orgId, catalogId: body.catalogId, installationId: persistedId, requestId },
+          "Plugin install persisted but the read-back found no row — removed concurrently (uninstall or catalog delete)?",
+        );
+        return c.json({
+          error: "internal_error",
+          message: "The plugin was installed, but confirming it failed — it may have been removed concurrently. Refresh the installed-plugins list to verify before retrying.",
+          requestId,
+        }, 500);
+      }
       // F-42: the row fetch echoes back the encrypted `config` blob.
       // Mask before returning — consistent with GET /available behavior and
       // prevents a round-tripping UI from re-submitting raw ciphertext.

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -37,6 +37,12 @@ import {
   parsePlanTier,
 } from "@atlas/api/lib/integrations/install/plan-rank";
 import { isRoutingIdUniqueViolation } from "@atlas/api/lib/integrations/install/routing-id-conflict";
+import {
+  assertSaasEncryptionKeyset,
+  deriveSecretLabel,
+  persistInstallRecord,
+} from "@atlas/api/lib/integrations/install/persist-form-install";
+import type { WorkspaceId } from "@useatlas/types";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 import {
   ErrorSchema,
@@ -165,6 +171,12 @@ interface CatalogRow extends Record<string, unknown> {
   config_schema: unknown;
   min_plan: string;
   enabled: boolean;
+  // 0092 / #2739 — three-pillar taxonomy, NOT NULL in the DB. Typed here
+  // because the install route narrows it (`chat`/`action` only) before
+  // handing the persist to the form-install spine (#4186). This is still
+  // an unvalidated `SELECT *` cast, so the narrow fails closed on any
+  // unexpected value rather than trusting the type.
+  pillar: string;
   // #3301 — false rows are hidden from the marketplace on SaaS deploys
   // (e.g. DuckDB, which is file-path based and not multi-tenant safe).
   // `NOT NULL DEFAULT true` in the DB; the filter still treats only an
@@ -956,6 +968,40 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
         }, 400);
       }
 
+      // #4186 — same routing decision, second axis: the marketplace persists
+      // through the form-install spine, whose singleton upsert serves ONLY the
+      // chat/action pillars (the `workspace_plugins_singleton` partial unique
+      // index). `form`-model rows on other pillars are differently shaped
+      // installs — datasource rows are multi-instance drafts owned by the
+      // ADR-0013 bridge under /admin/connections, knowledge rows are ingested
+      // via their own admin flow — so refuse them here exactly like the
+      // install-model gate above. Fail-closed: an unexpected/missing pillar
+      // (drifted row) is refused, never coerced to 'action'.
+      const catalogPillar =
+        catalogEntry.pillar === "chat" || catalogEntry.pillar === "action"
+          ? catalogEntry.pillar
+          : null;
+      if (catalogPillar === null) {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.install,
+          targetType: "plugin",
+          targetId: body.catalogId,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: body.catalogId,
+            pluginSlug: catalogEntry.slug,
+            orgId,
+            pillarRejected: catalogEntry.pillar ?? "unknown",
+          },
+        });
+        return c.json({
+          error: "pillar_unsupported",
+          message: `"${catalogEntry.slug}" is a ${catalogEntry.pillar ?? "unknown"}-pillar plugin and cannot be installed through the marketplace — use its dedicated flow (datasources connect under Admin → Connections).`,
+          requestId,
+        }, 400);
+      }
+
       // #3301 / #4001 defense-in-depth — the /available listing hides
       // `saas_eligible = false` rows on SaaS, but the install path must also
       // refuse them server-side: a workspace admin who already knows the
@@ -1055,6 +1101,36 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
           requestId,
         }, 422);
       }
+      // #4186 — spine step 1: the SaaS fail-closed keyset gate.
+      // `encryptSecretFields` degrades to plaintext passthrough when no
+      // keyset is configured (dev convenience); on SaaS that would persist
+      // the customer's credential in the clear. Same per-call refusal every
+      // form-install handler runs via `persistFormInstall`. Sync throw, so a
+      // plain try/catch keeps the audit + response shaping here in the route.
+      try {
+        assertSaasEncryptionKeyset(log, orgId as WorkspaceId, deriveSecretLabel(installSchema));
+      } catch (err) {
+        logAdminAction({
+          actionType: ADMIN_ACTIONS.plugin.install,
+          targetType: "plugin",
+          targetId: id,
+          scope: "workspace",
+          status: "failure",
+          metadata: {
+            pluginId: body.catalogId,
+            pluginSlug: catalogEntry.slug,
+            orgId,
+            keysetUnavailable: true,
+          },
+        });
+        return c.json({
+          error: "encryption_unavailable",
+          message: err instanceof Error
+            ? err.message
+            : "Encryption keyset unavailable — refusing to persist plaintext credentials.",
+          requestId,
+        }, 500);
+      }
       let encryptedConfig: Record<string, unknown>;
       try {
         encryptedConfig = encryptSecretFields(body.config ?? {}, installSchema);
@@ -1089,15 +1165,34 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
           requestId,
         }, 500);
       }
-      const rows = yield* queryEffect<WorkspacePluginRow>(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, installed_by)
-         VALUES ($1, $2, $3, $4, $5)
-         RETURNING *, (SELECT name FROM plugin_catalog WHERE id = $3) AS name,
-                     (SELECT slug FROM plugin_catalog WHERE id = $3) AS slug,
-                     (SELECT type FROM plugin_catalog WHERE id = $3) AS type,
-                     (SELECT description FROM plugin_catalog WHERE id = $3) AS description`,
-        [id, orgId, body.catalogId, JSON.stringify(encryptedConfig), userId],
-      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+      // #4186 — spine steps 3+4: the canonical post-0092 singleton upsert
+      // (explicit `install_id` + `pillar`, partial-index conflict target,
+      // returned-id invariant) + the unconditional lazy-loader evict, via
+      // `persistInstallRecord` — the same tested artifact every form/OAuth
+      // install handler persists through. The pre-#4186 hand-rolled INSERT
+      // here omitted `install_id`/`pillar` (both NOT NULL post-0096) and
+      // skipped the evict, so a re-install kept serving a stale cached
+      // PluginLike. Entered at `persistInstallRecord` rather than
+      // `persistFormInstall` because platform-admin-CRUD catalog rows carry
+      // a bare-UUID id, not the seeder's `catalog:<slug>` (so the slug-
+      // derived FK would miss); encryption ran above with the route's own
+      // F-42 audit shaping. On a conflict (TOCTOU race past the 409 check)
+      // the upsert returns the EXISTING row's id, which is what we audit
+      // and respond with.
+      const persistedId = yield* Effect.tryPromise({
+        try: () =>
+          persistInstallRecord({
+            workspaceId: orgId as WorkspaceId,
+            catalogId: body.catalogId,
+            displayName: catalogEntry.name,
+            log,
+            config: encryptedConfig,
+            newId: () => id,
+            pillar: catalogPillar,
+            installedBy: userId,
+          }),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.tapError((err) => Effect.sync(() => {
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.install,
           targetType: "plugin",
@@ -1113,13 +1208,23 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
         });
       })));
 
+      // Fetch the persisted row + joined catalog fields for the response —
+      // the spine's upsert only RETURNs the id.
+      const rows = yield* queryEffect<WorkspacePluginRow>(
+        `SELECT wp.*, pc.name, pc.slug, pc.type, pc.description
+           FROM workspace_plugins wp
+           JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+          WHERE wp.id = $1 AND wp.workspace_id = $2`,
+        [persistedId, orgId],
+      );
+
       if (rows.length === 0) {
         return c.json({ error: "internal_error", message: "Failed to install plugin — no row returned.", requestId }, 500);
       }
       logAdminAction({
         actionType: ADMIN_ACTIONS.plugin.install,
         targetType: "plugin",
-        targetId: id,
+        targetId: persistedId,
         scope: "workspace",
         metadata: {
           pluginId: body.catalogId,
@@ -1127,8 +1232,8 @@ workspaceMarketplace.openapi(installRoute, async (c) => {
           orgId,
         },
       });
-      log.info({ orgId, catalogId: body.catalogId, installationId: id }, "Plugin installed in workspace");
-      // F-42: the RETURNING clause echoes back the encrypted `config` blob.
+      log.info({ orgId, catalogId: body.catalogId, installationId: persistedId }, "Plugin installed in workspace");
+      // F-42: the row fetch echoes back the encrypted `config` blob.
       // Mask before returning — consistent with GET /available behavior and
       // prevents a round-tripping UI from re-submitting raw ciphertext.
       const installResponse = installRowToJson(rows[0]!);

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
@@ -24,7 +24,10 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
-import { buildFormInstallUpsertSql } from "../persist-form-install";
+import {
+  buildFormInstallUpsertSql,
+  MARKETPLACE_INSTALL_READBACK_SQL,
+} from "../persist-form-install";
 import {
   SALESFORCE_CATALOG_ID,
   SALESFORCE_LEGACY_PILLAR_CONVERGE_SQL,
@@ -178,6 +181,16 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
     expect(rows[0]?.install_id).toBe(`mp-a-${stamp}`);
     expect(rows[0]?.pillar).toBe("action");
     expect(rows[0]?.installed_by).toBe("admin-mp-1");
+
+    // The route's response read-back executes VERBATIM too — same
+    // plan-time-drift class the upsert smoke exists for.
+    const readback = await pool.query<{ id: string; name: string; slug: string }>(
+      MARKETPLACE_INSTALL_READBACK_SQL,
+      [`mp-a-${stamp}`, ws],
+    );
+    expect(readback.rows).toHaveLength(1);
+    expect(readback.rows[0]?.name).toBe("Marketplace Form");
+    expect(readback.rows[0]?.slug).toBe("spine-marketplace");
   }, PG_TEST_TIMEOUT_MS);
 
   it("chat pillar variant plans + executes with the same singleton semantics", async () => {

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
@@ -57,7 +57,11 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
       `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
        VALUES
          ('catalog:spine-email', 'Email', 'spine-email', 'integration', 'action', 'form'),
-         ('catalog:spine-chat',  'Chat',  'spine-chat',  'chat',        'chat',   'static-bot')
+         ('catalog:spine-chat',  'Chat',  'spine-chat',  'chat',        'chat',   'static-bot'),
+         -- #4186 marketplace shape: platform-admin CRUD rows carry a bare
+         -- UUID id, NOT the seeder's catalog:<slug> convention.
+         ('5f0f4be2-8a68-4c5e-9f0f-4be28a684c5e', 'Marketplace Form', 'spine-marketplace',
+          'integration', 'action', 'form')
        ON CONFLICT (id) DO NOTHING`,
     );
   }, PG_TEST_TIMEOUT_MS * 2);
@@ -75,21 +79,25 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
     const ws = `ws-spine-${stamp}`;
 
     // Fresh INSERT (config-updating variant) — returns the candidate id.
+    // installed_by ($5) attributes the first installer (#4186).
     const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
       `spine-a-${stamp}`,
       ws,
       "catalog:spine-email",
       JSON.stringify({ host: "smtp.example.com" }),
+      "admin-first",
     ]);
     expect(fresh.rows[0]?.id).toBe(`spine-a-${stamp}`);
 
     // Re-install (conflict path) — config updates, id stays the
     // existing row's (the returned-id invariant the handlers rely on).
+    // A different acting user must NOT overwrite installed_by.
     const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
       `spine-b-${stamp}`,
       ws,
       "catalog:spine-email",
       JSON.stringify({ host: "smtp2.example.com" }),
+      "admin-second",
     ]);
     expect(conflict.rows[0]?.id).toBe(`spine-a-${stamp}`);
 
@@ -99,6 +107,7 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
       ws,
       "catalog:spine-email",
       JSON.stringify({}),
+      null,
     ]);
     expect(stub.rows[0]?.id).toBe(`spine-a-${stamp}`);
 
@@ -108,8 +117,9 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
       config: { host?: string };
       enabled: boolean;
       status: string;
+      installed_by: string | null;
     }>(
-      `SELECT install_id, pillar, config, enabled, status
+      `SELECT install_id, pillar, config, enabled, status, installed_by
          FROM workspace_plugins WHERE workspace_id = $1`,
       [ws],
     );
@@ -120,6 +130,54 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
     expect(rows[0]?.config.host).toBe("smtp2.example.com");
     expect(rows[0]?.enabled).toBe(true);
     expect(rows[0]?.status).toBe("published");
+    // installed_by tracks the FIRST installer — never rewritten on conflict.
+    expect(rows[0]?.installed_by).toBe("admin-first");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("marketplace path (#4186): bare-UUID catalog id + installed_by attribution against the live schema", async () => {
+    // The marketplace POST /install persists through this exact builder via
+    // persistInstallRecord — with the FULL plugin_catalog.id (bare UUID for
+    // CRUD-created rows) and the authenticated admin as installed_by. The
+    // pre-#4186 route hand-rolled an INSERT without install_id/pillar, which
+    // 23502s against the post-0096 schema (both NOT NULL, filler trigger
+    // dropped) — this pins the replacement shape end-to-end.
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-mp-${stamp}`;
+    const catalogId = "5f0f4be2-8a68-4c5e-9f0f-4be28a684c5e";
+
+    const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
+      `mp-a-${stamp}`,
+      ws,
+      catalogId,
+      JSON.stringify({ apiKey: "enc:v1:aaaa:bbbb:cccc" }),
+      "admin-mp-1",
+    ]);
+    expect(fresh.rows[0]?.id).toBe(`mp-a-${stamp}`);
+
+    // Race-path re-install (a second admin slipping past the route's 409
+    // pre-check): existing id returned, installed_by attribution preserved.
+    const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true), [
+      `mp-b-${stamp}`,
+      ws,
+      catalogId,
+      JSON.stringify({ apiKey: "enc:v1:dddd:eeee:ffff" }),
+      "admin-mp-2",
+    ]);
+    expect(conflict.rows[0]?.id).toBe(`mp-a-${stamp}`);
+
+    const { rows } = await pool.query<{
+      install_id: string;
+      pillar: string;
+      installed_by: string | null;
+    }>(
+      `SELECT install_id, pillar, installed_by
+         FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2`,
+      [ws, catalogId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.install_id).toBe(`mp-a-${stamp}`);
+    expect(rows[0]?.pillar).toBe("action");
+    expect(rows[0]?.installed_by).toBe("admin-mp-1");
   }, PG_TEST_TIMEOUT_MS);
 
   it("chat pillar variant plans + executes with the same singleton semantics", async () => {
@@ -135,6 +193,7 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
       ws,
       "catalog:spine-chat",
       JSON.stringify({ chat_id: stamp }),
+      null,
     ]);
     expect(fresh.rows[0]?.id).toBe(`chat-a-${stamp}`);
 
@@ -143,6 +202,7 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
       ws,
       "catalog:spine-chat",
       JSON.stringify({ chat_id: `${stamp}-rotated` }),
+      null,
     ]);
     expect(conflict.rows[0]?.id).toBe(`chat-a-${stamp}`);
 
@@ -184,6 +244,7 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
       ws,
       SALESFORCE_CATALOG_ID,
       JSON.stringify({ instance_url: "https://new.my.salesforce.com" }),
+      null,
     ]);
     expect(upsert.rows[0]?.id).toBe(legacyId);
 

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
@@ -396,9 +396,12 @@ describe("buildFormInstallUpsertSql", () => {
         );
         expect(sql).toContain("RETURNING id");
         expect(sql).toContain(`'${pillar}'`);
-        // #4186 — installed_by ($5) is part of the canonical shape.
+        // #4186 — installed_by ($5) is part of the canonical shape, and
+        // in EVERY variant it attributes the first install only: the
+        // conflict SET must never rewrite it on a re-install.
         expect(sql).toContain("installed_by");
         expect(sql).toContain("$5");
+        expect(sql).not.toMatch(/DO UPDATE[\s\S]*installed_by/);
       }
     }
   });

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
@@ -73,6 +73,7 @@ const SECRET_SCHEMA: ConfigSchema = {
 
 type SpineModule = typeof import("../persist-form-install");
 let persistFormInstall!: SpineModule["persistFormInstall"];
+let persistInstallRecord!: SpineModule["persistInstallRecord"];
 let assertSaasEncryptionKeyset!: SpineModule["assertSaasEncryptionKeyset"];
 let buildFormInstallUpsertSql!: SpineModule["buildFormInstallUpsertSql"];
 let parseFormInstall!: SpineModule["parseFormInstall"];
@@ -81,6 +82,7 @@ let FormInstallValidationError!: SpineModule["FormInstallValidationError"];
 beforeAll(async () => {
   const mod = await import("../persist-form-install");
   persistFormInstall = mod.persistFormInstall;
+  persistInstallRecord = mod.persistInstallRecord;
   assertSaasEncryptionKeyset = mod.assertSaasEncryptionKeyset;
   buildFormInstallUpsertSql = mod.buildFormInstallUpsertSql;
   parseFormInstall = mod.parseFormInstall;
@@ -283,6 +285,31 @@ describe("persistFormInstall — workspace_plugins upsert", () => {
     // One param at the seam — the FK is derived, so a mismatched
     // catalogId/catalogSlug pair is unrepresentable.
     expect(p[2]).toBe("catalog:spine-test");
+    // #4186 — installed_by rides the canonical shape. The form spine has
+    // no acting user at its seam, so it always passes null.
+    expect(p[4]).toBeNull();
+  });
+
+  it("threads installedBy to the upsert when the caller attributes the install (#4186 marketplace)", async () => {
+    const { log } = makeLog();
+    const persistedId = await persistInstallRecord({
+      workspaceId: WSID,
+      catalogId: "bare-uuid-catalog-row", // platform-admin CRUD rows are NOT catalog:<slug>
+      displayName: "Marketplace Row",
+      log,
+      config: { host: "example.com" },
+      newId: () => "candidate-mp",
+      installedBy: "admin-7",
+    });
+    expect(persistedId).toBe("candidate-mp");
+    const [sql, params] = mockInternalQuery.mock.calls[0];
+    expect(sql).toContain("installed_by");
+    const p = params as unknown[];
+    expect(p[2]).toBe("bare-uuid-catalog-row");
+    expect(p[4]).toBe("admin-7");
+    // installed_by attributes the FIRST install only — the conflict SET
+    // must never rewrite it on a re-install.
+    expect(sql).not.toMatch(/DO UPDATE[\s\S]*installed_by/);
   });
 
   it("omits the config overwrite on conflict when updateConfigOnConflict is false", async () => {
@@ -369,6 +396,9 @@ describe("buildFormInstallUpsertSql", () => {
         );
         expect(sql).toContain("RETURNING id");
         expect(sql).toContain(`'${pillar}'`);
+        // #4186 — installed_by ($5) is part of the canonical shape.
+        expect(sql).toContain("installed_by");
+        expect(sql).toContain("$5");
       }
     }
   });

--- a/packages/api/src/lib/integrations/install/persist-form-install.ts
+++ b/packages/api/src/lib/integrations/install/persist-form-install.ts
@@ -103,6 +103,41 @@ export function buildFormInstallUpsertSql(
 }
 
 /**
+ * Read-back for the marketplace install response (#4186): the spine's
+ * upsert only RETURNs the id, and the route's 201 body needs the full
+ * `workspace_plugins` row plus the joined catalog display fields. Lives
+ * next to {@link buildFormInstallUpsertSql} for the same reason that
+ * builder is exported: the real-Postgres smoke executes this exact
+ * string against the live schema, closing the plan-time-SQL-drift class
+ * that broke the pre-spine hand-rolled INSERT.
+ */
+export const MARKETPLACE_INSTALL_READBACK_SQL = `SELECT wp.*, pc.name, pc.slug, pc.type, pc.description
+           FROM workspace_plugins wp
+           JOIN plugin_catalog pc ON pc.id = wp.catalog_id
+          WHERE wp.id = $1 AND wp.workspace_id = $2`;
+
+/**
+ * The keyset gate's refusal, as an identifiable class so route-level
+ * catches can narrow to exactly this failure (`instanceof`) and rethrow
+ * anything else — a broad `catch` around the gate would otherwise
+ * mislabel unrelated throws (e.g. `getEncryptionKeyset`'s malformed-
+ * config parse errors) as "keyset unavailable" and echo their raw
+ * messages to the client (#4186 review). Tagged class rather than
+ * `Data.TaggedError` for the same reason as
+ * {@link FormInstallValidationError}: it throws synchronously out
+ * through legacy Hono handlers that catch via `instanceof`.
+ */
+export class EncryptionKeysetUnavailableError extends Error {
+  readonly _tag = "EncryptionKeysetUnavailableError" as const;
+  constructor() {
+    super(
+      "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
+    );
+    this.name = "EncryptionKeysetUnavailableError";
+  }
+}
+
+/**
  * SaaS keyset gate. `encryptSecret` falls back to plaintext when no key
  * is configured (dev convenience). Boot logs a one-shot warning, but a
  * missed log in SaaS would leak the credential plaintext. Refuse the
@@ -135,9 +170,7 @@ export function assertSaasEncryptionKeyset(
       { workspaceId, ...extraLogFields },
       `Refusing form install: SaaS mode + no encryption keyset (would persist plaintext ${label})`,
     );
-    throw new Error(
-      "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
-    );
+    throw new EncryptionKeysetUnavailableError();
   }
 }
 
@@ -226,10 +259,10 @@ export interface PersistInstallRecordParams {
  * OAuth handlers (GitHub App, GitHub single-tenant, Salesforce, Jira)
  * stop carrying their own copies of the upsert + invariant — the drift
  * class that produced #3357 in the first place. The marketplace
- * `POST /install` route (#4186) is the third consumer: it takes the
- * full `plugin_catalog.id` (which for platform-admin-CRUD rows is a
- * bare UUID, NOT `catalog:<slug>`), so it enters here rather than
- * through {@link persistFormInstall}'s slug-derived FK.
+ * `POST /install` route (#4186) also persists through here: it takes
+ * the full `plugin_catalog.id` (which for platform-admin-CRUD rows is
+ * a bare UUID, NOT `catalog:<slug>`), so it enters at this seam rather
+ * than through {@link persistFormInstall}'s slug-derived FK.
  *
  * The evict is unconditional: a re-install that rotates credentials
  * must never keep serving a stale cached PluginLike built from the

--- a/packages/api/src/lib/integrations/install/persist-form-install.ts
+++ b/packages/api/src/lib/integrations/install/persist-form-install.ts
@@ -72,7 +72,11 @@ type InstallLogger = Pick<ReturnType<typeof createLogger>, "error" | "warn">;
  *
  * `installed_at` is NOT bumped on conflict (matches the Slack OAuth
  * handler) — the column tracks the first install, not the most recent
- * edit.
+ * edit. `installed_by` ($5, nullable) follows the same rule: it
+ * attributes the FIRST installer and is never rewritten on a
+ * re-install. The form handlers have no acting-user id at their seam
+ * and pass null; the marketplace `/install` route (#4186) passes the
+ * authenticated admin's id.
  *
  * Exported so the real-Postgres smoke executes this exact string
  * against the live schema — the drift class that broke the pre-spine
@@ -90,8 +94,8 @@ export function buildFormInstallUpsertSql(
                enabled = true`
     : `SET enabled = true`;
   return `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, '${pillar}', $4::jsonb, true, NOW())
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at, installed_by)
+         VALUES ($1, $2, $3, $1, '${pillar}', $4::jsonb, true, NOW(), $5)
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
          DO UPDATE
            ${conflictSet}
@@ -192,6 +196,14 @@ export interface PersistInstallRecordParams {
   readonly updateConfigOnConflict?: boolean;
   /** Default `'action'` — see {@link buildFormInstallUpsertSql}. */
   readonly pillar?: "chat" | "action";
+  /**
+   * Acting user attributed as `installed_by` (first install only —
+   * never rewritten on conflict, mirroring `installed_at`). Default
+   * `null`: the form/OAuth handlers run below the auth seam and have
+   * no user id; the marketplace `/install` route passes the
+   * authenticated admin's id (#4186).
+   */
+  readonly installedBy?: string | null;
   /** Override for the persist-failure log line. */
   readonly persistFailureMessage?: string;
   /**
@@ -213,7 +225,11 @@ export interface PersistInstallRecordParams {
  * Extracted from {@link persistFormInstall} (#3362 review) so the four
  * OAuth handlers (GitHub App, GitHub single-tenant, Salesforce, Jira)
  * stop carrying their own copies of the upsert + invariant — the drift
- * class that produced #3357 in the first place.
+ * class that produced #3357 in the first place. The marketplace
+ * `POST /install` route (#4186) is the third consumer: it takes the
+ * full `plugin_catalog.id` (which for platform-admin-CRUD rows is a
+ * bare UUID, NOT `catalog:<slug>`), so it enters here rather than
+ * through {@link persistFormInstall}'s slug-derived FK.
  *
  * The evict is unconditional: a re-install that rotates credentials
  * must never keep serving a stale cached PluginLike built from the
@@ -231,6 +247,7 @@ export async function persistInstallRecord(params: PersistInstallRecordParams): 
     newId = () => crypto.randomUUID(),
     updateConfigOnConflict = true,
     pillar = "action",
+    installedBy = null,
     persistFailureMessage = `Failed to persist ${displayName} install record — aborting install`,
     failureLogFields = {},
   } = params;
@@ -240,7 +257,7 @@ export async function persistInstallRecord(params: PersistInstallRecordParams): 
   try {
     const rows = await internalQuery<{ id: string }>(
       buildFormInstallUpsertSql(updateConfigOnConflict, pillar),
-      [candidateId, workspaceId, catalogId, JSON.stringify(config)],
+      [candidateId, workspaceId, catalogId, JSON.stringify(config), installedBy],
     );
     const returned = rows[0]?.id;
     if (typeof returned !== "string" || returned.length === 0) {
@@ -394,8 +411,14 @@ export async function persistFormInstall(
   return { id: persistedId, workspaceId, catalogId: catalogSlug };
 }
 
-/** The `secret: true` field keys of a parsed schema — the gate-log breadcrumb. */
-function deriveSecretLabel(schema: ConfigSchema | undefined): string {
+/**
+ * The `secret: true` field keys of a parsed schema — the gate-log
+ * breadcrumb for {@link assertSaasEncryptionKeyset}. Exported for
+ * callers that run the keyset gate themselves because their persist
+ * enters at {@link persistInstallRecord} (the marketplace `/install`
+ * route, #4186).
+ */
+export function deriveSecretLabel(schema: ConfigSchema | undefined): string {
   if (schema?.state === "parsed") {
     const keys = schema.fields.filter((f) => f.secret === true).map((f) => f.key);
     if (keys.length > 0) return keys.join("/");


### PR DESCRIPTION
# fix(marketplace): route POST /install through the Form-install persistence spine

Closes #4186

## What

`POST /api/v1/admin/plugins/marketplace/install` hand-rolled the `workspace_plugins` write with the pre-0092 INSERT shape: no `install_id`/`pillar` (both NOT NULL since 0092; the filler trigger that papered over the omission was dropped by 0096 — so every marketplace install 23502'd against the live schema, invisible behind the mocked route tests), no `ON CONFLICT`, no lazy-loader evict, no SaaS keyset gate.

The route now persists through the spine:

- **`persistInstallRecord`** — the same tested artifact the form-install spine and OAuth install handlers persist through: canonical singleton upsert (explicit `install_id` + `pillar`, partial-index conflict target, returned-id invariant) + unconditional lazy-loader evict. Entered below `persistFormInstall` because platform-admin-CRUD catalog rows carry bare-UUID ids, not the seeder's `catalog:<slug>` convention.
- **`installed_by` joins the canonical upsert as `$5`** — first-installer attribution, never rewritten on conflict (mirrors `installed_at`). Handlers pass `null`; the marketplace passes the authenticated admin.
- **`assertSaasEncryptionKeyset` gates the marketplace path** — fail-closed 500 + audit instead of plaintext passthrough on a keyless SaaS deploy. The gate's refusal is now an identifiable `EncryptionKeysetUnavailableError` so the route narrows with `instanceof` and rethrows anything else.
- **New pillar gate** — `form`-model rows outside chat/action (datasource, knowledge) are refused 400 like the #3681 install-model gate; the spine's partial singleton index only arbitrates chat/action. Fail-closed on missing/unknown pillar.
- **Truthful failure reporting** — the success audit fires immediately after the persist, before the response read-back, so a read-back failure can never leave a completed credential write unaudited; the read-back's error paths log "install is live despite the 500".

## Tests

- Route test pins the captured INSERT **byte-for-byte** to `buildFormInstallUpsertSql(...)` output (both pillars), so a re-hand-rolled copy can't drift back in; asserts installed_by threading, persisted-id threading (read-back params, audit targetId, response id), evict, pillar/keyset refusals, persist-failure audit, read-back empty-row 500.
- Real-Postgres smoke extends to the marketplace shape: bare-UUID catalog id, `installed_by` preserved across the conflict path, and the route's read-back SQL (`MARKETPLACE_INSTALL_READBACK_SQL`) executed verbatim against the live schema — the same plan-time-drift class that broke the pre-spine INSERT.

## Review

Internal review panel (4 specialist reviewers): round 1 CHANGES REQUESTED (read-back misreporting, broad keyset catch, type/comment accuracy) → fixed; round 2 **CLEAN** across all axes. Local `/ci`: all 27 gates green.

Follow-up (out of this diff's scope, will file): the platform catalog-create INSERT omits `pillar` — same 23502 class on a fresh row, pre-existing.

https://claude.ai/code/session_016oe6U5Ru79uS7DZLy26zVX

---
_Generated by [Claude Code](https://claude.ai/code/session_016oe6U5Ru79uS7DZLy26zVX)_