### PR TITLE
feat: answer-first finished turns — turn partitioner + receipt

### DIFF
--- a/packages/web/src/ui/__tests__/finished-turn.test.tsx
+++ b/packages/web/src/ui/__tests__/finished-turn.test.tsx
@@ -10,9 +10,11 @@
  * composition holds with today's actual cards.
  */
 
-import { expect, test } from "bun:test";
+import { expect, test, afterEach } from "bun:test";
 import React from "react";
-import { render, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+afterEach(cleanup);
 import { FinishedTurn } from "@/ui/components/chat/finished-turn";
 import type { TurnPart } from "@/ui/components/chat/turn-partitioner";
 
@@ -60,6 +62,9 @@ test("finished turn renders receipt, answer, and real SQL result card", () => {
   expect(artifact.textContent).toContain("Revenue by region");
   expect(artifact.textContent).toContain("Show SQL");
   expect(artifact.textContent).toContain("EU");
+  // The chart/table view toggles survive promotion (the fixture is chartable).
+  expect(artifact.textContent).toContain("Chart");
+  expect(artifact.textContent).toContain("Table");
 
   // Expand the receipt: the explore card + narration appear.
   fireEvent.click(toggle);

--- a/packages/web/src/ui/__tests__/finished-turn.test.tsx
+++ b/packages/web/src/ui/__tests__/finished-turn.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Integration smoke for the answer-first finished turn (#4298) with the REAL
+ * leaf renderers (no mocks): the receipt line renders and expands to the real
+ * explore card + narration, the answer is the dominant element, the promoted
+ * artifact renders through the real SQLResultCard with its affordances (Show
+ * SQL, data), and the <suggestions> block never reaches the transcript.
+ *
+ * The mocked-out behavioral matrix lives in
+ * components/chat/__tests__/turn-receipt.test.tsx; this file pins that the
+ * composition holds with today's actual cards.
+ */
+
+import { expect, test } from "bun:test";
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { FinishedTurn } from "@/ui/components/chat/finished-turn";
+import type { TurnPart } from "@/ui/components/chat/turn-partitioner";
+
+test("finished turn renders receipt, answer, and real SQL result card", () => {
+  const parts = [
+    { type: "text", text: "Let me check the schema." },
+    {
+      type: "tool-explore",
+      toolCallId: "c1",
+      state: "output-available",
+      input: { command: "cat semantic/entities/orders.yml" },
+      output: "columns: ...",
+    },
+    {
+      type: "tool-executeSQL",
+      toolCallId: "c2",
+      state: "output-available",
+      input: {
+        sql: "SELECT region, sum(total) FROM orders GROUP BY 1",
+        explanation: "Revenue by region",
+      },
+      output: {
+        success: true,
+        columns: ["region", "sum"],
+        rows: [
+          { region: "EU", sum: 100 },
+          { region: "US", sum: 200 },
+        ],
+        executionMs: 42,
+      },
+    },
+    {
+      type: "text",
+      text: "US leads with $200.\n<suggestions>\nBreak down by month\n</suggestions>",
+    },
+  ] as TurnPart[];
+
+  const { container, getByRole, getByTestId } = render(<FinishedTurn parts={parts} />);
+
+  // Receipt line + dominant answer + promoted artifact with its affordances.
+  const toggle = getByRole("button", { name: /Explored schema/ });
+  expect(toggle.textContent).toContain("Explored schema");
+  expect(getByTestId("turn-answer").textContent).toContain("US leads with $200.");
+  const artifact = getByTestId("answer-artifact");
+  expect(artifact.textContent).toContain("Revenue by region");
+  expect(artifact.textContent).toContain("Show SQL");
+  expect(artifact.textContent).toContain("EU");
+
+  // Expand the receipt: the explore card + narration appear.
+  fireEvent.click(toggle);
+  expect(container.textContent).toContain("cat semantic/entities/orders.yml");
+  expect(container.textContent).toContain("Let me check the schema.");
+  // Suggestions never render as answer text.
+  expect(container.textContent).not.toContain("Break down by month");
+});

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -21,6 +21,7 @@ import { useStopHandler } from "../hooks/use-stop-handler";
 import { ApiKeyBar } from "./chat/api-key-bar";
 import { TypingIndicator } from "./chat/typing-indicator";
 import { ToolPart } from "./chat/tool-part";
+import { FinishedTurn } from "./chat/finished-turn";
 import { Markdown } from "./chat/markdown";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { SuggestionChips } from "./chat/suggestion-chips";
@@ -1135,6 +1136,14 @@ export function AtlasChat({
                       m.role === "assistant" &&
                       msgIndex === messages.length - 1;
 
+                    // #4298 — only the actively-streaming turn keeps the live
+                    // part-by-part renderer; every completed turn renders
+                    // answer-first (receipt → answer → promoted artifact) via
+                    // the turn partitioner. Earlier messages are completed by
+                    // definition; the last one is completed once the stream
+                    // settles.
+                    const isStreamingTurn = isLastAssistant && isLoading;
+
                     // Skip rendering assistant messages with no visible content
                     // (happens when stream errors before producing any text).
                     // A message with attached context warnings is still
@@ -1160,27 +1169,31 @@ export function AtlasChat({
                         {hasWarnings && warningBucket && (
                           <ContextWarningBanner warnings={warningBucket.warnings} />
                         )}
-                        {m.parts?.map((part, i) => {
-                          if (part.type === "text" && part.text.trim()) {
-                            const displayText = parseSuggestions(part.text).text;
-                            if (!displayText.trim()) return null;
-                            return (
-                              <div key={i} className="max-w-[90%]">
-                                <div className="rounded-xl bg-zinc-100 px-4 py-3 text-sm text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">
-                                  <Markdown content={displayText} />
+                        {isStreamingTurn ? (
+                          m.parts?.map((part, i) => {
+                            if (part.type === "text" && part.text.trim()) {
+                              const displayText = parseSuggestions(part.text).text;
+                              if (!displayText.trim()) return null;
+                              return (
+                                <div key={i} className="max-w-[90%]">
+                                  <div className="rounded-xl bg-zinc-100 px-4 py-3 text-sm text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">
+                                    <Markdown content={displayText} />
+                                  </div>
                                 </div>
-                              </div>
-                            );
-                          }
-                          if (isToolUIPart(part)) {
-                            return (
-                              <div key={i} className="max-w-[95%]">
-                                <ToolPart part={part} pythonProgress={pythonProgress} />
-                              </div>
-                            );
-                          }
-                          return null;
-                        })}
+                              );
+                            }
+                            if (isToolUIPart(part)) {
+                              return (
+                                <div key={i} className="max-w-[95%]">
+                                  <ToolPart part={part} pythonProgress={pythonProgress} />
+                                </div>
+                              );
+                            }
+                            return null;
+                          })
+                        ) : (
+                          <FinishedTurn parts={m.parts} pythonProgress={pythonProgress} />
+                        )}
                         {/* Show inline error when the last assistant message is empty (stream failed before producing content) */}
                         {isLastAssistant && !hasVisibleParts && !isLoading && error && (
                           <div className="max-w-[90%]">

--- a/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
+++ b/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
@@ -8,7 +8,7 @@
  * - trailing text parts are the answer;
  * - the last successful executeSQL result is promoted as the answer-bearing
  *   artifact (and excluded from the activity the receipt renders);
- * - reasoning parts are never surfaced in either bucket.
+ * - reasoning parts are never surfaced in any bucket.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -328,9 +328,27 @@ describe("summarizeActivity", () => {
     expect(summarizeActivity(activity)).toBe("Explored schema · 2 queries");
   });
 
-  test("singular query", () => {
+  test("failed query carries a failure marker so a collapsed receipt never reads clean", () => {
     const { activity } = partitionTurn([sql({ success: false }), text("Failed.")]);
+    expect(summarizeActivity(activity)).toBe("1 query · 1 failed");
+  });
+
+  test("singular successful query in the receipt has no failure marker", () => {
+    // Two successes: the last is promoted out, one stays in the receipt.
+    const { activity } = partitionTurn([sql({}), sql({}), text("Answer.")]);
     expect(summarizeActivity(activity)).toBe("1 query");
+  });
+
+  test("output-error tool parts count as failed", () => {
+    const errored = {
+      type: "tool-executeSQL",
+      toolCallId: "call-err",
+      state: "output-error",
+      input: { sql: "SELECT boom" },
+      errorText: "connection reset",
+    } as TurnPart;
+    const { activity } = partitionTurn([explore(), errored, text("It broke.")]);
+    expect(summarizeActivity(activity)).toBe("Explored schema · 1 query · 1 failed");
   });
 
   test("python runs and unknown tools are counted", () => {

--- a/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
+++ b/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for the turn partitioner (#4298) — the pure function that splits a
+ * finished assistant turn's parts into { activity, answer, answerBearingArtifact }
+ * per CONTEXT.md § Chat turn presentation.
+ *
+ * Boundary rules under test (v1):
+ * - everything up to and including the last tool part is activity;
+ * - trailing text parts are the answer;
+ * - the last successful executeSQL result is promoted as the answer-bearing
+ *   artifact (and excluded from the activity the receipt renders);
+ * - reasoning parts are never surfaced in either bucket.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  partitionTurn,
+  summarizeActivity,
+  type TurnPart,
+} from "../turn-partitioner";
+
+/* ------------------------------------------------------------------ */
+/*  Part fixtures                                                      */
+/* ------------------------------------------------------------------ */
+
+function text(t: string, state?: "streaming" | "done"): TurnPart {
+  return { type: "text", text: t, ...(state ? { state } : {}) } as TurnPart;
+}
+
+function reasoning(t: string): TurnPart {
+  return { type: "reasoning", text: t } as TurnPart;
+}
+
+function stepStart(): TurnPart {
+  return { type: "step-start" } as TurnPart;
+}
+
+let nextCallId = 0;
+
+function sql(opts: {
+  success?: boolean;
+  state?: "input-streaming" | "input-available" | "output-available";
+  sql?: string;
+}): TurnPart {
+  const state = opts.state ?? "output-available";
+  return {
+    type: "tool-executeSQL",
+    toolCallId: `call-${nextCallId++}`,
+    state,
+    input: { sql: opts.sql ?? "SELECT 1", explanation: "test query" },
+    ...(state === "output-available"
+      ? {
+          output:
+            opts.success === false
+              ? { success: false, error: "boom" }
+              : { success: true, columns: ["n"], rows: [{ n: 1 }] },
+        }
+      : {}),
+  } as TurnPart;
+}
+
+function explore(command = "ls semantic/entities"): TurnPart {
+  return {
+    type: "tool-explore",
+    toolCallId: `call-${nextCallId++}`,
+    state: "output-available",
+    input: { command },
+    output: "entities.yml",
+  } as TurnPart;
+}
+
+function python(): TurnPart {
+  return {
+    type: "tool-executePython",
+    toolCallId: `call-${nextCallId++}`,
+    state: "output-available",
+    input: { code: "print(1)" },
+    output: { success: true, stdout: "1" },
+  } as TurnPart;
+}
+
+/* ------------------------------------------------------------------ */
+/*  partitionTurn                                                      */
+/* ------------------------------------------------------------------ */
+
+describe("partitionTurn", () => {
+  test("narration/answer boundary: text before the last tool part is activity, trailing text is the answer", () => {
+    const narration1 = text("Let me check the schema first.");
+    const exp = explore();
+    const narration2 = text("The region column looks unpopulated, checking...");
+    const query = sql({});
+    const answerText = text("Revenue was $1.2M last quarter.");
+    const parts = [narration1, exp, narration2, query, answerText];
+
+    const result = partitionTurn(parts);
+
+    // The successful query is promoted out; narration + explore stay in activity.
+    expect(result.activity.map((p) => p.part)).toEqual([narration1, exp, narration2]);
+    expect(result.answer.map((p) => p.part)).toEqual([answerText]);
+    expect(result.answerBearingArtifact?.part).toBe(query);
+  });
+
+  test("multi-query turn: only the last successful query is promoted; earlier ones stay in activity", () => {
+    const q1 = sql({ sql: "SELECT 1" });
+    const q2 = sql({ sql: "SELECT 2" });
+    const parts = [explore(), q1, q2, text("Answer.")];
+
+    const result = partitionTurn(parts);
+
+    expect(result.answerBearingArtifact?.part).toBe(q2);
+    expect(result.activity.map((p) => p.part)).toContain(q1);
+    expect(result.activity.map((p) => p.part)).not.toContain(q2);
+  });
+
+  test("failed last query: the previous successful query is promoted, the failure stays in activity", () => {
+    const good = sql({ sql: "SELECT 1" });
+    const bad = sql({ success: false, sql: "SELECT nope" });
+    const parts = [good, bad, text("I could not refine the result.")];
+
+    const result = partitionTurn(parts);
+
+    expect(result.answerBearingArtifact?.part).toBe(good);
+    expect(result.activity.map((p) => p.part)).toEqual([bad]);
+  });
+
+  test("all queries failed: nothing is promoted", () => {
+    const bad1 = sql({ success: false });
+    const bad2 = sql({ success: false });
+    const parts = [bad1, bad2, text("The query failed.")];
+
+    const result = partitionTurn(parts);
+
+    expect(result.answerBearingArtifact).toBeNull();
+    expect(result.activity.map((p) => p.part)).toEqual([bad1, bad2]);
+  });
+
+  test("zero-tool turn: no activity, all text is the answer", () => {
+    const a = text("Hello!");
+    const b = text("What would you like to know?");
+
+    const result = partitionTurn([a, b]);
+
+    expect(result.activity).toEqual([]);
+    expect(result.answer.map((p) => p.part)).toEqual([a, b]);
+    expect(result.answerBearingArtifact).toBeNull();
+  });
+
+  test("interrupted stream: tool ran but no trailing text — empty answer", () => {
+    const narration = text("Checking the data...");
+    const query = sql({});
+
+    const result = partitionTurn([narration, query]);
+
+    expect(result.answer).toEqual([]);
+    expect(result.answerBearingArtifact?.part).toBe(query);
+    expect(result.activity.map((p) => p.part)).toEqual([narration]);
+  });
+
+  test("non-executeSQL tools are never promoted", () => {
+    const parts = [explore(), python(), text("Done.")];
+
+    const result = partitionTurn(parts);
+
+    expect(result.answerBearingArtifact).toBeNull();
+    expect(result.activity).toHaveLength(2);
+  });
+
+  test("in-progress tool parts are activity but never promoted", () => {
+    const streaming = sql({ state: "input-streaming" });
+    const pending = sql({ state: "input-available" });
+
+    const result = partitionTurn([streaming, pending]);
+
+    expect(result.answerBearingArtifact).toBeNull();
+    expect(result.activity.map((p) => p.part)).toEqual([streaming, pending]);
+    expect(result.answer).toEqual([]);
+  });
+
+  test("streaming trailing text is still the answer (partial in-progress turn)", () => {
+    const query = sql({});
+    const partial = text("Revenue was", "streaming");
+
+    const result = partitionTurn([query, partial]);
+
+    expect(result.answer.map((p) => p.part)).toEqual([partial]);
+  });
+
+  test("reasoning parts are dropped from both buckets", () => {
+    const parts = [reasoning("thinking..."), sql({}), reasoning("more thinking"), text("Answer.")];
+
+    const result = partitionTurn(parts);
+
+    const surfaced = [
+      ...result.activity.map((p) => p.part),
+      ...result.answer.map((p) => p.part),
+      ...(result.answerBearingArtifact ? [result.answerBearingArtifact.part] : []),
+    ];
+    expect(surfaced.some((p) => (p as { type: string }).type === "reasoning")).toBe(false);
+    // A trailing reasoning part after the last tool must not leak into the answer either.
+    const trailing = partitionTurn([sql({}), reasoning("post-hoc"), text("Answer.")]);
+    expect(trailing.answer.map((p) => (p.part as { type: string }).type)).toEqual(["text"]);
+  });
+
+  test("step-start parts are dropped", () => {
+    const result = partitionTurn([stepStart(), sql({}), stepStart(), text("Answer.")]);
+
+    const surfaced = [...result.activity, ...result.answer].map(
+      (p) => (p.part as { type: string }).type,
+    );
+    expect(surfaced).not.toContain("step-start");
+  });
+
+  test("whitespace-only text parts are dropped from activity and answer", () => {
+    const result = partitionTurn([text("  \n "), sql({}), text("   ")]);
+
+    expect(result.activity).toEqual([]);
+    expect(result.answer).toEqual([]);
+  });
+
+  test("empty and undefined inputs produce an empty partition", () => {
+    for (const input of [undefined, [] as TurnPart[]]) {
+      const result = partitionTurn(input);
+      expect(result.activity).toEqual([]);
+      expect(result.answer).toEqual([]);
+      expect(result.answerBearingArtifact).toBeNull();
+    }
+  });
+
+  test("indices reference positions in the original parts array", () => {
+    const narration = text("Looking...");
+    const query = sql({});
+    const answerText = text("Done.");
+    const parts = [reasoning("hidden"), narration, query, answerText];
+
+    const result = partitionTurn(parts);
+
+    expect(result.activity).toEqual([{ part: narration, index: 1 }]);
+    expect(result.answerBearingArtifact).toEqual({ part: query, index: 2 });
+    expect(result.answer).toEqual([{ part: answerText, index: 3 }]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  summarizeActivity                                                  */
+/* ------------------------------------------------------------------ */
+
+describe("summarizeActivity", () => {
+  test("explore + queries reads like the receipt example", () => {
+    const { activity } = partitionTurn([
+      explore(),
+      sql({ sql: "SELECT 1" }),
+      sql({ sql: "SELECT 2" }),
+      sql({ sql: "SELECT 3" }),
+      text("Answer."),
+    ]);
+    // Three queries ran; the promoted one leaves the receipt, two remain.
+    expect(summarizeActivity(activity)).toBe("Explored schema · 2 queries");
+  });
+
+  test("singular query", () => {
+    const { activity } = partitionTurn([sql({ success: false }), text("Failed.")]);
+    expect(summarizeActivity(activity)).toBe("1 query");
+  });
+
+  test("python runs and unknown tools are counted", () => {
+    const dashboard = {
+      type: "tool-createDashboard",
+      toolCallId: "call-x",
+      state: "output-available",
+      input: {},
+      output: { id: "d1" },
+    } as TurnPart;
+    const { activity } = partitionTurn([python(), python(), dashboard, text("Done.")]);
+    expect(summarizeActivity(activity)).toBe("2 Python runs · 1 more step");
+  });
+
+  test("narration-only activity falls back to a generic label", () => {
+    // A single promoted query with leading narration leaves only text in the receipt.
+    const { activity } = partitionTurn([text("Checking..."), sql({}), text("Answer.")]);
+    expect(summarizeActivity(activity)).toBe("Working notes");
+  });
+
+  test("empty activity summarizes to an empty string", () => {
+    expect(summarizeActivity([])).toBe("");
+  });
+});

--- a/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
+++ b/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  activityAwaitsUser,
   partitionTurn,
   summarizeActivity,
   type TurnPart,
@@ -23,15 +24,15 @@ import {
 /* ------------------------------------------------------------------ */
 
 function text(t: string, state?: "streaming" | "done"): TurnPart {
-  return { type: "text", text: t, ...(state ? { state } : {}) } as TurnPart;
+  return { type: "text", text: t, state };
 }
 
 function reasoning(t: string): TurnPart {
-  return { type: "reasoning", text: t } as TurnPart;
+  return { type: "reasoning", text: t };
 }
 
 function stepStart(): TurnPart {
-  return { type: "step-start" } as TurnPart;
+  return { type: "step-start" };
 }
 
 let nextCallId = 0;
@@ -194,18 +195,16 @@ describe("partitionTurn", () => {
       ...result.answer.map((p) => p.part),
       ...(result.answerBearingArtifact ? [result.answerBearingArtifact.part] : []),
     ];
-    expect(surfaced.some((p) => (p as { type: string }).type === "reasoning")).toBe(false);
+    expect(surfaced.some((p) => p.type === "reasoning")).toBe(false);
     // A trailing reasoning part after the last tool must not leak into the answer either.
     const trailing = partitionTurn([sql({}), reasoning("post-hoc"), text("Answer.")]);
-    expect(trailing.answer.map((p) => (p.part as { type: string }).type)).toEqual(["text"]);
+    expect(trailing.answer.map((p) => p.part.type)).toEqual(["text"]);
   });
 
   test("step-start parts are dropped", () => {
     const result = partitionTurn([stepStart(), sql({}), stepStart(), text("Answer.")]);
 
-    const surfaced = [...result.activity, ...result.answer].map(
-      (p) => (p.part as { type: string }).type,
-    );
+    const surfaced = [...result.activity, ...result.answer].map((p) => p.part.type);
     expect(surfaced).not.toContain("step-start");
   });
 
@@ -236,6 +235,79 @@ describe("partitionTurn", () => {
     expect(result.activity).toEqual([{ part: narration, index: 1 }]);
     expect(result.answerBearingArtifact).toEqual({ part: query, index: 2 });
     expect(result.answer).toEqual([{ part: answerText, index: 3 }]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  activityAwaitsUser                                                 */
+/* ------------------------------------------------------------------ */
+
+/** A generic tool part with an arbitrary output envelope. */
+function toolWithOutput(output: unknown): TurnPart {
+  return {
+    type: "tool-someAction",
+    toolCallId: `call-${nextCallId++}`,
+    state: "output-available",
+    input: {},
+    output,
+  } as TurnPart;
+}
+
+describe("activityAwaitsUser", () => {
+  test("pending action approval awaits the user", () => {
+    const pending = toolWithOutput({
+      status: "pending",
+      actionId: "a1",
+      summary: "Send the email",
+    });
+    const { activity } = partitionTurn([pending, text("I need your approval.")]);
+    expect(activityAwaitsUser(activity)).toBe(true);
+  });
+
+  test("resolved action does not await the user", () => {
+    const executed = toolWithOutput({
+      status: "executed",
+      actionId: "a1",
+      result: { ok: true },
+    });
+    const { activity } = partitionTurn([executed, text("Done.")]);
+    expect(activityAwaitsUser(activity)).toBe(false);
+  });
+
+  test("staged dashboard change (#2365) awaits the user", () => {
+    const staged = toolWithOutput({
+      kind: "stage_required",
+      stageId: "s1",
+      stageKind: "remove_card",
+      target: { cardId: "c1", currentTitle: "T" },
+    });
+    const { activity } = partitionTurn([staged, text("Confirm the removal?")]);
+    expect(activityAwaitsUser(activity)).toBe(true);
+  });
+
+  test("REST write confirmation (#2929) awaits the user", () => {
+    const confirm = toolWithOutput({
+      status: "needs_confirmation",
+      method: "POST",
+      operationId: "op1",
+      datasourceId: "d1",
+      datasourceName: "CRM",
+      summary: "Create a contact",
+      confirm: { token: "t1" },
+    });
+    const { activity } = partitionTurn([confirm, text("Shall I create it?")]);
+    expect(activityAwaitsUser(activity)).toBe(true);
+  });
+
+  test("ordinary activity (explore, queries, narration) does not await the user", () => {
+    const { activity } = partitionTurn([
+      text("Checking..."),
+      explore(),
+      sql({ success: false }),
+      text("Answer."),
+    ]);
+    expect(activityAwaitsUser(activity)).toBe(false);
+    expect(activityAwaitsUser([])).toBe(false);
   });
 });
 

--- a/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Component tests for the collapsed receipt + finished-turn renderer (#4298):
+ * a finished turn renders receipt → answer → promoted artifact; the receipt
+ * expands on click to the full activity; narration never renders outside it.
+ */
+
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import React from "react";
+import type { TurnPart } from "../turn-partitioner";
+
+// Stub the heavy leaf renderers — this test pins the partition/receipt
+// composition, not card internals. CLAUDE.md "Mock all exports": tool-part.tsx
+// exports only ToolPart; markdown.tsx exports only Markdown.
+mock.module("@/ui/components/chat/tool-part", () => ({
+  ToolPart: ({ part }: { part: unknown }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "tool-part-stub" },
+      String((part as { type?: string }).type),
+    ),
+}));
+mock.module("@/ui/components/chat/markdown", () => ({
+  Markdown: ({ content }: { content: string }) =>
+    React.createElement("div", null, content),
+}));
+
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+const { TurnReceipt } = await import("../turn-receipt");
+const { FinishedTurn } = await import("../finished-turn");
+const { partitionTurn } = await import("../turn-partitioner");
+
+afterEach(cleanup);
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                           */
+/* ------------------------------------------------------------------ */
+
+let nextCallId = 0;
+
+function text(t: string): TurnPart {
+  return { type: "text", text: t } as TurnPart;
+}
+
+function sql(success = true): TurnPart {
+  return {
+    type: "tool-executeSQL",
+    toolCallId: `call-${nextCallId++}`,
+    state: "output-available",
+    input: { sql: "SELECT 1", explanation: "test" },
+    output: success
+      ? { success: true, columns: ["n"], rows: [{ n: 1 }] }
+      : { success: false, error: "boom" },
+  } as TurnPart;
+}
+
+function explore(): TurnPart {
+  return {
+    type: "tool-explore",
+    toolCallId: `call-${nextCallId++}`,
+    state: "output-available",
+    input: { command: "ls" },
+    output: "entities.yml",
+  } as TurnPart;
+}
+
+/* ------------------------------------------------------------------ */
+/*  TurnReceipt                                                        */
+/* ------------------------------------------------------------------ */
+
+describe("TurnReceipt", () => {
+  test("renders nothing for empty activity", () => {
+    const { container } = render(<TurnReceipt activity={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("collapsed by default: one summary line, no activity content", () => {
+    const { activity } = partitionTurn([
+      text("Checking the schema..."),
+      explore(),
+      sql(false),
+      text("Answer."),
+    ]);
+    const { getByRole, queryByTestId, queryByText } = render(
+      <TurnReceipt activity={activity} />,
+    );
+
+    const toggle = getByRole("button");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.textContent).toContain("Explored schema · 1 query");
+    expect(queryByTestId("tool-part-stub")).toBeNull();
+    expect(queryByText("Checking the schema...")).toBeNull();
+  });
+
+  test("expands on click to the full activity (tools + narration), collapses again", () => {
+    const { activity } = partitionTurn([
+      text("Checking the schema..."),
+      explore(),
+      sql(false),
+      text("Answer."),
+    ]);
+    const { getByRole, queryAllByTestId, queryByText } = render(
+      <TurnReceipt activity={activity} />,
+    );
+
+    const toggle = getByRole("button");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(queryAllByTestId("tool-part-stub")).toHaveLength(2);
+    expect(queryByText("Checking the schema...")).not.toBeNull();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(queryAllByTestId("tool-part-stub")).toHaveLength(0);
+  });
+
+  test("defaultOpen starts expanded", () => {
+    const { activity } = partitionTurn([explore(), text("Answer.")]);
+    const { getByRole, queryAllByTestId } = render(
+      <TurnReceipt activity={activity} defaultOpen />,
+    );
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    expect(queryAllByTestId("tool-part-stub")).toHaveLength(1);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  FinishedTurn                                                       */
+/* ------------------------------------------------------------------ */
+
+describe("FinishedTurn", () => {
+  test("renders receipt → answer → promoted artifact, in that order", () => {
+    const { container, getByTestId, getByRole } = render(
+      <FinishedTurn
+        parts={[
+          text("Looking at the data..."),
+          explore(),
+          sql(),
+          text("Revenue was $1.2M."),
+        ]}
+      />,
+    );
+
+    const receipt = getByRole("button");
+    const answer = getByTestId("turn-answer");
+    const artifact = getByTestId("answer-artifact");
+    expect(answer.textContent).toContain("Revenue was $1.2M.");
+    expect(artifact.textContent).toContain("tool-executeSQL");
+
+    const order = (a: Element, b: Element) =>
+      (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+    expect(order(receipt, answer)).toBe(true);
+    expect(order(answer, artifact)).toBe(true);
+    // Narration stays inside the (collapsed) receipt — never at answer weight.
+    expect(container.textContent).not.toContain("Looking at the data...");
+  });
+
+  test("suggestions block is stripped from the answer text", () => {
+    const { getByTestId } = render(
+      <FinishedTurn
+        parts={[
+          sql(),
+          text("Here you go.\n<suggestions>\nWhat about Q2?\n</suggestions>"),
+        ]}
+      />,
+    );
+    const answer = getByTestId("turn-answer");
+    expect(answer.textContent).toContain("Here you go.");
+    expect(answer.textContent).not.toContain("What about Q2?");
+  });
+
+  test("zero-tool turn renders the answer with no receipt", () => {
+    const { queryByRole, getByTestId } = render(
+      <FinishedTurn parts={[text("Just an answer.")]} />,
+    );
+    expect(queryByRole("button")).toBeNull();
+    expect(getByTestId("turn-answer").textContent).toContain("Just an answer.");
+  });
+
+  test("empty answer with no artifact: the receipt starts expanded so the work stays visible", () => {
+    // An interrupted stream (or an approval-parked action) ends the turn with
+    // activity only — collapsing it would hide the only content of the turn.
+    const { getByRole, queryAllByTestId } = render(
+      <FinishedTurn parts={[text("Working on it..."), explore()]} />,
+    );
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    expect(queryAllByTestId("tool-part-stub")).toHaveLength(1);
+  });
+
+  test("empty answer with a promoted artifact: the receipt stays collapsed", () => {
+    const { getByRole, getByTestId } = render(
+      <FinishedTurn parts={[explore(), sql()]} />,
+    );
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
+    expect(getByTestId("answer-artifact")).not.toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
@@ -39,7 +39,7 @@ afterEach(cleanup);
 let nextCallId = 0;
 
 function text(t: string): TurnPart {
-  return { type: "text", text: t } as TurnPart;
+  return { type: "text", text: t };
 }
 
 function sql(success = true): TurnPart {

--- a/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
@@ -194,4 +194,36 @@ describe("FinishedTurn", () => {
     expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
     expect(getByTestId("answer-artifact")).not.toBeNull();
   });
+
+  test("pending interactive card with trailing answer text: the receipt starts expanded", () => {
+    // An action approval's buttons are the turn's point — collapsing them
+    // behind the receipt would stall the flow even though answer text exists.
+    const pendingApproval = {
+      type: "tool-sendEmail",
+      toolCallId: "call-approval",
+      state: "output-available",
+      input: {},
+      output: { status: "pending", actionId: "a1", summary: "Send the email" },
+    } as TurnPart;
+    const { getByRole, queryAllByTestId, getByTestId } = render(
+      <FinishedTurn parts={[pendingApproval, text("I need your approval to send this.")]} />,
+    );
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    expect(queryAllByTestId("tool-part-stub")).toHaveLength(1);
+    expect(getByTestId("turn-answer").textContent).toContain("I need your approval");
+  });
+
+  test("resolved action with trailing answer text: the receipt stays collapsed", () => {
+    const executed = {
+      type: "tool-sendEmail",
+      toolCallId: "call-executed",
+      state: "output-available",
+      input: {},
+      output: { status: "executed", actionId: "a1", result: { ok: true } },
+    } as TurnPart;
+    const { getByRole } = render(
+      <FinishedTurn parts={[executed, text("The email went out.")]} />,
+    );
+    expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
+  });
 });

--- a/packages/web/src/ui/components/chat/finished-turn.tsx
+++ b/packages/web/src/ui/components/chat/finished-turn.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Markdown } from "./markdown";
+import { ToolPart } from "./tool-part";
+import { parseSuggestions } from "../../lib/helpers";
+import { partitionTurn, type TurnPart } from "./turn-partitioner";
+import { TurnReceipt } from "./turn-receipt";
+import type { PythonProgressData } from "./python-result-card";
+
+/**
+ * Answer-first rendering of a completed assistant turn (#4298): the activity
+ * collapses into a `TurnReceipt`, the answer is the dominant element, and at
+ * most one promoted answer-bearing artifact sits with it. Streaming turns keep
+ * the live part-by-part renderer — this component is for finished turns only.
+ * The suggestion chips and Save/Share row stay with the caller (they belong to
+ * the transcript row, not the turn's parts).
+ */
+export function FinishedTurn({
+  parts,
+  pythonProgress,
+}: {
+  parts: readonly TurnPart[] | undefined;
+  pythonProgress?: Map<string, PythonProgressData[]>;
+}) {
+  const { activity, answer, answerBearingArtifact } = partitionTurn(parts);
+
+  // A text part can be all <suggestions> block — stripped, it renders nothing.
+  const hasRenderedAnswer = answer.some(
+    ({ part }) => part.type === "text" && parseSuggestions(part.text).text.trim(),
+  );
+
+  return (
+    <>
+      <TurnReceipt
+        activity={activity}
+        pythonProgress={pythonProgress}
+        // With no answer and no artifact, the activity IS the turn (interrupted
+        // stream, approval-parked action) — start open so it isn't hidden
+        // behind a bare one-line receipt.
+        defaultOpen={!hasRenderedAnswer && !answerBearingArtifact}
+      />
+      {answer.map(({ part, index }) => {
+        if (part.type !== "text") return null;
+        const displayText = parseSuggestions(part.text).text;
+        if (!displayText.trim()) return null;
+        return (
+          <div
+            key={index}
+            data-testid="turn-answer"
+            className="max-w-[90%] text-[0.9375rem] leading-relaxed text-zinc-800 dark:text-zinc-200"
+          >
+            <Markdown content={displayText} />
+          </div>
+        );
+      })}
+      {answerBearingArtifact && (
+        <div className="max-w-[95%]" data-testid="answer-artifact">
+          <ToolPart part={answerBearingArtifact.part} pythonProgress={pythonProgress} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/ui/components/chat/finished-turn.tsx
+++ b/packages/web/src/ui/components/chat/finished-turn.tsx
@@ -3,7 +3,7 @@
 import { Markdown } from "./markdown";
 import { ToolPart } from "./tool-part";
 import { parseSuggestions } from "../../lib/helpers";
-import { partitionTurn, type TurnPart } from "./turn-partitioner";
+import { activityAwaitsUser, partitionTurn, type TurnPart } from "./turn-partitioner";
 import { TurnReceipt } from "./turn-receipt";
 import type { PythonProgressData } from "./python-result-card";
 
@@ -26,7 +26,7 @@ export function FinishedTurn({
 
   // A text part can be all <suggestions> block — stripped, it renders nothing.
   const hasRenderedAnswer = answer.some(
-    ({ part }) => part.type === "text" && parseSuggestions(part.text).text.trim(),
+    ({ part }) => parseSuggestions(part.text).text.trim(),
   );
 
   return (
@@ -34,13 +34,17 @@ export function FinishedTurn({
       <TurnReceipt
         activity={activity}
         pythonProgress={pythonProgress}
-        // With no answer and no artifact, the activity IS the turn (interrupted
-        // stream, approval-parked action) — start open so it isn't hidden
-        // behind a bare one-line receipt.
-        defaultOpen={!hasRenderedAnswer && !answerBearingArtifact}
+        // Start expanded when collapsing would hide the turn's substance:
+        // (a) no answer and no artifact — the activity IS the turn (e.g. an
+        // interrupted stream); (b) the activity holds an interactive card
+        // awaiting a user decision (action approval, staged change, REST write
+        // confirmation) — its buttons are the turn's point even when trailing
+        // answer text exists.
+        defaultOpen={
+          (!hasRenderedAnswer && !answerBearingArtifact) || activityAwaitsUser(activity)
+        }
       />
       {answer.map(({ part, index }) => {
-        if (part.type !== "text") return null;
         const displayText = parseSuggestions(part.text).text;
         if (!displayText.trim()) return null;
         return (

--- a/packages/web/src/ui/components/chat/turn-partitioner.ts
+++ b/packages/web/src/ui/components/chat/turn-partitioner.ts
@@ -1,0 +1,175 @@
+/**
+ * Turn partitioner (#4298) — the single seam that decides how a finished agent
+ * turn is presented, per CONTEXT.md § Chat turn presentation. A pure function
+ * (no React, no DOM) so both the chat transcript and the notebook renderer
+ * (#4301) partition identically, and the live working phase (#4300) can settle
+ * into the same shape.
+ *
+ * Boundary rules (v1 — all of them live here, nowhere else):
+ * - Everything up to and including the last tool part is **activity** (tool
+ *   executions + narration text between them). It renders inside the receipt.
+ * - Text parts after the last tool part are the **answer**. A zero-tool turn is
+ *   all answer; an interrupted stream can have an empty answer.
+ * - The last *successful* `executeSQL` result is promoted as the
+ *   **answer-bearing artifact** and excluded from `activity` — it sits with the
+ *   answer, everything else stays in the receipt.
+ * - Reasoning parts are never surfaced in any bucket — the receipt is activity,
+ *   not chain-of-thought. Non-renderable parts (step-start, data, source, file)
+ *   are dropped, matching what the transcript rendered before this seam.
+ *
+ * If this heuristic misfires in practice, the planned escape hatch is an
+ * explicit agent-emitted answer marker (see PRD #4292) — not more rules here.
+ */
+
+import { isToolUIPart, getToolName, type UIMessagePart, type UIDataTypes, type UITools } from "ai";
+
+/** One part of an assistant message, as delivered by the AI SDK. */
+export type TurnPart = UIMessagePart<UIDataTypes, UITools>;
+
+/**
+ * A part paired with its index in the original `parts` array. The index is the
+ * stable React key: partition output arrays re-shuffle across buckets, but the
+ * source position of a part never changes once streamed.
+ */
+export interface IndexedTurnPart {
+  part: TurnPart;
+  index: number;
+}
+
+/** The three presentation buckets of a finished turn. */
+export interface PartitionedTurn {
+  /**
+   * What the agent did on the way to the answer — tool parts plus narration
+   * text — excluding the promoted artifact. Rendered inside the receipt.
+   */
+  activity: IndexedTurnPart[];
+  /**
+   * The turn's user-facing text: non-empty text parts after the last tool
+   * part. Empty for an interrupted stream that never reached the answer.
+   */
+  answer: IndexedTurnPart[];
+  /**
+   * The at-most-one query result promoted to sit with the answer, or null
+   * when no successful `executeSQL` ran.
+   */
+  answerBearingArtifact: IndexedTurnPart | null;
+}
+
+/** `getToolName` throws on malformed parts; treat those as unnamed. */
+function safeToolName(part: TurnPart): string | null {
+  try {
+    return getToolName(part as Parameters<typeof getToolName>[0]);
+  } catch {
+    // intentionally ignored: a tool part without a recognizable name still
+    // renders in the receipt (ToolPart shows its own fallback card), it just
+    // can't be promoted or counted by name.
+    return null;
+  }
+}
+
+/** A completed executeSQL whose output reported success — the only promotable shape (v1). */
+function isPromotableQueryResult(part: TurnPart): boolean {
+  if (!isToolUIPart(part)) return false;
+  if (safeToolName(part) !== "executeSQL") return false;
+  if (part.state !== "output-available") return false;
+  const output = part.output;
+  return (
+    output != null &&
+    typeof output === "object" &&
+    Boolean((output as { success?: unknown }).success)
+  );
+}
+
+function isNonEmptyText(part: TurnPart): part is Extract<TurnPart, { type: "text" }> {
+  return part.type === "text" && part.text.trim().length > 0;
+}
+
+/**
+ * Split a finished assistant turn's parts into
+ * `{ activity, answer, answerBearingArtifact }`.
+ *
+ * Total over any parts array (in-progress tool parts are activity; a
+ * still-streaming trailing text part is the answer), but this slice only
+ * consumes it for completed turns — streaming turns keep the live renderer.
+ */
+export function partitionTurn(parts: readonly TurnPart[] | undefined): PartitionedTurn {
+  if (!parts || parts.length === 0) {
+    return { activity: [], answer: [], answerBearingArtifact: null };
+  }
+
+  let lastToolIndex = -1;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (isToolUIPart(parts[i])) {
+      lastToolIndex = i;
+      break;
+    }
+  }
+
+  let answerBearingArtifact: IndexedTurnPart | null = null;
+  for (let i = lastToolIndex; i >= 0; i--) {
+    if (isPromotableQueryResult(parts[i])) {
+      answerBearingArtifact = { part: parts[i], index: i };
+      break;
+    }
+  }
+
+  const activity: IndexedTurnPart[] = [];
+  const answer: IndexedTurnPart[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (i <= lastToolIndex) {
+      if (i === answerBearingArtifact?.index) continue; // promoted out of the receipt
+      if (isToolUIPart(part) || isNonEmptyText(part)) {
+        activity.push({ part, index: i });
+      }
+    } else if (isNonEmptyText(part)) {
+      answer.push({ part, index: i });
+    }
+  }
+
+  return { activity, answer, answerBearingArtifact };
+}
+
+/**
+ * The receipt's one-line summary of what stayed in it, e.g.
+ * "Explored schema · 2 queries". Counts describe the receipt's own contents —
+ * the promoted artifact is visible next to the answer, not re-counted here.
+ * Returns "" for empty activity (the receipt doesn't render then).
+ */
+export function summarizeActivity(activity: readonly IndexedTurnPart[]): string {
+  if (activity.length === 0) return "";
+
+  let explores = 0;
+  let queries = 0;
+  let pythonRuns = 0;
+  let otherSteps = 0;
+  for (const { part } of activity) {
+    if (!isToolUIPart(part)) continue;
+    switch (safeToolName(part)) {
+      case "explore":
+        explores++;
+        break;
+      case "executeSQL":
+        queries++;
+        break;
+      case "executePython":
+        pythonRuns++;
+        break;
+      default:
+        otherSteps++;
+    }
+  }
+
+  const segments: string[] = [];
+  if (explores > 0) segments.push("Explored schema");
+  if (queries > 0) segments.push(queries === 1 ? "1 query" : `${queries} queries`);
+  if (pythonRuns > 0) {
+    segments.push(pythonRuns === 1 ? "1 Python run" : `${pythonRuns} Python runs`);
+  }
+  if (otherSteps > 0) {
+    segments.push(otherSteps === 1 ? "1 more step" : `${otherSteps} more steps`);
+  }
+
+  // Narration-only receipts (the lone query was promoted) still need a label.
+  return segments.length > 0 ? segments.join(" · ") : "Working notes";
+}

--- a/packages/web/src/ui/components/chat/turn-partitioner.ts
+++ b/packages/web/src/ui/components/chat/turn-partitioner.ts
@@ -7,7 +7,8 @@
  *
  * Boundary rules (v1 — all of them live here, nowhere else):
  * - Everything up to and including the last tool part is **activity** (tool
- *   executions + narration text between them). It renders inside the receipt.
+ *   executions plus the narration text around them). It renders inside the
+ *   receipt.
  * - Text parts after the last tool part are the **answer**. A zero-tool turn is
  *   all answer; an interrupted stream can have an empty answer.
  * - The last *successful* `executeSQL` result is promoted as the
@@ -21,19 +22,35 @@
  * explicit agent-emitted answer marker (see PRD #4292) — not more rules here.
  */
 
-import { isToolUIPart, getToolName, type UIMessagePart, type UIDataTypes, type UITools } from "ai";
+import {
+  isToolUIPart,
+  getToolName,
+  type UIMessagePart,
+  type UIDataTypes,
+  type UITools,
+  type ToolUIPart,
+  type DynamicToolUIPart,
+} from "ai";
+import { isActionToolResult } from "../../lib/action-types";
+import { isRestWriteConfirmResult } from "../../lib/rest-operation-types";
 
 /** One part of an assistant message, as delivered by the AI SDK. */
 export type TurnPart = UIMessagePart<UIDataTypes, UITools>;
+
+/** The text arm of {@link TurnPart} — what `answer` and narration are made of. */
+export type TextTurnPart = Extract<TurnPart, { type: "text" }>;
+
+/** The tool arms of {@link TurnPart} — exactly what `isToolUIPart` narrows to. */
+export type ToolTurnPart = ToolUIPart<UITools> | DynamicToolUIPart;
 
 /**
  * A part paired with its index in the original `parts` array. The index is the
  * stable React key: partition output arrays re-shuffle across buckets, but the
  * source position of a part never changes once streamed.
  */
-export interface IndexedTurnPart {
-  part: TurnPart;
-  index: number;
+export interface IndexedTurnPart<P extends TurnPart = TurnPart> {
+  readonly part: P;
+  readonly index: number;
 }
 
 /** The three presentation buckets of a finished turn. */
@@ -42,35 +59,23 @@ export interface PartitionedTurn {
    * What the agent did on the way to the answer — tool parts plus narration
    * text — excluding the promoted artifact. Rendered inside the receipt.
    */
-  activity: IndexedTurnPart[];
+  readonly activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[];
   /**
    * The turn's user-facing text: non-empty text parts after the last tool
    * part. Empty for an interrupted stream that never reached the answer.
    */
-  answer: IndexedTurnPart[];
+  readonly answer: readonly IndexedTurnPart<TextTurnPart>[];
   /**
    * The at-most-one query result promoted to sit with the answer, or null
    * when no successful `executeSQL` ran.
    */
-  answerBearingArtifact: IndexedTurnPart | null;
-}
-
-/** `getToolName` throws on malformed parts; treat those as unnamed. */
-function safeToolName(part: TurnPart): string | null {
-  try {
-    return getToolName(part as Parameters<typeof getToolName>[0]);
-  } catch {
-    // intentionally ignored: a tool part without a recognizable name still
-    // renders in the receipt (ToolPart shows its own fallback card), it just
-    // can't be promoted or counted by name.
-    return null;
-  }
+  readonly answerBearingArtifact: IndexedTurnPart<ToolTurnPart> | null;
 }
 
 /** A completed executeSQL whose output reported success — the only promotable shape (v1). */
-function isPromotableQueryResult(part: TurnPart): boolean {
+function isPromotableQueryResult(part: TurnPart): part is ToolTurnPart {
   if (!isToolUIPart(part)) return false;
-  if (safeToolName(part) !== "executeSQL") return false;
+  if (getToolName(part) !== "executeSQL") return false;
   if (part.state !== "output-available") return false;
   const output = part.output;
   return (
@@ -80,7 +85,7 @@ function isPromotableQueryResult(part: TurnPart): boolean {
   );
 }
 
-function isNonEmptyText(part: TurnPart): part is Extract<TurnPart, { type: "text" }> {
+function isNonEmptyText(part: TurnPart): part is TextTurnPart {
   return part.type === "text" && part.text.trim().length > 0;
 }
 
@@ -105,16 +110,17 @@ export function partitionTurn(parts: readonly TurnPart[] | undefined): Partition
     }
   }
 
-  let answerBearingArtifact: IndexedTurnPart | null = null;
+  let answerBearingArtifact: IndexedTurnPart<ToolTurnPart> | null = null;
   for (let i = lastToolIndex; i >= 0; i--) {
-    if (isPromotableQueryResult(parts[i])) {
-      answerBearingArtifact = { part: parts[i], index: i };
+    const part = parts[i];
+    if (isPromotableQueryResult(part)) {
+      answerBearingArtifact = { part, index: i };
       break;
     }
   }
 
-  const activity: IndexedTurnPart[] = [];
-  const answer: IndexedTurnPart[] = [];
+  const activity: IndexedTurnPart<TextTurnPart | ToolTurnPart>[] = [];
+  const answer: IndexedTurnPart<TextTurnPart>[] = [];
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i];
     if (i <= lastToolIndex) {
@@ -131,12 +137,44 @@ export function partitionTurn(parts: readonly TurnPart[] | undefined): Partition
 }
 
 /**
+ * True when `output` is one of the interactive tool envelopes that waits on a
+ * user decision: a pending action approval, a staged dashboard change
+ * (#2365 `stage_required` — the card validates the full payload, the kind
+ * alone identifies the envelope family), or a REST write confirmation (#2929).
+ */
+function isPendingInteractiveResult(output: unknown): boolean {
+  if (output == null || typeof output !== "object") return false;
+  if ((output as { kind?: unknown }).kind === "stage_required") return true;
+  if (isRestWriteConfirmResult(output)) return true;
+  return isActionToolResult(output) && output.status === "pending";
+}
+
+/**
+ * True when any activity part is an interactive card awaiting the user
+ * (action approval, staged change, write confirmation). The receipt must not
+ * collapse these out of sight — even when the turn also has answer text
+ * ("I need your approval to…"), the decision buttons are the turn's point.
+ */
+export function activityAwaitsUser(
+  activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[],
+): boolean {
+  return activity.some(
+    ({ part }) =>
+      isToolUIPart(part) &&
+      part.state === "output-available" &&
+      isPendingInteractiveResult(part.output),
+  );
+}
+
+/**
  * The receipt's one-line summary of what stayed in it, e.g.
  * "Explored schema · 2 queries". Counts describe the receipt's own contents —
  * the promoted artifact is visible next to the answer, not re-counted here.
  * Returns "" for empty activity (the receipt doesn't render then).
  */
-export function summarizeActivity(activity: readonly IndexedTurnPart[]): string {
+export function summarizeActivity(
+  activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[],
+): string {
   if (activity.length === 0) return "";
 
   let explores = 0;
@@ -145,7 +183,7 @@ export function summarizeActivity(activity: readonly IndexedTurnPart[]): string 
   let otherSteps = 0;
   for (const { part } of activity) {
     if (!isToolUIPart(part)) continue;
-    switch (safeToolName(part)) {
+    switch (getToolName(part)) {
       case "explore":
         explores++;
         break;

--- a/packages/web/src/ui/components/chat/turn-partitioner.ts
+++ b/packages/web/src/ui/components/chat/turn-partitioner.ts
@@ -167,10 +167,30 @@ export function activityAwaitsUser(
 }
 
 /**
+ * A tool execution that ended in failure: the AI SDK's `output-error` state,
+ * or a completed result envelope reporting `success: false` (the executeSQL /
+ * executePython family). Action envelopes have their own resolved-failure
+ * states rendered by their cards; the receipt marker covers the common
+ * query-failure case.
+ */
+function isFailedToolPart(part: ToolTurnPart): boolean {
+  if (part.state === "output-error") return true;
+  if (part.state !== "output-available") return false;
+  const output = part.output;
+  return (
+    output != null &&
+    typeof output === "object" &&
+    (output as { success?: unknown }).success === false
+  );
+}
+
+/**
  * The receipt's one-line summary of what stayed in it, e.g.
  * "Explored schema · 2 queries". Counts describe the receipt's own contents —
  * the promoted artifact is visible next to the answer, not re-counted here.
- * Returns "" for empty activity (the receipt doesn't render then).
+ * Failed executions append a "· N failed" marker so a collapsed receipt never
+ * reads identically to a clean run. Returns "" for empty activity (the
+ * receipt doesn't render then).
  */
 export function summarizeActivity(
   activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[],
@@ -181,8 +201,10 @@ export function summarizeActivity(
   let queries = 0;
   let pythonRuns = 0;
   let otherSteps = 0;
+  let failed = 0;
   for (const { part } of activity) {
     if (!isToolUIPart(part)) continue;
+    if (isFailedToolPart(part)) failed++;
     switch (getToolName(part)) {
       case "explore":
         explores++;
@@ -207,6 +229,7 @@ export function summarizeActivity(
   if (otherSteps > 0) {
     segments.push(otherSteps === 1 ? "1 more step" : `${otherSteps} more steps`);
   }
+  if (failed > 0) segments.push(`${failed} failed`);
 
   // Narration-only receipts (the lone query was promoted) still need a label.
   return segments.length > 0 ? segments.join(" · ") : "Working notes";

--- a/packages/web/src/ui/components/chat/turn-receipt.tsx
+++ b/packages/web/src/ui/components/chat/turn-receipt.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { isToolUIPart } from "ai";
+import { cn } from "@/lib/utils";
+import { Markdown } from "./markdown";
+import { ToolPart } from "./tool-part";
+import { parseSuggestions } from "../../lib/helpers";
+import { summarizeActivity, type IndexedTurnPart } from "./turn-partitioner";
+import type { PythonProgressData } from "./python-result-card";
+
+/**
+ * The collapsed receipt a finished turn's activity settles into (#4298):
+ * one muted summary line ("Explored schema · 2 queries") that expands on
+ * click to the full activity — tool cards with today's affordances (Show
+ * SQL, result views) plus the agent's narration at sub-answer weight.
+ *
+ * Renders nothing for empty activity (a zero-tool turn has no receipt).
+ * `defaultOpen` lets the caller keep the work visible when the activity is
+ * the turn's only content (interrupted stream, approval-parked action).
+ */
+export function TurnReceipt({
+  activity,
+  pythonProgress,
+  defaultOpen = false,
+}: {
+  activity: IndexedTurnPart[];
+  pythonProgress?: Map<string, PythonProgressData[]>;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  if (activity.length === 0) return null;
+
+  return (
+    <div className="max-w-[95%]" data-testid="turn-receipt">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs text-zinc-500 transition-colors hover:bg-zinc-100/60 hover:text-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800/40 dark:hover:text-zinc-300"
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn("size-3.5 shrink-0 transition-transform", open && "rotate-90")}
+        />
+        <span>{summarizeActivity(activity)}</span>
+      </button>
+      {open && (
+        <div className="mt-1 space-y-2 border-l-2 border-zinc-200 pl-3 dark:border-zinc-800">
+          {activity.map(({ part, index }) => {
+            if (part.type === "text") {
+              const displayText = parseSuggestions(part.text).text;
+              if (!displayText.trim()) return null;
+              return (
+                <div
+                  key={index}
+                  className="text-xs leading-relaxed text-zinc-500 dark:text-zinc-400"
+                >
+                  <Markdown content={displayText} />
+                </div>
+              );
+            }
+            if (isToolUIPart(part)) {
+              return <ToolPart key={index} part={part} pythonProgress={pythonProgress} />;
+            }
+            // The partitioner only emits text + tool parts; this is a type-narrowing dead end.
+            return null;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/chat/turn-receipt.tsx
+++ b/packages/web/src/ui/components/chat/turn-receipt.tsx
@@ -2,12 +2,16 @@
 
 import { useState } from "react";
 import { ChevronRight } from "lucide-react";
-import { isToolUIPart } from "ai";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./markdown";
 import { ToolPart } from "./tool-part";
 import { parseSuggestions } from "../../lib/helpers";
-import { summarizeActivity, type IndexedTurnPart } from "./turn-partitioner";
+import {
+  summarizeActivity,
+  type IndexedTurnPart,
+  type TextTurnPart,
+  type ToolTurnPart,
+} from "./turn-partitioner";
 import type { PythonProgressData } from "./python-result-card";
 
 /**
@@ -17,15 +21,15 @@ import type { PythonProgressData } from "./python-result-card";
  * SQL, result views) plus the agent's narration at sub-answer weight.
  *
  * Renders nothing for empty activity (a zero-tool turn has no receipt).
- * `defaultOpen` lets the caller keep the work visible when the activity is
- * the turn's only content (interrupted stream, approval-parked action).
+ * `defaultOpen` lets the caller keep the work visible when collapsing would
+ * hide the turn's substance — see FinishedTurn for the policy.
  */
 export function TurnReceipt({
   activity,
   pythonProgress,
   defaultOpen = false,
 }: {
-  activity: IndexedTurnPart[];
+  activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[];
   pythonProgress?: Map<string, PythonProgressData[]>;
   defaultOpen?: boolean;
 }) {
@@ -61,11 +65,7 @@ export function TurnReceipt({
                 </div>
               );
             }
-            if (isToolUIPart(part)) {
-              return <ToolPart key={index} part={part} pythonProgress={pythonProgress} />;
-            }
-            // The partitioner only emits text + tool parts; this is a type-narrowing dead end.
-            return null;
+            return <ToolPart key={index} part={part} pythonProgress={pythonProgress} />;
           })}
         </div>
       )}


### PR DESCRIPTION
## Summary

Keystone structural slice of PRD #4292 (CONTEXT.md § Chat turn presentation). A finished agent turn no longer renders as an interleaved parade of cards and narration bubbles — it reads answer-first:

- **`partitionTurn` (pure, exported)** — splits a message's parts into `{ activity, answer, answerBearingArtifact }`. All v1 boundary rules live in this one seam: everything up to and including the last tool part is activity; trailing text is the answer; the last *successful* `executeSQL` is promoted as the at-most-one answer-bearing artifact (and leaves the receipt). Reasoning parts are never surfaced in any bucket. Total over partial/in-progress parts. Sibling slices #4300 (live working phase) and #4301 (notebook convergence) build on these exports (`partitionTurn`, `summarizeActivity`, `activityAwaitsUser`, `TurnPart`/`TextTurnPart`/`ToolTurnPart`/`IndexedTurnPart`/`PartitionedTurn`).
- **`TurnReceipt`** — the collapsed one-line summary the activity settles into ("Explored schema · 2 queries", with a "· N failed" marker when executions failed so a collapsed receipt never reads clean). Expands on click to the full activity with today's card affordances (Show SQL, result views) intact; narration renders at sub-answer weight inside it.
- **`FinishedTurn`** — receipt → dominant answer (no gray bubble, larger text) → promoted artifact (existing chart/table toggles intact). The receipt mounts expanded when collapsing would hide the turn's substance: empty answer with no artifact (interrupted stream), or a pending interactive card in the activity (action approval / staged change / REST write confirmation) even when trailing answer text exists.
- **`atlas-chat.tsx`** — only the actively-streaming turn keeps the live part-by-part renderer; every completed turn renders through the partitioner. Save/Share row, follow-up chips, and related suggestions are untouched.

Out of scope, unchanged: notebook renderer (#4301), live working phase (#4300), the `@useatlas/react` parallel chat copy used by `/demo` (this slice scopes to `packages/web` per the issue; convergence rides #4301's shared-partitioner work).

## Test plan

- [x] 24 partitioner unit tests: narration/answer boundary, promotion (multi-query, failed-last, all-failed, non-SQL-never), zero-tool turns, interrupted streams, in-progress parts, reasoning/step-start dropped, index stability, `summarizeActivity` copy incl. failure marker, `activityAwaitsUser` matrix
- [x] 11 component tests (mocked leaves): receipt collapsed-by-default/expand/collapse/aria-expanded/defaultOpen; FinishedTurn ordering (receipt → answer → artifact), suggestions stripped, pending-interactive-card expansion, resolved-card collapse
- [x] 1 integration smoke with the real cards (no mocks): real `SQLResultCard` promoted with Show SQL + Chart/Table toggles, real explore card + narration inside the expanded receipt
- [x] Full `packages/web` suite green (257 files); `/ci` wrapper: all 28 gates green
- [x] Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy): 2 rounds, converged clean

Closes #4298

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v