### PR TITLE
refactor(web): converge install dialogs on FormDialog + one installState union (#4203)

### DIFF
--- a/packages/web/src/app/admin/connections/__tests__/curated-install-dialog.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/curated-install-dialog.test.tsx
@@ -2,17 +2,18 @@
  * Secret-isolation coverage for the curated REST datasource install dialog.
  *
  * The dialog is a single long-lived instance reused across vendors (the page
- * swaps `candidate` rather than remounting). Its only guard against a pasted
- * credential bleeding from one vendor's install into the next is the
- * reset-on-open effect keyed on `[open, candidate?.slug]`. A regression there
- * (e.g. narrowing the dep array, or hoisting the field state) would silently
- * POST a live secret — say a Stripe `sk_live_…` — against a *different*
- * vendor's `install-form` endpoint. That's invisible to type-checking and to a
- * casual smoke test, so it's asserted here directly.
+ * swaps `candidate` rather than remounting). Since #4203 it rides `FormDialog`,
+ * whose reset-on-open effect is keyed on `[open, resetKey]`; the dialog passes
+ * `resetKey={candidate.slug}`, so switching vendors while open wipes the field.
+ * A regression there (e.g. dropping the `resetKey` prop, or FormDialog
+ * narrowing its effect deps) would silently POST a live secret — say a Stripe
+ * `sk_live_…` — against a *different* vendor's `install-form` endpoint. That's
+ * invisible to type-checking and to a casual smoke test, so it's asserted here
+ * directly against observable field state (not the implementation).
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { CuratedInstallDialog, type CuratedCandidate } from "../curated-install-dialog";
 
 const STRIPE: CuratedCandidate = { slug: "stripe-data", name: "Stripe", description: null };
@@ -60,5 +61,45 @@ describe("CuratedInstallDialog secret isolation", () => {
       <CuratedInstallDialog candidate={STRIPE} open onOpenChange={noop} onInstalled={noop} />,
     );
     expect(authInput().value).toBe("");
+  });
+});
+
+describe("CuratedInstallDialog error surface (rides FormDialog)", () => {
+  const originalFetch = globalThis.fetch;
+  let nextResponse: () => Response;
+
+  beforeEach(() => {
+    nextResponse = () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    globalThis.fetch = mock(() => Promise.resolve(nextResponse())) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  // A failed install surfaces through FormDialog's shared root-error banner —
+  // the same banner the REST / BYOT / catalog install dialogs use. This is the
+  // "a validation/error-surface fix reaches all of them" acceptance criterion.
+  test("surfaces a failed install through the shared FormDialog banner", async () => {
+    nextResponse = () =>
+      new Response(JSON.stringify({ message: "Invalid API key", requestId: "deadbeefcafe" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    render(<CuratedInstallDialog candidate={STRIPE} open onOpenChange={noop} onInstalled={noop} />);
+
+    await act(async () => {
+      fireEvent.change(authInput(), { target: { value: "sk_live_bad" } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("curated-install-submit"));
+    });
+
+    expect(await screen.findByText("Invalid API key (ref: deadbeef)")).toBeDefined();
   });
 });

--- a/packages/web/src/app/admin/connections/__tests__/install-form-error.test.ts
+++ b/packages/web/src/app/admin/connections/__tests__/install-form-error.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { installFormErrorMessage } from "../install-form-error";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("installFormErrorMessage", () => {
+  test("prefers the first field error (what the admin must fix)", async () => {
+    const res = jsonResponse(400, {
+      message: "Validation failed",
+      fieldErrors: { openapi_url: ["Could not reach the spec URL"] },
+    });
+    expect(await installFormErrorMessage(res)).toBe("openapi_url: Could not reach the spec URL");
+  });
+
+  test("falls back to the top-level message when there are no field errors", async () => {
+    const res = jsonResponse(409, { message: "Already installed" });
+    expect(await installFormErrorMessage(res)).toBe("Already installed");
+  });
+
+  test("appends a short request-id tail for log correlation", async () => {
+    const res = jsonResponse(500, { message: "Internal error", requestId: "abcdef1234567890" });
+    expect(await installFormErrorMessage(res)).toBe("Internal error (ref: abcdef12)");
+  });
+
+  test("keeps a status-only message on a non-JSON body (never widens to a generic error)", async () => {
+    const res = new Response("<html>gateway timeout</html>", { status: 504 });
+    expect(await installFormErrorMessage(res)).toBe("Install failed (504)");
+  });
+});

--- a/packages/web/src/app/admin/connections/__tests__/rest-install-dialog.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/rest-install-dialog.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Coverage for the Custom REST API install dialog after it was converged onto
+ * the shared {@link FormDialog} primitive (#4203).
+ *
+ * Two things this locks:
+ *   1. The dialog still POSTs the exact `install-form` wire body (spec URL +
+ *      auth) — the FormDialog refactor must not reshape the payload.
+ *   2. A failed install surfaces the server's message through FormDialog's
+ *      shared root-error banner. This is the "a validation/error-surface fix
+ *      in one install dialog reaches all of them" acceptance criterion:
+ *      RestInstallDialog no longer owns a bespoke `useState<error>` +
+ *      `<InlineError>` — the banner is FormDialog's, shared with the curated /
+ *      BYOT / catalog install dialogs.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { RestInstallDialog, buildRestInstallBody } from "../openapi-block";
+
+const noop = () => undefined;
+
+// The conditional wire-body shaping is the most substantive new logic in the
+// dialog and is driven by `auth_kind` — which is painful to exercise through
+// the Radix Select in jsdom. `buildRestInstallBody` is extracted precisely so
+// each auth kind's payload is asserted deterministically here.
+describe("buildRestInstallBody", () => {
+  const base = {
+    openapi_url: "  https://api.example.com/openapi.json  ",
+    auth_kind: "bearer",
+    auth_value: "tok",
+    auth_header_name: "X-API-Key",
+    auth_param_name: "api_key",
+    base_url_override: "",
+    display_name: "",
+  };
+
+  test("trims openapi_url and includes auth_value for bearer (no header/param)", () => {
+    expect(buildRestInstallBody(base)).toEqual({
+      openapi_url: "https://api.example.com/openapi.json",
+      auth_kind: "bearer",
+      auth_value: "tok",
+    });
+  });
+
+  test("omits auth_value entirely for auth_kind=none", () => {
+    const body = buildRestInstallBody({ ...base, auth_kind: "none" });
+    expect(body).toEqual({
+      openapi_url: "https://api.example.com/openapi.json",
+      auth_kind: "none",
+    });
+    expect("auth_value" in body).toBe(false);
+  });
+
+  test("apikey-header carries auth_header_name but not auth_param_name", () => {
+    const body = buildRestInstallBody({ ...base, auth_kind: "apikey-header" });
+    expect(body.auth_header_name).toBe("X-API-Key");
+    expect(body.auth_value).toBe("tok");
+    expect("auth_param_name" in body).toBe(false);
+  });
+
+  test("apikey-query carries auth_param_name but not auth_header_name", () => {
+    const body = buildRestInstallBody({ ...base, auth_kind: "apikey-query" });
+    expect(body.auth_param_name).toBe("api_key");
+    expect("auth_header_name" in body).toBe(false);
+  });
+
+  test("drops blank optional fields and trims populated ones", () => {
+    const blank = buildRestInstallBody(base);
+    expect("base_url_override" in blank).toBe(false);
+    expect("display_name" in blank).toBe(false);
+
+    const populated = buildRestInstallBody({
+      ...base,
+      base_url_override: "  https://staging.example.com/rest  ",
+      display_name: "  Twenty CRM  ",
+    });
+    expect(populated.base_url_override).toBe("https://staging.example.com/rest");
+    expect(populated.display_name).toBe("Twenty CRM");
+  });
+});
+
+describe("RestInstallDialog", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls: Array<{ url: string; method: string; body: unknown }>;
+  let nextResponse: () => Response;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    nextResponse = () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      fetchCalls.push({ url, method, body });
+      return Promise.resolve(nextResponse());
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  test("POSTs the spec URL + auth body to /install-form and fires onInstalled", async () => {
+    let installed = false;
+    render(
+      <RestInstallDialog open onOpenChange={noop} onInstalled={() => (installed = true)} />,
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("openapi-url-input"), {
+        target: { value: "https://api.example.com/openapi.json" },
+      });
+    });
+    // auth_kind defaults to "bearer", so the token field is disclosed.
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("openapi-auth-value"), {
+        target: { value: "secret-token" },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("openapi-install-submit"));
+    });
+
+    await waitFor(() => {
+      const call = fetchCalls.find(
+        (c) => c.method === "POST" && c.url.endsWith("/api/v1/integrations/openapi-generic/install-form"),
+      );
+      expect(call).toBeDefined();
+      expect(call?.body).toEqual({
+        openapi_url: "https://api.example.com/openapi.json",
+        auth_kind: "bearer",
+        auth_value: "secret-token",
+      });
+    });
+    expect(installed).toBe(true);
+  });
+
+  test("surfaces a failed install through FormDialog's shared error banner", async () => {
+    nextResponse = () =>
+      new Response(
+        JSON.stringify({ message: "Spec probe failed", requestId: "abcdef1234567890" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    render(<RestInstallDialog open onOpenChange={noop} onInstalled={noop} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("openapi-url-input"), {
+        target: { value: "https://bad.example.com/openapi.json" },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("openapi-install-submit"));
+    });
+
+    // The message (with the short request-id tail) renders in the shared banner.
+    expect(await screen.findByText("Spec probe failed (ref: abcdef12)")).toBeDefined();
+  });
+
+  test("client-validates a blank spec URL before hitting the network", async () => {
+    render(<RestInstallDialog open onOpenChange={noop} onInstalled={noop} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("openapi-install-submit"));
+    });
+
+    expect(await screen.findByText("OpenAPI spec URL is required")).toBeDefined();
+    expect(fetchCalls.some((c) => c.method === "POST")).toBe(false);
+  });
+});

--- a/packages/web/src/app/admin/connections/curated-install-dialog.tsx
+++ b/packages/web/src/app/admin/connections/curated-install-dialog.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { ExternalLink, Loader2 } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import { z } from "zod";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { InlineError } from "@/ui/components/admin/compact";
+import {
+  FormDialog,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/form-dialog";
 import { getApiUrl } from "@/lib/api-url";
+import { installFormErrorMessage } from "./install-form-error";
 
 /* ────────────────────────────────────────────────────────────────────────
  *  Curated REST datasource install — the one-credential form for a built-in
@@ -23,6 +21,11 @@ import { getApiUrl } from "@/lib/api-url";
  *  pre-wired server-side; the admin only pastes the secret. POSTs the slim
  *  `{ auth_value, display_name? }` body to the candidate's `install-form`
  *  handler (mirrors {@link DataCandidateFormDataSchema} on the API).
+ *
+ *  Rides the shared {@link FormDialog} primitive (arch-win #91 / #4203) — the
+ *  same credential → validate → save spine as `FormInstallModal`,
+ *  `RestInstallDialog`, and `ByotInstallModal` — so a fix to FormDialog's
+ *  error-surface / reset behavior reaches every install dialog at once.
  * ──────────────────────────────────────────────────────────────────────── */
 
 export interface CuratedCandidate {
@@ -46,6 +49,18 @@ const SECRET_FIELD: Record<string, { label: string; placeholder: string; help: s
   },
 };
 
+// `CuratedFormValues` is derived from the schema (`z.infer`) so the schema is
+// the single source of truth — a field can't drift between the two.
+const curatedSchema = z.object({
+  auth_value: z.string().min(1, "Credential is required"),
+  display_name: z.string(),
+});
+type CuratedFormValues = z.infer<typeof curatedSchema>;
+
+/** A fresh empty form for every open; the reset itself is FormDialog's job
+ *  (keyed on `[open, resetKey]`), so a plain constant is enough here. */
+const CURATED_DEFAULTS: CuratedFormValues = { auth_value: "", display_name: "" };
+
 export function CuratedInstallDialog({
   candidate,
   open,
@@ -57,130 +72,102 @@ export function CuratedInstallDialog({
   onOpenChange: (open: boolean) => void;
   onInstalled: () => void;
 }) {
-  const [authValue, setAuthValue] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const field = candidate
+    ? (SECRET_FIELD[candidate.slug] ?? {
+        label: "API key / token",
+        placeholder: "",
+        help: "Used read-only; encrypted at rest.",
+      })
+    : null;
 
-  // Reset the form whenever a different candidate opens the dialog so a
-  // previous vendor's pasted secret never leaks into the next install.
-  useEffect(() => {
-    if (open) {
-      setAuthValue("");
-      setDisplayName("");
-      setError(null);
+  async function handleSubmit(values: CuratedFormValues): Promise<void> {
+    // Unreachable — FormDialog only mounts when `candidate` is non-null (see the
+    // early return below) — but make the impossible state loud rather than
+    // resolving as a phantom success if a future refactor makes it reachable.
+    if (!candidate) throw new Error("No datasource candidate selected");
+    const body: Record<string, unknown> = { auth_value: values.auth_value };
+    if (values.display_name.trim()) body.display_name = values.display_name.trim();
+
+    const res = await fetch(
+      `${getApiUrl()}/api/v1/integrations/${encodeURIComponent(candidate.slug)}/install-form`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      // Throw so FormDialog's onSubmit wrapper surfaces it as the shared
+      // root-level error banner (the reset-on-open effect keyed on
+      // `[open, resetKey]` still wipes the pasted secret on the next open).
+      throw new Error(await installFormErrorMessage(res));
     }
-  }, [open, candidate?.slug]);
-
-  if (!candidate) return null;
-  const field = SECRET_FIELD[candidate.slug] ?? {
-    label: "API key / token",
-    placeholder: "",
-    help: "Used read-only; encrypted at rest.",
-  };
-
-  async function handleSubmit() {
-    if (!candidate) return;
-    setSaving(true);
-    setError(null);
-    const body: Record<string, unknown> = { auth_value: authValue };
-    if (displayName.trim()) body.display_name = displayName.trim();
-
-    try {
-      const res = await fetch(
-        `${getApiUrl()}/api/v1/integrations/${encodeURIComponent(candidate.slug)}/install-form`,
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify(body),
-        },
-      );
-      if (!res.ok) {
-        let message = `Install failed (${res.status})`;
-        try {
-          const b = (await res.json()) as {
-            message?: string;
-            fieldErrors?: Record<string, string[] | undefined>;
-            requestId?: string;
-          };
-          const firstField = b.fieldErrors ? Object.keys(b.fieldErrors)[0] : undefined;
-          const firstErr = firstField ? b.fieldErrors?.[firstField]?.[0] : undefined;
-          if (firstField && firstErr) message = `${firstField}: ${firstErr}`;
-          else if (b.message) message = b.message;
-          if (b.requestId) message = `${message} (ref: ${b.requestId.slice(0, 8)})`;
-        } catch {
-          // intentionally ignored: non-JSON body → keep the status-only message.
-        }
-        setError(message);
-        return;
-      }
-      toast.success(`${candidate.name} connected`);
-      onInstalled();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Install failed");
-    } finally {
-      setSaving(false);
-    }
+    toast.success(`${candidate.name} connected`);
+    onInstalled();
   }
 
+  if (!candidate || !field) return null;
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>Connect {candidate.name}</DialogTitle>
-          <DialogDescription>
-            {candidate.description ??
-              `Query ${candidate.name} as a read-only REST datasource. The spec is pre-wired — just paste your credential.`}
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-3">
-          <div className="space-y-1.5">
-            <Label htmlFor="curated-auth-value">{field.label}</Label>
-            <Input
-              id="curated-auth-value"
-              type="password"
-              placeholder={field.placeholder}
-              value={authValue}
-              onChange={(e) => setAuthValue(e.target.value)}
-              data-testid="curated-auth-value"
-              autoFocus
-            />
-            <p className="text-xs text-muted-foreground">{field.help}</p>
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="curated-display-name">Display name (optional)</Label>
-            <Input
-              id="curated-display-name"
-              placeholder={candidate.name}
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-            />
-          </div>
-
-          {error ? <InlineError>{error}</InlineError> : null}
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={saving || authValue.trim().length === 0}
-            data-testid="curated-install-submit"
-          >
-            {saving ? (
-              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-            ) : (
-              <ExternalLink className="mr-1.5 size-3.5" />
+    <FormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      // Keyed on the vendor slug so switching candidates while the dialog stays
+      // open re-fires the reset — a pasted `sk_live_…` never bleeds into the
+      // next vendor's install (regression-guarded in the sibling test).
+      resetKey={candidate.slug}
+      title={`Connect ${candidate.name}`}
+      description={
+        candidate.description ??
+        `Query ${candidate.name} as a read-only REST datasource. The spec is pre-wired — just paste your credential.`
+      }
+      schema={curatedSchema}
+      defaultValues={CURATED_DEFAULTS}
+      onSubmit={handleSubmit}
+      submitLabel="Connect"
+      submitTestId="curated-install-submit"
+      className="max-w-md"
+    >
+      {(form) => (
+        <>
+          <FormField
+            control={form.control}
+            name="auth_value"
+            render={({ field: rhf }) => (
+              <FormItem>
+                <FormLabel>{field.label}</FormLabel>
+                <FormControl>
+                  <Input
+                    id="curated-auth-value"
+                    type="password"
+                    placeholder={field.placeholder}
+                    data-testid="curated-auth-value"
+                    autoFocus
+                    {...rhf}
+                  />
+                </FormControl>
+                <FormDescription>{field.help}</FormDescription>
+                <FormMessage />
+              </FormItem>
             )}
-            Connect
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          />
+
+          <FormField
+            control={form.control}
+            name="display_name"
+            render={({ field: rhf }) => (
+              <FormItem>
+                <FormLabel>Display name (optional)</FormLabel>
+                <FormControl>
+                  <Input id="curated-display-name" placeholder={candidate.name} {...rhf} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </>
+      )}
+    </FormDialog>
   );
 }

--- a/packages/web/src/app/admin/connections/install-form-error.ts
+++ b/packages/web/src/app/admin/connections/install-form-error.ts
@@ -1,0 +1,31 @@
+/**
+ * Parse a failed `POST /api/v1/integrations/:slug/install-form` response into a
+ * single actionable message for the install dialogs (`RestInstallDialog`,
+ * `CuratedInstallDialog`) to throw — FormDialog then surfaces it as the shared
+ * root-level error banner (arch-win #91 / #4203).
+ *
+ * Surfaces the first field error (e.g. the spec-probe failure on `openapi_url`)
+ * so the admin sees exactly what to fix, else the top-level message, and
+ * appends a short request-id tail for log correlation whenever the body carries
+ * a `requestId` (the API always includes one on a 5xx, and on some 4xx too).
+ * Deliberately never widened to "Something went wrong": the route hands back
+ * actionable, server-typed copy and we render it verbatim.
+ */
+export async function installFormErrorMessage(res: Response): Promise<string> {
+  let message = `Install failed (${res.status})`;
+  try {
+    const b = (await res.json()) as {
+      message?: string;
+      fieldErrors?: Record<string, string[] | undefined>;
+      requestId?: string;
+    };
+    const firstField = b.fieldErrors ? Object.keys(b.fieldErrors)[0] : undefined;
+    const firstErr = firstField ? b.fieldErrors?.[firstField]?.[0] : undefined;
+    if (firstField && firstErr) message = `${firstField}: ${firstErr}`;
+    else if (b.message) message = b.message;
+    if (b.requestId) message = `${message} (ref: ${b.requestId.slice(0, 8)})`;
+  } catch {
+    // intentionally ignored: non-JSON body → keep the status-only message.
+  }
+  return message;
+}

--- a/packages/web/src/app/admin/connections/openapi-block.tsx
+++ b/packages/web/src/app/admin/connections/openapi-block.tsx
@@ -17,11 +17,11 @@
  */
 
 import { useState } from "react";
+import { type Control, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { toast } from "sonner";
 import {
   AlertTriangle,
-  ExternalLink,
   Loader2,
   Network,
   Plus,
@@ -45,12 +45,10 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -80,11 +78,20 @@ import {
   SectionEmpty,
   SectionHeader,
 } from "./section-header";
+import {
+  FormDialog,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/form-dialog";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
 import { getApiUrl } from "@/lib/api-url";
 import { cn } from "@/lib/utils";
+import { installFormErrorMessage } from "./install-form-error";
 
 const OPENAPI_SLUG = "openapi-generic";
 
@@ -820,7 +827,193 @@ function OperationsDialog({
 
 // ── Install dialog ───────────────────────────────────────────────────────────
 
-/** The freeform "Custom REST API" install dialog (OpenAPI spec URL + auth).
+/**
+ * Form value shape for the Custom REST API install (arch-win #91 / #4203).
+ * `auth_kind` is a plain string (validated against {@link AUTH_KINDS} on the
+ * server); every credential field is present-but-optional so the dialog can
+ * carry them across auth-kind switches without churn — {@link buildRestInstallBody}
+ * drops the ones the selected kind doesn't need. `RestFormValues` is derived
+ * from the schema (`z.infer`) so the schema is the single source of truth — a
+ * field added to one can't silently drift from the other.
+ */
+const restSchema = z.object({
+  openapi_url: z.string().min(1, "OpenAPI spec URL is required"),
+  auth_kind: z.string(),
+  auth_value: z.string(),
+  auth_header_name: z.string(),
+  auth_param_name: z.string(),
+  base_url_override: z.string(),
+  display_name: z.string(),
+});
+type RestFormValues = z.infer<typeof restSchema>;
+
+const REST_DEFAULTS: RestFormValues = {
+  openapi_url: "",
+  auth_kind: "bearer",
+  auth_value: "",
+  auth_header_name: "",
+  auth_param_name: "",
+  base_url_override: "",
+  display_name: "",
+};
+
+/**
+ * Assemble the `install-form` wire body from the form values, dropping the
+ * credential fields the selected `auth_kind` doesn't use (so a stale value from
+ * a previously-selected kind never leaks) and trimming/omitting blank optional
+ * fields. Exported as a pure function so the conditional shaping — the most
+ * substantive logic here — is unit-testable without rendering the dialog.
+ */
+export function buildRestInstallBody(values: RestFormValues): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    openapi_url: values.openapi_url.trim(),
+    auth_kind: values.auth_kind,
+  };
+  if (values.auth_kind !== "none") body.auth_value = values.auth_value;
+  if (values.auth_kind === "apikey-header") body.auth_header_name = values.auth_header_name.trim();
+  if (values.auth_kind === "apikey-query") body.auth_param_name = values.auth_param_name.trim();
+  if (values.base_url_override.trim()) body.base_url_override = values.base_url_override.trim();
+  if (values.display_name.trim()) body.display_name = values.display_name.trim();
+  return body;
+}
+
+/** Custom REST API install fields — the freeform OpenAPI-spec form body,
+ *  rendered inside {@link FormDialog}. Auth-specific inputs disclose off the
+ *  selected auth kind (none → no credential; bearer/basic → the secret;
+ *  api-key kinds → the secret PLUS a header or query-param name) via a
+ *  `useWatch` on `auth_kind`, mirroring the config-schema `showWhen` pattern
+ *  the catalog form uses. */
+function RestInstallFields({ control }: { control: Control<RestFormValues> }) {
+  const authKind = useWatch({ control, name: "auth_kind" });
+  return (
+    <>
+      <FormField
+        control={control}
+        name="openapi_url"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>OpenAPI spec URL</FormLabel>
+            <FormControl>
+              <Input
+                placeholder="https://crm.example.com/rest/open-api/core"
+                data-testid="openapi-url-input"
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="auth_kind"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Authentication</FormLabel>
+            <Select value={field.value} onValueChange={field.onChange}>
+              <FormControl>
+                <SelectTrigger data-testid="openapi-auth-kind">
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {AUTH_KINDS.map((k) => (
+                  <SelectItem key={k} value={k}>
+                    {k}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {authKind !== "none" ? (
+        <FormField
+          control={control}
+          name="auth_value"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                {authKind === "basic" ? "username:password" : "Token / API key"}
+              </FormLabel>
+              <FormControl>
+                <Input type="password" data-testid="openapi-auth-value" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+
+      {authKind === "apikey-header" ? (
+        <FormField
+          control={control}
+          name="auth_header_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>API key header name</FormLabel>
+              <FormControl>
+                <Input placeholder="X-API-Key" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+
+      {authKind === "apikey-query" ? (
+        <FormField
+          control={control}
+          name="auth_param_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>API key query param</FormLabel>
+              <FormControl>
+                <Input placeholder="api_key" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+
+      <FormField
+        control={control}
+        name="display_name"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Display name (optional)</FormLabel>
+            <FormControl>
+              <Input placeholder="Twenty CRM" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="base_url_override"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Base URL override (optional)</FormLabel>
+            <FormControl>
+              <Input placeholder="https://staging.example.com/rest" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}
+
+/** The freeform "Custom REST API" install dialog (OpenAPI spec URL + auth),
+ *  riding the shared {@link FormDialog} primitive (arch-win #91 / #4203) — the
+ *  same spine as `FormInstallModal` / `CuratedInstallDialog` / `ByotInstallModal`.
  *  Hosted by the connections page and opened from the Add picker. */
 export function RestInstallDialog({
   open,
@@ -831,193 +1024,36 @@ export function RestInstallDialog({
   onOpenChange: (open: boolean) => void;
   onInstalled: () => void;
 }) {
-  const [openapiUrl, setOpenapiUrl] = useState("");
-  const [authKind, setAuthKind] = useState<(typeof AUTH_KINDS)[number]>("bearer");
-  const [authValue, setAuthValue] = useState("");
-  const [authHeaderName, setAuthHeaderName] = useState("");
-  const [authParamName, setAuthParamName] = useState("");
-  const [baseUrlOverride, setBaseUrlOverride] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  function reset() {
-    setOpenapiUrl("");
-    setAuthKind("bearer");
-    setAuthValue("");
-    setAuthHeaderName("");
-    setAuthParamName("");
-    setBaseUrlOverride("");
-    setDisplayName("");
-    setError(null);
-  }
-
-  async function handleSubmit() {
-    setSaving(true);
-    setError(null);
-    const body: Record<string, unknown> = { openapi_url: openapiUrl.trim(), auth_kind: authKind };
-    if (authKind !== "none") body.auth_value = authValue;
-    if (authKind === "apikey-header") body.auth_header_name = authHeaderName.trim();
-    if (authKind === "apikey-query") body.auth_param_name = authParamName.trim();
-    if (baseUrlOverride.trim()) body.base_url_override = baseUrlOverride.trim();
-    if (displayName.trim()) body.display_name = displayName.trim();
-
-    try {
-      const res = await fetch(`${getApiUrl()}/api/v1/integrations/${OPENAPI_SLUG}/install-form`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        let message = `Install failed (${res.status})`;
-        try {
-          const b = (await res.json()) as {
-            message?: string;
-            fieldErrors?: Record<string, string[] | undefined>;
-            requestId?: string;
-          };
-          // Surface the first field error (e.g. the spec-probe failure on
-          // openapi_url) so the admin sees exactly what to fix.
-          const firstField = b.fieldErrors ? Object.keys(b.fieldErrors)[0] : undefined;
-          const firstErr = firstField ? b.fieldErrors?.[firstField]?.[0] : undefined;
-          if (firstField && firstErr) message = `${firstField}: ${firstErr}`;
-          else if (b.message) message = b.message;
-          if (b.requestId) message = `${message} (ref: ${b.requestId.slice(0, 8)})`;
-        } catch {
-          // intentionally ignored: non-JSON body → keep the status-only message.
-        }
-        setError(message);
-        return;
-      }
-      toast.success("REST datasource connected");
-      reset();
-      onInstalled();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Install failed");
-    } finally {
-      setSaving(false);
+  async function handleSubmit(values: RestFormValues): Promise<void> {
+    const res = await fetch(`${getApiUrl()}/api/v1/integrations/${OPENAPI_SLUG}/install-form`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(buildRestInstallBody(values)),
+    });
+    if (!res.ok) {
+      // Throw so FormDialog surfaces it as the shared root-level error banner.
+      throw new Error(await installFormErrorMessage(res));
     }
+    toast.success("REST datasource connected");
+    onInstalled();
   }
 
   return (
-    <Dialog
+    <FormDialog
       open={open}
-      onOpenChange={(o) => {
-        if (!o) reset();
-        onOpenChange(o);
-      }}
+      onOpenChange={onOpenChange}
+      title="Connect a REST datasource"
+      description="Point Atlas at an OpenAPI 3.x spec URL. Atlas probes the spec on install; the agent then queries it read-only. The credential is encrypted at rest."
+      schema={restSchema}
+      defaultValues={REST_DEFAULTS}
+      onSubmit={handleSubmit}
+      submitLabel="Connect"
+      submitTestId="openapi-install-submit"
+      className="max-w-lg"
     >
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Connect a REST datasource</DialogTitle>
-          <DialogDescription>
-            Point Atlas at an OpenAPI 3.x spec URL. Atlas probes the spec on install; the agent then
-            queries it read-only. The credential is encrypted at rest.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-3">
-          <div className="space-y-1.5">
-            <Label htmlFor="openapi-url">OpenAPI spec URL</Label>
-            <Input
-              id="openapi-url"
-              placeholder="https://crm.example.com/rest/open-api/core"
-              value={openapiUrl}
-              onChange={(e) => setOpenapiUrl(e.target.value)}
-              data-testid="openapi-url-input"
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="openapi-auth-kind">Authentication</Label>
-            <Select value={authKind} onValueChange={(v) => setAuthKind(v as (typeof AUTH_KINDS)[number])}>
-              <SelectTrigger id="openapi-auth-kind" data-testid="openapi-auth-kind">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {AUTH_KINDS.map((k) => (
-                  <SelectItem key={k} value={k}>
-                    {k}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {authKind !== "none" ? (
-            <div className="space-y-1.5">
-              <Label htmlFor="openapi-auth-value">
-                {authKind === "basic" ? "username:password" : "Token / API key"}
-              </Label>
-              <Input
-                id="openapi-auth-value"
-                type="password"
-                value={authValue}
-                onChange={(e) => setAuthValue(e.target.value)}
-                data-testid="openapi-auth-value"
-              />
-            </div>
-          ) : null}
-
-          {authKind === "apikey-header" ? (
-            <div className="space-y-1.5">
-              <Label htmlFor="openapi-header-name">API key header name</Label>
-              <Input
-                id="openapi-header-name"
-                placeholder="X-API-Key"
-                value={authHeaderName}
-                onChange={(e) => setAuthHeaderName(e.target.value)}
-              />
-            </div>
-          ) : null}
-
-          {authKind === "apikey-query" ? (
-            <div className="space-y-1.5">
-              <Label htmlFor="openapi-param-name">API key query param</Label>
-              <Input
-                id="openapi-param-name"
-                placeholder="api_key"
-                value={authParamName}
-                onChange={(e) => setAuthParamName(e.target.value)}
-              />
-            </div>
-          ) : null}
-
-          <div className="space-y-1.5">
-            <Label htmlFor="openapi-display-name">Display name (optional)</Label>
-            <Input
-              id="openapi-display-name"
-              placeholder="Twenty CRM"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="openapi-base-url">Base URL override (optional)</Label>
-            <Input
-              id="openapi-base-url"
-              placeholder="https://staging.example.com/rest"
-              value={baseUrlOverride}
-              onChange={(e) => setBaseUrlOverride(e.target.value)}
-            />
-          </div>
-
-          {error ? <InlineError>{error}</InlineError> : null}
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit} disabled={saving || openapiUrl.trim().length === 0} data-testid="openapi-install-submit">
-            {saving ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <ExternalLink className="mr-1.5 size-3.5" />}
-            Connect
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      {(form) => <RestInstallFields control={form.control} />}
+    </FormDialog>
   );
 }
 

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -937,6 +937,22 @@ const DEMO_EDIT_READONLY_TOOLTIP = "Switch to developer mode to edit the demo co
  */
 const DEMO_ADD_READONLY_TOOLTIP = "Delete the demo connection or switch to developer mode to add a new one";
 
+/**
+ * The add-a-datasource flow as one discriminated union (#4203). Replaces the
+ * old fan-out of four boolean/nullable dialog-open flags (`pickerOpen`,
+ * `customRestOpen`, `curatedCandidate`, `formInstallCandidate`): each install
+ * surface derives its `open` from `install.kind`, so exactly one can be open at
+ * a time and a new install path is one more variant, not another boolean +
+ * another close-reset to remember. Edit / delete / generate-prompt keep their
+ * own state — they aren't part of the add flow.
+ */
+type InstallState =
+  | { kind: "idle" }
+  | { kind: "picking" }
+  | { kind: "custom-rest" }
+  | { kind: "curated"; candidate: CuratedCandidate }
+  | { kind: "form-install"; candidate: DatasourceFormCandidate };
+
 export default function ConnectionsPage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
@@ -966,16 +982,11 @@ export default function ConnectionsPage() {
   // generate flow to; `null` when no prompt is pending.
   const [genPrompt, setGenPrompt] = useState<{ connectionId: string; groupLabel: string } | null>(null);
 
-  // Add-connection picker + the REST install dialogs it routes to. The
-  // picker replaces the old always-listed "Connect" provider rows.
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [customRestOpen, setCustomRestOpen] = useState(false);
-  const [curatedCandidate, setCuratedCandidate] = useState<CuratedCandidate | null>(null);
-  // Catalog datasource picked from the Add picker's form-install tiles
-  // (ClickHouse, Snowflake, BigQuery, …) — opens the schema-driven
-  // marketplace FormInstallModal (#3377).
-  const [formInstallCandidate, setFormInstallCandidate] =
-    useState<DatasourceFormCandidate | null>(null);
+  // Add-connection picker + the install dialogs it routes to, modeled as one
+  // discriminated union (#4203 — see {@link InstallState}). Covers the picker,
+  // the custom-REST dialog, the curated-candidate dialog, and the schema-driven
+  // marketplace FormInstallModal (ClickHouse / Snowflake / BigQuery, #3377).
+  const [install, setInstall] = useState<InstallState>({ kind: "idle" });
   // Bumped after a REST/curated install so the plugin-owned blocks
   // (OpenAPI, Salesforce) remount and refetch their own lists — their data
   // lives behind separate query keys from the `connections` fetch below.
@@ -1142,8 +1153,8 @@ export default function ConnectionsPage() {
     handleAdd(dbType);
   }
   function handleDatasourceInstalled() {
-    setCustomRestOpen(false);
-    setCuratedCandidate(null);
+    // Closes whichever add surface is open (custom-rest / curated / form-install).
+    setInstall({ kind: "idle" });
     refreshDatasources();
   }
   // Form-install tiles (ClickHouse / Snowflake / BigQuery / Elasticsearch).
@@ -1151,7 +1162,6 @@ export default function ConnectionsPage() {
   // #3295 the install registers into ConnectionRegistry immediately, so the
   // new connection belongs in the main list without a reload.
   function handleFormInstallInstalled() {
-    setFormInstallCandidate(null);
     handleDatasourceInstalled();
     refetch();
   }
@@ -1238,7 +1248,7 @@ export default function ConnectionsPage() {
               </Tooltip>
             </TooltipProvider>
           ) : (
-            <Button onClick={() => setPickerOpen(true)} size="sm" data-testid="add-connection-hero">
+            <Button onClick={() => setInstall({ kind: "picking" })} size="sm" data-testid="add-connection-hero">
               <Plus className="mr-2 size-4" />
               Add connection
             </Button>
@@ -1281,7 +1291,7 @@ export default function ConnectionsPage() {
               action={
                 <AddDatasourceButton
                   label="Add database"
-                  onClick={() => setPickerOpen(true)}
+                  onClick={() => setInstall({ kind: "picking" })}
                   demoReadOnly={demoReadOnly}
                   demoTooltip={DEMO_ADD_READONLY_TOOLTIP}
                   testId="add-database"
@@ -1303,7 +1313,7 @@ export default function ConnectionsPage() {
                   description="Connect Postgres, MySQL, Snowflake, and more."
                   action={
                     demoReadOnly ? null : (
-                      <Button size="sm" variant="outline" onClick={() => setPickerOpen(true)}>
+                      <Button size="sm" variant="outline" onClick={() => setInstall({ kind: "picking" })}>
                         <Plus className="mr-1.5 size-3.5" />
                         Add database
                       </Button>
@@ -1341,7 +1351,7 @@ export default function ConnectionsPage() {
           <OpenApiProviderBlock
             key={`rest-${datasourceRefreshKey}`}
             demoReadOnly={demoReadOnly}
-            onAdd={() => setPickerOpen(true)}
+            onAdd={() => setInstall({ kind: "picking" })}
             onChange={handleMutationSuccess}
           />
 
@@ -1416,26 +1426,28 @@ export default function ConnectionsPage() {
       />
 
       <AddConnectionPicker
-        open={pickerOpen}
-        onOpenChange={setPickerOpen}
+        open={install.kind === "picking"}
+        onOpenChange={(open) => setInstall(open ? { kind: "picking" } : { kind: "idle" })}
         demoReadOnly={demoReadOnly}
         onPickDatabase={handlePickDatabase}
-        onPickCustomRest={() => setCustomRestOpen(true)}
-        onPickCuratedForm={setCuratedCandidate}
-        onPickDatasourceForm={setFormInstallCandidate}
+        onPickCustomRest={() => setInstall({ kind: "custom-rest" })}
+        onPickCuratedForm={(candidate) => setInstall({ kind: "curated", candidate })}
+        onPickDatasourceForm={(candidate) => setInstall({ kind: "form-install", candidate })}
       />
 
       <RestInstallDialog
-        open={customRestOpen}
-        onOpenChange={setCustomRestOpen}
+        open={install.kind === "custom-rest"}
+        onOpenChange={(open) => {
+          if (!open) setInstall({ kind: "idle" });
+        }}
         onInstalled={handleDatasourceInstalled}
       />
 
       <CuratedInstallDialog
-        candidate={curatedCandidate}
-        open={curatedCandidate !== null}
+        candidate={install.kind === "curated" ? install.candidate : null}
+        open={install.kind === "curated"}
         onOpenChange={(open) => {
-          if (!open) setCuratedCandidate(null);
+          if (!open) setInstall({ kind: "idle" });
         }}
         onInstalled={handleDatasourceInstalled}
       />
@@ -1444,16 +1456,16 @@ export default function ConnectionsPage() {
           (ClickHouse / Snowflake / BigQuery / Elasticsearch, #3377) — the
           same modal Admin → Integrations uses, so install semantics
           (validation, secret encryption, edit-in-place) stay identical. */}
-      {formInstallCandidate ? (
+      {install.kind === "form-install" ? (
         <FormInstallModal
           open
           onOpenChange={(open) => {
-            if (!open) setFormInstallCandidate(null);
+            if (!open) setInstall({ kind: "idle" });
           }}
-          slug={formInstallCandidate.slug}
-          name={formInstallCandidate.name}
-          description={formInstallCandidate.description}
-          configSchema={formInstallCandidate.configSchema}
+          slug={install.candidate.slug}
+          name={install.candidate.name}
+          description={install.candidate.description}
+          configSchema={install.candidate.configSchema}
           // Surface the connection-name field so a workspace can install more
           // than one datasource of the same catalog (#3858) — e.g. an
           // Elasticsearch and an OpenSearch cluster under the unified slug.

--- a/packages/web/src/app/admin/integrations/__tests__/byot-install-modal.test.tsx
+++ b/packages/web/src/app/admin/integrations/__tests__/byot-install-modal.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Coverage for `ByotInstallModal` after #4203 converged the BYOT credential
+ * form onto the shared {@link FormDialog} primitive (it was an inline card
+ * form before). Three things this locks:
+ *
+ *   1. Slack's single-field submit POSTs `{ botToken }` to the legacy
+ *      `/api/v1/admin/integrations/slack/byot` endpoint and fires the success
+ *      callbacks (the wire contract the old inline form held).
+ *   2. A failed submit surfaces the server's message through FormDialog's
+ *      shared root-error banner — BYOT formats via `friendlyErrorOrNull` (a
+ *      DIFFERENT formatter than the REST/curated `installFormErrorMessage`),
+ *      so the "an error-surface fix reaches all of them" criterion needs its
+ *      own assertion here, not just for the other two dialogs.
+ *   3. Discord's dynamic 3-field schema (`botToken` / `applicationId` /
+ *      `publicKey`) — the multi-field path Slack's degenerate single-field
+ *      case can't reach — builds a 3-key required schema and body.
+ *
+ * The mutation hook needs `<AtlasProvider>` (API URL) + `<QueryClientProvider>`
+ * (TanStack cache); `globalThis.fetch` is mocked so no backend is hit.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor,
+  type RenderResult,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider } from "@/ui/context";
+import { ByotInstallModal } from "../byot-form";
+
+const testConfig = {
+  apiUrl: "http://localhost:3001",
+  isCrossOrigin: false,
+  authClient: {
+    getToken: async () => null,
+    getOrgId: () => null,
+    onAuthChange: () => () => undefined,
+  },
+};
+
+function render(ui: ReactElement): RenderResult {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <AtlasProvider config={testConfig}>{ui}</AtlasProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function fillField(id: string, value: string): void {
+  const el = document.getElementById(id) as HTMLInputElement | null;
+  if (!el) throw new Error(`field #${id} not rendered`);
+  fireEvent.change(el, { target: { value } });
+}
+
+function connectButton(): HTMLButtonElement {
+  const btn = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button'),
+  ).find((b) => b.textContent?.trim() === "Connect");
+  if (!btn) throw new Error("Connect button not rendered");
+  return btn;
+}
+
+describe("ByotInstallModal", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchCalls: Array<{ url: string; method: string; body: unknown }>;
+  let nextResponse: () => Response;
+
+  beforeEach(() => {
+    fetchCalls = [];
+    nextResponse = () =>
+      new Response(JSON.stringify({ message: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      fetchCalls.push({ url, method, body });
+      return Promise.resolve(nextResponse());
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  test("Slack: submit POSTs { botToken } and fires success callbacks", async () => {
+    const onSuccess = mock(() => undefined);
+    const onOpenChange = mock(() => undefined);
+    render(
+      <ByotInstallModal
+        slug="slack"
+        name="Slack"
+        open
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    await act(async () => {
+      fillField("slack-botToken", "xoxb-test-token");
+    });
+    await act(async () => {
+      fireEvent.click(connectButton());
+    });
+
+    await waitFor(() => {
+      const call = fetchCalls.find(
+        (c) => c.method === "POST" && c.url.endsWith("/api/v1/admin/integrations/slack/byot"),
+      );
+      expect(call).toBeDefined();
+      expect(call?.body).toEqual({ botToken: "xoxb-test-token" });
+    });
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  test("surfaces a failed submit through FormDialog's shared error banner", async () => {
+    nextResponse = () =>
+      new Response(JSON.stringify({ message: "Invalid bot token" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    const onSuccess = mock(() => undefined);
+    render(
+      <ByotInstallModal
+        slug="slack"
+        name="Slack"
+        open
+        onOpenChange={() => undefined}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    await act(async () => {
+      fillField("slack-botToken", "bad");
+    });
+    await act(async () => {
+      fireEvent.click(connectButton());
+    });
+
+    expect(await screen.findByText("Invalid bot token")).toBeDefined();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  test("Discord: 3-field submit POSTs all three keys", async () => {
+    render(
+      <ByotInstallModal
+        slug="discord"
+        name="Discord"
+        open
+        onOpenChange={() => undefined}
+        onSuccess={() => undefined}
+      />,
+    );
+
+    await act(async () => {
+      fillField("discord-botToken", "disc-token");
+      fillField("discord-applicationId", "app-123");
+      fillField("discord-publicKey", "pub-key");
+    });
+    await act(async () => {
+      fireEvent.click(connectButton());
+    });
+
+    await waitFor(() => {
+      const call = fetchCalls.find(
+        (c) => c.method === "POST" && c.url.endsWith("/api/v1/admin/integrations/discord/byot"),
+      );
+      expect(call).toBeDefined();
+      expect(call?.body).toEqual({
+        botToken: "disc-token",
+        applicationId: "app-123",
+        publicKey: "pub-key",
+      });
+    });
+  });
+});

--- a/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
+++ b/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
@@ -875,7 +875,8 @@ describe("CatalogCard — BYOT form submit (#2746)", () => {
       />,
     );
 
-    // CompactRow shows "Add token" — click it to expand the BYOT form.
+    // CompactRow shows "Add token" — click it to open the BYOT modal (#4203:
+    // ByotInstallModal rides FormDialog, so the form renders in a portal).
     const addToken = container.querySelector<HTMLButtonElement>(
       '[data-testid="catalog-card-slack-byot-toggle"]',
     );
@@ -884,9 +885,10 @@ describe("CatalogCard — BYOT form submit (#2746)", () => {
       fireEvent.click(addToken!);
     });
 
-    // Fill the token field + submit.
+    // Fill the token field + submit — the modal + its input live in a portal
+    // under document.body, so query the document rather than `container`.
     const tokenInput = await waitFor(() => {
-      const el = container.querySelector<HTMLInputElement>("input#slack-botToken");
+      const el = document.querySelector<HTMLInputElement>("input#slack-botToken");
       if (!el) throw new Error("token input not rendered");
       return el;
     });
@@ -895,7 +897,7 @@ describe("CatalogCard — BYOT form submit (#2746)", () => {
     });
 
     const submit = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("button"),
+      document.querySelectorAll<HTMLButtonElement>('[role="dialog"] button'),
     ).find((b) => b.textContent?.trim() === "Connect");
     expect(submit).toBeDefined();
     await act(async () => {

--- a/packages/web/src/app/admin/integrations/byot-form.tsx
+++ b/packages/web/src/app/admin/integrations/byot-form.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 /**
- * BYOT (bring-your-own-token) inline form. Slice 8 of 1.5.3 (#2746) lifted
+ * BYOT (bring-your-own-token) install modal. Slice 8 of 1.5.3 (#2746) lifted
  * the per-platform forms (`<SlackByotForm>`, `<TeamsByotForm>`,
  * `<DiscordByotForm>`) out of `page.tsx` and consolidated them here so the
  * unified catalog card flow exposes one mounting point for self-host
  * operators that haven't wired the platform's OAuth env vars.
+ *
+ * #4203 converged it onto the shared {@link FormDialog} primitive — the same
+ * credential → validate → save spine its catalog-card siblings
+ * (`FormInstallModal`, `StaticBotInstallModal`) already ride — so it's a modal
+ * opened from the card's "Add token" affordance rather than an inline form,
+ * and a fix to FormDialog's error surface reaches every install dialog at once.
  *
  * BYOT lives on the legacy `/api/v1/admin/integrations/:slug/byot`
  * endpoints because the catalog endpoint family (`/install`,
@@ -14,9 +20,17 @@
  * deliverable.
  */
 
-import { useState } from "react";
-import { Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { useMemo } from "react";
+import { z } from "zod";
+import {
+  FormDialog,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/form-dialog";
 import { Input } from "@/components/ui/input";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
@@ -130,17 +144,38 @@ const BYOT_FIELDS: Record<ByotEligibleSlug, readonly ByotField[]> = {
 // Component
 // ---------------------------------------------------------------------------
 
-export interface ByotFormProps {
+export interface ByotInstallModalProps {
   readonly slug: ByotEligibleSlug;
+  /** Platform display name from the catalog row — used in the modal title. */
+  readonly name: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
   readonly onSuccess: () => void;
-  /** Pushed up so the parent Shell can render the inline destructive strip. */
-  readonly onError: (message: string) => void;
 }
 
-export function ByotForm({ slug, onSuccess, onError }: ByotFormProps) {
+export function ByotInstallModal({ slug, name, open, onOpenChange, onSuccess }: ByotInstallModalProps) {
   const fields = BYOT_FIELDS[slug];
-  const [values, setValues] = useState<Record<string, string>>(() =>
-    Object.fromEntries(fields.map((f) => [f.key, ""])),
+
+  // Every BYOT field is required (the legacy endpoint rejects a partial body).
+  // The schema is built dynamically from `BYOT_FIELDS[slug]`, so a static
+  // `z.infer` isn't possible; the tuple annotation on `.map` keeps the entry
+  // type concrete (no `any` leak through `Object.fromEntries`) and the single
+  // `as` just pins the erased key set back to `Record<string, string>`.
+  const schema = useMemo(
+    () =>
+      z.object(
+        Object.fromEntries(
+          fields.map((f): [string, z.ZodString] => [
+            f.key,
+            z.string().min(1, `${f.label} is required`),
+          ]),
+        ),
+      ) as z.ZodType<Record<string, string>, Record<string, string>>,
+    [fields],
+  );
+  const defaultValues = useMemo(
+    () => Object.fromEntries(fields.map((f) => [f.key, ""])) as Record<string, string>,
+    [fields],
   );
 
   const mutation = useAdminMutation<{ message: string }>({
@@ -148,47 +183,55 @@ export function ByotForm({ slug, onSuccess, onError }: ByotFormProps) {
     method: "POST",
   });
 
-  const allFilled = fields.every((f) => (values[f.key] ?? "").trim().length > 0);
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!allFilled) return;
+  async function handleSubmit(values: Record<string, string>): Promise<void> {
     const body: Record<string, string> = {};
     for (const f of fields) body[f.key] = (values[f.key] ?? "").trim();
     const result = await mutation.mutate({ body });
-    if (result.ok) {
-      onSuccess();
-    } else {
-      onError(friendlyErrorOrNull(result.error) ?? `Couldn't connect ${slug}`);
+    if (!result.ok) {
+      // Throw so FormDialog surfaces it as the shared root-level error banner.
+      throw new Error(friendlyErrorOrNull(result.error) ?? `Couldn't connect ${name}`);
     }
+    onSuccess();
+    onOpenChange(false);
   }
 
   return (
-    <form
+    <FormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Connect ${name}`}
+      description={`Paste the bot credentials for ${name}. They're encrypted at rest and used only to route this workspace's messages.`}
+      schema={schema}
+      defaultValues={defaultValues}
       onSubmit={handleSubmit}
-      className="space-y-3"
-      data-testid={`catalog-card-${slug}-byot-form`}
+      submitLabel="Connect"
+      saving={mutation.saving}
+      className="max-w-md"
     >
-      {fields.map((f) => (
-        <div key={f.key} className="space-y-1.5">
-          <label htmlFor={`${slug}-${f.key}`} className="text-sm font-medium">
-            {f.label}
-          </label>
-          {f.helper && <p className="text-xs text-muted-foreground">{f.helper}</p>}
-          <Input
-            id={`${slug}-${f.key}`}
-            type={f.type === "password" ? "password" : "text"}
-            placeholder={f.placeholder}
-            value={values[f.key] ?? ""}
-            onChange={(e) => setValues((v) => ({ ...v, [f.key]: e.target.value }))}
-            disabled={mutation.saving}
+      {(form) =>
+        fields.map((f) => (
+          <FormField
+            key={f.key}
+            control={form.control}
+            name={f.key}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor={`${slug}-${f.key}`}>{f.label}</FormLabel>
+                {f.helper ? <FormDescription>{f.helper}</FormDescription> : null}
+                <FormControl>
+                  <Input
+                    id={`${slug}-${f.key}`}
+                    type={f.type === "password" ? "password" : "text"}
+                    placeholder={f.placeholder}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
           />
-        </div>
-      ))}
-      <Button type="submit" size="sm" disabled={mutation.saving || !allFilled}>
-        {mutation.saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
-        Connect
-      </Button>
-    </form>
+        ))
+      }
+    </FormDialog>
   );
 }

--- a/packages/web/src/app/admin/integrations/catalog-card.tsx
+++ b/packages/web/src/app/admin/integrations/catalog-card.tsx
@@ -19,7 +19,7 @@
  *   5. accessible + not installed
  *        - oauth + configurable → Connect (GET /:slug/install)
  *        - form                 → Install → FormInstallModal
- *        - BYOT-eligible        → "Add token" → inline {@link ByotForm}
+ *        - BYOT-eligible        → "Add token" → {@link ByotInstallModal}
  *        - static-bot / no path → inert "Connect" (handler ships in its own slice)
  *
  * Visual idiom: CompactRow when collapsed, Shell when expanded / installed.
@@ -94,7 +94,7 @@ import { formatDateTime } from "@/lib/format";
 import { getApiUrl } from "@/lib/api-url";
 import { FormInstallModal } from "./form-install-modal";
 import { StaticBotInstallModal } from "./static-bot-install-modal";
-import { ByotForm, isByotEligibleSlug, type ByotEligibleSlug } from "./byot-form";
+import { ByotInstallModal, isByotEligibleSlug, type ByotEligibleSlug } from "./byot-form";
 
 // ---------------------------------------------------------------------------
 // Icons + display
@@ -486,6 +486,10 @@ export function CatalogCard({ entry, status, onChange }: CatalogCardProps) {
   // Static-bot routing-identifier modal open state (#3140). Only the
   // form-shaped static-bot slugs (not Discord) capture their routing id here.
   const [staticBotModalOpen, setStaticBotModalOpen] = useState(false);
+  // BYOT modal open state (#4203). The "Add token" affordance opens
+  // {@link ByotInstallModal} — the same FormDialog-riding modal shape as the
+  // form / static-bot siblings — rather than expanding an inline card form.
+  const [byotModalOpen, setByotModalOpen] = useState(false);
   const isStaticBotForm =
     entry.installModel === "static-bot" && STATIC_BOT_FORM_SLUGS.has(entry.slug);
   // Driven by whichever disconnect mutation last fired so the inline
@@ -512,10 +516,15 @@ export function CatalogCard({ entry, status, onChange }: CatalogCardProps) {
 
   // ── useDisclosure for the expand / collapse panel ────────────────
   //
-  // `collapseOn` flips to true when the entry transitions to connected —
-  // the BYOT form auto-collapses after a successful submit, matching the
-  // legacy SlackCard / TeamsCard UX.
-  const { expanded, setExpanded, collapse, triggerRef, panelRef, panelId } = useDisclosure({
+  // Since #4203 the BYOT path opens a modal instead of expanding the card, so
+  // the disclosure hook's `setExpanded` / `triggerRef` are no longer wired to
+  // any trigger — a not-connected card stays a CompactRow until it connects
+  // (nothing sets `expanded` true anymore). Collapse-on-connect now rides
+  // `collapseOn: isConnected` + `onCollapseCleanup`, and the connected-card
+  // Shell's a11y wiring rides `panelRef` / `panelId`. (`collapse` survives only
+  // in the `onCollapse={!isConnected ? …}` ternary below, whose `!isConnected`
+  // branch the Shell can no longer reach — inert, a removal candidate.)
+  const { expanded, collapse, panelRef, panelId } = useDisclosure({
     collapseOn: isConnected,
     onCollapseCleanup: () => setInlineError(null),
   });
@@ -656,8 +665,7 @@ export function CatalogCard({ entry, status, onChange }: CatalogCardProps) {
           action={collapsedAction(entry, {
             canByot,
             isStaticBotForm,
-            triggerRef,
-            onByotToggle: () => setExpanded(true),
+            onByotOpen: () => setByotModalOpen(true),
             onFormOpen: () => setFormModalOpen(true),
             onStaticBotOpen: () => setStaticBotModalOpen(true),
           })}
@@ -686,6 +694,18 @@ export function CatalogCard({ entry, status, onChange }: CatalogCardProps) {
             configSchema={entry.configSchema}
             onInstalled={() => {
               toast.success(`${entry.name} installed`);
+              onChange();
+            }}
+          />
+        )}
+        {byotSlug && canByot && (
+          <ByotInstallModal
+            slug={byotSlug}
+            name={entry.name}
+            open={byotModalOpen}
+            onOpenChange={setByotModalOpen}
+            onSuccess={() => {
+              setInlineError(null);
               onChange();
             }}
           />
@@ -748,18 +768,6 @@ export function CatalogCard({ entry, status, onChange }: CatalogCardProps) {
           </p>
         )}
 
-        {/* BYOT inline form (slack/teams/discord with internal DB but no OAuth env). */}
-        {!isConnected && byotSlug && canByot && (
-          <ByotForm
-            slug={byotSlug}
-            onSuccess={() => {
-              setInlineError(null);
-              onChange();
-            }}
-            onError={setInlineError}
-          />
-        )}
-
         {/* Slack-only env-only hint, matching the pre-#2746 SlackCard copy. */}
         {entry.slug === "slack" &&
           isConnected &&
@@ -819,6 +827,18 @@ export function CatalogCard({ entry, status, onChange }: CatalogCardProps) {
           }}
         />
       )}
+      {byotSlug && canByot && (
+        <ByotInstallModal
+          slug={byotSlug}
+          name={entry.name}
+          open={byotModalOpen}
+          onOpenChange={setByotModalOpen}
+          onSuccess={() => {
+            setInlineError(null);
+            onChange();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -851,8 +871,8 @@ interface CollapsedActionOptions {
    * an OAuth dance. Excludes Discord (OAuth-shaped static-bot).
    */
   readonly isStaticBotForm: boolean;
-  readonly triggerRef: React.RefObject<HTMLButtonElement | null>;
-  readonly onByotToggle: () => void;
+  /** Opens {@link ByotInstallModal} (#4203) — replaces the old inline expand. */
+  readonly onByotOpen: () => void;
   readonly onFormOpen: () => void;
   readonly onStaticBotOpen: () => void;
 }
@@ -869,18 +889,16 @@ interface CollapsedActionOptions {
  */
 function collapsedAction(
   entry: IntegrationsCatalogEntry,
-  { canByot, isStaticBotForm, triggerRef, onByotToggle, onFormOpen, onStaticBotOpen }: CollapsedActionOptions,
+  { canByot, isStaticBotForm, onByotOpen, onFormOpen, onStaticBotOpen }: CollapsedActionOptions,
 ): React.ReactNode {
   // BYOT wins over OAuth Connect for chat slugs where the env vars are
   // missing — see canByot derivation in CatalogCard.
   if (canByot) {
     return (
       <Button
-        ref={triggerRef}
         size="sm"
         variant="outline"
-        aria-expanded={false}
-        onClick={onByotToggle}
+        onClick={onByotOpen}
         data-testid={`catalog-card-${entry.slug}-byot-toggle`}
       >
         <Plus className="mr-1.5 size-3.5" />

--- a/packages/web/src/components/form-dialog.tsx
+++ b/packages/web/src/components/form-dialog.tsx
@@ -42,6 +42,19 @@ interface FormDialogProps<TValues extends FieldValues> {
   extraFooter?: (form: UseFormReturn<TValues>) => ReactNode;
   /** Dialog content class name override. */
   className?: string;
+  /**
+   * Extra reset trigger — a STABLE identity key. The form resets to
+   * `defaultValues` on every open (see the effect below); pass a value here to
+   * ALSO reset while the dialog stays open and this value changes — e.g. a
+   * long-lived install dialog reused across vendors (curated REST) keys
+   * `resetKey` on the candidate slug so a pasted secret can't bleed from one
+   * vendor into the next. Restricted to a primitive so a caller can't pass an
+   * object/array literal whose reference churns every render and silently
+   * resets the form mid-typing.
+   */
+  resetKey?: string | number | boolean | null;
+  /** `data-testid` for the submit button (per-dialog e2e/unit hooks). */
+  submitTestId?: string;
 }
 
 /**
@@ -66,6 +79,8 @@ export function FormDialog<TValues extends FieldValues>({
   serverError,
   extraFooter,
   className,
+  resetKey,
+  submitTestId,
 }: FormDialogProps<TValues>) {
   const form = useForm<TValues>({
     resolver: zodResolver(schema),
@@ -76,7 +91,11 @@ export function FormDialog<TValues extends FieldValues>({
     if (open) {
       form.reset(defaultValues);
     }
-  }, [open]); // intentionally depends only on `open` — reset to latest defaultValues on each open
+    // Depends on `open` (reset to latest defaultValues on each open) and
+    // `resetKey` (reset while open when the caller's identity changes, e.g. the
+    // curated dialog swapping vendors). Intentionally NOT `defaultValues`,
+    // whose identity churns each render.
+  }, [open, resetKey]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -111,7 +130,11 @@ export function FormDialog<TValues extends FieldValues>({
 
             <DialogFooter>
               {extraFooter?.(form)}
-              <Button type="submit" disabled={saving || form.formState.isSubmitting}>
+              <Button
+                type="submit"
+                disabled={saving || form.formState.isSubmitting}
+                data-testid={submitTestId}
+              >
                 {(saving || form.formState.isSubmitting) && <Loader2 className="mr-2 size-4 animate-spin" />}
                 {submitLabel}
               </Button>


### PR DESCRIPTION
Closes #4203.

## What

The backend consolidated install onto one persistence spine (arch-win #91), but the web install surface never converged. This routes the three hand-rolled "enter credentials → validate → save" dialogs through the shared `FormDialog` primitive their siblings (`FormInstallModal`, `StaticBotInstallModal`, `ConnectionFormDialog`) already ride, and replaces the connections page's fan-out of dialog-open flags with one discriminated union.

## Changes

- **`RestInstallDialog`** (`openapi-block.tsx`) → rides `FormDialog`; **9 raw `useState` removed**. Auth-specific fields disclose off `auth_kind` via `useWatch` (mirroring the config-schema `showWhen` pattern). Wire-body assembly extracted to a pure, unit-tested `buildRestInstallBody`.
- **`CuratedInstallDialog`** (`curated-install-dialog.tsx`) → rides `FormDialog`; **4 `useState` removed**. The cross-vendor secret-wipe (a `sk_live_…` must never bleed into the next vendor's install) is preserved via a new `FormDialog` `resetKey` prop keyed on the candidate slug — regression-guarded by the existing secret-isolation test.
- **`ByotForm` → `ByotInstallModal`** (`byot-form.tsx`) → converted from an inline card form to a `FormDialog` modal, converging it with its two sibling modals on the same catalog card. `catalog-card.tsx` opens it from the "Add token" affordance (the `Record<string,string>` state blob is gone).
- **`page.tsx`** — the four install-flow flags (`pickerOpen`/`customRestOpen`/`curatedCandidate`/`formInstallCandidate`) collapse into one `InstallState` discriminated union (`idle | picking | custom-rest | curated | form-install`). Two-dialogs-open-at-once is now unrepresentable.
- **`FormDialog`** (`form-dialog.tsx`) — two additive, backward-compatible props: `resetKey` (primitive-typed) and `submitTestId`. Existing riders untouched.
- New shared `installFormErrorMessage` helper dedupes the `install-form` error parse across the REST + curated dialogs.

## Acceptance criteria

- [x] RestInstallDialog / CuratedInstallDialog / ByotForm ride `FormDialog`; ~200 LOC of loose credential `useState` removed
- [x] Connections page install flow driven by one `installState` union
- [x] A validation/error-surface fix in one install dialog reaches all of them — all three now throw into `FormDialog`'s shared root-error banner (proven by per-dialog error-surface tests)

## Tests

New: `rest-install-dialog.test.tsx` (dialog + `buildRestInstallBody` across all auth kinds), `byot-install-modal.test.tsx` (Slack success/error, Discord 3-field), `install-form-error.test.ts`. Updated: curated secret-isolation (now via `resetKey`) + error surface; `catalog-section` BYOT test for the modal. Web `type` + `lint` clean; all affected web suites green in isolation.

## Notes

- File-disjoint with #4190 (PR #4242, server-data-table module) per the milestone overlap analysis — no `useServerDataTable`/`columns.tsx` touched. Re-merged latest `main`.
- Internal review panel: converged CLEAN over 2 rounds (silent-failure / type-design / test-coverage / comment-accuracy).
- Local `ci-local.sh`: 26/27 gates pass. The lone failure is `@atlas/mcp`'s `smoke.test.ts` (billing-enforcement gate blocking `org_smoke` locally) — an environmental artifact orthogonal to this 100%-web diff; `main`'s own GitHub CI is green on the identical MCP code.

https://claude.ai/code/session_015E1b5xQeizyEQZktA9hm6N