### PR TITLE
refactor: PlatformInstallationStore — one seam behind the Slack + Discord stores

### DIFF
--- a/packages/api/src/lib/discord/__tests__/store.test.ts
+++ b/packages/api/src/lib/discord/__tests__/store.test.ts
@@ -4,7 +4,7 @@
  * `bot_token_encrypted` only, writes only populate the encrypted column.
  */
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 
 type CapturedQuery = { sql: string; params: unknown[] };
 let capturedQueries: CapturedQuery[] = [];
@@ -36,6 +36,9 @@ mock.module("@atlas/api/lib/logger", () => ({
 const {
   saveDiscordInstallation,
   getDiscordInstallation,
+  getDiscordInstallationByOrg,
+  deleteDiscordInstallation,
+  deleteDiscordInstallationByOrg,
 } = await import("../store");
 
 beforeEach(() => {
@@ -112,6 +115,119 @@ describe("F-41 discord encrypted-only writes + reads", () => {
         installed_at: "2026-04-20T00:00:00Z",
       },
     ];
+    const install = await getDiscordInstallation("g-1");
+    expect(install).toBeNull();
+  });
+});
+
+/**
+ * Byte-compat coverage for the four operations the seam now routes but
+ * the F-41 block above didn't exercise on the real `discord_installations`
+ * backend — most importantly the org-hijack rejection (a workspace-
+ * takeover invariant) driven through the actual upsert WHERE clause.
+ */
+describe("discord store — remaining ops through the seam", () => {
+  it("rejects when the guild is bound to a different org (hijack protection)", async () => {
+    // Atomic upsert returns 0 rows when the org-guard WHERE clause matches
+    // nothing — the seam maps that to the uniform hijack rejection.
+    mockInternalQueryResult = [];
+    await expect(
+      saveDiscordInstallation("g-1", { orgId: "org-mine" }),
+    ).rejects.toThrow("Guild g-1 is already bound to a different organization");
+  });
+
+  it("getDiscordInstallationByOrg queries by org_id and strips the secret", async () => {
+    mockInternalQueryResult = [
+      {
+        guild_id: "g-1",
+        org_id: "org-1",
+        guild_name: "Test",
+        bot_token_encrypted: "enc:v1:test:secret-token",
+        application_id: "app-1",
+        public_key: "pub-1",
+        installed_at: "2026-04-20T00:00:00Z",
+      },
+    ];
+    const result = await getDiscordInstallationByOrg("org-1");
+    expect(result).toEqual({
+      guild_id: "g-1",
+      org_id: "org-1",
+      guild_name: "Test",
+      application_id: "app-1",
+      public_key: "pub-1",
+      installed_at: "2026-04-20T00:00:00Z",
+    });
+    // Secret field stripped from the public shape.
+    expect((result as unknown as Record<string, unknown>).bot_token).toBeUndefined();
+    const select = capturedQueries.find((q) => q.sql.includes("SELECT"));
+    expect(select!.sql).toContain("WHERE org_id = $1");
+    expect(select!.params).toEqual(["org-1"]);
+  });
+
+  it("getDiscordInstallationByOrg returns null when no internal DB", async () => {
+    mockHasDB = false;
+    const result = await getDiscordInstallationByOrg("org-1");
+    expect(result).toBeNull();
+    expect(capturedQueries).toEqual([]);
+  });
+
+  it("deleteDiscordInstallation deletes by guild_id", async () => {
+    await deleteDiscordInstallation("g-1");
+    const del = capturedQueries.find((q) => q.sql.includes("DELETE"));
+    expect(del!.sql).toContain("WHERE guild_id = $1");
+    expect(del!.params).toEqual(["g-1"]);
+  });
+
+  it("deleteDiscordInstallation throws when no internal DB", async () => {
+    mockHasDB = false;
+    await expect(deleteDiscordInstallation("g-1")).rejects.toThrow(
+      "no internal database configured",
+    );
+  });
+
+  it("deleteDiscordInstallationByOrg returns true when a row was deleted", async () => {
+    mockInternalQueryResult = [{ guild_id: "g-1" }];
+    const result = await deleteDiscordInstallationByOrg("org-1");
+    expect(result).toBe(true);
+    const del = capturedQueries.find((q) => q.sql.includes("DELETE"));
+    expect(del!.sql).toContain("WHERE org_id = $1");
+    expect(del!.sql).toContain("RETURNING guild_id");
+    expect(del!.params).toEqual(["org-1"]);
+  });
+
+  it("deleteDiscordInstallationByOrg returns false when no matching row", async () => {
+    mockInternalQueryResult = [];
+    expect(await deleteDiscordInstallationByOrg("org-none")).toBe(false);
+  });
+});
+
+describe("discord store — single-guild env fallback", () => {
+  const savedClientId = process.env.DISCORD_CLIENT_ID;
+  beforeEach(() => {
+    mockHasDB = false;
+    delete process.env.DISCORD_CLIENT_ID;
+  });
+  afterEach(() => {
+    if (savedClientId !== undefined) process.env.DISCORD_CLIENT_ID = savedClientId;
+    else delete process.env.DISCORD_CLIENT_ID;
+  });
+
+  it("returns a single-guild record (bot_token null) when DISCORD_CLIENT_ID is set and no DB", async () => {
+    process.env.DISCORD_CLIENT_ID = "client-123";
+    const install = await getDiscordInstallation("g-1");
+    expect(install).toEqual({
+      guild_id: "g-1",
+      org_id: null,
+      guild_name: null,
+      bot_token: null,
+      application_id: null,
+      public_key: null,
+      installed_at: expect.any(String),
+    });
+    expect(capturedQueries).toEqual([]);
+  });
+
+  it("returns null when no DB and DISCORD_CLIENT_ID unset", async () => {
     const install = await getDiscordInstallation("g-1");
     expect(install).toBeNull();
   });

--- a/packages/api/src/lib/discord/store.ts
+++ b/packages/api/src/lib/discord/store.ts
@@ -8,11 +8,16 @@
  * platform-level env vars.
  */
 
-import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { internalQuery } from "@atlas/api/lib/db/internal";
 import { encryptSecret, decryptSecret, type OpaqueSecret } from "@atlas/api/lib/db/secret-encryption";
 import { activeKeyVersion } from "@atlas/api/lib/db/encryption-keys";
 import { createLogger } from "@atlas/api/lib/logger";
 import type { DiscordInstallation, DiscordInstallationWithSecret } from "@atlas/api/lib/integrations/types";
+import {
+  PlatformInstallationStore,
+  decryptOrHide,
+  type InstallationBackend,
+} from "@atlas/api/lib/integrations/platform-installation-store";
 
 export type { DiscordInstallation, DiscordInstallationWithSecret } from "@atlas/api/lib/integrations/types";
 
@@ -56,15 +61,18 @@ function parseInstallationRow(
   const encrypted = row.bot_token_encrypted;
   let botToken: string | null = null;
   if (typeof encrypted === "string" && encrypted.length > 0) {
-    try {
-      botToken = decryptSecret(encrypted);
-    } catch (err) {
+    // decrypt-or-hide-row: a present-but-undecryptable token hides the
+    // whole row (shared policy — see platform-installation-store).
+    // A NULL/empty column is the healthy OAuth-only case above and
+    // keeps `bot_token: null`.
+    const decrypted = decryptOrHide(encrypted, decryptSecret, (message) =>
       log.error(
-        { ...context, err: err instanceof Error ? err.message : String(err) },
+        { ...context, err: message },
         "Failed to decrypt discord_installations.bot_token_encrypted — row hidden from API; F-42 audit script catches residue",
-      );
-      return null;
-    }
+      ),
+    );
+    if (!decrypted.ok) return null;
+    botToken = decrypted.value;
   }
   return {
     guild_id: guildIdVal,
@@ -78,113 +86,68 @@ function parseInstallationRow(
 }
 
 // ---------------------------------------------------------------------------
-// Read operations
+// Backend adapter + seam
 // ---------------------------------------------------------------------------
 
-/**
- * Get the Discord installation for a guild. Checks internal DB first, then
- * falls back to env-based detection (DISCORD_CLIENT_ID set = single-guild mode).
- */
-export async function getDiscordInstallation(
-  guildId: string,
-): Promise<DiscordInstallationWithSecret | null> {
-  if (hasInternalDB()) {
-    try {
-      const rows = await internalQuery<Record<string, unknown>>(
-        `SELECT ${SELECT_COLS} FROM discord_installations WHERE guild_id = $1`,
-        [guildId],
-      );
-      if (rows.length > 0) {
-        return parseInstallationRow(rows[0], { guildId });
-      }
-      return null;
-    } catch (err) {
-      log.error(
-        { err: err instanceof Error ? err.message : String(err), guildId },
-        "Failed to query discord_installations",
-      );
-      throw err;
-    }
-  }
-
-  // Single-guild mode: no internal DB configured, use env var presence
-  const envClientId = process.env.DISCORD_CLIENT_ID;
-  if (envClientId) {
-    return {
-      guild_id: guildId,
-      org_id: null,
-      guild_name: null,
-      bot_token: null,
-      application_id: null,
-      public_key: null,
-      installed_at: new Date().toISOString(),
-    };
-  }
-
-  return null;
+/** Save payload for a Discord installation (OAuth2 callback or BYOT). */
+interface DiscordSaveInput {
+  orgId?: string;
+  guildName?: string;
+  botToken?: string;
+  applicationId?: string;
+  publicKey?: string;
 }
 
 /**
- * Get the Discord installation for an org. Returns null if not found or
- * if no internal database is configured (org-scoped lookups require a DB).
+ * The `discord_installations`-backed adapter. Owns the typed-column SQL
+ * + the versioned-keyset cipher; the {@link PlatformInstallationStore}
+ * seam owns the control flow and the shared invariants. The SQL is
+ * carried over unchanged from the pre-seam store — notably the
+ * hijack-guard (`WHERE discord_installations.org_id IS NULL OR
+ * discord_installations.org_id = $2`) and the `COALESCE`-per-column
+ * merge.
  */
-export async function getDiscordInstallationByOrg(
-  orgId: string,
-): Promise<DiscordInstallation | null> {
-  if (!hasInternalDB()) {
-    return null;
-  }
+const discordBackend: InstallationBackend<
+  DiscordInstallationWithSecret,
+  DiscordInstallation,
+  DiscordSaveInput
+> = {
+  name: "Discord",
+  routingNoun: "Guild",
+  // Unlike Slack, Discord's delete requires a DB — there is no
+  // single-guild env-only delete path, so a missing DB is an error.
+  deleteRequiresInternalDb: true,
 
-  try {
+  async selectByRouting(guildId) {
+    const rows = await internalQuery<Record<string, unknown>>(
+      `SELECT ${SELECT_COLS} FROM discord_installations WHERE guild_id = $1`,
+      [guildId],
+    );
+    if (rows.length === 0) return null;
+    return parseInstallationRow(rows[0], { guildId });
+  },
+
+  async selectByOrg(orgId) {
     const rows = await internalQuery<Record<string, unknown>>(
       `SELECT ${SELECT_COLS} FROM discord_installations WHERE org_id = $1`,
       [orgId],
     );
-    if (rows.length > 0) {
-      const full = parseInstallationRow(rows[0], { orgId });
-      if (!full) return null;
-      const { bot_token: _, ...pub } = full;
-      return pub;
-    }
-    return null;
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId },
-      "Failed to query discord_installations by org",
-    );
-    throw err;
-  }
-}
+    if (rows.length === 0) return null;
+    return parseInstallationRow(rows[0], { orgId });
+  },
 
-// ---------------------------------------------------------------------------
-// Write operations
-// ---------------------------------------------------------------------------
+  async upsert(guildId, input) {
+    const orgId = input.orgId ?? null;
+    const guildName = input.guildName ?? null;
+    const botToken = input.botToken ?? null;
+    const botTokenEncrypted: OpaqueSecret | null = botToken !== null ? encryptSecret(botToken) : null;
+    // Only stamp the key version when we actually wrote a ciphertext — a
+    // connect call that doesn't provide a token (BYOT-less OAuth path)
+    // leaves the existing column alone via COALESCE.
+    const botTokenKeyVersion = botTokenEncrypted !== null ? activeKeyVersion() : null;
+    const applicationId = input.applicationId ?? null;
+    const publicKey = input.publicKey ?? null;
 
-/**
- * Save or update a Discord installation (OAuth2 callback or BYOT credential submission).
- * Throws if the guild is already bound to a different organization (hijack protection).
- * Throws if the database write fails.
- */
-export async function saveDiscordInstallation(
-  guildId: string,
-  opts?: { orgId?: string; guildName?: string; botToken?: string; applicationId?: string; publicKey?: string },
-): Promise<void> {
-  if (!hasInternalDB()) {
-    throw new Error("Cannot save Discord installation — no internal database configured");
-  }
-
-  const orgId = opts?.orgId ?? null;
-  const guildName = opts?.guildName ?? null;
-  const botToken = opts?.botToken ?? null;
-  const botTokenEncrypted: OpaqueSecret | null = botToken !== null ? encryptSecret(botToken) : null;
-  // Only stamp the key version when we actually wrote a ciphertext — a
-  // connect call that doesn't provide a token (BYOT-less OAuth path)
-  // leaves the existing column alone via COALESCE.
-  const botTokenKeyVersion = botTokenEncrypted !== null ? activeKeyVersion() : null;
-  const applicationId = opts?.applicationId ?? null;
-  const publicKey = opts?.publicKey ?? null;
-
-  try {
     // Atomic upsert with hijack protection — the WHERE clause rejects rows
     // bound to a different org in one statement (no TOCTOU race).
     const rows = await internalQuery<{ guild_id: string }>(
@@ -202,40 +165,88 @@ export async function saveDiscordInstallation(
        RETURNING guild_id`,
       [guildId, orgId, guildName, botTokenEncrypted, applicationId, publicKey, botTokenKeyVersion],
     );
+    return rows.length > 0;
+  },
 
-    if (rows.length === 0) {
-      throw new Error(
-        `Guild ${guildId} is already bound to a different organization. ` +
-        `Disconnect the existing installation first.`,
-      );
-    }
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err.message : String(err), guildId },
-      "Failed to save discord_installations",
+  async deleteByRouting(guildId) {
+    await internalQuery("DELETE FROM discord_installations WHERE guild_id = $1", [guildId]);
+  },
+
+  async deleteByOrg(orgId) {
+    const rows = await internalQuery<{ guild_id: string }>(
+      "DELETE FROM discord_installations WHERE org_id = $1 RETURNING guild_id",
+      [orgId],
     );
-    throw err;
-  }
+    return rows.length > 0;
+  },
+
+  envFallback(guildId) {
+    // Single-guild mode: no internal DB configured, use env var presence.
+    const envClientId = process.env.DISCORD_CLIENT_ID;
+    if (envClientId) {
+      return {
+        guild_id: guildId,
+        org_id: null,
+        guild_name: null,
+        bot_token: null,
+        application_id: null,
+        public_key: null,
+        installed_at: new Date().toISOString(),
+      };
+    }
+    return null;
+  },
+
+  toPublic(full) {
+    const { bot_token: _drop, ...pub } = full;
+    return pub;
+  },
+};
+
+const store = new PlatformInstallationStore(discordBackend, log);
+
+// ---------------------------------------------------------------------------
+// Public API — thin wrappers over the seam (signatures unchanged)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the Discord installation for a guild. Checks internal DB first, then
+ * falls back to env-based detection (DISCORD_CLIENT_ID set = single-guild mode).
+ */
+export function getDiscordInstallation(
+  guildId: string,
+): Promise<DiscordInstallationWithSecret | null> {
+  return store.get(guildId);
+}
+
+/**
+ * Get the Discord installation for an org. Returns null if not found or
+ * if no internal database is configured (org-scoped lookups require a DB).
+ */
+export function getDiscordInstallationByOrg(
+  orgId: string,
+): Promise<DiscordInstallation | null> {
+  return store.getByOrg(orgId);
+}
+
+/**
+ * Save or update a Discord installation (OAuth2 callback or BYOT credential submission).
+ * Throws if the guild is already bound to a different organization (hijack protection).
+ * Throws if the database write fails.
+ */
+export function saveDiscordInstallation(
+  guildId: string,
+  opts?: { orgId?: string; guildName?: string; botToken?: string; applicationId?: string; publicKey?: string },
+): Promise<void> {
+  return store.save(guildId, opts ?? {});
 }
 
 /**
  * Remove a Discord installation by guild ID.
  * Throws if no internal DB or if the query fails.
  */
-export async function deleteDiscordInstallation(guildId: string): Promise<void> {
-  if (!hasInternalDB()) {
-    throw new Error("Cannot delete Discord installation — no internal database configured");
-  }
-
-  try {
-    await internalQuery("DELETE FROM discord_installations WHERE guild_id = $1", [guildId]);
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err.message : String(err), guildId },
-      "Failed to delete discord_installations",
-    );
-    throw err;
-  }
+export function deleteDiscordInstallation(guildId: string): Promise<void> {
+  return store.delete(guildId);
 }
 
 /**
@@ -243,22 +254,6 @@ export async function deleteDiscordInstallation(guildId: string): Promise<void> 
  * Returns true if a row was deleted, false if no matching row found.
  * Throws if no internal DB or if the query fails.
  */
-export async function deleteDiscordInstallationByOrg(orgId: string): Promise<boolean> {
-  if (!hasInternalDB()) {
-    throw new Error("Cannot delete Discord installation — no internal database configured");
-  }
-
-  try {
-    const rows = await internalQuery<{ guild_id: string }>(
-      "DELETE FROM discord_installations WHERE org_id = $1 RETURNING guild_id",
-      [orgId],
-    );
-    return rows.length > 0;
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId },
-      "Failed to delete discord_installations by org",
-    );
-    throw err;
-  }
+export function deleteDiscordInstallationByOrg(orgId: string): Promise<boolean> {
+  return store.deleteByOrg(orgId);
 }

--- a/packages/api/src/lib/integrations/__tests__/platform-installation-store.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/platform-installation-store.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for the PlatformInstallationStore seam — the single home of the
+ * five-op contract + the three shared invariants (org-hijack rejection,
+ * decrypt-or-hide-row, env fallback) that the Slack and Discord stores
+ * delegate to. Exercised with an in-memory fake backend so the
+ * invariants are pinned once, independent of either real backend's SQL.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { InstallationBackend } from "../platform-installation-store";
+
+let mockHasDB = true;
+// The seam's only value-import from db/internal is `hasInternalDB`, but
+// we mock the three exports the sibling store tests use so this file is
+// safe if ever run in the same process as them (mock.module is
+// process-global) and matches the repo's mock-all-exports convention.
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasDB,
+  internalQuery: mock(() => Promise.resolve([])),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const { PlatformInstallationStore, decryptOrHide } = await import(
+  "../platform-installation-store"
+);
+
+// --- Fake backend ------------------------------------------------------
+
+interface FakeFull {
+  readonly org_id: string | null;
+  readonly routing_id: string;
+  readonly secret: string;
+}
+type FakePublic = Omit<FakeFull, "secret">;
+interface FakeSaveInput {
+  orgId?: string;
+  secret: string;
+}
+
+const noopLog = { warn: () => {}, error: () => {} };
+
+/** A logger that records every `warn`/`error` call for assertions. */
+function makeSpyLog() {
+  const warns: Array<{ obj: Record<string, unknown>; msg: string }> = [];
+  const errors: Array<{ obj: Record<string, unknown>; msg: string }> = [];
+  return {
+    warns,
+    errors,
+    log: {
+      warn: (obj: Record<string, unknown>, msg: string) => warns.push({ obj, msg }),
+      error: (obj: Record<string, unknown>, msg: string) => errors.push({ obj, msg }),
+    },
+  };
+}
+
+/** A backend whose behavior each test tweaks via the returned handles. */
+function makeBackend(overrides: Partial<InstallationBackend<FakeFull, FakePublic, FakeSaveInput>> = {}) {
+  const calls: string[] = [];
+  const backend: InstallationBackend<FakeFull, FakePublic, FakeSaveInput> = {
+    name: "Fake",
+    routingNoun: "Fake workspace",
+    deleteRequiresInternalDb: false,
+    selectByRouting: async (id) => {
+      calls.push(`selectByRouting:${id}`);
+      return { org_id: "org-1", routing_id: id, secret: "s3cr3t" };
+    },
+    selectByOrg: async (orgId) => {
+      calls.push(`selectByOrg:${orgId}`);
+      return { org_id: orgId, routing_id: "r-1", secret: "s3cr3t" };
+    },
+    upsert: async (id) => {
+      calls.push(`upsert:${id}`);
+      return true;
+    },
+    deleteByRouting: async (id) => {
+      calls.push(`deleteByRouting:${id}`);
+    },
+    deleteByOrg: async (orgId) => {
+      calls.push(`deleteByOrg:${orgId}`);
+      return true;
+    },
+    envFallback: (id) => {
+      calls.push(`envFallback:${id}`);
+      return { org_id: null, routing_id: id, secret: "env" };
+    },
+    toPublic: (full) => {
+      const { secret: _drop, ...pub } = full;
+      return pub;
+    },
+    ...overrides,
+  };
+  return { backend, calls };
+}
+
+beforeEach(() => {
+  mockHasDB = true;
+});
+
+describe("PlatformInstallationStore", () => {
+  describe("save — org-hijack invariant (seam-level: pinned once with a fake backend)", () => {
+    it("rejects with a uniform error and logs the hijack attempt when the upsert matched no row", async () => {
+      const { backend } = makeBackend({ upsert: async () => false });
+      const spy = makeSpyLog();
+      const store = new PlatformInstallationStore(backend, spy.log);
+
+      await expect(store.save("T123", { secret: "x" })).rejects.toThrow(
+        "Fake workspace T123 is already bound to a different organization. Disconnect the existing installation first.",
+      );
+      // The rejection is auditable (security event) but not error-level.
+      expect(spy.warns).toHaveLength(1);
+      expect(spy.warns[0].obj).toEqual({ routingId: "T123" });
+      expect(spy.errors).toHaveLength(0);
+    });
+
+    it("resolves when the upsert wrote a row", async () => {
+      const upsertedIds: string[] = [];
+      const { backend } = makeBackend({
+        upsert: async (id) => {
+          upsertedIds.push(id);
+          return true;
+        },
+      });
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      await expect(store.save("T123", { secret: "x" })).resolves.toBeUndefined();
+      expect(upsertedIds).toEqual(["T123"]);
+    });
+
+    it("throws (no upsert attempt) when no internal DB", async () => {
+      mockHasDB = false;
+      const { backend, calls } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      await expect(store.save("T123", { secret: "x" })).rejects.toThrow(
+        "Cannot save Fake installation — no internal database configured",
+      );
+      expect(calls).toEqual([]);
+    });
+
+    it("logs and rethrows a backend DB error without masking it as a hijack", async () => {
+      const boom = new Error("disk full");
+      const { backend } = makeBackend({
+        upsert: async () => {
+          throw boom;
+        },
+      });
+      const spy = makeSpyLog();
+      const store = new PlatformInstallationStore(backend, spy.log);
+
+      await expect(store.save("T123", { secret: "x" })).rejects.toThrow("disk full");
+      // A DB fault is error-logged (not the warn-level hijack path) and
+      // never rendered as "already bound to a different organization".
+      expect(spy.errors).toHaveLength(1);
+      expect(spy.errors[0].obj).toEqual({ routingId: "T123", err: "disk full" });
+      expect(spy.warns).toHaveLength(0);
+    });
+  });
+
+  describe("get — env fallback vs DB", () => {
+    it("reads the backend when an internal DB is present", async () => {
+      const { backend, calls } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      const result = await store.get("T123");
+      expect(result).toEqual({ org_id: "org-1", routing_id: "T123", secret: "s3cr3t" });
+      expect(calls).toEqual(["selectByRouting:T123"]);
+    });
+
+    it("falls back to the env record when no internal DB (never queries)", async () => {
+      mockHasDB = false;
+      const { backend, calls } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      const result = await store.get("T123");
+      expect(result).toEqual({ org_id: null, routing_id: "T123", secret: "env" });
+      expect(calls).toEqual(["envFallback:T123"]);
+    });
+
+    it("logs and rethrows a DB error — never falls through to env", async () => {
+      const { backend } = makeBackend({
+        selectByRouting: async () => {
+          throw new Error("connection refused");
+        },
+      });
+      const spy = makeSpyLog();
+      const store = new PlatformInstallationStore(backend, spy.log);
+
+      await expect(store.get("T123")).rejects.toThrow("connection refused");
+      expect(spy.errors).toHaveLength(1);
+      expect(spy.errors[0].obj).toEqual({ routingId: "T123", err: "connection refused" });
+    });
+  });
+
+  describe("getByOrg — strip secret + no-DB gate", () => {
+    it("returns the secret-stripped public shape", async () => {
+      const { backend } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      const result = await store.getByOrg("org-1");
+      expect(result).toEqual({ org_id: "org-1", routing_id: "r-1" });
+      expect((result as Record<string, unknown>).secret).toBeUndefined();
+    });
+
+    it("returns null (no query) when no internal DB", async () => {
+      mockHasDB = false;
+      const { backend, calls } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      expect(await store.getByOrg("org-1")).toBeNull();
+      expect(calls).toEqual([]);
+    });
+
+    it("returns null when the backend hides the row", async () => {
+      const { backend } = makeBackend({ selectByOrg: async () => null });
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      expect(await store.getByOrg("org-1")).toBeNull();
+    });
+
+    it("logs and rethrows a DB error", async () => {
+      const { backend } = makeBackend({
+        selectByOrg: async () => {
+          throw new Error("timeout");
+        },
+      });
+      const spy = makeSpyLog();
+      const store = new PlatformInstallationStore(backend, spy.log);
+
+      await expect(store.getByOrg("org-1")).rejects.toThrow("timeout");
+      expect(spy.errors).toHaveLength(1);
+      expect(spy.errors[0].obj).toEqual({ orgId: "org-1", err: "timeout" });
+    });
+  });
+
+  describe("delete — per-backend no-DB policy", () => {
+    it("calls deleteByRouting when a DB is present", async () => {
+      const { backend, calls } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      await expect(store.delete("T123")).resolves.toBeUndefined();
+      expect(calls).toEqual(["deleteByRouting:T123"]);
+    });
+
+    it("logs and rethrows when deleteByRouting throws", async () => {
+      const { backend } = makeBackend({
+        deleteByRouting: async () => {
+          throw new Error("lock timeout");
+        },
+      });
+      const spy = makeSpyLog();
+      const store = new PlatformInstallationStore(backend, spy.log);
+
+      await expect(store.delete("T123")).rejects.toThrow("lock timeout");
+      expect(spy.errors).toHaveLength(1);
+      expect(spy.errors[0].obj).toEqual({ routingId: "T123", err: "lock timeout" });
+    });
+
+    it("warns and no-ops without a DB when deleteRequiresInternalDb is false", async () => {
+      mockHasDB = false;
+      let warned = false;
+      const { backend, calls } = makeBackend({ deleteRequiresInternalDb: false });
+      const store = new PlatformInstallationStore(backend, {
+        warn: () => {
+          warned = true;
+        },
+        error: () => {},
+      });
+
+      await expect(store.delete("T123")).resolves.toBeUndefined();
+      expect(warned).toBe(true);
+      expect(calls).toEqual([]);
+    });
+
+    it("throws without a DB when deleteRequiresInternalDb is true", async () => {
+      mockHasDB = false;
+      const { backend } = makeBackend({ deleteRequiresInternalDb: true });
+      const store = new PlatformInstallationStore(backend, noopLog);
+
+      await expect(store.delete("T123")).rejects.toThrow(
+        "Cannot delete Fake installation — no internal database configured",
+      );
+    });
+  });
+
+  describe("deleteByOrg", () => {
+    it("returns the backend boolean when a DB is present", async () => {
+      const { backend } = makeBackend({ deleteByOrg: async () => false });
+      const store = new PlatformInstallationStore(backend, noopLog);
+      expect(await store.deleteByOrg("org-1")).toBe(false);
+    });
+
+    it("throws when no internal DB", async () => {
+      mockHasDB = false;
+      const { backend } = makeBackend();
+      const store = new PlatformInstallationStore(backend, noopLog);
+      await expect(store.deleteByOrg("org-1")).rejects.toThrow(
+        "no internal database configured",
+      );
+    });
+
+    it("logs and rethrows a DB error", async () => {
+      const { backend } = makeBackend({
+        deleteByOrg: async () => {
+          throw new Error("connection lost");
+        },
+      });
+      const spy = makeSpyLog();
+      const store = new PlatformInstallationStore(backend, spy.log);
+
+      await expect(store.deleteByOrg("org-1")).rejects.toThrow("connection lost");
+      expect(spy.errors).toHaveLength(1);
+      expect(spy.errors[0].obj).toEqual({ orgId: "org-1", err: "connection lost" });
+    });
+  });
+});
+
+describe("decryptOrHide", () => {
+  it("returns { ok: true, value } on success", () => {
+    const result = decryptOrHide("blob", (c) => `plain:${c}`, () => {});
+    expect(result).toEqual({ ok: true, value: "plain:blob" });
+  });
+
+  it("returns { ok: false } and reports the message on failure", () => {
+    let reported = "";
+    const result = decryptOrHide(
+      "blob",
+      () => {
+        throw new Error("auth tag mismatch");
+      },
+      (msg) => {
+        reported = msg;
+      },
+    );
+    expect(result).toEqual({ ok: false });
+    expect(reported).toBe("auth tag mismatch");
+  });
+
+  it("stringifies a non-Error throw", () => {
+    let reported = "";
+    const result = decryptOrHide(
+      "blob",
+      () => {
+        throw "raw string failure";
+      },
+      (msg) => {
+        reported = msg;
+      },
+    );
+    expect(result).toEqual({ ok: false });
+    expect(reported).toBe("raw string failure");
+  });
+});

--- a/packages/api/src/lib/integrations/platform-installation-store.ts
+++ b/packages/api/src/lib/integrations/platform-installation-store.ts
@@ -1,0 +1,272 @@
+/**
+ * PlatformInstallationStore — the single seam behind the Slack and
+ * Discord installation stores.
+ *
+ * Both `lib/slack/store.ts` and `lib/discord/store.ts` persist the same
+ * five-operation contract (`get` / `getByOrg` / `save` / `delete` /
+ * `deleteByOrg`) over three shared invariants:
+ *
+ *   1. **decrypt-or-hide-row** — a stored credential that fails to
+ *      decrypt hides the whole row (the parse returns null) instead of
+ *      surfacing a broken install as connected. Captured by
+ *      {@link decryptOrHide}, which both platform parsers route their
+ *      cipher blob through.
+ *   2. **org-hijack-safe upsert** — an upsert whose `WHERE org_id IS
+ *      NULL OR org_id = $x` clause matched no row (the routing id is
+ *      already bound to a different org) is rejected with one uniform
+ *      error. The rejection lives HERE, in {@link PlatformInstallationStore.save},
+ *      so the invariant has exactly one *implementation*; each backend
+ *      only reports "row written?" as a boolean. (The real Slack and
+ *      Discord backends still integration-test the rejection end-to-end
+ *      through this seam — the point is structural centralization, not
+ *      test exclusivity.)
+ *   3. **single-tenant env fallback** — with no internal DB, `get`
+ *      resolves from a platform env var rather than the table.
+ *
+ * The two platforms diverge only in **backend** (Slack's `chat_cache`
+ * JSONB rows vs Discord's typed `discord_installations` columns) and
+ * **cipher** — both captured by the injected {@link InstallationBackend}.
+ * The two backends stay physically separate because their storage
+ * shapes and ciphers differ: Slack's cipher/format in particular is
+ * externally constrained by `@chat-adapter/slack` interop and the
+ * "don't disturb working machinery" rationale (ADR-0003 § Alternatives),
+ * so it cannot merge. (ADR-0003 itself decides the metadata-vs-
+ * credentials store split, not the Slack-vs-Discord backend split — the
+ * latter follows from the differing storage shapes, not the ADR.) This
+ * seam unifies the *contract*, not the storage — one seam, two backend
+ * adapters.
+ */
+
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+
+/**
+ * Minimal structural logger — satisfied by `pino.Logger`
+ * (`createLogger(...)`). Kept local so the seam doesn't couple to the
+ * concrete logger implementation and stays trivially fakeable in tests.
+ */
+export interface StoreLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+  error(obj: Record<string, unknown>, msg: string): void;
+}
+
+/**
+ * Result of a decrypt-or-hide attempt. `ok: false` means the stored
+ * ciphertext could not be decrypted and the caller must hide the whole
+ * row (return null) rather than expose a broken install.
+ */
+export type DecryptResult = { ok: true; value: string } | { ok: false };
+
+/**
+ * The decrypt-or-hide-row policy in one place: decrypt the stored
+ * cipher blob; on any failure, invoke `onError` (for a log line) and
+ * return `{ ok: false }` so the caller drops the row. Type-narrows the
+ * caught error to a message string on the caller's behalf.
+ *
+ * The "missing credential" case (Slack: hide; Discord: OAuth-only, keep
+ * with `bot_token: null`) is intentionally NOT handled here — it
+ * diverges per platform and stays in each parser. Only the shared
+ * "present-but-undecryptable ⇒ hide" step is centralized.
+ */
+export function decryptOrHide<Cipher>(
+  cipher: Cipher,
+  decrypt: (c: Cipher) => string,
+  onError: (message: string) => void,
+): DecryptResult {
+  try {
+    return { ok: true, value: decrypt(cipher) };
+  } catch (err) {
+    onError(err instanceof Error ? err.message : String(err));
+    return { ok: false };
+  }
+}
+
+/**
+ * Per-platform backend adapter. Owns the SQL and the cipher; the
+ * generic store owns the control flow and the three invariants above.
+ *
+ * @typeParam Full - the with-secret record (e.g. `SlackInstallationWithSecret`).
+ * @typeParam Public - the secret-stripped record returned by `getByOrg`.
+ * @typeParam SaveInput - the platform-shaped save payload.
+ */
+export interface InstallationBackend<Full, Public, SaveInput> {
+  /** Platform name for log/error text, e.g. `"Slack"` / `"Discord"`. */
+  readonly name: string;
+  /**
+   * The noun the hijack error names, e.g. `"Slack workspace"` /
+   * `"Guild"`. Rendered as `"<routingNoun> <id> is already bound to a
+   * different organization."`.
+   */
+  readonly routingNoun: string;
+  /**
+   * Whether `delete(routingId)` requires an internal DB. Slack's delete
+   * is a best-effort no-op + warning without one; Discord throws.
+   * Preserves each store's pre-seam behavior.
+   */
+  readonly deleteRequiresInternalDb: boolean;
+
+  /** SELECT + parse the record for a routing id; null when absent/hidden. */
+  selectByRouting(routingId: string): Promise<Full | null>;
+  /** SELECT + parse the record for an org; null when absent/hidden. */
+  selectByOrg(orgId: string): Promise<Full | null>;
+  /**
+   * Org-hijack-safe atomic upsert. Returns `true` when a row was
+   * written, `false` when the `WHERE org_id …` clause rejected a row
+   * bound to a different org. Never throws for the hijack case — the
+   * generic store maps `false` to the uniform rejection error.
+   */
+  upsert(routingId: string, input: SaveInput): Promise<boolean>;
+  /** DELETE by routing id (internal-DB path only). */
+  deleteByRouting(routingId: string): Promise<void>;
+  /** DELETE by org; `true` when a row was removed. */
+  deleteByOrg(orgId: string): Promise<boolean>;
+  /** Single-tenant env-var fallback record, or null. */
+  envFallback(routingId: string): Full | null;
+  /**
+   * Drop the secret field(s) for the public (org-scoped) shape.
+   *
+   * NOTE: the type system will NOT catch a passthrough — because every
+   * `Full` (with-secret) type structurally extends its `Public`
+   * counterpart, `toPublic: (full) => full` type-checks yet leaks the
+   * secret. The `{ bot_token: _drop, ...pub }` destructuring in each
+   * impl is the real guard; the store tests that assert the secret is
+   * absent are load-bearing, not redundant.
+   */
+  toPublic(full: Full): Public;
+}
+
+/**
+ * Generic installation store. Wraps a {@link InstallationBackend} with
+ * the shared five-op control flow: internal-DB gates, uniform
+ * error-log-and-rethrow, the env fallback, and the single org-hijack
+ * rejection.
+ */
+export class PlatformInstallationStore<Full, Public, SaveInput> {
+  constructor(
+    private readonly backend: InstallationBackend<Full, Public, SaveInput>,
+    private readonly log: StoreLogger,
+  ) {}
+
+  /**
+   * Get the record for a routing id. Reads the internal DB first, then
+   * falls back to the platform env var (single-tenant mode). A DB error
+   * is logged and rethrown — it never falls through to the env var, so
+   * a transient outage can't silently downgrade a multi-tenant deploy.
+   */
+  async get(routingId: string): Promise<Full | null> {
+    if (!hasInternalDB()) return this.backend.envFallback(routingId);
+    try {
+      return await this.backend.selectByRouting(routingId);
+    } catch (err) {
+      this.log.error(
+        { routingId, err: err instanceof Error ? err.message : String(err) },
+        `Failed to load ${this.backend.name} installation`,
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Get the secret-stripped record for an org. Returns null when no
+   * internal DB is configured (org-scoped lookups require one).
+   */
+  async getByOrg(orgId: string): Promise<Public | null> {
+    if (!hasInternalDB()) return null;
+    try {
+      const full = await this.backend.selectByOrg(orgId);
+      return full ? this.backend.toPublic(full) : null;
+    } catch (err) {
+      this.log.error(
+        { orgId, err: err instanceof Error ? err.message : String(err) },
+        `Failed to load ${this.backend.name} installation by org`,
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Save or update a record. Throws when no internal DB is configured,
+   * or when the routing id is already bound to a different org (the
+   * upsert matched no row) — the one place the org-hijack invariant is
+   * enforced.
+   */
+  async save(routingId: string, input: SaveInput): Promise<void> {
+    if (!hasInternalDB()) {
+      throw new Error(
+        `Cannot save ${this.backend.name} installation — no internal database configured`,
+      );
+    }
+    let written: boolean;
+    try {
+      written = await this.backend.upsert(routingId, input);
+    } catch (err) {
+      this.log.error(
+        { routingId, err: err instanceof Error ? err.message : String(err) },
+        `Failed to save ${this.backend.name} installation`,
+      );
+      throw err;
+    }
+    if (!written) {
+      // Auditable security event: someone tried to bind a routing id
+      // already owned by another org. `warn`, not `error` — it's a user
+      // error, not a system fault — but it must not be invisible.
+      this.log.warn(
+        { routingId },
+        `Rejected ${this.backend.name} installation — routing id already bound to a different organization`,
+      );
+      throw new Error(
+        `${this.backend.routingNoun} ${routingId} is already bound to a different organization. ` +
+          "Disconnect the existing installation first.",
+      );
+    }
+  }
+
+  /**
+   * Remove a record by routing id. Without an internal DB, Slack warns
+   * and no-ops while Discord throws — governed by
+   * {@link InstallationBackend.deleteRequiresInternalDb}.
+   */
+  async delete(routingId: string): Promise<void> {
+    if (!hasInternalDB()) {
+      if (this.backend.deleteRequiresInternalDb) {
+        throw new Error(
+          `Cannot delete ${this.backend.name} installation — no internal database configured`,
+        );
+      }
+      this.log.warn(
+        { routingId },
+        `Cannot delete ${this.backend.name} installation — no internal database configured`,
+      );
+      return;
+    }
+    try {
+      await this.backend.deleteByRouting(routingId);
+    } catch (err) {
+      this.log.error(
+        { routingId, err: err instanceof Error ? err.message : String(err) },
+        `Failed to delete ${this.backend.name} installation`,
+      );
+      throw err;
+    }
+  }
+
+  /**
+   * Remove the record for an org. Returns true when a row was deleted.
+   * Throws when no internal DB is configured.
+   */
+  async deleteByOrg(orgId: string): Promise<boolean> {
+    if (!hasInternalDB()) {
+      throw new Error(
+        `Cannot delete ${this.backend.name} installation — no internal database configured`,
+      );
+    }
+    try {
+      return await this.backend.deleteByOrg(orgId);
+    } catch (err) {
+      this.log.error(
+        { orgId, err: err instanceof Error ? err.message : String(err) },
+        `Failed to delete ${this.backend.name} installation by org`,
+      );
+      throw err;
+    }
+  }
+}

--- a/packages/api/src/lib/slack/__tests__/store.test.ts
+++ b/packages/api/src/lib/slack/__tests__/store.test.ts
@@ -174,6 +174,19 @@ describe("store (chat_cache-backed)", () => {
       const result = await getInstallation("T123");
       expect(result).toBeNull();
     });
+
+    it("hides the row when the stored botToken cannot be decrypted (decrypt-or-hide-row)", async () => {
+      mockHasInternalDB.mockReturnValue(true);
+      // A legacy Atlas-ciphertext string (enc:v…) is rejected by
+      // decryptSlackInstallationToken — the whole row is hidden rather
+      // than surfaced as a connected-but-broken install.
+      mockInternalQuery.mockResolvedValue([
+        { value: { botToken: "enc:v1:legacy:blob" }, installed_at: "2025-01-01T00:00:00.000Z" },
+      ]);
+
+      const result = await getInstallation("T123");
+      expect(result).toBeNull();
+    });
   });
 
   describe("getInstallationByOrg", () => {

--- a/packages/api/src/lib/slack/store.ts
+++ b/packages/api/src/lib/slack/store.ts
@@ -42,16 +42,17 @@
  * @see installation-encryption.ts — encrypt/decrypt helpers.
  */
 
-import {
-  hasInternalDB,
-  internalQuery,
-  getInternalDB,
-} from "@atlas/api/lib/db/internal";
+import { internalQuery, getInternalDB } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import type {
   SlackInstallation,
   SlackInstallationWithSecret,
 } from "@atlas/api/lib/integrations/types";
+import {
+  PlatformInstallationStore,
+  decryptOrHide,
+  type InstallationBackend,
+} from "@atlas/api/lib/integrations/platform-installation-store";
 import {
   encryptSlackInstallationToken,
   decryptSlackInstallationToken,
@@ -138,10 +139,6 @@ export interface StoredInstallation {
   installedAt?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Read operations
-// ---------------------------------------------------------------------------
-
 /**
  * Parse a chat_cache row → SlackInstallationWithSecret. Returns null
  * (and logs a warning) for any structurally invalid value.
@@ -160,16 +157,16 @@ function parseStoredInstallation(
     log.warn({ teamId }, "chat_cache slack installation missing botToken field");
     return null;
   }
-  let plaintext: string;
-  try {
-    plaintext = decryptSlackInstallationToken(v.botToken as StoredSlackBotToken);
-  } catch (err) {
-    log.error(
-      { teamId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to decrypt chat_cache slack bot token",
-    );
-    return null;
-  }
+  // decrypt-or-hide-row: an undecryptable token hides the whole row
+  // (shared policy — see platform-installation-store.decryptOrHide).
+  const decrypted = decryptOrHide(
+    v.botToken as StoredSlackBotToken,
+    decryptSlackInstallationToken,
+    (message) =>
+      log.error({ teamId, err: message }, "Failed to decrypt chat_cache slack bot token"),
+  );
+  if (!decrypted.ok) return null;
+  const plaintext = decrypted.value;
   // Prefer the row's persisted `installedAt` (when present), fall back
   // to the cache row's stored timestamp. A fresh `Date.now()` would
   // mask reads of legacy entries written before this field existed.
@@ -193,69 +190,58 @@ function parseStoredInstallation(
   };
 }
 
-/**
- * Get the bot token for a team. Checks internal DB (chat_cache) first,
- * then falls back to `SLACK_BOT_TOKEN` env var.
- */
-export async function getInstallation(
-  teamId: string,
-): Promise<SlackInstallationWithSecret | null> {
-  if (hasInternalDB()) {
-    try {
-      const rows = await internalQuery<{
-        value: unknown;
-        installed_at: string | null;
-      }>(
-        `SELECT value, to_char((value->>'${FIELD.installedAt}')::timestamptz AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS installed_at
-           FROM ${INSTALL_TABLE}
-          WHERE key = $1
-            AND (expires_at IS NULL OR expires_at > NOW())`,
-        [keyFor(teamId)],
-      );
-      if (rows.length === 0) return null;
-      return parseStoredInstallation(teamId, rows[0].value, rows[0].installed_at);
-    } catch (err) {
-      log.error(
-        { teamId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to query chat_cache for Slack installation",
-      );
-      throw err;
-    }
-  }
+// ---------------------------------------------------------------------------
+// Backend adapter + seam
+// ---------------------------------------------------------------------------
 
-  // Single-workspace mode: no internal DB configured, use env var.
-  const envToken = process.env.SLACK_BOT_TOKEN;
-  if (envToken) {
-    return {
-      team_id: teamId,
-      bot_token: envToken,
-      org_id: null,
-      workspace_name: null,
-      installed_at: new Date().toISOString(),
-    };
-  }
-  return null;
+/** Save payload for a Slack installation (OAuth flow). */
+interface SlackSaveInput {
+  botToken: string;
+  orgId?: string;
+  workspaceName?: string;
 }
 
 /**
- * Get the Slack installation for an org. Returns null if not found or
- * if no internal database is configured (org-scoped lookups require a
- * DB). Backed by the partial expression index on
- * `chat_cache.value->>'orgId'` filtered by the `slack:installation:`
- * key prefix.
+ * The `chat_cache`-backed adapter. Owns the JSONB SQL + the
+ * chat-adapter-compatible cipher; the {@link PlatformInstallationStore}
+ * seam owns the control flow and the shared invariants. The SQL is
+ * carried over unchanged from the pre-seam store; its exact literals are
+ * load-bearing — the partial expression index and `@chat-adapter/slack`
+ * interop depend on them.
  */
-export async function getInstallationByOrg(
-  orgId: string,
-): Promise<SlackInstallation | null> {
-  if (!hasInternalDB()) return null;
+const slackBackend: InstallationBackend<
+  SlackInstallationWithSecret,
+  SlackInstallation,
+  SlackSaveInput
+> = {
+  name: "Slack",
+  routingNoun: "Slack workspace",
+  // Slack's delete is best-effort without a DB — warn + no-op (a
+  // single-workspace deploy has nothing to delete).
+  deleteRequiresInternalDb: false,
 
-  try {
+  async selectByRouting(teamId) {
+    const rows = await internalQuery<{
+      value: unknown;
+      installed_at: string | null;
+    }>(
+      `SELECT value, to_char((value->>'${FIELD.installedAt}')::timestamptz AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS installed_at
+         FROM ${INSTALL_TABLE}
+        WHERE key = $1
+          AND (expires_at IS NULL OR expires_at > NOW())`,
+      [keyFor(teamId)],
+    );
+    if (rows.length === 0) return null;
+    return parseStoredInstallation(teamId, rows[0].value, rows[0].installed_at);
+  },
+
+  async selectByOrg(orgId) {
     // NOTE: the `key LIKE 'slack:installation:%'` predicate is a LITERAL
     // (not a `$1` parameter) so the planner can match it against the
     // partial expression index `idx_chat_cache_slack_org_id`'s WHERE
     // clause. A parameterized LIKE blocks the index match because
     // Postgres can't prove `$1 = 'slack:installation:%'` statically.
-    // Same pattern in `deleteInstallationByOrg` and the org-purge
+    // Same pattern in this backend's `deleteByOrg` and the org-purge
     // DELETE in `lib/db/internal.ts`.
     const rows = await internalQuery<{
       key: string;
@@ -272,53 +258,27 @@ export async function getInstallationByOrg(
     );
     if (rows.length === 0) return null;
     const teamId = rows[0].key.slice(KEY_PREFIX.length);
-    const full = parseStoredInstallation(teamId, rows[0].value, rows[0].installed_at);
-    if (!full) return null;
-    const { bot_token: _drop, ...pub } = full;
-    return pub;
-  } catch (err) {
-    log.error(
-      { orgId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to query chat_cache for Slack installation by org",
-    );
-    throw err;
-  }
-}
+    return parseStoredInstallation(teamId, rows[0].value, rows[0].installed_at);
+  },
 
-// ---------------------------------------------------------------------------
-// Write operations
-// ---------------------------------------------------------------------------
+  async upsert(teamId, input) {
+    const orgId = input.orgId ?? null;
+    const workspaceName = input.workspaceName ?? null;
 
-/**
- * Save or update a Slack installation (OAuth flow). Single atomic
- * upsert. Throws if the database write fails or if the team is
- * already bound to a different org.
- */
-export async function saveInstallation(
-  teamId: string,
-  botToken: string,
-  opts?: { orgId?: string; workspaceName?: string },
-): Promise<void> {
-  if (!hasInternalDB()) {
-    throw new Error("Cannot save Slack installation — no internal database configured");
-  }
-  const orgId = opts?.orgId ?? null;
-  const workspaceName = opts?.workspaceName ?? null;
+    const value: StoredInstallation = {
+      botToken: encryptSlackInstallationToken(input.botToken),
+      ...(workspaceName ? { teamName: workspaceName, workspaceName } : {}),
+      ...(orgId ? { orgId } : {}),
+      installedAt: new Date().toISOString(),
+    };
 
-  const value: StoredInstallation = {
-    botToken: encryptSlackInstallationToken(botToken),
-    ...(workspaceName ? { teamName: workspaceName, workspaceName } : {}),
-    ...(orgId ? { orgId } : {}),
-    installedAt: new Date().toISOString(),
-  };
-
-  const pool = getInternalDB();
-  // Atomic upsert with hijack protection — the WHERE clause rejects
-  // a row already bound to a different org in one statement (no TOCTOU
-  // race). Merges `value` so the chat-adapter's own writes (e.g.
-  // `botUserId` set by a future `auth.test` round-trip) aren't clobbered.
-  const result = await pool.query(
-    `INSERT INTO ${INSTALL_TABLE} (key, value, expires_at)
+    const pool = getInternalDB();
+    // Atomic upsert with hijack protection — the WHERE clause rejects
+    // a row already bound to a different org in one statement (no TOCTOU
+    // race). Merges `value` so the chat-adapter's own writes (e.g.
+    // `botUserId` set by a future `auth.test` round-trip) aren't clobbered.
+    const result = await pool.query(
+      `INSERT INTO ${INSTALL_TABLE} (key, value, expires_at)
      VALUES ($1, $2::jsonb, NULL)
      ON CONFLICT (key) DO UPDATE
        SET value = chat_cache.value || EXCLUDED.value,
@@ -326,43 +286,20 @@ export async function saveInstallation(
        WHERE chat_cache.value->>'${FIELD.orgId}' IS NULL
           OR chat_cache.value->>'${FIELD.orgId}' = $3
      RETURNING key`,
-    [keyFor(teamId), JSON.stringify(value), orgId],
-  );
-
-  if (result.rows.length === 0) {
-    throw new Error(
-      `Slack workspace ${teamId} is already bound to a different organization. ` +
-        "Disconnect the existing installation first.",
+      [keyFor(teamId), JSON.stringify(value), orgId],
     );
-  }
-}
+    return result.rows.length > 0;
+  },
 
-/**
- * Remove a Slack installation by team ID. No-op (with warning) when no
- * internal DB is configured.
- */
-export async function deleteInstallation(teamId: string): Promise<void> {
-  if (!hasInternalDB()) {
-    log.warn({ teamId }, "Cannot delete Slack installation — no internal database configured");
-    return;
-  }
-  const pool = getInternalDB();
-  await pool.query(`DELETE FROM ${INSTALL_TABLE} WHERE key = $1`, [keyFor(teamId)]);
-}
-
-/**
- * Remove the Slack installation for an org. Returns true if a row was
- * deleted, false if no matching row found. Throws if no internal DB
- * or if the query fails.
- */
-export async function deleteInstallationByOrg(orgId: string): Promise<boolean> {
-  if (!hasInternalDB()) {
-    throw new Error("Cannot delete Slack installation — no internal database configured");
-  }
-  try {
+  async deleteByRouting(teamId) {
     const pool = getInternalDB();
-    // Literal LIKE for partial-index match — see `getInstallationByOrg`
-    // for the planner-rationale comment.
+    await pool.query(`DELETE FROM ${INSTALL_TABLE} WHERE key = $1`, [keyFor(teamId)]);
+  },
+
+  async deleteByOrg(orgId) {
+    const pool = getInternalDB();
+    // Literal LIKE for partial-index match — see this backend's
+    // `selectByOrg` for the planner-rationale comment.
     const result = await pool.query(
       `DELETE FROM ${INSTALL_TABLE}
         WHERE key LIKE 'slack:installation:%'
@@ -371,13 +308,90 @@ export async function deleteInstallationByOrg(orgId: string): Promise<boolean> {
       [orgId],
     );
     return result.rows.length > 0;
-  } catch (err) {
-    log.error(
-      { orgId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to delete chat_cache Slack installation by org",
-    );
-    throw err;
-  }
+  },
+
+  envFallback(teamId) {
+    // Single-workspace mode: no internal DB configured, use env var.
+    const envToken = process.env.SLACK_BOT_TOKEN;
+    if (envToken) {
+      return {
+        team_id: teamId,
+        bot_token: envToken,
+        org_id: null,
+        workspace_name: null,
+        installed_at: new Date().toISOString(),
+      };
+    }
+    return null;
+  },
+
+  toPublic(full) {
+    const { bot_token: _drop, ...pub } = full;
+    return pub;
+  },
+};
+
+const store = new PlatformInstallationStore(slackBackend, log);
+
+// ---------------------------------------------------------------------------
+// Public API — thin wrappers over the seam (signatures unchanged)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the bot token for a team. Checks internal DB (chat_cache) first,
+ * then falls back to `SLACK_BOT_TOKEN` env var.
+ */
+export function getInstallation(
+  teamId: string,
+): Promise<SlackInstallationWithSecret | null> {
+  return store.get(teamId);
+}
+
+/**
+ * Get the Slack installation for an org. Returns null if not found or
+ * if no internal database is configured (org-scoped lookups require a
+ * DB). Backed by the partial expression index on
+ * `chat_cache.value->>'orgId'` filtered by the `slack:installation:`
+ * key prefix.
+ */
+export function getInstallationByOrg(
+  orgId: string,
+): Promise<SlackInstallation | null> {
+  return store.getByOrg(orgId);
+}
+
+/**
+ * Save or update a Slack installation (OAuth flow). Single atomic
+ * upsert. Throws if the database write fails or if the team is
+ * already bound to a different org.
+ */
+export function saveInstallation(
+  teamId: string,
+  botToken: string,
+  opts?: { orgId?: string; workspaceName?: string },
+): Promise<void> {
+  return store.save(teamId, {
+    botToken,
+    orgId: opts?.orgId,
+    workspaceName: opts?.workspaceName,
+  });
+}
+
+/**
+ * Remove a Slack installation by team ID. No-op (with warning) when no
+ * internal DB is configured.
+ */
+export function deleteInstallation(teamId: string): Promise<void> {
+  return store.delete(teamId);
+}
+
+/**
+ * Remove the Slack installation for an org. Returns true if a row was
+ * deleted, false if no matching row found. Throws if no internal DB
+ * or if the query fails.
+ */
+export function deleteInstallationByOrg(orgId: string): Promise<boolean> {
+  return store.deleteByOrg(orgId);
 }
 
 /** Get the bot token for a team — convenience wrapper. */


### PR DESCRIPTION
## Summary
- Extracts a generic `PlatformInstallationStore<Full, Public, SaveInput>` (`lib/integrations/platform-installation-store.ts`) that owns the shared five-op contract (`get`/`getByOrg`/`save`/`delete`/`deleteByOrg`) plus the three invariants — **decrypt-or-hide-row** (`decryptOrHide`), **org-hijack-safe upsert** (now one implementation, rejected in one place), and **single-tenant env fallback** — each parameterized by a per-platform backend adapter + cipher.
- `slack/store.ts` and `discord/store.ts` become thin backend adapters + wrappers over the seam. Slack keeps `chat_cache` + the `@chat-adapter/slack`-compatible cipher; Discord keeps `discord_installations` + `encryptSecret`. **Backend SQL and all ten public wrapper signatures are unchanged** — the byte-compat store tests still pass. **ADR-0003's two-store split is preserved** (one seam, two physically-separate backends).
- Bonus hardening: a uniform `warn`-level audit log on rejected cross-org bind (hijack) attempts for both platforms; Discord's org-hijack rejection + its 4 previously-untested ops now have real-backend coverage.

## Acceptance criteria (from #4201)
- [x] One store seam with two backend adapters; the org-hijack invariant lives in one implementation, exercised once at the seam (real backends still integration-test it end-to-end)
- [x] Slack's `chat_cache` format + cipher byte-compatible (interop with `@chat-adapter/slack` unchanged)
- [x] ADR-0003 two-store split preserved

## Test plan
- [x] New seam test (`platform-installation-store.test.ts`, 21 cases) pins the three invariants + per-backend no-DB delete policy + rethrow-logs-error paths with a fake backend
- [x] Existing Slack (26) + Discord (13) store tests green — byte-compat safety net, extended for decrypt-hide + Discord's remaining ops/hijack
- [x] `bun run type`, `bun run lint`, full `scripts/ci-local.sh` — all 27 gates green (DATABASE_URL unset)
- [x] Reviewed by the internal 4-specialist panel (2 rounds): CLEAN

Reviewed with the internal review panel (silent-failure, type-design, test-coverage, comment-accuracy); all findings addressed inline.

Closes #4201