### PR TITLE
docs(slice-3a): classify + verify SaaS-only pages, partition test (#4263)

### DIFF
--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -77,9 +77,9 @@ Atlas supports three regions at launch:
 
 | Region | ID | Compliance |
 |--------|-----|-----------|
-| **US East** | `us-east` | SOC 2 compliant |
-| **EU West** | `eu-west` | GDPR compliant |
-| **Asia Pacific** | `ap-southeast` | Regional data sovereignty |
+| **US East** | `us` | SOC 2 compliant |
+| **EU West** | `eu` | GDPR compliant |
+| **Asia Pacific** | `apac` | Regional data sovereignty |
 
 The platform's default region is pre-selected. Users can choose a different region based on their compliance requirements.
 

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -12,7 +12,7 @@ Atlas data residency controls let operators assign workspaces to geographic regi
 </Callout>
 
 <Callout title="Prerequisites">
-- Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
+- Active paid plan (Starter, Pro, or Business) on [app.useatlas.dev](https://app.useatlas.dev)
 - Internal database configured (`DATABASE_URL`)
 - Platform admin role for dashboard access
 - At least one region configured in `atlas.config.ts`

--- a/apps/docs/src/lib/__tests__/source-partition.test.ts
+++ b/apps/docs/src/lib/__tests__/source-partition.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { buildSectionSource, type CollectionLike } from "@/lib/compose";
+import { classifyByPath } from "@/lib/audience-taxonomy";
 
 /**
  * Source-partition test (PRD #4257's highest-value seam).
@@ -126,5 +127,127 @@ test("a shared page mounts into BOTH sections from the ONE real source file", ()
   );
   expect(selfHostedShared?.absolutePath).toBe(
     "content/shared/single-source-example.mdx",
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 3a (#4263) — the SaaS root stays free of self-hosted content.
+//
+// The saas-only pages enumerated in #4263 (billing & plans, enterprise SSO,
+// SCIM, PII masking, data residency, platform-ops, …) STAY at the site root and
+// are classified `saas-only` purely by living under `content/docs/`. This block
+// re-asserts the "SaaS never muddied by on-prem" guarantee against the taxonomy
+// classifier (`classifyByPath`, which reads the `CONTENT_ROOTS` SSOT) rather than
+// a bare path substring, and pins a representative set of the enumerated
+// saas-only topics into the root URL space. It also carries a negative control
+// so the classification assertion is a real leak detector, not a restatement of
+// self-hosted-free fixtures.
+//
+// Scope caveat: the PRODUCTION structural guarantee — that the root source is
+// never *wired* a self-hosted collection — lives at the call site in `source.ts`
+// (root = `docs + shared`, never `selfHosted`), which is bundler-only and can't
+// be loaded by `bun test`. These synthetic-fixture assertions characterize the
+// property; the negative control below proves the detector fires if that wiring
+// ever regressed.
+//
+// Uses its own uniquely-named topics fixture + source const (reusing only the
+// read-only top-of-file helpers), so sibling slices 3b (#4264) and 3c (#4265),
+// which also edit this file, don't collide with this block.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A representative slice of the #4263 saas-only pages. They live under
+// content/docs, so the directory taxonomy classifies each as `saas-only`.
+const saasOnlyTopics = [
+  doc(
+    "guides/billing-and-plans.mdx",
+    "content/docs/guides/billing-and-plans.mdx",
+    "Billing & Plans",
+  ),
+  doc(
+    "guides/enterprise-sso.mdx",
+    "content/docs/guides/enterprise-sso.mdx",
+    "Enterprise SSO",
+  ),
+  doc("guides/scim.mdx", "content/docs/guides/scim.mdx", "SCIM"),
+  doc(
+    "guides/pii-masking.mdx",
+    "content/docs/guides/pii-masking.mdx",
+    "PII Masking",
+  ),
+  doc(
+    "platform-ops/data-residency.mdx",
+    "content/docs/platform-ops/data-residency.mdx",
+    "Data Residency",
+  ),
+];
+
+// The SaaS root source is fed ONLY saas-only + api-reference + shared — never a
+// self-hosted collection.
+const saasOnlyRoot = buildSectionSource({
+  audience: collection([...saasOnlyTopics, ...apiDocs]),
+  shared: collection(sharedDocs),
+  baseUrl: "/",
+});
+const saasOnlyRootPages = saasOnlyRoot.getPages();
+const saasOnlyRootUrls = saasOnlyRootPages.map((p) => p.url);
+
+test("[#4263] every SaaS-root page classifies saas-only or shared — never self-hosted-only", () => {
+  // Cardinality floor FIRST: `.every()` is vacuously true on an empty array, so
+  // without this an empty getPages() (the composition regression this guarantee
+  // exists to catch) would pass silently. Exact count (5 saas topics + 2 api +
+  // 1 shared) also catches a shared page being double-mounted into the root.
+  expect(saasOnlyRootPages.length).toBe(
+    saasOnlyTopics.length + apiDocs.length + sharedDocs.length,
+  );
+  // The allow-list is the strong form: `saas-only || shared` implies
+  // `!== "self-hosted-only"` AND rejects a `null` class (a missing absolutePath),
+  // so it subsumes a separate "never self-hosted-only" check. Via classifyByPath
+  // (the taxonomy classifier), not a path substring.
+  expect(
+    saasOnlyRootPages.every((p) => {
+      const cls = classifyByPath(p.absolutePath ?? "");
+      return cls === "saas-only" || cls === "shared";
+    }),
+  ).toBe(true);
+});
+
+test("[#4263] leak detector has teeth: a self-hosted doc composed into root IS flagged", () => {
+  // Negative control. The test above builds root from only-saas fixtures, so its
+  // classifyByPath check is never seen to FAIL. First prove the predicate
+  // discriminates a real on-prem path; then prove that if the production wiring
+  // (source.ts) ever regressed to compose a self-hosted collection into the root,
+  // this seam flags it — so the assertion above is a real guard, not a fixture
+  // restatement.
+  expect(classifyByPath("content/self-hosted/docker.mdx")).toBe(
+    "self-hosted-only",
+  );
+
+  const leaky = buildSectionSource({
+    audience: collection([
+      ...saasOnlyTopics,
+      doc("docker.mdx", "content/self-hosted/docker.mdx", "Docker"),
+    ]),
+    shared: collection(sharedDocs),
+    baseUrl: "/",
+  });
+  expect(
+    leaky
+      .getPages()
+      .some((p) => classifyByPath(p.absolutePath ?? "") === "self-hosted-only"),
+  ).toBe(true);
+});
+
+test("[#4263] enumerated saas-only topics render at the site root, none under /self-hosted", () => {
+  for (const url of [
+    "/guides/billing-and-plans",
+    "/guides/enterprise-sso",
+    "/guides/scim",
+    "/guides/pii-masking",
+    "/platform-ops/data-residency",
+  ]) {
+    expect(saasOnlyRootUrls).toContain(url);
+  }
+  expect(saasOnlyRootUrls.every((u) => !u.startsWith("/self-hosted"))).toBe(
+    true,
   );
 });


### PR DESCRIPTION
## Slice 3a — classify + un-tab SaaS-only docs pages (#4263)

Per the **2026-07-03 grill banner** on #4263 this slice is near-trivial: SaaS-only
pages **stay at the site root** (`content/docs/**` IS the saas-only tree) → **no
file moves, no URL changes, no redirect input** from this slice.

### 1. Classify — no edits needed
Classification is directory-based via the slice-2 taxonomy (`CONTENT_ROOTS`):
everything under `content/docs/` resolves to `saas-only`. The 33 enumerated
saas-only pages (billing & plans, enterprise SSO, SCIM, PII masking,
white-labeling, multi-region login, multi-tenancy, compliance reporting, audit
retention, IP allowlisting, approval workflows, custom roles, proactive chat,
plugin marketplace, residency, onboarding emails, signup, hosted onboarding,
SaaS admin console, all of `platform-ops/`) already live under `content/docs/`
and are therefore already `saas-only`. No `audience:` frontmatter added — **no
existing content file uses it** (not even the slice-1/2 placeholders), so adding
it to 33 files would be churn against the established directory-is-SSOT
convention. `CONTENT_ROOTS` / `source.ts` untouched.

### 2. Un-tab — verified no-op
Exhaustively checked all 11 `content/docs` pages that use `<Tabs>`. **Only two
use hosted/self-hosted _audience_ tabs, and neither is saas-only:**
- `deployment/deploy.mdx` — `["SaaS (app.useatlas.dev)", "Self-Hosted"]` → self-hosted page, **#4264's**
- `guides/mcp.mdx` — `["Hosted (mcp.useatlas.dev)", "Self-hosted (stdio)"]` → shared page, **#4265's**

Every other `<Tabs>` (incl. `getting-started/hosted.mdx`'s PostgreSQL/MySQL tabs)
is a legitimate content tab (provider / OS / example), not an audience split. **No
saas-only page contains a hosted/self-hosted `<Tabs>`**, so the un-tab criterion
is satisfied with zero edits.

### 3. Source-partition test extended
`apps/docs/src/lib/__tests__/source-partition.test.ts` — self-contained,
clearly-labeled end-of-file block asserting the guarantee against the **taxonomy
classifier** (`classifyByPath`), not a path substring:
- cardinality floor + allow-list: every SaaS-root page classifies `saas-only` or
  `shared`, never `self-hosted-only`;
- **negative control**: a self-hosted doc composed into the root IS flagged —
  proving the check is a real leak detector, not a restatement of self-hosted-free
  fixtures (with an honest caveat that the production wiring guarantee lives in
  `source.ts`, which is bundler-only);
- enumerated saas-only topics render at the site root, never under `/self-hosted`.

Docs suite 41 → 42 pass; `bun run build` green (taxonomy gate passes, 645+ pages
+ `/self-hosted/*` generated).

### Truthfulness rider
Verified touched saas-only pages against source-of-truth. **2 trivial drifts
fixed inline**; no larger (issue-worthy) gaps found.
- `guides/signup.mdx` — launch region IDs `us-east`/`eu-west`/`ap-southeast` →
  `us`/`eu`/`apac`, matching the shipped prod `deploy/api/atlas.config.ts`
  residency keys + sibling `platform-ops/saas-environment-variables.mdx`.
- `platform-ops/data-residency.mdx` — prerequisite "Active Business plan" →
  "Active paid plan (Starter, Pro, or Business)"; residency is an all-paid
  entitlement (`packages/api/src/lib/billing/feature-entitlement.ts`), matching
  the page's own SaaS callout.
- **Verified accurate (no change):** all 10 enterprise-gate `requireEnterprise("…")`
  tags cited by the gate callouts (`sso`, `scim`, `pii-detection`, `branding`,
  `compliance`, `audit-retention`, `ip-allowlist`, `approval-workflows`, `roles`,
  `backups`) exist in `ee/src/**`; `multi-region-login.mdx` region front-door
  (`GET /api/v1/auth/region-map`, client `skip` decision); and env/config +
  route claims across billing, onboarding-emails, multi-tenancy, proactive-chat,
  plugin-marketplace, saas-environment-variables, byot-catalog-refresh, backups,
  custom-domains, admin-console (env vars, defaults, Stripe price IDs, admin
  routes all match code).

### Shared-file edits (conflict-awareness for parallel #4264/#4265)
- `source.ts` — **not touched**.
- `audience-taxonomy.ts` / `CONTENT_ROOTS` — **not touched**.
- Partition test — additive end-of-file block with uniquely-named fixtures
  (reuses only read-only top-of-file helpers); no mutation of the shared
  `root`/`selfHosted` fixtures.

### ⚠ Flagged for orchestrator — cross-slice content decision, NOT done here
6 saas-only pages carry dedicated **self-hosted operator sections** (headings) —
the real "SaaS muddied by on-prem" surface, but resolving them is a
content-architecture decision beyond this near-trivial slice (dropping loses
self-hosted content that siblings won't rescue — #4264/#4265 move *different*
files; the correct fix is reclassify-as-shared-with-`<WhenSelfHosted>` or extract
to the self-hosted tree). Pages:
`guides/billing-and-plans.mdx` (Stripe Setup / Self-Hosted Deployments),
`guides/multi-tenancy.mdx` (org-scoped connections / atlas init),
`guides/plugin-marketplace.mdx`, `guides/onboarding-emails.mdx` (Configuration),
`guides/signup.mdx` (Configuration), `platform-ops/mcp-load-test-tokens.mdx`.
The other ~27 saas-only pages carry only SaaS-relevant enterprise-gate disclosure
callouts (kept — they explain the tier/gate to a SaaS reader).

Refs #4263 (see flagged item for the residual self-hosted-prose decision).
