### PR TITLE
refactor(api): type the unified SQL pipeline's executed-result record (ExecutedSqlResult)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/sql-pipeline-seam.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-pipeline-seam.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, it, beforeEach, mock } from "bun:test";
 import { Effect } from "effect";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { ExecuteSqlSuccessResult } from "@useatlas/types";
 
 const whitelistedTables = new Set(["companies"]);
 
@@ -461,9 +462,62 @@ describe("unified SQL pipeline seam (#4185)", () => {
     const outcome = await runSeam({ kind: "bind-dashboard-parameters", values: {} });
     expect(outcome.kind).toBe("executed");
     if (outcome.kind === "executed") {
+      // The typed `ExecutedSqlResult` contract (#4244): every field the
+      // adapters read is now a compile-time-checked property, so a rename in
+      // either constructor site is caught here and in the wrapper adapters
+      // rather than silently desyncing an unchecked cast.
       expect(outcome.result.success).toBe(true);
+      expect(outcome.result.explanation).toBe("seam test");
       expect(outcome.result.columns).toEqual(["id"]);
+      expect(outcome.result.rows).toEqual([{ id: 1 }]);
       expect(outcome.result.row_count).toBe(1);
+      expect(outcome.result.truncated).toBe(false);
+      expect(outcome.result.cached).toBe(false);
+      // No classification masking runs in this seam (org pooling off), so the
+      // live path deterministically reports `maskingApplied: false`.
+      expect(outcome.result.maskingApplied).toBe(false);
+      expect(typeof outcome.result.executionMs).toBe("number");
     }
+  });
+
+  it("cache-hit executed outcome reports the cache-serve contract (cached, executionMs=0)", async () => {
+    // The SECOND `ExecutedSqlResult` construction site — the cache-hit
+    // constructor — sets the distinct values the live path can't: `cached:
+    // true` and the cache-serve `executionMs: 0`. Approval is not required
+    // (default mock), so the pre-step serves the pre-seeded entry and no DB
+    // round-trip happens. Runtime-verifies the field values `satisfies` only
+    // type-guards.
+    cacheIsEnabled = true;
+    cacheEntry = { columns: ["id"], rows: [{ id: 99 }], cachedAt: Date.now(), ttl: 60000, executionMs: 5 };
+    const outcome = await runSeam({ kind: "check-cache" });
+    expect(outcome.kind).toBe("executed");
+    if (outcome.kind === "executed") {
+      expect(outcome.result.success).toBe(true);
+      expect(outcome.result.cached).toBe(true);
+      expect(outcome.result.executionMs).toBe(0);
+      expect(outcome.result.columns).toEqual(["id"]);
+      expect(outcome.result.rows).toEqual([{ id: 99 }]);
+      expect(outcome.result.row_count).toBe(1);
+      expect(outcome.result.truncated).toBe(false);
+      expect(outcome.result.maskingApplied).toBe(false);
+    }
+    expect(mockDBConnection.query).not.toHaveBeenCalled();
+  });
+
+  // ── Wire-contract drift guard ───────────────────────────────────────
+  // The internal `ExecutedSqlResult` (private to sql.ts, reached here via the
+  // exported `SqlPipelineOutcome`) is the producer of the executeSQL tool's
+  // wire success shape: its widened record is finished into
+  // `ExecuteSqlSuccessResult` downstream, gaining `envContributions` — a
+  // 1-element array via `attachSingleEnvContribution` on the single-env path,
+  // or an N-element array via `mergeMemberResults` on fanout. Pin that the
+  // producer stays a valid wire success result (minus that downstream-added
+  // `envContributions`) so a rename on either side of the tool contract fails
+  // tsgo here instead of silently desyncing across the opaque `Record` seam.
+  it("type-level: ExecutedSqlResult stays wire-compatible with ExecuteSqlSuccessResult", () => {
+    type ExecutedResult = Extract<SqlPipelineOutcome, { kind: "executed" }>["result"];
+    type Check = ExecutedResult extends Omit<ExecuteSqlSuccessResult, "envContributions"> ? true : false;
+    const _: Check = true;
+    expect(_).toBe(true);
   });
 });

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1129,6 +1129,38 @@ export function buildSqlExecuteSpanAttrs(opts: {
   return attrs;
 }
 
+/**
+ * The response record produced by a successful SQL execution — the payload
+ * carried by {@link SqlPipelineOutcome}'s `executed` outcome. Built at TWO
+ * sites: {@link executeAndAuditEffect}'s live-query success path and the
+ * cache-hit constructor inside the `check-cache` pre-step. Both `satisfies`
+ * this interface so a field rename in one constructor is caught at compile
+ * time (previously the record was an untyped `Record<string, unknown>` and a
+ * rename could silently desync the `runUserQueryPipeline` adapter's field
+ * reads).
+ *
+ * `success` is always `true` here — the failure record shape lives in
+ * {@link pipelineErrorToResponse} and the wrappers' `{ success: false }`
+ * branches. `metadata` is present only when a plugin `beforeQuery` hook wrote
+ * into the mutable `hookMetadata` bag (the only hook whose dispatch context
+ * carries it). The agent wrapper widens this back to `Record<string, unknown>`
+ * at its single return seam, since the downstream consumers — the fanout
+ * merger and the single-env contribution wrapper — read the tool response by
+ * key as an opaque record.
+ */
+interface ExecutedSqlResult {
+  readonly success: true;
+  readonly explanation: string;
+  readonly row_count: number;
+  readonly columns: string[];
+  readonly rows: Record<string, unknown>[];
+  readonly truncated: boolean;
+  readonly cached: boolean;
+  readonly maskingApplied: boolean;
+  readonly executionMs: number;
+  readonly metadata?: Record<string, unknown>;
+}
+
 function executeAndAuditEffect(opts: {
   db: DBConnection;
   dbType: DBType;
@@ -1158,7 +1190,7 @@ function executeAndAuditEffect(opts: {
   connectionGroupId?: string;
   /** Planner reason that picked this connection (for the OTel `atlas.routing_reason` attribute). */
   routingReason?: RoutingReason;
-}): Effect.Effect<Record<string, unknown>, QueryExecutionError | EnterpriseUnavailableError> {
+}): Effect.Effect<ExecutedSqlResult, QueryExecutionError | EnterpriseUnavailableError> {
   const {
     db, dbType, connId, orgId, poolOrgId, targetHost, querySql, queryTimeout,
     rowLimit, explanation, classification, cacheKey, hookMetadata, dispatchHook,
@@ -1350,7 +1382,7 @@ function executeAndAuditEffect(opts: {
             maskingApplied,
             executionMs: durationMs,
             ...(hasHookMeta && { metadata: hookMetadata }),
-          } as Record<string, unknown>;
+          } satisfies ExecutedSqlResult;
         },
         catch: (err) => {
           // #2593 — preserve the `enterprise_load_failed` signal end-to-end
@@ -1480,7 +1512,7 @@ export interface SqlPipelineOptions {
  * without the core duplicating either format.
  */
 export type SqlPipelineOutcome =
-  | { readonly kind: "executed"; readonly result: Record<string, unknown> }
+  | { readonly kind: "executed"; readonly result: ExecutedSqlResult }
   | { readonly kind: "validation_failed"; readonly message: string }
   | { readonly kind: "approval_unavailable"; readonly message: string }
   | { readonly kind: "approval_identity_missing"; readonly message: string }
@@ -1545,6 +1577,18 @@ export function runSqlPipelineEffect(
         normalizedSql = bound.sql;
         bindParams = bound.values;
       } catch (err) {
+        // `DashboardParameterError` is the expected fail-closed rejection
+        // (missing value / bad placeholder) and carries an actionable
+        // message. Anything else is an unexpected binder fault (e.g. a
+        // `TypeError`) whose message we deliberately don't surface — log it
+        // so it stays diagnosable instead of vanishing behind the generic
+        // "Failed to bind query parameters." response.
+        if (!(err instanceof DashboardParameterError)) {
+          log.warn(
+            { err: err instanceof Error ? err : new Error(String(err)), connectionId: connId },
+            "Unexpected error binding dashboard parameters — returning generic bind-failure message",
+          );
+        }
         return {
           kind: "validation_failed" as const,
           message:
@@ -1804,7 +1848,7 @@ export function runSqlPipelineEffect(
                 // this response field intentionally reports the cache-serve
                 // cost (#3616 naming: two distinct "executionMs" meanings).
                 executionMs: 0,
-              } as Record<string, unknown>;
+              } satisfies ExecutedSqlResult;
             },
             catch: (err) => {
               // #2593 — preserve fail-closed signal through the cache path.
@@ -1993,12 +2037,12 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
           const result = outcome.result;
           return {
             kind: "ok",
-            columns: result.columns as string[],
-            rows: result.rows as Record<string, unknown>[],
-            rowCount: result.row_count as number,
-            executionMs: result.executionMs as number,
-            truncated: result.truncated as boolean,
-            maskingApplied: result.maskingApplied as boolean,
+            columns: result.columns,
+            rows: result.rows,
+            rowCount: result.row_count,
+            executionMs: result.executionMs,
+            truncated: result.truncated,
+            maskingApplied: result.maskingApplied,
           };
         }
         case "validation_failed":
@@ -2107,7 +2151,12 @@ async function executeSqlForConnection({
     Effect.map((outcome): Record<string, unknown> => {
       switch (outcome.kind) {
         case "executed":
-          return outcome.result;
+          // Widen the typed result to the opaque tool-response record the
+          // downstream consumers read by key — the fanout merger and the
+          // single-env contribution wrapper (`success`/`columns`/`rows`/
+          // `executionMs`/`error`). The spread is load-bearing: an interface
+          // is not assignable to `Record<string, unknown>`, but its spread is.
+          return { ...outcome.result };
         case "validation_failed":
         case "approval_unavailable":
         case "approval_identity_missing":


### PR DESCRIPTION
## Summary
- The `executed` outcome of `runSqlPipelineEffect` carried its result as an untyped `Record<string, unknown>`, built at two sites (live-query success path + cache-hit constructor) with `as` casts and read back with unchecked casts in the `runUserQueryPipeline` adapter — a field rename in either constructor was invisible to `tsgo`.
- Introduces a module-private `ExecutedSqlResult` interface; both construction sites now `satisfies` it and `SqlPipelineOutcome.executed.result` is typed. Drops the six unchecked `as` casts in the `runUserQueryPipeline` executed adapter. The agent wrapper widens back to `Record<string, unknown>` at its single return seam (opaque tool-response record for the fanout merger / single-env contribution wrapper) via a spread.
- Logs an unexpected (non-`DashboardParameterError`) dashboard-parameter binder fault before returning the generic bind-failure message, so a binder `TypeError` stays diagnosable (same-seam LOW finding from the #4185 panel).
- Strengthens the seam test to runtime-verify both construction sites' field values (live + cache-serve) and adds a compile-time wire-contract drift guard tying `ExecutedSqlResult` to `@useatlas/types`' `ExecuteSqlSuccessResult`.

Behavior-preserving refactor. Follow-up from #4185 / PR #4243 (accepted-as-out-of-scope type-design finding). Builds on the unified pipeline merged in #4243.

## Test plan
- [x] `bun run tsgo --noEmit` clean (packages/api)
- [x] Seam test `sql-pipeline-seam.test.ts` green (25 pass) incl. new cache-serve + drift-guard tests
- [x] All 41 affected api test files pass (`test-isolated.ts --affected`)
- [x] Internal review panel: CLEAN (2 rounds)
- [x] Local CI gates: 26/27 green; sole `test` FAIL is a pre-existing environmental `@atlas/mcp` smoke-test false-negative (needs a workspace/billing backend absent locally), reproduces on clean HEAD, and CI is green on that SHA on `main`

Closes #4244

https://claude.ai/code/session_015E1b5xQeizyEQZktA9hm6N