### PR TITLE
feat(docs): add /self-hosted section + shared single-source mount (#4259)

### DIFF
--- a/apps/docs/content/self-hosted/index.mdx
+++ b/apps/docs/content/self-hosted/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Self-Hosted Atlas
+description: Run and operate Atlas on your own infrastructure — Docker, sandboxing, BYO auth and models.
+icon: Server
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This is the landing page for the **Self-Hosted** documentation section. Every
+page under `/self-hosted/*` is written for operators running Atlas on their own
+infrastructure — Docker deploys, sandbox isolation, bring-your-own auth and
+models.
+
+<Callout title="Scaffolding placeholder">
+  This page exists to prove the `/self-hosted` route group renders end-to-end
+  (issue #4259). The self-hosted deployment, sandboxing and BYO guides are
+  migrated here in later slices (#4264). SaaS / Cloud docs stay at the site
+  root; the API reference stays at `/api-reference`.
+</Callout>
+
+The route injects a static audience value into the MDX render scope. A component
+reading it here renders: <AudienceLabel />.
+
+Shared concept pages are single-sourced — authored once in `content/shared/` and
+mounted into both this section and the SaaS root. See the
+[single-source example](./single-source-example) to watch one file adapt to its
+mount.

--- a/apps/docs/content/self-hosted/meta.json
+++ b/apps/docs/content/self-hosted/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Self-Hosted",
+  "description": "Deploy and operate Atlas on your own infrastructure",
+  "icon": "Server",
+  "pages": ["index", "..."]
+}

--- a/apps/docs/content/shared/single-source-example.mdx
+++ b/apps/docs/content/shared/single-source-example.mdx
@@ -1,0 +1,29 @@
+---
+title: Single-Source Example
+description: A shared concept page authored once and mounted into both the SaaS-root and self-hosted docs.
+icon: FileText
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+This page lives in `content/shared/` and is authored **once**. It is mounted
+into both human docs sections from that one file — full presence, single source
+— so there is no second copy to drift (PRD #4257).
+
+You are reading it at one of two URLs, from the same file on disk:
+
+- `/single-source-example` — the SaaS / Cloud docs at the site root
+- `/self-hosted/single-source-example` — the Self-Hosted docs
+
+<Callout title="Route-injected audience">
+  The section this page is mounted in injects a static `audience` value into the
+  MDX render scope. The component below reads it — so this one file renders a
+  different value on each mount, resolved at build time (never a reader-facing
+  tab):
+</Callout>
+
+This mount's audience is: **<AudienceLabel />**.
+
+Because both mounts resolve "Edit on GitHub" from the page's real
+`absolutePath`, the edit link on either URL points at this same
+`content/shared/single-source-example.mdx` — one place to fix it.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start -p 3003",
     "generate:api": "bun ./scripts/generate-openapi.ts",
+    "test": "bun test src/lib/__tests__",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -2,8 +2,38 @@ import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 import { transformerMetaHighlight } from "@shikijs/transformers";
 import { rehypeCodeDefaultOptions } from "fumadocs-core/mdx-plugins";
 
+// SaaS / Cloud docs — served at the site root (`docs.useatlas.dev/…`). This is
+// the default section and its URLs are unchanged by the segmentation (PRD #4257
+// keeps SaaS at root so shared/help-center links don't break). The generated
+// `api-reference/` tree lives inside this collection and stays at
+// `/api-reference/*`, untouched.
 export const docs = defineDocs({
   dir: "content/docs",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
+});
+
+// Self-hosted / on-prem docs — served at the new `/self-hosted/*` section
+// (issue #4259). Fed into its own loader alongside the shared collection.
+export const selfHosted = defineDocs({
+  dir: "content/self-hosted",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
+});
+
+// Audience-agnostic concept pages authored ONCE and mounted into BOTH human
+// section loaders (SaaS root + self-hosted) — full presence, single source.
+// NOTE: content/shared/ intentionally has NO root meta.json: it is concatenated
+// into another collection's flat source, and a second root meta.json collides
+// on the virtual path "meta.json" (spike #4258 finding).
+export const shared = defineDocs({
+  dir: "content/shared",
   docs: {
     postprocess: {
       includeProcessedMarkdown: true,

--- a/apps/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -1,52 +1,10 @@
 import { source } from "@/lib/source";
-import {
-  DocsPage,
-  DocsBody,
-  DocsTitle,
-  DocsDescription,
-} from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
-import defaultMdxComponents from "fumadocs-ui/mdx";
-import { Tab, Tabs } from "fumadocs-ui/components/tabs";
-import { Step, Steps } from "fumadocs-ui/components/steps";
-import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
-import { APIPage } from "@/components/api-page";
-import { ChangelogTimeline } from "@/components/changelog-timeline";
-import { LLMCopyButton } from "@/components/llm-copy-button";
-import { getGithubLastEdit } from "fumadocs-core/content/github";
+import { SectionDocsPage } from "@/components/section-docs-page";
+import { createSectionRelativeLink } from "@/lib/mdx-links";
 
-/**
- * Fetch the last commit date for a docs page via the GitHub API.
- * Returns undefined in development (to avoid rate limits) and on any
- * API failure (graceful degradation — the UI simply hides the date).
- * Results are cached for 24 hours (86400s) via Next.js fetch cache.
- */
-async function getLastUpdate(path: string): Promise<Date | undefined> {
-  if (process.env.NODE_ENV === "development") return undefined;
-
-  try {
-    const time = await getGithubLastEdit({
-      owner: "AtlasDevHQ",
-      repo: "atlas",
-      sha: "main",
-      // page.path already includes the .mdx extension (e.g., "guides/slack.mdx")
-      path: `apps/docs/content/docs/${path}`,
-      // getGithubLastEdit sets this as the raw Authorization header value
-      token: process.env.GITHUB_TOKEN
-        ? `Bearer ${process.env.GITHUB_TOKEN}`
-        : undefined,
-      options: { next: { revalidate: 86400 } },
-    });
-    return time ?? undefined;
-  } catch (error) {
-    console.warn(
-      `[docs] Failed to fetch last edit time for "${path}":`,
-      error instanceof Error ? error.message : error,
-    );
-    return undefined;
-  }
-}
-
+// SaaS / Cloud docs at the site root. Renders the existing content/docs tree
+// (unchanged URLs) plus the shared pages, with the "saas" audience injected.
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
 }) {
@@ -54,46 +12,13 @@ export default async function Page(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
-  const MDX = page.data.body;
-  const lastUpdate = await getLastUpdate(page.path);
-
-  const isFullWidth = page.data.full === true;
-
   return (
-    <DocsPage
-      toc={page.data.toc}
-      lastUpdate={lastUpdate}
-      full={isFullWidth}
-      editOnGithub={{
-        owner: "AtlasDevHQ",
-        repo: "atlas",
-        sha: "main",
-        path: `apps/docs/content/docs/${page.path}`,
-      }}
-    >
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
-      {!isFullWidth && (
-        <div className="flex items-center gap-2 border-b pb-4">
-          <LLMCopyButton url={`${page.url}.mdx`} />
-        </div>
-      )}
-      <DocsBody>
-        <MDX
-          components={{
-            ...defaultMdxComponents,
-            Tab,
-            Tabs,
-            Step,
-            Steps,
-            Accordion,
-            Accordions,
-            APIPage,
-            ChangelogTimeline,
-          }}
-        />
-      </DocsBody>
-    </DocsPage>
+    <SectionDocsPage
+      page={page}
+      audience="saas"
+      linkComponent={createSectionRelativeLink(source, page)}
+      showLLMCopy
+    />
   );
 }
 

--- a/apps/docs/src/app/(self-hosted)/self-hosted/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(self-hosted)/self-hosted/[[...slug]]/page.tsx
@@ -1,0 +1,44 @@
+import { selfHostedSource } from "@/lib/source";
+import { notFound } from "next/navigation";
+import { SectionDocsPage } from "@/components/section-docs-page";
+import { createSectionRelativeLink } from "@/lib/mdx-links";
+
+// Self-hosted / on-prem docs at /self-hosted. Renders self-hosted-only content
+// plus the SAME shared pages as the root, with the "self-hosted" audience
+// injected — so a shared page adapts to this mount from one source file.
+export default async function Page(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = selfHostedSource.getPage(params.slug);
+  if (!page) notFound();
+
+  return (
+    <SectionDocsPage
+      page={page}
+      audience="self-hosted"
+      linkComponent={createSectionRelativeLink(selfHostedSource, page)}
+      // The /llms.mdx/<slug> markdown twins are root-only for now; the
+      // self-hosted section gets its own machine-readable surfaces in a later
+      // slice (#4266), so the copy button would 404 here.
+      showLLMCopy={false}
+    />
+  );
+}
+
+export function generateStaticParams() {
+  return selfHostedSource.generateParams();
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = selfHostedSource.getPage(params.slug);
+  if (!page) notFound();
+
+  return {
+    title: page.data.title,
+    description: page.data.description,
+  };
+}

--- a/apps/docs/src/app/(self-hosted)/self-hosted/layout.tsx
+++ b/apps/docs/src/app/(self-hosted)/self-hosted/layout.tsx
@@ -1,18 +1,18 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
-import { source } from "@/lib/source";
+import { selfHostedSource } from "@/lib/source";
 import { sectionTabs, siteNavLinks } from "@/lib/nav";
 import type { ReactNode } from "react";
 
-// SaaS / Cloud section — served at the site root. The sidebar shows only the
-// SaaS tree (saas + shared, plus the API Reference tab, unchanged). The
-// cross-section switcher (Docs ↔ Self-Hosted ↔ API) is the shared sectionTabs().
+// Self-hosted section — served at /self-hosted. The sidebar shows only the
+// self-hosted tree (self-hosted + shared). The cross-section switcher and site
+// links are shared with the root layout so the two sections never drift.
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <DocsLayout
-      tree={source.getPageTree()}
+      tree={selfHostedSource.getPageTree()}
       nav={{
         title: "Atlas",
-        url: "/",
+        url: "/self-hosted",
       }}
       sidebar={{ tabs: sectionTabs() }}
       links={siteNavLinks}

--- a/apps/docs/src/components/section-docs-page.tsx
+++ b/apps/docs/src/components/section-docs-page.tsx
@@ -1,0 +1,124 @@
+import {
+  DocsPage,
+  DocsBody,
+  DocsTitle,
+  DocsDescription,
+} from "fumadocs-ui/page";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
+import { Step, Steps } from "fumadocs-ui/components/steps";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import { getGithubLastEdit } from "fumadocs-core/content/github";
+import type { ComponentProps, FC } from "react";
+import { APIPage } from "@/components/api-page";
+import { ChangelogTimeline } from "@/components/changelog-timeline";
+import { LLMCopyButton } from "@/components/llm-copy-button";
+import { AudienceProvider, AudienceLabel, type Audience } from "@/lib/audience";
+import { githubEditPath } from "@/lib/mdx-links";
+import type { SectionPage } from "@/lib/source";
+
+/**
+ * Fetch the last commit date for a docs page via the GitHub API.
+ * Returns undefined in development (to avoid rate limits) and on any API
+ * failure (graceful degradation — the UI simply hides the date). Results are
+ * cached for 24 hours (86400s) via Next.js fetch cache.
+ *
+ * `sourcePath` is the page's real source file, repo-relative under `apps/docs/`
+ * — for a shared page this is the one `apps/docs/content/shared/…` file on both
+ * mounts (spike #4258 caveat 1).
+ */
+async function getLastUpdate(sourcePath: string): Promise<Date | undefined> {
+  if (process.env.NODE_ENV === "development") return undefined;
+
+  try {
+    const time = await getGithubLastEdit({
+      owner: "AtlasDevHQ",
+      repo: "atlas",
+      sha: "main",
+      path: sourcePath,
+      // getGithubLastEdit sets this as the raw Authorization header value
+      token: process.env.GITHUB_TOKEN
+        ? `Bearer ${process.env.GITHUB_TOKEN}`
+        : undefined,
+      options: { next: { revalidate: 86400 } },
+    });
+    return time ?? undefined;
+  } catch (error) {
+    console.warn(
+      `[docs] Failed to fetch last edit time for "${sourcePath}":`,
+      error instanceof Error ? error.message : error,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Renders one docs page for a human section (SaaS root or self-hosted). Both
+ * route groups delegate here so a single-sourced shared page renders
+ * IDENTICALLY on both mounts — the only per-section inputs are:
+ *
+ * - `audience` — injected into the MDX render scope (a shared page reads it via
+ *   `<AudienceLabel/>` / `useAudience()` and adapts, resolved at build time).
+ * - `linkComponent` — the mount-specific `createRelativeLink` result, so
+ *   relative MDX links resolve against THIS section's source.
+ * - `showLLMCopy` — the markdown-twin copy button, wired only where the
+ *   `/llms.mdx/<slug>` route exists (the root today; self-hosted lands in a
+ *   later slice).
+ */
+export async function SectionDocsPage({
+  page,
+  audience,
+  linkComponent,
+  showLLMCopy,
+}: {
+  page: SectionPage;
+  audience: Audience;
+  linkComponent: FC<ComponentProps<"a">>;
+  showLLMCopy: boolean;
+}) {
+  const MDX = page.data.body;
+  const lastUpdate = await getLastUpdate(githubEditPath(page.absolutePath));
+  const isFullWidth = page.data.full === true;
+
+  return (
+    <DocsPage
+      toc={page.data.toc}
+      lastUpdate={lastUpdate}
+      full={isFullWidth}
+      editOnGithub={{
+        owner: "AtlasDevHQ",
+        repo: "atlas",
+        sha: "main",
+        path: githubEditPath(page.absolutePath),
+      }}
+    >
+      <DocsTitle>{page.data.title}</DocsTitle>
+      <DocsDescription>{page.data.description}</DocsDescription>
+      {showLLMCopy && !isFullWidth && (
+        <div className="flex items-center gap-2 border-b pb-4">
+          <LLMCopyButton url={`${page.url}.mdx`} />
+        </div>
+      )}
+      <DocsBody>
+        <AudienceProvider audience={audience}>
+          <MDX
+            components={{
+              ...defaultMdxComponents,
+              Tab,
+              Tabs,
+              Step,
+              Steps,
+              Accordion,
+              Accordions,
+              APIPage,
+              ChangelogTimeline,
+              AudienceLabel,
+              // Resolve relative MDX links against THIS mount's source.
+              a: linkComponent,
+            }}
+          />
+        </AudienceProvider>
+      </DocsBody>
+    </DocsPage>
+  );
+}

--- a/apps/docs/src/lib/__tests__/github-edit-path.test.ts
+++ b/apps/docs/src/lib/__tests__/github-edit-path.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, spyOn } from "bun:test";
+import { githubEditPath } from "@/lib/mdx-links";
+
+// Unit coverage for the pure "Edit on GitHub" / last-updated path derivation.
+// This is the function that fixed the shared-page edit link (it replaced the
+// hardcoded `content/docs/${page.path}`, which pointed shared pages at a
+// non-existent content/docs twin — spike #4258 caveat #1). Locking its three
+// branches keeps a refactor from silently 404-ing every shared page's edit link.
+
+test("prefixes apps/docs/ onto a Fumadocs relative absolutePath", () => {
+  expect(githubEditPath("content/docs/guides/slack.mdx")).toBe(
+    "apps/docs/content/docs/guides/slack.mdx",
+  );
+});
+
+test("a shared page resolves to the one real content/shared file", () => {
+  expect(githubEditPath("content/shared/single-source-example.mdx")).toBe(
+    "apps/docs/content/shared/single-source-example.mdx",
+  );
+});
+
+test("slices from the marker when given an absolute path containing apps/docs/", () => {
+  expect(
+    githubEditPath("/home/x/atlas/apps/docs/content/self-hosted/index.mdx"),
+  ).toBe("apps/docs/content/self-hosted/index.mdx");
+});
+
+test("degrades to apps/docs/ and warns for a missing absolutePath", () => {
+  const warn = spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    expect(githubEditPath(undefined)).toBe("apps/docs/");
+    // The anomaly must not be silent (Atlas: never silently swallow).
+    expect(warn).toHaveBeenCalledTimes(1);
+  } finally {
+    warn.mockRestore();
+  }
+});

--- a/apps/docs/src/lib/__tests__/source-partition.test.ts
+++ b/apps/docs/src/lib/__tests__/source-partition.test.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "bun:test";
+import { buildSectionSource, type CollectionLike } from "@/lib/compose";
+
+/**
+ * Source-partition test (PRD #4257's highest-value seam).
+ *
+ * Asserts, on the composed section loaders directly, that the three URL spaces
+ * do not cross-leak:
+ *   - SaaS root  = saas + api-reference + shared, all under `/`
+ *   - Self-hosted = self-hosted + shared, all under `/self-hosted`
+ *   - API         = the `/api-reference/*` subset of the root source
+ * and, critically, that NO self-hosted-only page appears in the SaaS root
+ * source — the machine-checkable form of "SaaS routes are structurally free of
+ * self-hosted quirks."
+ *
+ * Self-contained: it drives the real `buildSectionSource` composition
+ * (`toFumadocsSource` concat → `loader({baseUrl})`) with synthetic collection
+ * fixtures, so it needs neither the generated `.source/server` (which only the
+ * Next bundler can load) nor any network/filesystem access.
+ */
+
+type DocEntry = CollectionLike["docs"][number];
+
+// Minimal synthetic doc entry. The composition only reads `info.{path,fullPath}`
+// (fullPath becomes the page's `absolutePath`); the cast stands in for the rich
+// compiled-MDX fields a real collection carries.
+function doc(path: string, fullPath: string, title: string): DocEntry {
+  return { info: { path, fullPath }, title } as unknown as DocEntry;
+}
+
+function collection(docs: DocEntry[]): CollectionLike {
+  return { docs, meta: [] };
+}
+
+// saas-only + api-reference live together under content/docs (root source).
+const saasDocs = [
+  doc("index.mdx", "content/docs/index.mdx", "Introduction"),
+  doc("billing.mdx", "content/docs/billing.mdx", "Billing"),
+];
+const apiDocs = [
+  doc("api-reference/index.mdx", "content/docs/api-reference/index.mdx", "API"),
+  doc(
+    "api-reference/chat/postChat.mdx",
+    "content/docs/api-reference/chat/postChat.mdx",
+    "POST /chat",
+  ),
+];
+const selfHostedDocs = [
+  doc("index.mdx", "content/self-hosted/index.mdx", "Self-Hosted"),
+  doc("docker.mdx", "content/self-hosted/docker.mdx", "Docker"),
+];
+const sharedDocs = [
+  doc(
+    "single-source-example.mdx",
+    "content/shared/single-source-example.mdx",
+    "Single-Source Example",
+  ),
+];
+
+const root = buildSectionSource({
+  audience: collection([...saasDocs, ...apiDocs]),
+  shared: collection(sharedDocs),
+  baseUrl: "/",
+});
+const selfHosted = buildSectionSource({
+  audience: collection(selfHostedDocs),
+  shared: collection(sharedDocs),
+  baseUrl: "/self-hosted",
+});
+
+const rootPages = root.getPages();
+const selfHostedPages = selfHosted.getPages();
+const rootUrls = rootPages.map((p) => p.url);
+const selfHostedUrls = selfHostedPages.map((p) => p.url);
+
+test("SaaS root serves saas + api-reference + shared under /", () => {
+  expect(rootUrls).toContain("/");
+  expect(rootUrls).toContain("/billing");
+  expect(rootUrls).toContain("/api-reference");
+  expect(rootUrls).toContain("/api-reference/chat/postChat");
+  expect(rootUrls).toContain("/single-source-example");
+});
+
+test("no self-hosted-only page leaks into the SaaS root source", () => {
+  // URL space: nothing under /self-hosted.
+  expect(rootUrls.every((u) => !u.startsWith("/self-hosted"))).toBe(true);
+  // Source-file space: no page in the root source is authored under
+  // content/self-hosted/.
+  expect(
+    rootPages.every((p) => !p.absolutePath?.includes("content/self-hosted/")),
+  ).toBe(true);
+});
+
+test("self-hosted section serves self-hosted + shared under /self-hosted only", () => {
+  expect(selfHostedUrls).toContain("/self-hosted");
+  expect(selfHostedUrls).toContain("/self-hosted/docker");
+  expect(selfHostedUrls).toContain("/self-hosted/single-source-example");
+  // Every self-hosted URL is scoped under /self-hosted.
+  expect(selfHostedUrls.every((u) => u.startsWith("/self-hosted"))).toBe(true);
+});
+
+test("no saas-only or api page leaks into the self-hosted source", () => {
+  // No API reference pages.
+  expect(selfHostedUrls.every((u) => !u.includes("/api-reference"))).toBe(true);
+  // No page authored under content/docs (saas-only or api).
+  expect(
+    selfHostedPages.every((p) => !p.absolutePath?.includes("content/docs/")),
+  ).toBe(true);
+});
+
+test("a shared page mounts into BOTH sections from the ONE real source file", () => {
+  const rootShared = rootPages.find(
+    (p) => p.url === "/single-source-example",
+  );
+  const selfHostedShared = selfHostedPages.find(
+    (p) => p.url === "/self-hosted/single-source-example",
+  );
+
+  expect(rootShared).toBeDefined();
+  expect(selfHostedShared).toBeDefined();
+
+  // Both mounts resolve the edit target to the SAME real content/shared file
+  // (spike #4258 caveat #1 — one place to fix it, no phantom copies).
+  expect(rootShared?.absolutePath).toBe(
+    "content/shared/single-source-example.mdx",
+  );
+  expect(selfHostedShared?.absolutePath).toBe(
+    "content/shared/single-source-example.mdx",
+  );
+});

--- a/apps/docs/src/lib/audience.tsx
+++ b/apps/docs/src/lib/audience.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Which docs section a page is being rendered in. Injected at the route
+ * boundary (SaaS root vs `/self-hosted`) so a single shared MDX file can adapt
+ * to its mount — the reader only ever sees their audience's branch, resolved at
+ * build time rather than as a reader-facing tab (PRD #4257).
+ */
+export type Audience = "saas" | "self-hosted";
+
+const AudienceContext = createContext<Audience>("saas");
+
+/**
+ * Wrap a section's MDX render in the audience it belongs to. Each human route
+ * group renders exactly one static value ("saas" at the root, "self-hosted"
+ * under `/self-hosted`).
+ */
+export function AudienceProvider({
+  audience,
+  children,
+}: {
+  audience: Audience;
+  children: ReactNode;
+}) {
+  return (
+    <AudienceContext.Provider value={audience}>
+      {children}
+    </AudienceContext.Provider>
+  );
+}
+
+/** Read the current route's audience from any component inside the MDX scope. */
+export function useAudience(): Audience {
+  return useContext(AudienceContext);
+}
+
+/**
+ * MDX component that renders the current route's audience. Exposed to MDX so a
+ * shared page can prove the route-injected value: the same `content/shared/…`
+ * file renders `saas` at the root and `self-hosted` under `/self-hosted`. The
+ * `data-audience` attribute makes the injected value observable in the static
+ * HTML export (and assertable in a render test) without depending on visible
+ * copy.
+ */
+export function AudienceLabel() {
+  const audience = useAudience();
+  return <span data-audience={audience}>{audience}</span>;
+}

--- a/apps/docs/src/lib/compose.ts
+++ b/apps/docs/src/lib/compose.ts
@@ -1,0 +1,70 @@
+import { loader } from "fumadocs-core/source";
+import type { DocMethods, MetaMethods } from "fumadocs-mdx/runtime/types";
+import { toFumadocsSource } from "fumadocs-mdx/runtime/server";
+import type {
+  LoaderPluginOption,
+  MetaData,
+  PageData,
+} from "fumadocs-core/source";
+import { icons } from "lucide-react";
+import { createElement, type ReactElement } from "react";
+
+/**
+ * Resolve a lucide icon name (from a page's `icon:` frontmatter) to a React
+ * element. Shared by every section loader so icons render identically.
+ */
+export function icon(name?: string): ReactElement | undefined {
+  if (name && name in icons)
+    return createElement(icons[name as keyof typeof icons]);
+  return undefined;
+}
+
+/**
+ * A Fumadocs docs collection reduced to the two entry arrays a loader source is
+ * composed from. `defineDocs(...)` collections satisfy this (their `.docs` /
+ * `.meta` are exactly these shapes), and synthetic test fixtures can too.
+ */
+export interface CollectionLike<
+  Doc extends DocMethods & PageData = DocMethods & PageData,
+  Meta extends MetaMethods & MetaData = MetaMethods & MetaData,
+> {
+  readonly docs: readonly Doc[];
+  readonly meta: readonly Meta[];
+}
+
+/**
+ * Compose one docs section from an audience-owned collection plus the shared
+ * collection by CONCATENATING their entries into a single flat Fumadocs source
+ * (the composition shape validated by spike #4258). The same `shared`
+ * collection can be fed into more than one section loader; each mount renders
+ * the shared pages at its own `baseUrl` from the one real file on disk — full
+ * presence, single source, so there is nothing to drift.
+ *
+ * This helper deliberately imports NO generated `.source/server`, so it is
+ * unit-testable with synthetic collection fixtures (see `compose.test.ts`).
+ * Importing `.source/server` pulls in `*.mdx?collection=…` modules that only
+ * the Next bundler can resolve — a plain `bun test` cannot load them.
+ *
+ * The return type is left inferred (not widened to `LoaderOutput<LoaderConfig>`)
+ * so callers keep the rich per-page data type — `InferPageType<typeof source>`
+ * still resolves `body` / `toc` / `getText` for the llms + OG consumers.
+ */
+export function buildSectionSource<
+  Doc extends DocMethods & PageData,
+  Meta extends MetaMethods & MetaData,
+>(opts: {
+  audience: CollectionLike<Doc, Meta>;
+  shared: CollectionLike<Doc, Meta>;
+  baseUrl: string;
+  plugins?: LoaderPluginOption[];
+}) {
+  return loader({
+    baseUrl: opts.baseUrl,
+    source: toFumadocsSource(
+      [...opts.audience.docs, ...opts.shared.docs],
+      [...opts.audience.meta, ...opts.shared.meta],
+    ),
+    plugins: opts.plugins,
+    icon,
+  });
+}

--- a/apps/docs/src/lib/mdx-links.ts
+++ b/apps/docs/src/lib/mdx-links.ts
@@ -1,0 +1,51 @@
+import { createRelativeLink } from "fumadocs-ui/mdx";
+import type { LoaderConfig, LoaderOutput, Page } from "fumadocs-core/source";
+import type { ComponentProps, FC } from "react";
+
+/**
+ * Typed wrapper around fumadocs' `createRelativeLink`.
+ *
+ * Each section source concatenates two collections
+ * (`toFumadocsSource([...audience, ...shared], …)`), which yields a UNION
+ * `PageData`. `createRelativeLink`'s `source` parameter sits in a contravariant
+ * position (its internal `resolveHref`), so the concrete `LoaderOutput` a route
+ * holds is not assignable to the function's generic `LoaderOutput<C>` — a
+ * compile-only artifact; the runtime resolution is correct (spike #4258 caveat
+ * #2). Localize the single unavoidable cast here so route/render code never
+ * scatters `as unknown as` casts.
+ */
+export function createSectionRelativeLink<C extends LoaderConfig>(
+  source: LoaderOutput<C>,
+  page: Page,
+): FC<ComponentProps<"a">> {
+  // Widen to the base config here — the single localized cast (see JSDoc above).
+  return createRelativeLink(source as unknown as LoaderOutput<LoaderConfig>, page);
+}
+
+/**
+ * Repo-relative path (from the monorepo root) of a page's real source file, for
+ * the "Edit on GitHub" / last-updated links.
+ *
+ * A page's `absolutePath` is the ONE real file on disk — for a shared page it is
+ * `content/shared/…` on BOTH the root and `/self-hosted` mounts, so both mounts
+ * link to the same editable source (spike #4258 caveat #1). This replaces the
+ * old hardcoded `content/docs/${page.path}`, which pointed every shared page at
+ * a non-existent `content/docs/*` twin.
+ *
+ * fumadocs-mdx reports `absolutePath` relative to `apps/docs`
+ * (e.g. `content/docs/guides/slack.mdx`); we defensively also accept an absolute
+ * path that merely contains `apps/docs/`.
+ */
+export function githubEditPath(absolutePath: string | undefined): string {
+  if (!absolutePath) {
+    // Fumadocs always populates absolutePath; a missing one is a build-time
+    // anomaly. Surface it rather than silently emitting a bare directory path.
+    console.warn(
+      "[docs] githubEditPath: page has no absolutePath; edit link will be degraded",
+    );
+    return "apps/docs/";
+  }
+  const marker = "apps/docs/";
+  const idx = absolutePath.indexOf(marker);
+  return idx >= 0 ? absolutePath.slice(idx) : `apps/docs/${absolutePath}`;
+}

--- a/apps/docs/src/lib/nav.tsx
+++ b/apps/docs/src/lib/nav.tsx
@@ -1,0 +1,93 @@
+import { Book, Braces, Server } from "lucide-react";
+import { source, selfHostedSource } from "@/lib/source";
+
+/**
+ * The cross-section switcher shown in every human section's sidebar
+ * (SaaS root ↔ Self-Hosted ↔ API Reference). Built once from the section
+ * sources and reused by both human layouts so the switcher is identical
+ * everywhere and each section's sidebar still shows only its own tree.
+ *
+ * `urls` sets drive active-tab detection on sub-pages (Fumadocs matches a tab's
+ * `url` only exactly, so sub-pages need an explicit URL set — the pattern the
+ * previous Docs/API split already used). Clicking a tab whose pages live in a
+ * different route group simply navigates there.
+ */
+export function sectionTabs() {
+  const rootPages = source.getPages();
+  // SaaS root = everything in the root source that isn't the API reference
+  // (i.e. saas + shared). The API reference stays its own tab at /api-reference.
+  const saasUrls = new Set(
+    rootPages
+      .filter((p) => !p.url.startsWith("/api-reference"))
+      .map((p) => p.url),
+  );
+  const apiUrls = new Set(
+    rootPages
+      .filter((p) => p.url.startsWith("/api-reference"))
+      .map((p) => p.url),
+  );
+  const selfHostedUrls = new Set(
+    selfHostedSource.getPages().map((p) => p.url),
+  );
+
+  return [
+    {
+      title: "Docs",
+      description: "Cloud / SaaS guides, configuration, and concepts",
+      icon: <Book />,
+      url: "/",
+      urls: saasUrls,
+    },
+    {
+      title: "Self-Hosted",
+      description: "Deploy and operate Atlas on your own infrastructure",
+      icon: <Server />,
+      url: "/self-hosted",
+      urls: selfHostedUrls,
+    },
+    {
+      title: "API Reference",
+      description: "REST API endpoints and request/response schemas",
+      icon: <Braces />,
+      url: "/api-reference",
+      urls: apiUrls,
+    },
+  ];
+}
+
+/**
+ * Top-nav links shared by every section layout (external product + machine-
+ * readable surfaces + GitHub). Kept in one place so the sections never drift.
+ */
+export const siteNavLinks = [
+  {
+    text: "Home",
+    url: "https://www.useatlas.dev",
+    external: true,
+  },
+  {
+    text: "App",
+    url: "https://app.useatlas.dev",
+    external: true,
+  },
+  {
+    text: "llms.txt",
+    url: "/llms.txt",
+    external: true,
+  },
+  {
+    text: "llms-full.txt",
+    url: "/llms-full.txt",
+    external: true,
+  },
+  {
+    type: "icon" as const,
+    text: "GitHub",
+    url: "https://github.com/AtlasDevHQ/atlas",
+    icon: (
+      <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+      </svg>
+    ),
+  },
+];

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,15 +1,33 @@
-import { docs } from "@/../.source/server";
-import { loader } from "fumadocs-core/source";
+import { docs, selfHosted, shared } from "@/../.source/server";
 import { openapiPlugin } from "fumadocs-openapi/server";
-import { icons } from "lucide-react";
-import { createElement } from "react";
+import type { InferPageType } from "fumadocs-core/source";
+import { buildSectionSource } from "@/lib/compose";
 
-export const source = loader({
+// SaaS / Cloud docs at the site root (`/`). Existing `content/docs` — including
+// the generated `api-reference/` tree at `/api-reference/*` — plus the shared
+// concept pages, concatenated into one flat source. Existing root URLs are
+// unchanged; the shared pages are the only additions. `openapiPlugin` stays so
+// the API reference renders exactly as before.
+export const source = buildSectionSource({
+  audience: docs,
+  shared,
   baseUrl: "/",
-  source: docs.toFumadocsSource(),
   plugins: [openapiPlugin()],
-  icon(icon) {
-    if (icon && icon in icons)
-      return createElement(icons[icon as keyof typeof icons]);
-  },
 });
+
+// Self-hosted / on-prem docs at `/self-hosted`. Self-hosted-only content plus
+// the SAME `shared` collection — one source file per shared fact, mounted here
+// and at the root (full presence, single source).
+export const selfHostedSource = buildSectionSource({
+  audience: selfHosted,
+  shared,
+  baseUrl: "/self-hosted",
+});
+
+/**
+ * A page from either human section. Both sections share the same frontmatter
+ * schema, so the shared renderer can accept a page from either mount.
+ */
+export type SectionPage =
+  | InferPageType<typeof source>
+  | InferPageType<typeof selfHostedSource>;


### PR DESCRIPTION
Slice 1 of the docs-portal segmentation (PRD #4257). Establishes the three-section architecture **end-to-end with placeholders** — no bulk content migration (that is Slices 3a/3b/3c).

Closes #4259.

## Scope reconciliation (important)

The issue #4259 body ("What to build" / acceptance criteria) describes an **outdated** design (three fresh `/docs`, `/self-hosted`, `/api` prefixes; move API to `/api`; delete the root group). That design was **rejected** in the 2026-07-03 grill. This PR implements the **locked** scheme from the ⚠ banner at the top of #4259 + the "Decisions locked" block in PRD #4257:

- **SaaS docs STAY at the site root `/`** — existing URLs unchanged. The existing root `(docs)` route group is *adapted* (not deleted) to serve SaaS.
- **Self-hosted docs → a NEW `/self-hosted/*` section** (the one new section this slice adds).
- **API Reference STAYS at `/api-reference/*`**, untouched — no `/api` docs route created. (`src/app/api/search/route.ts` is the Fumadocs search handler, left as-is.)
- **Shared concept pages render at BOTH the root AND `/self-hosted` from ONE `content/shared/*` file** (full presence, single source → no rot).
- Section switcher toggles **SaaS (root) ↔ Self-Hosted (`/self-hosted`) ↔ API (`/api-reference`)**.

## How the locked scheme is realized

- **Content-dir choice (documented):** kept `content/docs/` **unchanged** as the SaaS-at-root tree (SaaS content + the generated `api-reference/`), and added `content/self-hosted/` + `content/shared/`. This keeps every existing root URL working and makes the diff cleanly reviewable — the ideal end-state rename to `content/saas/` is deferred to the bulk-migration slices. (The alternative — renaming `content/docs`→`content/saas` now — would churn 100+ files for zero URL benefit this slice.)
- **Source composition (spike #4258 mechanism):** each human section is one flat source built by concatenating collection entries — `toFumadocsSource([...audience.docs, ...shared.docs], [...audience.meta, ...shared.meta])` → `loader({ baseUrl })`. Root loader = `docs + shared` (`baseUrl:/`, keeps `openapiPlugin`); self-hosted loader = `selfHosted + shared` (`baseUrl:/self-hosted`). `content/shared/` intentionally has **no root `meta.json`** (virtual-path collision the spike hit).
- **Route groups:** existing `(docs)` adapted; new `(self-hosted)/self-hosted/{layout,[[...slug]]/page}.tsx` with its own `DocsLayout` + `generateStaticParams`.
- **Route-injected `audience`:** each human group injects a static `"saas"|"self-hosted"` value into the MDX render scope via a React context (`AudienceProvider`); a shared page reads it with `<AudienceLabel/>`. The **same** `content/shared/single-source-example.mdx` renders `data-audience="saas"` at `/single-source-example` and `data-audience="self-hosted"` at `/self-hosted/single-source-example`.
- **Switcher:** shared `sectionTabs()` (Docs ↔ Self-Hosted ↔ API Reference) reused by both human layouts; each section's sidebar shows only its own tree.

## Spike caveats addressed

- **Caveat #1 (edit path):** `githubEditPath(page.absolutePath)` derives the GitHub edit / last-updated path from the page's real `absolutePath` (`apps/docs/${absolutePath}`), replacing the hardcoded `content/docs/${page.path}`. Verified in the static export: the shared page's edit link resolves to `content/shared/single-source-example.mdx` on **both** mounts; existing root pages (e.g. changelog) still resolve to `content/docs/...`.
- **Caveat #2 (typed link):** one centralized generic `createSectionRelativeLink` wrapper localizes the single unavoidable `as unknown as LoaderOutput<LoaderConfig>` cast (the concat union `PageData` is non-assignable through `createRelativeLink`'s contravariant `resolveHref`). Route/render code stays cast-free.

## Testing

- `src/lib/__tests__/source-partition.test.ts` — drives the real `buildSectionSource` composition with synthetic fixtures (self-contained; the generated `.source/server` can't load under plain `bun test`). Asserts no cross-leak between SaaS-root / self-hosted / API sources in both URL-space and source-file-space, and that a shared page dual-mounts with identical `absolutePath`.
- `src/lib/__tests__/github-edit-path.test.ts` — locks the three branches of `githubEditPath`.
- New `test` script → auto-discovered by `scripts/test-others.ts` (apps/docs had zero test coverage before).

## Verification

`bun run build` (static export) succeeds and emits: existing root SaaS URLs unchanged; new `/self-hosted/` + `/self-hosted/single-source-example/`; the shared placeholder at **both** `/single-source-example/` and `/self-hosted/single-source-example/` from one file; `/api-reference/*` (472 pages) untouched; **no** `/docs/*` or `/api/*` docs routes. Review panel clean; all 28 local CI gates green.

## Not in scope (later slices)

Bulk content migration + un-tabbing (3a/3b/3c), audience taxonomy + `<WhenSaaS>`/`<WhenSelfHosted>` (#4260), search facet (#4262), self-hosted `llms.txt`/`.mdx` twins (#4266 — self-hosted `showLLMCopy={false}` for now), Caddy redirects (#4267).

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v