### PR TITLE
refactor(cli): shared workspace-REST client + command shell (#4196)

### DIFF
--- a/packages/cli/src/__tests__/credential.test.ts
+++ b/packages/cli/src/__tests__/credential.test.ts
@@ -12,8 +12,10 @@ import { describe, it, expect } from "bun:test";
 
 import {
   credentialHeaders,
+  NOT_LOGGED_IN_MESSAGE,
   readApiKeyFlag,
   resolveCredential,
+  resolveWorkspaceCredential,
   type CliCredential,
 } from "../lib/credential";
 
@@ -82,6 +84,50 @@ describe("readApiKeyFlag — both flag forms (#4112)", () => {
 
   it("does not consume a following flag as the key value", () => {
     expect(readApiKeyFlag(["sql", "SELECT 1", "--api-key", "--json"])).toBeUndefined();
+  });
+});
+
+describe("resolveWorkspaceCredential — the shared login/exit shape (#4196)", () => {
+  const session = { token: "sess_abc" };
+  function capture(): { io: { err: (l: string) => void }; err: string[] } {
+    const err: string[] = [];
+    return { io: { err: (l) => err.push(l) }, err };
+  }
+
+  it("prefers the `--api-key` flag over both ATLAS_API_KEY and the session", () => {
+    const { io, err } = capture();
+    const cred = resolveWorkspaceCredential(
+      ["metric", "run", "gmv", "--api-key", "flag_key"],
+      { apiKey: "env_key", session },
+      io,
+    );
+    expect(cred).toEqual({ apiKey: "flag_key" });
+    expect(err).toHaveLength(0);
+  });
+
+  it("falls back to deps.apiKey (ATLAS_API_KEY) over the session", () => {
+    const { io } = capture();
+    expect(resolveWorkspaceCredential(["metric", "run", "gmv"], { apiKey: "env_key", session }, io)).toEqual({
+      apiKey: "env_key",
+    });
+  });
+
+  it("uses the stored session when no key is present", () => {
+    const { io } = capture();
+    expect(resolveWorkspaceCredential(["metric", "run", "gmv"], { session }, io)).toEqual({
+      token: "sess_abc",
+    });
+  });
+
+  it("returns null and emits the shared not-logged-in copy when neither is present", () => {
+    const { io, err } = capture();
+    const cred = resolveWorkspaceCredential(["metric", "run", "gmv"], { session: null }, io);
+    expect(cred).toBeNull();
+    // The copy names BOTH remedies (login + the unattended key) — what the
+    // command suites assert via `.toContain("atlas login")` / `"ATLAS_API_KEY"`.
+    expect(err).toEqual([NOT_LOGGED_IN_MESSAGE]);
+    expect(NOT_LOGGED_IN_MESSAGE).toContain("atlas login");
+    expect(NOT_LOGGED_IN_MESSAGE).toContain("ATLAS_API_KEY");
   });
 });
 

--- a/packages/cli/src/__tests__/http.test.ts
+++ b/packages/cli/src/__tests__/http.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Shared workspace-HTTP primitives (#4196) — unit tests.
+ *
+ * `lib/http.ts` is the ONE fetch → timeout → ok → error-map execution path the
+ * lifecycle clients (`sql`/`metric`/`datasource`) ride, plus the byte-identical
+ * status copy (`defaultWorkspaceErrorInfo`) they share. The per-command suites
+ * exercise these through each client; this pins the shared units directly so the
+ * status→copy table + the transport invariants are tested ONCE, not re-asserted
+ * per client.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  asRecord,
+  defaultWorkspaceErrorInfo,
+  isAbortOrTimeout,
+  NO_WORKSPACE_MESSAGE,
+  serverMessage,
+  SESSION_INVALID_MESSAGE,
+  unreachableMessage,
+  workspaceRequest,
+  type WorkspaceRequestTarget,
+} from "../lib/http";
+import type { CliCredential } from "../lib/credential";
+
+const BASE = "http://localhost:3001";
+const TOKEN = "sess_bearer";
+
+/** A minimal typed error so we can assert the client's `toError`/`toNetworkError` ran. */
+class StubError extends Error {
+  constructor(
+    readonly kind: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "StubError";
+  }
+}
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | undefined;
+}
+
+/** One canned response, capturing method/url/headers/body. */
+function stubFetch(status: number, body: unknown): { fetchImpl: typeof fetch; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) new Headers(init.headers as Record<string, string>).forEach((v, k) => (headers[k] = v));
+    calls.push({
+      url: typeof url === "string" ? url : url.toString(),
+      method: init?.method ?? "GET",
+      headers,
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+    return new Response(body === undefined ? "" : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function target(fetchImpl: typeof fetch, credential: CliCredential = { token: TOKEN }): WorkspaceRequestTarget {
+  return { baseUrl: BASE, credential, fetchImpl };
+}
+
+const HANDLERS = {
+  toError: (status: number, body: Record<string, unknown>) =>
+    new StubError(`err_${status}`, serverMessage(body, status)),
+  toNetworkError: (message: string) => new StubError("network", message),
+  timeoutMessage: (seconds: number) => `Timed out after ${seconds}s doing the thing.`,
+};
+
+// ---------------------------------------------------------------------------
+
+describe("defaultWorkspaceErrorInfo — the shared status→copy table (#4196)", () => {
+  it("401 → unauthorized with the shared re-login copy", () => {
+    expect(defaultWorkspaceErrorInfo(401, { error: "auth_error" })).toEqual({
+      kind: "unauthorized",
+      message: SESSION_INVALID_MESSAGE,
+    });
+  });
+
+  it("400 bad_request → no_workspace with the shared guidance", () => {
+    expect(defaultWorkspaceErrorInfo(400, { error: "bad_request" })).toEqual({
+      kind: "no_workspace",
+      message: NO_WORKSPACE_MESSAGE,
+    });
+  });
+
+  it("a non-bad_request 400 → request_failed (the client special-cases its own 400s first)", () => {
+    const info = defaultWorkspaceErrorInfo(400, { error: "invalid_sql", message: "bad table" });
+    expect(info.kind).toBe("request_failed");
+    expect(info.message).toContain("bad table");
+  });
+
+  it("any other status → request_failed surfacing the server message + requestId", () => {
+    const info = defaultWorkspaceErrorInfo(500, { message: "boom", requestId: "req-9" });
+    expect(info.kind).toBe("request_failed");
+    expect(info.message).toBe("boom (request req-9)");
+  });
+
+  it("the shared copy names the actionable remedy", () => {
+    expect(SESSION_INVALID_MESSAGE).toContain("atlas login");
+    expect(NO_WORKSPACE_MESSAGE).toContain("not bound to a workspace");
+  });
+});
+
+describe("workspaceRequest — the shared transport (#4196)", () => {
+  it("POSTs to baseUrl+path with the credential header, Content-Type, and the JSON body", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { ok: true });
+    const out = await workspaceRequest(
+      target(fetchImpl),
+      { method: "POST", path: "/api/v1/execute-sql", body: { sql: "SELECT 1" } },
+      HANDLERS,
+    );
+    expect(out).toEqual({ ok: true });
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(`${BASE}/api/v1/execute-sql`);
+    expect(calls[0].headers["authorization"]).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0].headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(calls[0].body!)).toEqual({ sql: "SELECT 1" });
+  });
+
+  it("an api-key credential rides x-api-key, never Authorization", async () => {
+    const { fetchImpl, calls } = stubFetch(200, {});
+    await workspaceRequest(
+      target(fetchImpl, { apiKey: "atlas_wk_1" }),
+      { method: "GET", path: "/api/v1/admin/connections" },
+      HANDLERS,
+    );
+    expect(calls[0].headers["x-api-key"]).toBe("atlas_wk_1");
+    expect(calls[0].headers["authorization"]).toBeUndefined();
+  });
+
+  it("omits the body and Content-Type on a GET with no body", async () => {
+    const { fetchImpl, calls } = stubFetch(200, {});
+    await workspaceRequest(target(fetchImpl), { method: "GET", path: "/api/v1/admin/connections" }, HANDLERS);
+    expect(calls[0].body).toBeUndefined();
+    expect(calls[0].headers["content-type"]).toBeUndefined();
+  });
+
+  it("forwards a DELETE (no body) verbatim — the method contract covers all three verbs", async () => {
+    const { fetchImpl, calls } = stubFetch(200, { success: true });
+    await workspaceRequest(
+      target(fetchImpl),
+      { method: "DELETE", path: "/api/v1/admin/connections/prod-us" },
+      HANDLERS,
+    );
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].body).toBeUndefined();
+    expect(calls[0].headers["content-type"]).toBeUndefined();
+  });
+
+  it("degrades an empty/non-JSON 2xx body to {} rather than throwing", async () => {
+    const { fetchImpl } = stubFetch(200, undefined); // empty body
+    const out = await workspaceRequest(target(fetchImpl), { method: "POST", path: "/p", body: {} }, HANDLERS);
+    expect(out).toEqual({});
+  });
+
+  it("routes a non-2xx through the client's toError(status, body)", async () => {
+    const { fetchImpl } = stubFetch(403, { error: "forbidden", message: "nope" });
+    const err = await workspaceRequest(target(fetchImpl), { method: "GET", path: "/p" }, HANDLERS).catch((e) => e);
+    expect(err).toBeInstanceOf(StubError);
+    expect((err as StubError).kind).toBe("err_403");
+    expect((err as StubError).message).toContain("nope");
+  });
+
+  it("a timeout throws the client's network error with the timeout copy", async () => {
+    const fetchImpl = (() => {
+      const e = new Error("aborted");
+      e.name = "TimeoutError";
+      return Promise.reject(e);
+    }) as unknown as typeof fetch;
+    const err = await workspaceRequest(
+      { baseUrl: BASE, credential: { token: TOKEN }, fetchImpl, timeoutMs: 5_000 },
+      { method: "GET", path: "/p" },
+      HANDLERS,
+    ).catch((e) => e);
+    expect((err as StubError).kind).toBe("network");
+    expect((err as StubError).message).toBe("Timed out after 5s doing the thing.");
+  });
+
+  it("an unreachable API throws the client's network error naming the base URL", async () => {
+    const fetchImpl = (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+    const err = await workspaceRequest(
+      { baseUrl: BASE, credential: { token: TOKEN }, fetchImpl },
+      { method: "GET", path: "/p" },
+      HANDLERS,
+    ).catch((e) => e);
+    expect((err as StubError).kind).toBe("network");
+    expect((err as StubError).message).toContain(BASE);
+    expect((err as StubError).message).toContain("ECONNREFUSED");
+  });
+});
+
+describe("pure helpers", () => {
+  it("asRecord narrows objects and degrades non-objects to {}", () => {
+    expect(asRecord({ a: 1 })).toEqual({ a: 1 });
+    expect(asRecord(null)).toEqual({});
+    expect(asRecord("x")).toEqual({});
+  });
+
+  it("serverMessage prefers message > error > HTTP status and appends a requestId", () => {
+    expect(serverMessage({ message: "m" }, 400)).toBe("m");
+    expect(serverMessage({ error: "e" }, 400)).toBe("e");
+    expect(serverMessage({}, 418)).toBe("HTTP 418");
+    expect(serverMessage({ message: "m", requestId: "r1" }, 400)).toBe("m (request r1)");
+  });
+
+  it("serverMessage treats empty-string envelope fields as absent (the `.length > 0` guards)", () => {
+    // An empty `message` must fall through to `error`, not surface as "".
+    expect(serverMessage({ message: "", error: "e" }, 400)).toBe("e");
+    // An empty `error` (and message) must fall through to the HTTP status.
+    expect(serverMessage({ message: "", error: "" }, 500)).toBe("HTTP 500");
+    // An empty `requestId` must NOT produce a dangling "(request )" suffix.
+    expect(serverMessage({ message: "m", requestId: "" }, 400)).toBe("m");
+  });
+
+  it("isAbortOrTimeout recognizes TimeoutError and AbortError only", () => {
+    const t = new Error("x");
+    t.name = "TimeoutError";
+    const a = new Error("x");
+    a.name = "AbortError";
+    expect(isAbortOrTimeout(t)).toBe(true);
+    expect(isAbortOrTimeout(a)).toBe(true);
+    expect(isAbortOrTimeout(new Error("other"))).toBe(false);
+  });
+
+  it("unreachableMessage names the base URL and the underlying error", () => {
+    expect(unreachableMessage(BASE, new Error("down"))).toBe(`Could not reach the Atlas API at ${BASE}: down`);
+  });
+});

--- a/packages/cli/src/__tests__/workspace-command.test.ts
+++ b/packages/cli/src/__tests__/workspace-command.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The shared workspace-command shell (#4196) — unit tests.
+ *
+ * `runWorkspaceCommand` is the ONE place the REST-backed subcommands gather
+ * their credential inputs (base URL, stored session, `ATLAS_API_KEY`) and apply
+ * the process exit code — boilerplate that used to live verbatim in five
+ * `handleX` shells. This pins that gather-deps + exit-code contract ONCE so it
+ * isn't re-tested per command.
+ *
+ * `../lib/api-base` and `../lib/credentials` are mocked (Bun requires
+ * mock.module() to precede the import) so the shell is exercised without reading
+ * `ATLAS_API_URL`/disk; `process.exit` is spied so a non-zero exit is observed
+ * rather than killing the runner.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+import type { StoredSession } from "../lib/credentials";
+
+const SESSION: StoredSession = {
+  token: "sess_shell",
+  workspaceId: "org-shell",
+  createdAt: "2026-07-02T00:00:00Z",
+};
+
+let baseUrlToReturn = "http://api.shell.test";
+let sessionToReturn: StoredSession | null = null;
+/** Captures the base URL `runWorkspaceCommand` passes to `readSession`. */
+let readSessionArg: string | undefined;
+
+// Mock the two IO-touching helpers BEFORE importing the shell under test.
+mock.module("../lib/api-base", () => ({
+  resolveApiBaseUrl: () => baseUrlToReturn,
+}));
+mock.module("../lib/credentials", () => ({
+  defaultConfigDir: () => "/tmp/atlas-test",
+  credentialsPath: () => "/tmp/atlas-test/credentials.json",
+  normalizeBaseUrl: (u: string) => u,
+  readSession: (baseUrl: string) => {
+    readSessionArg = baseUrl;
+    return sessionToReturn;
+  },
+  saveSession: () => {},
+  updateSessionWorkspace: () => {},
+  clearSession: () => {},
+}));
+
+import { runWorkspaceCommand, type WorkspaceCommandDeps } from "../lib/workspace-command";
+
+describe("runWorkspaceCommand", () => {
+  let exitSpy: ReturnType<typeof spyOn>;
+  let origApiKey: string | undefined;
+
+  beforeEach(() => {
+    baseUrlToReturn = "http://api.shell.test";
+    sessionToReturn = null;
+    readSessionArg = undefined;
+    origApiKey = process.env.ATLAS_API_KEY;
+    delete process.env.ATLAS_API_KEY;
+    // Record the exit code without terminating the runner.
+    exitSpy = spyOn(process, "exit").mockImplementation(((_code?: number) => undefined) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    if (origApiKey === undefined) delete process.env.ATLAS_API_KEY;
+    else process.env.ATLAS_API_KEY = origApiKey;
+  });
+
+  it("threads the resolved base URL and stored session into the core deps", async () => {
+    sessionToReturn = SESSION;
+    let seen: WorkspaceCommandDeps | undefined;
+    await runWorkspaceCommand(["sql", "SELECT 1"], async (_args, deps) => {
+      seen = deps;
+      return 0;
+    });
+    expect(seen?.baseUrl).toBe("http://api.shell.test");
+    expect(seen?.session).toEqual(SESSION);
+    expect(seen?.apiKey).toBeUndefined();
+    // The session is read for the SAME base URL the deps carry — a wrong-URL
+    // read would load another workspace's session (or none) under a custom
+    // ATLAS_API_URL. tsgo catches a dropped arg; this pins the value.
+    expect(readSessionArg).toBe("http://api.shell.test");
+  });
+
+  it("forwards argv unchanged to the core", async () => {
+    let seenArgs: string[] | undefined;
+    await runWorkspaceCommand(["metric", "run", "gmv", "--json"], async (args) => {
+      seenArgs = args;
+      return 0;
+    });
+    expect(seenArgs).toEqual(["metric", "run", "gmv", "--json"]);
+  });
+
+  it("picks up ATLAS_API_KEY (trimmed) as the unattended-CI credential", async () => {
+    process.env.ATLAS_API_KEY = "  atlas_wk_env  ";
+    let seen: WorkspaceCommandDeps | undefined;
+    await runWorkspaceCommand(["sql", "SELECT 1"], async (_a, deps) => {
+      seen = deps;
+      return 0;
+    });
+    expect(seen?.apiKey).toBe("atlas_wk_env");
+  });
+
+  it("omits apiKey when ATLAS_API_KEY is empty/whitespace (no `apiKey: \"\"`)", async () => {
+    process.env.ATLAS_API_KEY = "   ";
+    let seen: WorkspaceCommandDeps | undefined;
+    await runWorkspaceCommand(["sql", "SELECT 1"], async (_a, deps) => {
+      seen = deps;
+      return 0;
+    });
+    expect(seen?.apiKey).toBeUndefined();
+    expect("apiKey" in (seen ?? {})).toBe(false);
+  });
+
+  it("does NOT exit on a zero exit code (the process ends naturally)", async () => {
+    await runWorkspaceCommand(["sql", "SELECT 1"], async () => 0);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits with the core's non-zero code", async () => {
+    await runWorkspaceCommand(["sql", "SELECT 1"], async () => 1);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("passes the exact exit code through (not a hardcoded 1)", async () => {
+    // A distinct code proves the shell threads the core's return value rather
+    // than exiting 1 on any failure.
+    await runWorkspaceCommand(["sql", "SELECT 1"], async () => 2);
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+});

--- a/packages/cli/src/commands/datasource.ts
+++ b/packages/cli/src/commands/datasource.ts
@@ -27,9 +27,7 @@
 
 import type { ConnectionDetail } from "@useatlas/types";
 import { renderTable } from "../../lib/output";
-import { resolveApiBaseUrl } from "../lib/api-base";
-import { readApiKeyFlag, resolveCredential } from "../lib/credential";
-import { readSession, type StoredSession } from "../lib/credentials";
+import { resolveWorkspaceCredential } from "../lib/credential";
 import { createProgressTracker } from "../progress";
 import {
   DatasourceCliError,
@@ -52,6 +50,12 @@ import {
   type DeferredSecret,
   type SecretCaptureDeps,
 } from "../lib/datasource-secret";
+import {
+  defaultCliIO,
+  runWorkspaceCommand,
+  type CliIO,
+  type WorkspaceCommandDeps,
+} from "../lib/workspace-command";
 
 const USAGE = `Manage the datasources of your logged-in workspace.
 
@@ -110,28 +114,14 @@ function isDatasourceSubcommand(value: string): value is DatasourceSubcommand {
   return (DATASOURCE_SUBCOMMANDS as readonly string[]).includes(value);
 }
 
-/** stdout/stderr sink — injected so tests can capture output. */
-export interface DatasourceIO {
-  readonly out: (line: string) => void;
-  readonly err: (line: string) => void;
-}
+/** stdout/stderr sink — the shared {@link CliIO}, injected so tests can capture output. */
+export type DatasourceIO = CliIO;
 
-const defaultIO: DatasourceIO = {
-  out: (line) => console.log(line),
-  err: (line) => console.error(line),
-};
-
-/** Everything `runDatasource` needs, injected so it stays server-free in tests. */
-export interface DatasourceRunDeps {
-  readonly baseUrl: string;
-  readonly session: StoredSession | null;
-  /**
-   * A workspace-scoped API key for unattended CI (#4046), resolved from the
-   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
-   * precedence over the stored session — CI never goes through `atlas login`.
-   */
-  readonly apiKey?: string;
-  readonly fetchImpl?: typeof fetch;
+/**
+ * Everything `runDatasource` needs — the shared {@link WorkspaceCommandDeps} plus
+ * the datasource-only secret-capture wiring for `create`.
+ */
+export interface DatasourceRunDeps extends WorkspaceCommandDeps {
   /**
    * Secret-capture probes + prompt for `create` (injected so tests exercise the
    * env/stdin/defer branches without a real TTY). Defaults to the live
@@ -284,7 +274,7 @@ function renderProfileResult(io: DatasourceIO, result: ProfileResult): void {
 export async function runDatasource(
   args: string[],
   deps: DatasourceRunDeps,
-  io: DatasourceIO = defaultIO,
+  io: DatasourceIO = defaultCliIO,
 ): Promise<number> {
   const subcommand = args[1];
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
@@ -300,13 +290,10 @@ export async function runDatasource(
 
   // A workspace API key (#4046, unattended CI) takes precedence over a stored
   // login; the flag (either `--api-key key` or `--api-key=key`) wins over the env
-  // var (deps.apiKey). Keys are workspace-pinned, so no rebind is needed.
-  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
-  const credential = resolveCredential(apiKey, deps.session);
-  if (!credential) {
-    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
-    return 1;
-  }
+  // var (deps.apiKey). Keys are workspace-pinned, so no rebind is needed. The
+  // shared resolver emits the "log in or set ATLAS_API_KEY" copy on `io.err`.
+  const credential = resolveWorkspaceCredential(args, deps, io);
+  if (!credential) return 1;
 
   const opts: DatasourceClientOptions = {
     baseUrl: deps.baseUrl,
@@ -672,19 +659,10 @@ function liveSecretCapture(): SecretCaptureDeps {
   };
 }
 
-/** Thin shell main() invokes: resolve the credential + base URL, then dispatch. */
+/** Thin shell main() invokes: the shared workspace-command shell dispatches the
+ * core, adding the live secret-capture wiring `create` needs. */
 export async function handleDatasource(args: string[]): Promise<void> {
-  const baseUrl = resolveApiBaseUrl();
-  const session = readSession(baseUrl);
-  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
-  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
-  // interactive login). `--api-key` (parsed in runDatasource) overrides it.
-  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
-  const code = await runDatasource(args, {
-    baseUrl,
-    session,
-    ...(apiKey ? { apiKey } : {}),
-    secretCapture: liveSecretCapture(),
-  });
-  if (code !== 0) process.exit(code);
+  return runWorkspaceCommand(args, (a, deps) =>
+    runDatasource(a, { ...deps, secretCapture: liveSecretCapture() }),
+  );
 }

--- a/packages/cli/src/commands/explore.ts
+++ b/packages/cli/src/commands/explore.ts
@@ -15,10 +15,14 @@
  * server or `process.exit`. `handleExplore` is the thin shell main() calls.
  */
 
-import { resolveApiBaseUrl } from "../lib/api-base";
-import { credentialHeaders, resolveCredential } from "../lib/credential";
-import { readSession, type StoredSession } from "../lib/credentials";
-import { asRecord, serverMessage } from "../lib/http";
+import { credentialHeaders, resolveCredential, NOT_LOGGED_IN_MESSAGE } from "../lib/credential";
+import { asRecord, serverMessage, SESSION_INVALID_MESSAGE } from "../lib/http";
+import {
+  defaultCliIO,
+  runWorkspaceCommand,
+  type CliIO,
+  type WorkspaceCommandDeps,
+} from "../lib/workspace-command";
 
 const USAGE = `Run a read-only command against your logged-in workspace's semantic layer.
 
@@ -43,29 +47,11 @@ Authentication: \`atlas login\` for interactive use (ambient session reuse — n
 key needed), OR a workspace API key via --api-key / ATLAS_API_KEY for unattended
 CI. Set ATLAS_API_URL to target a non-local API.`;
 
-/** stdout/stderr sink — injected so tests can capture output. */
-export interface ExploreIO {
-  readonly out: (line: string) => void;
-  readonly err: (line: string) => void;
-}
+/** stdout/stderr sink — the shared {@link CliIO}, injected so tests can capture output. */
+export type ExploreIO = CliIO;
 
-const defaultIO: ExploreIO = {
-  out: (line) => console.log(line),
-  err: (line) => console.error(line),
-};
-
-/** Everything `runExplore` needs, injected so it stays server-free in tests. */
-export interface ExploreRunDeps {
-  readonly baseUrl: string;
-  readonly session: StoredSession | null;
-  /**
-   * A workspace-scoped API key for unattended CI (#4046), resolved from the
-   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
-   * precedence over the stored session — CI never goes through `atlas login`.
-   */
-  readonly apiKey?: string;
-  readonly fetchImpl?: typeof fetch;
-}
+/** Everything `runExplore` needs — the shared {@link WorkspaceCommandDeps}. */
+export type ExploreRunDeps = WorkspaceCommandDeps;
 
 /** Response shape from `POST /api/v1/explore`. */
 interface ExploreResponse {
@@ -122,7 +108,7 @@ function parseExploreArgs(args: string[]): { command: string; apiKey?: string } 
 export async function runExplore(
   args: string[],
   deps: ExploreRunDeps,
-  io: ExploreIO = defaultIO,
+  io: ExploreIO = defaultCliIO,
 ): Promise<number> {
   if (args.includes("--help") || args.includes("-h")) {
     io.out(USAGE);
@@ -143,7 +129,7 @@ export async function runExplore(
   const apiKey = argApiKey ?? deps.apiKey;
   const credential = resolveCredential(apiKey, deps.session);
   if (!credential) {
-    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
+    io.err(NOT_LOGGED_IN_MESSAGE);
     return 1;
   }
 
@@ -168,7 +154,7 @@ export async function runExplore(
   }
 
   if (res.status === 401) {
-    io.err("Your session is no longer valid. Run `atlas login` again.");
+    io.err(SESSION_INVALID_MESSAGE);
     return 1;
   }
   if (!res.ok) {
@@ -201,14 +187,7 @@ export async function runExplore(
   return 0;
 }
 
-/** Thin shell main() invokes: resolve the credential + base URL, then dispatch. */
+/** Thin shell main() invokes: the shared workspace-command shell dispatches the core. */
 export async function handleExplore(args: string[]): Promise<void> {
-  const baseUrl = resolveApiBaseUrl();
-  const session = readSession(baseUrl);
-  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
-  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
-  // interactive login). `--api-key` (parsed in runExplore) overrides it.
-  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
-  const code = await runExplore(args, { baseUrl, session, ...(apiKey ? { apiKey } : {}) });
-  if (code !== 0) process.exit(code);
+  return runWorkspaceCommand(args, runExplore);
 }

--- a/packages/cli/src/commands/metric.ts
+++ b/packages/cli/src/commands/metric.ts
@@ -19,16 +19,21 @@
  * server or `process.exit`. `handleMetric` is the thin shell main() calls.
  */
 
+import { getFlag } from "../../lib/cli-utils";
 import { renderTable } from "../../lib/output";
-import { resolveApiBaseUrl } from "../lib/api-base";
-import { readApiKeyFlag, resolveCredential } from "../lib/credential";
-import { readSession, type StoredSession } from "../lib/credentials";
+import { resolveWorkspaceCredential } from "../lib/credential";
 import {
   MetricCliError,
   runMetric,
   type MetricClientOptions,
   type MetricRunResult,
 } from "../lib/metric-client";
+import {
+  defaultCliIO,
+  runWorkspaceCommand,
+  type CliIO,
+  type WorkspaceCommandDeps,
+} from "../lib/workspace-command";
 
 const USAGE = `Run a canonical metric against your logged-in workspace.
 
@@ -50,36 +55,11 @@ Authentication: \`atlas login\` for interactive use (ambient session reuse — n
 key needed), OR a workspace API key via --api-key / ATLAS_API_KEY for unattended
 CI. Set ATLAS_API_URL to target a non-local API.`;
 
-/** stdout/stderr sink — injected so tests can capture output. */
-export interface MetricIO {
-  readonly out: (line: string) => void;
-  readonly err: (line: string) => void;
-}
+/** stdout/stderr sink — the shared {@link CliIO}, injected so tests can capture output. */
+export type MetricIO = CliIO;
 
-const defaultIO: MetricIO = {
-  out: (line) => console.log(line),
-  err: (line) => console.error(line),
-};
-
-/** Everything `runMetricCommand` needs, injected so it stays server-free in tests. */
-export interface MetricRunDeps {
-  readonly baseUrl: string;
-  readonly session: StoredSession | null;
-  /**
-   * A workspace-scoped API key for unattended CI (#4046), resolved from the
-   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
-   * precedence over the stored session — CI never goes through `atlas login`.
-   */
-  readonly apiKey?: string;
-  readonly fetchImpl?: typeof fetch;
-}
-
-/** Read a `--flag value` option from argv, or undefined when absent. */
-function getFlagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx === args.length - 1) return undefined;
-  return args[idx + 1];
-}
+/** Everything `runMetricCommand` needs — the shared {@link WorkspaceCommandDeps}. */
+export type MetricRunDeps = WorkspaceCommandDeps;
 
 /** Flags whose following token is a value, not the metric id positional. */
 const METRIC_VALUE_FLAGS = new Set(["--connection", "--api-key"]);
@@ -136,7 +116,7 @@ function renderResult(io: MetricIO, result: MetricRunResult): void {
 export async function runMetricCommand(
   args: string[],
   deps: MetricRunDeps,
-  io: MetricIO = defaultIO,
+  io: MetricIO = defaultCliIO,
 ): Promise<number> {
   const subcommand = args[1];
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
@@ -161,16 +141,13 @@ export async function runMetricCommand(
   // A workspace API key (#4046, unattended CI) takes precedence over a stored
   // login; the flag (either `--api-key key` or `--api-key=key`) wins over the env
   // var (deps.apiKey) so an interactive override is possible. Keys are
-  // workspace-pinned, so no rebind is needed.
-  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
-  const credential = resolveCredential(apiKey, deps.session);
-  if (!credential) {
-    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
-    return 1;
-  }
+  // workspace-pinned, so no rebind is needed. The shared resolver emits the
+  // "log in or set ATLAS_API_KEY" copy on `io.err` when neither is present.
+  const credential = resolveWorkspaceCredential(args, deps, io);
+  if (!credential) return 1;
 
   const json = args.includes("--json");
-  const connectionId = getFlagValue(args, "--connection");
+  const connectionId = getFlag(args, "--connection");
 
   const opts: MetricClientOptions = {
     baseUrl: deps.baseUrl,
@@ -200,14 +177,7 @@ export async function runMetricCommand(
   }
 }
 
-/** Thin shell main() invokes: resolve the credential + base URL, then dispatch. */
+/** Thin shell main() invokes: the shared workspace-command shell dispatches the core. */
 export async function handleMetric(args: string[]): Promise<void> {
-  const baseUrl = resolveApiBaseUrl();
-  const session = readSession(baseUrl);
-  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
-  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
-  // interactive login). `--api-key` (parsed in runMetricCommand) overrides it.
-  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
-  const code = await runMetricCommand(args, { baseUrl, session, ...(apiKey ? { apiKey } : {}) });
-  if (code !== 0) process.exit(code);
+  return runWorkspaceCommand(args, runMetricCommand);
 }

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -27,14 +27,17 @@ import {
   quoteCsvField,
   renderTable,
 } from "../../lib/output";
-import { resolveApiBaseUrl } from "../lib/api-base";
 import {
-  readApiKeyFlag,
-  resolveCredential,
   credentialHeaders,
+  resolveWorkspaceCredential,
   type CliCredential,
 } from "../lib/credential";
-import { readSession, type StoredSession } from "../lib/credentials";
+import {
+  defaultCliIO,
+  runWorkspaceCommand,
+  type CliIO,
+  type WorkspaceCommandDeps,
+} from "../lib/workspace-command";
 
 // --- Types ---
 
@@ -61,29 +64,11 @@ interface QueryAPIError {
   message: string;
 }
 
-/** stdout/stderr sink — injected so tests can capture output (mirrors `sql.ts`). */
-export interface QueryIO {
-  readonly out: (line: string) => void;
-  readonly err: (line: string) => void;
-}
+/** stdout/stderr sink — the shared {@link CliIO}, injected so tests can capture output. */
+export type QueryIO = CliIO;
 
-const defaultIO: QueryIO = {
-  out: (line) => console.log(line),
-  err: (line) => console.error(line),
-};
-
-/** Everything `runQueryCommand` needs, injected so it stays server-free in tests. */
-export interface QueryRunDeps {
-  readonly baseUrl: string;
-  readonly session: StoredSession | null;
-  /**
-   * A workspace-scoped API key for unattended CI (#4046), resolved from the
-   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
-   * precedence over the stored session — CI never goes through `atlas login`.
-   */
-  readonly apiKey?: string;
-  readonly fetchImpl?: typeof fetch;
-}
+/** Everything `runQueryCommand` needs — the shared {@link WorkspaceCommandDeps}. */
+export type QueryRunDeps = WorkspaceCommandDeps;
 
 // --- Action approval ---
 
@@ -152,7 +137,7 @@ export async function handleActionApproval(
 export async function runQueryCommand(
   args: string[],
   deps: QueryRunDeps,
-  io: QueryIO = defaultIO,
+  io: QueryIO = defaultCliIO,
 ): Promise<number> {
   // The question is the first positional after "query" that isn't a flag and
   // isn't the value consumed by a value-taking flag (`--connection <id>`,
@@ -204,14 +189,9 @@ export async function runQueryCommand(
   // Resolve the workspace credential exactly like `sql`/`datasource`: a key
   // (the `--api-key` flag, else `ATLAS_API_KEY`) wins over the stored login.
   // A key rides `x-api-key`; a session bearer rides `Authorization: Bearer`.
-  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
-  const credential = resolveCredential(apiKey, deps.session);
-  if (!credential) {
-    io.err(
-      "Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.",
-    );
-    return 1;
-  }
+  // The shared resolver emits the "log in or set ATLAS_API_KEY" copy on `io.err`.
+  const credential = resolveWorkspaceCredential(args, deps, io);
+  if (!credential) return 1;
 
   const apiUrl = deps.baseUrl.replace(/\/$/, "");
   const fetchImpl = deps.fetchImpl ?? fetch;
@@ -427,17 +407,7 @@ export async function runQueryCommand(
 
 // --- Main handler ---
 
-/** Thin shell main() invokes: resolve the credential inputs + base URL, dispatch. */
+/** Thin shell main() invokes: the shared workspace-command shell dispatches the core. */
 export async function handleQuery(args: string[]): Promise<void> {
-  const baseUrl = resolveApiBaseUrl();
-  const session = readSession(baseUrl);
-  // ATLAS_API_KEY (#4046) is the unattended-CI credential — NOT persisted to
-  // ~/.atlas/credentials. `--api-key` (parsed in runQueryCommand) overrides it.
-  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
-  const code = await runQueryCommand(args, {
-    baseUrl,
-    session,
-    ...(apiKey ? { apiKey } : {}),
-  });
-  if (code !== 0) process.exit(code);
+  return runWorkspaceCommand(args, runQueryCommand);
 }

--- a/packages/cli/src/commands/sql.ts
+++ b/packages/cli/src/commands/sql.ts
@@ -24,10 +24,9 @@
  * server or `process.exit`. `handleSql` is the thin shell main() calls.
  */
 
+import { getFlag } from "../../lib/cli-utils";
 import { formatCsvValue, quoteCsvField, renderTable } from "../../lib/output";
-import { resolveApiBaseUrl } from "../lib/api-base";
-import { readApiKeyFlag } from "../lib/credential";
-import { readSession, type StoredSession } from "../lib/credentials";
+import { readApiKeyFlag, NOT_LOGGED_IN_MESSAGE } from "../lib/credential";
 import { resolveActiveWorkspace, formatWorkspaceError } from "../lib/workspaces";
 import {
   SqlCliError,
@@ -35,6 +34,12 @@ import {
   type SqlClientOptions,
   type SqlRunResult,
 } from "../lib/sql-client";
+import {
+  defaultCliIO,
+  runWorkspaceCommand,
+  type CliIO,
+  type WorkspaceCommandDeps,
+} from "../lib/workspace-command";
 
 const USAGE = `Run a single validated SELECT against your logged-in workspace.
 
@@ -63,36 +68,11 @@ Authentication: \`atlas login\` for interactive use (ambient session reuse — n
 key needed), OR a workspace API key via --api-key / ATLAS_API_KEY for unattended
 CI. Set ATLAS_API_URL to target a non-local API.`;
 
-/** stdout/stderr sink — injected so tests can capture output. */
-export interface SqlIO {
-  readonly out: (line: string) => void;
-  readonly err: (line: string) => void;
-}
+/** stdout/stderr sink — the shared {@link CliIO}, injected so tests can capture output. */
+export type SqlIO = CliIO;
 
-const defaultIO: SqlIO = {
-  out: (line) => console.log(line),
-  err: (line) => console.error(line),
-};
-
-/** Everything `runSqlCommand` needs, injected so it stays server-free in tests. */
-export interface SqlRunDeps {
-  readonly baseUrl: string;
-  readonly session: StoredSession | null;
-  /**
-   * A workspace-scoped API key for unattended CI (#4046), resolved from the
-   * `--api-key` flag or the `ATLAS_API_KEY` env var. When present it takes
-   * precedence over the stored session — CI never goes through `atlas login`.
-   */
-  readonly apiKey?: string;
-  readonly fetchImpl?: typeof fetch;
-}
-
-/** Read a `--flag value` option from argv, or undefined when absent. */
-function getFlagValue(args: string[], flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx === args.length - 1) return undefined;
-  return args[idx + 1];
-}
+/** Everything `runSqlCommand` needs — the shared {@link WorkspaceCommandDeps}. */
+export type SqlRunDeps = WorkspaceCommandDeps;
 
 /** Render a result as CSV (headers + rows), pipe-friendly. */
 function renderCsv(io: SqlIO, result: SqlRunResult): void {
@@ -124,7 +104,7 @@ function renderResult(io: SqlIO, result: SqlRunResult): void {
 export async function runSqlCommand(
   args: string[],
   deps: SqlRunDeps,
-  io: SqlIO = defaultIO,
+  io: SqlIO = defaultCliIO,
 ): Promise<number> {
   if (args.includes("--help") || args.includes("-h")) {
     io.out(USAGE);
@@ -138,7 +118,7 @@ export async function runSqlCommand(
     return 1;
   }
 
-  const connectionId = getFlagValue(args, "--connection");
+  const connectionId = getFlag(args, "--connection");
 
   // The SQL is the first positional after `sql` that isn't a flag and isn't the
   // value consumed by a value-taking flag (`--connection <id>`, `--workspace <id>`,
@@ -189,7 +169,7 @@ export async function runSqlCommand(
   }
 
   if (!deps.session) {
-    io.err("Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.");
+    io.err(NOT_LOGGED_IN_MESSAGE);
     return 1;
   }
 
@@ -252,14 +232,7 @@ async function runAndRender(
   }
 }
 
-/** Thin shell main() invokes: resolve the credential + base URL, then dispatch. */
+/** Thin shell main() invokes: the shared workspace-command shell dispatches the core. */
 export async function handleSql(args: string[]): Promise<void> {
-  const baseUrl = resolveApiBaseUrl();
-  const session = readSession(baseUrl);
-  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
-  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
-  // interactive login). `--api-key` (parsed in runSqlCommand) overrides it.
-  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
-  const code = await runSqlCommand(args, { baseUrl, session, ...(apiKey ? { apiKey } : {}) });
-  if (code !== 0) process.exit(code);
+  return runWorkspaceCommand(args, runSqlCommand);
 }

--- a/packages/cli/src/lib/credential.ts
+++ b/packages/cli/src/lib/credential.ts
@@ -95,3 +95,35 @@ export function resolveCredential(
   if (session) return { token: session.token };
   return null;
 }
+
+/**
+ * The "log in or set ATLAS_API_KEY" message every REST-backed subcommand
+ * surfaces when neither credential is present. Single-sourced so the copy can't
+ * drift across `sql`/`metric`/`query`/`explore`/`datasource` (#4196).
+ */
+export const NOT_LOGGED_IN_MESSAGE =
+  "Not logged in. Run `atlas login` first, or set ATLAS_API_KEY for unattended use.";
+
+/**
+ * Resolve the workspace credential for a command that doesn't rebind the active
+ * workspace (`metric`/`query`/`datasource` — `sql` interleaves the `--workspace`
+ * rebind and stays inline; `explore` pre-parses its key out of the command
+ * string). A `--api-key` flag or `ATLAS_API_KEY` (already collapsed into
+ * `deps.apiKey`) wins over the stored `atlas login` session. When neither is
+ * present, emits the shared {@link NOT_LOGGED_IN_MESSAGE} to `io.err` and returns
+ * `null` so the caller exits 1 — the login/exit-code shape is defined once here,
+ * not re-tested per client.
+ */
+export function resolveWorkspaceCredential(
+  args: string[],
+  deps: { readonly apiKey?: string; readonly session: { readonly token: string } | null },
+  io: { readonly err: (line: string) => void },
+): CliCredential | null {
+  const apiKey = readApiKeyFlag(args) ?? deps.apiKey;
+  const credential = resolveCredential(apiKey, deps.session);
+  if (!credential) {
+    io.err(NOT_LOGGED_IN_MESSAGE);
+    return null;
+  }
+  return credential;
+}

--- a/packages/cli/src/lib/datasource-client.ts
+++ b/packages/cli/src/lib/datasource-client.ts
@@ -44,7 +44,16 @@ import {
   parseDatasourceProfileStreamEvent,
 } from "@useatlas/schemas";
 import { credentialHeaders, type CliCredential } from "./credential";
-import { asRecord, isAbortOrTimeout, serverMessage, unreachableMessage, type FetchImpl } from "./http";
+import {
+  asRecord,
+  defaultWorkspaceErrorInfo,
+  NO_WORKSPACE_MESSAGE,
+  serverMessage,
+  SESSION_INVALID_MESSAGE,
+  unreachableMessage,
+  workspaceRequest,
+  type FetchImpl,
+} from "./http";
 
 /**
  * The server `error`-field discriminators this client branches on, pinned to the
@@ -128,108 +137,88 @@ interface RequestSpec {
 }
 
 /**
- * Issue one request against an admin-connection route and return its parsed
- * JSON body, mapping every documented failure status onto a typed
- * {@link DatasourceCliError} with an actionable message. The 403 branch
- * distinguishes the admin-role denial (the admin-role gate this surface is built
- * around — it fires for the read ops too, not just mutations) from the
- * admin-MFA-enrollment gate, since the remedies differ.
+ * Map a non-2xx admin-connection `(status, body)` onto a typed
+ * {@link DatasourceCliError}. Only the statuses that diverge from the shared
+ * default are spelled out; 401 (re-login), 400 `bad_request` (no-workspace), and
+ * any other status fall through to {@link defaultWorkspaceErrorInfo} so the
+ * byte-identical copy is defined once (#4196). The 403 branch distinguishes the
+ * admin-role denial (the admin-role gate this surface is built around — it fires
+ * for the read ops too, not just mutations) from the admin-MFA-enrollment gate,
+ * since the remedies differ; it closes over the operation label for that copy.
  */
-async function request(
-  opts: DatasourceClientOptions,
-  spec: RequestSpec,
-): Promise<unknown> {
-  const fetchImpl = opts.fetchImpl ?? fetch;
-  const timeoutMs = opts.timeoutMs ?? 30_000;
-
-  let res: Response;
-  try {
-    res = await fetchImpl(`${opts.baseUrl}${spec.path}`, {
-      method: spec.method,
-      headers: {
-        ...credentialHeaders(opts.credential),
-        ...(spec.body !== undefined ? { "Content-Type": "application/json" } : {}),
-      },
-      ...(spec.body !== undefined ? { body: JSON.stringify(spec.body) } : {}),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (err) {
-    if (isAbortOrTimeout(err)) {
-      throw new DatasourceCliError(
-        "network",
-        `Timed out after ${Math.round(timeoutMs / 1000)}s trying to ${spec.operation}.`,
-      );
-    }
-    throw new DatasourceCliError("network", unreachableMessage(opts.baseUrl, err));
-  }
-
-  if (res.ok) {
-    // intentionally ignored: a 2xx with an empty/non-JSON body degrades to {} —
-    // callers tolerate missing optional fields rather than crashing on parse.
-    return await res.json().catch(() => ({}));
-  }
-
-  // intentionally ignored: an error body that isn't JSON falls back to the
-  // HTTP-status message below via the empty record.
-  const body = asRecord(await res.json().catch(() => ({})));
-
-  switch (res.status) {
-    case 401:
-      throw new DatasourceCliError(
-        "unauthorized",
-        "Your session is no longer valid. Run `atlas login` again.",
-      );
+function toDatasourceError(
+  operation: string,
+  status: number,
+  body: Record<string, unknown>,
+): DatasourceCliError {
+  switch (status) {
     case 403: {
       if (body.error === ERR.mfaEnrollmentRequired) {
-        throw new DatasourceCliError("mfa_required", MFA_ENROLLMENT_MESSAGE);
+        return new DatasourceCliError("mfa_required", MFA_ENROLLMENT_MESSAGE);
       }
-      throw new DatasourceCliError(
+      return new DatasourceCliError(
         "forbidden",
-        `Cannot ${spec.operation}: the workspace admin role is required. Your login does not carry it — ask a workspace admin to run this, or sign in with an admin account (\`atlas login\`).`,
+        `Cannot ${operation}: the workspace admin role is required. Your login does not carry it — ask a workspace admin to run this, or sign in with an admin account (\`atlas login\`).`,
       );
     }
     case 400:
-      // requireOrgContext returns 400 bad_request when the credential has no
-      // bound workspace (a multi-workspace login pending the picker slice).
-      if (body.error === ERR.badRequest) {
-        throw new DatasourceCliError(
-          "no_workspace",
-          "Your login is not bound to a workspace. Single-workspace accounts bind automatically; in-flow workspace selection for multi-workspace accounts is coming soon (ADR-0026).",
-        );
-      }
-      // The create route's pre-flight test runs server-side and returns
-      // `connection_failed` with the upstream driver error scrubbed of any DSN.
-      // Surface it as a distinct kind so `create` exits with a fix-the-URL hint
-      // rather than a generic request failure.
+      // A `bad_request` (no bound workspace) falls through to the shared
+      // no-workspace default. The create route's pre-flight test runs
+      // server-side and returns `connection_failed` with the upstream driver
+      // error scrubbed of any DSN — surface it as a distinct kind so `create`
+      // exits with a fix-the-URL hint rather than a generic request failure.
       if (body.error === ERR.connectionFailed) {
-        throw new DatasourceCliError("connection_failed", serverMessage(body, res.status));
+        return new DatasourceCliError("connection_failed", serverMessage(body, status));
       }
-      throw new DatasourceCliError("request_failed", serverMessage(body, res.status));
+      if (body.error !== ERR.badRequest) {
+        return new DatasourceCliError("request_failed", serverMessage(body, status));
+      }
+      break;
     case 404:
       // The create route 404s with `not_available` when the deployment has no
       // internal DB (DATABASE_URL) — datasource provisioning isn't possible
       // there. Distinct from the id-not-found 404 the lifecycle ops surface.
       if (body.error === ERR.notAvailable) {
-        throw new DatasourceCliError("not_available", serverMessage(body, res.status));
+        return new DatasourceCliError("not_available", serverMessage(body, status));
       }
-      throw new DatasourceCliError("not_found", serverMessage(body, res.status));
+      return new DatasourceCliError("not_found", serverMessage(body, status));
     case 409:
-      throw new DatasourceCliError("conflict", serverMessage(body, res.status));
+      return new DatasourceCliError("conflict", serverMessage(body, status));
     case 429:
       // The plan-limit denial (`plan_limit_exceeded`) shares the 429 status with
       // rate limiting. Distinguish it so the message points at the plan cap, not
       // "slow down". A bare 429 (rate limit) falls through to request_failed.
       if (body.error === ERR.planLimitExceeded) {
-        throw new DatasourceCliError("plan_limit", serverMessage(body, res.status));
+        return new DatasourceCliError("plan_limit", serverMessage(body, status));
       }
-      throw new DatasourceCliError("request_failed", serverMessage(body, res.status));
+      return new DatasourceCliError("request_failed", serverMessage(body, status));
     case 503:
       // Fail-closed billing/plan-limit check fault (#3433): a transient infra
       // problem verifying the cap, not an upgrade prompt — tell the user to retry.
-      throw new DatasourceCliError("billing_unavailable", serverMessage(body, res.status));
-    default:
-      throw new DatasourceCliError("request_failed", serverMessage(body, res.status));
+      return new DatasourceCliError("billing_unavailable", serverMessage(body, status));
   }
+  const info = defaultWorkspaceErrorInfo(status, body);
+  return new DatasourceCliError(info.kind, info.message);
+}
+
+/**
+ * Issue one request against an admin-connection route and return its parsed JSON
+ * body, mapping every documented failure status onto a typed
+ * {@link DatasourceCliError} with an actionable message. A thin wrapper over the
+ * shared {@link workspaceRequest} transport (#4196) — this client's `request()`
+ * was the original of that abstraction; only the operation-labelled error copy
+ * and timeout subject stay local.
+ */
+async function request(opts: DatasourceClientOptions, spec: RequestSpec): Promise<unknown> {
+  return workspaceRequest(
+    opts,
+    { method: spec.method, path: spec.path, ...(spec.body !== undefined ? { body: spec.body } : {}) },
+    {
+      toError: (status, body) => toDatasourceError(spec.operation, status, body),
+      toNetworkError: (message) => new DatasourceCliError("network", message),
+      timeoutMessage: (seconds) => `Timed out after ${seconds}s trying to ${spec.operation}.`,
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -550,10 +539,7 @@ export async function profileDatasource(
     const body = asRecord(await res.json().catch(() => ({})));
     switch (res.status) {
       case 401:
-        throw new DatasourceCliError(
-          "unauthorized",
-          "Your session is no longer valid. Run `atlas login` again.",
-        );
+        throw new DatasourceCliError("unauthorized", SESSION_INVALID_MESSAGE);
       case 403:
         if (body.error === ERR.mfaEnrollmentRequired) {
           throw new DatasourceCliError("mfa_required", MFA_ENROLLMENT_MESSAGE);
@@ -570,10 +556,7 @@ export async function profileDatasource(
         throw new DatasourceCliError("forbidden", serverMessage(body, res.status));
       case 400:
         if (body.error === ERR.badRequest) {
-          throw new DatasourceCliError(
-            "no_workspace",
-            "Your login is not bound to a workspace. Single-workspace accounts bind automatically; in-flow workspace selection for multi-workspace accounts is coming soon (ADR-0026).",
-          );
+          throw new DatasourceCliError("no_workspace", NO_WORKSPACE_MESSAGE);
         }
         throw new DatasourceCliError("request_failed", serverMessage(body, res.status));
       case 404:

--- a/packages/cli/src/lib/http.ts
+++ b/packages/cli/src/lib/http.ts
@@ -1,6 +1,6 @@
 /**
  * Shared HTTP primitives for the workspace CLI clients (#4113 — milestone #77
- * sibling-consistency cleanup).
+ * sibling-consistency cleanup; finished in #4196).
  *
  * Each workspace CLI client (`sql-client`, `metric-client`, `datasource-client`,
  * and the `explore` command) is a thin, transport-only wrapper over one REST
@@ -9,9 +9,27 @@
  * definition, so a change to how a server error becomes user-facing copy (or how
  * a `requestId` is appended) can't drift between siblings.
  *
- * Nothing here calls `process.exit`, `console`, or `fetch` directly — the
- * clients inject `fetch` and own presentation, keeping these pure + unit-testable.
+ * This module owns two shared pieces:
+ *  - `workspaceRequest` — the ONE fetch → timeout → ok → error-map execution
+ *    path the three lifecycle clients (`sql-client`, `metric-client`,
+ *    `datasource-client`) ride for their buffered-body CRUD ops. It owns the
+ *    transport invariants (the fetch, the `AbortSignal.timeout`, the
+ *    network/timeout classification, the ok-body read) and delegates ALL error
+ *    mapping to the client's `toError` hook — it never touches the status copy
+ *    itself. (The streaming `profileDatasource` is a separate, un-timed NDJSON
+ *    path that does NOT ride this.)
+ *  - {@link defaultWorkspaceErrorInfo} — the byte-identical status copy (401
+ *    re-login, the no-workspace guidance). Each client's `toError` mapper spells
+ *    out only its OWN divergent statuses (a metric's 404 copy, a datasource's
+ *    admin-role 403) and falls through to this default for the rest.
+ * So the fetch block + the shared strings each exist exactly once, and per-client
+ * divergence stays local to that client's `toError`.
+ *
+ * Nothing here calls `process.exit` or `console` — the clients inject `fetch`
+ * and own presentation, keeping these pure + unit-testable.
  */
+
+import { credentialHeaders, type CliCredential } from "./credential";
 
 /** The global `fetch`, injectable so clients stay unit-testable without a live server. */
 export type FetchImpl = typeof fetch;
@@ -52,4 +70,148 @@ export function isAbortOrTimeout(err: unknown): boolean {
 /** The "couldn't reach the API" message shared verbatim across the clients. */
 export function unreachableMessage(baseUrl: string, err: unknown): string {
   return `Could not reach the Atlas API at ${baseUrl}: ${err instanceof Error ? err.message : String(err)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Shared error copy + status→kind default table (#4196).
+//
+// The 401 re-login string and the no-workspace guidance were pasted verbatim
+// across `sql-client`, `metric-client`, `datasource-client`, and the streaming
+// `profileDatasource` — a change to either could silently drift between the
+// siblings. They live here once; every client references these constants.
+// ---------------------------------------------------------------------------
+
+/** The 401 re-login hint every workspace client surfaces verbatim. */
+export const SESSION_INVALID_MESSAGE =
+  "Your session is no longer valid. Run `atlas login` again.";
+
+/**
+ * The 400 `bad_request` (no active org) guidance every workspace client
+ * surfaces verbatim — a multi-workspace login pending the picker slice
+ * (ADR-0026). The server's `requireOrgContext` returns 400 `bad_request` here.
+ */
+export const NO_WORKSPACE_MESSAGE =
+  "Your login is not bound to a workspace. Single-workspace accounts bind automatically; in-flow workspace selection for multi-workspace accounts is coming soon (ADR-0026).";
+
+/**
+ * The subset of failure kinds every workspace client shares under IDENTICAL
+ * names — the ones the default status→kind table below resolves. Each client's
+ * own kind union is a superset (it adds `forbidden`, `rate_limited`, etc.), so a
+ * `{ kind, message }` produced here is always assignable to that client's error
+ * constructor.
+ */
+export type SharedWorkspaceErrorKind = "unauthorized" | "no_workspace" | "request_failed";
+
+/** A resolved `{ kind, message }` a client feeds straight into its typed-error constructor. */
+export interface WorkspaceErrorInfo {
+  readonly kind: SharedWorkspaceErrorKind;
+  readonly message: string;
+}
+
+/**
+ * The DEFAULT status→kind mapping shared across the lifecycle clients: the two
+ * byte-identical branches (401 → re-login, 400 `bad_request` → no-workspace) plus
+ * the catch-all (`request_failed` with the server's message). Each client calls
+ * this for the statuses it does NOT special-case, so the shared copy is defined
+ * once and a client's `toError` mapper only spells out its genuine divergences.
+ */
+export function defaultWorkspaceErrorInfo(
+  status: number,
+  body: Record<string, unknown>,
+): WorkspaceErrorInfo {
+  if (status === 401) return { kind: "unauthorized", message: SESSION_INVALID_MESSAGE };
+  if (status === 400 && body.error === "bad_request") {
+    return { kind: "no_workspace", message: NO_WORKSPACE_MESSAGE };
+  }
+  return { kind: "request_failed", message: serverMessage(body, status) };
+}
+
+// ---------------------------------------------------------------------------
+// The one workspace-REST execution path (#4196).
+//
+// `datasource-client` already had this as a private `request(opts, spec)`; its
+// siblings re-inlined the whole fetch → timeout → ok → switch block. Lifted here
+// so the transport invariants live once and each client supplies only its
+// route (method/path/body) + its status→error mapping.
+// ---------------------------------------------------------------------------
+
+/** The connection target a workspace request runs against (a client-options subset). */
+export interface WorkspaceRequestTarget {
+  /** Normalized Atlas API base URL (no trailing slash). */
+  readonly baseUrl: string;
+  /** The workspace credential — a session bearer XOR a workspace API key. */
+  readonly credential: CliCredential;
+  /** Injectable for tests; defaults to the global `fetch`. */
+  readonly fetchImpl?: FetchImpl;
+  /** Per-request timeout in ms (default 30s). */
+  readonly timeoutMs?: number;
+}
+
+/** One REST route: the method, path (appended to `baseUrl`), and optional JSON body. */
+export interface WorkspaceRequestSpec {
+  readonly method: "GET" | "POST" | "DELETE";
+  readonly path: string;
+  /** Sent as a JSON body when present; a `Content-Type` header is added only then. */
+  readonly body?: unknown;
+}
+
+/**
+ * The per-client error hooks: how to turn a non-2xx `(status, body)` into the
+ * client's typed error, how to build its `network`-kind error, and the
+ * timeout-copy subject (which varies — "running the query" vs `trying to
+ * ${operation}`). `E extends Error` so the caller keeps its concrete error type.
+ */
+export interface WorkspaceRequestHandlers<E extends Error> {
+  /** Map a non-2xx `(status, body)` → the client's typed error. */
+  readonly toError: (status: number, body: Record<string, unknown>) => E;
+  /** Build the client's `network`-kind error (shared by the timeout + unreachable paths). */
+  readonly toNetworkError: (message: string) => E;
+  /** The client-specific timeout copy, e.g. `Timed out after ${s}s running the query.` */
+  readonly timeoutMessage: (timeoutSeconds: number) => string;
+}
+
+/**
+ * Issue ONE workspace-REST request and return its raw parsed-JSON body (a `{}`
+ * fallback on an empty/non-JSON 2xx — callers schema-validate or narrow it),
+ * mapping every documented failure onto the client's typed error via
+ * {@link WorkspaceRequestHandlers}. This is the single fetch → timeout → ok →
+ * error-map path the lifecycle clients share (#4196).
+ */
+export async function workspaceRequest<E extends Error>(
+  target: WorkspaceRequestTarget,
+  spec: WorkspaceRequestSpec,
+  handlers: WorkspaceRequestHandlers<E>,
+): Promise<unknown> {
+  const fetchImpl = target.fetchImpl ?? fetch;
+  const timeoutMs = target.timeoutMs ?? 30_000;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${target.baseUrl}${spec.path}`, {
+      method: spec.method,
+      headers: {
+        ...credentialHeaders(target.credential),
+        ...(spec.body !== undefined ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(spec.body !== undefined ? { body: JSON.stringify(spec.body) } : {}),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (isAbortOrTimeout(err)) {
+      throw handlers.toNetworkError(handlers.timeoutMessage(Math.round(timeoutMs / 1000)));
+    }
+    throw handlers.toNetworkError(unreachableMessage(target.baseUrl, err));
+  }
+
+  if (res.ok) {
+    // intentionally ignored: a 2xx with an empty/non-JSON body degrades to {} —
+    // callers tolerate missing optional fields (or fail their own schema parse)
+    // rather than crashing here.
+    return await res.json().catch(() => ({}));
+  }
+
+  // intentionally ignored: an error body that isn't JSON falls back to the
+  // HTTP-status message via the empty record.
+  const body = asRecord(await res.json().catch(() => ({})));
+  throw handlers.toError(res.status, body);
 }

--- a/packages/cli/src/lib/metric-client.ts
+++ b/packages/cli/src/lib/metric-client.ts
@@ -22,8 +22,13 @@
 
 import type { CliRestErrorCode, RunMetricRestResponse } from "@useatlas/types";
 import { RunMetricRestResponseSchema } from "@useatlas/schemas";
-import { credentialHeaders, type CliCredential } from "./credential";
-import { asRecord, isAbortOrTimeout, serverMessage, unreachableMessage, type FetchImpl } from "./http";
+import { type CliCredential } from "./credential";
+import {
+  defaultWorkspaceErrorInfo,
+  serverMessage,
+  workspaceRequest,
+  type FetchImpl,
+} from "./http";
 
 /**
  * The server `error`-field discriminators this client branches on, pinned to the
@@ -88,98 +93,81 @@ export interface RunMetricArgs {
 }
 
 /**
+ * Map a non-2xx metric-run `(status, body)` onto a typed {@link MetricCliError}.
+ * Only the statuses that diverge from the shared default are spelled out; 401
+ * (re-login), 400 `bad_request` (no-workspace), and any other status fall
+ * through to {@link defaultWorkspaceErrorInfo} so the byte-identical copy is
+ * defined once (#4196). Closes over the metric `id` for the 404 copy.
+ */
+function toMetricError(id: string, status: number, body: Record<string, unknown>): MetricCliError {
+  switch (status) {
+    case 403:
+      // Billing block, RLS-denied, or role — surface the server's message
+      // (it carries the actionable remedy, e.g. trial-expired guidance).
+      return new MetricCliError("forbidden", serverMessage(body, status));
+    case 404:
+      return new MetricCliError(
+        "not_found",
+        `Metric "${id}" not found in this workspace. Run \`atlas entities\` or check semantic/metrics/.`,
+      );
+    case 409:
+      return new MetricCliError("approval_required", serverMessage(body, status));
+    case 429:
+      // Per-identity rate-limit bucket, a workspace throttle, or the pipeline's
+      // concurrency cap — all 429. Surface the server's message (it names the
+      // remedy / retry hint) under a distinct kind, parity with `atlas sql`.
+      return new MetricCliError("rate_limited", serverMessage(body, status));
+    case 503:
+      // Datasource/enterprise subsystem unavailable, or a fail-closed billing
+      // check (#3433) — a transient "try again", not an upgrade prompt. Distinct
+      // kind, parity with `atlas sql`; the server message carries the detail.
+      return new MetricCliError("unavailable", serverMessage(body, status));
+    case 400:
+      // A `bad_request` (no bound workspace) falls through to the shared
+      // no-workspace default; every other 400 is an unsupported filter / wrong
+      // connection — the server message names the cause.
+      if (body.error !== ERR.badRequest) {
+        return new MetricCliError("invalid_request", serverMessage(body, status));
+      }
+  }
+  const info = defaultWorkspaceErrorInfo(status, body);
+  return new MetricCliError(info.kind, info.message);
+}
+
+/**
  * Execute a canonical metric by id against the bound workspace via
  * `POST /api/v1/metrics/{id}/run`, mapping every documented failure status onto
- * a typed {@link MetricCliError} with an actionable message.
+ * a typed {@link MetricCliError} with an actionable message. Rides the shared
+ * {@link workspaceRequest} transport (#4196); only the route, the response
+ * schema, and the metric-specific status copy live here.
  */
 export async function runMetric(
   opts: MetricClientOptions,
   args: RunMetricArgs,
 ): Promise<MetricRunResult> {
-  const fetchImpl = opts.fetchImpl ?? fetch;
-  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const raw = await workspaceRequest(
+    { ...opts, timeoutMs: opts.timeoutMs ?? 60_000 },
+    {
+      method: "POST",
+      path: `/api/v1/metrics/${encodeURIComponent(args.id)}/run`,
+      body: args.connectionId ? { connectionId: args.connectionId } : {},
+    },
+    {
+      toError: (status, body) => toMetricError(args.id, status, body),
+      toNetworkError: (message) => new MetricCliError("network", message),
+      timeoutMessage: (seconds) => `Timed out after ${seconds}s running metric "${args.id}".`,
+    },
+  );
 
-  let res: Response;
-  try {
-    res = await fetchImpl(
-      `${opts.baseUrl}/api/v1/metrics/${encodeURIComponent(args.id)}/run`,
-      {
-        method: "POST",
-        headers: {
-          ...credentialHeaders(opts.credential),
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(args.connectionId ? { connectionId: args.connectionId } : {}),
-        signal: AbortSignal.timeout(timeoutMs),
-      },
+  // Validate the 200 against the shared wire schema (the SSOT). A shape mismatch
+  // is a server bug / version skew — surface it rather than returning a
+  // half-filled result.
+  const parsed = RunMetricRestResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new MetricCliError(
+      "request_failed",
+      `The Atlas API returned an unexpected response shape for metric "${args.id}". Update the CLI, or check the server logs.`,
     );
-  } catch (err) {
-    if (isAbortOrTimeout(err)) {
-      throw new MetricCliError(
-        "network",
-        `Timed out after ${Math.round(timeoutMs / 1000)}s running metric "${args.id}".`,
-      );
-    }
-    throw new MetricCliError("network", unreachableMessage(opts.baseUrl, err));
   }
-
-  if (res.ok) {
-    // intentionally ignored: a non-JSON 2xx body becomes `undefined` and fails
-    // the schema parse below — surfaced as a typed error, never silent garbage.
-    const raw = await res.json().catch(() => undefined);
-    // Validate the 200 against the shared wire schema (the SSOT). A shape
-    // mismatch is a server bug / version skew — surface it rather than returning
-    // a half-filled result.
-    const parsed = RunMetricRestResponseSchema.safeParse(raw);
-    if (!parsed.success) {
-      throw new MetricCliError(
-        "request_failed",
-        `The Atlas API returned an unexpected response shape for metric "${args.id}". Update the CLI, or check the server logs.`,
-      );
-    }
-    return parsed.data;
-  }
-
-  // intentionally ignored: an error body that isn't JSON falls back to the
-  // HTTP-status message below via the empty record.
-  const body = asRecord(await res.json().catch(() => ({})));
-
-  switch (res.status) {
-    case 401:
-      throw new MetricCliError(
-        "unauthorized",
-        "Your session is no longer valid. Run `atlas login` again.",
-      );
-    case 403:
-      // Billing block, RLS-denied, or role — surface the server's message
-      // (it carries the actionable remedy, e.g. trial-expired guidance).
-      throw new MetricCliError("forbidden", serverMessage(body, res.status));
-    case 404:
-      throw new MetricCliError(
-        "not_found",
-        `Metric "${args.id}" not found in this workspace. Run \`atlas entities\` or check semantic/metrics/.`,
-      );
-    case 409:
-      throw new MetricCliError("approval_required", serverMessage(body, res.status));
-    case 429:
-      // Per-identity rate-limit bucket, a workspace throttle, or the pipeline's
-      // concurrency cap — all 429. Surface the server's message (it names the
-      // remedy / retry hint) under a distinct kind, parity with `atlas sql`.
-      throw new MetricCliError("rate_limited", serverMessage(body, res.status));
-    case 400:
-      if (body.error === ERR.badRequest) {
-        throw new MetricCliError(
-          "no_workspace",
-          "Your login is not bound to a workspace. Single-workspace accounts bind automatically; in-flow workspace selection for multi-workspace accounts is coming soon (ADR-0026).",
-        );
-      }
-      throw new MetricCliError("invalid_request", serverMessage(body, res.status));
-    case 503:
-      // Datasource/enterprise subsystem unavailable, or a fail-closed billing
-      // check (#3433) — a transient "try again", not an upgrade prompt. Distinct
-      // kind, parity with `atlas sql`; the server message carries the detail.
-      throw new MetricCliError("unavailable", serverMessage(body, res.status));
-    default:
-      throw new MetricCliError("request_failed", serverMessage(body, res.status));
-  }
+  return parsed.data;
 }

--- a/packages/cli/src/lib/sql-client.ts
+++ b/packages/cli/src/lib/sql-client.ts
@@ -26,8 +26,13 @@
 
 import type { CliRestErrorCode, ExecuteSqlRestResponse } from "@useatlas/types";
 import { ExecuteSqlRestResponseSchema } from "@useatlas/schemas";
-import { credentialHeaders, type CliCredential } from "./credential";
-import { asRecord, isAbortOrTimeout, serverMessage, unreachableMessage, type FetchImpl } from "./http";
+import { type CliCredential } from "./credential";
+import {
+  defaultWorkspaceErrorInfo,
+  serverMessage,
+  workspaceRequest,
+  type FetchImpl,
+} from "./http";
 
 /**
  * The server `error`-field discriminators this client branches on, pinned to the
@@ -93,95 +98,76 @@ export interface RunSqlArgs {
 }
 
 /**
- * Execute one validated SELECT against the bound workspace via
- * `POST /api/v1/execute-sql`, mapping every documented failure status onto a
- * typed {@link SqlCliError} with an actionable message.
+ * Map a non-2xx raw-SQL `(status, body)` onto a typed {@link SqlCliError}. Only
+ * the statuses that diverge from the shared default are spelled out; 401
+ * (re-login), 400 `bad_request` (no-workspace), and any other status fall
+ * through to {@link defaultWorkspaceErrorInfo} so the byte-identical copy is
+ * defined once (#4196).
  */
-export async function runSql(opts: SqlClientOptions, args: RunSqlArgs): Promise<SqlRunResult> {
-  const fetchImpl = opts.fetchImpl ?? fetch;
-  const timeoutMs = opts.timeoutMs ?? 60_000;
-
-  let res: Response;
-  try {
-    res = await fetchImpl(`${opts.baseUrl}/api/v1/execute-sql`, {
-      method: "POST",
-      headers: {
-        ...credentialHeaders(opts.credential),
-        "Content-Type": "application/json",
-      },
-      // ONLY sql (+ optional connectionId) — never an org/workspace field. The
-      // server derives the workspace from the credential (ADR-0027 §5).
-      body: JSON.stringify(
-        args.connectionId ? { sql: args.sql, connectionId: args.connectionId } : { sql: args.sql },
-      ),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (err) {
-    if (isAbortOrTimeout(err)) {
-      throw new SqlCliError(
-        "network",
-        `Timed out after ${Math.round(timeoutMs / 1000)}s running the query.`,
-      );
-    }
-    throw new SqlCliError("network", unreachableMessage(opts.baseUrl, err));
-  }
-
-  if (res.ok) {
-    // intentionally ignored: a non-JSON 2xx body becomes `undefined` and fails
-    // the schema parse below — surfaced as a typed error, never silent garbage.
-    const raw = await res.json().catch(() => undefined);
-    // Validate the 200 against the shared wire schema (the SSOT). A shape
-    // mismatch is a server bug / version skew — surface it rather than returning
-    // a half-filled result the renderer would silently mangle.
-    const parsed = ExecuteSqlRestResponseSchema.safeParse(raw);
-    if (!parsed.success) {
-      throw new SqlCliError(
-        "request_failed",
-        "The Atlas API returned an unexpected response shape for the query result. Update the CLI, or check the server logs.",
-      );
-    }
-    return parsed.data;
-  }
-
-  // intentionally ignored: an error body that isn't JSON falls back to the
-  // HTTP-status message below via the empty record.
-  const body = asRecord(await res.json().catch(() => ({})));
-
-  switch (res.status) {
-    case 401:
-      throw new SqlCliError(
-        "unauthorized",
-        "Your session is no longer valid. Run `atlas login` again.",
-      );
+function toSqlError(status: number, body: Record<string, unknown>): SqlCliError {
+  switch (status) {
     case 403:
       // Billing block, RLS-denied, or raw SQL disabled for the workspace by an
       // admin (#4095) — surface the server's message (it carries the actionable
       // remedy, e.g. trial-expired guidance, the RLS reason, or "use `atlas
       // query`").
-      throw new SqlCliError("forbidden", serverMessage(body, res.status));
+      return new SqlCliError("forbidden", serverMessage(body, status));
     case 404:
       // The ONLY 404 this route emits is a billing-gate block for a deleted
       // workspace (`workspace_deleted`). Distinct from a 403 billing/RLS block:
       // the remedy is "this workspace no longer exists", not "fix billing".
-      // Surface the gate's verbatim message.
-      throw new SqlCliError("workspace_not_found", serverMessage(body, res.status));
+      return new SqlCliError("workspace_not_found", serverMessage(body, status));
     case 409:
-      throw new SqlCliError("approval_required", serverMessage(body, res.status));
+      return new SqlCliError("approval_required", serverMessage(body, status));
     case 429:
-      throw new SqlCliError("rate_limited", serverMessage(body, res.status));
-    case 400:
-      if (body.error === ERR.badRequest) {
-        throw new SqlCliError(
-          "no_workspace",
-          "Your login is not bound to a workspace. Single-workspace accounts bind automatically; in-flow workspace selection for multi-workspace accounts is coming soon (ADR-0026).",
-        );
-      }
-      // invalid_sql / plugin_rejected / query_failed — the validation pipeline
-      // (or the datasource) rejected the SQL. The server message names the cause.
-      throw new SqlCliError("invalid_sql", serverMessage(body, res.status));
+      return new SqlCliError("rate_limited", serverMessage(body, status));
     case 503:
-      throw new SqlCliError("unavailable", serverMessage(body, res.status));
-    default:
-      throw new SqlCliError("request_failed", serverMessage(body, res.status));
+      return new SqlCliError("unavailable", serverMessage(body, status));
+    case 400:
+      // A `bad_request` (no bound workspace) falls through to the shared
+      // no-workspace default; every other 400 is the validation pipeline (or the
+      // datasource) rejecting the SQL — the server message names the cause.
+      if (body.error !== ERR.badRequest) {
+        return new SqlCliError("invalid_sql", serverMessage(body, status));
+      }
   }
+  const info = defaultWorkspaceErrorInfo(status, body);
+  return new SqlCliError(info.kind, info.message);
+}
+
+/**
+ * Execute one validated SELECT against the bound workspace via
+ * `POST /api/v1/execute-sql`, mapping every documented failure status onto a
+ * typed {@link SqlCliError} with an actionable message. Rides the shared
+ * {@link workspaceRequest} transport (#4196); only the route, the response
+ * schema, and the SQL-specific status copy live here.
+ */
+export async function runSql(opts: SqlClientOptions, args: RunSqlArgs): Promise<SqlRunResult> {
+  const raw = await workspaceRequest(
+    { ...opts, timeoutMs: opts.timeoutMs ?? 60_000 },
+    {
+      method: "POST",
+      path: "/api/v1/execute-sql",
+      // ONLY sql (+ optional connectionId) — never an org/workspace field. The
+      // server derives the workspace from the credential (ADR-0027 §5).
+      body: args.connectionId ? { sql: args.sql, connectionId: args.connectionId } : { sql: args.sql },
+    },
+    {
+      toError: toSqlError,
+      toNetworkError: (message) => new SqlCliError("network", message),
+      timeoutMessage: (seconds) => `Timed out after ${seconds}s running the query.`,
+    },
+  );
+
+  // Validate the 200 against the shared wire schema (the SSOT). A shape mismatch
+  // is a server bug / version skew — surface it rather than returning a
+  // half-filled result the renderer would silently mangle.
+  const parsed = ExecuteSqlRestResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new SqlCliError(
+      "request_failed",
+      "The Atlas API returned an unexpected response shape for the query result. Update the CLI, or check the server logs.",
+    );
+  }
+  return parsed.data;
 }

--- a/packages/cli/src/lib/workspace-command.ts
+++ b/packages/cli/src/lib/workspace-command.ts
@@ -1,0 +1,88 @@
+/**
+ * The command shell shared by the REST-backed workspace subcommands
+ * (`sql`/`metric`/`query`/`explore`/`datasource`) — #4196, finishing the
+ * explicitly-partial #4112/#4113 extraction.
+ *
+ * Every one of those `handleX` shells did the SAME five things: resolve the API
+ * base URL, read the stored session for it, pick up the unattended-CI
+ * `ATLAS_API_KEY` env var (trimmed, never persisted), dispatch the testable
+ * `runXCommand` core with those injected as deps, then `process.exit(code)` on a
+ * non-zero exit. That boilerplate lived verbatim in five files; it lives here
+ * once. Each command now supplies ONLY its arg-parse + render core.
+ *
+ * The `CliIO` sink and the `WorkspaceCommandDeps` shape were likewise duplicated
+ * per command; they are defined here as the shared vocabulary the cores type
+ * against (each command re-exports them under its historical local name so its
+ * tests' imports stay stable).
+ *
+ * This module owns the ONLY `process.exit` in the workspace-command path — the
+ * cores return an exit code and never exit, so they stay unit-testable without a
+ * live server or a real process.
+ */
+
+import { resolveApiBaseUrl } from "./api-base";
+import { readSession, type StoredSession } from "./credentials";
+
+/**
+ * The stdout/stderr sink injected into every command core so tests can capture
+ * output instead of writing to the real console. `defaultCliIO` is the live
+ * wiring used when a command runs for real.
+ */
+export interface CliIO {
+  readonly out: (line: string) => void;
+  readonly err: (line: string) => void;
+}
+
+/** The live console sink — the default when a command isn't under test. */
+export const defaultCliIO: CliIO = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+/**
+ * Everything a REST-backed workspace command core needs, injected so it stays
+ * server-free in tests: the resolved API base URL, the stored session (or null),
+ * the optional unattended-CI API key, and an injectable `fetch`. Commands that
+ * need extra wiring (e.g. `datasource`'s secret capture) extend this shape.
+ */
+export interface WorkspaceCommandDeps {
+  /** Normalized Atlas API base URL (no trailing slash). */
+  readonly baseUrl: string;
+  /** The `atlas login` session bound to `baseUrl`, or null when not logged in. */
+  readonly session: StoredSession | null;
+  /**
+   * A workspace-scoped API key for unattended CI (#4046), from the `--api-key`
+   * flag or `ATLAS_API_KEY`. When present it takes precedence over the stored
+   * session — CI never goes through `atlas login`.
+   */
+  readonly apiKey?: string;
+  /** Injectable `fetch` for tests; defaults to the global when omitted. */
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** A testable command core: parse argv + render, returning an exit code (never exits). */
+export type WorkspaceCommandRun = (
+  args: string[],
+  deps: WorkspaceCommandDeps,
+) => Promise<number>;
+
+/**
+ * The shell `handleX` invokes: resolve the base URL + session + `ATLAS_API_KEY`,
+ * dispatch `run` with those as deps, then `process.exit(code)` on a non-zero
+ * exit (a zero exit returns normally so the process ends naturally). This is the
+ * single place credential inputs are gathered and the exit code is applied — the
+ * cores are pure and return their code.
+ */
+export async function runWorkspaceCommand(
+  args: string[],
+  run: WorkspaceCommandRun,
+): Promise<void> {
+  const baseUrl = resolveApiBaseUrl();
+  const session = readSession(baseUrl);
+  // ATLAS_API_KEY (#4046) is the unattended-CI credential — it is NOT persisted
+  // to ~/.atlas/credentials (a CI secret managed by the CI system, not an
+  // interactive login). The `--api-key` flag (parsed in each core) overrides it.
+  const apiKey = process.env.ATLAS_API_KEY?.trim() || undefined;
+  const code = await run(args, { baseUrl, session, ...(apiKey ? { apiKey } : {}) });
+  if (code !== 0) process.exit(code);
+}


### PR DESCRIPTION
## Summary

Finishes the explicitly-partial #4112/#4113 extraction. The `fetch → timeout → ok → error-map` execution path and the byte-identical error copy that had been re-inlined across the workspace CLI clients now each live exactly once.

- **`lib/http.ts` — one workspace-REST call.** Lifts `datasource-client`'s private `request()` into a generic `workspaceRequest()` (one fetch/`AbortSignal.timeout`/ok-body path; a shared status→kind default table via `defaultWorkspaceErrorInfo`; per-client `toError` overrides). `sql`/`metric`/`datasource` clients ride it — each keeps only its route + genuinely divergent status copy. The 401 re-login string and the no-workspace guidance are single constants (`SESSION_INVALID_MESSAGE`/`NO_WORKSPACE_MESSAGE`), referenced by the lifecycle clients *and* the streaming `profileDatasource` pre-stream branch.
- **`lib/workspace-command.ts` — the command shell.** New `runWorkspaceCommand` owns the shared `CliIO`, `WorkspaceCommandDeps`, credential-input gather (base URL / session / `ATLAS_API_KEY`), and the one `process.exit`. The five `handleSql/Metric/Query/Explore/Datasource` shells collapse to one-liners; each command supplies only arg-parse + render.
- **`lib/credential.ts` — login shape.** `NOT_LOGGED_IN_MESSAGE` + `resolveWorkspaceCredential` single-source the "log in or set ATLAS_API_KEY" + null/exit shape. The duplicated `getFlagValue` (sql + metric) is deduped onto cli-utils `getFlag`.

Behavior-preserving: no change to auth or raw-query semantics (ADR-0026 / ADR-0027). The one parsing delta — `getFlag` adds a `--`-guard the old `getFlagValue` lacked — is a strict improvement (a `--connection --json` would previously have sent `--json` as the connection id) and touches neither auth nor query semantics.

Net `-469 / +531` across 11 files (a consolidation once the new abstractions + tests are counted).

## Test plan
- [x] All existing per-command/client suites unchanged and green (`sql-command`, `metric-command`, `query-command`, `explore`, `datasource-command`, `datasource-client`) — the regression net for behavior preservation.
- [x] New `http.test.ts` pins the shared status→copy table + transport paths (ok body, non-JSON 2xx → `{}`, non-2xx → `toError`, timeout, unreachable, GET/DELETE no-body) once (AC #3).
- [x] New `workspace-command.test.ts` pins the deps-gather + exit-code passthrough contract; `credential.test.ts` extended for `resolveWorkspaceCredential`.
- [x] Full CLI isolated suite (47 files) green; `tsgo` + eslint clean on the package.
- [x] Internal review-panel (4 specialists) run pre-PR — converged CLEAN in round 1 (one comment-accuracy MEDIUM + cheap test-strengthening LOWs fixed in-branch).

Closes #4196