### PR TITLE
docs: Slice 9 truthfulness backstop + de-muddy 6 SaaS pages (#4274, #4282)

### DIFF
--- a/apps/docs/content/docs/guides/api-keys.mdx
+++ b/apps/docs/content/docs/guides/api-keys.mdx
@@ -105,7 +105,7 @@ interactive session — a key cannot mint another key.
 
 ### RLS claims are bounded to the minter
 
-When the workspace uses [row-level security](/deployment/row-level-security), a key can
+When the workspace uses [row-level security](/security/row-level-security), a key can
 carry RLS claim values so queries are filtered. Those claims are **bounded to the minting
 admin's own claims**: you can only embed a claim key/value you already hold (the
 claims-axis mirror of the role ceiling — a key never grants reach the minter lacks).

--- a/apps/docs/content/docs/guides/billing-and-plans.mdx
+++ b/apps/docs/content/docs/guides/billing-and-plans.mdx
@@ -14,10 +14,8 @@ Billing is a per-seat **platform fee** — the listed plan price ($39 / $69 / $1
 On [app.useatlas.dev](https://app.useatlas.dev), billing is fully managed. View your usage, manage your plan, and update payment methods from **Admin > Billing** — no Stripe setup required on your end.
 </Callout>
 
-<Callout title="Self-hosted prerequisites">
-- Internal database configured (`DATABASE_URL`) — required for usage tracking
-- `STRIPE_SECRET_KEY` set — enables billing routes and Stripe integration
-- Admin role required for the billing dashboard
+<Callout>
+Running Atlas yourself? Self-hosted deployments are **free with no billing enforcement**. If you want to bill your own users, see [Self-Hosted Billing](/self-hosted/guides/self-hosted-billing) for the Stripe setup.
 </Callout>
 
 ---
@@ -115,7 +113,7 @@ The **Spend Policy** setting (`ATLAS_SPEND_POLICY`, workspace-scoped, hot-reload
 - **`continue`** (default) — keep serving at provider cost past the credit. The hard-limit ceiling is the **abuse / spend ceiling** (`ATLAS_ABUSE_CEILING`, default **500%** of the credit = 5× ≈ $100/seat) — a runaway-spend backstop, not an everyday limit. Usage from 100% to the ceiling is metered at cost; at or above it, requests return 429. Set the ceiling to `0` (or empty) for pure metering with no cutoff.
 - **`cutoff`** — hard-block the moment the credit is spent: the ceiling clamps to 100% of the credit, so any overage immediately returns 429.
 
-Metered overage is billed at provider cost (1:1, in cents) via Stripe when overage Price IDs are configured — see [Stripe Setup](#stripe-setup-self-hosted). To remove usage limits entirely, enable [BYOT](#byot-bring-your-own-token) and use your own API keys.
+Metered overage is billed at provider cost (1:1, in cents) via Stripe. On the hosted SaaS this is pre-configured — nothing to set up on your end. To remove usage limits entirely, enable [BYOT](#byot-bring-your-own-token) and use your own API keys.
 
 ### Enforcement Skipped
 
@@ -221,107 +219,7 @@ If a Stripe call fails during one of these actions, the operation still complete
 
 ---
 
-## Stripe Setup (Self-Hosted)
-
-<Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), Stripe is pre-configured. Skip this section — manage your subscription from **Admin > Billing** instead.
-</Callout>
-
-Set these two environment variables to enable billing — they are the only
-Stripe **secrets**, so they stay in env:
-
-| Variable | Description |
-|----------|-------------|
-| `STRIPE_SECRET_KEY` | Stripe secret key (test or live). Enables billing routes when set |
-| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret for verifying events |
-
-The six per-tier **seat Price IDs** are non-secret constants and live in the
-settings registry under **Admin → Settings → Billing** (platform admins only).
-They are runtime-editable and hot-reloadable — a pricing change takes effect
-without a redeploy ([#3703](https://github.com/AtlasDevHQ/atlas/issues/3703)).
-The matching environment variables still work as a fallback when no settings
-override is present:
-
-| Setting / env fallback | Description |
-|----------|-------------|
-| `STRIPE_STARTER_PRICE_ID` | Price ID for the Starter plan (monthly) |
-| `STRIPE_STARTER_ANNUAL_PRICE_ID` | Price ID for the Starter plan (annual) |
-| `STRIPE_PRO_PRICE_ID` | Price ID for the Pro plan (monthly) |
-| `STRIPE_PRO_ANNUAL_PRICE_ID` | Price ID for the Pro plan (annual) |
-| `STRIPE_BUSINESS_PRICE_ID` | Price ID for the Business plan (monthly) |
-| `STRIPE_BUSINESS_ANNUAL_PRICE_ID` | Price ID for the Business plan (annual) |
-
-A missing monthly Price ID silently omits that tier from checkout, so it is
-surfaced as an operator-actionable warning in the boot log (not a boot
-failure). Set the missing ID from **Admin → Settings → Billing**.
-
-### Metered-overage Price IDs (at-cost)
-
-For **at-cost metered overage** (the `continue` spend policy, usage past the
-included credit), Atlas bills the excess 1:1 with provider cost via a single
-shared Stripe **Billing Meter** (`atlas_usage_overage_cents`, priced at 1 cent
-per metered unit) plus a per-tier overage Price ID, added as a **second**
-subscription line item. These IDs are platform-scoped settings with env
-fallback — runtime-editable and hot-reloadable, exactly like the seat Price IDs
-above:
-
-| Setting / env fallback | Description |
-|----------|-------------|
-| `STRIPE_STARTER_OVERAGE_PRICE_ID` | At-cost overage Price ID for Starter (metered; billed in cents, 1:1 with provider cost) |
-| `STRIPE_PRO_OVERAGE_PRICE_ID` | At-cost overage Price ID for Pro |
-| `STRIPE_BUSINESS_OVERAGE_PRICE_ID` | At-cost overage Price ID for Business |
-
-Without an overage Price ID for a tier, usage past the credit is still metered
-and shown on the dashboard but **not billed** (a missing one surfaces as a boot
-warning, not a failure). SaaS pre-configures these; self-hosted operators who
-want to bill overage create the meter + prices in their own Stripe account.
-
-When `STRIPE_SECRET_KEY` is set:
-
-- Billing routes mount at `/api/v1/billing`
-- The Better Auth Stripe plugin handles checkout, webhooks, and subscription lifecycle at `/api/auth/stripe/*`
-- Plan changes from Stripe webhooks automatically update the workspace tier
-
-### Webhook Configuration
-
-Point your Stripe webhook endpoint to:
-
-```
-https://your-atlas.example.com/api/auth/stripe/webhook
-```
-
-For local development, use [Stripe CLI](https://docs.stripe.com/stripe-cli) to forward webhooks:
-
-```bash
-stripe listen --forward-to localhost:3001/api/auth/stripe/webhook
-```
-
-<Callout type="warn">
-The webhook signing secret (`STRIPE_WEBHOOK_SECRET`) must match the secret shown by `stripe listen` or configured in your Stripe dashboard. Mismatched secrets cause silent webhook failures.
-</Callout>
-
----
-
-## Self-Hosted Deployments
-
-Self-hosted Atlas has **no billing enforcement**. The `free` tier is assigned by default with unlimited queries, members, and connections. No Stripe configuration is needed.
-
-To run Atlas without any billing:
-
-1. Omit all `STRIPE_*` environment variables
-2. The billing routes will not mount
-3. The billing dashboard still works for monitoring (if `DATABASE_URL` is configured) but shows "Unlimited" for all limits
-
----
-
 ## Troubleshooting
-
-### Stripe webhooks not arriving
-
-- Verify `STRIPE_WEBHOOK_SECRET` matches the signing secret from your Stripe dashboard or `stripe listen` output
-- Ensure the webhook endpoint (`/api/auth/stripe/webhook`) is publicly reachable
-- Check Stripe dashboard **Developers > Webhooks** for failed delivery attempts
-- For local development, confirm `stripe listen` is running and forwarding to the correct port
 
 ### Plan not syncing after payment
 

--- a/apps/docs/content/docs/guides/signup.mdx
+++ b/apps/docs/content/docs/guides/signup.mdx
@@ -11,10 +11,8 @@ Atlas includes a self-serve signup flow that walks new users through account cre
 On [app.useatlas.dev](https://app.useatlas.dev), signup is available immediately at [app.useatlas.dev/signup](https://app.useatlas.dev/signup). Social login (Google, GitHub, Microsoft) is pre-configured. Skip to [How It Works](#how-it-works) for the user experience.
 </Callout>
 
-<Callout title="Self-hosted prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled (`ATLAS_AUTH_MODE=managed`)
-- Internal database configured (`DATABASE_URL`)
-- At least one LLM provider configured (`ATLAS_PROVIDER` + API key)
+<Callout>
+Running Atlas yourself? See [Self-Serve Signup (Self-Hosted)](/self-hosted/guides/self-serve-signup) for the managed-auth, social-login, and datasource setup that powers this wizard on your own deployment.
 </Callout>
 
 ---
@@ -103,34 +101,6 @@ Earlier builds saved the region with a `POST /api/v1/onboarding/assign-region` c
 
 ---
 
-## Enabling Social Login
-
-<Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), Google, GitHub, and Microsoft login are pre-configured. This section is for self-hosted operators only.
-</Callout>
-
-Social OAuth buttons appear automatically when the corresponding environment variables are set. Each provider requires both a client ID and client secret:
-
-| Provider | Environment Variables |
-|----------|----------------------|
-| Google | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
-| GitHub | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` |
-| Microsoft | `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET` |
-
-```bash
-# .env — enable Google and GitHub OAuth
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
-GITHUB_CLIENT_ID=your-github-client-id
-GITHUB_CLIENT_SECRET=your-github-client-secret
-```
-
-The signup page checks which providers are available via `GET /api/v1/onboarding/social-providers` and renders OAuth buttons accordingly. If no social providers are configured, only email/password signup is shown.
-
-See [Social Providers](/guides/social-providers) for detailed OAuth setup instructions per provider.
-
----
-
 ## Database Connection
 
 In the connect step (step 5 with the region step, step 4 without it), the user pastes a database URL (`postgresql://` or `mysql://`). The wizard:
@@ -208,26 +178,6 @@ Response (201):
 
 ---
 
-## Configuration (Self-Hosted)
-
-<Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), auth and datasource configuration is handled automatically during signup. This section is for self-hosted operators only.
-</Callout>
-
-```typescript
-// atlas.config.ts
-export default defineConfig({
-  auth: "managed",
-  datasources: {
-    default: { url: process.env.ATLAS_DATASOURCE_URL! },
-  },
-});
-```
-
-For most self-serve deployments, the datasource URL comes from the onboarding flow rather than a static config file. The `atlas.config.ts` is primarily used for self-hosted deployments with pre-configured connections.
-
----
-
 ## Claiming a Self-Serve (MCP) Trial
 
 <Callout type="info" title="SaaS only">
@@ -280,7 +230,7 @@ Signup creates your first workspace. If you later need another one — a separat
 
 ## See Also
 
-- [Authentication](/deployment/authentication) — Auth mode setup and configuration
+- [Self-Serve Signup (Self-Hosted)](/self-hosted/guides/self-serve-signup) — Managed-auth, social-login, and datasource setup for your own deployment
 - [Multi-Region Login](/guides/multi-region-login) — How returning users are routed back to their workspace's region
 - [Social Providers](/guides/social-providers) — Detailed OAuth setup per provider
 - [Admin Console](/guides/admin-console) — Manage connections and users after signup

--- a/apps/docs/content/docs/guides/starter-prompt-moderation.mdx
+++ b/apps/docs/content/docs/guides/starter-prompt-moderation.mdx
@@ -115,7 +115,7 @@ The admin UI is a thin layer over four endpoints. Each requires a workspace admi
 
 Every mutation writes `status = 'draft'` when called from developer mode and `'published'` otherwise. Draft starter prompts land in `draftCounts.starterPrompts` on `GET /api/v1/mode` and promote atomically via `POST /api/v1/admin/publish`.
 
-See the [API reference](/api-reference/admin-starter-prompts) for full request/response schemas.
+See the [API reference](/api-reference/admin-starter-prompts/getAdminStarterPromptsQueue) for full request/response schemas.
 
 ---
 

--- a/apps/docs/content/docs/guides/starter-prompts.mdx
+++ b/apps/docs/content/docs/guides/starter-prompts.mdx
@@ -39,7 +39,7 @@ Favorites are per-user, scoped to the current workspace, and persist across devi
 - **Unpin**: hover a pinned prompt in the empty state — the pin icon becomes an unpin affordance.
 - **Cross-surface cache**: pinning in chat immediately updates the notebook empty state and the widget (if embedded on the same origin) without a re-fetch. The TanStack Query cache shares across surfaces.
 
-API surface: `POST` / `DELETE` `/api/v1/starter-prompts/favorites` (see [API Reference](/api-reference/starter-prompts)).
+API surface: `POST` / `DELETE` `/api/v1/starter-prompts/favorites` (see [API Reference](/api-reference/starter-prompts/getStarterPrompts)).
 
 ---
 

--- a/apps/docs/content/docs/platform-ops/mcp-load-test-tokens.mdx
+++ b/apps/docs/content/docs/platform-ops/mcp-load-test-tokens.mdx
@@ -185,18 +185,6 @@ The `bearer` is **never** in metadata. If you find a bearer in any
 audit row, treat that as a P1 incident — the contract is that
 issuance and use are correlated only via the `jti`.
 
-## Self-hosted
-
-The endpoint works on self-hosted deployments too — operators load-test
-their single instance the same way. Standard auth applies; nothing here
-is SaaS-specific.
-
-When `residency.regions` isn't configured (the typical self-hosted
-case), the audience and issuer fall back to the request origin
-(matching the same shape `hosted.ts:resourceAudience` reads at the
-verifier boundary). Set `ATLAS_PUBLIC_API_URL` if your verifier
-audience differs from the request `Host`.
-
 ## Related
 
 - [MCP guide — hosted](/guides/mcp#hosted-protocol-reference) — DCR + PKCE flow for

--- a/apps/docs/content/self-hosted/deployment/load-testing.mdx
+++ b/apps/docs/content/self-hosted/deployment/load-testing.mdx
@@ -1,0 +1,73 @@
+---
+title: Load-Testing MCP
+description: Mint short-lived bearer JWTs to k6-drive your self-hosted MCP surface under load
+---
+
+The `POST /api/v1/me/load-test/mcp-token` endpoint mints a short-lived,
+MCP-scoped JWT bearer for the caller's own active workspace so k6 (or any HTTP
+client) can exercise your MCP surface under load without running the full OAuth
+2.1 ceremony (DCR + auth-code + PKCE) on every CI run. It works the same on a
+self-hosted deployment as on the hosted platform — standard auth applies and
+nothing about it is SaaS-specific.
+
+## Mint a bearer
+
+The token is signed by the same Better Auth JWKS the OAuth 2.1 path uses, so the
+MCP edge verifier resolves the matching public key through `/api/auth/jwks` and
+verifies it identically to a real OAuth-issued token — there is no "load-test
+only" verifier path.
+
+```bash
+# Step 1: sign in, capture the session token
+SESSION=$(curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"email":"'"$EMAIL"'","password":"'"$PASSWORD"'"}' \
+  https://atlas.internal.example.com/api/auth/sign-in/email \
+  | jq -r .token)
+
+# Step 2: mint the bearer (ttlSeconds is optional; default 300, ceiling 3600)
+TOKEN=$(curl -s -X POST \
+  -H "Authorization: Bearer $SESSION" \
+  -H "Content-Type: application/json" \
+  -d '{"ttlSeconds":600}' \
+  https://atlas.internal.example.com/api/v1/me/load-test/mcp-token \
+  | jq -r .bearer)
+
+# Step 3: drive k6 with the bearer as an env var so it never lands in stdout
+MCP_BEARER="$TOKEN" k6 run loadtest/mcp-profile.js
+```
+
+`Authorization: Bearer <session-token>` is required — cookie-only auth is
+rejected with 401. The session bearer comes from `POST /api/auth/sign-in/email`
+(Better Auth's `bearer()` plugin returns it in the response body's `token`
+field). The minted token is bound to the caller's active workspace and carries
+`scope: "mcp:read"` — write capability is gated at the tool layer and this
+endpoint never grants it. Every successful mint writes an awaited
+`admin_action_log` row; the `bearer` is **never** in the audit metadata (only the
+`jti`), so load traffic is filterable via `actor_id LIKE 'loadtest:%'` without
+leaking the credential.
+
+## Self-hosted specifics
+
+- **No org allowlist by default.** `ATLAS_LOADTEST_ALLOWED_ORGS` (a
+  comma-separated list of workspace ids) restricts who can mint; when it is
+  unset — the typical self-hosted case — every authenticated workspace member
+  can mint.
+- **Audience / issuer fall back to the request origin.** When
+  `residency.regions` isn't configured (the typical self-hosted case), the
+  token's `aud` and `iss` claims fall back to the request origin — the same
+  shape `hosted.ts:resourceAudience` reads at the verifier boundary. Set
+  `ATLAS_PUBLIC_API_URL` if your verifier audience differs from the request
+  `Host`.
+- **Requires an internal database.** The mint reads the Better Auth `jwks`
+  table, so `DATABASE_URL` must be set; otherwise the endpoint returns
+  `404 not_configured`. If the `jwks` table is empty, hit any `/api/auth/*`
+  endpoint once to seed the keypair, then retry.
+
+Do not embed bearers in logs or reuse them across CI runs — mint per-run with an
+appropriate TTL (5–10 minutes is enough for most load profiles); the short TTL
+is what bounds the blast radius.
+
+## Related
+
+- [MCP](/self-hosted/sdk/mcp) — the DCR + PKCE flow for real MCP clients.

--- a/apps/docs/content/self-hosted/deployment/meta.json
+++ b/apps/docs/content/self-hosted/deployment/meta.json
@@ -2,5 +2,5 @@
   "title": "Deployment",
   "description": "Deploy to Docker, Railway, or Vercel",
   "icon": "CloudUpload",
-  "pages": ["deploy", "authentication", "cache-configuration"]
+  "pages": ["deploy", "authentication", "cache-configuration", "load-testing"]
 }

--- a/apps/docs/content/self-hosted/guides/meta.json
+++ b/apps/docs/content/self-hosted/guides/meta.json
@@ -2,5 +2,12 @@
   "title": "Guides",
   "description": "Operator walkthroughs for self-hosted Atlas",
   "icon": "BookOpen",
-  "pages": ["self-hosted-models"]
+  "pages": [
+    "multi-tenancy",
+    "plugin-marketplace",
+    "onboarding-emails",
+    "self-serve-signup",
+    "self-hosted-billing",
+    "self-hosted-models"
+  ]
 }

--- a/apps/docs/content/self-hosted/guides/self-hosted-billing.mdx
+++ b/apps/docs/content/self-hosted/guides/self-hosted-billing.mdx
@@ -1,0 +1,124 @@
+---
+title: Self-Hosted Billing
+description: Self-hosted Atlas is free with no billing enforcement — and how to wire up Stripe if you want to bill your own users.
+icon: CreditCard
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Self-hosted Atlas has **no billing enforcement**. The `free` tier is assigned by
+default with unlimited queries, members, and connections, and no Stripe
+configuration is needed. This page is only relevant if you want to run Atlas as
+your own paid product and bill your users through Stripe.
+
+<Callout title="Prerequisites">
+- Internal database configured (`DATABASE_URL`) — required for usage tracking
+- `STRIPE_SECRET_KEY` set — enables billing routes and the Stripe integration
+- Admin role required for the billing dashboard
+</Callout>
+
+To run Atlas without any billing at all:
+
+1. Omit all `STRIPE_*` environment variables
+2. The billing routes will not mount
+3. The billing dashboard still works for monitoring (if `DATABASE_URL` is configured) but shows "Unlimited" for all limits
+
+The plan tiers, usage credit, spend policy, enforcement bands, and Stripe
+lifecycle handling are all documented on the hosted [Billing & Plans](/guides/billing-and-plans)
+page — they behave identically on a self-hosted deployment once Stripe is
+configured below.
+
+---
+
+## Stripe Setup
+
+Set these two environment variables to enable billing — they are the only Stripe
+**secrets**, so they stay in env:
+
+| Variable | Description |
+|----------|-------------|
+| `STRIPE_SECRET_KEY` | Stripe secret key (test or live). Enables billing routes when set |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret for verifying events |
+
+The six per-tier **seat Price IDs** are non-secret constants and live in the
+settings registry under **Admin → Settings → Billing** (platform admins only).
+They are runtime-editable and hot-reloadable — a pricing change takes effect
+without a redeploy ([#3703](https://github.com/AtlasDevHQ/atlas/issues/3703)).
+The matching environment variables still work as a fallback when no settings
+override is present:
+
+| Setting / env fallback | Description |
+|----------|-------------|
+| `STRIPE_STARTER_PRICE_ID` | Price ID for the Starter plan (monthly) |
+| `STRIPE_STARTER_ANNUAL_PRICE_ID` | Price ID for the Starter plan (annual) |
+| `STRIPE_PRO_PRICE_ID` | Price ID for the Pro plan (monthly) |
+| `STRIPE_PRO_ANNUAL_PRICE_ID` | Price ID for the Pro plan (annual) |
+| `STRIPE_BUSINESS_PRICE_ID` | Price ID for the Business plan (monthly) |
+| `STRIPE_BUSINESS_ANNUAL_PRICE_ID` | Price ID for the Business plan (annual) |
+
+A missing monthly Price ID silently omits that tier from checkout, so it is
+surfaced as an operator-actionable warning in the boot log (not a boot
+failure). Set the missing ID from **Admin → Settings → Billing**.
+
+### Metered-overage Price IDs (at-cost)
+
+For **at-cost metered overage** (the `continue` spend policy, usage past the
+included credit), Atlas bills the excess 1:1 with provider cost via a single
+shared Stripe **Billing Meter** (`atlas_usage_overage_cents`, priced at 1 cent
+per metered unit) plus a per-tier overage Price ID, added as a **second**
+subscription line item. These IDs are platform-scoped settings with env
+fallback — runtime-editable and hot-reloadable, exactly like the seat Price IDs
+above:
+
+| Setting / env fallback | Description |
+|----------|-------------|
+| `STRIPE_STARTER_OVERAGE_PRICE_ID` | At-cost overage Price ID for Starter (metered; billed in cents, 1:1 with provider cost) |
+| `STRIPE_PRO_OVERAGE_PRICE_ID` | At-cost overage Price ID for Pro |
+| `STRIPE_BUSINESS_OVERAGE_PRICE_ID` | At-cost overage Price ID for Business |
+
+Without an overage Price ID for a tier, usage past the credit is still metered
+and shown on the dashboard but **not billed** (a missing one surfaces as a boot
+warning, not a failure). Create the meter + prices in your own Stripe account to
+bill overage.
+
+When `STRIPE_SECRET_KEY` is set:
+
+- Billing routes mount at `/api/v1/billing`
+- The Better Auth Stripe plugin handles checkout, webhooks, and subscription lifecycle at `/api/auth/stripe/*`
+- Plan changes from Stripe webhooks automatically update the workspace tier
+
+### Webhook Configuration
+
+Point your Stripe webhook endpoint to:
+
+```
+https://your-atlas.example.com/api/auth/stripe/webhook
+```
+
+For local development, use [Stripe CLI](https://docs.stripe.com/stripe-cli) to forward webhooks:
+
+```bash
+stripe listen --forward-to localhost:3001/api/auth/stripe/webhook
+```
+
+<Callout type="warn">
+The webhook signing secret (`STRIPE_WEBHOOK_SECRET`) must match the secret shown by `stripe listen` or configured in your Stripe dashboard. Mismatched secrets cause silent webhook failures.
+</Callout>
+
+---
+
+## Troubleshooting
+
+### Stripe webhooks not arriving
+
+- Verify `STRIPE_WEBHOOK_SECRET` matches the signing secret from your Stripe dashboard or `stripe listen` output
+- Ensure the webhook endpoint (`/api/auth/stripe/webhook`) is publicly reachable
+- Check Stripe dashboard **Developers > Webhooks** for failed delivery attempts
+- For local development, confirm `stripe listen` is running and forwarding to the correct port
+
+---
+
+## See Also
+
+- [Billing & Plans](/guides/billing-and-plans) — Plan tiers, usage credit, spend policy, and enforcement (behaves identically once Stripe is configured)
+- [Environment Variables](/reference/environment-variables#stripe-billing) — Full Stripe variable reference

--- a/apps/docs/content/self-hosted/guides/self-serve-signup.mdx
+++ b/apps/docs/content/self-hosted/guides/self-serve-signup.mdx
@@ -1,0 +1,79 @@
+---
+title: Self-Serve Signup (Self-Hosted)
+description: Enable the browser-based signup wizard on your own deployment — managed auth, social login, and datasource setup.
+icon: UserPlus
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas ships a self-serve signup flow that walks new users through account
+creation, workspace setup, and database connection — all from the browser. The
+[user-facing walkthrough](/guides/signup) covers what the wizard does; this page
+covers the operator setup that turns it on for a self-hosted deployment.
+
+<Callout title="Prerequisites">
+- [Managed auth](/self-hosted/deployment/authentication#managed-auth) enabled (`ATLAS_AUTH_MODE=managed`)
+- Internal database configured (`DATABASE_URL`)
+- At least one LLM provider configured (`ATLAS_PROVIDER` + API key)
+</Callout>
+
+<Callout type="info">
+The business-email gate, multi-region residency step, and MCP-trial claim flow described in the [main signup guide](/guides/signup) are SaaS-only — a self-hosted signup is a five-step flow (email → create account → name workspace → connect database → done), and operators control who may sign up.
+</Callout>
+
+---
+
+## Configuration
+
+Point Atlas at managed auth and (optionally) a pre-configured datasource in
+`atlas.config.ts`:
+
+```typescript
+// atlas.config.ts
+export default defineConfig({
+  auth: "managed",
+  datasources: {
+    default: { url: process.env.ATLAS_DATASOURCE_URL! },
+  },
+});
+```
+
+For most self-serve deployments, the datasource URL comes from the onboarding
+flow rather than a static config file. The `atlas.config.ts` datasource is
+primarily used for self-hosted deployments with pre-configured connections.
+
+---
+
+## Enabling Social Login
+
+Social OAuth buttons appear automatically when the corresponding environment
+variables are set. Each provider requires both a client ID and client secret:
+
+| Provider | Environment Variables |
+|----------|----------------------|
+| Google | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
+| GitHub | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` |
+| Microsoft | `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET` |
+
+```bash
+# .env — enable Google and GitHub OAuth
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+```
+
+The signup page checks which providers are available via
+`GET /api/v1/onboarding/social-providers` and renders OAuth buttons accordingly.
+If no social providers are configured, only email/password signup is shown.
+
+See [Social Providers](/guides/social-providers) for detailed OAuth setup
+instructions per provider.
+
+---
+
+## See Also
+
+- [Self-Serve Signup](/guides/signup) — The user-facing wizard walkthrough and API endpoints
+- [Authentication](/self-hosted/deployment/authentication) — Managed-auth mode setup and configuration
+- [Social Providers](/guides/social-providers) — Detailed OAuth setup per provider

--- a/apps/docs/content/shared/guides/multi-tenancy.mdx
+++ b/apps/docs/content/shared/guides/multi-tenancy.mdx
@@ -7,15 +7,19 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Atlas supports multi-tenancy through [Better Auth organizations](https://www.better-auth.com/docs/plugins/organization). Each organization gets isolated semantic layers, connection pools, and query caches — preventing data leakage and noisy-neighbor issues between tenants.
 
+<WhenSaaS>
 <Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), multi-tenancy is built in. Your workspace is an organization — manage members and roles from **Admin > Organization**. The infrastructure sections below (per-org pooling, scaling config) are handled automatically.
+On [app.useatlas.dev](https://app.useatlas.dev), multi-tenancy is built in. Your workspace is an organization — manage members and roles from **Admin > Organization**. The infrastructure sections (per-org pooling, scaling config) are handled automatically.
 </Callout>
+</WhenSaaS>
 
+<WhenSelfHosted>
 <Callout title="Self-hosted prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled (`BETTER_AUTH_SECRET` set)
+- [Managed auth](/self-hosted/deployment/authentication#managed-auth) enabled (`BETTER_AUTH_SECRET` set)
 - An internal database (`DATABASE_URL`) — organizations and their data are stored here
 - At least one analytics datasource (`ATLAS_DATASOURCE_URL`)
 </Callout>
+</WhenSelfHosted>
 
 ---
 
@@ -149,13 +153,10 @@ If the on-disk directory is empty on first access (e.g., after a container resta
 
 ---
 
+<WhenSelfHosted>
 ## Org-scoped connections (Self-Hosted)
 
-<Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), per-org connection pooling is managed automatically. This section is for self-hosted operators only.
-</Callout>
-
-By default, all organizations share the same database connection pools. For SaaS deployments where tenant isolation is critical, enable **per-org pool isolation** — each org gets its own connection pool instances with independent limits.
+By default, all organizations share the same database connection pools. For deployments where tenant isolation is critical, enable **per-org pool isolation** — each org gets its own connection pool instances with independent limits.
 
 ### Configuration
 
@@ -207,6 +208,7 @@ curl https://your-atlas.com/api/v1/admin/connections \
 ```
 
 The admin console's **Connections** page shows pool stats including active/idle connections, query counts, error rates, and drain history for both base and org-scoped pools.
+</WhenSelfHosted>
 
 ---
 
@@ -326,11 +328,8 @@ The org switcher component is at `packages/web/src/ui/components/org-switcher.ts
 
 ---
 
+<WhenSelfHosted>
 ## `atlas init` with organizations (Self-Hosted)
-
-<Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), semantic layer initialization is handled through the admin console. This section is for self-hosted operators using the CLI.
-</Callout>
 
 The CLI supports org-scoped initialization via the `--org` flag:
 
@@ -357,6 +356,7 @@ bun run atlas -- init --org org-abc --no-import
 ```
 
 Without `--org`, `atlas init` writes to the top-level `semantic/entities/` directory (single-tenant mode).
+</WhenSelfHosted>
 
 ---
 
@@ -416,7 +416,7 @@ LRU eviction automatically frees pools for inactive orgs, but under sustained lo
 
 ## See Also
 
-- [Authentication](/deployment/authentication#managed-auth) — Set up managed auth (required for organizations)
+- [Authentication](/self-hosted/deployment/authentication#managed-auth) — Set up managed auth (required for organizations)
 - [Admin Console](/guides/admin-console) — Manage organizations, members, and connections via the web UI
 - [Multi-Datasource Routing](/deployment/multi-datasource) — Configure multiple databases per deployment
 - [Configuration Reference](/reference/config) — All `atlas.config.ts` fields including `pool.perOrg`

--- a/apps/docs/content/shared/guides/onboarding-emails.mdx
+++ b/apps/docs/content/shared/guides/onboarding-emails.mdx
@@ -7,15 +7,19 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Onboarding emails are an automated drip campaign sent to new users after signup. Each email is triggered by a milestone (e.g., connecting a database, running a first query) or sent on a time-based fallback if the milestone is not reached.
 
+<WhenSaaS>
 <Callout type="info" title="SaaS">
 Onboarding emails are pre-enabled on [app.useatlas.dev](https://app.useatlas.dev) — new users receive the welcome sequence automatically. No configuration needed.
 </Callout>
+</WhenSaaS>
 
+<WhenSelfHosted>
 <Callout title="Self-hosted prerequisites">
 - Internal database configured (`DATABASE_URL`)
 - Email delivery configured (`RESEND_API_KEY` or `ATLAS_SMTP_URL`)
 - Feature flag enabled (`ATLAS_ONBOARDING_EMAILS_ENABLED=true`)
 </Callout>
+</WhenSelfHosted>
 
 ---
 
@@ -35,13 +39,8 @@ Each email is sent at most once per user. If the user completes the milestone be
 
 ---
 
+<WhenSelfHosted>
 ## Configuration (Self-Hosted)
-
-<Callout type="info" title="SaaS">
-On [app.useatlas.dev](https://app.useatlas.dev), onboarding emails are enabled by default with no additional setup. Skip this section.
-</Callout>
-
-### Self-hosted setup
 
 Enable onboarding emails via environment variable:
 
@@ -52,6 +51,7 @@ ATLAS_EMAIL_FROM=Atlas <noreply@yourdomain.com>  # optional, defaults to "Atlas 
 ```
 
 See [Environment Variables](/reference/environment-variables#email-delivery) for all email configuration options.
+</WhenSelfHosted>
 
 ---
 

--- a/apps/docs/content/shared/guides/plugin-marketplace.mdx
+++ b/apps/docs/content/shared/guides/plugin-marketplace.mdx
@@ -7,11 +7,13 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 The plugins admin page lets workspace admins view, configure, health-check, enable, and disable plugins that are already loaded in their workspace. Install and uninstall happen outside the admin UI today — see [Installing plugins](#installing-plugins) below.
 
+<WhenSelfHosted>
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- [Managed auth](/self-hosted/deployment/authentication#managed-auth) enabled
 - An internal database configured (`DATABASE_URL`) — required for enable/disable state
 - A user with the `admin` role
 </Callout>
+</WhenSelfHosted>
 
 {/* When self-service browse ships (marketplace catalog UI + plan-required badge), update both this callout AND the "no web consumer yet" note under API endpoints below. */}
 <Callout type="warn" title="Self-service browse is not shipped yet">
@@ -44,6 +46,7 @@ The enable/disable toggle and configuration edits require an internal database (
 
 There is no self-service install UI today. Pick the path that matches your deployment:
 
+<WhenSelfHosted>
 ### Self-hosted (`atlas.config.ts`)
 
 1. Add the plugin package to `package.json` (`bun add @useatlas/bigquery`, etc.)
@@ -62,10 +65,13 @@ There is no self-service install UI today. Pick the path that matches your deplo
 3. Restart the server. The plugin appears on `/platform/plugin-registry`.
 
 See the [Plugin Authoring Guide](/plugins/authoring-guide) for the full `definePlugin()` API and the published plugins on [npm](https://www.npmjs.com/search?q=%40useatlas) for what's available.
+</WhenSelfHosted>
 
+<WhenSaaS>
 ### SaaS (app.useatlas.dev)
 
 SaaS workspaces don't edit `atlas.config.ts` directly. To request a plugin be installed on your workspace, contact your account manager or platform admin. Platform admins install plugins via the platform catalog (tracked under [Plugin Catalog](/platform-ops/plugin-catalog)). Plan gating is evaluated server-side — each plugin has a `minPlan` (default `"starter"`); plugins above your workspace's plan tier are not offered.
+</WhenSaaS>
 
 ---
 
@@ -94,13 +100,17 @@ Disabling a datasource plugin **does not** revoke access to already-open queries
 
 ## Uninstalling
 
+<WhenSelfHosted>
 ### Self-hosted
 
 Remove the plugin from `atlas.config.ts` and restart. The admin UI does not offer an uninstall button for config-loaded plugins.
+</WhenSelfHosted>
 
+<WhenSaaS>
 ### SaaS
 
 Contact your platform admin. Platform-installed plugins are uninstalled through the platform catalog.
+</WhenSaaS>
 
 ---
 

--- a/apps/docs/content/shared/reference/cli.mdx
+++ b/apps/docs/content/shared/reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Complete reference for the Atlas CLI — init, diff, query, the workspace commands (login, switch, sql, metric run, explore, datasource), migrate, import, export, migrate-import, index, learn, improve, doctor, validate, mcp, eval, canonical-eval, smoke, plugin, benchmark, completions, and operator subcommands (proactive / seed / ops).
+description: Complete reference for the Atlas CLI — init, diff, query, the workspace commands (login, logout, switch, sql, metric run, explore, datasource, entities), migrate, import, export, migrate-import, okf, index, learn, improve, doctor, validate, mcp, eval, canonical-eval, smoke, plugin, benchmark, completions, and operator subcommands (proactive / seed / ops).
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -143,6 +143,7 @@ bun run atlas -- query "your question" [options]
 | `--quiet` | Data only — no narrative, SQL, or stats |
 | `--auto-approve` | Auto-approve any pending actions |
 | `--connection <id>` | Query a specific datasource |
+| `--api-key <key>` | Use a workspace API key instead of your `atlas login` session (unattended CI). Overrides `ATLAS_API_KEY` |
 
 **Environment:**
 
@@ -233,7 +234,7 @@ bun run atlas -- switch acme-analytics
 ```
 
 <Callout title="switch vs. --workspace">
-`atlas switch` sets the **persistent** default workspace for all subsequent commands. The per-command `--workspace <id>` override — accepted by [`atlas sql`](#sql) — rebinds the session for that **single** command only (same membership gate) and does **not** change your saved default. `--workspace` applies to interactive `atlas login` sessions only; workspace API keys are pinned to one workspace.
+`atlas switch` sets the **persistent** default workspace for all subsequent commands. The per-command `--workspace <id>` override — accepted by [`atlas sql`](#sql) and [`atlas entities`](#entities) — rebinds the session for that **single** command only (same membership gate) and does **not** change your saved default. `--workspace` applies to interactive `atlas login` sessions only; workspace API keys are pinned to one workspace.
 </Callout>
 
 ## sql
@@ -450,6 +451,19 @@ Delete a datasource. This is a **soft** delete — recoverable with [`datasource
 ```bash
 bun run atlas -- datasource delete <id>
 ```
+
+## entities
+
+List the semantic entities visible to your logged-in workspace — a thin client over `GET /api/v1/semantic/entities`, authorized by your [`atlas login`](#login) session (workspace-scoped: it returns only the bound workspace's published entities). An interactive-session command: it requires `atlas login` and is **not** honored with a workspace API key.
+
+```bash
+bun run atlas -- entities [--json] [--workspace <id>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Machine-readable JSON output (`{ workspaceId, entities }`) |
+| `--workspace <id>` | Act on a specific workspace for this command only (does not change your saved default — use [`atlas switch`](#switch)) |
 
 ## doctor
 
@@ -1011,6 +1025,25 @@ bun run atlas -- migrate-import --bundle backup.json --target https://atlas.inte
 # Use env var for the API key
 ATLAS_API_KEY=sk-... bun run atlas -- migrate-import --bundle backup.json
 ```
+
+## okf
+
+Interop with [OKF (Open Knowledge Format)](https://okf.dev) bundles — import a bundle as a first-draft semantic layer, or export the semantic layer as an OKF v0.1 bundle. Pure file-to-file (no REST, no DB), so it ships in the published `atlas` binary.
+
+```bash
+bun run atlas -- okf import --bundle <dir> [--out ./semantic] [--name <name>] [--force]
+bun run atlas -- okf export --semantic ./semantic --out <dir> [--force]
+```
+
+| Flag | Applies to | Description |
+|------|-----------|-------------|
+| `--bundle <dir>` | `import` | OKF bundle directory to read (required) |
+| `--out <dir>` | both | Output directory. `import` default `./semantic`; required for `export` |
+| `--name <name>` | `import` | Catalog name for the draft (default: bundle directory name) |
+| `--semantic <dir>` | `export` | Semantic layer to read (default: `./semantic`) |
+| `--force` | both | Overwrite existing files / write into a non-empty output directory |
+
+`import` produces **drafts**: imported metric SQL is unverified prose until a human reviews it — authority never travels through a bundle. `export` preserves Atlas-specific semantics (whitelist enforcement, pinned-metric authority, glossary ambiguity gating) under an `atlas:` frontmatter extension so re-import is lossless.
 
 ## completions
 

--- a/apps/docs/content/shared/reference/config.mdx
+++ b/apps/docs/content/shared/reference/config.mdx
@@ -669,6 +669,7 @@ export default defineConfig({
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `priority` | `string[]` | No | Ordered list of backends to try. Valid values: `"vercel-sandbox"`, `"nsjail"`, `"sidecar"`, `"just-bash"` |
+| `vercel` | `{ teamId, projectId }` | No | Vercel Sandbox account identity for off-Vercel deploys (Railway/Fly). Non-secret; the `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` env vars override when set. The token stays in `VERCEL_TOKEN` (env only). Unused on the Vercel platform (OIDC) |
 
 **Env var shorthand:**
 
@@ -878,6 +879,7 @@ export default defineConfig({
 | `databaseUrl` | `string` | Conditional | — | Connection string for the region's internal database. Optional in the schema, but the URL for the region **this service serves** must resolve at boot (hard-validated by the region guard); URLs for other regions may be left empty |
 | `datasourceUrl` | `string` | No | — | Analytics datasource override for the region. When unset, uses the default datasource |
 | `apiUrl` | `string` | No | — | Public API endpoint for this region (e.g. `https://api-eu.useatlas.dev`). Used in `421 Misdirected Request` responses to redirect clients to the correct region |
+| `selectable` | `boolean` | No | `true` | Whether this region is offered in the signup data-residency picker. Set `false` for an internal region that must exist for boot/routing but must not be a selectable residency choice (e.g. the shared-config `staging` arm) |
 
 ---
 

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -637,6 +637,7 @@ Action framework settings. These can also be configured via [`atlas.config.ts`](
 | `ATLAS_ACTION_TIMEOUT` | — | Per-action execution timeout in milliseconds. No default — the action runs until it returns or the request is cancelled. `.env.example` shows `300000` (5 min) as a reasonable starting point |
 | `ATLAS_ACTION_MAX_PER_CONVERSATION` | — | Reserved — not yet enforced. `.env.example` shows `10` as a future default. Currently accepts any value without effect |
 | `ATLAS_EMAIL_ALLOWED_DOMAINS` | — | Comma-separated list of allowed email recipient domains for the email action plugin. When unset, all domains are allowed |
+| `ATLAS_EMAIL_ALLOWED_RECIPIENT_DOMAINS` | — | Comma-separated domains the **agent's `sendEmail` tool** may deliver to, in addition to workspace-member addresses (e.g. `example.com,partner.example`). Empty = workspace members only. Distinct from `ATLAS_EMAIL_ALLOWED_DOMAINS` (the email *action* plugin allowlist). Workspace-scoped |
 
 ```bash
 # Enable actions with admin-only approval
@@ -969,8 +970,22 @@ Stripe billing integration for SaaS deployments. Self-hosted deployments do not 
 | `STRIPE_PRO_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Pro plan (annual) |
 | `STRIPE_BUSINESS_PRICE_ID` | — | Stripe Price ID for the Business plan (monthly, $149/seat) |
 | `STRIPE_BUSINESS_ANNUAL_PRICE_ID` | — | Stripe Price ID for the Business plan (annual) |
+| `STRIPE_STARTER_OVERAGE_PRICE_ID` | — | Stripe Price ID for the Starter plan's at-cost metered usage overage (billed in cents, 1:1 with provider cost). Added as a second subscription item; required for Starter overage to be billed |
+| `STRIPE_PRO_OVERAGE_PRICE_ID` | — | Stripe Price ID for the Pro plan's at-cost metered usage overage. Required for Pro overage to be billed |
+| `STRIPE_BUSINESS_OVERAGE_PRICE_ID` | — | Stripe Price ID for the Business plan's at-cost metered usage overage. Required for Business overage to be billed |
 
 When `STRIPE_SECRET_KEY` is set, billing routes are mounted at `/api/v1/billing` and the Better Auth Stripe plugin handles checkout, webhooks, and subscription lifecycle at `/api/auth/stripe/*`.
+
+### Billing Enforcement
+
+Operator knobs that govern what happens once a workspace spends its included at-cost usage credit, plus the reconcile/reaper sweep cadences. All are runtime-editable via **Admin → Settings → Billing** (the env var is the boot fallback).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATLAS_SPEND_POLICY` | `continue` | What happens past the included credit. `continue` keeps serving at provider cost (bounded by the abuse ceiling); `cutoff` hard-blocks at the credit (overage returns 429). Workspace-scoped, hot-reloadable |
+| `ATLAS_ABUSE_CEILING` | `500` | Hard 429 cutoff for metered at-cost overage under the `continue` policy, as a percent of the credit (`500` = 5× = $100/seat). Usage from 100% to the ceiling is metered at cost; `0` or empty disables the cutoff. Workspace-scoped, hot-reloadable |
+| `ATLAS_BILLING_RECONCILE_INTERVAL_HOURS` | `6` | Hours between plan-tier reconciliation sweeps (heals `plan_tier` drift from Stripe and prunes the webhook event ledger). Platform-scoped, restart-required |
+| `ATLAS_UNCLAIMED_GRACE_REAP_INTERVAL_HOURS` | `1` | Hours between unclaimed-grace reaper sweeps (demotes lapsed unclaimed-trial workspaces to the locked tier; SaaS only). Platform-scoped, restart-required |
 
 For local development, use [Stripe CLI](https://docs.stripe.com/stripe-cli) to forward webhooks:
 
@@ -1069,6 +1084,7 @@ SaaS only. Required for custom domain support via Railway.
 | `ATLAS_DEMO_ENABLED` | `false` | Enable demo mode at `/demo`. Allows unauthenticated users to try Atlas against the sample database with an email gate |
 | `ATLAS_DEMO_RATE_LIMIT_RPM` | `10` | Max requests per minute per demo user |
 | `ATLAS_DEMO_MAX_STEPS` | `10` | Max agent steps per demo request (lower than authenticated default of 25) |
+| `ATLAS_DEMO_MODEL` | — | Model the public `/demo` path runs on — a gateway model id (e.g. `anthropic/claude-haiku-4.5`) or a direct model id matching the configured provider. Blank = the resolved default (Haiku on the gateway for SaaS). Platform-scoped, hot-reloadable |
 | `ATLAS_DEMO_INDUSTRY` | — | Industry label for the seeded `__demo__` connection (e.g. `cybersecurity`, `ecommerce`). Set this explicitly to pre-configure the demo dataset industry on a single-tenant deploy; in the hosted product it is captured during onboarding. Drives prompt-library industry filtering and the publish flow's demo-prompt archival cascade. See [Developer Mode](/guides/developer-mode) for the full demo lifecycle |
 
 Requires `BETTER_AUTH_SECRET` for demo token signing.

--- a/apps/docs/content/shared/reference/error-codes.mdx
+++ b/apps/docs/content/shared/reference/error-codes.mdx
@@ -55,15 +55,15 @@ Retrying these will not help — the request or configuration must be changed.
 
 These codes are returned by billing enforcement and workspace status middleware. They block requests before the agent loop runs.
 
-| Code | HTTP Status | Description | Common Cause | Fix |
-|------|-------------|-------------|--------------|-----|
-| `trial_expired` | 403 | Trial has expired | 14-day SaaS trial ended | Upgrade to a paid plan |
-| `subscription_required` | 403 | Subscription required | The workspace subscription has ended (past-due/canceled) | Resubscribe from the billing page to continue using Atlas |
-| `billing_check_failed` | 503 | Billing check failed | Failed to fetch plan data from internal DB | Retry — transient infrastructure issue |
-| `workspace_check_failed` | 503 | Workspace check failed | Failed to verify workspace status | Retry — transient infrastructure issue |
-| `workspace_throttled` | 429 | Workspace throttled | Workspace triggered abuse detection thresholds | Wait for the throttle delay to pass and retry. See [Abuse Prevention](/platform-ops/abuse-prevention) |
-| `workspace_suspended` | 403 | Workspace suspended | Admin suspended the workspace | Contact your workspace administrator |
-| `workspace_deleted` | 404 | Workspace deleted | Workspace has been permanently deleted | Create a new workspace |
+| Code | HTTP Status | Description | Common Cause | Fix | Retryable |
+|------|-------------|-------------|--------------|-----|-----------|
+| `trial_expired` | 403 | Trial has expired | 14-day SaaS trial ended | Upgrade to a paid plan | No |
+| `subscription_required` | 403 | Subscription required | The workspace subscription has ended (past-due/canceled) | Resubscribe from the billing page to continue using Atlas | No |
+| `billing_check_failed` | 503 | Billing check failed | Failed to fetch plan data from internal DB | Retry — transient infrastructure issue | Yes |
+| `workspace_check_failed` | 503 | Workspace check failed | Failed to verify workspace status | Retry — transient infrastructure issue | Yes |
+| `workspace_throttled` | 429 | Workspace throttled | Workspace triggered abuse detection thresholds | Wait for the throttle delay to pass and retry. See [Abuse Prevention](/platform-ops/abuse-prevention) | Yes |
+| `workspace_suspended` | 403 | Workspace suspended | Admin suspended the workspace | Contact your workspace administrator | No |
+| `workspace_deleted` | 404 | Workspace deleted | Workspace has been permanently deleted | Create a new workspace | No |
 
 ---
 
@@ -286,6 +286,18 @@ The `@useatlas/sdk` includes additional codes in the `AtlasErrorCode` type beyon
 | `invalid_response` | Server returned a 2xx status but the body wasn't valid JSON | SDK client-side | No |
 | `unknown_error` | Server returned an error response with an unrecognized error code | SDK client-side | No |
 | `not_available` | Feature not available (e.g., conversation history without `DATABASE_URL`) | Server (admin/CRUD routes) | No |
+
+---
+
+## CLI REST Error Codes
+
+The `atlas` CLI datasource commands (`datasource create` / `profile` / `list`) discriminate on these `error`-field codes (`CLI_REST_ERROR_CODES` in [`@useatlas/types/errors`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/types/src/errors.ts)). Four of them — `bad_request`, `forbidden_role`, `not_available`, `plan_limit_exceeded` — are shared with the tables above; the three below are specific to the datasource-lifecycle path:
+
+| Code | Trigger | Fix | Retryable |
+|------|---------|-----|-----------|
+| `mfa_enrollment_required` | The admin must enroll a second factor before mutating datasources | Enroll a passkey, then retry | No |
+| `connection_failed` | `datasource create` pre-flight connection test failed (driver error; the DSN is scrubbed from the message) | Fix the connection URL / credentials and retry | No |
+| `reconnect_required` | The datasource needs reconnection (e.g. a revoked OAuth token) before it can be profiled | Re-run the datasource's OAuth/connect flow | No |
 
 ---
 

--- a/apps/docs/content/shared/reference/react.mdx
+++ b/apps/docs/content/shared/reference/react.mdx
@@ -18,7 +18,7 @@ bun add @useatlas/react
 The hooks require these peer dependencies:
 
 ```bash
-bun add react react-dom ai @ai-sdk/react
+bun add react react-dom ai @ai-sdk/react @useatlas/sdk
 ```
 
 The pre-built `AtlasChat` component additionally uses `lucide-react`, `react-syntax-highlighter`, `recharts`, `tailwindcss`, and `exceljs` (all optional peer deps).

--- a/apps/docs/src/components/section-docs-page.tsx
+++ b/apps/docs/src/components/section-docs-page.tsx
@@ -15,6 +15,7 @@ import { ChangelogTimeline } from "@/components/changelog-timeline";
 import { LLMCopyButton } from "@/components/llm-copy-button";
 import { AudienceProvider, AudienceLabel, type Audience } from "@/lib/audience";
 import { audienceConditionals } from "@/lib/audience-conditionals";
+import { filterTocByAudience } from "@/lib/audience-markdown";
 import { githubEditPath } from "@/lib/mdx-links";
 import type { SectionPage } from "@/lib/source";
 
@@ -85,10 +86,20 @@ export async function SectionDocsPage({
   // that returns null, so its children never enter the emitted HTML / RSC
   // payload (unlike a client conditional). See audience-conditionals.tsx.
   const { WhenSaaS, WhenSelfHosted } = audienceConditionals(audience);
+  // `page.data.toc` is compiled from ALL headings in the raw MDX — the runtime
+  // audience conditional is invisible to it — so a `<WhenSelfHosted>`-wrapped
+  // section's heading would otherwise show in the SaaS mount's ToC and link to
+  // an anchor that never renders. Drop the inactive-branch headings so the ToC
+  // matches what this mount actually shows (PRD #4257 / #4282).
+  const toc = filterTocByAudience(
+    page.data.toc,
+    await page.data.getText("processed"),
+    audience,
+  );
 
   return (
     <DocsPage
-      toc={page.data.toc}
+      toc={toc}
       lastUpdate={lastUpdate}
       full={isFullWidth}
       editOnGithub={{

--- a/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
+++ b/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
@@ -3,7 +3,13 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { audienceConditionals } from "@/lib/audience-conditionals";
-import { stripInactiveAudienceBlocks } from "@/lib/audience-markdown";
+import {
+  stripInactiveAudienceBlocks,
+  filterTocByAudience,
+  tocTitleToText,
+  survivingHeadingTitles,
+  normalizeHeadingText,
+} from "@/lib/audience-markdown";
 import type { Audience } from "@/lib/audience";
 
 /**
@@ -191,4 +197,151 @@ test("an inline-code mention of a tag name is NOT treated as a residual tag", ()
   const out = stripInactiveAudienceBlocks(mention, "saas");
   expect(out).toContain("saas-md-token");
   expect(out).toContain("`<WhenSelfHosted>`"); // the mention survives, unstripped
+});
+
+// ── audience-aware table of contents (#4282) ─────────────────────────────────
+//
+// fumadocs compiles `page.data.toc` from ALL headings in the raw MDX — the
+// runtime audience conditional is invisible to it — so a heading authored inside
+// a `<WhenSelfHosted>` block would appear in the SaaS mount's ToC (and link to an
+// anchor that never renders). `filterTocByAudience` drops the inactive branch's
+// headings so the ToC matches what the mount actually shows.
+
+const TOC_MD = [
+  "# Intro",
+  "",
+  "Shared intro.",
+  "",
+  "## Shared Section",
+  "",
+  "<WhenSelfHosted>",
+  "## Org-scoped connections (Self-Hosted)",
+  "",
+  "Operator config with `atlas.config.ts`.",
+  "</WhenSelfHosted>",
+  "",
+  "## Another Shared Section",
+  "",
+  "<WhenSaaS>",
+  "## Billing (SaaS)",
+  "</WhenSaaS>",
+].join("\n");
+
+test("tocTitleToText flattens string, array, and element-like title nodes", () => {
+  expect(tocTitleToText("Plain")).toBe("Plain");
+  // fumadocs' array title node (in-memory React-element form): [<code>atlas
+  // init</code>, " with orgs"].
+  expect(
+    tocTitleToText([
+      { props: { children: "atlas init" } },
+      " with orgs (Self-Hosted)",
+    ]),
+  ).toBe("atlas init with orgs (Self-Hosted)");
+  expect(tocTitleToText({ children: "el text" })).toBe("el text");
+});
+
+test("survivingHeadingTitles omits headings inside the inactive branch", () => {
+  const saas = survivingHeadingTitles(TOC_MD, "saas");
+  expect(saas.has("Shared Section")).toBe(true);
+  expect(saas.has("Another Shared Section")).toBe(true);
+  expect(saas.has("Billing (SaaS)")).toBe(true); // active on saas
+  expect(saas.has("Org-scoped connections (Self-Hosted)")).toBe(false);
+
+  const selfHosted = survivingHeadingTitles(TOC_MD, "self-hosted");
+  expect(selfHosted.has("Org-scoped connections (Self-Hosted)")).toBe(true);
+  expect(selfHosted.has("Billing (SaaS)")).toBe(false); // inactive on self-hosted
+});
+
+test("filterTocByAudience drops the self-hosted heading from the SaaS ToC", () => {
+  const toc = [
+    { depth: 1, url: "#intro", title: "Intro" },
+    { depth: 2, url: "#shared-section", title: "Shared Section" },
+    {
+      depth: 2,
+      url: "#org-scoped-connections-self-hosted",
+      title: "Org-scoped connections (Self-Hosted)",
+    },
+    { depth: 2, url: "#another-shared-section", title: "Another Shared Section" },
+    { depth: 2, url: "#billing-saas", title: "Billing (SaaS)" },
+  ];
+
+  const saasToc = filterTocByAudience(toc, TOC_MD, "saas");
+  const saasTitles = saasToc.map((t) => t.title);
+  expect(saasTitles).toContain("Shared Section");
+  expect(saasTitles).toContain("Billing (SaaS)");
+  expect(saasTitles).not.toContain("Org-scoped connections (Self-Hosted)");
+
+  const selfHostedToc = filterTocByAudience(toc, TOC_MD, "self-hosted");
+  const shTitles = selfHostedToc.map((t) => t.title);
+  expect(shTitles).toContain("Org-scoped connections (Self-Hosted)");
+  expect(shTitles).not.toContain("Billing (SaaS)");
+});
+
+test("filterTocByAudience matches a code-containing heading (backticks normalized)", () => {
+  const md = [
+    "<WhenSelfHosted>",
+    "## `atlas init` with organizations (Self-Hosted)",
+    "</WhenSelfHosted>",
+    "",
+    "## Shared",
+  ].join("\n");
+  // Mirrors fumadocs' array title node for a heading with inline code.
+  const toc = [
+    {
+      depth: 2,
+      url: "#atlas-init-with-organizations-self-hosted",
+      title: [{ props: { children: "atlas init" } }, " with organizations (Self-Hosted)"],
+    },
+    { depth: 2, url: "#shared", title: "Shared" },
+  ];
+  const saas = filterTocByAudience(toc, md, "saas").map((t) =>
+    tocTitleToText(t.title),
+  );
+  expect(saas).toContain("Shared");
+  expect(saas).not.toContain("atlas init with organizations (Self-Hosted)");
+
+  // KEEP side (the path that actually exercises backtick normalization): on the
+  // self-hosted mount the code heading SURVIVES, so its backtick'd markdown form
+  // (`` ## `atlas init` … ``) must normalize to the SAME string as the ToC's
+  // array title node (backticks already gone) for the match to keep it. Without
+  // `normalizeHeadingText` stripping the backticks, the two wouldn't compare
+  // equal and this entry would be wrongly dropped.
+  const selfHosted = filterTocByAudience(toc, md, "self-hosted").map((t) =>
+    tocTitleToText(t.title),
+  );
+  expect(selfHosted).toContain("atlas init with organizations (Self-Hosted)");
+});
+
+test("normalizeHeadingText strips inline code, links, and emphasis", () => {
+  expect(normalizeHeadingText("`atlas init` with orgs")).toBe(
+    "atlas init with orgs",
+  );
+  expect(normalizeHeadingText("[Config](/reference/config) options")).toBe(
+    "Config options",
+  );
+  expect(normalizeHeadingText("**Bold** and _italic_ heading")).toBe(
+    "Bold and italic heading",
+  );
+});
+
+test("filterTocByAudience over-keeps a duplicate heading (fail-safe: shows, never hides)", () => {
+  // Same heading text in a shared section AND a self-hosted section. On the SaaS
+  // mount the self-hosted copy is stripped, but the shared copy keeps the title
+  // in the surviving set, so BOTH ToC entries survive. The documented fail-safe:
+  // a duplicate over-keeps (a possibly-dead anchor), never over-removes (a hidden
+  // real heading).
+  const md = [
+    "## Setup",
+    "",
+    "<WhenSelfHosted>",
+    "## Setup",
+    "",
+    "Operator-only setup.",
+    "</WhenSelfHosted>",
+  ].join("\n");
+  const toc = [
+    { depth: 2, url: "#setup", title: "Setup" },
+    { depth: 2, url: "#setup-1", title: "Setup" },
+  ];
+  expect(filterTocByAudience(toc, md, "saas").length).toBe(2);
 });

--- a/apps/docs/src/lib/__tests__/redirect-coverage.test.ts
+++ b/apps/docs/src/lib/__tests__/redirect-coverage.test.ts
@@ -51,7 +51,17 @@ const CADDYFILE = join(DOCS_ROOT, "../../deploy/docs/Caddyfile");
 // — a new file here that is neither allow-listed nor mapped fails the
 // completeness test, forcing either a redirect entry or an explicit born-here
 // acknowledgement.
-const BORN_UNDER_SELF_HOSTED = new Set(["index.mdx"]);
+const BORN_UNDER_SELF_HOSTED = new Set([
+  "index.mdx",
+  // #4282 — self-hosted operator sections extracted from three of the six saas
+  // pages the slice split (the rung-4 extractions; the other three used the
+  // `<WhenSelfHosted>` conditional and produced no file). Born here (the on-prem
+  // content had no pre-split /self-hosted URL of its own — it lived inline on a
+  // SaaS page), so they need no redirect.
+  "guides/self-hosted-billing.mdx",
+  "guides/self-serve-signup.mdx",
+  "deployment/load-testing.mdx",
+]);
 
 // Normalize a Caddyfile line so `redir <from> <to> 308` matches regardless of
 // the file's tab indentation / internal spacing.

--- a/apps/docs/src/lib/__tests__/source-partition.test.ts
+++ b/apps/docs/src/lib/__tests__/source-partition.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { buildSectionSource, type CollectionLike } from "@/lib/compose";
 import { classifyByPath } from "@/lib/audience-taxonomy";
 import { MOVED_SELF_HOSTED_SLUGS } from "@/lib/redirects";
+import { stripInactiveAudienceBlocks } from "@/lib/audience-markdown";
 
 /**
  * Source-partition test (PRD #4257's highest-value seam).
@@ -634,4 +635,108 @@ test("[#4265] every root-absolute link in a shared page resolves to a real page 
   expect(targets.size).toBeGreaterThan(0);
   const dangling = [...targets].filter((u) => !rootPageExists(u));
   expect(dangling).toEqual([]);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #4282 — the six saas-only pages that carried embedded self-hosted operator
+// SECTIONS are resolved so NO self-hosted operator content reaches the SaaS-root
+// emitted HTML. Two mechanisms, per-page judgment along the PRD #4257 ladder:
+//
+//   - rung-2 (shared + `<WhenSelfHosted>`): multi-tenancy, plugin-marketplace,
+//     onboarding-emails single-source into BOTH trees; each on-prem section is
+//     wrapped in the SERVER `<WhenSelfHosted>` conditional, which renders null on
+//     the SaaS mount (its children never enter the RSC flight payload — see
+//     audience-conditionals.tsx + its test).
+//   - rung-4 (extract): billing-and-plans, signup, mcp-load-test-tokens keep the
+//     SaaS page saas-only and move the on-prem section to a dedicated
+//     `/self-hosted/*` page, so the SaaS page no longer contains it at all.
+//
+// This is the finer-grained companion to the page-level partition tests above:
+// those prove no self-hosted-only PAGE reaches the SaaS source; this proves no
+// self-hosted SECTION reaches a SaaS page's emitted output.
+//
+// The shared-page assertions drive the REAL `stripInactiveAudienceBlocks` — the
+// same strip behind the `.mdx` twin / `llms-full.txt` SaaS surface and the
+// string-level mirror of the server `<WhenSelfHosted>` render (returns null). A
+// leak would surface identically in both. Fixtures use uniquely-named consts, so
+// they don't disturb the 3a/3b/3c blocks above.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DOCS_ROOT_4282 = join(CONTENT_DIR, "docs");
+const SELF_HOSTED_ROOT_4282 = join(CONTENT_DIR, "self-hosted");
+
+// rung-2: the ONE real shared source file, the self-hosted tokens that must be
+// ABSENT on the SaaS mount (all inside a `<WhenSelfHosted>` block), and a
+// shared-body token that must SURVIVE (so the strip isn't just deleting the page).
+const SHARED_WRAPPED_4282 = [
+  {
+    file: join(SHARED_ROOT, "guides/multi-tenancy.mdx"),
+    absent: [
+      "Org-scoped connections (Self-Hosted)",
+      "with organizations (Self-Hosted)",
+      "Self-hosted prerequisites",
+      "per-org pool isolation",
+      "ATLAS_ORG_ID",
+    ],
+    present: ["Member management", "Org switcher UI"],
+  },
+  {
+    file: join(SHARED_ROOT, "guides/plugin-marketplace.mdx"),
+    absent: ["import bigquery from", "does not offer an uninstall button"],
+    present: ["What the page shows for each plugin"],
+  },
+  {
+    file: join(SHARED_ROOT, "guides/onboarding-emails.mdx"),
+    absent: ["Configuration (Self-Hosted)", "ATLAS_ONBOARDING_EMAILS_ENABLED"],
+    present: ["Email Sequence", "Unsubscribe & Resubscribe"],
+  },
+] as const;
+
+test("[#4282] every shared page's self-hosted section is absent from the SaaS-mount markdown (kept on self-hosted)", () => {
+  for (const page of SHARED_WRAPPED_4282) {
+    const raw = readFileSync(page.file, "utf8");
+    // Sanity: the on-prem content really is in the single source (so the strip
+    // is doing work, not passing vacuously).
+    for (const tok of page.absent) expect(raw).toContain(tok);
+
+    // SaaS mount: the self-hosted section is gone; the shared body survives.
+    const saas = stripInactiveAudienceBlocks(raw, "saas");
+    for (const tok of page.absent) expect(saas).not.toContain(tok);
+    for (const tok of page.present) expect(saas).toContain(tok);
+
+    // Self-hosted mount: the on-prem section is preserved (no content lost).
+    const selfHosted = stripInactiveAudienceBlocks(raw, "self-hosted");
+    for (const tok of page.absent) expect(selfHosted).toContain(tok);
+  }
+});
+
+// rung-4: the on-prem section was EXTRACTED to a dedicated /self-hosted page.
+const EXTRACTED_4282 = [
+  {
+    saas: join(DOCS_ROOT_4282, "guides/billing-and-plans.mdx"),
+    extract: join(SELF_HOSTED_ROOT_4282, "guides/self-hosted-billing.mdx"),
+    tokens: ["Stripe Setup", "STRIPE_WEBHOOK_SECRET"],
+  },
+  {
+    saas: join(DOCS_ROOT_4282, "guides/signup.mdx"),
+    extract: join(SELF_HOSTED_ROOT_4282, "guides/self-serve-signup.mdx"),
+    tokens: ["Enabling Social Login", "GOOGLE_CLIENT_SECRET"],
+  },
+  {
+    saas: join(DOCS_ROOT_4282, "platform-ops/mcp-load-test-tokens.mdx"),
+    extract: join(SELF_HOSTED_ROOT_4282, "deployment/load-testing.mdx"),
+    tokens: ["ATLAS_PUBLIC_API_URL"],
+  },
+] as const;
+
+test("[#4282] extracted self-hosted sections are gone from the SaaS page and live on a /self-hosted page (no content lost)", () => {
+  for (const page of EXTRACTED_4282) {
+    expect(existsSync(page.extract)).toBe(true);
+    const saas = readFileSync(page.saas, "utf8");
+    const extract = readFileSync(page.extract, "utf8");
+    for (const tok of page.tokens) {
+      expect(saas).not.toContain(tok);
+      expect(extract).toContain(tok);
+    }
+  }
 });

--- a/apps/docs/src/lib/audience-markdown.ts
+++ b/apps/docs/src/lib/audience-markdown.ts
@@ -91,3 +91,90 @@ export function stripInactiveAudienceBlocks(
   }
   return out;
 }
+
+/**
+ * Normalize a markdown heading's inline formatting to the plain text that
+ * fumadocs' table-of-contents `title` carries — strip inline code backticks,
+ * bold/italic markers, and `[text](url)` link syntax (keeping the link text),
+ * then collapse whitespace. So `` ## `atlas init` with orgs `` and the ToC
+ * title node `[<code>atlas init</code>, " with orgs"]` both reduce to
+ * `atlas init with orgs` and compare equal.
+ */
+export function normalizeHeadingText(raw: string): string {
+  return raw
+    .replace(/`+/g, "") // inline-code backticks
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // [text](url) -> text
+    .replace(/[*_]{1,3}/g, "") // bold / italic markers
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * The normalized heading titles that SURVIVE the audience strip — i.e. the
+ * headings that actually render on `audience`'s mount. A heading authored inside
+ * an inactive `<WhenSaaS>` / `<WhenSelfHosted>` block is removed by
+ * `stripInactiveAudienceBlocks`, so it is absent from this set.
+ *
+ * Used to audience-filter fumadocs' `page.data.toc`, which is compiled from ALL
+ * headings in the raw MDX (the runtime audience conditional is invisible to it),
+ * so without filtering a self-hosted section's heading would appear in the SaaS
+ * mount's table of contents — and link to an anchor that no longer renders.
+ */
+export function survivingHeadingTitles(
+  markdown: string,
+  audience: Audience,
+): Set<string> {
+  const scoped = stripInactiveAudienceBlocks(markdown, audience);
+  const titles = new Set<string>();
+  // ATX headings only (fumadocs emits ATX in processed markdown). Skip fenced
+  // code blocks so a `# comment` inside ```bash isn't mistaken for a heading.
+  const withoutFences = scoped.replace(/```[\s\S]*?```/g, "");
+  for (const m of withoutFences.matchAll(/^#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/gm)) {
+    titles.add(normalizeHeadingText(m[1]));
+  }
+  return titles;
+}
+
+/** A fumadocs ToC item's `title` is a ReactNode; flatten it to plain text
+ * structurally (no React import) — handles a string, a number, an array of
+ * children, and an element-like `{ props: { children } }`. This is the in-memory
+ * React-element form fumadocs stores in `toc[].title` (what a SERVER component
+ * sees), e.g. for a heading with inline code the array
+ * `[{ props: { children: "atlas init" } }, " with orgs"]`. It does NOT parse the
+ * flight-serialized tuple form (`["$","code",…]`) — those are consumed by React's
+ * flight reader, never by this build-time code. */
+export function tocTitleToText(node: unknown): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(tocTitleToText).join("");
+  if (typeof node === "object") {
+    const obj = node as { props?: { children?: unknown }; children?: unknown };
+    if (obj.props && typeof obj.props === "object" && "children" in obj.props)
+      return tocTitleToText(obj.props.children);
+    if ("children" in obj) return tocTitleToText(obj.children);
+  }
+  return "";
+}
+
+/**
+ * Filter fumadocs' `page.data.toc` down to the headings that render on
+ * `audience`'s mount, so a `<WhenSelfHosted>`-wrapped section's heading never
+ * appears in the SaaS mount's table of contents (nor links to a dead anchor).
+ *
+ * Generic over the ToC item shape (only reads `title`), so it needs no fumadocs
+ * type import and stays unit-testable. Assumes heading texts are unique on a
+ * page (github-slugger disambiguates the anchors, but the ToC title is what we
+ * match on); a duplicate would over-keep, never over-remove — fail-safe toward
+ * showing a heading, not hiding a real one.
+ */
+export function filterTocByAudience<T extends { readonly title: unknown }>(
+  toc: readonly T[],
+  markdown: string,
+  audience: Audience,
+): T[] {
+  const surviving = survivingHeadingTitles(markdown, audience);
+  return toc.filter((item) =>
+    surviving.has(normalizeHeadingText(tocTitleToText(item.title))),
+  );
+}


### PR DESCRIPTION
Final slice of **v0.0.42 — Docs Portal Segmentation + Truthfulness Pass**. Combines the Slice 9 truthfulness backstop (#4274) with resolving the six SaaS pages that carried embedded self-hosted operator sections (#4282).

Closes #4274
Closes #4282

## PART A — `/docs-audit` backstop sweep (Parts A–J)

Ran the full audit (4 parallel agents) over the segmented portal (`content/docs` SaaS root + `content/self-hosted` + `content/shared` + generated api-reference), cross-referencing against source-of-truth (`config.ts`, `.env.example`, `atlas.ts`, OpenAPI, `plugins/*`, sdk/react/types, ROADMAP).

**Fixed inline** (all in `content/shared/reference/*`):
- **env vars** — added 3 Stripe overage price IDs, `ATLAS_DEMO_MODEL`, `ATLAS_EMAIL_ALLOWED_RECIPIENT_DOMAINS`, and a new *Billing Enforcement* subsection (`ATLAS_SPEND_POLICY`, `ATLAS_ABUSE_CEILING`, reconcile/reap intervals).
- **config** — `sandbox.vercel`, `residency.regions.*.selectable`.
- **cli** — new `okf` and `entities` sections, `query --api-key` row, `switch` callout + frontmatter.
- **sdk/errors** — `@useatlas/sdk` react peer dep, a CLI REST error-codes subsection, a Retryable column on the billing/workspace error table.
- **3 genuinely-dead links** — `api-keys.mdx` `/deployment/row-level-security` → `/security/row-level-security`; two api-reference *folder* URLs (no index) → concrete endpoint pages.

**Filed as follow-ups** (large gaps, linked to #4274, do not block closeout):
- **#4289** — repoint ~54 stale in-repo links to moved `/self-hosted` pages (live site already 308s them) + resolve ~145 cross-mount audience-leak links. Needs a per-link content-architecture pass, not mechanical repointing.
- **#4290** — undocumented feature surfaces (`admin-connection-group-descriptions`, `platform-demo` analytics, `platform-security-metrics`, admin revoke/mfa-reset/email-provider, query suggestions) + recently-shipped features (`atlas-regions.json`, apex `auth.md`, `@useatlas/plugin-sdk` `createDatasourcePlugin`/`measuredHealthCheck`) + react render-primitive gaps.

Audit verdict: no Critical findings; env/config/cli/plugins/sdk pages are otherwise accurate (Part E plugins fully clean).

## PART B — #4282: no self-hosted operator content on a SaaS-root HTML page

Per-page judgment along the PRD #4257 mechanism ladder:

| Page | Disposition |
|------|-------------|
| `guides/multi-tenancy` | **shared** + `<WhenSelfHosted>` — moved to `content/shared/guides`; per-org pooling, `atlas init --org`, prereqs wrapped |
| `guides/plugin-marketplace` | **shared** + `<WhenSelfHosted>`/`<WhenSaaS>` — install/uninstall paths split by audience |
| `guides/onboarding-emails` | **shared** + `<WhenSelfHosted>` — self-hosted config section wrapped |
| `guides/billing-and-plans` | **extract** — stays saas-only; Stripe-setup / self-hosted-deploy → `content/self-hosted/guides/self-hosted-billing.mdx` |
| `guides/signup` | **extract** — stays saas-only; social-login + self-hosted config → `content/self-hosted/guides/self-serve-signup.mdx` |
| `platform-ops/mcp-load-test-tokens` | **extract** — stays saas-only; `## Self-hosted` note → `content/self-hosted/deployment/load-testing.mdx` |

rung-2 pages single-source into both trees (SaaS URL unchanged); rung-4 pages are fundamentally-SaaS with a detachable operator appendix (respects "SaaS-only guides don't appear under /self-hosted"). **No content is lost** — every self-hosted section is preserved either on the `/self-hosted` mount or in a dedicated `/self-hosted/*` page.

### ToC leak fix (the RSC-payload-leak lesson, applied to the table of contents)
`page.data.toc` is compiled from **all** MDX headings at build time — the `<WhenSelfHosted>` server conditional only resolves at render — so an unfiltered SaaS ToC listed a self-hosted heading *and* linked to an anchor that never renders. Added `filterTocByAudience` (in `audience-markdown.ts`, wired in `section-docs-page.tsx`) to drop inactive-branch headings from the ToC. Fail-safe: a duplicate heading over-keeps (never hides a real heading).

### Tests
- **#4282 omission suite** (`source-partition.test.ts`): for the 3 shared pages, drives the **real** `stripInactiveAudienceBlocks(raw, "saas")` and asserts the self-hosted section is absent on the SaaS mount + present on self-hosted (no content lost); for the 3 extracts, asserts the operator tokens are gone from the SaaS page and live on the `/self-hosted` page.
- **ToC-filter unit tests** (`audience-conditionals.test.tsx`): `tocTitleToText`, `survivingHeadingTitles`, `normalizeHeadingText`, `filterTocByAudience` (incl. code-containing-heading keep-side + duplicate-heading fail-safe).

## Verification
- `cd apps/docs && bun run build` — **green**; 633+ SaaS-root + 102+ `/self-hosted` paths generate; classification build-gate passes.
- `bun test src/lib/__tests__` — **150 pass**.
- **Omission invariant verified in the emitted static HTML**: for all 3 shared pages, every self-hosted marker (section bodies *and* ToC headings/anchors) = 0 in the SaaS-root `out/**/index.html`, present on the `/self-hosted` mount; normal pages' ToCs unchanged (e.g. `/reference/config` = 45 anchors).
- eslint clean on `apps/docs/src`.

Internal review panel (type-design, comments, tests, code) run on the diff; actionable findings folded in.

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v