### PR TITLE
docs: KB guide — SaaS-first prerequisites + operator-guardrail settings framing

### DIFF
--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -8,9 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The Knowledge Base is Atlas's fourth integration pillar (alongside datasources, chat platforms, and action targets, shipped in `v0.0.40`): a place to host the knowledge that informs data answers but isn't schema — business rules, runbooks, product definitions, deprecation notices. You upload it as plain markdown, review it, publish it, and the agent reads it alongside your semantic layer when answering questions.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
-- An internal database configured (`DATABASE_URL`)
-- A user with the `admin` role
+On [app.useatlas.dev](https://app.useatlas.dev) there is nothing to set up — the Knowledge Base is available to every workspace admin out of the box. Self-hosted deployments need the internal database (`DATABASE_URL`) and [managed auth](/deployment/authentication#managed-auth): collections are organization-scoped, so the no-auth dev mode (`ATLAS_AUTH_MODE=none`) cannot reach them.
 </Callout>
 
 ---
@@ -42,7 +40,7 @@ The endpoint can be anything that serves a tarball or zip, including git-forge r
 
 ## Uploading a bundle
 
-Upload collections accept `.tar`, `.tar.gz`/`.tgz`, and `.zip` bundles. A plain folder of markdown files works — ingest is deliberately lenient:
+Upload collections accept `.tar`, `.tar.gz`/`.tgz`, and `.zip` bundles. A folder of plain markdown files — archived in any of those formats — works; ingest is deliberately lenient:
 
 - Documents missing OKF `type` or `title` frontmatter have them stamped at ingest, so stored documents are always conformant OKF.
 - Documents with *malformed* frontmatter are rejected per-file, not silently repaired.
@@ -102,7 +100,7 @@ Uninstalling a collection **archives** its documents — they leave the agent's 
 
 ## Settings
 
-All Knowledge Base knobs live in the settings registry — platform-scoped, adjustable from the admin console without a redeploy (self-hosted deployments can also set them as environment variables):
+All Knowledge Base knobs are platform-scoped operator guardrails (abuse caps and budgets), not workspace preferences. On the hosted SaaS they are managed by Atlas. Self-hosted deployments adjust them from the admin console at runtime — they live in the settings registry, so no redeploy — or set them as environment variables:
 
 | Setting | Default | What it does |
 |---------|---------|--------------|


### PR DESCRIPTION
Accuracy pass on the Knowledge Base guide (`apps/docs/content/docs/guides/knowledge-base.mdx`) prompted by review feedback: the prerequisites and settings framing read self-hosted-first for a SaaS-first product.

**Prerequisites callout.** Previously listed "managed auth enabled / internal DB / a user with the `admin` role" — circular for a feature that lives behind the admin console, and all three are givens on app.useatlas.dev. Now SaaS-first: nothing to set up on hosted; self-hosted needs `DATABASE_URL` + managed auth. The managed-auth requirement is real and now explained: collections are organization-scoped — `requireOrgContext` (`packages/api/src/api/routes/admin-router.ts`) returns 400 without an `activeOrganizationId`, which `ATLAS_AUTH_MODE=none` can never provide (verified against code, not just asserted).

**Settings intro.** Said the knobs are "adjustable from the admin console", but all six are `scope: "platform"`, `saasVisible: false` (`packages/api/src/lib/settings.ts:1382-1465`) — a SaaS *workspace* admin can't see or change them. Now framed as what they are: platform-scoped operator guardrails, Atlas-managed on hosted, runtime-tunable (settings registry, no redeploy) or env-settable on self-hosted.

**Upload wording.** "A plain folder of markdown files works" could read as raw-directory upload; the folder must be archived (`.tar`/`.tar.gz`/`.zip` — `bundle-archive.ts` accepts only those container formats). Tightened.

A full 20-claim verification of the guide against the implementation found no other hard inaccuracies (sync semantics, draft/publish lifecycle, egress hardening, searchKnowledge tiers, mirror/ToC behavior all check out). Follow-up issues filed from the same review: #4235 (per-tier KB caps via plan limits), #4236 (hot-reload `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS`).

https://claude.ai/code/session_01DGfTzGkdXbbM7UqqVcx5bz