### PR TITLE
feat: multiline chat composer (Enter sends, Shift+Enter newline)

### DIFF
--- a/e2e/browser/accessibility.spec.ts
+++ b/e2e/browser/accessibility.spec.ts
@@ -23,7 +23,7 @@ async function assertNoAxeViolations(page: Page) {
 test.describe("Accessibility", () => {
   test("chat page has zero critical/serious axe violations", async ({ page }) => {
     await page.goto("/");
-    await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
     await assertNoAxeViolations(page);
   });
 

--- a/e2e/browser/auth.spec.ts
+++ b/e2e/browser/auth.spec.ts
@@ -14,7 +14,7 @@ async function login(page: import("@playwright/test").Page, email: string, passw
 }
 
 async function waitForChatUI(page: import("@playwright/test").Page) {
-  await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+  await page.locator('textarea[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
 
   // Dismiss password change dialog if it appears (shouldn't after setup, but just in case)
   const changeDialog = page.locator("text=Change your password");
@@ -44,7 +44,7 @@ test.describe("Auth Flows", () => {
     await waitForChatUI(page);
 
     await expect(
-      page.locator('input[placeholder="Ask a question about your data..."]'),
+      page.locator('textarea[placeholder="Ask a question about your data..."]'),
     ).toBeVisible();
   });
 
@@ -83,7 +83,7 @@ test.describe("Auth Flows", () => {
     await waitForChatUI(page);
 
     await expect(
-      page.locator('input[placeholder="Ask a question about your data..."]'),
+      page.locator('textarea[placeholder="Ask a question about your data..."]'),
     ).toBeVisible();
   });
 

--- a/e2e/browser/composer-multiline.spec.ts
+++ b/e2e/browser/composer-multiline.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { ensureChatReady } from "./helpers";
+
+/**
+ * #4295 — the multiline composer. Shift+Enter inserts a newline (and the
+ * textarea grows to show it); Enter sends the whole two-line message as one
+ * user turn. The non-send assertions (value, growth) run before the send so
+ * they cost no LLM tokens if they fail.
+ */
+test.describe("Multiline composer @llm", () => {
+  // The send is a real agent turn; LLM turns take 60-120s via gateway.
+  test.describe.configure({ timeout: 300_000 });
+
+  test("Shift+Enter produces a two-line message; Enter sends it", async ({ page }) => {
+    await ensureChatReady(page);
+    const composer = page.locator('textarea[placeholder="Ask a question about your data..."]');
+
+    await composer.fill("how many companies are there?");
+    const singleLineBox = await composer.boundingBox();
+
+    await composer.press("Shift+Enter");
+    await composer.pressSequentially("answer in one short sentence.");
+
+    // Shift+Enter inserted a literal newline — one value, two lines.
+    await expect(composer).toHaveValue(
+      "how many companies are there?\nanswer in one short sentence.",
+    );
+
+    // The composer grew to fit the second line (auto-grow, not inner scroll).
+    const twoLineBox = await composer.boundingBox();
+    expect(twoLineBox!.height).toBeGreaterThan(singleLineBox!.height);
+
+    // Enter sends the two-line message as ONE user turn. Playwright's text
+    // matcher normalizes the newline to a space, so a single-locator hit on
+    // the joined text proves both lines landed in the same message.
+    await composer.press("Enter");
+    await expect(
+      page.getByText("how many companies are there? answer in one short sentence."),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The composer cleared and locked for the streaming turn…
+    await expect(composer).toHaveValue("");
+    await expect(composer).toBeDisabled({ timeout: 10_000 });
+
+    // …and unlocks when the turn completes, leaving a clean state behind.
+    await expect(composer).toBeEnabled({ timeout: 180_000 });
+  });
+});

--- a/e2e/browser/composer-multiline.spec.ts
+++ b/e2e/browser/composer-multiline.spec.ts
@@ -3,9 +3,10 @@ import { ensureChatReady } from "./helpers";
 
 /**
  * #4295 — the multiline composer. Shift+Enter inserts a newline (and the
- * textarea grows to show it); Enter sends the whole two-line message as one
- * user turn. The non-send assertions (value, growth) run before the send so
- * they cost no LLM tokens if they fail.
+ * textarea grows to show it), growth caps at max-h-40 (160px) with inner
+ * scroll, and Enter sends the whole two-line message as one user turn. The
+ * non-send assertions (value, growth, cap) run before the send so they cost
+ * no LLM tokens if they fail.
  */
 test.describe("Multiline composer @llm", () => {
   // The send is a real agent turn; LLM turns take 60-120s via gateway.
@@ -17,6 +18,7 @@ test.describe("Multiline composer @llm", () => {
 
     await composer.fill("how many companies are there?");
     const singleLineBox = await composer.boundingBox();
+    expect(singleLineBox, "composer must be visible before Shift+Enter").not.toBeNull();
 
     await composer.press("Shift+Enter");
     await composer.pressSequentially("answer in one short sentence.");
@@ -28,18 +30,38 @@ test.describe("Multiline composer @llm", () => {
 
     // The composer grew to fit the second line (auto-grow, not inner scroll).
     const twoLineBox = await composer.boundingBox();
+    expect(twoLineBox).not.toBeNull();
     expect(twoLineBox!.height).toBeGreaterThan(singleLineBox!.height);
+
+    // Growth caps at max-h-40 (160px), after which the textarea scrolls
+    // instead of eating the viewport.
+    for (let i = 0; i < 12; i++) await composer.press("Shift+Enter");
+    const cappedBox = await composer.boundingBox();
+    expect(cappedBox).not.toBeNull();
+    expect(cappedBox!.height).toBeLessThanOrEqual(161);
+    expect(
+      await composer.evaluate((el) => el.scrollHeight > el.clientHeight),
+      "content beyond the cap must scroll inside the textarea",
+    ).toBe(true);
+
+    // Restore the two-line message for the send.
+    await composer.fill("how many companies are there?\nanswer in one short sentence.");
 
     // Enter sends the two-line message as ONE user turn. Playwright's text
     // matcher normalizes the newline to a space, so a single-locator hit on
-    // the joined text proves both lines landed in the same message.
+    // the joined text shows both lines landed together (the toHaveValue
+    // assertion above is what rules out a split send).
     await composer.press("Enter");
     await expect(
       page.getByText("how many companies are there? answer in one short sentence."),
     ).toBeVisible({ timeout: 10_000 });
 
-    // The composer cleared and locked for the streaming turn…
+    // The composer cleared, shrank back to a single line, and locked for the
+    // streaming turn…
     await expect(composer).toHaveValue("");
+    const clearedBox = await composer.boundingBox();
+    expect(clearedBox).not.toBeNull();
+    expect(clearedBox!.height).toBe(singleLineBox!.height);
     await expect(composer).toBeDisabled({ timeout: 10_000 });
 
     // …and unlocks when the turn completes, leaving a clean state behind.

--- a/e2e/browser/forgot-password.spec.ts
+++ b/e2e/browser/forgot-password.spec.ts
@@ -109,7 +109,7 @@ test.describe("Password reset", () => {
     await page.locator('input[type="password"]').fill(NEW_PASSWORD);
     await page.locator('button[type="submit"]').click();
     await expect(
-      page.locator('input[placeholder="Ask a question about your data..."]'),
+      page.locator('textarea[placeholder="Ask a question about your data..."]'),
     ).toBeVisible({ timeout: 15_000 });
 
     // 5. Rotate back to the e2e password so other specs can log in.

--- a/e2e/browser/global-setup.ts
+++ b/e2e/browser/global-setup.ts
@@ -38,7 +38,7 @@ setup("authenticate as admin", async ({ page }) => {
     await page.locator('button[type="submit"]').click();
 
     // Wait for either: chat UI loads, or error appears (locator.or avoids dangling promises)
-    const chatInput = page.locator('input[placeholder="Ask a question about your data..."]');
+    const chatInput = page.locator('textarea[placeholder="Ask a question about your data..."]');
     const errorMsg = page.getByText(/invalid|incorrect/i).first();
     const outcome = chatInput.or(errorMsg);
 
@@ -92,7 +92,7 @@ setup("authenticate as admin", async ({ page }) => {
     const changeDialog = page.locator("text=Change your password");
     if (await changeDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
       await page.reload();
-      await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+      await page.locator('textarea[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
     }
   }
 

--- a/e2e/browser/helpers.ts
+++ b/e2e/browser/helpers.ts
@@ -2,7 +2,7 @@ import { type Page, expect } from "@playwright/test";
 
 /** Send a chat message and wait for the response to finish streaming. */
 export async function askQuestion(page: Page, question: string) {
-  const input = page.locator('input[placeholder="Ask a question about your data..."]');
+  const input = page.locator('textarea[placeholder="Ask a question about your data..."]');
   await input.fill(question);
 
   // Click the "Ask" button specifically (not any other submit button like password change)
@@ -27,7 +27,7 @@ export async function waitForSQLResult(page: Page) {
 export async function startNewChat(page: Page) {
   await page.locator('button:has-text("+ New")').click();
 
-  const input = page.locator('input[placeholder="Ask a question about your data..."]');
+  const input = page.locator('textarea[placeholder="Ask a question about your data..."]');
   await expect(input).toHaveValue("");
 }
 
@@ -43,6 +43,6 @@ export async function dismissTourIfVisible(page: Page) {
 /** Navigate to home and ensure chat UI is ready. */
 export async function ensureChatReady(page: Page) {
   await page.goto("/");
-  await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+  await page.locator('textarea[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
   await dismissTourIfVisible(page);
 }

--- a/e2e/browser/mobile.spec.ts
+++ b/e2e/browser/mobile.spec.ts
@@ -5,7 +5,7 @@ test.describe("Mobile Responsive", () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto("/");
 
-    const input = page.locator('input[placeholder="Ask a question about your data..."]');
+    const input = page.locator('textarea[placeholder="Ask a question about your data..."]');
     await input.waitFor({ timeout: 15_000 });
     await expect(input).toBeVisible();
 
@@ -22,7 +22,7 @@ test.describe("Mobile Responsive", () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto("/");
 
-    await page.locator('input[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
+    await page.locator('textarea[placeholder="Ask a question about your data..."]').waitFor({ timeout: 15_000 });
 
     await page.getByRole("button", { name: "Toggle Sidebar" }).first().click();
 
@@ -36,7 +36,7 @@ test.describe("Mobile Responsive", () => {
     await page.setViewportSize({ width: 768, height: 1024 });
     await page.goto("/");
 
-    const input = page.locator('input[placeholder="Ask a question about your data..."]');
+    const input = page.locator('textarea[placeholder="Ask a question about your data..."]');
     await input.waitFor({ timeout: 15_000 });
     await expect(input).toBeVisible();
 

--- a/e2e/browser/passkey-signin.spec.ts
+++ b/e2e/browser/passkey-signin.spec.ts
@@ -187,7 +187,7 @@ test.describe("Passkey-only sign-in (no password) @llm", () => {
       // After a successful signIn.passkey(), the page navigates to "/".
       // Reaching the chat UI proves an authenticated session exists.
       await expect(
-        page.locator('input[placeholder="Ask a question about your data..."]'),
+        page.locator('textarea[placeholder="Ask a question about your data..."]'),
       ).toBeVisible({ timeout: 15_000 });
 
       // Sanity: an authenticated route is reachable. /api/v1/admin/audit

--- a/e2e/browser/stop-button.spec.ts
+++ b/e2e/browser/stop-button.spec.ts
@@ -16,7 +16,7 @@ test.describe("Stop button @llm", () => {
   });
 
   test("stopping an in-flight turn unlocks the composer and the next send succeeds", async ({ page }) => {
-    const input = page.locator('input[placeholder="Ask a question about your data..."]');
+    const input = page.locator('textarea[placeholder="Ask a question about your data..."]');
 
     await input.fill("how many companies are there?");
     await page.getByRole("button", { name: "Send" }).click();

--- a/packages/web/src/ui/__tests__/chat-composer.test.tsx
+++ b/packages/web/src/ui/__tests__/chat-composer.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * #4295 — the multiline chat composer. Covers the acceptance criteria at the
+ * component boundary:
+ *   - Enter sends the current value (and never inserts a newline)
+ *   - Shift+Enter does NOT send — the default newline insertion is left alone
+ *   - Enter mid-IME-composition commits the composition instead of sending
+ *   - streaming ⇒ textarea locked, send slot becomes a Stop control
+ *   - loadingConversation ⇒ textarea and Send both locked
+ *   - empty value ⇒ Enter still prevents the default (no leading newline);
+ *     the empty-send no-op guard itself lives in the caller (`handleSend`)
+ * Auto-grow is height-measurement driven and is covered by the browser test
+ * (e2e/browser/composer-multiline.spec.ts), not here — happy-dom has no layout.
+ */
+import { describe, expect, test, afterEach, mock } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { ChatComposer } from "../components/chat/chat-composer";
+
+afterEach(() => cleanup());
+
+function renderComposer(overrides: Partial<Parameters<typeof ChatComposer>[0]> = {}) {
+  const props = {
+    value: "how many companies are there?",
+    onValueChange: mock((_v: string) => {}),
+    onSend: mock((_text: string) => {}),
+    streaming: false,
+    loadingConversation: false,
+    onStop: mock(() => {}),
+    ...overrides,
+  };
+  const utils = render(<ChatComposer {...props} />);
+  const textarea = utils.getByLabelText("Chat message") as HTMLTextAreaElement;
+  return { ...utils, props, textarea };
+}
+
+describe("ChatComposer (#4295)", () => {
+  test("renders a textarea (not an input) with the current value", () => {
+    const { textarea } = renderComposer();
+    expect(textarea.tagName).toBe("TEXTAREA");
+    expect(textarea.value).toBe("how many companies are there?");
+  });
+
+  test("Enter sends the current value and prevents the default newline", () => {
+    const { textarea, props } = renderComposer();
+    const notPrevented = fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(props.onSend).toHaveBeenCalledTimes(1);
+    expect(props.onSend).toHaveBeenCalledWith("how many companies are there?");
+    // fireEvent returns false when preventDefault() was called.
+    expect(notPrevented).toBe(false);
+  });
+
+  test("Shift+Enter does not send and leaves the default alone (newline inserts)", () => {
+    const { textarea, props } = renderComposer();
+    const notPrevented = fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(props.onSend).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true);
+  });
+
+  test("Enter during IME composition commits the composition, not a send", () => {
+    const { textarea, props } = renderComposer();
+    const notPrevented = fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+    expect(props.onSend).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true);
+  });
+
+  test("Enter on an empty composer still prevents default (no leading newline)", () => {
+    const { textarea, props } = renderComposer({ value: "" });
+    const notPrevented = fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(notPrevented).toBe(false);
+    // The composer delegates; the trim/no-op guard is handleSend's.
+    expect(props.onSend).toHaveBeenCalledWith("");
+  });
+
+  test("typing forwards the new value through onValueChange", () => {
+    const { textarea, props } = renderComposer();
+    fireEvent.change(textarea, { target: { value: "line one\nline two" } });
+    expect(props.onValueChange).toHaveBeenCalledWith("line one\nline two");
+  });
+
+  test("clicking Send submits the current value", () => {
+    const { getByLabelText, props } = renderComposer();
+    fireEvent.click(getByLabelText("Send"));
+    expect(props.onSend).toHaveBeenCalledTimes(1);
+    expect(props.onSend).toHaveBeenCalledWith("how many companies are there?");
+  });
+
+  test("empty value marks Send aria-disabled (empty-input affordance)", () => {
+    const { getByLabelText } = renderComposer({ value: "   " });
+    expect(getByLabelText("Send").getAttribute("aria-disabled")).toBe("true");
+  });
+
+  test("streaming: textarea is locked and the send slot becomes Stop", () => {
+    const { textarea, getByLabelText, queryByLabelText, props } = renderComposer({
+      streaming: true,
+    });
+    expect(textarea.disabled).toBe(true);
+    expect(queryByLabelText("Send")).toBeNull();
+    const stop = getByLabelText("Stop");
+    // type="button" so Stop can never submit the form (#4294).
+    expect(stop.getAttribute("type")).toBe("button");
+    fireEvent.click(stop);
+    expect(props.onStop).toHaveBeenCalledTimes(1);
+  });
+
+  test("loadingConversation: textarea and Send are both locked (#3068)", () => {
+    const { textarea, getByLabelText, props } = renderComposer({
+      loadingConversation: true,
+    });
+    expect(textarea.disabled).toBe(true);
+    expect((getByLabelText("Send") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(props.onSend).not.toHaveBeenCalled();
+  });
+
+  test("iOS no-zoom sizing: text-base at mobile widths, sm:text-sm above", () => {
+    const { textarea } = renderComposer();
+    expect(textarea.className).toContain("text-base");
+    expect(textarea.className).toContain("sm:text-sm");
+  });
+});

--- a/packages/web/src/ui/__tests__/chat-composer.test.tsx
+++ b/packages/web/src/ui/__tests__/chat-composer.test.tsx
@@ -3,13 +3,17 @@
  * component boundary:
  *   - Enter sends the current value (and never inserts a newline)
  *   - Shift+Enter does NOT send — the default newline insertion is left alone
- *   - Enter mid-IME-composition commits the composition instead of sending
- *   - streaming ⇒ textarea locked, send slot becomes a Stop control
+ *   - Enter mid-IME-composition never sends (left to the IME to commit)
+ *   - streaming ⇒ textarea locked, send slot becomes a Stop control, and no
+ *     path (Enter, form submit) reaches onSend
  *   - loadingConversation ⇒ textarea and Send both locked
- *   - empty value ⇒ Enter still prevents the default (no leading newline);
- *     the empty-send no-op guard itself lives in the caller (`handleSend`)
- * Auto-grow is height-measurement driven and is covered by the browser test
- * (e2e/browser/composer-multiline.spec.ts), not here — happy-dom has no layout.
+ *   - empty value ⇒ Enter still prevents the default (no leading newline) and
+ *     onSend is never called (`handleSend` re-applies the same guard for the
+ *     chip / starter-prompt / retry paths that bypass the composer)
+ * Auto-grow *measurement* is layout-driven and is covered by the browser test
+ * (e2e/browser/composer-multiline.spec.ts) — happy-dom has no layout — but the
+ * effect's mechanism (style.height written on `value` changes, including
+ * programmatic fills) is pinned here.
  */
 import { describe, expect, test, afterEach, mock } from "bun:test";
 import { render, cleanup, fireEvent } from "@testing-library/react";
@@ -55,19 +59,25 @@ describe("ChatComposer (#4295)", () => {
     expect(notPrevented).toBe(true);
   });
 
-  test("Enter during IME composition commits the composition, not a send", () => {
+  test("Enter during IME composition does not send and leaves the default alone", () => {
     const { textarea, props } = renderComposer();
     const notPrevented = fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
     expect(props.onSend).not.toHaveBeenCalled();
     expect(notPrevented).toBe(true);
   });
 
-  test("Enter on an empty composer still prevents default (no leading newline)", () => {
+  test("Enter on an empty composer prevents default (no leading newline) and does not send", () => {
     const { textarea, props } = renderComposer({ value: "" });
     const notPrevented = fireEvent.keyDown(textarea, { key: "Enter" });
     expect(notPrevented).toBe(false);
-    // The composer delegates; the trim/no-op guard is handleSend's.
-    expect(props.onSend).toHaveBeenCalledWith("");
+    expect(props.onSend).not.toHaveBeenCalled();
+  });
+
+  test("whitespace-only value never reaches onSend (Enter or Send click)", () => {
+    const { textarea, getByLabelText, props } = renderComposer({ value: "   \n  " });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.click(getByLabelText("Send"));
+    expect(props.onSend).not.toHaveBeenCalled();
   });
 
   test("typing forwards the new value through onValueChange", () => {
@@ -101,6 +111,17 @@ describe("ChatComposer (#4295)", () => {
     expect(props.onStop).toHaveBeenCalledTimes(1);
   });
 
+  test("streaming: neither Enter nor a form submit reaches onSend", () => {
+    const { textarea, container, props } = renderComposer({ streaming: true });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    // A real browser can't submit here (Stop is type="button"), but the
+    // component holds its own invariant for any future submit trigger.
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(props.onSend).not.toHaveBeenCalled();
+  });
+
   test("loadingConversation: textarea and Send are both locked (#3068)", () => {
     const { textarea, getByLabelText, props } = renderComposer({
       loadingConversation: true,
@@ -115,5 +136,17 @@ describe("ChatComposer (#4295)", () => {
     const { textarea } = renderComposer();
     expect(textarea.className).toContain("text-base");
     expect(textarea.className).toContain("sm:text-sm");
+  });
+
+  test("auto-grow effect re-writes style.height when `value` changes programmatically", () => {
+    // happy-dom has no layout (scrollHeight is 0), so the browser spec owns
+    // the measured growth; this pins the mechanism — the [value]-keyed effect
+    // writes an explicit height for ANY value change (prefill, restore), not
+    // just user typing.
+    const { textarea, props, rerender } = renderComposer({ value: "one line" });
+    expect(textarea.style.height).not.toBe("");
+    textarea.style.height = ""; // clear what mount wrote
+    rerender(<ChatComposer {...props} value={"one line\ntwo lines"} />);
+    expect(textarea.style.height).toBe(`${textarea.scrollHeight}px`);
   });
 });

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -12,6 +12,7 @@ import { UserMenu } from "./user-menu";
 import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations, transformMessages } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
+import { ChatComposer } from "./chat/chat-composer";
 import { ErrorBanner } from "./chat/error-banner";
 import { ContextWarningBanner } from "./chat/context-warning-banner";
 import { ResumeBanner } from "./chat/resume-banner";
@@ -44,7 +45,7 @@ import { ShareDialog } from "./chat/share-dialog";
 import { ConversationSidebar } from "./conversations/conversation-sidebar";
 import { ChangePasswordDialog } from "./admin/change-password-dialog";
 import { usePasswordStatus } from "@/ui/hooks/use-password-status";
-import { Star, TableProperties, BookOpen, Send, Pin, Square } from "lucide-react";
+import { Star, TableProperties, BookOpen, Pin } from "lucide-react";
 import { SchemaExplorer } from "./schema-explorer/schema-explorer";
 import { ConversationMemoryControl } from "./conversation-memory-control";
 import { PromptLibrary } from "./chat/prompt-library";
@@ -52,7 +53,6 @@ import { StarterPromptList } from "./chat/starter-prompt-list";
 import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import { useContextWarnings } from "../hooks/use-context-warnings";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { parseSuggestions } from "../lib/helpers";
 import { ErrorBoundary } from "./error-boundary";
@@ -1274,51 +1274,14 @@ export function AtlasChat({
                     empty state above, so the two never disagree (composer hidden
                     ⇔ override shown). */}
                 {!(showDataSetupGate && messages.length === 0) && (
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    handleSend(input);
-                  }}
-                  className="flex flex-none gap-2 border-t border-zinc-100 pt-4 dark:border-zinc-800"
-                >
-                  <Input
+                  <ChatComposer
                     value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    placeholder="Ask a question about your data..."
-                    className="min-w-0 flex-1 py-3 text-base sm:text-sm"
-                    // #3068 — also disabled while a conversation's history loads
-                    // (deep link / sidebar open) so a send can't race the load.
-                    disabled={isLoading || loadingConversation}
-                    aria-label="Chat message"
+                    onValueChange={setInput}
+                    onSend={handleSend}
+                    streaming={isLoading}
+                    loadingConversation={loadingConversation}
+                    onStop={stopTurn}
                   />
-                  {/* #4294 — while a turn streams, the send slot becomes a Stop
-                      control: aborts the client stream (composer unlocks
-                      immediately) and best-effort cancels generation server-side.
-                      `type="button"` so it can never submit the form. */}
-                  {isLoading ? (
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="outline"
-                      onClick={stopTurn}
-                      aria-label="Stop"
-                      className="size-10 shrink-0"
-                    >
-                      <Square className="size-3.5" fill="currentColor" />
-                    </Button>
-                  ) : (
-                    <Button
-                      type="submit"
-                      size="icon"
-                      disabled={loadingConversation}
-                      aria-disabled={!input.trim() ? true : undefined}
-                      aria-label="Send"
-                      className="size-10 shrink-0"
-                    >
-                      <Send className="size-4" />
-                    </Button>
-                  )}
-                </form>
                 )}
               </>
             )}

--- a/packages/web/src/ui/components/chat/chat-composer.tsx
+++ b/packages/web/src/ui/components/chat/chat-composer.tsx
@@ -9,8 +9,9 @@ interface ChatComposerProps {
   value: string;
   onValueChange: (value: string) => void;
   /**
-   * Send `value`. The caller owns the guards (empty-input trim no-op,
-   * loading-conversation drop) — see `handleSend` in atlas-chat.tsx.
+   * Send `value`. The composer skips the call while locked or when the value
+   * is whitespace-only; `handleSend` in atlas-chat.tsx re-applies both guards
+   * (it is also reached by chip / starter-prompt / retry paths).
    */
   onSend: (text: string) => void;
   /** True while a turn streams — locks the textarea and swaps Send → Stop. */
@@ -27,8 +28,9 @@ interface ChatComposerProps {
  * #4295 — the multiline chat composer: an auto-growing textarea where Enter
  * sends and Shift+Enter inserts a newline. Grows with content up to the
  * `max-h-40` cap, then scrolls. Mobile virtual keyboards fire plain Enter, so
- * the return key sends there too — exactly the single-line composer's
- * behavior; the on-screen Send button is the affordance either way.
+ * the return key sends there too — matching the single-line composer, where
+ * Enter also sent (via implicit form submission); the on-screen Send button
+ * is the affordance either way.
  */
 export function ChatComposer({
   value,
@@ -41,10 +43,22 @@ export function ChatComposer({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const locked = streaming || loadingConversation;
 
+  // Defense-in-depth around onSend: both send paths (Enter keydown, form
+  // submit) funnel through here. A disabled textarea never fires keydown and
+  // Stop/Send button states already block submit in a real browser, but the
+  // component should hold its own invariants for any future trigger.
+  function trySend() {
+    if (locked) return;
+    if (!value.trim()) return;
+    onSend(value);
+  }
+
   // Auto-grow with content; the CSS max-height caps it, after which the
   // textarea scrolls. Height is JS-driven (same approach as NotebookCellInput)
-  // because CSS `field-sizing: content` hasn't shipped in Safari — the iOS
-  // no-zoom requirement makes Safari a first-class target here. Keyed on
+  // because CSS `field-sizing: content` hasn't shipped in Safari as of 2026 —
+  // the iOS no-zoom requirement makes Safari a first-class target here (the
+  // explicit `field-sizing-fixed` below opts out of the base primitive's
+  // `field-sizing-content` so only one mechanism drives the height). Keyed on
   // `value` rather than onChange so programmatic fills — the `?prompt=`
   // prefill, schema-explorer inserts, restore-on-send-failure — resize too.
   useLayoutEffect(() => {
@@ -58,7 +72,7 @@ export function ChatComposer({
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        onSend(value);
+        trySend();
       }}
       className="flex flex-none items-end gap-2 border-t border-zinc-100 pt-4 dark:border-zinc-800"
     >
@@ -68,21 +82,19 @@ export function ChatComposer({
         onChange={(e) => onValueChange(e.target.value)}
         onKeyDown={(e) => {
           if (e.key !== "Enter" || e.shiftKey) return;
-          // Enter mid-IME-composition commits the composition; only a plain
-          // Enter outside composition sends.
+          // Enter mid-IME-composition is left to the IME to commit (the
+          // handler stands down); only a plain Enter outside composition sends.
           if (e.nativeEvent.isComposing) return;
           // Always swallow plain Enter (an empty composer must not gain a
-          // leading newline); a disabled textarea never fires keydown in a
-          // real browser, but guard anyway for programmatic dispatch.
+          // leading newline), then let trySend apply the locked/empty guards.
           e.preventDefault();
-          if (locked) return;
-          onSend(value);
+          trySend();
         }}
         placeholder="Ask a question about your data..."
         rows={1}
         // text-base at mobile widths so iOS doesn't zoom on focus;
         // min-h-10 keeps the single-line composer flush with the size-10 button.
-        className="max-h-40 min-h-10 min-w-0 flex-1 resize-none overflow-y-auto text-base sm:text-sm"
+        className="field-sizing-fixed max-h-40 min-h-10 min-w-0 flex-1 resize-none overflow-y-auto text-base sm:text-sm"
         disabled={locked}
         aria-label="Chat message"
       />

--- a/packages/web/src/ui/components/chat/chat-composer.tsx
+++ b/packages/web/src/ui/components/chat/chat-composer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useLayoutEffect, useRef } from "react";
+import { Send, Square } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface ChatComposerProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  /**
+   * Send `value`. The caller owns the guards (empty-input trim no-op,
+   * loading-conversation drop) — see `handleSend` in atlas-chat.tsx.
+   */
+  onSend: (text: string) => void;
+  /** True while a turn streams — locks the textarea and swaps Send → Stop. */
+  streaming: boolean;
+  /**
+   * #3068 — true while a conversation's history loads (deep link / sidebar
+   * open); locks the composer so a send can't race the load.
+   */
+  loadingConversation: boolean;
+  onStop: () => void;
+}
+
+/**
+ * #4295 — the multiline chat composer: an auto-growing textarea where Enter
+ * sends and Shift+Enter inserts a newline. Grows with content up to the
+ * `max-h-40` cap, then scrolls. Mobile virtual keyboards fire plain Enter, so
+ * the return key sends there too — exactly the single-line composer's
+ * behavior; the on-screen Send button is the affordance either way.
+ */
+export function ChatComposer({
+  value,
+  onValueChange,
+  onSend,
+  streaming,
+  loadingConversation,
+  onStop,
+}: ChatComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const locked = streaming || loadingConversation;
+
+  // Auto-grow with content; the CSS max-height caps it, after which the
+  // textarea scrolls. Height is JS-driven (same approach as NotebookCellInput)
+  // because CSS `field-sizing: content` hasn't shipped in Safari — the iOS
+  // no-zoom requirement makes Safari a first-class target here. Keyed on
+  // `value` rather than onChange so programmatic fills — the `?prompt=`
+  // prefill, schema-explorer inserts, restore-on-send-failure — resize too.
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSend(value);
+      }}
+      className="flex flex-none items-end gap-2 border-t border-zinc-100 pt-4 dark:border-zinc-800"
+    >
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter" || e.shiftKey) return;
+          // Enter mid-IME-composition commits the composition; only a plain
+          // Enter outside composition sends.
+          if (e.nativeEvent.isComposing) return;
+          // Always swallow plain Enter (an empty composer must not gain a
+          // leading newline); a disabled textarea never fires keydown in a
+          // real browser, but guard anyway for programmatic dispatch.
+          e.preventDefault();
+          if (locked) return;
+          onSend(value);
+        }}
+        placeholder="Ask a question about your data..."
+        rows={1}
+        // text-base at mobile widths so iOS doesn't zoom on focus;
+        // min-h-10 keeps the single-line composer flush with the size-10 button.
+        className="max-h-40 min-h-10 min-w-0 flex-1 resize-none overflow-y-auto text-base sm:text-sm"
+        disabled={locked}
+        aria-label="Chat message"
+      />
+      {/* #4294 — while a turn streams, the send slot becomes a Stop control:
+          aborts the client stream (composer unlocks immediately) and
+          best-effort cancels generation server-side. `type="button"` so it
+          can never submit the form. */}
+      {streaming ? (
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onClick={onStop}
+          aria-label="Stop"
+          className="size-10 shrink-0"
+        >
+          <Square className="size-3.5" fill="currentColor" />
+        </Button>
+      ) : (
+        <Button
+          type="submit"
+          size="icon"
+          disabled={loadingConversation}
+          aria-disabled={!value.trim() ? true : undefined}
+          aria-label="Send"
+          className="size-10 shrink-0"
+        >
+          <Send className="size-4" />
+        </Button>
+      )}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the single-line `<Input>` chat composer with an auto-growing shadcn `Textarea`, extracted into a dedicated `ChatComposer` component (`packages/web/src/ui/components/chat/chat-composer.tsx`) — Enter sends, Shift+Enter inserts a newline, Enter mid-IME-composition never sends
- Grows with content up to `max-h-40` (160px) then scrolls; height is JS-driven keyed on `value` (NotebookCellInput precedent, with explicit `field-sizing-fixed` so only one mechanism drives height) so programmatic fills (`?prompt=` prefill, schema-explorer insert, restore-on-send-failure) resize too
- Preserves every existing behavior: `?prompt=` prefill, disabled-while-loading (#3068), empty-input no-op guard (now also enforced in-component as defense-in-depth), iOS `text-base sm:text-sm` no-zoom sizing, and the #4294 Stop control in the send slot
- 14 unit tests at the component boundary + new `@llm` browser spec (Shift+Enter two-line value, measured growth, 160px cap + inner scroll, Enter sends as one turn, shrink-back after send); e2e selectors updated `input` → `textarea` across specs/helpers

## Test plan
- [x] `bun test packages/web/src/ui/__tests__/chat-composer.test.tsx` — 14 pass
- [x] Full local CI wrapper (`scripts/ci-local.sh`) — all 27 gates green
- [x] Verified live against a local self-hosted stack via Playwright: 40→56px growth on Shift+Enter, 160px cap with inner scroll, two-line bubble renders `pre-wrap`, empty Enter no-ops, mobile 375px font-size 16px (no iOS zoom), `?prompt=` prefill lands and resizes, Stop unlocks the composer
- [ ] `e2e/browser/composer-multiline.spec.ts` (@llm) in the browser-test lane

Slice of PRD #4292. Internal review panel (4 specialist reviewers): CLEAN — advisory findings fixed in-branch.

Closes #4295

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v