### PR TITLE
docs(portal): audience-link hygiene pass — repoint stale /self-hosted + resolve cross-mount leaks (#4289)

### DIFF
--- a/apps/docs/content/docs/getting-started/hosted.mdx
+++ b/apps/docs/content/docs/getting-started/hosted.mdx
@@ -11,7 +11,7 @@ import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 Get up and running on Atlas's hosted platform. No servers, no CLI, no configuration files — sign up, connect your database, and start querying.
 
 <Callout type="info" title="Looking for self-hosted?">
-  This guide is for the hosted platform at [app.useatlas.dev](https://app.useatlas.dev). To deploy Atlas on your own infrastructure, see the [Self-Hosted Quick Start](/getting-started/quick-start).
+  This guide is for the hosted platform at [app.useatlas.dev](https://app.useatlas.dev). To deploy Atlas on your own infrastructure, see the [Self-Hosted Quick Start](/self-hosted/getting-started/quick-start).
 </Callout>
 
 ## Sign up and create a workspace

--- a/apps/docs/content/docs/guides/actions.mdx
+++ b/apps/docs/content/docs/guides/actions.mdx
@@ -335,7 +335,7 @@ When using the [Slack integration](/guides/slack), pending actions show as ephem
 | `analyst` | Yes | Yes | No |
 | `admin` | Yes | Yes | Yes |
 
-See [Authentication](/deployment/authentication#roles) for role configuration.
+See Authentication for role configuration.
 
 ---
 
@@ -359,6 +359,6 @@ See [Troubleshooting](/guides/troubleshooting#action-framework) for more diagnos
 
 - [Plugin Authoring Guide](/plugins/authoring-guide) — Building custom action plugins
 - [Configuration](/reference/config#actions) — Declarative action configuration in `atlas.config.ts`
-- [Authentication](/deployment/authentication#roles) — Role-based approval (actions require auth)
+- Authentication — Role-based approval (actions require auth)
 - [Admin Console](/guides/admin-console) — Monitor and manage actions from the web UI
 - [Environment Variables](/reference/environment-variables#actions) — `ATLAS_ACTIONS_ENABLED` and per-action settings

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The admin console is a built-in web UI for managing your Atlas deployment. Access it at `/admin` in the Atlas web app.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled (or auth mode `none` for local dev)
+- Managed auth enabled (or auth mode `none` for local dev)
 - A user with the `admin` role
 - When auth mode is `none` (local development), all users have implicit admin access
 </Callout>
@@ -943,7 +943,7 @@ For more, see [Troubleshooting](/guides/troubleshooting).
 
 ## See Also
 
-- [Authentication](/deployment/authentication#managed-auth) — Set up managed auth (required for multi-user admin)
+- Authentication — Set up managed auth (required for multi-user admin)
 - [Multi-Datasource Routing](/deployment/multi-datasource) — Configure and monitor multiple datasource connections
 - [SDK Reference](/reference/sdk#admin) — Programmatic access to admin endpoints
 - [Scheduled Tasks](/guides/scheduled-tasks) — Configure recurring queries managed via the admin console

--- a/apps/docs/content/docs/guides/api-keys.mdx
+++ b/apps/docs/content/docs/guides/api-keys.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 API keys provide programmatic access to the Atlas API. Use them to authenticate requests from the [TypeScript SDK](/reference/sdk), [MCP server](/guides/mcp), or [embeddable widget](/guides/embedding-widget) without requiring interactive login.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - A user with the `admin` role
 - `DATABASE_URL` configured (keys are stored in the internal database)
 </Callout>
@@ -218,4 +218,4 @@ All endpoints require admin authentication.
 - [SDK Reference](/reference/sdk) — Use API keys with the TypeScript SDK
 - [MCP Server](/guides/mcp) — Configure Atlas as an MCP tool provider
 - [Embedding Widget](/guides/embedding-widget) — Embed Atlas in your application
-- [Authentication](/deployment/authentication) — Auth modes and configuration
+- Authentication — Auth modes and configuration

--- a/apps/docs/content/docs/guides/approval-workflows.mdx
+++ b/apps/docs/content/docs/guides/approval-workflows.mdx
@@ -12,7 +12,7 @@ Atlas supports approval workflows for sensitive queries. Admins define rules tha
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for all approval workflow endpoints

--- a/apps/docs/content/docs/guides/caching.mdx
+++ b/apps/docs/content/docs/guides/caching.mdx
@@ -102,7 +102,7 @@ Clears all cached entries. Returns the count of flushed entries. The cache is al
 
 ## See Also
 
-- [Cache Configuration](/deployment/cache-configuration) — Environment variables, `atlas.config.ts` settings, and external cache backends
+- [Cache Configuration](/self-hosted/deployment/cache-configuration) — Environment variables, `atlas.config.ts` settings, and external cache backends
 - [Configuration](/reference/config#query-cache) — Cache config options in `atlas.config.ts`
 - [Environment Variables](/reference/environment-variables) — `ATLAS_CACHE_*` variables
 - [Admin Console](/guides/admin-console) — Cache stats and flush UI

--- a/apps/docs/content/docs/guides/choosing-an-integration.mdx
+++ b/apps/docs/content/docs/guides/choosing-an-integration.mdx
@@ -137,6 +137,6 @@ Set `ATLAS_AUTH_MODE` explicitly to override auto-detection. Valid values: `none
 ## Related
 
 - [Embedding Widget](/guides/embedding-widget) — full widget configuration and customization guide
-- [Authentication](/deployment/authentication) — detailed auth setup, roles, rate limiting, and audit logging
+- Authentication — detailed auth setup, roles, rate limiting, and audit logging
 - [Environment Variables](/reference/environment-variables) — all configuration variables with defaults
 - [SDK documentation](https://www.npmjs.com/package/@useatlas/sdk) — `@useatlas/sdk` on npm

--- a/apps/docs/content/docs/guides/compliance-reporting.mdx
+++ b/apps/docs/content/docs/guides/compliance-reporting.mdx
@@ -12,7 +12,7 @@ Atlas provides compliance reports built on top of audit log data, PII classifica
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for compliance report endpoints

--- a/apps/docs/content/docs/guides/custom-roles.mdx
+++ b/apps/docs/content/docs/guides/custom-roles.mdx
@@ -12,7 +12,7 @@ Atlas supports custom role definitions with granular permission flags. Move beyo
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for all role management endpoints

--- a/apps/docs/content/docs/guides/dashboards.mdx
+++ b/apps/docs/content/docs/guides/dashboards.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Dashboards let you pin query results from chat and organize them into persistent, shareable layouts. **Chart cards** store a SQL query, chart configuration, and cached results — refreshable on demand or on a schedule; **text cards** store markdown for [section headers](#section-headers-text-cards) and explainers (no SQL, no data).
 
 <Callout title="Prerequisites">
-- An [internal database](/deployment/authentication#managed-auth) configured (`DATABASE_URL`)
+- An internal database configured (`DATABASE_URL`)
 - At least one query result in chat to add
 </Callout>
 

--- a/apps/docs/content/docs/guides/embedding-widget.mdx
+++ b/apps/docs/content/docs/guides/embedding-widget.mdx
@@ -1688,7 +1688,7 @@ For more, see [Troubleshooting](/guides/troubleshooting).
 - [SDK Reference](/reference/sdk) — TypeScript SDK for server-side and headless integrations
 - [Choosing an Integration](/guides/choosing-an-integration) — Compare widget, hooks, SDK, and REST API
 - [Rate Limiting & Retry](/guides/rate-limiting#widget--embed-behavior) — How the widget handles 429 responses
-- [Authentication](/deployment/authentication) — Auth mode setup for widget deployments
+- Authentication — Auth mode setup for widget deployments
 
 ---
 

--- a/apps/docs/content/docs/guides/enterprise-sso.mdx
+++ b/apps/docs/content/docs/guides/enterprise-sso.mdx
@@ -12,7 +12,7 @@ Atlas supports enterprise SSO via SAML 2.0 and OpenID Connect (OIDC). Admins reg
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for all SSO management endpoints
@@ -459,6 +459,6 @@ Choose SAML when your IdP mandates it or for compliance requirements. Choose OID
 ## See Also
 
 - [IP Allowlisting](/guides/ip-allowlisting) — Restrict access by IP range
-- [Authentication](/deployment/authentication) — Auth mode setup and configuration
+- Authentication — Auth mode setup and configuration
 - [Admin Console](/guides/admin-console) — Manage users and sessions
 - [Environment Variables](/reference/environment-variables) — Full variable reference

--- a/apps/docs/content/docs/guides/integrations.mdx
+++ b/apps/docs/content/docs/guides/integrations.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The Integrations page provides a central hub for connecting Atlas to external platforms. Manage Slack, Microsoft Teams, Discord, Telegram, Google Chat, GitHub, Linear, WhatsApp, Email, and webhook delivery from a single admin page.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - A user with the `admin` role
 - `DATABASE_URL` configured (connection state is stored in the internal database)
 </Callout>
@@ -350,7 +350,7 @@ Click **Disconnect** and confirm. Email delivery will fall back to environment v
 
 ### Auth Emails (Password Reset, Verification)
 
-The same email transport powers password reset and email verification. The workspace-level provider you configure here is used when a user is signed in (verification re-sends, magic links). The unauthenticated **Forgot password?** flow on `/login` runs without a session and therefore can't see workspace overrides — it falls through to the platform-level provider (`ATLAS_EMAIL_PROVIDER` settings or the `RESEND_API_KEY` / `ATLAS_SMTP_URL` env vars). On a deployment with no platform-level provider, the **Forgot password?** link on `/login` is hidden — see [Password reset](/deployment/authentication#password-reset) for the full flow.
+The same email transport powers password reset and email verification. The workspace-level provider you configure here is used when a user is signed in (verification re-sends, magic links). The unauthenticated **Forgot password?** flow on `/login` runs without a session and therefore can't see workspace overrides — it falls through to the platform-level provider (`ATLAS_EMAIL_PROVIDER` settings or the `RESEND_API_KEY` / `ATLAS_SMTP_URL` env vars). On a deployment with no platform-level provider, the **Forgot password?** link on `/login` is hidden — see Password reset for the full flow.
 
 ### Self-Hosted
 

--- a/apps/docs/content/docs/guides/ip-allowlisting.mdx
+++ b/apps/docs/content/docs/guides/ip-allowlisting.mdx
@@ -12,7 +12,7 @@ Atlas supports per-workspace IP allowlisting. When configured, only requests ori
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for all IP allowlist endpoints
@@ -256,6 +256,6 @@ IPv4 and IPv6 ranges are matched independently — an IPv4 address will not matc
 ## See Also
 
 - [Enterprise SSO](/guides/enterprise-sso) — SAML/OIDC single sign-on and enforcement
-- [Authentication](/deployment/authentication) — Auth mode setup and configuration
+- Authentication — Auth mode setup and configuration
 - [Admin Console](/guides/admin-console) — Manage users and sessions
 - [Environment Variables](/reference/environment-variables) — Full variable reference

--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The Knowledge Base is Atlas's fourth integration pillar (alongside datasources, chat platforms, and action targets, shipped in `v0.0.40`): a place to host the knowledge that informs data answers but isn't schema — business rules, runbooks, product definitions, deprecation notices. You upload it as plain markdown, review it, publish it, and the agent reads it alongside your semantic layer when answering questions.
 
 <Callout title="Prerequisites">
-On [app.useatlas.dev](https://app.useatlas.dev) there is nothing to set up — the Knowledge Base is available to every workspace admin out of the box. Self-hosted deployments need the internal database (`DATABASE_URL`) and [managed auth](/deployment/authentication#managed-auth): collections are organization-scoped, so the no-auth dev mode (`ATLAS_AUTH_MODE=none`) cannot reach them.
+On [app.useatlas.dev](https://app.useatlas.dev) there is nothing to set up — the Knowledge Base is available to every workspace admin out of the box. Self-hosted deployments need the internal database (`DATABASE_URL`) and managed auth: collections are organization-scoped, so the no-auth dev mode (`ATLAS_AUTH_MODE=none`) cannot reach them.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/guides/model-routing.mdx
+++ b/apps/docs/content/docs/guides/model-routing.mdx
@@ -12,7 +12,7 @@ Atlas supports workspace-level model routing. Each workspace can configure its o
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for all model config endpoints

--- a/apps/docs/content/docs/guides/multi-region-login.mdx
+++ b/apps/docs/content/docs/guides/multi-region-login.mdx
@@ -6,7 +6,7 @@ description: How returning users are routed back to their workspace's region on 
 import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="info" title="SaaS multi-region only">
-This flow exists only on the hosted Atlas SaaS when more than one data region is configured. Self-hosted and single-region deployments authenticate against one API base and never engage the region front-door — sign-in is the standard email/password (or SSO) flow described in [Authentication](/deployment/authentication).
+This flow exists only on the hosted Atlas SaaS when more than one data region is configured. Self-hosted and single-region deployments authenticate against one API base and never engage the region front-door — sign-in is the standard email/password (or SSO) flow.
 </Callout>
 
 Under [regional identity isolation (ADR-0024)](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md), each region (US, EU, Asia Pacific) is a **fully independent stack** — its own internal database **and** its own [Better Auth](https://www.better-auth.com/) instance. An EU workspace's `user`, `organization`, `member`, and `session` rows live **only** in the EU database; the US API genuinely returns `401` for it. That isolation is the residency promise, but it creates a routing problem at login: a returning user types an email and password, and the browser must figure out **which region's API** to send them to *before* any session exists.
@@ -56,7 +56,7 @@ Once a user has selected a region (during signup or a prior login), Atlas persis
 The `atlas_region` cookie is client-writable, so only its **region key** is honored. The actual API base is always re-derived from the server's region map — a tampered cookie can never repoint authenticated traffic at an attacker-controlled host. A stale cookie (a region that was removed) falls through to the cold fan-out. This same validation governs the pre-auth API base during signup; see [Self-Serve Signup](/guides/signup#region-selection).
 </Callout>
 
-The cookie is also what makes the rest of the session regional: the auth client reads it at load and binds its base URL to the region's API, so every credentialed call rides the host-only, same-site session cookie for that region (see [host-only session cookies](/deployment/authentication#cross-origin-deployment-self-hosted)).
+The cookie is also what makes the rest of the session regional: the auth client reads it at load and binds its base URL to the region's API, so every credentialed call rides the host-only, same-site session cookie for that region.
 
 ## Same email = two accounts
 
@@ -77,11 +77,11 @@ The region probe is an **account-existence oracle** — exactly like any forgot-
 - **Hash-only input.** `POST /api/v1/auth/region-probe` accepts *only* a 64-character lowercase hex sha256, never a raw email, so it can confirm a guessed address but can't be used to harvest a region's email list.
 - **Boolean-only output.** The probe returns just `{ exists }`.
 - **No global store.** The email→region mapping is computed transiently per request; each region only ever checks its own `user` table.
-- **Rate-limited at two layers.** The `app.useatlas.dev` front-door rate-limits per client IP (the primary per-user control), keying on the leftmost `X-Forwarded-For` hop set by the platform edge; every regional probe additionally rate-limits per IP as a backstop. For the regional probe's per-IP limit to key on the real client IP, set [`ATLAS_TRUST_PROXY=true`](/deployment/authentication#rate-limiting) on the regional APIs.
+- **Rate-limited at two layers.** The `app.useatlas.dev` front-door rate-limits per client IP (the primary per-user control), keying on the leftmost `X-Forwarded-For` hop set by the platform edge; every regional probe additionally rate-limits per IP as a backstop. For the regional probe's per-IP limit to key on the real client IP, set `ATLAS_TRUST_PROXY=true` on the regional APIs.
 
 ## Related
 
 - [Self-Serve Signup](/guides/signup) — the new-user flow, where the region is chosen before account creation
-- [Authentication](/deployment/authentication) — auth modes, sessions, and host-only cookies
+- Authentication — auth modes, sessions, and host-only cookies
 - [Data Residency](/platform-ops/data-residency) — operator-side region configuration and migration
 - [ADR-0024: Regional identity isolation](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0024-regional-identity-isolation.md) — the architecture decision behind this flow

--- a/apps/docs/content/docs/guides/organizations.mdx
+++ b/apps/docs/content/docs/guides/organizations.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 Organizations (also called workspaces) are the top-level boundary for all data in Atlas. Each organization has its own connections, semantic layer, conversations, audit logs, and settings. Members of one organization cannot see data from another.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 </Callout>
 
 ---

--- a/apps/docs/content/docs/guides/pii-masking.mdx
+++ b/apps/docs/content/docs/guides/pii-masking.mdx
@@ -12,7 +12,7 @@ Atlas can auto-detect personally identifiable information (PII) in your database
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role required for managing PII classifications

--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The sandbox is the isolated execution environment that Atlas uses to run the **explore** tool (file browsing, grep, find on the semantic layer) and **Python** tool (data analysis scripts). The admin page lets you select which backend to use and — in SaaS mode — connect your own cloud sandbox providers.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - A user with the `admin` role
 </Callout>
 
@@ -200,7 +200,7 @@ When the **Sidecar** backend is selected, an additional **Sidecar URL** field ap
 - Leave empty to use the platform default
 
 <Callout type="info">
-The sidecar is a separate service that runs explore and Python commands in an isolated container. See the [Docker deployment example](/deployment/deploy#deploy-with-docker) for a production sidecar setup.
+The sidecar is a separate service that runs explore and Python commands in an isolated container. See the [Docker deployment example](/self-hosted/deployment/deploy#deploy-with-docker) for a production sidecar setup.
 </Callout>
 
 <Callout type="info">
@@ -285,4 +285,4 @@ All endpoints require admin authentication.
 - [Admin Console](/guides/admin-console) — Overview of all admin pages
 - [Integrations Hub](/guides/integrations) — Connect Slack, Teams, and other platforms
 - [Environment Variables](/reference/environment-variables) — Full variable reference
-- [Docker Deployment](/deployment/deploy#deploy-with-docker) — Sidecar setup in Docker
+- [Docker Deployment](/self-hosted/deployment/deploy#deploy-with-docker) — Sidecar setup in Docker

--- a/apps/docs/content/docs/guides/scim.mdx
+++ b/apps/docs/content/docs/guides/scim.mdx
@@ -12,7 +12,7 @@ Atlas supports SCIM 2.0 (RFC 7643/7644) for automated user provisioning from ent
 </Callout>
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - [SSO configured](/guides/enterprise-sso) (recommended but not required)

--- a/apps/docs/content/docs/guides/semantic-editor.mdx
+++ b/apps/docs/content/docs/guides/semantic-editor.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The semantic editor lets workspace admins create and manage semantic entities directly from the admin console — no YAML files or CLI required.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - An internal database configured (`DATABASE_URL`)
 - A user with the `admin` role
 - **SaaS mode** — entity editing is available on app.useatlas.dev. In self-hosted mode the semantic layer is read-only in the UI (manage it via YAML files or the CLI)

--- a/apps/docs/content/docs/guides/semantic-layer-wizard.mdx
+++ b/apps/docs/content/docs/guides/semantic-layer-wizard.mdx
@@ -13,7 +13,7 @@ The wizard is the **one shared generation flow** for a [Connection group](/seman
 <Callout title="Prerequisites">
 - An **admin** or **owner** role in your Atlas workspace
 - At least one [datasource connection](/guides/admin-console#connections) configured
-- [Managed auth](/deployment/authentication#managed-auth) enabled with an internal database (`DATABASE_URL`)
+- Managed auth enabled with an internal database (`DATABASE_URL`)
 </Callout>
 
 ---

--- a/apps/docs/content/docs/guides/social-providers.mdx
+++ b/apps/docs/content/docs/guides/social-providers.mdx
@@ -13,7 +13,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 Atlas's managed auth (Better Auth) supports social login — no plugin required. Adding social providers requires a small configuration change to the `betterAuth()` call in `packages/api/src/lib/auth/server.ts`. This guide walks through setting up each provider.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled (`BETTER_AUTH_SECRET` + `DATABASE_URL`)
+- Managed auth enabled (`BETTER_AUTH_SECRET` + `DATABASE_URL`)
 - `BETTER_AUTH_URL` set to your API's public URL (e.g. `https://api.example.com`)
 - OAuth credentials from the provider you want to enable
 </Callout>
@@ -373,7 +373,7 @@ BETTER_AUTH_TRUSTED_ORIGINS=https://app.example.com
 BETTER_AUTH_URL=https://api.example.com
 ```
 
-See [Cross-origin deployment](/deployment/authentication#cross-origin-deployment) for details.
+See Cross-origin deployment for details.
 
 ### Account linking
 
@@ -385,7 +385,7 @@ When a user signs in with a social provider using the same verified email as an 
 
 ## Related
 
-- [Authentication](/deployment/authentication) — full auth mode reference including managed auth setup
+- Authentication — full auth mode reference including managed auth setup
 - [Admin Console](/guides/admin-console) — manage users and roles
 - [Row-Level Security](/security/row-level-security) — tenant isolation with JWT claims
 - [Troubleshooting](/guides/troubleshooting#auth-issues) — general auth troubleshooting

--- a/apps/docs/content/docs/guides/troubleshooting.mdx
+++ b/apps/docs/content/docs/guides/troubleshooting.mdx
@@ -272,7 +272,7 @@ BETTER_AUTH_TRUSTED_ORIGINS=https://app.example.com
 BETTER_AUTH_URL=https://api.example.com
 ```
 
-See [Authentication - Cross-origin deployment](/deployment/authentication#cross-origin-deployment).
+See Authentication - Cross-origin deployment.
 
 #### JWKS Fetch Failures (BYOT)
 
@@ -382,6 +382,6 @@ Key things to look for in debug logs:
 - [Error Codes](/reference/error-codes) — Full catalog of every runtime error code, HTTP status, and retry guidance
 - [CLI Reference](/reference/cli#doctor) — `atlas doctor` and `atlas validate` command details
 - [Environment Variables](/reference/environment-variables) — All configuration variables with defaults
-- [Authentication](/deployment/authentication) — Auth mode setup and CORS configuration
+- Authentication — Auth mode setup and CORS configuration
 - [Row-Level Security](/security/row-level-security) — RLS configuration and auth mode compatibility
 - [Rate Limiting & Retry](/guides/rate-limiting) — Rate limit configuration and client-side handling

--- a/apps/docs/content/docs/guides/white-labeling.mdx
+++ b/apps/docs/content/docs/guides/white-labeling.mdx
@@ -12,7 +12,7 @@ White-labeling lets customers remove Atlas branding and replace it with their ow
 </Callout>
 
 <Callout title="Prerequisites">
-- Atlas deployed with an [internal database](/deployment/deploy) (`DATABASE_URL`)
+- Atlas deployed with an [internal database](/self-hosted/deployment/deploy) (`DATABASE_URL`)
 - Active Business plan on [app.useatlas.dev](https://app.useatlas.dev)
 - Admin role (`admin`, `owner`, or `platform_admin`)
 </Callout>

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -33,7 +33,7 @@ Atlas works across four onboarding shapes. Pick the one that matches what you wa
   />
   <Card
     title="Self-host on my infrastructure"
-    href="/getting-started/quick-start"
+    href="/self-hosted/getting-started/quick-start"
     description="Docker, Vercel, Railway — your data never leaves your network. Free and AGPL-licensed."
   />
 </Cards>
@@ -97,7 +97,7 @@ The YAML format is a first-class concept. Read these before authoring anything i
 
 <Accordion title="For developers — plugin authoring, architecture, frameworks">
 
-- [Bring Your Own Frontend](/frameworks/overview) — Use Atlas with any frontend framework (Nuxt, SvelteKit, React/Vite, TanStack Start)
+- [Bring Your Own Frontend](/self-hosted/frameworks/overview) — Use Atlas with any frontend framework (Nuxt, SvelteKit, React/Vite, TanStack Start)
 - [Plugin Authoring Guide](/plugins/authoring-guide) — Build datasource, context, interaction, action, and sandbox plugins
 - [Sandbox Architecture](/architecture/sandbox) — Platform-agnostic code execution sandboxing design
 - [SQL Validation Pipeline](/security/sql-validation) — 7-layer defense-in-depth for read-only SQL enforcement; REST/OpenAPI operations get their own parallel safety stack via `validateRestOperation` (see [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic))
@@ -107,8 +107,8 @@ The YAML format is a first-class concept. Read these before authoring anything i
 
 <Accordion title="Deployment & operations">
 
-- [Deploy](/deployment/deploy) — One-click deploy to Railway, Vercel, or Docker
-- [Authentication](/deployment/authentication) — Configure auth modes: none, API key, managed, BYOT
+- [Deploy](/self-hosted/deployment/deploy) — One-click deploy to Railway, Vercel, or Docker
+- [Authentication](/self-hosted/deployment/authentication) — Configure auth modes: none, API key, managed, BYOT
 - [Multi-Datasource Routing](/deployment/multi-datasource) — Route per-conversation across datasources, including cross-environment scope
 - [Schema Evolution](/deployment/schema-evolution) — Detecting database drift with `atlas diff` and the inline drift drawer
 

--- a/apps/docs/content/docs/platform-ops/platform-admin.mdx
+++ b/apps/docs/content/docs/platform-ops/platform-admin.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The platform admin console provides operators with a unified view across all workspaces. Monitor resource usage, manage workspace lifecycles, detect noisy neighbors, and enforce plan changes — all from a single dashboard.
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - `platform_admin` user role (assigned via `ATLAS_ADMIN_EMAIL` at first signup or directly in the database)
 </Callout>

--- a/apps/docs/content/docs/platform-ops/plugin-catalog.mdx
+++ b/apps/docs/content/docs/platform-ops/plugin-catalog.mdx
@@ -8,7 +8,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 The plugin catalog is the platform-level registry of plugins available for installation. Platform operators add plugins to the catalog, set plan-tier requirements, and control visibility. Workspaces install plugins from this catalog via the [Plugin Marketplace](/guides/plugin-marketplace).
 
 <Callout title="Prerequisites">
-- [Managed auth](/deployment/authentication#managed-auth) enabled
+- Managed auth enabled
 - Internal database configured (`DATABASE_URL`)
 - [`platform_admin` user role](/platform-ops/platform-admin#platform-admin-role)
 </Callout>

--- a/apps/docs/content/docs/security/row-level-security.mdx
+++ b/apps/docs/content/docs/security/row-level-security.mdx
@@ -320,7 +320,7 @@ Each branch of a UNION gets its own RLS conditions independently.
 
 ### "RLS is enabled but no authenticated user is available"
 
-Authentication is required. Check that your auth mode provides user context. See [Authentication](/deployment/authentication).
+Authentication is required. Check that your auth mode provides user context.
 
 ### "RLS policy requires claim X but it is missing"
 
@@ -395,7 +395,7 @@ When RLS is enabled, you will only see data that belongs to your organization or
 
 ## See Also
 
-- [Authentication](/deployment/authentication) — Auth mode setup (RLS requires an auth mode that provides user claims)
+- Authentication — Auth mode setup (RLS requires an auth mode that provides user claims)
 - [Configuration](/reference/config#rls-row-level-security) — Declarative RLS policies in `atlas.config.ts`
 - [Environment Variables](/reference/environment-variables#row-level-security) — Env var shorthand for a single RLS policy
 - [SQL Validation Pipeline](/security/sql-validation) — How RLS injection fits into the 7-layer validation pipeline

--- a/apps/docs/content/docs/security/sql-validation.mdx
+++ b/apps/docs/content/docs/security/sql-validation.mdx
@@ -298,7 +298,7 @@ When a query fails at any validation layer, the response includes a structured e
 
 Database errors that might expose connection details or internal state (passwords, connection strings, SSL certificates) are automatically scrubbed before being returned to the agent. The full error is logged server-side.
 
-All queries — successful and failed — are recorded in the [audit log](/deployment/authentication#audit-logging) with user attribution, timing, and error details.
+All queries — successful and failed — are recorded in the audit log with user attribution, timing, and error details.
 
 ## What this means for you
 

--- a/apps/docs/content/shared/architecture/content-mode.mdx
+++ b/apps/docs/content/shared/architecture/content-mode.mdx
@@ -287,7 +287,7 @@ These are locked by tests and CLAUDE.md rules:
 
 ## See also
 
-- [Developer Mode](/guides/developer-mode) — end-user view of the mode system
-- [Starter Prompts](/guides/starter-prompts) — one of the four mode-participating content types
+- <AudienceLink saas="/guides/developer-mode">Developer Mode</AudienceLink> — end-user view of the mode system
+- <AudienceLink saas="/guides/starter-prompts">Starter Prompts</AudienceLink> — one of the four mode-participating content types
 - [Environment Variables](/reference/environment-variables) — `ATLAS_DEMO_INDUSTRY` and friends
 - [Error Codes](/reference/error-codes#content-mode-registry-1515) — `upstream_error` for content-mode failures

--- a/apps/docs/content/shared/architecture/enterprise.mdx
+++ b/apps/docs/content/shared/architecture/enterprise.mdx
@@ -181,19 +181,19 @@ Every feature in the table below calls `requireEnterprise(...)` or `requireEnter
 
 | Category | Feature label | What's gated | Guide |
 |---|---|---|---|
-| **Identity** | `sso` | SAML 2.0 / OIDC providers, domain verification, IdP test connection, auto-provisioning toggles | [Enterprise SSO](/guides/enterprise-sso) |
-| **Identity** | `scim` | SCIM 2.0 connections, group mapping, sync-status endpoints | [SCIM Directory Sync](/guides/scim) |
-| **Identity** | `roles` | Custom role definitions, permission flag CRUD, role assignment beyond the built-in admin/member/owner triad | [Custom Roles](/guides/custom-roles) |
-| **Network** | `ip-allowlist` | CIDR allowlist CRUD, request-time allowlist enforcement | [IP Allowlisting](/guides/ip-allowlisting) |
-| **Governance** | `approval-workflows` | Approval rules, request lifecycle, expiration sweeps, pending-count queries | [Approval Workflows](/guides/approval-workflows) |
-| **Compliance** | `pii-detection` | Column classification CRUD, masking config, PII scan triggers (write paths via `requireEnterpriseEffect`); query-time row masking gated inline via `isEnterpriseEnabled()` in `masking.ts` so AGPL deployments simply skip masking instead of failing the query | [PII Masking](/guides/pii-masking) |
-| **Compliance** | `compliance` | SOC 2 / ISO / GDPR report generation, evidence aggregation | [Compliance Reporting](/guides/compliance-reporting) |
-| **Audit** | `audit-retention` | Long-tail retention policies, archive/export, retention policy CRUD | [Audit Retention](/guides/audit-retention) |
-| **Platform** | `backups` | Scheduled backups, restore, integrity verification | [Backups](/platform-ops/backups) |
-| **Platform** | `model-routing` | Per-workspace model overrides, routing rules, BYOT model config beyond defaults | [Model Routing](/guides/model-routing) |
-| **Platform** | `branding` | White-label branding, custom logo / colors / favicon, hosted-product theming | [White Labeling](/guides/white-labeling) |
-| **Platform** | (admin-domains route) | Custom domains for SaaS workspaces — gated inline via `Effect.fail(new EnterpriseError(...))` in `admin-domains.ts` rather than a `requireEnterprise` label | [Custom Domains](/platform-ops/custom-domains) |
-| **Platform ops** | (resolveDeployMode) | Abuse prevention surfaces, data residency routing, SLA monitoring — gated indirectly via `isEnterpriseEnabled()` checks at the service-init layer rather than per-call `requireEnterprise` | [Abuse Prevention](/platform-ops/abuse-prevention), [Data Residency](/platform-ops/data-residency) |
+| **Identity** | `sso` | SAML 2.0 / OIDC providers, domain verification, IdP test connection, auto-provisioning toggles | <AudienceLink saas="/guides/enterprise-sso">Enterprise SSO</AudienceLink> |
+| **Identity** | `scim` | SCIM 2.0 connections, group mapping, sync-status endpoints | <AudienceLink saas="/guides/scim">SCIM Directory Sync</AudienceLink> |
+| **Identity** | `roles` | Custom role definitions, permission flag CRUD, role assignment beyond the built-in admin/member/owner triad | <AudienceLink saas="/guides/custom-roles">Custom Roles</AudienceLink> |
+| **Network** | `ip-allowlist` | CIDR allowlist CRUD, request-time allowlist enforcement | <AudienceLink saas="/guides/ip-allowlisting">IP Allowlisting</AudienceLink> |
+| **Governance** | `approval-workflows` | Approval rules, request lifecycle, expiration sweeps, pending-count queries | <AudienceLink saas="/guides/approval-workflows">Approval Workflows</AudienceLink> |
+| **Compliance** | `pii-detection` | Column classification CRUD, masking config, PII scan triggers (write paths via `requireEnterpriseEffect`); query-time row masking gated inline via `isEnterpriseEnabled()` in `masking.ts` so AGPL deployments simply skip masking instead of failing the query | <AudienceLink saas="/guides/pii-masking">PII Masking</AudienceLink> |
+| **Compliance** | `compliance` | SOC 2 / ISO / GDPR report generation, evidence aggregation | <AudienceLink saas="/guides/compliance-reporting">Compliance Reporting</AudienceLink> |
+| **Audit** | `audit-retention` | Long-tail retention policies, archive/export, retention policy CRUD | <AudienceLink saas="/guides/audit-retention">Audit Retention</AudienceLink> |
+| **Platform** | `backups` | Scheduled backups, restore, integrity verification | <AudienceLink saas="/platform-ops/backups">Backups</AudienceLink> |
+| **Platform** | `model-routing` | Per-workspace model overrides, routing rules, BYOT model config beyond defaults | <AudienceLink saas="/guides/model-routing">Model Routing</AudienceLink> |
+| **Platform** | `branding` | White-label branding, custom logo / colors / favicon, hosted-product theming | <AudienceLink saas="/guides/white-labeling">White Labeling</AudienceLink> |
+| **Platform** | (admin-domains route) | Custom domains for SaaS workspaces — gated inline via `Effect.fail(new EnterpriseError(...))` in `admin-domains.ts` rather than a `requireEnterprise` label | <AudienceLink saas="/platform-ops/custom-domains">Custom Domains</AudienceLink> |
+| **Platform ops** | (resolveDeployMode) | Abuse prevention surfaces, data residency routing, SLA monitoring — gated indirectly via `isEnterpriseEnabled()` checks at the service-init layer rather than per-call `requireEnterprise` | <AudienceLink saas="/platform-ops/abuse-prevention">Abuse Prevention</AudienceLink>, <AudienceLink saas="/platform-ops/data-residency">Data Residency</AudienceLink> |
 
 The labels are stable identifiers — once a feature ships with a label, audit log entries and admin UI surfaces lock onto it. Don't rename a label without a migration plan.
 

--- a/apps/docs/content/shared/architecture/entitlements.mdx
+++ b/apps/docs/content/shared/architecture/entitlements.mdx
@@ -207,5 +207,5 @@ If `pagerduty.implementation_status === "coming_soon"`, layer 3 would resolve to
 
 - [Reference: Config — Catalog](/reference/config#catalog) — declaring `min_plan` on a catalog entry
 - [Architecture: Enterprise (/ee) Boundary](/architecture/enterprise) — the EE-vs-AGPL split that backs the SaaS-only admin surfaces this gate consumes
-- [Deployment: Plugin Catalog](/deployment/plugin-catalog) — the catalog seeder behaviour and per-row toggles
-- [Guides: Billing & Plans](/guides/billing-and-plans) — what each tier costs and how `plan_tier` gets set
+- <AudienceLink saas="/deployment/plugin-catalog">Deployment: Plugin Catalog</AudienceLink> — the catalog seeder behaviour and per-row toggles
+- <AudienceLink saas="/guides/billing-and-plans">Guides: Billing & Plans</AudienceLink> — what each tier costs and how `plan_tier` gets set

--- a/apps/docs/content/shared/comparisons/raw-mcp.mdx
+++ b/apps/docs/content/shared/comparisons/raw-mcp.mdx
@@ -30,7 +30,7 @@ Atlas sits between the AI and the database, providing context before query gener
 | Capability | Raw MCP | Atlas |
 |---|---|---|
 | **Business context** | Column names only | Entity YAML with descriptions, sample values, joins, metrics, glossary + dynamic learned patterns |
-| **SQL validation** | None | [7-layer pipeline](/security/sql-validation) (empty check, regex guard, AST parse, table whitelist, RLS, auto-LIMIT, timeout) |
+| **SQL validation** | None | <AudienceLink saas="/security/sql-validation">7-layer pipeline</AudienceLink> (empty check, regex guard, AST parse, table whitelist, RLS, auto-LIMIT, timeout) |
 | **Table access control** | Full schema visible | Only tables defined in the semantic layer |
 | **Row-level security** | None | Automatic WHERE clause injection based on user identity (multi-column, array, OR-logic) |
 | **Mutation protection** | Depends on DB user permissions | SELECT-only enforcement at the application layer, independent of DB permissions |
@@ -109,7 +109,7 @@ GROUP BY 1, 2
 ORDER BY 1 DESC
 ```
 
-Before this query reaches the database, Atlas validates it through the [SQL validation pipeline](/security/sql-validation):
+Before this query reaches the database, Atlas validates it through the <AudienceLink saas="/security/sql-validation">SQL validation pipeline</AudienceLink>:
 
 0. **Empty check** — rejects empty or whitespace-only input
 1. **Regex guard** — confirms no DML/DDL keywords
@@ -125,11 +125,11 @@ The security gap between raw MCP and Atlas is not theoretical. Here are three co
 
 ### No validation = SQL injection surface
 
-MCP servers pass AI-generated SQL directly to the database. If a user crafts a prompt that causes the AI to generate `SELECT 1; DROP TABLE users`, there's nothing between that SQL and your database except the connection's permission level. Atlas blocks this at [multiple layers](/security/sql-validation#layer-1-regex-mutation-guard) — the regex guard catches `DROP`, and the AST parser rejects multi-statement queries.
+MCP servers pass AI-generated SQL directly to the database. If a user crafts a prompt that causes the AI to generate `SELECT 1; DROP TABLE users`, there's nothing between that SQL and your database except the connection's permission level. Atlas blocks this at <AudienceLink saas="/security/sql-validation#layer-1-regex-mutation-guard">multiple layers</AudienceLink> — the regex guard catches `DROP`, and the AST parser rejects multi-statement queries.
 
 ### No RLS = data leakage
 
-In a multi-tenant application, raw MCP has no concept of row-level isolation. The AI can query any row in any table the connection can access. Atlas injects [WHERE clauses automatically](/security/row-level-security) based on the authenticated user's identity claims — fail-closed, so missing claims block the query entirely.
+In a multi-tenant application, raw MCP has no concept of row-level isolation. The AI can query any row in any table the connection can access. Atlas injects <AudienceLink saas="/security/row-level-security">WHERE clauses automatically</AudienceLink> based on the authenticated user's identity claims — fail-closed, so missing claims block the query entirely.
 
 ### No audit = compliance gap
 
@@ -146,7 +146,7 @@ Raw MCP is a reasonable choice when:
 Once any of these change — multiple users, sensitive data, production workloads, compliance requirements — you need the semantic layer, validation, and audit trail that Atlas provides.
 
 <Callout type="info">
-Atlas has its own [MCP server](/guides/mcp) (stdio + SSE transport) that gives Claude Desktop and Cursor the same validated, context-aware SQL execution as the API. You don't have to choose between MCP compatibility and safety.
+Atlas has its own <AudienceLink saas="/guides/mcp">MCP server</AudienceLink> (stdio + SSE transport) that gives Claude Desktop and Cursor the same validated, context-aware SQL execution as the API. You don't have to choose between MCP compatibility and safety.
 </Callout>
 
 ## The semantic layer advantage
@@ -163,8 +163,8 @@ A semantic layer is that governance. It's the difference between an AI that can 
 
 ## Related
 
-- [MCP Server](/guides/mcp) — use Atlas as an MCP server with full validation and semantic context
-- [SQL Validation Pipeline](/security/sql-validation) — the 7-layer defense-in-depth pipeline
-- [Row-Level Security](/security/row-level-security) — automatic tenant isolation
+- <AudienceLink saas="/guides/mcp">MCP Server</AudienceLink> — use Atlas as an MCP server with full validation and semantic context
+- <AudienceLink saas="/security/sql-validation">SQL Validation Pipeline</AudienceLink> — the 7-layer defense-in-depth pipeline
+- <AudienceLink saas="/security/row-level-security">Row-Level Security</AudienceLink> — automatic tenant isolation
 - [Semantic Layer](/getting-started/semantic-layer) — how entity YAML files provide business context
 - [Atlas vs Alternatives](/comparisons) — comparisons with WrenAI, Vanna, and Metabase

--- a/apps/docs/content/shared/comparisons/vanna.mdx
+++ b/apps/docs/content/shared/comparisons/vanna.mdx
@@ -49,7 +49,7 @@ Atlas also learns from usage, but through a different mechanism: `atlas learn` r
 
 ## SQL Safety
 
-Atlas enforces read-only access through a [7-layer SQL validation pipeline](/security/sql-validation): empty check, regex mutation guard, AST parsing (single SELECT only), table whitelist (only semantic layer entities), RLS injection, auto LIMIT, and statement timeout.
+Atlas enforces read-only access through a <AudienceLink saas="/security/sql-validation">7-layer SQL validation pipeline</AudienceLink>: empty check, regex mutation guard, AST parsing (single SELECT only), table whitelist (only semantic layer entities), RLS injection, auto LIMIT, and statement timeout.
 
 Vanna v2.0 added parameterized queries and row-level security, but does not include a 7-layer SQL validation pipeline. The generated SQL is passed to your database connection with basic guardrails. You're responsible for adding additional protections -- read-only database users, mutation guards, and timeout enforcement.
 

--- a/apps/docs/content/shared/getting-started/concepts.mdx
+++ b/apps/docs/content/shared/getting-started/concepts.mdx
@@ -438,6 +438,6 @@ Atlas's **glossary**, **query patterns**, **sample values**, and **catalog** don
 - [Quick Start](/self-hosted/getting-started/quick-start) — get Atlas running and generate your first semantic layer
 </WhenSelfHosted>
 
-- [SQL Validation](/security/sql-validation) — how the semantic layer powers the table whitelist
-- [Schema Evolution](/deployment/schema-evolution) — detecting and resolving drift between your database and semantic layer
+- <AudienceLink saas="/security/sql-validation">SQL Validation</AudienceLink> — how the semantic layer powers the table whitelist
+- <AudienceLink saas="/deployment/schema-evolution">Schema Evolution</AudienceLink> — detecting and resolving drift between your database and semantic layer
 - [CLI Reference](/reference/cli) — `atlas init`, `atlas diff`, and other semantic layer commands

--- a/apps/docs/content/shared/getting-started/connect-your-data.mdx
+++ b/apps/docs/content/shared/getting-started/connect-your-data.mdx
@@ -734,7 +734,7 @@ Atlas datasources are not limited to SQL. Point Atlas at any REST service that p
 
 REST/OpenAPI datasources install from **Admin &gt; Connections** like any other datasource. For a generic API, paste its OpenAPI spec URL plus a credential; pre-wired vendors need less setup — Stripe and Notion take just a credential (no spec URL), and GitHub connects via OAuth. Either way, no `bun run atlas -- init` step is needed; the operation surface comes from the spec.
 
-See the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) guide for the full walkthrough, and [Multi-Datasource Routing](/deployment/multi-datasource) for mixing REST and SQL sources in one deployment.
+See the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) guide for the full walkthrough, and <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink> for mixing REST and SQL sources in one deployment.
 
 ---
 
@@ -776,7 +776,7 @@ See [Semantic Layer](/getting-started/semantic-layer) for a deep dive, or [CLI R
 ## Multi-source configuration
 
 <Callout type="info">
-For a comprehensive guide on how the agent routes queries across datasources, semantic layer organization per source, cross-source relationships, and troubleshooting, see [Multi-Datasource Routing](/deployment/multi-datasource).
+For a comprehensive guide on how the agent routes queries across datasources, semantic layer organization per source, cross-source relationships, and troubleshooting, see <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink>.
 </Callout>
 
 To query multiple datasources from a single Atlas deployment, list them in `atlas.config.ts`:
@@ -846,15 +846,15 @@ ATLAS_QUERY_TIMEOUT=15000
 
 Lower the row limit to reduce load. Reduce the timeout to kill runaway queries faster.
 
-For multi-tenant deployments, see [Row-Level Security](/security/row-level-security).
+For multi-tenant deployments, see <AudienceLink saas="/security/row-level-security">Row-Level Security</AudienceLink>.
 
 ---
 
 ## See Also
 
 - [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) — Connect Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service
-- [Multi-Datasource Routing](/deployment/multi-datasource) — Connect multiple databases and REST APIs in a single deployment
+- <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink> — Connect multiple databases and REST APIs in a single deployment
 - [Configuration](/reference/config#datasources) — Declarative datasource configuration in `atlas.config.ts`
 - [Semantic Layer](/getting-started/semantic-layer) — Generate entity YAML files from your connected database
 - [CLI Reference](/reference/cli#init) — `atlas init` command for profiling your database
-- [Row-Level Security](/security/row-level-security) — Automatic data isolation per tenant
+- <AudienceLink saas="/security/row-level-security">Row-Level Security</AudienceLink> — Automatic data isolation per tenant

--- a/apps/docs/content/shared/getting-started/semantic-layer.mdx
+++ b/apps/docs/content/shared/getting-started/semantic-layer.mdx
@@ -361,7 +361,7 @@ metrics:
 4. **Use metrics** -- If a question matches a defined metric, the agent uses that metric's SQL exactly
 5. **Write validated SQL** -- The agent writes a query using only tables and columns defined in the semantic layer
 
-The semantic layer also powers the [table whitelist](/security/sql-validation) -- queries can only reference tables that have an entity YAML file.
+The semantic layer also powers the <AudienceLink saas="/security/sql-validation">table whitelist</AudienceLink> -- queries can only reference tables that have an entity YAML file.
 
 ---
 
@@ -382,7 +382,7 @@ Use `atlas diff` to detect schema drift between your database and semantic layer
 bun run atlas -- diff                    # Compare DB schema vs YAML files
 ```
 
-See the [Schema Evolution guide](/deployment/schema-evolution) for a complete workflow on detecting drift, updating YAMLs, and preserving manual enrichments. See [CLI Reference](/reference/cli) for all options.
+See the <AudienceLink saas="/deployment/schema-evolution">Schema Evolution guide</AudienceLink> for a complete workflow on detecting drift, updating YAMLs, and preserving manual enrichments. See [CLI Reference](/reference/cli) for all options.
 
 ---
 
@@ -404,7 +404,7 @@ Re-run `atlas init --enrich` after manual edits to fill in any missing fields wi
 ## See Also
 
 - [Semantic Layer Concepts](/getting-started/concepts) — Definitions of entities, dimensions, measures, joins, and metrics
-- [Schema Evolution](/deployment/schema-evolution) — Detect database drift and update your semantic layer
+- <AudienceLink saas="/deployment/schema-evolution">Schema Evolution</AudienceLink> — Detect database drift and update your semantic layer
 - [CLI Reference](/reference/cli#init) — `atlas init` command flags for profiling databases
 - [Configuration](/reference/config#semantic-layer-path) — Override the default semantic layer directory
-- [SQL Validation Pipeline](/security/sql-validation) — How entity YAMLs define the table whitelist
+- <AudienceLink saas="/security/sql-validation">SQL Validation Pipeline</AudienceLink> — How entity YAMLs define the table whitelist

--- a/apps/docs/content/shared/guides/multi-tenancy.mdx
+++ b/apps/docs/content/shared/guides/multi-tenancy.mdx
@@ -416,8 +416,8 @@ LRU eviction automatically frees pools for inactive orgs, but under sustained lo
 
 ## See Also
 
-- [Authentication](/self-hosted/deployment/authentication#managed-auth) — Set up managed auth (required for organizations)
-- [Admin Console](/guides/admin-console) — Manage organizations, members, and connections via the web UI
-- [Multi-Datasource Routing](/deployment/multi-datasource) — Configure multiple databases per deployment
+- <AudienceLink selfHosted="/self-hosted/deployment/authentication#managed-auth">Authentication</AudienceLink> — Set up managed auth (required for organizations)
+- <AudienceLink saas="/guides/admin-console">Admin Console</AudienceLink> — Manage organizations, members, and connections via the web UI
+- <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink> — Configure multiple databases per deployment
 - [Configuration Reference](/reference/config) — All `atlas.config.ts` fields including `pool.perOrg`
-- [Troubleshooting](/guides/troubleshooting) — General diagnostic steps
+- <AudienceLink saas="/guides/troubleshooting">Troubleshooting</AudienceLink> — General diagnostic steps

--- a/apps/docs/content/shared/guides/onboarding-emails.mdx
+++ b/apps/docs/content/shared/guides/onboarding-emails.mdx
@@ -62,7 +62,7 @@ Admins can view onboarding email status for their organization via the admin API
 - **List statuses** — `GET /api/v1/admin/onboarding-emails` returns per-user progress (sent steps, pending steps, unsubscribe status)
 - **View sequence** — `GET /api/v1/admin/onboarding-emails/sequence` returns the configured sequence steps with triggers and timing
 
-See the [API Reference](/api-reference/admin-onboarding-emails/getAdminOnboardingEmails) for full endpoint documentation.
+See the <AudienceLink saas="/api-reference/admin-onboarding-emails/getAdminOnboardingEmails">API Reference</AudienceLink> for full endpoint documentation.
 
 ---
 
@@ -82,5 +82,5 @@ Both endpoints require a signed `token` bound to the `userId` (HMAC-SHA256 over 
 ## See Also
 
 - [Environment Variables — Email Delivery](/reference/environment-variables#email-delivery)
-- [Guided Tour](/guides/guided-tour) — In-app walkthrough complementing the email sequence
-- [Signup](/guides/signup) — User registration flow that triggers the welcome email
+- <AudienceLink saas="/guides/guided-tour">Guided Tour</AudienceLink> — In-app walkthrough complementing the email sequence
+- <AudienceLink saas="/guides/signup">Signup</AudienceLink> — User registration flow that triggers the welcome email

--- a/apps/docs/content/shared/guides/plugin-marketplace.mdx
+++ b/apps/docs/content/shared/guides/plugin-marketplace.mdx
@@ -133,6 +133,6 @@ The marketplace catalog API (`GET /api/v1/admin/plugins/marketplace/available`, 
 
 ## See also
 
-- [Admin Console — Plugins](/guides/admin-console#plugins) — Overview of the plugins admin page
-- [Plugin Catalog](/platform-ops/plugin-catalog) — Platform operator guide for managing the catalog
+- <AudienceLink saas="/guides/admin-console#plugins">Admin Console — Plugins</AudienceLink> — Overview of the plugins admin page
+- <AudienceLink saas="/platform-ops/plugin-catalog">Plugin Catalog</AudienceLink> — Platform operator guide for managing the catalog
 - [Plugin Authoring Guide](/plugins/authoring-guide) — Build custom plugins

--- a/apps/docs/content/shared/integrations/twenty.mdx
+++ b/apps/docs/content/shared/integrations/twenty.mdx
@@ -164,4 +164,4 @@ operator at the missing env var.
 - [Plugin SDK docs](/plugins/authoring-guide)
 - [Twenty REST API](https://twenty.com/developers/section/rest-api)
 - [Twenty metadata API](https://twenty.com/developers/section/api-and-webhooks/metadata-api)
-- [Encryption key rotation](/platform-ops/encryption-key-rotation)
+- <AudienceLink saas="/platform-ops/encryption-key-rotation">Encryption key rotation</AudienceLink>

--- a/apps/docs/content/shared/plugins/authoring-guide.mdx
+++ b/apps/docs/content/shared/plugins/authoring-guide.mdx
@@ -929,7 +929,7 @@ connection: {
 
 These are ignored when a custom `validate` function is provided.
 
-Both properties are consumed during SQL validation: `parserDialect` sets the AST parser mode used in layer 2, and `forbiddenPatterns` are checked as additional regex guards in layer 1. See [SQL Validation Pipeline](/security/sql-validation) for the full layer breakdown.
+Both properties are consumed during SQL validation: `parserDialect` sets the AST parser mode used in layer 2, and `forbiddenPatterns` are checked as additional regex guards in layer 1. See <AudienceLink saas="/security/sql-validation">SQL Validation Pipeline</AudienceLink> for the full layer breakdown.
 
 ## Plugin Lifecycle
 
@@ -1132,5 +1132,5 @@ myPlugin({ apiKey: process.env.MY_API_KEY! })
 - [Plugin Cookbook](/plugins/cookbook) — Real-world patterns for caching, hooks, credentials, and error handling
 - [Plugin Composition](/plugins/composition) — How multiple plugins interact (ordering, priority, constraints)
 - [Configuration](/reference/config#plugins) — Registering plugins in `atlas.config.ts`
-- [SQL Validation Pipeline](/security/sql-validation) — How plugin hooks and custom validators fit into validation
+- <AudienceLink saas="/security/sql-validation">SQL Validation Pipeline</AudienceLink> — How plugin hooks and custom validators fit into validation
 - [Enterprise (`/ee`) boundary](/architecture/enterprise) — License split, the `isEnterpriseEnabled` / `requireEnterprise` API, and how plugins should (and shouldn't) interact with the gate

--- a/apps/docs/content/shared/plugins/datasources/bigquery.mdx
+++ b/apps/docs/content/shared/plugins/datasources/bigquery.mdx
@@ -54,7 +54,7 @@ When running locally, either set `GOOGLE_APPLICATION_CREDENTIALS` to a service a
 
 ### Install from the admin console
 
-You don't have to edit `atlas.config.ts` to add a BigQuery connection. A workspace admin can install BigQuery from **Admin → Connections**: click **Add datasource**, pick the BigQuery tile (under *Databases*), and fill in the schema-driven install form. The form has three fields, matching the catalog's config schema: **Service Account JSON** (required — paste the full service account key JSON), **GCP Project ID** (required), and an optional **Description** shown in the agent system prompt. The service-account JSON is encrypted at rest (it's a `secret: true` field) while the project ID stays in plaintext, and the connection registers immediately — it's queryable via `executeSQL` as soon as the install succeeds, no reload required. Re-submitting the form edits the existing install in place. This works on SaaS too. See [Admin Console — Connections](/guides/admin-console#connections).
+You don't have to edit `atlas.config.ts` to add a BigQuery connection. A workspace admin can install BigQuery from **Admin → Connections**: click **Add datasource**, pick the BigQuery tile (under *Databases*), and fill in the schema-driven install form. The form has three fields, matching the catalog's config schema: **Service Account JSON** (required — paste the full service account key JSON), **GCP Project ID** (required), and an optional **Description** shown in the agent system prompt. The service-account JSON is encrypted at rest (it's a `secret: true` field) while the project ID stays in plaintext, and the connection registers immediately — it's queryable via `executeSQL` as soon as the install succeeds, no reload required. Re-submitting the form edits the existing install in place. This works on SaaS too. See <AudienceLink saas="/guides/admin-console#connections">Admin Console — Connections</AudienceLink>.
 
 ## SQL Dialect
 
@@ -136,7 +136,7 @@ BigQuery profiles into a semantic layer (entities, metrics, glossary) the same w
 - **CLI** — `bun run atlas -- init` (and `diff`) against a named BigQuery datasource from `atlas.config.ts` (`--connection <name>`).
 - **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
 
-See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+See the <AudienceLink saas="/guides/semantic-layer-wizard">semantic layer wizard</AudienceLink> for the full flow.
 
 ## Validation
 

--- a/apps/docs/content/shared/plugins/datasources/clickhouse.mdx
+++ b/apps/docs/content/shared/plugins/datasources/clickhouse.mdx
@@ -39,7 +39,7 @@ The plugin rewrites `clickhouse://` to `http://` and `clickhouses://` to `https:
 
 ### Install from the admin console
 
-You don't have to edit `atlas.config.ts` to add a ClickHouse connection. A workspace admin can install ClickHouse from **Admin → Connections**: click **Add datasource**, pick the ClickHouse tile (under *Databases*), and fill in the schema-driven install form — paste the connection URL and submit. The URL is encrypted at rest (it's a `secret: true` field in the catalog's config schema), and the connection registers immediately — it's queryable via `executeSQL` as soon as the install succeeds, no reload required. Re-submitting the form edits the existing install in place. This works on SaaS too. See [Admin Console — Connections](/guides/admin-console#connections).
+You don't have to edit `atlas.config.ts` to add a ClickHouse connection. A workspace admin can install ClickHouse from **Admin → Connections**: click **Add datasource**, pick the ClickHouse tile (under *Databases*), and fill in the schema-driven install form — paste the connection URL and submit. The URL is encrypted at rest (it's a `secret: true` field in the catalog's config schema), and the connection registers immediately — it's queryable via `executeSQL` as soon as the install succeeds, no reload required. Re-submitting the form edits the existing install in place. This works on SaaS too. See <AudienceLink saas="/guides/admin-console#connections">Admin Console — Connections</AudienceLink>.
 
 ### Connection string format
 
@@ -68,7 +68,7 @@ ClickHouse profiles into a semantic layer (entities, metrics, glossary) the same
 - **CLI** — `bun run atlas -- init` (and `diff`) against a named ClickHouse datasource from `atlas.config.ts` (`--connection <name>`) or a `clickhouse://` `ATLAS_DATASOURCE_URL`.
 - **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
 
-See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+See the <AudienceLink saas="/guides/semantic-layer-wizard">semantic layer wizard</AudienceLink> for the full flow.
 
 ## Validation
 

--- a/apps/docs/content/shared/plugins/datasources/duckdb.mdx
+++ b/apps/docs/content/shared/plugins/datasources/duckdb.mdx
@@ -73,7 +73,7 @@ DuckDB profiles into a semantic layer (entities, metrics, glossary) the same way
 - **CLI** — `bun run atlas -- init` (and `diff`) against a DuckDB file, or load flat files directly with `--csv <files>` / `--parquet <files>` (no DB server needed; requires `@duckdb/node-api`).
 - **In-product wizard / MCP** — on a self-hosted deployment, the same connection can be profiled from the install wizard or the `profile_datasource` MCP tool.
 
-See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+See the <AudienceLink saas="/guides/semantic-layer-wizard">semantic layer wizard</AudienceLink> for the full flow.
 
 ## Validation
 

--- a/apps/docs/content/shared/plugins/datasources/elasticsearch.mdx
+++ b/apps/docs/content/shared/plugins/datasources/elasticsearch.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
 ```
 
 When admins install the datasource from **Admin → Connections**
-([admin console guide](/guides/admin-console#connections)), the same fields are
+(<AudienceLink saas="/guides/admin-console#connections">admin console guide</AudienceLink>), the same fields are
 entered through a form; the `secret: true` fields are encrypted at rest and
 masked in the UI.
 

--- a/apps/docs/content/shared/plugins/datasources/index.mdx
+++ b/apps/docs/content/shared/plugins/datasources/index.mdx
@@ -45,5 +45,5 @@ Never commit credentials to version control. Use environment variables (`process
 | Connection caching | No (stateless REST) | No (stateless HTTP) | Yes (in-process) | Yes (pool) | Yes (pool) | Yes (session) | No (stateless `fetch`) |
 
 <Callout type="info">
-The table above compares the **SQL** datasources. REST services are connected through the built-in [OpenAPI (Generic REST)](/plugins/datasources/openapi-generic) datasource instead — the agent calls operations via the `executeRestOperation` tool (not `executeSQL`), reads are allowed by default, and writes require a per-endpoint `write_allowlist` plus confirm-before-write. See [Multi-Datasource Routing](/deployment/multi-datasource) for mixing REST and SQL sources in one deployment.
+The table above compares the **SQL** datasources. REST services are connected through the built-in [OpenAPI (Generic REST)](/plugins/datasources/openapi-generic) datasource instead — the agent calls operations via the `executeRestOperation` tool (not `executeSQL`), reads are allowed by default, and writes require a per-endpoint `write_allowlist` plus confirm-before-write. See <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink> for mixing REST and SQL sources in one deployment.
 </Callout>

--- a/apps/docs/content/shared/plugins/datasources/salesforce.mdx
+++ b/apps/docs/content/shared/plugins/datasources/salesforce.mdx
@@ -113,7 +113,7 @@ Salesforce profiles into a semantic layer (entities mapped to SObjects, plus met
 - **CLI** — `bun run atlas -- init` (and `diff`) against a configured Salesforce datasource.
 - **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
 
-See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+See the <AudienceLink saas="/guides/semantic-layer-wizard">semantic layer wizard</AudienceLink> for the full flow.
 
 ## Validation
 

--- a/apps/docs/content/shared/plugins/datasources/snowflake.mdx
+++ b/apps/docs/content/shared/plugins/datasources/snowflake.mdx
@@ -39,7 +39,7 @@ export default defineConfig({
 
 ### Install from the admin console
 
-You don't have to edit `atlas.config.ts` to add a Snowflake connection. A workspace admin can install Snowflake from **Admin → Connections**: click **Add datasource**, pick the Snowflake tile (under *Databases*), and fill in the schema-driven install form — paste the connection URL (plus an optional schema and description) and submit. The URL is encrypted at rest (it's a `secret: true` field in the catalog's config schema), and the connection registers immediately — it's queryable via `executeSQL` as soon as the install succeeds, no reload required. Re-submitting the form edits the existing install in place. This works on SaaS too. See [Admin Console — Connections](/guides/admin-console#connections).
+You don't have to edit `atlas.config.ts` to add a Snowflake connection. A workspace admin can install Snowflake from **Admin → Connections**: click **Add datasource**, pick the Snowflake tile (under *Databases*), and fill in the schema-driven install form — paste the connection URL (plus an optional schema and description) and submit. The URL is encrypted at rest (it's a `secret: true` field in the catalog's config schema), and the connection registers immediately — it's queryable via `executeSQL` as soon as the install succeeds, no reload required. Re-submitting the form edits the existing install in place. This works on SaaS too. See <AudienceLink saas="/guides/admin-console#connections">Admin Console — Connections</AudienceLink>.
 
 ### Connection string format
 
@@ -76,7 +76,7 @@ Snowflake profiles into a semantic layer (entities, metrics, glossary) the same 
 - **CLI** — `bun run atlas -- init` (and `diff`) against a named Snowflake datasource from `atlas.config.ts` (`--connection <name>`) or a `snowflake://` `ATLAS_DATASOURCE_URL`.
 - **MCP** — the `profile_datasource` tool, to profile directly from an MCP client.
 
-See the [semantic layer wizard](/guides/semantic-layer-wizard) for the full flow.
+See the <AudienceLink saas="/guides/semantic-layer-wizard">semantic layer wizard</AudienceLink> for the full flow.
 
 ## Validation
 

--- a/apps/docs/content/shared/plugins/interactions/chat.mdx
+++ b/apps/docs/content/shared/plugins/interactions/chat.mdx
@@ -457,7 +457,7 @@ The `chunkIntervalMs` setting controls how frequently messages are edited on pla
 
 Routes are mounted under the plugin's base path (e.g., `/api/plugins/chat-interaction/webhooks/slack`).
 
-Slack OAuth install + callback are NOT mounted under the chat-plugin prefix — they live at the canonical integration surface `/api/v1/integrations/slack/{install,callback}` (owned by `SlackOAuthInstallHandler`). See [Integrations guide](/guides/integrations) for the operator/customer seam and install-model design.
+Slack OAuth install + callback are NOT mounted under the chat-plugin prefix — they live at the canonical integration surface `/api/v1/integrations/slack/{install,callback}` (owned by `SlackOAuthInstallHandler`). See <AudienceLink saas="/guides/integrations">Integrations guide</AudienceLink> for the operator/customer seam and install-model design.
 
 ## Install consent language
 
@@ -555,7 +555,7 @@ Set `errorsAsEphemeral: false` to post errors publicly in the thread.
 ## Proactive Direct Messages
 
 <Callout type="info" title="Configuring the proactive chat tier?">
-This section documents the plugin-level `sendDirectMessage()` mechanic. For the **operator-facing** controls — workspace kill switch, channel allowlist, monthly quota, sensitivity preset, public-dataset HITL workflow, and the activation announcement — see the [Proactive Chat admin guide](/guides/proactive-chat).
+This section documents the plugin-level `sendDirectMessage()` mechanic. For the **operator-facing** controls — workspace kill switch, channel allowlist, monthly quota, sensitivity preset, public-dataset HITL workflow, and the activation announcement — see the <AudienceLink saas="/guides/proactive-chat">Proactive Chat admin guide</AudienceLink>.
 </Callout>
 
 The bridge exposes a `sendDirectMessage()` method for programmatic DMs — useful for digest delivery, alert notifications, and anomaly detection.

--- a/apps/docs/content/shared/plugins/interactions/mcp.mdx
+++ b/apps/docs/content/shared/plugins/interactions/mcp.mdx
@@ -14,7 +14,7 @@ Tool bridging and resource registration are handled internally by `@atlas/mcp` -
 </Callout>
 
 <Callout type="info">
-For one-command setup against Claude Desktop / Cursor / Continue, prefer `bunx @useatlas/mcp init --local` — see the [MCP guide](/guides/mcp). This page documents using `@useatlas/mcp` as an Atlas plugin inside an existing project.
+For one-command setup against Claude Desktop / Cursor / Continue, prefer `bunx @useatlas/mcp init --local` — see the <AudienceLink saas="/guides/mcp">MCP guide</AudienceLink>. This page documents using `@useatlas/mcp` as an Atlas plugin inside an existing project.
 </Callout>
 
 ## Installation
@@ -23,7 +23,7 @@ For one-command setup against Claude Desktop / Cursor / Continue, prefer `bunx @
 bun add @useatlas/mcp @modelcontextprotocol/sdk
 ```
 
-When loaded inside an Atlas project (monorepo dev or a `create-atlas-agent` scaffold), the `@atlas/mcp` server runtime is resolved via dynamic import — you don't need to depend on it directly. Standalone `bunx @useatlas/mcp serve` outside an Atlas project is intentionally not supported; the zero-config path for connecting any MCP client to Atlas is `bunx @useatlas/mcp init --hosted` against Atlas SaaS (see the [hosted endpoint reference](/guides/mcp#hosted-protocol-reference)).
+When loaded inside an Atlas project (monorepo dev or a `create-atlas-agent` scaffold), the `@atlas/mcp` server runtime is resolved via dynamic import — you don't need to depend on it directly. Standalone `bunx @useatlas/mcp serve` outside an Atlas project is intentionally not supported; the zero-config path for connecting any MCP client to Atlas is `bunx @useatlas/mcp init --hosted` against Atlas SaaS (see the <AudienceLink saas="/guides/mcp#hosted-protocol-reference">hosted endpoint reference</AudienceLink>).
 
 ## Configuration
 
@@ -81,7 +81,7 @@ Add Atlas as an MCP server in your Claude Desktop configuration:
 }
 ```
 
-See the [MCP guide](/guides/mcp) for full setup instructions.
+See the <AudienceLink saas="/guides/mcp">MCP guide</AudienceLink> for full setup instructions.
 
 ## Troubleshooting
 

--- a/apps/docs/content/shared/reference/api.mdx
+++ b/apps/docs/content/shared/reference/api.mdx
@@ -9,7 +9,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 Atlas exposes a Hono-based HTTP API. All endpoints are mounted under `/api/`. Use the [SDK](/reference/sdk) for a typed client, or call the API directly.
 
 <Callout>
-For detailed endpoint documentation with request/response schemas, see the **[interactive API Reference](/api-reference/chat/postChat)**, auto-generated from the OpenAPI specification.
+For detailed endpoint documentation with request/response schemas, see the **<AudienceLink saas="/api-reference/chat/postChat">interactive API Reference</AudienceLink>**, auto-generated from the OpenAPI specification.
 </Callout>
 
 ## OpenAPI Specification
@@ -36,7 +36,7 @@ All examples below use `http://localhost:3001` as the base URL. Replace with you
 
 ## Authentication
 
-Authentication headers depend on the configured [auth mode](/self-hosted/deployment/authentication):
+Authentication headers depend on the configured <AudienceLink selfHosted="/self-hosted/deployment/authentication">auth mode</AudienceLink>:
 
 | Auth Mode | Header |
 |-----------|--------|
@@ -428,7 +428,7 @@ See [Environment Variables](/reference/environment-variables) for configuration.
 
 CORS is configured via `ATLAS_CORS_ORIGIN` (defaults to `*`). When an explicit origin is set, credentials (cookies) are allowed. The `Retry-After`, `x-conversation-id`, and `x-run-id` headers are exposed to the client.
 
-For cross-origin managed auth deployments, see the [cross-origin section](/self-hosted/deployment/authentication#cross-origin-deployment) in the authentication guide.
+For cross-origin managed auth deployments, see the <AudienceLink selfHosted="/self-hosted/deployment/authentication#cross-origin-deployment">cross-origin section</AudienceLink> in the authentication guide.
 
 ---
 
@@ -437,5 +437,5 @@ For cross-origin managed auth deployments, see the [cross-origin section](/self-
 - [SDK Reference](/reference/sdk) — Typed TypeScript client for the Atlas API
 - [Error Codes](/reference/error-codes) — Full catalog of every error code, HTTP status, and retry guidance
 - [Environment Variables](/reference/environment-variables) — Configuration that affects API behavior
-- [Authentication](/self-hosted/deployment/authentication) — Auth mode setup and configuration
-- [Rate Limiting & Retry](/guides/rate-limiting) — Rate limit configuration and client-side handling
+- <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> — Auth mode setup and configuration
+- <AudienceLink saas="/guides/rate-limiting">Rate Limiting & Retry</AudienceLink> — Rate limit configuration and client-side handling

--- a/apps/docs/content/shared/reference/cli.mdx
+++ b/apps/docs/content/shared/reference/cli.mdx
@@ -180,7 +180,7 @@ The commands in this group act on a **workspace** through a running Atlas API �
 - **Ambient `atlas login` session (recommended).** Run [`atlas login`](#login) once; the OAuth device flow stores a session in `~/.atlas/credentials` and every later `atlas` command (and any agent running in that logged-in shell) reuses it automatically — the `gh auth login` / `railway login` model. No key to provision.
 - **Workspace API key (unattended CI).** Mint a workspace-scoped key on the `/admin/api-keys` page and pass it via the `ATLAS_API_KEY` environment variable or `--api-key <key>` (the flag overrides the env var). Honored by the REST-backed commands — [`query`](#query), `sql`, `metric run`, `explore`, and `datasource`. A key is pinned to one workspace, so the `--workspace` override does not apply to it. Commands that need an interactive session (`switch`, `entities`) still require `atlas login`.
 
-Set `ATLAS_API_URL` (default `http://localhost:3001`) to target a non-local API. See [API Key Management](/guides/api-keys) for the full credential model — ambient login vs. workspace key, scope, and RLS-claim bounds — and [Environment Variables](/reference/environment-variables#workspace-cli-credentials) for `ATLAS_API_URL` / `ATLAS_API_KEY` / `ATLAS_DATASOURCE_SECRET`.
+Set `ATLAS_API_URL` (default `http://localhost:3001`) to target a non-local API. See <AudienceLink saas="/guides/api-keys">API Key Management</AudienceLink> for the full credential model — ambient login vs. workspace key, scope, and RLS-claim bounds — and [Environment Variables](/reference/environment-variables#workspace-cli-credentials) for `ATLAS_API_URL` / `ATLAS_API_KEY` / `ATLAS_DATASOURCE_SECRET`.
 
 ## login
 
@@ -357,7 +357,7 @@ bun run atlas -- datasource <command> [id] [options]
 | `--new-group <name>` | (`create`) Create a new inline environment/group. Mutually exclusive with `--group` |
 
 <Callout type="warn" title="Every datasource command requires the workspace admin role">
-The admin-connection routes are admin-gated end to end, so every `datasource` subcommand — including read-only `list` / `get` / `test` — requires the workspace `admin` or `owner` role. A non-admin member is denied with an actionable message. (A workspace API key reaches this surface by design, so CI can provision and profile connections — see [API Key Management](/guides/api-keys#scope-data-plane--the-datasource-cli-not-console-admin).)
+The admin-connection routes are admin-gated end to end, so every `datasource` subcommand — including read-only `list` / `get` / `test` — requires the workspace `admin` or `owner` role. A non-admin member is denied with an actionable message. (A workspace API key reaches this surface by design, so CI can provision and profile connections — see <AudienceLink saas="/guides/api-keys#scope-data-plane--the-datasource-cli-not-console-admin">API Key Management</AudienceLink>.)
 </Callout>
 
 ### datasource list
@@ -398,7 +398,7 @@ ATLAS_DATASOURCE_SECRET="postgres://user:pass@host:5432/db" bun run atlas -- dat
 ```
 
 <Callout title="Secret capture — stdin / env var, never a flag">
-The connection URL is captured by exactly one of two paths, in priority order: (1) the `ATLAS_DATASOURCE_SECRET` environment variable (the headless-agent path — read at request time, never lands in argv), or (2) a masked stdin prompt (the interactive path — keystrokes don't echo and don't enter shell history). With **no TTY and no env var** (a CI runner), `create` fails closed and defers datasource creation to the dashboard or the [Atlas MCP](/guides/mcp); a set-but-empty `ATLAS_DATASOURCE_SECRET` is treated as a misconfiguration and fails loudly rather than silently prompting.
+The connection URL is captured by exactly one of two paths, in priority order: (1) the `ATLAS_DATASOURCE_SECRET` environment variable (the headless-agent path — read at request time, never lands in argv), or (2) a masked stdin prompt (the interactive path — keystrokes don't echo and don't enter shell history). With **no TTY and no env var** (a CI runner), `create` fails closed and defers datasource creation to the dashboard or the <AudienceLink saas="/guides/mcp">Atlas MCP</AudienceLink>; a set-but-empty `ATLAS_DATASOURCE_SECRET` is treated as a misconfiguration and fails loudly rather than silently prompting.
 </Callout>
 
 The new datasource lands as a **draft** — run [`atlas datasource publish`](#datasource-publish) (or publish it in the Atlas console), or it stays developer-mode-only. The command suggests `atlas datasource test <id>` to verify connectivity.
@@ -426,7 +426,7 @@ bun run atlas -- datasource publish
 bun run atlas -- datasource publish <id>
 ```
 
-The MCP equivalent is the [`publish_datasources`](/guides/mcp#publish_datasources) tool. Drafts created by the CLI/MCP are already queryable in developer mode before publishing; `publish` is what exposes them on the published `/chat` surface.
+The MCP equivalent is the <AudienceLink saas="/guides/mcp#publish_datasources">`publish_datasources`</AudienceLink> tool. Drafts created by the CLI/MCP are already queryable in developer mode before publishing; `publish` is what exposes them on the published `/chat` surface.
 
 ### datasource archive
 
@@ -948,7 +948,7 @@ atlas improve --min-confidence 0.7
 atlas improve --entities orders,users,products
 ```
 
-See the [Semantic Expert guide](/guides/semantic-expert) for full documentation.
+See the <AudienceLink saas="/guides/semantic-expert">Semantic Expert guide</AudienceLink> for full documentation.
 
 ## benchmark
 
@@ -970,7 +970,7 @@ bun run atlas -- benchmark [options]
 
 ## export
 
-Export workspace data to a portable migration bundle (JSON). Reads from the internal database. Used as the first step in a self-hosted → SaaS migration workflow. See [Migration guide](/guides/migration) for the full workflow.
+Export workspace data to a portable migration bundle (JSON). Reads from the internal database. Used as the first step in a self-hosted → SaaS migration workflow. See <AudienceLink saas="/guides/migration">Migration guide</AudienceLink> for the full workflow.
 
 > **Operator-only.** `export` is direct-DB tooling and ships in the [`atlas-operator`](#operator-subcommands) binary, not the published `atlas` CLI.
 
@@ -1234,9 +1234,9 @@ ATLAS_TEARDOWN_OK=1 bun run atlas-operator -- ops teardown-verify-accounts \
 
 ## See Also
 
-- [API Key Management](/guides/api-keys) — The credential model behind the [workspace commands](#workspace-commands): ambient `atlas login` reuse vs. a workspace API key for unattended CI
-- [Schema Evolution](/deployment/schema-evolution) — Detecting database drift with `atlas diff` and updating entity YAMLs
-- [MCP Server](/guides/mcp) — Using `atlas mcp` with Claude Desktop and Cursor
+- <AudienceLink saas="/guides/api-keys">API Key Management</AudienceLink> — The credential model behind the [workspace commands](#workspace-commands): ambient `atlas login` reuse vs. a workspace API key for unattended CI
+- <AudienceLink saas="/deployment/schema-evolution">Schema Evolution</AudienceLink> — Detecting database drift with `atlas diff` and updating entity YAMLs
+- <AudienceLink saas="/guides/mcp">MCP Server</AudienceLink> — Using `atlas mcp` with Claude Desktop and Cursor
 - [Environment Variables](/reference/environment-variables) — Variables that affect CLI behavior (`ATLAS_DATASOURCE_URL`, `ATLAS_SCHEMA`, etc.)
 - [Configuration](/reference/config) — Declarative config file that the CLI reads and validates
-- [Troubleshooting](/guides/troubleshooting) — Diagnostic steps when CLI commands fail
+- <AudienceLink saas="/guides/troubleshooting">Troubleshooting</AudienceLink> — Diagnostic steps when CLI commands fail

--- a/apps/docs/content/shared/reference/config.mdx
+++ b/apps/docs/content/shared/reference/config.mdx
@@ -7,7 +7,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
 <Callout type="info" title="Self-hosted only">
-  Configuration files are used for self-hosted deployments. Hosted users at [app.useatlas.dev](https://app.useatlas.dev) can skip this — configure datasources, plugins, and settings from the admin console instead. See [Workspace Settings](/guides/workspace-settings).
+  Configuration files are used for self-hosted deployments. Hosted users at [app.useatlas.dev](https://app.useatlas.dev) can skip this — configure datasources, plugins, and settings from the admin console instead. See <AudienceLink saas="/guides/workspace-settings">Workspace Settings</AudienceLink>.
 </Callout>
 
 Atlas can be configured via environment variables (see [Environment Variables](/reference/environment-variables)) or a declarative `atlas.config.ts` file. For multi-datasource setups, plugins, RLS, or actions, use the config file. For simple single-datasource deployments, env vars alone are sufficient.
@@ -40,7 +40,7 @@ Config loading is **binary**: when a config file exists, it is used exclusively.
 3. **Secrets should stay in env vars** — reference them via `process.env` in the config file (this is user code executing at import time, not a config-loader merge)
 
 <Callout type="info">
-Auth mode resolution priority: `ATLAS_AUTH_MODE` env var (highest) → config file `auth` field → auto-detection from env var presence (lowest). Setting `auth: "managed"` in the config file pins the auth mode without needing `ATLAS_AUTH_MODE`, but the env var still overrides if set. See [Authentication](/self-hosted/deployment/authentication) for details.
+Auth mode resolution priority: `ATLAS_AUTH_MODE` env var (highest) → config file `auth` field → auto-detection from env var presence (lowest). Setting `auth: "managed"` in the config file pins the auth mode without needing `ATLAS_AUTH_MODE`, but the env var still overrides if set. See <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> for details.
 </Callout>
 
 ```typescript
@@ -172,7 +172,7 @@ export default defineConfig({
 | `idleTimeoutMs` | `number` | No | — | Idle connection timeout in milliseconds |
 | `rateLimit` | `object` | No | `{ queriesPerMinute: 60, concurrency: 5 }` | Per-datasource rate limiting. `queriesPerMinute` caps queries per minute (default: 60). `concurrency` caps concurrent queries (default: 5) |
 
-The `"default"` datasource is used when the agent's `executeSQL` tool is called without a `connectionId`. See [Multi-Datasource Routing](/deployment/multi-datasource) for a full guide on how the agent selects and queries multiple datasources.
+The `"default"` datasource is used when the agent's `executeSQL` tool is called without a `connectionId`. See <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink> for a full guide on how the agent selects and queries multiple datasources.
 
 ---
 
@@ -226,7 +226,7 @@ export default defineConfig({
 });
 ```
 
-When set to `"auto"` (or omitted), Atlas detects the mode from environment variables. See [Authentication](/self-hosted/deployment/authentication) for full setup guides.
+When set to `"auto"` (or omitted), Atlas detects the mode from environment variables. See <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> for full setup guides.
 
 ---
 
@@ -302,7 +302,7 @@ Connection pools are automatically warmed at startup and drained when consecutiv
 | `ATLAS_POOL_WARMUP` | `2` | Number of `SELECT 1` probes per connection at startup. `0` disables warmup |
 | `ATLAS_POOL_DRAIN_THRESHOLD` | `5` | Consecutive query errors before the pool is drained and recreated |
 
-Auto-drain has a 30-second cooldown to prevent drain storms. Manual drain is available via the [admin console](/guides/admin-console#pool-stats) or `POST /api/v1/admin/connections/:id/drain`.
+Auto-drain has a 30-second cooldown to prevent drain storms. Manual drain is available via the <AudienceLink saas="/guides/admin-console#pool-stats">admin console</AudienceLink> or `POST /api/v1/admin/connections/:id/drain`.
 
 ### Per-Org Pool Isolation
 
@@ -376,7 +376,7 @@ The first three are **workspace-scoped runtime settings**, not `atlas.config.ts`
 | Auto-Promote Min Repetitions | `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | Platform | `5` | Minimum times a pending pattern must be seen before auto-promotion |
 | Pattern Decay Window (days) | `ATLAS_LEARN_DECAY_UNSEEN_DAYS` | Platform | `30` | An auto-promoted pattern unseen this long is demoted to pending. Human approvals are never auto-demoted |
 
-See [Learned query patterns](/guides/semantic-expert#learned-query-patterns) for how performance-weighting and the nightly job work together.
+See <AudienceLink saas="/guides/semantic-expert#learned-query-patterns">Learned query patterns</AudienceLink> for how performance-weighting and the nightly job work together.
 
 ```bash
 ATLAS_LEARN_CONFIDENCE_THRESHOLD=0.7
@@ -423,7 +423,7 @@ ATLAS_STARTER_PROMPT_MAX_FAVORITES=10
 
 Define RLS policies that inject WHERE clauses on every query based on user JWT claims. Each policy specifies which tables it applies to, which column to filter on, and which JWT claim provides the value.
 
-See [Row-Level Security](/security/row-level-security) for the full guide.
+See <AudienceLink saas="/security/row-level-security">Row-Level Security</AudienceLink> for the full guide.
 
 <Tabs items={["Single policy", "Per-table policies", "All tables", "OR-combined"]}>
 <Tab value="Single policy">
@@ -558,7 +558,7 @@ For per-table policies or multi-condition policies, use the config file.
 
 ## Actions
 
-Configure the [action framework](/guides/actions) with default approval modes and per-action overrides.
+Configure the <AudienceLink saas="/guides/actions">action framework</AudienceLink> with default approval modes and per-action overrides.
 
 ```typescript
 // atlas.config.ts — action framework
@@ -623,7 +623,7 @@ export default defineConfig({
 });
 ```
 
-See [Scheduled Tasks](/guides/scheduled-tasks) for the full guide.
+See <AudienceLink saas="/guides/scheduled-tasks">Scheduled Tasks</AudienceLink> for the full guide.
 
 ---
 
@@ -959,7 +959,7 @@ Each entry in `configSchema` is a strict object with the following fields:
 - **Form entries need a schema.** When `install_model === "form"`, `configSchema` is required and must be non-empty. A missing or empty schema fails Zod parsing at config-load time (the install route can't validate user input without it)
 - **Strict shape.** Every entry is parsed with `.strict()` — unknown fields are rejected
 
-See also: [`packages/api/src/lib/config.ts:CatalogEntrySchema`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/config.ts) for the authoritative Zod schema, and the [Plugin Catalog deployment guide](/deployment/plugin-catalog) for the seeder behaviour.
+See also: [`packages/api/src/lib/config.ts:CatalogEntrySchema`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/config.ts) for the authoritative Zod schema, and the <AudienceLink saas="/deployment/plugin-catalog">Plugin Catalog deployment guide</AudienceLink> for the seeder behaviour.
 
 ---
 
@@ -1090,7 +1090,7 @@ export default defineConfig({
 
 - [Environment Variables](/reference/environment-variables) — Env-var-only configuration (used when no config file exists)
 - [CLI Reference](/reference/cli) — `atlas validate` checks your config file for errors
-- [Deploy](/self-hosted/deployment/deploy) — Platform-specific deployment with config examples
-- [Multi-Datasource Routing](/deployment/multi-datasource) — Guide for configuring multiple datasources
+- <AudienceLink selfHosted="/self-hosted/deployment/deploy">Deploy</AudienceLink> — Platform-specific deployment with config examples
+- <AudienceLink saas="/deployment/multi-datasource">Multi-Datasource Routing</AudienceLink> — Guide for configuring multiple datasources
 - [Plugin Authoring Guide](/plugins/authoring-guide) — Building plugins registered via the config file
-- [Row-Level Security](/security/row-level-security) — Full RLS guide for the `rls` config option
+- <AudienceLink saas="/security/row-level-security">Row-Level Security</AudienceLink> — Full RLS guide for the `rls` config option

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -7,7 +7,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
 <Callout type="info" title="Self-hosted only">
-  Environment variables are used for self-hosted deployments. Hosted users at [app.useatlas.dev](https://app.useatlas.dev) can skip this — the platform manages all configuration through the admin console. See [Workspace Settings](/guides/workspace-settings).
+  Environment variables are used for self-hosted deployments. Hosted users at [app.useatlas.dev](https://app.useatlas.dev) can skip this — the platform manages all configuration through the admin console. See <AudienceLink saas="/guides/workspace-settings">Workspace Settings</AudienceLink>.
 </Callout>
 
 Atlas can be configured entirely via environment variables. Most have safe defaults — a minimal deployment needs only an LLM provider key and a datasource URL. For multi-datasource setups or advanced configuration, see the [Configuration reference](/reference/config).
@@ -139,7 +139,7 @@ OPENAI_COMPATIBLE_BASE_URL=http://localhost:8000/v1  # Required
 
 **Demo data fallback chain:** When `ATLAS_DEMO_DATA=true` and `ATLAS_DATASOURCE_URL` is not set, Atlas resolves the analytics datasource by checking `DATABASE_URL_UNPOOLED` first, then `DATABASE_URL`. This lets a single Postgres instance (e.g. Neon on Vercel) serve as both the analytics datasource and Atlas's internal database.
 
-> **SaaS multi-region only:** `ATLAS_REGION_US_DB_URL`, `ATLAS_REGION_EU_DB_URL`, and `ATLAS_REGION_APAC_DB_URL` are part of the SaaS boot contract (`SAAS_ENV_KEYS` in `packages/api/src/lib/effect/saas-env.ts`) — the per-region internal Postgres URLs the data-residency router targets. Self-hosted single-region deploys use `DATABASE_URL` only and never set these. See the [SaaS environment variables reference](/platform-ops/saas-environment-variables).
+> **SaaS multi-region only:** `ATLAS_REGION_US_DB_URL`, `ATLAS_REGION_EU_DB_URL`, and `ATLAS_REGION_APAC_DB_URL` are part of the SaaS boot contract (`SAAS_ENV_KEYS` in `packages/api/src/lib/effect/saas-env.ts`) — the per-region internal Postgres URLs the data-residency router targets. Self-hosted single-region deploys use `DATABASE_URL` only and never set these. See the <AudienceLink saas="/platform-ops/saas-environment-variables">SaaS environment variables reference</AudienceLink>.
 
 <Tabs items={["Local development", "Production (separate DBs)", "Vercel (shared DB)"]}>
 <Tab value="Local development">
@@ -194,7 +194,7 @@ ATLAS_DEMO_DATA=true
 
 ## Knowledge Base
 
-Caps and cadence for hosted [Knowledge Base collections](/guides/knowledge-base). These are **platform-scoped settings-registry knobs** — a platform admin can change them in Admin → Settings without a redeploy; the env var form below is honored on self-hosted deployments (precedence: settings registry > env > default). All six clamp non-positive or unparseable overrides back to the default, with a logged warning.
+Caps and cadence for hosted <AudienceLink saas="/guides/knowledge-base">Knowledge Base collections</AudienceLink>. These are **platform-scoped settings-registry knobs** — a platform admin can change them in Admin → Settings without a redeploy; the env var form below is honored on self-hosted deployments (precedence: settings registry > env > default). All six clamp non-positive or unparseable overrides back to the default, with a logged warning.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -209,7 +209,7 @@ Caps and cadence for hosted [Knowledge Base collections](/guides/knowledge-base)
 
 ## Security
 
-Query safety and SQL validation settings. See [SQL Validation Pipeline](/security/sql-validation) for how these are enforced.
+Query safety and SQL validation settings. See <AudienceLink saas="/security/sql-validation">SQL Validation Pipeline</AudienceLink> for how these are enforced.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -217,7 +217,7 @@ Query safety and SQL validation settings. See [SQL Validation Pipeline](/securit
 | `ATLAS_QUERY_TIMEOUT` | `30000` | Query timeout in milliseconds |
 | `ATLAS_TABLE_WHITELIST` | `true` | Only allow queries against tables defined in the semantic layer |
 | `ATLAS_SCHEMA` | — | PostgreSQL schema name. When set to a non-`public` value, the API sets `search_path` to `"<schema>", public` on each connection. When unset, no `search_path` is set and PostgreSQL uses its server default (typically `public`). Also used by `atlas doctor` to verify the schema exists |
-| `ATLAS_ENCRYPTION_KEYS` | — | F-47 versioned at-rest encryption keyset. Comma-separated `version:key` pairs (e.g. `v2:NEW-KEY,v1:OLD-KEY`). The first entry is the active write key; later entries are legacy read-only keys kept available during a rotation soak. **Preferred form for production** — see the [encryption key rotation guide](/platform-ops/encryption-key-rotation) |
+| `ATLAS_ENCRYPTION_KEYS` | — | F-47 versioned at-rest encryption keyset. Comma-separated `version:key` pairs (e.g. `v2:NEW-KEY,v1:OLD-KEY`). The first entry is the active write key; later entries are legacy read-only keys kept available during a rotation soak. **Preferred form for production** — see the <AudienceLink saas="/platform-ops/encryption-key-rotation">encryption key rotation guide</AudienceLink> |
 | `ATLAS_ENCRYPTION_KEY` | — | Legacy single-key form, treated as an implicit `v1` when `ATLAS_ENCRYPTION_KEYS` is unset. Takes precedence over `BETTER_AUTH_SECRET`. Kept for back-compat — new deployments should set `ATLAS_ENCRYPTION_KEYS` instead. Key derivation order: `ATLAS_ENCRYPTION_KEYS` → `ATLAS_ENCRYPTION_KEY` → `BETTER_AUTH_SECRET` (the last is deprecated under SaaS — startup warns) |
 | `ATLAS_STRICT_PLUGIN_SECRETS` | `false` | F-42 / #1835: when `true`, plugin admin write paths reject PUTs whose catalog schema is corrupt or carries per-key secret/passthrough drift. SaaS regions opt in; self-hosted defaults to off. Tolerant idempotent passthrough is the baseline |
 | `ATLAS_POOL_WARMUP` | `2` | Number of warmup probes per connection at startup. Set to `0` to disable warmup |
@@ -243,7 +243,7 @@ ATLAS_SCHEMA=analytics        # Non-default PostgreSQL schema
 
 ## Auth
 
-Authentication mode and per-mode settings. See [Authentication](/self-hosted/deployment/authentication) for full setup guides.
+Authentication mode and per-mode settings. See <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> for full setup guides.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -260,7 +260,7 @@ When `ATLAS_AUTH_MODE` is not set, Atlas auto-detects based on which variables a
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_API_KEY` | — | **Legacy operator god-key** — a single env-configured shared secret for self-hosted simple-key auth. Clients send `Authorization: Bearer <key>` or `X-API-Key: <key>`. This is distinct from a **workspace-scoped API key**: the *same variable name* is also read by the REST-backed workspace CLI commands (`atlas sql` / `metric run` / `explore` / `datasource`) as a per-member workspace key ([#4046](https://github.com/AtlasDevHQ/atlas/issues/4046)) — see [Workspace CLI credentials](#workspace-cli-credentials) and [API Key Management](/guides/api-keys) |
+| `ATLAS_API_KEY` | — | **Legacy operator god-key** — a single env-configured shared secret for self-hosted simple-key auth. Clients send `Authorization: Bearer <key>` or `X-API-Key: <key>`. This is distinct from a **workspace-scoped API key**: the *same variable name* is also read by the REST-backed workspace CLI commands (`atlas sql` / `metric run` / `explore` / `datasource`) as a per-member workspace key ([#4046](https://github.com/AtlasDevHQ/atlas/issues/4046)) — see [Workspace CLI credentials](#workspace-cli-credentials) and <AudienceLink saas="/guides/api-keys">API Key Management</AudienceLink> |
 | `ATLAS_API_KEY_ROLE` | `admin` | Role for the operator god-key above. Valid values: `member`, `admin`, `owner`. Invalid values fall back to `admin` with a warning at startup. Does not apply to workspace keys, which carry their own server-side role |
 
 ```bash
@@ -323,7 +323,7 @@ GITHUB_CLIENT_SECRET=ghs_...
 
 ### OAuth Provider (MCP / DCR)
 
-Atlas issues OAuth 2.1 access tokens via `@better-auth/oauth-provider` so MCP clients (Claude Desktop, ChatGPT, Cursor) can connect to the [hosted MCP endpoint](/guides/mcp#hosted-protocol-reference) via Dynamic Client Registration + PKCE. Most operators leave these on defaults; tune only when SaaS regions or stricter threat models require it.
+Atlas issues OAuth 2.1 access tokens via `@better-auth/oauth-provider` so MCP clients (Claude Desktop, ChatGPT, Cursor) can connect to the <AudienceLink saas="/guides/mcp#hosted-protocol-reference">hosted MCP endpoint</AudienceLink> via Dynamic Client Registration + PKCE. Most operators leave these on defaults; tune only when SaaS regions or stricter threat models require it.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -353,7 +353,7 @@ ATLAS_AUTH_ROLE_CLAIM=app_metadata.atlas_role
 
 ### Workspace CLI credentials
 
-How the `atlas` CLI authenticates to a running Atlas API for the [workspace commands](/reference/cli#workspace-commands) (`login`, `switch`, `sql`, `metric run`, `explore`, `datasource`). The recommended path is an ambient `atlas login` device-flow session stored in `~/.atlas/credentials`; the variables below cover targeting a non-local API and the unattended-CI / headless paths. See [API Key Management](/guides/api-keys) for the full credential model.
+How the `atlas` CLI authenticates to a running Atlas API for the [workspace commands](/reference/cli#workspace-commands) (`login`, `switch`, `sql`, `metric run`, `explore`, `datasource`). The recommended path is an ambient `atlas login` device-flow session stored in `~/.atlas/credentials`; the variables below cover targeting a non-local API and the unattended-CI / headless paths. See <AudienceLink saas="/guides/api-keys">API Key Management</AudienceLink> for the full credential model.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -391,7 +391,7 @@ ATLAS_RATE_LIMIT_RPM=30
 ATLAS_TRUST_PROXY=true
 ```
 
-See [Rate Limiting & Retry](/guides/rate-limiting) for client-side handling, SDK retry patterns, and troubleshooting.
+See <AudienceLink saas="/guides/rate-limiting">Rate Limiting & Retry</AudienceLink> for client-side handling, SDK retry patterns, and troubleshooting.
 
 ### Abuse Prevention
 
@@ -403,7 +403,7 @@ See [Rate Limiting & Retry](/guides/rate-limiting) for client-side handling, SDK
 | `ATLAS_ABUSE_UNIQUE_TABLES` | `50` | Max unique tables accessed per window |
 | `ATLAS_ABUSE_THROTTLE_DELAY_MS` | `2000` | Delay injected for throttled workspaces (ms) |
 | `ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS` | `60` | Minimum seconds between abuse-prevention escalation steps for the same workspace. Prevents a single bad-actor burst from cascading the workspace through every escalation tier in one window. Set `0` to disable (test-only). Invalid values fall back to the default with a warning |
-| `ATLAS_LOADTEST_ALLOWED_ORGS` | _unset_ | Comma-separated workspace IDs designated for load testing. Listed workspaces (a) may mint MCP load-test JWTs via `POST /api/v1/me/load-test/mcp-token` (see [MCP load-test tokens](/platform-ops/mcp-load-test-tokens)) and (b) bypass abuse-prevention escalation so a load run can't auto-suspend the workspace it's running against. Operator escape hatch — never a substitute for raising thresholds. |
+| `ATLAS_LOADTEST_ALLOWED_ORGS` | _unset_ | Comma-separated workspace IDs designated for load testing. Listed workspaces (a) may mint MCP load-test JWTs via `POST /api/v1/me/load-test/mcp-token` (see <AudienceLink saas="/platform-ops/mcp-load-test-tokens">MCP load-test tokens</AudienceLink>) and (b) bypass abuse-prevention escalation so a load run can't auto-suspend the workspace it's running against. Operator escape hatch — never a substitute for raising thresholds. |
 
 ```bash
 # Stricter abuse detection for production
@@ -416,7 +416,7 @@ ATLAS_ABUSE_THROTTLE_DELAY_MS=5000
 ATLAS_LOADTEST_ALLOWED_ORGS=ws_dharma_uuid,ws_canary_uuid
 ```
 
-See [Abuse Prevention](/platform-ops/abuse-prevention) for details on graduated response and admin reinstatement.
+See <AudienceLink saas="/platform-ops/abuse-prevention">Abuse Prevention</AudienceLink> for details on graduated response and admin reinstatement.
 
 ### Session Timeouts
 
@@ -450,7 +450,7 @@ Idle and absolute timeouts can also be configured via [`atlas.config.ts`](/refer
 
 ## MCP Transport
 
-Actor binding for the [MCP server](/guides/mcp). The transport runs in one of two modes — bound (governed) or unbound (trusted).
+Actor binding for the <AudienceLink saas="/guides/mcp">MCP server</AudienceLink>. The transport runs in one of two modes — bound (governed) or unbound (trusted).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -488,7 +488,7 @@ ATLAS_SEMANTIC_INDEX_ENABLED=false
 
 ## Row-Level Security
 
-Env var shorthand for a single global RLS policy. For per-table policies, use [`atlas.config.ts`](/reference/config#rls-row-level-security). See [Row-Level Security](/security/row-level-security) for the full guide.
+Env var shorthand for a single global RLS policy. For per-table policies, use [`atlas.config.ts`](/reference/config#rls-row-level-security). See <AudienceLink saas="/security/row-level-security">Row-Level Security</AudienceLink> for the full guide.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -601,7 +601,7 @@ ATLAS_PUBLIC_URL=https://api.example.com
 
 ## Data Residency
 
-Settings for multi-region deployments with per-workspace region routing. See also [`residency` in atlas.config.ts](/reference/config#residency) and the [Data Residency guide](/platform-ops/data-residency).
+Settings for multi-region deployments with per-workspace region routing. See also [`residency` in atlas.config.ts](/reference/config#residency) and the <AudienceLink saas="/platform-ops/data-residency">Data Residency guide</AudienceLink>.
 
 <Callout type="info">
 **Per-service scoping (#3176).** Each `ATLAS_REGION_*_DB_URL` only has to be set on the api service whose `ATLAS_API_REGION` **claims that region** — the US service needs `ATLAS_REGION_US_DB_URL`, the EU service needs `ATLAS_REGION_EU_DB_URL`, and so on. The shared `deploy/api/atlas.config.ts` declares all regions in one map, but a non-claimed region's URL may be left unset/empty on a given service without aborting its boot. Only the **claimed** region's URL is hard-validated at boot (by `RegionGuardLive`); an empty or malformed claimed URL still fails boot.
@@ -628,7 +628,7 @@ Settings for multi-region deployments with per-workspace region routing. See als
 
 ## Actions
 
-Action framework settings. These can also be configured via [`atlas.config.ts`](/reference/config#actions). See the [Actions guide](/guides/actions) for the full setup.
+Action framework settings. These can also be configured via [`atlas.config.ts`](/reference/config#actions). See the <AudienceLink saas="/guides/actions">Actions guide</AudienceLink> for the full setup.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -651,7 +651,7 @@ ATLAS_EMAIL_ALLOWED_DOMAINS=example.com,trusted-partner.com
 
 ## Scheduler
 
-Scheduled task execution. Can also be configured via [`atlas.config.ts`](/reference/config#scheduler). See [Scheduled Tasks](/guides/scheduled-tasks) for the full guide.
+Scheduled task execution. Can also be configured via [`atlas.config.ts`](/reference/config#scheduler). See <AudienceLink saas="/guides/scheduled-tasks">Scheduled Tasks</AudienceLink> for the full guide.
 
 <Callout type="info">
 **Multi-region (SaaS): run a single global scheduler.** In a multi-region SaaS
@@ -723,7 +723,7 @@ The first three are the self-host fallback tier for **workspace-scoped runtime s
 | `ATLAS_PYTHON_ENABLED` | — | Set `true` to enable the `executePython` agent tool. Requires `ATLAS_SANDBOX_URL` to be set (Python runs in the sandbox sidecar for isolation) |
 | `ATLAS_PYTHON_TIMEOUT` | `30000` | Python execution timeout in milliseconds |
 
-See [Python Tool](/guides/python) for the full guide.
+See <AudienceLink saas="/guides/python">Python Tool</AudienceLink> for the full guide.
 
 ---
 
@@ -761,7 +761,7 @@ Password-reset / signup-verification emails are sent through a durable `email_ou
 | `SLACK_ENCRYPTION_KEY` | — | At-rest encryption key for per-Workspace Slack OAuth credentials in `chat_cache`. Failure mode differs by deploy mode: **on SaaS** (`deployMode === "saas"`), `ChatAdapterEnvGuardLive` fails boot with `ChatAdapterEnvMissingError` when any Slack OAuth catalog entry is `enabled` but the key (or the other Slack envs) is missing — incident response should look for the boot-failure error, not for dropped events. **On self-hosted**, the guard is a no-op; `SLACK_BUILDER.build()` returns `null` and the adapter silently doesn't activate (the api still boots — fix the env when ready). Sources: `packages/api/src/lib/effect/saas-guards.ts:793` (the guard), `packages/api/src/lib/effect/saas-env.ts` (env wiring) |
 | `ATLAS_SLACK_INSTALL_TABLE` | `chat_cache` | Override the SQL table OAuth installs land in. Must be a valid SQL identifier. Set this on self-hosted deploys that customize the chat plugin's `state.tablePrefix` (e.g. `myorg_` → `myorg_cache`) so OAuth installs land in the same physical table the chat-adapter reads from. SaaS pins the default. Source: `packages/api/src/lib/slack/store.ts` |
 
-See [Slack guide](/guides/slack) for the full setup.
+See <AudienceLink saas="/guides/slack">Slack guide</AudienceLink> for the full setup.
 
 ---
 
@@ -854,7 +854,7 @@ The createJiraTicket action uses a static API-token credential; the catalog-driv
 | `JIRA_API_TOKEN` | — | Jira API token. Generate at [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) |
 | `JIRA_DEFAULT_PROJECT` | — | Default project key for issue creation (e.g. `PROJ`). Can be overridden per-action |
 
-Requires the [action framework](/guides/actions) to be enabled (`ATLAS_ACTIONS_ENABLED=true`).
+Requires the <AudienceLink saas="/guides/actions">action framework</AudienceLink> to be enabled (`ATLAS_ACTIONS_ENABLED=true`).
 
 ```bash
 # JIRA integration for the createJiraTicket action
@@ -1037,7 +1037,7 @@ Operator-only, **SaaS staging region only** (the `api-staging` service with `ATL
 | `ATLAS_DEPLOY_MODE` | `auto` | Deployment mode: `saas` (hosted product features, enterprise-gated), `self-hosted`, or `auto` (detect from environment). When `auto`, resolves to `saas` if enterprise is enabled and an internal database is configured |
 | `ATLAS_ENTERPRISE_ENABLED` | `false` | Set `true` to enable enterprise features (SSO, SCIM, PII detection, custom roles). Requires a valid license key for production use |
 | `ATLAS_ENTERPRISE_LICENSE_KEY` | — | License key for enterprise features. Obtain from [useatlas.dev/enterprise](https://www.useatlas.dev/enterprise) |
-| `ATLAS_APPROVAL_EXPIRY_HOURS` | `24` | Hours before pending approval requests auto-expire. See [Approval Workflows](/guides/approval-workflows) |
+| `ATLAS_APPROVAL_EXPIRY_HOURS` | `24` | Hours before pending approval requests auto-expire. See <AudienceLink saas="/guides/approval-workflows">Approval Workflows</AudienceLink> |
 | `ATLAS_SCIM_OVERRIDE_POLICY` | `strict` | F-57 SCIM provenance gate. Controls admin mutations on SCIM-provisioned users: `strict` blocks the mutation with `409 SCIM_MANAGED` so the IdP stays canonical; `override` allows the mutation but stamps the audit row with `metadata.scim_override = true`. No-op for workspaces with no SCIM provider configured |
 
 These can also be configured via [`atlas.config.ts`](/reference/config#enterprise).
@@ -1085,7 +1085,7 @@ SaaS only. Required for custom domain support via Railway.
 | `ATLAS_DEMO_RATE_LIMIT_RPM` | `10` | Max requests per minute per demo user |
 | `ATLAS_DEMO_MAX_STEPS` | `10` | Max agent steps per demo request (lower than authenticated default of 25) |
 | `ATLAS_DEMO_MODEL` | — | Model the public `/demo` path runs on — a gateway model id (e.g. `anthropic/claude-haiku-4.5`) or a direct model id matching the configured provider. Blank = the resolved default (Haiku on the gateway for SaaS). Platform-scoped, hot-reloadable |
-| `ATLAS_DEMO_INDUSTRY` | — | Industry label for the seeded `__demo__` connection (e.g. `cybersecurity`, `ecommerce`). Set this explicitly to pre-configure the demo dataset industry on a single-tenant deploy; in the hosted product it is captured during onboarding. Drives prompt-library industry filtering and the publish flow's demo-prompt archival cascade. See [Developer Mode](/guides/developer-mode) for the full demo lifecycle |
+| `ATLAS_DEMO_INDUSTRY` | — | Industry label for the seeded `__demo__` connection (e.g. `cybersecurity`, `ecommerce`). Set this explicitly to pre-configure the demo dataset industry on a single-tenant deploy; in the hosted product it is captured during onboarding. Drives prompt-library industry filtering and the publish flow's demo-prompt archival cascade. See <AudienceLink saas="/guides/developer-mode">Developer Mode</AudienceLink> for the full demo lifecycle |
 
 Requires `BETTER_AUTH_SECRET` for demo token signing.
 
@@ -1123,8 +1123,8 @@ Destructive operator-CLI subcommands gated by explicit env confirmation. None of
 |----------|---------|-------------|
 | `ATLAS_SETTINGS_REFRESH_INTERVAL` | `30000` | Hot-reload interval for settings in milliseconds (default: 30s). Controls how often the API re-reads workspace-level settings from the database. Set to `0` to disable periodic refresh |
 | `ATLAS_HEALTH_PLUGIN_CACHE_TTL_MS` | `15000` (15s) | TTL for the plugin-liveness health cache. `0` disables caching (every call re-probes upstream). Max accepted value `300000` (5m); values above the max or unparseable fall back to the default with a warn. Source: `packages/api/src/lib/plugins/registry.ts` |
-| `ATLAS_DASHBOARD_DRAFTS_ENABLED` | `true` | Per-user dashboard drafts. When enabled, admin mutations to a bound dashboard write to the caller's draft and the **Publish** flow promotes them via an atomic three-way merge against the persisted baseline. Set to the literal string `false` to fall back to the direct-write model — draft fetch returns `503` and the chat-bound editor degrades to a read-only viewer. See [Dashboards → Chat as editor](/guides/dashboards#chat-as-editor) |
-| `ATLAS_INTERNAL_SCREENSHOT_COOKIE` | — | Service cookie value used by the `screenshotDashboard` vision tool (#2367). The headless Chromium worker calls back into `/admin/dashboards/:id/screenshot` and must authenticate as the requesting user; without this cookie the screenshot request is rejected and the agent falls back to its last-good description. Set this on **both** the API and web services when running behind a reverse proxy. See [Dashboards → Chat as editor](/guides/dashboards#chat-as-editor) |
+| `ATLAS_DASHBOARD_DRAFTS_ENABLED` | `true` | Per-user dashboard drafts. When enabled, admin mutations to a bound dashboard write to the caller's draft and the **Publish** flow promotes them via an atomic three-way merge against the persisted baseline. Set to the literal string `false` to fall back to the direct-write model — draft fetch returns `503` and the chat-bound editor degrades to a read-only viewer. See <AudienceLink saas="/guides/dashboards#chat-as-editor">Dashboards → Chat as editor</AudienceLink> |
+| `ATLAS_INTERNAL_SCREENSHOT_COOKIE` | — | Service cookie value used by the `screenshotDashboard` vision tool (#2367). The headless Chromium worker calls back into `/admin/dashboards/:id/screenshot` and must authenticate as the requesting user; without this cookie the screenshot request is rejected and the agent falls back to its last-good description. Set this on **both** the API and web services when running behind a reverse proxy. See <AudienceLink saas="/guides/dashboards#chat-as-editor">Dashboards → Chat as editor</AudienceLink> |
 | `ATLAS_WEB_BASE_URL` | `http://localhost:3000` | Base URL of the Next.js web app used by `screenshotDashboard` to construct the screenshot target URL (`${ATLAS_WEB_BASE_URL}/dashboards/:id`). Set to the production web origin when self-hosting (e.g. `https://atlas.acme.com`) so the headless Chromium worker hits the right host |
 
 ---
@@ -1158,14 +1158,14 @@ The sub-processor publisher fetches Atlas's authoritative sub-processor list (th
 | `OTEL_EXPORTER_OTLP_HEADERS` | — | Auth/header(s) your collector requires, in W3C Baggage format (percent-encode spaces, e.g. `authorization=Bearer%20<token>`). Most hosted collectors are non-functional without this. Set per-service in production |
 | `OTEL_SERVICE_NAME` | `atlas-api` | Overrides the `service.name` resource attribute reported on emitted spans |
 
-See [Observability](/platform-ops/observability) for the full setup guide.
+See <AudienceLink saas="/platform-ops/observability">Observability</AudienceLink> for the full setup guide.
 
 ---
 
 ## See Also
 
 - [Configuration](/reference/config) — Declarative `atlas.config.ts` for multi-datasource, plugins, and RLS
-- [Deploy](/self-hosted/deployment/deploy) — Platform-specific env var setup for Railway, Vercel, and Docker
-- [Authentication](/self-hosted/deployment/authentication) — Auth mode setup and required variables
+- <AudienceLink selfHosted="/self-hosted/deployment/deploy">Deploy</AudienceLink> — Platform-specific env var setup for Railway, Vercel, and Docker
+- <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> — Auth mode setup and required variables
 - [CLI Reference](/reference/cli) — `atlas doctor` validates your environment configuration
-- [Troubleshooting](/guides/troubleshooting) — Diagnosing startup errors from missing or invalid variables
+- <AudienceLink saas="/guides/troubleshooting">Troubleshooting</AudienceLink> — Diagnosing startup errors from missing or invalid variables

--- a/apps/docs/content/shared/reference/error-codes.mdx
+++ b/apps/docs/content/shared/reference/error-codes.mdx
@@ -36,12 +36,12 @@ Retrying these will not help — the request or configuration must be changed.
 
 | Code | HTTP Status | Description | Common Cause | Fix |
 |------|-------------|-------------|--------------|-----|
-| `auth_error` | 401 | Authentication failed | Invalid API key or revoked token | Check your API key or sign in again. See [Authentication](/self-hosted/deployment/authentication) |
+| `auth_error` | 401 | Authentication failed | Invalid API key or revoked token | Check your API key or sign in again. See <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> |
 | `session_expired` | 401 | Session expired | Session token has expired or been revoked | Sign in again to get a new session |
 | `forbidden` | 403 | Access denied | User lacks the required role (e.g., admin endpoints require `admin` role) | Request the appropriate role from your Atlas administrator |
 | `forbidden_role` | 403 | Admin role required | Non-admin user tried to access an admin endpoint | Sign in with an admin account or request the admin role |
 | `org_not_found` | 400 | No active organization | Request requires an active organization but none is selected | Select an organization in the org switcher and try again |
-| `configuration_error` | 400 | Atlas is not fully configured | Missing environment variables, invalid config file, or startup diagnostics failed | Run `atlas doctor` to identify the issue. See [Troubleshooting](/guides/troubleshooting) |
+| `configuration_error` | 400 | Atlas is not fully configured | Missing environment variables, invalid config file, or startup diagnostics failed | Run `atlas doctor` to identify the issue. See <AudienceLink saas="/guides/troubleshooting">Troubleshooting</AudienceLink> |
 | `no_datasource` | 400 | No datasource configured | `ATLAS_DATASOURCE_URL` is not set | Set `ATLAS_DATASOURCE_URL` in your environment. See [Environment Variables](/reference/environment-variables) |
 | `invalid_request` | 400 | Invalid request | Malformed JSON body or missing required fields | Check the request body format. See [API Reference](/reference/api) |
 | `validation_error` | 422 | Request validation failed | Request body doesn't match the expected schema (wrong types, missing fields) | Check the `details` field for specific field errors |
@@ -61,7 +61,7 @@ These codes are returned by billing enforcement and workspace status middleware.
 | `subscription_required` | 403 | Subscription required | The workspace subscription has ended (past-due/canceled) | Resubscribe from the billing page to continue using Atlas | No |
 | `billing_check_failed` | 503 | Billing check failed | Failed to fetch plan data from internal DB | Retry — transient infrastructure issue | Yes |
 | `workspace_check_failed` | 503 | Workspace check failed | Failed to verify workspace status | Retry — transient infrastructure issue | Yes |
-| `workspace_throttled` | 429 | Workspace throttled | Workspace triggered abuse detection thresholds | Wait for the throttle delay to pass and retry. See [Abuse Prevention](/platform-ops/abuse-prevention) | Yes |
+| `workspace_throttled` | 429 | Workspace throttled | Workspace triggered abuse detection thresholds | Wait for the throttle delay to pass and retry. See <AudienceLink saas="/platform-ops/abuse-prevention">Abuse Prevention</AudienceLink> | Yes |
 | `workspace_suspended` | 403 | Workspace suspended | Admin suspended the workspace | Contact your workspace administrator | No |
 | `workspace_deleted` | 404 | Workspace deleted | Workspace has been permanently deleted | Create a new workspace | No |
 
@@ -75,9 +75,9 @@ The `ChatErrorCode` catalog above is scoped to the chat-stream endpoint — the 
 
 | Code | HTTP Status | Trigger | Fix | Retryable |
 |------|-------------|---------|-----|-----------|
-| `demo_readonly` | 403 | Write against the `__demo__` connection while in published mode | Switch to developer mode to manage demo content. See [Developer Mode](/guides/developer-mode) | No |
-| `workspace_migrating` | 409 | Write attempted while the workspace's data is being moved to a new region | Transient — retry once the migration completes (typically minutes). See [Data Residency](/platform-ops/data-residency) | Yes |
-| `misdirected_request` | 421 | Request reached a regional API that doesn't hold this workspace's data | Use the `correctApiUrl` field in the response body to retarget. The SDK can be initialized with the correct regional URL once and cached. See [Regional API routing](/platform-ops/data-residency#misrouting-detection) | No |
+| `demo_readonly` | 403 | Write against the `__demo__` connection while in published mode | Switch to developer mode to manage demo content. See <AudienceLink saas="/guides/developer-mode">Developer Mode</AudienceLink> | No |
+| `workspace_migrating` | 409 | Write attempted while the workspace's data is being moved to a new region | Transient — retry once the migration completes (typically minutes). See <AudienceLink saas="/platform-ops/data-residency">Data Residency</AudienceLink> | Yes |
+| `misdirected_request` | 421 | Request reached a regional API that doesn't hold this workspace's data | Use the `correctApiUrl` field in the response body to retarget. The SDK can be initialized with the correct regional URL once and cached. See <AudienceLink saas="/platform-ops/data-residency#misrouting-detection">Regional API routing</AudienceLink> | No |
 
 ### Starter-prompt favorites
 
@@ -157,11 +157,11 @@ The scheduler runs proactive prompts and report deliveries on workspace cron sch
 
 | Code | `_tag` | HTTP Status | Trigger | Fix | Retryable |
 |------|--------|-------------|---------|-----|-----------|
-| `conflict` | `UnsafeRegionMigrationResetError` | 409 | Operator attempted to reset a region migration that had already passed Phase 3 (cutover). Re-running Phase 1 on a workspace that already moved would re-export stale data and corrupt the destination. `migrationId`, `workspaceId`, `targetRegion`, and `sourceRegion` are on the error instance and structured logs (correlate via `requestId`), not in the response body | Follow the data-residency manual-intervention runbook in [Data Residency](/platform-ops/data-residency). The code path is closed by design; this is not retryable | No |
+| `conflict` | `UnsafeRegionMigrationResetError` | 409 | Operator attempted to reset a region migration that had already passed Phase 3 (cutover). Re-running Phase 1 on a workspace that already moved would re-export stale data and corrupt the destination. `migrationId`, `workspaceId`, `targetRegion`, and `sourceRegion` are on the error instance and structured logs (correlate via `requestId`), not in the response body | Follow the data-residency manual-intervention runbook in <AudienceLink saas="/platform-ops/data-residency">Data Residency</AudienceLink>. The code path is closed by design; this is not retryable | No |
 
 ### Self-serve trial claim-gating (#3651)
 
-A workspace provisioned over MCP by `start_trial` starts **unclaimed (metered)**: setup and client-paid MCP querying work immediately, but Atlas-token Q&A (the web `/api/v1/query` endpoint, chat platforms, and the scheduler) is withheld until the owner claims the account by verifying their email on the web. These codes are surfaced inline by `/api/v1/query` (they are plain `Error` subclasses, not `mapTaggedError` tags). See [Self-Serve Signup](/guides/signup#claiming-a-self-serve-mcp-trial).
+A workspace provisioned over MCP by `start_trial` starts **unclaimed (metered)**: setup and client-paid MCP querying work immediately, but Atlas-token Q&A (the web `/api/v1/query` endpoint, chat platforms, and the scheduler) is withheld until the owner claims the account by verifying their email on the web. These codes are surfaced inline by `/api/v1/query` (they are plain `Error` subclasses, not `mapTaggedError` tags). See <AudienceLink saas="/guides/signup#claiming-a-self-serve-mcp-trial">Self-Serve Signup</AudienceLink>.
 
 | Code | Class | HTTP Status | Trigger | Fix | Retryable |
 |------|-------|-------------|---------|-----|-----------|
@@ -170,11 +170,11 @@ A workspace provisioned over MCP by `start_trial` starts **unclaimed (metered)**
 
 ### Self-serve trial signup over MCP (`start_trial`)
 
-The anonymous onboarding tool [`start_trial`](/guides/mcp#start_trial) (#3649/#3654) provisions a trial workspace before any actor or bearer exists. Because it runs outside the MCP dispatch gate, its failures are returned as the structured MCP tool-error envelope (`{ code, message, hint?, request_id?, retry_after? }`, an `isError: true` tool result parsed by `parseAtlasMcpToolError`) — **not** the HTTP `{ error, message, requestId }` shape. The `code` is always one of the closed [`AtlasMcpToolErrorCode`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/types/src/mcp.ts) catalog; `start_trial` emits the four below.
+The anonymous onboarding tool <AudienceLink saas="/guides/mcp#start_trial">`start_trial`</AudienceLink> (#3649/#3654) provisions a trial workspace before any actor or bearer exists. Because it runs outside the MCP dispatch gate, its failures are returned as the structured MCP tool-error envelope (`{ code, message, hint?, request_id?, retry_after? }`, an `isError: true` tool result parsed by `parseAtlasMcpToolError`) — **not** the HTTP `{ error, message, requestId }` shape. The `code` is always one of the closed [`AtlasMcpToolErrorCode`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/types/src/mcp.ts) catalog; `start_trial` emits the four below.
 
 | Code | Trigger | `hint` / extras | Agent recovery |
 |------|---------|-----------------|----------------|
-| `validation_failed` | Missing/malformed email or workspace name, a missing Turnstile token, a declined elicitation, an already-registered email, **or a business-email denial** (freemium/disposable address — the shared [business-email policy](/guides/signup#business-email-only-signup)). The business-email case carries a "use your work email" `hint` so it's distinguishable from a malformed-email rejection | `hint` on the business-email and already-registered cases | Permanent — fix the input. For the business-email hint, retry with a work email; for "already registered", sign in on the web instead |
+| `validation_failed` | Missing/malformed email or workspace name, a missing Turnstile token, a declined elicitation, an already-registered email, **or a business-email denial** (freemium/disposable address — the shared <AudienceLink saas="/guides/signup#business-email-only-signup">business-email policy</AudienceLink>). The business-email case carries a "use your work email" `hint` so it's distinguishable from a malformed-email rejection | `hint` on the business-email and already-registered cases | Permanent — fix the input. For the business-email hint, retry with a work email; for "already registered", sign in on the web instead |
 | `rate_limited` | Per-IP / per-email creation-attempt limit tripped (#3654) | `retry_after` (seconds) | Wait `retry_after` seconds, then retry. Self-serve signups are throttled per IP and per email |
 | `forbidden` | Cloudflare Turnstile `siteverify` failed (bot-check), or the tool was reached off-SaaS (where it isn't registered) | — | Refresh the Turnstile challenge and retry. Never leaks the secret, the token, or Cloudflare error codes |
 | `internal_error` | Account created but the workspace/grace-window couldn't be provisioned (`org_failed` / `trial_not_assigned`), or an unexpected failure | `request_id` | Retry once; if it persists, quote `request_id` to support. The orphaned account may need an operator to reap it |
@@ -460,9 +460,9 @@ try {
 
 ## See Also
 
-- [Troubleshooting](/guides/troubleshooting) — Startup errors, connection issues, and diagnostic codes
+- <AudienceLink saas="/guides/troubleshooting">Troubleshooting</AudienceLink> — Startup errors, connection issues, and diagnostic codes
 - [SDK Reference](/reference/sdk#error-handling) — Full SDK API with error handling examples
 - [React Hooks Reference](/reference/react) — `ChatErrorInfo` and client-side error parsing in `useAtlasChat`
-- [Rate Limiting & Retry](/guides/rate-limiting) — Rate limit configuration, 429 handling, and backoff patterns
+- <AudienceLink saas="/guides/rate-limiting">Rate Limiting & Retry</AudienceLink> — Rate limit configuration, 429 handling, and backoff patterns
 - [Environment Variables](/reference/environment-variables) — Configuration that affects error behavior
 - [API Overview](/reference/api#error-responses) — HTTP error response format

--- a/apps/docs/content/shared/reference/react.mdx
+++ b/apps/docs/content/shared/reference/react.mdx
@@ -1133,7 +1133,7 @@ When a conversation runs against a multi-member connection group, the `executeSQ
 | `ExecuteSqlResult` | Discriminated union of success/failure — `success: true` carries `columns`, `rows`, `truncated`, `envContributions`; `success: false` carries `error` plus the partial `envContributions` that did execute |
 | `ConversationRoutingMode` | `"auto"` / `"pin"` / `"all"` — the persisted routing mode for the conversation. Embedders that render the env/member picker should branch on this to show the right active state |
 
-See the [Cross-Environment Scope](/deployment/multi-datasource#cross-environment-scope-routing) guide for the partial-failure rendering pattern and the conversation-routing semantics.
+See the <AudienceLink saas="/deployment/multi-datasource#cross-environment-scope-routing">Cross-Environment Scope</AudienceLink> guide for the partial-failure rendering pattern and the conversation-routing semantics.
 
 ### Starter-prompt types
 
@@ -1149,7 +1149,7 @@ interface FavoriteStarterPrompt {
 }
 ```
 
-The `AtlasChat` widget also accepts a [`starterPrompts` prop](#atlaschat-props) that overrides the adaptive empty-state list. For script-tag embeds, the same list can be supplied via the `data-starter-prompts` JSON attribute — see [Embedding the Widget](/guides/embedding-widget) for details.
+The `AtlasChat` widget also accepts a [`starterPrompts` prop](#atlaschat-props) that overrides the adaptive empty-state list. For script-tag embeds, the same list can be supplied via the `data-starter-prompts` JSON attribute — see <AudienceLink saas="/guides/embedding-widget">Embedding the Widget</AudienceLink> for details.
 
 ---
 
@@ -1237,9 +1237,9 @@ The `AtlasChat` component uses the same hooks internally — you can start with 
 
 ## See Also
 
-- [Embedding Widget](/guides/embedding-widget) — Script-tag widget embedding (no React required)
+- <AudienceLink saas="/guides/embedding-widget">Embedding Widget</AudienceLink> — Script-tag widget embedding (no React required)
 - [SDK Reference](/reference/sdk) — Typed TypeScript client for server-side and headless usage
 - [MCP onboarding (SDK)](/sdk/mcp) — Full embedded-onboarding walkthrough that the [`useMcpConnect`](#usemcpconnect) hook wraps
 - [Error Codes](/reference/error-codes) — Full catalog of `ChatErrorCode` and `ClientErrorCode` values
-- [Authentication](/self-hosted/deployment/authentication) — Auth mode setup (affects `useAtlasAuth` behavior)
-- [Choosing an Integration](/guides/choosing-an-integration) — Compare widget, hooks, SDK, and REST API
+- <AudienceLink selfHosted="/self-hosted/deployment/authentication">Authentication</AudienceLink> — Auth mode setup (affects `useAtlasAuth` behavior)
+- <AudienceLink saas="/guides/choosing-an-integration">Choosing an Integration</AudienceLink> — Compare widget, hooks, SDK, and REST API

--- a/apps/docs/content/shared/reference/sdk.mdx
+++ b/apps/docs/content/shared/reference/sdk.mdx
@@ -485,7 +485,7 @@ const { runs } = await atlas.scheduledTasks.listRuns(task.id, { limit: 10 });
 await atlas.scheduledTasks.delete(task.id);
 ```
 
-See [Scheduled Tasks](/guides/scheduled-tasks) for full configuration details.
+See <AudienceLink saas="/guides/scheduled-tasks">Scheduled Tasks</AudienceLink> for full configuration details.
 
 ---
 
@@ -641,7 +641,7 @@ const { plugins } = await atlas.admin.plugins();
 const pluginHealth = await atlas.admin.pluginHealth("clickhouse");
 ```
 
-See [Admin Console](/guides/admin-console) for details on each endpoint.
+See <AudienceLink saas="/guides/admin-console">Admin Console</AudienceLink> for details on each endpoint.
 
 ---
 
@@ -678,13 +678,13 @@ interface RollbackActionResponse {
 }
 ```
 
-See [Actions Framework](/guides/actions#rollback) for the full rollback lifecycle and error cases.
+See <AudienceLink saas="/guides/actions#rollback">Actions Framework</AudienceLink> for the full rollback lifecycle and error cases.
 
 ---
 
 ## Error Handling
 
-All API errors are thrown as `AtlasError` instances. See [Error Codes](/reference/error-codes) for the full catalog of every error code, HTTP status, retry guidance, and a complete retry-with-backoff example. See [Rate Limiting & Retry](/guides/rate-limiting) for backoff patterns and handling 429 responses.
+All API errors are thrown as `AtlasError` instances. See [Error Codes](/reference/error-codes) for the full catalog of every error code, HTTP status, retry guidance, and a complete retry-with-backoff example. See <AudienceLink saas="/guides/rate-limiting">Rate Limiting & Retry</AudienceLink> for backoff patterns and handling 429 responses.
 
 ```typescript
 import { AtlasError } from "@useatlas/sdk";
@@ -1053,7 +1053,7 @@ try {
 
 ## Cross-Environment Querying
 
-The cross-environment scope ([multi-datasource routing guide](/deployment/multi-datasource#cross-environment-scope-routing)) lets a single conversation route SQL across multiple group members (`us-int` + `eu` + `apac`) and merge the results. Wire-level, every `executeSQL` tool call now carries a `envContributions: ConnectionContribution[]` array — a 1-element array for single-env executions, one entry per group member for fanouts:
+The cross-environment scope (<AudienceLink saas="/deployment/multi-datasource#cross-environment-scope-routing">multi-datasource routing guide</AudienceLink>) lets a single conversation route SQL across multiple group members (`us-int` + `eu` + `apac`) and merge the results. Wire-level, every `executeSQL` tool call now carries a `envContributions: ConnectionContribution[]` array — a 1-element array for single-env executions, one entry per group member for fanouts:
 
 ```typescript
 import type {
@@ -1079,7 +1079,7 @@ function renderResult(result: ExecuteSqlSuccessResult) {
 }
 ```
 
-`ExecuteSqlResult` is a discriminated union — `success: true` carries `columns`, `rows`, `truncated`, and `envContributions`; `success: false` carries `error` and the partial `envContributions` that did execute (so partial failures stay observable). See the [Multi-Datasource Routing guide](/deployment/multi-datasource#cross-environment-scope-routing) for the partial-failure rendering pattern.
+`ExecuteSqlResult` is a discriminated union — `success: true` carries `columns`, `rows`, `truncated`, and `envContributions`; `success: false` carries `error` and the partial `envContributions` that did execute (so partial failures stay observable). See the <AudienceLink saas="/deployment/multi-datasource#cross-environment-scope-routing">Multi-Datasource Routing guide</AudienceLink> for the partial-failure rendering pattern.
 
 ---
 
@@ -1115,5 +1115,5 @@ This is useful when building custom UIs that load persisted conversations from t
 - [API Overview](/reference/api) — HTTP endpoints the SDK wraps
 - [Error Codes](/reference/error-codes) — Full catalog of every error code, retryable classification, and fix guidance
 - [React Hooks Reference](/reference/react) — React hooks that use the same API (for browser UIs)
-- [Rate Limiting & Retry](/guides/rate-limiting) — Server-side rate limit configuration and client-side retry patterns
-- [Embedding Widget](/guides/embedding-widget) — Drop-in chat widget (alternative to building a custom UI with the SDK)
+- <AudienceLink saas="/guides/rate-limiting">Rate Limiting & Retry</AudienceLink> — Server-side rate limit configuration and client-side retry patterns
+- <AudienceLink saas="/guides/embedding-widget">Embedding Widget</AudienceLink> — Drop-in chat widget (alternative to building a custom UI with the SDK)

--- a/apps/docs/content/shared/sdk/starter-prompts.mdx
+++ b/apps/docs/content/shared/sdk/starter-prompts.mdx
@@ -113,7 +113,7 @@ This has three practical implications:
   won't include any pins.
 
 For background on API-key to user binding, see
-[API Keys](/guides/api-keys).
+<AudienceLink saas="/guides/api-keys">API Keys</AudienceLink>.
 
 ---
 
@@ -151,5 +151,5 @@ them correctly.
 ## See also
 
 - [SDK Reference](/reference/sdk) — full method index
-- [API Keys](/guides/api-keys) — creating and managing keys
+- <AudienceLink saas="/guides/api-keys">API Keys</AudienceLink> — creating and managing keys
 - `GET /api/v1/starter-prompts` — underlying REST endpoint

--- a/apps/docs/content/shared/semantic-layer/multi-env.mdx
+++ b/apps/docs/content/shared/semantic-layer/multi-env.mdx
@@ -29,7 +29,7 @@ Open a group's detail page and use **Add member** / **Remove member**. The add f
 When `us-int` and `eu` were created as separate top-level connections and should logically be the same `prod` environment, use **Merge into group** from either source group's `…` menu:
 
 1. Pick the target group
-2. The wizard renders the schema diff between the two groups' primary members. Column-level mismatches are flagged red; the merge is gated on resolving them (either reconcile the YAML drift in the [drift drawer](/guides/admin-console#drift-drawer) first, or accept the merge as-is if the mismatches are tolerable)
+2. The wizard renders the schema diff between the two groups' primary members. Column-level mismatches are flagged red; the merge is gated on resolving them (either reconcile the YAML drift in the <AudienceLink saas="/guides/admin-console#drift-drawer">drift drawer</AudienceLink> first, or accept the merge as-is if the mismatches are tolerable)
 3. Confirm — the source members move into the target group atomically and the source group is deleted
 
 ### Archive a group

--- a/apps/docs/content/shared/semantic-layer/why-yaml.mdx
+++ b/apps/docs/content/shared/semantic-layer/why-yaml.mdx
@@ -49,5 +49,5 @@ For side-by-side feature matrices that name specific products (Cube, Metabase, T
 - [The Semantic Layer overview](/semantic-layer) — the canonical questions and a 20-line YAML excerpt
 - [YAML format reference](/getting-started/semantic-layer) — every field, every type
 - [Glossary & Metrics](/semantic-layer/glossary-and-metrics) — the two files that turn a schema into a domain model
-- [MCP Server](/guides/mcp) — how agents consume the YAML through the Model Context Protocol
+- <AudienceLink saas="/guides/mcp">MCP Server</AudienceLink> — how agents consume the YAML through the Model Context Protocol
 - [Comparisons](/comparisons) — feature matrices vs Cube, Metabase, ThoughtSpot, WrenAI, Vanna, raw MCP

--- a/apps/docs/src/components/section-docs-page.tsx
+++ b/apps/docs/src/components/section-docs-page.tsx
@@ -14,7 +14,10 @@ import { APIPage } from "@/components/api-page";
 import { ChangelogTimeline } from "@/components/changelog-timeline";
 import { LLMCopyButton } from "@/components/llm-copy-button";
 import { AudienceProvider, AudienceLabel, type Audience } from "@/lib/audience";
-import { audienceConditionals } from "@/lib/audience-conditionals";
+import {
+  audienceConditionals,
+  makeAudienceLink,
+} from "@/lib/audience-conditionals";
 import { filterTocByAudience } from "@/lib/audience-markdown";
 import { githubEditPath } from "@/lib/mdx-links";
 import type { SectionPage } from "@/lib/source";
@@ -86,6 +89,10 @@ export async function SectionDocsPage({
   // that returns null, so its children never enter the emitted HTML / RSC
   // payload (unlike a client conditional). See audience-conditionals.tsx.
   const { WhenSaaS, WhenSelfHosted } = audienceConditionals(audience);
+  // Per-mount cross-link: renders `linkComponent` for this audience's href and
+  // plain text when it has none, so a shared page never links across the
+  // SaaS/self-hosted boundary (#4289).
+  const AudienceLink = makeAudienceLink(audience, linkComponent);
   // `page.data.toc` is compiled from ALL headings in the raw MDX — the runtime
   // audience conditional is invisible to it — so a `<WhenSelfHosted>`-wrapped
   // section's heading would otherwise show in the SaaS mount's ToC and link to
@@ -134,6 +141,9 @@ export async function SectionDocsPage({
               // from the emitted HTML on the opposite mount (PRD #4257).
               WhenSaaS,
               WhenSelfHosted,
+              // Per-mount cross-link (#4289): links within this audience's
+              // surface only, plain text otherwise.
+              AudienceLink,
               // Resolve relative MDX links against THIS mount's source.
               a: linkComponent,
             }}

--- a/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
+++ b/apps/docs/src/lib/__tests__/audience-conditionals.test.tsx
@@ -2,9 +2,14 @@ import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
-import { audienceConditionals } from "@/lib/audience-conditionals";
+import type { ComponentProps } from "react";
+import {
+  audienceConditionals,
+  makeAudienceLink,
+} from "@/lib/audience-conditionals";
 import {
   stripInactiveAudienceBlocks,
+  resolveAudienceLinks,
   filterTocByAudience,
   tocTitleToText,
   survivingHeadingTitles,
@@ -93,6 +98,159 @@ test("audience-conditionals.tsx stays a server module resolved from its argument
   expect(audienceConditionals("self-hosted").WhenSaaS).not.toBe(a.WhenSaaS);
 });
 
+// ── <AudienceLink> cross-link component (#4289) ──────────────────────────────
+//
+// A shared page mounts into BOTH sections, so a single hard-coded root-absolute
+// link leaks across the SaaS/self-hosted boundary. `<AudienceLink>` links only
+// within the current mount's audience and renders plain text otherwise, so the
+// emitted HTML on each mount can never point into the other audience's surface.
+
+// A stand-in for the mount's `createRelativeLink` result: a plain anchor.
+const StubLink = (props: ComponentProps<"a">) => <a {...props} />;
+
+test("AudienceLink on the SaaS mount links its saas href and drops a self-hosted-only href", () => {
+  const AudienceLink = makeAudienceLink("saas", StubLink);
+  // saas href present → a real link on the saas mount.
+  expect(
+    renderToStaticMarkup(
+      <AudienceLink saas="/guides/admin-console">Admin Console</AudienceLink>,
+    ),
+  ).toBe('<a href="/guides/admin-console">Admin Console</a>');
+  // Only a self-hosted href → the saas mount renders PLAIN TEXT (no anchor, no
+  // `/self-hosted` href), so a SaaS reader is never sent into the self-hosted
+  // section.
+  const selfHostedOnly = renderToStaticMarkup(
+    <AudienceLink selfHosted="/self-hosted/deployment/authentication">
+      Authentication
+    </AudienceLink>,
+  );
+  expect(selfHostedOnly).toBe("Authentication");
+  expect(selfHostedOnly).not.toContain("/self-hosted");
+});
+
+test("AudienceLink on the self-hosted mount links its selfHosted href and drops a saas-only href", () => {
+  const AudienceLink = makeAudienceLink("self-hosted", StubLink);
+  expect(
+    renderToStaticMarkup(
+      <AudienceLink selfHosted="/self-hosted/deployment/authentication">
+        Authentication
+      </AudienceLink>,
+    ),
+  ).toBe('<a href="/self-hosted/deployment/authentication">Authentication</a>');
+  // Only a saas href → plain text on the self-hosted mount (no leak into a
+  // saas-only page).
+  const saasOnly = renderToStaticMarkup(
+    <AudienceLink saas="/guides/admin-console">Admin Console</AudienceLink>,
+  );
+  expect(saasOnly).toBe("Admin Console");
+  expect(saasOnly).not.toContain("/guides/admin-console");
+});
+
+// ── <AudienceLink> markdown resolution (twin + llms-full.txt) ─────────────────
+//
+// The string-surface twin of the component: `getText("processed")` preserves the
+// raw `<AudienceLink>` tag (and BOTH hrefs) verbatim, so the `.mdx`/`.txt`
+// surfaces must resolve it to this audience's href — or the opposite audience's
+// target would leak into the machine surface.
+
+test("resolveAudienceLinks emits this mount's href and plain text for the other", () => {
+  const md =
+    'See <AudienceLink saas="/guides/x" selfHosted="/self-hosted/y">the guide</AudienceLink>.';
+  expect(resolveAudienceLinks(md, "saas")).toBe("See [the guide](/guides/x).");
+  expect(resolveAudienceLinks(md, "self-hosted")).toBe(
+    "See [the guide](/self-hosted/y).",
+  );
+
+  // A saas-only link degrades to plain text on the self-hosted surface (matching
+  // the component's bare-fragment branch) — no href leaks.
+  const saasOnly = 'A <AudienceLink saas="/guides/x">link</AudienceLink> here.';
+  expect(resolveAudienceLinks(saasOnly, "self-hosted")).toBe("A link here.");
+  expect(resolveAudienceLinks(saasOnly, "self-hosted")).not.toContain("/guides/x");
+});
+
+test("resolveAudienceLinks resolves several links on one line independently", () => {
+  // e.g. a "See Also" table row / list line with multiple cross-links.
+  const md =
+    '| <AudienceLink saas="/a">A</AudienceLink> | <AudienceLink selfHosted="/self-hosted/b">B</AudienceLink> |';
+  expect(resolveAudienceLinks(md, "saas")).toBe("| [A](/a) | B |");
+  expect(resolveAudienceLinks(md, "self-hosted")).toBe("| A | [B](/self-hosted/b) |");
+});
+
+test("resolveAudienceLinks is order-independent in the attribute list", () => {
+  // The JSDoc claims attribute order is free; author them reversed to prove it.
+  const md =
+    'x <AudienceLink selfHosted="/self-hosted/y" saas="/guides/x">t</AudienceLink> z';
+  expect(resolveAudienceLinks(md, "saas")).toBe("x [t](/guides/x) z");
+  expect(resolveAudienceLinks(md, "self-hosted")).toBe("x [t](/self-hosted/y) z");
+});
+
+test("resolveAudienceLinks FAILS CLOSED on an unexpected audience — neither href leaks", () => {
+  // `Audience` is a closed 2-member union, so this is only reachable via an
+  // unchecked cast — but the whole module is defensive on exactly that. An
+  // unexpected value must match NEITHER branch and drop to plain text (parity
+  // with stripInactiveAudienceBlocks), NOT fall through to the self-hosted href.
+  const md =
+    'See <AudienceLink saas="/guides/x" selfHosted="/self-hosted/y">the guide</AudienceLink>.';
+  const bogus = resolveAudienceLinks(md, "enterprise" as unknown as Audience);
+  expect(bogus).toBe("See the guide.");
+  expect(bogus).not.toContain("/self-hosted/y");
+  expect(bogus).not.toContain("/guides/x");
+});
+
+test("makeAudienceLink FAILS CLOSED on an unexpected audience — renders plain text", () => {
+  const AudienceLink = makeAudienceLink(
+    "enterprise" as unknown as Audience,
+    StubLink,
+  );
+  const html = renderToStaticMarkup(
+    <AudienceLink saas="/guides/x" selfHosted="/self-hosted/y">
+      the guide
+    </AudienceLink>,
+  );
+  expect(html).toBe("the guide");
+  expect(html).not.toContain("href");
+});
+
+test("resolveAudienceLinks degrades an unquoted/malformed href to plain text (fail-safe, no leak)", () => {
+  // `attr` only reads a double-quoted value (the codemod always emits one). An
+  // unquoted authoring typo yields no href → plain text; it never leaks a target
+  // and never throws (the element is well-formed, so no residual tag survives).
+  const md = "A <AudienceLink saas=/guides/x>link</AudienceLink> here.";
+  expect(resolveAudienceLinks(md, "saas")).toBe("A link here.");
+});
+
+test("stripInactiveAudienceBlocks also resolves AudienceLinks to the mount audience", () => {
+  const md = [
+    "<WhenSaaS>",
+    "  Hosted note.",
+    "</WhenSaaS>",
+    "",
+    'Docs: <AudienceLink saas="/guides/x" selfHosted="/self-hosted/y">here</AudienceLink>.',
+  ].join("\n");
+  const saas = stripInactiveAudienceBlocks(md, "saas");
+  expect(saas).toContain("[here](/guides/x)");
+  expect(saas).not.toContain("/self-hosted/y");
+  const selfHosted = stripInactiveAudienceBlocks(md, "self-hosted");
+  expect(selfHosted).toContain("[here](/self-hosted/y)");
+  expect(selfHosted).not.toContain("/guides/x");
+});
+
+test("markdown strip FAILS CLOSED on a malformed/unclosed AudienceLink", () => {
+  // An unclosed cross-link would otherwise pass its raw tag (and both hrefs) into
+  // the machine surface — fail the page instead.
+  const malformed = 'Text <AudienceLink saas="/guides/x">no closing tag here.';
+  expect(() => stripInactiveAudienceBlocks(malformed, "saas")).toThrow(
+    /residual <When…> \/ <AudienceLink> tag/,
+  );
+});
+
+test("an inline-code mention of AudienceLink is NOT treated as a residual tag", () => {
+  const mention = "Authors use `<AudienceLink>` for shared-page cross-links.";
+  expect(stripInactiveAudienceBlocks(mention, "saas")).toContain(
+    "`<AudienceLink>`",
+  );
+});
+
 // ── markdown text surfaces (twin + llms-full.txt) ────────────────────────────
 
 // Note the INLINE mention of the tag names in the intro — a real doc sentence
@@ -171,7 +329,7 @@ test("markdown strip FAILS CLOSED on a malformed/unclosed inactive block", () =>
   // A silent pass would leak the self-hosted tail into the saas surface; assert
   // it throws instead.
   expect(() => stripInactiveAudienceBlocks(unclosed, "saas")).toThrow(
-    /residual <When…> tag/,
+    /residual <When…> \/ <AudienceLink> tag/,
   );
 });
 
@@ -182,7 +340,7 @@ test("markdown strip FAILS CLOSED on an unsupported single-line inline audience 
   const inline =
     "Price is <WhenSaaS>$39</WhenSaaS><WhenSelfHosted>free</WhenSelfHosted>/mo.";
   expect(() => stripInactiveAudienceBlocks(inline, "saas")).toThrow(
-    /residual <When…> tag/,
+    /residual <When…> \/ <AudienceLink> tag/,
   );
 });
 

--- a/apps/docs/src/lib/__tests__/source-partition.test.ts
+++ b/apps/docs/src/lib/__tests__/source-partition.test.ts
@@ -740,3 +740,73 @@ test("[#4282] extracted self-hosted sections are gone from the SaaS page and liv
     }
   }
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #4289 — the audience-link hygiene pass. Two lightweight scans over the real
+// content tree (read-only, no bundler) keep the two cross-mount link leaks this
+// slice fixed from silently regressing — one drift guard per half of #4289:
+//
+//   1. Part 1 (stale moved-slug): a SaaS-root page (content/docs/**) must not
+//      link to a BARE old-root slug that slice #4264 moved under /self-hosted/*
+//      (`MOVED_SELF_HOSTED_SLUGS`). Those old URLs only 308-redirect on the live
+//      site (#4267); the in-repo link is stale. The genuine self-hosting handoffs
+//      were repointed to `/self-hosted/*` (which START with `/self-hosted`, so
+//      they never match this bare-root pattern), and the managed-auth boilerplate
+//      was de-linked — so after the pass the SaaS tree carries zero. (Only
+//      root-absolute `](/…)` / `href="/…"` links are modelled; a relative stale
+//      link would evade this — acceptable, docs author root-absolute links.)
+//   2. Part 2, Direction B (/self-hosted leak on the SaaS mount): a shared page
+//      (content/shared/**) must not carry a bare `](/self-hosted/…)` markdown link
+//      that survives on the SaaS mount — it would send a SaaS reader into the
+//      self-hosted section. A legitimate self-hosted target is authored either
+//      inside a `<WhenSelfHosted>` block or via `<AudienceLink selfHosted="…">`;
+//      both resolve away on the SaaS mount. We MODEL the SaaS mount with
+//      `stripInactiveAudienceBlocks(_, "saas")` — the exact strip behind the
+//      `.mdx` twin / `llms-full.txt` — and assert no `/self-hosted` link survives.
+//      (Part 2 Direction A — shared → saas-only leaks — is resolved in-content via
+//      `<AudienceLink saas=…>`; it has no cheap bare-link guard, so it is not
+//      re-checked here.)
+//
+// Reuses the read-only filesystem consts above (`saasTreeFiles`, `sharedMdxFiles`,
+// `CONTENT_DIR`) and the `MOVED_SELF_HOSTED_SLUGS` redirect SSOT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A bare old-root moved slug at a markdown-link or href-attr path boundary. The
+// alternation is anchored right after `](/` or `href="/`, so a link ALREADY under
+// `/self-hosted/…` starts with `/self-hosted` and can never match. The trailing
+// lookahead pins the slug's end (anchor, close-paren, or closing quote), so a
+// longer distinct slug that merely shares a prefix does not false-match.
+const MOVED_SLUG_ALT = MOVED_SELF_HOSTED_SLUGS.map((s) =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+).join("|");
+const STALE_MOVED_IN_SAAS = new RegExp(
+  `(?:\\]\\(|href=")/(?:${MOVED_SLUG_ALT})(?=[#)"]|$)`,
+);
+
+test("[#4289] no SaaS-root page links to a bare old-root moved slug (stale in-repo link)", () => {
+  const saasMdx = saasTreeFiles.filter((p) => p.endsWith(".mdx"));
+  // Non-vacuous floor: we actually scanned the SaaS tree.
+  expect(saasMdx.length).toBeGreaterThan(0);
+  const offenders = saasMdx.filter((f) =>
+    STALE_MOVED_IN_SAAS.test(readFileSync(f, "utf8")),
+  );
+  expect(offenders).toEqual([]);
+});
+
+const SELF_HOSTED_MD_LINK = /\]\(\/self-hosted\//;
+
+test("[#4289] no shared page leaks a /self-hosted link on the SaaS mount (Direction B)", () => {
+  expect(sharedMdxFiles.length).toBeGreaterThan(0);
+  const offenders = sharedMdxFiles.filter((f) => {
+    // Model the SaaS mount: <WhenSelfHosted> blocks removed, <AudienceLink>
+    // resolved to its saas branch (plain text for a self-hosted-only target).
+    // Mask fenced code so a `](/self-hosted/…)` inside a code EXAMPLE isn't a
+    // false leak (a real cross-link lives in prose, not a fence).
+    const saasMount = stripInactiveAudienceBlocks(
+      readFileSync(f, "utf8"),
+      "saas",
+    ).replace(/```[\s\S]*?```/g, "");
+    return SELF_HOSTED_MD_LINK.test(saasMount);
+  });
+  expect(offenders).toEqual([]);
+});

--- a/apps/docs/src/lib/audience-conditionals.tsx
+++ b/apps/docs/src/lib/audience-conditionals.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentProps, FC, ReactNode } from "react";
 import type { Audience } from "@/lib/audience";
 
 /**
@@ -51,5 +51,56 @@ export function audienceConditionals(audience: Audience): AudienceConditionals {
   return {
     WhenSaaS: audience === "saas" ? ShowChildren : RenderNothing,
     WhenSelfHosted: audience === "self-hosted" ? ShowChildren : RenderNothing,
+  };
+}
+
+/**
+ * Props for `<AudienceLink>` — a per-mount link with an OPTIONAL href for each
+ * audience. The link resolves to at most ONE audience's href; the omitted
+ * audience renders the same text as PLAIN prose (no `<a>`), so the link can
+ * never cross the SaaS/self-hosted boundary (PRD #4257, slice #4289).
+ */
+export interface AudienceLinkProps {
+  /** href used only on the SaaS mount; omit to render plain text there. */
+  readonly saas?: string;
+  /** href used only on the self-hosted mount; omit to render plain text there. */
+  readonly selfHosted?: string;
+  readonly children?: ReactNode;
+}
+
+/**
+ * Build the mount-scoped `<AudienceLink>` for the shared-page cross-link problem
+ * (#4289). A shared page (`content/shared/**`) mounts into BOTH the SaaS root and
+ * `/self-hosted`, so a single hard-coded root-absolute link leaks: a
+ * `[Admin Console](/guides/admin-console)` (a SaaS-only page) sends a self-hosted
+ * reader to SaaS content, and a `[Auth](/self-hosted/...)` sends a SaaS reader
+ * into the self-hosted section. `<AudienceLink>` picks the href for THIS mount and
+ * renders plain text when the current audience has no appropriate target — so
+ * the emitted HTML on each mount only ever links within that audience's surface.
+ *
+ * The active branch renders through the injected `LinkComponent` (the mount's
+ * `createRelativeLink` result — the same component mapped to `a`) so client-side
+ * navigation and fumadocs' link handling stay consistent with an ordinary MDX
+ * link; the inactive branch is a bare fragment (no anchor), the string-surface
+ * twin of `resolveAudienceLinks(…)` dropping the link in the `.mdx` /
+ * `llms-full.txt` output.
+ */
+export function makeAudienceLink(
+  audience: Audience,
+  LinkComponent: FC<ComponentProps<"a">>,
+): (props: AudienceLinkProps) => ReactNode {
+  return function AudienceLink({ saas, selfHosted, children }: AudienceLinkProps) {
+    // Explicit positive match per audience (fail closed): an unexpected audience
+    // yields NO href — plain text — mirroring the both-branches-stripped
+    // behaviour of `stripInactiveAudienceBlocks`, rather than silently defaulting
+    // to one branch's target on a cross-boundary primitive.
+    const href =
+      audience === "saas"
+        ? saas
+        : audience === "self-hosted"
+          ? selfHosted
+          : undefined;
+    if (href == null || href === "") return <>{children}</>;
+    return <LinkComponent href={href}>{children}</LinkComponent>;
   };
 }

--- a/apps/docs/src/lib/audience-markdown.ts
+++ b/apps/docs/src/lib/audience-markdown.ts
@@ -2,11 +2,58 @@ import type { Audience } from "@/lib/audience";
 
 const AUDIENCE_TAGS = ["WhenSaaS", "WhenSelfHosted"] as const;
 
-/** Any raw audience tag, open or close, block OR inline. Used as the fail-closed
- * post-condition AFTER code spans are masked out (so a doc sentence that MENTIONS
- * `` `<WhenSaaS>` `` in inline code is not a false positive). `\b` after the name
- * avoids matching a differently-named component like `<WhenSaaSFoo>`. */
-const RESIDUAL_AUDIENCE_TAG = /<\/?When(?:SaaS|SelfHosted)\b/;
+/** Any raw audience construct, open or close, block OR inline: the two
+ * `<When…>` conditionals AND the `<AudienceLink>` cross-link (#4289). Used as the
+ * fail-closed post-condition AFTER code spans are masked out (so a doc sentence
+ * that MENTIONS `` `<WhenSaaS>` `` / `` `<AudienceLink>` `` in inline code is not
+ * a false positive). `\b` after the name avoids matching a differently-named
+ * component like `<WhenSaaSFoo>`. */
+const RESIDUAL_AUDIENCE_TAG = /<\/?(?:When(?:SaaS|SelfHosted)|AudienceLink)\b/;
+
+/**
+ * Inline `<AudienceLink saas="…" selfHosted="…">text</AudienceLink>` — the
+ * cross-link a shared page uses instead of a bare root-absolute markdown link, so
+ * it never leaks across the SaaS/self-hosted boundary (#4289). Non-greedy body,
+ * so several on one line (e.g. a "See Also" list row) each resolve independently.
+ * Attribute order is free and either href may be absent.
+ */
+const AUDIENCE_LINK = /<AudienceLink\b([^>]*)>([\s\S]*?)<\/AudienceLink>/g;
+
+/** Pull a double-quoted `name="value"` attribute out of an `<AudienceLink>` tag's
+ * attribute string, or null when absent. */
+function attr(attrs: string, name: string): string | null {
+  const m = new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`).exec(attrs);
+  return m ? m[1] : null;
+}
+
+/**
+ * Resolve every `<AudienceLink>` in a page's PROCESSED MARKDOWN to `audience`'s
+ * mount: the string-surface twin of the `makeAudienceLink` server component.
+ * fumadocs' `getText("processed")` preserves custom MDX tags verbatim, so without
+ * this the `.mdx` twin / `llms-full.txt` would carry the raw `<AudienceLink>` tag
+ * (and BOTH hrefs) — re-leaking the opposite audience's target into the machine
+ * surface the HTML conditional closes. The active audience's href becomes an
+ * ordinary `[text](href)` markdown link; when this audience has no href the link
+ * degrades to plain `text` (matching the component's bare-fragment branch).
+ */
+export function resolveAudienceLinks(
+  markdown: string,
+  audience: Audience,
+): string {
+  return markdown.replace(AUDIENCE_LINK, (_full, attrs: string, text: string) => {
+    // Explicit positive match (fail closed): an unexpected audience matches
+    // neither branch and drops to plain text — the same both-branches-stripped
+    // posture `stripInactiveAudienceBlocks` takes, rather than defaulting to one
+    // audience's href on a cross-boundary primitive.
+    const href =
+      audience === "saas"
+        ? attr(attrs, "saas")
+        : audience === "self-hosted"
+          ? attr(attrs, "selfHosted")
+          : null;
+    return href ? `[${text}](${href})` : text;
+  });
+}
 
 /** Mask fenced and inline code spans (their raw tag MENTIONS must be spared) so
  * the residual check only sees real tags. Returns text safe to scan, not to emit. */
@@ -77,16 +124,22 @@ export function stripInactiveAudienceBlocks(
   }
   // Unwrap the ACTIVE branch's tags, keeping its prose (nothing if none active).
   if (active) out = out.replace(tagsOf(active), "");
+  // Resolve inline `<AudienceLink>` cross-links to this mount's href (or plain
+  // text), the string twin of the `makeAudienceLink` server component (#4289).
+  // With an unknown audience `resolveAudienceLinks` matches neither branch and
+  // keeps no href, mirroring the fail-closed both-branches-stripped behaviour above.
+  out = resolveAudienceLinks(out, audience);
   out = out.replace(/\n{3,}/g, "\n\n");
 
-  // Fail closed: after masking code-span mentions, NO raw audience tag may
-  // survive. This catches both a malformed/unclosed BLOCK and the unsupported
-  // single-line INLINE form (`<WhenSelfHosted>x</WhenSelfHosted>` on one line) —
-  // the strip only handles block-form, so an inline usage must fail the
-  // build/page rather than silently leak the other audience's prose.
+  // Fail closed: after masking code-span mentions, NO raw audience construct may
+  // survive. This catches a malformed/unclosed `<When…>` BLOCK, the unsupported
+  // single-line INLINE `<When…>` form (`<WhenSelfHosted>x</WhenSelfHosted>` on one
+  // line — the strip only handles block-form), and a malformed `<AudienceLink>`
+  // the inline resolver could not close — any must fail the build/page rather
+  // than silently leak the other audience's prose or link target.
   if (RESIDUAL_AUDIENCE_TAG.test(maskCodeSpans(out))) {
     throw new Error(
-      `[docs] audience strip left a residual <When…> tag while resolving "${audience}" — a branch was not removed. Audience conditionals must be BLOCK-form (opening/closing tags each on their own line); inline usage is unsupported. Also check for malformed/unclosed tags.`,
+      `[docs] audience strip left a residual <When…> / <AudienceLink> tag while resolving "${audience}" — a branch or cross-link was not resolved. <When…> conditionals must be BLOCK-form (opening/closing tags each on their own line); <AudienceLink> must be a single well-formed element. Also check for malformed/unclosed tags.`,
     );
   }
   return out;


### PR DESCRIPTION
Closes #4289. Follow-up from the Slice 9 truthfulness backstop (#4274). The live site already 308-redirects the old URLs (#4267), so this is **in-repo hygiene + audience cleanliness, not a broken-site fix**.

## Part 1 — stale moved-slug links in SaaS-root pages (`content/docs/**`)

**Repoint (9)** the genuine self-hosting handoffs to `/self-hosted/*`: `index.mdx` (the portal landing — its "Self-host on my infrastructure" section deliberately routes readers to self-hosting), `getting-started/hosted.mdx`, `guides/white-labeling.mdx`, `guides/sandbox.mdx`, `guides/caching.mdx` → deploy / cache-configuration / quick-start / frameworks.

**De-link (40)** the managed-auth boilerplate.

### The boilerplate content-architecture call (the reason this was deferred, not mechanical)

`/deployment/authentication` moved to `/self-hosted/*` and is **self-hosted operator content** (auth modes configured via env: `none` / API-key / managed / BYOT, `BETTER_AUTH_SECRET`, `DATABASE_URL`, CORS, roles, audit-logging). On the hosted product **managed auth is automatic — a SaaS reader configures nothing.**

Rule applied: **de-link** the `[Managed auth](/deployment/authentication#managed-auth) enabled` prerequisite boilerplate and the See-also/inline auth references on SaaS pages (keep the prose, drop the cross-boundary link). Repointing a SaaS page *into* `/self-hosted/*` would re-muddy exactly the boundary this milestone exists to clean, and there is no SaaS auth page to send them to. `index.mdx` is the **sole exception** — its "Deployment & operations" accordion is a deliberate self-hosting handoff, so its auth link repoints alongside deploy. A few standalone "See X." sentences that became purely dangling were tightened (RLS, multi-region-login).

## Part 2 — cross-mount audience-leak links on shared pages (`content/shared/**`)

Mechanism: a new **`<AudienceLink saas="…" selfHosted="…">`** component (`makeAudienceLink`, extending `audience-conditionals.tsx`) that links only within the current mount's audience and renders **plain text** when this audience has no appropriate target — so a shared page (mounted into BOTH `/` and `/self-hosted`) can never point across the boundary. `resolveAudienceLinks` is the string-surface twin, folded into `stripInactiveAudienceBlocks`, so the `.mdx` twins / `llms-full.txt` resolve it too; the fail-closed residual guard now also catches a malformed `<AudienceLink>`.

- **Direction A — shared → saas-only (117 links):** wrapped `saas="…"` → working link on the SaaS mount, plain text on the self-hosted mount (no leak into saas-only content). No self-hosted equivalents exist for these targets yet — a documented **content gap**, not this pass's job to fill (see caveat below).
- **Direction B — shared → `/self-hosted` (12 links):** wrapped `selfHosted="…"` → working link on the self-hosted mount, plain text on the SaaS mount. **3** of the 15 raw `/self-hosted` links were already inside `<WhenSelfHosted>` blocks (stripped on the SaaS mount → no leak) and were left untouched.

## Part 3 — CI drift guards (`source-partition.test.ts`, `[#4289]` block)

Two lightweight scans (read-only content walk; 3a/3b/3c/9 blocks untouched):
1. No SaaS-root page links a **bare old-root moved slug** (repointed `/self-hosted/*` links start with `/self-hosted`, so they don't match; boundary-anchored so a prefix-sharing slug can't false-match).
2. No shared page **leaks a `/self-hosted` link on the SaaS mount** — modelled with `stripInactiveAudienceBlocks(_, "saas")` (drops `<WhenSelfHosted>` blocks + resolves `<AudienceLink>`), so both mitigation forms pass and a bare regression fails.

## Verification

- **0 genuine leaks** on both mounts (self-hosted mount has no saas-only markdown link; SaaS mount has no `/self-hosted` link) — verified against the real audience-strip + on the built `out/` twins.
- `cd apps/docs && bun run build` **green** (both mounts' pages, `.mdx` twins, `llms-full.txt`).
- `audience-conditionals.test.tsx` (24) + `source-partition.test.ts` (23) pass; eslint + tsgo clean.

## For #4290 conflict-awareness (parallel)

- `content/docs/guides/mcp.mdx` — **untouched**.
- `content/shared/reference/react.mdx` — 4 localized single-line `<AudienceLink>` wraps (incl. `:1244` Direction B).
- `content/shared/plugins/*` — 10 files, each 1–3 single-line wraps.

All edits are single-line link wraps (rebaseable). Reference pages (`environment-variables`, `config`, `error-codes`, `cli`, `sdk`, `api`, `react`) edited heavily but localized.

## Caveat for reviewer judgment

Direction A degrades to plain text on the self-hosted mount because many targets (`sql-validation`, `row-level-security`, `api-keys`, `multi-datasource`, `guides/mcp`, …) are **audience-general but filed `saas-only`** (`content/docs/`). The clean long-term fix is to reclassify those targets to `shared` (slice-3c-style), which is out of scope here and conflicts with #4290's ownership of `guides/mcp.mdx`. Plain-text-on-self-hosted is the honest, non-leaking interim state under the segmentation philosophy.

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v
