### PR TITLE
feat(discovery): agent region directory (atlas-regions.json)

### DIFF
--- a/apps/www/public/.well-known/atlas-regions.json
+++ b/apps/www/public/.well-known/atlas-regions.json
@@ -1,0 +1,26 @@
+{
+  "default": "us",
+  "regions": [
+    {
+      "id": "us",
+      "label": "United States",
+      "api": "https://api.useatlas.dev",
+      "mcp": "https://mcp.useatlas.dev/mcp",
+      "authMd": "https://api.useatlas.dev/auth.md"
+    },
+    {
+      "id": "eu",
+      "label": "Europe",
+      "api": "https://api-eu.useatlas.dev",
+      "mcp": "https://mcp-eu.useatlas.dev/mcp",
+      "authMd": "https://api-eu.useatlas.dev/auth.md"
+    },
+    {
+      "id": "apac",
+      "label": "Asia Pacific",
+      "api": "https://api-apac.useatlas.dev",
+      "mcp": "https://mcp-apac.useatlas.dev/mcp",
+      "authMd": "https://api-apac.useatlas.dev/auth.md"
+    }
+  ]
+}

--- a/apps/www/serve.test.ts
+++ b/apps/www/serve.test.ts
@@ -37,6 +37,10 @@ beforeAll(async () => {
     join(fixtureDir, ".well-known", "oauth-protected-resource.json"),
     `${JSON.stringify({ resource: "https://api.useatlas.dev" })}\n`,
   );
+  writeFileSync(
+    join(fixtureDir, ".well-known", "atlas-regions.json"),
+    `${JSON.stringify({ default: "us", regions: [{ id: "us" }] })}\n`,
+  );
   // A page + its markdown twin, for the Accept: text/markdown branch.
   mkdirSync(join(fixtureDir, "markdown"), { recursive: true });
   writeFileSync(join(fixtureDir, "markdown", "guide.md"), "# Guide — markdown twin\n");
@@ -105,10 +109,19 @@ describe("apex agent discovery — OAuth/OIDC redirects", () => {
 });
 
 describe("apex agent discovery — .well-known + homepage", () => {
-  it("serves /.well-known/oauth-protected-resource as JSON", async () => {
+  it("serves /.well-known/oauth-protected-resource as JSON with CORS", async () => {
     const res = await req("/.well-known/oauth-protected-resource");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("serves /.well-known/atlas-regions.json (region directory) with CORS", async () => {
+    const res = await req("/.well-known/atlas-regions.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await res.json()).toMatchObject({ default: "us" });
   });
 
   it("404s a registered well-known route whose backing file is missing", async () => {
@@ -123,6 +136,7 @@ describe("apex agent discovery — .well-known + homepage", () => {
     expect(link).toContain('</auth.md>; rel="auth.md"');
     expect(link).toContain('rel="oauth-authorization-server"');
     expect(link).toContain('rel="oauth-protected-resource"');
+    expect(link).toContain('rel="atlas-regions"');
   });
 
   it("404s an unknown path (no 404.html fixture → plain Not Found)", async () => {

--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -66,6 +66,7 @@ const HOMEPAGE_LINK_HEADER = [
   '</.well-known/oauth-protected-resource>; rel="oauth-protected-resource"; type="application/json"',
   '</.well-known/oauth-authorization-server>; rel="oauth-authorization-server"; type="application/json"',
   '</.well-known/agent-skills/index.json>; rel="agent-skills"; type="application/json"',
+  '</.well-known/atlas-regions.json>; rel="atlas-regions"; type="application/json"',
   '</auth.md>; rel="auth.md"; type="text/markdown"',
 ].join(", ");
 
@@ -78,6 +79,13 @@ const WELL_KNOWN_ROUTES: Record<string, { file: string; contentType: string }> =
   },
   "/.well-known/oauth-protected-resource": {
     file: "/.well-known/oauth-protected-resource.json",
+    contentType: "application/json; charset=utf-8",
+  },
+  // The agent-facing region directory (ADR-0024): resolve your residency
+  // region here, then follow that region's own host discovery. Keeps its `.json`
+  // in the URL like the sibling agent docs (agent-skills, mcp/server-card).
+  "/.well-known/atlas-regions.json": {
+    file: "/.well-known/atlas-regions.json",
     contentType: "application/json; charset=utf-8",
   },
 };
@@ -277,6 +285,10 @@ export async function handleRequest(req: Request): Promise<Response> {
             ...SECURITY_HEADERS,
             "Content-Type": wellKnown.contentType,
             "Cache-Control": "public, max-age=300",
+            // These are public discovery documents fetched cross-origin by
+            // agents / MCP clients / readiness scanners — CORS-open, matching
+            // the API's own `.well-known` responses.
+            "Access-Control-Allow-Origin": "*",
           },
         });
       }

--- a/deploy/dns/dns-aid.md
+++ b/deploy/dns/dns-aid.md
@@ -33,12 +33,29 @@ publish two entry points under `_agents.useatlas.dev`:
 
 | Owner name | Purpose | Target |
 |---|---|---|
-| `_mcp._agents.useatlas.dev` | The MCP agent endpoint | `mcp.useatlas.dev` |
-| `_index._agents.useatlas.dev` | The org's agent index (skills / server-card) | `useatlas.dev` |
+| `_mcp._agents.useatlas.dev` | The MCP agent endpoint (US / default region) | `mcp.useatlas.dev` |
+| `_index._agents.useatlas.dev` | The org's agent index (skills / server-card / **region directory**) | `useatlas.dev` |
 
 > The draft requires the SVCB **TargetName** to be a real host with no DNS-SD
 > underscore labels (public X.509 certs are used in the connection), which both
 > `mcp.useatlas.dev` and `useatlas.dev` satisfy.
+
+### Regions are NOT more DNS records — they live in the index
+
+Atlas is residency-isolated (ADR-0024): `api-eu` / `api-apac` are fully
+independent stacks, and **region is the user's chosen residency, not their
+network location** — so it is deliberately *not* a DNS/geo-routing decision.
+DNS-AID's `_index._agents` is the enumeration entry point *by design*; the region
+list lives one layer up, in the HTTP **region directory** at
+`useatlas.dev/.well-known/atlas-regions.json` (generated from the same
+`residency.regions` SSOT as the signup picker). An agent resolves its region
+there, then follows that region's own host discovery
+(`api-eu.useatlas.dev/auth.md`, which advertises `mcp-eu.useatlas.dev`).
+
+So the two records above are the **complete** DNS footprint — **no per-region
+SVCB records are needed**. (You *could* add `_mcp-eu._agents` / `_mcp-apac._agents`
+pointing at the regional MCP hosts for DNS-only agents, but DNS-SD labels name a
+*service*, not a region, and it duplicates the directory — not recommended.)
 
 ---
 

--- a/packages/api/scripts/generate-apex-discovery.ts
+++ b/packages/api/scripts/generate-apex-discovery.ts
@@ -32,7 +32,7 @@
 //
 // Usage: cd packages/api && bun scripts/generate-apex-discovery.ts
 
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderAuthMd } from "@atlas/api/api/routes/auth-md";
@@ -91,6 +91,130 @@ export const API_PROTECTED_RESOURCE = {
 } as const satisfies ProtectedResourceMetadata;
 
 // ---------------------------------------------------------------------------
+// Region directory (the agent analogue of the browser's front-door)
+// ---------------------------------------------------------------------------
+
+/**
+ * The selectable residency regions, mirrored from
+ * `deploy/api/atlas.config.ts` `residency.regions` (the SAME SSOT the signup
+ * picker + login front-door consume). `assertRegionsMatchConfig()` below fails
+ * generation if this list drifts from that config, so the apex directory can't
+ * silently disagree with what the platform actually offers.
+ *
+ * Only `id`, `label`, `api` are stated; the MCP host + auth.md URL are DERIVED
+ * from `api` (§ `mcpHostFor`) so they can't drift from it. `staging`
+ * (`selectable: false`) is intentionally excluded — real signups never see it.
+ */
+const SELECTABLE_REGIONS = [
+  { id: "us", label: "United States", api: "https://api.useatlas.dev" },
+  { id: "eu", label: "Europe", api: "https://api-eu.useatlas.dev" },
+  { id: "apac", label: "Asia Pacific", api: "https://api-apac.useatlas.dev" },
+] as const;
+
+const DEFAULT_REGION = "us";
+
+/**
+ * Map a regional API host to its MCP resource host — the `api*.useatlas.dev`
+ * → `mcp*.useatlas.dev` brand-mirror the live `.well-known` router applies
+ * (`well-known.ts:brandedMcpHost`). Kept as a derivation (not a second literal)
+ * so a region's MCP host is always consistent with its API host.
+ */
+function mcpHostFor(api: string): string {
+  const brand = api.replace(
+    /^https:\/\/api(-[a-z0-9]+)?\.useatlas\.dev$/,
+    "https://mcp$1.useatlas.dev",
+  );
+  return `${brand}/mcp`;
+}
+
+/** One entry in the region directory an agent reads to pick its residency host. */
+interface RegionDirectoryEntry {
+  readonly id: string;
+  readonly label: string;
+  /** Regional API base / OAuth issuer host. */
+  readonly api: string;
+  /** Regional MCP resource host (`<host>/mcp`). */
+  readonly mcp: string;
+  /** That region's own agent-onboarding document (region-correct discovery). */
+  readonly authMd: string;
+}
+
+interface RegionDirectory {
+  readonly default: string;
+  readonly regions: readonly RegionDirectoryEntry[];
+}
+
+/**
+ * The agent-facing region directory served at
+ * `useatlas.dev/.well-known/atlas-regions.json`. Atlas residency makes the
+ * *host* the region (ADR-0024), so an agent resolves its region here, then
+ * follows that host's own `/auth.md` + `.well-known` (which advertise the
+ * regional MCP endpoint). This is the machine-readable analogue of the browser
+ * signup/front-door region picker.
+ */
+export function buildRegionDirectory(): RegionDirectory {
+  return {
+    default: DEFAULT_REGION,
+    regions: SELECTABLE_REGIONS.map((r) => ({
+      id: r.id,
+      label: r.label,
+      api: r.api,
+      mcp: mcpHostFor(r.api),
+      authMd: `${r.api}/auth.md`,
+    })),
+  };
+}
+
+/**
+ * Fail generation if `SELECTABLE_REGIONS` drifts from the deploy-config SSOT:
+ * every selectable region there must be listed here with the same `apiUrl`, and
+ * this list must name no region the config marks `selectable: false` / omits.
+ * Regex-parses `residency.regions` from source (the config imports `@atlas/api`
+ * modules that don't resolve from this script's cwd, so we read, not import) —
+ * the same read-the-source discipline as check-auth-md-discovery-parity.ts.
+ */
+function assertRegionsMatchConfig(): void {
+  const src = readFileSync(join(repoRoot, "deploy/api/atlas.config.ts"), "utf8");
+  const regionsAt = src.indexOf("regions:", src.indexOf("residency:"));
+  if (regionsAt === -1) {
+    throw new Error(
+      "generate-apex-discovery: could not locate residency.regions in deploy/api/atlas.config.ts — the config shape moved; update assertRegionsMatchConfig().",
+    );
+  }
+  // Region blocks are flat (no nested braces): `"id": { label: ..., apiUrl: "...", [selectable: false] }`.
+  const configRegions = new Map<string, string>(); // id -> apiUrl, selectable only
+  const block = /"(\w+)":\s*\{([^}]*)\}/g;
+  for (let m = block.exec(src.slice(regionsAt)); m; m = block.exec(src.slice(regionsAt))) {
+    const [, id, body] = m;
+    if (/selectable:\s*false/.test(body)) continue;
+    const apiUrl = body.match(/apiUrl:\s*"([^"]+)"/)?.[1];
+    if (apiUrl) configRegions.set(id, apiUrl);
+  }
+
+  const listed = new Map<string, string>(SELECTABLE_REGIONS.map((r) => [r.id, r.api]));
+  const problems: string[] = [];
+  for (const [id, apiUrl] of configRegions) {
+    if (!listed.has(id)) {
+      problems.push(`config marks region "${id}" (${apiUrl}) selectable, but the apex region directory omits it`);
+    } else if (listed.get(id) !== apiUrl) {
+      problems.push(`region "${id}" apiUrl mismatch: config=${apiUrl}, directory=${listed.get(id)}`);
+    }
+  }
+  for (const [id] of listed) {
+    if (!configRegions.has(id)) {
+      problems.push(`apex region directory lists "${id}", but the config has no such selectable region`);
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      "generate-apex-discovery: apex region directory drifted from deploy/api/atlas.config.ts residency.regions:\n  - " +
+        problems.join("\n  - ") +
+        "\nUpdate SELECTABLE_REGIONS in this generator to match the config.",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Output targets (relative to packages/api/scripts/)
 // ---------------------------------------------------------------------------
 
@@ -109,6 +233,8 @@ const OUTPUTS = {
     repoRoot,
     "apps/docs/src/app/.well-known/oauth-protected-resource/resource-metadata.generated.json",
   ),
+  /** Served at `useatlas.dev/.well-known/atlas-regions.json` — the region directory. */
+  wwwRegions: join(repoRoot, "apps/www/public/.well-known/atlas-regions.json"),
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -151,18 +277,22 @@ function jsonArtifact(value: unknown): string {
 }
 
 function main(): void {
+  assertRegionsMatchConfig();
+
   const authMd = renderCanonicalAuthMd();
   const protectedResource = jsonArtifact(API_PROTECTED_RESOURCE);
 
   writeFileSync(OUTPUTS.wwwAuthMd, authMd);
   writeFileSync(OUTPUTS.wwwProtectedResource, protectedResource);
   writeFileSync(OUTPUTS.docsProtectedResource, protectedResource);
+  writeFileSync(OUTPUTS.wwwRegions, jsonArtifact(buildRegionDirectory()));
 
   console.log(
     "Generated apex discovery artifacts:\n" +
       `  ${OUTPUTS.wwwAuthMd}\n` +
       `  ${OUTPUTS.wwwProtectedResource}\n` +
-      `  ${OUTPUTS.docsProtectedResource}`,
+      `  ${OUTPUTS.docsProtectedResource}\n` +
+      `  ${OUTPUTS.wwwRegions}`,
   );
 }
 

--- a/packages/api/src/api/__tests__/apex-discovery-generator.test.ts
+++ b/packages/api/src/api/__tests__/apex-discovery-generator.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect } from "bun:test";
 import {
   renderCanonicalAuthMd,
   API_PROTECTED_RESOURCE,
+  buildRegionDirectory,
 } from "../../../scripts/generate-apex-discovery";
 
 describe("apex-discovery generator", () => {
@@ -49,6 +50,26 @@ describe("apex-discovery generator", () => {
     expect(API_PROTECTED_RESOURCE.bearer_methods_supported).toEqual(["header"]);
     expect(API_PROTECTED_RESOURCE.resource_policy_uri).toBe(
       "https://www.useatlas.dev/privacy",
+    );
+  });
+
+  it("builds a region directory with the us default and per-region hosts", () => {
+    const dir = buildRegionDirectory();
+    expect(dir.default).toBe("us");
+    expect(dir.regions.map((r) => r.id)).toEqual(["us", "eu", "apac"]);
+  });
+
+  it("derives each region's MCP host via the api*→mcp* brand-mirror", () => {
+    const dir = buildRegionDirectory();
+    const eu = dir.regions.find((r) => r.id === "eu");
+    expect(eu).toMatchObject({
+      api: "https://api-eu.useatlas.dev",
+      mcp: "https://mcp-eu.useatlas.dev/mcp",
+      authMd: "https://api-eu.useatlas.dev/auth.md",
+    });
+    // US has no region suffix — mirror must not inject a stray hyphen.
+    expect(dir.regions.find((r) => r.id === "us")?.mcp).toBe(
+      "https://mcp.useatlas.dev/mcp",
     );
   });
 });

--- a/scripts/check-apex-discovery-drift.sh
+++ b/scripts/check-apex-discovery-drift.sh
@@ -7,10 +7,13 @@
 # resolving the brand domain finds it on the first hop:
 #   - apps/www/public/auth.md                                  (agent onboarding)
 #   - apps/www/public/.well-known/oauth-protected-resource.json (RFC 9728)
+#   - apps/www/public/.well-known/atlas-regions.json            (region directory)
 #   - apps/docs/.../oauth-protected-resource/resource-metadata.generated.json
-# All three are GENERATED from one source in packages/api by
+# All are GENERATED from one source in packages/api by
 # `scripts/generate-apex-discovery.ts` — auth.md via the SAME renderer the live
-# `api.useatlas.dev/auth.md` route serves, the JSON from one canonical body.
+# `api.useatlas.dev/auth.md` route serves, the protected-resource JSON from one
+# canonical body, and the region directory from the region SSOT (with a parity
+# assertion in the generator against deploy/api/atlas.config.ts residency.regions).
 #
 # This gate re-runs the generator and fails if any emitted file differs from
 # the committed copy (a hand-edit, or an upstream change to the auth.md builder
@@ -26,6 +29,7 @@ cd "$ROOT"
 FILES=(
   "apps/www/public/auth.md"
   "apps/www/public/.well-known/oauth-protected-resource.json"
+  "apps/www/public/.well-known/atlas-regions.json"
   "apps/docs/src/app/.well-known/oauth-protected-resource/resource-metadata.generated.json"
 )
 


### PR DESCRIPTION
## Summary

Follow-up to #4253/#4255. Atlas is residency-isolated (ADR-0024) — `api-eu`/`api-apac` are independent stacks and `api.useatlas.dev` `401`s a non-US workspace — but the apex + DNS discovery we shipped was **US-pinned**, with no way for an EU/APAC agent to reach its region. Browsers have the login front-door chooser; **agents had no equivalent.**

This adds the agent analogue: a machine-readable **region directory** the apex serves, so an agent resolves its residency host and follows *that host's* own discovery (already region-correct — verified live that `api-eu.useatlas.dev` advertises `mcp-eu.useatlas.dev`). Enumerate-not-route, same model + SSOT as the browser signup picker (ADR-0024 makes region = host, never a DNS/geo decision).

`useatlas.dev/.well-known/atlas-regions.json`:
```json
{ "default": "us", "regions": [
  { "id":"us","label":"United States","api":"https://api.useatlas.dev","mcp":"https://mcp.useatlas.dev/mcp","authMd":"https://api.useatlas.dev/auth.md" },
  { "id":"eu",...,"mcp":"https://mcp-eu.useatlas.dev/mcp",... }, { "id":"apac",... } ] }
```

- **Generated** from `SELECTABLE_REGIONS` (mirrors `deploy/api/atlas.config.ts residency.regions`); MCP host **derived** via the `api*→mcp*` brand-mirror, `authMd` derived from `api`. `assertRegionsMatchConfig()` **fails generation** if the list drifts from the config SSOT (regex-parses source — config can't be imported from this cwd). Drift-gated like the other apex artifacts.
- `serve.ts` serves it + advertises it in the homepage `Link` header, and I added **`ACAO:*` to the shared well-known handler** (cross-origin agent docs — aligns www with the API's CORS-open discovery; `oauth-protected-resource`/`api-catalog` previously lacked it).
- `dns-aid.md`: documents that regions live in the `_index` → HTTP directory, **not** more DNS records.

## Test plan
- [x] Generator builds the directory (us default, `["us","eu","apac"]`, brand-mirrored MCP hosts); `assertRegionsMatchConfig` **verified to catch** an apiUrl typo.
- [x] `serve.test.ts`: region directory served (200/json/CORS) + in the Link header; oauth-protected-resource now asserts CORS. 12 www tests pass.
- [x] Drift gate (incl. `atlas-regions.json`), `@atlas/www` type gate, root tsgo, lint — all green.

## Notes
No linked issue (continuation of the agent-discovery thread from #4253). Independent DNS finding while here: `api-apac` briefly `SERVFAIL`ed — confirmed **transient DNSSEC-propagation churn** after enabling signing (`cd=1` resolves everything; flips between hosts; now `AD:true`), not a defect.