### PR TITLE
feat(discovery): scopes_supported + canonical auth.md heading for agent readiness

### DIFF
--- a/apps/docs/src/app/.well-known/oauth-protected-resource/resource-metadata.generated.json
+++ b/apps/docs/src/app/.well-known/oauth-protected-resource/resource-metadata.generated.json
@@ -6,6 +6,10 @@
   "bearer_methods_supported": [
     "header"
   ],
+  "scopes_supported": [
+    "mcp:read",
+    "mcp:write"
+  ],
   "resource_documentation": "https://docs.useatlas.dev/api-reference",
   "resource_name": "Atlas API",
   "resource_policy_uri": "https://www.useatlas.dev/privacy",

--- a/apps/www/public/.well-known/oauth-protected-resource.json
+++ b/apps/www/public/.well-known/oauth-protected-resource.json
@@ -6,6 +6,10 @@
   "bearer_methods_supported": [
     "header"
   ],
+  "scopes_supported": [
+    "mcp:read",
+    "mcp:write"
+  ],
   "resource_documentation": "https://docs.useatlas.dev/api-reference",
   "resource_name": "Atlas API",
   "resource_policy_uri": "https://www.useatlas.dev/privacy",

--- a/apps/www/public/auth.md
+++ b/apps/www/public/auth.md
@@ -1,6 +1,7 @@
-# Connecting an agent to Atlas
+# auth.md
 
-This document is for autonomous agents (and the humans integrating them).
+**Connecting an agent to Atlas.** This document is for autonomous agents (and
+the humans integrating them).
 It describes how to register with Atlas and connect an MCP client, from a
 cold start with no account, workspace, or credentials. Every flow named
 here already exists; this file introduces no new authentication mechanism —

--- a/apps/www/serve.test.ts
+++ b/apps/www/serve.test.ts
@@ -25,7 +25,7 @@ let handleRequest: (req: Request) => Promise<Response>;
 let fixtureDir: string;
 let prevOutDir: string | undefined;
 
-const AUTH_MD_BODY = "# Connecting an agent to Atlas\n";
+const AUTH_MD_BODY = "# auth.md\n";
 
 beforeAll(async () => {
   fixtureDir = mkdtempSync(join(tmpdir(), "www-serve-"));
@@ -66,7 +66,7 @@ describe("apex agent discovery — /auth.md", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
-    expect(await res.text()).toContain("Connecting an agent to Atlas");
+    expect(await res.text()).toContain("# auth.md");
   });
 
   it("answers the OPTIONS preflight it advertises with 204 + CORS", async () => {

--- a/packages/api/scripts/generate-apex-discovery.ts
+++ b/packages/api/scripts/generate-apex-discovery.ts
@@ -63,6 +63,7 @@ interface ProtectedResourceMetadata {
   readonly resource: string;
   readonly authorization_servers: readonly string[];
   readonly bearer_methods_supported: readonly string[];
+  readonly scopes_supported: readonly string[];
   readonly resource_documentation: string;
   readonly resource_name: string;
   readonly resource_policy_uri: string;
@@ -84,6 +85,14 @@ export const API_PROTECTED_RESOURCE = {
   resource: "https://api.useatlas.dev",
   authorization_servers: ["https://api.useatlas.dev"],
   bearer_methods_supported: ["header"],
+  // The scopes an agent requests when obtaining an access token for this
+  // resource. RFC 9728 §2 lists `scopes_supported` as OPTIONAL, but agent
+  // readiness scanners (and the MCP authorization spec) expect it, and the
+  // sibling per-workspace MCP protected-resource metadata advertises the same
+  // `mcp:*` set (well-known.ts). These are the data-access scopes the Atlas
+  // authorization server issues; the OIDC sign-in scopes (openid/profile/email)
+  // are advertised by the auth-server metadata, not the resource.
+  scopes_supported: ["mcp:read", "mcp:write"],
   resource_documentation: "https://docs.useatlas.dev/api-reference",
   resource_name: "Atlas API",
   resource_policy_uri: "https://www.useatlas.dev/privacy",

--- a/packages/api/src/api/__tests__/apex-discovery-generator.test.ts
+++ b/packages/api/src/api/__tests__/apex-discovery-generator.test.ts
@@ -48,6 +48,12 @@ describe("apex-discovery generator", () => {
       "https://api.useatlas.dev",
     ]);
     expect(API_PROTECTED_RESOURCE.bearer_methods_supported).toEqual(["header"]);
+    // scopes_supported is what an agent-readiness scanner (and the MCP auth
+    // spec) look for; it mirrors the sibling MCP protected-resource metadata.
+    expect(API_PROTECTED_RESOURCE.scopes_supported).toEqual([
+      "mcp:read",
+      "mcp:write",
+    ]);
     expect(API_PROTECTED_RESOURCE.resource_policy_uri).toBe(
       "https://www.useatlas.dev/privacy",
     );

--- a/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
+++ b/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
@@ -48,7 +48,7 @@ const HOSTS: ResolvedHosts = {
 const ADVERTISED_SCOPES = ["mcp:read", "mcp:write"] as const;
 
 const FAITHFUL_DOC = [
-  "# Connecting an agent to Atlas",
+  "# auth.md",
   "- Authorization server (issuer): `https://api.useatlas.dev/api/auth`",
   "- MCP resource server: `https://mcp.useatlas.dev/mcp`",
   "Metadata: `https://api.useatlas.dev/.well-known/oauth-authorization-server/api/auth`",

--- a/packages/api/src/lib/mcp/auth-md.ts
+++ b/packages/api/src/lib/mcp/auth-md.ts
@@ -106,9 +106,10 @@ export function buildAuthMd(opts: BuildAuthMdOptions): string {
     .map((s) => `- \`${s.name}\` — ${s.grants}`)
     .join("\n");
 
-  return `# Connecting an agent to Atlas
+  return `# auth.md
 
-This document is for autonomous agents (and the humans integrating them).
+**Connecting an agent to Atlas.** This document is for autonomous agents (and
+the humans integrating them).
 It describes how to register with Atlas and connect an MCP client, from a
 cold start with no account, workspace, or credentials. Every flow named
 here already exists; this file introduces no new authentication mechanism —


### PR DESCRIPTION
## Summary

Closes two agent-readiness gaps on the apex discovery surface (`useatlas.dev` + docs) flagged by an [isitagentready.com](https://isitagentready.com) scan. Follow-up to the already-merged #4253 (apex auth.md/OAuth metadata SSOT) and #4256 (region directory); no dedicated tracking issue.

- **`scopes_supported` was missing from the RFC 9728 OAuth Protected Resource metadata.** The field is optional in RFC 9728, but agent-readiness scanners and the MCP authorization spec expect it. Added `["mcp:read", "mcp:write"]` — the data-access scopes the Atlas authorization server issues, matching the sibling per-workspace MCP protected-resource metadata (`well-known.ts`). Regenerated into both the www static mirror and the docs route's generated body.
- **`/auth.md` led with `# Connecting an agent to Atlas`,** so auth.md-aware scanners/agents didn't recognize it as an auth.md document ("missing the expected Auth.md heading"). Made the H1 the canonical `# auth.md` marker and folded the descriptive title into a bold lead sentence — no content removed.

Both artifacts stay generator-derived (`generate-apex-discovery.ts`), so the apex-discovery **drift gate** and the **auth.md ⇄ .well-known parity guard** keep them in lockstep.

**Deliberately not included:** the scanner also wants an `agent_auth` block (WorkOS agent-verified registration: `identity_endpoint`/`claim_uri`/`revocation_uri`). Atlas serves none of those endpoints, and `check-auth-md-discovery-parity.ts` (`FORBIDDEN_FRAGMENTS`) plus unit tests actively fail the build if `agent_auth` appears in the discovery docs — a discovery document must never advertise an endpoint that 404s (#3824). Fully passing that check means building the WorkOS agent-verified flow, which is a roadmap decision, not a metadata tweak.

## Test Plan

- [x] Unit tests added/updated — `apex-discovery-generator.test.ts` asserts the new `scopes_supported`; heading fixtures updated in `auth-md-discovery-parity.test.ts` and `apps/www/serve.test.ts`
- [x] auth.md content-contract suite (`lib/mcp/__tests__/auth-md.test.ts`) still green — asserts hosts/scopes/endpoints, not exact prose
- [x] Parity guard (`check-auth-md-discovery-parity.ts`) passes; apex-discovery drift gate output is idempotent
- [x] Full local CI (`scripts/ci-local.sh`) — all 28 gates green

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — deferred; discovery-metadata polish, not a headline user-facing feature

https://claude.ai/code/session_01NLcA6M75achneVdmA9Sxxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLcA6M75achneVdmA9Sxxa)_