### PR TITLE
fix(marketplace): platform catalog CRUD names pillar explicitly

### DIFF
--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -666,11 +666,12 @@ describe("Platform Plugin Catalog", () => {
 
       // #4232 — pillar is NOT NULL with no default and the deriving
       // trigger was dropped by 0096: the INSERT must name it explicitly,
-      // derived from type (datasource→datasource).
+      // derived from type (datasource→datasource). Positions pinned by
+      // the builder: $5 = type, $6 = pillar.
       const insert = findCapturedQuery("INSERT INTO plugin_catalog");
       expect(insert?.sql).toContain("pillar");
-      expect(insert?.params).toContain("datasource");
-      expect(insert?.params[insert.params.indexOf("datasource") + 1]).toBe("datasource");
+      expect(insert?.params[4]).toBe("datasource");
+      expect(insert?.params[5]).toBe("datasource");
     });
 
     it("derives the action pillar for non-datasource types (#4232)", async () => {
@@ -688,8 +689,8 @@ describe("Platform Plugin Catalog", () => {
       expect(res.status).toBe(201);
 
       const insert = findCapturedQuery("INSERT INTO plugin_catalog");
-      expect(insert?.params).toContain("sandbox");
-      expect(insert?.params[insert.params.indexOf("sandbox") + 1]).toBe("action");
+      expect(insert?.params[4]).toBe("sandbox");
+      expect(insert?.params[5]).toBe("action");
     });
 
     it("returns 409 on duplicate slug", async () => {
@@ -741,9 +742,9 @@ describe("Platform Plugin Catalog", () => {
       });
       expect(res.status).toBe(200);
 
-      // The dropped 0096 sync trigger's semantics, now in the statement:
-      // re-derive only when type ACTUALLY changes (bare `type` in an
-      // UPDATE's SET reads the OLD row).
+      // The 0092 sync trigger's semantics (dropped by 0096), now in the
+      // statement: re-derive only when type ACTUALLY changes (bare `type`
+      // in an UPDATE's SET reads the OLD row).
       const update = findCapturedQuery("UPDATE plugin_catalog");
       expect(update?.sql).toContain("pillar = CASE WHEN type IS DISTINCT FROM");
       expect(update?.params).toEqual(["action", "action", "cat-1"]);
@@ -769,6 +770,9 @@ describe("Platform Plugin Catalog", () => {
         body: JSON.stringify({}),
       });
       expect(res.status).toBe(400);
+      // #4232 — this is the buildCatalogUpdateSql(...) === null seam.
+      const body = await json(res);
+      expect(body.error).toBe("bad_request");
     });
   });
 

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -663,6 +663,33 @@ describe("Platform Plugin Catalog", () => {
       expect(res.status).toBe(201);
       const body = await json(res);
       expect(body.slug).toBe("bigquery");
+
+      // #4232 — pillar is NOT NULL with no default and the deriving
+      // trigger was dropped by 0096: the INSERT must name it explicitly,
+      // derived from type (datasource→datasource).
+      const insert = findCapturedQuery("INSERT INTO plugin_catalog");
+      expect(insert?.sql).toContain("pillar");
+      expect(insert?.params).toContain("datasource");
+      expect(insert?.params[insert.params.indexOf("datasource") + 1]).toBe("datasource");
+    });
+
+    it("derives the action pillar for non-datasource types (#4232)", async () => {
+      setQueryResult("SELECT id FROM plugin_catalog WHERE slug", []);
+      setQueryResult("INSERT INTO plugin_catalog", [
+        { ...sampleCatalogRow, type: "sandbox", pillar: "action" },
+      ]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Sandbox", slug: "sandbox-x", type: "sandbox" }),
+      });
+      expect(res.status).toBe(201);
+
+      const insert = findCapturedQuery("INSERT INTO plugin_catalog");
+      expect(insert?.params).toContain("sandbox");
+      expect(insert?.params[insert.params.indexOf("sandbox") + 1]).toBe("action");
     });
 
     it("returns 409 on duplicate slug", async () => {
@@ -695,6 +722,31 @@ describe("Platform Plugin Catalog", () => {
       expect(res.status).toBe(200);
       const body = await json(res);
       expect(body.name).toBe("BigQuery v2");
+
+      // A type-less update must not touch pillar (#4232).
+      const update = findCapturedQuery("UPDATE plugin_catalog");
+      expect(update?.sql).not.toContain("pillar");
+    });
+
+    it("re-derives pillar when the update changes type (#4232)", async () => {
+      setQueryResult("UPDATE plugin_catalog", [
+        { ...sampleCatalogRow, type: "action", pillar: "action" },
+      ]);
+
+      const app = buildPlatformApp();
+      const res = await app.request("/catalog/cat-1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: "action" }),
+      });
+      expect(res.status).toBe(200);
+
+      // The dropped 0096 sync trigger's semantics, now in the statement:
+      // re-derive only when type ACTUALLY changes (bare `type` in an
+      // UPDATE's SET reads the OLD row).
+      const update = findCapturedQuery("UPDATE plugin_catalog");
+      expect(update?.sql).toContain("pillar = CASE WHEN type IS DISTINCT FROM");
+      expect(update?.params).toEqual(["action", "action", "cat-1"]);
     });
 
     it("returns 404 for non-existent entry", async () => {

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -47,6 +47,10 @@ import {
 import type { WorkspaceId } from "@useatlas/types";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 import {
+  buildCatalogCreateSql,
+  buildCatalogUpdateSql,
+} from "@atlas/api/lib/integrations/catalog-crud";
+import {
   ErrorSchema,
   AuthErrorSchema,
   createIdParamSchema,
@@ -370,23 +374,8 @@ platformCatalog.openapi(createCatalogRoute, async (c) => {
       // Operator-curated-only gate (#4174/#4099): the one interactive path
       // that creates catalog rows; platform_admin-gated.
       assertOperatorCatalogWrite("platform-admin-crud");
-      const rows = yield* queryEffect<CatalogRow>(
-        `INSERT INTO plugin_catalog (id, name, slug, description, type, npm_package, icon_url, config_schema, min_plan, enabled)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-         RETURNING *`,
-        [
-          id,
-          body.name,
-          body.slug,
-          body.description ?? null,
-          body.type,
-          body.npmPackage ?? null,
-          body.iconUrl ?? null,
-          body.configSchema ? JSON.stringify(body.configSchema) : null,
-          body.minPlan,
-          body.enabled,
-        ],
-      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+      const create = buildCatalogCreateSql(id, body);
+      const rows = yield* queryEffect<CatalogRow>(create.sql, create.params).pipe(Effect.tapError((err) => Effect.sync(() => {
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.catalogCreate,
           targetType: "plugin",
@@ -429,26 +418,10 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
       const { id } = c.req.valid("param");
       const body = c.req.valid("json");
 
-      // Build dynamic SET clause
-      const setClauses: string[] = [];
-      const params: unknown[] = [];
-      let paramIdx = 1;
-
-      if (body.name !== undefined) { setClauses.push(`name = $${paramIdx++}`); params.push(body.name); }
-      if (body.description !== undefined) { setClauses.push(`description = $${paramIdx++}`); params.push(body.description); }
-      if (body.type !== undefined) { setClauses.push(`type = $${paramIdx++}`); params.push(body.type); }
-      if (body.npmPackage !== undefined) { setClauses.push(`npm_package = $${paramIdx++}`); params.push(body.npmPackage); }
-      if (body.iconUrl !== undefined) { setClauses.push(`icon_url = $${paramIdx++}`); params.push(body.iconUrl); }
-      if (body.configSchema !== undefined) { setClauses.push(`config_schema = $${paramIdx++}`); params.push(JSON.stringify(body.configSchema)); }
-      if (body.minPlan !== undefined) { setClauses.push(`min_plan = $${paramIdx++}`); params.push(body.minPlan); }
-      if (body.enabled !== undefined) { setClauses.push(`enabled = $${paramIdx++}`); params.push(body.enabled); }
-
-      if (setClauses.length === 0) {
+      const update = buildCatalogUpdateSql(id, body);
+      if (update === null) {
         return c.json({ error: "bad_request", message: "No fields to update.", requestId }, 400);
       }
-
-      setClauses.push(`updated_at = now()`);
-      params.push(id);
 
       // Keys only — see ADMIN_ACTIONS.plugin JSDoc. configSchema may hint at
       // secret shapes and `enabled: false` carries forensic signal that the
@@ -476,10 +449,7 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
       // Operator-curated-only gate (#4174/#4099): this UPDATE can repoint
       // trust-carrying fields (npm_package, config_schema); platform_admin-gated.
       assertOperatorCatalogWrite("platform-admin-crud");
-      const rows = yield* queryEffect<CatalogRow>(
-        `UPDATE plugin_catalog SET ${setClauses.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
-        params,
-      ).pipe(Effect.tapError((err) => Effect.sync(() => {
+      const rows = yield* queryEffect<CatalogRow>(update.sql, update.params).pipe(Effect.tapError((err) => Effect.sync(() => {
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.catalogUpdate,
           targetType: "plugin",

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -45,7 +45,6 @@ import {
   MARKETPLACE_INSTALL_READBACK_SQL,
 } from "@atlas/api/lib/integrations/install/persist-form-install";
 import type { WorkspaceId } from "@useatlas/types";
-import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 import {
   buildCatalogCreateSql,
   buildCatalogUpdateSql,
@@ -371,9 +370,8 @@ platformCatalog.openapi(createCatalogRoute, async (c) => {
         return c.json({ error: "conflict", message: `A catalog entry with slug "${body.slug}" already exists.`, requestId }, 409);
       }
 
-      // Operator-curated-only gate (#4174/#4099): the one interactive path
-      // that creates catalog rows; platform_admin-gated.
-      assertOperatorCatalogWrite("platform-admin-crud");
+      // Operator-curated-only gate (#4174/#4099) lives inside the builder,
+      // next to the SQL (catalog-crud.ts).
       const create = buildCatalogCreateSql(id, body);
       const rows = yield* queryEffect<CatalogRow>(create.sql, create.params).pipe(Effect.tapError((err) => Effect.sync(() => {
         logAdminAction({
@@ -446,9 +444,8 @@ platformCatalog.openapi(updateCatalogRoute, async (c) => {
         priorLookup = { slug: null, failed: true };
       }
 
-      // Operator-curated-only gate (#4174/#4099): this UPDATE can repoint
-      // trust-carrying fields (npm_package, config_schema); platform_admin-gated.
-      assertOperatorCatalogWrite("platform-admin-crud");
+      // Operator-curated-only gate (#4174/#4099) lives inside the builder,
+      // next to the SQL (catalog-crud.ts).
       const rows = yield* queryEffect<CatalogRow>(update.sql, update.params).pipe(Effect.tapError((err) => Effect.sync(() => {
         logAdminAction({
           actionType: ADMIN_ACTIONS.plugin.catalogUpdate,

--- a/packages/api/src/lib/integrations/__tests__/catalog-crud-pg.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-crud-pg.test.ts
@@ -2,8 +2,8 @@
  * Real-Postgres coverage for the platform-admin catalog CRUD SQL
  * (#4232). Mirrors the `persist-form-install-pg.test.ts` harness: skips
  * cleanly when `TEST_DATABASE_URL` is unset, runs every migration into a
- * unique per-test schema, and executes {@link buildCatalogCreateSql} /
- * {@link buildCatalogUpdateSql} VERBATIM against the live schema.
+ * unique per-test-file schema, and executes {@link buildCatalogCreateSql}
+ * / {@link buildCatalogUpdateSql} VERBATIM against the live schema.
  *
  * What this catches that the mocked route tests can't: plan-time /
  * constraint-time SQL errors. The pre-#4232 `POST /catalog` INSERT
@@ -25,6 +25,7 @@ import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import {
   buildCatalogCreateSql,
   buildCatalogUpdateSql,
+  type CatalogType,
 } from "../catalog-crud";
 
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
@@ -35,12 +36,12 @@ const describeIfPg = TEST_DB_URL ? describe : describe.skip;
 const PG_TEST_TIMEOUT_MS = 30_000;
 
 /** Minimal valid `POST /catalog` body for a given type/slug. */
-function createFields(type: string, slug: string) {
+function createFields(type: CatalogType, slug: string) {
   return {
     name: `Catalog ${slug}`,
     slug,
     type,
-    minPlan: "starter",
+    minPlan: "starter" as const,
     enabled: true,
   };
 }
@@ -79,7 +80,7 @@ describeIfPg("platform catalog CRUD against the live schema (#4232)", () => {
     ["interaction", "action"],
     ["action", "action"],
     ["sandbox", "action"],
-  ])(
+  ] as const)(
     "POST /catalog INSERT executes verbatim for type %s and derives pillar %s",
     async (type, expectedPillar) => {
       const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
@@ -96,7 +97,20 @@ describeIfPg("platform catalog CRUD against the live schema (#4232)", () => {
     PG_TEST_TIMEOUT_MS,
   );
 
-  it("PUT /catalog/:id re-derives pillar when type changes (dropped 0096 sync trigger)", async () => {
+  it("a pillar-less INSERT still 23502s — the schema demands explicit naming", async () => {
+    // Deliberately fails if someone reintroduces a column default or a
+    // deriving trigger: every writer must keep naming pillar (#4232).
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    await expect(
+      pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type)
+         VALUES ($1, $2, $3, 'action')`,
+        [crypto.randomUUID(), "No Pillar", `crud-nopillar-${stamp}`],
+      ),
+    ).rejects.toMatchObject({ code: "23502" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("PUT /catalog/:id re-derives pillar when type changes (0092 sync trigger semantics, dropped by 0096)", async () => {
     const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
     const id = crypto.randomUUID();
     const create = buildCatalogCreateSql(id, createFields("action", `crud-sync-${stamp}`));
@@ -117,6 +131,7 @@ describeIfPg("platform catalog CRUD against the live schema (#4232)", () => {
     await pool.query(create.sql, create.params);
 
     const update = buildCatalogUpdateSql(id, { name: "Renamed" });
+    expect(update).not.toBeNull();
     const { rows } = await pool.query<{ name: string; pillar: string }>(update!.sql, update!.params);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.name).toBe("Renamed");
@@ -125,9 +140,10 @@ describeIfPg("platform catalog CRUD against the live schema (#4232)", () => {
 
   it("PUT /catalog/:id with an unchanged type does NOT clobber an explicit knowledge pillar", async () => {
     // Knowledge-pillar rows (type 'context', pillar 'knowledge' — 0161 /
-    // ADR-0028) are created by the knowledge ingest seam with pillar named
-    // explicitly; the CRUD mapping never derives 'knowledge'. The dropped
-    // sync trigger only re-derived pillar when type ACTUALLY changed
+    // ADR-0028) are created by the built-in knowledge seeder
+    // (`seed-builtin-knowledge-catalog.ts`) with pillar named explicitly;
+    // the CRUD mapping never derives 'knowledge'. The 0092 sync trigger
+    // (dropped by 0096) only re-derived pillar when type ACTUALLY changed
     // (`IS DISTINCT FROM`), so a same-type PUT on a knowledge row must
     // preserve pillar='knowledge' rather than rewrite it to 'action'.
     const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
@@ -139,13 +155,16 @@ describeIfPg("platform catalog CRUD against the live schema (#4232)", () => {
     );
 
     const sameType = buildCatalogUpdateSql(id, { type: "context", name: "OKF v2" });
+    expect(sameType).not.toBeNull();
     const same = await pool.query<{ pillar: string; name: string }>(sameType!.sql, sameType!.params);
     expect(same.rows[0]?.name).toBe("OKF v2");
     expect(same.rows[0]?.pillar).toBe("knowledge");
 
     // An ACTUAL type change re-derives per the mapping — same semantics
-    // the 0092 sync trigger had.
+    // the 0092 sync trigger had. One-way: flipping type back to 'context'
+    // would land on 'action', not 'knowledge' (the mapping can't emit it).
     const changed = buildCatalogUpdateSql(id, { type: "action" });
+    expect(changed).not.toBeNull();
     const after = await pool.query<{ pillar: string }>(changed!.sql, changed!.params);
     expect(after.rows[0]?.pillar).toBe("action");
   }, PG_TEST_TIMEOUT_MS);

--- a/packages/api/src/lib/integrations/__tests__/catalog-crud-pg.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-crud-pg.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Real-Postgres coverage for the platform-admin catalog CRUD SQL
+ * (#4232). Mirrors the `persist-form-install-pg.test.ts` harness: skips
+ * cleanly when `TEST_DATABASE_URL` is unset, runs every migration into a
+ * unique per-test schema, and executes {@link buildCatalogCreateSql} /
+ * {@link buildCatalogUpdateSql} VERBATIM against the live schema.
+ *
+ * What this catches that the mocked route tests can't: plan-time /
+ * constraint-time SQL errors. The pre-#4232 `POST /catalog` INSERT
+ * omitted `pillar` — NOT NULL since 0092, and 0096 dropped
+ * `trg_plugin_catalog_default_pillar` (the BEFORE INSERT trigger that
+ * derived it from `type`) — so every platform catalog create 23502'd at
+ * runtime while the mocked tests stayed green. 0096 also dropped
+ * `trg_plugin_catalog_sync_pillar_on_type_change`, so a `PUT` that
+ * changes `type` silently left `pillar` stale.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import {
+  buildCatalogCreateSql,
+  buildCatalogUpdateSql,
+} from "../catalog-crud";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+// Full migration set + queries can take several seconds on shared CI
+// runners (matches migrate-pg.test.ts's budget).
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+/** Minimal valid `POST /catalog` body for a given type/slug. */
+function createFields(type: string, slug: string) {
+  return {
+    name: `Catalog ${slug}`,
+    slug,
+    type,
+    minPlan: "starter",
+    enabled: true,
+  };
+}
+
+describeIfPg("platform catalog CRUD against the live schema (#4232)", () => {
+  let pool: Pool;
+  const schemaName = `catalog_crud_pg_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`catalog-crud-pg: SET search_path failed on new connection: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`catalog-crud-pg: schema cleanup failed: ${message}`);
+    });
+    await pool.end();
+  });
+
+  // Every type CreateCatalogBodySchema admits, with the pillar the 0092
+  // trigger used to derive (ADR-0006: chat→chat, datasource→datasource,
+  // everything else→action). The route doesn't admit 'chat'/'integration',
+  // but the mapping module serves the catalog-seeder too, which does.
+  it.each([
+    ["datasource", "datasource"],
+    ["context", "action"],
+    ["interaction", "action"],
+    ["action", "action"],
+    ["sandbox", "action"],
+  ])(
+    "POST /catalog INSERT executes verbatim for type %s and derives pillar %s",
+    async (type, expectedPillar) => {
+      const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+      const id = crypto.randomUUID();
+      const create = buildCatalogCreateSql(id, createFields(type, `crud-${type}-${stamp}`));
+
+      // Pre-#4232 this throws 23502: `pillar` is NOT NULL with no default
+      // and the deriving trigger is gone (0096).
+      const { rows } = await pool.query<{ id: string; pillar: string }>(create.sql, create.params);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe(id);
+      expect(rows[0]?.pillar).toBe(expectedPillar);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it("PUT /catalog/:id re-derives pillar when type changes (dropped 0096 sync trigger)", async () => {
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    const id = crypto.randomUUID();
+    const create = buildCatalogCreateSql(id, createFields("action", `crud-sync-${stamp}`));
+    await pool.query(create.sql, create.params);
+
+    const update = buildCatalogUpdateSql(id, { type: "datasource" });
+    expect(update).not.toBeNull();
+    const { rows } = await pool.query<{ type: string; pillar: string }>(update!.sql, update!.params);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe("datasource");
+    expect(rows[0]?.pillar).toBe("datasource");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("PUT /catalog/:id without a type change leaves pillar untouched", async () => {
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    const id = crypto.randomUUID();
+    const create = buildCatalogCreateSql(id, createFields("datasource", `crud-noop-${stamp}`));
+    await pool.query(create.sql, create.params);
+
+    const update = buildCatalogUpdateSql(id, { name: "Renamed" });
+    const { rows } = await pool.query<{ name: string; pillar: string }>(update!.sql, update!.params);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe("Renamed");
+    expect(rows[0]?.pillar).toBe("datasource");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("PUT /catalog/:id with an unchanged type does NOT clobber an explicit knowledge pillar", async () => {
+    // Knowledge-pillar rows (type 'context', pillar 'knowledge' — 0161 /
+    // ADR-0028) are created by the knowledge ingest seam with pillar named
+    // explicitly; the CRUD mapping never derives 'knowledge'. The dropped
+    // sync trigger only re-derived pillar when type ACTUALLY changed
+    // (`IS DISTINCT FROM`), so a same-type PUT on a knowledge row must
+    // preserve pillar='knowledge' rather than rewrite it to 'action'.
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    const id = crypto.randomUUID();
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ($1, $2, $3, 'context', 'knowledge', 'form')`,
+      [id, "OKF Collection", `crud-knowledge-${stamp}`],
+    );
+
+    const sameType = buildCatalogUpdateSql(id, { type: "context", name: "OKF v2" });
+    const same = await pool.query<{ pillar: string; name: string }>(sameType!.sql, sameType!.params);
+    expect(same.rows[0]?.name).toBe("OKF v2");
+    expect(same.rows[0]?.pillar).toBe("knowledge");
+
+    // An ACTUAL type change re-derives per the mapping — same semantics
+    // the 0092 sync trigger had.
+    const changed = buildCatalogUpdateSql(id, { type: "action" });
+    const after = await pool.query<{ pillar: string }>(changed!.sql, changed!.params);
+    expect(after.rows[0]?.pillar).toBe("action");
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/integrations/__tests__/catalog-crud.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-crud.test.ts
@@ -47,10 +47,21 @@ describe("buildCatalogCreateSql", () => {
       enabled: true,
     });
     expect(sql).toContain("pillar");
-    // Param order is pinned by the pg test executing this verbatim; here
-    // just assert the derived pillar rides along with the type.
-    expect(params).toContain("datasource");
-    expect(params[params.indexOf("datasource") + 1]).toBe("datasource");
+    // Full-array pin: constraint-visible drift (id/pillar/NOT NULLs) is
+    // additionally covered by the pg test executing this verbatim.
+    expect(params).toEqual([
+      "id-1",
+      "BigQuery",
+      "bigquery",
+      null,
+      "datasource",
+      "datasource",
+      null,
+      null,
+      null,
+      "starter",
+      true,
+    ]);
   });
 
   it("serializes configSchema and defaults optionals to null", () => {
@@ -62,8 +73,19 @@ describe("buildCatalogCreateSql", () => {
       minPlan: "starter",
       enabled: false,
     });
-    expect(params).toContain('{"fields":[]}');
-    expect(params).toContain(null);
+    expect(params).toEqual([
+      "id-2",
+      "Email",
+      "email",
+      null,
+      "action",
+      "action",
+      null,
+      null,
+      '{"fields":[]}',
+      "starter",
+      false,
+    ]);
   });
 });
 

--- a/packages/api/src/lib/integrations/__tests__/catalog-crud.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-crud.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure-unit coverage for the catalog CRUD SQL builders (#4232). The
+ * live-schema execution of these statements lives in
+ * `catalog-crud-pg.test.ts`; this file pins the pieces that don't need
+ * a database — the ADR-0006 type→pillar mapping and the shape/param
+ * discipline of the dynamic UPDATE builder.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  buildCatalogCreateSql,
+  buildCatalogUpdateSql,
+  pillarFromCatalogType,
+} from "../catalog-crud";
+
+describe("pillarFromCatalogType", () => {
+  // ADR-0006 / the 0092 trigger's CASE: chat→chat, datasource→datasource,
+  // everything else→action. Covers both the CRUD route's admitted types
+  // (datasource/context/interaction/action/sandbox) and the seeder's
+  // (chat/integration), which share this mapping.
+  it.each([
+    ["chat", "chat"],
+    ["datasource", "datasource"],
+    ["context", "action"],
+    ["interaction", "action"],
+    ["action", "action"],
+    ["sandbox", "action"],
+    ["integration", "action"],
+  ] as const)("maps %s → %s", (type, pillar) => {
+    expect(pillarFromCatalogType(type)).toBe(pillar);
+  });
+
+  it("never derives the knowledge pillar (explicit-naming writers only)", () => {
+    // 'knowledge' rows are type 'context' with pillar named by the
+    // knowledge seeder/ingest — the derivation maps context to action.
+    expect(pillarFromCatalogType("context")).not.toBe("knowledge");
+  });
+});
+
+describe("buildCatalogCreateSql", () => {
+  it("names pillar explicitly and derives it from type (#4232)", () => {
+    const { sql, params } = buildCatalogCreateSql("id-1", {
+      name: "BigQuery",
+      slug: "bigquery",
+      type: "datasource",
+      minPlan: "starter",
+      enabled: true,
+    });
+    expect(sql).toContain("pillar");
+    // Param order is pinned by the pg test executing this verbatim; here
+    // just assert the derived pillar rides along with the type.
+    expect(params).toContain("datasource");
+    expect(params[params.indexOf("datasource") + 1]).toBe("datasource");
+  });
+
+  it("serializes configSchema and defaults optionals to null", () => {
+    const { params } = buildCatalogCreateSql("id-2", {
+      name: "Email",
+      slug: "email",
+      type: "action",
+      configSchema: { fields: [] },
+      minPlan: "starter",
+      enabled: false,
+    });
+    expect(params).toContain('{"fields":[]}');
+    expect(params).toContain(null);
+  });
+});
+
+describe("buildCatalogUpdateSql", () => {
+  it("returns null when no updatable field is present", () => {
+    expect(buildCatalogUpdateSql("id-1", {})).toBeNull();
+  });
+
+  it("does not touch pillar when type is absent", () => {
+    const update = buildCatalogUpdateSql("id-1", { name: "Renamed", enabled: false });
+    expect(update).not.toBeNull();
+    expect(update!.sql).not.toContain("pillar");
+    expect(update!.params).toEqual(["Renamed", false, "id-1"]);
+  });
+
+  it("re-derives pillar only when type actually changes (#4232)", () => {
+    const update = buildCatalogUpdateSql("id-1", { type: "datasource" });
+    expect(update).not.toBeNull();
+    // The CASE's bare `type` reads the OLD row in an UPDATE's SET — the
+    // guard that keeps a same-type PUT from clobbering an explicitly
+    // named pillar (e.g. knowledge rows).
+    expect(update!.sql).toContain("pillar = CASE WHEN type IS DISTINCT FROM $1 THEN $2 ELSE pillar END");
+    expect(update!.params).toEqual(["datasource", "datasource", "id-1"]);
+  });
+
+  it("keeps param placeholders aligned when type rides with other fields", () => {
+    const update = buildCatalogUpdateSql("id-9", {
+      name: "New name",
+      type: "sandbox",
+      enabled: true,
+    });
+    expect(update).not.toBeNull();
+    expect(update!.sql).toContain("name = $1");
+    expect(update!.sql).toContain("type = $2");
+    expect(update!.sql).toContain("pillar = CASE WHEN type IS DISTINCT FROM $2 THEN $3 ELSE pillar END");
+    expect(update!.sql).toContain("enabled = $4");
+    expect(update!.sql).toContain("WHERE id = $5");
+    expect(update!.params).toEqual(["New name", "sandbox", "action", true, "id-9"]);
+  });
+});

--- a/packages/api/src/lib/integrations/catalog-crud.ts
+++ b/packages/api/src/lib/integrations/catalog-crud.ts
@@ -11,6 +11,28 @@
  * 23502s in production.
  */
 
+import type { Pillar, PlanTier } from "@useatlas/types";
+
+/**
+ * The `plugin_catalog.type` values the DB admits
+ * (`chk_plugin_catalog_type` in db/schema.ts / migration 0092). The CRUD
+ * route's Zod enum and the seeder's `CatalogEntryType` are both subsets.
+ */
+export type CatalogType =
+  | "datasource"
+  | "context"
+  | "interaction"
+  | "action"
+  | "sandbox"
+  | "chat"
+  | "integration";
+
+/** A statement + its positionally-aligned parameter list. */
+export interface CatalogSqlStatement {
+  readonly sql: string;
+  readonly params: unknown[];
+}
+
 /**
  * Map a `plugin_catalog.type` to its ADR-0006 pillar. Mirrors the
  * BEFORE-INSERT trigger 0092 installed and 0096 dropped
@@ -20,18 +42,31 @@
  * Every `plugin_catalog` writer must name `pillar` explicitly since 0096.
  *
  * `'knowledge'` (0161 / ADR-0028) is deliberately absent: it is never
- * derived from a type — the knowledge seeder/ingest names it explicitly
+ * derived from a type — the built-in knowledge seeder names it explicitly
  * on rows of type `context`, and the update builder below only re-derives
- * pillar when `type` actually changes, so those rows survive CRUD edits.
+ * pillar when `type` actually changes, so those rows survive
+ * type-preserving CRUD edits. A type change away from `context`
+ * re-derives to `action` and is one-way: flipping type back does NOT
+ * restore `knowledge` — re-seed or fix the row manually.
  */
-export function pillarFromCatalogType(type: string): "chat" | "datasource" | "action" {
+export function pillarFromCatalogType(type: CatalogType): Exclude<Pillar, "knowledge"> {
   switch (type) {
     case "chat":
       return "chat";
     case "datasource":
       return "datasource";
-    default:
+    case "context":
+    case "interaction":
+    case "action":
+    case "sandbox":
+    case "integration":
       return "action";
+    default: {
+      // Compile-time exhaustiveness: adding a CatalogType forces a
+      // pillar decision here instead of silently landing on 'action'.
+      const unmapped: never = type;
+      throw new Error(`Unmapped catalog type: ${String(unmapped)}`);
+    }
   }
 }
 
@@ -40,11 +75,11 @@ export interface CatalogCreateFields {
   name: string;
   slug: string;
   description?: string;
-  type: string;
+  type: CatalogType;
   npmPackage?: string;
   iconUrl?: string;
   configSchema?: unknown;
-  minPlan: string;
+  minPlan: PlanTier;
   enabled: boolean;
 }
 
@@ -52,11 +87,11 @@ export interface CatalogCreateFields {
 export interface CatalogUpdateFields {
   name?: string;
   description?: string;
-  type?: string;
+  type?: CatalogType;
   npmPackage?: string;
   iconUrl?: string;
   configSchema?: unknown;
-  minPlan?: string;
+  minPlan?: PlanTier;
   enabled?: boolean;
 }
 
@@ -67,7 +102,7 @@ export interface CatalogUpdateFields {
 export function buildCatalogCreateSql(
   id: string,
   fields: CatalogCreateFields,
-): { sql: string; params: unknown[] } {
+): CatalogSqlStatement {
   // `pillar` named explicitly (#4232): NOT NULL since 0092, and 0096
   // dropped the trigger that used to derive it — omitting it is a 23502
   // on every create.
@@ -98,7 +133,7 @@ export function buildCatalogCreateSql(
 export function buildCatalogUpdateSql(
   id: string,
   fields: CatalogUpdateFields,
-): { sql: string; params: unknown[] } | null {
+): CatalogSqlStatement | null {
   const setClauses: string[] = [];
   const params: unknown[] = [];
   let paramIdx = 1;
@@ -120,6 +155,10 @@ export function buildCatalogUpdateSql(
   }
   if (fields.npmPackage !== undefined) { setClauses.push(`npm_package = $${paramIdx++}`); params.push(fields.npmPackage); }
   if (fields.iconUrl !== undefined) { setClauses.push(`icon_url = $${paramIdx++}`); params.push(fields.iconUrl); }
+  // NOTE the create/update asymmetry, preserved verbatim from the
+  // pre-#4232 route: create maps a falsy configSchema to SQL NULL, while
+  // an update stringifies whatever arrived (`null` → JSONB 'null', a
+  // non-NULL value) — there is no way to clear the column via PUT.
   if (fields.configSchema !== undefined) { setClauses.push(`config_schema = $${paramIdx++}`); params.push(JSON.stringify(fields.configSchema)); }
   if (fields.minPlan !== undefined) { setClauses.push(`min_plan = $${paramIdx++}`); params.push(fields.minPlan); }
   if (fields.enabled !== undefined) { setClauses.push(`enabled = $${paramIdx++}`); params.push(fields.enabled); }

--- a/packages/api/src/lib/integrations/catalog-crud.ts
+++ b/packages/api/src/lib/integrations/catalog-crud.ts
@@ -1,0 +1,135 @@
+/**
+ * SQL artifacts for the platform-admin plugin-catalog CRUD routes
+ * (`api/routes/admin-marketplace.ts` `POST /catalog` + `PUT /catalog/:id`).
+ *
+ * Extracted from the route handlers so real-Postgres coverage
+ * (`__tests__/catalog-crud-pg.test.ts`) can execute the exact statements
+ * the routes run — the same plan-time drift class
+ * `install/persist-form-install-pg.test.ts` exists for (#4186): a mocked
+ * route test can't see a column the live schema requires, so an INSERT
+ * that omits a NOT-NULL column (#4232) stays green in unit tests and
+ * 23502s in production.
+ */
+
+/**
+ * Map a `plugin_catalog.type` to its ADR-0006 pillar. Mirrors the
+ * BEFORE-INSERT trigger 0092 installed and 0096 dropped
+ * (`trg_plugin_catalog_default_pillar`): chat→chat,
+ * datasource→datasource, everything else (context, interaction, action,
+ * sandbox, and the pre-#2650 admin-UI grouping `integration`)→action.
+ * Every `plugin_catalog` writer must name `pillar` explicitly since 0096.
+ *
+ * `'knowledge'` (0161 / ADR-0028) is deliberately absent: it is never
+ * derived from a type — the knowledge seeder/ingest names it explicitly
+ * on rows of type `context`, and the update builder below only re-derives
+ * pillar when `type` actually changes, so those rows survive CRUD edits.
+ */
+export function pillarFromCatalogType(type: string): "chat" | "datasource" | "action" {
+  switch (type) {
+    case "chat":
+      return "chat";
+    case "datasource":
+      return "datasource";
+    default:
+      return "action";
+  }
+}
+
+/** `POST /catalog` body after Zod validation (CreateCatalogBodySchema). */
+export interface CatalogCreateFields {
+  name: string;
+  slug: string;
+  description?: string;
+  type: string;
+  npmPackage?: string;
+  iconUrl?: string;
+  configSchema?: unknown;
+  minPlan: string;
+  enabled: boolean;
+}
+
+/** `PUT /catalog/:id` body after Zod validation (UpdateCatalogBodySchema). */
+export interface CatalogUpdateFields {
+  name?: string;
+  description?: string;
+  type?: string;
+  npmPackage?: string;
+  iconUrl?: string;
+  configSchema?: unknown;
+  minPlan?: string;
+  enabled?: boolean;
+}
+
+/**
+ * The INSERT behind `POST /catalog`, with its parameter list co-located
+ * so SQL and params can't drift apart across call sites.
+ */
+export function buildCatalogCreateSql(
+  id: string,
+  fields: CatalogCreateFields,
+): { sql: string; params: unknown[] } {
+  // `pillar` named explicitly (#4232): NOT NULL since 0092, and 0096
+  // dropped the trigger that used to derive it — omitting it is a 23502
+  // on every create.
+  return {
+    sql: `INSERT INTO plugin_catalog (id, name, slug, description, type, pillar, npm_package, icon_url, config_schema, min_plan, enabled)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING *`,
+    params: [
+      id,
+      fields.name,
+      fields.slug,
+      fields.description ?? null,
+      fields.type,
+      pillarFromCatalogType(fields.type),
+      fields.npmPackage ?? null,
+      fields.iconUrl ?? null,
+      fields.configSchema ? JSON.stringify(fields.configSchema) : null,
+      fields.minPlan,
+      fields.enabled,
+    ],
+  };
+}
+
+/**
+ * The dynamic UPDATE behind `PUT /catalog/:id`. Returns `null` when the
+ * body carries no updatable field (the route maps that to 400).
+ */
+export function buildCatalogUpdateSql(
+  id: string,
+  fields: CatalogUpdateFields,
+): { sql: string; params: unknown[] } | null {
+  const setClauses: string[] = [];
+  const params: unknown[] = [];
+  let paramIdx = 1;
+
+  if (fields.name !== undefined) { setClauses.push(`name = $${paramIdx++}`); params.push(fields.name); }
+  if (fields.description !== undefined) { setClauses.push(`description = $${paramIdx++}`); params.push(fields.description); }
+  if (fields.type !== undefined) {
+    // Keep pillar consistent when type changes (#4232) — the semantics of
+    // `trg_plugin_catalog_sync_pillar_on_type_change`, dropped by 0096.
+    // In an UPDATE's SET, a bare column reference reads the OLD row, so
+    // the CASE re-derives pillar only when type ACTUALLY changes; a
+    // same-type PUT preserves an explicitly-named pillar (e.g. the
+    // knowledge seeder's 'knowledge' rows, which the mapping never emits).
+    const typeIdx = paramIdx++;
+    const pillarIdx = paramIdx++;
+    setClauses.push(`type = $${typeIdx}`);
+    setClauses.push(`pillar = CASE WHEN type IS DISTINCT FROM $${typeIdx} THEN $${pillarIdx} ELSE pillar END`);
+    params.push(fields.type, pillarFromCatalogType(fields.type));
+  }
+  if (fields.npmPackage !== undefined) { setClauses.push(`npm_package = $${paramIdx++}`); params.push(fields.npmPackage); }
+  if (fields.iconUrl !== undefined) { setClauses.push(`icon_url = $${paramIdx++}`); params.push(fields.iconUrl); }
+  if (fields.configSchema !== undefined) { setClauses.push(`config_schema = $${paramIdx++}`); params.push(JSON.stringify(fields.configSchema)); }
+  if (fields.minPlan !== undefined) { setClauses.push(`min_plan = $${paramIdx++}`); params.push(fields.minPlan); }
+  if (fields.enabled !== undefined) { setClauses.push(`enabled = $${paramIdx++}`); params.push(fields.enabled); }
+
+  if (setClauses.length === 0) return null;
+
+  setClauses.push(`updated_at = now()`);
+  params.push(id);
+  return {
+    sql: `UPDATE plugin_catalog SET ${setClauses.join(", ")} WHERE id = $${paramIdx} RETURNING *`,
+    params,
+  };
+}

--- a/packages/api/src/lib/integrations/catalog-crud.ts
+++ b/packages/api/src/lib/integrations/catalog-crud.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Pillar, PlanTier } from "@useatlas/types";
+import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
 /**
  * The `plugin_catalog.type` values the DB admits
@@ -103,6 +104,11 @@ export function buildCatalogCreateSql(
   id: string,
   fields: CatalogCreateFields,
 ): CatalogSqlStatement {
+  // Operator-curated-only gate (#4174/#4099), moved here from the route
+  // with the SQL: the statement can't be obtained without passing it.
+  // The one interactive path that creates catalog rows; platform_admin-
+  // gated at the route.
+  assertOperatorCatalogWrite("platform-admin-crud");
   // `pillar` named explicitly (#4232): NOT NULL since 0092, and 0096
   // dropped the trigger that used to derive it — omitting it is a 23502
   // on every create.
@@ -165,6 +171,10 @@ export function buildCatalogUpdateSql(
 
   if (setClauses.length === 0) return null;
 
+  // Operator-curated-only gate (#4174/#4099) — this UPDATE can repoint
+  // trust-carrying fields (npm_package, config_schema); asserted only
+  // when a statement is actually built (an empty body writes nothing).
+  assertOperatorCatalogWrite("platform-admin-crud");
   setClauses.push(`updated_at = now()`);
   params.push(id);
   return {

--- a/packages/api/src/lib/integrations/catalog-seeder.ts
+++ b/packages/api/src/lib/integrations/catalog-seeder.ts
@@ -47,6 +47,7 @@ import {
   type ImplementationStatus,
 } from "@useatlas/types";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
+import { pillarFromCatalogType } from "@atlas/api/lib/integrations/catalog-crud";
 
 const log = createLogger("integrations.catalog-seeder");
 
@@ -549,12 +550,13 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
       : JSON.stringify(entry.configSchema);
 
   // Derived per the three-pillar taxonomy (ADR-0006 / migration 0092).
-  // Migration 0097 (#2744 hotfix) dropped the BEFORE-INSERT trigger that
-  // used to default this from `type`, so every writer must name pillar
-  // explicitly. Datasource rows are seeded by
-  // `seed-builtin-datasource-catalog.ts` (pillar='datasource'); this
-  // seeder only handles 'chat' + 'integration' rows.
-  const pillar = pillarFromType(entry.type);
+  // Migration 0096 dropped the BEFORE-INSERT trigger that used to default
+  // this from `type`, so every writer must name pillar explicitly.
+  // Datasource rows are seeded by `seed-builtin-datasource-catalog.ts`
+  // (pillar='datasource'); this seeder only handles 'chat' +
+  // 'integration' rows. Shared mapping (#4232): catalog-crud.ts is the
+  // one statement of type→pillar for every explicit-naming writer.
+  const pillar = pillarFromCatalogType(entry.type);
 
   // Operator-curated-only gate (#4174/#4099): rows here come from the
   // operator's own atlas.config.ts declaration.
@@ -594,17 +596,6 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
       configSchemaJson,
     ],
   );
-}
-
-/**
- * Map `CatalogEntry.type` to `plugin_catalog.pillar`. Mirrors the
- * mapping enforced by the 0092 BEFORE-INSERT trigger (dropped by 0097):
- * chat→chat, integration→action. `'datasource'` is handled by a
- * separate seeder so it isn't represented here — the type union doesn't
- * admit it.
- */
-function pillarFromType(type: CatalogEntryType): "chat" | "action" {
-  return type === "chat" ? "chat" : "action";
 }
 
 /**

--- a/packages/api/src/lib/integrations/catalog-seeder.ts
+++ b/packages/api/src/lib/integrations/catalog-seeder.ts
@@ -555,7 +555,9 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
   // Datasource rows are seeded by `seed-builtin-datasource-catalog.ts`
   // (pillar='datasource'); this seeder only handles 'chat' +
   // 'integration' rows. Shared mapping (#4232): catalog-crud.ts is the
-  // one statement of type→pillar for every explicit-naming writer.
+  // one statement of the type→pillar DERIVATION — used by the CRUD
+  // routes and this seeder; the built-in datasource/knowledge/OpenAPI
+  // seeds name pillar as SQL literals and don't derive.
   const pillar = pillarFromCatalogType(entry.type);
 
   // Operator-curated-only gate (#4174/#4099): rows here come from the

--- a/packages/api/src/lib/plugins/__tests__/catalog-provenance.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/catalog-provenance.test.ts
@@ -52,7 +52,10 @@ const GUARD_IMPORT = 'from "@atlas/api/lib/plugins/catalog-provenance"';
  * #4099.
  */
 const KNOWN_CATALOG_WRITE_SITES = {
-  "packages/api/src/api/routes/admin-marketplace.ts": "platform-admin-crud",
+  // #4232 — the platform-admin CRUD SQL moved out of the route into the
+  // catalog-crud builders (verbatim-executed by catalog-crud-pg.test.ts);
+  // the guard moved with it, so the SQL can't be built without passing it.
+  "packages/api/src/lib/integrations/catalog-crud.ts": "platform-admin-crud",
   "packages/api/src/lib/db/seed-builtin-datasource-catalog.ts":
     "builtin-datasource-seed",
   "packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts":


### PR DESCRIPTION
## Summary
- `POST /catalog` inserted into `plugin_catalog` without `pillar` — NOT NULL since migration 0092 with no default, and 0096 dropped `trg_plugin_catalog_default_pillar` — so every platform-admin catalog create failed with 23502 at runtime, invisible behind the mocked route tests. `PUT /catalog/:id` had the companion bug: 0096 also dropped the sync trigger, so a `type` change left `pillar` stale.
- The CRUD SQL is extracted into `lib/integrations/catalog-crud.ts` so real-Postgres coverage executes it **verbatim** (the `persist-form-install-pg.test.ts` drift class, #4186): `buildCatalogCreateSql` derives pillar via `pillarFromCatalogType` (the 0092 trigger's ADR-0006 mapping: chat→chat, datasource→datasource, else→action, compile-time-exhaustive over `CatalogType`); `buildCatalogUpdateSql` re-derives pillar in-statement only when `type` ACTUALLY changes (`CASE WHEN type IS DISTINCT FROM $n` over the OLD row), so a same-type PUT can't clobber an explicitly named pillar (knowledge rows, 0161/ADR-0028 — a type change away from `context` is a documented one-way ratchet).
- The operator-catalog-write gate (`assertOperatorCatalogWrite("platform-admin-crud")`) moved into the builders with the SQL — the statement can't be built without passing it — and the write-site registry follows. `catalog-seeder` consolidates its private type→pillar copy onto the shared derivation.

## Test plan
- [x] `catalog-crud-pg.test.ts` (real PG): create INSERT verbatim for all 5 admitted types with derived pillar (red pre-fix: 23502 ×5), pillar-less INSERT still 23502s (schema pin), type-change re-derivation, name-only no-touch, knowledge same-type no-clobber + one-way re-derive — 9/9 green against a fully-migrated local schema
- [x] `catalog-crud.test.ts` (pure unit): full ADR-0006 mapping incl. seeder-only types, full-array param pins, builder-null on empty body, placeholder alignment with mixed fields — 14/14
- [x] `admin-marketplace.test.ts` (mocked route seam): INSERT params carry derived pillar ($5/$6), PUT with type carries the `IS DISTINCT FROM` pillar CASE, type-less PUT doesn't touch pillar, empty-PUT 400 asserts the builder-null seam — 101 pass
- [x] `catalog-provenance.test.ts` write-site registry green with the gate relocated
- [x] `/review-panel` round 1 CLEAN (all four specialists; MEDIUMs fixed in-branch)
- [x] `/ci` local wrapper: all 27 gates green (faithful posture); `-pg` suites additionally exercised green against real local Postgres

Closes #4232