### PR TITLE
refactor(web): give Conversation scope one owning module (#4189)

### DIFF
--- a/packages/web/src/ui/__tests__/use-conversation-scope.test.tsx
+++ b/packages/web/src/ui/__tests__/use-conversation-scope.test.tsx
@@ -1,0 +1,394 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { act, renderHook, waitFor, cleanup } from "@testing-library/react";
+import {
+  conversationScopeReducer,
+  INITIAL_CONVERSATION_SCOPE,
+  useConversationScope,
+  type ConversationScopeState,
+} from "../hooks/use-conversation-scope";
+import { useChatRoutingPreferenceStore } from "@/lib/stores/chat-routing-preference-store";
+import type {
+  ChatEnvGroup,
+  ChatEnvSelection,
+  ConversationScopeSource,
+} from "../components/chat/env-picker";
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const SINGLE_GROUP: ChatEnvGroup[] = [
+  {
+    id: "g1",
+    name: "prod",
+    primaryConnectionId: "c1",
+    members: [{ connectionId: "c1", dbType: "postgres", description: null }],
+  },
+];
+
+const MULTI_MEMBER_GROUP: ChatEnvGroup[] = [
+  {
+    id: "g1",
+    name: "prod",
+    primaryConnectionId: "c1",
+    members: [
+      { connectionId: "c1", dbType: "postgres", description: null },
+      { connectionId: "c2", dbType: "postgres", description: null },
+    ],
+  },
+];
+
+/** A non-initial state, so a transition's untouched fields are observable. */
+const SEEDED_STATE: ConversationScopeState = {
+  groupId: "g1",
+  connectionId: "c1",
+  routingMode: "pin",
+  restExcludedDatasourceIds: ["x1"],
+  restFocusDatasourceId: "f1",
+  groupReach: "g1",
+  sqlProvenance: "default",
+  restProvenance: "default",
+  reachProvenance: "default",
+};
+
+// ── Pure reducer — transitions unit-tested outside any component ──────
+
+describe("conversationScopeReducer — seedResolved (#4189)", () => {
+  test("restore applies all six values + marks SQL/reach explicit, leaves REST provenance", () => {
+    const next = conversationScopeReducer(INITIAL_CONVERSATION_SCOPE, {
+      type: "seedResolved",
+      decision: {
+        kind: "restore",
+        groupId: "g1",
+        connectionId: "c2",
+        routingMode: "all",
+        restExcludedDatasourceIds: ["x1"],
+        restFocusDatasourceId: "f1",
+        groupReach: "g1",
+      },
+    });
+    expect(next).toEqual({
+      groupId: "g1",
+      connectionId: "c2",
+      routingMode: "all",
+      restExcludedDatasourceIds: ["x1"],
+      restFocusDatasourceId: "f1",
+      groupReach: "g1",
+      sqlProvenance: "explicit",
+      restProvenance: "unset", // unchanged from INITIAL — mirrors the old effect
+      reachProvenance: "explicit",
+    });
+  });
+
+  test("seed preserves routingMode + REST provenance, marks SQL/reach default", () => {
+    // Start from a state with a routingMode set to prove seed never touches it
+    // (a seed decision carries no routingMode).
+    const start: ConversationScopeState = {
+      ...INITIAL_CONVERSATION_SCOPE,
+      routingMode: "auto",
+      restProvenance: "explicit",
+    };
+    const next = conversationScopeReducer(start, {
+      type: "seedResolved",
+      decision: {
+        kind: "seed",
+        groupId: "g1",
+        connectionId: "c1",
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
+        groupReach: null,
+      },
+    });
+    expect(next.groupId).toBe("g1");
+    expect(next.connectionId).toBe("c1");
+    expect(next.routingMode).toBe("auto"); // preserved
+    expect(next.sqlProvenance).toBe("default");
+    expect(next.reachProvenance).toBe("default");
+    expect(next.restProvenance).toBe("explicit"); // preserved (decoupled)
+  });
+});
+
+describe("conversationScopeReducer — conversationRestored (#4189)", () => {
+  test("restore kind: SQL + REST + reach all explicit", () => {
+    const source = {
+      kind: "restore" as const,
+      groupId: "g1",
+      connectionId: "c2",
+      routingMode: "all" as const,
+      restExcludedDatasourceIds: ["x1"],
+      restFocusDatasourceId: null,
+      groupReach: "g1",
+    };
+    const next = conversationScopeReducer(INITIAL_CONVERSATION_SCOPE, {
+      type: "conversationRestored",
+      decision: source,
+    });
+    expect(next).toEqual({
+      groupId: "g1",
+      connectionId: "c2",
+      routingMode: "all",
+      restExcludedDatasourceIds: ["x1"],
+      restFocusDatasourceId: null,
+      groupReach: "g1",
+      sqlProvenance: "explicit",
+      restProvenance: "explicit",
+      reachProvenance: "explicit",
+    });
+  });
+
+  test("seed kind: REST + reach restored explicit, SQL reset to unset/null", () => {
+    // A row with no usable SQL scope but a live REST scope (the #3078 seam):
+    // the REST + reach survive as explicit while SQL defers to the seed effect.
+    const next = conversationScopeReducer(SEEDED_STATE, {
+      type: "conversationRestored",
+      decision: {
+        kind: "seed",
+        restExcludedDatasourceIds: ["x9"],
+        restFocusDatasourceId: "f9",
+        groupReach: "g2",
+      },
+    });
+    expect(next.groupId).toBeNull();
+    expect(next.connectionId).toBeNull();
+    expect(next.routingMode).toBeNull();
+    expect(next.sqlProvenance).toBe("unset");
+    expect(next.restExcludedDatasourceIds).toEqual(["x9"]);
+    expect(next.restFocusDatasourceId).toBe("f9");
+    expect(next.restProvenance).toBe("explicit");
+    expect(next.groupReach).toBe("g2");
+    expect(next.reachProvenance).toBe("explicit");
+  });
+});
+
+describe("conversationScopeReducer — user intents (#4189)", () => {
+  test("selectionApplied sets SQL + reach explicit, leaves REST untouched", () => {
+    const next = conversationScopeReducer(SEEDED_STATE, {
+      type: "selectionApplied",
+      next: {
+        groupReach: null,
+        groupId: "g2",
+        connectionId: "c3",
+        routingMode: "auto",
+      },
+    });
+    expect(next.groupReach).toBeNull();
+    expect(next.groupId).toBe("g2");
+    expect(next.connectionId).toBe("c3");
+    expect(next.routingMode).toBe("auto");
+    expect(next.sqlProvenance).toBe("explicit");
+    expect(next.reachProvenance).toBe("explicit");
+    // REST axis untouched.
+    expect(next.restExcludedDatasourceIds).toEqual(["x1"]);
+    expect(next.restFocusDatasourceId).toBe("f1");
+    expect(next.restProvenance).toBe("default");
+  });
+
+  test("restExcludedApplied marks REST + SQL explicit (not reach)", () => {
+    const next = conversationScopeReducer(SEEDED_STATE, {
+      type: "restExcludedApplied",
+      next: ["x1", "x2"],
+    });
+    expect(next.restExcludedDatasourceIds).toEqual(["x1", "x2"]);
+    expect(next.restProvenance).toBe("explicit");
+    expect(next.sqlProvenance).toBe("explicit");
+    expect(next.reachProvenance).toBe("default"); // untouched
+  });
+
+  test("restFocusApplied marks REST + SQL explicit (not reach)", () => {
+    const next = conversationScopeReducer(SEEDED_STATE, {
+      type: "restFocusApplied",
+      next: null,
+    });
+    expect(next.restFocusDatasourceId).toBeNull();
+    expect(next.restProvenance).toBe("explicit");
+    expect(next.sqlProvenance).toBe("explicit");
+    expect(next.reachProvenance).toBe("default");
+  });
+
+  test("resetForNewChat returns the fresh-chat initial state", () => {
+    const next = conversationScopeReducer(SEEDED_STATE, {
+      type: "resetForNewChat",
+    });
+    expect(next).toEqual(INITIAL_CONVERSATION_SCOPE);
+  });
+});
+
+// ── Hook integration — seed effect + persist-back ────────────────────
+
+function resetPreferenceStore() {
+  localStorage.clear();
+  act(() => {
+    useChatRoutingPreferenceStore.setState({
+      workspaceId: null,
+      groupId: null,
+      connectionId: null,
+      routingMode: null,
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: null,
+      _hasHydrated: true,
+    });
+  });
+}
+
+describe("useConversationScope — seed/restore effect + persist-back (#4189)", () => {
+  beforeEach(() => {
+    resetPreferenceStore();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("seeds the group-primary default on a fresh chat once inputs are ready", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: SINGLE_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: null,
+        sessionResolved: true,
+      }),
+    );
+    await waitFor(() => expect(result.current.scope.groupId).toBe("g1"));
+    expect(result.current.scope.connectionId).toBe("c1");
+  });
+
+  test("stays unseeded until the preference store has hydrated", async () => {
+    act(() => {
+      useChatRoutingPreferenceStore.setState({ _hasHydrated: false });
+    });
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: SINGLE_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: null,
+        sessionResolved: true,
+      }),
+    );
+    // Give effects a chance to run; the gate must keep it null.
+    await Promise.resolve();
+    expect(result.current.scope.groupId).toBeNull();
+  });
+
+  test("applySelection persists the pick to the sticky preference", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: MULTI_MEMBER_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: "ws1",
+        sessionResolved: true,
+      }),
+    );
+    const selection: ChatEnvSelection = {
+      groupReach: null,
+      groupId: "g1",
+      connectionId: "c2",
+      routingMode: "pin",
+    };
+    act(() => result.current.applySelection(selection));
+    expect(result.current.scope.connectionId).toBe("c2");
+    expect(result.current.scope.routingMode).toBe("pin");
+    const pref = useChatRoutingPreferenceStore.getState();
+    expect(pref.workspaceId).toBe("ws1");
+    expect(pref.groupId).toBe("g1");
+    expect(pref.connectionId).toBe("c2");
+    expect(pref.routingMode).toBe("pin");
+  });
+
+  test("applyRestExcluded persists the exclude-set + keeps current SQL scope", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: MULTI_MEMBER_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: "ws1",
+        sessionResolved: true,
+      }),
+    );
+    // Establish an SQL pick first, then toggle a REST exclusion.
+    act(() =>
+      result.current.applySelection({
+        groupReach: null,
+        groupId: "g1",
+        connectionId: "c1",
+        routingMode: "pin",
+      }),
+    );
+    act(() => result.current.applyRestExcluded(["d1"]));
+    expect(result.current.scope.restExcludedDatasourceIds).toEqual(["d1"]);
+    const pref = useChatRoutingPreferenceStore.getState();
+    expect(pref.restExcludedDatasourceIds).toEqual(["d1"]);
+    // The exclude toggle carried the current SQL scope into the preference.
+    expect(pref.groupId).toBe("g1");
+    expect(pref.connectionId).toBe("c1");
+  });
+
+  test("applyRestFocus persists the focus", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: MULTI_MEMBER_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: "ws1",
+        sessionResolved: true,
+      }),
+    );
+    act(() => result.current.applyRestFocus("d7"));
+    expect(result.current.scope.restFocusDatasourceId).toBe("d7");
+    expect(useChatRoutingPreferenceStore.getState().restFocusDatasourceId).toBe(
+      "d7",
+    );
+  });
+
+  test("restore applies an opened conversation's persisted scope", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: MULTI_MEMBER_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: "ws1",
+        sessionResolved: true,
+      }),
+    );
+    const source: ConversationScopeSource = {
+      connectionGroupId: "g1",
+      connectionId: "c2",
+      routingMode: "all",
+      restExcludedDatasourceIds: ["d1"],
+      restFocusDatasourceId: null,
+      groupReach: "g1",
+    };
+    act(() => result.current.restore(source, MULTI_MEMBER_GROUP));
+    expect(result.current.scope.groupId).toBe("g1");
+    expect(result.current.scope.connectionId).toBe("c2");
+    expect(result.current.scope.routingMode).toBe("all");
+    expect(result.current.scope.restExcludedDatasourceIds).toEqual(["d1"]);
+    expect(result.current.scope.groupReach).toBe("g1");
+  });
+
+  test("resetForNewChat clears an explicit scope then re-seeds the default", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: SINGLE_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: null,
+        sessionResolved: true,
+      }),
+    );
+    // Restore a conversation's explicit "all" scope (this does NOT persist to the
+    // sticky preference — so the reset below re-seeds the bare default, not it).
+    act(() =>
+      result.current.restore(
+        {
+          connectionGroupId: "g1",
+          connectionId: "c1",
+          routingMode: "all",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
+        },
+        SINGLE_GROUP,
+      ),
+    );
+    expect(result.current.scope.routingMode).toBe("all");
+    act(() => result.current.resetForNewChat());
+    // The new chat re-seeds from scratch: SQL default seed (single group), and
+    // the explicit "all" mode is gone (a seed carries no routingMode).
+    await waitFor(() => expect(result.current.scope.groupId).toBe("g1"));
+    expect(result.current.scope.routingMode).toBeNull();
+  });
+});

--- a/packages/web/src/ui/__tests__/use-conversation-scope.test.tsx
+++ b/packages/web/src/ui/__tests__/use-conversation-scope.test.tsx
@@ -267,7 +267,42 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
     expect(result.current.scope.groupId).toBeNull();
   });
 
-  test("applySelection persists the pick to the sticky preference", async () => {
+  test("stays unseeded until the session has resolved", async () => {
+    const { result } = renderHook(() =>
+      useConversationScope({
+        groups: SINGLE_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: null,
+        sessionResolved: false, // the resolver returns `wait`
+      }),
+    );
+    await Promise.resolve();
+    expect(result.current.scope.groupId).toBeNull();
+  });
+
+  test("the seed settles — the effect does not loop after applying it", async () => {
+    // The effect now depends on the whole reducer `state` (not the old
+    // individual value fields). Guard the "re-runs the resolver, which then
+    // no-ops, rather than looping" claim: once seeded, renders must stop.
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useConversationScope({
+        groups: SINGLE_GROUP,
+        groupsLoaded: true,
+        activeWorkspaceId: null,
+        sessionResolved: true,
+      });
+    });
+    await waitFor(() => expect(result.current.scope.groupId).toBe("g1"));
+    const afterSeed = renders;
+    // Let any further effect passes drain; a looping effect would keep bumping
+    // the count (or hang). It must be quiescent.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(renders).toBe(afterSeed);
+  });
+
+  test("applySelection persists the pick + carries the current REST scope forward", async () => {
     const { result } = renderHook(() =>
       useConversationScope({
         groups: MULTI_MEMBER_GROUP,
@@ -276,8 +311,12 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
         sessionResolved: true,
       }),
     );
+    // Establish a REST scope first, so the selection below must carry it into the
+    // preference (the #3066/#3067 "an env change must not drop the REST scope"
+    // contract). A dropped carry would leave the pref REST fields empty.
+    act(() => result.current.applyRestExcluded(["d1"]));
     const selection: ChatEnvSelection = {
-      groupReach: null,
+      groupReach: "g1",
       groupId: "g1",
       connectionId: "c2",
       routingMode: "pin",
@@ -290,6 +329,9 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
     expect(pref.groupId).toBe("g1");
     expect(pref.connectionId).toBe("c2");
     expect(pref.routingMode).toBe("pin");
+    expect(pref.groupReach).toBe("g1"); // the picked reach is persisted
+    expect(pref.restExcludedDatasourceIds).toEqual(["d1"]); // carried, not dropped
+    expect(pref.restFocusDatasourceId).toBeNull();
   });
 
   test("applyRestExcluded persists the exclude-set + keeps current SQL scope", async () => {
@@ -319,7 +361,7 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
     expect(pref.connectionId).toBe("c1");
   });
 
-  test("applyRestFocus persists the focus", async () => {
+  test("applyRestFocus persists the focus + carries the current SQL scope forward", async () => {
     const { result } = renderHook(() =>
       useConversationScope({
         groups: MULTI_MEMBER_GROUP,
@@ -328,11 +370,23 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
         sessionResolved: true,
       }),
     );
+    // Establish an SQL pick first; the focus below must carry it (the #3078
+    // "a focus toggle must not drop the SQL scope from the preference" contract).
+    act(() =>
+      result.current.applySelection({
+        groupReach: null,
+        groupId: "g1",
+        connectionId: "c2",
+        routingMode: "pin",
+      }),
+    );
     act(() => result.current.applyRestFocus("d7"));
     expect(result.current.scope.restFocusDatasourceId).toBe("d7");
-    expect(useChatRoutingPreferenceStore.getState().restFocusDatasourceId).toBe(
-      "d7",
-    );
+    const pref = useChatRoutingPreferenceStore.getState();
+    expect(pref.restFocusDatasourceId).toBe("d7");
+    expect(pref.groupId).toBe("g1"); // SQL scope carried
+    expect(pref.connectionId).toBe("c2");
+    expect(pref.routingMode).toBe("pin");
   });
 
   test("restore applies an opened conversation's persisted scope", async () => {

--- a/packages/web/src/ui/__tests__/use-conversation-scope.test.tsx
+++ b/packages/web/src/ui/__tests__/use-conversation-scope.test.tsx
@@ -343,10 +343,12 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
         sessionResolved: true,
       }),
     );
-    // Establish an SQL pick first, then toggle a REST exclusion.
+    // Establish an SQL pick + a non-null reach first, then toggle a REST
+    // exclusion — the toggle must carry BOTH forward (the #3078/#3895 "a REST
+    // toggle must not drop the SQL scope / reach from the preference" contract).
     act(() =>
       result.current.applySelection({
-        groupReach: null,
+        groupReach: "g1",
         groupId: "g1",
         connectionId: "c1",
         routingMode: "pin",
@@ -356,9 +358,10 @@ describe("useConversationScope — seed/restore effect + persist-back (#4189)", 
     expect(result.current.scope.restExcludedDatasourceIds).toEqual(["d1"]);
     const pref = useChatRoutingPreferenceStore.getState();
     expect(pref.restExcludedDatasourceIds).toEqual(["d1"]);
-    // The exclude toggle carried the current SQL scope into the preference.
+    // The exclude toggle carried the current SQL scope + reach into the preference.
     expect(pref.groupId).toBe("g1");
     expect(pref.connectionId).toBe("c1");
+    expect(pref.groupReach).toBe("g1");
   });
 
   test("applyRestFocus persists the focus + carries the current SQL scope forward", async () => {

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -30,12 +30,13 @@ import {
 import {
   ChatEnvPicker,
   shouldRenderEnvPicker,
-  resolveConversationScope,
-  resolveEnvSelection,
   useChatEnvGroups,
-  type ConversationRoutingMode,
-  type EnvSelectionProvenance,
 } from "./chat/env-picker";
+import {
+  useConversationScope,
+  INITIAL_CONVERSATION_SCOPE,
+  type ConversationScope,
+} from "../hooks/use-conversation-scope";
 import { useMode } from "@/ui/hooks/use-mode";
 import type { QuerySuggestion } from "@/ui/lib/types";
 import { ShareDialog } from "./chat/share-dialog";
@@ -55,7 +56,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { parseSuggestions } from "../lib/helpers";
 import { ErrorBoundary } from "./error-boundary";
 import { useUiStore } from "@/lib/stores/ui-store";
-import { useChatRoutingPreferenceStore } from "@/lib/stores/chat-routing-preference-store";
 import { chatSearchParams, resolveConversationUrlAction } from "./search-params";
 
 /* Static SVG icons — hoisted to avoid recreation on every render */
@@ -210,64 +210,16 @@ export function AtlasChat({
   // the second 409s after a visible success toast.
   const [pinningText, setPinningText] = useState<string | null>(null);
   const [relatedSuggestions, setRelatedSuggestions] = useState<QuerySuggestion[]>([]);
-  // #2345 — chat-header env/member picker state. The connection-group
-  // is the *content scope* (sticky to the conversation row across
-  // turns); the connection id is the *execution target* (a per-turn
-  // override that the agent honours for one turn only). Both default
-  // to `null` so the legacy single-connection flow continues to render
-  // without a picker.
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
-  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
-  // #2518 — three-state Auto/Pin/All cross-environment routing picker.
-  const [selectedRoutingMode, setSelectedRoutingMode] =
-    useState<ConversationRoutingMode | null>(null);
-  // #3066 — per-conversation REST datasource exclude-set (excluded
-  // `install_id`s). Empty = all in scope. Seeded from the sticky preference on
-  // a fresh chat, restored from the row when a conversation is opened.
-  const [selectedRestExcluded, setSelectedRestExcluded] = useState<string[]>([]);
-  // #3067 — per-conversation REST-only focus (a single `install_id`, or null =
-  // not focused). When set, the conversation targets only that datasource and
-  // SQL is suspended. Seeded from the sticky preference on a fresh chat,
-  // restored from the row when a conversation is opened.
-  const [selectedRestFocus, setSelectedRestFocus] = useState<string | null>(null);
-  // #3895 (ADR-0022) — per-conversation Group reach. `null` = All sources (every
-  // visible group reachable — the new default); a group id = Focus → that group.
-  // The cross-group axis ABOVE member routing. Seeded from the sticky preference
-  // on a fresh chat, restored from the row when a conversation is opened.
-  const [selectedGroupReach, setSelectedGroupReach] = useState<string | null>(null);
-  // #3044 — persisted env-picker preference so a reload restores the user's
-  // last selection instead of re-seeding from the first group. Select fields
-  // individually so the store object identity doesn't churn effect deps.
-  const prefWorkspaceId = useChatRoutingPreferenceStore((s) => s.workspaceId);
-  const prefGroupId = useChatRoutingPreferenceStore((s) => s.groupId);
-  const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
-  const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
-  const prefRestExcluded = useChatRoutingPreferenceStore((s) => s.restExcludedDatasourceIds);
-  const prefRestFocus = useChatRoutingPreferenceStore((s) => s.restFocusDatasourceId);
-  const prefGroupReach = useChatRoutingPreferenceStore((s) => s.groupReach);
-  const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
-  const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
-  // #3064 — how the current picker SQL scope (group / member / mode) was set, so
-  // the seed/restore effect knows whether it may replace it. A ref (not state)
-  // because it must update synchronously alongside a setSelected* call without
-  // re-triggering the effect itself.
-  const selectionProvenanceRef = useRef<EnvSelectionProvenance>("unset");
-  // #3078 — the REST scope (exclude-set + focus) has its OWN provenance,
-  // decoupled from the SQL `selectionProvenanceRef`. Opening a conversation
-  // makes the row's REST scope authoritative ("explicit") even when its SQL
-  // scope must be seeded (an all-null row), and a REST toggle marks it explicit
-  // too. While it's explicit, `resolveEnvSelection` passes the current REST scope
-  // through any SQL seed/restore instead of clobbering it — the seam that fixes
-  // the all-null-SQL exclude-set data loss. `handleNewChat` resets it to "unset".
-  const restScopeProvenanceRef = useRef<EnvSelectionProvenance>("unset");
-  // #3895 — the Group reach has its OWN provenance, decoupled from the SQL
-  // member-routing (`selectionProvenanceRef`) and REST (`restScopeProvenanceRef`)
-  // provenances (the #3078 decoupling, applied to the reach axis). Opening a
-  // conversation makes the row's reach authoritative ("explicit") regardless of
-  // the SQL decision; a reach pick marks it explicit too. While explicit,
-  // `resolveEnvSelection` passes the current reach through any SQL seed/restore
-  // instead of clobbering it. `handleNewChat` resets it to "unset".
-  const groupReachProvenanceRef = useRef<EnvSelectionProvenance>("unset");
+  // #2345 / #4189 — the conversation's env/member/REST/reach scope lives in the
+  // `useConversationScope` hook (one owning module for the three (value,
+  // provenance) axes + sticky preference). The hook needs transport-derived
+  // inputs (activeWorkspaceId / sessionResolved / envGroups), so it's called
+  // below them — but the transport's chat-request getters need to read the
+  // LATEST scope. This mirror ref bridges that: the getters read
+  // `scopeRef.current` (lazy, at fetch time), and the hook's `scope` is synced
+  // into it on every render right after the hook call (the same latest-value ref
+  // pattern as `refreshConvosRef`).
+  const scopeRef = useRef<ConversationScope>(INITIAL_CONVERSATION_SCOPE);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -311,17 +263,17 @@ export function AtlasChat({
     // Refs inside `useAtlasTransport` snapshot these at fetch time so
     // a picker change mid-conversation reaches the agent on the very
     // next turn without rebuilding the transport.
-    getConnectionId: () => selectedConnectionId,
-    getConnectionGroupId: () => selectedGroupId,
-    getRoutingMode: () => selectedRoutingMode,
+    getConnectionId: () => scopeRef.current.connectionId,
+    getConnectionGroupId: () => scopeRef.current.groupId,
+    getRoutingMode: () => scopeRef.current.routingMode,
     // #3066 — forward the REST exclude-set on every turn (always, even []).
-    getRestExcludedDatasourceIds: () => selectedRestExcluded,
+    getRestExcludedDatasourceIds: () => scopeRef.current.restExcludedDatasourceIds,
     // #3067 — forward the REST-only focus on every turn (always, even null) so
     // a clear actually nulls the row instead of inheriting the stale focus.
-    getRestFocusDatasourceId: () => selectedRestFocus,
+    getRestFocusDatasourceId: () => scopeRef.current.restFocusDatasourceId,
     // #3895 — forward the Group reach on every turn (always, even null) so a
     // widen back to All sources nulls the row instead of inheriting stale Focus.
-    getGroupReach: () => selectedGroupReach,
+    getGroupReach: () => scopeRef.current.groupReach,
     // #3749 — onRunId: capture the active run id for correlation/telemetry only
     // (not used to target a resume). getResumeConversationId: a resume targets the
     // bound CONVERSATION (not the run id); the affordance only shows once a
@@ -388,126 +340,29 @@ export function AtlasChat({
   // draft-count and showed a misleading "No connection configured" prompt.
   const showDevChatEmpty = shouldShowDevChatEmpty({ mode, ...envGroupsQuery });
 
-  // Seed / restore the env-picker selection on a fresh chat. #3064 — the
-  // decision is centralized in `resolveEnvSelection`: it waits until groups,
-  // the persisted preference, and the workspace id are all ready (so a
-  // default seed never pre-empts a restorable preference — the reset-on-reload
-  // bug), restores a workspace-matching sticky preference over the default
-  // seed, and never clobbers an explicit pick. Provenance is tracked in a ref
-  // so a default-seeded value can still yield to a later-arriving match.
-  useEffect(() => {
-    const decision = resolveEnvSelection({
-      groups: envGroupsQuery.groups,
-      current: {
-        groupId: selectedGroupId,
-        connectionId: selectedConnectionId,
-        routingMode: selectedRoutingMode,
-        restExcludedDatasourceIds: selectedRestExcluded,
-        restFocusDatasourceId: selectedRestFocus,
-        groupReach: selectedGroupReach,
-      },
-      provenance: selectionProvenanceRef.current,
-      // #3078 — REST scope provenance is independent of the SQL provenance. When
-      // it's "explicit" (a conversation-open restore or a user toggle), the
-      // resolver passes the current REST scope through instead of clobbering it
-      // with the default seed / sticky preference while SQL seeds or restores.
-      restProvenance: restScopeProvenanceRef.current,
-      // #3895 — Group reach provenance, independent of both (same seam as REST).
-      groupReachProvenance: groupReachProvenanceRef.current,
-      preference: {
-        workspaceId: prefWorkspaceId,
-        groupId: prefGroupId,
-        connectionId: prefConnectionId,
-        routingMode: prefRoutingMode,
-        restExcludedDatasourceIds: prefRestExcluded,
-        restFocusDatasourceId: prefRestFocus,
-        groupReach: prefGroupReach,
-      },
-      activeWorkspaceId,
-      preferenceHydrated: prefHasHydrated,
-      sessionResolved,
-      // #3078 — a settled fetch means an empty `groups` is a real zero-group
-      // (REST-only) workspace, not a cold start; lets the resolver seed the
-      // sticky REST preference there instead of waiting forever.
-      groupsLoaded: envGroupsQuery.hasLoaded,
-    });
-
-    switch (decision.kind) {
-      case "restore":
-        setSelectedGroupId(decision.groupId);
-        setSelectedConnectionId(decision.connectionId);
-        // Apply the stored mode faithfully, including an explicit null
-        // (pre-#2518 back-compat → "pin"); a truthy guard here would drop it.
-        setSelectedRoutingMode(decision.routingMode);
-        // #3066 — seed the sticky preference's exclude-set onto this fresh chat.
-        setSelectedRestExcluded(decision.restExcludedDatasourceIds);
-        // #3067 — seed the sticky preference's REST-only focus too.
-        setSelectedRestFocus(decision.restFocusDatasourceId);
-        // #3895 — seed the sticky preference's Group reach too.
-        setSelectedGroupReach(decision.groupReach);
-        // A restored sticky preference is the user's deliberate prior choice —
-        // mark it explicit so a later effect run can't seed over it. The reach
-        // has its own provenance but settles together with the SQL scope here.
-        selectionProvenanceRef.current = "explicit";
-        groupReachProvenanceRef.current = "explicit";
-        break;
-      case "seed":
-        setSelectedGroupId(decision.groupId);
-        setSelectedConnectionId(decision.connectionId);
-        // #3066 — a default seed excludes nothing.
-        setSelectedRestExcluded(decision.restExcludedDatasourceIds);
-        // #3067 — a default seed is not focused (SQL active).
-        setSelectedRestFocus(decision.restFocusDatasourceId);
-        // #3895 — a default seed is All sources (null), unless the reach was
-        // explicit and passed through.
-        setSelectedGroupReach(decision.groupReach);
-        // Record that this was auto-seeded: a workspace-matching preference
-        // arriving later is still restored over it (the resolver re-runs), but
-        // a second default seed is suppressed.
-        selectionProvenanceRef.current = "default";
-        groupReachProvenanceRef.current = "default";
-        break;
-      case "wait":
-      case "noop":
-        // Inputs not ready yet, or the selection is already settled — do
-        // nothing and let the effect re-run when a dependency changes.
-        break;
-      default: {
-        // Exhaustiveness guard — a new EnvSelectionDecision variant (e.g. the
-        // v0.0.4 REST-scope work on this branch's milestone) must add a branch.
-        const _exhaustive: never = decision;
-        void _exhaustive;
-      }
-    }
-  }, [
-    envGroupsQuery.groups,
-    // #3078 — re-evaluate once the fetch settles, so the zero-group REST-only
-    // path can seed the sticky preference instead of staying in `wait`.
-    envGroupsQuery.hasLoaded,
-    selectedGroupId,
-    selectedConnectionId,
-    // routingMode is part of `current` the resolver reads — keep it in deps so a
-    // mode-only change re-evaluates restore-vs-noop rather than going stale.
-    selectedRoutingMode,
-    // #3066 — exclude-set is part of `current`; keep it in deps so a pref-only
-    // exclude change re-evaluates restore-vs-noop rather than going stale.
-    selectedRestExcluded,
-    // #3067 — focus is part of `current` too; keep it in deps for the same reason.
-    selectedRestFocus,
-    // #3895 — reach is part of `current` too; keep it in deps so a pref-only reach
-    // change re-evaluates restore-vs-noop rather than going stale.
-    selectedGroupReach,
-    prefWorkspaceId,
-    prefGroupId,
-    prefConnectionId,
-    prefRoutingMode,
-    prefRestExcluded,
-    prefRestFocus,
-    prefGroupReach,
-    prefHasHydrated,
+  // #4189 — the conversation's scope (SQL group/member/mode + REST exclude/focus
+  // + Group reach) and its sticky-preference seeding live in one owning hook. It
+  // runs the fresh-chat seed/restore effect internally (the #3064 precedence:
+  // wait for groups + preference + workspace id, restore a matching sticky
+  // preference over the default seed, never clobber an explicit pick), owns the
+  // three (value, provenance) axes, and persists picks back to the preference.
+  const {
+    scope,
+    restore: restoreConversationScope,
+    applySelection: applyScopeSelection,
+    applyRestExcluded: applyScopeRestExcluded,
+    applyRestFocus: applyScopeRestFocus,
+    resetForNewChat: resetScopeForNewChat,
+  } = useConversationScope({
+    groups: envGroupsQuery.groups,
+    groupsLoaded: envGroupsQuery.hasLoaded,
     activeWorkspaceId,
     sessionResolved,
-  ]);
+  });
+  // Mirror the latest scope into the ref the transport getters read at fetch
+  // time (declared above the transport; see `scopeRef`). Assigning during render
+  // is the same latest-value pattern as `refreshConvosRef` below.
+  scopeRef.current = scope;
 
   const convos = useConversations({
     apiUrl,
@@ -890,45 +745,12 @@ export function AtlasChat({
       boundConversationIdRef.current = id;
       convos.setSelectedId(id);
       // Restore the conversation's persisted scope, validated against the
-      // currently-visible env groups. The SQL scope and the REST scope are
-      // restored INDEPENDENTLY (#3078):
-      //
-      //   - REST scope (exclude-set + focus) is always restored from the row and
-      //     marked `restProvenance: "explicit"` regardless of the SQL decision —
-      //     it is not tied to SQL routing. Marking it explicit (before the
-      //     setState calls, so the re-running seed/restore effect already sees
-      //     it) is what stops that effect from clobbering a restored exclude-set
-      //     when the SQL scope must be seeded. Before #3078 a `seed` cleared the
-      //     exclude-set and the always-sent transport array then wiped it on the
-      //     next turn (the data-loss bug).
-      //   - SQL scope: a `restore` is authoritative (precedence row > sticky
-      //     preference > default seed) — mark it `explicit` so the effect can't
-      //     replace it. A `seed` means the row carried no usable SQL scope
-      //     (all-null legacy row, or a group since archived): reset to `unset` so
-      //     the effect seeds the default / restores the sticky preference,
-      //     never sending stale-or-null routing the chip would misrepresent.
-      const decision = resolveConversationScope(data, envGroupsQuery.groups);
-      // REST scope — restored on BOTH decision kinds, made authoritative.
-      restScopeProvenanceRef.current = "explicit";
-      setSelectedRestExcluded(decision.restExcludedDatasourceIds);
-      setSelectedRestFocus(decision.restFocusDatasourceId);
-      // #3895 — Group reach — restored on BOTH decision kinds (read straight from
-      // the row's `group_reach`, independent of the SQL member-routing decision),
-      // made authoritative so the seed/restore effect can't clobber it.
-      groupReachProvenanceRef.current = "explicit";
-      setSelectedGroupReach(decision.groupReach);
-      // SQL scope — restore vs defer-to-seed.
-      if (decision.kind === "restore") {
-        selectionProvenanceRef.current = "explicit";
-        setSelectedGroupId(decision.groupId);
-        setSelectedConnectionId(decision.connectionId);
-        setSelectedRoutingMode(decision.routingMode);
-      } else {
-        selectionProvenanceRef.current = "unset";
-        setSelectedGroupId(null);
-        setSelectedConnectionId(null);
-        setSelectedRoutingMode(null);
-      }
+      // currently-visible env groups (#3065 / #3078 / #3895). The hook owns the
+      // per-axis restore-vs-seed precedence (row > sticky preference > default
+      // seed) and the (value, provenance) bookkeeping — REST scope + Group reach
+      // are always restored from the row and made authoritative regardless of the
+      // SQL decision, while an all-null SQL scope defers to the seed effect.
+      restoreConversationScope(data, envGroupsQuery.groups);
       setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
       // the wire, so any prior in-memory bucket is stale relative to the
@@ -972,31 +794,12 @@ export function AtlasChat({
     setMobileSidebarOpen(false);
     setPythonProgress(new Map());
     warningCtl.reset();
-    // #3065 — a new chat is not bound to any conversation's scope. Reset the
-    // selection provenance and clear the picker so the seed/restore effect
-    // re-runs from scratch — seeding from the sticky preference (or the
-    // default), exactly as on a fresh page load. Without this, a
-    // just-opened conversation's `explicit` scope would carry into the new
-    // chat and the effect would no-op on it.
-    selectionProvenanceRef.current = "unset";
-    // #3078 — reset the REST scope provenance too, so a just-opened
-    // conversation's `explicit` REST scope doesn't carry into the new chat and
-    // block the seed/restore effect from seeding the sticky preference / default.
-    restScopeProvenanceRef.current = "unset";
-    // #3895 — reset the Group reach provenance + value too, so a just-opened
-    // conversation's `explicit` reach doesn't carry into the new chat. The new
-    // chat re-seeds reach from the sticky preference (or the All-sources default).
-    groupReachProvenanceRef.current = "unset";
-    setSelectedGroupReach(null);
-    setSelectedGroupId(null);
-    setSelectedConnectionId(null);
-    setSelectedRoutingMode(null);
-    // #3066 — clear the exclude-set so the new chat re-seeds from the sticky
-    // preference (or the empty default), matching the env reset above.
-    setSelectedRestExcluded([]);
-    // #3067 — clear focus too; the new chat re-seeds focus from the sticky
-    // preference (or the not-focused default).
-    setSelectedRestFocus(null);
+    // #3065 — a new chat is not bound to any conversation's scope. Reset every
+    // axis (value + provenance) to `unset` so the hook's seed/restore effect
+    // re-runs from scratch — seeding from the sticky preference (or the default),
+    // exactly as on a fresh page load. Without this, a just-opened conversation's
+    // `explicit` scope would carry into the new chat and the effect would no-op.
+    resetScopeForNewChat();
   }
 
   // #3068 — the single bridge from URL → conversation state. A deep link / page
@@ -1153,85 +956,24 @@ export function AtlasChat({
                     groups={envGroupsQuery.groups}
                     emptyReason={envGroupsQuery.reason}
                     transportError={envGroupsQuery.error}
-                    activeGroupId={selectedGroupId}
-                    activeConnectionId={selectedConnectionId}
-                    activeRoutingMode={selectedRoutingMode}
-                    activeGroupReach={selectedGroupReach}
+                    activeGroupId={scope.groupId}
+                    activeConnectionId={scope.connectionId}
+                    activeRoutingMode={scope.routingMode}
+                    activeGroupReach={scope.groupReach}
                     restDatasources={envGroupsQuery.restDatasources}
-                    restExcludedDatasourceIds={selectedRestExcluded}
-                    onRestExcludedChange={(next) => {
-                      // #3066 — a scope toggle is a deliberate pick: mark the
-                      // selection explicit (so the seed/restore effect can't
-                      // re-seed over it) and remember it in the sticky
-                      // preference so new chats inherit it. The full next set
-                      // (incl. []) is forwarded verbatim. #3078 — mark the REST
-                      // scope's own provenance explicit too (keeping the SQL
-                      // provenance explicit avoids a stray pref-restore of SQL as
-                      // a side effect of a REST toggle).
-                      selectionProvenanceRef.current = "explicit";
-                      restScopeProvenanceRef.current = "explicit";
-                      setSelectedRestExcluded(next);
-                      setRoutingPreference({
-                        workspaceId: activeWorkspaceId,
-                        groupId: selectedGroupId,
-                        connectionId: selectedConnectionId,
-                        routingMode: selectedRoutingMode,
-                        restExcludedDatasourceIds: next,
-                        restFocusDatasourceId: selectedRestFocus,
-                        // #3895 — carry the current reach so a REST toggle doesn't
-                        // drop it from the sticky preference.
-                        groupReach: selectedGroupReach,
-                      });
-                    }}
-                    restFocusDatasourceId={selectedRestFocus}
-                    onRestFocusChange={(next) => {
-                      // #3067 — focusing / clearing is a deliberate pick: mark
-                      // explicit and remember it in the sticky preference so new
-                      // chats inherit it. `null` clears focus (re-enables SQL).
-                      // #3078 — mark the REST scope's own provenance explicit too.
-                      selectionProvenanceRef.current = "explicit";
-                      restScopeProvenanceRef.current = "explicit";
-                      setSelectedRestFocus(next);
-                      setRoutingPreference({
-                        workspaceId: activeWorkspaceId,
-                        groupId: selectedGroupId,
-                        connectionId: selectedConnectionId,
-                        routingMode: selectedRoutingMode,
-                        restExcludedDatasourceIds: selectedRestExcluded,
-                        restFocusDatasourceId: next,
-                        // #3895 — carry the current reach so a focus toggle doesn't
-                        // drop it from the sticky preference.
-                        groupReach: selectedGroupReach,
-                      });
-                    }}
-                    onSelect={({ groupReach, groupId, connectionId, routingMode }) => {
-                      // #3064 — a user pick is authoritative; mark it explicit
-                      // so the seed/restore effect never replaces it. #3895 — a
-                      // reach pick (All sources / Focus → group) sets the reach +
-                      // member routing together, so mark BOTH provenances explicit.
-                      selectionProvenanceRef.current = "explicit";
-                      groupReachProvenanceRef.current = "explicit";
-                      setSelectedGroupReach(groupReach);
-                      setSelectedGroupId(groupId);
-                      setSelectedConnectionId(connectionId);
-                      setSelectedRoutingMode(routingMode);
-                      // #3044 — remember this pick (scoped to the active
-                      // workspace) so a reload restores it. #3066 — carry the
-                      // current exclude-set so an env change doesn't drop it.
-                      setRoutingPreference({
-                        workspaceId: activeWorkspaceId,
-                        groupId,
-                        connectionId,
-                        routingMode,
-                        restExcludedDatasourceIds: selectedRestExcluded,
-                        // #3067 — carry the current focus so an env change
-                        // doesn't drop it from the sticky preference.
-                        restFocusDatasourceId: selectedRestFocus,
-                        // #3895 — persist the picked Group reach so new chats
-                        // inherit it (mirrors the REST scope's sticky seeding).
-                        groupReach,
-                      });
-                    }}
+                    restExcludedDatasourceIds={scope.restExcludedDatasourceIds}
+                    // #3066 — a scope toggle is a deliberate pick: the hook marks
+                    // it explicit (so the seed/restore effect can't re-seed over
+                    // it) and persists it back to the sticky preference so new
+                    // chats inherit it. The full next set (incl. []) is verbatim.
+                    onRestExcludedChange={applyScopeRestExcluded}
+                    restFocusDatasourceId={scope.restFocusDatasourceId}
+                    // #3067 — focusing / clearing is a deliberate pick; `null`
+                    // clears focus (re-enables SQL). The hook persists it.
+                    onRestFocusChange={applyScopeRestFocus}
+                    // #3064 / #3895 — a user pick (group / member / mode / reach)
+                    // is authoritative; the hook marks it explicit and persists it.
+                    onSelect={applyScopeSelection}
                   />
                   {!embedded && (
                   <>

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -212,9 +212,10 @@ export function AtlasChat({
   const [relatedSuggestions, setRelatedSuggestions] = useState<QuerySuggestion[]>([]);
   // #2345 / #4189 — the conversation's env/member/REST/reach scope lives in the
   // `useConversationScope` hook (one owning module for the three (value,
-  // provenance) axes + sticky preference). The hook needs transport-derived
-  // inputs (activeWorkspaceId / sessionResolved / envGroups), so it's called
-  // below them — but the transport's chat-request getters need to read the
+  // provenance) axes + sticky preference). The hook needs inputs derived from the
+  // transport (envGroups / sessionResolved via authResolved) and the session
+  // (activeWorkspaceId), so it's called below both — but the transport's
+  // chat-request getters need to read the
   // LATEST scope. This mirror ref bridges that: the getters read
   // `scopeRef.current` (lazy, at fetch time), and the hook's `scope` is synced
   // into it on every render right after the hook call (the same latest-value ref

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -212,11 +212,11 @@ export function AtlasChat({
   const [relatedSuggestions, setRelatedSuggestions] = useState<QuerySuggestion[]>([]);
   // #2345 / #4189 — the conversation's env/member/REST/reach scope lives in the
   // `useConversationScope` hook (one owning module for the three (value,
-  // provenance) axes + sticky preference). The hook needs inputs derived from the
-  // transport (envGroups / sessionResolved via authResolved) and the session
-  // (activeWorkspaceId), so it's called below both — but the transport's
-  // chat-request getters need to read the
-  // LATEST scope. This mirror ref bridges that: the getters read
+  // provenance) axes + sticky preference). Its inputs only settle below the
+  // transport: `sessionResolved` (via `authResolved`) and `envGroupsQuery` (whose
+  // fetch is gated on `authResolved`), plus the session-derived `activeWorkspaceId`
+  // — so the hook is called below them. But the transport's chat-request getters
+  // need to read the LATEST scope. This mirror ref bridges that: the getters read
   // `scopeRef.current` (lazy, at fetch time), and the hook's `scope` is synced
   // into it on every render right after the hook call (the same latest-value ref
   // pattern as `refreshConvosRef`).
@@ -843,7 +843,7 @@ export function AtlasChat({
         break;
       default: {
         // Exhaustiveness guard — a new ConversationUrlAction variant must add a
-        // branch (mirrors the EnvSelectionDecision consumer above).
+        // branch (same `never`-checked pattern as the scope hook's decision consumers).
         const _exhaustive: never = action;
         void _exhaustive;
       }

--- a/packages/web/src/ui/hooks/use-conversation-scope.ts
+++ b/packages/web/src/ui/hooks/use-conversation-scope.ts
@@ -7,10 +7,11 @@
  * per-conversation, authoritative SQL routing + REST scope, seeded by a
  * workspace-sticky preference (ADR-0011). Before this module that state was
  * shattered across `atlas-chat.tsx` — six `useState`, three hand-synced
- * provenance refs, and seven field-by-field preference-store selectors — with
- * the seed/restore/new-chat/persist-back transitions fanned out to 6 `setState`
- * + 3 ref assignments at each of five call sites. Adding a scope axis (#3895 was
- * the last) meant duplicating the provenance-decoupling dance everywhere.
+ * provenance refs, and seven scope-field preference-store selectors (plus a
+ * hydration flag and a setter) — with the seed/restore/new-chat/persist-back
+ * transitions fanned out to as many as 6 `setState` + 3 ref assignments across
+ * six call sites. Adding a scope axis (#3895 was the last) meant duplicating the
+ * provenance-decoupling dance everywhere.
  *
  * This hook owns the three **(value, provenance) axes** plus the sticky
  * preference, and exposes one flat {@link ConversationScope} object plus intent
@@ -64,7 +65,10 @@ export interface ConversationScope {
   readonly groupId: string | null;
   readonly connectionId: string | null;
   readonly routingMode: ConversationRoutingMode | null;
-  readonly restExcludedDatasourceIds: string[];
+  // `ReadonlyArray`, not `string[]`, so the array handed out on `scope` (and
+  // aliased into the transport getter) can't be mutated out-of-band — matches
+  // `ResolveEnvSelectionInput.current.restExcludedDatasourceIds` in env-picker.
+  readonly restExcludedDatasourceIds: ReadonlyArray<string>;
   readonly restFocusDatasourceId: string | null;
   readonly groupReach: string | null;
 }
@@ -84,18 +88,23 @@ export interface ConversationScopeState extends ConversationScope {
   readonly reachProvenance: EnvSelectionProvenance;
 }
 
-/** A fresh chat: nothing selected, every axis `unset`. */
-export const INITIAL_CONVERSATION_SCOPE: ConversationScopeState = {
+/**
+ * A fresh chat: nothing selected, every axis `unset`. Frozen — it is shared as
+ * the reducer's initial value, the `resetForNewChat` return (by reference), and
+ * the transport mirror ref's seed, so freezing forbids any accidental in-place
+ * mutation of the shared constant.
+ */
+export const INITIAL_CONVERSATION_SCOPE: ConversationScopeState = Object.freeze({
   groupId: null,
   connectionId: null,
   routingMode: null,
-  restExcludedDatasourceIds: [],
+  restExcludedDatasourceIds: [] as ReadonlyArray<string>,
   restFocusDatasourceId: null,
   groupReach: null,
   sqlProvenance: "unset",
   restProvenance: "unset",
   reachProvenance: "unset",
-};
+});
 
 /**
  * A {@link resolveEnvSelection} decision that actually mutates the scope — the
@@ -109,7 +118,7 @@ export type AppliedEnvSelectionDecision = Extract<
 
 /**
  * The scope transitions, as a closed set of intents. Each mirrors exactly one
- * of the five fan-out sites the old component held:
+ * of the six fan-out sites the old component held:
  *
  *   - `seedResolved` — the fresh-chat seed/restore effect applied a
  *     {@link resolveEnvSelection} decision (seed the default / restore the
@@ -231,7 +240,7 @@ export function conversationScopeReducer(
     case "restExcludedApplied":
       // A REST exclude toggle. Mark REST `explicit`; keep SQL `explicit` too so
       // the toggle doesn't trigger a stray sticky-preference restore of the SQL
-      // scope as a side effect (the old handler's rationale, verbatim).
+      // scope as a side effect (the old handler's rationale, preserved).
       return {
         ...state,
         restExcludedDatasourceIds: action.next,
@@ -365,10 +374,23 @@ export function useConversationScope({
       sessionResolved,
       groupsLoaded,
     });
-    if (decision.kind === "seed" || decision.kind === "restore") {
-      dispatch({ type: "seedResolved", decision });
+    switch (decision.kind) {
+      case "seed":
+      case "restore":
+        dispatch({ type: "seedResolved", decision });
+        break;
+      case "wait":
+      case "noop":
+        // Inputs not ready or already settled — leave the state alone.
+        break;
+      default: {
+        // Exhaustiveness guard — a new `EnvSelectionDecision` variant must add a
+        // branch here (restores the compile-time net the old inline switch held,
+        // so a future kind can't be silently skipped by the `Extract` filter).
+        const _exhaustive: never = decision;
+        void _exhaustive;
+      }
     }
-    // wait / noop → inputs not ready or already settled; leave the state alone.
   }, [
     groups,
     groupsLoaded,

--- a/packages/web/src/ui/hooks/use-conversation-scope.ts
+++ b/packages/web/src/ui/hooks/use-conversation-scope.ts
@@ -1,0 +1,470 @@
+"use client";
+
+/**
+ * Conversation scope — the one owning module (#4189).
+ *
+ * CONTEXT.md defines **Conversation scope** as a single umbrella concept: the
+ * per-conversation, authoritative SQL routing + REST scope, seeded by a
+ * workspace-sticky preference (ADR-0011). Before this module that state was
+ * shattered across `atlas-chat.tsx` — six `useState`, three hand-synced
+ * provenance refs, and seven field-by-field preference-store selectors — with
+ * the seed/restore/new-chat/persist-back transitions fanned out to 6 `setState`
+ * + 3 ref assignments at each of five call sites. Adding a scope axis (#3895 was
+ * the last) meant duplicating the provenance-decoupling dance everywhere.
+ *
+ * This hook owns the three **(value, provenance) axes** plus the sticky
+ * preference, and exposes one flat {@link ConversationScope} object plus intent
+ * methods. The pure resolvers stay in `env-picker.tsx`; this is the missing
+ * state-owning shell around them.
+ *
+ * ## The three axes
+ *
+ *   - **SQL** — `groupId` / `connectionId` / `routingMode` (the member-routing
+ *     triple), provenance `sqlProvenance`.
+ *   - **REST** — `restExcludedDatasourceIds` / `restFocusDatasourceId`,
+ *     provenance `restProvenance` (#3078: decoupled from SQL so opening a
+ *     conversation can restore the row's REST scope even while the SQL scope
+ *     defers to a seed).
+ *   - **Reach** — `groupReach` (#3895 / ADR-0022: `null` = All sources, a group
+ *     id = Focus → that group), provenance `reachProvenance` (same decoupling as
+ *     REST).
+ *
+ * ## Value + provenance are one atomic reducer state
+ *
+ * The old code kept each axis' value in `useState` and its provenance in a
+ * `useRef`, mutating the ref *before* the `setState` so the re-running
+ * seed/restore effect would read the fresh provenance. Folding both into one
+ * reducer state removes that ordering hazard entirely: every transition updates
+ * value and provenance in a single dispatch, so the effect (which re-runs on the
+ * state change) can never observe a (new value, stale provenance) pair. The pure
+ * {@link conversationScopeReducer} is exported so the seed / restore /
+ * new-chat-reset transitions are unit-testable outside any component.
+ */
+
+import { useEffect, useReducer } from "react";
+import { useChatRoutingPreferenceStore } from "@/lib/stores/chat-routing-preference-store";
+import {
+  resolveConversationScope,
+  resolveEnvSelection,
+  type ChatEnvGroup,
+  type ChatEnvSelection,
+  type ConversationRoutingMode,
+  type ConversationScopeDecision,
+  type ConversationScopeSource,
+  type EnvSelectionDecision,
+  type EnvSelectionProvenance,
+} from "../components/chat/env-picker";
+
+/**
+ * The flat scope object the orchestrator holds — the six axis values with no
+ * provenance bookkeeping. This is what the chat transport forwards on every turn
+ * and what the `<ChatEnvPicker>` renders from.
+ */
+export interface ConversationScope {
+  readonly groupId: string | null;
+  readonly connectionId: string | null;
+  readonly routingMode: ConversationRoutingMode | null;
+  readonly restExcludedDatasourceIds: string[];
+  readonly restFocusDatasourceId: string | null;
+  readonly groupReach: string | null;
+}
+
+/**
+ * The reducer state: the six values plus each axis' provenance. Provenance
+ * governs whether the seed/restore effect may replace an axis (see
+ * {@link EnvSelectionProvenance}): `explicit` short-circuits it, `default`
+ * yields to a later-arriving sticky-preference match, `unset` is a fresh chat.
+ */
+export interface ConversationScopeState extends ConversationScope {
+  /** How the SQL scope (group / member / mode) came to be. */
+  readonly sqlProvenance: EnvSelectionProvenance;
+  /** How the REST scope (exclude-set + focus) came to be (#3078, decoupled). */
+  readonly restProvenance: EnvSelectionProvenance;
+  /** How the Group reach came to be (#3895, decoupled). */
+  readonly reachProvenance: EnvSelectionProvenance;
+}
+
+/** A fresh chat: nothing selected, every axis `unset`. */
+export const INITIAL_CONVERSATION_SCOPE: ConversationScopeState = {
+  groupId: null,
+  connectionId: null,
+  routingMode: null,
+  restExcludedDatasourceIds: [],
+  restFocusDatasourceId: null,
+  groupReach: null,
+  sqlProvenance: "unset",
+  restProvenance: "unset",
+  reachProvenance: "unset",
+};
+
+/**
+ * A {@link resolveEnvSelection} decision that actually mutates the scope — the
+ * `seed` / `restore` arms. `wait` / `noop` are handled in the effect (they never
+ * dispatch), so the reducer's `seedResolved` branch is exhaustive over these two.
+ */
+export type AppliedEnvSelectionDecision = Extract<
+  EnvSelectionDecision,
+  { kind: "seed" | "restore" }
+>;
+
+/**
+ * The scope transitions, as a closed set of intents. Each mirrors exactly one
+ * of the five fan-out sites the old component held:
+ *
+ *   - `seedResolved` — the fresh-chat seed/restore effect applied a
+ *     {@link resolveEnvSelection} decision (seed the default / restore the
+ *     sticky preference). Only `seed` / `restore` decisions are dispatched;
+ *     `wait` / `noop` never reach the reducer.
+ *   - `conversationRestored` — a saved conversation opened; apply a
+ *     {@link resolveConversationScope} decision (row > preference > seed).
+ *   - `selectionApplied` — the user picked a group / member / mode / reach.
+ *   - `restExcludedApplied` — the user toggled a REST exclude checkbox.
+ *   - `restFocusApplied` — the user focused / cleared a REST datasource.
+ *   - `resetForNewChat` — the user started a new chat.
+ */
+export type ConversationScopeAction =
+  | {
+      readonly type: "seedResolved";
+      readonly decision: AppliedEnvSelectionDecision;
+    }
+  | {
+      readonly type: "conversationRestored";
+      readonly decision: ConversationScopeDecision;
+    }
+  | { readonly type: "selectionApplied"; readonly next: ChatEnvSelection }
+  | { readonly type: "restExcludedApplied"; readonly next: string[] }
+  | { readonly type: "restFocusApplied"; readonly next: string | null }
+  | { readonly type: "resetForNewChat" };
+
+/**
+ * Pure scope state machine. Every branch mirrors the exact provenance mutations
+ * the old inline fan-out performed — see the per-branch notes. Kept pure (no
+ * store, no effects) so the transitions are unit-testable without rendering.
+ */
+export function conversationScopeReducer(
+  state: ConversationScopeState,
+  action: ConversationScopeAction,
+): ConversationScopeState {
+  switch (action.type) {
+    case "seedResolved": {
+      const decision = action.decision;
+      if (decision.kind === "restore") {
+        // A restored sticky preference is the user's deliberate prior choice —
+        // mark SQL + reach `explicit` so a later effect run can't seed over it.
+        // REST provenance is intentionally left as-is (the old effect's restore
+        // branch set the REST *values* but never touched its provenance ref).
+        return {
+          ...state,
+          groupId: decision.groupId,
+          connectionId: decision.connectionId,
+          routingMode: decision.routingMode,
+          restExcludedDatasourceIds: decision.restExcludedDatasourceIds,
+          restFocusDatasourceId: decision.restFocusDatasourceId,
+          groupReach: decision.groupReach,
+          sqlProvenance: "explicit",
+          reachProvenance: "explicit",
+        };
+      }
+      // seed — the group-primary / All-sources default. `routingMode` is NOT in
+      // a seed decision, so it is preserved (a fresh chat leaves it null). SQL +
+      // reach become `default`: a workspace-matching preference arriving later
+      // is still restored over this, but a second default seed is suppressed.
+      return {
+        ...state,
+        groupId: decision.groupId,
+        connectionId: decision.connectionId,
+        restExcludedDatasourceIds: decision.restExcludedDatasourceIds,
+        restFocusDatasourceId: decision.restFocusDatasourceId,
+        groupReach: decision.groupReach,
+        sqlProvenance: "default",
+        reachProvenance: "default",
+      };
+    }
+    case "conversationRestored": {
+      const decision = action.decision;
+      // REST scope + Group reach are restored from the row on BOTH decision
+      // kinds and made authoritative (#3078 / #3895): they are independent of
+      // the SQL member-routing decision, so a row's exclude-set / focus / reach
+      // survives even when its SQL scope must be seeded (an all-null row).
+      const base: ConversationScopeState = {
+        ...state,
+        restExcludedDatasourceIds: decision.restExcludedDatasourceIds,
+        restFocusDatasourceId: decision.restFocusDatasourceId,
+        restProvenance: "explicit",
+        groupReach: decision.groupReach,
+        reachProvenance: "explicit",
+      };
+      if (decision.kind === "restore") {
+        // The row carried a usable SQL scope — authoritative, mark `explicit`.
+        return {
+          ...base,
+          groupId: decision.groupId,
+          connectionId: decision.connectionId,
+          routingMode: decision.routingMode,
+          sqlProvenance: "explicit",
+        };
+      }
+      // seed — the row had no usable SQL scope; reset SQL to `unset` and let the
+      // seed/restore effect seed the default / restore the sticky preference.
+      return {
+        ...base,
+        groupId: null,
+        connectionId: null,
+        routingMode: null,
+        sqlProvenance: "unset",
+      };
+    }
+    case "selectionApplied": {
+      // A user group / member / mode / reach pick. Both the SQL and reach axes
+      // are set together, so mark BOTH `explicit`; REST is untouched.
+      const { groupReach, groupId, connectionId, routingMode } = action.next;
+      return {
+        ...state,
+        groupReach,
+        groupId,
+        connectionId,
+        routingMode,
+        sqlProvenance: "explicit",
+        reachProvenance: "explicit",
+      };
+    }
+    case "restExcludedApplied":
+      // A REST exclude toggle. Mark REST `explicit`; keep SQL `explicit` too so
+      // the toggle doesn't trigger a stray sticky-preference restore of the SQL
+      // scope as a side effect (the old handler's rationale, verbatim).
+      return {
+        ...state,
+        restExcludedDatasourceIds: action.next,
+        restProvenance: "explicit",
+        sqlProvenance: "explicit",
+      };
+    case "restFocusApplied":
+      // A REST focus / clear. Same provenance treatment as the exclude toggle.
+      return {
+        ...state,
+        restFocusDatasourceId: action.next,
+        restProvenance: "explicit",
+        sqlProvenance: "explicit",
+      };
+    case "resetForNewChat":
+      // A new chat is bound to no conversation's scope — reset every axis so the
+      // seed/restore effect re-runs from scratch (sticky preference, else default).
+      return INITIAL_CONVERSATION_SCOPE;
+    default: {
+      // Exhaustiveness guard — a new action variant must add a branch.
+      const _exhaustive: never = action;
+      void _exhaustive;
+      return state;
+    }
+  }
+}
+
+/** Environment inputs the seed/restore effect needs to decide correctly. */
+export interface UseConversationScopeArgs {
+  /** Resolved groups from `/api/v1/me/connection-groups`. */
+  readonly groups: ReadonlyArray<ChatEnvGroup>;
+  /** A `/me/connection-groups` fetch has settled at least once (#3078). */
+  readonly groupsLoaded: boolean;
+  /** Active workspace id (`null` = self-hosted / no active org). */
+  readonly activeWorkspaceId: string | null;
+  /** The auth session has resolved, so {@link activeWorkspaceId} is final. */
+  readonly sessionResolved: boolean;
+}
+
+/**
+ * The scope object + the intent methods the orchestrator drives. `restore` and
+ * `resetForNewChat` are called from the conversation-open / new-chat handlers;
+ * `applySelection` / `applyRestExcluded` / `applyRestFocus` wire straight to the
+ * picker's `onSelect` / `onRestExcludedChange` / `onRestFocusChange` and persist
+ * the pick back to the sticky preference internally.
+ */
+export interface UseConversationScopeResult {
+  readonly scope: ConversationScope;
+  /** Restore an opened conversation's persisted scope (row > preference > seed). */
+  readonly restore: (
+    source: ConversationScopeSource,
+    groups: ReadonlyArray<ChatEnvGroup>,
+  ) => void;
+  /** Apply a user group / member / mode / reach pick (and persist it). */
+  readonly applySelection: (next: ChatEnvSelection) => void;
+  /** Apply a REST exclude-set toggle (and persist it). */
+  readonly applyRestExcluded: (next: string[]) => void;
+  /** Apply a REST focus / clear (and persist it). */
+  readonly applyRestFocus: (next: string | null) => void;
+  /** Reset to a fresh chat (no persist — the preference is unchanged). */
+  readonly resetForNewChat: () => void;
+}
+
+/**
+ * The state-owning shell around the pure resolvers. Owns the three
+ * (value, provenance) axes, reads + writes the sticky preference, and runs the
+ * fresh-chat seed/restore effect internally so the orchestrator only holds the
+ * flat {@link ConversationScope} and calls intent methods.
+ */
+export function useConversationScope({
+  groups,
+  groupsLoaded,
+  activeWorkspaceId,
+  sessionResolved,
+}: UseConversationScopeArgs): UseConversationScopeResult {
+  const [state, dispatch] = useReducer(
+    conversationScopeReducer,
+    INITIAL_CONVERSATION_SCOPE,
+  );
+
+  // Sticky preference (#3044). Select fields individually so the store object
+  // identity doesn't churn the seed effect's deps.
+  const prefWorkspaceId = useChatRoutingPreferenceStore((s) => s.workspaceId);
+  const prefGroupId = useChatRoutingPreferenceStore((s) => s.groupId);
+  const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
+  const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
+  const prefRestExcluded = useChatRoutingPreferenceStore(
+    (s) => s.restExcludedDatasourceIds,
+  );
+  const prefRestFocus = useChatRoutingPreferenceStore(
+    (s) => s.restFocusDatasourceId,
+  );
+  const prefGroupReach = useChatRoutingPreferenceStore((s) => s.groupReach);
+  const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
+  const setRoutingPreference = useChatRoutingPreferenceStore(
+    (s) => s.setPreference,
+  );
+
+  // Seed / restore the picker selection on a fresh chat. The decision is
+  // centralized in `resolveEnvSelection`: it waits until groups, the persisted
+  // preference, and the workspace id are all ready (so a default seed never
+  // pre-empts a restorable preference — the reset-on-reload bug #3064), restores
+  // a workspace-matching sticky preference over the default seed, and never
+  // clobbers an explicit pick. Only `seed` / `restore` decisions are dispatched;
+  // `wait` / `noop` leave the state untouched so the reducer never churns.
+  useEffect(() => {
+    const decision = resolveEnvSelection({
+      groups,
+      current: {
+        groupId: state.groupId,
+        connectionId: state.connectionId,
+        routingMode: state.routingMode,
+        restExcludedDatasourceIds: state.restExcludedDatasourceIds,
+        restFocusDatasourceId: state.restFocusDatasourceId,
+        groupReach: state.groupReach,
+      },
+      provenance: state.sqlProvenance,
+      restProvenance: state.restProvenance,
+      groupReachProvenance: state.reachProvenance,
+      preference: {
+        workspaceId: prefWorkspaceId,
+        groupId: prefGroupId,
+        connectionId: prefConnectionId,
+        routingMode: prefRoutingMode,
+        restExcludedDatasourceIds: prefRestExcluded,
+        restFocusDatasourceId: prefRestFocus,
+        groupReach: prefGroupReach,
+      },
+      activeWorkspaceId,
+      preferenceHydrated: prefHasHydrated,
+      sessionResolved,
+      groupsLoaded,
+    });
+    if (decision.kind === "seed" || decision.kind === "restore") {
+      dispatch({ type: "seedResolved", decision });
+    }
+    // wait / noop → inputs not ready or already settled; leave the state alone.
+  }, [
+    groups,
+    groupsLoaded,
+    // `state` covers every `state.*` read above. The reducer returns a new
+    // reference only for a real transition, and only `seed` / `restore` are
+    // dispatched, so this re-runs the resolver (which then no-ops) rather than
+    // looping — matching the old value-state deps run-for-run.
+    state,
+    prefWorkspaceId,
+    prefGroupId,
+    prefConnectionId,
+    prefRoutingMode,
+    prefRestExcluded,
+    prefRestFocus,
+    prefGroupReach,
+    prefHasHydrated,
+    activeWorkspaceId,
+    sessionResolved,
+  ]);
+
+  // Intent methods. Not manually memoized — React Compiler handles that, and
+  // hand-kept dep arrays for the persist-back closures would be a drift footgun
+  // (the exact class this refactor removes). Each closes over the current render's
+  // `state`, so the persisted preference carries the up-to-date sibling axes.
+  const restore = (
+    source: ConversationScopeSource,
+    groupsAtOpen: ReadonlyArray<ChatEnvGroup>,
+  ) => {
+    dispatch({
+      type: "conversationRestored",
+      decision: resolveConversationScope(source, groupsAtOpen),
+    });
+  };
+
+  const applySelection = (next: ChatEnvSelection) => {
+    dispatch({ type: "selectionApplied", next });
+    // Persist the pick (scoped to the active workspace) so a reload restores it.
+    // Carry the CURRENT REST scope so an env change doesn't drop it.
+    setRoutingPreference({
+      workspaceId: activeWorkspaceId,
+      groupId: next.groupId,
+      connectionId: next.connectionId,
+      routingMode: next.routingMode,
+      restExcludedDatasourceIds: state.restExcludedDatasourceIds,
+      restFocusDatasourceId: state.restFocusDatasourceId,
+      groupReach: next.groupReach,
+    });
+  };
+
+  const applyRestExcluded = (next: string[]) => {
+    dispatch({ type: "restExcludedApplied", next });
+    // Carry the current SQL scope + focus + reach so the exclude change doesn't
+    // drop them from the sticky preference.
+    setRoutingPreference({
+      workspaceId: activeWorkspaceId,
+      groupId: state.groupId,
+      connectionId: state.connectionId,
+      routingMode: state.routingMode,
+      restExcludedDatasourceIds: next,
+      restFocusDatasourceId: state.restFocusDatasourceId,
+      groupReach: state.groupReach,
+    });
+  };
+
+  const applyRestFocus = (next: string | null) => {
+    dispatch({ type: "restFocusApplied", next });
+    setRoutingPreference({
+      workspaceId: activeWorkspaceId,
+      groupId: state.groupId,
+      connectionId: state.connectionId,
+      routingMode: state.routingMode,
+      restExcludedDatasourceIds: state.restExcludedDatasourceIds,
+      restFocusDatasourceId: next,
+      groupReach: state.groupReach,
+    });
+  };
+
+  const resetForNewChat = () => {
+    dispatch({ type: "resetForNewChat" });
+  };
+
+  const scope: ConversationScope = {
+    groupId: state.groupId,
+    connectionId: state.connectionId,
+    routingMode: state.routingMode,
+    restExcludedDatasourceIds: state.restExcludedDatasourceIds,
+    restFocusDatasourceId: state.restFocusDatasourceId,
+    groupReach: state.groupReach,
+  };
+
+  return {
+    scope,
+    restore,
+    applySelection,
+    applyRestExcluded,
+    applyRestFocus,
+    resetForNewChat,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracts the per-conversation scope state machine out of `atlas-chat.tsx` (1582 LOC) into one owning module, `useConversationScope` — the missing state-owning shell around the pure resolvers in `env-picker.tsx` (which are **unchanged**).
- The hook owns the three **(value, provenance)** axes — SQL (group/member/mode), REST (exclude-set/focus), reach — plus the sticky preference. It folds each axis' value + provenance into one `useReducer` state (removing the old "mutate-ref-before-setState" ordering hazard), runs the fresh-chat seed/restore effect internally, and exposes one flat `scope` object plus intent methods: `restore()`, `applySelection()`, `applyRestExcluded()`, `applyRestFocus()`, `resetForNewChat()` — each persisting back to the preference where the old inline handlers did.
- `atlas-chat.tsx` drops ~180 LOC of scope bookkeeping (6 `useState` + 3 provenance refs + 7 preference selectors + the seed effect + 3 persist-back handlers); the transport getters read a scope mirror ref. **No UX behavior change.**

Adding a scope axis is now one field in the module, not a multi-site `setState` fan-out (the exact pain #3895 hit).

## Acceptance criteria
- [x] One module owns the three (value, provenance) axes + sticky-preference seeding; the orchestrator holds a single scope object
- [x] Seed / restore / new-chat-reset / persist-back transitions unit-tested outside the component (pure reducer + `renderHook`)
- [x] Pure resolvers unchanged; no scope-picker UX behavior change
- [x] Adding a scope axis = one field in the module, not a multi-site setState fan-out

## Test plan
- [x] `use-conversation-scope.test.tsx` — 17 tests: every reducer transition (exact provenance mutations), seed/hydration/session gates, persist-back sibling-axis carry (#3066/#3067/#3078/#3895), restore, reset→re-seed, and a no-churn "seed settles, effect doesn't loop" guard
- [x] Existing `env-picker.test.tsx` (135) + `conversation-url-open.test.tsx` + all AtlasChat-importing tests pass (156 total)
- [x] `tsgo` type-clean, ESLint clean, internal review panel CLEAN (2 rounds)
- [ ] CI `api-tests` shards (real Postgres) green

Closes #4189