### PR TITLE
chore(release): scaffold @useatlas/react ref → ^0.2.0 + bun.lock catch-up

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -324,7 +324,7 @@
     },
     "packages/plugin-sdk": {
       "name": "@useatlas/plugin-sdk",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "devDependencies": {
         "@types/node": "^25.9.4",
         "ai": "^6.0.208",
@@ -343,7 +343,7 @@
     },
     "packages/react": {
       "name": "@useatlas/react",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.3.0",
         "@tanstack/react-query": "^5.101.1",

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-bedrock": "^3.1075.0",
     "@ai-sdk/provider": "^3.0.10",
     "@ai-sdk/react": "^3.0.210",
-    "@useatlas/react": "^0.1.0",
+    "@useatlas/react": "^0.2.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
     "@useatlas/types": "^0.2.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -20,7 +20,7 @@
     "@ai-sdk/openai": "^3.0.74",
     "@ai-sdk/provider": "^3.0.10",
     "@ai-sdk/react": "^3.0.210",
-    "@useatlas/react": "^0.1.0",
+    "@useatlas/react": "^0.2.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
     "@useatlas/types": "^0.2.0",


### PR DESCRIPTION
Post-publish follow-up for the `@useatlas/react@0.2.0` release (tagged `react-v0.2.0` @ `b34a39fc5`, now live on npm).

## What
- **create-atlas templates** (`docker`, `nextjs-standalone`): `@useatlas/react` `^0.1.0` → `^0.2.0`. Sequenced *after* publish per the `0.0.x`/scaffold ref-bump discipline (bumping before publish breaks Deploy Validation's registry `npm install`).
- **bun.lock**: catch committed workspace versions up to their `package.json` — `plugin-sdk` 0.0.16→0.0.17 and `react` 0.1.1→0.2.0. Both versions are already published; the committed lock had lagged, leaving `bun install` to perpetually re-dirty the working tree.

## Guards
- `check-published-symbols` — `react@^0.2.0 → 0.2.0 ok` (all 5 pinned pkgs ok)
- `check-unpublished-versions` — all publishable packages published

## Out of scope (flagged, not fixed)
The templates also pin `@useatlas/types@^0.2.0` while npm is at `0.5.0`. That's a pre-existing lag across three minors, not part of this release's follow-up — bumping it risks pulling breaking changes into the scaffold and needs its own Deploy-Validation pass. `check-published-symbols` confirms the scaffold only uses symbols present in 0.2.0, so it's safe to defer.

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v