### PR TITLE
refactor(api): one sandbox backend-selection module shared by explore + python (#4187)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/python-rest-egress.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress.test.ts
@@ -203,10 +203,15 @@ describe("executePython REST egress (#2927, layer 0)", () => {
     expect(mockUpdateNetworkPolicyCalls).toEqual([{ allow: { "crm.internal": [] } }]);
   });
 
-  it("SECURITY (self-hosted asymmetry): a configured sidecar bypasses the resolver and applies NO network policy", async () => {
-    // When ATLAS_SANDBOX_URL is set, useSidecar() wins over the Vercel backend.
-    // The resolver must NOT run (the guard is `useVercelSandbox() && !useSidecar()`)
-    // and the sidecar — which has no networkPolicy equivalent — gets no narrowing.
+  it("SECURITY (self-hosted asymmetry): the sidecar backend bypasses the resolver and applies NO network policy", async () => {
+    // When the sidecar is the selected backend (ATLAS_SANDBOX_URL set, no Vercel),
+    // the egress resolver must NOT run — the shared selector only resolves the
+    // REST datasource when the Vercel step is actually reached — and the sidecar,
+    // which has no networkPolicy equivalent, gets no narrowing. Under the unified
+    // #4187 policy Vercel outranks the sidecar, so we clear ATLAS_RUNTIME here to
+    // make the sidecar the genuinely-selected backend (the prior test relied on
+    // Python's now-removed sidecar-first ordering).
+    delete process.env.ATLAS_RUNTIME;
     process.env.ATLAS_SANDBOX_URL = "http://sandbox-sidecar:8080";
     let resolverCalls = 0;
     const result = await runPython(async () => {

--- a/packages/api/src/lib/tools/__tests__/python-sandbox-priority.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sandbox-priority.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #4187 — the Python tool now routes through the SAME backend-selection policy
+ * as explore, so it honors the operator's `sandbox.priority` (and, transitively,
+ * `ATLAS_SANDBOX_PRIORITY`, which `config.ts` folds into that field).
+ *
+ * Before #4187 `getPythonBackend` was a hand-rolled `sidecar > vercel > nsjail`
+ * chain with ZERO references to `sandbox.priority` — so a SaaS deploy that pins
+ * `["vercel-sandbox"]` (deny-all, no fallback) could have Python silently run on
+ * a configured sidecar instead, the exact posture bug this issue closes. These
+ * tests lock:
+ *   1. a single-backend pin fails CLOSED when the pinned backend is unavailable,
+ *      never falling through to a configured-but-unpinned sidecar; and
+ *   2. the pin actually routes Python to the pinned backend (positive control).
+ */
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
+import { _setConfigForTest, _resetConfig, type ResolvedConfig } from "@atlas/api/lib/config";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
+  getRequestContext: () => undefined,
+}));
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (_n: string, _a: unknown, fn: () => Promise<unknown>) => fn(),
+  withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+
+// Count sidecar dispatches so a pin that excludes the sidecar can prove Python
+// never touched it. Mock every export the import graph could reach.
+let sidecarExecCalls = 0;
+mock.module("@atlas/api/lib/tools/python-sidecar", () => ({
+  executePythonViaSidecar: async () => {
+    sidecarExecCalls += 1;
+    return { success: true, output: "[sidecar]" };
+  },
+  executePythonViaSidecarStream: async () => {
+    sidecarExecCalls += 1;
+    return { success: true, output: "[sidecar]" };
+  },
+}));
+
+// The AST import guard shells out to python3; stub Bun.spawn to return a clean
+// parse so validation never blocks these selection-focused tests.
+const savedSpawn = Bun.spawn;
+function stubImportGuard() {
+  Bun.spawn = ((...args: unknown[]) => {
+    const cmd = args[0] as string[];
+    if (cmd[0] === "python3") {
+      return {
+        stdin: { write: () => {}, end: () => {} },
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode('{"imports":[],"calls":[]}'));
+            c.close();
+          },
+        }),
+        stderr: new ReadableStream({ start: (c) => c.close() }),
+        exited: Promise.resolve(0),
+        kill: () => {},
+      };
+    }
+    // Any other spawn (e.g. nsjail) — return an empty success.
+    return {
+      stdin: { write: () => {}, end: () => {} },
+      stdout: new ReadableStream({ start: (c) => c.close() }),
+      stderr: new ReadableStream({ start: (c) => c.close() }),
+      exited: Promise.resolve(0),
+      kill: () => {},
+    };
+  }) as unknown as typeof Bun.spawn;
+}
+
+const { executePython } = await import("@atlas/api/lib/tools/python");
+
+async function runPython(): Promise<{ success: boolean; error?: string; output?: string }> {
+  const result = await executePython.execute!(
+    { code: "result = 1", explanation: "test", data: undefined },
+    {} as never,
+  );
+  return result as { success: boolean; error?: string; output?: string };
+}
+
+describe("executePython honors sandbox.priority (#4187)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    sidecarExecCalls = 0;
+    _resetConfig();
+    stubImportGuard();
+    // A sidecar IS configured — a correct pin must ignore it.
+    process.env.ATLAS_SANDBOX_URL = "http://sidecar.test";
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+    delete process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TOKEN;
+    delete process.env.ATLAS_SANDBOX;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    _resetConfig();
+    Bun.spawn = savedSpawn;
+  });
+
+  it("fails CLOSED on a ['vercel-sandbox'] pin when Vercel is unavailable — never falls through to the sidecar", async () => {
+    _setConfigForTest({
+      sandbox: { priority: ["vercel-sandbox"] },
+      deployMode: "saas",
+    } as unknown as ResolvedConfig);
+    // No Vercel credentials → the pinned backend cannot be constructed.
+
+    const result = await runPython();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("All backends in sandbox.priority");
+    expect(result.error).toContain("vercel-sandbox");
+    // The posture fix: the configured sidecar was NOT used despite being available.
+    expect(sidecarExecCalls).toBe(0);
+  });
+
+  it("routes Python to the pinned sidecar when the operator pins ['sidecar'] (positive control)", async () => {
+    _setConfigForTest({
+      sandbox: { priority: ["sidecar"] },
+      deployMode: "self-hosted",
+    } as unknown as ResolvedConfig);
+
+    const result = await runPython();
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("[sidecar]");
+    expect(sidecarExecCalls).toBe(1);
+  });
+
+  it("REFUSES (never runs unsandboxed) when no isolation backend is available", async () => {
+    // No config pin, no sidecar, no Vercel, no nsjail (PATH cleared so
+    // findNsjailBinary is deterministically null regardless of host) — the
+    // default chain exhausts and Python must refuse, unlike explore's just-bash.
+    _resetConfig();
+    delete process.env.ATLAS_SANDBOX_URL;
+    process.env.PATH = "";
+    delete process.env.ATLAS_NSJAIL_PATH;
+
+    const result = await runPython();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("requires a sandbox");
+    expect(sidecarExecCalls).toBe(0);
+  });
+
+  it("hard-fails when ATLAS_SANDBOX=nsjail but the nsjail binary is absent", async () => {
+    // This path was previously untestable (python-nsjail.test.ts:504-509 gave up
+    // because fs was globally mocked present); the #4187 decoupling makes it
+    // deterministic. PATH="" ⇒ findNsjailBinary() === null ⇒ the explicit-nsjail
+    // hard-fail step surfaces as an error, never a downgrade to the sidecar.
+    _resetConfig();
+    process.env.ATLAS_SANDBOX = "nsjail";
+    process.env.PATH = "";
+    delete process.env.ATLAS_NSJAIL_PATH;
+
+    const result = await runPython();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ATLAS_SANDBOX=nsjail");
+    expect(result.error).toContain("could not be initialized");
+    // Even with a sidecar configured, an explicit-nsjail pin never falls through.
+    expect(sidecarExecCalls).toBe(0);
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/sandbox-selection-parity.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sandbox-selection-parity.test.ts
@@ -1,0 +1,111 @@
+/**
+ * #4187 AC1 — "explore and python resolve the same backend for the same
+ * env/config." Both tools feed the ONE shared `planSandboxSelection` policy, so
+ * the only remaining drift vector is their two snapshot builders
+ * (`snapshotExploreSandboxEnv` vs `snapshotPythonSandboxEnv`). This test drives
+ * a matrix of env/config states through BOTH builders and asserts they produce
+ * the SAME plan — so a future edit to one builder's detection semantics can't
+ * silently reintroduce the exact divergence this issue fixed.
+ *
+ * The two builders intentionally differ on `nsjailAvailable` (explore feeds the
+ * pin-inclusive `useNsjail()`, python the pure `isNsjailAvailable()`) and on
+ * `nsjailFailed` (python has no runtime-degradation flag). The matrix here keeps
+ * nsjail's binary absent (PATH cleared) and `_nsjailFailed` false (fresh module),
+ * so those documented differences don't apply and the resulting PLANS must match
+ * exactly — which is the property AC1 actually cares about.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
+  getRequestContext: () => undefined,
+}));
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (_n: string, _a: unknown, fn: () => Promise<unknown>) => fn(),
+  withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+
+const { planSandboxSelection } = await import("@atlas/api/lib/tools/backends/selection");
+const { snapshotExploreSandboxEnv } = await import("@atlas/api/lib/tools/explore");
+const { snapshotPythonSandboxEnv } = await import("@atlas/api/lib/tools/python");
+const { _setConfigForTest, _resetConfig } = await import("@atlas/api/lib/config");
+
+async function bothPlans() {
+  const explorePlan = planSandboxSelection(snapshotExploreSandboxEnv());
+  const pythonPlan = planSandboxSelection(await snapshotPythonSandboxEnv());
+  const shape = (p: typeof explorePlan) => ({
+    source: p.source,
+    onExhausted: p.onExhausted,
+    steps: p.steps.map((s) => ({ kind: s.kind, hardFail: s.hardFail })),
+  });
+  return { explore: shape(explorePlan), python: shape(pythonPlan) };
+}
+
+describe("explore + python resolve the same backend plan (#4187 AC1)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    _resetConfig();
+    // Neutralize all backend inputs; each case sets exactly what it exercises.
+    delete process.env.ATLAS_RUNTIME;
+    delete process.env.VERCEL;
+    delete process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_PROJECT_ID;
+    delete process.env.VERCEL_TOKEN;
+    delete process.env.ATLAS_SANDBOX;
+    delete process.env.ATLAS_SANDBOX_URL;
+    delete process.env.ATLAS_NSJAIL_PATH;
+    // nsjail binary deterministically absent (both builders detect false).
+    process.env.PATH = "";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    _resetConfig();
+  });
+
+  // 2×2×2 over the env-driven default chain (Vercel × sidecar × explicit-nsjail).
+  const vercelStates = [false, true];
+  const sidecarStates = [false, true];
+  const explicitNsjailStates = [false, true];
+
+  for (const vercel of vercelStates) {
+    for (const sidecar of sidecarStates) {
+      for (const explicitNsjail of explicitNsjailStates) {
+        it(`agrees for vercel=${vercel} sidecar=${sidecar} explicitNsjail=${explicitNsjail}`, async () => {
+          if (vercel) process.env.ATLAS_RUNTIME = "vercel";
+          if (sidecar) process.env.ATLAS_SANDBOX_URL = "http://sidecar.test";
+          if (explicitNsjail) process.env.ATLAS_SANDBOX = "nsjail";
+
+          const { explore, python } = await bothPlans();
+          expect(python).toEqual(explore);
+        });
+      }
+    }
+  }
+
+  it("agrees on a config-priority pin (SaaS deny-all)", async () => {
+    _setConfigForTest({
+      sandbox: { priority: ["vercel-sandbox"] },
+      deployMode: "saas",
+    } as unknown as Parameters<typeof _setConfigForTest>[0]);
+    process.env.ATLAS_RUNTIME = "vercel";
+
+    const { explore, python } = await bothPlans();
+    expect(python).toEqual(explore);
+    expect(python.source).toBe("config-priority");
+    expect(python.onExhausted).toBe("fail-closed");
+  });
+
+  it("agrees on a config-priority list that includes just-bash", async () => {
+    _setConfigForTest({
+      sandbox: { priority: ["sidecar", "just-bash"] },
+      deployMode: "self-hosted",
+    } as unknown as Parameters<typeof _setConfigForTest>[0]);
+
+    const { explore, python } = await bothPlans();
+    expect(python).toEqual(explore);
+    expect(python.onExhausted).toBe("just-bash");
+  });
+});

--- a/packages/api/src/lib/tools/backends/__tests__/nsjail-args.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/nsjail-args.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  assembleNsjailArgs,
+  buildNsjailArgs,
+  buildPythonNsjailArgs,
+  BASE_JAIL_ENV,
+} from "@atlas/api/lib/tools/backends/nsjail";
+
+// ---------------------------------------------------------------------------
+// Golden exact-array locks for the shared nsjail arg assembler.
+//
+// nsjail arg-building is security-critical (it is the sandbox boundary) and,
+// per #4187, now lives in ONE place (assembleNsjailArgs) fed by the explore and
+// Python spec adapters. These tests pin the FULL arg array for each tool so any
+// accidental drift in the shared serialization — a dropped `-u 65534`, a
+// reordered mount, a changed rlimit — fails loudly rather than silently
+// weakening isolation. The existing explore-nsjail / python-nsjail suites check
+// individual flags; this file asserts byte-for-byte equality of the whole list.
+// ---------------------------------------------------------------------------
+
+const NSJAIL_LIMIT_ENV = [
+  "ATLAS_NSJAIL_TIME_LIMIT",
+  "ATLAS_NSJAIL_MEMORY_LIMIT",
+] as const;
+
+describe("assembleNsjailArgs golden arrays", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Neutralize any ambient resource-limit overrides so the golden arrays
+    // reflect the built-in defaults (10s/256MB explore, 30s/512MB Python).
+    for (const key of NSJAIL_LIMIT_ENV) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of NSJAIL_LIMIT_ENV) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("explore args are byte-for-byte stable (defaults)", () => {
+    expect(buildNsjailArgs("/usr/local/bin/nsjail", "/semantic-root", "ls -la")).toEqual([
+      "/usr/local/bin/nsjail",
+      "--mode", "o",
+      "-R", "/semantic-root:/semantic",
+      "-R", "/bin",
+      "-R", "/usr/bin",
+      "-R", "/lib",
+      "-R", "/lib64",
+      "-R", "/usr/lib",
+      "-R", "/dev/null",
+      "-R", "/dev/zero",
+      "-R", "/dev/urandom",
+      "--proc_path", "/proc",
+      "-T", "/tmp",
+      "--cwd", "/semantic",
+      "-t", "10",
+      "--rlimit_as", "256",
+      "--rlimit_fsize", "10",
+      "--rlimit_nproc", "5",
+      "--rlimit_nofile", "64",
+      "-u", "65534",
+      "-g", "65534",
+      "--quiet",
+      "--", "/bin/bash", "-c", "ls -la",
+    ]);
+  });
+
+  it("Python args are byte-for-byte stable (defaults)", () => {
+    expect(
+      buildPythonNsjailArgs(
+        "/usr/local/bin/nsjail",
+        "/tmp/pyexec-x",
+        "/tmp/pyexec-x/user_code.py",
+        "/tmp/pyexec-x/wrapper.py",
+        "/tmp/pyexec-x/charts",
+        "__ATLAS_RESULT_x__",
+      ),
+    ).toEqual([
+      "/usr/local/bin/nsjail",
+      "--mode", "o",
+      "-R", "/bin",
+      "-R", "/usr/bin",
+      "-R", "/usr/local/bin",
+      "-R", "/lib",
+      "-R", "/lib64",
+      "-R", "/usr/lib",
+      "-R", "/usr/local/lib",
+      "-R", "/dev/null",
+      "-R", "/dev/zero",
+      "-R", "/dev/urandom",
+      "--proc_path", "/proc",
+      "-T", "/tmp",
+      "-R", "/tmp/pyexec-x/wrapper.py:/tmp/wrapper.py",
+      "-R", "/tmp/pyexec-x/user_code.py:/tmp/user_code.py",
+      "-B", "/tmp/pyexec-x/charts:/tmp/charts",
+      "--cwd", "/tmp",
+      "-t", "30",
+      "--rlimit_as", "512",
+      "--rlimit_fsize", "50",
+      "--rlimit_nproc", "16",
+      "--rlimit_nofile", "128",
+      "-u", "65534",
+      "-g", "65534",
+      "--pass_fd", "0",
+      "--quiet",
+      "--", "/usr/bin/python3", "/tmp/wrapper.py", "/tmp/user_code.py",
+    ]);
+  });
+
+  it("both tools run as nobody (65534) and suppress nsjail logs", () => {
+    const explore = buildNsjailArgs("/nsjail", "/root", "echo hi");
+    const python = buildPythonNsjailArgs("/nsjail", "/t", "/t/c.py", "/t/w.py", "/t/charts", "m");
+    for (const args of [explore, python]) {
+      expect(args[args.indexOf("-u") + 1]).toBe("65534");
+      expect(args[args.indexOf("-g") + 1]).toBe("65534");
+      expect(args).toContain("--quiet");
+      expect(args).toContain("--mode");
+    }
+  });
+
+  it("assembleNsjailArgs omits --pass_fd unless passStdin is set", () => {
+    const withoutStdin = assembleNsjailArgs({
+      nsjailPath: "/nsjail",
+      systemMounts: ["/bin"],
+      cwd: "/tmp",
+      timeLimitSec: 5,
+      rlimitAs: 128,
+      rlimitFsize: 10,
+      rlimitNproc: 3,
+      rlimitNofile: 32,
+      command: ["/bin/true"],
+    });
+    expect(withoutStdin).not.toContain("--pass_fd");
+
+    const withStdin = assembleNsjailArgs({
+      nsjailPath: "/nsjail",
+      systemMounts: ["/bin"],
+      cwd: "/tmp",
+      timeLimitSec: 5,
+      rlimitAs: 128,
+      rlimitFsize: 10,
+      rlimitNproc: 3,
+      rlimitNofile: 32,
+      passStdin: true,
+      command: ["/bin/true"],
+    });
+    expect(withStdin[withStdin.indexOf("--pass_fd") + 1]).toBe("0");
+  });
+
+  it("BASE_JAIL_ENV carries no secrets", () => {
+    expect(BASE_JAIL_ENV).toEqual({
+      PATH: "/bin:/usr/bin",
+      HOME: "/tmp",
+      LANG: "C.UTF-8",
+    });
+  });
+});

--- a/packages/api/src/lib/tools/backends/__tests__/selection.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/selection.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+import {
+  planSandboxSelection,
+  runSandboxPlan,
+  firstAvailableBackend,
+  formatSandboxPriorityFailure,
+  type SandboxSelectionEnv,
+  type SandboxStep,
+  type StepAttempt,
+} from "@atlas/api/lib/tools/backends/selection";
+import type { SandboxBackendName } from "@atlas/api/lib/config";
+
+// ---------------------------------------------------------------------------
+// The whole point of this module (#4187): the priority policy is a PURE
+// function of an env snapshot, so it is unit-testable WITHOUT the `import(...?t=)`
+// cache-busting the old module-level-state selection forced (see the historical
+// explore-backend.test.ts helper). Every test here builds a plain object.
+// ---------------------------------------------------------------------------
+
+const BASE: SandboxSelectionEnv = {
+  atlasSandbox: undefined,
+  vercelAvailable: false,
+  sidecarAvailable: false,
+  nsjailAvailable: false,
+  nsjailFailed: false,
+  configPriority: undefined,
+};
+
+function env(overrides: Partial<SandboxSelectionEnv>): SandboxSelectionEnv {
+  return { ...BASE, ...overrides };
+}
+
+const kinds = (steps: readonly SandboxStep[]) => steps.map((s) => s.kind);
+
+describe("planSandboxSelection — default chain", () => {
+  it("degrades to just-bash (no steps) when nothing is available", () => {
+    const plan = planSandboxSelection(BASE);
+    expect(plan.source).toBe("default-chain");
+    expect(plan.steps).toHaveLength(0);
+    expect(plan.onExhausted).toBe("just-bash");
+  });
+
+  it("ranks Vercel above sidecar (the canonical order — resolves the divergence)", () => {
+    const plan = planSandboxSelection(env({ vercelAvailable: true, sidecarAvailable: true }));
+    expect(kinds(plan.steps)).toEqual(["vercel-sandbox", "sidecar"]);
+  });
+
+  it("ranks sidecar above nsjail auto-detect", () => {
+    const plan = planSandboxSelection(env({ sidecarAvailable: true, nsjailAvailable: true }));
+    expect(kinds(plan.steps)).toEqual(["sidecar", "nsjail"]);
+  });
+
+  it("makes explicit nsjail (ATLAS_SANDBOX=nsjail) a hard-fail step and drops sidecar/auto after it", () => {
+    const plan = planSandboxSelection(
+      env({ atlasSandbox: "nsjail", sidecarAvailable: true, nsjailAvailable: true }),
+    );
+    expect(kinds(plan.steps)).toEqual(["nsjail"]);
+    expect(plan.steps[0]!.hardFail).toBe(true);
+  });
+
+  it("still ranks Vercel ahead of explicit nsjail (soft Vercel, then hard-fail nsjail)", () => {
+    const plan = planSandboxSelection(env({ atlasSandbox: "nsjail", vercelAvailable: true }));
+    expect(kinds(plan.steps)).toEqual(["vercel-sandbox", "nsjail"]);
+    expect(plan.steps[0]!.hardFail).toBe(false);
+    expect(plan.steps[1]!.hardFail).toBe(true);
+  });
+
+  it("excludes nsjail entirely once it is marked failed — even when explicitly pinned", () => {
+    const explicit = planSandboxSelection(
+      env({ atlasSandbox: "nsjail", sidecarAvailable: true, nsjailAvailable: true, nsjailFailed: true }),
+    );
+    // Degraded: explicit nsjail is skipped, falls through to sidecar.
+    expect(kinds(explicit.steps)).toEqual(["sidecar"]);
+
+    const auto = planSandboxSelection(env({ nsjailAvailable: true, nsjailFailed: true }));
+    expect(auto.steps).toHaveLength(0);
+  });
+});
+
+describe("planSandboxSelection — config priority", () => {
+  it("uses the configured order verbatim and fails closed without just-bash (SaaS pin)", () => {
+    const plan = planSandboxSelection(env({ configPriority: ["vercel-sandbox"] }));
+    expect(kinds(plan.steps)).toEqual(["vercel-sandbox"]);
+    expect(plan.onExhausted).toBe("fail-closed");
+    // Narrow on the discriminant — `configPriority` lives only on this arm.
+    expect(plan.source).toBe("config-priority");
+    if (plan.source === "config-priority") {
+      expect(plan.configPriority).toEqual(["vercel-sandbox"]);
+    }
+  });
+
+  it("degrades to just-bash when the operator includes it in the list", () => {
+    const plan = planSandboxSelection(env({ configPriority: ["sidecar", "just-bash"] }));
+    expect(plan.onExhausted).toBe("just-bash");
+    expect(kinds(plan.steps)).toEqual(["sidecar", "just-bash"]);
+  });
+
+  it("config priority overrides the env-driven default chain", () => {
+    // Even with Vercel available, an explicit pin to sidecar wins.
+    const plan = planSandboxSelection(
+      env({ vercelAvailable: true, configPriority: ["sidecar", "just-bash"] }),
+    );
+    expect(kinds(plan.steps)).toEqual(["sidecar", "just-bash"]);
+  });
+});
+
+describe("firstAvailableBackend", () => {
+  it("returns the first step whose kind reports available", () => {
+    const plan = planSandboxSelection(env({ vercelAvailable: true, sidecarAvailable: true }));
+    // Vercel unavailable at report time → sidecar is named.
+    expect(firstAvailableBackend(plan, (k) => k === "sidecar")).toBe("sidecar");
+  });
+
+  it("returns null when no step is available (caller reports just-bash)", () => {
+    const plan = planSandboxSelection(env({ sidecarAvailable: true }));
+    expect(firstAvailableBackend(plan, () => false)).toBeNull();
+  });
+});
+
+describe("runSandboxPlan — shared walk semantics", () => {
+  const okStep = async (): Promise<StepAttempt<string>> => ({ backend: "backend" });
+  const failStep =
+    (reason: string) =>
+    async (step: SandboxStep): Promise<StepAttempt<string>> => ({
+      failure: { name: step.kind, reason },
+    });
+
+  it("returns the first step that constructs a backend", async () => {
+    const plan = planSandboxSelection(env({ vercelAvailable: true, sidecarAvailable: true }));
+    const outcome = await runSandboxPlan<string>(plan, async (step) =>
+      step.kind === "vercel-sandbox" ? failStep("nope")(step) : okStep(),
+    );
+    expect(outcome.kind).toBe("backend");
+    if (outcome.kind === "backend") expect(outcome.selected).toBe("sidecar");
+  });
+
+  it("falls through soft failures and reports 'exhausted' with the collected failures", async () => {
+    const plan = planSandboxSelection(env({ vercelAvailable: true, sidecarAvailable: true }));
+    const outcome = await runSandboxPlan<string>(plan, failStep("down"));
+    expect(outcome.kind).toBe("exhausted");
+    if (outcome.kind === "exhausted") {
+      expect(outcome.failures.map((f) => f.name)).toEqual(["vercel-sandbox", "sidecar"]);
+    }
+  });
+
+  it("short-circuits to 'hard-fail' when the explicit-nsjail step fails", async () => {
+    const plan = planSandboxSelection(env({ atlasSandbox: "nsjail" }));
+    const outcome = await runSandboxPlan<string>(plan, failStep("binary missing"));
+    expect(outcome.kind).toBe("hard-fail");
+    if (outcome.kind === "hard-fail") {
+      expect(outcome.step.kind).toBe("nsjail");
+      expect(outcome.reason).toBe("binary missing");
+    }
+  });
+
+  it("treats a thrown tryStep as a soft failure and keeps walking", async () => {
+    const plan = planSandboxSelection(env({ vercelAvailable: true, sidecarAvailable: true }));
+    const outcome = await runSandboxPlan<string>(plan, async (step) => {
+      if (step.kind === "vercel-sandbox") throw new Error("boom");
+      return okStep();
+    });
+    expect(outcome.kind).toBe("backend");
+    if (outcome.kind === "backend") expect(outcome.selected).toBe("sidecar");
+  });
+
+  it("reports 'fail-closed' for a config pin with no just-bash", async () => {
+    const plan = planSandboxSelection(env({ configPriority: ["vercel-sandbox"] }));
+    const outcome = await runSandboxPlan<string>(plan, failStep("401"));
+    expect(outcome.kind).toBe("fail-closed");
+  });
+});
+
+describe("SaaS pin resolves identically for both tools (AC1 + AC4)", () => {
+  // The SaaS deploy config is `sandbox.priority: ["vercel-sandbox"]` with no
+  // fallback. Both tools build the SAME plan from it and, on a Vercel failure,
+  // BOTH fail closed — no silent downgrade to a weaker backend.
+  const saasEnv = env({ configPriority: ["vercel-sandbox"], vercelAvailable: true });
+
+  it("plans a single Vercel step that fails closed", () => {
+    const plan = planSandboxSelection(saasEnv);
+    expect(kinds(plan.steps)).toEqual(["vercel-sandbox"]);
+    expect(plan.onExhausted).toBe("fail-closed");
+  });
+
+  it("even a mistakenly-configured sidecar cannot override the pin", () => {
+    const plan = planSandboxSelection({ ...saasEnv, sidecarAvailable: true });
+    // Only the pinned backend is ever attempted.
+    expect(kinds(plan.steps)).toEqual(["vercel-sandbox"]);
+  });
+});
+
+describe("formatSandboxPriorityFailure", () => {
+  it("includes per-backend reasons and self-hosted just-bash guidance", () => {
+    const msg = formatSandboxPriorityFailure(
+      ["vercel-sandbox", "sidecar"],
+      [
+        { name: "vercel-sandbox", reason: "401 invalid token" },
+        { name: "sidecar", reason: "connection refused" },
+      ],
+      "self-hosted",
+    );
+    expect(msg).toContain("vercel-sandbox: 401 invalid token");
+    expect(msg).toContain("sidecar: connection refused");
+    expect(msg).toContain("VERCEL_TEAM_ID");
+    expect(msg).toContain("ATLAS_SANDBOX_URL");
+    expect(msg).toContain("Add 'just-bash'");
+  });
+
+  it("suppresses the just-bash suggestion in SaaS mode", () => {
+    const msg = formatSandboxPriorityFailure(
+      ["vercel-sandbox"],
+      [{ name: "vercel-sandbox", reason: "401" }],
+      "saas",
+    );
+    expect(msg).not.toContain("Add 'just-bash'");
+  });
+});
+
+// Type-level guard: the plan's kinds are drawn from the config backend names.
+const _typecheck: SandboxBackendName = "vercel-sandbox";
+void _typecheck;

--- a/packages/api/src/lib/tools/backends/__tests__/sidecar-transport.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/sidecar-transport.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, afterEach } from "bun:test";
+import {
+  isSidecarConnectionError,
+  isSidecarTimeoutError,
+  sidecarRequestHeaders,
+} from "@atlas/api/lib/tools/backends/sidecar-transport";
+
+// The connection/timeout classifiers and the bearer-auth header were copy-pasted
+// across explore-sidecar + python-sidecar (exec + stream). #4187 consolidated
+// them here; these tests pin the classification and header shape so the three
+// call sites can't drift.
+
+describe("isSidecarConnectionError", () => {
+  it("matches the fetch-down signatures", () => {
+    expect(isSidecarConnectionError("connect ECONNREFUSED 127.0.0.1:8080")).toBe(true);
+    expect(isSidecarConnectionError("TypeError: fetch failed")).toBe(true);
+    expect(isSidecarConnectionError("Failed to connect to host")).toBe(true);
+  });
+
+  it("does not match timeouts or arbitrary errors", () => {
+    expect(isSidecarConnectionError("TimeoutError: the operation timed out")).toBe(false);
+    expect(isSidecarConnectionError("HTTP 500")).toBe(false);
+    expect(isSidecarConnectionError("")).toBe(false);
+  });
+});
+
+describe("isSidecarTimeoutError", () => {
+  it("matches abort/timeout signatures", () => {
+    expect(isSidecarTimeoutError("TimeoutError")).toBe(true);
+    expect(isSidecarTimeoutError("the operation timed out")).toBe(true);
+    expect(isSidecarTimeoutError("The operation was aborted")).toBe(true);
+  });
+
+  it("does not match connection refusals", () => {
+    expect(isSidecarTimeoutError("ECONNREFUSED")).toBe(false);
+  });
+});
+
+describe("sidecarRequestHeaders", () => {
+  const saved = process.env.SIDECAR_AUTH_TOKEN;
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.SIDECAR_AUTH_TOKEN;
+    else process.env.SIDECAR_AUTH_TOKEN = saved;
+  });
+
+  it("omits Authorization when no token is configured", () => {
+    delete process.env.SIDECAR_AUTH_TOKEN;
+    expect(sidecarRequestHeaders()).toEqual({ "Content-Type": "application/json" });
+  });
+
+  it("adds a bearer Authorization header when a token is set", () => {
+    process.env.SIDECAR_AUTH_TOKEN = "sekret";
+    expect(sidecarRequestHeaders()).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer sekret",
+    });
+  });
+});

--- a/packages/api/src/lib/tools/backends/index.ts
+++ b/packages/api/src/lib/tools/backends/index.ts
@@ -9,3 +9,5 @@ export * from "./types";
 export * from "./shared";
 export * from "./nsjail";
 export * from "./detect";
+export * from "./sidecar-transport";
+export * from "./selection";

--- a/packages/api/src/lib/tools/backends/nsjail.ts
+++ b/packages/api/src/lib/tools/backends/nsjail.ts
@@ -60,7 +60,110 @@ interface NsjailLogger {
 }
 
 /**
- * Build the nsjail CLI args for a single command execution.
+ * Minimal /dev mounts every jail needs — no secrets, no device access beyond
+ * the three benign character devices. Shared by every nsjail spec.
+ */
+const DEV_MOUNTS: readonly string[] = ["/dev/null", "/dev/zero", "/dev/urandom"];
+
+/**
+ * Declarative description of a single nsjail invocation. This is the ONE place
+ * the actual `nsjail` flag sequence is assembled; the explore and Python arg
+ * builders below differ only in the data they feed here (mounts, resource
+ * limits, working directory, command), never in the flag-emission logic. That
+ * keeps the two security-critical jail configs from drifting in how they set
+ * `--mode`, `-u/-g`, `--quiet`, rlimits, etc. — a bug in the serialization can
+ * only ever exist in one function.
+ */
+export interface NsjailSpec {
+  readonly nsjailPath: string;
+  /** Read-only bind mounts emitted before the `/dev` mounts (`-R <m>`). */
+  readonly systemMounts: readonly string[];
+  /**
+   * Extra bind mounts emitted after the `/proc` + tmpfs setup and before
+   * `--cwd`. Each carries its own flag so a spec can mix read-only (`-R`) and
+   * writable (`-B`) mounts (e.g. Python's code files vs. its chart dir).
+   */
+  readonly extraMounts?: readonly { readonly flag: "-R" | "-B"; readonly value: string }[];
+  readonly cwd: string;
+  readonly timeLimitSec: number;
+  readonly rlimitAs: number;
+  readonly rlimitFsize: number;
+  readonly rlimitNproc: number;
+  readonly rlimitNofile: number;
+  /** When true, pass fd 0 (stdin) through to the jailed process (`--pass_fd 0`). */
+  readonly passStdin?: boolean;
+  /** Program + args after the `--` separator. */
+  readonly command: readonly string[];
+}
+
+/**
+ * Assemble the nsjail CLI args from a {@link NsjailSpec}. The single source of
+ * truth for the jail flag sequence shared by explore and Python (AC: nsjail
+ * arg-building exists once). The constant hardening flags (`--mode o`,
+ * run-as-nobody `65534`, `--quiet`, the `/dev` + `/proc` + tmpfs setup) are
+ * baked in here so no caller can accidentally omit one.
+ */
+export function assembleNsjailArgs(spec: NsjailSpec): string[] {
+  const args: string[] = [spec.nsjailPath, "--mode", "o"];
+
+  // Read-only system bind mounts
+  for (const mount of spec.systemMounts) {
+    args.push("-R", mount);
+  }
+
+  // Minimal /dev
+  for (const dev of DEV_MOUNTS) {
+    args.push("-R", dev);
+  }
+
+  // /proc for correct namespace operation
+  args.push("--proc_path", "/proc");
+
+  // Writable tmpfs for scratch
+  args.push("-T", "/tmp");
+
+  // Spec-specific extra mounts (read-only code files, writable chart dir, …)
+  for (const mount of spec.extraMounts ?? []) {
+    args.push(mount.flag, mount.value);
+  }
+
+  // Working directory
+  args.push("--cwd", spec.cwd);
+
+  // Time limit
+  args.push("-t", String(spec.timeLimitSec));
+
+  // Resource limits
+  args.push(
+    "--rlimit_as",
+    String(spec.rlimitAs),
+    "--rlimit_fsize",
+    String(spec.rlimitFsize),
+    "--rlimit_nproc",
+    String(spec.rlimitNproc),
+    "--rlimit_nofile",
+    String(spec.rlimitNofile),
+  );
+
+  // Run as nobody
+  args.push("-u", "65534", "-g", "65534");
+
+  // Pass stdin through (Python data injection)
+  if (spec.passStdin) {
+    args.push("--pass_fd", "0");
+  }
+
+  // Suppress nsjail info logs but keep error diagnostics
+  args.push("--quiet");
+
+  // Command to execute
+  args.push("--", ...spec.command);
+
+  return args;
+}
+
+/**
+ * Build the nsjail CLI args for a single explore (shell) command execution.
  *
  * Shared between testNsjailCapabilities (capability check) and
  * createNsjailBackend (real execution) so both exercise the exact
@@ -85,78 +188,101 @@ export function buildNsjailArgs(
     nsjailLog,
   );
 
-  return [
+  return assembleNsjailArgs({
     nsjailPath,
-    "--mode",
-    "o",
-
-    // Read-only bind mounts
-    "-R",
-    `${semanticRoot}:/semantic`,
-    "-R",
-    "/bin",
-    "-R",
-    "/usr/bin",
-    "-R",
-    "/lib",
-    "-R",
-    "/lib64",
-    "-R",
-    "/usr/lib",
-
-    // Minimal /dev
-    "-R",
-    "/dev/null",
-    "-R",
-    "/dev/zero",
-    "-R",
-    "/dev/urandom",
-
-    // /proc for correct namespace operation
-    "--proc_path",
-    "/proc",
-
-    // Writable tmpfs for scratch
-    "-T",
-    "/tmp",
-
-    // Working directory
-    "--cwd",
-    "/semantic",
-
-    // Time limit
-    "-t",
-    String(timeLimit),
-
-    // Resource limits
-    "--rlimit_as",
-    String(memoryLimit),
-    "--rlimit_fsize",
-    "10",
-    "--rlimit_nproc",
-    "5",
-    "--rlimit_nofile",
-    "64",
-
-    // Run as nobody
-    "-u",
-    "65534",
-    "-g",
-    "65534",
-
-    // Suppress nsjail info logs but keep error diagnostics
-    "--quiet",
-
-    // Command to execute
-    "--",
-    "/bin/bash",
-    "-c",
-    command,
-  ];
+    systemMounts: [
+      `${semanticRoot}:/semantic`,
+      "/bin",
+      "/usr/bin",
+      "/lib",
+      "/lib64",
+      "/usr/lib",
+    ],
+    cwd: "/semantic",
+    timeLimitSec: timeLimit,
+    rlimitAs: memoryLimit,
+    rlimitFsize: 10,
+    rlimitNproc: 5,
+    rlimitNofile: 64,
+    command: ["/bin/bash", "-c", command],
+  });
 }
 
-/** Minimal env passed into the jail — no secrets. */
-const JAIL_ENV: Record<string, string> = {
+/** Default Python execution timeout in seconds. */
+const PYTHON_DEFAULT_TIME_LIMIT = 30;
+
+/** Default Python memory limit in MB. */
+const PYTHON_DEFAULT_MEMORY_LIMIT = 512;
+
+/** Default Python max processes. */
+const PYTHON_DEFAULT_NPROC = 16;
+
+/**
+ * Build the nsjail CLI args for a single Python execution. Co-located with
+ * {@link buildNsjailArgs} (the explore twin) so both nsjail arg builders live
+ * in one module; delegates the flag serialization to {@link assembleNsjailArgs}.
+ *
+ * `_tmpDir` and `_resultMarker` are unused by arg-building (the tmp dir is
+ * reflected in the code/chart mount paths; the marker is passed to the jail via
+ * env — see python-nsjail.ts) but kept in the signature for call-site symmetry.
+ */
+export function buildPythonNsjailArgs(
+  nsjailPath: string,
+  _tmpDir: string,
+  codeFile: string,
+  wrapperFile: string,
+  chartDir: string,
+  _resultMarker: string,
+): string[] {
+  const timeLimit = parsePositiveInt(
+    "ATLAS_NSJAIL_TIME_LIMIT",
+    PYTHON_DEFAULT_TIME_LIMIT,
+    "time limit",
+    log,
+  );
+  const memoryLimit = parsePositiveInt(
+    "ATLAS_NSJAIL_MEMORY_LIMIT",
+    PYTHON_DEFAULT_MEMORY_LIMIT,
+    "memory limit",
+    log,
+  );
+
+  return assembleNsjailArgs({
+    nsjailPath,
+    // System libs + Python runtime (adds /usr/local/{bin,lib} over explore)
+    systemMounts: [
+      "/bin",
+      "/usr/bin",
+      "/usr/local/bin",
+      "/lib",
+      "/lib64",
+      "/usr/lib",
+      "/usr/local/lib",
+    ],
+    // Bind-mount code files (read-only) and chart dir (writable, -B) into the jail
+    extraMounts: [
+      { flag: "-R", value: `${wrapperFile}:/tmp/wrapper.py` },
+      { flag: "-R", value: `${codeFile}:/tmp/user_code.py` },
+      { flag: "-B", value: `${chartDir}:/tmp/charts` },
+    ],
+    cwd: "/tmp",
+    timeLimitSec: timeLimit,
+    rlimitAs: memoryLimit,
+    rlimitFsize: 50, // 50 MB for chart output
+    rlimitNproc: PYTHON_DEFAULT_NPROC,
+    rlimitNofile: 128,
+    passStdin: true,
+    command: ["/usr/bin/python3", "/tmp/wrapper.py", "/tmp/user_code.py"],
+  });
+}
+
+/**
+ * Minimal env passed into an explore (shell) jail — no secrets. Also the base
+ * for the Python jail env (python-nsjail.ts spreads this and adds
+ * MPLBACKEND / ATLAS_CHART_DIR / ATLAS_RESULT_MARKER), so the shared
+ * `HOME`/`LANG` no longer live in three places.
+ */
+export const BASE_JAIL_ENV: Record<string, string> = {
   PATH: "/bin:/usr/bin",
   HOME: "/tmp",
   LANG: "C.UTF-8",
@@ -178,7 +304,7 @@ export async function testNsjailCapabilities(
   try {
     const args = buildNsjailArgs(nsjailPath, semanticRoot, "echo nsjail-ok");
     const proc = Bun.spawn(args, {
-      env: JAIL_ENV,
+      env: BASE_JAIL_ENV,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/packages/api/src/lib/tools/backends/selection.ts
+++ b/packages/api/src/lib/tools/backends/selection.ts
@@ -1,0 +1,275 @@
+/**
+ * Sandbox backend selection — the ONE priority policy shared by the explore and
+ * Python tools.
+ *
+ * Before #4187 the priority "dance" was hand-rolled at ~5 sites and the two
+ * tools had diverged: explore ranked `vercel > nsjail-explicit > sidecar >
+ * nsjail-auto` (and honored `sandbox.priority` / `ATLAS_SANDBOX_PRIORITY` /
+ * sandbox plugins), while Python ranked `sidecar > vercel > nsjail` and ignored
+ * the operator's priority override entirely — a latent posture bug given SaaS
+ * pins `sandbox.priority: ["vercel-sandbox"]` (deny-all, no fallback).
+ *
+ * This module makes the decision a PURE function of an environment snapshot:
+ *   {@link planSandboxSelection} turns an immutable {@link SandboxSelectionEnv}
+ *   into an ordered {@link SandboxPlan}, and {@link runSandboxPlan} walks that
+ *   plan with a tool-specific construction callback. Both tools feed the SAME
+ *   planner, so they resolve the SAME backend for the same env/config, and the
+ *   policy is unit-testable without cache-busting a stateful tool module.
+ *
+ * The planner covers only the env/config-driven chain. The plugin front-of-line
+ * (explore's `wireSandboxPlugins`) and the per-workspace BYOC override sit
+ * ahead of it in each tool and are attempted before this plan is built.
+ */
+
+import type { SandboxBackendName } from "@atlas/api/lib/config";
+
+/**
+ * Immutable snapshot of the environment + config inputs that decide which
+ * sandbox backend is used. Captured once by the caller so {@link
+ * planSandboxSelection} is pure — no live `process.env` / config reads happen
+ * inside the policy, which is what makes it testable without import-cache
+ * busting.
+ */
+export interface SandboxSelectionEnv {
+  /** `process.env.ATLAS_SANDBOX` — `"nsjail"` pins nsjail as the explicit (hard-fail) backend. */
+  readonly atlasSandbox: string | undefined;
+  /** Vercel Sandbox usable this process (`useVercelSandbox()`). */
+  readonly vercelAvailable: boolean;
+  /** Sidecar configured (`useSidecar()` — `ATLAS_SANDBOX_URL` set). */
+  readonly sidecarAvailable: boolean;
+  /**
+   * nsjail binary detected on this host (auto-detect). Producers may feed a
+   * pin-inclusive value (explore's `useNsjail()` returns true for the explicit
+   * pin OR a detected binary); the planner only consults this field on the
+   * auto-detect branch (`atlasSandbox !== "nsjail"`), where it is exactly binary
+   * detection, so the pin-inclusive and pure-detection producers agree there.
+   */
+  readonly nsjailAvailable: boolean;
+  /** nsjail permanently marked failed this process (exit 109 / hard init failure). */
+  readonly nsjailFailed: boolean;
+  /**
+   * Operator-configured backend priority. Sourced from `getConfig().sandbox
+   * .priority`, which `config.ts` also populates from `ATLAS_SANDBOX_PRIORITY`,
+   * so honoring this field honors BOTH the config-file and env-var overrides.
+   */
+  readonly configPriority: readonly SandboxBackendName[] | undefined;
+}
+
+/** A single backend to attempt, in order. */
+export interface SandboxStep {
+  readonly kind: SandboxBackendName;
+  /**
+   * When true, a construction failure at this step must fail the whole tool
+   * (never fall through to a weaker backend). Set for the explicit-nsjail step:
+   * `ATLAS_SANDBOX=nsjail` is hard-fail by contract.
+   */
+  readonly hardFail: boolean;
+}
+
+/**
+ * Discriminated on `source` so illegal states are unrepresentable: only the
+ * config-priority arm carries `configPriority` (non-optional there) and only it
+ * can be `"fail-closed"` (the SaaS deny-all pin without `just-bash`). The
+ * default chain always degrades to `just-bash` on exhaustion.
+ */
+export type SandboxPlan =
+  | {
+      readonly source: "config-priority";
+      readonly steps: readonly SandboxStep[];
+      /**
+       * `"just-bash"` when the operator kept it in the list (degrade allowed);
+       * `"fail-closed"` when they omitted it (throw a config error).
+       */
+      readonly onExhausted: "just-bash" | "fail-closed";
+      readonly configPriority: readonly SandboxBackendName[];
+    }
+  | {
+      readonly source: "default-chain";
+      readonly steps: readonly SandboxStep[];
+      /** The default chain always degrades to the unsandboxed fallback on exhaustion. */
+      readonly onExhausted: "just-bash";
+    };
+
+/**
+ * Turn an env snapshot into an ordered backend plan. Pure — the single
+ * statement of the priority policy for both tools.
+ *
+ * Operator-configured priority (`sandbox.priority` / `ATLAS_SANDBOX_PRIORITY`)
+ * takes precedence over the built-in chain. Absent that, the default chain is
+ * `Vercel > nsjail-explicit > sidecar > nsjail-auto > just-bash`, matching the
+ * documented order in CLAUDE.md.
+ */
+export function planSandboxSelection(env: SandboxSelectionEnv): SandboxPlan {
+  // Operator-configured priority wins (config file or ATLAS_SANDBOX_PRIORITY).
+  const configPriority = env.configPriority;
+  if (configPriority && configPriority.length > 0) {
+    return {
+      source: "config-priority",
+      steps: configPriority.map((kind) => ({ kind, hardFail: false })),
+      // just-bash in the list ⇒ an unsandboxed fallback is allowed; omit it and
+      // the pin fails closed (the SaaS deny-all posture).
+      onExhausted: configPriority.includes("just-bash") ? "just-bash" : "fail-closed",
+      configPriority,
+    };
+  }
+
+  // Default chain.
+  const steps: SandboxStep[] = [];
+
+  // Vercel Sandbox is highest priority — a soft step (init failure falls
+  // through to the next backend, unless a single-backend config pin says
+  // otherwise, which is the config-priority path above).
+  if (env.vercelAvailable) {
+    steps.push({ kind: "vercel-sandbox", hardFail: false });
+  }
+
+  if (env.atlasSandbox === "nsjail" && !env.nsjailFailed) {
+    // Explicit nsjail is hard-fail by contract; nothing after it is reachable.
+    // (Vercel still precedes it: an operator on Vercel with ATLAS_SANDBOX=nsjail
+    // gets Vercel first, matching the long-standing explore behavior.)
+    steps.push({ kind: "nsjail", hardFail: true });
+  } else {
+    // Sidecar takes priority over nsjail auto-detection (Railway sets
+    // ATLAS_SANDBOX_URL), then nsjail auto-detect on PATH.
+    if (env.sidecarAvailable) {
+      steps.push({ kind: "sidecar", hardFail: false });
+    }
+    if (env.nsjailAvailable && !env.nsjailFailed) {
+      steps.push({ kind: "nsjail", hardFail: false });
+    }
+  }
+
+  return { source: "default-chain", steps, onExhausted: "just-bash" };
+}
+
+/**
+ * The backend a health/status reporter would name for this plan: the first step
+ * whose kind reports available, else `null` (⇒ the caller reports the fallback,
+ * typically `"just-bash"`). Kept separate from {@link runSandboxPlan} because
+ * reporting must not actually construct backends.
+ */
+export function firstAvailableBackend(
+  plan: SandboxPlan,
+  isAvailable: (kind: SandboxBackendName) => boolean,
+): SandboxBackendName | null {
+  for (const step of plan.steps) {
+    if (isAvailable(step.kind)) return step.kind;
+  }
+  return null;
+}
+
+/** A backend that could not be constructed, with a sanitized operator-facing reason. */
+export interface BackendInitFailure {
+  readonly name: SandboxBackendName;
+  readonly reason: string;
+}
+
+/** Result of attempting one plan step's tool-specific construction. */
+export type StepAttempt<T> = { readonly backend: T } | { readonly failure: BackendInitFailure };
+
+/**
+ * The outcome of walking a plan. The runner never constructs the `just-bash`
+ * fallback or formats error messages itself — that stays tool-specific (explore
+ * builds a bash backend; Python refuses). The runner owns only the shared WALK
+ * semantics (soft fall-through, hard-fail short-circuit, exhaustion), so both
+ * tools enforce one policy.
+ */
+export type SandboxPlanOutcome<T> =
+  /** A step constructed a backend. */
+  | { readonly kind: "backend"; readonly backend: T; readonly selected: SandboxBackendName }
+  /** A hard-fail step (explicit nsjail) failed to construct — do not fall through. */
+  | { readonly kind: "hard-fail"; readonly step: SandboxStep; readonly reason: string; readonly failures: readonly BackendInitFailure[] }
+  /** Config-priority exhausted with no `just-bash` in the list — fail closed. */
+  | { readonly kind: "fail-closed"; readonly failures: readonly BackendInitFailure[] }
+  /** Every step exhausted and `onExhausted === "just-bash"` — caller degrades (explore) or refuses (Python). */
+  | { readonly kind: "exhausted"; readonly failures: readonly BackendInitFailure[] };
+
+/**
+ * Walk a plan, attempting each step's tool-specific construction in order.
+ *
+ * A `tryStep` returning `{ failure }` (or throwing) falls through to the next
+ * step, except at a hard-fail step where it short-circuits to `"hard-fail"`.
+ * When the steps are exhausted, the outcome reflects `plan.onExhausted`. The
+ * caller maps the outcome to a backend / degraded fallback / error message.
+ *
+ * `onStepError` is invoked when a step *throws* (as opposed to returning a
+ * `{ failure }`): a throw is unexpected (a module-load or construction bug), so
+ * the caller logs it rather than letting exhaustion silently erase the reason.
+ * Returned `{ failure }` values are anticipated and logged by the caller's own
+ * `tryStep`; they are surfaced to the caller via the outcome's `failures[]`.
+ */
+export async function runSandboxPlan<T>(
+  plan: SandboxPlan,
+  tryStep: (step: SandboxStep) => Promise<StepAttempt<T>>,
+  onStepError?: (step: SandboxStep, reason: string) => void,
+): Promise<SandboxPlanOutcome<T>> {
+  const failures: BackendInitFailure[] = [];
+
+  for (const step of plan.steps) {
+    let attempt: StepAttempt<T>;
+    try {
+      attempt = await tryStep(step);
+    } catch (err) {
+      // A thrown error from a soft step is treated as that step's failure and
+      // falls through; a hard-fail step surfaces it below. Surface the throw to
+      // the caller's logger — it is unexpected and would otherwise vanish.
+      const reason = err instanceof Error ? err.message : String(err);
+      onStepError?.(step, reason);
+      attempt = { failure: { name: step.kind, reason } };
+    }
+
+    if ("backend" in attempt) {
+      return { kind: "backend", backend: attempt.backend, selected: step.kind };
+    }
+
+    failures.push(attempt.failure);
+    if (step.hardFail) {
+      return { kind: "hard-fail", step, reason: attempt.failure.reason, failures };
+    }
+  }
+
+  return plan.onExhausted === "fail-closed"
+    ? { kind: "fail-closed", failures }
+    : { kind: "exhausted", failures };
+}
+
+/**
+ * Exhaustiveness guard for the `SandboxPlanOutcome` switches in both tools.
+ * Pins the "every outcome is handled" contract at the switch (a new outcome
+ * member becomes a compile error at the `default` case) rather than relying
+ * solely on each function's return-type annotation.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled sandbox selection outcome: ${JSON.stringify(value)}`);
+}
+
+/**
+ * Operator-facing message for a `config-priority` plan that failed closed (all
+ * pinned backends failed and `just-bash` was not in the list — the SaaS
+ * deny-all posture). Shared by explore and Python so the guidance can't drift.
+ */
+export function formatSandboxPriorityFailure(
+  priority: readonly SandboxBackendName[],
+  failures: readonly BackendInitFailure[],
+  deployMode: "saas" | "self-hosted" | undefined,
+): string {
+  const summary =
+    failures.length > 0
+      ? ` Failed backends: ${failures.map((f) => `${f.name}: ${f.reason}`).join("; ")}.`
+      : "";
+  const guidance: string[] = [];
+  if (priority.includes("vercel-sandbox")) {
+    guidance.push(
+      "For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, VERCEL_PROJECT_ID, and VERCEL_TOKEN.",
+    );
+  }
+  if (priority.includes("sidecar")) {
+    guidance.push("For sidecar, set ATLAS_SANDBOX_URL.");
+  }
+  if (deployMode !== "saas") {
+    guidance.push("Add 'just-bash' to the priority list if you want an unsandboxed fallback.");
+  }
+  guidance.push("Fix the backend configuration.");
+
+  return `All backends in sandbox.priority (${priority.join(", ")}) failed to initialize.${summary} ${guidance.join(" ")}`;
+}

--- a/packages/api/src/lib/tools/backends/sidecar-transport.ts
+++ b/packages/api/src/lib/tools/backends/sidecar-transport.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared HTTP transport helpers for the sandbox sidecar backends.
+ *
+ * The explore sidecar (`explore-sidecar.ts`) and the Python sidecar
+ * (`python-sidecar.ts`, both the buffered and streaming paths) talk to the same
+ * sidecar service over HTTP with the same auth scheme and the same fetch-error
+ * classification. Before #4187 the connection/timeout classifiers and the
+ * bearer-auth header were copy-pasted across three call sites; this module is
+ * the single home for them so a change to how a down sidecar is detected can't
+ * land in one path and miss another.
+ */
+
+/**
+ * True when a fetch rejection detail indicates the sidecar is unreachable
+ * (connection refused / DNS / socket failure) rather than a slow/timed-out or
+ * HTTP-level error. Callers treat this as "the service is down": explore
+ * invalidates its backend cache to fall back; Python surfaces an unreachable
+ * error.
+ */
+export function isSidecarConnectionError(detail: string): boolean {
+  return (
+    detail.includes("ECONNREFUSED") ||
+    detail.includes("fetch failed") ||
+    detail.includes("Failed to connect")
+  );
+}
+
+/**
+ * True when a fetch rejection detail indicates the request timed out or was
+ * aborted (as opposed to the connection being refused outright).
+ */
+export function isSidecarTimeoutError(detail: string): boolean {
+  return (
+    detail.includes("TimeoutError") ||
+    detail.includes("timed out") ||
+    detail.includes("aborted")
+  );
+}
+
+/**
+ * Request headers for a sidecar call: JSON content type plus an optional
+ * `Authorization: Bearer <token>` when `SIDECAR_AUTH_TOKEN` is configured.
+ * One statement of the auth scheme shared by every sidecar request.
+ */
+export function sidecarRequestHeaders(): Record<string, string> {
+  const authToken = process.env.SIDECAR_AUTH_TOKEN;
+  return {
+    "Content-Type": "application/json",
+    ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+  };
+}

--- a/packages/api/src/lib/tools/explore-nsjail.ts
+++ b/packages/api/src/lib/tools/explore-nsjail.ts
@@ -12,7 +12,7 @@
 
 import type { ExploreBackend, ExecResult } from "./backends/types";
 import { readLimited, MAX_OUTPUT } from "./backends/shared";
-import { findNsjailBinary, buildNsjailArgs } from "./backends/nsjail";
+import { findNsjailBinary, buildNsjailArgs, BASE_JAIL_ENV } from "./backends/nsjail";
 import { createLogger } from "@atlas/api/lib/logger";
 import * as fs from "fs";
 
@@ -21,13 +21,6 @@ const log = createLogger("nsjail-sandbox");
 // Re-export nsjail detection utilities for backward compatibility.
 // startup.ts dynamically imports these from this module path.
 export { findNsjailBinary, isNsjailAvailable, testNsjailCapabilities } from "./backends/nsjail";
-
-/** Minimal env passed into the jail — no secrets. */
-const JAIL_ENV: Record<string, string> = {
-  PATH: "/bin:/usr/bin",
-  HOME: "/tmp",
-  LANG: "C.UTF-8",
-};
 
 /** Callbacks injected by the explore module to avoid circular dynamic imports. */
 export interface NsjailCallbacks {
@@ -69,7 +62,7 @@ export async function createNsjailBackend(
       try {
         const args = buildNsjailArgs(nsjailPath, semanticRoot, command, log);
         proc = Bun.spawn(args, {
-          env: JAIL_ENV,
+          env: BASE_JAIL_ENV,
           stdout: "pipe",
           stderr: "pipe",
         });

--- a/packages/api/src/lib/tools/explore-sidecar.ts
+++ b/packages/api/src/lib/tools/explore-sidecar.ts
@@ -13,6 +13,11 @@
 import type { ExploreBackend, ExecResult } from "./backends/types";
 import type { SidecarExecResponse } from "@atlas/api/lib/sidecar-types";
 import { createLogger } from "@atlas/api/lib/logger";
+import {
+  isSidecarConnectionError,
+  isSidecarTimeoutError,
+  sidecarRequestHeaders,
+} from "./backends/sidecar-transport";
 
 const log = createLogger("explore-sidecar");
 
@@ -26,8 +31,6 @@ export async function createSidecarBackend(
   sidecarUrl: string,
   options?: { semanticRoot?: string },
 ): Promise<ExploreBackend> {
-  const authToken = process.env.SIDECAR_AUTH_TOKEN;
-
   // Compute sidecar cwd for org-scoped directories.
   // The sidecar mounts the host's semantic/ at /semantic. If the semantic
   // root is semantic/.orgs/org123, the sidecar cwd is .orgs/org123
@@ -99,10 +102,7 @@ export async function createSidecarBackend(
       try {
         response = await fetch(execUrl, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
-          },
+          headers: sidecarRequestHeaders(),
           body: JSON.stringify({ command, timeout, ...(sidecarCwd ? { cwd: sidecarCwd } : {}) }),
           signal: AbortSignal.timeout(timeout + HTTP_OVERHEAD_MS),
         });
@@ -110,11 +110,7 @@ export async function createSidecarBackend(
         const detail = err instanceof Error ? err.message : String(err);
 
         // Connection refused or timeout — sidecar may be down
-        if (
-          detail.includes("ECONNREFUSED") ||
-          detail.includes("fetch failed") ||
-          detail.includes("Failed to connect")
-        ) {
+        if (isSidecarConnectionError(detail)) {
           log.error({ err: detail, url: execUrl }, "Sidecar connection failed");
           // Invalidate backend cache so the next call re-evaluates the backend priority chain.
           // If the sidecar stays down, the system falls back to just-bash.
@@ -127,7 +123,7 @@ export async function createSidecarBackend(
           );
         }
 
-        if (detail.includes("TimeoutError") || detail.includes("timed out") || detail.includes("aborted")) {
+        if (isSidecarTimeoutError(detail)) {
           log.warn({ command, timeout }, "Sidecar request timed out");
           return {
             stdout: "",

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -31,6 +31,15 @@ import { getSetting } from "@atlas/api/lib/settings";
 import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
 import { capOutput } from "./backends/shared";
+import {
+  planSandboxSelection,
+  runSandboxPlan,
+  firstAvailableBackend,
+  formatSandboxPriorityFailure,
+  assertNever,
+  type SandboxSelectionEnv,
+  type BackendInitFailure,
+} from "./backends/selection";
 import { EXPLORE_TOOL_DESCRIPTION } from "./descriptions";
 
 const log = createLogger("explore");
@@ -148,47 +157,46 @@ function isBackendAvailable(name: SandboxBackendName): boolean {
 }
 
 /**
+ * Snapshot the env + config inputs that drive backend selection into the
+ * immutable shape the shared pure planner ({@link planSandboxSelection})
+ * consumes. Captures explore's runtime failure flag (`_nsjailFailed`) so the
+ * degraded chain matches health reporting. The Python tool builds the same
+ * snapshot shape, which is what makes the two tools resolve the same backend.
+ */
+export function snapshotExploreSandboxEnv(): SandboxSelectionEnv {
+  return {
+    atlasSandbox: process.env.ATLAS_SANDBOX,
+    vercelAvailable: useVercelSandbox(),
+    sidecarAvailable: useSidecar(),
+    // useNsjail() reports the explicit pin OR a detected binary; the planner
+    // only consults this field on the auto-detect branch (ATLAS_SANDBOX !==
+    // "nsjail"), where it is exactly binary detection.
+    nsjailAvailable: useNsjail(),
+    nsjailFailed: _nsjailFailed,
+    configPriority: getConfig()?.sandbox?.priority,
+  };
+}
+
+/**
  * Returns which explore backend is active (for health endpoint).
  *
  * Plugin detection is lazy — _activeSandboxPluginId is only set after the
  * first explore command triggers getExploreBackend(). Before that, this
- * function falls through to the built-in detection chain.
+ * function falls through to the shared selection policy.
  *
  * When `sandbox.priority` is configured, the first available backend in the
- * priority list is returned instead of the hardcoded chain.
+ * priority list is returned instead of the default chain.
  */
 export function getExploreBackendType(): ExploreBackendType {
   if (_activeSandboxPluginId) return "plugin";
-
-  // Config-driven priority
-  const configPriority = getConfig()?.sandbox?.priority;
-  if (configPriority && configPriority.length > 0) {
-    for (const name of configPriority) {
-      if (isBackendAvailable(name)) return name;
-    }
-    return "just-bash";
-  }
-
-  // Default chain
-  if (useVercelSandbox()) return "vercel-sandbox";
-  // Explicit nsjail (ATLAS_SANDBOX=nsjail) — hard-fail if unavailable
-  if (process.env.ATLAS_SANDBOX === "nsjail" && !_nsjailFailed) return "nsjail";
-  // Sidecar takes priority over nsjail auto-detection (Railway sets ATLAS_SANDBOX_URL)
-  if (useSidecar() && !_sidecarFailed) return "sidecar";
-  // nsjail auto-detect (binary on PATH)
-  if (!_nsjailFailed && useNsjail()) return "nsjail";
-  return "just-bash";
+  const plan = planSandboxSelection(snapshotExploreSandboxEnv());
+  return firstAvailableBackend(plan, isBackendAvailable) ?? "just-bash";
 }
 
 /**
  * Try to create a specific backend by name. Returns a backend on success,
  * otherwise a sanitized reason suitable for operator-facing config errors.
  */
-interface BackendInitFailure {
-  name: SandboxBackendName;
-  reason: string;
-}
-
 interface BackendInitResult {
   backend: ExploreBackend | null;
   failure?: BackendInitFailure;
@@ -198,29 +206,7 @@ function unavailable(name: SandboxBackendName, reason: string): BackendInitResul
   return { backend: null, failure: { name, reason } };
 }
 
-function formatSandboxPriorityFailure(
-  priority: readonly SandboxBackendName[],
-  failures: readonly BackendInitFailure[],
-  deployMode: "saas" | "self-hosted" | undefined,
-): string {
-  const summary = failures.length > 0
-    ? ` Failed backends: ${failures.map((f) => `${f.name}: ${f.reason}`).join("; ")}.`
-    : "";
-  const guidance: string[] = [];
-  if (priority.includes("vercel-sandbox")) {
-    guidance.push("For Vercel Sandbox off-Vercel, set VERCEL_TEAM_ID, VERCEL_PROJECT_ID, and VERCEL_TOKEN.");
-  }
-  if (priority.includes("sidecar")) {
-    guidance.push("For sidecar, set ATLAS_SANDBOX_URL.");
-  }
-  if (deployMode !== "saas") {
-    guidance.push("Add 'just-bash' to the priority list if you want an unsandboxed fallback.");
-  }
-  guidance.push("Fix the backend configuration.");
-
-  return `All backends in sandbox.priority (${priority.join(", ")}) failed to initialize.${summary} ${guidance.join(" ")}`;
-}
-
+/** Kept for the existing explore-backend test that pins the priority-failure copy. */
 export const _formatSandboxPriorityFailureForTest = formatSandboxPriorityFailure;
 
 async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, orgId?: string): Promise<BackendInitResult> {
@@ -282,11 +268,19 @@ async function tryCreateBackend(name: SandboxBackendName, semanticRoot: string, 
         const { createSidecarBackend } = await import("./explore-sidecar");
         return { backend: await createSidecarBackend(sidecarUrl, { semanticRoot }) };
       } catch (err) {
-        _sidecarFailed = true;
+        // A transient sidecar init failure (e.g. malformed ATLAS_SANDBOX_URL,
+        // sidecar momentarily down) is a SOFT failure: fall through to the next
+        // backend but do NOT set the process-global `_sidecarFailed` flag
+        // (#3196). That flag is reserved for the deliberate, permanent mark made
+        // by the startup health probe (`markSidecarFailed`). Pinning it here
+        // would strand the deployment on the weaker fallback until restart even
+        // after the sidecar recovers, and make `getExploreBackendType()` report
+        // "just-bash" for a still-configured sidecar. Recovery instead happens
+        // on the next backend-cache resolution (invalidateExploreBackend).
         const detail = errorMessage(err);
         log.warn(
           { error: detail },
-          "sidecar backend failed to initialize — trying next in priority",
+          "sidecar backend failed to initialize — trying next in priority (retried on the next backend-cache resolution)",
         );
         return unavailable(name, detail);
       }
@@ -489,149 +483,87 @@ function getExploreBackend(semanticRoot: string, orgId?: string): Promise<Explor
         }
       }
 
-      // --- Config-driven priority ---
-      const configPriority = getConfig()?.sandbox?.priority;
-      if (configPriority && configPriority.length > 0) {
+      // --- Env/config-driven backend chain (the shared #4187 policy) ---
+      //
+      // `planSandboxSelection` produces the ONE priority policy shared with the
+      // Python tool (config `sandbox.priority` / `ATLAS_SANDBOX_PRIORITY` when
+      // set, else the default Vercel > nsjail-explicit > sidecar > nsjail-auto
+      // chain). `runSandboxPlan` walks it, deferring per-backend construction to
+      // `tryCreateBackend`. Both the config-priority and default-chain fall-
+      // through behaviors that used to be hand-rolled here now live in one place
+      // — see explore-default-chain-fallthrough.test.ts for the invariants.
+      const plan = planSandboxSelection(snapshotExploreSandboxEnv());
+      if (plan.source === "config-priority") {
         log.info(
-          { priority: configPriority },
+          { priority: plan.configPriority },
           "Using configured sandbox priority: %s",
-          configPriority.join(" > "),
+          plan.configPriority.join(" > "),
         );
-        const failures: BackendInitFailure[] = [];
-        for (const name of configPriority) {
-          const result = await tryCreateBackend(name, semanticRoot, orgId);
-          if (result.backend) {
-            log.info(
-              { backend: name, source: "config" },
-              "Explore backend selected: %s (config priority)",
-              name,
-            );
-            return result.backend;
-          }
-          if (result.failure) {
-            failures.push(result.failure);
-          }
-          log.debug(
-            { backend: name, reason: result.failure?.reason },
-            "Backend %s unavailable — trying next in priority",
-            name,
-          );
-        }
-        // All config backends failed
-        if (configPriority.includes("just-bash")) {
-          // just-bash was in the list but somehow failed (should not happen) — try once more
-          log.warn(
-            { priority: configPriority },
-            "All higher-priority backends in sandbox.priority unavailable — using just-bash",
-          );
-          return createBashBackend(semanticRoot);
-        }
-        // Operator did NOT include just-bash — respect their intent
-        throw new Error(formatSandboxPriorityFailure(configPriority, failures, getConfig()?.deployMode));
       }
-
-      // --- Default priority chain ---
-
-      // Priority 1: Vercel Sandbox (Firecracker VM)
-      // Init failures fall through to the next backend in the chain, mirroring
-      // `tryCreateBackend` (the config-priority path). Without this local
-      // try/catch the throw escapes to the outer IIFE `.catch` below, which
-      // only invalidates the cache and rethrows — it does NOT degrade to
-      // nsjail/sidecar/just-bash that are sitting right there in the chain.
-      // SaaS is unaffected: it pins `sandbox.priority: ["vercel-sandbox"]` and
-      // takes the config-priority path above, which fails closed by design.
-      if (useVercelSandbox()) {
-        try {
-          const { createSandboxBackend } = await import("./explore-sandbox");
-          return await createSandboxBackend(semanticRoot);
-        } catch (err) {
-          const detail = errorMessage(err);
+      const outcome = await runSandboxPlan<ExploreBackend>(
+        plan,
+        async (step) => {
+          const result = await tryCreateBackend(step.kind, semanticRoot, orgId);
+          return result.backend
+            ? { backend: result.backend }
+            : { failure: result.failure ?? { name: step.kind, reason: "unavailable" } };
+        },
+        (step, reason) =>
           log.warn(
-            { error: detail },
-            "vercel-sandbox backend failed to initialize — falling through to next backend in default priority",
-          );
-        }
-      }
+            { backend: step.kind, reason },
+            "Explore sandbox step threw during construction — treated as soft failure",
+          ),
+      );
 
-      // Priority 2: nsjail explicit (ATLAS_SANDBOX=nsjail) — hard-fail if init fails
-      if (process.env.ATLAS_SANDBOX === "nsjail" && !_nsjailFailed) {
-        try {
-          const { createNsjailBackend } = await import("./explore-nsjail");
-          return await createNsjailBackend(semanticRoot, {
-            onInfrastructureError: invalidateExploreBackend,
-            onNsjailFailed: markNsjailFailed,
-          });
-        } catch (err) {
-          // @atlas-ok-ternary: detail is concatenated into a thrown Error message
-          // — per #1829 non-goal, don't modify throw new Error(...) constructors.
-          const detail = err instanceof Error ? err.message : String(err);
+      switch (outcome.kind) {
+        case "backend":
+          log.info(
+            { backend: outcome.selected, source: plan.source },
+            "Explore backend selected: %s",
+            outcome.selected,
+          );
+          return outcome.backend;
+
+        case "hard-fail":
+          // Explicit nsjail (ATLAS_SANDBOX=nsjail) failed — hard-fail by
+          // contract, never fall through to a weaker backend.
           throw new Error(
             "nsjail was explicitly requested (ATLAS_SANDBOX=nsjail) but failed to initialize: " +
-              detail + ". Fix the nsjail installation or remove ATLAS_SANDBOX to allow fallback.",
-            { cause: err },
+              outcome.reason +
+              ". Fix the nsjail installation or remove ATLAS_SANDBOX to allow fallback.",
           );
-        }
-      }
 
-      // Priority 3: Sidecar service (HTTP-isolated microservice)
-      // When ATLAS_SANDBOX_URL is set, sidecar is the intended backend (Railway).
-      // Skips nsjail auto-detection entirely — no noisy namespace warnings.
-      // Same fall-through fix as the Vercel branch above: an init failure
-      // (e.g. malformed ATLAS_SANDBOX_URL) logs and degrades to the next
-      // backend instead of hard-failing the explore tool. We deliberately do
-      // NOT set the process-global `_sidecarFailed` flag here (#3196 review):
-      // that flag is for a *deliberate, permanent* mark (the startup health
-      // probe via markSidecarFailed). A transient init failure on this path
-      // should be retried on the next backend-cache resolution — the resolved
-      // backend is cached per semantic root, so a down sidecar isn't re-probed
-      // every request, and recovery happens when the cache is invalidated
-      // (invalidateExploreBackend). Pinning the flag here would strand the
-      // deployment on the weaker fallback until process restart even after the
-      // sidecar recovers.
-      if (useSidecar()) {
-        try {
-          const { createSidecarBackend } = await import("./explore-sidecar");
-          return await createSidecarBackend(process.env.ATLAS_SANDBOX_URL!, { semanticRoot });
-        } catch (err) {
-          const detail = errorMessage(err);
-          log.warn(
-            { error: detail },
-            "sidecar backend failed to initialize — falling through to next backend in default priority (retried on the next backend-cache resolution)",
+        case "fail-closed":
+          // Config-priority pin with no `just-bash` fallback (the SaaS deny-all
+          // posture) — respect the operator's intent and fail closed. `fail-closed`
+          // only arises from the config-priority arm, which carries the pin.
+          throw new Error(
+            formatSandboxPriorityFailure(
+              plan.source === "config-priority" ? plan.configPriority : [],
+              outcome.failures,
+              getConfig()?.deployMode,
+            ),
           );
-        }
-      }
 
-      // Priority 4: nsjail auto-detect (binary on PATH, graceful fallback)
-      if (!_nsjailFailed && useNsjail()) {
-        try {
-          const { createNsjailBackend } = await import("./explore-nsjail");
-          return await createNsjailBackend(semanticRoot, {
-            onInfrastructureError: invalidateExploreBackend,
-            onNsjailFailed: markNsjailFailed,
-          });
-        } catch (err) {
-          const detail = errorMessage(err);
-          _nsjailFailed = true;
-          log.error(
-            { error: detail, fallback: "just-bash" },
-            "nsjail backend failed to initialize, falling back to just-bash",
-          );
+        case "exhausted": {
+          // Default chain bottomed out — degrade to just-bash (no isolation).
+          if (process.env.NODE_ENV === "production") {
+            log.warn(
+              "SECURITY DEGRADATION: Explore tool running without process isolation (just-bash fallback). " +
+                "In production, this means shell commands execute directly on the host with only OverlayFs " +
+                "read-only protection — no namespace, network, or resource isolation. " +
+                "Install nsjail, configure a sidecar (ATLAS_SANDBOX_URL), or deploy on Vercel for sandboxed execution. " +
+                "See: https://github.com/google/nsjail",
+            );
+          } else {
+            log.debug("Explore tool using just-bash backend (acceptable for development)");
+          }
+          return createBashBackend(semanticRoot);
         }
-      }
 
-      // Priority 5: just-bash (no process isolation)
-      if (process.env.NODE_ENV === "production") {
-        log.warn(
-          "SECURITY DEGRADATION: Explore tool running without process isolation (just-bash fallback). " +
-            "In production, this means shell commands execute directly on the host with only OverlayFs " +
-            "read-only protection — no namespace, network, or resource isolation. " +
-            "Install nsjail, configure a sidecar (ATLAS_SANDBOX_URL), or deploy on Vercel for sandboxed execution. " +
-            "See: https://github.com/google/nsjail",
-        );
-      } else {
-        log.debug("Explore tool using just-bash backend (acceptable for development)");
+        default:
+          return assertNever(outcome);
       }
-      return createBashBackend(semanticRoot);
     })().catch((err) => {
       // Identity-guarded: if invalidation already evicted this promise and a
       // newer backend was cached under the same key, deleting blindly would

--- a/packages/api/src/lib/tools/python-nsjail.ts
+++ b/packages/api/src/lib/tools/python-nsjail.ts
@@ -12,7 +12,8 @@
 
 import type { PythonBackend, PythonResult } from "./python";
 import { PYTHON_SECURITY_AND_SETUP, PYTHON_EXEC_AND_COLLECT } from "./python-wrapper";
-import { readLimited, MAX_OUTPUT, parsePositiveInt } from "./backends/shared";
+import { readLimited, MAX_OUTPUT } from "./backends/shared";
+import { buildPythonNsjailArgs, BASE_JAIL_ENV } from "./backends/nsjail";
 import { randomUUID } from "crypto";
 import { mkdirSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
@@ -20,14 +21,9 @@ import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("python-nsjail");
 
-/** Default Python execution timeout in seconds. */
-const DEFAULT_TIME_LIMIT = 30;
-
-/** Default memory limit in MB. */
-const DEFAULT_MEMORY_LIMIT = 512;
-
-/** Default max processes. */
-const DEFAULT_NPROC = 16;
+// Re-export the nsjail arg builder from its canonical home (backends/nsjail.ts,
+// co-located with the explore twin) for callers/tests importing it here.
+export { buildPythonNsjailArgs };
 
 /**
  * Non-streaming Python wrapper for nsjail. Composes shared fragments
@@ -65,82 +61,16 @@ if _atlas_data:
 ${PYTHON_EXEC_AND_COLLECT}
 `;
 
-/** Build nsjail args for Python execution. */
-export function buildPythonNsjailArgs(
-  nsjailPath: string,
-  tmpDir: string,
-  codeFile: string,
-  wrapperFile: string,
-  chartDir: string,
-  _resultMarker: string,
-): string[] {
-  const timeLimit = parsePositiveInt("ATLAS_NSJAIL_TIME_LIMIT", DEFAULT_TIME_LIMIT, "time limit", log);
-  const memoryLimit = parsePositiveInt("ATLAS_NSJAIL_MEMORY_LIMIT", DEFAULT_MEMORY_LIMIT, "memory limit", log);
-  const nproc = DEFAULT_NPROC;
-
-  return [
-    nsjailPath,
-    "--mode", "o",
-
-    // Read-only bind mounts: system libs + Python runtime
-    "-R", "/bin",
-    "-R", "/usr/bin",
-    "-R", "/usr/local/bin",
-    "-R", "/lib",
-    "-R", "/lib64",
-    "-R", "/usr/lib",
-    "-R", "/usr/local/lib",
-
-    // Minimal /dev
-    "-R", "/dev/null",
-    "-R", "/dev/zero",
-    "-R", "/dev/urandom",
-
-    // /proc for correct namespace operation
-    "--proc_path", "/proc",
-
-    // Writable tmpfs for scratch
-    "-T", "/tmp",
-
-    // Bind-mount code files and chart dir into the jail (read-write for charts)
-    "-R", `${wrapperFile}:/tmp/wrapper.py`,
-    "-R", `${codeFile}:/tmp/user_code.py`,
-    "-B", `${chartDir}:/tmp/charts`,
-
-    // Working directory
-    "--cwd", "/tmp",
-
-    // Time limit
-    "-t", String(timeLimit),
-
-    // Resource limits (higher than explore for data science workloads)
-    "--rlimit_as", String(memoryLimit),
-    "--rlimit_fsize", "50",  // 50 MB for chart output
-    "--rlimit_nproc", String(nproc),
-    "--rlimit_nofile", "128",
-
-    // Run as nobody
-    "-u", "65534",
-    "-g", "65534",
-
-    // Pass stdin through
-    "--pass_fd", "0",
-
-    // Suppress nsjail info logs
-    "--quiet",
-
-    // Command: python3 wrapper.py user_code.py
-    "--",
-    "/usr/bin/python3", "/tmp/wrapper.py", "/tmp/user_code.py",
-  ];
-}
-
-/** Minimal env for the Python jail — no secrets. */
+/**
+ * Minimal env for the Python jail — no secrets. Spreads the shared
+ * {@link BASE_JAIL_ENV} (HOME/LANG), widens PATH to reach the Python runtime
+ * under /usr/local/bin, and adds the matplotlib backend + chart dir + result
+ * marker the wrapper reads.
+ */
 function buildJailEnv(resultMarker: string): Record<string, string> {
   return {
+    ...BASE_JAIL_ENV,
     PATH: "/bin:/usr/bin:/usr/local/bin",
-    HOME: "/tmp",
-    LANG: "C.UTF-8",
     MPLBACKEND: "Agg",
     ATLAS_CHART_DIR: "/tmp/charts",
     ATLAS_RESULT_MARKER: resultMarker,

--- a/packages/api/src/lib/tools/python-sidecar.ts
+++ b/packages/api/src/lib/tools/python-sidecar.ts
@@ -11,6 +11,11 @@
 import type { SidecarPythonRequest, SidecarPythonStreamEvent } from "@atlas/api/lib/sidecar-types";
 import type { PythonChart, PythonProgressEvent, PythonResult, RechartsChart } from "./python";
 import { createLogger } from "@atlas/api/lib/logger";
+import {
+  isSidecarConnectionError,
+  isSidecarTimeoutError,
+  sidecarRequestHeaders,
+} from "./backends/sidecar-transport";
 
 const log = createLogger("python-sidecar");
 
@@ -30,8 +35,6 @@ export async function executePythonViaSidecar(
   code: string,
   data?: { columns: string[]; rows: unknown[][] },
 ): Promise<PythonResult> {
-  const authToken = process.env.SIDECAR_AUTH_TOKEN;
-
   let baseUrl: URL;
   try {
     baseUrl = new URL(sidecarUrl);
@@ -58,28 +61,21 @@ export async function executePythonViaSidecar(
   try {
     response = await fetch(execUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
-      },
+      headers: sidecarRequestHeaders(),
       body: JSON.stringify(requestBody),
       signal: AbortSignal.timeout(timeout + HTTP_OVERHEAD_MS),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
 
-    if (
-      detail.includes("ECONNREFUSED") ||
-      detail.includes("fetch failed") ||
-      detail.includes("Failed to connect")
-    ) {
+    if (isSidecarConnectionError(detail)) {
       log.error({ err: detail, url: execUrl }, "Sidecar connection failed for Python execution");
       return pythonError(
         `Python sidecar unreachable at ${baseUrl.origin}: ${detail}. Check that the sandbox-sidecar service is running.`,
       );
     }
 
-    if (detail.includes("TimeoutError") || detail.includes("timed out") || detail.includes("aborted")) {
+    if (isSidecarTimeoutError(detail)) {
       log.warn({ timeout }, "Python sidecar request timed out");
       return pythonError(`Python execution timed out after ${timeout}ms`);
     }
@@ -164,8 +160,6 @@ export async function executePythonViaSidecarStream(
   data: { columns: string[]; rows: unknown[][] } | undefined,
   onProgress: (event: PythonProgressEvent) => void,
 ): Promise<PythonResult> {
-  const authToken = process.env.SIDECAR_AUTH_TOKEN;
-
   let baseUrl: URL;
   try {
     baseUrl = new URL(sidecarUrl);
@@ -189,21 +183,14 @@ export async function executePythonViaSidecarStream(
   try {
     response = await fetch(execUrl, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
-      },
+      headers: sidecarRequestHeaders(),
       body: JSON.stringify(requestBody),
       signal: AbortSignal.timeout(timeout + HTTP_OVERHEAD_MS),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    const isConnectionError =
-      detail.includes("ECONNREFUSED") ||
-      detail.includes("fetch failed") ||
-      detail.includes("Failed to connect");
 
-    if (isConnectionError) {
+    if (isSidecarConnectionError(detail)) {
       log.warn({ err: detail }, "Streaming endpoint unreachable, falling back to non-streaming");
       return executePythonViaSidecar(sidecarUrl, code, data);
     }

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -19,6 +19,13 @@ import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig } from "@atlas/api/lib/config";
 import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
+import {
+  planSandboxSelection,
+  runSandboxPlan,
+  formatSandboxPriorityFailure,
+  assertNever,
+  type SandboxSelectionEnv,
+} from "./backends/selection";
 import { getStreamWriter } from "./python-stream";
 import type { PythonSandboxOptions } from "./python-sandbox";
 import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
@@ -329,97 +336,178 @@ async function vercelSandboxOptionsFor(
 }
 
 /**
- * Resolve the Python execution backend.
+ * Snapshot the env + config inputs that drive backend selection into the shape
+ * the shared pure planner ({@link planSandboxSelection}) consumes — the SAME
+ * snapshot the explore tool builds, which is what makes the two tools resolve
+ * the same backend for the same env/config (#4187).
  *
- * Priority:
- * 1. Sidecar (ATLAS_SANDBOX_URL) — HTTP-isolated container
- * 2. Vercel (ATLAS_RUNTIME=vercel) — Python 3.13 in Firecracker microVM
- * 3. nsjail explicit (ATLAS_SANDBOX=nsjail) — hard-fail if unavailable
- * 4. nsjail auto-detect (on PATH or ATLAS_NSJAIL_PATH) — graceful fallback
- * 5. No backend — error
+ * `nsjailFailed` is always `false`: unlike explore, the Python nsjail backend
+ * has no exit-109 runtime-degradation callback, so it re-attempts nsjail each
+ * turn (its prior behavior). The config priority (`sandbox.priority`, also fed
+ * by `ATLAS_SANDBOX_PRIORITY`) is honored here for the first time — before
+ * #4187 the Python tool ignored it entirely, a latent posture bug given SaaS
+ * pins `["vercel-sandbox"]`.
+ */
+export async function snapshotPythonSandboxEnv(): Promise<SandboxSelectionEnv> {
+  const { isNsjailAvailable } = await import("./backends/nsjail");
+  return {
+    atlasSandbox: process.env.ATLAS_SANDBOX,
+    vercelAvailable: useVercelSandbox(),
+    sidecarAvailable: useSidecar(),
+    nsjailAvailable: isNsjailAvailable(),
+    nsjailFailed: false,
+    configPriority: getConfig()?.sandbox?.priority,
+  };
+}
+
+/**
+ * Resolve the Python execution backend through the shared selection policy
+ * ({@link planSandboxSelection} + {@link runSandboxPlan}) so explore and Python
+ * agree on the chosen backend and both honor `sandbox.priority` /
+ * `ATLAS_SANDBOX_PRIORITY`. The default chain is Vercel > nsjail-explicit >
+ * sidecar > nsjail-auto (there is no `just-bash` step — Python refuses to run
+ * without process isolation).
  *
- * `restDatasource` (when non-null) bounds the **Vercel sandbox**'s egress to the
- * datasource host (#2927 layer 0): the per-request network allowlist replaces
- * the default `deny-all`. The sidecar and nsjail backends ignore it — the
- * sidecar has no network policy (its network is open) and nsjail has no network
- * at all. The caller only passes a non-null datasource when the Vercel backend
- * will actually be selected. NB: this opens egress only; no credential is
- * injected, so the authenticated read path stays the host-side
- * `executeRestOperation` tool.
+ * `resolveVercelOptions` is called ONLY if/when the Vercel step is actually
+ * reached; it lazily resolves the per-request REST datasource and bounds the
+ * sandbox egress to that host (#2927 layer 0). Absent datasource → deny-all.
+ * The sidecar and nsjail backends ignore it — the sidecar's network is open and
+ * nsjail has no network. NB: egress-open only; no credential is injected, so the
+ * authenticated read path stays the host-side `executeRestOperation` tool.
  */
 async function getPythonBackend(
-  restDatasource?: RestDatasource | null,
+  resolveVercelOptions: () => Promise<PythonSandboxOptions>,
 ): Promise<PythonBackend | { error: string }> {
-  // 1. Sidecar
-  if (useSidecar()) {
-    const sidecarUrl = process.env.ATLAS_SANDBOX_URL!;
-    const { executePythonViaSidecar, executePythonViaSidecarStream } = await import("./python-sidecar");
-    return {
-      exec: (code, data) => executePythonViaSidecar(sidecarUrl, code, data),
-      execStream: (code, data, onProgress) =>
-        executePythonViaSidecarStream(sidecarUrl, code, data, onProgress),
-    };
+  const { findNsjailBinary } = await import("./backends/nsjail");
+  const plan = planSandboxSelection(await snapshotPythonSandboxEnv());
+  if (plan.source === "config-priority") {
+    log.info(
+      { priority: plan.configPriority },
+      "Using configured sandbox priority for Python: %s",
+      plan.configPriority.join(" > "),
+    );
   }
 
-  // 2. Vercel sandbox (Python 3.13 runtime)
-  if (useVercelSandbox()) {
-    let createPythonSandboxBackend;
-    try {
-      ({ createPythonSandboxBackend } = await import("./python-sandbox"));
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      log.error({ err: detail }, "Vercel Python sandbox module not available");
-      return { error: `Vercel Python sandbox unavailable: ${detail}` };
-    }
-    // Bound egress to the datasource host (#2927 layer 0). Absent
-    // datasource → default options (deny-all network).
-    return createPythonSandboxBackend(await vercelSandboxOptionsFor(restDatasource ?? null));
-  }
-
-  // 3. nsjail explicit (ATLAS_SANDBOX=nsjail) — hard-fail
-  if (process.env.ATLAS_SANDBOX === "nsjail") {
-    try {
-      const { findNsjailBinary } = await import("./backends/nsjail");
-      const nsjailPath = findNsjailBinary();
-      if (nsjailPath) {
-        const { createPythonNsjailBackend } = await import("./python-nsjail");
-        return createPythonNsjailBackend(nsjailPath);
+  const outcome = await runSandboxPlan<PythonBackend>(
+    plan,
+    async (step) => {
+    switch (step.kind) {
+      case "sidecar": {
+        // Read into a null-checked local (no non-null assertion). The default
+        // chain only reaches this step when ATLAS_SANDBOX_URL is set, but a
+        // config pin can list "sidecar" with the URL unset — guard for it.
+        const sidecarUrl = process.env.ATLAS_SANDBOX_URL;
+        if (!sidecarUrl) {
+          return { failure: { name: step.kind, reason: "not configured (set ATLAS_SANDBOX_URL)" } };
+        }
+        const { executePythonViaSidecar, executePythonViaSidecarStream } = await import(
+          "./python-sidecar"
+        );
+        return {
+          backend: {
+            exec: (code, data) => executePythonViaSidecar(sidecarUrl, code, data),
+            execStream: (code, data, onProgress) =>
+              executePythonViaSidecarStream(sidecarUrl, code, data, onProgress),
+          },
+        };
       }
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      log.error({ err: detail }, "nsjail explicitly requested but Python nsjail backend failed to load");
-    }
-    return {
-      error: "ATLAS_SANDBOX=nsjail but nsjail binary not found. Python execution unavailable.",
-    };
-  }
 
-  // 4. nsjail auto-detect
-  try {
-    const { findNsjailBinary } = await import("./backends/nsjail");
-    const nsjailPath = findNsjailBinary();
-    if (nsjailPath) {
-      const { createPythonNsjailBackend } = await import("./python-nsjail");
-      return createPythonNsjailBackend(nsjailPath);
-    }
-  } catch (err) {
-    if (
-      err != null &&
-      typeof err === "object" &&
-      "code" in err &&
-      (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND"
-    ) {
-      log.debug("nsjail module not available, skipping nsjail Python backend");
-    } else {
-      const detail = err instanceof Error ? err.message : String(err);
-      log.error({ err: detail }, "Unexpected error initializing nsjail Python backend");
-    }
-  }
+      case "vercel-sandbox": {
+        if (!useVercelSandbox()) {
+          return {
+            failure: {
+              name: step.kind,
+              reason: "not configured (set ATLAS_RUNTIME=vercel, VERCEL=1, or VERCEL_* credentials)",
+            },
+          };
+        }
+        let createPythonSandboxBackend;
+        try {
+          ({ createPythonSandboxBackend } = await import("./python-sandbox"));
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          log.error({ err: detail }, "Vercel Python sandbox module not available");
+          return { failure: { name: step.kind, reason: `runtime unavailable: ${detail}` } };
+        }
+        // Bound egress to the datasource host (#2927 layer 0). Resolved lazily,
+        // only now that the Vercel step is actually selected.
+        return { backend: createPythonSandboxBackend(await resolveVercelOptions()) };
+      }
 
-  // 5. No backend
-  return {
-    error: "Python execution requires a sandbox (ATLAS_SANDBOX_URL or nsjail). See deployment docs.",
-  };
+      case "nsjail": {
+        const nsjailPath = findNsjailBinary();
+        if (!nsjailPath) {
+          return { failure: { name: step.kind, reason: "nsjail binary not found" } };
+        }
+        const { createPythonNsjailBackend } = await import("./python-nsjail");
+        return { backend: createPythonNsjailBackend(nsjailPath) };
+      }
+
+      case "just-bash":
+        // Python has no unsandboxed mode; refuse rather than run without
+        // isolation. A default-chain exhaustion surfaces as the "requires a
+        // sandbox" error below; a config pin to just-bash fails the same way.
+        return {
+          failure: {
+            name: step.kind,
+            reason: "Python requires process isolation; the just-bash fallback cannot execute Python",
+          },
+        };
+
+      default:
+        return assertNever(step.kind);
+    }
+    },
+    (step, reason) =>
+      log.warn(
+        { backend: step.kind, reason },
+        "Python sandbox step threw during construction — treated as soft failure",
+      ),
+  );
+
+  switch (outcome.kind) {
+    case "backend":
+      log.debug({ backend: outcome.selected, source: plan.source }, "Python backend selected");
+      return outcome.backend;
+
+    case "hard-fail":
+      // Explicit nsjail (ATLAS_SANDBOX=nsjail) could not be initialized.
+      return {
+        error:
+          `ATLAS_SANDBOX=nsjail but the nsjail Python backend could not be initialized: ${outcome.reason}. ` +
+          "Python execution unavailable.",
+      };
+
+    case "fail-closed":
+      // Config-priority pin with no fallback (the SaaS deny-all posture).
+      // `fail-closed` only arises from the config-priority arm, which carries the pin.
+      return {
+        error: formatSandboxPriorityFailure(
+          plan.source === "config-priority" ? plan.configPriority : [],
+          outcome.failures,
+          getConfig()?.deployMode,
+        ),
+      };
+
+    case "exhausted": {
+      // No isolation backend was available. Surface any attempted-backend
+      // reasons (e.g. a Vercel/nsjail that was tried and failed) so the operator
+      // can tell a missing binary from a crashing runtime — but keep the base
+      // message (and its ATLAS_SANDBOX_URL hint) intact for empty-attempt cases.
+      const attempted =
+        outcome.failures.length > 0
+          ? ` Attempted: ${outcome.failures.map((f) => `${f.name}: ${f.reason}`).join("; ")}.`
+          : "";
+      return {
+        error:
+          "Python execution requires a sandbox (ATLAS_SANDBOX_URL or nsjail). See deployment docs." +
+          attempted,
+      };
+    }
+
+    default:
+      return assertNever(outcome);
+  }
 }
 
 // --- Tool definition ---
@@ -596,16 +684,18 @@ Blocked: subprocess, os, socket, shutil, sys, ctypes, importlib, exec(), eval(),
         }
       }
 
-      // 0b. Operator chain (BYOC not engaged). Resolve the REST datasource
-      // only when the Vercel backend will actually be selected — the
-      // sidecar / nsjail backends have no network policy to narrow (see
-      // getPythonBackend).
+      // 0b. Operator chain (BYOC not engaged). The REST datasource is resolved
+      // lazily — only if the shared selector actually reaches the Vercel step
+      // (the sidecar / nsjail backends have no network policy to narrow). This
+      // replaces the old `useVercelSandbox() && !useSidecar()` heuristic with
+      // the real selection decision, so the egress resolve tracks the backend
+      // that is truly chosen (e.g. it is skipped when a config pin routes away
+      // from Vercel).
       if (!resolvedBackend) {
-        const operatorVercel = useVercelSandbox() && !useSidecar();
-        if (operatorVercel && !restDatasourceResolved) {
-          await resolveRestDatasourceFailSoft();
-        }
-        resolvedBackend = await getPythonBackend(operatorVercel ? restDatasource : null);
+        resolvedBackend = await getPythonBackend(async () => {
+          if (!restDatasourceResolved) await resolveRestDatasourceFailSoft();
+          return vercelSandboxOptionsFor(restDatasource);
+        });
       }
       if ("error" in resolvedBackend) {
         log.error(resolvedBackend.error);

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -15,6 +15,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { withSpan } from "@atlas/api/lib/tracing";
 import { getConfig } from "@atlas/api/lib/config";
 import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
@@ -425,7 +426,9 @@ async function getPythonBackend(
         try {
           ({ createPythonSandboxBackend } = await import("./python-sandbox"));
         } catch (err) {
-          const detail = err instanceof Error ? err.message : String(err);
+          // Scrub via errorMessage (matches explore's tryCreateBackend) so an
+          // operator-facing reason can never carry a connection string.
+          const detail = errorMessage(err);
           log.error({ err: detail }, "Vercel Python sandbox module not available");
           return { failure: { name: step.kind, reason: `runtime unavailable: ${detail}` } };
         }


### PR DESCRIPTION
Closes #4187.

## What

Deepens the hand-rolled sandbox backend-priority "dance" (previously ~5 sites, **diverged** between the two tools) into a single selection module consumed by both `explore` and `python`.

`packages/api/src/lib/tools/backends/selection.ts` is the new home:
- `planSandboxSelection(env)` — a **pure** function turning an immutable `SandboxSelectionEnv` snapshot into an ordered, discriminated `SandboxPlan`. This is the ONE priority policy.
- `runSandboxPlan(plan, tryStep, onStepError?)` — the shared async walk (soft fall-through, hard-fail short-circuit, exhaustion), with tool-specific per-backend construction injected via `tryStep`.
- `firstAvailableBackend` (health reporting) + `formatSandboxPriorityFailure` (fail-closed messaging) + `assertNever`.

Both tools build the same-shaped snapshot and feed the same planner, so they resolve the **same backend for the same env/config**. The canonical order is now `Vercel > nsjail-explicit > sidecar > nsjail-auto > just-bash` (per CLAUDE.md).

### The security fix
`python.ts` previously had **zero** references to `sandbox.priority` / `ATLAS_SANDBOX_PRIORITY` and ranked `sidecar > vercel` — the opposite of explore. On a SaaS deploy that pins `sandbox.priority: ["vercel-sandbox"]` (deny-all, no fallback), python could silently run on a mistakenly-configured sidecar. Now python routes through the shared policy: it honors the pin and **fails closed** exactly like explore. Python still has no `just-bash` step — it refuses rather than run unsandboxed.

### Dedup (each now exists once)
- **nsjail arg-building** — `assembleNsjailArgs(spec)` is the single flag serializer; `buildNsjailArgs` (explore) + `buildPythonNsjailArgs` (python, moved into `backends/nsjail.ts`, re-exported) are thin spec adapters. Golden byte-for-byte tests lock both.
- **`JAIL_ENV`** — de-triplicated into `BASE_JAIL_ENV`.
- **sidecar transport** — the ECONNREFUSED/timeout classifiers + bearer-auth header (copy-pasted 3×) collapse into `backends/sidecar-transport.ts`.

## Acceptance criteria
- [x] One priority policy: explore + python resolve the same backend for the same env/config (`sandbox-selection-parity.test.ts` drives a matrix through both snapshot builders → identical plans)
- [x] python honors `sandbox.priority`, `ATLAS_SANDBOX_PRIORITY` (config-derived), and the shared plugin/selection seam
- [x] Selection logic unit-testable **without** import-cache-busting (`selection.test.ts` is a pure planner test — no `import(...?t=)`)
- [x] SaaS pin (`["vercel-sandbox"]`, deny-all, no fallback) unchanged, covered for **both** tools (`explore-default-chain-fallthrough.test.ts` + `python-sandbox-priority.test.ts`)
- [x] nsjail arg-building + sidecar transport/classifier each exist once (golden + unit tests)

## Test plan
- New: `backends/__tests__/selection.test.ts` (pure planner), `backends/__tests__/nsjail-args.test.ts` (golden arg arrays), `backends/__tests__/sidecar-transport.test.ts`, `__tests__/python-sandbox-priority.test.ts` (posture: pin fail-closed, exhausted→refuse, explicit-nsjail hard-fail), `__tests__/sandbox-selection-parity.test.ts` (AC1).
- All existing explore/python/nsjail/sidecar/byoc/egress/health/admin-sandbox tests green. `tsgo` + `eslint` clean.

## Review
Internal review-panel run twice (silent-failure, type-design, test-coverage, comment-accuracy) → **CLEAN**. Fixes from round 1: discriminated `SandboxPlan` union, `onStepError` logging so thrown steps can't vanish, `assertNever` guards, `NsjailSpec` numeric narrowing, removed a non-null assertion, and the three coverage gaps above. One deliberate non-goal noted by the panel: the explicit-nsjail hard-fail path propagates the failure **message** (identical operator-facing text) but not the original error's `cause` chain, since the reason now flows through the shared string seam — acceptable, message is fully preserved.

https://claude.ai/code/session_015E1b5xQeizyEQZktA9hm6N