### PR TITLE
chore(www): type-check app-root serve.ts/serve.test.ts in CI

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -10,7 +10,8 @@
     "dev": "next dev --turbopack -p 3002",
     "build": "next build",
     "start": "bun serve.ts",
-    "test": "bun test serve.test.ts"
+    "test": "bun test serve.test.ts",
+    "type": "tsgo -p tsconfig.serve.json"
   },
   "dependencies": {
     "next": "^16.2.9",

--- a/apps/www/tsconfig.serve.json
+++ b/apps/www/tsconfig.serve.json
@@ -1,0 +1,14 @@
+{
+  // Type-checks the app-root runtime files (serve.ts, serve.test.ts) that the
+  // main tsconfig's `include` (src/** only) leaves out and `next build` ignores
+  // — so they were invisible to CI type-checking. Run via the `type` script,
+  // wired into the root `type` job. `incremental: false` keeps it from writing
+  // a tsbuildinfo (the repo .gitignore only covers the exact `tsconfig.tsbuildinfo`).
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun", "node"],
+    "noEmit": true,
+    "incremental": false
+  },
+  "include": ["serve.ts", "serve.test.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:docs": "bun run --filter '@atlas/docs' build",
     "start": "sh scripts/start.sh",
     "lint": "eslint packages/ ee/ plugins/ apps/ examples/ create-atlas/",
-    "type": "bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build && bun run --filter '@useatlas/sdk' build && bun run --filter '@useatlas/react' build && tsgo --noEmit && bun run --filter '@atlas/web' type",
+    "type": "bun run --filter '@useatlas/types' build && bun run --filter '@useatlas/plugin-sdk' build && bun run --filter '@useatlas/sdk' build && bun run --filter '@useatlas/react' build && tsgo --noEmit && bun run --filter '@atlas/web' type && bun run --filter '@atlas/www' type",
     "atlas": "bun packages/cli/bin/atlas.ts",
     "atlas-operator": "bun packages/cli/bin/atlas-operator.ts",
     "mcp": "bun packages/mcp/bin/serve.ts",


### PR DESCRIPTION
## Summary

Follow-up to #4253. `apps/www/serve.ts` + `serve.test.ts` live at the app root, outside the main tsconfig's `include` (`src/**` only), and `next build` ignores them — so CI never type-checked them (a blind spot I verified around manually in #4253).

- New `apps/www/tsconfig.serve.json` (bun+node types, `noEmit`, `incremental: false` so it writes no tsbuildinfo) covering exactly those two files.
- Exposed as the `@atlas/www` `type` script, appended to the root `type` chain that the CI `type` job runs.

## Test plan
- [x] `bun run --filter '@atlas/www' type` green on clean tree.
- [x] Injected a deliberate type error into `serve.ts` → the gate **fails** (TS2322); reverted.
- [x] Full `bun run type` chain green end-to-end (SDK builds + tsgo + web + www).
- [x] No stray `tsbuildinfo`, no lockfile churn.