### PR TITLE
refactor(integrations): shared OAuth install seams (verify + reconnect + token-refresh)

### DIFF
--- a/packages/api/src/lib/integrations/install/__tests__/jira-token-refresh.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/jira-token-refresh.test.ts
@@ -245,6 +245,35 @@ describe("refreshJiraToken — transient failure", () => {
     expect(markUpdate).toBeUndefined();
   });
 
+  it("on HTTP 200 missing the rotated refresh_token: throws a plain Error, does NOT mark reconnect_needed or persist", async () => {
+    // Jira/Linear require the rotated refresh_token in the success body
+    // (`requiresRefreshTokenInResponse`). A 200 that omits it fails the
+    // success guard and — because 200 is not a permanent-failure status —
+    // degrades to a TRANSIENT retry, never a Reconnect and never a
+    // persisted bundle with a stale refresh token. Pin the rotation-
+    // required guard's 2xx-classification branch (the one the Salesforce
+    // suite structurally can't cover).
+    mockReadCredentialBundle.mockResolvedValueOnce(STORED_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ access_token: "new-access-token", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(refreshMod.refreshJiraToken(JIRA_ARGS)).rejects.toThrow(/HTTP 200/);
+
+    const markUpdate = mockInternalQuery.mock.calls.find(
+      (c) =>
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'reconnect_needed'"),
+    );
+    expect(markUpdate).toBeUndefined();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+
   it("on HTTP 400 with an unknown error code (e.g. invalid_request): throws plain Error, does NOT mark reconnect_needed", async () => {
     // PERMANENT_REFRESH_FAILURE_CODES is intentionally narrow. An
     // unknown 400 shouldn't strand every workspace on the assumption

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-callback-verify.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-callback-verify.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Direct unit tests for {@link verifyCallbackState} — the shared step-1
+ * catalog-slug state guard extracted from the seven OAuth handlers
+ * (#4188).
+ *
+ * The fail-closed invariant under test: a state token bound to a catalog
+ * OTHER than the handler's own slug is rejected (`null`), and a valid,
+ * catalog-matched token yields the branded workspace id. Previously
+ * re-asserted across seven handler suites; now it lives here once against
+ * the REAL sign/verify path (`mintOAuthStateToken` +
+ * `verifyOAuthStateToken`), so a signature regression can't slip past a
+ * mock.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { mutateLastChar } from "../../../../__test-utils__/base64url";
+import type { WorkspaceId } from "@useatlas/types";
+import { mintOAuthStateToken } from "../oauth-state-token";
+import { verifyCallbackState } from "../oauth-callback-verify";
+
+const ORIGINAL_ENV = { ...process.env };
+const WSID = "ws-verify-test-1" as WorkspaceId;
+const REJECTION_MESSAGE = "Test OAuth callback received state bound to a different catalog — rejecting";
+
+function makeLog(): { warn: ReturnType<typeof mock> } {
+  return { warn: mock(() => undefined) };
+}
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-one";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+describe("verifyCallbackState", () => {
+  it("returns the branded workspaceId when the token is valid and catalog-matched", () => {
+    const token = mintOAuthStateToken(WSID, "jira");
+    const log = makeLog();
+
+    const result = verifyCallbackState(token, "jira", log, REJECTION_MESSAGE);
+
+    expect(result).toEqual({ workspaceId: WSID });
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("rejects (null) and logs when the token is bound to a DIFFERENT catalog", () => {
+    // The fail-closed invariant: a token minted for salesforce must not
+    // pass a jira handler's guard even though the signature is valid.
+    const token = mintOAuthStateToken(WSID, "salesforce");
+    const log = makeLog();
+
+    const result = verifyCallbackState(token, "jira", log, REJECTION_MESSAGE);
+
+    expect(result).toBeNull();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      { expected: "jira", got: "salesforce" },
+      REJECTION_MESSAGE,
+    );
+  });
+
+  it("returns null WITHOUT logging when the signature is tampered", () => {
+    // A forged/tampered token fails signature verification — a distinct
+    // rejection path from catalog mismatch, and one that must NOT log the
+    // catalog-mismatch line (nothing to compare).
+    const good = mintOAuthStateToken(WSID, "jira");
+    const [h, p, s] = good.split(".");
+    const tampered = `${h}.${mutateLastChar(p)}.${s}`;
+    const log = makeLog();
+
+    const result = verifyCallbackState(tampered, "jira", log, REJECTION_MESSAGE);
+
+    expect(result).toBeNull();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns null on a garbage/empty token", () => {
+    const log = makeLog();
+    expect(verifyCallbackState("", "jira", log, REJECTION_MESSAGE)).toBeNull();
+    expect(verifyCallbackState("not-a-token", "jira", log, REJECTION_MESSAGE)).toBeNull();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-reconnect.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-reconnect.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Direct unit tests for the shared reconnect-status seam (#4188):
+ * {@link markReconnectNeeded} / {@link clearReconnectNeeded} and the
+ * fail-closed {@link writeCredentialWithReconnectFallback}.
+ *
+ * The two invariants under test — previously re-asserted per platform:
+ *
+ *   1. The `mark`/`clear` pair emits the exact `config || jsonb_build_object`
+ *      UPDATE keyed on `(workspace_id, catalog_id)`, and swallows a DB
+ *      failure (best-effort) rather than propagating.
+ *   2. `writeCredentialWithReconnectFallback` enforces the fail-closed
+ *      Reconnect rule: on a credential-write throw the install row is NOT
+ *      rolled back, `status` is flipped to `reconnect_needed`, and the
+ *      caller gets `credentialResult.written: false`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import type { WorkspaceId } from "@useatlas/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the SUT import)
+// ---------------------------------------------------------------------------
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
+  Promise.resolve([]),
+);
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const mockSaveCredentialBundle: Mock<
+  (ws: string, cat: string, bundle: unknown) => Promise<void>
+> = mock(() => Promise.resolve());
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  saveCredentialBundle: mockSaveCredentialBundle,
+  readCredentialBundle: mock(() => Promise.resolve(null)),
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+type Seam = typeof import("../oauth-reconnect");
+let seam!: Seam;
+
+beforeEach(async () => {
+  seam ??= await import("../oauth-reconnect");
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mockSaveCredentialBundle.mockClear();
+  mockSaveCredentialBundle.mockImplementation(() => Promise.resolve());
+});
+
+afterEach(() => {
+  mockInternalQuery.mockClear();
+  mockSaveCredentialBundle.mockClear();
+});
+
+const WSID = "ws-reconnect-test-1" as WorkspaceId;
+
+function makeLog(): { info: ReturnType<typeof mock>; warn: ReturnType<typeof mock> } {
+  return { info: mock(() => undefined), warn: mock(() => undefined) };
+}
+
+const BUNDLE = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  expiresAt: null,
+  tokenType: "Bearer",
+  scope: "read",
+  instanceUrl: "https://example.test",
+};
+
+const INSTALL_RECORD = { id: "row-1", workspaceId: WSID, catalogId: "jira" };
+
+function findUpdate(status: "reconnect_needed" | "ok") {
+  return mockInternalQuery.mock.calls.find(
+    (c) => (c[0] as string).includes("UPDATE workspace_plugins") && (c[0] as string).includes(`'${status}'`),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// markReconnectNeeded / clearReconnectNeeded
+// ---------------------------------------------------------------------------
+
+describe("markReconnectNeeded", () => {
+  it("fires the reconnect_needed UPDATE keyed on (workspace_id, catalog_id)", async () => {
+    const log = makeLog();
+    await seam.markReconnectNeeded(WSID, "catalog:jira", log, "mark failed");
+
+    const call = findUpdate("reconnect_needed");
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual([WSID, "catalog:jira"]);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("swallows a DB failure (best-effort) and logs instead of throwing", async () => {
+    mockInternalQuery.mockImplementationOnce(() => Promise.reject(new Error("row disconnected")));
+    const log = makeLog();
+
+    await seam.markReconnectNeeded(WSID, "catalog:jira", log, "mark failed message");
+
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn.mock.calls[0]?.[1]).toBe("mark failed message");
+  });
+});
+
+describe("clearReconnectNeeded", () => {
+  it("fires the status='ok' UPDATE keyed on (workspace_id, catalog_id)", async () => {
+    const log = makeLog();
+    await seam.clearReconnectNeeded(WSID, "catalog:linear", log, "clear failed");
+
+    const call = findUpdate("ok");
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual([WSID, "catalog:linear"]);
+  });
+
+  it("swallows a DB failure (best-effort)", async () => {
+    mockInternalQuery.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+    const log = makeLog();
+    await seam.clearReconnectNeeded(WSID, "catalog:linear", log, "clear failed message");
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeCredentialWithReconnectFallback — the fail-closed invariant
+// ---------------------------------------------------------------------------
+
+describe("writeCredentialWithReconnectFallback — success", () => {
+  it("persists the bundle and returns written:true with the slug echoed back", async () => {
+    const log = makeLog();
+    const result = await seam.writeCredentialWithReconnectFallback({
+      workspaceId: WSID,
+      catalogId: "catalog:jira",
+      slug: "jira",
+      bundle: BUNDLE,
+      installRecord: INSTALL_RECORD,
+      log,
+      displayName: "Jira",
+      successLogFields: { cloudid: "cloud-1" },
+    });
+
+    expect(mockSaveCredentialBundle).toHaveBeenCalledWith(WSID, "catalog:jira", BUNDLE);
+    expect(result).toEqual({
+      workspaceId: WSID,
+      catalogId: "jira",
+      installRecord: INSTALL_RECORD,
+      credentialResult: { written: true },
+    });
+    // No status flip on the happy path.
+    expect(findUpdate("reconnect_needed")).toBeUndefined();
+    expect(log.info).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("writeCredentialWithReconnectFallback — partial failure (fail-closed)", () => {
+  it("flips reconnect_needed and returns written:false WITHOUT rolling back the install row", async () => {
+    mockSaveCredentialBundle.mockImplementationOnce(() => Promise.reject(new Error("db write failed")));
+    const log = makeLog();
+
+    const result = await seam.writeCredentialWithReconnectFallback({
+      workspaceId: WSID,
+      catalogId: "catalog:jira",
+      slug: "jira",
+      bundle: BUNDLE,
+      installRecord: INSTALL_RECORD,
+      log,
+      displayName: "Jira",
+      failureLogFields: { cloudid: "cloud-1" },
+    });
+
+    // Install record preserved (no rollback DELETE), Reconnect surfaced.
+    expect(result.installRecord).toEqual(INSTALL_RECORD);
+    expect(result.credentialResult.written).toBe(false);
+    expect(result.credentialResult.reason).toContain("Reconnect");
+    expect(result.catalogId).toBe("jira");
+
+    // The status flip is the persistent-Reconnect-CTA signal.
+    const flip = findUpdate("reconnect_needed");
+    expect(flip).toBeDefined();
+    expect(flip?.[1]).toEqual([WSID, "catalog:jira"]);
+    // Only the status flip UPDATE — no rollback statement.
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("still returns written:false when the status-flip UPDATE itself fails (best-effort)", async () => {
+    mockSaveCredentialBundle.mockImplementationOnce(() => Promise.reject(new Error("db write failed")));
+    mockInternalQuery.mockImplementationOnce(() => Promise.reject(new Error("status flip failed")));
+    const log = makeLog();
+
+    const result = await seam.writeCredentialWithReconnectFallback({
+      workspaceId: WSID,
+      catalogId: "catalog:salesforce",
+      slug: "salesforce",
+      bundle: BUNDLE,
+      installRecord: { ...INSTALL_RECORD, catalogId: "salesforce" },
+      log,
+      displayName: "Salesforce",
+    });
+
+    expect(result.credentialResult.written).toBe(false);
+    // Two warns: the credential-write failure + the swallowed flip failure.
+    expect(log.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api/src/lib/integrations/install/github-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-oauth-handler.ts
@@ -61,10 +61,8 @@ import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import { persistInstallRecord } from "./persist-form-install";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
 import {
   exchangeUserCodeForToken,
   findUserInstallation,
@@ -164,17 +162,15 @@ export class GitHubOAuthInstallHandler implements OAuthPlatformInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    // ── 1. Verify state — null on every failure mode ─────────────
-    const verified = verifyOAuthStateToken(stateToken);
+    // ── 1. Verify state + catalog binding (shared seam) ──────────
+    const verified = verifyCallbackState(
+      stateToken,
+      GITHUB_SLUG,
+      log,
+      "GitHub OAuth callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    if (verified.catalogId !== GITHUB_SLUG) {
-      log.warn(
-        { expected: GITHUB_SLUG, got: verified.catalogId },
-        "GitHub OAuth callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
-    const workspaceId = verified.workspaceId as WorkspaceId;
+    const { workspaceId } = verified;
 
     // ── 2. Require both code and installation_id ─────────────────
     // The App's user-OAuth-during-install option MUST be enabled — we

--- a/packages/api/src/lib/integrations/install/github-single-tenant-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-single-tenant-oauth-handler.ts
@@ -35,10 +35,8 @@ import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import { persistInstallRecord } from "./persist-form-install";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
 import {
   GITHUB_APP_SECRET_FIELDS_SCHEMA,
   GITHUB_SINGLE_TENANT_CATALOG_ID,
@@ -124,16 +122,14 @@ export class GitHubSingleTenantOAuthInstallHandler implements OAuthPlatformInsta
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    const verified = verifyOAuthStateToken(stateToken);
+    const verified = verifyCallbackState(
+      stateToken,
+      GITHUB_SINGLE_TENANT_SLUG,
+      log,
+      "GitHub single-tenant callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    if (verified.catalogId !== GITHUB_SINGLE_TENANT_SLUG) {
-      log.warn(
-        { expected: GITHUB_SINGLE_TENANT_SLUG, got: verified.catalogId },
-        "GitHub single-tenant callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
-    const workspaceId = verified.workspaceId as WorkspaceId;
+    const { workspaceId } = verified;
 
     // Single-tenant accepts the supplied identifier from EITHER:
     //   - `extras.installationId` (route passes the query-param branch

--- a/packages/api/src/lib/integrations/install/jira-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/jira-oauth-handler.ts
@@ -50,16 +50,13 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
-import { saveCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import { persistInstallRecord } from "./persist-form-install";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
+import { writeCredentialWithReconnectFallback } from "./oauth-reconnect";
 import type {
   CatalogId,
   CredentialResult,
@@ -381,17 +378,15 @@ export class JiraOAuthInstallHandler implements OAuthPlatformInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    // ── 1. Verify state — null on every failure mode ─────────────
-    const verified = verifyOAuthStateToken(stateToken);
+    // ── 1. Verify state + catalog binding (shared seam) ──────────
+    const verified = verifyCallbackState(
+      stateToken,
+      JIRA_SLUG,
+      log,
+      "Jira OAuth callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    const workspaceId = verified.workspaceId as WorkspaceId;
-    if (verified.catalogId !== JIRA_SLUG) {
-      log.warn(
-        { expected: JIRA_SLUG, got: verified.catalogId },
-        "Jira OAuth callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
+    const { workspaceId } = verified;
 
     // ── 2. Exchange code for tokens ───────────────────────────────
     const tokens = await exchangeAuthCodeForTokens({
@@ -498,53 +493,21 @@ export class JiraOAuthInstallHandler implements OAuthPlatformInstallHandler {
       instanceUrl: `https://api.atlassian.com/ex/jira/${cloudid}`,
     };
 
-    try {
-      await saveCredentialBundle(workspaceId, JIRA_CATALOG_ID, bundle);
-      log.info(
-        { workspaceId, cloudid, siteUrl: primaryResource.url },
-        "Jira install completed (both stores written)",
-      );
-      return {
-        workspaceId,
-        catalogId: JIRA_SLUG,
-        installRecord,
-        credentialResult: { written: true },
-      };
-    } catch (err) {
-      const errMessage = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { workspaceId, cloudid, err: errMessage },
-        "Jira install record written but integration_credentials write failed — Reconnect required",
-      );
-      // Mirror Salesforce: flip `status: "reconnect_needed"` so the
-      // admin card surfaces a persistent Reconnect CTA. Without this,
-      // the OAuth callback's `?reconnect=jira` query param shows once
-      // and then disappears on the next admin-page reload.
-      try {
-        await internalQuery(
-          `UPDATE workspace_plugins
-              SET config = config || jsonb_build_object('status', 'reconnect_needed')
-            WHERE workspace_id = $1 AND catalog_id = $2`,
-          [workspaceId, JIRA_CATALOG_ID],
-        );
-      } catch (statusErr) {
-        log.warn(
-          {
-            workspaceId,
-            err: statusErr instanceof Error ? statusErr.message : String(statusErr),
-          },
-          "Failed to mark Jira install as reconnect_needed after credential write failure",
-        );
-      }
-      return {
-        workspaceId,
-        catalogId: JIRA_SLUG,
-        installRecord,
-        credentialResult: {
-          written: false,
-          reason: "Credential persist failed — admin should retry via Reconnect",
-        },
-      };
-    }
+    // Persist the credential bundle (ADR-0003 SECOND write) with the
+    // shared fail-closed Reconnect fallback: a credential-write failure
+    // flips `status: "reconnect_needed"` so the admin card surfaces a
+    // persistent Reconnect CTA (without it the callback's `?reconnect=jira`
+    // query param shows once then vanishes on the next page load).
+    return writeCredentialWithReconnectFallback({
+      workspaceId,
+      catalogId: JIRA_CATALOG_ID,
+      slug: JIRA_SLUG,
+      bundle,
+      installRecord,
+      log,
+      displayName: "Jira",
+      successLogFields: { cloudid, siteUrl: primaryResource.url },
+      failureLogFields: { cloudid },
+    });
   }
 }

--- a/packages/api/src/lib/integrations/install/jira-token-refresh.ts
+++ b/packages/api/src/lib/integrations/install/jira-token-refresh.ts
@@ -1,38 +1,35 @@
 /**
- * Jira access-token refresh (#2659).
+ * Jira access-token refresh (#2659) — a config over the shared
+ * {@link refreshOAuthCredential} flow (#4188).
  *
- * Mirrors {@link ./salesforce-token-refresh.ts}; Atlassian-specific
- * twists:
+ * Atlassian-specific dimensions captured in {@link JIRA_REFRESH_CONFIG}:
  *
+ *   - **JSON token body.** Atlassian's `oauth/token` takes a JSON body
+ *     (Salesforce/Linear are form-encoded).
  *   - **Refresh tokens rotate on every refresh.** Atlassian returns a
  *     fresh `refresh_token` in the success response and the previous
- *     value MUST NOT be reused; persisting the new value back to
- *     `integration_credentials` is non-optional, not opportunistic
- *     (Salesforce sometimes returns one, sometimes not — we kept the
- *     old value when omitted).
- *   - **Permanent failures classify the same way.** Atlassian returns
- *     `invalid_grant` when the stored refresh token is rejected; we
- *     flip `workspace_plugins.config.status` to `"reconnect_needed"`
- *     and surface `IntegrationReconnectRequiredError`.
- *   - **Operator-side misconfig stays transient.** `invalid_client` is
- *     wrong env (`JIRA_CLIENT_ID` / `JIRA_CLIENT_SECRET` typo); marking
- *     the workspace `reconnect_needed` would force every tenant admin
- *     to re-run OAuth after the operator fixes the env. Treated as
- *     transient like Salesforce.
+ *     value MUST NOT be reused — so the success guard requires it
+ *     (`requiresRefreshTokenInResponse: true`) and the rotated value is
+ *     persisted back to `integration_credentials`, non-optionally.
+ *   - **Permanent failure classification.** `invalid_grant` (RFC 6749's
+ *     "refresh token rejected") flips `reconnect_needed`. `invalid_client`
+ *     is deliberately absent — it's operator env misconfig
+ *     (`JIRA_CLIENT_ID`/`SECRET` typo) and marking every tenant
+ *     reconnect-needed would force needless re-OAuth after the operator
+ *     fixes the env. Any 4xx qualifies for permanent classification.
  *
+ * @see ./oauth-token-refresh.ts — the shared exchange + classification flow
  * @see ./jira-oauth-handler.ts — the initial OAuth dance
- * @see ./salesforce-token-refresh.ts — first reference implementation
  * @see ../credentials/store.ts — the credential bundle store
  */
 
-import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import {
-  readCredentialBundle,
-  saveCredentialBundle,
-  type CredentialBundle,
-} from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import {
+  refreshOAuthCredential,
+  expiresInToAbsolute,
+  type OAuthRefreshConfig,
+} from "./oauth-token-refresh";
 import { JIRA_CATALOG_ID, JIRA_SLUG } from "./jira-oauth-handler";
 
 // Re-export so the lazy-builder + future callers can pull from this
@@ -43,16 +40,14 @@ export { IntegrationReconnectRequiredError };
 /** @deprecated #2708 — use {@link IntegrationReconnectRequiredError}; alias removed next release. */
 export { JiraReconnectRequiredError } from "@atlas/api/lib/effect/errors";
 
-const log = createLogger("integrations.install.jira-refresh");
-
 const TOKEN_URL = "https://auth.atlassian.com/oauth/token";
 
 /**
  * Atlassian error codes that prove the install will never recover
- * without a fresh OAuth dance. `invalid_grant` is the canonical
- * "refresh token rejected" code from RFC 6749. Kept narrow on purpose
- * — an unknown error code surfaces as transient so we don't mis-classify
- * the install as "reconnect needed" without evidence.
+ * without a fresh OAuth dance. `invalid_grant` is the canonical "refresh
+ * token rejected" code from RFC 6749. Kept narrow on purpose — an
+ * unknown error code surfaces as transient so we don't mis-classify the
+ * install as "reconnect needed" without evidence.
  */
 const PERMANENT_REFRESH_FAILURE_CODES = new Set([
   "invalid_grant",
@@ -60,138 +55,33 @@ const PERMANENT_REFRESH_FAILURE_CODES = new Set([
   "access_denied",
 ]);
 
-interface JiraRefreshSuccess {
-  readonly access_token: string;
-  readonly refresh_token: string;
-  readonly expires_in?: number;
-  readonly token_type?: string;
-  readonly scope?: string;
-}
-
-interface JiraRefreshFailure {
-  readonly error: string;
-  readonly error_description?: string;
-}
-
-type JiraRefreshResponse = JiraRefreshSuccess | JiraRefreshFailure;
-
-function isRefreshSuccess(r: JiraRefreshResponse): r is JiraRefreshSuccess {
-  return (
-    "access_token" in r &&
-    typeof r.access_token === "string" &&
-    "refresh_token" in r &&
-    typeof r.refresh_token === "string"
-  );
-}
-
-interface RefreshArgs {
-  readonly clientId: string;
-  readonly clientSecret: string;
-  readonly refreshToken: string;
-}
-
-/**
- * POST `auth.atlassian.com/oauth/token` with `grant_type=refresh_token`.
- * On HTTP 4xx carrying one of the {@link PERMANENT_REFRESH_FAILURE_CODES},
- * throws `IntegrationReconnectRequiredError`. On anything else (network failure,
- * 5xx, unknown 4xx), throws a plain `Error` so the caller treats it as
- * transient.
- */
-async function exchangeRefreshToken(
-  args: RefreshArgs,
-  workspaceId: string,
-): Promise<JiraRefreshSuccess> {
-  let resp: Response;
-  try {
-    resp = await fetch(TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        client_id: args.clientId,
-        client_secret: args.clientSecret,
-        refresh_token: args.refreshToken,
-      }),
-    });
-  } catch (err) {
-    // Network failure — transient. Let the caller retry on the next
-    // tool call. Don't flip reconnect_needed without evidence.
-    throw new Error(
-      `Atlassian token endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
-      { cause: err },
-    );
-  }
-
-  let parsed: JiraRefreshResponse;
-  try {
-    parsed = (await resp.json()) as JiraRefreshResponse;
-  } catch (err) {
-    throw new Error(
-      `Atlassian refresh returned unparseable body (HTTP ${resp.status})`,
-      { cause: err },
-    );
-  }
-
-  if (!resp.ok || !isRefreshSuccess(parsed)) {
-    const failure = parsed as JiraRefreshFailure;
-    const errorCode = failure.error ?? `http_${resp.status}`;
-    if (resp.status >= 400 && resp.status < 500 && PERMANENT_REFRESH_FAILURE_CODES.has(errorCode)) {
-      log.warn(
-        { workspaceId, errorCode, description: failure.error_description },
-        "Jira refresh failed permanently — flagging reconnect_needed",
-      );
-      throw new IntegrationReconnectRequiredError({
-        message: "Jira install needs to be reconnected — refresh token rejected by Atlassian.",
-        workspaceId,
-        platform: "jira",
-        upstreamError: errorCode,
-      });
-    }
-    // Unknown error code or 5xx — treat as transient.
-    throw new Error(`Jira refresh failed: ${errorCode} (HTTP ${resp.status})`);
-  }
-
-  return parsed;
-}
-
-/**
- * Mark the install row as `reconnect_needed`. JSONB merge so unrelated
- * config fields (cloudid, scopes, etc.) survive.
- */
-async function markReconnectNeeded(workspaceId: string): Promise<void> {
-  try {
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('status', 'reconnect_needed')
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, JIRA_CATALOG_ID],
-    );
-  } catch (err) {
-    log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to mark Jira install as reconnect_needed (install row may have been disconnected)",
-    );
-  }
-}
-
-/**
- * Clear the `reconnect_needed` marker on a successful refresh. Idempotent.
- */
-async function clearReconnectNeeded(workspaceId: string): Promise<void> {
-  try {
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('status', 'ok')
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, JIRA_CATALOG_ID],
-    );
-  } catch (err) {
-    log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to clear reconnect_needed flag after successful Jira refresh",
-    );
-  }
-}
+const JIRA_REFRESH_CONFIG: OAuthRefreshConfig = {
+  platform: "jira",
+  displayName: "Jira",
+  endpointName: "Atlassian",
+  catalogId: JIRA_CATALOG_ID,
+  logName: "integrations.install.jira-refresh",
+  bodyEncoding: "json",
+  requiresRefreshTokenInResponse: true,
+  permanentFailureCodes: PERMANENT_REFRESH_FAILURE_CODES,
+  isPermanentFailureStatus: (status) => status >= 400 && status < 500,
+  noRefreshTokenMessage:
+    "Jira install has no refresh token — App must grant the offline_access scope.",
+  refreshRejectedMessage:
+    "Jira install needs to be reconnected — refresh token rejected by Atlassian.",
+  // Atlassian rotates the refresh token on every refresh — the success
+  // guard already asserted it's present, so we don't fall back to the
+  // stored value the way Salesforce does.
+  toBundle: (r, stored) => ({
+    accessToken: r.access_token,
+    refreshToken: r.refresh_token ?? stored.refreshToken,
+    expiresAt: expiresInToAbsolute(r.expires_in),
+    tokenType: r.token_type ?? stored.tokenType,
+    scope: r.scope ?? stored.scope,
+    instanceUrl: stored.instanceUrl,
+    ...(stored.extra ? { extra: stored.extra } : {}),
+  }),
+};
 
 export interface RefreshJiraTokenArgs {
   readonly workspaceId: string;
@@ -206,75 +96,8 @@ export interface RefreshJiraTokenArgs {
  * `IntegrationReconnectRequiredError` and flips
  * `workspace_plugins.config.status` to `"reconnect_needed"`.
  */
-export async function refreshJiraToken(
-  args: RefreshJiraTokenArgs,
-): Promise<CredentialBundle> {
-  const bundle = await readCredentialBundle(args.workspaceId, JIRA_CATALOG_ID);
-  if (!bundle) {
-    throw new Error(
-      `No Jira credentials found for workspace ${args.workspaceId} — install was disconnected`,
-    );
-  }
-  if (!bundle.refreshToken) {
-    log.warn(
-      { workspaceId: args.workspaceId },
-      "Jira credential bundle has no refresh_token — flagging reconnect_needed",
-    );
-    await markReconnectNeeded(args.workspaceId);
-    throw new IntegrationReconnectRequiredError({
-      message: "Jira install has no refresh token — App must grant the offline_access scope.",
-      workspaceId: args.workspaceId,
-      platform: "jira",
-      upstreamError: "no_refresh_token",
-    });
-  }
-
-  let refreshed: JiraRefreshSuccess;
-  try {
-    refreshed = await exchangeRefreshToken(
-      {
-        clientId: args.clientId,
-        clientSecret: args.clientSecret,
-        refreshToken: bundle.refreshToken,
-      },
-      args.workspaceId,
-    );
-  } catch (err) {
-    if (err instanceof IntegrationReconnectRequiredError) {
-      await markReconnectNeeded(args.workspaceId);
-    }
-    throw err;
-  }
-
-  // Atlassian rotates the refresh token on every refresh — `refresh_token`
-  // is required in the success response. The `isRefreshSuccess` guard
-  // already asserted both fields are present, so we don't fall back to
-  // the old value the way Salesforce does.
-  const expiresAt =
-    typeof refreshed.expires_in === "number" && Number.isFinite(refreshed.expires_in)
-      ? Date.now() + refreshed.expires_in * 1000
-      : null;
-
-  const next: CredentialBundle = {
-    accessToken: refreshed.access_token,
-    refreshToken: refreshed.refresh_token,
-    expiresAt,
-    tokenType: refreshed.token_type ?? bundle.tokenType,
-    scope: refreshed.scope ?? bundle.scope,
-    instanceUrl: bundle.instanceUrl,
-    ...(bundle.extra ? { extra: bundle.extra } : {}),
-  };
-
-  await saveCredentialBundle(args.workspaceId, JIRA_CATALOG_ID, next);
-  // Independent UPDATE so a failure to clear the flag doesn't roll back
-  // a successful refresh.
-  await clearReconnectNeeded(args.workspaceId);
-
-  log.info(
-    { workspaceId: args.workspaceId, instanceUrl: next.instanceUrl },
-    "Jira token refreshed successfully",
-  );
-  return next;
+export function refreshJiraToken(args: RefreshJiraTokenArgs): Promise<CredentialBundle> {
+  return refreshOAuthCredential(JIRA_REFRESH_CONFIG, args, TOKEN_URL);
 }
 
 /** Re-export to keep the slug constant in one place for catalog wiring. */

--- a/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
@@ -45,13 +45,11 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
-import { saveCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
+import { writeCredentialWithReconnectFallback } from "./oauth-reconnect";
 import type {
   CatalogId,
   CredentialResult,
@@ -419,17 +417,15 @@ export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    // ── 1. Verify state — null on every failure mode ─────────────
-    const verified = verifyOAuthStateToken(stateToken);
+    // ── 1. Verify state + catalog binding (shared seam) ──────────
+    const verified = verifyCallbackState(
+      stateToken,
+      LINEAR_SLUG,
+      log,
+      "Linear OAuth callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    const workspaceId = verified.workspaceId as WorkspaceId;
-    if (verified.catalogId !== LINEAR_SLUG) {
-      log.warn(
-        { expected: LINEAR_SLUG, got: verified.catalogId },
-        "Linear OAuth callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
+    const { workspaceId } = verified;
 
     // ── 2. Exchange code for tokens ───────────────────────────────
     const tokens = await exchangeAuthCodeForTokens({
@@ -519,57 +515,23 @@ export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
       instanceUrl: GRAPHQL_URL,
     };
 
-    try {
-      await saveCredentialBundle(workspaceId, LINEAR_CATALOG_ID, bundle);
-      log.info(
-        {
-          workspaceId,
-          organizationId: viewer.organizationId,
-          organizationName: viewer.organizationName,
-        },
-        "Linear install completed (both stores written)",
-      );
-      return {
-        workspaceId,
-        catalogId: LINEAR_SLUG,
-        installRecord,
-        credentialResult: { written: true },
-      };
-    } catch (err) {
-      const errMessage = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { workspaceId, err: errMessage },
-        "Linear install record written but integration_credentials write failed — Reconnect required",
-      );
-      // Flip `status: "reconnect_needed"` so the admin card surfaces a
-      // persistent Reconnect CTA. Mirror Jira / Salesforce behaviour —
-      // without this the `?reconnect=linear` callback query param shows
-      // once and then disappears on the next admin-page reload.
-      try {
-        await internalQuery(
-          `UPDATE workspace_plugins
-              SET config = config || jsonb_build_object('status', 'reconnect_needed')
-            WHERE workspace_id = $1 AND catalog_id = $2`,
-          [workspaceId, LINEAR_CATALOG_ID],
-        );
-      } catch (statusErr) {
-        log.warn(
-          {
-            workspaceId,
-            err: statusErr instanceof Error ? statusErr.message : String(statusErr),
-          },
-          "Failed to mark Linear install as reconnect_needed after credential write failure",
-        );
-      }
-      return {
-        workspaceId,
-        catalogId: LINEAR_SLUG,
-        installRecord,
-        credentialResult: {
-          written: false,
-          reason: "Credential persist failed — admin should retry via Reconnect",
-        },
-      };
-    }
+    // Persist the credential bundle (ADR-0003 SECOND write) with the
+    // shared fail-closed Reconnect fallback: a credential-write failure
+    // flips `status: "reconnect_needed"` so the admin card surfaces a
+    // persistent Reconnect CTA (without it the callback's `?reconnect=linear`
+    // query param shows once then vanishes on the next page load).
+    return writeCredentialWithReconnectFallback({
+      workspaceId,
+      catalogId: LINEAR_CATALOG_ID,
+      slug: LINEAR_SLUG,
+      bundle,
+      installRecord,
+      log,
+      displayName: "Linear",
+      successLogFields: {
+        organizationId: viewer.organizationId,
+        organizationName: viewer.organizationName,
+      },
+    });
   }
 }

--- a/packages/api/src/lib/integrations/install/linear-token-refresh.ts
+++ b/packages/api/src/lib/integrations/install/linear-token-refresh.ts
@@ -1,36 +1,33 @@
 /**
- * Linear access-token refresh (#2750).
+ * Linear access-token refresh (#2750) — a config over the shared
+ * {@link refreshOAuthCredential} flow (#4188).
  *
- * Mirrors {@link ./jira-token-refresh.ts}; Linear-specific twists:
+ * Linear-specific dimensions captured in {@link LINEAR_REFRESH_CONFIG}:
  *
+ *   - **Form-encoded token body.** Linear's `/oauth/token` accepts
+ *     `application/x-www-form-urlencoded`, matching Salesforce (Atlassian
+ *     is the odd one out with JSON).
  *   - **Refresh tokens rotate on every refresh.** Like Atlassian, Linear
- *     returns a fresh `refresh_token` in the success response and the
- *     previous value MUST NOT be reused. Persisting the new value back
- *     to `integration_credentials` is non-optional.
- *   - **Token endpoint is form-encoded.** Linear's `/oauth/token`
- *     accepts `application/x-www-form-urlencoded`, matching Salesforce
- *     (Atlassian is the odd one out with JSON).
- *   - **Permanent failures classify the same way.** Linear returns
- *     `invalid_grant` when the stored refresh token is rejected and
- *     `invalid_client` when the OAuth App credentials are wrong. Only
- *     `invalid_grant` and Linear-side scope revocation flip
- *     `reconnect_needed`; `invalid_client` stays transient (operator-
- *     side env misconfig should not force every tenant admin to re-
- *     OAuth after the operator fixes the env).
+ *     returns a fresh `refresh_token` and the previous value MUST NOT be
+ *     reused (`requiresRefreshTokenInResponse: true`).
+ *   - **Permanent failure classification.** Only `invalid_grant` /
+ *     `unauthorized_client` / `access_denied` flip `reconnect_needed`;
+ *     `invalid_client` stays transient (operator-side env misconfig
+ *     should not force every tenant admin to re-OAuth). Any 4xx qualifies
+ *     for permanent classification.
  *
+ * @see ./oauth-token-refresh.ts — the shared exchange + classification flow
  * @see ./linear-oauth-handler.ts — the initial OAuth dance
- * @see ./jira-token-refresh.ts — sibling reference implementation
  * @see ../credentials/store.ts — the credential bundle store
  */
 
-import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import {
-  readCredentialBundle,
-  saveCredentialBundle,
-  type CredentialBundle,
-} from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import {
+  refreshOAuthCredential,
+  expiresInToAbsolute,
+  type OAuthRefreshConfig,
+} from "./oauth-token-refresh";
 import { LINEAR_CATALOG_ID, LINEAR_SLUG } from "./linear-oauth-handler";
 
 // Re-export so the lazy-builder + future callers can pull from this
@@ -41,21 +38,15 @@ export { IntegrationReconnectRequiredError };
 /** @deprecated #2708 — use {@link IntegrationReconnectRequiredError}; alias removed next release. */
 export { LinearReconnectRequiredError } from "@atlas/api/lib/effect/errors";
 
-const log = createLogger("integrations.install.linear-refresh");
-
 const TOKEN_URL = "https://api.linear.app/oauth/token";
 
 /**
- * Linear error codes that prove the install will never recover without
- * a fresh OAuth dance. `invalid_grant` is RFC 6749's "refresh token
+ * Linear error codes that prove the install will never recover without a
+ * fresh OAuth dance. `invalid_grant` is RFC 6749's "refresh token
  * rejected"; `unauthorized_client` and `access_denied` cover scope
- * revocation. Kept narrow on purpose — an unknown error code surfaces
- * as transient so we don't mis-classify the install as "reconnect
- * needed" without evidence.
- *
- * `invalid_client` is intentionally NOT in this set — that signals
- * wrong env wiring (`LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET` typo),
- * not a per-Workspace problem.
+ * revocation. `invalid_client` is intentionally NOT in this set — that
+ * signals wrong env wiring (`LINEAR_CLIENT_ID`/`SECRET` typo), not a
+ * per-Workspace problem.
  */
 const PERMANENT_REFRESH_FAILURE_CODES = new Set([
   "invalid_grant",
@@ -63,141 +54,33 @@ const PERMANENT_REFRESH_FAILURE_CODES = new Set([
   "access_denied",
 ]);
 
-interface LinearRefreshSuccess {
-  readonly access_token: string;
-  readonly refresh_token: string;
-  readonly expires_in?: number;
-  readonly token_type?: string;
-  readonly scope?: string;
-}
-
-interface LinearRefreshFailure {
-  readonly error: string;
-  readonly error_description?: string;
-}
-
-type LinearRefreshResponse = LinearRefreshSuccess | LinearRefreshFailure;
-
-function isRefreshSuccess(r: LinearRefreshResponse): r is LinearRefreshSuccess {
-  return (
-    "access_token" in r &&
-    typeof r.access_token === "string" &&
-    "refresh_token" in r &&
-    typeof r.refresh_token === "string"
-  );
-}
-
-interface RefreshArgs {
-  readonly clientId: string;
-  readonly clientSecret: string;
-  readonly refreshToken: string;
-}
-
-/**
- * POST `api.linear.app/oauth/token` with `grant_type=refresh_token`.
- * On HTTP 4xx carrying one of the {@link PERMANENT_REFRESH_FAILURE_CODES},
- * throws `IntegrationReconnectRequiredError`. On anything else (network failure,
- * 5xx, unknown 4xx, `invalid_client`), throws a plain `Error` so the
- * caller treats it as transient.
- */
-async function exchangeRefreshToken(
-  args: RefreshArgs,
-  workspaceId: string,
-): Promise<LinearRefreshSuccess> {
-  const body = new URLSearchParams({
-    grant_type: "refresh_token",
-    client_id: args.clientId,
-    client_secret: args.clientSecret,
-    refresh_token: args.refreshToken,
-  });
-
-  let resp: Response;
-  try {
-    resp = await fetch(TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-    });
-  } catch (err) {
-    // Network failure — transient. Let the caller retry on the next
-    // tool call. Don't flip reconnect_needed without evidence.
-    throw new Error(
-      `Linear token endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
-      { cause: err },
-    );
-  }
-
-  let parsed: LinearRefreshResponse;
-  try {
-    parsed = (await resp.json()) as LinearRefreshResponse;
-  } catch (err) {
-    throw new Error(
-      `Linear refresh returned unparseable body (HTTP ${resp.status})`,
-      { cause: err },
-    );
-  }
-
-  if (!resp.ok || !isRefreshSuccess(parsed)) {
-    const failure = parsed as LinearRefreshFailure;
-    const errorCode = failure.error ?? `http_${resp.status}`;
-    if (resp.status >= 400 && resp.status < 500 && PERMANENT_REFRESH_FAILURE_CODES.has(errorCode)) {
-      log.warn(
-        { workspaceId, errorCode, description: failure.error_description },
-        "Linear refresh failed permanently — flagging reconnect_needed",
-      );
-      throw new IntegrationReconnectRequiredError({
-        message: "Linear install needs to be reconnected — refresh token rejected by Linear.",
-        workspaceId,
-        platform: "linear",
-        upstreamError: errorCode,
-      });
-    }
-    // Unknown error code, 5xx, or `invalid_client` (operator env
-    // misconfig) — treat as transient.
-    throw new Error(`Linear refresh failed: ${errorCode} (HTTP ${resp.status})`);
-  }
-
-  return parsed;
-}
-
-/**
- * Mark the install row as `reconnect_needed`. JSONB merge so unrelated
- * config fields (organization_id, scopes, etc.) survive.
- */
-async function markReconnectNeeded(workspaceId: string): Promise<void> {
-  try {
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('status', 'reconnect_needed')
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, LINEAR_CATALOG_ID],
-    );
-  } catch (err) {
-    log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to mark Linear install as reconnect_needed (install row may have been disconnected)",
-    );
-  }
-}
-
-/**
- * Clear the `reconnect_needed` marker on a successful refresh. Idempotent.
- */
-async function clearReconnectNeeded(workspaceId: string): Promise<void> {
-  try {
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('status', 'ok')
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, LINEAR_CATALOG_ID],
-    );
-  } catch (err) {
-    log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to clear reconnect_needed flag after successful Linear refresh",
-    );
-  }
-}
+const LINEAR_REFRESH_CONFIG: OAuthRefreshConfig = {
+  platform: "linear",
+  displayName: "Linear",
+  endpointName: "Linear",
+  catalogId: LINEAR_CATALOG_ID,
+  logName: "integrations.install.linear-refresh",
+  bodyEncoding: "form",
+  requiresRefreshTokenInResponse: true,
+  permanentFailureCodes: PERMANENT_REFRESH_FAILURE_CODES,
+  isPermanentFailureStatus: (status) => status >= 400 && status < 500,
+  noRefreshTokenMessage:
+    "Linear install has no refresh token — App must request the offline scope.",
+  refreshRejectedMessage:
+    "Linear install needs to be reconnected — refresh token rejected by Linear.",
+  // Linear rotates the refresh token on every refresh — the success
+  // guard already asserted it's present, so we don't fall back to the
+  // stored value the way Salesforce sometimes does.
+  toBundle: (r, stored) => ({
+    accessToken: r.access_token,
+    refreshToken: r.refresh_token ?? stored.refreshToken,
+    expiresAt: expiresInToAbsolute(r.expires_in),
+    tokenType: r.token_type ?? stored.tokenType,
+    scope: r.scope ?? stored.scope,
+    instanceUrl: stored.instanceUrl,
+    ...(stored.extra ? { extra: stored.extra } : {}),
+  }),
+};
 
 export interface RefreshLinearTokenArgs {
   readonly workspaceId: string;
@@ -212,75 +95,8 @@ export interface RefreshLinearTokenArgs {
  * `IntegrationReconnectRequiredError` and flips
  * `workspace_plugins.config.status` to `"reconnect_needed"`.
  */
-export async function refreshLinearToken(
-  args: RefreshLinearTokenArgs,
-): Promise<CredentialBundle> {
-  const bundle = await readCredentialBundle(args.workspaceId, LINEAR_CATALOG_ID);
-  if (!bundle) {
-    throw new Error(
-      `No Linear credentials found for workspace ${args.workspaceId} — install was disconnected`,
-    );
-  }
-  if (!bundle.refreshToken) {
-    log.warn(
-      { workspaceId: args.workspaceId },
-      "Linear credential bundle has no refresh_token — flagging reconnect_needed",
-    );
-    await markReconnectNeeded(args.workspaceId);
-    throw new IntegrationReconnectRequiredError({
-      message: "Linear install has no refresh token — App must request the offline scope.",
-      workspaceId: args.workspaceId,
-      platform: "linear",
-      upstreamError: "no_refresh_token",
-    });
-  }
-
-  let refreshed: LinearRefreshSuccess;
-  try {
-    refreshed = await exchangeRefreshToken(
-      {
-        clientId: args.clientId,
-        clientSecret: args.clientSecret,
-        refreshToken: bundle.refreshToken,
-      },
-      args.workspaceId,
-    );
-  } catch (err) {
-    if (err instanceof IntegrationReconnectRequiredError) {
-      await markReconnectNeeded(args.workspaceId);
-    }
-    throw err;
-  }
-
-  // Linear rotates the refresh token on every refresh — `refresh_token`
-  // is required in the success response. The `isRefreshSuccess` guard
-  // already asserted both fields are present, so we don't fall back to
-  // the stored value the way Salesforce sometimes does.
-  const expiresAt =
-    typeof refreshed.expires_in === "number" && Number.isFinite(refreshed.expires_in)
-      ? Date.now() + refreshed.expires_in * 1000
-      : null;
-
-  const next: CredentialBundle = {
-    accessToken: refreshed.access_token,
-    refreshToken: refreshed.refresh_token,
-    expiresAt,
-    tokenType: refreshed.token_type ?? bundle.tokenType,
-    scope: refreshed.scope ?? bundle.scope,
-    instanceUrl: bundle.instanceUrl,
-    ...(bundle.extra ? { extra: bundle.extra } : {}),
-  };
-
-  await saveCredentialBundle(args.workspaceId, LINEAR_CATALOG_ID, next);
-  // Independent UPDATE so a failure to clear the flag doesn't roll back
-  // a successful refresh.
-  await clearReconnectNeeded(args.workspaceId);
-
-  log.info(
-    { workspaceId: args.workspaceId },
-    "Linear token refreshed successfully",
-  );
-  return next;
+export function refreshLinearToken(args: RefreshLinearTokenArgs): Promise<CredentialBundle> {
+  return refreshOAuthCredential(LINEAR_REFRESH_CONFIG, args, TOKEN_URL);
 }
 
 /** Re-export to keep the slug constant in one place for catalog wiring. */

--- a/packages/api/src/lib/integrations/install/oauth-callback-verify.ts
+++ b/packages/api/src/lib/integrations/install/oauth-callback-verify.ts
@@ -1,0 +1,71 @@
+/**
+ * `verifyCallbackState` — the shared step-1 of every OAuth install
+ * handler's `handleCallback` (#4188).
+ *
+ * Seven OAuth handlers (Slack, Salesforce, Jira, Linear, GitHub App,
+ * GitHub single-tenant, OAuth-datasource) opened `handleCallback` with a
+ * structurally identical two-step guard (differing only in the
+ * per-platform rejection log copy and statement order):
+ *
+ *   1. `verifyOAuthStateToken(stateToken)` → `null` on every failure
+ *      mode (forged / expired / invalid signature). Return `null`.
+ *   2. Catalog-slug binding check — the dispatch routes by slug, so a
+ *      token bound to a *different* catalog reaching this handler is a
+ *      bug or a cross-catalog forge attempt. Log + return `null`.
+ *
+ * Extracting it to one seam means the fail-closed invariant "a state
+ * token bound to a different catalog is rejected" exists once, with a
+ * direct unit test, instead of being re-asserted across seven handler
+ * suites. See {@link ./types.ts} `OAuthPlatformInstallHandler`.
+ *
+ * The per-platform rejection log copy is threaded through
+ * `rejectionLogMessage` so the operator-facing wording each handler
+ * shipped ("Jira OAuth callback received state bound to a different
+ * catalog — rejecting") is preserved verbatim.
+ *
+ * @see ./oauth-state-token.ts — the verify primitive this wraps
+ */
+
+import type { WorkspaceId } from "@useatlas/types";
+import type { createLogger } from "@atlas/api/lib/logger";
+import { verifyOAuthStateToken } from "./oauth-state-token";
+import type { CatalogId } from "./types";
+
+/** Minimal logger surface — the guard only ever `warn`s on rejection. */
+type CallbackVerifyLogger = Pick<ReturnType<typeof createLogger>, "warn">;
+
+/**
+ * The verified, catalog-matched result: the branded workspace id the
+ * state token was minted from. The token's signature guarantees the
+ * round-trip preserved the exact bytes minted at `startInstall`, so the
+ * brand promotion is sound (mirrors the per-handler comment the seam
+ * replaces — we don't pull `assertWorkspaceId` from `@useatlas/chat`
+ * because the verifier already filtered empty strings and that would add
+ * a cross-package dep this module otherwise doesn't need).
+ */
+export interface VerifiedCallbackState {
+  readonly workspaceId: WorkspaceId;
+}
+
+/**
+ * Verify an OAuth callback's CSRF state token and assert it is bound to
+ * `expectedSlug`. Returns the branded `workspaceId` on success, or
+ * `null` on ANY failure (invalid signature OR catalog mismatch) — the
+ * caller returns `null` from `handleCallback`, which the route maps to a
+ * benign "install could not be verified" without leaking which check
+ * failed.
+ */
+export function verifyCallbackState(
+  stateToken: string,
+  expectedSlug: CatalogId,
+  log: CallbackVerifyLogger,
+  rejectionLogMessage: string,
+): VerifiedCallbackState | null {
+  const verified = verifyOAuthStateToken(stateToken);
+  if (!verified) return null;
+  if (verified.catalogId !== expectedSlug) {
+    log.warn({ expected: expectedSlug, got: verified.catalogId }, rejectionLogMessage);
+    return null;
+  }
+  return { workspaceId: verified.workspaceId as WorkspaceId };
+}

--- a/packages/api/src/lib/integrations/install/oauth-datasource-handler.ts
+++ b/packages/api/src/lib/integrations/install/oauth-datasource-handler.ts
@@ -55,10 +55,8 @@ import { baselineSpecDiffRecord } from "@atlas/api/lib/openapi/diff";
 import { DEFAULT_REPRESENTATION_MODE } from "@atlas/api/lib/openapi/catalog";
 import { getGitHubInstallationToken } from "@atlas/api/lib/github/installation-token";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
 import { exchangeUserCodeForToken, findUserInstallation } from "./github-app-oauth";
 import {
   GITHUB_APP_SECRET_FIELDS_SCHEMA,
@@ -152,17 +150,15 @@ export class OAuthDatasourceInstallHandler implements OAuthDatasourceInstallHand
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    // ── 1. Verify state — null on every failure mode ─────────────
-    const verified = verifyOAuthStateToken(stateToken);
+    // ── 1. Verify state + catalog binding (shared seam) ──────────
+    const verified = verifyCallbackState(
+      stateToken,
+      this.config.slug,
+      log,
+      "OAuth-datasource callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    if (verified.catalogId !== this.config.slug) {
-      log.warn(
-        { expected: this.config.slug, got: verified.catalogId },
-        "OAuth-datasource callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
-    const workspaceId = verified.workspaceId as WorkspaceId;
+    const { workspaceId } = verified;
 
     // ── 2. Require both installation_id and the user-OAuth code ──
     const installationIdRaw = extras?.installationId;

--- a/packages/api/src/lib/integrations/install/oauth-reconnect.ts
+++ b/packages/api/src/lib/integrations/install/oauth-reconnect.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared `reconnect_needed` status seam for OAuth installs (#4188).
+ *
+ * `workspace_plugins.config.status` is the credential-health signal the
+ * admin console reads to render the "Reconnect needed" CTA. Two flows
+ * flip it, and both were copy-pasted per platform:
+ *
+ *   - **Install callback tail** — the three credential-bundle handlers
+ *     (Jira / Salesforce / Linear) write `integration_credentials`
+ *     SECOND (ADR-0003 two-store). If that write throws, the install
+ *     row is already committed, so the handler flips
+ *     `status: "reconnect_needed"` and returns
+ *     `credentialResult.written: false`. This is the **fail-closed
+ *     invariant**: an install can never present as "Installed" with no
+ *     credential behind it. Consolidated here as
+ *     {@link writeCredentialWithReconnectFallback}.
+ *
+ *   - **Token refresh** — the three refreshers
+ *     (`{jira,linear,salesforce}-token-refresh.ts`) flip the same status
+ *     on a permanent refresh failure and clear it on success. Their
+ *     `markReconnectNeeded` / `clearReconnectNeeded` pairs were
+ *     byte-identical apart from the catalog id and the platform name in
+ *     the log line. Consolidated as the `(workspaceId, catalogId)`-keyed
+ *     pair below.
+ *
+ * The `config || jsonb_build_object('status', …)` JSONB merge is an
+ * upsert — unrelated config keys (cloudid, scopes, instance_url, …)
+ * survive, and re-flipping is idempotent. Both UPDATEs are independent,
+ * best-effort statements: a failure to flip/clear is logged and
+ * swallowed (the caller has already thrown the tagged error or persisted
+ * the fresh credentials), never propagated.
+ *
+ * @see ./types.ts — {@link CredentialResult} / {@link InstallRecord}
+ * @see docs/adr/0003-two-store-chat-install-metadata-credentials.md
+ * @see docs/adr/0005-integration-credentials-table.md
+ */
+
+import type { WorkspaceId } from "@useatlas/types";
+import type { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { saveCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { CatalogId, CredentialResult, InstallRecord } from "./types";
+
+type ReconnectLogger = Pick<ReturnType<typeof createLogger>, "info" | "warn">;
+
+/**
+ * Flip `workspace_plugins.config.status` to `"reconnect_needed"` for
+ * `(workspaceId, catalogId)`. JSONB merge so unrelated config fields
+ * survive. Best-effort: the install row vanishing between a credential
+ * read and this UPDATE (concurrent disconnect) is rare but possible —
+ * log + swallow, since the caller already surfaced the reconnect signal
+ * via a thrown tagged error or a `written: false` result.
+ */
+export async function markReconnectNeeded(
+  workspaceId: string,
+  catalogId: string,
+  log: Pick<ReturnType<typeof createLogger>, "warn">,
+  failureLogMessage: string,
+): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE workspace_plugins
+          SET config = config || jsonb_build_object('status', 'reconnect_needed')
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, catalogId],
+    );
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      failureLogMessage,
+    );
+  }
+}
+
+/**
+ * Clear the `reconnect_needed` marker (set `status: "ok"`) after a
+ * successful refresh. Idempotent — a no-op JSONB merge when status was
+ * already "ok". Best-effort: the refresh already persisted the fresh
+ * credentials, so a failed clear is a cosmetic stale badge until the
+ * next refresh, never a reason to fail the refresh (which would evict
+ * the freshly-rotated cached plugin instance).
+ */
+export async function clearReconnectNeeded(
+  workspaceId: string,
+  catalogId: string,
+  log: Pick<ReturnType<typeof createLogger>, "warn">,
+  failureLogMessage: string,
+): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE workspace_plugins
+          SET config = config || jsonb_build_object('status', 'ok')
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, catalogId],
+    );
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      failureLogMessage,
+    );
+  }
+}
+
+export interface WriteCredentialWithReconnectFallbackArgs {
+  readonly workspaceId: WorkspaceId;
+  /** Full `plugin_catalog.id` FK ("catalog:jira") — the write + flip key. */
+  readonly catalogId: string;
+  /** Catalog slug ("jira") — the value echoed back in the return envelope. */
+  readonly slug: CatalogId;
+  readonly bundle: CredentialBundle;
+  readonly installRecord: InstallRecord;
+  readonly log: ReconnectLogger;
+  /** Platform name composed into the log lines ("Jira" / "Salesforce" / "Linear"). */
+  readonly displayName: string;
+  /** Structured fields for the success `info` log (never secrets). `workspaceId` is added automatically. */
+  readonly successLogFields?: Record<string, unknown>;
+  /** Structured fields for the partial-failure `warn` log (never secrets). `workspaceId` + `err` are added automatically. */
+  readonly failureLogFields?: Record<string, unknown>;
+}
+
+/**
+ * ADR-0003 two-store SECOND write: persist the credential bundle to
+ * `integration_credentials`, and on failure enforce the fail-closed
+ * Reconnect invariant.
+ *
+ *   - Success → `credentialResult: { written: true }`.
+ *   - Failure → the install row stays (never rolled back); flip
+ *     `status: "reconnect_needed"` so the admin card surfaces a
+ *     persistent Reconnect CTA (without it the callback's `?reconnect=`
+ *     query param shows once then vanishes on the next page load), and
+ *     return `credentialResult: { written: false, reason: … }`.
+ *
+ * The credential-write throw is the ONLY branch that flips status here —
+ * a status-flip failure is itself best-effort (see
+ * {@link markReconnectNeeded}). Returns the full handler envelope so the
+ * caller's `handleCallback` tail is a single `return`.
+ */
+export async function writeCredentialWithReconnectFallback(
+  args: WriteCredentialWithReconnectFallbackArgs,
+): Promise<{
+  readonly workspaceId: WorkspaceId;
+  readonly catalogId: CatalogId;
+  readonly installRecord: InstallRecord;
+  readonly credentialResult: CredentialResult;
+}> {
+  const { workspaceId, catalogId, slug, bundle, installRecord, log, displayName } = args;
+  try {
+    await saveCredentialBundle(workspaceId, catalogId, bundle);
+    log.info(
+      { workspaceId, ...(args.successLogFields ?? {}) },
+      `${displayName} install completed (both stores written)`,
+    );
+    return { workspaceId, catalogId: slug, installRecord, credentialResult: { written: true } };
+  } catch (err) {
+    const errMessage = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { workspaceId, ...(args.failureLogFields ?? {}), err: errMessage },
+      `${displayName} install record written but integration_credentials write failed — Reconnect required`,
+    );
+    // Flip status so the admin card surfaces a persistent Reconnect CTA.
+    await markReconnectNeeded(
+      workspaceId,
+      catalogId,
+      log,
+      `Failed to mark ${displayName} install as reconnect_needed after credential write failure`,
+    );
+    return {
+      workspaceId,
+      catalogId: slug,
+      installRecord,
+      credentialResult: {
+        written: false,
+        reason: "Credential persist failed — admin should retry via Reconnect",
+      },
+    };
+  }
+}

--- a/packages/api/src/lib/integrations/install/oauth-token-refresh.ts
+++ b/packages/api/src/lib/integrations/install/oauth-token-refresh.ts
@@ -1,0 +1,266 @@
+/**
+ * `refreshOAuthCredential` — the one refresh-token rotation flow the
+ * three per-platform refreshers collapse onto (#4188).
+ *
+ * `{jira,linear,salesforce}-token-refresh.ts` were ~280–330 LOC each and
+ * their headers described each other as mirrors of a sibling refresher.
+ * The HTTP exchange, the permanent-vs-transient classification, and the
+ * `mark`/`clearReconnectNeeded` orchestration were near-identical modulo
+ * the {@link OAuthRefreshConfig} dimensions (body encoding, permanent-code
+ * set, status predicate, rotation flag, bundle assembly); only those
+ * dimensions actually vary per platform, and everything else lives here
+ * once.
+ *
+ * The classification contract (unchanged from the originals):
+ *
+ *   - **Permanent** → the install is broken until a fresh OAuth dance.
+ *     An HTTP status in `isPermanentFailureStatus` carrying a code in
+ *     `permanentFailureCodes` throws {@link IntegrationReconnectRequiredError}
+ *     and flips `workspace_plugins.config.status` to `"reconnect_needed"`.
+ *   - **Transient** → network failure, 5xx, unparseable body, an unknown
+ *     4xx code, or an operator-side code (`invalid_client`) deliberately
+ *     kept OUT of `permanentFailureCodes`. Throws a plain `Error`, never
+ *     flips status — the agent loop's next call retries.
+ *
+ * @see ./oauth-reconnect.ts — the shared status mark/clear pair
+ * @see ./jira-token-refresh.ts — Jira config (JSON body, rotation-required)
+ * @see ./linear-token-refresh.ts — Linear config (form body, rotation-required)
+ * @see ./salesforce-token-refresh.ts — Salesforce config (form body, per-tenant token URL)
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  readCredentialBundle,
+  saveCredentialBundle,
+  type CredentialBundle,
+} from "@atlas/api/lib/integrations/credentials/store";
+import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import { markReconnectNeeded, clearReconnectNeeded } from "./oauth-reconnect";
+
+/**
+ * Superset of the OAuth token-refresh success bodies across platforms.
+ * `expires_in` is Jira/Linear; `instance_url` / `issued_at` / `id_token`
+ * are Salesforce. Each config's `toBundle` reads only the fields its
+ * platform sends.
+ */
+export interface RefreshSuccessResponse {
+  readonly access_token: string;
+  readonly refresh_token?: string;
+  readonly token_type?: string;
+  readonly scope?: string;
+  readonly expires_in?: number;
+  readonly instance_url?: string;
+  readonly issued_at?: string;
+  readonly id_token?: string;
+}
+
+interface RefreshFailureResponse {
+  // Optional: the parsed body is untrusted JSON widened to this shape, so
+  // `error` may be absent — hence the `?? http_<status>` fallback below.
+  readonly error?: string;
+  readonly error_description?: string;
+}
+
+type RefreshResponse = RefreshSuccessResponse | RefreshFailureResponse;
+
+/** The per-invocation inputs shared by every platform's refresher. */
+export interface OAuthRefreshArgs {
+  readonly workspaceId: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+/**
+ * The per-platform dimensions of the refresh flow. Adding a fourth
+ * OAuth-credential refresher is a new value of this shape — no copied
+ * exchange / classify / mark-reconnect code.
+ */
+export interface OAuthRefreshConfig {
+  /** Tagged-error `platform` discriminator ("jira" / "linear" / "salesforce"). */
+  readonly platform: string;
+  /** Platform name in the "No X credentials" / "X refresh failed" messages. */
+  readonly displayName: string;
+  /** Vendor name in the endpoint-level messages ("Atlassian" for Jira, else `displayName`). */
+  readonly endpointName: string;
+  /** Full `plugin_catalog.id` FK ("catalog:jira") — the credential + status key. */
+  readonly catalogId: string;
+  /** Logger name ("integrations.install.jira-refresh"). */
+  readonly logName: string;
+  /** Token endpoint body encoding — Atlassian is JSON, everyone else form-encoded. */
+  readonly bodyEncoding: "json" | "form";
+  /**
+   * Whether the success response MUST carry a rotated `refresh_token`
+   * (Jira/Linear rotate on every refresh; Salesforce usually omits it
+   * and the stored value rolls forward). Drives the success guard.
+   */
+  readonly requiresRefreshTokenInResponse: boolean;
+  /** Upstream error codes that prove the install is broken (reconnect-needed). */
+  readonly permanentFailureCodes: ReadonlySet<string>;
+  /** Which HTTP statuses qualify for permanent classification (Jira/Linear: any 4xx; Salesforce: exactly 400). */
+  readonly isPermanentFailureStatus: (status: number) => boolean;
+  /** `IntegrationReconnectRequiredError.message` when the stored bundle has no refresh token. */
+  readonly noRefreshTokenMessage: string;
+  /** `IntegrationReconnectRequiredError.message` when upstream rejects the refresh token. */
+  readonly refreshRejectedMessage: string;
+  /** Assemble the persisted bundle from the success body + the stored bundle. */
+  readonly toBundle: (response: RefreshSuccessResponse, stored: CredentialBundle) => CredentialBundle;
+}
+
+function isRefreshSuccess(
+  config: OAuthRefreshConfig,
+  r: RefreshResponse,
+): r is RefreshSuccessResponse {
+  if (!("access_token" in r) || typeof r.access_token !== "string") return false;
+  if (
+    config.requiresRefreshTokenInResponse &&
+    (!("refresh_token" in r) || typeof r.refresh_token !== "string")
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * POST the token endpoint with `grant_type=refresh_token`. On a
+ * permanent-classified failure throws {@link IntegrationReconnectRequiredError};
+ * on anything else (network, 5xx, unknown/transient 4xx) throws a plain
+ * `Error` so the caller treats it as transient.
+ */
+async function exchangeRefreshToken(
+  config: OAuthRefreshConfig,
+  args: OAuthRefreshArgs,
+  tokenUrl: string,
+  refreshToken: string,
+): Promise<RefreshSuccessResponse> {
+  const params = {
+    grant_type: "refresh_token",
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    refresh_token: refreshToken,
+  };
+  const { headers, body } =
+    config.bodyEncoding === "json"
+      ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(params) }
+      : {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams(params).toString(),
+        };
+
+  let resp: Response;
+  try {
+    resp = await fetch(tokenUrl, { method: "POST", headers, body });
+  } catch (err) {
+    // Network failure — transient. Let the caller retry on the next tool
+    // call. Don't flip reconnect_needed without evidence.
+    throw new Error(
+      `${config.endpointName} token endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  let parsed: RefreshResponse;
+  try {
+    parsed = (await resp.json()) as RefreshResponse;
+  } catch (err) {
+    throw new Error(
+      `${config.endpointName} refresh returned unparseable body (HTTP ${resp.status})`,
+      { cause: err },
+    );
+  }
+
+  if (!resp.ok || !isRefreshSuccess(config, parsed)) {
+    const failure = parsed as RefreshFailureResponse;
+    const errorCode = failure.error ?? `http_${resp.status}`;
+    if (config.isPermanentFailureStatus(resp.status) && config.permanentFailureCodes.has(errorCode)) {
+      createLogger(config.logName).warn(
+        { workspaceId: args.workspaceId, errorCode, description: failure.error_description },
+        `${config.displayName} refresh failed permanently — flagging reconnect_needed`,
+      );
+      throw new IntegrationReconnectRequiredError({
+        message: config.refreshRejectedMessage,
+        workspaceId: args.workspaceId,
+        platform: config.platform,
+        upstreamError: errorCode,
+      });
+    }
+    // Unknown error code, 5xx, or an operator-side code — treat as transient.
+    throw new Error(`${config.displayName} refresh failed: ${errorCode} (HTTP ${resp.status})`);
+  }
+
+  return parsed;
+}
+
+/**
+ * Refresh the OAuth access token for `args.workspaceId`. Returns the
+ * updated `CredentialBundle` (also persisted to `integration_credentials`).
+ * On permanent failure throws {@link IntegrationReconnectRequiredError}
+ * and flips `workspace_plugins.config.status` to `"reconnect_needed"`.
+ *
+ * `tokenUrl` is resolved by the caller — constant for Jira/Linear,
+ * per-tenant (`<loginUrl>/services/oauth2/token`) for Salesforce.
+ */
+export async function refreshOAuthCredential(
+  config: OAuthRefreshConfig,
+  args: OAuthRefreshArgs,
+  tokenUrl: string,
+): Promise<CredentialBundle> {
+  const log = createLogger(config.logName);
+  const disconnectedMessage = `Failed to mark ${config.displayName} install as reconnect_needed (install row may have been disconnected)`;
+
+  const bundle = await readCredentialBundle(args.workspaceId, config.catalogId);
+  if (!bundle) {
+    throw new Error(
+      `No ${config.displayName} credentials found for workspace ${args.workspaceId} — install was disconnected`,
+    );
+  }
+  if (!bundle.refreshToken) {
+    log.warn(
+      { workspaceId: args.workspaceId },
+      `${config.displayName} credential bundle has no refresh_token — flagging reconnect_needed`,
+    );
+    await markReconnectNeeded(args.workspaceId, config.catalogId, log, disconnectedMessage);
+    throw new IntegrationReconnectRequiredError({
+      message: config.noRefreshTokenMessage,
+      workspaceId: args.workspaceId,
+      platform: config.platform,
+      upstreamError: "no_refresh_token",
+    });
+  }
+
+  let refreshed: RefreshSuccessResponse;
+  try {
+    refreshed = await exchangeRefreshToken(config, args, tokenUrl, bundle.refreshToken);
+  } catch (err) {
+    if (err instanceof IntegrationReconnectRequiredError) {
+      await markReconnectNeeded(args.workspaceId, config.catalogId, log, disconnectedMessage);
+    }
+    throw err;
+  }
+
+  const next = config.toBundle(refreshed, bundle);
+
+  await saveCredentialBundle(args.workspaceId, config.catalogId, next);
+  // Independent UPDATE so a failed clear doesn't roll back a successful refresh.
+  await clearReconnectNeeded(
+    args.workspaceId,
+    config.catalogId,
+    log,
+    `Failed to clear reconnect_needed flag after successful ${config.displayName} refresh`,
+  );
+
+  log.info(
+    { workspaceId: args.workspaceId, instanceUrl: next.instanceUrl },
+    `${config.displayName} token refreshed successfully`,
+  );
+  return next;
+}
+
+/**
+ * Shared helper — Jira/Linear return `expires_in` (seconds); compute the
+ * absolute expiry ms so the store needn't remember when it was issued.
+ */
+export function expiresInToAbsolute(expiresIn: number | undefined): number | null {
+  return typeof expiresIn === "number" && Number.isFinite(expiresIn)
+    ? Date.now() + expiresIn * 1000
+    : null;
+}

--- a/packages/api/src/lib/integrations/install/salesforce-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/salesforce-oauth-handler.ts
@@ -63,14 +63,12 @@ import { Data } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
-import { saveCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import { persistInstallRecord } from "./persist-form-install";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
+import { writeCredentialWithReconnectFallback } from "./oauth-reconnect";
 import type {
   CatalogId,
   CredentialResult,
@@ -388,17 +386,15 @@ export class SalesforceOAuthInstallHandler implements OAuthPlatformInstallHandle
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    // ── 1. Verify state — null on every failure mode ─────────────
-    const verified = verifyOAuthStateToken(stateToken);
+    // ── 1. Verify state + catalog binding (shared seam) ──────────
+    const verified = verifyCallbackState(
+      stateToken,
+      SALESFORCE_SLUG,
+      log,
+      "Salesforce OAuth callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    const workspaceId = verified.workspaceId as WorkspaceId;
-    if (verified.catalogId !== SALESFORCE_SLUG) {
-      log.warn(
-        { expected: SALESFORCE_SLUG, got: verified.catalogId },
-        "Salesforce OAuth callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
+    const { workspaceId } = verified;
 
     // ── 2. Exchange code for tokens ───────────────────────────────
     const tokens = await exchangeAuthCodeForTokens({
@@ -466,57 +462,22 @@ export class SalesforceOAuthInstallHandler implements OAuthPlatformInstallHandle
       ...(tokens.id_token ? { extra: { id_token: tokens.id_token } } : {}),
     };
 
-    try {
-      await saveCredentialBundle(workspaceId, SALESFORCE_CATALOG_ID, bundle);
-      log.info(
-        { workspaceId, instanceUrl: tokens.instance_url },
-        "Salesforce install completed (both stores written)",
-      );
-      return {
-        workspaceId,
-        catalogId: SALESFORCE_SLUG,
-        installRecord,
-        credentialResult: { written: true },
-      };
-    } catch (err) {
-      const errMessage = err instanceof Error ? err.message : String(err);
-      log.warn(
-        { workspaceId, instanceUrl: tokens.instance_url, err: errMessage },
-        "Salesforce install record written but integration_credentials write failed — Reconnect required",
-      );
-      // Codex P1 — flip status to `reconnect_needed` so the admin card
-      // surfaces a persistent Reconnect CTA. Without this, the OAuth
-      // callback's `?reconnect=salesforce` query param shows once and
-      // then disappears on the next admin-page reload, leaving the card
-      // in the "Installed" state with no credentials behind it.
-      // Best-effort UPDATE — if it fails the install record is still
-      // present and the user lands on `?reconnect=` via the callback's
-      // partial-failure redirect; the warn log captures the divergence.
-      try {
-        await internalQuery(
-          `UPDATE workspace_plugins
-              SET config = config || jsonb_build_object('status', 'reconnect_needed')
-            WHERE workspace_id = $1 AND catalog_id = $2`,
-          [workspaceId, SALESFORCE_CATALOG_ID],
-        );
-      } catch (statusErr) {
-        log.warn(
-          {
-            workspaceId,
-            err: statusErr instanceof Error ? statusErr.message : String(statusErr),
-          },
-          "Failed to mark Salesforce install as reconnect_needed after credential write failure",
-        );
-      }
-      return {
-        workspaceId,
-        catalogId: SALESFORCE_SLUG,
-        installRecord,
-        credentialResult: {
-          written: false,
-          reason: "Credential persist failed — admin should retry via Reconnect",
-        },
-      };
-    }
+    // Persist the credential bundle (ADR-0003 SECOND write) with the
+    // shared fail-closed Reconnect fallback: a credential-write failure
+    // flips `status: "reconnect_needed"` so the admin card surfaces a
+    // persistent Reconnect CTA (without it the callback's
+    // `?reconnect=salesforce` query param shows once then vanishes on the
+    // next page load, leaving an "Installed" card with no credential).
+    return writeCredentialWithReconnectFallback({
+      workspaceId,
+      catalogId: SALESFORCE_CATALOG_ID,
+      slug: SALESFORCE_SLUG,
+      bundle,
+      installRecord,
+      log,
+      displayName: "Salesforce",
+      successLogFields: { instanceUrl: tokens.instance_url },
+      failureLogFields: { instanceUrl: tokens.instance_url },
+    });
   }
 }

--- a/packages/api/src/lib/integrations/install/salesforce-token-refresh.ts
+++ b/packages/api/src/lib/integrations/install/salesforce-token-refresh.ts
@@ -1,54 +1,37 @@
 /**
- * Salesforce access-token refresh (#2658).
+ * Salesforce access-token refresh (#2658) — a config over the shared
+ * {@link refreshOAuthCredential} flow (#4188).
  *
- * Salesforce access tokens are short-lived; the rotation flow exchanges
- * the stored `refresh_token` for a fresh `access_token` against
- * `<loginUrl>/services/oauth2/token` with `grant_type=refresh_token`.
+ * Salesforce exchanges the stored `refresh_token` for a fresh
+ * `access_token` against `<loginUrl>/services/oauth2/token`. The
+ * Salesforce-specific dimensions captured in
+ * {@link SALESFORCE_REFRESH_CONFIG} + {@link refreshSalesforceToken}:
  *
- * Outcomes:
+ *   - **Per-tenant token URL.** The login host is operator-supplied
+ *     (`SALESFORCE_LOGIN_URL`, default `login.salesforce.com`), so the
+ *     token URL is resolved per call rather than a module constant.
+ *   - **Refresh token usually rolls forward.** Salesforce sometimes
+ *     returns a new `refresh_token`, sometimes not — we keep whichever
+ *     non-empty value we have (`requiresRefreshTokenInResponse: false`;
+ *     `toBundle` falls back to the stored value) so the chain doesn't
+ *     break.
+ *   - **Permanent failure classification.** `invalid_grant` /
+ *     `inactive_user` / `org_locked` / `inactive_org` flip
+ *     `reconnect_needed`, but ONLY on an HTTP 400. `invalid_client` /
+ *     `rate_limit_exceeded` and 5xx stay transient — operator-side or
+ *     recoverable failures must not force every tenant admin to re-OAuth.
  *
- *   - Refresh succeeded: persist the new bundle (the existing
- *     refresh_token usually rolls forward — Salesforce sometimes
- *     returns a new one, sometimes not — we keep whichever non-empty
- *     value we have so the chain doesn't break), bump
- *     `integration_credentials.updated_at`, and return the bundle.
- *
- *   - Refresh failed in a way that proves the install is broken
- *     (revoked Connected App, deleted user, etc. — Salesforce returns
- *     `invalid_grant`): flip `workspace_plugins.config.status` to
- *     `"reconnect_needed"`. The admin UI surfaces a Reconnect CTA on
- *     the integration card; until the admin re-runs the OAuth dance
- *     the install is in a quarantined state.
- *
- *   - Refresh failed transiently (network blip, 5xx): throw without
- *     marking reconnect-needed. The agent loop's next call retries.
- *
- * The classification "permanent vs. transient" is the key complexity:
- *   - Permanent → tenant-install-broken errors: `invalid_grant`,
- *     `inactive_user`, `org_locked`, `inactive_org`. These prove the
- *     specific Workspace's install needs admin action; the admin re-runs
- *     OAuth from the Reconnect CTA.
- *   - Transient → network failures, 5xx, unparseable bodies,
- *     `rate_limit_exceeded` (per-org throttle that recovers on its
- *     own), AND `invalid_client` / `invalid_client_id` (these are
- *     OPERATOR-side misconfig — wrong `SALESFORCE_CLIENT_ID`/`SECRET`
- *     env vars affect every Workspace; flipping reconnect_needed would
- *     force every workspace admin to re-run OAuth after the operator
- *     fixes the env, even though the actual install is fine). No
- *     reconnect-needed marker; let the caller retry on next tool call.
- *
+ * @see ./oauth-token-refresh.ts — the shared exchange + classification flow
  * @see ./salesforce-oauth-handler.ts — the initial OAuth dance
  * @see ../credentials/store.ts — the credential bundle store
  */
 
-import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import {
-  readCredentialBundle,
-  saveCredentialBundle,
-  type CredentialBundle,
-} from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import {
+  refreshOAuthCredential,
+  type OAuthRefreshConfig,
+} from "./oauth-token-refresh";
 import {
   DEFAULT_ACCESS_TOKEN_LIFETIME_MS,
   SALESFORCE_CATALOG_ID,
@@ -63,7 +46,7 @@ export { IntegrationReconnectRequiredError };
 /** @deprecated #2708 — use {@link IntegrationReconnectRequiredError}; alias removed next release. */
 export { SalesforceReconnectRequiredError } from "@atlas/api/lib/effect/errors";
 
-const log = createLogger("integrations.install.salesforce-refresh");
+const DEFAULT_LOGIN_URL = "https://login.salesforce.com";
 
 /**
  * Salesforce error codes that prove the install will never recover
@@ -79,152 +62,41 @@ const PERMANENT_REFRESH_FAILURE_CODES = new Set([
   "inactive_org",
 ]);
 
-interface SalesforceRefreshSuccess {
-  readonly access_token: string;
-  readonly refresh_token?: string;
-  readonly instance_url?: string;
-  readonly token_type?: string;
-  readonly issued_at?: string;
-  readonly scope?: string;
-  readonly id_token?: string;
-}
-
-interface SalesforceRefreshFailure {
-  readonly error: string;
-  readonly error_description?: string;
-}
-
-type SalesforceRefreshResponse = SalesforceRefreshSuccess | SalesforceRefreshFailure;
-
-function isRefreshSuccess(r: SalesforceRefreshResponse): r is SalesforceRefreshSuccess {
-  return "access_token" in r && typeof r.access_token === "string";
-}
-
-interface RefreshArgs {
-  readonly loginUrl: string;
-  readonly clientId: string;
-  readonly clientSecret: string;
-  readonly refreshToken: string;
-}
-
-/**
- * POST `<loginUrl>/services/oauth2/token` with `grant_type=refresh_token`.
- * On HTTP 400 carrying one of the {@link PERMANENT_REFRESH_FAILURE_CODES}
- * codes, throws `IntegrationReconnectRequiredError`. On anything else
- * (network failure, 5xx, unknown 4xx), throws a plain `Error` so the
- * caller treats it as transient.
- */
-async function exchangeRefreshToken(
-  args: RefreshArgs,
-  workspaceId: string,
-): Promise<SalesforceRefreshSuccess> {
-  const body = new URLSearchParams({
-    grant_type: "refresh_token",
-    client_id: args.clientId,
-    client_secret: args.clientSecret,
-    refresh_token: args.refreshToken,
-  });
-
-  let resp: Response;
-  try {
-    resp = await fetch(`${args.loginUrl}/services/oauth2/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-    });
-  } catch (err) {
-    // Network failure — transient. Let the caller retry on the next
-    // tool call. Don't flip reconnect_needed without evidence.
-    throw new Error(
-      `Salesforce token endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
-      { cause: err },
-    );
-  }
-
-  let parsed: SalesforceRefreshResponse;
-  try {
-    parsed = (await resp.json()) as SalesforceRefreshResponse;
-  } catch (err) {
-    throw new Error(
-      `Salesforce refresh returned unparseable body (HTTP ${resp.status})`,
-      { cause: err },
-    );
-  }
-
-  if (!resp.ok || !isRefreshSuccess(parsed)) {
-    const failure = parsed as SalesforceRefreshFailure;
-    const errorCode = failure.error ?? `http_${resp.status}`;
-    if (resp.status === 400 && PERMANENT_REFRESH_FAILURE_CODES.has(errorCode)) {
-      log.warn(
-        { workspaceId, errorCode, description: failure.error_description },
-        "Salesforce refresh failed permanently — flagging reconnect_needed",
-      );
-      throw new IntegrationReconnectRequiredError({
-        message: "Salesforce install needs to be reconnected — refresh token rejected by upstream.",
-        workspaceId,
-        platform: "salesforce",
-        upstreamError: errorCode,
-      });
-    }
-    // Unknown error code or 5xx — treat as transient.
-    throw new Error(`Salesforce refresh failed: ${errorCode} (HTTP ${resp.status})`);
-  }
-
-  return parsed;
-}
-
-/**
- * Mark the install row as `reconnect_needed` in `workspace_plugins.config`.
- * Uses a JSONB set so we don't touch unrelated config fields (instance_url,
- * scopes, etc.). Safe to call multiple times — JSONB `||` is an upsert.
- */
-async function markReconnectNeeded(workspaceId: string): Promise<void> {
-  try {
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('status', 'reconnect_needed')
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, SALESFORCE_CATALOG_ID],
-    );
-  } catch (err) {
-    // The install row vanishing between the credential read and this
-    // UPDATE is rare but possible (concurrent disconnect). Log + swallow
-    // — the caller already threw `IntegrationReconnectRequiredError`,
-    // which is the signal the route surface needs.
-    log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to mark Salesforce install as reconnect_needed (install row may have been disconnected)",
-    );
-  }
-}
-
-/**
- * Clear the `reconnect_needed` marker on a successful refresh. Idempotent:
- * if the field was already unset (status was "ok"), the JSONB merge with
- * `status: "ok"` is a no-op.
- */
-async function clearReconnectNeeded(workspaceId: string): Promise<void> {
-  try {
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('status', 'ok')
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, SALESFORCE_CATALOG_ID],
-    );
-  } catch (err) {
-    // Log + swallow — the refresh itself already succeeded and the new
-    // credentials are persisted. Worst case is a cosmetic stale
-    // "Reconnect needed" badge in the admin UI until the next refresh
-    // (which will retry this UPDATE). Don't propagate: surfacing this
-    // failure would falsely signal that the refresh itself failed, and
-    // the agent would unnecessarily evict the cached plugin instance
-    // built on the freshly-rotated token.
-    log.warn(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Failed to clear reconnect_needed flag after successful Salesforce refresh",
-    );
-  }
-}
+const SALESFORCE_REFRESH_CONFIG: OAuthRefreshConfig = {
+  platform: "salesforce",
+  displayName: "Salesforce",
+  endpointName: "Salesforce",
+  catalogId: SALESFORCE_CATALOG_ID,
+  logName: "integrations.install.salesforce-refresh",
+  bodyEncoding: "form",
+  requiresRefreshTokenInResponse: false,
+  permanentFailureCodes: PERMANENT_REFRESH_FAILURE_CODES,
+  isPermanentFailureStatus: (status) => status === 400,
+  noRefreshTokenMessage:
+    "Salesforce install has no refresh token — Connected App must grant the refresh_token / offline_access scopes.",
+  refreshRejectedMessage:
+    "Salesforce install needs to be reconnected — refresh token rejected by upstream.",
+  // Salesforce typically does NOT return a new refresh_token (the
+  // existing one keeps working); preserve the stored value when the
+  // refresh response omits it, and carry a rotated id_token into `extra`.
+  toBundle: (r, stored) => {
+    const issuedMs = r.issued_at ? Number.parseInt(r.issued_at, 10) : NaN;
+    const expiresAt = Number.isFinite(issuedMs) ? issuedMs + DEFAULT_ACCESS_TOKEN_LIFETIME_MS : null;
+    return {
+      accessToken: r.access_token,
+      refreshToken: r.refresh_token ?? stored.refreshToken,
+      expiresAt,
+      tokenType: r.token_type ?? stored.tokenType,
+      scope: r.scope ?? stored.scope,
+      instanceUrl: r.instance_url ?? stored.instanceUrl,
+      ...(r.id_token
+        ? { extra: { ...(stored.extra ?? {}), id_token: r.id_token } }
+        : stored.extra
+          ? { extra: stored.extra }
+          : {}),
+    };
+  },
+};
 
 export interface RefreshSalesforceTokenArgs {
   readonly workspaceId: string;
@@ -235,96 +107,23 @@ export interface RefreshSalesforceTokenArgs {
 
 /**
  * Refresh the Salesforce access token for `workspaceId`. Returns the
- * updated `CredentialBundle` (also persisted to
- * `integration_credentials`). On permanent failure throws
- * `IntegrationReconnectRequiredError` and flips
- * `workspace_plugins.config.status` to `"reconnect_needed"`.
+ * updated `CredentialBundle` (also persisted to `integration_credentials`).
+ * On permanent failure throws `IntegrationReconnectRequiredError` and
+ * flips `workspace_plugins.config.status` to `"reconnect_needed"`.
  *
- * Callers (LazyPluginLoader builder, agent tool-call wrapper) catch
- * the tagged error to evict the cached plugin instance and surface a
- * specific message to the agent / admin UI.
+ * Callers (LazyPluginLoader builder, agent tool-call wrapper) catch the
+ * tagged error to evict the cached plugin instance and surface a specific
+ * message to the agent / admin UI.
  */
-export async function refreshSalesforceToken(
+export function refreshSalesforceToken(
   args: RefreshSalesforceTokenArgs,
 ): Promise<CredentialBundle> {
-  const bundle = await readCredentialBundle(args.workspaceId, SALESFORCE_CATALOG_ID);
-  if (!bundle) {
-    throw new Error(
-      `No Salesforce credentials found for workspace ${args.workspaceId} — install was disconnected`,
-    );
-  }
-  if (!bundle.refreshToken) {
-    // No refresh_token in the bundle — this happens when the operator's
-    // Connected App didn't grant `refresh_token` scope. Surface as
-    // reconnect-needed so admin re-runs the dance with a Connected App
-    // that does grant it.
-    log.warn(
-      { workspaceId: args.workspaceId },
-      "Salesforce credential bundle has no refresh_token — flagging reconnect_needed",
-    );
-    await markReconnectNeeded(args.workspaceId);
-    throw new IntegrationReconnectRequiredError({
-      message: "Salesforce install has no refresh token — Connected App must grant the refresh_token / offline_access scopes.",
-      workspaceId: args.workspaceId,
-      platform: "salesforce",
-      upstreamError: "no_refresh_token",
-    });
-  }
-
-  const loginUrl = (args.loginUrl ?? "https://login.salesforce.com").replace(/\/+$/, "");
-
-  let refreshed: SalesforceRefreshSuccess;
-  try {
-    refreshed = await exchangeRefreshToken(
-      {
-        loginUrl,
-        clientId: args.clientId,
-        clientSecret: args.clientSecret,
-        refreshToken: bundle.refreshToken,
-      },
-      args.workspaceId,
-    );
-  } catch (err) {
-    if (err instanceof IntegrationReconnectRequiredError) {
-      await markReconnectNeeded(args.workspaceId);
-    }
-    throw err;
-  }
-
-  // Salesforce typically does NOT return a new refresh_token (the
-  // existing one keeps working); preserve the stored value when the
-  // refresh response omits it.
-  const nextRefreshToken = refreshed.refresh_token ?? bundle.refreshToken;
-  const issuedMs = refreshed.issued_at ? Number.parseInt(refreshed.issued_at, 10) : NaN;
-  const expiresAt = Number.isFinite(issuedMs) ? issuedMs + DEFAULT_ACCESS_TOKEN_LIFETIME_MS : null;
-
-  const next: CredentialBundle = {
-    accessToken: refreshed.access_token,
-    refreshToken: nextRefreshToken,
-    expiresAt,
-    tokenType: refreshed.token_type ?? bundle.tokenType,
-    scope: refreshed.scope ?? bundle.scope,
-    instanceUrl: refreshed.instance_url ?? bundle.instanceUrl,
-    ...(refreshed.id_token
-      ? { extra: { ...(bundle.extra ?? {}), id_token: refreshed.id_token } }
-      : bundle.extra
-        ? { extra: bundle.extra }
-        : {}),
-  };
-
-  await saveCredentialBundle(args.workspaceId, SALESFORCE_CATALOG_ID, next);
-  // If the install had previously been flagged for reconnect, the
-  // successful refresh clears it. Independent UPDATE (not part of the
-  // credential write transaction) so a failure to clear the flag
-  // doesn't roll back a successful refresh — the worst case is a
-  // cosmetic "Reconnect needed" lingering until the next refresh.
-  await clearReconnectNeeded(args.workspaceId);
-
-  log.info(
-    { workspaceId: args.workspaceId, instanceUrl: next.instanceUrl },
-    "Salesforce token refreshed successfully",
+  const loginUrl = (args.loginUrl ?? DEFAULT_LOGIN_URL).replace(/\/+$/, "");
+  return refreshOAuthCredential(
+    SALESFORCE_REFRESH_CONFIG,
+    args,
+    `${loginUrl}/services/oauth2/token`,
   );
-  return next;
 }
 
 /** Re-export to keep the slug constant in one place for catalog wiring. */

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -42,10 +42,8 @@ import { saveInstallation } from "@atlas/api/lib/slack/store";
 import { BillingCheckFailedError, ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
 import { checkChatIntegrationLimit, checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
-import {
-  mintOAuthStateToken,
-  verifyOAuthStateToken,
-} from "./oauth-state-token";
+import { mintOAuthStateToken } from "./oauth-state-token";
+import { verifyCallbackState } from "./oauth-callback-verify";
 import type {
   CatalogId,
   CredentialResult,
@@ -180,28 +178,18 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     readonly installRecord: InstallRecord;
     readonly credentialResult: CredentialResult;
   } | null> {
-    // ── 1. Verify state token — null on every failure mode ────────
-    const verified = verifyOAuthStateToken(stateToken);
+    // ── 1. Verify state token + catalog binding (shared seam) ─────
+    // A token bound to a different catalog slug shouldn't reach the
+    // Slack handler — the dispatch routes by slug. If it does, it's a
+    // bug or a cross-catalog forge attempt; the seam returns null.
+    const verified = verifyCallbackState(
+      stateToken,
+      SLACK_SLUG,
+      log,
+      "Slack OAuth callback received state bound to a different catalog — rejecting",
+    );
     if (!verified) return null;
-    // Promote the verified workspaceId string to the brand. The token
-    // was minted from a branded WorkspaceId at startInstall time; the
-    // signed payload guarantees the round-trip preserves the same
-    // bytes, so the assertion is sound here. We don't pull
-    // `assertWorkspaceId` from `@useatlas/chat` (used at the proactive
-    // listener boundary) because that helper rejects empty strings —
-    // which the token verifier already filters out — and would add a
-    // cross-package dep this module otherwise doesn't need.
-    const workspaceId = verified.workspaceId as WorkspaceId;
-    if (verified.catalogId !== SLACK_SLUG) {
-      // A token bound to a different catalog slug shouldn't reach the
-      // Slack handler — the dispatch routes by slug. If it does, it's
-      // a bug or a cross-catalog forge attempt; treat as invalid state.
-      log.warn(
-        { expected: SLACK_SLUG, got: verified.catalogId },
-        "Slack OAuth callback received state bound to a different catalog — rejecting",
-      );
-      return null;
-    }
+    const { workspaceId } = verified;
 
     // ── 2. Exchange code via Slack's oauth.v2.access ──────────────
     // `slackAPI` handles the form-encoded request body Slack's


### PR DESCRIPTION
## Summary

The OAuth-install family under `packages/api/src/lib/integrations/install/` copy-pasted its choreography per platform. This extracts three shared seams beside the spine (arch survey 2026-07-01), behavior-preserving:

- **`verifyCallbackState`** (`oauth-callback-verify.ts`) — the step-1 state-verify + catalog-slug guard shared by all 7 OAuth handlers (Slack, Salesforce, Jira, Linear, GitHub App, GitHub single-tenant, OAuth-datasource). The "state token bound to a different catalog is rejected" fail-closed invariant now exists once.
- **`writeCredentialWithReconnectFallback` + `markReconnectNeeded` / `clearReconnectNeeded`** (`oauth-reconnect.ts`) — the ADR-0003 second-write fail-closed Reconnect tail (×3 handlers) and the reconnect-status flip pair (×3 refreshers). The `reconnect_needed` UPDATE now lives in exactly one place.
- **`refreshOAuthCredential`** (`oauth-token-refresh.ts`) — the three token refreshers (`{jira,linear,salesforce}-token-refresh.ts`) collapse to a config over one shared exchange + permanent/transient classification + mark/clear orchestration. Adding a 4th OAuth-credential refresher is now a config, not a copied ~300-LOC file.

Net **−700 LOC** across the tracked handler/refresher files. No per-platform behavior change — existing handler + refresh test suites pass unchanged. Adds direct unit tests for the catalog-slug guard and the fail-closed credential-write invariant.

Scoped to the OAuth-handler / token-refresh seams only (`*-oauth-handler.ts` + `*-token-refresh.ts`); does not touch `slack/store.ts` or `discord/store.ts`.

## Test plan

- [x] All 3 token-refresh suites + all 7 handler suites pass unchanged (76 handler + 26 refresh tests)
- [x] New `oauth-callback-verify.test.ts` (catalog-slug guard, real sign/verify) + `oauth-reconnect.test.ts` (mark/clear + fail-closed write) — 12 tests
- [x] New pin: rotation-required HTTP-200-missing-refresh_token → transient (no false Reconnect)
- [x] `bun run type` clean; `eslint` clean on changed files
- [x] Full local CI wrapper: all 27 gates green (incl. full `test` suite)
- [x] Internal review panel: CLEAN (2 rounds — silent-failure, type-design, test-coverage, comment-accuracy)

## Reviewer notes

- Internal review panel (4 specialists) converged CLEAN. No CRITICAL/HIGH. The one observable deviation: Linear refresh success now additionally logs its (non-secret, constant) `instanceUrl` — left as benign enrichment.
- `RefreshSuccessResponse` is a deliberate optional-field superset (per type-design review) rather than a per-platform generic; all fields optional + read defensively so no illegal state is representable.

Closes #4188