### PR TITLE
refactor(ee): eeRead/eeWrite combinators for the enterprise-gate + DB-guard preamble

### DIFF
--- a/ee/src/audit/retention.ts
+++ b/ee/src/audit/retention.ts
@@ -2,7 +2,8 @@
  * Enterprise audit log retention — configurable retention policies,
  * soft-delete purging, hard-delete cleanup, and compliance export.
  *
- * All mutating operations call `requireEnterpriseEffect("audit-retention")`.
+ * All read/write operations route through the `eeRead`/`eeWrite` combinators,
+ * which apply the `requireEnterpriseEffect("audit-retention")` gate.
  * Read operations (get policy) are gated too so non-enterprise users
  * don't see partial config states.
  *

--- a/ee/src/audit/retention.ts
+++ b/ee/src/audit/retention.ts
@@ -16,15 +16,13 @@
  */
 
 import { Effect, Layer } from "effect";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   AuditRetention,
   type AuditRetentionShape,
 } from "@atlas/api/lib/effect/services";
-import { requireInternalDBEffect } from "../lib/db-guard";
 import {
-  hasInternalDB,
   internalQuery,
   getInternalDB,
 } from "@atlas/api/lib/db/internal";
@@ -197,10 +195,7 @@ function rowToPolicy(row: RetentionConfigRow): AuditRetentionPolicy {
  * Returns null if no policy is configured (unlimited retention).
  */
 export const getRetentionPolicy = (orgId: string): Effect.Effect<AuditRetentionPolicy | null, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    if (!hasInternalDB()) return null;
-
+  eeRead("audit-retention", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<RetentionConfigRow>(
       `SELECT id, org_id, retention_days, hard_delete_delay_days, updated_at, updated_by, last_purge_at, last_purge_count
        FROM audit_retention_config
@@ -210,7 +205,7 @@ export const getRetentionPolicy = (orgId: string): Effect.Effect<AuditRetentionP
 
     if (rows.length === 0) return null;
     return rowToPolicy(rows[0]);
-  });
+  }));
 
 /**
  * Set or update the audit retention policy for an organization.
@@ -221,10 +216,7 @@ export const setRetentionPolicy = (
   input: SetRetentionPolicyInput,
   updatedBy: string | null,
 ): Effect.Effect<AuditRetentionPolicy, RetentionError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    yield* requireInternalDBEffect("audit retention configuration");
-
+  eeWrite("audit-retention", "audit retention configuration", Effect.gen(function* () {
     // Validate retention days
     if (input.retentionDays !== null) {
       if (!Number.isInteger(input.retentionDays) || input.retentionDays < MIN_RETENTION_DAYS) {
@@ -275,7 +267,7 @@ export const setRetentionPolicy = (
     }
 
     return rowToPolicy(rows[0]);
-  });
+  }));
 
 // ── Purge operations ─────────────────────────────────────────────────
 
@@ -288,10 +280,7 @@ export const setRetentionPolicy = (
  * Returns the count of soft-deleted entries per org.
  */
 export const purgeExpiredEntries = (orgId?: string): Effect.Effect<PurgeResult[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    if (!hasInternalDB()) return [];
-
+  eeRead("audit-retention", [], Effect.gen(function* () {
     const pool = getInternalDB();
     const results: PurgeResult[] = [];
 
@@ -341,7 +330,7 @@ export const purgeExpiredEntries = (orgId?: string): Effect.Effect<PurgeResult[]
     }
 
     return results;
-  });
+  }));
 
 /**
  * Permanently delete audit log entries that were soft-deleted
@@ -350,10 +339,7 @@ export const purgeExpiredEntries = (orgId?: string): Effect.Effect<PurgeResult[]
  * Processes all orgs with retention configs.
  */
 export const hardDeleteExpired = (orgId?: string): Effect.Effect<HardDeleteResult, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    if (!hasInternalDB()) return { deletedCount: 0 };
-
+  eeRead("audit-retention", { deletedCount: 0 }, Effect.gen(function* () {
     const pool = getInternalDB();
 
     // Get retention configs — scoped to orgId when provided, all orgs for scheduler
@@ -421,7 +407,7 @@ export const hardDeleteExpired = (orgId?: string): Effect.Effect<HardDeleteResul
     }
 
     return { deletedCount: totalDeleted };
-  });
+  }));
 
 // ── Export ────────────────────────────────────────────────────────────
 
@@ -449,10 +435,7 @@ export const exportAuditLog = (options: ExportOptions): Effect.Effect<{
   totalAvailable: number;
   truncated: boolean;
 }, RetentionError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    yield* requireInternalDBEffect("audit log export");
-
+  eeWrite("audit-retention", "audit log export", Effect.gen(function* () {
     const conditions: string[] = ["a.org_id = $1", "(a.deleted_at IS NULL)"];
     const params: unknown[] = [options.orgId];
     let paramIdx = 2;
@@ -561,7 +544,7 @@ export const exportAuditLog = (options: ExportOptions): Effect.Effect<{
       totalAvailable,
       truncated,
     };
-  });
+  }));
 
 // ── Admin action log retention (F-36) ──────────────────────────────────
 //
@@ -595,10 +578,7 @@ export const exportAuditLog = (options: ExportOptions): Effect.Effect<{
  * mirroring the F-27 zero-row suppression on `hardDeleteExpired`.
  */
 export const purgeAdminActionExpired = (orgId?: string): Effect.Effect<AdminActionPurgeResult[], EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    if (!hasInternalDB()) return [];
-
+  eeRead("audit-retention", [], Effect.gen(function* () {
     const pool = getInternalDB();
 
     // Fetch applicable retention configs — mirrors audit-log path. A DB
@@ -724,7 +704,7 @@ export const purgeAdminActionExpired = (orgId?: string): Effect.Effect<AdminActi
     }
 
     return results;
-  });
+  }));
 
 /**
  * GDPR / CCPA erasure of a single user's identifiers from `admin_action_log`.
@@ -760,10 +740,7 @@ export const anonymizeUserAdminActions = (
   userId: string,
   initiatedBy: AnonymizeInitiatedBy,
 ): Effect.Effect<AnonymizeResult, RetentionError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    yield* requireInternalDBEffect("admin action log erasure");
-
+  eeWrite("audit-retention", "admin action log erasure", Effect.gen(function* () {
     // Input validation: empty / whitespace userId would scan every row
     // matching `actor_id = ''` (empty-string matches nothing in practice,
     // but whitespace-only values could poison the audit trail by writing
@@ -832,7 +809,7 @@ export const anonymizeUserAdminActions = (
     });
 
     return { anonymizedRowCount };
-  });
+  }));
 
 // ── Admin-action retention policy CRUD (F-36 Phase 2) ─────────────────
 //
@@ -856,10 +833,7 @@ export const anonymizeUserAdminActions = (
 export const getAdminActionRetentionPolicy = (
   orgId: string,
 ): Effect.Effect<AuditRetentionPolicy | null, EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    if (!hasInternalDB()) return null;
-
+  eeRead("audit-retention", null, Effect.gen(function* () {
     // `Effect.tryPromise` (not `Effect.promise`) — a DB error on read must
     // route through the typed error channel so the Phase 2 HTTP route's
     // `Effect.tapError` on this call fires the stage:policy_read failure
@@ -877,7 +851,7 @@ export const getAdminActionRetentionPolicy = (
 
     if (rows.length === 0) return null;
     return rowToPolicy(rows[0]);
-  });
+  }));
 
 /**
  * Set or update the admin-action retention policy for an organization.
@@ -898,10 +872,7 @@ export const setAdminActionRetentionPolicy = (
   input: SetRetentionPolicyInput,
   updatedBy: string | null,
 ): Effect.Effect<AuditRetentionPolicy, RetentionError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    yield* requireInternalDBEffect("admin-action retention configuration");
-
+  eeWrite("audit-retention", "admin-action retention configuration", Effect.gen(function* () {
     if (input.retentionDays !== null) {
       if (!Number.isInteger(input.retentionDays) || input.retentionDays < MIN_RETENTION_DAYS) {
         return yield* Effect.fail(new RetentionError({
@@ -964,7 +935,7 @@ export const setAdminActionRetentionPolicy = (
     }
 
     return rowToPolicy(rows[0]);
-  });
+  }));
 
 /**
  * Preview the count of `admin_action_log` rows that would be scrubbed by
@@ -983,10 +954,7 @@ export const setAdminActionRetentionPolicy = (
 export const previewAdminActionErasure = (
   userId: string,
 ): Effect.Effect<{ anonymizableRowCount: number }, RetentionError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("audit-retention");
-    if (!hasInternalDB()) return { anonymizableRowCount: 0 };
-
+  eeRead("audit-retention", { anonymizableRowCount: 0 }, Effect.gen(function* () {
     if (typeof userId !== "string" || userId.trim() === "") {
       return yield* Effect.fail(new RetentionError({
         message: `Invalid userId: must be a non-empty string.`,
@@ -1016,7 +984,7 @@ export const previewAdminActionErasure = (
       return yield* Effect.fail(new Error(`previewAdminActionErasure: unexpected count shape — ${typeof raw} ${String(raw)}`));
     }
     return { anonymizableRowCount: parsed };
-  });
+  }));
 
 // ── Tag wiring (#2569 — slice 7/11 of #2017; split in #2587) ─────────
 //

--- a/ee/src/auth/ip-allowlist.ts
+++ b/ee/src/auth/ip-allowlist.ts
@@ -11,9 +11,8 @@
 
 import { Effect, Layer } from "effect";
 import ipaddr from "ipaddr.js";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -219,10 +218,7 @@ function rowToEntry(row: IPAllowlistRow): IPAllowlistEntry {
  * List IP allowlist entries for an organization.
  */
 export const listIPAllowlistEntries = (orgId: string): Effect.Effect<IPAllowlistEntry[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("ip-allowlist");
-    if (!hasInternalDB()) return [];
-
+  eeRead("ip-allowlist", [], Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<IPAllowlistRow>(
       `SELECT id, org_id, cidr, description, created_at, created_by
        FROM ip_allowlist
@@ -231,7 +227,7 @@ export const listIPAllowlistEntries = (orgId: string): Effect.Effect<IPAllowlist
       [orgId],
     ));
     return rows.map(rowToEntry);
-  });
+  }));
 
 /**
  * Add a CIDR range to an organization's IP allowlist.
@@ -248,10 +244,7 @@ export const addIPAllowlistEntry = (
   description: string | null,
   createdBy: string | null,
 ): Effect.Effect<IPAllowlistEntry, IPAllowlistError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("ip-allowlist");
-    yield* requireInternalDBEffect("IP allowlist management");
-
+  eeWrite("ip-allowlist", "IP allowlist management", Effect.gen(function* () {
     // Validate CIDR format
     const parsed = parseCIDR(cidr);
     if (!parsed) {
@@ -282,16 +275,13 @@ export const addIPAllowlistEntry = (
     log.info({ orgId, cidr: normalizedCidr }, "IP allowlist entry added");
     invalidateCache(orgId);
     return rowToEntry(rows[0]);
-  });
+  }));
 
 /**
  * Remove an IP allowlist entry by ID.
  */
 export const removeIPAllowlistEntry = (orgId: string, entryId: string): Effect.Effect<boolean, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("ip-allowlist");
-    if (!hasInternalDB()) return false;
-
+  eeRead("ip-allowlist", false, Effect.gen(function* () {
     const pool = getInternalDB();
     const result = yield* Effect.promise(() =>
       pool.query(
@@ -306,7 +296,7 @@ export const removeIPAllowlistEntry = (orgId: string, entryId: string): Effect.E
       invalidateCache(orgId);
     }
     return deleted;
-  });
+  }));
 
 // ── Middleware helper ─────────────────────────────────────────────────
 

--- a/ee/src/auth/ip-allowlist.ts
+++ b/ee/src/auth/ip-allowlist.ts
@@ -5,7 +5,8 @@
  * allowed CIDR ranges can access the workspace. Uses `ipaddr.js` for
  * robust IP/CIDR parsing with full IPv4-mapped IPv6 support.
  *
- * CRUD functions call `requireEnterprise("ip-allowlist")`.
+ * CRUD functions route through the `eeRead`/`eeWrite` combinators, which apply
+ * the `requireEnterpriseEffect("ip-allowlist")` gate.
  * Validation helpers do not require a license.
  */
 

--- a/ee/src/auth/roles.test.ts
+++ b/ee/src/auth/roles.test.ts
@@ -37,6 +37,7 @@ const {
   isValidRoleName,
   listRoles,
   getRole,
+  getRoleByName,
   createRole,
   updateRole,
   deleteRole,
@@ -585,6 +586,46 @@ describe("seedBuiltinRoles", () => {
 
     const inserts = ee.capturedQueries.filter((q) => q.sql.includes("INSERT"));
     expect(inserts.length).toBe(1);
+  });
+});
+
+// Guards the eeWrite/eeRead adoption (#4200): with no internal DB, writes must
+// fail loud (never silently no-op) and reads must short-circuit to their empty
+// value — the regression a future eeWrite→eeRead swap (or vice versa) would
+// introduce. The gate + DB guard run before any validation, so no valid input
+// is needed to reach the guard.
+describe("no internal DB", () => {
+  beforeEach(() => {
+    resetMocks();
+    ee.setHasInternalDB(false);
+  });
+
+  it("createRole fails loud", async () => {
+    await expect(
+      run(createRole("org-1", { name: "data-engineer", permissions: ["query"] })),
+    ).rejects.toThrow("Internal database required for custom role management.");
+  });
+
+  it("updateRole fails loud", async () => {
+    await expect(
+      run(updateRole("org-1", "role-1", { description: "x" })),
+    ).rejects.toThrow("Internal database required for custom role management.");
+  });
+
+  it("deleteRole fails loud", async () => {
+    await expect(
+      run(deleteRole("org-1", "role-1")),
+    ).rejects.toThrow("Internal database required for role deletion.");
+  });
+
+  it("assignRole fails loud", async () => {
+    await expect(
+      run(assignRole("org-1", "user-1", "data-engineer")),
+    ).rejects.toThrow("Internal database required for role assignment.");
+  });
+
+  it("getRoleByName short-circuits to null", async () => {
+    expect(await run(getRoleByName("org-1", "analyst"))).toBeNull();
   });
 });
 

--- a/ee/src/auth/roles.ts
+++ b/ee/src/auth/roles.ts
@@ -11,9 +11,8 @@
  */
 
 import { Effect, Layer } from "effect";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -162,10 +161,7 @@ export function isValidRoleName(name: string): boolean {
  * Lazily seeds built-in roles on first access per org.
  */
 export const listRoles = (orgId: string): Effect.Effect<CustomRole[], EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    if (!hasInternalDB()) return [];
-
+  eeRead("roles", [], Effect.gen(function* () {
     // Lazy seed: ensure built-in roles exist for this org
     yield* seedBuiltinRoles(orgId);
 
@@ -177,16 +173,13 @@ export const listRoles = (orgId: string): Effect.Effect<CustomRole[], Enterprise
       [orgId],
     ));
     return rows.map(rowToRole);
-  });
+  }));
 
 /**
  * Get a single role by ID, scoped to org.
  */
 export const getRole = (orgId: string, roleId: string): Effect.Effect<CustomRole | null, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    if (!hasInternalDB()) return null;
-
+  eeRead("roles", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<CustomRoleRow>(
       `SELECT id, org_id, name, description, permissions, is_builtin, created_at, updated_at
        FROM custom_roles
@@ -194,7 +187,7 @@ export const getRole = (orgId: string, roleId: string): Effect.Effect<CustomRole
       [roleId, orgId],
     ));
     return rows[0] ? rowToRole(rows[0]) : null;
-  });
+  }));
 
 /**
  * Get a single role by name, scoped to org. Used by the audit path for
@@ -203,10 +196,7 @@ export const getRole = (orgId: string, roleId: string): Effect.Effect<CustomRole
  * a string that tenant admins can rename later.
  */
 export const getRoleByName = (orgId: string, name: string): Effect.Effect<CustomRole | null, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    if (!hasInternalDB()) return null;
-
+  eeRead("roles", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<CustomRoleRow>(
       `SELECT id, org_id, name, description, permissions, is_builtin, created_at, updated_at
        FROM custom_roles
@@ -214,7 +204,7 @@ export const getRoleByName = (orgId: string, name: string): Effect.Effect<Custom
       [orgId, name.toLowerCase()],
     ));
     return rows[0] ? rowToRole(rows[0]) : null;
-  });
+  }));
 
 /**
  * Create a custom role for an organization.
@@ -223,10 +213,7 @@ export const createRole = (
   orgId: string,
   input: { name: string; description?: string; permissions: string[] },
 ): Effect.Effect<CustomRole, RoleError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    yield* requireInternalDBEffect("custom role management");
-
+  eeWrite("roles", "custom role management", Effect.gen(function* () {
     // Validate name
     const name = input.name.toLowerCase().trim();
     if (!isValidRoleName(name)) {
@@ -268,7 +255,7 @@ export const createRole = (
 
     log.info({ orgId, roleName: name }, "Custom role created");
     return rowToRole(rows[0]);
-  });
+  }));
 
 /**
  * Update a custom role's description and/or permissions.
@@ -279,10 +266,7 @@ export const updateRole = (
   roleId: string,
   input: { description?: string; permissions?: string[] },
 ): Effect.Effect<CustomRole, RoleError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    yield* requireInternalDBEffect("custom role management");
-
+  eeWrite("roles", "custom role management", Effect.gen(function* () {
     // Fetch existing
     const existing = yield* getRole(orgId, roleId);
     if (!existing) return yield* Effect.fail(new RoleError({ message: "Role not found.", code: "not_found" }));
@@ -328,16 +312,13 @@ export const updateRole = (
 
     log.info({ orgId, roleId }, "Custom role updated");
     return rowToRole(rows[0]);
-  });
+  }));
 
 /**
  * Delete a custom role. Built-in roles cannot be deleted.
  */
 export const deleteRole = (orgId: string, roleId: string): Effect.Effect<boolean, RoleError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    yield* requireInternalDBEffect("role deletion");
-
+  eeWrite("roles", "role deletion", Effect.gen(function* () {
     // Check if it's a built-in role
     const role = yield* getRole(orgId, roleId);
     if (!role) return false;
@@ -365,7 +346,7 @@ export const deleteRole = (orgId: string, roleId: string): Effect.Effect<boolean
       log.info({ orgId, roleId, roleName: role.name }, "Custom role deleted");
     }
     return deleted;
-  });
+  }));
 
 /**
  * List members assigned to a specific role in an organization.
@@ -375,10 +356,7 @@ export const listRoleMembers = (
   orgId: string,
   roleId: string,
 ): Effect.Effect<Array<{ userId: string; role: string; createdAt: string }>, RoleError | EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    if (!hasInternalDB()) return [];
-
+  eeRead("roles", [], Effect.gen(function* () {
     // First get the role name
     const role = yield* getRole(orgId, roleId);
     if (!role) return yield* Effect.fail(new RoleError({ message: "Role not found.", code: "not_found" }));
@@ -402,7 +380,7 @@ export const listRoleMembers = (
       role: r.role,
       createdAt: String(r.createdAt),
     }));
-  });
+  }));
 
 /**
  * Assign a role to a user by updating their role in the Better Auth member table.
@@ -413,10 +391,7 @@ export const assignRole = (
   userId: string,
   roleName: string,
 ): Effect.Effect<{ userId: string; role: string }, RoleError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("roles");
-    yield* requireInternalDBEffect("role assignment");
-
+  eeWrite("roles", "role assignment", Effect.gen(function* () {
     // Belt-and-suspenders: refuse to write a built-in Atlas role name into
     // `member.role` from the custom-role assignment path. createRole already
     // blocks these names, but a legacy row could exist from before the guard
@@ -452,7 +427,7 @@ export const assignRole = (
 
     log.info({ orgId, userId, roleName }, "Role assigned to user");
     return { userId: result[0].userId, role: result[0].role };
-  });
+  }));
 
 // ── Seeding ──────────────────────────────────────────────────────
 

--- a/ee/src/auth/roles.ts
+++ b/ee/src/auth/roles.ts
@@ -5,8 +5,9 @@
  * Three built-in roles (admin, analyst, viewer) are seeded on migration and
  * cannot be deleted. Custom roles are per-organization.
  *
- * CRUD functions call `requireEnterprise("roles")` — unlicensed deployments
- * get a clear error. Permission check helpers do NOT require a license and
+ * CRUD functions route through the `eeRead`/`eeWrite` combinators, which apply
+ * the `requireEnterpriseEffect("roles")` gate — unlicensed deployments get a
+ * clear error. Permission check helpers do NOT require a license and
  * fall back to legacy admin/member role mapping.
  */
 

--- a/ee/src/auth/scim.ts
+++ b/ee/src/auth/scim.ts
@@ -14,9 +14,8 @@
  */
 
 import { Effect, Layer } from "effect";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -146,10 +145,7 @@ export function isValidScimGroupName(name: string): boolean {
  * Reads from the `scimProvider` table created by @better-auth/scim.
  */
 export const listConnections = (orgId: string): Effect.Effect<SCIMConnection[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("scim");
-    if (!hasInternalDB()) return [];
-
+  eeRead("scim", [], Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<SCIMConnectionRow>(
       `SELECT id, "providerId", "organizationId"
        FROM "scimProvider"
@@ -158,16 +154,13 @@ export const listConnections = (orgId: string): Effect.Effect<SCIMConnection[], 
       [orgId],
     ));
     return rows.map(rowToConnection);
-  });
+  }));
 
 /**
  * Delete a SCIM provider connection (revoke access).
  */
 export const deleteConnection = (orgId: string, connectionId: string): Effect.Effect<boolean, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("scim");
-    if (!hasInternalDB()) return false;
-
+  eeRead("scim", false, Effect.gen(function* () {
     const pool = getInternalDB();
     const result = yield* Effect.promise(() =>
       pool.query(
@@ -181,7 +174,7 @@ export const deleteConnection = (orgId: string, connectionId: string): Effect.Ef
       log.info({ orgId, connectionId }, "SCIM connection deleted");
     }
     return deleted;
-  });
+  }));
 
 // ── Sync Status ─────────────────────────────────────────────────────
 
@@ -190,12 +183,7 @@ export const deleteConnection = (orgId: string, connectionId: string): Effect.Ef
  * Counts active connections and users provisioned via SCIM.
  */
 export const getSyncStatus = (orgId: string): Effect.Effect<SCIMSyncStatus, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("scim");
-    if (!hasInternalDB()) {
-      return { connections: 0, provisionedUsers: 0, lastSyncAt: null };
-    }
-
+  eeRead("scim", { connections: 0, provisionedUsers: 0, lastSyncAt: null }, Effect.gen(function* () {
     // All three queries are independent — run in parallel per CLAUDE.md
     const [connRows, userRows, lastSyncRows] = yield* Effect.promise(() => Promise.all([
       internalQuery<{ count: string; [key: string]: unknown }>(
@@ -227,7 +215,7 @@ export const getSyncStatus = (orgId: string): Effect.Effect<SCIMSyncStatus, Ente
     const lastSyncAt = lastSyncRows[0]?.last_sync ?? null;
 
     return { connections, provisionedUsers, lastSyncAt };
-  });
+  }));
 
 // ── Group → Role Mapping ────────────────────────────────────────────
 
@@ -235,9 +223,7 @@ export const getSyncStatus = (orgId: string): Effect.Effect<SCIMSyncStatus, Ente
  * List SCIM group → role mappings for an organization.
  */
 export const listGroupMappings = (orgId: string): Effect.Effect<SCIMGroupMapping[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("scim");
-    if (!hasInternalDB()) return [];
+  eeRead("scim", [], Effect.gen(function* () {
     yield* ensureGroupMappingsTable();
 
     const rows = yield* Effect.promise(() => internalQuery<SCIMGroupMappingRow>(
@@ -248,7 +234,7 @@ export const listGroupMappings = (orgId: string): Effect.Effect<SCIMGroupMapping
       [orgId],
     ));
     return rows.map(rowToGroupMapping);
-  });
+  }));
 
 /**
  * Create a SCIM group → role mapping.
@@ -259,9 +245,7 @@ export const createGroupMapping = (
   scimGroupName: string,
   roleName: string,
 ): Effect.Effect<SCIMGroupMapping, SCIMError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("scim");
-    yield* requireInternalDBEffect("SCIM group mapping");
+  eeWrite("scim", "SCIM group mapping", Effect.gen(function* () {
     yield* ensureGroupMappingsTable();
 
     // Validate group name
@@ -298,15 +282,13 @@ export const createGroupMapping = (
 
     log.info({ orgId, scimGroupName, roleName }, "SCIM group mapping created");
     return rowToGroupMapping(rows[0]);
-  });
+  }));
 
 /**
  * Delete a SCIM group → role mapping.
  */
 export const deleteGroupMapping = (orgId: string, mappingId: string): Effect.Effect<boolean, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("scim");
-    if (!hasInternalDB()) return false;
+  eeRead("scim", false, Effect.gen(function* () {
     yield* ensureGroupMappingsTable();
 
     const pool = getInternalDB();
@@ -322,7 +304,7 @@ export const deleteGroupMapping = (orgId: string, mappingId: string): Effect.Eff
       log.info({ orgId, mappingId }, "SCIM group mapping deleted");
     }
     return deleted;
-  });
+  }));
 
 /**
  * Resolve a SCIM group display name to an Atlas role name.

--- a/ee/src/auth/scim.ts
+++ b/ee/src/auth/scim.ts
@@ -7,7 +7,8 @@
  * `@better-auth/scim` plugin registered in server.ts — this module only
  * wraps the enterprise gate and the custom group-mapping layer.
  *
- * Every admin-facing CRUD function calls `requireEnterprise("scim")` —
+ * Every admin-facing CRUD function routes through the `eeRead`/`eeWrite`
+ * combinators, which apply the `requireEnterpriseEffect("scim")` gate —
  * unlicensed deployments get a clear error. The `resolveGroupToRole`
  * helper is designed for the provisioning hot path and intentionally
  * skips the gate, returning null when no mapping exists.

--- a/ee/src/auth/sso.ts
+++ b/ee/src/auth/sso.ts
@@ -12,7 +12,7 @@ import { Effect, Layer } from "effect";
 import { generateVerificationToken, verifyDnsTxt } from "../lib/domain-verification";
 import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -225,10 +225,7 @@ export const verifyDomain = (
   providerId: string,
   orgId: string,
 ): Effect.Effect<{ status: string; message: string }, SSOError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    yield* requireInternalDBEffect("SSO domain verification");
-
+  eeWrite("sso", "SSO domain verification", Effect.gen(function* () {
     const rows = yield* Effect.tryPromise({
       try: () => internalQuery<SSOProviderRow>(
         `SELECT id, org_id, type, issuer, domain, enabled, sso_enforced, config, created_at, updated_at, verification_token, domain_verified, domain_verified_at, domain_verification_status
@@ -290,7 +287,7 @@ export const verifyDomain = (
 
     log.info({ providerId, domain: provider.domain }, "SSO domain verified via DNS TXT record");
     return { status: "verified", message: "Domain verified successfully." };
-  });
+  }));
 
 /**
  * Check if a domain is available for SSO registration.
@@ -337,10 +334,7 @@ export const checkDomainAvailability = (
  * List SSO providers for an organization.
  */
 export const listSSOProviders = (orgId: string): Effect.Effect<SSOProvider[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    if (!hasInternalDB()) return [];
-
+  eeRead("sso", [], Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<SSOProviderRow>(
       `SELECT id, org_id, type, issuer, domain, enabled, sso_enforced, config, created_at, updated_at, verification_token, domain_verified, domain_verified_at, domain_verification_status
        FROM sso_providers
@@ -349,16 +343,13 @@ export const listSSOProviders = (orgId: string): Effect.Effect<SSOProvider[], En
       [orgId],
     ));
     return rows.map(rowToProvider);
-  });
+  }));
 
 /**
  * Get a single SSO provider by ID, scoped to org.
  */
 export const getSSOProvider = (orgId: string, providerId: string): Effect.Effect<SSOProvider | null, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    if (!hasInternalDB()) return null;
-
+  eeRead("sso", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<SSOProviderRow>(
       `SELECT id, org_id, type, issuer, domain, enabled, sso_enforced, config, created_at, updated_at, verification_token, domain_verified, domain_verified_at, domain_verification_status
        FROM sso_providers
@@ -366,7 +357,7 @@ export const getSSOProvider = (orgId: string, providerId: string): Effect.Effect
       [providerId, orgId],
     ));
     return rows[0] ? rowToProvider(rows[0]) : null;
-  });
+  }));
 
 /**
  * Create a new SSO provider for an organization.
@@ -376,10 +367,7 @@ export const createSSOProvider = (
   orgId: string,
   input: CreateSSOProviderRequest,
 ): Effect.Effect<SSOProvider, SSOError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    yield* requireInternalDBEffect("SSO provider management");
-
+  eeWrite("sso", "SSO provider management", Effect.gen(function* () {
     // Validate type
     if (!isValidSSOProviderType(input.type)) {
       return yield* Effect.fail(new SSOError({ message: `Invalid SSO provider type: ${input.type}. Must be one of: ${SSO_PROVIDER_TYPES.join(", ")}`, code: "validation" }));
@@ -445,7 +433,7 @@ export const createSSOProvider = (
 
     log.info({ orgId, type: input.type, domain, issuer: input.issuer, autoVerified }, "SSO provider created");
     return rowToProvider(rows[0]);
-  });
+  }));
 
 /**
  * Update an existing SSO provider.
@@ -455,10 +443,7 @@ export const updateSSOProvider = (
   providerId: string,
   input: UpdateSSOProviderRequest,
 ): Effect.Effect<SSOProvider, SSOError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    yield* requireInternalDBEffect("SSO provider management");
-
+  eeWrite("sso", "SSO provider management", Effect.gen(function* () {
     // Fetch existing
     const existing = yield* getSSOProvider(orgId, providerId);
     if (!existing) return yield* Effect.fail(new SSOError({ message: "SSO provider not found.", code: "not_found" }));
@@ -543,16 +528,13 @@ export const updateSSOProvider = (
 
     log.info({ orgId, providerId }, "SSO provider updated");
     return rowToProvider(rows[0]);
-  });
+  }));
 
 /**
  * Delete an SSO provider.
  */
 export const deleteSSOProvider = (orgId: string, providerId: string): Effect.Effect<boolean, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    if (!hasInternalDB()) return false;
-
+  eeRead("sso", false, Effect.gen(function* () {
     const pool = getInternalDB();
     const result = yield* Effect.promise(() =>
       pool.query(
@@ -566,7 +548,7 @@ export const deleteSSOProvider = (orgId: string, providerId: string): Effect.Eff
       log.info({ orgId, providerId }, "SSO provider deleted");
     }
     return deleted;
-  });
+  }));
 
 // ── Domain matching ─────────────────────────────────────────────────
 
@@ -925,10 +907,7 @@ export const isSSOEnforcedForDomain = (emailDomain: string): Effect.Effect<{
  * Requires enterprise license and at least one active (enabled) SSO provider.
  */
 export const setSSOEnforcement = (orgId: string, enforced: boolean): Effect.Effect<{ enforced: boolean; orgId: string }, SSOEnforcementError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("sso");
-    yield* requireInternalDBEffect("SSO enforcement");
-
+  eeWrite("sso", "SSO enforcement", Effect.gen(function* () {
     if (enforced) {
       // Verify at least one active SSO provider exists for this org
       const active = yield* Effect.promise(() => internalQuery<{ id: string }>(
@@ -952,7 +931,7 @@ export const setSSOEnforcement = (orgId: string, enforced: boolean): Effect.Effe
 
     log.info({ orgId, enforced }, "SSO enforcement %s", enforced ? "enabled" : "disabled");
     return { enforced, orgId };
-  });
+  }));
 
 // ── Tag wiring (#2570 — slice 8/11 of #2017) ─────────────────────────
 

--- a/ee/src/auth/sso.ts
+++ b/ee/src/auth/sso.ts
@@ -3,7 +3,8 @@
  *
  * CRUD for per-organization SAML/OIDC identity providers,
  * domain-based auto-provisioning, and DNS TXT domain ownership
- * verification. Every CRUD function calls `requireEnterprise("sso")`
+ * verification. Every CRUD function routes through the `eeRead`/`eeWrite`
+ * combinators, which apply the `requireEnterpriseEffect("sso")` gate
  * — unlicensed deployments get a clear error. Validation helpers
  * and domain-matching functions do not require a license.
  */

--- a/ee/src/branding/white-label.ts
+++ b/ee/src/branding/white-label.ts
@@ -14,9 +14,8 @@
  */
 
 import { Effect, Layer } from "effect";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -120,10 +119,7 @@ function validateBrandingInput(input: SetWorkspaceBrandingInput): Effect.Effect<
  * Returns null if no custom branding is set.
  */
 export const getWorkspaceBranding = (orgId: string): Effect.Effect<WorkspaceBranding | null, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("branding");
-    if (!hasInternalDB()) return null;
-
+  eeRead("branding", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<BrandingRow>(
       `SELECT id, org_id, logo_url, logo_text, primary_color, favicon_url,
               hide_atlas_branding, created_at, updated_at
@@ -135,7 +131,7 @@ export const getWorkspaceBranding = (orgId: string): Effect.Effect<WorkspaceBran
 
     if (rows.length === 0) return null;
     return rowToBranding(rows[0]);
-  });
+  }));
 
 /**
  * Get workspace branding without enterprise check (public endpoint).
@@ -169,9 +165,7 @@ export const setWorkspaceBranding = (
   orgId: string,
   input: SetWorkspaceBrandingInput,
 ): Effect.Effect<WorkspaceBranding, BrandingError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("branding");
-    yield* requireInternalDBEffect("workspace branding");
+  eeWrite("branding", "workspace branding", Effect.gen(function* () {
     yield* validateBrandingInput(input);
 
     const rows = yield* Effect.promise(() => internalQuery<BrandingRow>(
@@ -200,16 +194,13 @@ export const setWorkspaceBranding = (
 
     log.info({ orgId }, "Workspace branding saved");
     return rowToBranding(rows[0]);
-  });
+  }));
 
 /**
  * Delete workspace branding for an organization (reset to Atlas defaults).
  */
 export const deleteWorkspaceBranding = (orgId: string): Effect.Effect<boolean, EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("branding");
-    yield* requireInternalDBEffect("workspace branding");
-
+  eeWrite("branding", "workspace branding", Effect.gen(function* () {
     const pool = getInternalDB();
     const result = yield* Effect.promise(() =>
       pool.query(`DELETE FROM workspace_branding WHERE org_id = $1 RETURNING id`, [orgId]),
@@ -220,7 +211,7 @@ export const deleteWorkspaceBranding = (orgId: string): Effect.Effect<boolean, E
       log.info({ orgId }, "Workspace branding deleted — reverted to Atlas defaults");
     }
     return deleted;
-  });
+  }));
 
 // ── Tag wiring (#2572 — slice 10/11 of #2017) ────────────────────────
 //

--- a/ee/src/branding/white-label.ts
+++ b/ee/src/branding/white-label.ts
@@ -1,8 +1,9 @@
 /**
  * Enterprise workspace branding (white-labeling).
  *
- * CRUD for per-organization branding settings. Every mutation calls
- * `requireEnterpriseEffect("branding")` — unlicensed deployments get a clear error.
+ * CRUD for per-organization branding settings. Every mutation routes through
+ * the `eeWrite` combinator (reads through `eeRead`), which applies the
+ * `requireEnterpriseEffect("branding")` gate — unlicensed deployments get a clear error.
  * Read operations (getWorkspaceBranding) also gate on enterprise so the admin
  * UI can show the feature-disabled state.
  *

--- a/ee/src/compliance/reports.ts
+++ b/ee/src/compliance/reports.ts
@@ -12,9 +12,8 @@
  */
 
 import { Effect, Layer } from "effect";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeWrite } from "../lib/ee-query";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
@@ -78,9 +77,7 @@ export const generateDataAccessReport = (
   orgId: string,
   filters: ComplianceReportFilters,
 ): Effect.Effect<DataAccessReport, ReportError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("compliance");
-    yield* requireInternalDBEffect("compliance reports", () => new ReportError({ message: "Internal database not available", code: "not_available" }));
+  eeWrite("compliance", "compliance reports", Effect.gen(function* () {
     yield* validateFilters(filters);
 
     const conditions: string[] = ["a.org_id = $1", "a.success = true"];
@@ -221,7 +218,7 @@ export const generateDataAccessReport = (
       filters,
       generatedAt: new Date().toISOString(),
     };
-  });
+  }), () => new ReportError({ message: "Internal database not available", code: "not_available" }));
 
 // ── User Activity Report ────────────────────────────────────────
 
@@ -238,9 +235,7 @@ export const generateUserActivityReport = (
   orgId: string,
   filters: ComplianceReportFilters,
 ): Effect.Effect<UserActivityReport, ReportError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("compliance");
-    yield* requireInternalDBEffect("compliance reports", () => new ReportError({ message: "Internal database not available", code: "not_available" }));
+  eeWrite("compliance", "compliance reports", Effect.gen(function* () {
     yield* validateFilters(filters);
 
     const conditions: string[] = ["a.org_id = $1", "a.success = true"];
@@ -346,7 +341,7 @@ export const generateUserActivityReport = (
       filters,
       generatedAt: new Date().toISOString(),
     };
-  });
+  }), () => new ReportError({ message: "Internal database not available", code: "not_available" }));
 
 // ── CSV export ──────────────────────────────────────────────────
 

--- a/ee/src/compliance/reports.ts
+++ b/ee/src/compliance/reports.ts
@@ -6,7 +6,8 @@
  * 2. User Activity Report — query counts, last login, tables accessed, role info
  *
  * Both reports query the internal DB (audit_log + user/session/member tables)
- * and are enterprise-gated via requireEnterpriseEffect("compliance").
+ * and are enterprise-gated via the `eeWrite` combinator, which applies the
+ * `requireEnterpriseEffect("compliance")` gate.
  *
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -20,7 +20,7 @@
 import { Effect, Layer } from "effect";
 import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -325,10 +325,7 @@ function getExpiryHours(): number {
 
 /** List all approval rules for an organization. */
 export const listApprovalRules = (orgId: string): Effect.Effect<ApprovalRule[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    if (!hasInternalDB()) return [];
-
+  eeRead("approval-workflows", [], Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
       `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at
        FROM approval_rules
@@ -337,14 +334,11 @@ export const listApprovalRules = (orgId: string): Effect.Effect<ApprovalRule[], 
       [orgId],
     ));
     return rows.map(rowToRule).filter((r): r is ApprovalRule => r !== null);
-  });
+  }));
 
 /** Get a single approval rule by ID. */
 export const getApprovalRule = (orgId: string, ruleId: string): Effect.Effect<ApprovalRule | null, ApprovalError | EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    if (!hasInternalDB()) return null;
-
+  eeRead("approval-workflows", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
       `SELECT id, org_id, name, rule_type, pattern, threshold, enabled, origin, created_at, updated_at
        FROM approval_rules
@@ -359,17 +353,14 @@ export const getApprovalRule = (orgId: string, ruleId: string): Effect.Effect<Ap
       return yield* Effect.fail(new ApprovalError({ message: `Approval rule "${ruleId}" exists but has an invalid type "${rows[0].rule_type}".`, code: "validation" }));
     }
     return rule;
-  });
+  }));
 
 /** Create a new approval rule. */
 export const createApprovalRule = (
   orgId: string,
   input: CreateApprovalRuleRequest,
 ): Effect.Effect<ApprovalRule, ApprovalError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    yield* requireInternalDBEffect("approval rules", () => new ApprovalError({ message: "Internal database required for approval rules.", code: "validation" }));
-
+  eeWrite("approval-workflows", "approval rules", Effect.gen(function* () {
     yield* validateRuleInput(input);
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalRuleRow>(
@@ -397,7 +388,7 @@ export const createApprovalRule = (
     const rule = rowToRule(rows[0]);
     if (!rule) return yield* Effect.fail(new ApprovalError({ message: `Created rule has unexpected rule_type "${rows[0].rule_type}" after insert.`, code: "conflict" }));
     return rule;
-  });
+  }), () => new ApprovalError({ message: "Internal database required for approval rules.", code: "validation" }));
 
 /** Update an existing approval rule. */
 export const updateApprovalRule = (
@@ -405,10 +396,7 @@ export const updateApprovalRule = (
   ruleId: string,
   input: UpdateApprovalRuleRequest,
 ): Effect.Effect<ApprovalRule, ApprovalError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    yield* requireInternalDBEffect("approval rules", () => new ApprovalError({ message: "Internal database required for approval rules.", code: "validation" }));
-
+  eeWrite("approval-workflows", "approval rules", Effect.gen(function* () {
     // Check the rule exists
     const existing = yield* getApprovalRule(orgId, ruleId);
     if (!existing) {
@@ -475,14 +463,11 @@ export const updateApprovalRule = (
     const rule = rowToRule(rows[0]);
     if (!rule) return yield* Effect.fail(new ApprovalError({ message: `Updated rule has unexpected rule_type "${rows[0].rule_type}" after update.`, code: "conflict" }));
     return rule;
-  });
+  }), () => new ApprovalError({ message: "Internal database required for approval rules.", code: "validation" }));
 
 /** Delete an approval rule. Returns true if deleted, false if not found. */
 export const deleteApprovalRule = (orgId: string, ruleId: string): Effect.Effect<boolean, EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    if (!hasInternalDB()) return false;
-
+  eeRead("approval-workflows", false, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<{ id: string }>(
       `DELETE FROM approval_rules WHERE org_id = $1 AND id = $2 RETURNING id`,
       [orgId, ruleId],
@@ -492,7 +477,7 @@ export const deleteApprovalRule = (orgId: string, ruleId: string): Effect.Effect
       return true;
     }
     return false;
-  });
+  }));
 
 // ── Matching ────────────────────────────────────────────────────────
 
@@ -795,10 +780,7 @@ export const createApprovalRequest = (opts: {
    */
   origin?: ApprovalRequestOrigin | null;
 }): Effect.Effect<ApprovalRequest, ApprovalError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    yield* requireInternalDBEffect("approval queue", () => new ApprovalError({ message: "Internal database required for approval queue.", code: "validation" }));
-
+  eeWrite("approval-workflows", "approval queue", Effect.gen(function* () {
     // F-54/F-55 defense-in-depth: refuse to insert any row whose ruleId or
     // orgId smells like an internal sentinel. The `__identity_missing__`
     // rule + `__unknown__` org are produced by the defensive identityMissing
@@ -900,7 +882,7 @@ export const createApprovalRequest = (opts: {
     const request = rowToRequest(rows[0]);
     if (!request) return yield* Effect.fail(new ApprovalError({ message: `Created request has unexpected status "${rows[0].status}" after insert.`, code: "conflict" }));
     return request;
-  });
+  }), () => new ApprovalError({ message: "Internal database required for approval queue.", code: "validation" }));
 
 /** List approval requests for an organization, optionally filtered by status. */
 export const listApprovalRequests = (
@@ -909,10 +891,7 @@ export const listApprovalRequests = (
   limit = 100,
   offset = 0,
 ): Effect.Effect<ApprovalRequest[], EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    if (!hasInternalDB()) return [];
-
+  eeRead("approval-workflows", [], Effect.gen(function* () {
     const safeLimit = Math.min(Math.max(1, limit), 1000);
     const safeOffset = Math.max(0, offset);
 
@@ -931,17 +910,14 @@ export const listApprovalRequests = (
 
     const rows = yield* Effect.promise(() => internalQuery<ApprovalQueueRow>(sql, params));
     return rows.map(rowToRequest).filter((r): r is ApprovalRequest => r !== null);
-  });
+  }));
 
 /** Get a single approval request by ID. */
 export const getApprovalRequest = (
   orgId: string,
   requestId: string,
 ): Effect.Effect<ApprovalRequest | null, ApprovalError | EnterpriseError> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    if (!hasInternalDB()) return null;
-
+  eeRead("approval-workflows", null, Effect.gen(function* () {
     const rows = yield* Effect.promise(() => internalQuery<ApprovalQueueRow>(
       `SELECT ${APPROVAL_QUEUE_COLUMNS}
        FROM approval_queue
@@ -956,7 +932,7 @@ export const getApprovalRequest = (
       return yield* Effect.fail(new ApprovalError({ message: `Approval request "${requestId}" exists but has an invalid status "${rows[0].status}".`, code: "validation" }));
     }
     return request;
-  });
+  }));
 
 /** Approve or deny an approval request. */
 export const reviewApprovalRequest = (
@@ -967,10 +943,7 @@ export const reviewApprovalRequest = (
   action: "approve" | "deny",
   comment?: string,
 ): Effect.Effect<ApprovalRequest, ApprovalError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("approval-workflows");
-    yield* requireInternalDBEffect("approval queue", () => new ApprovalError({ message: "Internal database required for approval queue.", code: "validation" }));
-
+  eeWrite("approval-workflows", "approval queue", Effect.gen(function* () {
     // Fetch the current request
     const existing = yield* getApprovalRequest(orgId, requestId);
     if (!existing) {
@@ -1017,7 +990,7 @@ export const reviewApprovalRequest = (
     const request = rowToRequest(rows[0]);
     if (!request) return yield* Effect.fail(new ApprovalError({ message: `Reviewed request has unexpected status "${rows[0].status}" after update.`, code: "conflict" }));
     return request;
-  });
+  }), () => new ApprovalError({ message: "Internal database required for approval queue.", code: "validation" }));
 
 /**
  * Expire stale pending approval requests for the given org. Returns count of

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -10,10 +10,12 @@
  * of executing. Designated approvers (via custom roles) can approve or deny.
  * Approved queries can then be re-executed. Stale requests auto-expire.
  *
- * All exported functions return Effect. CRUD and listing operations call
- * `requireEnterpriseEffect()` (fails with EnterpriseError). Functions in the agent's
+ * All exported functions return Effect. CRUD and listing operations route
+ * through the `eeRead`/`eeWrite` combinators, which apply `requireEnterpriseEffect()`
+ * (fails with EnterpriseError). Functions in the agent's
  * critical path (`checkApprovalRequired`, `hasApprovedRequest`,
- * `expireStaleRequests`, `getPendingCount`) catch `EnterpriseError` and return
+ * `expireStaleRequests`, `getPendingCount`) are deliberately NOT combinator-wrapped —
+ * they check the DB first, then catch `EnterpriseError` and return
  * a safe default (false, 0, or empty) while re-throwing unexpected errors.
  */
 

--- a/ee/src/lib/ee-query.test.ts
+++ b/ee/src/lib/ee-query.test.ts
@@ -6,28 +6,15 @@ import { createEEMock, EnterpriseError } from "../__mocks__/internal";
 //
 // The combinator composes three guards. We mock the enterprise gate
 // (`../index`) and `hasInternalDB` (`@atlas/api/lib/db/internal`) via the
-// shared factory, and shim `./db-guard` so `requireInternalDBEffect` reads the
-// same toggled `hasInternalDB` — mirroring the real guard's behaviour without
-// pulling in core config.
+// shared factory. We deliberately do NOT mock `./db-guard`: the REAL
+// `requireInternalDBEffect` reads `hasInternalDB` from the (already-mocked)
+// `@atlas/api/lib/db/internal`, so letting it run exercises the actual
+// collaborator — including its default no-DB message — rather than a shim copy.
 
 const ee = createEEMock();
 
 mock.module("../index", () => ee.enterpriseMock);
 mock.module("@atlas/api/lib/db/internal", () => ee.internalDBMock);
-
-const hasDB = () => (ee.internalDBMock.hasInternalDB as () => boolean)();
-mock.module("./db-guard", () => ({
-  requireInternalDB: (label: string, factory?: () => Error) => {
-    if (!hasDB()) {
-      if (factory) throw factory();
-      throw new Error(`Internal database required for ${label}.`);
-    }
-  },
-  requireInternalDBEffect: (label: string, factory?: () => Error) =>
-    hasDB()
-      ? Effect.void
-      : Effect.fail(factory?.() ?? new Error(`Internal database required for ${label}.`)),
-}));
 
 // Import after mocks
 const { eeRead, eeWrite } = await import("./ee-query");
@@ -72,13 +59,21 @@ describe("eeRead", () => {
     expect(ran).toBe(false);
   });
 
-  it("preserves the per-function empty value (null, 0, {}) verbatim", async () => {
+  it("preserves the per-function empty value (null, 0, false, {}) verbatim", async () => {
     ee.setHasInternalDB(false);
     expect(await run(eeRead("roles", null, Effect.succeed<string | null>("x")))).toBeNull();
     expect(await run(eeRead("q", 0, Effect.succeed(99)))).toBe(0);
+    expect(await run(eeRead("delete", false, Effect.succeed(true)))).toBe(false);
     expect(await run(eeRead("ip", { allowed: true }, Effect.succeed({ allowed: false })))).toEqual({
       allowed: true,
     });
+  });
+
+  it("propagates the query's own failure (E channel) unchanged when DB present", async () => {
+    const failing: Effect.Effect<number[], Error> = Effect.fail(new Error("boom"));
+    const err = await runFail(eeRead("roles", [], failing));
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("boom");
   });
 
   it("fails with EnterpriseError and never touches the DB when unlicensed", async () => {
@@ -151,5 +146,12 @@ describe("eeWrite", () => {
     const err = await runFail(eeWrite("roles", "role assignment", query));
     expect(err).toBeInstanceOf(EnterpriseError);
     expect(ran).toBe(false);
+  });
+
+  it("propagates the query's own failure (E channel) unchanged when licensed + DB present", async () => {
+    const failing: Effect.Effect<string, Error> = Effect.fail(new Error("write boom"));
+    const err = await runFail(eeWrite("roles", "role assignment", failing));
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("write boom");
   });
 });

--- a/ee/src/lib/ee-query.test.ts
+++ b/ee/src/lib/ee-query.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Effect } from "effect";
+import { createEEMock, EnterpriseError } from "../__mocks__/internal";
+
+// ── Mocks ───────────────────────────────────────────────────────────
+//
+// The combinator composes three guards. We mock the enterprise gate
+// (`../index`) and `hasInternalDB` (`@atlas/api/lib/db/internal`) via the
+// shared factory, and shim `./db-guard` so `requireInternalDBEffect` reads the
+// same toggled `hasInternalDB` — mirroring the real guard's behaviour without
+// pulling in core config.
+
+const ee = createEEMock();
+
+mock.module("../index", () => ee.enterpriseMock);
+mock.module("@atlas/api/lib/db/internal", () => ee.internalDBMock);
+
+const hasDB = () => (ee.internalDBMock.hasInternalDB as () => boolean)();
+mock.module("./db-guard", () => ({
+  requireInternalDB: (label: string, factory?: () => Error) => {
+    if (!hasDB()) {
+      if (factory) throw factory();
+      throw new Error(`Internal database required for ${label}.`);
+    }
+  },
+  requireInternalDBEffect: (label: string, factory?: () => Error) =>
+    hasDB()
+      ? Effect.void
+      : Effect.fail(factory?.() ?? new Error(`Internal database required for ${label}.`)),
+}));
+
+// Import after mocks
+const { eeRead, eeWrite } = await import("./ee-query");
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Run an Effect, converting failures to rejected promises for assertions. */
+const run = <A, E>(effect: Effect.Effect<A, E>) =>
+  Effect.runPromise(effect as Effect.Effect<A, never>);
+
+/** Run an Effect and return the failure (Effect.Either left) for assertions. */
+const runFail = <A, E>(effect: Effect.Effect<A, E>) =>
+  Effect.runPromise(Effect.flip(effect) as Effect.Effect<E, never>);
+
+beforeEach(() => {
+  ee.reset();
+});
+
+// ── eeRead ──────────────────────────────────────────────────────────
+
+describe("eeRead", () => {
+  it("runs the query when enterprise is enabled and a DB is present", async () => {
+    let ran = false;
+    const query = Effect.sync(() => {
+      ran = true;
+      return [1, 2, 3];
+    });
+    const result = await run(eeRead("roles", [], query));
+    expect(result).toEqual([1, 2, 3]);
+    expect(ran).toBe(true);
+  });
+
+  it("short-circuits to whenNoDb without running the query when no DB", async () => {
+    ee.setHasInternalDB(false);
+    let ran = false;
+    const query = Effect.sync(() => {
+      ran = true;
+      return [1, 2, 3];
+    });
+    const result = await run(eeRead("roles", [], query));
+    expect(result).toEqual([]);
+    expect(ran).toBe(false);
+  });
+
+  it("preserves the per-function empty value (null, 0, {}) verbatim", async () => {
+    ee.setHasInternalDB(false);
+    expect(await run(eeRead("roles", null, Effect.succeed<string | null>("x")))).toBeNull();
+    expect(await run(eeRead("q", 0, Effect.succeed(99)))).toBe(0);
+    expect(await run(eeRead("ip", { allowed: true }, Effect.succeed({ allowed: false })))).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("fails with EnterpriseError and never touches the DB when unlicensed", async () => {
+    ee.setEnterpriseEnabled(false);
+    let ran = false;
+    const query = Effect.sync(() => {
+      ran = true;
+      return [1];
+    });
+    const err = await runFail(eeRead("roles", [], query));
+    expect(err).toBeInstanceOf(EnterpriseError);
+    expect(ran).toBe(false);
+  });
+
+  it("gates before the DB check — unlicensed + no DB still fails EnterpriseError", async () => {
+    ee.setEnterpriseEnabled(false);
+    ee.setHasInternalDB(false);
+    const err = await runFail(eeRead("roles", [], Effect.succeed([1])));
+    expect(err).toBeInstanceOf(EnterpriseError);
+  });
+});
+
+// ── eeWrite ─────────────────────────────────────────────────────────
+
+describe("eeWrite", () => {
+  it("runs the query when enterprise is enabled and a DB is present", async () => {
+    let ran = false;
+    const query = Effect.sync(() => {
+      ran = true;
+      return "written";
+    });
+    const result = await run(eeWrite("roles", "role assignment", query));
+    expect(result).toBe("written");
+    expect(ran).toBe(true);
+  });
+
+  it("fails loud with the default message when no DB, without running the query", async () => {
+    ee.setHasInternalDB(false);
+    let ran = false;
+    const query = Effect.sync(() => {
+      ran = true;
+      return "written";
+    });
+    const err = await runFail(eeWrite("roles", "role assignment", query));
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("Internal database required for role assignment.");
+    expect(ran).toBe(false);
+  });
+
+  it("fails with the domain error from errorFactory when supplied and no DB", async () => {
+    ee.setHasInternalDB(false);
+    class ApprovalError extends Error {
+      readonly _tag = "ApprovalError";
+    }
+    const err = await runFail(
+      eeWrite("approval rules", "approval rules", Effect.succeed("x"), () => new ApprovalError("boom")),
+    );
+    expect(err).toBeInstanceOf(ApprovalError);
+    expect((err as Error).message).toBe("boom");
+  });
+
+  it("fails with EnterpriseError before the DB requirement when unlicensed", async () => {
+    ee.setEnterpriseEnabled(false);
+    ee.setHasInternalDB(false);
+    let ran = false;
+    const query = Effect.sync(() => {
+      ran = true;
+      return "written";
+    });
+    const err = await runFail(eeWrite("roles", "role assignment", query));
+    expect(err).toBeInstanceOf(EnterpriseError);
+    expect(ran).toBe(false);
+  });
+});

--- a/ee/src/lib/ee-query.ts
+++ b/ee/src/lib/ee-query.ts
@@ -14,9 +14,15 @@
  *
  * The individual guards were extracted long ago (`requireEnterpriseEffect` in
  * `../index`, `requireInternalDBEffect` in `./db-guard`, `hasInternalDB` in
- * core); this composes the *combination* so the ~90 sites that re-type it stop
- * doing so by hand, and so a new EE query cannot reach the internal DB without
- * routing through the gate + guard — the wrapper is the only door.
+ * core); this composes the *combination* so the dozens of read/write functions
+ * that re-type it stop doing so by hand. Because the gate + guard now live in
+ * one wrapper rather than a hand-copied preamble, a reviewer can tell at a
+ * glance whether a new gated EE query routes through it — the point is that
+ * skipping the gate or DB guard becomes visually obvious in review, not that
+ * it's mechanically impossible. (Deliberately-ungated helpers — public getters
+ * like `getWorkspaceBrandingPublic`, provisioning-hot-path lookups like
+ * `resolveGroupToRole` — stay explicit `Effect.gen`s and are the documented
+ * exceptions.)
  *
  * These are leverage-via-composition, NOT a full collapse. The per-function
  * empty-value variance (`[]` vs `null` vs `0` vs `{ allowed: true }`) is
@@ -41,7 +47,7 @@ import { requireInternalDBEffect } from "./db-guard";
  * When unlicensed, fails with `EnterpriseError` (never touching the DB). When
  * licensed but DB-less, returns `whenNoDb` without running `query`.
  *
- * `whenNoDb` is the per-function empty value (`[]`, `null`, `0`,
+ * `whenNoDb` is the per-function empty value (`[]`, `null`, `0`, `false`,
  * `{ allowed: true }`, …) and is passed explicitly — it is `NoInfer` so the
  * result type `A` is driven by `query`, and `whenNoDb` is merely checked
  * against it (e.g. `null` against `CustomRole | null`).
@@ -50,11 +56,11 @@ import { requireInternalDBEffect } from "./db-guard";
  * @param whenNoDb - Value returned when no internal DB is configured.
  * @param query - The DB-backed read; only evaluated when gate + guard pass.
  */
-export const eeRead = <A, E>(
+export const eeRead = <A, E, R>(
   feature: string,
   whenNoDb: NoInfer<A>,
-  query: Effect.Effect<A, E>,
-): Effect.Effect<A, E | EnterpriseError> =>
+  query: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | EnterpriseError, R> =>
   Effect.gen(function* () {
     yield* requireEnterpriseEffect(feature);
     if (!hasInternalDB()) return whenNoDb;
@@ -76,12 +82,12 @@ export const eeRead = <A, E>(
  * @param query - The DB-backed write; only evaluated when gate + guard pass.
  * @param errorFactory - Optional factory for a domain-specific no-DB error, preserving per-module typing.
  */
-export const eeWrite = <A, E>(
+export const eeWrite = <A, E, R>(
   feature: string,
   label: string,
-  query: Effect.Effect<A, E>,
+  query: Effect.Effect<A, E, R>,
   errorFactory?: () => Error,
-): Effect.Effect<A, E | EnterpriseError | Error> =>
+): Effect.Effect<A, E | EnterpriseError | Error, R> =>
   Effect.gen(function* () {
     yield* requireEnterpriseEffect(feature);
     yield* requireInternalDBEffect(label, errorFactory);

--- a/ee/src/lib/ee-query.ts
+++ b/ee/src/lib/ee-query.ts
@@ -1,0 +1,89 @@
+/**
+ * EE read/write combinators — the enterprise-gate + internal-DB guard preamble,
+ * composed once.
+ *
+ * Every EE read/write function opens with the same two-step preamble:
+ *
+ *   // read:
+ *   yield* requireEnterpriseEffect("<feature>");   // 403 when unlicensed
+ *   if (!hasInternalDB()) return []/null/0/…;        // graceful empty, no DB
+ *
+ *   // write:
+ *   yield* requireEnterpriseEffect("<feature>");   // 403 when unlicensed
+ *   yield* requireInternalDBEffect("<label>");       // fail loud, no DB
+ *
+ * The individual guards were extracted long ago (`requireEnterpriseEffect` in
+ * `../index`, `requireInternalDBEffect` in `./db-guard`, `hasInternalDB` in
+ * core); this composes the *combination* so the ~90 sites that re-type it stop
+ * doing so by hand, and so a new EE query cannot reach the internal DB without
+ * routing through the gate + guard — the wrapper is the only door.
+ *
+ * These are leverage-via-composition, NOT a full collapse. The per-function
+ * empty-value variance (`[]` vs `null` vs `0` vs `{ allowed: true }`) is
+ * deliberate and passed EXPLICITLY as `whenNoDb`; likewise the write path's
+ * per-module typed error is preserved via the optional `errorFactory`. This is
+ * on purpose: papering over that variance — or over the per-method fail-loud
+ * policies baked into the Noop layers (#2594) — would erase intended semantics.
+ *
+ * @module
+ */
+
+import { Effect } from "effect";
+import type { EnterpriseError } from "@atlas/api/lib/effect/errors";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { requireEnterpriseEffect } from "../index";
+import { requireInternalDBEffect } from "./db-guard";
+
+/**
+ * Read-path combinator: enterprise gate → internal-DB short-circuit → query.
+ *
+ * Runs `query` only when enterprise is enabled AND an internal DB is present.
+ * When unlicensed, fails with `EnterpriseError` (never touching the DB). When
+ * licensed but DB-less, returns `whenNoDb` without running `query`.
+ *
+ * `whenNoDb` is the per-function empty value (`[]`, `null`, `0`,
+ * `{ allowed: true }`, …) and is passed explicitly — it is `NoInfer` so the
+ * result type `A` is driven by `query`, and `whenNoDb` is merely checked
+ * against it (e.g. `null` against `CustomRole | null`).
+ *
+ * @param feature - Feature label forwarded to `requireEnterpriseEffect` (drives the 403 message).
+ * @param whenNoDb - Value returned when no internal DB is configured.
+ * @param query - The DB-backed read; only evaluated when gate + guard pass.
+ */
+export const eeRead = <A, E>(
+  feature: string,
+  whenNoDb: NoInfer<A>,
+  query: Effect.Effect<A, E>,
+): Effect.Effect<A, E | EnterpriseError> =>
+  Effect.gen(function* () {
+    yield* requireEnterpriseEffect(feature);
+    if (!hasInternalDB()) return whenNoDb;
+    return yield* query;
+  });
+
+/**
+ * Write-path combinator: enterprise gate → internal-DB requirement → query.
+ *
+ * Runs `query` only when enterprise is enabled AND an internal DB is present.
+ * Unlike reads, the write path fails loud when DB-less rather than returning an
+ * empty value: `requireInternalDBEffect(label, errorFactory)` fails with the
+ * per-module typed error (`ApprovalError`, `ReportError`, …) when `errorFactory`
+ * is supplied, or a plain `Error(`Internal database required for ${label}.`)`
+ * otherwise — identical to the hand-written preamble.
+ *
+ * @param feature - Feature label forwarded to `requireEnterpriseEffect` (drives the 403 message).
+ * @param label - Operation label forwarded to `requireInternalDBEffect` (drives the no-DB message).
+ * @param query - The DB-backed write; only evaluated when gate + guard pass.
+ * @param errorFactory - Optional factory for a domain-specific no-DB error, preserving per-module typing.
+ */
+export const eeWrite = <A, E>(
+  feature: string,
+  label: string,
+  query: Effect.Effect<A, E>,
+  errorFactory?: () => Error,
+): Effect.Effect<A, E | EnterpriseError | Error> =>
+  Effect.gen(function* () {
+    yield* requireEnterpriseEffect(feature);
+    yield* requireInternalDBEffect(label, errorFactory);
+    return yield* query;
+  });

--- a/ee/src/platform/model-routing.ts
+++ b/ee/src/platform/model-routing.ts
@@ -10,9 +10,8 @@
  */
 
 import { Effect, Layer } from "effect";
-import { requireEnterpriseEffect } from "../index";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
-import { requireInternalDBEffect } from "../lib/db-guard";
+import { eeRead, eeWrite } from "../lib/ee-query";
 import {
   hasInternalDB,
   internalQuery,
@@ -353,10 +352,7 @@ const promiseError = (err: unknown): Error =>
 export const getWorkspaceModelConfig = (
   orgId: string,
 ): Effect.Effect<WorkspaceModelConfig | null, EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("model-routing");
-    if (!hasInternalDB()) return null;
-
+  eeRead("model-routing", null, Effect.gen(function* () {
     const rows = yield* Effect.tryPromise({
       try: () =>
         internalQuery<ModelConfigRow>(
@@ -371,7 +367,7 @@ export const getWorkspaceModelConfig = (
 
     if (rows.length === 0) return null;
     return rowToConfig(rows[0]);
-  });
+  }));
 
 /**
  * `RawWorkspaceModelConfig` (decrypted workspace model configuration,
@@ -510,9 +506,7 @@ export const setWorkspaceModelConfig = (
   orgId: string,
   config: SetWorkspaceModelConfigRequest,
 ): Effect.Effect<WorkspaceModelConfig, ModelConfigError | EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("model-routing");
-    yield* requireInternalDBEffect("workspace model configuration");
+  eeWrite("model-routing", "workspace model configuration", Effect.gen(function* () {
     yield* validateConfig(config);
 
     // Provider-transition guard: switching from gateway-on-platform-credits
@@ -617,7 +611,7 @@ export const setWorkspaceModelConfig = (
     }
 
     return rowToConfig(rows[0]);
-  });
+  }));
 
 /**
  * Delete the workspace model configuration for an organization.
@@ -626,10 +620,7 @@ export const setWorkspaceModelConfig = (
 export const deleteWorkspaceModelConfig = (
   orgId: string,
 ): Effect.Effect<boolean, EnterpriseError | Error> =>
-  Effect.gen(function* () {
-    yield* requireEnterpriseEffect("model-routing");
-    if (!hasInternalDB()) return false;
-
+  eeRead("model-routing", false, Effect.gen(function* () {
     const pool = getInternalDB();
     const result = yield* Effect.tryPromise({
       try: () =>
@@ -642,7 +633,7 @@ export const deleteWorkspaceModelConfig = (
       log.info({ orgId }, "Workspace model config deleted — reverting to platform default");
     }
     return deleted;
-  });
+  }));
 
 /**
  * After a BYOT discovery refresh, compare the workspace's saved model

--- a/ee/src/platform/model-routing.ts
+++ b/ee/src/platform/model-routing.ts
@@ -2,7 +2,8 @@
  * Enterprise workspace-level model routing.
  *
  * CRUD for per-organization LLM provider/model configuration. Every CRUD
- * function calls `requireEnterpriseEffect("model-routing")` — unlicensed
+ * function routes through the `eeRead`/`eeWrite` combinators, which apply the
+ * `requireEnterpriseEffect("model-routing")` gate — unlicensed
  * deployments get a clear error. API keys are stored encrypted using the
  * same AES-256-GCM pattern as connection URLs.
  *


### PR DESCRIPTION
Closes #4200

## What

Every EE read/write function opened with the same hand-typed preamble:
`yield* requireEnterpriseEffect("<feature>")` then either `if (!hasInternalDB()) return []/null/…` (reads) or `yield* requireInternalDBEffect(...)` (writes). This extracts that *combination* into two combinators in `ee/src/lib/ee-query.ts`:

```ts
eeRead(feature, whenNoDb, query)              // gate → DB short-circuit → query
eeWrite(feature, label, query, errorFactory?) // gate → DB require (fail-loud) → query
```

The per-function empty value (`whenNoDb`) and per-module typed no-DB error (`errorFactory`) are passed **explicitly** — leverage-via-composition, not a full collapse, so the deliberate per-method fail-loud/fail-soft variance (#2594) is preserved.

## Adoption

Converted the **canonical** gate+DB-guard sites across: `auth/{roles,sso,scim,ip-allowlist}`, `governance/approval`, `audit/retention`, `compliance/reports`, `platform/model-routing`, `branding/white-label`.

Deliberately **left untouched** (non-canonical — behavior would change): reversed-order sites (`approval`'s `expireStaleRequests`/`getPendingCount`/`hasApprovedRequest`, which DB-check *before* the gate and catch `EnterpriseError` into a graceful default), no-gate login-flow/public helpers (`findProviderByDomain`, `isSSOEnforced`, `getWorkspaceBrandingPublic`, `resolveGroupToRole`, `checkIPAllowlist`), logic-between-guards (`checkDomainAvailability`, backups' `ensureTable()`-before-guard), and `compliance/masking` / `backups/*` (no canonical pairs).

## Guarantees

- **Behavior identical site-for-site** — the 403 `EnterpriseError` path, each no-DB short-circuit value, and each fail-loud `requireInternalDBEffect` label/errorFactory are preserved verbatim.
- The combinator lives in `ee/src/lib/` (composing the existing guard helpers), so `check-ee-imports.sh` stays green — core never imports `@atlas/ee`.
- New `ee/src/lib/ee-query.test.ts` (gate-before-DB ordering, no-DB short-circuit, per-value preservation, fail-loud default + errorFactory, `E`-channel propagation); full `ee` suite green (48/48), `ee/src` typechecks clean.

Reviewed by the internal panel (silent-failure, type-design, test-coverage, comment-accuracy) — all four non-blocking; their MEDIUM/LOW suggestions folded in (R-channel generic, faithful db-guard test, docstring refresh, no-DB write regression tests).

https://claude.ai/code/session_015E1b5xQeizyEQZktA9hm6N