### PR TITLE
refactor: type-strength follow-ups from the v0.0.41 review panel (#4278)

### DIFF
--- a/packages/api/src/lib/discord/store.ts
+++ b/packages/api/src/lib/discord/store.ts
@@ -110,7 +110,8 @@ interface DiscordSaveInput {
 const discordBackend: InstallationBackend<
   DiscordInstallationWithSecret,
   DiscordInstallation,
-  DiscordSaveInput
+  DiscordSaveInput,
+  "bot_token"
 > = {
   name: "Discord",
   routingNoun: "Guild",

--- a/packages/api/src/lib/integrations/__tests__/platform-installation-store.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/platform-installation-store.test.ts
@@ -201,6 +201,23 @@ describe("PlatformInstallationStore", () => {
       expect((result as Record<string, unknown>).secret).toBeUndefined();
     });
 
+    // Compile-time backstop for the strip (#4278): when a backend names its
+    // secret via the SecretKey param, a pass-through `toPublic` must fail
+    // `tsgo`. The @ts-expect-error IS the assertion — it fails the type-check
+    // (unused-directive) if the enforcement ever regresses. `bun test` doesn't
+    // type-check, but the `type` CI gate compiles this file.
+    it("rejects a pass-through toPublic at compile time (type-level)", () => {
+      type StrippingFn = InstallationBackend<FakeFull, FakePublic, FakeSaveInput, "secret">["toPublic"];
+      const stripping: StrippingFn = (full) => {
+        const { secret: _drop, ...pub } = full;
+        return pub;
+      };
+      // @ts-expect-error a pass-through leaks `secret` — the SecretKey brand forbids it
+      const leaking: StrippingFn = (full) => full;
+      expect(typeof stripping).toBe("function");
+      expect(typeof leaking).toBe("function");
+    });
+
     it("returns null (no query) when no internal DB", async () => {
       mockHasDB = false;
       const { backend, calls } = makeBackend();

--- a/packages/api/src/lib/integrations/platform-installation-store.ts
+++ b/packages/api/src/lib/integrations/platform-installation-store.ts
@@ -87,8 +87,16 @@ export function decryptOrHide<Cipher>(
  * @typeParam Full - the with-secret record (e.g. `SlackInstallationWithSecret`).
  * @typeParam Public - the secret-stripped record returned by `getByOrg`.
  * @typeParam SaveInput - the platform-shaped save payload.
+ * @typeParam SecretKey - the key(s) `toPublic` must strip (e.g. `"bot_token"`).
+ *   Defaults to `never` (no compile-time strip enforcement); real backends name
+ *   their secret so a pass-through `toPublic` fails `tsgo` — see `toPublic`.
  */
-export interface InstallationBackend<Full, Public, SaveInput> {
+export interface InstallationBackend<
+  Full,
+  Public,
+  SaveInput,
+  SecretKey extends keyof Full = never,
+> {
   /** Platform name for log/error text, e.g. `"Slack"` / `"Discord"`. */
   readonly name: string;
   /**
@@ -124,14 +132,15 @@ export interface InstallationBackend<Full, Public, SaveInput> {
   /**
    * Drop the secret field(s) for the public (org-scoped) shape.
    *
-   * NOTE: the type system will NOT catch a passthrough — because every
-   * `Full` (with-secret) type structurally extends its `Public`
-   * counterpart, `toPublic: (full) => full` type-checks yet leaks the
-   * secret. The `{ bot_token: _drop, ...pub }` destructuring in each
-   * impl is the real guard; the store tests that assert the secret is
-   * absent are load-bearing, not redundant.
+   * The return type intersects `Public` with `{ [K in SecretKey]?: never }`,
+   * so a value that still carries the secret (`toPublic: (full) => full`)
+   * fails `tsgo` — the secret key's `string` value isn't assignable to
+   * `never`. This compile-enforces the strip that used to rest solely on the
+   * `{ bot_token: _drop, ...pub }` destructuring; the store tests asserting
+   * the secret is absent stay as belt-and-braces (#4278). A backend that
+   * leaves `SecretKey` at its `never` default gets no enforcement.
    */
-  toPublic(full: Full): Public;
+  toPublic(full: Full): Public & Partial<Record<SecretKey, never>>;
 }
 
 /**

--- a/packages/api/src/lib/slack/store.ts
+++ b/packages/api/src/lib/slack/store.ts
@@ -212,7 +212,8 @@ interface SlackSaveInput {
 const slackBackend: InstallationBackend<
   SlackInstallationWithSecret,
   SlackInstallation,
-  SlackSaveInput
+  SlackSaveInput,
+  "bot_token"
 > = {
   name: "Slack",
   routingNoun: "Slack workspace",

--- a/packages/plugin-sdk/src/__tests__/datasource-factory.test.ts
+++ b/packages/plugin-sdk/src/__tests__/datasource-factory.test.ts
@@ -493,3 +493,40 @@ describe("static connection caching", () => {
     expect(conns).toHaveLength(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Type-level: createStaticConnection is mandatory when TConn narrows (#4278)
+// ---------------------------------------------------------------------------
+
+describe("static-connection requirement (type-level)", () => {
+  interface NarrowConn extends PluginDBConnection {
+    marker(): void;
+  }
+  const baseOptions = {
+    id: "narrow",
+    name: "Narrow DataSource",
+    dbType: "testdb" as const,
+    dialect: "x",
+    configSchema: ConfigSchema,
+    connectionConfigSchema: ConnectionSchema,
+    describeStaticTarget: (c: TestConfig) => String(c.url),
+    buildConnection: (_p: TestRuntimeConfig) => makeConn(),
+    attachIntrospection: (built: PluginDBConnection) => built,
+  };
+
+  test("a narrowed TConn without createStaticConnection fails tsgo", () => {
+    // The @ts-expect-error IS the assertion: narrowing TConn below
+    // PluginDBConnection makes createStaticConnection required, so omitting it
+    // must not compile. Regressing the requirement turns this into an
+    // unused-directive type error under the `type` CI gate.
+    // @ts-expect-error createStaticConnection required when TConn narrows (#4278)
+    const bad = createDatasourcePlugin<TestConfig, TestRuntimeConfig, NarrowConn>(baseOptions);
+    // Supplying it compiles.
+    const good = createDatasourcePlugin<TestConfig, TestRuntimeConfig, NarrowConn>({
+      ...baseOptions,
+      createStaticConnection: () => ({ ...makeConn(), marker() {} }),
+    });
+    expect(typeof bad).toBe("function");
+    expect(typeof good).toBe("function");
+  });
+});

--- a/packages/plugin-sdk/src/helpers.ts
+++ b/packages/plugin-sdk/src/helpers.ts
@@ -794,12 +794,30 @@ function configHasUrl(config: unknown): boolean {
  * });
  * ```
  */
+/**
+ * When `TConn` is narrower than {@link PluginDBConnection}, the default
+ * `buildStatic` (`buildConnection(...) as TConn`) is unsound — `buildConnection`
+ * only promises a `PluginDBConnection`. This conditional makes
+ * `createStaticConnection` a REQUIRED member of the options in exactly that
+ * case, so a narrowing plugin that forgets it fails `tsgo` (#4278). When `TConn`
+ * is the `PluginDBConnection` default, `PluginDBConnection extends TConn` holds
+ * and the requirement collapses to `unknown` (stays optional). Intersecting a
+ * required member with the interface's optional one makes it required — a
+ * narrower `TConn` therefore *cannot* reach the `as TConn` fallback, which makes
+ * that cast provably safe rather than discipline-guarded.
+ */
+type StaticConnectionRequirement<TConfig, TConn extends PluginDBConnection> =
+  PluginDBConnection extends TConn
+    ? unknown
+    : { createStaticConnection(runtime: DatasourcePluginRuntime<TConfig, TConn>): TConn };
+
 export function createDatasourcePlugin<
   TConfig,
   TRuntimeConfig,
   TConn extends PluginDBConnection = PluginDBConnection,
 >(
-  options: CreateDatasourcePluginOptions<TConfig, TRuntimeConfig, TConn>,
+  options: CreateDatasourcePluginOptions<TConfig, TRuntimeConfig, TConn> &
+    StaticConnectionRequirement<TConfig, TConn>,
 ): DatasourcePluginFactory<TConfig> {
   // Derive the log label by stripping a trailing " DataSource" suffix without a
   // polynomial-backtracking regex: `\s+` before an anchored literal is a ReDoS
@@ -824,9 +842,13 @@ export function createDatasourcePlugin<
     /**
      * Fresh static connection. Default: run the config-time config through the
      * STRICT schema and reuse `buildConnection` — sound because static mode
-     * implies a fully-specified config. `as TConn` is only exercised on the
-     * default path, where TConn is the PluginDBConnection default (plugins
-     * that narrow TConn supply `createStaticConnection`).
+     * implies a fully-specified config. The `as TConn` fallback is now
+     * type-guaranteed, not discipline-guarded: {@link StaticConnectionRequirement}
+     * forces `createStaticConnection` to be present whenever `TConn` narrows
+     * below `PluginDBConnection`, so this branch is reachable only when
+     * `TConn` IS `PluginDBConnection` (where `buildConnection`'s return type
+     * already satisfies it). TS still needs the cast because `TConn` stays
+     * abstract inside the generic body.
      */
     const buildStatic = (): TConn =>
       options.createStaticConnection

--- a/packages/web/src/app/admin/audit/columns.tsx
+++ b/packages/web/src/app/admin/audit/columns.tsx
@@ -8,25 +8,11 @@ import { Clock, User, Code, Timer, Rows3, CheckCircle, Table2, Bot } from "lucid
 
 // ── Types ─────────────────────────────────────────────────────────
 
-export interface AuditRow {
-  id: string;
-  user_id: string | null;
-  sql: string;
-  success: boolean;
-  duration_ms: number;
-  row_count: number | null;
-  timestamp: string;
-  user_email?: string | null;
-  error?: string | null;
-  source_id?: string | null;
-  tables_accessed: string[] | null;
-  columns_accessed: string[] | null;
-  // MCP attribution (migration 0049). NULL for non-MCP rows; populated by the
-  // MCP transport with the actor kind, OAuth client id, and dispatched tool.
-  actor_kind?: string | null;
-  client_id?: string | null;
-  tool_name?: string | null;
-}
+// SSOT: `AuditRow` is derived from `AuditRowSchema` (`admin-schemas.ts`) via
+// `z.infer` and re-exported here for the table's consumers. Keeping the shape
+// in the schema means the Zod parse and this type can't drift (#4278).
+export type { AuditRow } from "@/ui/lib/admin-schemas";
+import type { AuditRow } from "@/ui/lib/admin-schemas";
 
 // ── Columns ───────────────────────────────────────────────────────
 

--- a/packages/web/src/app/admin/audit/page.tsx
+++ b/packages/web/src/app/admin/audit/page.tsx
@@ -186,7 +186,7 @@ export default function AuditPage() {
     defaultPerPage: LIMIT,
     defaultSorting: [{ id: "timestamp", desc: true }],
     schema: AuditRowsResponseSchema,
-    select: (r) => ({ rows: r.rows as AuditRow[], total: r.total }),
+    select: (r) => ({ rows: r.rows, total: r.total }),
     enabled: tab !== "analytics",
     buildPath: (binding) =>
       `/api/v1/admin/audit?${buildQueryString({

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -197,6 +197,14 @@ export const AuditRowsResponseSchema = z.object({
   total: z.number(),
 });
 
+/**
+ * The audit-row shape, derived from {@link AuditRowSchema} so the schema is the
+ * single source of truth. The audit table's `columns.tsx` re-exports this;
+ * deriving it (rather than hand-writing a parallel interface) means a schema
+ * change can't silently drift from the rendered table (#4278).
+ */
+export type AuditRow = z.infer<typeof AuditRowSchema>;
+
 // `AuditConnectionMetaSchema` removed in #2444 — the audit page now reuses
 // the canonical `ConnectionsResponseSchema` so every consumer of
 // `/api/v1/admin/connections` shares the same TanStack Query cache shape

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -166,31 +166,41 @@ export const AuditFacetsSchema = z.object({
 });
 
 /**
+ * The strict audit-row shape — one field per `audit_log` column the table
+ * knows about. This object is the SSOT: the exported {@link AuditRow} type is
+ * inferred from it (no index signature, so typos on property access still fail
+ * `tsgo`), while {@link AuditRowSchema} adds `.passthrough()` on top for the
+ * wire parse only.
+ */
+const AuditRowShape = z.object({
+  id: z.string(),
+  user_id: z.string().nullable(),
+  sql: z.string(),
+  success: z.boolean(),
+  duration_ms: z.number(),
+  row_count: z.number().nullable(),
+  timestamp: z.string(),
+  user_email: z.string().nullable().optional(),
+  error: z.string().nullable().optional(),
+  source_id: z.string().nullable().optional(),
+  tables_accessed: z.array(z.string()).nullable(),
+  columns_accessed: z.array(z.string()).nullable(),
+  // MCP attribution (migration 0049) — NULL for non-MCP rows; populated by
+  // the MCP transport with the actor kind, OAuth client id, and dispatched
+  // tool.
+  actor_kind: z.string().nullable().optional(),
+  client_id: z.string().nullable().optional(),
+  tool_name: z.string().nullable().optional(),
+});
+
+/**
  * One audit-log row as returned by `GET /api/v1/admin/audit` (the route
  * selects `a.*`, so every audit_log column is present). Validating here turns
  * a wire-shape drift into a TS/runtime error instead of a silent `undefined`.
- * `.passthrough()` keeps forward-compat columns the table doesn't render yet.
+ * `.passthrough()` keeps forward-compat columns the table doesn't render yet —
+ * on the runtime parse ONLY; the derived {@link AuditRow} type stays strict.
  */
-export const AuditRowSchema = z
-  .object({
-    id: z.string(),
-    user_id: z.string().nullable(),
-    sql: z.string(),
-    success: z.boolean(),
-    duration_ms: z.number(),
-    row_count: z.number().nullable(),
-    timestamp: z.string(),
-    user_email: z.string().nullable().optional(),
-    error: z.string().nullable().optional(),
-    source_id: z.string().nullable().optional(),
-    tables_accessed: z.array(z.string()).nullable(),
-    columns_accessed: z.array(z.string()).nullable(),
-    // MCP attribution (migration 0049) — NULL for non-MCP rows.
-    actor_kind: z.string().nullable().optional(),
-    client_id: z.string().nullable().optional(),
-    tool_name: z.string().nullable().optional(),
-  })
-  .passthrough();
+export const AuditRowSchema = AuditRowShape.passthrough();
 
 export const AuditRowsResponseSchema = z.object({
   rows: z.array(AuditRowSchema),
@@ -198,12 +208,15 @@ export const AuditRowsResponseSchema = z.object({
 });
 
 /**
- * The audit-row shape, derived from {@link AuditRowSchema} so the schema is the
- * single source of truth. The audit table's `columns.tsx` re-exports this;
- * deriving it (rather than hand-writing a parallel interface) means a schema
- * change can't silently drift from the rendered table (#4278).
+ * The audit-row shape, derived from {@link AuditRowShape} (the strict object,
+ * NOT the passthrough schema) so the schema is the single source of truth AND
+ * the type keeps typo-detection on property access — a `.passthrough()` infer
+ * would add an `[key: string]: unknown` index signature that silently swallows
+ * typos. The audit table's `columns.tsx` re-exports this; deriving it (rather
+ * than hand-writing a parallel interface) means a schema change can't silently
+ * drift from the rendered table (#4278).
  */
-export type AuditRow = z.infer<typeof AuditRowSchema>;
+export type AuditRow = z.infer<typeof AuditRowShape>;
 
 // `AuditConnectionMetaSchema` removed in #2444 — the audit page now reuses
 // the canonical `ConnectionsResponseSchema` so every consumer of


### PR DESCRIPTION
## Summary

Closes #4278.

Three independent compile-time hardenings from the v0.0.41 pre-tag review panel — each turns an invariant that was held by tests/discipline into one a *type* enforces. No runtime behavior change; all three land with a CI-validated `@ts-expect-error` regression backstop.

**1. `InstallationBackend.toPublic` secret-strip is now compile-enforced.**
A new `SecretKey extends keyof Full = never` type param brands the return as `Public & Partial<Record<SecretKey, never>>`, so a pass-through `toPublic: (full) => full` fails `tsgo` (the secret's `string` value isn't assignable to `never`). The Slack and Discord backends annotate `"bot_token"`. The per-impl `{ bot_token: _drop, ...pub }` destructuring and the runtime strip tests stay as belt-and-braces. Enforcement is opt-in per backend (a backend that leaves `SecretKey` at its `never` default gets none) — an accepted, documented tradeoff, with the runtime strip tests still catching any actual leak.

**2. `AuditRow` derives from its Zod schema (SSOT).**
`AuditRow` is now inferred from a strict object shape in `admin-schemas.ts` and re-exported from `columns.tsx`; the drift-hiding `as AuditRow[]` cast in the audit page is removed. The wire parse (`AuditRowSchema`) keeps `.passthrough()` for forward-compat, but the exported *type* is derived from the strict shape — deriving from the passthrough schema would (in Zod v4) add an `[key: string]: unknown` index signature that silently swallows property-access typos, loosening the very type this hardens.

**3. `createDatasourcePlugin` requires `createStaticConnection` when `TConn` narrows.**
A `StaticConnectionRequirement` conditional makes `createStaticConnection` a required option whenever `TConn` narrows below `PluginDBConnection`, so the default `as TConn` fallback is now type-guaranteed (reachable only when `TConn` IS `PluginDBConnection`) rather than discipline-guarded. Chose acceptance option (a); the coupled `config.url!` asserts are option (b) and left as-is (runtime-guarded by `hasStaticConfig`).

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

Two `@ts-expect-error` compile-time backstops added — verified they are validated by the `type` CI gate (reverting either invariant flips the directive to an `Unused '@ts-expect-error'` error): one in `platform-installation-store.test.ts` (pass-through `toPublic` must not compile) and one in `datasource-factory.test.ts` (narrowed `TConn` without `createStaticConnection` must not compile). Existing store + datasource-factory suites stay green.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — all 28 local `scripts/ci-local.sh` gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area) — `refactor`, `architecture`, `area: api`, `area: types`
- [ ] CHANGELOG.md updated — internal type-strength change, not user-facing

https://claude.ai/code/session_01S1okJe1tWeWATtUVkSHFnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1okJe1tWeWATtUVkSHFnE)_