### PR TITLE
Slice 2 — audience taxonomy + build-time <WhenSaaS>/<WhenSelfHosted> + fork marker (#4260)

### DIFF
--- a/apps/docs/content/shared/single-source-example.mdx
+++ b/apps/docs/content/shared/single-source-example.mdx
@@ -24,6 +24,23 @@ You are reading it at one of two URLs, from the same file on disk:
 
 This mount's audience is: **<AudienceLabel />**.
 
+## Audience-conditional content (resolved at build time)
+
+The two notes below are wrapped in `<WhenSaaS>` / `<WhenSelfHosted>`. Only the
+current mount's note is emitted into the static HTML — the other branch is
+**absent** from the export, not hidden with CSS. A reader on one mount is
+structurally unable to see the other audience's branch (PRD #4257).
+
+<WhenSaaS>
+  **Cloud (SaaS) only.** You are reading the site-root edition of this page.
+  Build verification token: `audience-saas-only-a7f2`.
+</WhenSaaS>
+
+<WhenSelfHosted>
+  **Self-Hosted only.** You are reading the `/self-hosted` edition of this page.
+  Build verification token: `audience-self-hosted-only-a7f2`.
+</WhenSelfHosted>
+
 Because both mounts resolve "Edit on GitHub" from the page's real
 `absolutePath`, the edit link on either URL points at this same
 `content/shared/single-source-example.mdx` — one place to fix it.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,8 @@
     "lucide-react": "^1.21.0",
     "next": "^16.2.9",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.9.4",

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,6 +1,29 @@
 import { defineDocs, defineConfig } from "fumadocs-mdx/config";
 import { transformerMetaHighlight } from "@shikijs/transformers";
 import { rehypeCodeDefaultOptions } from "fumadocs-core/mdx-plugins";
+import { pageSchema } from "fumadocs-core/source/schema";
+import { z } from "zod";
+
+// Extend the default page frontmatter with the two audience-taxonomy fields
+// (PRD #4257, slice #4260). Both are OPTIONAL and applied to every section
+// collection so `page.data.audience` / `page.data.fork` are readable by the
+// build-time gate in `src/lib/source.ts`.
+//
+// The `audience` value set is the SSOT `AUDIENCE_CLASSES` in
+// `src/lib/audience-taxonomy.ts` — kept in sync here as a literal because a
+// fumadocs config module must not pull the `@/` app graph into its own bundle.
+// A `keep-in-sync` unit test (`__tests__/audience-taxonomy.test.ts`) asserts the
+// two lists never drift.
+const audienceDocSchema = pageSchema.extend({
+  // Optional explicit classification. When present it MUST agree with the file's
+  // content-root directory (enforced by validateContentTaxonomy) — a mismatch is
+  // a hard "ambiguous" build error.
+  audience: z.enum(["saas-only", "self-hosted-only", "shared"]).optional(),
+  // Fork marker: a stable key shared by two files that INTENTIONALLY diverge per
+  // audience (a deliberate fork, not a forgotten single-source). Both members of
+  // a cross-audience duplicate must carry the same key or the build fails.
+  fork: z.string().optional(),
+});
 
 // SaaS / Cloud docs — served at the site root (`docs.useatlas.dev/…`). This is
 // the default section and its URLs are unchanged by the segmentation (PRD #4257
@@ -10,6 +33,7 @@ import { rehypeCodeDefaultOptions } from "fumadocs-core/mdx-plugins";
 export const docs = defineDocs({
   dir: "content/docs",
   docs: {
+    schema: audienceDocSchema,
     postprocess: {
       includeProcessedMarkdown: true,
     },
@@ -21,6 +45,7 @@ export const docs = defineDocs({
 export const selfHosted = defineDocs({
   dir: "content/self-hosted",
   docs: {
+    schema: audienceDocSchema,
     postprocess: {
       includeProcessedMarkdown: true,
     },
@@ -35,6 +60,7 @@ export const selfHosted = defineDocs({
 export const shared = defineDocs({
   dir: "content/shared",
   docs: {
+    schema: audienceDocSchema,
     postprocess: {
       includeProcessedMarkdown: true,
     },

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -3,22 +3,21 @@ import { transformerMetaHighlight } from "@shikijs/transformers";
 import { rehypeCodeDefaultOptions } from "fumadocs-core/mdx-plugins";
 import { pageSchema } from "fumadocs-core/source/schema";
 import { z } from "zod";
+// Relative import (NOT the `@/` alias): the fumadocs config bundle can't resolve
+// tsconfig paths, and `audience-classes.ts` is a zero-dependency leaf so it
+// bundles cleanly here. Single-sourcing the enum means there is no second
+// literal to drift.
+import { AUDIENCE_CLASSES } from "./src/lib/audience-classes";
 
 // Extend the default page frontmatter with the two audience-taxonomy fields
 // (PRD #4257, slice #4260). Both are OPTIONAL and applied to every section
 // collection so `page.data.audience` / `page.data.fork` are readable by the
 // build-time gate in `src/lib/source.ts`.
-//
-// The `audience` value set is the SSOT `AUDIENCE_CLASSES` in
-// `src/lib/audience-taxonomy.ts` — kept in sync here as a literal because a
-// fumadocs config module must not pull the `@/` app graph into its own bundle.
-// A `keep-in-sync` unit test (`__tests__/audience-taxonomy.test.ts`) asserts the
-// two lists never drift.
 const audienceDocSchema = pageSchema.extend({
   // Optional explicit classification. When present it MUST agree with the file's
   // content-root directory (enforced by validateContentTaxonomy) — a mismatch is
-  // a hard "ambiguous" build error.
-  audience: z.enum(["saas-only", "self-hosted-only", "shared"]).optional(),
+  // a hard "ambiguous" build error. Value set is the shared `AUDIENCE_CLASSES`.
+  audience: z.enum(AUDIENCE_CLASSES).optional(),
   // Fork marker: a stable key shared by two files that INTENTIONALLY diverge per
   // audience (a deliberate fork, not a forgotten single-source). Both members of
   // a cross-audience duplicate must carry the same key or the build fails.

--- a/apps/docs/src/app/llms-full.txt/route.ts
+++ b/apps/docs/src/app/llms-full.txt/route.ts
@@ -8,7 +8,9 @@ export async function GET() {
   const results = await Promise.all(
     pages.map(async (page) => {
       try {
-        return await getLLMText(page);
+        // `source` is the root/SaaS section, so resolve audience conditionals
+        // to the saas branch (PRD #4257).
+        return await getLLMText(page, "saas");
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`[llms-full.txt] ${page.url}: ${msg}`);

--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -29,7 +29,9 @@ export async function GET(
   const page = source.getPage(pageSlug);
   if (!page) notFound();
 
-  return new Response(await getLLMText(page));
+  // Markdown twins are root/SaaS-only today (self-hosted twins land in #4266),
+  // so the saas branch is the correct one to resolve here.
+  return new Response(await getLLMText(page, "saas"));
 }
 
 export function generateStaticParams() {

--- a/apps/docs/src/components/section-docs-page.tsx
+++ b/apps/docs/src/components/section-docs-page.tsx
@@ -14,6 +14,7 @@ import { APIPage } from "@/components/api-page";
 import { ChangelogTimeline } from "@/components/changelog-timeline";
 import { LLMCopyButton } from "@/components/llm-copy-button";
 import { AudienceProvider, AudienceLabel, type Audience } from "@/lib/audience";
+import { audienceConditionals } from "@/lib/audience-conditionals";
 import { githubEditPath } from "@/lib/mdx-links";
 import type { SectionPage } from "@/lib/source";
 
@@ -79,6 +80,10 @@ export async function SectionDocsPage({
   const MDX = page.data.body;
   const lastUpdate = await getLastUpdate(githubEditPath(page.absolutePath));
   const isFullWidth = page.data.full === true;
+  // Server-resolved per this mount: the inactive branch is a server component
+  // that returns null, so its children never enter the emitted HTML / RSC
+  // payload (unlike a client conditional). See audience-conditionals.tsx.
+  const { WhenSaaS, WhenSelfHosted } = audienceConditionals(audience);
 
   return (
     <DocsPage
@@ -113,6 +118,10 @@ export async function SectionDocsPage({
               APIPage,
               ChangelogTimeline,
               AudienceLabel,
+              // Build-time audience conditionals: the omitted branch is absent
+              // from the emitted HTML on the opposite mount (PRD #4257).
+              WhenSaaS,
+              WhenSelfHosted,
               // Resolve relative MDX links against THIS mount's source.
               a: linkComponent,
             }}

--- a/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
+++ b/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
@@ -165,6 +165,30 @@ test("markdown strip FAILS CLOSED on a malformed/unclosed inactive block", () =>
   // A silent pass would leak the self-hosted tail into the saas surface; assert
   // it throws instead.
   expect(() => stripInactiveAudienceBlocks(unclosed, "saas")).toThrow(
-    /residual <When…> block tag/,
+    /residual <When…> tag/,
   );
+});
+
+test("markdown strip FAILS CLOSED on an unsupported single-line inline audience tag", () => {
+  // The strip only handles block-form; a fully-inline form escapes the block
+  // patterns, so the post-condition must throw rather than leak the self-hosted
+  // prose into the saas surface.
+  const inline =
+    "Price is <WhenSaaS>$39</WhenSaaS><WhenSelfHosted>free</WhenSelfHosted>/mo.";
+  expect(() => stripInactiveAudienceBlocks(inline, "saas")).toThrow(
+    /residual <When…> tag/,
+  );
+});
+
+test("an inline-code mention of a tag name is NOT treated as a residual tag", () => {
+  const mention = [
+    "Use `<WhenSaaS>` and `<WhenSelfHosted>` for per-audience prose.",
+    "",
+    "<WhenSaaS>",
+    "  Cloud. `saas-md-token`.",
+    "</WhenSaaS>",
+  ].join("\n");
+  const out = stripInactiveAudienceBlocks(mention, "saas");
+  expect(out).toContain("saas-md-token");
+  expect(out).toContain("`<WhenSelfHosted>`"); // the mention survives, unstripped
 });

--- a/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
+++ b/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
@@ -1,0 +1,102 @@
+import { test, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { audienceConditionals } from "@/lib/audience-conditionals";
+import { stripInactiveAudienceBlocks } from "@/lib/audience-markdown";
+import type { Audience } from "@/lib/audience";
+
+/**
+ * The security-relevant tests (PRD #4257, slice #4260's driving invariant).
+ *
+ * `audienceConditionals(audience)` returns SERVER components resolved for one
+ * mount. The inactive branch is `RenderNothing`, which never renders its
+ * children — so the opposite audience's content is ABSENT from the emitted HTML,
+ * not hidden. (The authoritative proof is the static-export grep in the PR; a
+ * client conditional would pass a render-string test yet still leak its children
+ * into the RSC flight payload. These tests pin the server-component logic.)
+ */
+
+const SAAS_TOKEN = "SAAS_BRANCH_ONLY_TOKEN";
+const SELF_HOSTED_TOKEN = "SELF_HOSTED_BRANCH_ONLY_TOKEN";
+
+function renderBothBranches(audience: Audience): string {
+  const { WhenSaaS, WhenSelfHosted } = audienceConditionals(audience);
+  return renderToStaticMarkup(
+    <>
+      <WhenSaaS>
+        <span>{SAAS_TOKEN}</span>
+      </WhenSaaS>
+      <WhenSelfHosted>
+        <span>{SELF_HOSTED_TOKEN}</span>
+      </WhenSelfHosted>
+    </>,
+  );
+}
+
+test("SaaS mount emits ONLY the saas branch — self-hosted branch is absent from the HTML", () => {
+  const html = renderBothBranches("saas");
+  expect(html).toContain(SAAS_TOKEN);
+  // Core invariant: not hidden, ABSENT. If this ever renders the self-hosted
+  // branch, a SaaS reader could receive self-hosted-only content.
+  expect(html).not.toContain(SELF_HOSTED_TOKEN);
+});
+
+test("self-hosted mount emits ONLY the self-hosted branch — saas branch is absent", () => {
+  const html = renderBothBranches("self-hosted");
+  expect(html).toContain(SELF_HOSTED_TOKEN);
+  expect(html).not.toContain(SAAS_TOKEN);
+});
+
+test("the inactive conditional renders literally nothing (no wrapper element)", () => {
+  const { WhenSelfHosted } = audienceConditionals("saas");
+  const html = renderToStaticMarkup(
+    <WhenSelfHosted>
+      <p>{SELF_HOSTED_TOKEN}</p>
+    </WhenSelfHosted>,
+  );
+  expect(html).toBe("");
+});
+
+// ── markdown text surfaces (twin + llms-full.txt) ────────────────────────────
+
+// Note the INLINE mention of the tag names in the intro — a real doc sentence
+// that explains the components. The strip must NOT treat that as a block, or a
+// non-greedy match would span from the inline `<WhenSelfHosted>` mention through
+// the real block and swallow the active branch's content (a real regression we
+// hit against the static export).
+const MD = [
+  "Intro prose mentioning `<WhenSaaS>` / `<WhenSelfHosted>` inline.",
+  "",
+  "<WhenSaaS>",
+  "  Cloud note. Token: `saas-md-token`.",
+  "</WhenSaaS>",
+  "",
+  "<WhenSelfHosted>",
+  "  Self-hosted note. Token: `self-hosted-md-token`.",
+  "</WhenSelfHosted>",
+  "",
+  "Outro prose.",
+].join("\n");
+
+const BLOCK_TAG_LINE = /^[ \t]*<\/?When(SaaS|SelfHosted)>[ \t]*$/m;
+
+test("markdown strip keeps the saas branch and removes the self-hosted branch", () => {
+  const out = stripInactiveAudienceBlocks(MD, "saas");
+  expect(out).toContain("saas-md-token");
+  expect(out).not.toContain("self-hosted-md-token");
+  // Both surrounding prose lines survive (the active branch wasn't swallowed).
+  expect(out).toContain("Intro prose");
+  expect(out).toContain("Outro prose.");
+  // No standalone block tag lines remain (active unwrapped, inactive removed);
+  // the inline mention in the intro is preserved.
+  expect(out).not.toMatch(BLOCK_TAG_LINE);
+  expect(out).toContain("`<WhenSaaS>`");
+});
+
+test("markdown strip keeps the self-hosted branch and removes the saas branch", () => {
+  const out = stripInactiveAudienceBlocks(MD, "self-hosted");
+  expect(out).toContain("self-hosted-md-token");
+  expect(out).not.toContain("saas-md-token");
+  expect(out).toContain("Intro prose");
+  expect(out).toContain("Outro prose.");
+  expect(out).not.toMatch(BLOCK_TAG_LINE);
+});

--- a/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
+++ b/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
@@ -1,4 +1,6 @@
 import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { audienceConditionals } from "@/lib/audience-conditionals";
 import { stripInactiveAudienceBlocks } from "@/lib/audience-markdown";
@@ -56,6 +58,35 @@ test("the inactive conditional renders literally nothing (no wrapper element)", 
   expect(html).toBe("");
 });
 
+// Structural anti-regression guard. `renderToStaticMarkup` emits no RSC flight
+// payload, so it CANNOT distinguish the secure server component from an insecure
+// client conditional (which would leak its children into the payload). The one
+// thing keeping the branch out of the payload is that audience-conditionals.tsx
+// is a server module resolved from the arg, not `"use client"` context — pin
+// exactly that, so a future context-based "simplification" fails CI, not just
+// the manual static-export grep.
+test("audience-conditionals.tsx stays a server module resolved from its argument (no client context)", () => {
+  const src = readFileSync(
+    fileURLToPath(new URL("../audience-conditionals.tsx", import.meta.url)),
+    "utf8",
+  );
+  // No "use client" directive — the load-bearing signal; a client module would
+  // re-open the flight-payload leak. (Checked as the literal directive string,
+  // not prose — the JSDoc deliberately NAMES the client anti-pattern.)
+  expect(src).not.toContain('"use client"');
+  // No hook imported (context/state) — checked on import statements, so the
+  // JSDoc's `useAudience()` mention is not a false positive.
+  expect(src).not.toMatch(/^\s*import\b[^\n]*\b(useContext|useAudience|useState)\b/m);
+  // The factory is a pure function of its argument: the same audience always
+  // yields the same active/inactive pairing, independent of any surrounding
+  // provider (there is no provider to read).
+  const a = audienceConditionals("saas");
+  const b = audienceConditionals("saas");
+  expect(a.WhenSaaS).toBe(b.WhenSaaS);
+  expect(a.WhenSelfHosted).toBe(b.WhenSelfHosted);
+  expect(audienceConditionals("self-hosted").WhenSaaS).not.toBe(a.WhenSaaS);
+});
+
 // ── markdown text surfaces (twin + llms-full.txt) ────────────────────────────
 
 // Note the INLINE mention of the tag names in the intro — a real doc sentence
@@ -99,4 +130,41 @@ test("markdown strip keeps the self-hosted branch and removes the saas branch", 
   expect(out).toContain("Intro prose");
   expect(out).toContain("Outro prose.");
   expect(out).not.toMatch(BLOCK_TAG_LINE);
+});
+
+test("markdown strip is robust to CRLF line endings (no leak)", () => {
+  const crlf = MD.replace(/\n/g, "\r\n");
+  const out = stripInactiveAudienceBlocks(crlf, "saas");
+  expect(out).toContain("saas-md-token");
+  expect(out).not.toContain("self-hosted-md-token");
+  expect(out).not.toMatch(BLOCK_TAG_LINE);
+});
+
+test("markdown strip tolerates tag attributes / trailing whitespace (no leak)", () => {
+  const withAttrs = [
+    "<WhenSaaS >",
+    "  Cloud. `saas-md-token`.",
+    "</WhenSaaS>",
+    "",
+    '<WhenSelfHosted className="x">',
+    "  Self-hosted. `self-hosted-md-token`.",
+    "</WhenSelfHosted>",
+  ].join("\n");
+  const out = stripInactiveAudienceBlocks(withAttrs, "saas");
+  expect(out).toContain("saas-md-token");
+  expect(out).not.toContain("self-hosted-md-token");
+  expect(out).not.toMatch(BLOCK_TAG_LINE);
+});
+
+test("markdown strip FAILS CLOSED on a malformed/unclosed inactive block", () => {
+  const unclosed = [
+    "Intro.",
+    "<WhenSelfHosted>",
+    "  Self-hosted secret `self-hosted-md-token` with no closing tag.",
+  ].join("\n");
+  // A silent pass would leak the self-hosted tail into the saas surface; assert
+  // it throws instead.
+  expect(() => stripInactiveAudienceBlocks(unclosed, "saas")).toThrow(
+    /residual <When…> block tag/,
+  );
 });

--- a/apps/docs/src/lib/__tests__/audience-taxonomy.test.ts
+++ b/apps/docs/src/lib/__tests__/audience-taxonomy.test.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "bun:test";
+import {
+  AUDIENCE_CLASSES,
+  classifyByPath,
+  resolveClassification,
+  assertClassified,
+  audienceMounts,
+  detectForkViolations,
+  assertNoUnmarkedForks,
+  validateContentTaxonomy,
+  type ContentEntry,
+} from "@/lib/audience-taxonomy";
+
+/**
+ * Audience-taxonomy unit tests (PRD #4257, slice #4260). Pure logic — no
+ * generated `.source/server`, no network/filesystem — mirroring
+ * `source-partition.test.ts`. Proves:
+ *  - every content file classifies to exactly one audience, and a missing /
+ *    invalid / ambiguous classification is a HARD error (build-failing);
+ *  - `shared` mounts into BOTH human trees (shared-presence);
+ *  - the fork-marker convention: a marked pair is recognized, an un-marked
+ *    duplicate is flagged.
+ */
+
+// ── classification ──────────────────────────────────────────────────────────
+
+test("directory manifest classifies each content root to exactly one audience", () => {
+  expect(classifyByPath("content/docs/index.mdx")).toBe("saas-only");
+  expect(classifyByPath("content/docs/api-reference/chat/postChat.mdx")).toBe(
+    "saas-only",
+  );
+  expect(classifyByPath("content/self-hosted/docker.mdx")).toBe(
+    "self-hosted-only",
+  );
+  expect(classifyByPath("content/shared/single-source-example.mdx")).toBe(
+    "shared",
+  );
+});
+
+test("classification is robust to absolute filesystem paths", () => {
+  expect(
+    classifyByPath("/home/x/apps/docs/content/docs/guides/slack.mdx"),
+  ).toBe("saas-only");
+});
+
+test("an orphan file (under no known root) fails to classify — hard error", () => {
+  const orphan: ContentEntry = { absolutePath: "content/misc/stray.mdx" };
+  expect(classifyByPath(orphan.absolutePath)).toBeNull();
+  const result = resolveClassification(orphan);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toContain("orphan");
+  expect(() => assertClassified([orphan])).toThrow(/taxonomy check failed/);
+});
+
+test("build FAILS on a missing classification within a batch of valid pages", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/index.mdx" },
+    { absolutePath: "content/self-hosted/index.mdx" },
+    { absolutePath: "content/nowhere/oops.mdx" }, // orphan
+  ];
+  expect(() => assertClassified(entries)).toThrow(/oops\.mdx/);
+});
+
+test("an explicit `audience:` that AGREES with the directory is accepted", () => {
+  const result = resolveClassification({
+    absolutePath: "content/shared/x.mdx",
+    audience: "shared",
+  });
+  expect(result).toEqual({ ok: true, class: "shared" });
+});
+
+test("build FAILS on an ambiguous classification (frontmatter contradicts directory)", () => {
+  const entry: ContentEntry = {
+    absolutePath: "content/docs/x.mdx",
+    audience: "shared", // lives in the saas tree — contradiction
+  };
+  const result = resolveClassification(entry);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toContain("ambiguous");
+  expect(() => assertClassified([entry])).toThrow(/ambiguous/);
+});
+
+test("build FAILS on an invalid `audience:` value", () => {
+  const entry: ContentEntry = {
+    absolutePath: "content/docs/x.mdx",
+    audience: "everyone",
+  };
+  const result = resolveClassification(entry);
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toContain("invalid audience");
+});
+
+// ── shared-presence ─────────────────────────────────────────────────────────
+
+test("a `shared` page mounts into BOTH human trees; single-audience pages into one", () => {
+  expect(audienceMounts("shared")).toEqual(["saas", "self-hosted"]);
+  expect(audienceMounts("saas-only")).toEqual(["saas"]);
+  expect(audienceMounts("self-hosted-only")).toEqual(["self-hosted"]);
+});
+
+// ── fork-marker convention ──────────────────────────────────────────────────
+
+test("an un-marked cross-audience duplicate is flagged", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/deployment.mdx" },
+    { absolutePath: "content/self-hosted/deployment.mdx" },
+  ];
+  const violations = detectForkViolations(entries);
+  expect(violations).toHaveLength(1);
+  expect(violations[0]?.kind).toBe("unmarked");
+  expect(violations[0]?.topic).toBe("deployment");
+  expect(() => assertNoUnmarkedForks(entries)).toThrow(/fork-marker check failed/);
+});
+
+test("a fork pair marked with the SAME key is recognized (no violation)", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/deployment.mdx", fork: "deployment" },
+    { absolutePath: "content/self-hosted/deployment.mdx", fork: "deployment" },
+  ];
+  expect(detectForkViolations(entries)).toHaveLength(0);
+  expect(() => assertNoUnmarkedForks(entries)).not.toThrow();
+});
+
+test("a fork pair with DIFFERENT keys is flagged as mismatched", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/deployment.mdx", fork: "deploy-saas" },
+    { absolutePath: "content/self-hosted/deployment.mdx", fork: "deploy-oss" },
+  ];
+  const violations = detectForkViolations(entries);
+  expect(violations).toHaveLength(1);
+  expect(violations[0]?.kind).toBe("mismatched");
+});
+
+test("a half-marked duplicate (only one side declares fork) is flagged", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/deployment.mdx", fork: "deployment" },
+    { absolutePath: "content/self-hosted/deployment.mdx" }, // no marker
+  ];
+  expect(detectForkViolations(entries)[0]?.kind).toBe("unmarked");
+});
+
+test("section landing pages (index) are NOT treated as a fork duplicate", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/index.mdx" },
+    { absolutePath: "content/self-hosted/index.mdx" },
+  ];
+  expect(detectForkViolations(entries)).toHaveLength(0);
+});
+
+test("a shared page is never a fork duplicate even if a same-slug tree page exists", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/shared/overview.mdx" },
+    { absolutePath: "content/docs/overview.mdx" },
+  ];
+  // Only saas-only vs self-hosted-only pairs are fork candidates; shared is
+  // single-sourced, so this same-slug pair is not a cross-audience duplicate.
+  expect(detectForkViolations(entries)).toHaveLength(0);
+});
+
+// ── end-to-end gate ─────────────────────────────────────────────────────────
+
+test("validateContentTaxonomy passes a well-formed corpus and dedupes shared mounts", () => {
+  const entries: ContentEntry[] = [
+    { absolutePath: "content/docs/index.mdx" },
+    { absolutePath: "content/self-hosted/index.mdx" },
+    // shared page appears once per mount — same absolutePath, deduped:
+    { absolutePath: "content/shared/example.mdx" },
+    { absolutePath: "content/shared/example.mdx" },
+  ];
+  expect(() => validateContentTaxonomy(entries)).not.toThrow();
+});
+
+test("validateContentTaxonomy throws on either failure class", () => {
+  expect(() =>
+    validateContentTaxonomy([{ absolutePath: "content/nowhere/x.mdx" }]),
+  ).toThrow(/taxonomy check failed/);
+  expect(() =>
+    validateContentTaxonomy([
+      { absolutePath: "content/docs/deployment.mdx" },
+      { absolutePath: "content/self-hosted/deployment.mdx" },
+    ]),
+  ).toThrow(/fork-marker check failed/);
+});
+
+// ── drift guard: schema literals must match the SSOT ─────────────────────────
+
+test("AUDIENCE_CLASSES matches the enum literal duplicated in source.config.ts", () => {
+  // source.config.ts cannot import the app graph, so it re-declares the enum as
+  // a literal. Keep this list in lockstep with that `z.enum([...])`.
+  expect([...AUDIENCE_CLASSES]).toEqual([
+    "saas-only",
+    "self-hosted-only",
+    "shared",
+  ]);
+});

--- a/apps/docs/src/lib/__tests__/audience-taxonomy.test.ts
+++ b/apps/docs/src/lib/__tests__/audience-taxonomy.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import {
   AUDIENCE_CLASSES,
+  CONTENT_ROOTS,
   classifyByPath,
   resolveClassification,
   assertClassified,
@@ -88,6 +89,24 @@ test("build FAILS on an invalid `audience:` value", () => {
   const result = resolveClassification(entry);
   expect(result.ok).toBe(false);
   if (!result.ok) expect(result.error).toContain("invalid audience");
+});
+
+test("an empty absolutePath is a hard error, distinct from an orphan", () => {
+  const result = resolveClassification({ absolutePath: "" });
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.error).toContain("empty absolutePath");
+    expect(result.error).not.toContain("orphan");
+  }
+});
+
+test("CONTENT_ROOTS covers every audience class (no class can be undirectoried)", () => {
+  // A future AudienceClass added without a matching content root would silently
+  // orphan every such page; assert the manifest stays exhaustive.
+  const covered = new Set(CONTENT_ROOTS.map((r) => r.class));
+  for (const cls of AUDIENCE_CLASSES) {
+    expect(covered.has(cls)).toBe(true);
+  }
 });
 
 // ── shared-presence ─────────────────────────────────────────────────────────
@@ -182,11 +201,11 @@ test("validateContentTaxonomy throws on either failure class", () => {
   ).toThrow(/fork-marker check failed/);
 });
 
-// ── drift guard: schema literals must match the SSOT ─────────────────────────
+// ── SSOT contract ────────────────────────────────────────────────────────────
 
-test("AUDIENCE_CLASSES matches the enum literal duplicated in source.config.ts", () => {
-  // source.config.ts cannot import the app graph, so it re-declares the enum as
-  // a literal. Keep this list in lockstep with that `z.enum([...])`.
+test("AUDIENCE_CLASSES pins the three-class contract (single-sourced from audience-classes.ts)", () => {
+  // `source.config.ts` imports this SAME tuple for its `z.enum(...)`, so there is
+  // no second literal to drift; this pins the public members of the contract.
   expect([...AUDIENCE_CLASSES]).toEqual([
     "saas-only",
     "self-hosted-only",

--- a/apps/docs/src/lib/audience-classes.ts
+++ b/apps/docs/src/lib/audience-classes.ts
@@ -1,0 +1,18 @@
+/**
+ * The audience-class SSOT (PRD #4257, slice #4260).
+ *
+ * A zero-dependency leaf module — NO `@/` app-graph imports, no React — so it
+ * can be imported by BOTH the app graph (`audience-taxonomy.ts`) and the
+ * fumadocs config bundle (`source.config.ts`, via a relative import). That keeps
+ * the three-value classification set single-sourced instead of duplicated as two
+ * hand-synced literals.
+ */
+
+/** The three audience classes a content file can belong to. */
+export const AUDIENCE_CLASSES = [
+  "saas-only",
+  "self-hosted-only",
+  "shared",
+] as const;
+
+export type AudienceClass = (typeof AUDIENCE_CLASSES)[number];

--- a/apps/docs/src/lib/audience-conditionals.tsx
+++ b/apps/docs/src/lib/audience-conditionals.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import type { Audience } from "@/lib/audience";
+
+/**
+ * Build-time audience conditionals — the segmentation's CORE security primitive
+ * (PRD #4257, slice #4260).
+ *
+ * These are SERVER components, resolved PER MOUNT from the route's static
+ * `audience` prop (NOT React context). That distinction is load-bearing: a
+ * CLIENT conditional (`useAudience() === … ? children : null`) still serializes
+ * its `children` into the RSC flight payload that Next inlines into the static
+ * HTML — so the "hidden" branch is present in the emitted HTML, only visually
+ * absent. A SERVER component that returns `null` never renders its children, so
+ * the branch is absent from the emitted HTML entirely (verified against the
+ * static export). A SaaS reader is structurally unable to receive the
+ * self-hosted branch, and vice versa.
+ *
+ * `SectionDocsPage` builds these once for its mount and passes them into the MDX
+ * `components` map, so authoring stays declarative:
+ *   <WhenSaaS>…</WhenSaaS> / <WhenSelfHosted>…</WhenSelfHosted>.
+ */
+
+interface ConditionalProps {
+  children?: ReactNode;
+}
+
+/** Active branch: render children unchanged. */
+function ShowChildren({ children }: ConditionalProps): ReactNode {
+  return <>{children}</>;
+}
+
+/**
+ * Inactive branch: render nothing. Because this is a server component that never
+ * touches `children`, those child elements are never rendered and never enter
+ * the RSC flight payload — the branch is absent from the emitted HTML.
+ */
+function RenderNothing(_props: ConditionalProps): ReactNode {
+  return null;
+}
+
+export interface AudienceConditionals {
+  readonly WhenSaaS: (props: ConditionalProps) => ReactNode;
+  readonly WhenSelfHosted: (props: ConditionalProps) => ReactNode;
+}
+
+/**
+ * Resolve the two audience conditionals for a given mount. On the SaaS mount
+ * `WhenSelfHosted` is `RenderNothing`; on the self-hosted mount `WhenSaaS` is.
+ */
+export function audienceConditionals(audience: Audience): AudienceConditionals {
+  return {
+    WhenSaaS: audience === "saas" ? ShowChildren : RenderNothing,
+    WhenSelfHosted: audience === "self-hosted" ? ShowChildren : RenderNothing,
+  };
+}

--- a/apps/docs/src/lib/audience-markdown.ts
+++ b/apps/docs/src/lib/audience-markdown.ts
@@ -1,0 +1,39 @@
+import type { Audience } from "@/lib/audience";
+
+/**
+ * Resolve `<WhenSaaS>` / `<WhenSelfHosted>` blocks in a page's PROCESSED
+ * MARKDOWN for a given mount (PRD #4257, slice #4260).
+ *
+ * fumadocs' `getText("processed")` preserves custom MDX component tags verbatim
+ * (a `<Callout>` shows up as literal `<Callout>` too), so a shared page's
+ * markdown twin / `llms-full.txt` would otherwise carry BOTH audience branches —
+ * leaking the self-hosted branch into the SaaS-root machine surface, the same
+ * class of leak the HTML conditionals close. This applies the audience decision
+ * to those text surfaces: the inactive branch is removed entirely and the active
+ * branch is unwrapped (tags dropped, prose kept).
+ *
+ * Pure string logic — no `.source/server`, no React — so it is unit-testable.
+ */
+export function stripInactiveAudienceBlocks(
+  markdown: string,
+  audience: Audience,
+): string {
+  const active = audience === "saas" ? "WhenSaaS" : "WhenSelfHosted";
+  const inactive = audience === "saas" ? "WhenSelfHosted" : "WhenSaaS";
+
+  // Match only BLOCK component tags — a tag alone on its own line (as MDX block
+  // JSX renders in processed markdown). Anchoring to line boundaries (`gm`, with
+  // `$` before the newline) leaves INLINE mentions untouched, e.g. a doc
+  // sentence that writes `` `<WhenSaaS>` `` to explain the component — those
+  // carry no audience content and must survive.
+  const inactiveBlock = new RegExp(
+    `^[ \\t]*<${inactive}>[ \\t]*\\n[\\s\\S]*?^[ \\t]*</${inactive}>[ \\t]*$\\n?`,
+    "gm",
+  );
+  const activeTags = new RegExp(`^[ \\t]*</?${active}>[ \\t]*$\\n?`, "gm");
+
+  return markdown
+    .replace(inactiveBlock, "")
+    .replace(activeTags, "")
+    .replace(/\n{3,}/g, "\n\n");
+}

--- a/apps/docs/src/lib/audience-markdown.ts
+++ b/apps/docs/src/lib/audience-markdown.ts
@@ -1,5 +1,27 @@
 import type { Audience } from "@/lib/audience";
 
+/** Match only BLOCK component tags — a tag alone on its own line (as MDX block
+ * JSX renders in processed markdown), tolerant of attributes and trailing
+ * whitespace. Line-anchored (`m`, `$` before the newline) so an INLINE mention
+ * like a doc sentence writing `` `<WhenSaaS>` `` is spared — those carry no
+ * audience content. */
+const RESIDUAL_BLOCK_TAG = /^[ \t]*<\/?When(?:SaaS|SelfHosted)(?:\s[^>]*)?>[ \t]*$/m;
+
+const AUDIENCE_TAGS = ["WhenSaaS", "WhenSelfHosted"] as const;
+
+/** The `<Tag>…</Tag>` block (open+close on their own lines, prose between). */
+function blockOf(tag: string): RegExp {
+  return new RegExp(
+    `^[ \\t]*<${tag}(?:\\s[^>]*)?>[ \\t]*\\n[\\s\\S]*?^[ \\t]*</${tag}>[ \\t]*$\\n?`,
+    "gm",
+  );
+}
+
+/** The bare open/close `<Tag>` / `</Tag>` lines, for unwrapping (keep prose). */
+function tagsOf(tag: string): RegExp {
+  return new RegExp(`^[ \\t]*</?${tag}(?:\\s[^>]*)?>[ \\t]*$\\n?`, "gm");
+}
+
 /**
  * Resolve `<WhenSaaS>` / `<WhenSelfHosted>` blocks in a page's PROCESSED
  * MARKDOWN for a given mount (PRD #4257, slice #4260).
@@ -12,28 +34,47 @@ import type { Audience } from "@/lib/audience";
  * to those text surfaces: the inactive branch is removed entirely and the active
  * branch is unwrapped (tags dropped, prose kept).
  *
+ * Fails CLOSED. Line endings are normalized first (CRLF would otherwise defeat
+ * the line-anchored patterns), tag attributes/whitespace are tolerated, and an
+ * unexpected audience value strips BOTH branches (mirroring the explicit
+ * positive-match in `audienceConditionals`). As a post-condition it THROWS if
+ * any block-form audience tag survives — an unresolved branch (malformed /
+ * unclosed tag, or a future MDX-emit change) must fail the build/page rather
+ * than silently leak the other audience. Both callers compose fail-closed:
+ * `llms-full.txt` catches per page and emits a visible placeholder; `llms.mdx`
+ * lets the throw fail that page's static generation.
+ *
  * Pure string logic — no `.source/server`, no React — so it is unit-testable.
  */
 export function stripInactiveAudienceBlocks(
   markdown: string,
   audience: Audience,
 ): string {
-  const active = audience === "saas" ? "WhenSaaS" : "WhenSelfHosted";
-  const inactive = audience === "saas" ? "WhenSelfHosted" : "WhenSaaS";
+  const normalized = markdown.replace(/\r\n/g, "\n");
 
-  // Match only BLOCK component tags — a tag alone on its own line (as MDX block
-  // JSX renders in processed markdown). Anchoring to line boundaries (`gm`, with
-  // `$` before the newline) leaves INLINE mentions untouched, e.g. a doc
-  // sentence that writes `` `<WhenSaaS>` `` to explain the component — those
-  // carry no audience content and must survive.
-  const inactiveBlock = new RegExp(
-    `^[ \\t]*<${inactive}>[ \\t]*\\n[\\s\\S]*?^[ \\t]*</${inactive}>[ \\t]*$\\n?`,
-    "gm",
-  );
-  const activeTags = new RegExp(`^[ \\t]*</?${active}>[ \\t]*$\\n?`, "gm");
+  // Resolve the active tag by EXPLICIT positive match (fail closed): an
+  // unexpected audience keeps neither branch.
+  const active =
+    audience === "saas"
+      ? "WhenSaaS"
+      : audience === "self-hosted"
+        ? "WhenSelfHosted"
+        : null;
 
-  return markdown
-    .replace(inactiveBlock, "")
-    .replace(activeTags, "")
-    .replace(/\n{3,}/g, "\n\n");
+  let out = normalized;
+  // Remove every INACTIVE branch's block: with a known audience that is the one
+  // opposite branch; with an unknown audience it is both.
+  for (const tag of AUDIENCE_TAGS) {
+    if (tag !== active) out = out.replace(blockOf(tag), "");
+  }
+  // Unwrap the ACTIVE branch's tags, keeping its prose (nothing if none active).
+  if (active) out = out.replace(tagsOf(active), "");
+  out = out.replace(/\n{3,}/g, "\n\n");
+
+  if (RESIDUAL_BLOCK_TAG.test(out)) {
+    throw new Error(
+      `[docs] audience strip left a residual <When…> block tag while resolving "${audience}" — a branch was not removed (check for malformed/unclosed tags or attributes)`,
+    );
+  }
+  return out;
 }

--- a/apps/docs/src/lib/audience-markdown.ts
+++ b/apps/docs/src/lib/audience-markdown.ts
@@ -1,13 +1,20 @@
 import type { Audience } from "@/lib/audience";
 
-/** Match only BLOCK component tags — a tag alone on its own line (as MDX block
- * JSX renders in processed markdown), tolerant of attributes and trailing
- * whitespace. Line-anchored (`m`, `$` before the newline) so an INLINE mention
- * like a doc sentence writing `` `<WhenSaaS>` `` is spared — those carry no
- * audience content. */
-const RESIDUAL_BLOCK_TAG = /^[ \t]*<\/?When(?:SaaS|SelfHosted)(?:\s[^>]*)?>[ \t]*$/m;
-
 const AUDIENCE_TAGS = ["WhenSaaS", "WhenSelfHosted"] as const;
+
+/** Any raw audience tag, open or close, block OR inline. Used as the fail-closed
+ * post-condition AFTER code spans are masked out (so a doc sentence that MENTIONS
+ * `` `<WhenSaaS>` `` in inline code is not a false positive). `\b` after the name
+ * avoids matching a differently-named component like `<WhenSaaSFoo>`. */
+const RESIDUAL_AUDIENCE_TAG = /<\/?When(?:SaaS|SelfHosted)\b/;
+
+/** Mask fenced and inline code spans (their raw tag MENTIONS must be spared) so
+ * the residual check only sees real tags. Returns text safe to scan, not to emit. */
+function maskCodeSpans(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, "") // fenced blocks first
+    .replace(/`[^`\n]*`/g, ""); // then inline-code spans
+}
 
 /** The `<Tag>…</Tag>` block (open+close on their own lines, prose between). */
 function blockOf(tag: string): RegExp {
@@ -38,9 +45,10 @@ function tagsOf(tag: string): RegExp {
  * the line-anchored patterns), tag attributes/whitespace are tolerated, and an
  * unexpected audience value strips BOTH branches (mirroring the explicit
  * positive-match in `audienceConditionals`). As a post-condition it THROWS if
- * any block-form audience tag survives — an unresolved branch (malformed /
- * unclosed tag, or a future MDX-emit change) must fail the build/page rather
- * than silently leak the other audience. Both callers compose fail-closed:
+ * any raw audience tag survives (after masking inline-code mentions) — an
+ * unresolved branch, whether a malformed/unclosed block, an unsupported
+ * single-line inline form, or a future MDX-emit change, must fail the build/page
+ * rather than silently leak the other audience. Both callers compose fail-closed:
  * `llms-full.txt` catches per page and emits a visible placeholder; `llms.mdx`
  * lets the throw fail that page's static generation.
  *
@@ -71,9 +79,14 @@ export function stripInactiveAudienceBlocks(
   if (active) out = out.replace(tagsOf(active), "");
   out = out.replace(/\n{3,}/g, "\n\n");
 
-  if (RESIDUAL_BLOCK_TAG.test(out)) {
+  // Fail closed: after masking code-span mentions, NO raw audience tag may
+  // survive. This catches both a malformed/unclosed BLOCK and the unsupported
+  // single-line INLINE form (`<WhenSelfHosted>x</WhenSelfHosted>` on one line) —
+  // the strip only handles block-form, so an inline usage must fail the
+  // build/page rather than silently leak the other audience's prose.
+  if (RESIDUAL_AUDIENCE_TAG.test(maskCodeSpans(out))) {
     throw new Error(
-      `[docs] audience strip left a residual <When…> block tag while resolving "${audience}" — a branch was not removed (check for malformed/unclosed tags or attributes)`,
+      `[docs] audience strip left a residual <When…> tag while resolving "${audience}" — a branch was not removed. Audience conditionals must be BLOCK-form (opening/closing tags each on their own line); inline usage is unsupported. Also check for malformed/unclosed tags.`,
     );
   }
   return out;

--- a/apps/docs/src/lib/audience-taxonomy.ts
+++ b/apps/docs/src/lib/audience-taxonomy.ts
@@ -1,0 +1,280 @@
+import type { Audience } from "@/lib/audience";
+
+/**
+ * The declarative audience taxonomy for the segmented docs portal (PRD #4257).
+ *
+ * Every content file resolves to exactly ONE audience class. Classification is
+ * driven by a directory manifest (`CONTENT_ROOTS`) rather than per-file
+ * frontmatter, because the SaaS tree (`content/docs/**`) is hundreds of files
+ * plus a fully generated `api-reference/` tree — requiring an `audience:` line
+ * on each of those does not fit the collection shape. The directory is the
+ * SSOT; an OPTIONAL `audience:` frontmatter field lets an author state a page's
+ * class explicitly, and is machine-checked to AGREE with the directory (a
+ * contradiction is a hard "ambiguous" build error — the teeth that catch a
+ * mis-filed page).
+ *
+ * This module imports NO generated `.source/server` and no React runtime, so it
+ * is fully unit-testable with synthetic entries (see
+ * `__tests__/audience-taxonomy.test.ts`). The build-time gate lives in
+ * `src/lib/source.ts`, which feeds the real pages through
+ * `validateContentTaxonomy` and throws — failing `next build` — on any orphan,
+ * ambiguous classification, or un-marked cross-audience duplicate.
+ */
+
+/** The three audience classes a content file can belong to. */
+export const AUDIENCE_CLASSES = [
+  "saas-only",
+  "self-hosted-only",
+  "shared",
+] as const;
+export type AudienceClass = (typeof AUDIENCE_CLASSES)[number];
+
+export function isAudienceClass(value: unknown): value is AudienceClass {
+  return (
+    typeof value === "string" &&
+    (AUDIENCE_CLASSES as readonly string[]).includes(value)
+  );
+}
+
+interface ContentRoot {
+  readonly prefix: string;
+  readonly class: AudienceClass;
+}
+
+/**
+ * The taxonomy manifest: each content-root directory maps to exactly one
+ * audience class. The three roots are disjoint, so a file matches at most one.
+ * A file under none of them is an ORPHAN (a hard build error).
+ */
+export const CONTENT_ROOTS: readonly ContentRoot[] = [
+  { prefix: "content/self-hosted/", class: "self-hosted-only" },
+  { prefix: "content/shared/", class: "shared" },
+  { prefix: "content/docs/", class: "saas-only" },
+];
+
+/**
+ * Which human section(s) a class is mounted into. `shared` is the single-source
+ * case — one file on disk, mounted into BOTH human trees (full presence, single
+ * source). This is the machine-readable form of the shared-presence guarantee.
+ */
+export const AUDIENCE_MOUNTS: Record<AudienceClass, readonly Audience[]> = {
+  "saas-only": ["saas"],
+  "self-hosted-only": ["self-hosted"],
+  shared: ["saas", "self-hosted"],
+};
+
+export function audienceMounts(cls: AudienceClass): readonly Audience[] {
+  return AUDIENCE_MOUNTS[cls];
+}
+
+/**
+ * Match a file path against the manifest. Robust to both repo-relative paths
+ * (`content/docs/x.mdx`) and absolute filesystem paths that merely CONTAIN a
+ * known root (`/…/apps/docs/content/docs/x.mdx`) — same defensive approach as
+ * `githubEditPath`.
+ */
+function matchRoot(
+  absolutePath: string,
+): { readonly root: ContentRoot; readonly rel: string } | null {
+  for (const root of CONTENT_ROOTS) {
+    const idx = absolutePath.indexOf(root.prefix);
+    if (idx >= 0) {
+      return { root, rel: absolutePath.slice(idx + root.prefix.length) };
+    }
+  }
+  return null;
+}
+
+/** The audience class implied by a file's content-root directory, or null. */
+export function classifyByPath(absolutePath: string): AudienceClass | null {
+  return matchRoot(absolutePath)?.root.class ?? null;
+}
+
+export interface ContentEntry {
+  /** Real source file path, e.g. `content/docs/guides/slack.mdx`. */
+  readonly absolutePath: string;
+  /** Optional explicit `audience:` frontmatter declaration. */
+  readonly audience?: string | null;
+  /** Optional `fork:` frontmatter marker (a stable divergence key). */
+  readonly fork?: string | null;
+}
+
+export type Classification =
+  | { readonly ok: true; readonly class: AudienceClass }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Resolve a single content file to its audience class, or an error string.
+ *
+ * Fails (build error) when the file is:
+ *  - an ORPHAN — under no known content root (missing classification), or
+ *  - INVALID — declares an `audience:` value outside `AUDIENCE_CLASSES`, or
+ *  - AMBIGUOUS — declares an `audience:` that contradicts its directory.
+ */
+export function resolveClassification(entry: ContentEntry): Classification {
+  const dirClass = classifyByPath(entry.absolutePath);
+  if (dirClass === null) {
+    return {
+      ok: false,
+      error: `orphan page "${entry.absolutePath}" is not under any known content root (${CONTENT_ROOTS.map(
+        (r) => r.prefix,
+      ).join(", ")}) — every page must live in exactly one audience tree`,
+    };
+  }
+
+  const declared = entry.audience;
+  if (declared != null && declared !== "") {
+    if (!isAudienceClass(declared)) {
+      return {
+        ok: false,
+        error: `invalid audience "${declared}" in "${entry.absolutePath}" — expected one of ${AUDIENCE_CLASSES.join(
+          ", ",
+        )}`,
+      };
+    }
+    if (declared !== dirClass) {
+      return {
+        ok: false,
+        error: `ambiguous audience for "${entry.absolutePath}": frontmatter declares "${declared}" but its directory implies "${dirClass}" — move the file or fix the frontmatter`,
+      };
+    }
+  }
+
+  return { ok: true, class: dirClass };
+}
+
+/** Throw an aggregated build error if any entry fails to classify cleanly. */
+export function assertClassified(entries: readonly ContentEntry[]): void {
+  const errors: string[] = [];
+  for (const entry of entries) {
+    const result = resolveClassification(entry);
+    if (!result.ok) errors.push(result.error);
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `[docs] audience taxonomy check failed (${errors.length} page(s)):\n  - ${errors.join(
+        "\n  - ",
+      )}`,
+    );
+  }
+}
+
+/**
+ * A file's "topic" — its slug relative to its content root, without extension
+ * or a trailing `/index`. Two files with the SAME topic in different audience
+ * trees cover the same logical page. Returns "" for a section landing page
+ * (each section legitimately owns its own landing page — never a fork).
+ */
+function topicKey(absolutePath: string): string | null {
+  const matched = matchRoot(absolutePath);
+  if (!matched) return null;
+  return matched.rel
+    .replace(/\.mdx?$/i, "")
+    .replace(/(^|\/)index$/i, "")
+    .replace(/^\/+|\/+$/g, "");
+}
+
+export interface ForkViolation {
+  readonly topic: string;
+  readonly kind: "unmarked" | "mismatched";
+  readonly files: readonly string[];
+  readonly message: string;
+}
+
+/**
+ * Detect cross-audience duplicate pages that are NOT declared intentional forks.
+ *
+ * A "duplicate" is the SAME topic authored as two distinct files across the
+ * saas-only and self-hosted-only trees. `shared/` pages are single-sourced (one
+ * file, two mounts) and can never be duplicates, so they are excluded. Section
+ * landing pages (topic "") are excluded — each section owns its own.
+ *
+ * The fork-marker convention: to KEEP a topic as two deliberately divergent
+ * files (rather than single-sourcing it into `content/shared/`), mark BOTH
+ * files with the same `fork:` key. An un-marked duplicate is flagged (someone
+ * forgot to single-source, or forgot to declare the fork); a duplicate whose
+ * two members carry DIFFERENT keys is flagged as mismatched.
+ */
+export function detectForkViolations(
+  entries: readonly ContentEntry[],
+): ForkViolation[] {
+  const byTopic = new Map<
+    string,
+    { path: string; cls: AudienceClass; fork: string }[]
+  >();
+
+  for (const entry of entries) {
+    const cls = classifyByPath(entry.absolutePath);
+    if (cls !== "saas-only" && cls !== "self-hosted-only") continue;
+    const topic = topicKey(entry.absolutePath);
+    if (!topic) continue; // orphan or section landing page
+    const bucket = byTopic.get(topic) ?? [];
+    bucket.push({ path: entry.absolutePath, cls, fork: (entry.fork ?? "").trim() });
+    byTopic.set(topic, bucket);
+  }
+
+  const violations: ForkViolation[] = [];
+  for (const [topic, files] of byTopic) {
+    // Only a cross-audience pair is a fork candidate; a same-tree slug
+    // collision is a different (routing) problem, not a fork.
+    if (new Set(files.map((f) => f.cls)).size < 2) continue;
+
+    const paths = files.map((f) => f.path).toSorted();
+    const markers = files.map((f) => f.fork);
+    if (markers.some((m) => m === "")) {
+      violations.push({
+        topic,
+        kind: "unmarked",
+        files: paths,
+        message: `topic "${topic}" is duplicated across audiences without a fork marker — single-source it into content/shared/, or mark BOTH files with a matching \`fork:\` key: ${paths.join(
+          ", ",
+        )}`,
+      });
+      continue;
+    }
+    if (new Set(markers).size !== 1) {
+      violations.push({
+        topic,
+        kind: "mismatched",
+        files: paths,
+        message: `topic "${topic}" fork markers disagree (${[
+          ...new Set(markers),
+        ].join(
+          " vs ",
+        )}) — both members of an intentional fork must share the SAME \`fork:\` key: ${paths.join(
+          ", ",
+        )}`,
+      });
+    }
+  }
+  return violations;
+}
+
+/** Throw an aggregated build error on any un-marked / mismatched fork pair. */
+export function assertNoUnmarkedForks(entries: readonly ContentEntry[]): void {
+  const violations = detectForkViolations(entries);
+  if (violations.length > 0) {
+    throw new Error(
+      `[docs] fork-marker check failed (${violations.length} topic(s)):\n  - ${violations
+        .map((v) => v.message)
+        .join("\n  - ")}`,
+    );
+  }
+}
+
+/**
+ * The single build-time gate. Feed it every real page (from both section
+ * sources); it dedupes by source file (a `shared` page appears once per mount)
+ * and throws on the first class of failure — orphan/ambiguous classification or
+ * an un-marked cross-audience duplicate. Called from `src/lib/source.ts`, so a
+ * violation fails `next build`.
+ */
+export function validateContentTaxonomy(entries: readonly ContentEntry[]): void {
+  const unique = new Map<string, ContentEntry>();
+  for (const entry of entries) {
+    if (!unique.has(entry.absolutePath)) unique.set(entry.absolutePath, entry);
+  }
+  const deduped = [...unique.values()];
+  assertClassified(deduped);
+  assertNoUnmarkedForks(deduped);
+}

--- a/apps/docs/src/lib/audience-taxonomy.ts
+++ b/apps/docs/src/lib/audience-taxonomy.ts
@@ -22,7 +22,7 @@ export { AUDIENCE_CLASSES, type AudienceClass };
  * `__tests__/audience-taxonomy.test.ts`). The build-time gate lives in
  * `src/lib/source.ts`, which feeds the real pages through
  * `validateContentTaxonomy` and throws — failing `next build` — on any orphan,
- * ambiguous classification, or un-marked cross-audience duplicate.
+ * invalid, or ambiguous classification, or un-marked cross-audience duplicate.
  */
 
 export function isAudienceClass(value: unknown): value is AudienceClass {

--- a/apps/docs/src/lib/audience-taxonomy.ts
+++ b/apps/docs/src/lib/audience-taxonomy.ts
@@ -1,4 +1,8 @@
 import type { Audience } from "@/lib/audience";
+import { AUDIENCE_CLASSES, type AudienceClass } from "@/lib/audience-classes";
+
+// Re-export the SSOT so existing importers keep resolving these from here.
+export { AUDIENCE_CLASSES, type AudienceClass };
 
 /**
  * The declarative audience taxonomy for the segmented docs portal (PRD #4257).
@@ -20,14 +24,6 @@ import type { Audience } from "@/lib/audience";
  * `validateContentTaxonomy` and throws — failing `next build` — on any orphan,
  * ambiguous classification, or un-marked cross-audience duplicate.
  */
-
-/** The three audience classes a content file can belong to. */
-export const AUDIENCE_CLASSES = [
-  "saas-only",
-  "self-hosted-only",
-  "shared",
-] as const;
-export type AudienceClass = (typeof AUDIENCE_CLASSES)[number];
 
 export function isAudienceClass(value: unknown): value is AudienceClass {
   return (
@@ -57,11 +53,11 @@ export const CONTENT_ROOTS: readonly ContentRoot[] = [
  * case — one file on disk, mounted into BOTH human trees (full presence, single
  * source). This is the machine-readable form of the shared-presence guarantee.
  */
-export const AUDIENCE_MOUNTS: Record<AudienceClass, readonly Audience[]> = {
+export const AUDIENCE_MOUNTS = {
   "saas-only": ["saas"],
   "self-hosted-only": ["self-hosted"],
   shared: ["saas", "self-hosted"],
-};
+} as const satisfies Record<AudienceClass, readonly Audience[]>;
 
 export function audienceMounts(cls: AudienceClass): readonly Audience[] {
   return AUDIENCE_MOUNTS[cls];
@@ -112,6 +108,15 @@ export type Classification =
  *  - AMBIGUOUS — declares an `audience:` that contradicts its directory.
  */
 export function resolveClassification(entry: ContentEntry): Classification {
+  if (entry.absolutePath === "") {
+    // Fail closed: a page with no source path can't be classified. Distinct
+    // message from a genuine orphan so the cause (a missing `absolutePath`, not a
+    // mis-filed page) is obvious.
+    return {
+      ok: false,
+      error: `unclassifiable page: empty absolutePath — fumadocs should always populate this, so a blank one is a build-time anomaly`,
+    };
+  }
   const dirClass = classifyByPath(entry.absolutePath);
   if (dirClass === null) {
     return {
@@ -265,8 +270,8 @@ export function assertNoUnmarkedForks(entries: readonly ContentEntry[]): void {
 /**
  * The single build-time gate. Feed it every real page (from both section
  * sources); it dedupes by source file (a `shared` page appears once per mount)
- * and throws on the first class of failure — orphan/ambiguous classification or
- * an un-marked cross-audience duplicate. Called from `src/lib/source.ts`, so a
+ * and throws on any failure — an orphan/invalid/ambiguous classification, or an
+ * un-marked cross-audience duplicate. Called from `src/lib/source.ts`, so a
  * violation fails `next build`.
  */
 export function validateContentTaxonomy(entries: readonly ContentEntry[]): void {

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,10 +1,17 @@
-import { source } from "./source";
 import type { InferPageType } from "fumadocs-core/source";
+import type { source } from "@/lib/source";
+import type { Audience } from "@/lib/audience";
+import { stripInactiveAudienceBlocks } from "@/lib/audience-markdown";
 
 export async function getLLMText(
   page: InferPageType<typeof source>,
+  audience: Audience,
 ): Promise<string> {
   const processed = await page.data.getText("processed");
+  // Resolve `<WhenSaaS>` / `<WhenSelfHosted>` for this surface's audience so the
+  // markdown twin / llms-full.txt never carry the other audience's branch — the
+  // same isolation the HTML conditionals enforce (PRD #4257).
+  const scoped = stripInactiveAudienceBlocks(processed, audience);
 
-  return `# ${page.data.title} (${page.url})\n\n${processed}`;
+  return `# ${page.data.title} (${page.url})\n\n${scoped}`;
 }

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -2,6 +2,10 @@ import { docs, selfHosted, shared } from "@/../.source/server";
 import { openapiPlugin } from "fumadocs-openapi/server";
 import type { InferPageType } from "fumadocs-core/source";
 import { buildSectionSource } from "@/lib/compose";
+import {
+  validateContentTaxonomy,
+  type ContentEntry,
+} from "@/lib/audience-taxonomy";
 
 // SaaS / Cloud docs at the site root (`/`). Existing `content/docs` — including
 // the generated `api-reference/` tree at `/api-reference/*` — plus the shared
@@ -31,3 +35,24 @@ export const selfHostedSource = buildSectionSource({
 export type SectionPage =
   | InferPageType<typeof source>
   | InferPageType<typeof selfHostedSource>;
+
+function toEntry(page: SectionPage): ContentEntry {
+  return {
+    absolutePath: page.absolutePath ?? "",
+    audience: page.data.audience,
+    fork: page.data.fork,
+  };
+}
+
+/**
+ * Build-time taxonomy gate (PRD #4257, slice #4260). Every real page from both
+ * human sections is fed through `validateContentTaxonomy`, which throws — and so
+ * fails `next build` — on any orphan/ambiguous classification or un-marked
+ * cross-audience duplicate. Runs once at module init; `getPages()` is the union
+ * of the two mounts, so a `shared` page appears twice and is deduped by source
+ * file inside the validator.
+ */
+validateContentTaxonomy([
+  ...source.getPages().map(toEntry),
+  ...selfHostedSource.getPages().map(toEntry),
+]);

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -47,8 +47,8 @@ function toEntry(page: SectionPage): ContentEntry {
 /**
  * Build-time taxonomy gate (PRD #4257, slice #4260). Every real page from both
  * human sections is fed through `validateContentTaxonomy`, which throws — and so
- * fails `next build` — on any orphan/ambiguous classification or un-marked
- * cross-audience duplicate. Runs once at module init; `getPages()` is the union
+ * fails `next build` — on any orphan/invalid/ambiguous classification or
+ * un-marked cross-audience duplicate. Runs once at module init; `getPages()` is the union
  * of the two mounts, so a `shared` page appears twice and is deduped by source
  * file inside the validator.
  */

--- a/bun.lock
+++ b/bun.lock
@@ -99,6 +99,7 @@
         "next": "^16.2.9",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@shikijs/transformers": "^4.2.0",

--- a/docs/development/docs-portal-audiences.md
+++ b/docs/development/docs-portal-audiences.md
@@ -57,6 +57,13 @@ and wired into the MDX `components` map per route in
 </WhenSelfHosted>
 ```
 
+Use **block form** — the opening and closing tags each on their own line. The
+machine-text surfaces (markdown twin, `llms-full.txt`) resolve the branch by
+stripping the inactive block; a single-line inline form
+(`<WhenSelfHosted>…</WhenSelfHosted>` on one line) is unsupported there and
+**fails the build** rather than risk leaking the other audience's prose into a
+SaaS-root surface.
+
 They resolve **server-side, per mount, from the route's static `audience` prop**
 (the same value `AudienceProvider` carries for `<AudienceLabel/>`) — **not** via
 React context. That distinction is load-bearing: a client conditional

--- a/docs/development/docs-portal-audiences.md
+++ b/docs/development/docs-portal-audiences.md
@@ -1,0 +1,111 @@
+# Docs portal audience taxonomy (`apps/docs`)
+
+The docs site is segmented into three route sections (PRD #4257):
+
+| Section         | Mount          | Content root           | Audience class     |
+| --------------- | -------------- | ---------------------- | ------------------ |
+| SaaS / Cloud    | site root `/`  | `content/docs/**`      | `saas-only`        |
+| Self-Hosted     | `/self-hosted` | `content/self-hosted/**` | `self-hosted-only` |
+| API reference   | `/api-reference` | (generated, inside `content/docs`) | `saas-only` |
+| Shared concepts | both trees     | `content/shared/**`    | `shared`           |
+
+Every content file resolves to **exactly one** audience class. This is the
+machine-checked contract that keeps a SaaS reader from ever seeing self-hosted
+quirks and vice versa.
+
+## Classification (directory manifest)
+
+Classification is driven by the content-root directory, declared once in the
+`CONTENT_ROOTS` manifest in
+[`src/lib/audience-taxonomy.ts`](../../apps/docs/src/lib/audience-taxonomy.ts).
+The directory a file lives in **is** its audience class — there is no per-file
+`audience:` line to forget on the hundreds of `content/docs` pages (including the
+generated `api-reference/` tree).
+
+You MAY still add an explicit `audience:` frontmatter field
+(`saas-only | self-hosted-only | shared`) to a page to document its class. When
+present it is checked to **agree** with the directory; a contradiction (e.g. a
+`content/docs/*` page that declares `audience: shared`) is a hard build error.
+
+The gate runs at build time in
+[`src/lib/source.ts`](../../apps/docs/src/lib/source.ts) via
+`validateContentTaxonomy`, which **fails `next build`** on:
+
+- **missing** classification — an orphan file under no known content root;
+- **invalid** classification — an `audience:` value outside the three classes;
+- **ambiguous** classification — an `audience:` that contradicts the directory.
+
+Pure logic is unit-tested in
+[`__tests__/audience-taxonomy.test.ts`](../../apps/docs/src/lib/__tests__/audience-taxonomy.test.ts)
+with synthetic entries (no generated `.source/server` needed).
+
+## Build-time conditionals — `<WhenSaaS>` / `<WhenSelfHosted>`
+
+A `shared` page authored **once** can adapt per mount using the two conditional
+components from [`src/lib/audience.tsx`](../../apps/docs/src/lib/audience.tsx):
+
+```mdx
+<WhenSaaS>
+  Cloud-only guidance (billing, regions, …).
+</WhenSaaS>
+
+<WhenSelfHosted>
+  Self-hosted-only guidance (Docker, BYO auth, …).
+</WhenSelfHosted>
+```
+
+These resolve at **route/build time** from the audience injected by
+`AudienceProvider` (the SaaS root injects `saas`; `/self-hosted` injects
+`self-hosted`). On the SaaS mount `<WhenSelfHosted>` renders `null`, so the
+self-hosted branch is **absent from the emitted static HTML** — not hidden with
+CSS, not a reader-facing tab. A reader can never toggle to the other audience's
+branch because it was never sent to them. This is the segmentation's core
+security invariant; it is proven two ways:
+
+- a render-string test
+  ([`__tests__/audience-conditionals.test.tsx`](../../apps/docs/src/lib/__tests__/audience-conditionals.test.tsx))
+  asserts the omitted branch's token is absent from the rendered HTML string;
+- the static export (`bun run build`) is grepped: the token in a shared page's
+  `<WhenSelfHosted>` block appears in the `/self-hosted` HTML output but **not**
+  in the site-root HTML, and vice versa.
+
+## Fork-marker convention
+
+Prefer single-sourcing a concept into `content/shared/` (full presence, one
+file, no drift). Sometimes, though, a topic genuinely needs **two different
+pages** — one for each audience — because the guidance diverges (a "fork"). To
+keep two divergent files instead of single-sourcing, mark **both** with the same
+`fork:` key:
+
+```yaml
+# content/docs/deployment.mdx
+---
+title: Deployment
+fork: deployment
+---
+```
+
+```yaml
+# content/self-hosted/deployment.mdx
+---
+title: Deployment
+fork: deployment
+---
+```
+
+The `fork:` key is a stable string shared by the two members of an intentional
+divergence. It exists so a reviewer can tell a **deliberate fork** apart from a
+**forgotten sync** (someone copied a page into both trees and now edits both).
+
+The check (`detectForkViolations` / `assertNoUnmarkedForks`, run in the same
+build-time gate) considers the same topic slug appearing across the `saas-only`
+and `self-hosted-only` trees:
+
+- **both members carry the same `fork:` key** → recognized intentional fork, OK;
+- **no marker / only one side marked** → flagged as an un-marked duplicate
+  (single-source it into `content/shared/`, or declare the fork);
+- **members carry different keys** → flagged as mismatched.
+
+Section landing pages (`index`) and `shared/` pages are never fork candidates —
+each section owns its landing page, and shared pages are single-sourced by
+construction.

--- a/docs/development/docs-portal-audiences.md
+++ b/docs/development/docs-portal-audiences.md
@@ -1,12 +1,12 @@
 # Docs portal audience taxonomy (`apps/docs`)
 
-The docs site is segmented into three route sections (PRD #4257):
+The docs site has two human route sections plus a cross-cutting `shared`
+collection mounted into both (PRD #4257):
 
-| Section         | Mount          | Content root           | Audience class     |
+| Tree            | Mount          | Content root           | Audience class     |
 | --------------- | -------------- | ---------------------- | ------------------ |
-| SaaS / Cloud    | site root `/`  | `content/docs/**`      | `saas-only`        |
+| SaaS / Cloud    | site root `/`  | `content/docs/**` (incl. the generated `api-reference/` at `/api-reference`) | `saas-only`        |
 | Self-Hosted     | `/self-hosted` | `content/self-hosted/**` | `self-hosted-only` |
-| API reference   | `/api-reference` | (generated, inside `content/docs`) | `saas-only` |
 | Shared concepts | both trees     | `content/shared/**`    | `shared`           |
 
 Every content file resolves to **exactly one** audience class. This is the
@@ -42,7 +42,10 @@ with synthetic entries (no generated `.source/server` needed).
 ## Build-time conditionals — `<WhenSaaS>` / `<WhenSelfHosted>`
 
 A `shared` page authored **once** can adapt per mount using the two conditional
-components from [`src/lib/audience.tsx`](../../apps/docs/src/lib/audience.tsx):
+components. They are built by the `audienceConditionals(audience)` factory in
+[`src/lib/audience-conditionals.tsx`](../../apps/docs/src/lib/audience-conditionals.tsx)
+and wired into the MDX `components` map per route in
+[`src/components/section-docs-page.tsx`](../../apps/docs/src/components/section-docs-page.tsx):
 
 ```mdx
 <WhenSaaS>
@@ -54,12 +57,17 @@ components from [`src/lib/audience.tsx`](../../apps/docs/src/lib/audience.tsx):
 </WhenSelfHosted>
 ```
 
-These resolve at **route/build time** from the audience injected by
-`AudienceProvider` (the SaaS root injects `saas`; `/self-hosted` injects
-`self-hosted`). On the SaaS mount `<WhenSelfHosted>` renders `null`, so the
-self-hosted branch is **absent from the emitted static HTML** — not hidden with
-CSS, not a reader-facing tab. A reader can never toggle to the other audience's
-branch because it was never sent to them. This is the segmentation's core
+They resolve **server-side, per mount, from the route's static `audience` prop**
+(the same value `AudienceProvider` carries for `<AudienceLabel/>`) — **not** via
+React context. That distinction is load-bearing: a client conditional
+(`useAudience() === … ? children : null`) would still serialize its `children`
+into the RSC flight payload Next inlines into the static HTML, so the "hidden"
+branch would be present in the emitted HTML. Instead the inactive branch is a
+**server component that returns `null`** and never renders its children, so the
+branch is **absent from the emitted static HTML** (and the RSC payload) — not
+hidden with CSS, not a reader-facing tab. A reader can never toggle to the other
+audience's branch because it was never sent to them. **Do not** "simplify" these
+to `useAudience()` — that reintroduces the leak. This is the segmentation's core
 security invariant; it is proven two ways:
 
 - a render-string test


### PR DESCRIPTION
## Summary

Slice 2 of the docs-portal segmentation (PRD #4257), built on the merged #4279 foundation. Makes audience ownership **explicit + machine-checked** and enables per-audience content variation resolved at **route/build time** — never a reader-facing tab.

- **Declarative classification** via a directory **taxonomy manifest** (`CONTENT_ROOTS` in `apps/docs/src/lib/audience-taxonomy.ts`): every content file resolves to exactly one class (`saas-only` | `self-hosted-only` | `shared`). An optional `audience:` frontmatter field must AGREE with the directory. The build-time gate in `src/lib/source.ts` throws — failing `next build` — on any orphan / invalid / ambiguous classification, or un-marked cross-audience duplicate.
- **`<WhenSaaS>` / `<WhenSelfHosted>`** are SERVER components resolved per mount from the route's static `audience` prop (`audienceConditionals()` wired into the MDX components map). The inactive branch returns `null` and never renders its children.
- **Fork-marker convention** (`fork:` key) distinguishes a deliberate per-audience divergence from a forgotten single-source; the gate flags un-marked / mismatched duplicates. Documented in `docs/development/docs-portal-audiences.md`.
- The markdown text surfaces (twin, `llms-full.txt`) resolve the conditional too (`stripInactiveAudienceBlocks`), so the SaaS-root machine surfaces don't carry the self-hosted branch either — fail-closed (throws on any residual/inline tag).

### Why the taxonomy MANIFEST, not per-file frontmatter
The SaaS tree is `content/docs/**` — hundreds of hand-authored files plus a fully generated `api-reference/` tree. Requiring an `audience:` line on each doesn't fit; the directory is the SSOT. The optional `audience:` frontmatter still lets an author state a class explicitly and is machine-checked to agree (a mis-filed page is a hard "ambiguous" build error — the teeth on the "ambiguous" branch).

### The core invariant — proven ABSENT (not hidden) in the emitted HTML
The driving requirement: a SaaS reader must be structurally unable to see the self-hosted branch — it must not be in the emitted HTML at all.

The subtlety: a **client** conditional (`useAudience() === … ? children : null`) would pass a render-string test yet still serialize its `children` into the RSC flight payload Next inlines into the static HTML — so the "hidden" branch is present in the emitted HTML. First implementation hit exactly this; the leak was visible in `out/single-source-example/index.html` inside a `self.__next_f.push(...)` script. Fix: resolve on the **server** so the inactive branch never renders its children.

Proven against the actual `bun run build` static export (a shared page carries greppable sentinel tokens `audience-saas-only-a7f2` / `audience-self-hosted-only-a7f2`):

| Emitted surface | saas token | self-hosted token |
|---|---|---|
| `out/single-source-example/index.html` (SaaS mount, incl. RSC payload) | present | **ABSENT** |
| `out/self-hosted/single-source-example/index.html` (self-hosted mount) | **ABSENT** | present |
| `out/llms.mdx/single-source-example/index.md` (SaaS twin) | present | **ABSENT** |
| `out/llms-full.txt` (SaaS aggregate) | present | **ABSENT** |
| all `__next*.txt` RSC payload files (both mounts) | — | no cross-audience leak |

Build-gate proven empirically too: injecting an ambiguous `audience:` frontmatter → `next build` exits 1 ("ambiguous audience … contradicts directory"); an un-marked cross-audience duplicate → exits 1 ("fork-marker check failed"); the same duplicate marked with a matching `fork:` key → exits 0.

### No regression to the foundation
Root SaaS URLs unchanged, `/self-hosted` still works, `/api-reference` untouched; no `/docs` or `/api` docs-route prefixes.

## Test plan
- [x] `apps/docs` unit tests (`bun test src/lib/__tests__`) — 39 pass: classification (orphan/invalid/ambiguous/empty-path), `CONTENT_ROOTS` coverage, shared-presence, fork detection (unmarked/marked/mismatched/half-marked/index+shared-excluded), server-resolved conditionals absent-branch, a structural anti-regression guard (pins `audience-conditionals.tsx` as a server module — no `"use client"`/hook import), and markdown-strip CRLF/attribute/unclosed/inline fail-closed.
- [x] `bun run build` (static export) — build green + all-surfaces omission grep passes (table above).
- [x] `/review-panel` — 2 rounds, converged clean (silent-failure, type-design, test-coverage, comment). Findings addressed: server-resolved conditionals (the payload leak), single-sourced `AUDIENCE_CLASSES` leaf, fail-closed markdown strip (CRLF/attributes/inline), doc misattribution corrected.
- [x] `/ci` (`scripts/ci-local.sh`) — all 28 local gates green.

Closes #4260