### PR TITLE
feat: dashboard draft-first editing spine — every edit lands in your draft (#4315)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -6269,6 +6269,31 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Drafts unavailable — internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "patchDashboardsById"
@@ -8278,6 +8303,31 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Drafts unavailable — internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "postDashboardsByIdCards"
@@ -8665,6 +8715,31 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Drafts unavailable — internal database not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "patchDashboardsByIdCardsByCardId"
@@ -8773,6 +8848,31 @@
           },
           "500": {
             "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Drafts unavailable — internal database not configured",
             "content": {
               "application/json": {
                 "schema": {
@@ -9049,6 +9149,18 @@
             "required": true,
             "name": "cardId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "published",
+                "draft"
+              ]
+            },
+            "required": false,
+            "name": "view",
+            "in": "query"
           }
         ],
         "responses": {
@@ -9278,6 +9390,18 @@
             },
             "required": false,
             "name": "format",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "published",
+                "draft"
+              ]
+            },
+            "required": false,
+            "name": "view",
             "in": "query"
           }
         ],

--- a/e2e/browser/dashboard-drafts-editing.spec.ts
+++ b/e2e/browser/dashboard-drafts-editing.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Dashboard draft-first editing spine (#4315) @llm
+ *
+ * The foundational browser contract from ADR-0029: entering Edit is explicit,
+ * the canvas then renders the caller's DRAFT (not the published copy), a
+ * persistent "Editing your draft" bar is shown, and switching back to View
+ * shows the untouched published state. The two-view split is simulated with
+ * route mocks — `GET /:id` returns published, `GET /:id?view=draft` returns the
+ * draft — so the contract that matters (Edit toggles the view + the bar, View
+ * shows published) is exercised without a real DB.
+ *
+ * @llm tag — same suite segmentation as the sibling drafts specs.
+ */
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+const DASH_ID = "44444444-5555-6666-7777-888888888888";
+const AT = "2026-07-04T10:00:00.000Z";
+
+function card(id: string, title: string, sql: string) {
+  return {
+    id,
+    dashboardId: DASH_ID,
+    position: 0,
+    title,
+    sql,
+    chartConfig: null,
+    cachedColumns: null,
+    cachedRows: null,
+    cachedAt: null,
+    connectionGroupId: null,
+    layout: null,
+    createdAt: AT,
+    updatedAt: AT,
+  };
+}
+
+function dashboard(title: string, cardTitle: string, cardSql: string) {
+  return {
+    id: DASH_ID,
+    orgId: "org-1",
+    ownerId: "u1",
+    title,
+    description: null,
+    shareToken: null,
+    shareExpiresAt: null,
+    shareMode: "public" as const,
+    refreshSchedule: null,
+    lastRefreshAt: null,
+    nextRefreshAt: null,
+    parameters: [],
+    createdAt: AT,
+    updatedAt: AT,
+    cards: [card("card-1", cardTitle, cardSql)],
+  };
+}
+
+async function installMocks(page: Page, seen: { draftViewFetched: boolean }): Promise<void> {
+  // The dashboard resource: `?view=draft` returns the DRAFT board, else the
+  // published board. Anchored regex so sub-paths (/draft/status, /stage,
+  // /sessions) are NOT captured here.
+  await page.route(
+    new RegExp(`/api/v1/dashboards/${DASH_ID}(\\?[^/]*)?$`),
+    async (route: Route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      const isDraft = route.request().url().includes("view=draft");
+      if (isDraft) seen.draftViewFetched = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          isDraft
+            ? dashboard("Draft Board", "Draft tile", "SELECT draft")
+            : dashboard("Published Board", "Published tile", "SELECT published"),
+        ),
+      });
+    },
+  );
+
+  await page.route(`**/api/v1/dashboards/${DASH_ID}/draft/status`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasDraft: true,
+        publishedBaselineAt: AT,
+        dashboardUpdatedAt: AT,
+        staleBaseline: false,
+        updatedAt: AT,
+      }),
+    });
+  });
+
+  await page.route(`**/api/v1/dashboards/${DASH_ID}/stage`, async (route: Route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ stages: [] }) });
+  });
+
+  await page.route(`**/api/v1/dashboards/${DASH_ID}/sessions`, async (route: Route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ sessions: [] }) });
+  });
+
+  // Tile render batch — return a trivial result regardless of view.
+  await page.route(`**/api/v1/dashboards/${DASH_ID}/cards/**/render**`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ columns: ["n"], rows: [{ n: 1 }], truncated: false, rowCount: 1, executionMs: 1 }),
+    });
+  });
+
+  await page.route("**/api/v1/dashboards", async (route: Route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        dashboards: [{ id: DASH_ID, title: "Published Board", cardCount: 1, updatedAt: AT }],
+        total: 1,
+      }),
+    });
+  });
+}
+
+test.describe("Dashboard draft-first editing @llm", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  test("enter Edit renders the draft + persistent bar; View shows published untouched", async ({
+    page,
+  }) => {
+    const seen = { draftViewFetched: false };
+    await installMocks(page, seen);
+
+    await page.goto(`/dashboards/${DASH_ID}`);
+
+    // 1) View mode: the canvas shows the PUBLISHED board.
+    await expect(page.getByText("Published tile")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("editing-draft-bar")).toHaveCount(0);
+
+    // 2) Entering Edit is explicit — click the Edit control.
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    // 3) The canvas now renders the caller's DRAFT (a `?view=draft` fetch).
+    await expect(page.getByText("Draft tile")).toBeVisible({ timeout: 10_000 });
+    await expect.poll(() => seen.draftViewFetched, { timeout: 10_000 }).toBe(true);
+
+    // 4) A persistent "Editing your draft" bar is shown while editing (the
+    //    draft exists → the richer Draft block with Publish/Discard).
+    await expect(page.getByTestId("draft-status-banner")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("draft-status-banner")).toContainText(/editing your draft/i);
+    await expect(page.getByTestId("draft-publish-button")).toBeVisible();
+
+    // 5) Switching back to View shows the untouched PUBLISHED board.
+    await page.getByRole("button", { name: "View" }).click();
+    await expect(page.getByText("Published tile")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -222,6 +222,27 @@ mock.module("@atlas/api/lib/dashboards", () => ({
   rowToCard: realDashboards.rowToCard,
 }));
 
+// #4315 — versioning mock. Keep everything REAL except the two DB-touching
+// seams the direct-manipulation + draft-aware-execution routes call
+// (`applyEditToDraft`, `loadDraft`). `isDashboardDraftsEnabled` stays real so
+// the env flag drives routing: the legacy suite runs flag-OFF (published
+// path, these spies never fire), the draft-first suite runs flag-ON.
+const realVersioning = await import("@atlas/api/lib/dashboard-versioning");
+type ApplyEditResult = import("@atlas/api/lib/dashboard-versioning").ApplyEditToDraftResult;
+type DraftRowT = import("@atlas/api/lib/dashboard-versioning").DraftRow;
+const mockApplyEditToDraft = mock(
+  (..._args: unknown[]): Promise<ApplyEditResult> =>
+    Promise.resolve({ ok: false, reason: "no_db" }),
+);
+const mockLoadDraft = mock(
+  (..._args: unknown[]): Promise<DraftRowT | null> => Promise.resolve(null),
+);
+mock.module("@atlas/api/lib/dashboard-versioning", () => ({
+  ...realVersioning,
+  applyEditToDraft: mockApplyEditToDraft,
+  loadDraft: mockLoadDraft,
+}));
+
 // #2368 — bound-chat-context mocks for the new sessions endpoints.
 // Real module exports must stay surface-complete (CLAUDE.md "Mock all
 // exports — partial mocks cause SyntaxError"); copy the unmocked ones
@@ -438,9 +459,17 @@ const { _resetDashboardRateLimit } = await import("../routes/dashboards");
 
 describe("dashboard routes", () => {
   const origDatabaseUrl = process.env.DATABASE_URL;
+  const origDraftsFlag = process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED;
 
   beforeEach(() => {
     process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    // #4315 — these cases assert the LEGACY direct-published CRUD path
+    // (addCard/updateCard/removeCard/updateDashboard call the published
+    // helpers). With drafts ON those direct-manipulation ops route to the
+    // caller's draft instead; that behavior is covered in
+    // `dashboards-drafts-routing.test.ts`. Opt out of the draft path here so
+    // this file keeps exercising the CRUD-forwarding + validation contract.
+    process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = "false";
     capturedLogs.length = 0;
     mockAuthenticateRequest.mockReset();
     mockAuthenticateRequest.mockResolvedValue({
@@ -475,6 +504,10 @@ describe("dashboard routes", () => {
     mockRefreshCard.mockResolvedValue({ ok: true });
     mockGetCard.mockReset();
     mockGetCard.mockResolvedValue({ ok: true, data: mockCardData });
+    mockApplyEditToDraft.mockReset();
+    mockApplyEditToDraft.mockResolvedValue({ ok: false, reason: "no_db" });
+    mockLoadDraft.mockReset();
+    mockLoadDraft.mockResolvedValue(null);
     mockShareDashboard.mockReset();
     mockShareDashboard.mockResolvedValue({ ok: true, data: { token: "share-token-123", expiresAt: null, shareMode: "public" } });
     mockUnshareDashboard.mockReset();
@@ -502,6 +535,8 @@ describe("dashboard routes", () => {
   afterEach(() => {
     if (origDatabaseUrl !== undefined) process.env.DATABASE_URL = origDatabaseUrl;
     else delete process.env.DATABASE_URL;
+    if (origDraftsFlag === undefined) delete process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED;
+    else process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = origDraftsFlag;
   });
 
   // -------------------------------------------------------------------------
@@ -2761,5 +2796,415 @@ describe("dashboard routes", () => {
       expect(response.status).toBe(422);
       expect(mockExportDashboard).not.toHaveBeenCalled();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // #4315 — draft-first editing spine. With drafts ON + a real user, every
+  // direct-manipulation edit routes to the caller's DRAFT; nothing but publish
+  // writes the published tables. Draft-aware execution runs the draft's SQL.
+  // -------------------------------------------------------------------------
+  describe("draft-first routing (#4315)", () => {
+    const DASH_WITH_CARD = {
+      ...mockDashboardData,
+      cards: [mockCardData],
+    };
+    const draftView = {
+      ...mockDashboardData,
+      lastRefreshAt: null,
+      nextRefreshAt: null,
+      cards: [],
+    };
+
+    beforeEach(() => {
+      // The parent beforeEach forces the flag OFF; opt back IN for this suite.
+      process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = "true";
+      mockGetDashboard.mockResolvedValue({ ok: true, data: DASH_WITH_CARD });
+      mockApplyEditToDraft.mockResolvedValue({
+        ok: true,
+        snapshot: {
+          dashboardId: VALID_ID,
+          title: "Revenue Dashboard",
+          description: null,
+          cards: [],
+        },
+        // Test fixture: `mockDashboardData` carries `cardCount` (a list-view
+        // field) and the route only echoes the view back, so cast at the
+        // boundary rather than reconstruct the full wire type.
+        view: draftView as unknown as Extract<ApplyEditResult, { ok: true }>["view"],
+      });
+    });
+
+    it("PATCH /:id routes a rename to the draft, never the published table", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Renamed" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; title?: string },
+      ];
+      expect(change).toMatchObject({ kind: "updateMeta", title: "Renamed" });
+      // The published title was NOT touched.
+      expect(mockUpdateDashboard).not.toHaveBeenCalled();
+    });
+
+    it("POST /:id/cards stages the new card into the draft (published addCard not called)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "New card",
+            sql: "SELECT 1",
+            chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; card?: { title: string; sql: string } },
+      ];
+      expect(change.kind).toBe("addCard");
+      expect(change.card).toMatchObject({ title: "New card", sql: "SELECT 1" });
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
+    it("PATCH /:id/cards/:cardId updates the draft card (published updateCard not called)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Edited" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; cardId: string; updates: { title?: string } },
+      ];
+      expect(change).toMatchObject({ kind: "updateCard", cardId: VALID_CARD_ID });
+      expect(change.updates).toMatchObject({ title: "Edited" });
+      expect(mockUpdateCard).not.toHaveBeenCalled();
+    });
+
+    it("DELETE /:id/cards/:cardId removes from the draft (published removeCard not called)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(204);
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; cardId: string },
+      ];
+      expect(change).toMatchObject({ kind: "removeCard", cardId: VALID_CARD_ID });
+      expect(mockRemoveCard).not.toHaveBeenCalled();
+    });
+
+    it("returns 503 and never publishes when the draft store is unavailable", async () => {
+      mockApplyEditToDraft.mockResolvedValueOnce({ ok: false, reason: "no_db" });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "New card",
+            sql: "SELECT 1",
+            chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+          }),
+        }),
+      );
+      expect(response.status).toBe(503);
+      // Critically: it did NOT silently fall back to writing published.
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
+    it("render?view=draft executes the DRAFT card's SQL, not the published SQL", async () => {
+      mockLoadDraft.mockResolvedValue({
+        userId: "u1",
+        dashboardId: VALID_ID,
+        snapshot: {
+          dashboardId: VALID_ID,
+          title: "Revenue Dashboard",
+          description: null,
+          cards: [
+            {
+              id: VALID_CARD_ID,
+              position: 0,
+              title: "Total Revenue",
+              sql: "SELECT draft_only_sql",
+              chartConfig: null,
+              connectionGroupId: null,
+              layout: null,
+            },
+          ],
+        },
+        baseline: {
+          dashboardId: VALID_ID,
+          title: "Revenue Dashboard",
+          description: null,
+          cards: [],
+        },
+        publishedBaselineAt: mockDashboardData.updatedAt,
+        createdAt: mockDashboardData.updatedAt,
+        updatedAt: mockDashboardData.updatedAt,
+      });
+      const response = await app.fetch(
+        new Request(
+          `http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/render?view=draft`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ parameters: {} }),
+          },
+        ),
+      );
+      expect(response.status).toBe(200);
+      expect(mockRunUserQueryPipeline).toHaveBeenCalled();
+      const runArg = mockRunUserQueryPipeline.mock.calls[0][0];
+      expect(runArg.sql).toBe("SELECT draft_only_sql");
+    });
+
+    it("refresh?view=draft runs the draft SQL and does NOT persist to the published cache", async () => {
+      mockLoadDraft.mockResolvedValue({
+        userId: "u1",
+        dashboardId: VALID_ID,
+        snapshot: {
+          dashboardId: VALID_ID,
+          title: "Revenue Dashboard",
+          description: null,
+          cards: [
+            {
+              id: VALID_CARD_ID,
+              position: 0,
+              title: "Total Revenue",
+              sql: "SELECT draft_refresh_sql",
+              chartConfig: null,
+              connectionGroupId: null,
+              layout: null,
+            },
+          ],
+        },
+        baseline: {
+          dashboardId: VALID_ID,
+          title: "Revenue Dashboard",
+          description: null,
+          cards: [],
+        },
+        publishedBaselineAt: mockDashboardData.updatedAt,
+        createdAt: mockDashboardData.updatedAt,
+        updatedAt: mockDashboardData.updatedAt,
+      });
+      const response = await app.fetch(
+        new Request(
+          `http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/refresh?view=draft`,
+          { method: "POST" },
+        ),
+      );
+      expect(response.status).toBe(200);
+      const runArg = mockRunUserQueryPipeline.mock.calls[0][0];
+      expect(runArg.sql).toBe("SELECT draft_refresh_sql");
+      // The invariant: a draft refresh never writes the published card cache.
+      expect(mockRefreshCard).not.toHaveBeenCalled();
+      // The freshly-run rows are overlaid on the draft card, in-memory.
+      const body = (await response.json()) as {
+        id: string;
+        cachedColumns: string[];
+        cachedRows: Record<string, unknown>[];
+        cachedAt: string | null;
+      };
+      expect(body.id).toBe(VALID_CARD_ID);
+      expect(body.cachedColumns).toEqual(["month", "total"]);
+      expect(body.cachedRows).toEqual([{ month: "Jan", total: 1000 }]);
+      expect(typeof body.cachedAt).toBe("string");
+    });
+
+    it("render?view=draft 404s when the card was removed in the draft (never runs published)", async () => {
+      // A draft exists, but its snapshot no longer contains VALID_CARD_ID.
+      mockLoadDraft.mockResolvedValue({
+        userId: "u1",
+        dashboardId: VALID_ID,
+        snapshot: { dashboardId: VALID_ID, title: "Revenue Dashboard", description: null, cards: [] },
+        baseline: { dashboardId: VALID_ID, title: "Revenue Dashboard", description: null, cards: [] },
+        publishedBaselineAt: mockDashboardData.updatedAt,
+        createdAt: mockDashboardData.updatedAt,
+        updatedAt: mockDashboardData.updatedAt,
+      });
+      const response = await app.fetch(
+        new Request(
+          `http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/render?view=draft`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ parameters: {} }),
+          },
+        ),
+      );
+      expect(response.status).toBe(404);
+      // Critically: it did NOT silently run the published card under the draft view.
+      expect(mockRunUserQueryPipeline).not.toHaveBeenCalled();
+    });
+
+    it("refresh?view=draft 404s when the card was removed in the draft", async () => {
+      mockLoadDraft.mockResolvedValue({
+        userId: "u1",
+        dashboardId: VALID_ID,
+        snapshot: { dashboardId: VALID_ID, title: "Revenue Dashboard", description: null, cards: [] },
+        baseline: { dashboardId: VALID_ID, title: "Revenue Dashboard", description: null, cards: [] },
+        publishedBaselineAt: mockDashboardData.updatedAt,
+        createdAt: mockDashboardData.updatedAt,
+        updatedAt: mockDashboardData.updatedAt,
+      });
+      const response = await app.fetch(
+        new Request(
+          `http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/refresh?view=draft`,
+          { method: "POST" },
+        ),
+      );
+      expect(response.status).toBe(404);
+      expect(mockRunUserQueryPipeline).not.toHaveBeenCalled();
+    });
+
+    it("CSV export with view=draft streams the DRAFT card's data", async () => {
+      mockLoadDraft.mockResolvedValue({
+        userId: "u1",
+        dashboardId: VALID_ID,
+        snapshot: {
+          dashboardId: VALID_ID,
+          title: "Revenue Dashboard",
+          description: null,
+          cards: [
+            {
+              id: VALID_CARD_ID,
+              position: 0,
+              title: "Total Revenue",
+              sql: "SELECT draft_csv_sql",
+              chartConfig: null,
+              connectionGroupId: null,
+              layout: null,
+            },
+          ],
+        },
+        baseline: { dashboardId: VALID_ID, title: "Revenue Dashboard", description: null, cards: [] },
+        publishedBaselineAt: mockDashboardData.updatedAt,
+        createdAt: mockDashboardData.updatedAt,
+        updatedAt: mockDashboardData.updatedAt,
+      });
+      const response = await app.fetch(
+        new Request(
+          `http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/render?format=csv&view=draft`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ parameters: {} }),
+          },
+        ),
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toContain("text/csv");
+      // The CSV ran the DRAFT SQL, not the published SQL.
+      const runArg = mockRunUserQueryPipeline.mock.calls[0][0];
+      expect(runArg.sql).toBe("SELECT draft_csv_sql");
+    });
+
+    it("PATCH /:id with ONLY parameters writes the live row (never the draft)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ parameters: [{ key: "region", type: "text", label: "Region" }] }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      // Parameters are operational metadata (ADR-0029) — they stay on the live
+      // row and NEVER route to the draft snapshot.
+      expect(mockUpdateDashboard).toHaveBeenCalledTimes(1);
+      expect(mockApplyEditToDraft).not.toHaveBeenCalled();
+    });
+
+    it("PATCH /:id with {title, parameters} splits: title→draft, parameters→live row", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Renamed",
+            parameters: [{ key: "region", type: "text", label: "Region" }],
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      // parameters → live row
+      expect(mockUpdateDashboard).toHaveBeenCalledTimes(1);
+      const [, , updates] = mockUpdateDashboard.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { parameters?: unknown; title?: string },
+      ];
+      expect(updates).toHaveProperty("parameters");
+      expect(updates).not.toHaveProperty("title");
+      // title → draft
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; title?: string },
+      ];
+      expect(change).toMatchObject({ kind: "updateMeta", title: "Renamed" });
+    });
+
+    it("maps applyEditToDraft unknown_card → 404 and save_failed → 500", async () => {
+      mockApplyEditToDraft.mockResolvedValueOnce({ ok: false, reason: "unknown_card", cardId: VALID_CARD_ID });
+      const r404 = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Edited" }),
+        }),
+      );
+      expect(r404.status).toBe(404);
+
+      mockApplyEditToDraft.mockResolvedValueOnce({ ok: false, reason: "save_failed" });
+      const r500 = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Edited" }),
+        }),
+      );
+      expect(r500.status).toBe(500);
+    });
+
+    it("maps applyEditToDraft load_failed → 500 (transient, distinct from no_db 503)", async () => {
+      mockApplyEditToDraft.mockResolvedValueOnce({ ok: false, reason: "load_failed" });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "New card",
+            sql: "SELECT 1",
+            chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+          }),
+        }),
+      );
+      expect(response.status).toBe(500);
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
   });
 });

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -6,6 +6,7 @@
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
+import { randomUUID } from "node:crypto";
 import { Effect } from "effect";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
@@ -43,6 +44,7 @@ import {
   type SharedDashboardFailReason,
 } from "@atlas/api/lib/dashboards";
 import { CHART_TYPES } from "@atlas/api/lib/dashboard-types";
+import type { DashboardCard, DashboardWithCards } from "@atlas/api/lib/dashboard-types";
 import {
   isDashboardDraftsEnabled,
   forkOrLoadDraft,
@@ -51,6 +53,9 @@ import {
   publishDraft,
   rebaseDraft,
   materializeDraftView,
+  applyEditToDraft,
+  type DashboardSnapshotCard,
+  type ApplyEditToDraftResult,
 } from "@atlas/api/lib/dashboard-versioning";
 import {
   stageChange,
@@ -59,7 +64,7 @@ import {
   listStagedChangesForUser,
 } from "@atlas/api/lib/stage-tracker";
 import { SHARE_MODES } from "@useatlas/types/share";
-import { dashboardParametersSchema, renderCardRequestSchema, renderCardQuerySchema, dashboardChartConfigSchema, dashboardCardAnnotationsSchema } from "@useatlas/schemas";
+import { dashboardParametersSchema, renderCardRequestSchema, renderCardQuerySchema, refreshCardQuerySchema, dashboardChartConfigSchema, dashboardCardAnnotationsSchema } from "@useatlas/schemas";
 import {
   resolveDashboardParameterValues,
   extractPlaceholderNames,
@@ -596,6 +601,7 @@ const updateDashboardRoute = createRoute({
     404: { description: "Not found", content: { "application/json": { schema: ErrorSchema } } },
     422: { description: "Validation error", content: { "application/json": { schema: ErrorSchema.extend({ details: z.array(z.unknown()).optional() }) } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Drafts unavailable — internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -634,6 +640,7 @@ const addCardRoute = createRoute({
     404: { description: "Dashboard not found", content: { "application/json": { schema: ErrorSchema } } },
     422: { description: "Validation error", content: { "application/json": { schema: ErrorSchema.extend({ details: z.array(z.unknown()).optional() }) } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Drafts unavailable — internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -659,6 +666,7 @@ const updateCardRoute = createRoute({
     404: { description: "Card not found", content: { "application/json": { schema: ErrorSchema } } },
     422: { description: "Validation error", content: { "application/json": { schema: ErrorSchema.extend({ details: z.array(z.unknown()).optional() }) } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Drafts unavailable — internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -681,6 +689,7 @@ const removeCardRoute = createRoute({
     403: { description: "Forbidden", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
     404: { description: "Card not found", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Drafts unavailable — internal database not configured", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -721,6 +730,7 @@ const refreshCardRoute = createRoute({
       id: z.string().openapi({ param: { name: "id", in: "path" }, example: "00000000-0000-0000-0000-000000000000" }),
       cardId: z.string().openapi({ param: { name: "cardId", in: "path" }, example: "00000000-0000-0000-0000-000000000000" }),
     }),
+    query: refreshCardQuerySchema,
   },
   responses: {
     200: { description: "Card refreshed with new data", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -984,6 +994,133 @@ const getSharedDashboardRoute = createRoute({
 
 const authed = createAdminRouter();
 authed.use(requireOrgContext());
+
+// ---------------------------------------------------------------------------
+// Draft-first routing (#4315, ADR-0029)
+//
+// Direct manipulation (rename, add/update/remove card, layout) must land in
+// the caller's per-user DRAFT, never the published tables — publish is the
+// only promotion path. These helpers centralize "does this caller draft?"
+// and the failure→HTTP mapping so every direct-manipulation handler enforces
+// the invariant identically.
+// ---------------------------------------------------------------------------
+
+/**
+ * True when this caller's direct-manipulation edits must route to their
+ * per-user draft instead of the published tables. Requires drafts-on AND a
+ * real user id.
+ *
+ * The `!userId` fall-through to the legacy direct-published write is
+ * DEFENSIVE, not a deliberate open hole: every direct-manipulation route here
+ * is behind `authed` + `requireOrgContext()`, so a caller normally always has
+ * a `user.id`. The only way to reach it with no user is a single-operator
+ * `auth: none` self-host — where there is exactly one operator and no teammate
+ * to leak a live edit to, so writing published directly is safe. This is
+ * intentionally ASYMMETRIC with the bound-tool path (`bound-dashboard.ts`
+ * `maybeApplyToDraft`), which *rejects* the no-user case: the bound editor can
+ * run in a hosted/multi-user context without a userId, so an unattributable
+ * bound edit going live IS the ADR-0029 privacy hole. A flag-off caller (or a
+ * deploy with no internal DB) also keeps the legacy path — there's no draft
+ * store to hold the edit.
+ */
+function shouldRouteToDraft(userId: string | null | undefined): userId is string {
+  return isDashboardDraftsEnabled() && typeof userId === "string" && userId.length > 0;
+}
+
+/** Map an `applyEditToDraft` failure to an HTTP body + status. */
+function draftEditFailResponse(
+  result: Extract<ApplyEditToDraftResult, { ok: false }>,
+  requestId: string,
+): { body: { error: string; message: string; requestId: string }; status: 404 | 500 | 503 } {
+  switch (result.reason) {
+    case "no_db":
+      return {
+        body: {
+          error: "drafts_unavailable",
+          message:
+            "Dashboard edits are saved to your private draft, which needs the internal database. It is not configured on this deployment.",
+          requestId,
+        },
+        status: 503,
+      };
+    case "load_failed":
+      return {
+        body: {
+          error: "internal_error",
+          message: "Could not load your draft (a transient database error). Please retry.",
+          requestId,
+        },
+        status: 500,
+      };
+    case "unknown_card":
+      return {
+        body: {
+          error: "not_found",
+          message: `Card ${result.cardId} was not found in your draft — it may have been removed. Reload and retry.`,
+          requestId,
+        },
+        status: 404,
+      };
+    case "save_failed":
+      return {
+        body: {
+          error: "internal_error",
+          message: "Could not save your draft. Please retry.",
+          requestId,
+        },
+        status: 500,
+      };
+  }
+}
+
+/**
+ * The outcome of resolving which card a draft-aware execution (render /
+ * single-card refresh / CSV export) should run (#4315, ADR-0029). A tagged
+ * union rather than a `DashboardCard | null | sentinel`, so a caller can't
+ * accidentally run the "card was removed in the draft" case as a card (a bare
+ * `if (card)` would treat a string sentinel as truthy) and the render/refresh
+ * `isDraftExec` branch doesn't depend on an implicit null-vs-string ordering.
+ */
+type DraftExecResolution =
+  // The caller is viewing their draft and the card exists there — run this
+  // (its SQL / chartConfig / connectionGroupId are the in-progress edits, not
+  // the last-published definition the caller separately loaded).
+  | { kind: "override"; card: DashboardCard }
+  // No draft override applies — run the published card the caller already
+  // loaded (view=published, flag off, anonymous, or no draft exists).
+  | { kind: "published" }
+  // The caller asked for the draft view and HAS a draft, but the card id isn't
+  // in it (removed in the draft) → the route 404s rather than silently running
+  // the published card under a draft view.
+  | { kind: "not_in_draft" };
+
+/**
+ * Resolve the card a draft-aware execution should run. Reuses
+ * `shouldRouteToDraft` so "is this a drafting caller" has one definition
+ * across the edit and exec paths.
+ */
+async function resolveDraftExecCard(
+  userId: string | null | undefined,
+  view: "published" | "draft" | undefined,
+  published: DashboardWithCards,
+  cardId: string,
+): Promise<DraftExecResolution> {
+  if (view !== "draft" || !shouldRouteToDraft(userId)) return { kind: "published" };
+  // Note: `loadDraft` returns null for BOTH "no draft" and "load threw" (it
+  // logs + swallows). Both resolve to `{ kind: "published" }` here, so the
+  // caller runs the PUBLISHED card exactly as a plain published-view request
+  // would (the render path stays read-only; the refresh path still persists the
+  // published cache — the same write any published refresh does, never a draft
+  // write). The draft-first invariant is safe either way, but a transient
+  // draft-load error will quietly fall back to published under the draft view
+  // rather than surfacing to the user.
+  const draft = await loadDraft(userId, published.id);
+  if (!draft) return { kind: "published" };
+  const card = materializeDraftView(published, draft.snapshot).cards.find(
+    (cd) => cd.id === cardId,
+  );
+  return card ? { kind: "override", card } : { kind: "not_in_draft" };
+}
 
 // Outer app for the authenticated admin routes
 const dashboards = new OpenAPIHono({ defaultHook: validationHook });
@@ -1512,7 +1649,7 @@ authed.openapi(
   async (c) => {
     return runEffect(c, Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
-      const { orgId } = yield* AuthContext;
+      const { orgId, user } = yield* AuthContext;
       const { id } = c.req.valid("param");
       if (!UUID_RE.test(id)) {
         return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
@@ -1574,17 +1711,55 @@ authed.openapi(
         }
       }
 
-      // Apply remaining updates (title, description)
-      const { refreshSchedule: _, ...otherUpdates } = parsed;
-      if (Object.keys(otherUpdates).length > 0) {
-        const result = yield* Effect.promise(() => updateDashboard(id, { orgId }, otherUpdates));
+      // Parameters are dashboard-level operational metadata — NOT part of the
+      // per-user draft snapshot (which owns title/description/cards). ADR-0029
+      // keeps share/refresh/parameter metadata on the live row, so apply a
+      // parameter replacement directly (it is workspace-shared config, not a
+      // private content edit).
+      if (parsed.parameters !== undefined) {
+        const result = yield* Effect.promise(() =>
+          updateDashboard(id, { orgId }, { parameters: parsed.parameters }),
+        );
         if (!result.ok) {
           const fail = crudFailResponse(result.reason, requestId);
           return c.json(fail.body, fail.status);
         }
       }
 
-      // Return updated dashboard
+      // Title / description ARE draft content (#4315). Route them to the
+      // caller's private draft when drafts are on — nothing but publish may
+      // write the published title/description. Anonymous / flag-off callers
+      // fall through to the legacy direct-published write.
+      const metaUpdates: { title?: string; description?: string | null } = {};
+      if (parsed.title !== undefined) metaUpdates.title = parsed.title;
+      if (parsed.description !== undefined) metaUpdates.description = parsed.description;
+
+      if (Object.keys(metaUpdates).length > 0) {
+        const uid = user?.id;
+        if (shouldRouteToDraft(uid)) {
+          const published = yield* Effect.promise(() => getDashboard(id, { orgId }));
+          if (!published.ok) {
+            const fail = crudFailResponse(published.reason, requestId);
+            return c.json(fail.body, fail.status);
+          }
+          const edit = yield* Effect.promise(() =>
+            applyEditToDraft(uid, published.data, { kind: "updateMeta", ...metaUpdates }),
+          );
+          if (!edit.ok) {
+            const fail = draftEditFailResponse(edit, requestId);
+            return c.json(fail.body, fail.status);
+          }
+          return c.json(edit.view, 200);
+        }
+        const result = yield* Effect.promise(() => updateDashboard(id, { orgId }, metaUpdates));
+        if (!result.ok) {
+          const fail = crudFailResponse(result.reason, requestId);
+          return c.json(fail.body, fail.status);
+        }
+      }
+
+      // Return updated dashboard (published view — reflects the
+      // parameters/schedule writes above; a draft meta edit returned earlier).
       const updated = yield* Effect.promise(() => getDashboard(id, { orgId }));
       if (!updated.ok) return c.body(null, 204);
       return c.json(updated.data, 200);
@@ -1628,7 +1803,7 @@ authed.openapi(
   async (c) => {
     return runEffect(c, Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
-      const { orgId } = yield* AuthContext;
+      const { orgId, user } = yield* AuthContext;
       const { id } = c.req.valid("param");
       if (!UUID_RE.test(id)) {
         return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
@@ -1669,6 +1844,35 @@ authed.openapi(
           );
         }
       }
+      // #4315 — a new card lands in the caller's private draft, not the
+      // published tables. Mint the card id here (as the bound editor does) so
+      // subsequent draft edits/layout in the same session resolve, and stage
+      // it into the draft snapshot. `cachedColumns`/`cachedRows` are a
+      // published-cache concept and are intentionally dropped on the draft
+      // path — a draft card's data comes from a draft-aware render.
+      const uid = user?.id;
+      if (shouldRouteToDraft(uid)) {
+        const draftCard: DashboardSnapshotCard = {
+          id: randomUUID(),
+          position: 0,
+          title: parsed.title,
+          sql: parsed.sql,
+          chartConfig: parsed.chartConfig ?? null,
+          annotations: parsed.annotations ?? [],
+          connectionGroupId: parsed.connectionGroupId ?? null,
+          layout: parsed.layout ?? null,
+        };
+        const edit = yield* Effect.promise(() =>
+          applyEditToDraft(uid, dash.data, { kind: "addCard", card: draftCard }),
+        );
+        if (!edit.ok) {
+          const fail = draftEditFailResponse(edit, requestId);
+          return c.json(fail.body, fail.status);
+        }
+        const created = edit.view.cards.find((cd) => cd.id === draftCard.id);
+        return c.json(created ?? edit.view, 201);
+      }
+
       const result = yield* Effect.promise(() => addCard({
         dashboardId: id,
         title: parsed.title,
@@ -1704,7 +1908,7 @@ authed.openapi(
   async (c) => {
     return runEffect(c, Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
-      const { orgId } = yield* AuthContext;
+      const { orgId, user } = yield* AuthContext;
       const { id, cardId } = c.req.valid("param");
       if (!UUID_RE.test(id) || !UUID_RE.test(cardId)) {
         return c.json({ error: "invalid_request", message: "Invalid ID format." }, 400);
@@ -1718,15 +1922,27 @@ authed.openapi(
       }
 
       const parsed = c.req.valid("json");
+      const uid = user?.id;
+      const routeDraft = shouldRouteToDraft(uid);
+
       // #3207 — if this update turns on autoComparison, validate it against the
       // card's EXISTING sql (updateCard never changes the query) + the
-      // dashboard's params, the same as the add path. getCard is only needed
-      // when the flag is actually being set.
+      // dashboard's params. Source the SQL from the DRAFT when routing to a
+      // draft (the card may only exist in the draft), else the published row.
       if (parsed.chartConfig?.kpi?.autoComparison) {
-        const existing = yield* Effect.promise(() => getCard(cardId, id));
-        if (existing.ok) {
+        let existingSql: string | undefined;
+        if (routeDraft) {
+          const draft = yield* Effect.promise(() => loadDraft(uid, id));
+          existingSql =
+            draft?.snapshot.cards.find((cd) => cd.id === cardId)?.sql ??
+            dash.data.cards.find((cd) => cd.id === cardId)?.sql;
+        } else {
+          const existing = yield* Effect.promise(() => getCard(cardId, id));
+          if (existing.ok) existingSql = existing.data.sql;
+        }
+        if (existingSql !== undefined) {
           const updateAutoErr = validateAutoComparison(
-            existing.data.sql,
+            existingSql,
             parsed.chartConfig.kpi,
             dash.data.parameters,
           );
@@ -1735,6 +1951,21 @@ authed.openapi(
           }
         }
       }
+
+      // #4315 — the edit lands in the caller's private draft; nothing but
+      // publish writes the published card.
+      if (routeDraft) {
+        const edit = yield* Effect.promise(() =>
+          applyEditToDraft(uid, dash.data, { kind: "updateCard", cardId, updates: parsed }),
+        );
+        if (!edit.ok) {
+          const fail = draftEditFailResponse(edit, requestId);
+          return c.json(fail.body, fail.status);
+        }
+        const updated = edit.view.cards.find((cd) => cd.id === cardId);
+        return c.json(updated ?? edit.view, 200);
+      }
+
       const result = yield* Effect.promise(() => updateCard(cardId, id, parsed));
       if (!result.ok) {
         const fail = crudFailResponse(result.reason, requestId);
@@ -1760,7 +1991,7 @@ authed.openapi(
 authed.openapi(removeCardRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
-    const { orgId } = yield* AuthContext;
+    const { orgId, user } = yield* AuthContext;
     const { id, cardId } = c.req.valid("param");
     if (!UUID_RE.test(id) || !UUID_RE.test(cardId)) {
       return c.json({ error: "invalid_request", message: "Invalid ID format." }, 400);
@@ -1770,6 +2001,20 @@ authed.openapi(removeCardRoute, async (c) => {
     if (!dash.ok) {
       const fail = crudFailResponse(dash.reason, requestId);
       return c.json(fail.body, fail.status);
+    }
+
+    // #4315 — removing a card removes it from the caller's private draft; the
+    // published card is untouched until publish promotes the deletion.
+    const uid = user?.id;
+    if (shouldRouteToDraft(uid)) {
+      const edit = yield* Effect.promise(() =>
+        applyEditToDraft(uid, dash.data, { kind: "removeCard", cardId }),
+      );
+      if (!edit.ok) {
+        const fail = draftEditFailResponse(edit, requestId);
+        return c.json(fail.body, fail.status);
+      }
+      return c.body(null, 204);
     }
 
     const result = yield* Effect.promise(() => removeCard(cardId, id));
@@ -1814,11 +2059,12 @@ authed.openapi(previewCardRoute, async (c) => {
 authed.openapi(refreshCardRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
-    const { orgId } = yield* AuthContext;
+    const { orgId, user } = yield* AuthContext;
     const { id, cardId } = c.req.valid("param");
     if (!UUID_RE.test(id) || !UUID_RE.test(cardId)) {
       return c.json({ error: "invalid_request", message: "Invalid ID format." }, 400);
     }
+    const { view } = c.req.valid("query");
 
     const dash = yield* Effect.promise(() => getDashboard(id, { orgId }));
     if (!dash.ok) {
@@ -1831,11 +2077,24 @@ authed.openapi(refreshCardRoute, async (c) => {
       return c.json({ error: "not_found", message: "Card not found." }, 404);
     }
 
+    // #4315 — draft-aware execution. When the caller is refreshing while
+    // viewing their draft, run the DRAFT card's SQL/config (its private
+    // working copy), not the published definition. Falls back to published
+    // when no draft exists — never another user's draft.
+    const resolved = yield* Effect.promise(() =>
+      resolveDraftExecCard(user?.id, view, dash.data, cardId),
+    );
+    if (resolved.kind === "not_in_draft") {
+      return c.json({ error: "not_found", message: "Card not found in your draft." }, 404);
+    }
+    const isDraftExec = resolved.kind === "override";
+    const execCard = isDraftExec ? resolved.card : cardResult.data;
+
     // #3138: a text / section-block card has no SQL — there's nothing to
     // refresh. Return it unchanged rather than running it through the query
     // pipeline (which would reject an empty query).
-    if (cardResult.data.kind === "text") {
-      return c.json(cardResult.data, 200);
+    if (execCard.kind === "text") {
+      return c.json(execCard, 200);
     }
 
     // Resolve group-scoped execution. A card pointing at a group with
@@ -1846,7 +2105,7 @@ authed.openapi(refreshCardRoute, async (c) => {
     try {
       resolvedConnectionId = yield* Effect.promise(() =>
         resolveCardConnectionId(
-          { connectionGroupId: cardResult.data.connectionGroupId },
+          { connectionGroupId: execCard.connectionGroupId },
           dash.data.orgId,
         ),
       );
@@ -1884,9 +2143,9 @@ authed.openapi(refreshCardRoute, async (c) => {
     const { runUserQueryPipeline } = yield* Effect.promise(() => import("@atlas/api/lib/tools/sql"));
     const outcome = yield* Effect.promise(() =>
       runUserQueryPipeline({
-        sql: cardResult.data.sql,
+        sql: execCard.sql,
         ...(resolvedConnectionId && { connectionId: resolvedConnectionId }),
-        explanation: `Dashboard card refresh: ${cardResult.data.title}`,
+        explanation: `Dashboard card refresh: ${execCard.title}`,
         parameters: defaultParamValues,
       }),
     );
@@ -1894,6 +2153,23 @@ authed.openapi(refreshCardRoute, async (c) => {
     if (outcome.kind !== "ok") {
       const { body, status } = userQueryOutcomeToResponse(outcome, requestId);
       return c.json(body as never, status);
+    }
+
+    // #4315 — a draft refresh runs the draft's SQL but MUST NOT persist to the
+    // published card cache: the draft's query is un-published, so writing its
+    // results into the shared cache would leak draft data to teammates and
+    // violate the "only publish writes published" invariant. Return the
+    // freshly-run rows overlaid on the draft card, in-memory.
+    if (isDraftExec) {
+      return c.json(
+        {
+          ...execCard,
+          cachedColumns: outcome.columns,
+          cachedRows: outcome.rows,
+          cachedAt: new Date().toISOString(),
+        },
+        200,
+      );
     }
 
     const refreshResult = yield* Effect.promise(() => refreshCard(cardId, id, {
@@ -1923,12 +2199,12 @@ authed.openapi(refreshCardRoute, async (c) => {
 authed.openapi(renderCardRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
-    const { orgId } = yield* AuthContext;
+    const { orgId, user } = yield* AuthContext;
     const { id, cardId } = c.req.valid("param");
     if (!UUID_RE.test(id) || !UUID_RE.test(cardId)) {
       return c.json({ error: "invalid_request", message: "Invalid ID format." }, 400);
     }
-    const { format } = c.req.valid("query");
+    const { format, view } = c.req.valid("query");
     const asCsv = format === "csv";
     const { parameters: suppliedParameters } = c.req.valid("json");
 
@@ -1943,10 +2219,21 @@ authed.openapi(renderCardRoute, async (c) => {
       return c.json({ error: "not_found", message: "Card not found." }, 404);
     }
 
+    // #4315 — draft-aware execution. When rendering while viewing the draft,
+    // run the DRAFT card's SQL/config (never persisted — render is ephemeral),
+    // else the published definition. Falls back to published when no draft.
+    const resolved = yield* Effect.promise(() =>
+      resolveDraftExecCard(user?.id, view, dash.data, cardId),
+    );
+    if (resolved.kind === "not_in_draft") {
+      return c.json({ error: "not_found", message: "Card not found in your draft." }, 404);
+    }
+    const execCard = resolved.kind === "override" ? resolved.card : cardResult.data;
+
     // #3138: a text card has no query — render returns an empty result set
     // (no parameters bind, no SQL runs). The tile renders its markdown, not
     // this payload.
-    if (cardResult.data.kind === "text") {
+    if (execCard.kind === "text") {
       // #3210 — a text card has no tabular data to export. The UI never offers
       // the affordance on text tiles; reject here too (defence in depth) rather
       // than streaming an empty CSV.
@@ -1980,7 +2267,7 @@ authed.openapi(renderCardRoute, async (c) => {
     try {
       resolvedConnectionId = yield* Effect.promise(() =>
         resolveCardConnectionId(
-          { connectionGroupId: cardResult.data.connectionGroupId },
+          { connectionGroupId: execCard.connectionGroupId },
           dash.data.orgId,
         ),
       );
@@ -2009,7 +2296,7 @@ authed.openapi(renderCardRoute, async (c) => {
     //   - `autoComparison` (#3207): re-run the card's OWN sql with the bound
     //     date window shifted back one period (derived server-side; the prior
     //     window binds through the same parameter protocol).
-    const chartConfig = cardResult.data.chartConfig;
+    const chartConfig = execCard.chartConfig;
     const kpi = chartConfig?.type === "kpi" ? chartConfig.kpi : undefined;
     const comparisonSql = kpi?.comparisonSql;
 
@@ -2020,7 +2307,7 @@ authed.openapi(renderCardRoute, async (c) => {
     if (!comparisonSql && kpi?.autoComparison) {
       const priorValues = derivePriorPeriodValues(paramValues, kpi.comparisonDateParams);
       if (priorValues) {
-        comparisonRunSql = cardResult.data.sql;
+        comparisonRunSql = execCard.sql;
         comparisonParamValues = priorValues;
       } else {
         // No derivable prior window (a bound is missing/unparseable, or the
@@ -2037,9 +2324,9 @@ authed.openapi(renderCardRoute, async (c) => {
     const [outcome, comparisonOutcome] = yield* Effect.promise(() =>
       Promise.all([
         runUserQueryPipeline({
-          sql: cardResult.data.sql,
+          sql: execCard.sql,
           ...(resolvedConnectionId && { connectionId: resolvedConnectionId }),
-          explanation: `Dashboard card render: ${cardResult.data.title}`,
+          explanation: `Dashboard card render: ${execCard.title}`,
           parameters: paramValues,
         }),
         // The comparison is isolated with its own `.catch`: `runUserQueryPipeline`
@@ -2052,7 +2339,7 @@ authed.openapi(renderCardRoute, async (c) => {
           ? runUserQueryPipeline({
               sql: comparisonRunSql,
               ...(resolvedConnectionId && { connectionId: resolvedConnectionId }),
-              explanation: `Dashboard KPI comparison: ${cardResult.data.title}`,
+              explanation: `Dashboard KPI comparison: ${execCard.title}`,
               parameters: comparisonParamValues,
             }).catch((err) => {
               log.warn(
@@ -2073,7 +2360,7 @@ authed.openapi(renderCardRoute, async (c) => {
     // `{ error, message, requestId }` envelope regardless of `format`.
     if (asCsv && outcome.kind === "ok") {
       const csv = toCsv(outcome.columns, outcome.rows);
-      const filename = csvFilename(cardResult.data.title, new Date());
+      const filename = csvFilename(execCard.title, new Date());
       return new Response(csv, {
         status: 200,
         headers: {

--- a/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
@@ -24,6 +24,7 @@ import {
   loadDraft,
   forkOrLoadDraft,
   saveDraft,
+  applyEditToDraft,
   discardDraft,
   publishDraft,
   rebaseDraft,
@@ -941,6 +942,78 @@ describe("dashboard-versioning DB helpers", () => {
       setResults({ rows: [] });
       const ok = await saveDraft("u1", "dash-1", snapshot([]));
       expect(ok).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // applyEditToDraft — the single seam every direct-manipulation REST route
+  // funnels through (#4315). Exercises the real fork→apply→save wiring + all
+  // four failure returns (the route tests mock this function out).
+  // -------------------------------------------------------------------------
+
+  describe("applyEditToDraft", () => {
+    it("happy path: forks/loads, applies the change, saves, returns the draft view", async () => {
+      enableInternalDB();
+      const published = dashboardWithCards([card("c1")]);
+      const snap = snapshot([card("c1")]);
+      // forkOrLoadDraft loads the existing row (1 query), then saveDraft UPDATE.
+      setResults({ rows: [draftRow({ draft: snap })] }, { rows: [{ user_id: "u1" }] });
+      const result = await applyEditToDraft("u1", published, {
+        kind: "updateMeta",
+        title: "Renamed in draft",
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.snapshot.title).toBe("Renamed in draft");
+        expect(result.view.title).toBe("Renamed in draft");
+      }
+      // The persisted UPDATE targeted the draft table, never a published one.
+      const sqls = queryCalls.map((q) => q.sql).join("\n");
+      expect(sqls).toContain("UPDATE dashboard_user_drafts");
+      expect(sqls).not.toContain("dashboard_cards");
+    });
+
+    it("returns no_db when the internal DB is not configured", async () => {
+      // DB intentionally NOT enabled.
+      const result = await applyEditToDraft("u1", dashboardWithCards([card("c1")]), {
+        kind: "updateMeta",
+        title: "x",
+      });
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+    });
+
+    it("returns load_failed (not no_db) when the DB is configured but the load throws", async () => {
+      enableInternalDB();
+      queryThrow = new Error("connection reset by peer");
+      const result = await applyEditToDraft("u1", dashboardWithCards([card("c1")]), {
+        kind: "updateMeta",
+        title: "x",
+      });
+      expect(result).toEqual({ ok: false, reason: "load_failed" });
+    });
+
+    it("returns unknown_card when the change targets a card absent from the draft", async () => {
+      enableInternalDB();
+      const snap = snapshot([card("c1")]);
+      setResults({ rows: [draftRow({ draft: snap })] });
+      const result = await applyEditToDraft("u1", dashboardWithCards([card("c1")]), {
+        kind: "updateCard",
+        cardId: "does-not-exist",
+        updates: { title: "nope" },
+      });
+      expect(result).toEqual({ ok: false, reason: "unknown_card", cardId: "does-not-exist" });
+    });
+
+    it("returns save_failed when the persist UPDATE matches no row", async () => {
+      enableInternalDB();
+      const snap = snapshot([card("c1")]);
+      // load returns the row; saveDraft UPDATE returns no rows → false.
+      setResults({ rows: [draftRow({ draft: snap })] }, { rows: [] });
+      const result = await applyEditToDraft("u1", dashboardWithCards([card("c1")]), {
+        kind: "updateMeta",
+        title: "x",
+      });
+      expect(result).toEqual({ ok: false, reason: "save_failed" });
     });
   });
 

--- a/packages/api/src/lib/dashboard-versioning.ts
+++ b/packages/api/src/lib/dashboard-versioning.ts
@@ -771,6 +771,54 @@ export async function saveDraft(
   }
 }
 
+export type ApplyEditToDraftResult =
+  | { ok: true; snapshot: DashboardSnapshot; view: DashboardWithCards }
+  // The internal DB is NOT configured on this deployment — drafts are
+  // structurally unavailable (a static condition → 503, not retryable).
+  | { ok: false; reason: "no_db" }
+  // The internal DB IS configured but the fork/load returned null-from-throw
+  // (pool exhaustion, timeout, a jsonb/constraint error, a network blip) — a
+  // TRANSIENT failure the caller should retry (→ 500), distinct from `no_db`.
+  | { ok: false; reason: "load_failed" }
+  | { ok: false; reason: "unknown_card"; cardId: string }
+  | { ok: false; reason: "save_failed" };
+
+/**
+ * Route a single direct-manipulation edit (rename, add/update/remove card,
+ * layout) into the caller's per-user draft (#4315, ADR-0029). Fork-or-load
+ * the draft from `published`, apply `change` to the snapshot, persist it,
+ * and return the materialized draft view.
+ *
+ * This is the ONE seam the direct-manipulation REST routes funnel through,
+ * so the draft-first invariant — "no path writes the published tables
+ * except publish" — is enforced in a single, unit-testable place rather
+ * than re-derived per route. Failure modes are returned as a discriminated
+ * union (never thrown) so the route layer maps them to HTTP without a
+ * `try/catch`.
+ */
+export async function applyEditToDraft(
+  userId: string,
+  published: DashboardWithCards,
+  change: DraftChange,
+): Promise<ApplyEditToDraftResult> {
+  const draftRow = await forkOrLoadDraft(userId, published);
+  if (!draftRow) {
+    // `forkOrLoadDraft` returns null both when the DB is unconfigured AND when
+    // a query threw (it logs + swallows to null). Split the two so on-call
+    // isn't told "not configured on this deployment" for a transient blip.
+    return { ok: false, reason: hasInternalDB() ? "load_failed" : "no_db" };
+  }
+  const applied = applyChangeToDraft(draftRow.snapshot, change);
+  if (!applied.ok) return { ok: false, reason: "unknown_card", cardId: applied.cardId };
+  const saved = await saveDraft(userId, published.id, applied.snapshot);
+  if (!saved) return { ok: false, reason: "save_failed" };
+  return {
+    ok: true,
+    snapshot: applied.snapshot,
+    view: materializeDraftView(published, applied.snapshot),
+  };
+}
+
 /** Discard the user's draft for a dashboard. Idempotent. */
 export async function discardDraft(userId: string, dashboardId: string): Promise<boolean> {
   if (!hasInternalDB()) return false;

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard-drafts.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard-drafts.test.ts
@@ -252,29 +252,28 @@ describe("bound-dashboard tools — drafts flag", () => {
       expect(sqls).not.toContain("INSERT INTO dashboard_cards");
     });
 
-    it("addCard without a userId falls back to direct-published (anonymous bound chat)", async () => {
+    // #4315 — the anonymous-bound bypass is CLOSED. With drafts ON, a bound
+    // edit that can't be attributed to a user (no userId) must NOT write to
+    // the published tables — the privacy hole where anonymous edits went
+    // straight live. The tool rejects instead of forking a draft or writing
+    // published.
+    it("addCard without a userId is rejected and never writes published (drafts ON)", async () => {
       enableInternalDB();
-      setResults(
-        { rows: [{ next_pos: 1 }] },
-        {
-          rows: [
-            { ...cardRow, id: "card-new", position: 1, title: "Anon", sql: "SELECT 1" },
-          ],
-        },
-      );
       const tools = createBoundDashboardTools({
         dashboardId: "dash-1",
         orgId: "org-1",
         // userId intentionally omitted.
       });
-      const result = await runTool<{ kind: string }>(tools.addCard, {
+      const result = await runTool<{ kind: string; error?: string }>(tools.addCard, {
         title: "Anon",
         sql: "SELECT 1",
         chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
       });
-      expect(result.kind).toBe("ok");
+      expect(result.kind).toBe("err");
+      expect(result.error).toMatch(/sign/i);
       const sqls = queryCalls.map((c) => c.sql).join("\n");
-      expect(sqls).toContain("INSERT INTO dashboard_cards");
+      // Nothing was written — not to published, not to a draft.
+      expect(sqls).not.toContain("INSERT INTO dashboard_cards");
       expect(sqls).not.toContain("dashboard_user_drafts");
     });
 

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
@@ -148,6 +148,7 @@ async function runTool<T = unknown>(tool: any, args: unknown): Promise<T> {
 
 describe("createBoundDashboardTools", () => {
   const origDbUrl = process.env.DATABASE_URL;
+  const origDraftsFlag = process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED;
 
   beforeEach(() => {
     queryCalls = [];
@@ -157,12 +158,22 @@ describe("createBoundDashboardTools", () => {
     screenshotMock.mockClear();
     invalidateScreenshotMock.mockClear();
     delete process.env.DATABASE_URL;
+    // #4315 — this file asserts the LEGACY direct-published tool wiring
+    // (addCard → lib.addCard, updateDashboardMeta → UPDATE dashboards).
+    // With drafts ON those ops route to the caller's draft, and an anonymous
+    // (userId-less) `ctx` is now REJECTED rather than silently written to
+    // published (the closed privacy hole). Force the flag OFF so these cases
+    // keep exercising the direct-published path; the drafts-ON behavior lives
+    // in `bound-dashboard-drafts.test.ts`.
+    process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = "false";
     _resetPool(null);
   });
 
   afterEach(() => {
     if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
     else delete process.env.DATABASE_URL;
+    if (origDraftsFlag === undefined) delete process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED;
+    else process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = origDraftsFlag;
     _resetPool(null);
   });
 

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -83,16 +83,17 @@ export interface BoundDashboardToolContext {
 }
 
 /**
- * Apply a change to the user's draft snapshot when the drafts flag is
- * on and we have a userId; otherwise the caller falls through to the
- * direct-published path. Returns:
+ * Apply a change to the user's draft snapshot when the drafts flag is on.
+ * Returns:
  *   - `{ routed: true, ok: true }`  → draft updated, the legacy path
  *     should NOT run.
- *   - `{ routed: true, ok: false, error }` → drafts path was selected
- *     but failed; surface the error and skip the legacy path so we
- *     don't double-write.
- *   - `{ routed: false }` → flag off or no userId; caller runs the
- *     legacy direct-published mutation.
+ *   - `{ routed: true, ok: false, error }` → the drafts path OWNS this op but
+ *     failed OR refused; surface the error and skip the legacy path so we
+ *     don't double-write. #4315: the no-userId case now lands here (a
+ *     REJECTION) — an unattributable bound edit must never fall through to a
+ *     direct-published write (the closed ADR-0029 privacy hole).
+ *   - `{ routed: false }` → flag OFF only; caller runs the legacy
+ *     direct-published mutation.
  */
 async function maybeApplyToDraft(
   ctx: BoundDashboardToolContext,
@@ -103,7 +104,21 @@ async function maybeApplyToDraft(
   | { routed: false }
 > {
   if (!isDashboardDraftsEnabled()) return { routed: false };
-  if (!ctx.userId) return { routed: false };
+  // #4315 — close the anonymous-bound bypass. Previously a bound edit with
+  // no userId fell through to the legacy direct-published path, so an
+  // anonymous edit went STRAIGHT LIVE to the org — the privacy hole ADR-0029
+  // calls out. With drafts on, an edit that can't be attributed to a user
+  // can't land in a private draft either, so we REJECT rather than write to
+  // published. `routed: true` here means "the draft path owns this op and it
+  // failed" — the caller must NOT fall through to the published write.
+  if (!ctx.userId) {
+    return {
+      routed: true,
+      ok: false,
+      error:
+        "This edit can't be saved: dashboard edits land in your private draft, which requires a signed-in user. Sign in and retry — edits never write to the published dashboard.",
+    };
+  }
   const published = await getDashboard(ctx.dashboardId, {
     orgId: ctx.orgId ?? undefined,
   });

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -141,8 +141,29 @@ export type RenderCardRequestWire = z.infer<typeof renderCardRequestSchema>;
  */
 export const renderCardQuerySchema = z.object({
   format: z.enum(["json", "csv"]).optional(),
+  /**
+   * Draft-aware execution (#4315, ADR-0029). `view=draft` runs the card's
+   * DRAFT SQL/config (the caller's private working copy) instead of the
+   * published definition, so the parameter bar / CSV export reflect the
+   * edits being made rather than the last-published query. Omitted/`published`
+   * runs the published definition. Viewers with no draft always fall back to
+   * published — never a leak of another user's draft.
+   */
+  view: z.enum(["published", "draft"]).optional(),
 });
 export type RenderCardQueryWire = z.infer<typeof renderCardQuerySchema>;
+
+/**
+ * Single-card refresh query. `view=draft` (#4315) runs the DRAFT SQL and
+ * returns the freshly-run rows WITHOUT persisting them to the published
+ * card cache — the draft's query is un-published, so writing its results
+ * into the shared cache would violate the draft-first invariant. Omitted/
+ * `published` keeps the legacy behavior (run published SQL, persist cache).
+ */
+export const refreshCardQuerySchema = z.object({
+  view: z.enum(["published", "draft"]).optional(),
+});
+export type RefreshCardQueryWire = z.infer<typeof refreshCardQuerySchema>;
 
 // ---------------------------------------------------------------------------
 // Text / section cards (#3138 — text blocks slice)

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/dashboard-card-render.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/dashboard-card-render.test.ts
@@ -87,6 +87,30 @@ describe("renderDashboardCard", () => {
     });
   });
 
+  test("appends ?view=draft when the context requests the draft view (#4315)", async () => {
+    const calls: Array<{ url: string }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      calls.push({ url: String(url) });
+      return okResponse({ columns: [], rows: [] });
+    }) as unknown as typeof fetch;
+
+    await renderDashboardCard(baseCard, { region: "us" }, { ...CTX, view: "draft" });
+    expect(calls[0].url).toBe(
+      "https://api.test/api/v1/dashboards/dash-1/cards/card-1/render?view=draft",
+    );
+  });
+
+  test("omits the view param when published (default) — runs the published SQL", async () => {
+    const calls: Array<{ url: string }> = [];
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      calls.push({ url: String(url) });
+      return okResponse({ columns: [], rows: [] });
+    }) as unknown as typeof fetch;
+
+    await renderDashboardCard(baseCard, { region: "us" }, { ...CTX, view: "published" });
+    expect(calls[0].url).toBe("https://api.test/api/v1/dashboards/dash-1/cards/card-1/render");
+  });
+
   test("maps a non-OK response to ok:false with the backend message (never throws)", async () => {
     globalThis.fetch = mock(async () =>
       errResponse(409, { error: "approval_required", message: "Approval required." }),

--- a/packages/web/src/app/(workspace)/dashboards/[id]/dashboard-card-render.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/dashboard-card-render.ts
@@ -19,6 +19,14 @@ export interface CardRenderContext {
   apiUrl: string;
   dashboardId: string;
   isCrossOrigin: boolean;
+  /**
+   * #4315 — when `"draft"`, render the caller's DRAFT card SQL (the private
+   * working copy being edited) instead of the published definition. Omitted /
+   * `"published"` renders the published SQL. The server falls back to
+   * published when no draft exists, so this is safe to pass whenever the
+   * canvas is showing the draft view.
+   */
+  view?: "draft" | "published";
 }
 
 export type CardRenderEntry =
@@ -41,7 +49,8 @@ export async function renderDashboardCard(
   ctx: CardRenderContext,
 ): Promise<CardRenderEntry> {
   try {
-    const res = await fetch(`${ctx.apiUrl}/api/v1/dashboards/${ctx.dashboardId}/cards/${card.id}/render`, {
+    const viewSuffix = ctx.view === "draft" ? "?view=draft" : "";
+    const res = await fetch(`${ctx.apiUrl}/api/v1/dashboards/${ctx.dashboardId}/cards/${card.id}/render${viewSuffix}`, {
       method: "POST",
       credentials: ctx.isCrossOrigin ? "include" : "same-origin",
       headers: { "Content-Type": "application/json" },

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -94,8 +94,15 @@ export default function DashboardViewPage() {
   const searchParams = useSearchParams();
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
 
+  // #4315 — the canvas renders the caller's DRAFT while editing (the private
+  // working copy every edit lands in), the published state otherwise. The URL
+  // is the fetch cache key, so toggling Edit re-fetches the correct view. The
+  // server overlays the draft only when one exists (non-forking); a viewer or
+  // a board with no draft still gets published, so this never leaks.
+  const [editing, setEditing] = useState(false);
+
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(
-    `/api/v1/dashboards/${id}`,
+    editing ? `/api/v1/dashboards/${id}?view=draft` : `/api/v1/dashboards/${id}`,
   );
 
   // #2365 — pending destructive stages for THIS user on THIS dashboard.
@@ -119,7 +126,6 @@ export default function DashboardViewPage() {
   const [suggestError, setSuggestError] = useState<string | null>(null);
   const [addingSuggestion, setAddingSuggestion] = useState<number | null>(null);
 
-  const [editing, setEditing] = useState(false);
   const [density, setDensity] = useState<Density>("comfortable");
   // #3211 — whole-dashboard export state. `exportError` surfaces a failed
   // render (or a partial-render warning) in the same banner family as the
@@ -241,7 +247,10 @@ export default function DashboardViewPage() {
 
   async function handleRefreshCard(cardId: string) {
     setRefreshingCardId(cardId);
-    await mutate({ path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh`, method: "POST" });
+    // #4315 — while editing, a single-card refresh runs the DRAFT SQL (server
+    // returns fresh rows without persisting to the published cache).
+    const viewSuffix = editing ? "?view=draft" : "";
+    await mutate({ path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh${viewSuffix}`, method: "POST" });
     setRefreshingCardId(null);
   }
 
@@ -341,8 +350,10 @@ export default function DashboardViewPage() {
     }
 
     try {
+      // #4315 — export the DRAFT card's data while editing (runs the draft SQL).
+      const viewParam = editing ? "&view=draft" : "";
       const res = await fetch(
-        `${apiUrl}/api/v1/dashboards/${id}/cards/${card.id}/render?format=csv`,
+        `${apiUrl}/api/v1/dashboards/${id}/cards/${card.id}/render?format=csv${viewParam}`,
         {
           method: "POST",
           credentials: isCrossOrigin ? "include" : "same-origin",
@@ -736,6 +747,8 @@ export default function DashboardViewPage() {
         apiUrl,
         dashboardId: id,
         isCrossOrigin,
+        // #4315 — the canvas shows the draft while editing; render its SQL.
+        view: editing ? "draft" : "published",
       });
       // A newer change superseded this batch — discard its results.
       if (seq !== paramReqSeq.current) return;
@@ -826,11 +839,13 @@ export default function DashboardViewPage() {
       setComparisons({});
       return;
     }
+    // #4315 — while editing, the KPI comparison runs the draft card's SQL too.
+    const viewParam = editing ? "?view=draft" : "";
     const entries = await Promise.all(
       kpiCards.map(async (card): Promise<[string, KpiComparisonResult | null]> => {
         try {
           const res = await fetch(
-            `${apiUrl}/api/v1/dashboards/${id}/cards/${card.id}/render`,
+            `${apiUrl}/api/v1/dashboards/${id}/cards/${card.id}/render${viewParam}`,
             {
               method: "POST",
               credentials: isCrossOrigin ? "include" : "same-origin",
@@ -969,6 +984,8 @@ export default function DashboardViewPage() {
               rebasing={rebasing}
               error={draftError}
               onDismissError={clearDraftError}
+              editing={editing}
+              onExitEditing={() => setEditing(false)}
             />
 
             {dashboard.parameters.length > 0 && (

--- a/packages/web/src/ui/components/dashboards/draft-status-banner.tsx
+++ b/packages/web/src/ui/components/dashboards/draft-status-banner.tsx
@@ -39,6 +39,18 @@ import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
 interface DraftStatusBannerProps {
   hasDraft: boolean;
   staleBaseline: boolean;
+  /**
+   * #4315 — the page is in explicit edit mode. Makes this a PERSISTENT bar
+   * shown for the whole editing session, not just a transient notice once a
+   * draft exists. Two states: before the first edit forks a draft
+   * (`editing && !hasDraft`) it renders a quiet "Editing your draft — no
+   * changes yet" bar with only a Done control; once `hasDraft` flips true the
+   * richer Draft block below (which owns the Publish / Discard controls) takes
+   * over.
+   */
+  editing: boolean;
+  /** Leave edit mode (used by the persistent bar's Done action). */
+  onExitEditing?: () => void;
   /** Used by the parent to gate rendering — passed through so the discard confirm survives layout shifts. */
   discardOpen: boolean;
   onDiscardOpenChange: (open: boolean) => void;
@@ -69,13 +81,47 @@ export function DraftStatusBanner({
   rebasing,
   error,
   onDismissError,
+  editing,
+  onExitEditing,
 }: DraftStatusBannerProps) {
-  // Bail entirely when there's no draft AND no error — the banner is
-  // a transient surface; we don't want a permanent empty row.
-  if (!hasDraft && !error) return null;
+  // Bail entirely when there's nothing to show — no draft, no error, and not
+  // in edit mode. In edit mode the bar is PERSISTENT (#4315) so the user
+  // always sees they're editing a private draft.
+  if (!hasDraft && !error && !editing) return null;
 
   return (
     <div className="mx-4 mt-3 space-y-2 sm:mx-6">
+      {/* #4315 — persistent editing bar BEFORE the first edit forks a draft.
+          Once `hasDraft` flips true the richer Draft block below takes over. */}
+      {editing && !hasDraft && (
+        <div
+          data-testid="editing-draft-bar"
+          className="flex flex-wrap items-center gap-2 rounded-md border border-amber-200 bg-amber-50/70 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-200"
+        >
+          <Badge
+            variant="outline"
+            className="border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-100"
+          >
+            <Pencil className="mr-1 size-3" aria-hidden="true" />
+            Editing your draft
+          </Badge>
+          <span className="min-w-0 flex-1">
+            Changes are private to you until you Publish. No edits yet.
+          </span>
+          {onExitEditing && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 border-amber-300 bg-white text-amber-900 hover:bg-amber-100 dark:border-amber-800 dark:bg-zinc-900 dark:text-amber-100 dark:hover:bg-amber-900/30"
+              onClick={onExitEditing}
+              data-testid="editing-done-button"
+            >
+              Done
+            </Button>
+          )}
+        </div>
+      )}
+
       {hasDraft && (
         <div
           data-testid="draft-status-banner"
@@ -90,8 +136,8 @@ export function DraftStatusBanner({
             Draft
           </Badge>
           <span className="min-w-0 flex-1">
-            You have unpublished changes. Only you can see them until you
-            publish.
+            Editing your draft — unpublished changes only you can see until you
+            Publish.
           </span>
           <div className="flex items-center gap-1.5">
             <Button


### PR DESCRIPTION
## Summary

Foundational slice of the dashboard elevation PRD (#4313), implementing the [ADR-0029](../blob/main/docs/adr/0029-dashboards-draft-first-editing.md) draft-first model. Establishes and enforces the invariant: **no path writes the published dashboard tables except publish.**

- **Direct manipulation routes to the draft.** Rename, add/update/remove-card REST routes funnel through a single `applyEditToDraft` seam that forks/loads the caller's per-user draft, applies the change, and returns the materialized draft view — when drafts are on and the caller has a user id. Anonymous / flag-off callers keep the legacy direct-published path (documented `auth:none` carve-out). Parameters + refresh schedule stay on the live row per ADR-0029.
- **Draft-aware execution.** `render` / single-card `refresh` / CSV export run the **draft's** SQL under `?view=draft` (`resolveDraftExecCard`). A draft refresh returns freshly-run rows overlaid in-memory and **never** persists to the published card cache.
- **Anonymous-bound bypass closed.** A bound edit with no `userId` is now rejected rather than written straight to published (the ADR-0029 privacy hole).
- **Canvas + explicit edit.** The canvas renders the caller's draft while editing (`?view=draft`), published otherwise; a persistent "Editing your draft" bar makes entering edit explicit.
- **Error precision.** `applyEditToDraft` distinguishes `no_db` (503) from a transient `load_failed` (500); `resolveDraftExecCard` is a tagged union so a card removed in the draft 404s rather than silently running published.

## Test plan
- [x] `applyEditToDraft` unit tests — happy path + `no_db` / `load_failed` / `unknown_card` / `save_failed`
- [x] Route seam: every direct-manipulation op routes to the draft; published helpers not called; `no_db`→503, `load_failed`→500, `unknown_card`→404, `save_failed`→500
- [x] Draft-aware render/refresh/CSV run the draft SQL; refresh does not persist; removed-in-draft card 404s
- [x] `parameters`→live row while `title`→draft split
- [x] Anonymous bound edit rejected; never writes published
- [x] Browser flow spec: enter Edit → `?view=draft` → persistent bar → View shows published untouched
- [x] `/ci` local: type, lint, full test suite, schema-drift, openapi-drift all green

Internal review panel (silent-failure, type-design, test-coverage, comment) run in two rounds — converged CLEAN.

Closes #4315

---
_Generated by [Claude Code](https://claude.ai/code/session_01S88Cgp7Kuy4n9KHNnJHX9T)_