### PR TITLE
chore(create-atlas): bump scaffold @useatlas/types ref → ^0.5.0

### DIFF
--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -26,7 +26,7 @@
     "@useatlas/react": "^0.2.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
-    "@useatlas/types": "^0.2.0",
+    "@useatlas/types": "^0.5.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "@better-auth/api-key": "^1.6.20",
     "@better-auth/oauth-provider": "^1.6.20",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -23,7 +23,7 @@
     "@useatlas/react": "^0.2.0",
     "@useatlas/sdk": "^0.1.0",
     "@useatlas/twenty": "^0.0.6",
-    "@useatlas/types": "^0.2.0",
+    "@useatlas/types": "^0.5.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "ai": "^6.0.208",
     "@better-auth/api-key": "^1.6.20",


### PR DESCRIPTION
Catches the last lagging `@useatlas/*` ref in the scaffold templates up to npm.

## What
`@useatlas/types` `^0.2.0` → `^0.5.0` in both templates (`docker`, `nextjs-standalone`). It was the only remaining lag — `react` (^0.2.0), `sdk` (^0.1.0), `twenty` (^0.0.6), `webhook-publisher` (^0.0.1) all already match npm.

## Why it's safe (not a risky three-minor jump)
The scaffold `src/` is generated from monorepo source that already compiles against the workspace `@useatlas/types@0.5.0`. Pinning the template to `^0.5.0` *aligns* the pin with the code; leaving it at `^0.2.0` was the actual mismatch.

## Verification
- `check-published-symbols` — `types@^0.5.0 → 0.5.0 ok` (no scaffold value import removed across 0.2→0.5)
- CI **Scaffold (docker)** + **Scaffold (vercel)** do a real registry `npm install` + build against `types@0.5.0` — the authoritative gate.

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v