### PR TITLE
docs(4267): Slice 7 — Caddy 308 redirect map + redirect-coverage test

### DIFF
--- a/apps/docs/src/app/(self-hosted)/self-hosted/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(self-hosted)/self-hosted/[[...slug]]/page.tsx
@@ -2,6 +2,7 @@ import { selfHostedSource } from "@/lib/source";
 import { notFound } from "next/navigation";
 import { SectionDocsPage } from "@/components/section-docs-page";
 import { createSectionRelativeLink } from "@/lib/mdx-links";
+import { canonicalForSelfHostedMount } from "@/lib/redirects";
 
 // Self-hosted / on-prem docs at /self-hosted. Renders self-hosted-only content
 // plus the SAME shared pages as the root, with the "self-hosted" audience
@@ -40,5 +41,13 @@ export async function generateMetadata(props: {
   return {
     title: page.data.title,
     description: page.data.description,
+    // Canonical tag (#4267). A self-hosted-only page canonicalizes to its own
+    // /self-hosted URL (its old root URL now 308-redirects here); a shared page
+    // canonicalizes back to its site-root mount to avoid duplicate-content
+    // dilution. See canonicalForSelfHostedMount for the full rationale. Resolved
+    // against metadataBase (https://docs.useatlas.dev) in layout.tsx.
+    alternates: {
+      canonical: canonicalForSelfHostedMount(page.url, page.absolutePath),
+    },
   };
 }

--- a/apps/docs/src/lib/__tests__/redirect-coverage.test.ts
+++ b/apps/docs/src/lib/__tests__/redirect-coverage.test.ts
@@ -1,0 +1,224 @@
+import { test, expect, describe } from "bun:test";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import {
+  SELF_HOSTED_REDIRECTS,
+  MOVED_SELF_HOSTED_SLUGS,
+  canonicalForSelfHostedMount,
+} from "@/lib/redirects";
+
+/**
+ * Redirect-coverage test (PRD #4257 slice #4267).
+ *
+ * Slice #4264 (PR #4283) MOVED twelve self-hosted-only pages from the site root
+ * into the new `/self-hosted/*` section. This test guards that no pre-split
+ * on-prem URL 404s after the move — in BOTH directions:
+ *
+ *   forward (map -> Caddyfile / disk):
+ *     - the captured pre-split URL set is `SELF_HOSTED_REDIRECTS` — the checked-in
+ *       SSOT derived from the 3b git renames (see `@/lib/redirects`), *not* a list
+ *       hand-typed here that could drift;
+ *     - every captured old URL has a bare + trailing-slash 308 entry in the real
+ *       `deploy/docs/Caddyfile` pointing at its `/self-hosted` counterpart;
+ *     - every redirect target resolves to a real page on disk (no 404);
+ *     - the old root file is gone, so a redirect can't shadow a still-live page.
+ *
+ *   reverse (Caddyfile / disk -> map):
+ *     - every `/self-hosted` `redir` the Caddyfile actually serves is one the map
+ *       declares AND points at a real page — so a stale line left behind after a
+ *       page is deleted, or a hand-added stray, can't silently 308 -> 404;
+ *     - no moved page under content/self-hosted/ is missing from the map (a new
+ *       file there that isn't an acknowledged born-here page fails).
+ *
+ * Also unit-tests `canonicalForSelfHostedMount` — the one branching piece of
+ * logic in this slice, and a stated deliverable (canonical tags).
+ *
+ * Self-contained: read-only reads of the Caddyfile + a content/ filesystem walk;
+ * no bundler, no network, no git-at-runtime (CI checks out shallow).
+ */
+
+// src/lib/__tests__ -> apps/docs
+const DOCS_ROOT = join(import.meta.dir, "../../..");
+const CONTENT_SELF_HOSTED = join(DOCS_ROOT, "content/self-hosted");
+const CONTENT_DOCS = join(DOCS_ROOT, "content/docs");
+// apps/docs -> repo root -> deploy/docs/Caddyfile
+const CADDYFILE = join(DOCS_ROOT, "../../deploy/docs/Caddyfile");
+
+// Pages physically under content/self-hosted/ that were BORN there (there was no
+// `/self-hosted` before the split, so they have no pre-split URL and need no
+// redirect). Paths are relative to content/self-hosted/, forward-slash. Every
+// other .mdx under content/self-hosted/ MUST be a moved page in the redirect map
+// — a new file here that is neither allow-listed nor mapped fails the
+// completeness test, forcing either a redirect entry or an explicit born-here
+// acknowledgement.
+const BORN_UNDER_SELF_HOSTED = new Set(["index.mdx"]);
+
+// Normalize a Caddyfile line so `redir <from> <to> 308` matches regardless of
+// the file's tab indentation / internal spacing.
+const normalize = (line: string): string => line.trim().replace(/\s+/g, " ");
+
+const caddyLines: string[] = (() => {
+  if (!existsSync(CADDYFILE)) {
+    throw new Error(
+      `Caddyfile not found at ${CADDYFILE} — redirect-coverage test cannot verify the /self-hosted redirects`,
+    );
+  }
+  return readFileSync(CADDYFILE, "utf8").split("\n").map(normalize);
+})();
+
+function hasRedir(from: string, to: string): boolean {
+  return caddyLines.includes(`redir ${from} ${to} 308`);
+}
+
+// A `/self-hosted` URL (bare or trailing-slash) resolves to a real page iff the
+// section has a leaf `<slug>.mdx` or a section-index `<slug>/index.mdx`. The
+// twelve frozen slugs are all leaves today; the index arm keeps the check honest
+// if a future appended slug maps to a section landing page.
+function pageResolves(selfHostedUrl: string): boolean {
+  const slug = selfHostedUrl
+    .replace(/^\/self-hosted\/?/, "")
+    .replace(/\/$/, "");
+  if (slug === "") return existsSync(join(CONTENT_SELF_HOSTED, "index.mdx"));
+  return (
+    existsSync(join(CONTENT_SELF_HOSTED, `${slug}.mdx`)) ||
+    existsSync(join(CONTENT_SELF_HOSTED, slug, "index.mdx"))
+  );
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  // `withFileTypes` skips a per-entry statSync and does NOT follow directory
+  // symlinks, so a stray symlink under content/ can't drive unbounded recursion.
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+describe("self-hosted redirect coverage (#4267)", () => {
+  test("the move set is non-empty and derived 1:1 from the moved slugs", () => {
+    expect(MOVED_SELF_HOSTED_SLUGS.length).toBeGreaterThan(0);
+    expect(SELF_HOSTED_REDIRECTS.length).toBe(MOVED_SELF_HOSTED_SLUGS.length);
+  });
+
+  for (const { slug, from, to } of SELF_HOSTED_REDIRECTS) {
+    describe(`/${slug}`, () => {
+      test("is a clean /self-hosted prefix move (new URL derived, not typed)", () => {
+        expect(from).toBe(`/${slug}`);
+        expect(to).toBe(`/self-hosted/${slug}`);
+      });
+
+      test("has a bare-path 308 redirect in the Caddyfile", () => {
+        expect(hasRedir(from, to)).toBe(true);
+      });
+
+      test("has a trailing-slash 308 redirect in the Caddyfile", () => {
+        expect(hasRedir(`${from}/`, `${to}/`)).toBe(true);
+      });
+
+      test("target resolves to a real /self-hosted page (no 404)", () => {
+        expect(pageResolves(to)).toBe(true);
+      });
+
+      test("old root page is gone (redirect can't shadow a live page)", () => {
+        expect(existsSync(join(CONTENT_DOCS, `${slug}.mdx`))).toBe(false);
+      });
+    });
+  }
+
+  test("every /self-hosted redirect the Caddyfile serves is mapped and resolves (no stale/stray line)", () => {
+    const expectedFrom = new Set<string>();
+    const expectedTo = new Set<string>();
+    for (const { from, to } of SELF_HOSTED_REDIRECTS) {
+      expectedFrom.add(from).add(`${from}/`);
+      expectedTo.add(to).add(`${to}/`);
+    }
+    const redirLine = /^redir (\S+) (\S+) 308$/;
+    // Collect offenders (rather than asserting per-line) so a real failure names
+    // the exact Caddyfile line instead of a bare `false !== true`.
+    const unmapped: string[] = []; // hand-added stray or mismatched from/to
+    const unresolved: string[] = []; // stale 308 -> a page that no longer exists
+    for (const line of caddyLines) {
+      const match = redirLine.exec(line);
+      if (!match) continue;
+      const [, redirFrom, redirTo] = match;
+      // Only this slice's block (mcp-hosted etc. target other prefixes).
+      if (!redirTo.startsWith("/self-hosted")) continue;
+      // The line must be one the map declares ...
+      if (!expectedFrom.has(redirFrom) || !expectedTo.has(redirTo)) {
+        unmapped.push(line);
+        continue;
+      }
+      // ... and must resolve to a real page (catches a stale 308 -> 404 left
+      // behind after a page is deleted from both the map and disk).
+      if (!pageResolves(redirTo)) unresolved.push(line);
+    }
+    expect(unmapped).toEqual([]);
+    expect(unresolved).toEqual([]);
+  });
+
+  test("no moved content/self-hosted page is missing from the redirect map", () => {
+    const mapped = new Set<string>(MOVED_SELF_HOSTED_SLUGS);
+    const orphans: string[] = [];
+    for (const file of walk(CONTENT_SELF_HOSTED)) {
+      if (!file.endsWith(".mdx")) continue;
+      // Forward-slash the relative path so it matches map slugs on any OS.
+      const rel = relative(CONTENT_SELF_HOSTED, file).split(sep).join("/");
+      if (BORN_UNDER_SELF_HOSTED.has(rel)) continue;
+      const slug = rel.replace(/\.mdx$/, "");
+      if (!mapped.has(slug)) orphans.push(slug);
+    }
+    // Any orphan is either a page that moved from root without a redirect, or a
+    // newly born-here page that needs allow-listing. Either way: review it.
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe("canonicalForSelfHostedMount (#4267)", () => {
+  test("a self-hosted-only page canonicalizes to its own /self-hosted URL", () => {
+    expect(
+      canonicalForSelfHostedMount(
+        "/self-hosted/deployment/authentication",
+        "content/self-hosted/deployment/authentication.mdx",
+      ),
+    ).toBe("/self-hosted/deployment/authentication");
+  });
+
+  test("a shared page canonicalizes back to its site-root URL", () => {
+    expect(
+      canonicalForSelfHostedMount(
+        "/self-hosted/changelog",
+        "content/shared/changelog.mdx",
+      ),
+    ).toBe("/changelog");
+  });
+
+  test("a shared page mounted at the bare /self-hosted root maps back to /", () => {
+    expect(
+      canonicalForSelfHostedMount("/self-hosted", "content/shared/index.mdx"),
+    ).toBe("/");
+  });
+
+  test("a missing absolutePath falls back to self-hosted-only (no crash)", () => {
+    // Falls back to the safe assumption; the fn also warns (build-time anomaly).
+    expect(canonicalForSelfHostedMount("/self-hosted/docker", undefined)).toBe(
+      "/self-hosted/docker",
+    );
+    expect(canonicalForSelfHostedMount("/self-hosted/docker", "")).toBe(
+      "/self-hosted/docker",
+    );
+  });
+
+  test("does not strip a look-alike /self-hostedX prefix", () => {
+    // Boundary-anchored: only the `/self-hosted` segment is a mount prefix, so a
+    // self-hosted-only page whose slug itself starts with `self-hosted` is safe.
+    expect(
+      canonicalForSelfHostedMount(
+        "/self-hosted/self-hosted-models",
+        "content/self-hosted/guides/self-hosted-models.mdx",
+      ),
+    ).toBe("/self-hosted/self-hosted-models");
+  });
+});

--- a/apps/docs/src/lib/__tests__/source-partition.test.ts
+++ b/apps/docs/src/lib/__tests__/source-partition.test.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { buildSectionSource, type CollectionLike } from "@/lib/compose";
 import { classifyByPath } from "@/lib/audience-taxonomy";
+import { MOVED_SELF_HOSTED_SLUGS } from "@/lib/redirects";
 
 /**
  * Source-partition test (PRD #4257's highest-value seam).
@@ -164,25 +165,10 @@ const saasTreeFiles = contentFiles.filter((p) =>
   p.includes(`${join(CONTENT_DIR, "docs")}/`),
 );
 
-// Old-root slug → the self-hosted-only pages relocated by this slice (#4264).
-// Intentionally FROZEN to slice #4264's scope — this is a migration-landing
-// assertion, not a live inventory of the self-hosted tree. Later slices that
-// move more pages add their own block; they do not extend this list.
-const MOVED_SELF_HOSTED_SLUGS = [
-  "getting-started/quick-start",
-  "deployment/deploy",
-  "deployment/authentication",
-  "deployment/cache-configuration",
-  "frameworks/overview",
-  "frameworks/react-vite",
-  "frameworks/nuxt",
-  "frameworks/sveltekit",
-  "frameworks/tanstack-start",
-  "guides/self-hosted-models",
-  "contributing/ci",
-  "contributing/eval-harness",
-];
-
+// Old-root slug → the self-hosted-only pages relocated by slice #4264. This
+// migration-landing assertion and the #4267 redirect-coverage test share ONE
+// frozen move set — `MOVED_SELF_HOSTED_SLUGS` in `@/lib/redirects` (the redirect
+// SSOT) — so the redirect map and this partition check can never drift apart.
 test("every moved self-hosted-only page lives under content/self-hosted/ and NOT content/docs/", () => {
   for (const slug of MOVED_SELF_HOSTED_SLUGS) {
     expect(selfHostedFiles).toContain(

--- a/apps/docs/src/lib/redirects.ts
+++ b/apps/docs/src/lib/redirects.ts
@@ -1,0 +1,121 @@
+/**
+ * Self-hosted section redirect map — reviewed SSOT (PRD #4257, slice #4267).
+ *
+ * When slice #4264 (PR #4283) un-tabbed the docs portal, twelve self-hosted-only
+ * pages MOVED from the site root into the new `/self-hosted/*` section. Their old
+ * root URLs must keep working — external / customer-help-center inbound links and
+ * SEO both depend on it — so `deploy/docs/Caddyfile` 308-redirects each old URL to
+ * its `/self-hosted` counterpart, following the existing `mcp-hosted` prior art.
+ *
+ * This module is the single source of truth for that move set. It is exactly the
+ * git-renamed set from the 3b merge (commit 60f51bb49): every slug below is a
+ *   content/docs/<slug>.mdx  ->  content/self-hosted/<slug>.mdx
+ * rename. Verify / regenerate with (the pathspec must span BOTH the old and new
+ * trees, or git records each move as an Add, not a Rename, and reports nothing;
+ * the `.mdx$` filter drops the two `meta.json` section-nav renames, which are
+ * config, not pages, and carry no redirect):
+ *   git log --diff-filter=R --find-renames --name-status \
+ *     -- apps/docs/content/docs apps/docs/content/self-hosted \
+ *     | grep -E 'self-hosted/.*\.mdx$'
+ * Because the move is a clean prefix — old `/<slug>` -> new `/self-hosted/<slug>`
+ * — the new URL is *derived* from the slug, never hand-typed, so old and new can
+ * never disagree.
+ *
+ * Only these moved on-prem pages get redirects. SaaS pages stay at the site root
+ * and the API reference stays at `/api-reference/*` (both unchanged) — see the
+ * locked decisions in #4257.
+ *
+ * Drift guards (why this can't silently rot):
+ *  - `source-partition.test.ts` asserts every slug here now lives under
+ *    content/self-hosted/ and no longer under content/docs/.
+ *  - `redirect-coverage.test.ts` asserts the Caddyfile carries a bare +
+ *    trailing-slash 308 for each entry, that each target resolves to a real page
+ *    (no 404), that the old root file is gone (no shadowed live page), and that
+ *    no *other* moved page under content/self-hosted/ is missing from this map.
+ */
+
+/**
+ * Old-root slugs of the self-hosted-only pages relocated by slice #4264 (PR
+ * #4283). FROZEN to that move set — v0.0.42 moves no further pages (3a moved
+ * nothing; 3c added `/self-hosted` mounts of shared pages that KEPT their root
+ * URLs; the `/api-reference -> /api` move, #4261, was dropped). A later slice
+ * that genuinely moves more pages appends its own entries here.
+ */
+export const MOVED_SELF_HOSTED_SLUGS = [
+  "getting-started/quick-start",
+  "deployment/deploy",
+  "deployment/authentication",
+  "deployment/cache-configuration",
+  "frameworks/overview",
+  "frameworks/react-vite",
+  "frameworks/nuxt",
+  "frameworks/sveltekit",
+  "frameworks/tanstack-start",
+  "guides/self-hosted-models",
+  "contributing/ci",
+  "contributing/eval-harness",
+] as const;
+
+export interface DocRedirect {
+  /** Slug shared by the old and new URL (the clean-prefix move). */
+  readonly slug: string;
+  /**
+   * Pre-split public URL at the site root, no trailing slash. The `/${string}`
+   * template type makes the leading slash a compile error to omit.
+   */
+  readonly from: `/${string}`;
+  /**
+   * Post-split URL under the `/self-hosted` section, no trailing slash. The
+   * `/self-hosted/${string}` template type makes a target outside the section a
+   * compile error — the prefix invariant is enforced, not just documented.
+   */
+  readonly to: `/self-hosted/${string}`;
+}
+
+/**
+ * old root URL -> new `/self-hosted` URL, derived from the clean-prefix move.
+ * The Caddyfile emits a bare (`from` -> `to`) and a trailing-slash
+ * (`from/` -> `to/`) 308 for each entry, matching the `mcp-hosted` prior art;
+ * file_server then handles the bare -> trailing 301 at the destination.
+ */
+export const SELF_HOSTED_REDIRECTS: readonly DocRedirect[] =
+  MOVED_SELF_HOSTED_SLUGS.map((slug) => ({
+    slug,
+    from: `/${slug}`,
+    to: `/self-hosted/${slug}`,
+  }));
+
+/**
+ * Canonical URL for a page rendered under the `/self-hosted` mount (#4267).
+ *
+ * A self-hosted-only page's canonical home IS its `/self-hosted` URL — its old
+ * root URL now 308-redirects here, so crawlers should index the `/self-hosted`
+ * one. A SHARED page, though, is mounted into BOTH the site root and
+ * `/self-hosted` from a single source file, so the site-root mount is its
+ * canonical home (the PRD's clean, KB-linkable SaaS surface); for it this
+ * returns the stripped root URL, so the split doesn't dilute the page across two
+ * duplicate URLs. `absolutePath` under `content/shared/` is the reliable
+ * shared-mount signal (the same seam `source-partition.test` keys on).
+ *
+ * `absolutePath` is falsy only if Fumadocs fails to populate it — a build-time
+ * anomaly that would silently mis-canonicalize a shared page, so surface it
+ * (matching `githubEditPath` in `mdx-links.ts`) and fall back to the safe
+ * self-hosted-only assumption.
+ */
+export function canonicalForSelfHostedMount(
+  url: string,
+  absolutePath: string | undefined,
+): string {
+  if (!absolutePath) {
+    console.warn(
+      `[docs] canonicalForSelfHostedMount: page ${url} has no absolutePath; ` +
+        "treating as self-hosted-only for canonical (may mis-canonicalize a shared page)",
+    );
+  }
+  const isSharedMount = absolutePath?.includes("content/shared/") ?? false;
+  if (!isSharedMount) return url;
+  // Shared mount -> canonical is the site-root URL: strip the leading
+  // `/self-hosted` segment (anchored + boundary-aware so a hypothetical
+  // `/self-hostedX` can't match); `/self-hosted` itself maps back to `/`.
+  return url.replace(/^\/self-hosted(?=\/|$)/, "") || "/";
+}

--- a/deploy/docs/Caddyfile
+++ b/deploy/docs/Caddyfile
@@ -71,6 +71,47 @@
 	redir /guides/mcp-hosted /guides/mcp 308
 	redir /guides/mcp-hosted/ /guides/mcp/ 308
 
+	# ── BEGIN /self-hosted section redirects (#4267) ─────────────────────────
+	# Slice #4264 (PR #4283) un-tabbed the docs portal and MOVED twelve
+	# self-hosted-only pages from the site root into the new /self-hosted
+	# section (a clean-prefix rename: /<slug> -> /self-hosted/<slug>). Their old
+	# root URLs 308-redirect to the /self-hosted counterpart so external /
+	# help-center inbound links and SEO survive the move — same shape as the
+	# mcp-hosted block above: an EXACT-path bare + trailing-slash pair per page
+	# (file_server then does the bare -> trailing 301 at the destination). Only
+	# these moved on-prem pages redirect; SaaS root URLs and /api-reference/* are
+	# unchanged (#4257 locked decisions).
+	#
+	# SSOT for this list: apps/docs/src/lib/redirects.ts (MOVED_SELF_HOSTED_SLUGS)
+	# — apps/docs/src/lib/__tests__/redirect-coverage.test.ts fails if this block
+	# and that map ever drift apart, if a target 404s, or if a moved page is
+	# missing a redirect. Keep the two in lockstep.
+	redir /getting-started/quick-start /self-hosted/getting-started/quick-start 308
+	redir /getting-started/quick-start/ /self-hosted/getting-started/quick-start/ 308
+	redir /deployment/deploy /self-hosted/deployment/deploy 308
+	redir /deployment/deploy/ /self-hosted/deployment/deploy/ 308
+	redir /deployment/authentication /self-hosted/deployment/authentication 308
+	redir /deployment/authentication/ /self-hosted/deployment/authentication/ 308
+	redir /deployment/cache-configuration /self-hosted/deployment/cache-configuration 308
+	redir /deployment/cache-configuration/ /self-hosted/deployment/cache-configuration/ 308
+	redir /frameworks/overview /self-hosted/frameworks/overview 308
+	redir /frameworks/overview/ /self-hosted/frameworks/overview/ 308
+	redir /frameworks/react-vite /self-hosted/frameworks/react-vite 308
+	redir /frameworks/react-vite/ /self-hosted/frameworks/react-vite/ 308
+	redir /frameworks/nuxt /self-hosted/frameworks/nuxt 308
+	redir /frameworks/nuxt/ /self-hosted/frameworks/nuxt/ 308
+	redir /frameworks/sveltekit /self-hosted/frameworks/sveltekit 308
+	redir /frameworks/sveltekit/ /self-hosted/frameworks/sveltekit/ 308
+	redir /frameworks/tanstack-start /self-hosted/frameworks/tanstack-start 308
+	redir /frameworks/tanstack-start/ /self-hosted/frameworks/tanstack-start/ 308
+	redir /guides/self-hosted-models /self-hosted/guides/self-hosted-models 308
+	redir /guides/self-hosted-models/ /self-hosted/guides/self-hosted-models/ 308
+	redir /contributing/ci /self-hosted/contributing/ci 308
+	redir /contributing/ci/ /self-hosted/contributing/ci/ 308
+	redir /contributing/eval-harness /self-hosted/contributing/eval-harness 308
+	redir /contributing/eval-harness/ /self-hosted/contributing/eval-harness/ 308
+	# ── END /self-hosted section redirects (#4267) ───────────────────────────
+
 	# /<slug>.mdx -> /llms.mdx/<slug>/index.md (canonical markdown alias).
 	# `not path /llms.mdx*` keeps the regex from re-matching the bare
 	# /llms.mdx surface and the /llms.mdx/<slug> paths handled below.


### PR DESCRIPTION
## Slice 7 — Caddy 308 redirect map + redirect-coverage test

Closes #4267. Part of #4257 (v0.0.42 — Docs Portal Segmentation).

Slice 3b (#4264, merged PR #4283) un-tabbed the docs portal and **moved twelve self-hosted-only pages** from the site root into the new `/self-hosted/*` section. Their old root URLs must keep working — external / customer-help-center inbound links and SEO both depend on it. This slice closes that gap so **no pre-split on-prem URL 404s**.

### Scope (per #4267's 2026-07-03 banner + #4257's locked decisions)

Only the **moved on-prem pages** get redirects. **No SaaS redirects** (SaaS pages stay at the site root, unchanged) and **no `/api-reference → /api` redirects** (the API reference stays at `/api-reference/*`; the #4261 api-move was dropped).

### The redirect map (old → new)

Derived from the 3b git renames (clean `/self-hosted` prefix — old `/<slug>` → new `/self-hosted/<slug>`):

| Old (site root) | New (`/self-hosted`) |
|---|---|
| `/getting-started/quick-start` | `/self-hosted/getting-started/quick-start` |
| `/deployment/deploy` | `/self-hosted/deployment/deploy` |
| `/deployment/authentication` | `/self-hosted/deployment/authentication` |
| `/deployment/cache-configuration` | `/self-hosted/deployment/cache-configuration` |
| `/frameworks/overview` | `/self-hosted/frameworks/overview` |
| `/frameworks/react-vite` | `/self-hosted/frameworks/react-vite` |
| `/frameworks/nuxt` | `/self-hosted/frameworks/nuxt` |
| `/frameworks/sveltekit` | `/self-hosted/frameworks/sveltekit` |
| `/frameworks/tanstack-start` | `/self-hosted/frameworks/tanstack-start` |
| `/guides/self-hosted-models` | `/self-hosted/guides/self-hosted-models` |
| `/contributing/ci` | `/self-hosted/contributing/ci` |
| `/contributing/eval-harness` | `/self-hosted/contributing/eval-harness` |

### How the set was derived from 3b's renames

The move set is the git-renamed set from the 3b merge (commit `60f51bb49`). Verify / regenerate with (the pathspec must span **both** trees, or git records each move as an Add, not a Rename, and reports nothing):

```
git log --diff-filter=R --find-renames --name-status \
  -- apps/docs/content/docs apps/docs/content/self-hosted \
  | grep -E 'self-hosted/.*\.mdx$'
```

That lists exactly these 12 `content/docs/<slug>.mdx → content/self-hosted/<slug>.mdx` renames. (The two `meta.json` renames are section-nav config, not pages — no redirect.) The new URL is **derived** from the slug, never hand-typed, so old and new can't disagree.

### What's in the change set

- **`deploy/docs/Caddyfile`** — a clearly-delimited `BEGIN/END /self-hosted section redirects (#4267)` block of permanent **308** redirects, mirroring the existing `mcp-hosted` prior art exactly: an **exact-path** bare + trailing-slash pair per page (`file_server` then does the bare → trailing 301 at the destination). 24 lines = 12 bare + 12 trailing.
- **`apps/docs/src/lib/redirects.ts`** (new) — the reviewed SSOT map. `MOVED_SELF_HOSTED_SLUGS` is the frozen git-renamed set; `SELF_HOSTED_REDIRECTS` derives `from`/`to` from each slug. Also exports `canonicalForSelfHostedMount`.
- **Canonical tags** in the self-hosted route's `generateMetadata` — self-hosted-only pages canonicalize to their `/self-hosted` URL (crawlers index the new URL); **shared** pages (mounted into both sections from one file) canonicalize back to their **site-root** primary, so the split doesn't dilute a shared page across two duplicate URLs.
- **`apps/docs/src/lib/__tests__/redirect-coverage.test.ts`** (new) — see below.
- **`source-partition.test.ts`** — de-duped onto the shared SSOT slug list (one home for the move set → the redirect map and the migration-landing assertion can't drift apart).

### Redirect-coverage test

Self-contained (read-only Caddyfile read + a `content/` filesystem walk; **no git-at-runtime** — CI checks out shallow). Asserts, in both directions:

- **forward (map → Caddyfile / disk):** every captured old URL has a bare + trailing-slash 308 in the real Caddyfile → its `/self-hosted` counterpart; every target resolves to a real page (no 404); the old root file is gone (a redirect can't shadow a still-live page).
- **reverse (Caddyfile / disk → map):** every `/self-hosted` `redir` the Caddyfile serves is one the map declares **and** resolves to a real page (catches a stale line → 404 or a hand-added stray); and no moved page under `content/self-hosted/` is missing from the map (`index.mdx` is the one acknowledged born-here page).
- **canonical helper unit tests** — the 5 branch cases (self-hosted-only, shared → root, bare `/self-hosted` → `/`, missing `absolutePath` fallback, `/self-hostedX` look-alike non-strip).

### Merge-coordination note

The Caddyfile block is fenced with `BEGIN/END /self-hosted section redirects (#4267)` comment markers. **Slice 6 (#4266)** also edits `deploy/docs/Caddyfile` (self-hosted machine surfaces / `/llms.mdx` twins) — the fenced block keeps the two changes cleanly separable.

### Gates

- `/review-panel` — **CLEAN**, converged in 2 rounds (silent-failure, type-design, comment-accuracy, test-coverage).
- Local `/ci` — **28/28 gates green** (incl. full test suite).
- `cd apps/docs && bun run build` — green; verified in the static export: moved page → `<link rel="canonical" href=".../self-hosted/deployment/authentication/">`, shared page `/self-hosted/changelog` → `<link rel="canonical" href=".../changelog/">`.

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v
