### PR TITLE
docs(#4290): undocumented feature surfaces + recently-shipped features

### DIFF
--- a/apps/docs/content/docs/deployment/multi-datasource.mdx
+++ b/apps/docs/content/docs/deployment/multi-datasource.mdx
@@ -280,6 +280,21 @@ The `executeSQL` tool exposes a `scope` parameter (`auto` / `pin` / `all`) that 
 
 OTel traces tag each agent step with `atlas.routing_mode` for cross-environment analytics; see [Observability](/platform-ops/observability).
 
+### Source-catalog descriptions
+
+Before the agent picks a datasource it reads a compact **Source catalog** — one entry per SQL connection group plus one per REST datasource — that summarizes what each source contains. A good description is what lets the agent route "how many EU orders today?" to the right group instead of guessing. Each SQL group's description is generated automatically from that group's entities when you save the [semantic-layer wizard](/guides/semantic-layer-wizard), and is **operator-refinable** — a workspace admin can override it to sharpen the agent's source selection.
+
+Edit descriptions from **Admin → Connections** (the same surface that manages [connection groups](/semantic-layer/multi-env#connection-groups)). A manual edit stamps the row `source: manual` and is **never clobbered by a later re-profile**; clearing it (saving a blank value) deletes the override outright — the catalog entry then falls back to the entity-name summary until the next re-profile regenerates the auto seed.
+
+The API is org-scoped and requires the `admin:connections` permission:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/admin/connection-groups` | List the workspace's group descriptions with provenance (`auto` vs `manual`) |
+| `PATCH` | `/api/v1/admin/connection-groups/{groupId}` | Set the manual description (non-blank body) or clear it (blank body, reverting to the auto seed) |
+
+Descriptions are capped at 2000 characters. This catalog is the ADR-0022 §4 source-routing signal — it drives which datasource the agent targets, so keep each one a crisp statement of what that environment holds (`"EU production replica — orders, customers, refunds"`), not a schema dump.
+
 ### Per-conversation REST datasource scope
 
 REST/OpenAPI datasources (see [OpenAPI datasources](/plugins/datasources/openapi-generic)) carry their own per-conversation scope axis, controlled from the same chat-header picker and **independent of SQL routing mode**:

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -425,6 +425,24 @@ All status changes record the reviewer and timestamp. Approve/reject use optimis
 
 ---
 
+## Query Suggestions
+
+<Callout type="info">
+Requires an internal database (`DATABASE_URL`). Suggestions are auto-generated from query frequency — there's nothing to author by hand.
+</Callout>
+
+Query suggestions are the **contextual "questions you can ask"** Atlas surfaces to end users for a given table. They're distinct from [Learned Patterns](#learned-patterns): a learned pattern is a SQL template the agent reuses, while a suggestion is a user-facing prompt, **score-ranked** by how often the underlying query is run and how often the suggestion is clicked. They're stored in `query_suggestions` and served to the chat/table UI by the user-facing endpoints:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/suggestions?table=<name>` | Suggestions for one or more tables (repeat `table` to combine), ordered by score |
+| `GET` | `/api/v1/suggestions/popular` | Top suggestions across all tables |
+| `POST` | `/api/v1/suggestions/{id}/click` | Track engagement (fire-and-forget, always `204`) — feeds the click-weighted score |
+
+Admins prune noise from the same data via `GET /suggestions` (filter by `table` / `min_frequency`) and `DELETE /suggestions/{id}` under the admin API (see [Admin API Endpoints](#api-endpoints)). Non-admin reads only see published suggestions; admin/dev-mode reads overlay drafts.
+
+---
+
 ## Prompt Library
 
 **Route:** `/admin/prompts`

--- a/apps/docs/content/docs/guides/demo-mode.mdx
+++ b/apps/docs/content/docs/guides/demo-mode.mdx
@@ -116,6 +116,24 @@ curl -X POST https://your-atlas.example.com/api/v1/demo/chat \
 
 ---
 
+## Operator: demo funnel analytics
+
+The endpoints above are the visitor path. Operators watch the funnel — who started a demo, what they asked, and what it cost — from a separate **platform-admin** surface mounted at `/api/v1/platform/demo`. Every route requires the `platform_admin` role **and** MFA, and needs an internal database (`DATABASE_URL`). Lead emails and the questions visitors ask are PII-adjacent, so platform-admin gating *is* the access control for this data.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/config` | Current demo model, max-steps, and RPM, plus the resolved effective model |
+| `PUT` | `/config` | Update the demo model, max-steps, and RPM |
+| `GET` | `/leads` | Demo leads with per-email session + conversation counts and a token/cost spend rollup |
+| `GET` | `/transcript?email=<addr>` | The full question/answer transcript for one lead email |
+| `GET` | `/metrics` | Token + cache + latency rollup — aggregate and per-model |
+
+### Changing demo limits without a redeploy
+
+`PUT /config` writes `ATLAS_DEMO_MODEL`, `ATLAS_DEMO_MAX_STEPS`, and `ATLAS_DEMO_RATE_LIMIT_RPM` to the settings registry at platform scope. They are **hot-reloadable** — a change takes effect within the settings refresh window (~30s), no restart required. The [environment variables](#environment-variables) above are the boot default; once the internal DB is up, the operator console (or `PUT /config`) is the authoritative surface for these three knobs. A blank `model` clears the override and reverts the demo to the resolved default model.
+
+---
+
 ## Limitations
 
 - **No plugin tools** — demo sessions use default tools only (executeSQL, explore). Custom actions and plugin-provided tools are not available

--- a/apps/docs/content/docs/guides/integrations.mdx
+++ b/apps/docs/content/docs/guides/integrations.mdx
@@ -311,6 +311,10 @@ Click **Disconnect** and confirm. WhatsApp messaging stops working until you rec
 
 Configure email delivery for digests and notifications. Email supports multiple providers: **SMTP**, **SendGrid**, **Postmark**, and **Amazon SES**.
 
+<Callout type="info" title="Resend baseline vs. workspace override">
+The same per-workspace email configuration is also managed from the dedicated **Admin → Email Provider** page (`/api/v1/admin/email-provider` — `GET` / `PUT` / `DELETE`, plus `POST /test` to send a test message). On the hosted SaaS platform that page shows Atlas's **Resend baseline** as a locked default row — the shared "Atlas owns delivery" identity that applies until you configure your own provider. Anything you set installs a per-workspace **override** that supersedes the baseline; removing it reverts delivery to the baseline (self-hosted) or platform default. Both surfaces write the same per-org `email_installations` record, so configure it in whichever place you prefer.
+</Callout>
+
 Email uses the **form-based install model** (`POST /api/v1/integrations/email/install-form`) — there is no operator-side App Registration. The catalog entry declares the provider-specific fields and the install handler validates + persists them. Secret fields (passwords, API keys) are encrypted at rest via the same `encryptSecretFields` path the other form-based integrations use.
 
 ### Setup

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -849,10 +849,38 @@ The single endpoint accepts:
 
 The MCP SDK handles dispatch automatically — clients pointed at the URL above just work.
 
+### Agent region discovery
+
+The brand apex `useatlas.dev` is the first host an agent (or an agent-readiness scanner) resolves. It can't run the per-request OAuth machinery — that lives on the regional `api.*` hosts — so it serves a **static mirror** of the canonical (US-region) agent-discovery surface, generated from the same source the live API advertises so the copies can't drift:
+
+| Path (on `useatlas.dev`) | What it is |
+|--------------------------|------------|
+| `/.well-known/atlas-regions.json` | Machine-readable region directory (below) |
+| `/auth.md` | Static mirror of the US-region [`auth.md`](#authentication) onboarding document |
+| `/.well-known/oauth-protected-resource` | RFC 9728 metadata describing the REST API as a bearer-protected resource |
+| `/.well-known/openid-configuration`, `/.well-known/oauth-authorization-server` | **302 redirects** to the live Better-Auth-generated docs on `api.useatlas.dev` (these are dynamic and never frozen) |
+
+An agent that has only the brand name and needs to pick a residency region reads **`useatlas.dev/.well-known/atlas-regions.json`** — the agent-facing analogue of the browser signup/login region picker. Atlas residency makes the *host* the region (ADR-0024), so the agent resolves its region here, then follows that host's own `/auth.md` + `.well-known` documents (which advertise the regional MCP endpoint):
+
+```json
+{
+  "default": "us",
+  "regions": [
+    { "id": "us",   "label": "United States", "api": "https://api.useatlas.dev",      "mcp": "https://mcp.useatlas.dev/mcp",      "authMd": "https://api.useatlas.dev/auth.md" },
+    { "id": "eu",   "label": "Europe",        "api": "https://api-eu.useatlas.dev",   "mcp": "https://mcp-eu.useatlas.dev/mcp",   "authMd": "https://api-eu.useatlas.dev/auth.md" },
+    { "id": "apac", "label": "Asia Pacific",  "api": "https://api-apac.useatlas.dev", "mcp": "https://mcp-apac.useatlas.dev/mcp", "authMd": "https://api-apac.useatlas.dev/auth.md" }
+  ]
+}
+```
+
+Each entry gives the region's API/OAuth-issuer host, its MCP resource host, and its own region-correct `auth.md`. The directory is derived from the same `residency.regions` config the signup picker consumes, and a CI drift gate regenerates it, so it can never disagree with the regions the platform actually offers.
+
 ### Authentication
 
 <Callout type="info" title="One file, human- and machine-readable">
 Atlas hosts the whole agent-registration story — the OAuth 2.1 + DCR + PKCE flow, the discovery documents, the scopes, and the `start_trial` self-serve path — as a single document at [`mcp.useatlas.dev/auth.md`](https://mcp.useatlas.dev/auth.md). It's the canonical end-to-end description of how an agent registers with Atlas: an integrator can read it, and an `auth.md`-aware agent can fetch it at that conventional path to self-navigate the flow. The sections below restate the same flow in context; the hosted file is the source of truth.
+
+The same document is reachable at three conventional locations, all rendered from one source: the MCP brand host [`mcp.useatlas.dev/auth.md`](https://mcp.useatlas.dev/auth.md), each regional API host (`api.useatlas.dev/auth.md`, `api-eu.useatlas.dev/auth.md`, …), and — for an agent that starts from the bare brand — a static mirror at the [apex `useatlas.dev/auth.md`](https://useatlas.dev/auth.md) (see [Agent region discovery](#agent-region-discovery) above). The apex copy is byte-for-byte the US-region file and is regenerated + drift-checked in CI, so it never advertises a stale scope or host.
 </Callout>
 
 Atlas's authorization server lives at `/api/auth`. Three discovery documents drive the OAuth flow:

--- a/apps/docs/content/docs/security/passkeys.mdx
+++ b/apps/docs/content/docs/security/passkeys.mdx
@@ -269,6 +269,35 @@ compliance queries can split recovery from off-boarding.
 Workspace admins can only reset users in their own org. Cross-org
 resets require a platform admin and emit the same audit row.
 
+### Off-boarding: revoke all authentication
+
+MFA reset is *recovery* — it lets the same person back in. **Off-boarding**
+is the opposite: when a contractor rolls off or an account is compromised
+you want to close *every* way that account can authenticate, and you do
+**not** want re-enrollment. The user detail page's **Danger zone** card
+exposes this as **Revoke all authentication**, the sibling of Reset MFA.
+
+1. Workspace admin (or platform admin, cross-org) opens
+   **Admin → Users → \<user\>** and clicks **Revoke all authentication**.
+2. A preview (`GET /api/v1/admin/users/{id}/revoke-auth/preview`) shows the
+   per-class counts — sessions, trusted devices, passkeys, OAuth
+   access/refresh tokens — that the action would delete, so the admin sees
+   the blast radius before confirming.
+3. On confirm (`POST /api/v1/admin/users/{id}/revoke-auth`), the API deletes,
+   **atomically in one transaction**: every active session, every
+   trusted-device cookie (and its adjacent verification rows), every passkey,
+   and every OAuth access and refresh token. Either all classes are revoked or
+   the whole thing rolls back — there is no half-revoked state where sessions
+   are gone but a passkey still admits on the next SSO redirect.
+
+Unlike MFA reset, this **does** tear down sessions and OAuth grants — that is
+the point. Nothing about the identity itself is destroyed, so a re-hired user
+can enroll fresh credentials later. The audit row carries the per-class
+counts, the actor, the target email, and an optional reason; the action type
+is `user.auth_revoke`, distinct from `user.mfa_reset`, so compliance queries
+can split off-boarding from recovery. Probing a user in another workspace
+returns the same `404` as a missing user (no cross-org existence leak).
+
 ### What we don't ship — and why
 
 Atlas deliberately does **not** offer the following recovery

--- a/apps/docs/content/docs/security/two-factor-auth.mdx
+++ b/apps/docs/content/docs/security/two-factor-auth.mdx
@@ -78,7 +78,8 @@ Once enrolled, every subsequent sign-in prompts for a fresh TOTP code
 before the session is authorized. If you lose access to your
 authenticator, use a backup code (each one is single-use). If you
 exhaust all backup codes, contact a `platform_admin` to reset your
-account.
+account — the admin-mediated recovery flow is documented under
+[Passkeys → What happens if you're locked out](./passkeys#what-happens-if-youre-locked-out).
 
 ### Regenerating Backup Codes
 
@@ -145,7 +146,37 @@ admin-role members only — admin/owner accounts are the API-gated, highest-valu
 logins (see [Scope](#scope)). It is backed by
 `GET /api/v1/admin/security/metrics` and requires the internal database, so it
 is unavailable in datasource-only deployments. Cross-workspace operators get a
-fleet-wide roll-up of the same enrollment metrics at `/platform/security`.
+fleet-wide roll-up of the same enrollment metrics at `/platform/security` — see
+the next section.
+
+### Platform-operator fleet view
+
+On a multi-tenant deployment (app.useatlas.dev, or a self-hosted operator running
+many workspaces), a `platform_admin` sees the same adoption buckets summed across
+**every** workspace, plus a per-workspace breakdown, at **`/platform/security`**.
+It answers product questions like *"75% of workspaces have at least one passkey
+enrolled — promote it to non-admin users."*
+
+The page is backed by `GET /api/v1/platform/admin/security/metrics`, which returns
+two payloads:
+
+- **`aggregate`** — one set of buckets (admin count, MFA-enrolled, two-factor-only,
+  passkey-only, both-factors, no-factors, active trust devices, active
+  trust-device users) summed across every **active** workspace. Same shape as the
+  workspace endpoint, so the platform dashboard reuses the workspace traffic-light
+  tile. A user who is admin in *N* workspaces contributes *N* to the counts — the
+  unit of analysis is "an admin in a workspace", which is what drives nudge
+  decisions.
+- **`workspaces`** — one row per workspace with the same per-workspace buckets,
+  capped at 1000 rows (a region past that needs pagination, not a wall of rows).
+
+Suspended and soft-deleted workspaces are excluded — they aren't taking new
+logins, so their counters would be misleading noise. Trust-device grants are
+counted against the verification rows directly, so a single "trust this device"
+cookie held by a user who is admin in three workspaces counts **once** in the
+aggregate (it still shows in each of the three per-workspace rows). Like the
+workspace twin, this endpoint requires `platform_admin` + MFA and the internal
+database.
 
 ## Operator Reference
 

--- a/apps/docs/content/shared/plugins/authoring-guide.mdx
+++ b/apps/docs/content/shared/plugins/authoring-guide.mdx
@@ -533,6 +533,18 @@ Most sandbox plugins need the same two pieces of infrastructure, so `@useatlas/p
 
 - **`collectSemanticFiles(localDir, sandboxDir, logger?)`** — recursively walks the local semantic tree and returns `{ path, content: Uint8Array }[]` ready to upload into the sandbox (the content is a Node `Buffer` at runtime; the type is the portable `Uint8Array`). It carries a **symlink-escape guard**: a symlink whose real target resolves outside the semantic root is skipped (and logged), never uploaded — and symlink cycles are broken so a self-referential tree terminates. This is a security property — single-sourcing it means a fix lands once for every sandbox backend. SDKs that want string content (e.g. E2B's `files.write`) decode via `Buffer.from(f.content).toString("utf-8")` at the call site.
 - **`runHealthCheckWithTimeout(fn, { timeoutMs, cleanup, logger })`** — wraps a `healthCheck()` probe in the `Promise.race` timeout, attaches a measured `latencyMs`, and runs `cleanup` in every failing branch (timeout or throw). The optional `logger.warn` fires on each failing branch (timeout, probe throw, cleanup throw). The probe owns its happy-path teardown; `cleanup` is the safety net that reaps a sandbox reference the probe captured but could not release (it must be idempotent/guarded). `await using` is intentionally not used — the timeout can win while the SDK is still mid-create with no `AbortSignal`, so an explicit guarded cleanup fires immediately.
+- **`measuredHealthCheck(fn)`** — the latency bracket `runHealthCheckWithTimeout` composes, usable on its own for **any** plugin's `healthCheck()` (not just sandboxes). `fn` returns a `PluginHealthResult` *without* `latencyMs` (stamped here, measured probe-start to settle); a throw or rejection becomes `{ healthy: false, message }` with the message narrowed via `err instanceof Error ? err.message : String(err)`. It adds no timeout or cleanup — reach for it when you want the measure-and-narrow boilerplate gone but don't need the `Promise.race`/cleanup ceremony:
+
+  ```typescript
+  import { measuredHealthCheck } from "@useatlas/plugin-sdk";
+
+  async healthCheck(): Promise<PluginHealthResult> {
+    return measuredHealthCheck(async () => {
+      await conn.query("SELECT 1", 5000);
+      return { healthy: true };
+    });
+  }
+  ```
 
 ```typescript
 import { collectSemanticFiles, runHealthCheckWithTimeout } from "@useatlas/plugin-sdk";
@@ -813,6 +825,40 @@ Tables are automatically prefixed with `plugin_{pluginId}_` to avoid collisions 
 ## Datasource Plugin Properties
 
 Beyond the basics shown in [step 4](#4-plugin-object), datasource plugins support several additional properties.
+
+### `createDatasourcePlugin` — the assembly factory
+
+For a SQL (or SQL-shaped) datasource, prefer **`createDatasourcePlugin`** over hand-assembling the plugin object. It is the datasource-specific sibling of [`createPlugin`](#createplugin-vs-defineplugin): it absorbs the boilerplate every url-shaped datasource (ClickHouse, Snowflake, DuckDB, BigQuery, Elasticsearch, Salesforce) used to repeat —
+
+- the **static-vs-adapter-only mode branch** — a fully-specified config wires a boot connection; a bare `plugin({})` registers as an adapter, exposing only `createFromConfig` for per-workspace datasources;
+- the **`createFromConfig` wrapper** — strict-parse the decrypted per-(workspace, install) config → `buildConnection` → `attachIntrospection` (per-workspace connections, ADR-0013; introspection bound to the built connection, ADR-0017);
+- the standard `initialize()` mode log line, the adapter-only + [`measuredHealthCheck`](#shared-sandbox-helpers) static health probe, and optional static-connection caching with close-guarded teardown.
+
+You supply only the per-dialect substance: a **lenient `configSchema`** (every field optional so `plugin({})` parses as adapter-only) paired with a **strict `connectionConfigSchema`**, a `buildConnection`, an `attachIntrospection`, and — only where your dialect diverges — a mode predicate, static-connection builder, health probe, hooks, or `initialize` extras.
+
+```typescript
+import { createDatasourcePlugin } from "@useatlas/plugin-sdk";
+
+export const mydbPlugin = createDatasourcePlugin({
+  id: "mydb-datasource",
+  name: "MyDB DataSource",
+  dbType: "mydb",
+  parserDialect: "PostgresQL",
+  forbiddenPatterns: MYDB_FORBIDDEN_PATTERNS,
+  dialect: "This datasource uses MyDB SQL dialect.",
+  configSchema: MyDBConfigSchema,               // lenient — {} parses (adapter-only)
+  connectionConfigSchema: MyDBConnectionSchema, // strict — url required
+  describeStaticTarget: (c) => extractHost(c.url!),
+  buildConnection: (parsed, rt) => createMyDBConnection({ url: parsed.url, logger: rt.logger }),
+  attachIntrospection: (built, { parsed }) => ({
+    ...built,
+    listObjects: (o) => listMyDBObjects({ url: parsed.url, schema: o?.schema }),
+    profile: (o) => profileMyDB({ url: parsed.url, ...o }),
+  }),
+});
+```
+
+The factory it returns is called with config for the schema-validated `atlas.config.ts` path (`mydbPlugin({ url })`), or `.build(config)` to assemble from an already-validated config (tests / custom wiring). The `connection`-level knobs below (`entities`, `dialect`, `connection.validate`) are the same fields this factory fills in and a hand-rolled plugin sets directly.
 
 ### `entities`
 

--- a/apps/docs/content/shared/reference/react.mdx
+++ b/apps/docs/content/shared/reference/react.mdx
@@ -1078,6 +1078,8 @@ type ClientErrorCode =
   | "offline";            // navigator.onLine === false
 ```
 
+`ChatErrorCode`, `ClientErrorCode`, and `ChatErrorInfo` are all root-exported — `import type { ChatErrorInfo, ChatErrorCode, ClientErrorCode } from "@useatlas/react"` — so a custom `ErrorBanner` can narrow on both the server `code` and the client-side `clientCode` returned by [`parseChatError`](#parsechaterror).
+
 ### Hook Option & Return Types
 
 All hooks export their option and return types for use in wrapper components:
@@ -1150,6 +1152,83 @@ interface FavoriteStarterPrompt {
 ```
 
 The `AtlasChat` widget also accepts a [`starterPrompts` prop](#atlaschat-props) that overrides the adaptive empty-state list. For script-tag embeds, the same list can be supplied via the `data-starter-prompts` JSON attribute — see [Embedding the Widget](/guides/embedding-widget) for details.
+
+---
+
+## Shared render primitives
+
+Beyond the `AtlasChat` component and the hooks, `@useatlas/react` **root-exports** the leaf render components and pure utilities that `AtlasChat` uses internally. Reach for these when you build a custom UI with the [hooks](#hooks-vs-atlaschat-component) and want to render Atlas's tool results — SQL result tables, charts, Markdown, error banners — with the *same* components the pre-built chat uses, rather than re-implementing them.
+
+<Callout type="warn">
+These are lower-level than the hooks and `AtlasChat`. Their prop shapes track the components' internals and can change between minor versions — treat them as an advanced surface, and pin your `@useatlas/react` version if you depend on the exact props. The [stability policy](/reference/stability) covers the component and hook API; these primitives are best-effort.
+</Callout>
+
+### Components
+
+```typescript
+import { Markdown, DataTable, ErrorBanner, SQLResultCard } from "@useatlas/react";
+```
+
+| Export | Renders |
+|--------|---------|
+| `Markdown` | Chat-flavored Markdown (GFM tables, fenced code, sanitized HTML) |
+| `DataTable` | A query result grid with sorting, formatting, and CSV/Excel export |
+| `SQLResultCard` | The full `executeSQL` result card — table, chart toggle, row count, error state. Also exports `SQLResultCardProps`, `SqlResultActionContext`, `PreviousExecution` |
+| `PythonResultCard` | The `runPython` result card (stdout, artifacts, progress). Also exports `PythonResultCardProps`, `PythonProgressData` |
+| `ResultCardBase` / `ResultCardErrorBoundary` | The shared card chrome + an error boundary to wrap a custom card. Also exports `ResultCardBaseProps` |
+| `ErrorBanner` | The inline error surface driven by a parsed `ChatErrorInfo` |
+
+<Callout type="info">
+`ResultChart` (Recharts) is **not** on the root entry — it statically imports `recharts`, an optional peer, so it lives behind the `@useatlas/react/chart` subpath and `AtlasChat` reaches it only via `lazy()`. The **chart-detection** utilities below are pure (their one Recharts import is type-only), so they are safe to import from the root.
+</Callout>
+
+### Chart detection
+
+Pure functions that decide which chart (if any) fits a result set, plus the palette constants — no Recharts runtime:
+
+```typescript
+import {
+  detectCharts, transformData, classifyColumn,
+  categoryFromChartClick, categoryFromPieClick,
+  resolveThresholdLines, resolveAnnotationLines,
+  CHART_COLORS_LIGHT, CHART_COLORS_DARK,
+  THRESHOLD_LINE_LIGHT, THRESHOLD_LINE_DARK,
+  ANNOTATION_LINE_LIGHT, ANNOTATION_LINE_DARK,
+  MAX_THRESHOLD_LINES, MAX_ANNOTATION_LINES,
+} from "@useatlas/react";
+```
+
+Their types — `ChartDetectionResult`, `ChartRecommendation`, `ChartType`, `ClassifiedColumn`, `ColumnType`, `RechartsRow`, `ThresholdInput`, `ThresholdLine`, `AnnotationInput`, `AnnotationLine` — are exported alongside.
+
+### Tool-part + export helpers
+
+```typescript
+import {
+  getToolArgs, getToolResult, isToolComplete,   // read AI-SDK tool parts
+  parseCSV, toCsvString, downloadCSV, downloadBlob, downloadExcel, coerceExcelCell,
+  parseAttachmentFilename, parseSuggestions, normalizeList,
+  categoryMatchesSelection, formatCell,          // cross-filter matching + cell formatting
+} from "@useatlas/react";
+```
+
+### Tool renderer types
+
+Type your own `executeSQL` / `explore` / `runPython` renderers against the same wire shapes `AtlasChat` uses:
+
+```typescript
+import type {
+  ToolRendererProps, ToolRenderers,
+  SQLToolResult, ExploreToolResult, PythonToolResult,
+} from "@useatlas/react";
+```
+
+### Cold-start starter prompts
+
+The static fallback set the widget's empty state shows while the adaptive list loads (or when it resolves empty). Exported so a custom empty state draws from the same source instead of hardcoding a divergent list:
+
+```typescript
+import { DEFAULT_STARTER_PROMPTS, DEFAULT_STARTER_PROMPT_TEXTS } from "@useatlas/react";
+```
 
 ---
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -91,6 +91,10 @@ export type {
   Message,
   ConversationWithMessages,
   ChatErrorCode,
+  // Client-side error classification. Re-exported (from @useatlas/types via
+  // ./lib/types) so consumers can name the `ChatErrorInfo.clientCode` field's
+  // type from the same barrel that exports ChatErrorInfo / ChatErrorCode.
+  ClientErrorCode,
   ChatErrorInfo,
 } from "./lib/types";
 export { AUTH_MODES, parseChatError } from "./lib/types";


### PR DESCRIPTION
Closes #4290. Documents feature surfaces that exist in code with thin/zero prose docs, plus recently-shipped features (v0.0.36–v0.0.41). Every claim was verified against the actual route/source code, then re-verified by the `/review-panel` comment-analyzer against source (all accurate).

## Per-item disposition

### HIGH — new section each (verified vs route source)
| Item | Disposition | Where it landed | Audience |
|------|-------------|-----------------|----------|
| connection-group **source-catalog descriptions** (`admin-connection-group-descriptions.ts`, `GET/PATCH /api/v1/admin/connection-groups`, `admin:connections`, 2000-char cap, `source: manual`, ADR-0022 §4) | **Documented** | `docs/deployment/multi-datasource.mdx` → new "Source-catalog descriptions" section | saas-only (`content/docs`) |
| operator **demo-funnel analytics** (`platform-demo.ts`, `/api/v1/platform/demo` config/leads/transcript/metrics, platform_admin+MFA, hot-reloadable settings) | **Documented** | `docs/guides/demo-mode.mdx` → new "Operator: demo funnel analytics" section | saas-only |
| **platform security-metrics** (`platform-security-metrics.ts`, `GET /api/v1/platform/admin/security/metrics`, aggregate + per-workspace ≤1000, suspended/deleted excluded) | **Documented** | `docs/security/two-factor-auth.mdx` → new "Platform-operator fleet view" section (expands the prior one-line `/platform/security` mention) | saas-only |

### Recently-shipped (HIGH/MEDIUM)
| Item | Disposition | Where |
|------|-------------|-------|
| **`atlas-regions.json`** machine-readable region directory (#4256) | **Documented** | `docs/guides/mcp.mdx` → new "Agent region discovery" subsection (with the byte-accurate JSON) |
| **apex-hosted `auth.md` / OAuth-metadata SSOT** (#4253) | **Documented** | `docs/guides/mcp.mdx` → same subsection (apex static mirror + 302 redirects) + amended the existing auth.md callout to name all three canonical locations |
| **`createDatasourcePlugin` + `measuredHealthCheck`** plugin-sdk factories | **Documented** | `shared/plugins/authoring-guide.mdx` → new `createDatasourcePlugin` subsection under Datasource Plugin Properties + a `measuredHealthCheck` bullet in the health-helper list |

### React reference (F-2 / F-3)
- **F-3** — the root-exported shared render primitives (`Markdown`, `DataTable`, `ErrorBanner`, `SQLResultCard`, `PythonResultCard`, `ResultCardBase`/`ResultCardErrorBoundary`, chart-detection fns/consts, tool-part helpers, tool-renderer types, `DEFAULT_STARTER_PROMPTS`) were absent from the reference. **Documented** as a new "Shared render primitives" section in `shared/reference/react.mdx`, with the accurate caveat that `ResultChart` is **not** root-exported (lives behind `@useatlas/react/chart`).
- **F-2 decision** — chose the **barrel fix** over the doc-only note (the cleaner option): `ClientErrorCode` was already re-exported by `packages/react/src/lib/types.ts` but omitted from the root `index.ts` barrel while its siblings `ChatErrorCode`/`ChatErrorInfo` were exported. Added a **type-only** `export type { ClientErrorCode }` (the one source change) + a doc note in `react.mdx`. Type-only, so it does not trip `check-published-symbols.ts`.

### MEDIUM triage
| Item | Disposition |
|------|-------------|
| `admin-revoke.ts` (force-revoke-all-auth off-boarding) | **Documented** — new "Off-boarding: revoke all authentication" section in `docs/security/passkeys.mdx`, next to the MFA-reset how-to it's contrasted against (`user.auth_revoke`, atomic all-or-nothing, preview endpoint, cross-org 404) |
| `admin-mfa-reset.ts` | **Acknowledged already-documented** — the how-to already lives in `passkeys.mdx` ("What happens if you're locked out"). Closed the forward-ref gap by linking to it from `two-factor-auth.mdx` (which previously said "contact a platform_admin" with no link) |
| `admin-email-provider.ts` (BYOT per-workspace email) | **Acknowledged substantially-covered** — `docs/guides/integrations.mdx#email` already documents setup/providers/test/disconnect (same `email_installations` store). Added the one undocumented distinctive: the SaaS **Resend baseline** (locked default) + override model, naming the `/api/v1/admin/email-provider` surface |
| `suggestions.ts` + `admin-suggestions.ts` (contextual query suggestions) | **Documented** — new "Query Suggestions" section in `docs/guides/admin-console.mdx` (was only two endpoint rows, no prose): user-facing `GET /api/v1/suggestions`, `/popular`, `/{id}/click`, score-ranked, plus the admin CRUD |

## Classification / build gate
No new files — every change edits an existing file already classified under `content/docs` (saas-only) or `content/shared` (shared), so the `validateContentTaxonomy` build gate is satisfied. `cd apps/docs && bun run build` is **green** (all 635+ pages generated). All new cross-links + anchors verified against real routes.

## Gates
- **`/review-panel`** — **CLEAN** on all four axes (silent-failure, type-design, test-coverage, comment/doc-accuracy). The comment-analyzer cross-checked every doc claim against source and found all accurate; one wording nuance it flagged (the "reverts to seed" timing in multi-datasource.mdx) was tightened.
- **Docs build** — green.
- Local react-package `tsc` shows only pre-existing toolchain-artifact errors (bun-types 1.3.14 + root tsconfig `moduleResolution: "bundler"` vs the package's local `tsc` binary) — **zero** reference my source; CI's tsgo-based `ci` check is the authoritative type gate.

## #4289 conflict-awareness (MODERATE overlap)
Both PRs touch `shared/reference/react.mdx` + `guides/mcp.mdx`. My additions are localized:
- `react.mdx`: new "Shared render primitives" section inserted **before** "Full Example" (~line 1156, away from #4289's See-Also edit at ~1244) + a one-line note after the Auth&Error code block (~1080).
- `mcp.mdx`: new "Agent region discovery" subsection + an edit to the existing auth.md callout, both within the Hosted-protocol-reference section (~826–900).

**Not merging** — handing back per instructions; orchestrator serializes + rebases.

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v
