### PR TITLE
refactor: hot-reload ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS — drop the restart requirement

### DIFF
--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -108,7 +108,7 @@ All Knowledge Base knobs are platform-scoped operator guardrails (abuse caps and
 | `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` | `1000000` (1 MB) | Max decoded size per document (oversized files rejected per-file) |
 | `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) | Max bundle upload size; also bounds decompression |
 | `ATLAS_KNOWLEDGE_TOC_MAX_BYTES` | `12000` | Cap on the collection table of contents injected into the agent's system prompt |
-| `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often synced collections pull their endpoint (read at scheduler start — requires a restart) |
+| `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often synced collections pull their endpoint (hot-reloaded — applies by the next scheduled tick) |
 | `ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS` | `60` | Per-sync download time budget |
 
 See the [environment variables reference](/reference/environment-variables#knowledge-base) for details.

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -202,7 +202,7 @@ Caps and cadence for hosted [Knowledge Base collections](/guides/knowledge-base)
 | `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` | `1000000` (1 MB) | Maximum decoded size of any single document in a knowledge bundle; oversized documents are rejected per-file (surfaced in the upload result, never silently skipped) |
 | `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) | Maximum raw upload size of a knowledge bundle; also reused as the decoded-total cap that aborts a decompression bomb mid-inflate |
 | `ATLAS_KNOWLEDGE_TOC_MAX_BYTES` | `12000` (≈3k tokens) | Maximum size of the Knowledge Base collection table-of-contents injected into the agent's system prompt. Collections beyond the cap are omitted from the prompt but remain browsable via the explore tool |
-| `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often bundle-sync collections pull their endpoint (default nightly). **Read once at scheduler start — requires a restart to apply** |
+| `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often bundle-sync collections pull their endpoint (default nightly). Hot-reloaded — a change takes effect by the next scheduled tick, no restart needed |
 | `ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS` | `60` | Per-sync time budget for downloading a collection's bundle endpoint, bounding the whole fetch including redirects and body streaming |
 
 ---

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -3220,9 +3220,9 @@ export function makeSchedulerLive(
           // interrupts them automatically (no `setInterval` handle to clear).
 
           // Stop the knowledge bundle sync scheduler (#4211) — still a
-          // `setInterval` + `unref()` scheduler (not yet folded onto
-          // `registerPeriodicFiber` like the #4195 trio above), so its timer
-          // must be cleared explicitly here.
+          // self-rescheduling `setTimeout` + `unref()` scheduler (not yet
+          // folded onto `registerPeriodicFiber` like the #4195 trio above),
+          // so its pending timer must be cleared explicitly here.
           yield* Effect.tryPromise({
             try: async () => {
               const { stopKnowledgeBundleSyncScheduler } = await import(

--- a/packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts
@@ -146,7 +146,9 @@ describe("interval hot-reload (#4236)", () => {
       // Operator changes the setting between ticks (env tier stands in for
       // the registry's DB-override tier — same getSettingAuto read path).
       process.env[KEY] = "1";
-      await Bun.sleep(150); // let the 72ms tick fire and re-arm
+      // Generous margin over the 72ms tick — the assertion is a strict lower
+      // bound, so headroom guards against a congested-CI real-timer delay.
+      await Bun.sleep(300); // let the 72ms tick fire and re-arm
       expect(CYCLE_CALLS).toBeGreaterThanOrEqual(2); // initial + ≥1 tick
       expect(_getArmedKnowledgeSyncIntervalMs()).toBe(60 * 60 * 1000);
       stopKnowledgeBundleSyncScheduler();

--- a/packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts
@@ -37,6 +37,7 @@ mock.module("@atlas/api/lib/logger", () => {
 
 const {
   DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS,
+  MAX_TIMER_DELAY_MS,
   getKnowledgeSyncIntervalMs,
   startKnowledgeBundleSyncScheduler,
   stopKnowledgeBundleSyncScheduler,
@@ -85,6 +86,13 @@ describe("getKnowledgeSyncIntervalMs", () => {
     withEnv("0", () => expect(getKnowledgeSyncIntervalMs()).toBe(DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS));
     withEnv("-2", () => expect(getKnowledgeSyncIntervalMs()).toBe(DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS));
     withEnv("nonsense", () => expect(getKnowledgeSyncIntervalMs()).toBe(DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS));
+  });
+
+  it("clamps an over-large value to the max timer delay (no 32-bit overflow hot-loop)", () => {
+    // 2^31−1 ms ≈ 596.5h; 1000h would overflow setTimeout and clamp to 1ms.
+    withEnv("1000", () => expect(getKnowledgeSyncIntervalMs()).toBe(MAX_TIMER_DELAY_MS));
+    // A value just under the cap is honored unchanged.
+    withEnv("500", () => expect(getKnowledgeSyncIntervalMs()).toBe(500 * 60 * 60 * 1000));
   });
 });
 
@@ -161,6 +169,10 @@ describe("interval hot-reload (#4236)", () => {
       await Bun.sleep(200);
       expect(CYCLE_CALLS).toBe(1); // ticks fired but were skipped in-flight
       stopKnowledgeBundleSyncScheduler();
+      // Drain the still-sleeping mocked cycle so its `.finally` clears
+      // `_inFlight` before the next test — `_reset` in `beforeEach` also clears
+      // it, but draining keeps the leak from ever crossing a boundary.
+      await Bun.sleep(CYCLE_DELAY_MS);
     });
   });
 });

--- a/packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts
@@ -2,17 +2,20 @@
  * Tests for the knowledge bundle sync scheduler (`knowledge-bundle-sync.ts`,
  * #4211) — the periodic pull fiber over enabled `bundle-sync` collections.
  * Covers the settings-driven interval resolution, lifecycle (start / stop /
- * double-start guard / bad-override clamp), and the manual trigger delegating
- * to the sync cycle. The cycle itself is mocked — its behavior is pinned in
- * `lib/knowledge/__tests__/sync.test.ts`.
+ * double-start guard / bad-override clamp), the per-tick interval hot-reload
+ * (#4236, including the overlap guard under a slow cycle), and the manual
+ * trigger delegating to the sync cycle. The cycle itself is mocked — its
+ * behavior is pinned in `lib/knowledge/__tests__/sync.test.ts`.
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 let CYCLE_CALLS = 0;
+let CYCLE_DELAY_MS = 0;
 mock.module("@atlas/api/lib/knowledge/sync", () => ({
   runKnowledgeSyncCycle: async () => {
     CYCLE_CALLS++;
+    if (CYCLE_DELAY_MS > 0) await Bun.sleep(CYCLE_DELAY_MS);
     return { inspected: 0, succeeded: 0, failed: 0, queryFailed: false };
   },
   syncCollection: async () => {
@@ -40,6 +43,7 @@ const {
   isKnowledgeBundleSyncSchedulerRunning,
   triggerKnowledgeBundleSyncCycle,
   _resetKnowledgeBundleSyncScheduler,
+  _getArmedKnowledgeSyncIntervalMs,
 } = await import("../knowledge-bundle-sync");
 
 const KEY = "ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS";
@@ -57,6 +61,7 @@ function withEnv(value: string | undefined, fn: () => void): void {
 
 beforeEach(() => {
   CYCLE_CALLS = 0;
+  CYCLE_DELAY_MS = 0;
   _resetKnowledgeBundleSyncScheduler();
 });
 afterEach(() => {
@@ -109,6 +114,54 @@ describe("lifecycle", () => {
       stopKnowledgeBundleSyncScheduler();
       expect(isKnowledgeBundleSyncSchedulerRunning()).toBe(false);
     }
+  });
+});
+
+describe("interval hot-reload (#4236)", () => {
+  async function withEnvAsync(value: string, fn: () => Promise<void>): Promise<void> {
+    const prev = process.env[KEY];
+    process.env[KEY] = value;
+    try {
+      await fn();
+    } finally {
+      if (prev === undefined) delete process.env[KEY];
+      else process.env[KEY] = prev;
+    }
+  }
+
+  it("re-reads the configured interval when arming the next tick — no restart", async () => {
+    // 0.00002h = 72ms — fast enough to observe a tick within the test.
+    await withEnvAsync("0.00002", async () => {
+      startKnowledgeBundleSyncScheduler();
+      expect(_getArmedKnowledgeSyncIntervalMs()).toBeCloseTo(72, 6);
+
+      // Operator changes the setting between ticks (env tier stands in for
+      // the registry's DB-override tier — same getSettingAuto read path).
+      process.env[KEY] = "1";
+      await Bun.sleep(150); // let the 72ms tick fire and re-arm
+      expect(CYCLE_CALLS).toBeGreaterThanOrEqual(2); // initial + ≥1 tick
+      expect(_getArmedKnowledgeSyncIntervalMs()).toBe(60 * 60 * 1000);
+      stopKnowledgeBundleSyncScheduler();
+    });
+  });
+
+  it("an explicit start-time override stays fixed (not re-read per tick)", () => {
+    withEnv("6", () => {
+      startKnowledgeBundleSyncScheduler(60_000);
+      expect(_getArmedKnowledgeSyncIntervalMs()).toBe(60_000);
+      stopKnowledgeBundleSyncScheduler();
+      expect(_getArmedKnowledgeSyncIntervalMs()).toBeNull();
+    });
+  });
+
+  it("a slow in-flight cycle still never overlaps the next tick", async () => {
+    await withEnvAsync("0.00002", async () => {
+      CYCLE_DELAY_MS = 300; // initial cycle outlives several 72ms ticks
+      startKnowledgeBundleSyncScheduler();
+      await Bun.sleep(200);
+      expect(CYCLE_CALLS).toBe(1); // ticks fired but were skipped in-flight
+      stopKnowledgeBundleSyncScheduler();
+    });
   });
 });
 

--- a/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
+++ b/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
@@ -146,6 +146,18 @@ function runCycleWithDefectGuard(): void {
 }
 
 /**
+ * Clamp a millisecond delay into `setTimeout`'s safe range. Non-finite /
+ * non-positive → the 24h default; over-large → `MAX_TIMER_DELAY_MS` (a bigger
+ * value overflows the 32-bit timer and hot-loops at 1ms). Applied to BOTH
+ * arming paths — the registry read and an explicit start-time override — so the
+ * overflow guard is a genuine guarantee, not just a registry-path one (#4236).
+ */
+function clampTimerDelayMs(ms: number): number {
+  if (!Number.isFinite(ms) || ms <= 0) return DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS;
+  return Math.min(ms, MAX_TIMER_DELAY_MS);
+}
+
+/**
  * Arm the next tick, re-reading the configured interval so a settings change
  * (admin console / DB override, ~30s registry hot-reload) takes effect by the
  * following tick — no restart. An explicit start-time override stays fixed.
@@ -154,7 +166,10 @@ function runCycleWithDefectGuard(): void {
  */
 function armNextTick(): void {
   if (!_running) return;
-  const interval = _intervalOverrideMs ?? getKnowledgeSyncIntervalMs();
+  // getKnowledgeSyncIntervalMs already returns a clamped value; clamp again so
+  // an explicit start-time override (which bypasses that function) can't
+  // overflow the timer either — the guard covers every arming path.
+  const interval = clampTimerDelayMs(_intervalOverrideMs ?? getKnowledgeSyncIntervalMs());
   if (_armedIntervalMs !== null && _armedIntervalMs !== interval) {
     log.info(
       { previousMs: _armedIntervalMs, intervalMs: interval },
@@ -171,6 +186,10 @@ function armNextTick(): void {
     try {
       runCycleWithDefectGuard();
     } catch (err: unknown) {
+      // Defensive / near-unreachable: runCycleWithDefectGuard delegates to an
+      // async cycle (rejections, not sync throws) and its only sync statements
+      // are the in-flight guard + a debug log. This catch exists so a future
+      // refactor that adds a throwing sync pre-check can't kill the chain.
       log.error(
         { err: err instanceof Error ? err.message : String(err) },
         "Knowledge bundle sync tick threw synchronously — re-arming anyway",

--- a/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
+++ b/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
@@ -12,17 +12,18 @@
  * Cadence: `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` — a settings-registry knob
  * (default 24, i.e. nightly), NOT a bespoke env var (CLAUDE.md SaaS-first
  * configuration rule; the env var of the same name is the registry's standard
- * env-tier fallback). Read once at scheduler start (`requiresRestart: true`,
- * mirroring `ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS`).
+ * env-tier fallback). Hot-reloaded (#4236): the interval is re-read via
+ * `getSettingAuto` when arming each next tick, so an admin-console change
+ * takes effect by the following tick without a process restart.
  *
- * Lifecycle: `setInterval`-based with `unref()` (doesn't pin the process), an
- * initial cycle on start, a single-running guard, and an in-flight overlap
- * guard so a slow cycle never races the next tick. Promise-native cycle → the
- * Promise `withSpan` (self-spanned, so it never slots into
- * `SCHEDULER_WORK_SPAN_NAMES` in `effect/layers.ts`). This is now the last
- * `setInterval`-based scheduler — its former siblings (`openapi-spec-refresh.ts`,
- * `byot-catalog-refresh.ts`) were folded onto `registerPeriodicFiber` by #4195;
- * this job is a candidate for the same treatment.
+ * Lifecycle: self-rescheduling `setTimeout` chain with `unref()` (doesn't pin
+ * the process), an initial cycle on start, a single-running guard, and an
+ * in-flight overlap guard so a slow cycle never races the next tick.
+ * Promise-native cycle → the Promise `withSpan` (self-spanned, so it never
+ * slots into `SCHEDULER_WORK_SPAN_NAMES` in `effect/layers.ts`). Its former
+ * siblings (`openapi-spec-refresh.ts`, `byot-catalog-refresh.ts`) were folded
+ * onto `registerPeriodicFiber` by #4195; this job is a candidate for the same
+ * treatment.
  *
  * @see ../knowledge/sync.ts — the per-collection sync + cycle walk.
  */
@@ -44,7 +45,7 @@ export const DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
  * The periodic sync interval (ms). Reads the settings-registry knob
  * `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` (default 24). Fractional hours are
  * legal (an operator can soak-test at 0.1h); non-positive / unparseable
- * values fall back to the default rather than hot-looping `setInterval`.
+ * values fall back to the default rather than hot-looping the timer.
  */
 export function getKnowledgeSyncIntervalMs(): number {
   const raw = getSettingAuto("ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS");
@@ -94,14 +95,18 @@ export async function runKnowledgeBundleSyncCycle(): Promise<KnowledgeSyncCycleR
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle (setInterval-based — the last such scheduler after #4195 folded
-// the OpenAPI/BYOT refresh jobs onto registerPeriodicFiber)
+// Lifecycle (self-rescheduling setTimeout — each tick re-reads the interval so
+// the settings knob hot-reloads, #4236)
 // ---------------------------------------------------------------------------
 
-let _timer: ReturnType<typeof setInterval> | null = null;
+let _timer: ReturnType<typeof setTimeout> | null = null;
 let _running = false;
 /** A still-running cycle, so a slow tick never overlaps the next one. */
 let _inFlight = false;
+/** A start-time test/caller override; null = re-read the registry per tick. */
+let _intervalOverrideMs: number | null = null;
+/** The delay the pending timer was armed with (observable by tests). */
+let _armedIntervalMs: number | null = null;
 
 function runCycleWithDefectGuard(): void {
   if (_inFlight) {
@@ -124,9 +129,26 @@ function runCycleWithDefectGuard(): void {
 }
 
 /**
+ * Arm the next tick, re-reading the configured interval so a settings change
+ * (admin console / DB override, ~30s registry hot-reload) takes effect by the
+ * following tick — no restart. An explicit start-time override stays fixed.
+ */
+function armNextTick(): void {
+  if (!_running) return;
+  const interval = _intervalOverrideMs ?? getKnowledgeSyncIntervalMs();
+  _armedIntervalMs = interval;
+  _timer = setTimeout(() => {
+    runCycleWithDefectGuard();
+    armNextTick();
+  }, interval);
+  _timer.unref();
+}
+
+/**
  * Start the knowledge bundle sync scheduler. Runs an initial cycle
- * immediately, then repeats at the configured interval. No-op if already
- * running. A non-positive / non-finite `intervalMs` override falls back to the
+ * immediately, then repeats at the configured interval, re-reading the
+ * settings knob when arming each next tick. No-op if already running. A
+ * non-positive / non-finite `intervalMs` override falls back to the
  * (already-validated) configured interval rather than hot-looping.
  */
 export function startKnowledgeBundleSyncScheduler(intervalMs?: number): void {
@@ -134,24 +156,28 @@ export function startKnowledgeBundleSyncScheduler(intervalMs?: number): void {
     log.debug("Knowledge bundle sync scheduler already running — skipping start");
     return;
   }
-  const interval =
+  _intervalOverrideMs =
     intervalMs !== undefined && Number.isFinite(intervalMs) && intervalMs > 0
       ? intervalMs
-      : getKnowledgeSyncIntervalMs();
+      : null;
   _running = true;
-  log.info({ intervalMs: interval }, "Starting knowledge bundle sync scheduler");
+  log.info(
+    { intervalMs: _intervalOverrideMs ?? getKnowledgeSyncIntervalMs() },
+    "Starting knowledge bundle sync scheduler (interval re-read each tick)",
+  );
 
   runCycleWithDefectGuard();
-  _timer = setInterval(runCycleWithDefectGuard, interval);
-  _timer.unref();
+  armNextTick();
 }
 
 export function stopKnowledgeBundleSyncScheduler(): void {
   if (_timer) {
-    clearInterval(_timer);
+    clearTimeout(_timer);
     _timer = null;
   }
   _running = false;
+  _intervalOverrideMs = null;
+  _armedIntervalMs = null;
   log.info("Knowledge bundle sync scheduler stopped");
 }
 
@@ -162,6 +188,11 @@ export function isKnowledgeBundleSyncSchedulerRunning(): boolean {
 /** Test-only: reset scheduler state. */
 export function _resetKnowledgeBundleSyncScheduler(): void {
   stopKnowledgeBundleSyncScheduler();
+}
+
+/** Test-only: the delay (ms) the pending tick was armed with, or null. */
+export function _getArmedKnowledgeSyncIntervalMs(): number | null {
+  return _armedIntervalMs;
 }
 
 /**

--- a/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
+++ b/packages/api/src/lib/scheduler/knowledge-bundle-sync.ts
@@ -42,10 +42,19 @@ const log = createLogger("knowledge-bundle-sync-scheduler");
 export const DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * `setTimeout`/`setInterval` clamp delays above 2^31−1 ms (~24.85 days) down to
+ * 1ms — so an over-large interval would hot-loop, the exact opposite of intent.
+ * We cap at the max representable delay instead (≈596.5h). See #4236 review.
+ */
+export const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+/**
  * The periodic sync interval (ms). Reads the settings-registry knob
  * `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` (default 24). Fractional hours are
  * legal (an operator can soak-test at 0.1h); non-positive / unparseable
- * values fall back to the default rather than hot-looping the timer.
+ * values fall back to the default rather than hot-looping the timer, and
+ * over-large values are clamped to `MAX_TIMER_DELAY_MS` (a bigger value would
+ * overflow the 32-bit timer and hot-loop at 1ms — see #4236).
  */
 export function getKnowledgeSyncIntervalMs(): number {
   const raw = getSettingAuto("ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS");
@@ -58,7 +67,15 @@ export function getKnowledgeSyncIntervalMs(): number {
     );
     return DEFAULT_KNOWLEDGE_SYNC_INTERVAL_MS;
   }
-  return hours * 60 * 60 * 1000;
+  const ms = hours * 60 * 60 * 1000;
+  if (ms > MAX_TIMER_DELAY_MS) {
+    log.warn(
+      { raw, maxHours: MAX_TIMER_DELAY_MS / (60 * 60 * 1000) },
+      "ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS exceeds the max timer delay — clamping to avoid a 32-bit overflow hot-loop",
+    );
+    return MAX_TIMER_DELAY_MS;
+  }
+  return ms;
 }
 
 /**
@@ -132,14 +149,35 @@ function runCycleWithDefectGuard(): void {
  * Arm the next tick, re-reading the configured interval so a settings change
  * (admin console / DB override, ~30s registry hot-reload) takes effect by the
  * following tick — no restart. An explicit start-time override stays fixed.
+ * Logs when the re-read interval differs from the previously-armed one so an
+ * operator has evidence a cadence change actually took effect (#4236).
  */
 function armNextTick(): void {
   if (!_running) return;
   const interval = _intervalOverrideMs ?? getKnowledgeSyncIntervalMs();
+  if (_armedIntervalMs !== null && _armedIntervalMs !== interval) {
+    log.info(
+      { previousMs: _armedIntervalMs, intervalMs: interval },
+      "Knowledge bundle sync interval changed — new cadence applies from this tick",
+    );
+  }
   _armedIntervalMs = interval;
+  // Self-rescheduling chain: the re-arm must survive a synchronous throw in the
+  // cycle kickoff (setInterval used to guarantee this) — otherwise the loop
+  // would die with `_running` still true and no pending timer. try/finally
+  // keeps the chain alive; the cycle's own async errors are handled in
+  // `runCycleWithDefectGuard`.
   _timer = setTimeout(() => {
-    runCycleWithDefectGuard();
-    armNextTick();
+    try {
+      runCycleWithDefectGuard();
+    } catch (err: unknown) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Knowledge bundle sync tick threw synchronously — re-arming anyway",
+      );
+    } finally {
+      armNextTick();
+    }
   }, interval);
   _timer.unref();
 }
@@ -185,9 +223,15 @@ export function isKnowledgeBundleSyncSchedulerRunning(): boolean {
   return _running;
 }
 
-/** Test-only: reset scheduler state. */
+/**
+ * Test-only: reset scheduler state to pristine (as if never started). Unlike
+ * production `stop()` — which leaves a real in-flight cycle to finish — this
+ * also clears `_inFlight`, so a slow mocked cycle from a prior test can't leak
+ * its guard into the next test's initial cycle (#4236 review).
+ */
 export function _resetKnowledgeBundleSyncScheduler(): void {
   stopKnowledgeBundleSyncScheduler();
+  _inFlight = false;
 }
 
 /** Test-only: the delay (ms) the pending tick was armed with, or null. */

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1436,20 +1436,19 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   },
 
   // Knowledge Base — bundle-sync cadence + fetch caps (#4211). Platform-scoped
-  // operator knobs; the interval is read once at scheduler start (mirrors
-  // ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS), the fetch timeout is read per sync.
+  // operator knobs; both hot-reload — the interval is re-read when the
+  // scheduler arms each next tick (#4236), the fetch timeout is read per sync.
   {
     key: "ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS",
     section: "Knowledge Base",
     label: "Bundle Sync Interval (hours)",
     description:
-      "How often bundle-sync knowledge collections pull their endpoint (default 24 — nightly). Read at scheduler start; non-positive values fall back to the default.",
+      "How often bundle-sync knowledge collections pull their endpoint (default 24 — nightly). Hot-reloaded — a change takes effect by the next scheduled tick; non-positive values fall back to the default.",
     type: "number",
     default: "24",
     envVar: "ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS",
     scope: "platform",
     saasVisible: false,
-    requiresRestart: true,
   },
   {
     key: "ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS",


### PR DESCRIPTION
## Summary

Closes #4236.

`ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` was the one Knowledge Base knob that fell short of the SaaS-first no-restart bar: it was declared `requiresRestart: true` and read once at scheduler start via a fixed `setInterval`, so changing the sync cadence on SaaS meant bouncing the API service. Every other KB setting hot-reloads (~30s) via `getSettingAuto`.

This converts the knowledge bundle sync scheduler to a **self-rescheduling `setTimeout` chain** that re-reads the interval when arming each next tick, so an admin-console change takes effect by the following tick — no restart. The in-flight overlap guard, initial cycle, `unref()`, and single-running guard are all preserved; an explicit start-time override (used by tests) stays fixed.

`requiresRestart: true` is removed from the registry entry, and the "requires a restart" notes are dropped from both docs tables.

Hardening added in response to the internal review panel:
- **Overflow clamp** — `setTimeout` collapses delays above 2³¹−1 ms (~596.5h) to 1ms, which would hot-loop; `getKnowledgeSyncIntervalMs` now clamps (with a `log.warn`), and `armNextTick` re-applies the clamp so an explicit override can't overflow either. The guard covers every arming path.
- **Exception-safe re-arm** — a synchronous throw in the tick kickoff re-arms via `try/finally` instead of killing the loop with `_running` still true (a regression `setInterval` didn't have).
- **Observability** — logs when the re-read interval differs from the previously-armed one, so an operator has evidence a cadence change took effect.

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

New/updated tests in `packages/api/src/lib/scheduler/__tests__/knowledge-bundle-sync.test.ts` cover: interval hot-reload (change between ticks re-arms at the new cadence without restart), fixed start-time override, the overlap guard under a slow in-flight cycle (with a drain so `_inFlight` can't leak across the isolated-file boundary), and the overflow clamp. 11/11 pass.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — all 28 local `scripts/ci-local.sh` gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area) — `refactor`, `area: api`
- [ ] CHANGELOG.md updated (if user-facing change) — operator/settings change, no per-tag changelog entry needed

https://claude.ai/code/session_01S1okJe1tWeWATtUVkSHFnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1okJe1tWeWATtUVkSHFnE)_