### PR TITLE
feat: surface chat failures visibly + unify empty-state copy

### DIFF
--- a/e2e/browser/conversations.spec.ts
+++ b/e2e/browser/conversations.spec.ts
@@ -28,11 +28,13 @@ test.describe("Conversations @llm", () => {
     // Click "+ New"
     await startNewChat(page);
 
-    // The empty state should be visible again. Keyed by testid, not copy —
-    // the empty-state heading shares the "Ask your data anything" phrasing
-    // with the standalone header tagline (#4297), so a text locator would
-    // match both and trip Playwright strict mode.
+    // The empty state should be visible again. Located by testid: the
+    // empty-state heading now shares the "Ask your data anything" phrasing
+    // with the standalone header tagline (#4297), so a bare text locator
+    // would be ambiguous on standalone (non-embedded) surfaces — and the
+    // testid stays robust to copy changes on this embedded one.
     await expect(page.getByTestId("chat-empty-state")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("chat-empty-state")).toContainText("Ask your data anything");
   });
 
   test("clicking a previous conversation reloads its messages", async ({ page }) => {

--- a/e2e/browser/conversations.spec.ts
+++ b/e2e/browser/conversations.spec.ts
@@ -31,8 +31,9 @@ test.describe("Conversations @llm", () => {
     // The empty state should be visible again. Located by testid: the
     // empty-state heading now shares the "Ask your data anything" phrasing
     // with the standalone header tagline (#4297), so a bare text locator
-    // would be ambiguous on standalone (non-embedded) surfaces — and the
-    // testid stays robust to copy changes on this embedded one.
+    // would be ambiguous on standalone (non-embedded) surfaces. The copy
+    // containment below is deliberate — it pins the #4297 phrasing
+    // unification; only the element LOOKUP is copy-independent.
     await expect(page.getByTestId("chat-empty-state")).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId("chat-empty-state")).toContainText("Ask your data anything");
   });

--- a/e2e/browser/conversations.spec.ts
+++ b/e2e/browser/conversations.spec.ts
@@ -28,8 +28,11 @@ test.describe("Conversations @llm", () => {
     // Click "+ New"
     await startNewChat(page);
 
-    // Starter prompts should be visible again (empty state)
-    await expect(page.locator("text=What would you like to know?")).toBeVisible({ timeout: 5_000 });
+    // The empty state should be visible again. Keyed by testid, not copy —
+    // the empty-state heading shares the "Ask your data anything" phrasing
+    // with the standalone header tagline (#4297), so a text locator would
+    // match both and trip Playwright strict mode.
+    await expect(page.getByTestId("chat-empty-state")).toBeVisible({ timeout: 5_000 });
   });
 
   test("clicking a previous conversation reloads its messages", async ({ page }) => {

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -91,9 +91,10 @@ function ChatPage() {
 
   // A failed `/api/health` probe means the API is unreachable / misconfigured.
   // Surface the actionable error + a Retry instead of rendering an
-  // apparently-working chat wired to a dead backend — in `embedded` mode
-  // `<AtlasChat>` only renders `healthWarning` as a faint inline hint, far too
-  // subtle for a hard failure. Restores the pre-#3081 inline page's health gate.
+  // apparently-working chat wired to a dead backend. `<AtlasChat>` renders its
+  // own `healthWarning` banner (#4297), but only inside an otherwise-live chat
+  // surface — this page-level gate replaces the whole surface with a Retry
+  // before that chat mounts. Restores the pre-#3081 inline page's health gate.
   if (healthWarning) {
     return (
       <div className="flex h-full items-center justify-center p-8">

--- a/packages/web/src/ui/__tests__/action-error-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/action-error-banner.test.tsx
@@ -29,7 +29,8 @@ describe("ActionErrorBanner", () => {
     const { container } = render(
       <ActionErrorBanner failure={{ title: "Message failed to send" }} />,
     );
-    expect(container.textContent).not.toContain("Request ID");
+    // With no detail, requestId, retry, or dismiss, the title is the ONLY text.
+    expect(container.textContent?.trim()).toBe("Message failed to send");
   });
 
   test("retry button invokes the failure's retry and renders only when provided", () => {

--- a/packages/web/src/ui/__tests__/action-error-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/action-error-banner.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, test, mock } from "bun:test";
+import { render, fireEvent } from "@testing-library/react";
+import { ActionErrorBanner } from "../components/chat/error-banner";
+
+describe("ActionErrorBanner", () => {
+  test("renders title as an alert", () => {
+    const { getByRole } = render(
+      <ActionErrorBanner failure={{ title: "Couldn't pin starter prompt" }} />,
+    );
+    const alert = getByRole("alert");
+    expect(alert.textContent).toContain("Couldn't pin starter prompt");
+  });
+
+  test("renders detail and request ID when present", () => {
+    const { container } = render(
+      <ActionErrorBanner
+        failure={{
+          title: "Couldn't pin starter prompt",
+          detail: "Favorites are limited to 20 prompts.",
+          requestId: "req-123",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain("Favorites are limited to 20 prompts.");
+    expect(container.textContent).toContain("Request ID: req-123");
+  });
+
+  test("omits detail and request ID rows when absent", () => {
+    const { container } = render(
+      <ActionErrorBanner failure={{ title: "Message failed to send" }} />,
+    );
+    expect(container.textContent).not.toContain("Request ID");
+  });
+
+  test("retry button invokes the failure's retry and renders only when provided", () => {
+    const retry = mock(() => {});
+    const { getByText, rerender, queryByText } = render(
+      <ActionErrorBanner failure={{ title: "Message failed to send", retry }} />,
+    );
+    fireEvent.click(getByText("Try again"));
+    expect(retry).toHaveBeenCalledTimes(1);
+
+    rerender(<ActionErrorBanner failure={{ title: "Message failed to send" }} />);
+    expect(queryByText("Try again")).toBeNull();
+  });
+
+  test("dismiss button invokes onDismiss and renders only when provided", () => {
+    const onDismiss = mock(() => {});
+    const { getByLabelText, rerender, queryByLabelText } = render(
+      <ActionErrorBanner
+        failure={{ title: "Couldn't unpin starter prompt" }}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(getByLabelText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    rerender(<ActionErrorBanner failure={{ title: "Couldn't unpin starter prompt" }} />);
+    expect(queryByLabelText("Dismiss")).toBeNull();
+  });
+});

--- a/packages/web/src/ui/__tests__/action-error-banner.test.tsx
+++ b/packages/web/src/ui/__tests__/action-error-banner.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, test, mock } from "bun:test";
 import { render, fireEvent } from "@testing-library/react";
-import { ActionErrorBanner } from "../components/chat/error-banner";
+import {
+  ActionErrorBanner,
+  clearFailureOfKind,
+  type StoredActionFailure,
+} from "../components/chat/error-banner";
 
 describe("ActionErrorBanner", () => {
   test("renders title as an alert", () => {
@@ -58,5 +62,27 @@ describe("ActionErrorBanner", () => {
 
     rerender(<ActionErrorBanner failure={{ title: "Couldn't unpin starter prompt" }} />);
     expect(queryByLabelText("Dismiss")).toBeNull();
+  });
+});
+
+// #4297 — the kind-scoped clear discipline: machine-initiated / implicit
+// clears may only supersede their own kind, never an unrelated failure the
+// user hasn't seen.
+describe("clearFailureOfKind", () => {
+  const pinFailure: StoredActionFailure = {
+    kind: "pin",
+    title: "Couldn't pin starter prompt",
+  };
+
+  test("clears a failure of the matching kind", () => {
+    expect(clearFailureOfKind("pin")(pinFailure)).toBeNull();
+  });
+
+  test("preserves a failure of a different kind by identity (setState bail-out)", () => {
+    expect(clearFailureOfKind("resume")(pinFailure)).toBe(pinFailure);
+  });
+
+  test("passes through null", () => {
+    expect(clearFailureOfKind("send")(null)).toBeNull();
   });
 });

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -53,6 +53,7 @@ import { PromptLibrary } from "./chat/prompt-library";
 import { StarterPromptList } from "./chat/starter-prompt-list";
 import type { StarterPrompt } from "@useatlas/types/starter-prompt";
 import { useContextWarnings } from "../hooks/use-context-warnings";
+import { useTransientNotice } from "../hooks/use-transient-notice";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { parseSuggestions } from "../lib/helpers";
@@ -115,6 +116,14 @@ function SaveButton({
     </Button>
   );
 }
+
+/**
+ * #4297 — which action produced the stored failure. Scopes machine-initiated
+ * clears: the auto-resume path may supersede only a `"resume"` failure, never
+ * an unrelated one the user hasn't seen yet.
+ */
+type ChatActionKind = "send" | "load" | "pin" | "unpin" | "resume";
+type StoredActionFailure = ChatActionFailure & { readonly kind: ChatActionKind };
 
 interface AtlasChatProps {
   /**
@@ -202,24 +211,13 @@ export function AtlasChat({
   const runIdRef = useRef<string | null>(null);
   // #4297 — real failures (send / load / pin / unpin / resume) surface as a
   // persistent structured banner (`ActionErrorBanner`): visible until retried,
-  // superseded by a newer action, or explicitly dismissed. Genuinely
-  // informational transients (pin success / already-pinned) stay on the quiet
-  // auto-dismissing notice line — successes may whisper; failures must not.
-  const [actionFailure, setActionFailure] = useState<ChatActionFailure | null>(null);
-  const [transientNotice, setTransientNotice] = useState("");
-  // One dismissal timer at a time: a new notice supersedes the old one's
-  // timeout so a stale timer can't clip a fresh notice early.
-  const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const showTransientNotice = useCallback((message: string, ms: number) => {
-    setTransientNotice(message);
-    if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current);
-    noticeTimerRef.current = setTimeout(() => setTransientNotice(""), ms);
-  }, []);
-  useEffect(() => {
-    return () => {
-      if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current);
-    };
-  }, []);
+  // superseded by a newer user action (including "+ New"), or explicitly
+  // dismissed. Machine-initiated paths (auto-resume) clear only their own
+  // `kind`, so they can't erase a failure the user hasn't seen. Genuinely
+  // informational transients (pin success / already-pinned) go through
+  // `useTransientNotice` — successes may whisper; failures must not.
+  const [actionFailure, setActionFailure] = useState<StoredActionFailure | null>(null);
+  const { notice: transientNotice, showNotice: showTransientNotice } = useTransientNotice();
   const [loadingConversation, setLoadingConversation] = useState(false);
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
   const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
@@ -229,7 +227,7 @@ export function AtlasChat({
   const setPromptLibraryOpen = useUiStore((s) => s.setPromptLibraryOpen);
   // Tracks the message text being pinned so the affordance disables
   // mid-flight — without this, a quick double-click fires two POSTs and
-  // the second 409s after a visible success toast.
+  // the second 409s right after a visible success notice.
   const [pinningText, setPinningText] = useState<string | null>(null);
   const [relatedSuggestions, setRelatedSuggestions] = useState<QuerySuggestion[]>([]);
   // #2345 / #4189 — the conversation's env/member/REST/reach scope lives in the
@@ -475,11 +473,7 @@ export function AtlasChat({
   // `useRunStatus` fires this stable wrapper, which dispatches to the latest
   // `handleResume` (kept current by the effect below it).
   const handleResumeRef = useRef<() => void>(() => {});
-  const handleParkedResolved = useCallback(() => {
-    // #4297 — a fresh (auto-)resume supersedes any earlier failure banner.
-    setActionFailure(null);
-    handleResumeRef.current();
-  }, []);
+  const handleParkedResolved = useCallback(() => handleResumeRef.current(), []);
 
   // #3749 — durable run status for the open conversation. Fetched once its
   // history has committed (not mid-load) so the affordance reflects the mounted
@@ -506,14 +500,21 @@ export function AtlasChat({
     refetchRunStatus: runStatusCtl.refetch,
     isLoading,
     resetPendingWarnings: warningCtl.resetPending,
+    // #4297 — fires only when a resume actually begins (after the hook's
+    // re-entrancy guard), so a guarded no-op click can never erase the banner
+    // without retrying. Kind-scoped because auto-resume is machine-initiated:
+    // it must not clear an unrelated failure the user hasn't seen.
+    onStart: () => {
+      setActionFailure((f) => (f && f.kind === "resume" ? null : f));
+    },
     onError: (message) => {
       // #4297 — a failed resume is a real failure: persistent banner, not a
       // fading whisper. Retry through the ref — this callback is constructed
       // before `handleResume` exists (same seam as `handleParkedResolved`).
       setActionFailure({
+        kind: "resume",
         title: message,
         retry: () => {
-          setActionFailure(null);
           handleResumeRef.current();
         },
       });
@@ -638,11 +639,17 @@ export function AtlasChat({
           showTransientNotice("Already pinned — it'll show up in a new chat.", 4000);
           return;
         }
-        console.warn("pin failed:", res.status, res.statusText, body.requestId, body.message);
+        // Narrow at the seam: the cast above is unvalidated, and these values
+        // render as JSX outside the transcript's ErrorBoundary — a non-string
+        // (proxy error page, envelope drift) must not take down the surface.
+        const detail = typeof body.message === "string" ? body.message : undefined;
+        const requestId = typeof body.requestId === "string" ? body.requestId : undefined;
+        console.warn("pin failed:", res.status, res.statusText, requestId, detail);
         setActionFailure({
+          kind: "pin",
           title: "Couldn't pin starter prompt",
-          detail: body.message,
-          requestId: body.requestId,
+          detail,
+          requestId,
           retry: () => {
             void handlePin(text);
           },
@@ -672,6 +679,7 @@ export function AtlasChat({
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("pin request failed:", msg);
       setActionFailure({
+        kind: "pin",
         title: "Couldn't pin starter prompt",
         retry: () => {
           void handlePin(text);
@@ -702,16 +710,25 @@ export function AtlasChat({
       );
       if (!res.ok && res.status !== 404) {
         // 404 is fine — the pin is gone either way.
-        const body = (await res.json().catch(() => ({}))) as { requestId?: string };
+        const body = (await res.json().catch(() => ({}))) as {
+          requestId?: string;
+          message?: string;
+        };
+        // Same seam-narrowing as the pin path — see the comment there.
+        const detail = typeof body.message === "string" ? body.message : undefined;
+        const requestId = typeof body.requestId === "string" ? body.requestId : undefined;
         console.warn(
           "unpin failed:",
           res.status,
           res.statusText,
-          body.requestId ?? "(no requestId — non-JSON body)",
+          requestId ?? "(no requestId — non-JSON body)",
+          detail,
         );
         setActionFailure({
+          kind: "unpin",
           title: "Couldn't unpin starter prompt",
-          requestId: body.requestId,
+          detail,
+          requestId,
           retry: () => {
             void handleUnpin(favoriteId);
           },
@@ -725,6 +742,7 @@ export function AtlasChat({
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("unpin request failed:", msg);
       setActionFailure({
+        kind: "unpin",
         title: "Couldn't unpin starter prompt",
         retry: () => {
           void handleUnpin(favoriteId);
@@ -755,8 +773,12 @@ export function AtlasChat({
       console.error("Failed to send message:", err instanceof Error ? err.message : String(err));
       setInput(saved);
       setActionFailure({
+        kind: "send",
         title: "Message failed to send",
         detail: "Your message was put back in the composer.",
+        // Safe only while the draft is untouched: editing the restored text
+        // clears this failure (see the composer's onValueChange), so a stale
+        // "Try again" can never clobber an edit with the original text.
         retry: () => handleSend(saved),
       });
     });
@@ -837,6 +859,7 @@ export function AtlasChat({
     } catch (err: unknown) {
       console.warn("Failed to load conversation:", err instanceof Error ? err.message : String(err));
       setActionFailure({
+        kind: "load",
         title: "Couldn't load the conversation",
         // Retry through the ref so a later attempt uses the freshest handler
         // (this closure would otherwise pin the env groups it saw at failure).
@@ -863,6 +886,9 @@ export function AtlasChat({
 
   function handleNewChat() {
     setMessages([]);
+    // #4297 — a fresh chat supersedes any failure banner (e.g. a "Couldn't
+    // load the conversation" whose retry targets the just-abandoned id).
+    setActionFailure(null);
     // #3068 — clear the bound + most-recently-requested refs and the URL
     // (`?id=`) so the open effect re-seeds a fresh chat instead of treating the
     // just-left conversation as still loaded. Clearing the requested ref also
@@ -1350,8 +1376,9 @@ export function AtlasChat({
                 {/* #4297 — failed action (send / load / pin / unpin / resume).
                     Composer-adjacent so it sits where the user is looking
                     after acting; persistent until retried, superseded, or
-                    dismissed. Distinct from the chat-stream ErrorBanner below,
-                    which owns mid-stream wire errors. */}
+                    dismissed. Distinct from the ErrorBanner below, which owns
+                    errors from the chat turn itself (request + stream failures
+                    surfaced by useChat). */}
                 {actionFailure && (
                   <ActionErrorBanner
                     failure={actionFailure}
@@ -1385,11 +1412,7 @@ export function AtlasChat({
                 {!error && !loadingConversation && (
                   <ResumeBanner
                     runStatus={runStatusCtl.runStatus}
-                    onResume={() => {
-                      // #4297 — a fresh attempt supersedes the failure banner.
-                      setActionFailure(null);
-                      handleResume();
-                    }}
+                    onResume={handleResume}
                     resuming={resuming}
                   />
                 )}
@@ -1402,7 +1425,15 @@ export function AtlasChat({
                 {!(showDataSetupGate && messages.length === 0) && (
                   <ChatComposer
                     value={input}
-                    onValueChange={setInput}
+                    onValueChange={(v) => {
+                      setInput(v);
+                      // #4297 — editing the restored draft makes the composer
+                      // the retry vehicle; clearing here keeps the banner's
+                      // stale "Try again" (which resends the ORIGINAL text)
+                      // from clobbering the edit. Send-kind only — typing must
+                      // not dismiss an unrelated pin/load/resume failure.
+                      setActionFailure((f) => (f && f.kind === "send" ? null : f));
+                    }}
                     onSend={handleSend}
                     streaming={isLoading}
                     loadingConversation={loadingConversation}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -13,7 +13,7 @@ import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations, transformMessages } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
 import { ChatComposer } from "./chat/chat-composer";
-import { ErrorBanner } from "./chat/error-banner";
+import { ErrorBanner, ActionErrorBanner, type ChatActionFailure } from "./chat/error-banner";
 import { ContextWarningBanner } from "./chat/context-warning-banner";
 import { ResumeBanner } from "./chat/resume-banner";
 import { useRunStatus } from "../hooks/use-run-status";
@@ -200,7 +200,26 @@ export function AtlasChat({
   // "the active turn". The resume endpoint loads the latest non-terminal run by
   // conversation id, so this value is NOT used to target a resume.
   const runIdRef = useRef<string | null>(null);
-  const [transientWarning, setTransientWarning] = useState("");
+  // #4297 — real failures (send / load / pin / unpin / resume) surface as a
+  // persistent structured banner (`ActionErrorBanner`): visible until retried,
+  // superseded by a newer action, or explicitly dismissed. Genuinely
+  // informational transients (pin success / already-pinned) stay on the quiet
+  // auto-dismissing notice line — successes may whisper; failures must not.
+  const [actionFailure, setActionFailure] = useState<ChatActionFailure | null>(null);
+  const [transientNotice, setTransientNotice] = useState("");
+  // One dismissal timer at a time: a new notice supersedes the old one's
+  // timeout so a stale timer can't clip a fresh notice early.
+  const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showTransientNotice = useCallback((message: string, ms: number) => {
+    setTransientNotice(message);
+    if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current);
+    noticeTimerRef.current = setTimeout(() => setTransientNotice(""), ms);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (noticeTimerRef.current) clearTimeout(noticeTimerRef.current);
+    };
+  }, []);
   const [loadingConversation, setLoadingConversation] = useState(false);
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
   const setMobileSidebarOpen = useUiStore((s) => s.setMobileSidebarOpen);
@@ -456,7 +475,11 @@ export function AtlasChat({
   // `useRunStatus` fires this stable wrapper, which dispatches to the latest
   // `handleResume` (kept current by the effect below it).
   const handleResumeRef = useRef<() => void>(() => {});
-  const handleParkedResolved = useCallback(() => handleResumeRef.current(), []);
+  const handleParkedResolved = useCallback(() => {
+    // #4297 — a fresh (auto-)resume supersedes any earlier failure banner.
+    setActionFailure(null);
+    handleResumeRef.current();
+  }, []);
 
   // #3749 — durable run status for the open conversation. Fetched once its
   // history has committed (not mid-load) so the affordance reflects the mounted
@@ -484,8 +507,16 @@ export function AtlasChat({
     isLoading,
     resetPendingWarnings: warningCtl.resetPending,
     onError: (message) => {
-      setTransientWarning(message);
-      setTimeout(() => setTransientWarning(""), 5000);
+      // #4297 — a failed resume is a real failure: persistent banner, not a
+      // fading whisper. Retry through the ref — this callback is constructed
+      // before `handleResume` exists (same seam as `handleParkedResolved`).
+      setActionFailure({
+        title: message,
+        retry: () => {
+          setActionFailure(null);
+          handleResumeRef.current();
+        },
+      });
     },
   });
   // #4294 — the Stop control's orchestration lives in `useStopHandler`
@@ -582,6 +613,8 @@ export function AtlasChat({
 
   async function handlePin(text: string) {
     if (!text.trim()) return;
+    // A fresh attempt supersedes any earlier failure banner (#4297).
+    setActionFailure(null);
     setPinningText(text);
     try {
       const res = await fetch(`${apiUrl}/api/v1/starter-prompts/favorites`, {
@@ -602,14 +635,18 @@ export function AtlasChat({
           // the authoritative list.
           console.warn("pin duplicate:", body.requestId);
           await queryClient.invalidateQueries({ queryKey: starterPromptsQueryKey });
-          setTransientWarning("Already pinned — it'll show up in a new chat.");
-          setTimeout(() => setTransientWarning(""), 4000);
+          showTransientNotice("Already pinned — it'll show up in a new chat.", 4000);
           return;
         }
-        const msg = body.message ?? "Failed to pin starter prompt.";
-        console.warn("pin failed:", res.status, res.statusText, body.requestId, msg);
-        setTransientWarning(msg);
-        setTimeout(() => setTransientWarning(""), 5000);
+        console.warn("pin failed:", res.status, res.statusText, body.requestId, body.message);
+        setActionFailure({
+          title: "Couldn't pin starter prompt",
+          detail: body.message,
+          requestId: body.requestId,
+          retry: () => {
+            void handlePin(text);
+          },
+        });
         return;
       }
       const body = (await res.json()) as {
@@ -630,13 +667,16 @@ export function AtlasChat({
           ...base.filter((p) => !(p.provenance === "favorite" && p.text === body.favorite.text)),
         ];
       });
-      setTransientWarning("Pinned as starter prompt.");
-      setTimeout(() => setTransientWarning(""), 3000);
+      showTransientNotice("Pinned as starter prompt.", 3000);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("pin request failed:", msg);
-      setTransientWarning("Failed to pin starter prompt.");
-      setTimeout(() => setTransientWarning(""), 5000);
+      setActionFailure({
+        title: "Couldn't pin starter prompt",
+        retry: () => {
+          void handlePin(text);
+        },
+      });
     } finally {
       setPinningText(null);
     }
@@ -649,6 +689,8 @@ export function AtlasChat({
     const raw = favoriteId.startsWith("favorite:")
       ? favoriteId.slice("favorite:".length)
       : favoriteId;
+    // A fresh attempt supersedes any earlier failure banner (#4297).
+    setActionFailure(null);
     try {
       const res = await fetch(
         `${apiUrl}/api/v1/starter-prompts/favorites/${encodeURIComponent(raw)}`,
@@ -667,8 +709,13 @@ export function AtlasChat({
           res.statusText,
           body.requestId ?? "(no requestId — non-JSON body)",
         );
-        setTransientWarning("Failed to unpin starter prompt.");
-        setTimeout(() => setTransientWarning(""), 5000);
+        setActionFailure({
+          title: "Couldn't unpin starter prompt",
+          requestId: body.requestId,
+          retry: () => {
+            void handleUnpin(favoriteId);
+          },
+        });
         return;
       }
       queryClient.setQueryData<StarterPrompt[]>(starterPromptsQueryKey, (prev) =>
@@ -677,8 +724,12 @@ export function AtlasChat({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("unpin request failed:", msg);
-      setTransientWarning("Failed to unpin starter prompt.");
-      setTimeout(() => setTransientWarning(""), 5000);
+      setActionFailure({
+        title: "Couldn't unpin starter prompt",
+        retry: () => {
+          void handleUnpin(favoriteId);
+        },
+      });
     }
   }
 
@@ -689,6 +740,8 @@ export function AtlasChat({
     // conversation or be clobbered when the in-flight load commits. The composer
     // is disabled too; this also guards the chip / starter-prompt send paths.
     if (loadingConversation) return;
+    // A fresh attempt supersedes any earlier failure banner (#4297).
+    setActionFailure(null);
     const saved = text;
     setInput("");
     // Drop any unattached warnings from a stalled earlier turn so they
@@ -701,8 +754,11 @@ export function AtlasChat({
     sendMessage({ text: saved }).catch((err: unknown) => {
       console.error("Failed to send message:", err instanceof Error ? err.message : String(err));
       setInput(saved);
-      setTransientWarning("Failed to send message. Please try again.");
-      setTimeout(() => setTransientWarning(""), 5000);
+      setActionFailure({
+        title: "Message failed to send",
+        detail: "Your message was put back in the composer.",
+        retry: () => handleSend(saved),
+      });
     });
   }
 
@@ -729,6 +785,8 @@ export function AtlasChat({
     // in-flight load settles (`loadingConversation` is one of its deps), and the
     // stale check below stops that in-flight load from committing over this one.
     if (loadingConversation) return;
+    // A fresh attempt supersedes any earlier failure banner (#4297).
+    setActionFailure(null);
     // Mark bound for the open effect's dedup once we actually begin loading: a
     // redundant dispatch is then a no-op, and a load that fails below isn't
     // retried on every render.
@@ -778,8 +836,14 @@ export function AtlasChat({
       warningCtl.reset();
     } catch (err: unknown) {
       console.warn("Failed to load conversation:", err instanceof Error ? err.message : String(err));
-      setTransientWarning("Failed to load conversation. Please try again.");
-      setTimeout(() => setTransientWarning(""), 5000);
+      setActionFailure({
+        title: "Couldn't load the conversation",
+        // Retry through the ref so a later attempt uses the freshest handler
+        // (this closure would otherwise pin the env groups it saw at failure).
+        retry: () => {
+          void handleSelectConversationRef.current(id);
+        },
+      });
       // #3068 — the open failed and never committed. Reset the dedup ref to the
       // still-mounted conversation so the failed id isn't treated as loaded. If
       // no newer navigation superseded this attempt, roll the URL + requested id
@@ -1033,8 +1097,35 @@ export function AtlasChat({
             </header>
             )}
 
-            {(healthWarning || transientWarning || convos.fetchError) && (
-              <p className="mb-2 text-xs text-zinc-400 dark:text-zinc-500">{healthWarning || transientWarning || convos.fetchError}</p>
+            {/* #4297 — the quiet line is for informational transients ONLY
+                (pin success / already-pinned). Failures render as structured
+                banners and never auto-dismiss unseen. */}
+            {transientNotice && (
+              <p role="status" className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
+                {transientNotice}
+              </p>
+            )}
+            {healthWarning && (
+              <ActionErrorBanner
+                failure={{ title: "Connection problem", detail: healthWarning }}
+              />
+            )}
+            {convos.fetchError && (
+              <ActionErrorBanner
+                failure={{
+                  title: "Couldn't load conversation history",
+                  detail: convos.fetchError,
+                  retry: () => {
+                    convos.fetchList().catch((err: unknown) => {
+                      // The failure re-surfaces via `convos.fetchError`; log for correlation.
+                      console.warn(
+                        "Conversation list refetch failed:",
+                        err instanceof Error ? err.message : String(err),
+                      );
+                    });
+                  },
+                }}
+              />
             )}
 
             {isManaged && !isSignedIn ? (
@@ -1067,13 +1158,19 @@ export function AtlasChat({
                     ) : showDevChatEmpty ? (
                       <DeveloperChatEmptyState />
                     ) : (
-                    <div className="flex h-full flex-col items-center justify-center gap-6">
+                    <div
+                      className="flex h-full flex-col items-center justify-center gap-6"
+                      data-testid="chat-empty-state"
+                    >
+                      {/* #4297 — one value proposition across the surface: this
+                          heading and the standalone header tagline share the
+                          brand phrasing (www hero / metadata) verbatim. */}
                       <div className="text-center">
                         <p className="text-lg font-medium text-zinc-500 dark:text-zinc-400">
-                          What would you like to know?
+                          Ask your data anything
                         </p>
                         <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-500">
-                          Ask a question about your data to get started
+                          Start with a question about your data
                         </p>
                       </div>
                       <StarterPromptList
@@ -1250,6 +1347,18 @@ export function AtlasChat({
                 </ErrorBoundary>
                 </ScrollArea>
 
+                {/* #4297 — failed action (send / load / pin / unpin / resume).
+                    Composer-adjacent so it sits where the user is looking
+                    after acting; persistent until retried, superseded, or
+                    dismissed. Distinct from the chat-stream ErrorBanner below,
+                    which owns mid-stream wire errors. */}
+                {actionFailure && (
+                  <ActionErrorBanner
+                    failure={actionFailure}
+                    onDismiss={() => setActionFailure(null)}
+                  />
+                )}
+
                 {error && (
                   <ErrorBanner
                     error={error}
@@ -1276,7 +1385,11 @@ export function AtlasChat({
                 {!error && !loadingConversation && (
                   <ResumeBanner
                     runStatus={runStatusCtl.runStatus}
-                    onResume={handleResume}
+                    onResume={() => {
+                      // #4297 — a fresh attempt supersedes the failure banner.
+                      setActionFailure(null);
+                      handleResume();
+                    }}
                     resuming={resuming}
                   />
                 )}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -794,10 +794,18 @@ export function AtlasChat({
         // Safe only while the draft is untouched: editing the restored text
         // clears this failure (see the composer's onValueChange), so a stale
         // "Try again" can never clobber an edit with the original text.
-        retry: () => handleSend(saved),
+        // Through the ref so the retry evaluates the CURRENT render's guards —
+        // a closure-captured handleSend would freeze isLoading /
+        // loadingConversation at the failing render's (false) values, making
+        // the guards above no-ops on exactly this path.
+        retry: () => handleSendRef.current(saved),
       });
     });
   }
+  // Latest-value ref for the banner retry above — the same render-phase
+  // assignment pattern as handleSelectConversationRef below.
+  const handleSendRef = useRef(handleSend);
+  handleSendRef.current = handleSend;
 
   function handleSuggestionSelect(text: string, id: string) {
     fetch(`${apiUrl}/api/v1/suggestions/${id}/click`, {

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -13,7 +13,12 @@ import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations, transformMessages } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
 import { ChatComposer } from "./chat/chat-composer";
-import { ErrorBanner, ActionErrorBanner, type ChatActionFailure } from "./chat/error-banner";
+import {
+  ErrorBanner,
+  ActionErrorBanner,
+  clearFailureOfKind,
+  type StoredActionFailure,
+} from "./chat/error-banner";
 import { ContextWarningBanner } from "./chat/context-warning-banner";
 import { ResumeBanner } from "./chat/resume-banner";
 import { useRunStatus } from "../hooks/use-run-status";
@@ -116,14 +121,6 @@ function SaveButton({
     </Button>
   );
 }
-
-/**
- * #4297 — which action produced the stored failure. Scopes machine-initiated
- * clears: the auto-resume path may supersede only a `"resume"` failure, never
- * an unrelated one the user hasn't seen yet.
- */
-type ChatActionKind = "send" | "load" | "pin" | "unpin" | "resume";
-type StoredActionFailure = ChatActionFailure & { readonly kind: ChatActionKind };
 
 interface AtlasChatProps {
   /**
@@ -505,15 +502,16 @@ export function AtlasChat({
     // without retrying. Kind-scoped because auto-resume is machine-initiated:
     // it must not clear an unrelated failure the user hasn't seen.
     onStart: () => {
-      setActionFailure((f) => (f && f.kind === "resume" ? null : f));
+      setActionFailure(clearFailureOfKind("resume"));
     },
-    onError: (message) => {
+    onError: (message, detail) => {
       // #4297 — a failed resume is a real failure: persistent banner, not a
       // fading whisper. Retry through the ref — this callback is constructed
       // before `handleResume` exists (same seam as `handleParkedResolved`).
       setActionFailure({
         kind: "resume",
         title: message,
+        detail,
         retry: () => {
           handleResumeRef.current();
         },
@@ -625,7 +623,10 @@ export function AtlasChat({
         body: JSON.stringify({ text }),
       });
       if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as {
+        const body = (await res
+          .json()
+          // intentionally ignored: non-JSON error body — status/statusText logged below
+          .catch(() => ({}))) as {
           error?: string;
           message?: string;
           requestId?: string;
@@ -644,7 +645,13 @@ export function AtlasChat({
         // (proxy error page, envelope drift) must not take down the surface.
         const detail = typeof body.message === "string" ? body.message : undefined;
         const requestId = typeof body.requestId === "string" ? body.requestId : undefined;
-        console.warn("pin failed:", res.status, res.statusText, requestId, detail);
+        console.warn(
+          "pin failed:",
+          res.status,
+          res.statusText,
+          requestId ?? "(no requestId — non-JSON body)",
+          detail,
+        );
         setActionFailure({
           kind: "pin",
           title: "Couldn't pin starter prompt",
@@ -710,7 +717,10 @@ export function AtlasChat({
       );
       if (!res.ok && res.status !== 404) {
         // 404 is fine — the pin is gone either way.
-        const body = (await res.json().catch(() => ({}))) as {
+        const body = (await res
+          .json()
+          // intentionally ignored: non-JSON error body — status/statusText logged below
+          .catch(() => ({}))) as {
           requestId?: string;
           message?: string;
         };
@@ -758,6 +768,11 @@ export function AtlasChat({
     // conversation or be clobbered when the in-flight load commits. The composer
     // is disabled too; this also guards the chip / starter-prompt send paths.
     if (loadingConversation) return;
+    // #4297 — the composer is stream-disabled, but the failure banner's
+    // "Try again" is not: a retry clicked mid-stream must not erase the
+    // banner, null the live run's id (degrading Stop to client-only), or
+    // race a second stream. Guard BEFORE the clear, like every other path.
+    if (isLoading) return;
     // A fresh attempt supersedes any earlier failure banner (#4297).
     setActionFailure(null);
     const saved = text;
@@ -1432,7 +1447,7 @@ export function AtlasChat({
                       // stale "Try again" (which resends the ORIGINAL text)
                       // from clobbering the edit. Send-kind only — typing must
                       // not dismiss an unrelated pin/load/resume failure.
-                      setActionFailure((f) => (f && f.kind === "send" ? null : f));
+                      setActionFailure(clearFailureOfKind("send"));
                     }}
                     onSend={handleSend}
                     streaming={isLoading}

--- a/packages/web/src/ui/components/chat/error-banner.tsx
+++ b/packages/web/src/ui/components/chat/error-banner.tsx
@@ -23,6 +23,29 @@ export interface ChatActionFailure {
 }
 
 /**
+ * #4297 — which action produced a failure STORED in chat state (standing
+ * conditions like the health warning render directly and never carry a kind).
+ * Scopes narrow clears — machine-initiated (auto-resume supersedes only a
+ * `"resume"` failure) and implicit (composer edits clear only a `"send"`
+ * failure) — so neither can erase an unrelated failure the user hasn't seen.
+ * Deliberate user actions clear unscoped: a fresh attempt supersedes whatever
+ * banner is up.
+ */
+export type ChatActionKind = "send" | "load" | "pin" | "unpin" | "resume";
+export type StoredActionFailure = ChatActionFailure & { readonly kind: ChatActionKind };
+
+/**
+ * Functional-updater factory for the kind-scoped clears described on
+ * `ChatActionKind`. Identity-preserving on a non-matching kind so React's
+ * setState bails out of the re-render.
+ */
+export function clearFailureOfKind(
+  kind: ChatActionKind,
+): (failure: StoredActionFailure | null) => StoredActionFailure | null {
+  return (failure) => (failure && failure.kind === kind ? null : failure);
+}
+
+/**
  * Structured error surface for failed chat actions — the same visual grade as
  * `ErrorBanner` (icon, title, detail, request id, retry) but fed by a
  * `ChatActionFailure` instead of a chat-stream `Error`. The component never

--- a/packages/web/src/ui/components/chat/error-banner.tsx
+++ b/packages/web/src/ui/components/chat/error-banner.tsx
@@ -6,26 +6,28 @@ import { parseChatError, type AuthMode, type ClientErrorCode } from "../../lib/t
 import { WifiOff, ServerCrash, ShieldAlert, Clock, AlertTriangle, MessageSquarePlus, X } from "lucide-react";
 
 /**
- * A failed chat-surface action (send / load / pin / unpin / resume) described
- * for `ActionErrorBanner`. Unlike the chat-stream `ErrorBanner` below — which
- * parses a wire `Error` via `parseChatError` — these failures originate from
- * explicit fetch call sites that already know the user-facing title, any
- * server-provided detail/request id, and how to re-run the action (#4297).
+ * A failure (or standing error condition) on the chat surface, described for
+ * `ActionErrorBanner` — failed actions (send / load / pin / unpin / resume) as
+ * well as standing conditions like the transport health warning or the
+ * conversation-list fetch error. Unlike the chat-stream `ErrorBanner` below —
+ * which parses a wire `Error` via `parseChatError` — these come from call
+ * sites that already know the user-facing title, any server-provided
+ * detail/request id, and — when retryable — how to re-run the action (#4297).
  */
 export interface ChatActionFailure {
-  title: string;
-  detail?: string;
-  requestId?: string;
+  readonly title: string;
+  readonly detail?: string;
+  readonly requestId?: string;
   /** Re-runs the failed action. Omit when the action isn't retryable. */
-  retry?: () => void;
+  readonly retry?: () => void;
 }
 
 /**
  * Structured error surface for failed chat actions — the same visual grade as
  * `ErrorBanner` (icon, title, detail, request id, retry) but fed by a
- * `ChatActionFailure` instead of a chat-stream `Error`. Failures rendered here
- * are persistent: they never auto-dismiss, and clear only when retried,
- * superseded by a newer action, or explicitly dismissed via `onDismiss`.
+ * `ChatActionFailure` instead of a chat-stream `Error`. The component never
+ * auto-dismisses; callers keep it mounted until the failure is retried,
+ * superseded, resolved, or dismissed via `onDismiss` (#4297).
  */
 export function ActionErrorBanner({
   failure,

--- a/packages/web/src/ui/components/chat/error-banner.tsx
+++ b/packages/web/src/ui/components/chat/error-banner.tsx
@@ -29,7 +29,8 @@ export interface ChatActionFailure {
  * `"resume"` failure) and implicit (composer edits clear only a `"send"`
  * failure) — so neither can erase an unrelated failure the user hasn't seen.
  * Deliberate user actions clear unscoped: a fresh attempt supersedes whatever
- * banner is up.
+ * banner is up (resume is the exception — its clear seam is shared with
+ * auto-resume, so it stays kind-scoped even on a ResumeBanner click).
  */
 export type ChatActionKind = "send" | "load" | "pin" | "unpin" | "resume";
 export type StoredActionFailure = ChatActionFailure & { readonly kind: ChatActionKind };

--- a/packages/web/src/ui/components/chat/error-banner.tsx
+++ b/packages/web/src/ui/components/chat/error-banner.tsx
@@ -3,7 +3,76 @@
 import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { parseChatError, type AuthMode, type ClientErrorCode } from "../../lib/types";
-import { WifiOff, ServerCrash, ShieldAlert, Clock, AlertTriangle, MessageSquarePlus } from "lucide-react";
+import { WifiOff, ServerCrash, ShieldAlert, Clock, AlertTriangle, MessageSquarePlus, X } from "lucide-react";
+
+/**
+ * A failed chat-surface action (send / load / pin / unpin / resume) described
+ * for `ActionErrorBanner`. Unlike the chat-stream `ErrorBanner` below — which
+ * parses a wire `Error` via `parseChatError` — these failures originate from
+ * explicit fetch call sites that already know the user-facing title, any
+ * server-provided detail/request id, and how to re-run the action (#4297).
+ */
+export interface ChatActionFailure {
+  title: string;
+  detail?: string;
+  requestId?: string;
+  /** Re-runs the failed action. Omit when the action isn't retryable. */
+  retry?: () => void;
+}
+
+/**
+ * Structured error surface for failed chat actions — the same visual grade as
+ * `ErrorBanner` (icon, title, detail, request id, retry) but fed by a
+ * `ChatActionFailure` instead of a chat-stream `Error`. Failures rendered here
+ * are persistent: they never auto-dismiss, and clear only when retried,
+ * superseded by a newer action, or explicitly dismissed via `onDismiss`.
+ */
+export function ActionErrorBanner({
+  failure,
+  onDismiss,
+}: {
+  failure: ChatActionFailure;
+  /** Renders a dismiss affordance. Omit for standing conditions (e.g. a health warning) that should stay visible. */
+  onDismiss?: () => void;
+}) {
+  return (
+    <div
+      className="mb-2 rounded-lg border border-red-300 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400 px-4 py-3 text-sm"
+      role="alert"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="size-4 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="font-medium">{failure.title}</p>
+          {failure.detail && <p className="mt-1 text-xs opacity-80">{failure.detail}</p>}
+          {failure.requestId && (
+            <p className="mt-1 text-xs opacity-60">Request ID: {failure.requestId}</p>
+          )}
+          {failure.retry && (
+            <Button
+              variant="link"
+              size="sm"
+              onClick={failure.retry}
+              className="mt-2 h-auto p-0 text-xs font-medium text-red-700 dark:text-red-400"
+            >
+              Try again
+            </Button>
+          )}
+        </div>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            className="-m-1 rounded-md p-1 text-red-700/70 hover:bg-red-100 hover:text-red-700 dark:text-red-400/70 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
 /** Icon for each client error code */
 function ErrorIcon({ clientCode }: { clientCode?: ClientErrorCode }) {

--- a/packages/web/src/ui/hooks/__tests__/use-resume-handler.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-resume-handler.test.tsx
@@ -119,4 +119,59 @@ describe("useResumeHandler (#3749)", () => {
     expect(onStart).not.toHaveBeenCalled();
     expect(opts.regenerate).not.toHaveBeenCalled();
   });
+
+  test("onStart does NOT fire on a re-entrant call while a resume is in flight", async () => {
+    let resolveFirst: () => void = () => {};
+    const regenerate = mock(
+      () => new Promise<void>((res) => { resolveFirst = res; }),
+    );
+    const onStart = mock(() => {});
+    const opts = makeOpts({ regenerate, onStart });
+    const { result } = renderHook(() => useResumeHandler(opts));
+
+    await act(async () => {
+      result.current.resume();
+    });
+    await act(async () => {
+      result.current.resume();
+    });
+    // One real start, one guarded no-op — the supersede seam fired exactly once.
+    expect(onStart).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst();
+    });
+    await waitFor(() => expect(result.current.resuming).toBe(false));
+  });
+
+  test("onStart fires before onError on a failed resume (clear-then-report ordering)", async () => {
+    const order: string[] = [];
+    const opts = makeOpts({
+      regenerate: mock(() => Promise.reject(new Error("boom"))),
+      onStart: mock(() => {
+        order.push("onStart");
+      }),
+      onError: mock(() => {
+        order.push("onError");
+      }),
+    });
+    const { result } = renderHook(() => useResumeHandler(opts));
+    await act(async () => {
+      result.current.resume();
+    });
+    await waitFor(() => expect(order).toEqual(["onStart", "onError"]));
+  });
+
+  test("onError receives the narrowed underlying error as detail (#4297)", async () => {
+    const opts = makeOpts({ regenerate: mock(() => Promise.reject(new Error("socket hang up"))) });
+    const { result } = renderHook(() => useResumeHandler(opts));
+    await act(async () => {
+      result.current.resume();
+    });
+    await waitFor(() => expect(opts.onError).toHaveBeenCalledTimes(1));
+    expect(opts.onError.mock.calls[0]).toEqual([
+      "Failed to resume the interrupted turn. Please try again.",
+      "socket hang up",
+    ]);
+  });
 });

--- a/packages/web/src/ui/hooks/__tests__/use-resume-handler.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-resume-handler.test.tsx
@@ -95,4 +95,28 @@ describe("useResumeHandler (#3749)", () => {
     });
     expect(opts.regenerate).not.toHaveBeenCalled();
   });
+
+  // #4297 — onStart is the caller's supersede seam for its failure banner: it
+  // must fire exactly when a resume actually begins, and NEVER on a guarded
+  // no-op call (otherwise a click could erase the banner without retrying).
+  test("onStart fires when a resume actually begins", async () => {
+    const onStart = mock(() => {});
+    const opts = makeOpts({ onStart });
+    const { result } = renderHook(() => useResumeHandler(opts));
+    await act(async () => {
+      result.current.resume();
+    });
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  test("onStart does NOT fire on a guarded no-op call (isLoading)", async () => {
+    const onStart = mock(() => {});
+    const opts = makeOpts({ onStart, isLoading: true });
+    const { result } = renderHook(() => useResumeHandler(opts));
+    await act(async () => {
+      result.current.resume();
+    });
+    expect(onStart).not.toHaveBeenCalled();
+    expect(opts.regenerate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/ui/hooks/__tests__/use-transient-notice.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-transient-notice.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useTransientNotice } from "../use-transient-notice";
 
@@ -30,12 +30,19 @@ describe("useTransientNotice (#4297)", () => {
     await waitFor(() => expect(result.current.notice).toBe(""), { timeout: 1000 });
   });
 
-  test("unmount clears the pending timer without state updates", async () => {
-    const { result, unmount } = renderHook(() => useTransientNotice());
-    act(() => result.current.showNotice("bye", 30));
-    unmount();
-    // Let the timer deadline pass — a leaked timer would fire setState on an
-    // unmounted hook (surfacing as a console error under strict test runners).
-    await new Promise((r) => setTimeout(r, 60));
+  test("unmount cancels the pending dismissal timer", () => {
+    // React 19 silently ignores setState on an unmounted component, so a
+    // leaked timer would be invisible to a render-side assertion — assert the
+    // cancellation itself instead.
+    const clearSpy = spyOn(globalThis, "clearTimeout");
+    try {
+      const { result, unmount } = renderHook(() => useTransientNotice());
+      act(() => result.current.showNotice("bye", 30));
+      const callsBefore = clearSpy.mock.calls.length;
+      unmount();
+      expect(clearSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+    } finally {
+      clearSpy.mockRestore();
+    }
   });
 });

--- a/packages/web/src/ui/hooks/__tests__/use-transient-notice.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-transient-notice.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useTransientNotice } from "../use-transient-notice";
+
+describe("useTransientNotice (#4297)", () => {
+  test("shows a notice and auto-dismisses it after its timeout", async () => {
+    const { result } = renderHook(() => useTransientNotice());
+    expect(result.current.notice).toBe("");
+
+    act(() => result.current.showNotice("Pinned as starter prompt.", 30));
+    expect(result.current.notice).toBe("Pinned as starter prompt.");
+
+    await waitFor(() => expect(result.current.notice).toBe(""));
+  });
+
+  test("a newer notice supersedes the older notice's dismissal timer", async () => {
+    const { result } = renderHook(() => useTransientNotice());
+
+    act(() => result.current.showNotice("first", 30));
+    act(() => result.current.showNotice("second", 250));
+
+    // Wait past the FIRST notice's deadline: its (superseded) timer must not
+    // clip the second notice early.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 90));
+    });
+    expect(result.current.notice).toBe("second");
+
+    // The second notice still dismisses on its own schedule.
+    await waitFor(() => expect(result.current.notice).toBe(""), { timeout: 1000 });
+  });
+
+  test("unmount clears the pending timer without state updates", async () => {
+    const { result, unmount } = renderHook(() => useTransientNotice());
+    act(() => result.current.showNotice("bye", 30));
+    unmount();
+    // Let the timer deadline pass — a leaked timer would fire setState on an
+    // unmounted hook (surfacing as a console error under strict test runners).
+    await new Promise((r) => setTimeout(r, 60));
+  });
+});

--- a/packages/web/src/ui/hooks/use-resume-handler.ts
+++ b/packages/web/src/ui/hooks/use-resume-handler.ts
@@ -18,7 +18,14 @@ export interface UseResumeHandlerOptions {
   isLoading: boolean;
   /** Drop any unattached warning frames before the resumed stream starts. */
   resetPendingWarnings: () => void;
-  /** Surface a transient failure message to the user. */
+  /**
+   * #4297 — fires when a resume attempt actually begins, i.e. AFTER the
+   * re-entrancy guard passes. Callers clear their resume-failure surface here
+   * rather than before calling `resume()`, so a guarded no-op call can never
+   * erase a failure banner without a retry actually happening.
+   */
+  onStart?: () => void;
+  /** Surface the failure to the user (rendered persistently — see #4297). */
   onError: (message: string) => void;
 }
 
@@ -36,7 +43,8 @@ export interface UseResumeHandlerReturn {
  *
  *   1. re-entrancy guard — ignore while already resuming or a stream is live, so
  *      a double-click can't fork the turn or double-charge the step budget;
- *   2. optimistic clear of the banner + set the in-flight flag;
+ *   2. set the in-flight flag, fire `onStart` (the caller's failure-banner
+ *      supersede seam — #4297), and optimistically clear the run-status banner;
  *   3. `regenerate({ body: { [ATLAS_RESUME_MARKER]: true } })` — NOT `sendMessage`,
  *      so no phantom user message is appended; the marker routes it to the resume
  *      endpoint via the transport;
@@ -51,6 +59,7 @@ export function useResumeHandler(opts: UseResumeHandlerOptions): UseResumeHandle
     refetchRunStatus,
     isLoading,
     resetPendingWarnings,
+    onStart,
     onError,
   } = opts;
   const [resuming, setResuming] = useState(false);
@@ -58,6 +67,7 @@ export function useResumeHandler(opts: UseResumeHandlerOptions): UseResumeHandle
   const resume = useCallback(() => {
     if (resuming || isLoading) return;
     setResuming(true);
+    onStart?.();
     clearRunStatus();
     resetPendingWarnings();
     regenerate({ body: { [ATLAS_RESUME_MARKER]: true } })
@@ -79,6 +89,7 @@ export function useResumeHandler(opts: UseResumeHandlerOptions): UseResumeHandle
     clearRunStatus,
     resetPendingWarnings,
     refetchRunStatus,
+    onStart,
     onError,
   ]);
 

--- a/packages/web/src/ui/hooks/use-resume-handler.ts
+++ b/packages/web/src/ui/hooks/use-resume-handler.ts
@@ -25,20 +25,25 @@ export interface UseResumeHandlerOptions {
    * erase a failure banner without a retry actually happening.
    */
   onStart?: () => void;
-  /** Surface the failure to the user (rendered persistently — see #4297). */
-  onError: (message: string) => void;
+  /**
+   * Surface the failure to the user (rendered persistently — see #4297).
+   * `detail` carries the narrowed underlying error message for the banner's
+   * detail row, matching the pin/unpin failure surfaces.
+   */
+  onError: (message: string, detail?: string) => void;
 }
 
 export interface UseResumeHandlerReturn {
-  /** True while a user-initiated resume stream is in flight. */
+  /** True while a resume stream is in flight. */
   resuming: boolean;
   /** Activate the resume. Re-entrant calls (already resuming / streaming) are no-ops. */
   resume: () => void;
 }
 
 /**
- * #3749 — orchestrate a user-initiated resume of an interrupted turn. Extracted
- * from the chat component so the AC-bearing sequence is unit-testable without the
+ * #3749 — orchestrate a resume of an interrupted turn (user-initiated via the
+ * banner, or auto-initiated on the parked→running poll flip). Extracted from
+ * the chat component so the AC-bearing sequence is unit-testable without the
  * full `AtlasChat` harness:
  *
  *   1. re-entrancy guard — ignore while already resuming or a stream is live, so
@@ -72,11 +77,9 @@ export function useResumeHandler(opts: UseResumeHandlerOptions): UseResumeHandle
     resetPendingWarnings();
     regenerate({ body: { [ATLAS_RESUME_MARKER]: true } })
       .catch((err: unknown) => {
-        console.error(
-          "Failed to resume turn:",
-          err instanceof Error ? err.message : String(err),
-        );
-        onError("Failed to resume the interrupted turn. Please try again.");
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error("Failed to resume turn:", detail);
+        onError("Failed to resume the interrupted turn. Please try again.", detail);
       })
       .finally(() => {
         setResuming(false);

--- a/packages/web/src/ui/hooks/use-transient-notice.ts
+++ b/packages/web/src/ui/hooks/use-transient-notice.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseTransientNoticeReturn {
+  /** The currently visible notice, or `""` when none. */
+  notice: string;
+  /** Show `message` for `ms` milliseconds, superseding any prior notice. */
+  showNotice: (message: string, ms: number) => void;
+}
+
+/**
+ * #4297 — the quiet auto-dismissing notice line for genuinely informational
+ * transients (pin success / already-pinned). Failures must NOT flow through
+ * here — they surface via the persistent `ActionErrorBanner` instead.
+ *
+ * One dismissal timer at a time: showing a new notice cancels the previous
+ * notice's timeout, so a stale timer can't clip a fresh notice early (the bug
+ * class the old per-call-site `setTimeout(() => setWarning(""), …)` had).
+ * The pending timer is cleared on unmount.
+ */
+export function useTransientNotice(): UseTransientNoticeReturn {
+  const [notice, setNotice] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showNotice = useCallback((message: string, ms: number) => {
+    setNotice(message);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setNotice(""), ms);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { notice, showNotice };
+}


### PR DESCRIPTION
## Summary
- Real failures on the chat surface (send / conversation load / pin / unpin / resume, plus the transport health warning and conversation-list fetch error) no longer whisper as faint auto-dismissing `text-zinc-400` one-liners — they surface through a new `ActionErrorBanner` at the same structured grade as the chat-stream `ErrorBanner`: icon, title, server-provided detail, request ID where present, and a retry where the action is retryable. Failures persist until retried, superseded by a newer action, or dismissed; genuinely informational transients (pin success / already-pinned) keep the quiet line via a new unit-tested `useTransientNotice` hook.
- Failure-state discipline is kind-scoped (`clearFailureOfKind`): machine-initiated clears (auto-resume) and implicit clears (composer edits) can only supersede their own kind, never a failure the user hasn't seen. `useResumeHandler` grew an `onStart` seam (fired after its re-entrancy guard) plus `onError` detail passthrough; all retry closures route through latest-value refs so guards evaluate current state.
- Empty-state value prop unified on the brand phrasing: the empty body heading is now "Ask your data anything" (matching the standalone header tagline / www hero), with the e2e assertion moved to a `data-testid` + deliberate copy containment.

## Review
- Internal review panel (silent-failure / type-design / pr-test / comment): 3 rounds, converged clean; all must-fix findings addressed in-branch (`isLoading` guard on send retry, seam narrowing of unvalidated error-body casts, comment-rot fix in `(workspace)/page.tsx`, vacuous unmount test replaced with a `clearTimeout` spy).
- `/ci`: all 28 local gates green (full suite); web suite 261 files green.

## Test plan
- [x] `ActionErrorBanner` unit tests: title/detail/requestId render, `role="alert"`, retry/dismiss affordances + absence branches, `clearFailureOfKind` kind-scoping + identity preservation
- [x] `useTransientNotice` tests: auto-dismiss, supersede-timer invariant, unmount cancellation
- [x] `useResumeHandler` tests: `onStart` fires iff a resume actually begins (guarded no-op + re-entrancy arms), clear-then-report ordering, narrowed detail passthrough
- [x] e2e `conversations.spec.ts` empty-state assertion keyed by testid + pins the unified copy
- [x] Full `bun run test` (web 261 files) + `scripts/ci-local.sh` all gates

## Notes / out of scope
- `packages/react` (the separately published embeddable component) still carries the old "What would you like to know?" empty-state copy — separate publish train, not named by #4297; flag if it should follow.
- Conversation-load failures carry no request ID because `fetch-client.ts` throws status-only Errors (pre-existing plumbing); the banner supports it as soon as the client surfaces one.

Closes #4297

https://claude.ai/code/session_01BiSxUCmK9zbQLmFqSeDF9v