### PR TITLE
refactor: render notebook assistant turns via the shared turn partitioner

### DIFF
--- a/packages/web/src/ui/components/chat/finished-turn.tsx
+++ b/packages/web/src/ui/components/chat/finished-turn.tsx
@@ -25,7 +25,11 @@ export function FinishedTurn({
 }: {
   parts: readonly TurnPart[] | undefined;
   pythonProgress?: Map<string, PythonProgressData[]>;
-  /** Notebook rerun-comparison metadata, forwarded to SQL result cards (#4301). */
+  /**
+   * Notebook rerun-comparison metadata (#4301). Deliberately bound to the
+   * promoted artifact's SQL card only — the snapshot describes the cell's
+   * result, not the intermediate queries inside the receipt.
+   */
   previousExecution?: PreviousExecution;
 }) {
   const { activity, answer, answerBearingArtifact } = partitionTurn(parts);
@@ -40,7 +44,6 @@ export function FinishedTurn({
       <TurnReceipt
         activity={activity}
         pythonProgress={pythonProgress}
-        previousExecution={previousExecution}
         // Start expanded when collapsing would hide the turn's substance:
         // (a) no answer and no artifact — the activity IS the turn (e.g. an
         // interrupted stream); (b) the activity holds an interactive card

--- a/packages/web/src/ui/components/chat/finished-turn.tsx
+++ b/packages/web/src/ui/components/chat/finished-turn.tsx
@@ -6,6 +6,7 @@ import { parseSuggestions } from "../../lib/helpers";
 import { activityAwaitsUser, partitionTurn, type TurnPart } from "./turn-partitioner";
 import { TurnReceipt } from "./turn-receipt";
 import type { PythonProgressData } from "./python-result-card";
+import type { PreviousExecution } from "../notebook/types";
 
 /**
  * Answer-first rendering of a completed assistant turn (#4298): the activity
@@ -13,14 +14,19 @@ import type { PythonProgressData } from "./python-result-card";
  * most one promoted answer-bearing artifact sits with it. Streaming turns keep
  * the live part-by-part renderer — this component is for finished turns only.
  * The suggestion chips and Save/Share row stay with the caller (they belong to
- * the transcript row, not the turn's parts).
+ * the transcript row, not the turn's parts). Consumed by both the chat
+ * transcript and the notebook cell output (#4301) — the shared seam that keeps
+ * the two surfaces from drifting in formatting.
  */
 export function FinishedTurn({
   parts,
   pythonProgress,
+  previousExecution,
 }: {
   parts: readonly TurnPart[] | undefined;
   pythonProgress?: Map<string, PythonProgressData[]>;
+  /** Notebook rerun-comparison metadata, forwarded to SQL result cards (#4301). */
+  previousExecution?: PreviousExecution;
 }) {
   const { activity, answer, answerBearingArtifact } = partitionTurn(parts);
 
@@ -34,6 +40,7 @@ export function FinishedTurn({
       <TurnReceipt
         activity={activity}
         pythonProgress={pythonProgress}
+        previousExecution={previousExecution}
         // Start expanded when collapsing would hide the turn's substance:
         // (a) no answer and no artifact — the activity IS the turn (e.g. an
         // interrupted stream); (b) the activity holds an interactive card
@@ -59,7 +66,11 @@ export function FinishedTurn({
       })}
       {answerBearingArtifact && (
         <div className="max-w-[95%]" data-testid="answer-artifact">
-          <ToolPart part={answerBearingArtifact.part} pythonProgress={pythonProgress} />
+          <ToolPart
+            part={answerBearingArtifact.part}
+            pythonProgress={pythonProgress}
+            previousExecution={previousExecution}
+          />
         </div>
       )}
     </>

--- a/packages/web/src/ui/components/chat/turn-receipt.tsx
+++ b/packages/web/src/ui/components/chat/turn-receipt.tsx
@@ -13,7 +13,6 @@ import {
   type ToolTurnPart,
 } from "./turn-partitioner";
 import type { PythonProgressData } from "./python-result-card";
-import type { PreviousExecution } from "../notebook/types";
 
 /**
  * The collapsed receipt a finished turn's activity settles into (#4298):
@@ -28,13 +27,10 @@ import type { PreviousExecution } from "../notebook/types";
 export function TurnReceipt({
   activity,
   pythonProgress,
-  previousExecution,
   defaultOpen = false,
 }: {
   activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[];
   pythonProgress?: Map<string, PythonProgressData[]>;
-  /** Notebook rerun-comparison metadata, forwarded to SQL result cards (#4301). */
-  previousExecution?: PreviousExecution;
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
@@ -69,14 +65,7 @@ export function TurnReceipt({
                 </div>
               );
             }
-            return (
-              <ToolPart
-                key={index}
-                part={part}
-                pythonProgress={pythonProgress}
-                previousExecution={previousExecution}
-              />
-            );
+            return <ToolPart key={index} part={part} pythonProgress={pythonProgress} />;
           })}
         </div>
       )}

--- a/packages/web/src/ui/components/chat/turn-receipt.tsx
+++ b/packages/web/src/ui/components/chat/turn-receipt.tsx
@@ -13,6 +13,7 @@ import {
   type ToolTurnPart,
 } from "./turn-partitioner";
 import type { PythonProgressData } from "./python-result-card";
+import type { PreviousExecution } from "../notebook/types";
 
 /**
  * The collapsed receipt a finished turn's activity settles into (#4298):
@@ -27,10 +28,13 @@ import type { PythonProgressData } from "./python-result-card";
 export function TurnReceipt({
   activity,
   pythonProgress,
+  previousExecution,
   defaultOpen = false,
 }: {
   activity: readonly IndexedTurnPart<TextTurnPart | ToolTurnPart>[];
   pythonProgress?: Map<string, PythonProgressData[]>;
+  /** Notebook rerun-comparison metadata, forwarded to SQL result cards (#4301). */
+  previousExecution?: PreviousExecution;
   defaultOpen?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
@@ -65,7 +69,14 @@ export function TurnReceipt({
                 </div>
               );
             }
-            return <ToolPart key={index} part={part} pythonProgress={pythonProgress} />;
+            return (
+              <ToolPart
+                key={index}
+                part={part}
+                pythonProgress={pythonProgress}
+                previousExecution={previousExecution}
+              />
+            );
           })}
         </div>
       )}

--- a/packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx
+++ b/packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Notebook cell output renders finished assistant turns through the SHARED
+ * turn partitioner + turn components (#4301) — the same FinishedTurn the chat
+ * transcript uses (#4298) — so the two surfaces cannot drift in formatting.
+ * Notebook-specific chrome (typing indicator, "No output yet", collapsed
+ * preview, the AssistantTurn gutter, rerun comparison, live-run failure
+ * dedup) is pinned here too.
+ *
+ * The partition/receipt policy matrix (defaultOpen, pending interactive
+ * cards, suggestion stripping) lives in chat/__tests__/turn-receipt.test.tsx
+ * and ui/__tests__/finished-turn.test.tsx — not re-tested here.
+ */
+
+import { expect, test, afterEach } from "bun:test";
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import type { UIMessage } from "@ai-sdk/react";
+
+afterEach(cleanup);
+
+import { NotebookCellOutput } from "../notebook-cell-output";
+
+function makeMessage(parts: unknown[]): UIMessage {
+  return { id: "a1", role: "assistant", parts } as UIMessage;
+}
+
+const narration = { type: "text", text: "Let me check the schema." };
+const exploreCall = {
+  type: "tool-explore",
+  toolCallId: "c1",
+  state: "output-available",
+  input: { command: "cat semantic/entities/orders.yml" },
+  output: "columns: ...",
+};
+const successfulQuery = {
+  type: "tool-executeSQL",
+  toolCallId: "c2",
+  state: "output-available",
+  input: {
+    sql: "SELECT region, sum(total) FROM orders GROUP BY 1",
+    explanation: "Revenue by region",
+  },
+  output: {
+    success: true,
+    columns: ["region", "sum"],
+    rows: [
+      { region: "EU", sum: 100 },
+      { region: "US", sum: 200 },
+    ],
+    executionMs: 42,
+  },
+};
+const answerText = { type: "text", text: "US leads with $200." };
+
+function failedQuery(toolCallId: string) {
+  return {
+    type: "tool-executeSQL",
+    toolCallId,
+    state: "output-available",
+    input: { sql: "SELECT broken", explanation: "Broken query" },
+    output: { success: false, error: "column does not exist" },
+  };
+}
+
+test("finished cell renders receipt → answer → promoted artifact via the shared turn components, inside the notebook gutter", () => {
+  const { container, getByTestId, getByRole } = render(
+    <NotebookCellOutput
+      assistantMessage={makeMessage([narration, exploreCall, successfulQuery, answerText])}
+      status="idle"
+      collapsed={false}
+    />,
+  );
+
+  // Shared composition: collapsed receipt, dominant answer, promoted artifact.
+  const receipt = getByTestId("turn-receipt");
+  expect(receipt.textContent).toContain("Explored schema");
+  expect(getByTestId("turn-answer").textContent).toContain("US leads with $200.");
+  const artifact = getByTestId("answer-artifact");
+  expect(artifact.textContent).toContain("Revenue by region");
+  expect(artifact.textContent).toContain("Show SQL");
+  // Receipt is collapsed: activity narration stays hidden until expanded.
+  expect(container.textContent).not.toContain("Let me check the schema.");
+  expect(getByRole("button", { name: /Explored schema/ })).toBeTruthy();
+  // Notebook chrome: everything sits inside the AssistantTurn gutter.
+  const gutter = container.querySelector('[data-slot="assistant-turn"]');
+  expect(gutter).not.toBeNull();
+  expect(gutter!.contains(receipt)).toBe(true);
+  expect(gutter!.contains(artifact)).toBe(true);
+});
+
+test("rerun comparison (previousExecution) reaches the promoted artifact's result card", () => {
+  const { getByTestId } = render(
+    <NotebookCellOutput
+      assistantMessage={makeMessage([successfulQuery, answerText])}
+      status="idle"
+      collapsed={false}
+      previousExecution={{ rowCount: 5, executionMs: 3000 }}
+    />,
+  );
+  // 5 previous rows vs 2 current → "(was 5 rows · 3.0s)" in the card header.
+  expect(getByTestId("answer-artifact").textContent).toContain("was 5 rows · 3.0s");
+});
+
+test("running cell keeps the live part-by-part renderer — no receipt, parts in stream order", () => {
+  const { container, queryByTestId } = render(
+    <NotebookCellOutput
+      assistantMessage={makeMessage([narration, exploreCall])}
+      status="running"
+      collapsed={false}
+    />,
+  );
+  expect(queryByTestId("turn-receipt")).toBeNull();
+  expect(queryByTestId("turn-answer")).toBeNull();
+  // Narration is visible immediately while streaming.
+  expect(container.textContent).toContain("Let me check the schema.");
+});
+
+test("running cell still folds repeated identical SQL failures (Tried N times badge)", () => {
+  const { container } = render(
+    <NotebookCellOutput
+      assistantMessage={makeMessage([failedQuery("c1"), failedQuery("c2")])}
+      status="running"
+      collapsed={false}
+    />,
+  );
+  expect(container.textContent).toContain("Tried 2 times");
+  // The duplicate is skipped — the error renders once, not twice.
+  const occurrences = container.textContent!.split("column does not exist").length - 1;
+  expect(occurrences).toBe(1);
+});
+
+test("collapsed cell renders the truncated text preview, not the turn components", () => {
+  const { container, queryByTestId } = render(
+    <NotebookCellOutput
+      assistantMessage={makeMessage([narration, exploreCall, successfulQuery, answerText])}
+      status="idle"
+      collapsed
+    />,
+  );
+  expect(queryByTestId("turn-receipt")).toBeNull();
+  expect(container.textContent).toContain("Let me check the schema.");
+});
+
+test("running with no message yet shows the typing indicator; idle with no message shows the empty state", () => {
+  const running = render(
+    <NotebookCellOutput assistantMessage={null} status="running" collapsed={false} />,
+  );
+  expect(running.container.querySelector('[data-slot="assistant-turn"]')).toBeNull();
+  running.unmount();
+
+  const idle = render(
+    <NotebookCellOutput assistantMessage={null} status="idle" collapsed={false} />,
+  );
+  expect(idle.container.textContent).toContain("No output yet");
+});

--- a/packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx
+++ b/packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx
@@ -7,8 +7,10 @@
  * dedup) is pinned here too.
  *
  * The partition/receipt policy matrix (defaultOpen, pending interactive
- * cards, suggestion stripping) lives in chat/__tests__/turn-receipt.test.tsx
- * and ui/__tests__/finished-turn.test.tsx — not re-tested here.
+ * cards, suggestion stripping) lives in
+ * ui/components/chat/__tests__/turn-receipt.test.tsx and
+ * ui/__tests__/finished-turn.test.tsx (both relative to src/) — not
+ * re-tested here.
  */
 
 import { expect, test, afterEach } from "bun:test";
@@ -129,6 +131,26 @@ test("running cell still folds repeated identical SQL failures (Tried N times ba
   expect(occurrences).toBe(1);
 });
 
+test("error-status cell takes the finished path: receipt with a failure count, no live-path fold", () => {
+  const { container, getByTestId, queryByTestId } = render(
+    <NotebookCellOutput
+      assistantMessage={makeMessage([failedQuery("c1"), failedQuery("c2")])}
+      status="error"
+      collapsed={false}
+    />,
+  );
+  // The receipt's summary counts the retries; the live-path badge is gone.
+  const receipt = getByTestId("turn-receipt");
+  expect(receipt.textContent).toContain("2 queries · 2 failed");
+  expect(container.textContent).not.toContain("Tried 2 times");
+  expect(queryByTestId("turn-answer")).toBeNull();
+  // No answer and no artifact → the receipt starts expanded (shared policy),
+  // so the failed cards are visible without a click — both of them: the
+  // finished path accepts the un-folded stacking (see notebook-cell-output).
+  const occurrences = container.textContent!.split("column does not exist").length - 1;
+  expect(occurrences).toBe(2);
+});
+
 test("collapsed cell renders the truncated text preview, not the turn components", () => {
   const { container, queryByTestId } = render(
     <NotebookCellOutput
@@ -145,6 +167,8 @@ test("running with no message yet shows the typing indicator; idle with no messa
   const running = render(
     <NotebookCellOutput assistantMessage={null} status="running" collapsed={false} />,
   );
+  // The animated dots are the indicator's only stable hook — no text/testid.
+  expect(running.container.querySelector(".animate-typing-dot")).not.toBeNull();
   expect(running.container.querySelector('[data-slot="assistant-turn"]')).toBeNull();
   running.unmount();
 

--- a/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
@@ -4,6 +4,7 @@ import type { UIMessage } from "@ai-sdk/react";
 import { isToolUIPart } from "ai";
 import type { CellStatus, PreviousExecution } from "./types";
 import { AssistantTurn } from "@/ui/components/chat/assistant-turn";
+import { FinishedTurn } from "@/ui/components/chat/finished-turn";
 import { ToolPart } from "@/ui/components/chat/tool-part";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
@@ -45,6 +46,22 @@ export function NotebookCellOutput({ assistantMessage, status, collapsed, previo
     );
   }
 
+  // #4301 — finished cells render through the same partitioner + turn
+  // components as the chat transcript (receipt → answer → promoted artifact),
+  // so the two surfaces cannot drift in formatting. Only the actively-running
+  // cell keeps the live part-by-part renderer below, mirroring the chat's
+  // streaming-turn carve-out (#4298).
+  if (status !== "running") {
+    return (
+      <AssistantTurn className="space-y-2 text-sm">
+        <FinishedTurn parts={assistantMessage.parts} previousExecution={previousExecution} />
+      </AssistantTurn>
+    );
+  }
+
+  // Live path: while the agent retries the same SQL verbatim, fold identical
+  // failures instead of stacking red blocks. Finished cells don't need this —
+  // failures settle into the receipt, whose summary counts them.
   const { failureRuns, skipFailureIndex } = computeSqlFailureDedup(assistantMessage.parts);
 
   return (

--- a/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-cell-output.tsx
@@ -61,7 +61,10 @@ export function NotebookCellOutput({ assistantMessage, status, collapsed, previo
 
   // Live path: while the agent retries the same SQL verbatim, fold identical
   // failures instead of stacking red blocks. Finished cells don't need this —
-  // failures settle into the receipt, whose summary counts them.
+  // failures settle into the receipt, whose summary counts them. (An
+  // all-failure turn starts with the receipt expanded, so the retries do
+  // stack there — accepted: the "N failed" count labels the repetition, and
+  // matching the chat surface exactly is the point of #4301.)
   const { failureRuns, skipFailureIndex } = computeSqlFailureDedup(assistantMessage.parts);
 
   return (


### PR DESCRIPTION
## Summary
- Finished notebook cells now render through the same `FinishedTurn` seam as the chat transcript (receipt → answer → promoted artifact via `partitionTurn` from #4298), so the two surfaces cannot drift in formatting. Only the actively-running cell keeps the live part-by-part renderer, mirroring the chat's streaming carve-out; the live-path SQL failure dedup ("Tried N times") stays there.
- Notebook chrome preserved: `AssistantTurn` gutter, typing indicator, "No output yet", collapsed preview, and the rerun comparison — `FinishedTurn` grows an optional `previousExecution` passthrough bound to the promoted artifact's SQL card only (the snapshot describes the cell's result, not intermediate queries). `TurnReceipt` is untouched.
- Pending interactive cards keep the receipt default-open in the notebook too — inherited structurally from the shared components (policy pinned in `turn-receipt.test.tsx`).
- New test file pins the notebook seam: shared composition inside the gutter, `status="error"` through the finished path (receipt failure count replaces the live fold), rerun comparison on the artifact, live-path preservation + dedup, collapsed preview, and the empty states.

## Not in scope (recommended follow-up)
`@useatlas/react` (published npm package) carries its own parallel chat renderer used by `/demo` that also hasn't converged onto the shared partitioner. Converging it means exporting the partitioner from a published package (version bump + publish-ordering rules), so it's deliberately left out of this slice — worth its own issue.

## Test plan
- [x] `bun test packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx` — 7 pass
- [x] Full web suite green (260/260 files); `finished-turn` / `turn-receipt` / `turn-partitioner` suites unchanged and green
- [x] `/review-panel` x2 rounds (silent-failure, type-design, test-coverage, comment) — round 2 clean on all axes
- [x] `/ci` — all 28 local gates green

Closes #4301

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v