### PR TITLE
refactor(api): periodic-DB-job runner for the scheduler's three refresh jobs (#4195)

### DIFF
--- a/packages/api/src/api/__tests__/admin-scheduler.test.ts
+++ b/packages/api/src/api/__tests__/admin-scheduler.test.ts
@@ -52,13 +52,14 @@ mock.module("@atlas/api/lib/scheduler/byot-catalog-refresh", () => ({
   BYOT_CATALOG_REFRESH_ACTOR: "system:byot-catalog-refresh",
   // The route only imports the three above, but the "mock all named exports"
   // rule requires the rest to be stubbed so a partial-mock SyntaxError
-  // doesn't leak into sibling tests.
-  startByotCatalogRefreshScheduler: () => {},
-  stopByotCatalogRefreshScheduler: () => {},
+  // doesn't leak into sibling tests. Post-#4195 the module no longer owns a
+  // `setInterval` lifecycle (start/stop/_reset gone); it now exposes the
+  // fiber's interval getter instead.
+  getByotCatalogRefreshIntervalMs: () => 86_400_000,
   runByotCatalogRefreshCycle: () => {
     throw new Error("unreachable in admin-scheduler tests");
   },
-  _resetByotCatalogRefreshScheduler: () => {},
+  _getDormancyThresholdMsForTests: () => 0,
   _resetBackoffForTests: () => {},
   _resetEeProbeForTests: () => {},
   _computeBackoffMsForTests: () => 0,

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -440,8 +440,11 @@ describe("makeSchedulerLive", () => {
     },
     {
       // Background-work fibers spanned by #2987. `settings_refresh` is forked
-      // in `SettingsLive`; the other eight in `makeSchedulerLive`. The source
-      // scan reads the whole file, so the defining function doesn't matter.
+      // in `SettingsLive`; the rest in `makeSchedulerLive`. The source scan
+      // reads the whole file, so the defining function doesn't matter. The
+      // final three (#4195) are the BYOT/OpenAPI refresh jobs that folded off
+      // their bespoke `setInterval` lifecycle onto `registerPeriodicFiber`
+      // (two are DB cycles; `openapi_spec_refresh` is the non-DB Tier-1 sibling).
       constName: "SCHEDULER_WORK_SPAN_NAMES",
       record: SCHEDULER_WORK_SPAN_NAMES as Record<string, string>,
       expectedKeys: [
@@ -454,6 +457,9 @@ describe("makeSchedulerLive", () => {
         "stripe_teardown_sweep",
         "unclaimed_grace_reap",
         "overage_report",
+        "byot_catalog_refresh",
+        "openapi_spec_refresh",
+        "openapi_install_rediscover",
       ],
     },
   ] as const;

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -3219,8 +3219,10 @@ export function makeSchedulerLive(
           // fibers forked `forkScoped` on this Layer's scope, so scope shutdown
           // interrupts them automatically (no `setInterval` handle to clear).
 
-          // Stop the knowledge bundle sync scheduler (#4211) symmetrically —
-          // same setInterval + `unref()` lifecycle as the siblings above.
+          // Stop the knowledge bundle sync scheduler (#4211) — still a
+          // `setInterval` + `unref()` scheduler (not yet folded onto
+          // `registerPeriodicFiber` like the #4195 trio above), so its timer
+          // must be cleared explicitly here.
           yield* Effect.tryPromise({
             try: async () => {
               const { stopKnowledgeBundleSyncScheduler } = await import(

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -168,10 +168,12 @@ function withFiberDeathLog<A, E, R>(
 // the span, so a failed-but-recovered tick still records span status OK (the
 // error itself goes to `log.warn`). These spans answer "is the fiber still
 // ticking?" via presence/absence + cadence, NOT "did this tick error?". The
-// exceptions are the two `spanResultAttributes` fibers — `orphan_task_reconcile`
-// (#2944) and `unclaimed_grace_reap` (#3796) — which deliberately invert the
-// ordering (raw tick spanned, recovery applied OUTSIDE) to keep their result
-// attributes truthful; see `registerPeriodicFiber` below.
+// exceptions are the `spanResultAttributes` fibers — `orphan_task_reconcile`
+// (#2944), `unclaimed_grace_reap` (#3796), and the three #4195 DB/refresh jobs
+// (`byot_catalog_refresh`, `openapi_spec_refresh`, `openapi_install_rediscover`)
+// — which deliberately invert the ordering (raw tick spanned, recovery applied
+// OUTSIDE) to keep their result attributes truthful; see `registerPeriodicFiber`
+// below.
 //
 // Membership splits into two single-source records, by fiber kind:
 //
@@ -179,11 +181,11 @@ function withFiberDeathLog<A, E, R>(
 //     expired in-memory or DB state). Eight were retrofitted with a span by
 //     #2945 (the TTL/ratelimit/state sweeps below); the ninth,
 //     `orphan_task_reconcile` (#2944), shipped with its span from day one and
-//     additionally attaches the orphan count as a result attribute (one of
-//     the two `spanResultAttributes` fibers in these records — the other is
-//     `unclaimed_grace_reap` in the work record; the BYOT catalog-refresh
-//     fiber and the scheduler engine use that 4th arg elsewhere, inside
-//     their own modules). The tenth,
+//     additionally attaches the orphan count as a result attribute (the sole
+//     `spanResultAttributes` fiber in THIS record — the work record adds
+//     `unclaimed_grace_reap` plus the three #4195 DB/refresh jobs; the
+//     scheduler engine uses that 4th arg elsewhere, inside its own module).
+//     The tenth,
 //     `trial_rate_limit_cleanup` (#3654), sweeps the unauthenticated
 //     `start_trial` per-IP/email attempt-limiter maps. The eleventh,
 //     `agent_runs_retention_sweep` (#3745, ADR-0020), deletes terminal
@@ -195,11 +197,13 @@ function withFiberDeathLog<A, E, R>(
 //     recurring side-effecting work rather than evicting state):
 //     `sub_processor_publisher`, `settings_refresh`, `onboarding_email`,
 //     `expert_scheduler`, `promote_decay`, `billing_reconcile`,
-//     `stripe_teardown_sweep`, `unclaimed_grace_reap`, `overage_report`.
-//     Spanned by #2987 (+#3423 for billing_reconcile, #3992 for
-//     overage_report) — identical rationale and wrap shape, no result
-//     attributes except `unclaimed_grace_reap` (#3796), which attaches the
-//     reaped count.
+//     `stripe_teardown_sweep`, `unclaimed_grace_reap`, `overage_report`, and
+//     the three #4195 DB/refresh jobs `byot_catalog_refresh`,
+//     `openapi_spec_refresh`, `openapi_install_rediscover`. Spanned by #2987
+//     (+#3423 for billing_reconcile, #3992 for overage_report, #4195 for the
+//     DB/refresh trio) — identical rationale and wrap shape. `unclaimed_grace_reap`
+//     (#3796) and the three #4195 jobs attach result attributes (cycle counts);
+//     the rest carry none.
 //
 // Two records, not one: "cleanup sweep" vs "background work" is a real
 // distinction (it drives the log wording and the operator's mental model),
@@ -212,10 +216,11 @@ function withFiberDeathLog<A, E, R>(
 // periodic heartbeat log when the queue is idle PLUS a separate watchdog
 // fiber that raises an error log when no tick is observed in > 2× the
 // interval. A per-tick span would be redundant with that, so #2987 leaves
-// them on heartbeat + watchdog. Self-spanning module fibers
-// (`byot_catalog_refresh`, `openapi_install_rediscover`, `openapi_spec_refresh`,
-// the scheduler engine `tick`/`task.run`) define their span inside their own
-// module and so never appear in either record here.
+// them on heartbeat + watchdog. The scheduler engine's own `tick`/`task.run`
+// spans are self-defined inside `scheduler/engine.ts` and so never appear in
+// either record here. (The BYOT/OpenAPI refresh trio USED to be self-spanning
+// too, but #4195 folded them onto `registerPeriodicFiber` and moved their
+// spans into `SCHEDULER_WORK_SPAN_NAMES` above.)
 //
 // Span names follow the existing `atlas.<area>.<op>` dotted convention
 // (cf. `atlas.sql.execute`, `atlas.scheduler.task.run`, and the
@@ -259,6 +264,13 @@ export const SCHEDULER_WORK_SPAN_NAMES = {
   stripe_teardown_sweep: "atlas.scheduler.stripe_teardown_sweep",
   unclaimed_grace_reap: "atlas.scheduler.unclaimed_grace_reap",
   overage_report: "atlas.scheduler.overage_report",
+  // #4195 — the three DB/refresh jobs folded off their bespoke `setInterval`
+  // lifecycle onto `registerPeriodicFiber`. Each now carries its per-tick span
+  // here (previously self-spanned inside its own module) with the cycle result
+  // attached via `spanResultAttributes`.
+  byot_catalog_refresh: "atlas.scheduler.byot_catalog_refresh",
+  openapi_spec_refresh: "atlas.scheduler.openapi_spec_refresh",
+  openapi_install_rediscover: "atlas.scheduler.openapi_install_rediscover",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ── registerPeriodicFiber — the periodic-fiber choreography, once (#4130) ──
@@ -2106,72 +2118,131 @@ export function makeSchedulerLive(
         ),
       );
 
-      // Start BYOT catalog refresh scheduler (#2284) — daily refresh of
-      // workspace_model_catalog rows whose `fetched_at` is older than TTL.
-      // No-ops when the internal DB is unavailable; safe to start
-      // unconditionally otherwise (self-hosted installs without EE simply
-      // have no workspace configs to walk).
-      yield* Effect.tryPromise({
-        try: async () => {
-          const { startByotCatalogRefreshScheduler } = await import(
-            "@atlas/api/lib/scheduler/byot-catalog-refresh"
-          );
-          startByotCatalogRefreshScheduler();
+      // ── Periodic fiber: BYOT catalog refresh (#2284; folded onto the fiber
+      // seam by #4195) ─────────────────────────────────────────────────────
+      // Daily refresh of workspace_model_catalog rows whose `fetched_at` is
+      // older than the TTL. Gated on an internal DB (nothing to walk without
+      // one); self-hosted installs without EE simply have no configs to walk.
+      // The scan → forEach → tally → audit cycle body is the shared
+      // `runPeriodicDbCycle` skeleton; this registration owns only the fiber.
+      yield* registerPeriodicFiber({
+        name: "byot_catalog_refresh",
+        intervalMs: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports -- read the interval constant synchronously at build time (same pattern as stripe_teardown_sweep)
+          const { getByotCatalogRefreshIntervalMs } = require("@atlas/api/lib/scheduler/byot-catalog-refresh") as {
+            getByotCatalogRefreshIntervalMs: () => number;
+          };
+          return getByotCatalogRefreshIntervalMs();
         },
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
-        Effect.catchAll((err) => {
-          log.error({ err: errorMessage(err) }, "BYOT catalog refresh scheduler failed to start");
-          return Effect.void;
+        gate: {
+          check: () => {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+            const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+              hasInternalDB: () => boolean;
+            };
+            return hasInternalDB();
+          },
+          skipLog: "No internal database — BYOT catalog refresh scheduler not started",
+        },
+        tick: Effect.tryPromise({
+          try: () => import("@atlas/api/lib/scheduler/byot-catalog-refresh"),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(Effect.flatMap((m) => m.runByotCatalogRefreshCycle())),
+        spanResultAttributes: (result) => ({
+          "atlas.byot.status": result.status,
+          "atlas.byot.inspected": result.inspected,
+          "atlas.byot.refreshed": result.refreshed,
+          "atlas.byot.failed": result.failed,
         }),
-      );
+        onTickFailure: {
+          level: "warn",
+          message: "BYOT catalog refresh tick failed — will retry next interval",
+        },
+        startLog: "BYOT catalog refresh scheduler started",
+      });
 
-      // Start shared OpenAPI spec refresh scheduler (#2970, Tier-1) — periodic
-      // conditional-GET of the cross-workspace public-spec cache (Stripe/GitHub/
-      // Notion). A `304` re-arms freshness for every workspace for free; a `200`
-      // re-normalizes the changed doc once. Process-local cache (no DB), so it's
-      // safe to start unconditionally; an empty cache makes the cycle a no-op.
-      yield* Effect.tryPromise({
-        try: async () => {
-          const { startOpenApiSpecRefreshScheduler } = await import(
-            "@atlas/api/lib/scheduler/openapi-spec-refresh"
-          );
-          startOpenApiSpecRefreshScheduler();
+      // ── Periodic fiber: shared OpenAPI spec refresh (#2970, Tier-1; #4195) ──
+      // Periodic conditional-GET of the cross-workspace public-spec cache
+      // (Stripe/GitHub/Notion). A `304` re-arms freshness for every workspace
+      // for free; a `200` re-normalizes the changed doc once. Process-local
+      // cache (no DB), so it starts unconditionally (no gate); an empty cache
+      // makes the cycle a no-op. Not a `runPeriodicDbCycle` caller — it has no
+      // internal-DB working set (the variance the #4195 skeleton isolates).
+      yield* registerPeriodicFiber({
+        name: "openapi_spec_refresh",
+        intervalMs: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports -- read the settings-backed interval synchronously at build time
+          const { getSharedSpecRefreshIntervalMs } = require("@atlas/api/lib/scheduler/openapi-spec-refresh") as {
+            getSharedSpecRefreshIntervalMs: () => number;
+          };
+          return getSharedSpecRefreshIntervalMs();
         },
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
-        Effect.catchAll((err) => {
-          log.error(
-            { err: errorMessage(err) },
-            "Shared OpenAPI spec refresh scheduler failed to start",
-          );
-          return Effect.void;
+        tick: Effect.tryPromise({
+          try: async () => {
+            const { runOpenApiSpecRefreshCycle } = await import(
+              "@atlas/api/lib/scheduler/openapi-spec-refresh"
+            );
+            return runOpenApiSpecRefreshCycle();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
         }),
-      );
+        spanResultAttributes: (result) => ({
+          "atlas.openapi_spec_refresh.inspected": result.inspected,
+          "atlas.openapi_spec_refresh.updated": result.updated,
+          "atlas.openapi_spec_refresh.not_modified": result.notModified,
+          "atlas.openapi_spec_refresh.failed": result.failed,
+        }),
+        onTickFailure: {
+          level: "warn",
+          message: "Shared OpenAPI spec refresh tick failed — will retry next interval",
+        },
+        startLog: "Shared OpenAPI spec refresh scheduler started",
+      });
 
-      // Start Tier-2 per-install OpenAPI re-discovery scheduler (#2978) — periodic
-      // re-probe of each installed openapi-generic datasource whose per-install
-      // `spec_refresh_interval` has elapsed, updating the persisted snapshot + drift
-      // diff + watermark. Orthogonal to the Tier-1 shared-cache refresh above (this
-      // one mutates per-install snapshots; that one only warms the process-local
-      // public-spec cache). No-ops when the internal DB is unavailable.
-      yield* Effect.tryPromise({
-        try: async () => {
-          const { startOpenApiInstallRediscoverScheduler } = await import(
-            "@atlas/api/lib/scheduler/openapi-install-rediscover"
-          );
-          startOpenApiInstallRediscoverScheduler();
+      // ── Periodic fiber: Tier-2 per-install OpenAPI re-discovery (#2978; #4195) ──
+      // Periodic re-probe of each installed openapi-generic datasource whose
+      // per-install `spec_refresh_interval` has elapsed, updating the persisted
+      // snapshot + drift diff + watermark. Orthogonal to the Tier-1 shared-cache
+      // refresh above (this one mutates per-install snapshots; that one only
+      // warms the process-local public-spec cache). Gated on an internal DB; its
+      // cycle body is the shared `runPeriodicDbCycle` skeleton.
+      yield* registerPeriodicFiber({
+        name: "openapi_install_rediscover",
+        intervalMs: () => {
+          // eslint-disable-next-line @typescript-eslint/no-require-imports -- read the interval synchronously at build time
+          const { getInstallRediscoverIntervalMs } = require("@atlas/api/lib/scheduler/openapi-install-rediscover") as {
+            getInstallRediscoverIntervalMs: () => number;
+          };
+          return getInstallRediscoverIntervalMs();
         },
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
-        Effect.catchAll((err) => {
-          log.error(
-            { err: errorMessage(err) },
-            "OpenAPI install rediscover scheduler failed to start",
-          );
-          return Effect.void;
+        gate: {
+          check: () => {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+            const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+              hasInternalDB: () => boolean;
+            };
+            return hasInternalDB();
+          },
+          skipLog: "No internal database — OpenAPI rediscover scheduler not started",
+        },
+        tick: Effect.tryPromise({
+          try: () => import("@atlas/api/lib/scheduler/openapi-install-rediscover"),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(Effect.flatMap((m) => m.runOpenApiInstallRediscoverCycle())),
+        spanResultAttributes: (result) => ({
+          "atlas.openapi_rediscover.status": result.status,
+          "atlas.openapi_rediscover.inspected": result.inspected,
+          "atlas.openapi_rediscover.due": result.due,
+          "atlas.openapi_rediscover.refreshed": result.refreshed,
+          "atlas.openapi_rediscover.breaking": result.breaking,
+          "atlas.openapi_rediscover.failed": result.failed,
         }),
-      );
+        onTickFailure: {
+          level: "warn",
+          message: "OpenAPI install rediscover tick failed — will retry next interval",
+        },
+        startLog: "OpenAPI install rediscover scheduler started",
+      });
 
       // Start knowledge bundle sync scheduler (#4211) — periodic pull of every
       // enabled `bundle-sync` knowledge collection's endpoint, re-running the
@@ -3142,66 +3213,11 @@ export function makeSchedulerLive(
             );
           }
 
-          // Stop the BYOT catalog refresh scheduler (#2284) alongside the
-          // main scheduler so a Layer-scope shutdown clears its setInterval
-          // timer (clearing the timer is what releases the `unref()`'d handle
-          // from the event loop and lets the test process exit cleanly).
-          yield* Effect.tryPromise({
-            try: async () => {
-              const { stopByotCatalogRefreshScheduler } = await import(
-                "@atlas/api/lib/scheduler/byot-catalog-refresh"
-              );
-              stopByotCatalogRefreshScheduler();
-            },
-            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-          }).pipe(
-            Effect.catchAll((err) => {
-              log.warn({ err: errorMessage(err) }, "Failed to stop BYOT catalog refresh scheduler");
-              return Effect.void;
-            }),
-          );
-
-          // Stop the shared OpenAPI spec refresh scheduler (#2970) symmetrically —
-          // clear its setInterval so the `unref()`'d handle is released and a
-          // test process (or a re-created ManagedRuntime) exits cleanly.
-          yield* Effect.tryPromise({
-            try: async () => {
-              const { stopOpenApiSpecRefreshScheduler } = await import(
-                "@atlas/api/lib/scheduler/openapi-spec-refresh"
-              );
-              stopOpenApiSpecRefreshScheduler();
-            },
-            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-          }).pipe(
-            Effect.catchAll((err) => {
-              log.warn(
-                { err: errorMessage(err) },
-                "Failed to stop shared OpenAPI spec refresh scheduler",
-              );
-              return Effect.void;
-            }),
-          );
-
-          // Stop the Tier-2 OpenAPI re-discovery scheduler (#2978) symmetrically —
-          // clear its setInterval so the `unref()`'d handle is released and a test
-          // process (or a re-created ManagedRuntime) exits cleanly.
-          yield* Effect.tryPromise({
-            try: async () => {
-              const { stopOpenApiInstallRediscoverScheduler } = await import(
-                "@atlas/api/lib/scheduler/openapi-install-rediscover"
-              );
-              stopOpenApiInstallRediscoverScheduler();
-            },
-            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-          }).pipe(
-            Effect.catchAll((err) => {
-              log.warn(
-                { err: errorMessage(err) },
-                "Failed to stop OpenAPI install rediscover scheduler",
-              );
-              return Effect.void;
-            }),
-          );
+          // #4195 — the BYOT catalog refresh (#2284), shared OpenAPI spec
+          // refresh (#2970), and Tier-2 install re-discovery (#2978) no longer
+          // need explicit stop calls here: they are now `registerPeriodicFiber`
+          // fibers forked `forkScoped` on this Layer's scope, so scope shutdown
+          // interrupts them automatically (no `setInterval` handle to clear).
 
           // Stop the knowledge bundle sync scheduler (#4211) symmetrically —
           // same setInterval + `unref()` lifecycle as the siblings above.

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-query.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-query.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for `buildStaleCatalogQuery` (#2284, dormancy gate #2377) — the stale
+ * BYOT-catalog selection SQL. Coverage added by #4195 (the periodic-DB-job
+ * runner pass): the real-Postgres smoke (`migrate-pg.test.ts`) asserts the
+ * dormancy predicate's ROW-SELECTION semantics against a live DB, but the pure
+ * query BUILDER — which arm is emitted, and that each arm carries the right
+ * parameters + ordering — had no fast unit test guarding it against drift.
+ *
+ * These are structural assertions on the emitted SQL string (the builder is a
+ * pure function of the boolean); the semantic behavior is covered by the smoke.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { buildStaleCatalogQuery } from "../byot-catalog-query";
+
+describe("buildStaleCatalogQuery", () => {
+  describe("dormancy disabled (legacy TTL-only)", () => {
+    const sql = buildStaleCatalogQuery(false);
+
+    it("selects the org/provider/region tuple the scheduler walks", () => {
+      expect(sql).toContain("SELECT wmc.org_id, wmc.provider, wmc.bedrock_region");
+    });
+
+    it("filters to the three BYOT providers", () => {
+      expect(sql).toContain("wmc.provider IN ('anthropic', 'openai', 'bedrock')");
+    });
+
+    it("gates on the TTL ($1) and bounds by the limit ($2)", () => {
+      expect(sql).toContain("wmcat.fetched_at < now() - ($1::bigint * interval '1 ms')");
+      expect(sql).toContain("LIMIT $2");
+    });
+
+    it("selects never-fetched catalogs — the `fetched_at IS NULL OR` WHERE arm, not just the ordering", () => {
+      // Dropping this predicate would silently stop refreshing never-fetched
+      // rows while ORDER BY … NULLS FIRST stayed green.
+      expect(sql).toContain("wmcat.fetched_at IS NULL OR");
+    });
+
+    it("orders least-recently-fetched first — NULLS FIRST drains never-fetched rows", () => {
+      expect(sql).toContain("ORDER BY wmcat.fetched_at NULLS FIRST");
+    });
+
+    it("does NOT join organization and does NOT reference the dormancy param $3", () => {
+      expect(sql).not.toContain("organization");
+      expect(sql).not.toContain("last_active_at");
+      expect(sql).not.toContain("$3");
+    });
+  });
+
+  describe("dormancy enabled (#2377 gate)", () => {
+    const sql = buildStaleCatalogQuery(true);
+
+    it("LEFT JOINs organization and gates on last_active_at via the dormancy param $3", () => {
+      expect(sql).toContain("LEFT JOIN organization org ON org.id = wmc.org_id");
+      expect(sql).toContain(
+        "org.last_active_at IS NULL OR org.last_active_at > now() - ($3::bigint * interval '1 ms')",
+      );
+    });
+
+    it("treats a missing org row as active — the IS NULL arm keeps orphaned configs refreshing", () => {
+      expect(sql).toContain("org.last_active_at IS NULL");
+    });
+
+    it("keeps the TTL ($1) + limit ($2) + never-fetched predicates from the legacy query", () => {
+      expect(sql).toContain("wmcat.fetched_at < now() - ($1::bigint * interval '1 ms')");
+      expect(sql).toContain("wmcat.fetched_at IS NULL OR");
+      expect(sql).toContain("LIMIT $2");
+    });
+  });
+
+  it("both arms are a single SELECT statement (no chaining)", () => {
+    for (const sql of [buildStaleCatalogQuery(false), buildStaleCatalogQuery(true)]) {
+      expect(sql.trim().startsWith("SELECT")).toBe(true);
+      expect(sql).not.toContain(";");
+    }
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
@@ -305,10 +305,8 @@ mock.module("@atlas/api/lib/bedrock-catalog", () => ({
 
 const {
   runByotCatalogRefreshCycle,
-  startByotCatalogRefreshScheduler,
-  stopByotCatalogRefreshScheduler,
   isByotCatalogRefreshSchedulerRunning,
-  _resetByotCatalogRefreshScheduler,
+  getByotCatalogRefreshIntervalMs,
   _resetBackoffForTests,
   _resetEeProbeForTests,
   _computeBackoffMsForTests,
@@ -318,7 +316,6 @@ const {
 } = await import("../byot-catalog-refresh");
 
 function resetAll() {
-  _resetByotCatalogRefreshScheduler();
   _resetBackoffForTests();
   _resetEeProbeForTests();
   mockInternalDB = true;
@@ -344,36 +341,21 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("byot catalog refresh scheduler — lifecycle", () => {
+describe("byot catalog refresh scheduler — registration surface", () => {
   beforeEach(resetAll);
 
-  it("starts and stops cleanly", () => {
-    expect(isByotCatalogRefreshSchedulerRunning()).toBe(false);
-    startByotCatalogRefreshScheduler(60_000);
+  // Post-#4195 the refresh is a `registerPeriodicFiber` fiber (owned by
+  // `effect/layers.ts`), not a bespoke `setInterval` lifecycle. The module now
+  // only exposes the fiber's inputs: the interval + the enablement-gate signal
+  // the admin scheduler surface reads.
+  it("reports the daily interval the fiber registration reads", () => {
+    expect(getByotCatalogRefreshIntervalMs()).toBe(ONE_DAY_MS);
+  });
+
+  it("running-signal reflects internal-DB presence (the registration gate)", () => {
+    mockInternalDB = true;
     expect(isByotCatalogRefreshSchedulerRunning()).toBe(true);
-    stopByotCatalogRefreshScheduler();
-    expect(isByotCatalogRefreshSchedulerRunning()).toBe(false);
-  });
-
-  it("does not double-start", () => {
-    startByotCatalogRefreshScheduler(60_000);
-    startByotCatalogRefreshScheduler(60_000);
-    expect(isByotCatalogRefreshSchedulerRunning()).toBe(true);
-    stopByotCatalogRefreshScheduler();
-  });
-
-  it("stop is idempotent — calling stop twice or without start is a no-op", () => {
-    stopByotCatalogRefreshScheduler();
-    expect(isByotCatalogRefreshSchedulerRunning()).toBe(false);
-    startByotCatalogRefreshScheduler(60_000);
-    stopByotCatalogRefreshScheduler();
-    stopByotCatalogRefreshScheduler();
-    expect(isByotCatalogRefreshSchedulerRunning()).toBe(false);
-  });
-
-  it("refuses to start without an internal DB", () => {
     mockInternalDB = false;
-    startByotCatalogRefreshScheduler(60_000);
     expect(isByotCatalogRefreshSchedulerRunning()).toBe(false);
   });
 

--- a/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
@@ -77,10 +77,6 @@ mock.module("@atlas/api/lib/audit/error-scrub", () => ({
 const {
   runOpenApiInstallRediscoverCycle,
   triggerOpenApiInstallRediscoverCycle,
-  startOpenApiInstallRediscoverScheduler,
-  stopOpenApiInstallRediscoverScheduler,
-  isOpenApiInstallRediscoverSchedulerRunning,
-  _resetOpenApiInstallRediscoverScheduler,
   getInstallRediscoverIntervalMs,
   OPENAPI_REDISCOVER_ACTOR,
   DEFAULT_REDISCOVER_INTERVAL_MS,
@@ -208,7 +204,6 @@ function runCycle(args: RunArgs) {
 }
 
 function resetAll() {
-  _resetOpenApiInstallRediscoverScheduler();
   mockHasDB = true;
   auditCalls = [];
   dbQueryCalls = [];
@@ -217,40 +212,13 @@ function resetAll() {
 const cycleRows = () => auditCalls.filter((c) => c.actionType === "connection.spec_refresh_cycle");
 const probeRows = () => auditCalls.filter((c) => c.actionType === "connection.probe");
 
-// ── Lifecycle ─────────────────────────────────────────────────────────────
+// ── Registration surface ────────────────────────────────────────────────────
+// Post-#4195 this job is scheduled by `registerPeriodicFiber` in
+// `effect/layers.ts`; the module no longer owns a `setInterval` lifecycle. The
+// interval getter (its fiber input) is covered below.
 
-describe("openapi install rediscover — lifecycle", () => {
+describe("openapi install rediscover — actor", () => {
   beforeEach(resetAll);
-
-  it("starts and stops cleanly", () => {
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
-    startOpenApiInstallRediscoverScheduler(60_000);
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(true);
-    stopOpenApiInstallRediscoverScheduler();
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
-  });
-
-  it("does not double-start", () => {
-    startOpenApiInstallRediscoverScheduler(60_000);
-    startOpenApiInstallRediscoverScheduler(60_000);
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(true);
-    stopOpenApiInstallRediscoverScheduler();
-  });
-
-  it("stop is idempotent — calling stop twice or without start is a no-op", () => {
-    stopOpenApiInstallRediscoverScheduler();
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
-    startOpenApiInstallRediscoverScheduler(60_000);
-    stopOpenApiInstallRediscoverScheduler();
-    stopOpenApiInstallRediscoverScheduler();
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
-  });
-
-  it("refuses to start without an internal DB (it reads workspace_plugins)", () => {
-    mockHasDB = false;
-    startOpenApiInstallRediscoverScheduler(60_000);
-    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
-  });
 
   it("reserved system actor matches the audit pattern + is distinct from siblings", () => {
     expect(OPENAPI_REDISCOVER_ACTOR).toBe("system:openapi-install-rediscover");

--- a/packages/api/src/lib/scheduler/__tests__/openapi-spec-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/openapi-spec-refresh.test.ts
@@ -9,20 +9,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   DEFAULT_SHARED_SPEC_REFRESH_INTERVAL_MS,
   getSharedSpecRefreshIntervalMs,
-  startOpenApiSpecRefreshScheduler,
-  stopOpenApiSpecRefreshScheduler,
-  isOpenApiSpecRefreshSchedulerRunning,
   triggerOpenApiSpecRefreshCycle,
-  _resetOpenApiSpecRefreshScheduler,
 } from "../openapi-spec-refresh";
 import { __resetSharedSpecCacheForTests } from "@atlas/api/lib/openapi/shared-spec-cache";
 
 beforeEach(() => {
-  _resetOpenApiSpecRefreshScheduler();
   __resetSharedSpecCacheForTests();
 });
 afterEach(() => {
-  _resetOpenApiSpecRefreshScheduler();
   __resetSharedSpecCacheForTests();
 });
 
@@ -56,33 +50,10 @@ describe("getSharedSpecRefreshIntervalMs", () => {
   });
 });
 
-describe("lifecycle", () => {
-  it("starts, reports running, and stops", () => {
-    expect(isOpenApiSpecRefreshSchedulerRunning()).toBe(false);
-    startOpenApiSpecRefreshScheduler(60_000);
-    expect(isOpenApiSpecRefreshSchedulerRunning()).toBe(true);
-    stopOpenApiSpecRefreshScheduler();
-    expect(isOpenApiSpecRefreshSchedulerRunning()).toBe(false);
-  });
-
-  it("double-start is a no-op (single-running guard)", () => {
-    startOpenApiSpecRefreshScheduler(60_000);
-    startOpenApiSpecRefreshScheduler(60_000); // must not throw or double-register
-    expect(isOpenApiSpecRefreshSchedulerRunning()).toBe(true);
-    stopOpenApiSpecRefreshScheduler();
-  });
-
-  it("falls back to the configured interval on a non-positive override (no hot loop)", () => {
-    // A 0 / negative / NaN interval would make setInterval fire continuously —
-    // start must clamp to the validated default rather than spin the event loop.
-    for (const bad of [0, -1000, Number.NaN]) {
-      startOpenApiSpecRefreshScheduler(bad);
-      expect(isOpenApiSpecRefreshSchedulerRunning()).toBe(true);
-      stopOpenApiSpecRefreshScheduler();
-      expect(isOpenApiSpecRefreshSchedulerRunning()).toBe(false);
-    }
-  });
-});
+// Post-#4195 the fiber lifecycle (start/stop/interval-clamping) is owned by
+// `registerPeriodicFiber` in `effect/layers.ts` and exercised by its behavioral
+// contract tests; this module now only exposes the interval getter (above) and
+// the manual cycle trigger (below).
 
 describe("triggerOpenApiSpecRefreshCycle", () => {
   it("over an empty cache inspects nothing and makes no network call", async () => {

--- a/packages/api/src/lib/scheduler/__tests__/periodic-db-job.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/periodic-db-job.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for `runPeriodicDbCycle` (#4195) — the shared scan → guard → forEach →
+ * tally → audit skeleton the BYOT + OpenAPI-rediscover jobs build on. The two
+ * jobs exercise it transitively, but this suite pins the fail-soft contract
+ * (`E = never`: a bad tick can never kill the enclosing `registerPeriodicFiber`
+ * repeat loop) at the seam, independent of any caller — including the sync
+ * callbacks (`tally`, `emitCycleAudit`) whose throws are guarded to a logged
+ * error rather than a fiber-killing defect.
+ *
+ * `hasInternalDB` is the only `db/internal` export the module imports, so a
+ * one-symbol mock is sufficient here (no partial-mock strand).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Effect } from "effect";
+import type { createLogger } from "@atlas/api/lib/logger";
+// Type-only — erased at runtime, so it does not load the module before the mock.
+import type { PeriodicDbCycleSpec } from "../periodic-db-job";
+
+let dbAvailable = true;
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => dbAvailable,
+}));
+
+const { runPeriodicDbCycle } = await import("../periodic-db-job");
+
+// A silent logger cast to the pino shape — the skeleton only calls info/error,
+// and this keeps pino (and its dev-mode worker transport) out of the test.
+type Logger = ReturnType<typeof createLogger>;
+const silentLog = {
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+  debug: () => {},
+} as unknown as Logger;
+
+interface FakeResult {
+  status: "success" | "failure";
+  inspected: number;
+  ok: number;
+  failed: number;
+  error?: string;
+}
+type FakeRow = { id: number };
+type FakeOutcome = { kind: "ok" } | { kind: "fail"; error: string };
+
+interface Recorder {
+  scanCalls: number;
+  tallied: Array<{ row: FakeRow; outcome: FakeOutcome }>;
+  audits: FakeResult[];
+}
+
+function makeSpec(
+  rec: Recorder,
+  overrides: Partial<PeriodicDbCycleSpec<FakeRow, FakeOutcome, FakeResult>>,
+): PeriodicDbCycleSpec<FakeRow, FakeOutcome, FakeResult> {
+  return {
+    log: silentLog,
+    label: "Fake job",
+    emptyResult: () => ({ status: "success", inspected: 0, ok: 0, failed: 0 }),
+    failureResult: (error) => ({ status: "failure", inspected: 0, ok: 0, failed: 0, error }),
+    scan: async () => {
+      rec.scanCalls++;
+      return [];
+    },
+    applyRow: async () => ({ kind: "ok" }),
+    defectOutcome: (error) => ({ kind: "fail", error }),
+    tally: (result, row, outcome) => {
+      rec.tallied.push({ row, outcome });
+      if (outcome.kind === "ok") result.ok++;
+      else result.failed++;
+    },
+    emitCycleAudit: (result) => {
+      rec.audits.push({ ...result });
+    },
+    ...overrides,
+  };
+}
+
+function freshRecorder(): Recorder {
+  return { scanCalls: 0, tallied: [], audits: [] };
+}
+
+beforeEach(() => {
+  dbAvailable = true;
+});
+afterEach(() => {
+  dbAvailable = true;
+});
+
+describe("runPeriodicDbCycle", () => {
+  it("no internal DB → zeroed success + one cycle audit, and never scans", async () => {
+    dbAvailable = false;
+    const rec = freshRecorder();
+    const result = await Effect.runPromise(runPeriodicDbCycle(makeSpec(rec, {})));
+
+    expect(result).toEqual({ status: "success", inspected: 0, ok: 0, failed: 0 });
+    expect(rec.scanCalls).toBe(0);
+    expect(rec.tallied).toHaveLength(0);
+    expect(rec.audits).toEqual([{ status: "success", inspected: 0, ok: 0, failed: 0 }]);
+  });
+
+  it("scan rejection → failure result carrying the error + one cycle audit, no tally", async () => {
+    const rec = freshRecorder();
+    const spec = makeSpec(rec, {
+      scan: async () => {
+        rec.scanCalls++;
+        throw new Error("boom-scan");
+      },
+    });
+    const result = await Effect.runPromise(runPeriodicDbCycle(spec));
+
+    expect(result.status).toBe("failure");
+    expect(result.error).toBe("boom-scan");
+    expect(rec.tallied).toHaveLength(0);
+    expect(rec.audits).toHaveLength(1);
+    expect(rec.audits[0]?.status).toBe("failure");
+  });
+
+  it("empty working set → zeroed success + one cycle audit, no tally", async () => {
+    const rec = freshRecorder();
+    const result = await Effect.runPromise(runPeriodicDbCycle(makeSpec(rec, {})));
+
+    expect(result).toEqual({ status: "success", inspected: 0, ok: 0, failed: 0 });
+    expect(rec.scanCalls).toBe(1);
+    expect(rec.tallied).toHaveLength(0);
+    expect(rec.audits).toHaveLength(1);
+  });
+
+  it("populated set → stamps inspected, tallies every row once, one final audit", async () => {
+    const rec = freshRecorder();
+    const rows: FakeRow[] = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const spec = makeSpec(rec, {
+      scan: async () => {
+        rec.scanCalls++;
+        return rows;
+      },
+      applyRow: async (row) => (row.id === 2 ? { kind: "fail", error: "row-2" } : { kind: "ok" }),
+    });
+    const result = await Effect.runPromise(runPeriodicDbCycle(spec));
+
+    expect(result.inspected).toBe(3);
+    expect(result.ok).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(rec.tallied.map((t) => t.row.id)).toEqual([1, 2, 3]);
+    expect(rec.audits).toHaveLength(1);
+    expect(rec.audits[0]?.inspected).toBe(3);
+  });
+
+  it("per-row apply rejection is folded via defectOutcome and counted — the loop survives", async () => {
+    const rec = freshRecorder();
+    const spec = makeSpec(rec, {
+      scan: async () => [{ id: 1 }, { id: 2 }],
+      applyRow: async (row) => {
+        if (row.id === 1) throw new Error("kaboom");
+        return { kind: "ok" };
+      },
+    });
+    const result = await Effect.runPromise(runPeriodicDbCycle(spec));
+
+    // Row 1's rejection → defectOutcome({ kind: "fail" }) → counted; row 2 still runs.
+    expect(result.inspected).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.ok).toBe(1);
+    expect(rec.tallied[0]?.outcome).toEqual({ kind: "fail", error: "kaboom" });
+  });
+
+  it("a throwing tally callback is guarded — the cycle finishes and still audits (no fiber-killing defect)", async () => {
+    const rec = freshRecorder();
+    const spec = makeSpec(rec, {
+      scan: async () => [{ id: 1 }, { id: 2 }],
+      tally: (result, row, outcome) => {
+        rec.tallied.push({ row, outcome });
+        if (row.id === 1) throw new Error("tally-boom");
+        result.ok++;
+      },
+    });
+
+    // Must resolve (not reject) — a throw in tally would otherwise defect the
+    // fiber; the skeleton catches it, logs, and moves on.
+    const result = await Effect.runPromise(runPeriodicDbCycle(spec));
+
+    expect(result.inspected).toBe(2);
+    expect(rec.tallied).toHaveLength(2); // both rows attempted despite row 1 throwing
+    expect(rec.audits).toHaveLength(1); // cycle still completed + audited
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/periodic-db-job.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/periodic-db-job.test.ts
@@ -165,6 +165,23 @@ describe("runPeriodicDbCycle", () => {
     expect(rec.tallied[0]?.outcome).toEqual({ kind: "fail", error: "kaboom" });
   });
 
+  it("a throwing emitCycleAudit is guarded — the cycle resolves with its result intact (no fiber-killing defect)", async () => {
+    // Exercise the no-DB terminal path specifically: there `emitAudit` is the
+    // only guard between a thrown cycle-audit and an escaping defect (no row
+    // loop around it). The cycle must still resolve, returning the zeroed result.
+    dbAvailable = false;
+    const rec = freshRecorder();
+    const spec = makeSpec(rec, {
+      emitCycleAudit: () => {
+        throw new Error("audit-boom");
+      },
+    });
+
+    const result = await Effect.runPromise(runPeriodicDbCycle(spec));
+
+    expect(result).toEqual({ status: "success", inspected: 0, ok: 0, failed: 0 });
+  });
+
   it("a throwing tally callback is guarded — the cycle finishes and still audits (no fiber-killing defect)", async () => {
     const rec = freshRecorder();
     const spec = makeSpec(rec, {

--- a/packages/api/src/lib/scheduler/__tests__/slack-token.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/slack-token.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for `resolveSlackBotToken` (#3379) — the single statement of the
+ * scheduled-delivery Slack sender-resolution rule: per-team bot token from the
+ * store first, then the `SLACK_BOT_TOKEN` env fallback. Coverage added by #4195
+ * (the periodic-DB-job runner pass) — the delivery + preflight consumers relied
+ * on this seam being correct but it had no direct unit test.
+ *
+ * The `getBotTokenImpl` injection parameter is the intended test seam: it lets
+ * these cases exercise the store-first-then-env chain without dragging the
+ * dynamically-imported `@atlas/api/lib/slack/store` into the module graph.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { resolveSlackBotToken } from "../slack-token";
+
+const KEY = "SLACK_BOT_TOKEN";
+let saved: string | undefined;
+
+beforeEach(() => {
+  saved = process.env[KEY];
+  delete process.env[KEY];
+});
+afterEach(() => {
+  if (saved === undefined) delete process.env[KEY];
+  else process.env[KEY] = saved;
+});
+
+describe("resolveSlackBotToken", () => {
+  it("returns the per-team bot token when the store has one (env not consulted)", async () => {
+    process.env[KEY] = "xoxb-env-fallback";
+    let seenTeam: string | undefined;
+    const token = await resolveSlackBotToken("T123", async (id) => {
+      seenTeam = id;
+      return "xoxb-team-token";
+    });
+    expect(seenTeam).toBe("T123");
+    expect(token).toBe("xoxb-team-token");
+  });
+
+  it("prefers a non-empty team token over a set env token when both exist", async () => {
+    process.env[KEY] = "xoxb-env";
+    const token = await resolveSlackBotToken("T999", async () => "xoxb-team");
+    expect(token).toBe("xoxb-team");
+  });
+
+  it("falls back to SLACK_BOT_TOKEN when the store returns null for the team", async () => {
+    process.env[KEY] = "xoxb-env-fallback";
+    const token = await resolveSlackBotToken("T123", async () => null);
+    expect(token).toBe("xoxb-env-fallback");
+  });
+
+  it("treats an empty-string team token as absent and falls back to env", async () => {
+    process.env[KEY] = "xoxb-env";
+    const token = await resolveSlackBotToken("T123", async () => "");
+    expect(token).toBe("xoxb-env");
+  });
+
+  it("skips the store lookup entirely when teamId is undefined and uses the env token", async () => {
+    process.env[KEY] = "xoxb-env-fallback";
+    let called = false;
+    const token = await resolveSlackBotToken(undefined, async () => {
+      called = true;
+      return "unreachable";
+    });
+    expect(called).toBe(false);
+    expect(token).toBe("xoxb-env-fallback");
+  });
+
+  it("returns null when there is neither a team token nor an env token", async () => {
+    const token = await resolveSlackBotToken("T123", async () => null);
+    expect(token).toBeNull();
+  });
+
+  it("treats an empty-string SLACK_BOT_TOKEN as absent (no sender)", async () => {
+    process.env[KEY] = "";
+    const token = await resolveSlackBotToken("T123", async () => null);
+    expect(token).toBeNull();
+  });
+
+  it("returns null with no team and no env — the fully-unconfigured case", async () => {
+    const token = await resolveSlackBotToken(undefined, async () => "unreachable");
+    expect(token).toBeNull();
+  });
+});

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -34,17 +34,20 @@
  *     over a 48 h window is the "scheduler stopped" signal (mirroring the
  *     F-27 audit-purge invariant).
  *
- * Lifecycle mirrors `ee/src/audit/purge-scheduler.ts`: setInterval-based
- * with `unref()` so it doesn't pin the process, an initial tick on start,
- * and a single-running guard so double-start is a no-op.
+ * Lifecycle: scheduled by `registerPeriodicFiber` in `effect/layers.ts`
+ * (#4195) — a `forkScoped` fiber that runs an initial cycle on boot then
+ * repeats on the configured cadence, gated on an internal DB and interrupted
+ * cleanly on layer-scope shutdown. The scan → forEach → tally → audit cycle
+ * body is the shared `runPeriodicDbCycle` skeleton.
  *
- * @see ee/src/audit/purge-scheduler.ts
+ * @see ./periodic-db-job.ts — the shared DB-cycle skeleton this cycle uses.
+ * @see ../effect/layers.ts — `registerPeriodicFiber`, the fiber scheduler.
  */
 
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { withEffectSpan } from "@atlas/api/lib/tracing";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { runPeriodicDbCycle } from "@atlas/api/lib/scheduler/periodic-db-job";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { buildStaleCatalogQuery } from "@atlas/api/lib/scheduler/byot-catalog-query";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -456,128 +459,74 @@ interface CycleOptions {
 /**
  * Run a single refresh cycle. Errors are caught and surfaced as `status:
  * "failure"` (stale-row query failed) or per-row `failed` counts — the
- * scheduler must not throw out of the tick or the `setInterval` loop dies.
+ * scheduler must not throw out of the tick or the repeat loop dies. The
+ * scan → guard → forEach → tally → audit choreography is the shared
+ * `runPeriodicDbCycle` skeleton (#4195); this function supplies only the
+ * BYOT-specific scan query, per-row apply, and per-outcome tally + backoff
+ * bookkeeping. The per-tick span is applied by `registerPeriodicFiber` around
+ * the fiber, not here (#2945 attribution is preserved via that fiber's
+ * `spanResultAttributes`).
  */
 export const runByotCatalogRefreshCycle = (
   opts: CycleOptions = {},
-): Effect.Effect<ByotRefreshCycleResult> =>
-  // Span the whole cycle so a slow/failing upstream provider refresh shows
-  // up in the trace waterfall alongside atlas.scheduler.tick — logs + audit
-  // rows alone gave no latency attribution (#2945).
-  withEffectSpan(
-    "atlas.scheduler.byot_catalog_refresh",
-    {},
-    Effect.gen(function* () {
-    if (!hasInternalDB()) {
-      const result = zeroResult();
-      emitCycleAudit(result);
-      return result;
-    }
+): Effect.Effect<ByotRefreshCycleResult> => {
+  const staleThresholdMs = opts.staleThresholdMs ?? DEFAULT_INTERVAL_MS;
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const dormancyThresholdMs = opts.dormancyThresholdMs ?? getDormancyThresholdMs();
+  const now = opts.nowFn ?? Date.now;
 
-    const staleThresholdMs = opts.staleThresholdMs ?? DEFAULT_INTERVAL_MS;
-    const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
-    const dormancyThresholdMs = opts.dormancyThresholdMs ?? getDormancyThresholdMs();
-    const now = opts.nowFn ?? Date.now;
-
-    const fetchResult = yield* Effect.tryPromise({
-      try: () => findStaleByotCatalogs(staleThresholdMs, batchSize, dormancyThresholdMs),
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    }).pipe(
-      Effect.map((rows) => ({ ok: true as const, rows })),
-      Effect.catchAll((err) => {
-        log.error({ err: errorMessage(err) }, "BYOT catalog refresh: failed to query stale rows");
-        return Effect.succeed({ ok: false as const, error: errorMessage(err) });
-      }),
-    );
-
-    if (!fetchResult.ok) {
-      const failed: ByotRefreshCycleResult = {
-        status: "failure",
-        ...ZERO_COUNTS,
-        error: fetchResult.error,
-      };
-      emitCycleAudit(failed);
-      return failed;
-    }
-
-    const rows = fetchResult.rows;
-    const result: ByotRefreshCycleResult = { status: "success", ...ZERO_COUNTS, inspected: rows.length };
-
-    if (rows.length === 0) {
-      emitCycleAudit(result);
-      return result;
-    }
-
-    log.info({ count: rows.length }, "BYOT catalog refresh: cycle starting");
-
-    // Sequential — one upstream provider call at a time. `Effect.forEach`
-    // with `{ concurrency: 1 }` stays in the Effect chain so a fiber
-    // interrupt cancels cleanly mid-cycle.
-    yield* Effect.forEach(
-      rows,
-      (row) =>
-        Effect.gen(function* () {
-          const outcome = yield* Effect.tryPromise({
-            try: () => refreshOne(row, now()),
-            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-          }).pipe(
-            Effect.catchAll((err) =>
-              Effect.succeed({ kind: "failed" as const, error: errorMessage(err) }),
-            ),
-          );
-
-          const key = backoffKey(row.orgId, row.provider, regionForKey(row));
-          if (outcome.kind === "refreshed") {
-            recordSuccess(key);
-            result.refreshed++;
-            emitPerRowAudit({
-              action: ADMIN_ACTIONS.model_config.catalogRefresh,
-              orgId: row.orgId,
-              status: "success",
-              metadata: {
-                provider: providerOfRow(row),
-                modelCount: outcome.modelCount,
-                source: outcome.source,
-                triggeredBy: "scheduler",
-              },
-            });
-          } else if (outcome.kind === "skipped") {
-            countSkip(result, outcome.reason);
-            emitPerRowAudit({
-              action: ADMIN_ACTIONS.model_config.catalogRefreshSkip,
-              orgId: row.orgId,
-              status: skipStatus(outcome.reason),
-              metadata: { provider: providerOfRow(row), reason: outcome.reason },
-            });
-          } else {
-            recordFailure(key, now());
-            result.failed++;
-            emitPerRowAudit({
-              action: ADMIN_ACTIONS.model_config.catalogRefresh,
-              orgId: row.orgId,
-              status: "failure",
-              metadata: {
-                provider: providerOfRow(row),
-                error: outcome.error,
-                triggeredBy: "scheduler",
-              },
-            });
-          }
-        }),
-      { concurrency: 1 },
-    );
-
-    log.info({ ...result }, "BYOT catalog refresh: cycle complete");
-    emitCycleAudit(result);
-    return result;
-  }),
-    (result) => ({
-      "atlas.byot.status": result.status,
-      "atlas.byot.inspected": result.inspected ?? 0,
-      "atlas.byot.refreshed": result.refreshed,
-      "atlas.byot.failed": result.failed,
-    }),
-  );
+  return runPeriodicDbCycle<StaleRow, RefreshOutcome, ByotRefreshCycleResult>({
+    log,
+    label: "BYOT catalog refresh",
+    emptyResult: zeroResult,
+    failureResult: (error) => ({ status: "failure", ...ZERO_COUNTS, error }),
+    scan: () => findStaleByotCatalogs(staleThresholdMs, batchSize, dormancyThresholdMs),
+    // Sequential per-row upstream provider call; `runPeriodicDbCycle` runs
+    // these at `{ concurrency: 1 }` so a fiber interrupt cancels cleanly.
+    applyRow: (row) => refreshOne(row, now()),
+    defectOutcome: (error) => ({ kind: "failed", error }),
+    tally: (result, row, outcome) => {
+      const key = backoffKey(row.orgId, row.provider, regionForKey(row));
+      if (outcome.kind === "refreshed") {
+        recordSuccess(key);
+        result.refreshed++;
+        emitPerRowAudit({
+          action: ADMIN_ACTIONS.model_config.catalogRefresh,
+          orgId: row.orgId,
+          status: "success",
+          metadata: {
+            provider: providerOfRow(row),
+            modelCount: outcome.modelCount,
+            source: outcome.source,
+            triggeredBy: "scheduler",
+          },
+        });
+      } else if (outcome.kind === "skipped") {
+        countSkip(result, outcome.reason);
+        emitPerRowAudit({
+          action: ADMIN_ACTIONS.model_config.catalogRefreshSkip,
+          orgId: row.orgId,
+          status: skipStatus(outcome.reason),
+          metadata: { provider: providerOfRow(row), reason: outcome.reason },
+        });
+      } else {
+        recordFailure(key, now());
+        result.failed++;
+        emitPerRowAudit({
+          action: ADMIN_ACTIONS.model_config.catalogRefresh,
+          orgId: row.orgId,
+          status: "failure",
+          metadata: {
+            provider: providerOfRow(row),
+            error: outcome.error,
+            triggeredBy: "scheduler",
+          },
+        });
+      }
+    },
+    emitCycleAudit,
+  });
+};
 
 function countSkip(result: ByotRefreshCycleResult, reason: ByotCatalogRefreshSkipReason): void {
   switch (reason) {
@@ -663,82 +612,38 @@ function emitCycleAudit(result: ByotRefreshCycleResult): void {
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle (setInterval-based, mirrors ee/audit/purge-scheduler.ts)
+// Scheduling — via `registerPeriodicFiber` in `effect/layers.ts` (#4195)
 // ---------------------------------------------------------------------------
 //
-// #3764 — deliberately NOT on `engine.ts`'s `Effect.runFork` + `Schedule`
-// fiber pattern, by the same reasoning as `openapi-install-rediscover.ts` +
-// `openapi-spec-refresh.ts` + `ee/audit/purge-scheduler.ts` (which all share
-// this `setInterval` + `unref()` shape and cross-reference each other):
-//   • The cycle is self-contained and idempotent — it emits an audit row and
-//     mutates catalog staleness; there are no per-tick "running" rows that a
-//     mid-flight interrupt must clean up. `engine.ts` needs the fiber pattern
-//     ONLY because its `Effect.onInterrupt` finalizer must release orphaned
-//     `task_run` rows on shutdown (see engine.ts:306). Nothing here is
-//     interrupt-sensitive, so the fiber pattern would add machinery for a
-//     guarantee we don't need.
-//   • `_timer.unref()` keeps the timer from pinning the process — the desired
-//     posture for a best-effort background refresher.
-//   • `{ concurrency: 1 }` inside the cycle (see `runByotCatalogRefreshCycle`)
-//     already prevents a slow cycle from overlapping the next tick.
-// `Effect.runPromise` here boots a fresh default-runtime fiber per cycle, which
-// is fine: each cycle is a fully self-contained program, not a re-entry into a
-// surrounding Effect.
+// The BYOT refresh no longer hand-rolls a `setInterval` lifecycle. Its cycle
+// body is the shared `runPeriodicDbCycle` skeleton (above); the fiber that
+// repeats it — interval, per-tick span, `withFiberDeathLog`, and the
+// `hasInternalDB()` enablement gate — is owned by `registerPeriodicFiber`
+// (arch-win #100 / #4130), forked `forkScoped` for the pod lifetime and
+// interrupted cleanly on layer-scope shutdown. `Schedule.spaced` there spaces
+// ticks by completion, so a slow cycle can never overlap the next — the old
+// `setInterval` model had no cross-tick overlap guard beyond the daily cadence
+// and the in-cycle `{ concurrency: 1 }` (unlike the two OpenAPI siblings, byot
+// never carried an `_inFlight` flag). See `scheduler/periodic-db-job.ts` for
+// how the DB-cycle skeleton and the fiber scheduler compose.
 
-let _timer: ReturnType<typeof setInterval> | null = null;
-let _running = false;
-
-function runCycleWithDefectGuard(): void {
-  Effect.runPromise(runByotCatalogRefreshCycle()).catch((err: unknown) => {
-    log.error(
-      { err: err instanceof Error ? err.message : String(err) },
-      "BYOT catalog refresh cycle defected past catchAll — cycle row may not have been emitted",
-    );
-  });
+/**
+ * The periodic tick interval (ms) — a daily cadence, mirroring the staleness
+ * TTL. `registerPeriodicFiber` reads this once at registration.
+ */
+export function getByotCatalogRefreshIntervalMs(): number {
+  return DEFAULT_INTERVAL_MS;
 }
 
 /**
- * Start the BYOT catalog refresh scheduler. Runs an initial cycle
- * immediately, then repeats at the configured interval. No-op if already
- * running or if the internal DB is unavailable.
+ * Whether the BYOT catalog refresh is active on this pod. Post-#4195 the
+ * refresh runs as a `forkScoped` periodic fiber (via `registerPeriodicFiber`)
+ * for the whole pod lifetime whenever an internal DB is present — there is no
+ * separate start/stop flag, so "running" reflects the registration gate
+ * (`hasInternalDB()`), which the admin scheduler surface reports.
  */
-export function startByotCatalogRefreshScheduler(intervalMs?: number): void {
-  if (_running) {
-    log.debug("BYOT catalog refresh scheduler already running — skipping start");
-    return;
-  }
-  if (!hasInternalDB()) {
-    log.debug("No internal database — BYOT catalog refresh scheduler not started");
-    return;
-  }
-
-  const interval = intervalMs ?? DEFAULT_INTERVAL_MS;
-  _running = true;
-  log.info({ intervalMs: interval }, "Starting BYOT catalog refresh scheduler");
-
-  runCycleWithDefectGuard();
-  _timer = setInterval(() => {
-    runCycleWithDefectGuard();
-  }, interval);
-  _timer.unref();
-}
-
-export function stopByotCatalogRefreshScheduler(): void {
-  if (_timer) {
-    clearInterval(_timer);
-    _timer = null;
-  }
-  _running = false;
-  log.info("BYOT catalog refresh scheduler stopped");
-}
-
 export function isByotCatalogRefreshSchedulerRunning(): boolean {
-  return _running;
-}
-
-/** Test-only: reset scheduler state. */
-export function _resetByotCatalogRefreshScheduler(): void {
-  stopByotCatalogRefreshScheduler();
+  return hasInternalDB();
 }
 
 /**

--- a/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
+++ b/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
@@ -15,15 +15,16 @@
  * env-tier fallback). Read once at scheduler start (`requiresRestart: true`,
  * mirroring `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS`).
  *
- * Lifecycle mirrors `openapi-spec-refresh.ts` / `byot-catalog-refresh.ts`:
- * `setInterval`-based with `unref()` (doesn't pin the process), an initial
- * cycle on start, a single-running guard, and an in-flight overlap guard so a
- * slow cycle never races the next tick. Promise-native cycle → the Promise
- * `withSpan` (self-spanned, so it never slots into `SCHEDULER_WORK_SPAN_NAMES`
- * in `effect/layers.ts` — same note as the spec-refresh sibling).
+ * Lifecycle: `setInterval`-based with `unref()` (doesn't pin the process), an
+ * initial cycle on start, a single-running guard, and an in-flight overlap
+ * guard so a slow cycle never races the next tick. Promise-native cycle → the
+ * Promise `withSpan` (self-spanned, so it never slots into
+ * `SCHEDULER_WORK_SPAN_NAMES` in `effect/layers.ts`). This is now the last
+ * `setInterval`-based scheduler — its former siblings (`openapi-spec-refresh.ts`,
+ * `byot-catalog-refresh.ts`) were folded onto `registerPeriodicFiber` by #4195;
+ * this job is a candidate for the same treatment.
  *
  * @see ../knowledge/sync.ts — the per-collection sync + cycle walk.
- * @see ./openapi-spec-refresh.ts — the lifecycle pattern this follows.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -93,7 +94,8 @@ export async function runKnowledgeBundleSyncCycle(): Promise<KnowledgeSyncCycleR
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle (setInterval-based, mirrors openapi-spec-refresh.ts)
+// Lifecycle (setInterval-based — the last such scheduler after #4195 folded
+// the OpenAPI/BYOT refresh jobs onto registerPeriodicFiber)
 // ---------------------------------------------------------------------------
 
 let _timer: ReturnType<typeof setInterval> | null = null;

--- a/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
+++ b/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
@@ -45,11 +45,11 @@
  * negatively-caching a half-applied refresh.
  *
  * ## Lifecycle
- * `setInterval`-based with `unref()` (doesn't pin the process), an initial cycle on
- * start, a single-running guard (double-start is a no-op), and an in-flight guard so
- * a slow cycle never overlaps the next tick — mirrors `byot-catalog-refresh.ts` +
- * `openapi-spec-refresh.ts`. No-op without an internal DB (it reads
- * `workspace_plugins`).
+ * Scheduled by `registerPeriodicFiber` in `effect/layers.ts` (#4195): a
+ * `forkScoped` fiber that runs an initial cycle on boot then repeats on the
+ * configured cadence, gated on an internal DB (it reads `workspace_plugins`) and
+ * interrupted cleanly on layer-scope shutdown. `Schedule.spaced` spaces ticks by
+ * completion, so a slow cycle never overlaps the next.
  *
  * Like every other per-process scheduler here (BYOT, Tier-1, semantic-expert), this
  * takes no distributed lock — it relies on the deploy invariant that each regional
@@ -59,15 +59,16 @@
  * duplicate egress + audit rows, not corruption. A cross-scheduler distributed
  * singleton is the right home for replica gating if that invariant is ever lifted.
  *
- * @see ./byot-catalog-refresh.ts — the periodic-fiber pattern this follows.
+ * @see ./periodic-db-job.ts — the shared DB-cycle skeleton this job's cycle uses.
+ * @see ../effect/layers.ts — `registerPeriodicFiber`, the fiber scheduler.
  * @see ./openapi-spec-refresh.ts — the Tier-1 sibling this is deliberately NOT.
  * @see ../openapi/rediscover.ts — the shared re-probe → snapshot → diff core.
  */
 
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { withEffectSpan } from "@atlas/api/lib/tracing";
-import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { runPeriodicDbCycle } from "@atlas/api/lib/scheduler/periodic-db-job";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { OPENAPI_GENERIC_CATALOG_ID, type OpenApiSnapshot } from "@atlas/api/lib/openapi/catalog";
@@ -507,239 +508,110 @@ function emitCycleAudit(result: RediscoverCycleResult): void {
 /**
  * Run a single re-discovery cycle. Never throws — a failure in the candidate query
  * surfaces as `status: "failure"` + an emitted cycle row; per-install failures are
- * isolated and counted. Returns the structured {@link RediscoverCycleResult}.
+ * isolated and counted. Returns the structured {@link RediscoverCycleResult}. The
+ * scan → guard → forEach → tally → audit choreography is the shared
+ * `runPeriodicDbCycle` skeleton (#4195); this function supplies only the
+ * rediscover-specific candidate query, per-install apply, and per-outcome tally +
+ * drift bookkeeping. The per-tick span is applied by `registerPeriodicFiber` around
+ * the fiber, not here — its `spanResultAttributes` preserve the trace attribution.
  */
 export const runOpenApiInstallRediscoverCycle = (
   opts: RediscoverCycleOptions = {},
-): Effect.Effect<RediscoverCycleResult> =>
-  // Span the whole cycle so a slow/failing upstream re-probe shows up in the trace
-  // waterfall alongside the other scheduler ticks.
-  withEffectSpan(
-    "atlas.scheduler.openapi_install_rediscover",
-    {},
-    Effect.gen(function* () {
-      if (!hasInternalDB()) {
-        const result: RediscoverCycleResult = { status: "success", ...ZERO_COUNTS };
-        emitCycleAudit(result);
-        return result;
+): Effect.Effect<RediscoverCycleResult> => {
+  const nowFn = opts.now ?? Date.now;
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const query = opts.query ?? defaultQuery;
+  const deps: CycleDeps = {
+    rediscover: opts.rediscover ?? defaultRediscover,
+    persistSuccess: opts.persistSuccess ?? defaultPersistSuccess,
+    stampChecked: opts.stampChecked ?? defaultStampChecked,
+  };
+
+  // Stamp one ISO timestamp for the whole cycle so every watermark written this
+  // tick is consistent (and the due-calc uses the same instant). Resolved up
+  // front — the scan doesn't consume it, so hoisting it above the skeleton is
+  // behaviorally identical to the pre-#4195 "after the empty check" placement.
+  const nowMs = nowFn();
+  const nowIso = new Date(nowMs).toISOString();
+
+  return runPeriodicDbCycle<DueCandidateRow, InstallOutcome, RediscoverCycleResult>({
+    log,
+    label: "OpenAPI rediscover",
+    emptyResult: () => ({ status: "success", ...ZERO_COUNTS }),
+    failureResult: (error) => ({ status: "failure", ...ZERO_COUNTS, error }),
+    scan: () => query(batchSize),
+    // Sequential per-install probe; `runPeriodicDbCycle` runs these at
+    // `{ concurrency: 1 }`. Each probe is `AbortSignal.timeout`-bounded, so a
+    // slow upstream delays (but does not stall) the rest.
+    applyRow: (row) => runInstall(row, nowMs, nowIso, deps),
+    // runInstall is designed never to throw; this is belt-and-braces so a
+    // surprise defect counts as a failure rather than aborting the loop. Phase
+    // it "rediscover": runInstall stamps internally on its own fault paths, so a
+    // defect that escapes it left nothing persisted.
+    defectOutcome: (error) => ({ kind: "failed", phase: "rediscover", error }),
+    tally: (result, row, outcome) => {
+      switch (outcome.kind) {
+        case "not_due":
+          result.skippedNotDue++;
+          return;
+        case "refreshed":
+          result.due++;
+          result.refreshed++;
+          emitInstallAudit(row, "success", {
+            operationCount: outcome.operationCount,
+            ...driftMetadata(outcome.drift),
+          });
+          // #2979 — a SCHEDULED breaking re-probe also raises the attention
+          // signal: count it + write the dedicated audit row. Additive/clean
+          // refreshes carry `breaking: null` and stay quiet.
+          if (outcome.breaking) {
+            result.breaking++;
+            emitBreakingDriftAudit(row, outcome.breaking);
+          }
+          return;
+        case "probe_failed":
+          result.due++;
+          result.failed++;
+          emitInstallAudit(row, "failure", { reason: "probe_failed", probeReason: outcome.reason });
+          return;
+        case "config_skip":
+          result.due++;
+          result.skippedConfig++;
+          emitInstallAudit(row, "failure", {
+            reason: outcome.reason,
+            ...(outcome.detail !== undefined ? { authKind: outcome.detail } : {}),
+          });
+          return;
+        case "failed":
+          result.due++;
+          result.failed++;
+          // Surface the retry semantics in the audit `reason`: `persist_failed`
+          // retries next tick; `rediscover_fault` is deferred a full interval.
+          emitInstallAudit(row, "failure", {
+            reason: outcome.phase === "persist" ? "persist_failed" : "rediscover_fault",
+            error: outcome.error,
+          });
+          return;
       }
-
-      const nowFn = opts.now ?? Date.now;
-      const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
-      const query = opts.query ?? defaultQuery;
-      const deps: CycleDeps = {
-        rediscover: opts.rediscover ?? defaultRediscover,
-        persistSuccess: opts.persistSuccess ?? defaultPersistSuccess,
-        stampChecked: opts.stampChecked ?? defaultStampChecked,
-      };
-
-      const fetchResult = yield* Effect.tryPromise({
-        try: () => query(batchSize),
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
-        Effect.map((rows) => ({ ok: true as const, rows })),
-        Effect.catchAll((err) => {
-          log.error(
-            { err: errorMessage(err) },
-            "OpenAPI rediscover: failed to query due candidates",
-          );
-          return Effect.succeed({ ok: false as const, error: errorMessage(err) });
-        }),
-      );
-
-      if (!fetchResult.ok) {
-        const failed: RediscoverCycleResult = {
-          status: "failure",
-          ...ZERO_COUNTS,
-          error: fetchResult.error,
-        };
-        emitCycleAudit(failed);
-        return failed;
-      }
-
-      const rows = fetchResult.rows;
-      const result: RediscoverCycleResult = { status: "success", ...ZERO_COUNTS, inspected: rows.length };
-
-      if (rows.length === 0) {
-        emitCycleAudit(result);
-        return result;
-      }
-
-      // Stamp one ISO timestamp for the whole cycle so every watermark written this
-      // tick is consistent (and the due-calc uses the same instant).
-      const nowMs = nowFn();
-      const nowIso = new Date(nowMs).toISOString();
-
-      log.info({ count: rows.length }, "OpenAPI rediscover: cycle starting");
-
-      // Sequential — one upstream probe at a time (concurrency: 1), so a noisy
-      // install can't fan out egress and a fiber interrupt cancels cleanly
-      // mid-cycle. Each probe is `AbortSignal.timeout`-bounded, so a slow upstream
-      // delays (but does not stall) the rest; per-install failures are contained.
-      yield* Effect.forEach(
-        rows,
-        (row) =>
-          Effect.gen(function* () {
-            const outcome = yield* Effect.tryPromise({
-              try: () => runInstall(row, nowMs, nowIso, deps),
-              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-            }).pipe(
-              // runInstall is designed never to throw; this is belt-and-braces so a
-              // surprise defect counts as a failure rather than aborting the loop.
-              // Phase it "rediscover": runInstall stamps internally on its own fault
-              // paths, so a defect that escapes it left nothing persisted.
-              Effect.catchAll((err) =>
-                Effect.succeed({ kind: "failed" as const, phase: "rediscover" as const, error: errorMessage(err) }),
-              ),
-            );
-
-            switch (outcome.kind) {
-              case "not_due":
-                result.skippedNotDue++;
-                return;
-              case "refreshed":
-                result.due++;
-                result.refreshed++;
-                emitInstallAudit(row, "success", {
-                  operationCount: outcome.operationCount,
-                  ...driftMetadata(outcome.drift),
-                });
-                // #2979 — a SCHEDULED breaking re-probe also raises the attention
-                // signal: count it + write the dedicated audit row. Additive/clean
-                // refreshes carry `breaking: null` and stay quiet.
-                if (outcome.breaking) {
-                  result.breaking++;
-                  emitBreakingDriftAudit(row, outcome.breaking);
-                }
-                return;
-              case "probe_failed":
-                result.due++;
-                result.failed++;
-                emitInstallAudit(row, "failure", { reason: "probe_failed", probeReason: outcome.reason });
-                return;
-              case "config_skip":
-                result.due++;
-                result.skippedConfig++;
-                emitInstallAudit(row, "failure", {
-                  reason: outcome.reason,
-                  ...(outcome.detail !== undefined ? { authKind: outcome.detail } : {}),
-                });
-                return;
-              case "failed":
-                result.due++;
-                result.failed++;
-                // Surface the retry semantics in the audit `reason`: `persist_failed`
-                // retries next tick; `rediscover_fault` is deferred a full interval.
-                emitInstallAudit(row, "failure", {
-                  reason: outcome.phase === "persist" ? "persist_failed" : "rediscover_fault",
-                  error: outcome.error,
-                });
-                return;
-            }
-          }),
-        { concurrency: 1 },
-      );
-
-      log.info({ ...result }, "OpenAPI rediscover: cycle complete");
-      emitCycleAudit(result);
-      return result;
-    }),
-    (result) => ({
-      "atlas.openapi_rediscover.status": result.status,
-      "atlas.openapi_rediscover.inspected": result.inspected,
-      "atlas.openapi_rediscover.due": result.due,
-      "atlas.openapi_rediscover.refreshed": result.refreshed,
-      "atlas.openapi_rediscover.breaking": result.breaking,
-      "atlas.openapi_rediscover.failed": result.failed,
-    }),
-  );
+    },
+    emitCycleAudit,
+  });
+};
 
 // ---------------------------------------------------------------------------
-// Lifecycle (setInterval-based, mirrors byot-catalog-refresh.ts + openapi-spec-refresh.ts)
+// Scheduling — via `registerPeriodicFiber` in `effect/layers.ts` (#4195)
 // ---------------------------------------------------------------------------
 //
-// #3764 — deliberately NOT on `engine.ts`'s `Effect.runFork` + `Schedule`
-// fiber pattern, by the same reasoning as `byot-catalog-refresh.ts` +
-// `openapi-spec-refresh.ts` + `ee/audit/purge-scheduler.ts` (all sharing this
-// `setInterval` + `unref()` shape): the cycle is self-contained and idempotent
-// (re-probes install status), with no per-tick rows a mid-flight interrupt
-// must release — so it doesn't need `engine.ts`'s `Effect.onInterrupt`
-// task_run cleanup (engine.ts:306). `_inFlight` already prevents overlap and
-// `unref()` keeps the timer from pinning the process; `Effect.runPromise` per
-// cycle is a self-contained program, not a re-entry into a surrounding Effect.
-
-let _timer: ReturnType<typeof setInterval> | null = null;
-let _running = false;
-/** A still-running cycle, so a slow tick (network I/O) never overlaps the next one. */
-let _inFlight = false;
-
-function runCycleWithDefectGuard(): void {
-  if (_inFlight) {
-    log.debug("OpenAPI rediscover cycle still in flight — skipping this tick");
-    return;
-  }
-  _inFlight = true;
-  Effect.runPromise(runOpenApiInstallRediscoverCycle())
-    .catch((err: unknown) => {
-      // The cycle catches its own errors; this only fires on an unexpected defect so
-      // the loop survives and the next tick still runs.
-      log.error(
-        { err: err instanceof Error ? err.message : String(err) },
-        "OpenAPI rediscover cycle defected past its internal catch",
-      );
-    })
-    .finally(() => {
-      _inFlight = false;
-    });
-}
-
-/**
- * Start the Tier-2 OpenAPI re-discovery scheduler. Runs an initial cycle
- * immediately, then repeats at the configured interval. No-op if already running or
- * if the internal DB is unavailable (it reads `workspace_plugins`). A non-positive /
- * non-finite `intervalMs` falls back to the configured default rather than
- * hot-looping `setInterval`.
- */
-export function startOpenApiInstallRediscoverScheduler(intervalMs?: number): void {
-  if (_running) {
-    log.debug("OpenAPI rediscover scheduler already running — skipping start");
-    return;
-  }
-  if (!hasInternalDB()) {
-    log.debug("No internal database — OpenAPI rediscover scheduler not started");
-    return;
-  }
-
-  const interval =
-    intervalMs !== undefined && Number.isFinite(intervalMs) && intervalMs > 0
-      ? intervalMs
-      : getInstallRediscoverIntervalMs();
-  _running = true;
-  log.info({ intervalMs: interval }, "Starting OpenAPI install rediscover scheduler");
-
-  runCycleWithDefectGuard();
-  _timer = setInterval(runCycleWithDefectGuard, interval);
-  _timer.unref();
-}
-
-export function stopOpenApiInstallRediscoverScheduler(): void {
-  if (_timer) {
-    clearInterval(_timer);
-    _timer = null;
-  }
-  _running = false;
-  log.info("OpenAPI install rediscover scheduler stopped");
-}
-
-export function isOpenApiInstallRediscoverSchedulerRunning(): boolean {
-  return _running;
-}
-
-/** Test-only: reset scheduler state. */
-export function _resetOpenApiInstallRediscoverScheduler(): void {
-  stopOpenApiInstallRediscoverScheduler();
-  _inFlight = false;
-}
+// The Tier-2 re-discovery no longer hand-rolls a `setInterval` lifecycle. Its
+// cycle body is the shared `runPeriodicDbCycle` skeleton (above); the fiber
+// that repeats it — interval, per-tick span, `withFiberDeathLog`, and the
+// `hasInternalDB()` enablement gate — is owned by `registerPeriodicFiber`
+// (arch-win #100 / #4130), forked `forkScoped` for the pod lifetime.
+// `Schedule.spaced` there spaces ticks by completion, so a slow cycle can never
+// overlap the next — subsuming the old `_inFlight` guard. See
+// `scheduler/periodic-db-job.ts` for how the two seams compose.
+// The loop cadence is `getInstallRediscoverIntervalMs()` (above), which the
+// `registerPeriodicFiber` registration reads once at boot.
 
 /**
  * Manual-trigger entry point (admin scheduler page / tests). Runs a single cycle and

--- a/packages/api/src/lib/scheduler/openapi-spec-refresh.ts
+++ b/packages/api/src/lib/scheduler/openapi-spec-refresh.ts
@@ -21,18 +21,19 @@
  * snapshot/diff/persist path.
  *
  * ## Lifecycle
- * `setInterval`-based with `unref()` (doesn't pin the process), an initial cycle
- * on start, and a single-running guard so double-start is a no-op — mirrors
- * `byot-catalog-refresh.ts`. No internal-DB dependency (the cache is process-
- * local), so it starts unconditionally; a cycle with an empty cache is a cheap
- * no-op.
+ * Scheduled by `registerPeriodicFiber` in `effect/layers.ts` (#4195): a
+ * `forkScoped` fiber that runs an initial cycle on boot then repeats on the
+ * configured cadence, interrupted cleanly on layer-scope shutdown. No internal-DB
+ * dependency (the cache is process-local), so it starts unconditionally; a cycle
+ * with an empty cache is a cheap no-op.
  *
- * @see ./byot-catalog-refresh.ts — the periodic-refresh pattern this follows.
+ * @see ../effect/layers.ts — `registerPeriodicFiber`, the fiber scheduler.
+ * @see ./periodic-db-job.ts — the DB-cycle skeleton the byot/rediscover siblings
+ *   share and that this (non-DB) job deliberately does NOT use.
  * @see ../openapi/shared-spec-cache.ts — the cache + the per-cycle logic.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { withSpan } from "@atlas/api/lib/tracing";
 import {
   refreshSharedSpecsCycle,
   type SharedRefreshCycleResult,
@@ -73,121 +74,42 @@ export function getSharedSpecRefreshIntervalMs(): number {
  * `refreshSharedSpecsCycle` isolates per-catalog failures (logged + counted) so a
  * down upstream can't stall the others or kill the scheduler loop.
  *
- * Span + heartbeat (#3183 L-1): the cycle was the only periodic refresh fiber
- * without a per-tick span — its siblings `byot-catalog-refresh.ts` and
- * `openapi-install-rediscover.ts` both emit one, so a wedged spec-refresh fiber
- * was invisible until a catalog drift surfaced. Wrap the cycle in
- * `atlas.scheduler.openapi_spec_refresh` (presence/absence against the cadence is
- * the liveness signal) and emit a per-cycle `log.info` heartbeat so a hung tick
- * is visible in logs too, not just traces. This is a `setInterval` scheduler with
- * a Promise-native cycle, so it uses the Promise `withSpan` (not the Effect
- * `withEffectSpan` the byot/rediscover cycles use); it self-spans here and so
- * never slots into `SCHEDULER_WORK_SPAN_NAMES` in `effect/layers.ts`.
+ * Heartbeat (#3183 L-1): emits a per-cycle `log.info` start line, and — for the
+ * empty-cache case `refreshSharedSpecsCycle` doesn't otherwise log — a completion
+ * heartbeat, so a hung tick is visible in logs. The per-tick liveness SPAN
+ * (`atlas.scheduler.openapi_spec_refresh`) is applied by `registerPeriodicFiber`
+ * around the fiber in `effect/layers.ts` (#4195), where the fiber's
+ * `spanResultAttributes` carry the inspected/updated/not-modified/failed counts.
+ * This job schedules through `registerPeriodicFiber` like its siblings but,
+ * having no internal-DB working set (its cache is process-local), does NOT use
+ * the `runPeriodicDbCycle` DB-cycle skeleton the byot/rediscover jobs share.
  */
 export async function runOpenApiSpecRefreshCycle(): Promise<SharedRefreshCycleResult> {
-  return withSpan(
-    "atlas.scheduler.openapi_spec_refresh",
-    {},
-    async () => {
-      log.info("Shared OpenAPI spec refresh cycle starting");
-      const result = await refreshSharedSpecsCycle({ specUrlFor: specUrlForCatalog });
-      // `refreshSharedSpecsCycle` already emits a detailed "cycle complete" log
-      // (with per-catalog counts) when the working set is non-empty. Emit our own
-      // completion heartbeat for the empty-cache case — the common shape on a
-      // fresh pod or low-traffic region — so the cadence is unbroken there too
-      // and the two paths each leave exactly one start + one complete log.
-      if (result.inspected === 0) {
-        log.info("Shared OpenAPI spec refresh cycle complete — empty working set (no cached specs to refresh)");
-      }
-      return result;
-    },
-    (result) => ({
-      "atlas.openapi_spec_refresh.inspected": result.inspected,
-      "atlas.openapi_spec_refresh.updated": result.updated,
-      "atlas.openapi_spec_refresh.not_modified": result.notModified,
-      "atlas.openapi_spec_refresh.failed": result.failed,
-    }),
-  );
+  log.info("Shared OpenAPI spec refresh cycle starting");
+  const result = await refreshSharedSpecsCycle({ specUrlFor: specUrlForCatalog });
+  // `refreshSharedSpecsCycle` already emits a detailed "cycle complete" log
+  // (with per-catalog counts) when the working set is non-empty. Emit our own
+  // completion heartbeat for the empty-cache case — the common shape on a
+  // fresh pod or low-traffic region — so the cadence is unbroken there too
+  // and the two paths each leave exactly one start + one complete log.
+  if (result.inspected === 0) {
+    log.info("Shared OpenAPI spec refresh cycle complete — empty working set (no cached specs to refresh)");
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle (setInterval-based, mirrors byot-catalog-refresh.ts)
+// Scheduling — via `registerPeriodicFiber` in `effect/layers.ts` (#4195)
 // ---------------------------------------------------------------------------
-
-let _timer: ReturnType<typeof setInterval> | null = null;
-let _running = false;
-/** A still-running cycle, so a slow tick never overlaps the next one. */
-let _inFlight = false;
-
-function runCycleWithDefectGuard(): void {
-  // Overlap guard: a cycle does network I/O (conditional GETs). With the default
-  // 24h cadence overlap is impossible, but a misconfigured short interval — or a
-  // very slow upstream — could otherwise start a second cycle before the first
-  // finished, racing on the shared-cache pointers. Skip this tick if one is still
-  // in flight; the next tick picks the work back up.
-  if (_inFlight) {
-    log.debug("Shared OpenAPI spec refresh cycle still in flight — skipping this tick");
-    return;
-  }
-  _inFlight = true;
-  runOpenApiSpecRefreshCycle()
-    .catch((err: unknown) => {
-      // The cycle catches per-catalog failures internally; this guard only fires
-      // on an unexpected defect (e.g. the registry import threw) so the loop
-      // survives and the next tick still runs.
-      log.error(
-        { err: err instanceof Error ? err.message : String(err) },
-        "Shared OpenAPI spec refresh cycle defected past its internal catch",
-      );
-    })
-    .finally(() => {
-      _inFlight = false;
-    });
-}
-
-/**
- * Start the shared OpenAPI spec refresh scheduler. Runs an initial cycle
- * immediately, then repeats at the configured interval. No-op if already running.
- * A non-positive / non-finite `intervalMs` falls back to the configured default
- * rather than hot-looping `setInterval`.
- */
-export function startOpenApiSpecRefreshScheduler(intervalMs?: number): void {
-  if (_running) {
-    log.debug("Shared OpenAPI spec refresh scheduler already running — skipping start");
-    return;
-  }
-  // Validate the explicit override: a 0 / negative / NaN interval would make
-  // setInterval fire continuously. Fall back to the (already-validated) configured
-  // interval so a bad caller-supplied value can't spin the event loop.
-  const interval =
-    intervalMs !== undefined && Number.isFinite(intervalMs) && intervalMs > 0
-      ? intervalMs
-      : getSharedSpecRefreshIntervalMs();
-  _running = true;
-  log.info({ intervalMs: interval }, "Starting shared OpenAPI spec refresh scheduler");
-
-  runCycleWithDefectGuard();
-  _timer = setInterval(runCycleWithDefectGuard, interval);
-  _timer.unref();
-}
-
-export function stopOpenApiSpecRefreshScheduler(): void {
-  if (_timer) {
-    clearInterval(_timer);
-    _timer = null;
-  }
-  _running = false;
-  log.info("Shared OpenAPI spec refresh scheduler stopped");
-}
-
-export function isOpenApiSpecRefreshSchedulerRunning(): boolean {
-  return _running;
-}
-
-/** Test-only: reset scheduler state. */
-export function _resetOpenApiSpecRefreshScheduler(): void {
-  stopOpenApiSpecRefreshScheduler();
-}
+//
+// The Tier-1 refresh no longer hand-rolls a `setInterval` lifecycle. The fiber
+// that repeats `runOpenApiSpecRefreshCycle` — interval
+// (`getSharedSpecRefreshIntervalMs`), per-tick span, and `withFiberDeathLog` —
+// is owned by `registerPeriodicFiber` (arch-win #100 / #4130), forked
+// `forkScoped` for the pod lifetime. It starts unconditionally (no internal-DB
+// gate; the cache is process-local). `Schedule.spaced` there spaces ticks by
+// completion, so a slow cycle can never overlap the next — subsuming the old
+// `_inFlight` guard.
 
 /**
  * Manual-trigger entry point (admin scheduler page / tests). Runs a single cycle

--- a/packages/api/src/lib/scheduler/periodic-db-job.ts
+++ b/packages/api/src/lib/scheduler/periodic-db-job.ts
@@ -1,0 +1,185 @@
+/**
+ * periodic-db-job.ts — the shared cycle skeleton for scheduler jobs that walk
+ * an internal-DB working set once per tick (#4195).
+ *
+ * ## Relationship to `registerPeriodicFiber` (arch-win #100 / #4130)
+ * These are two composable seams, not competitors:
+ *
+ *   - `registerPeriodicFiber` (lib/effect/layers.ts) SCHEDULES a fiber: it owns
+ *     the interval (`Schedule.spaced` + `forkScoped`), the per-tick span, the
+ *     `withFiberDeathLog`, and the enablement gate. It answers *when* a tick runs
+ *     and *that* the loop keeps running.
+ *   - `runPeriodicDbCycle` (this module) SHAPES one tick *when that tick is a DB
+ *     cycle*: guard on an internal DB → scan a bounded working set → apply each
+ *     row sequentially (`concurrency: 1`) → tally the outcome → emit the cycle
+ *     audit row. It answers *what* one tick does.
+ *
+ * The two compose: a DB job passes `runPeriodicDbCycle(...)` (via its
+ * `run*Cycle` Effect) as the `tick` of a `registerPeriodicFiber` registration.
+ * The fiber machinery then lives once in `layers.ts` and the DB-cycle
+ * choreography lives once here — where, pre-#4195, `byot-catalog-refresh.ts`
+ * and `openapi-install-rediscover.ts` each hand-rolled BOTH.
+ *
+ * The Tier-1 shared-spec refresh (`openapi-spec-refresh.ts`) is deliberately NOT
+ * a caller: it has no internal-DB working set (its cache is process-local), so
+ * it schedules through `registerPeriodicFiber` but supplies its own tick body
+ * rather than this skeleton — the variance the issue names.
+ *
+ * ## Fail-soft contract
+ * The returned Effect NEVER fails (`E = never`): a scan fault is folded into a
+ * `status: "failure"` result (audited), and every per-row fault is caught and
+ * counted, so the enclosing fiber's repeat loop can never die on a bad tick.
+ * The no-internal-DB path is a zero-count success that still emits the cycle
+ * audit row (the "scheduler alive, nothing to do" signal).
+ */
+
+import { Effect } from "effect";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import type { createLogger } from "@atlas/api/lib/logger";
+
+type Logger = ReturnType<typeof createLogger>;
+
+/**
+ * The minimum shape every DB-cycle result carries. `inspected` is stamped by
+ * the skeleton (= scanned row count); each job's own result type extends this
+ * with its per-outcome tallies.
+ */
+export interface PeriodicDbCycleResult {
+  status: "success" | "failure";
+  inspected: number;
+}
+
+export interface PeriodicDbCycleSpec<Row, Outcome, Result extends PeriodicDbCycleResult> {
+  /** The job's logger — used for the three cycle log lines below. */
+  readonly log: Logger;
+  /** Human label prefixing the cycle logs (e.g. "BYOT catalog refresh"). */
+  readonly label: string;
+  /**
+   * A FRESH, zeroed success result (`inspected` 0) on every call — must not
+   * return a shared singleton, since the populated path mutates it in place.
+   * Used for the no-DB + empty paths, and as the seed for the populated path
+   * (`inspected` is then stamped and `tally` accumulates into it).
+   */
+  readonly emptyResult: () => Result;
+  /** A zeroed failure result carrying the scan error (`status: "failure"`). */
+  readonly failureResult: (error: string) => Result;
+  /**
+   * Bounded scan of the working set. Only invoked when an internal DB is
+   * present; a rejection is caught and folded into a failure result.
+   */
+  readonly scan: () => Promise<readonly Row[]>;
+  /** Apply one row. May reject; an unexpected rejection maps via `defectOutcome`. */
+  readonly applyRow: (row: Row) => Promise<Outcome>;
+  /** Map an unexpected per-row rejection to a terminal outcome (belt-and-braces). */
+  readonly defectOutcome: (error: string) => Outcome;
+  /**
+   * Fold one row's outcome into `result` and emit its per-row audit. Mutates
+   * `result` in place — this is where each job's per-outcome tally + backoff /
+   * drift bookkeeping lives.
+   */
+  readonly tally: (result: Result, row: Row, outcome: Outcome) => void;
+  /** Emit the cycle-level audit row. Fires on EVERY terminal path (no-DB, scan-fail, empty, done). */
+  readonly emitCycleAudit: (result: Result) => void;
+}
+
+/**
+ * Run a single periodic DB cycle. See the module docstring for the contract.
+ * Never throws / never fails — the result is always returned and always
+ * audited.
+ */
+export const runPeriodicDbCycle = <Row, Outcome, Result extends PeriodicDbCycleResult>(
+  spec: PeriodicDbCycleSpec<Row, Outcome, Result>,
+): Effect.Effect<Result> =>
+  Effect.gen(function* () {
+    // The synchronous spec callbacks (`tally`, `emitCycleAudit`) run OUTSIDE the
+    // `Effect.tryPromise` boundaries, so a throw in one would be an Effect DEFECT
+    // — and `registerPeriodicFiber` recovers typed failures, NOT defects, so such
+    // a throw would kill the periodic fiber permanently (pre-#4195 the
+    // `Effect.runPromise(...).catch()` driver logged it and the loop survived).
+    // Guard them here so the fail-soft contract holds structurally: a stray throw
+    // degrades to a logged error and the loop lives on. Both callers already
+    // guard their emitters internally; this is belt-and-braces at the seam.
+    const emitAudit = (r: Result): void => {
+      try {
+        spec.emitCycleAudit(r);
+      } catch (err) {
+        spec.log.error(
+          { err: errorMessage(err) },
+          `${spec.label}: cycle audit emission threw`,
+        );
+      }
+    };
+
+    if (!hasInternalDB()) {
+      const result = spec.emptyResult();
+      emitAudit(result);
+      return result;
+    }
+
+    const fetchResult = yield* Effect.tryPromise({
+      try: spec.scan,
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.map((rows) => ({ ok: true as const, rows })),
+      Effect.catchAll((err) => {
+        spec.log.error(
+          { err: errorMessage(err) },
+          `${spec.label}: failed to query the working set`,
+        );
+        return Effect.succeed({ ok: false as const, error: errorMessage(err) });
+      }),
+    );
+
+    if (!fetchResult.ok) {
+      const failed = spec.failureResult(fetchResult.error);
+      emitAudit(failed);
+      return failed;
+    }
+
+    const rows = fetchResult.rows;
+    const result = spec.emptyResult();
+    result.inspected = rows.length;
+
+    if (rows.length === 0) {
+      emitAudit(result);
+      return result;
+    }
+
+    spec.log.info({ count: rows.length }, `${spec.label}: cycle starting`);
+
+    // Sequential — one row at a time (`concurrency: 1`), so a noisy row can't
+    // fan out egress and a fiber interrupt cancels cleanly mid-cycle. Each
+    // per-row apply is wrapped so a surprise rejection counts as a failure
+    // rather than aborting the loop.
+    yield* Effect.forEach(
+      rows,
+      (row) =>
+        Effect.gen(function* () {
+          const outcome = yield* Effect.tryPromise({
+            try: () => spec.applyRow(row),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(
+            Effect.catchAll((err) => Effect.succeed(spec.defectOutcome(errorMessage(err)))),
+          );
+          try {
+            spec.tally(result, row, outcome);
+          } catch (err) {
+            // A tally throw would defect the fiber (see `emitAudit` note above).
+            // Log + skip the row so one bad row can't stop the loop.
+            spec.log.error(
+              { err: errorMessage(err) },
+              `${spec.label}: tally threw for a row — skipping it`,
+            );
+          }
+        }),
+      { concurrency: 1 },
+    );
+
+    // Cast for pino's `LogFn`: spreading the generic `Result` leaves its
+    // `extends string ? never` guard unresolved (a generic spread is not
+    // provably `Record<string, unknown>`), so pin it to a plain record.
+    spec.log.info({ ...result } as Record<string, unknown>, `${spec.label}: cycle complete`);
+    emitAudit(result);
+    return result;
+  });

--- a/packages/api/src/lib/scheduler/periodic-db-job.ts
+++ b/packages/api/src/lib/scheduler/periodic-db-job.ts
@@ -60,9 +60,15 @@ export interface PeriodicDbCycleSpec<Row, Outcome, Result extends PeriodicDbCycl
    * return a shared singleton, since the populated path mutates it in place.
    * Used for the no-DB + empty paths, and as the seed for the populated path
    * (`inspected` is then stamped and `tally` accumulates into it).
+   *
+   * Must be a PURE, non-throwing constructor: unlike `tally`/`emitCycleAudit`,
+   * a throw here is NOT guarded and would defect (and kill) the periodic fiber.
    */
   readonly emptyResult: () => Result;
-  /** A zeroed failure result carrying the scan error (`status: "failure"`). */
+  /**
+   * A zeroed failure result carrying the scan error (`status: "failure"`).
+   * Must be a PURE, non-throwing constructor (see `emptyResult`).
+   */
   readonly failureResult: (error: string) => Result;
   /**
    * Bounded scan of the working set. Only invoked when an internal DB is
@@ -71,7 +77,11 @@ export interface PeriodicDbCycleSpec<Row, Outcome, Result extends PeriodicDbCycl
   readonly scan: () => Promise<readonly Row[]>;
   /** Apply one row. May reject; an unexpected rejection maps via `defectOutcome`. */
   readonly applyRow: (row: Row) => Promise<Outcome>;
-  /** Map an unexpected per-row rejection to a terminal outcome (belt-and-braces). */
+  /**
+   * Map an unexpected per-row rejection to a terminal outcome (belt-and-braces).
+   * Must be a PURE, non-throwing mapper (it runs eagerly inside `Effect.succeed`,
+   * so a throw here is NOT guarded and would defect the fiber — see `emptyResult`).
+   */
   readonly defectOutcome: (error: string) => Outcome;
   /**
    * Fold one row's outcome into `result` and emit its per-row audit. Mutates


### PR DESCRIPTION
Closes #4195.

## What

Folds the three periodic scheduler refresh jobs off their hand-rolled `setInterval` lifecycle onto the shared `registerPeriodicFiber` seam (arch-win #100 / #4130), and extracts the DB-cycle choreography they duplicated into one skeleton. Two periodic mechanisms no longer coexist.

**New: `scheduler/periodic-db-job.ts` — `runPeriodicDbCycle`.** The scan → internal-DB guard → `forEach({concurrency:1})` → tally → cycle-audit skeleton, once. Each job supplies only its scan query, per-row apply, per-outcome tally, and result factories. Distinct from `registerPeriodicFiber`: that *schedules a fiber* (when/that a tick runs); this *shapes one DB tick* (what it does). The two compose — a job's `run*Cycle` Effect is the fiber's `tick`.

- `byot-catalog-refresh.ts` + `openapi-install-rediscover.ts` — cycle bodies rebuilt on the skeleton; ~150 LOC of duplicated lifecycle + choreography collapses. Their `setInterval`/`_timer`/`_running`/`_inFlight`/`start`/`stop`/`isRunning`/`_reset`/`runCycleWithDefectGuard` are gone.
- `openapi-spec-refresh.ts` — folded onto `registerPeriodicFiber` too, but it's the *non-DB* variance the issue names (process-local cache, no internal-DB working set), so it keeps its own thin tick and does **not** use the skeleton.
- `effect/layers.ts` — the 3 copy-pasted start blocks become 3 `registerPeriodicFiber` registrations (their spans move into `SCHEDULER_WORK_SPAN_NAMES`, attribution preserved via `spanResultAttributes`); the 3 symmetric shutdown blocks are deleted (`forkScoped` interrupts on scope shutdown).
- `admin-scheduler.ts` still reads `isByotCatalogRefreshSchedulerRunning()`, now backed by the registration gate (`hasInternalDB()`), documented.

## Acceptance criteria
- [x] Runner owns the cycle skeleton once; the fiber lifecycle is owned by `registerPeriodicFiber`; ~150 LOC of duplication collapses.
- [x] The three jobs supply scan/apply/tally only; `layers.ts` starts them via one registration path.
- [x] Per-job apply steps unit-testable; **coverage added for the gaps** (`slack-token.ts`, `byot-catalog-query.ts`) plus a direct `periodic-db-job.test.ts` pinning the fail-soft contract.
- [x] Relationship to `registerPeriodicFiber` documented (`periodic-db-job.ts` header: one schedules fibers, this shapes DB cycles).

## Hardening (internal review-panel)
Fail-soft made structural: a synchronous throw in `tally`/`emitCycleAudit` (which run outside the `tryPromise` boundary) would defect and permanently kill the fiber — now guarded to a logged error so the loop survives, matching the pre-refactor `runCycleWithDefectGuard` guarantee. The remaining pure-constructor callbacks document the must-not-throw invariant.

## Testing
- `bun run type` clean; lint clean.
- `--affected` (scheduler + `layers.test.ts` + all 4 `makeSchedulerLive`-building suites + `admin-scheduler`): green.
- New `periodic-db-job.test.ts` (7 cases): no-DB / scan-reject / empty / populated tally / per-row defect fold / throwing-tally guard / throwing-emitCycleAudit guard.
- Local `ci-local.sh`: 26/27 gates green. The one `test`-gate failure is the DB-dependent `@atlas/mcp` `smoke.test.ts` (billing-gate `organization` query) failing only because `TEST_DATABASE_URL` is unset locally — this branch touches zero `packages/mcp/` files and `main`'s CI is green on it; the `api-tests` shards run it against real Postgres.

https://claude.ai/code/session_015E1b5xQeizyEQZktA9hm6N