### PR TITLE
fix(dashboards): REST/draft card parity, preview-card org check, body-less render

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -7934,9 +7934,20 @@
                     "minLength": 1,
                     "maxLength": 200
                   },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "chart",
+                      "text"
+                    ]
+                  },
                   "sql": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "content": {
+                    "type": "string",
+                    "maxLength": 5000
                   },
                   "chartConfig": {
                     "type": [
@@ -8159,8 +8170,7 @@
                   }
                 },
                 "required": [
-                  "title",
-                  "sql"
+                  "title"
                 ]
               }
             }
@@ -8371,6 +8381,10 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 200
+                  },
+                  "sql": {
+                    "type": "string",
+                    "minLength": 1
                   },
                   "chartConfig": {
                     "type": [
@@ -9406,6 +9420,7 @@
           }
         ],
         "requestBody": {
+          "required": false,
           "content": {
             "application/json": {
               "schema": {

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -496,7 +496,14 @@ mock.module("@atlas/api/lib/config", () => ({
 }));
 
 import { createConnectionMock } from "@atlas/api/testing/connection";
-mock.module("@atlas/api/lib/db/connection", () => createConnectionMock());
+// #4318 — controllable so the preview-card org-check tests can force a
+// connection out of the caller's org (returns false → route 403s).
+const mockIsConnectionVisibleInMode = mock(
+  (..._args: unknown[]): Promise<boolean> => Promise.resolve(true),
+);
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({ isConnectionVisibleInMode: mockIsConnectionVisibleInMode }),
+);
 
 // Import after all mocks. The dynamic import avoids hoisting routes/dashboards.ts
 // past the mock.module() calls — a static `import` would load the module before
@@ -576,6 +583,9 @@ describe("dashboard routes", () => {
       truncated: false,
       maskingApplied: false,
     });
+    // #4318 — default: every connection is in the caller's org (visible).
+    mockIsConnectionVisibleInMode.mockReset();
+    mockIsConnectionVisibleInMode.mockResolvedValue(true);
     mockListSessionsForDashboard.mockReset();
     mockListSessionsForDashboard.mockResolvedValue([]);
     mockGetSessionTranscript.mockReset();
@@ -935,6 +945,63 @@ describe("dashboard routes", () => {
       const body = (await response.json()) as { error: string };
       expect(body.error).toBe("invalid_connection_group");
     });
+
+    // #4318 — REST/draft parity: a text / section card is creatable via REST.
+    it("creates a text card via REST, forwarding content (no sql) to addCard", async () => {
+      mockAddCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", kind: "text", content: "## Top of funnel" }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      const addArgs = mockAddCard.mock.calls[0] as unknown as [{ content?: string | null; sql: string }];
+      expect(addArgs[0].content).toBe("## Top of funnel");
+      // A text card stores sql = '' and never reaches the SQL pipeline.
+      expect(addArgs[0].sql).toBe("");
+    });
+
+    it("returns 422 for a text card with no content and never calls addCard (#4318)", async () => {
+      mockAddCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", kind: "text" }),
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
+    it("returns 422 for a text card that also carries sql and never calls addCard (#4318)", async () => {
+      mockAddCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", kind: "text", content: "# H", sql: "SELECT 1" }),
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
+    it("returns 422 for a chart card that carries content and never calls addCard (#4318)", async () => {
+      mockAddCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          // kind defaults to "chart"; `content` is only valid on a text card.
+          body: JSON.stringify({ title: "Revenue", sql: "SELECT 1", content: "# nope" }),
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -989,6 +1056,21 @@ describe("dashboard routes", () => {
       expect(clearResp.status).toBe(200);
       const clearArgs = mockUpdateCard.mock.calls[0] as unknown as [string, string, { annotations?: unknown }];
       expect(clearArgs[2].annotations).toEqual([]);
+    });
+
+    // #4318 — REST/draft parity: a card's SQL is editable via REST.
+    it("forwards a card-SQL edit to updateCard (#4318)", async () => {
+      mockUpdateCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sql: "SELECT COUNT(*) FROM orders" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      const args = mockUpdateCard.mock.calls[0] as unknown as [string, string, { sql?: string }];
+      expect(args[2].sql).toBe("SELECT COUNT(*) FROM orders");
     });
   });
 
@@ -1181,6 +1263,60 @@ describe("dashboard routes", () => {
       const callArgs = mockRunUserQueryPipeline.mock.calls[0][0];
       expect(callArgs).toMatchObject({ sql: "SELECT 1", connectionId: "analytics-replica" });
     });
+
+    // #4318 — preview-card verifies a client-supplied connectionId belongs to
+    // the caller's org BEFORE executing (parity with addCard's group check).
+    it("rejects a connectionId outside the caller's org with 403, never executing (#4318)", async () => {
+      mockRunUserQueryPipeline.mockClear();
+      // The connection is not visible in the caller's workspace.
+      mockIsConnectionVisibleInMode.mockResolvedValueOnce(false);
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/preview-card`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sql: "SELECT 1", connectionId: "other-org-conn" }),
+        }),
+      );
+      expect(response.status).toBe(403);
+      const body = (await response.json()) as { error: string };
+      expect(body.error).toBe("connection_forbidden");
+      // Fail closed: the SQL never reached the pipeline.
+      expect(mockRunUserQueryPipeline).not.toHaveBeenCalled();
+      // The org check was actually consulted with the caller's org + connection.
+      expect(mockIsConnectionVisibleInMode).toHaveBeenCalledTimes(1);
+      const [orgArg, connArg] = mockIsConnectionVisibleInMode.mock.calls[0] as unknown as [string, string, string];
+      expect(orgArg).toBe("org-1");
+      expect(connArg).toBe("other-org-conn");
+    });
+
+    it("executes when the connectionId is in the caller's org (#4318)", async () => {
+      mockRunUserQueryPipeline.mockClear();
+      mockIsConnectionVisibleInMode.mockResolvedValueOnce(true);
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/preview-card`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sql: "SELECT 1", connectionId: "in-org-conn" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the org check when no connectionId is supplied (#4318)", async () => {
+      mockRunUserQueryPipeline.mockClear();
+      mockIsConnectionVisibleInMode.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/preview-card`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sql: "SELECT 1" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(mockIsConnectionVisibleInMode).not.toHaveBeenCalled();
+      expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -1286,6 +1422,29 @@ describe("dashboard routes", () => {
       // date_from defaulted (a resolved ISO date), q supplied.
       expect(callArgs.parameters?.q).toBe("paid");
       expect(callArgs.parameters?.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    // #4318 — a body-less POST falls back to parameter defaults (mirrors the
+    // export route's `?? {}`) rather than throwing a 500 on `undefined`.
+    it("renders with parameter defaults when the request has no body (never 500) (#4318)", async () => {
+      mockRunUserQueryPipeline.mockClear();
+      mockGetDashboard.mockResolvedValueOnce({ ok: true, data: paramDashboard });
+      mockGetCard.mockResolvedValueOnce({ ok: true, data: paramCard });
+
+      // No body, no Content-Type — the body-less case that previously 500'd.
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}/render`, {
+          method: "POST",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(1);
+      const callArgs = mockRunUserQueryPipeline.mock.calls[0][0];
+      // Every parameter resolved to its default: date_from → an ISO date, q → its
+      // declared null default.
+      expect(callArgs.parameters?.date_from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(callArgs.parameters?.q).toBeNull();
     });
 
     it("rejects an invalid parameter value with 400 (never reaches the pipeline)", async () => {
@@ -3061,6 +3220,49 @@ describe("dashboard routes", () => {
       expect(change.kind).toBe("addCard");
       expect(change.card).toMatchObject({ title: "New card", sql: "SELECT 1" });
       expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
+    // #4318 — a text card creates via REST into the draft: content carried,
+    // sql = '' (a text card never touches the SQL pipeline).
+    it("POST /:id/cards stages a TEXT card into the draft with content + empty sql (#4318)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "Section", kind: "text", content: "## Funnel" }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; card?: { content?: string | null; sql: string } },
+      ];
+      expect(change.kind).toBe("addCard");
+      expect(change.card).toMatchObject({ content: "## Funnel", sql: "" });
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
+    // #4318 — a card-SQL edit routes to the draft's updateCard change.
+    it("PATCH /:id/cards/:cardId routes a SQL edit to the draft updateCard change (#4318)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sql: "SELECT 42" }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(mockApplyEditToDraft).toHaveBeenCalledTimes(1);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { kind: string; cardId: string; updates: { sql?: string } },
+      ];
+      expect(change).toMatchObject({ kind: "updateCard", cardId: VALID_CARD_ID });
+      expect(change.updates).toMatchObject({ sql: "SELECT 42" });
+      expect(mockUpdateCard).not.toHaveBeenCalled();
     });
 
     it("PATCH /:id/cards/:cardId updates the draft card (published updateCard not called)", async () => {

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -13,6 +13,7 @@ import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { z } from "zod";
 import { createLogger, hashShareToken } from "@atlas/api/lib/logger";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { isConnectionVisibleInMode } from "@atlas/api/lib/db/connection";
 import { verifyGroupBelongsToOrg } from "@atlas/api/lib/conversations";
 import {
   listSessionsForDashboard,
@@ -64,7 +65,7 @@ import {
   listStagedChangesForUser,
 } from "@atlas/api/lib/stage-tracker";
 import { SHARE_MODES } from "@useatlas/types/share";
-import { dashboardParametersSchema, renderCardRequestSchema, renderCardQuerySchema, refreshCardQuerySchema, dashboardChartConfigSchema, dashboardCardAnnotationsSchema } from "@useatlas/schemas";
+import { dashboardParametersSchema, renderCardRequestSchema, renderCardQuerySchema, refreshCardQuerySchema, dashboardChartConfigSchema, dashboardCardAnnotationsSchema, dashboardCardKindSchema, dashboardTextCardContentSchema } from "@useatlas/schemas";
 import {
   resolveDashboardParameterValues,
   extractPlaceholderNames,
@@ -109,23 +110,72 @@ const UpdateDashboardSchema = z.object({
   parameters: dashboardParametersSchema.optional(),
 });
 
-const AddCardSchema = z.object({
-  title: z.string().min(1).max(200),
-  sql: z.string().min(1),
-  chartConfig: ChartConfigSchema.nullable().optional(),
-  /** Event annotations (#3209) — dated markers rendered as vertical reference
-   *  lines on a line / area card. Omitted → the card has none. */
-  annotations: dashboardCardAnnotationsSchema.optional(),
-  cachedColumns: z.array(z.string()).nullable().optional(),
-  cachedRows: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
-  /** Group-scoped execution target (1.4.4). Resolved to a physical
-   * connection at view time via the group's primary member. */
-  connectionGroupId: z.string().nullable().optional(),
-  layout: CardLayoutSchema.nullable().optional(),
-});
+const AddCardSchema = z
+  .object({
+    title: z.string().min(1).max(200),
+    // #4318 — `kind` defaults to "chart" so every existing caller (which omits
+    // it) keeps working unchanged. A "text" / section card carries `content`
+    // (markdown) and NO `sql`; a "chart" card carries `sql` and no `content`.
+    // This widens the REST input surface to the parity the draft / bound-editor
+    // path already has (text cards + a card kind) — the routing itself stays
+    // draft-first via `applyEditToDraft`.
+    kind: dashboardCardKindSchema.optional(),
+    // Optional at the object level; the kind-specific requirement is enforced in
+    // the `.superRefine` below (chart → sql required; text → sql forbidden).
+    sql: z.string().min(1).optional(),
+    /** Markdown body of a text / section card (#3138). Required for a text
+     *  card, rejected on a chart card (enforced in `.superRefine`). */
+    content: dashboardTextCardContentSchema.optional(),
+    chartConfig: ChartConfigSchema.nullable().optional(),
+    /** Event annotations (#3209) — dated markers rendered as vertical reference
+     *  lines on a line / area card. Omitted → the card has none. */
+    annotations: dashboardCardAnnotationsSchema.optional(),
+    cachedColumns: z.array(z.string()).nullable().optional(),
+    cachedRows: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+    /** Group-scoped execution target (1.4.4). Resolved to a physical
+     * connection at view time via the group's primary member. */
+    connectionGroupId: z.string().nullable().optional(),
+    layout: CardLayoutSchema.nullable().optional(),
+  })
+  .superRefine((v, ctx) => {
+    const kind = v.kind ?? "chart";
+    if (kind === "text") {
+      // A text card renders its markdown; it never touches the SQL pipeline.
+      if (v.content === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A text card requires `content`.", path: ["content"] });
+      }
+      if (v.sql !== undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A text card cannot carry `sql`.", path: ["sql"] });
+      }
+      if (v.chartConfig != null) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A text card cannot carry `chartConfig`.", path: ["chartConfig"] });
+      }
+    } else {
+      if (v.sql === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "A chart card requires `sql`.", path: ["sql"] });
+      }
+      if (v.content !== undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "`content` is only valid on a text card.", path: ["content"] });
+      }
+    }
+  });
 
 const UpdateCardSchema = z.object({
   title: z.string().min(1).max(200).optional(),
+  // #4318 — card-SQL edits are reachable through the REST route, matching the
+  // draft / bound-editor `editSql` capability (which the input surface omitted).
+  // Omitted → the card's query is unchanged; a chart card's SQL is replaced in
+  // place. The new query runs through the full validation/execution pipeline at
+  // render/refresh time (as the draft path does), not at store time. Text-card
+  // content edits are intentionally NOT here: the draft/bound surface has no
+  // "edit markdown in place" op either (remove + re-add), so mirroring it keeps
+  // parity and avoids the `content`-presence kind-flip hazard on a chart card.
+  // The update path carries no `kind`, so a `sql` edit on a TEXT card is NOT
+  // rejected here — it persists a dead, non-empty `sql` the card ignores (kind
+  // stays "text" because `rowToCard` derives kind from content-presence, which
+  // wins). Inert, not a discriminant corruption; the bound editor rejects it for
+  // cleanliness, but the REST seam has no kind context without an extra read.
+  sql: z.string().min(1).optional(),
   chartConfig: ChartConfigSchema.nullable().optional(),
   /** Replace the card's event annotations (#3209). Omitted → unchanged; an
    *  explicit array (including `[]` to clear) replaces them. */
@@ -765,7 +815,10 @@ const renderCardRoute = createRoute({
       cardId: z.string().openapi({ param: { name: "cardId", in: "path" }, example: "00000000-0000-0000-0000-000000000000" }),
     }),
     query: renderCardQuerySchema,
-    body: { content: { "application/json": { schema: renderCardRequestSchema } } },
+    // #4318 — the body is OPTIONAL: a body-less `POST …/render` falls back to
+    // every parameter's server-resolved default (same as the `export` route,
+    // `required: false`). Marking it required would 500 an empty POST.
+    body: { content: { "application/json": { schema: renderCardRequestSchema } }, required: false },
   },
   responses: {
     200: {
@@ -1833,7 +1886,7 @@ authed.openapi(
       // #3207 — a KPI card requesting an automatic prior-period comparison must
       // filter by both window params, declared as `date`. Reject up front so a
       // misconfigured card can't persist a delta the render path can't produce.
-      const addAutoErr = validateAutoComparison(parsed.sql, parsed.chartConfig?.kpi, dash.data.parameters);
+      const addAutoErr = validateAutoComparison(parsed.sql ?? "", parsed.chartConfig?.kpi, dash.data.parameters);
       if (addAutoErr) {
         return c.json({ error: "invalid_request", message: addAutoErr, requestId }, 400);
       }
@@ -1863,14 +1916,21 @@ authed.openapi(
       // it into the draft snapshot. `cachedColumns`/`cachedRows` are a
       // published-cache concept and are intentionally dropped on the draft
       // path — a draft card's data comes from a draft-aware render.
+      // #4318 — a text / section card carries markdown `content`, no SQL. A
+      // chart card carries `sql`, no content. The schema's `.superRefine`
+      // guarantees the kind-specific fields are present, so `sql ?? ""` and the
+      // kind-gated content are always well-formed here.
+      const kind = parsed.kind ?? "chart";
       const uid = user?.id;
       if (shouldRouteToDraft(uid)) {
         const draftCard: DashboardSnapshotCard = {
           id: randomUUID(),
           position: 0,
           title: parsed.title,
-          sql: parsed.sql,
+          // A text card stores sql = '' and content = markdown (#3138).
+          sql: parsed.sql ?? "",
           chartConfig: parsed.chartConfig ?? null,
+          content: kind === "text" ? parsed.content ?? null : null,
           annotations: parsed.annotations ?? [],
           connectionGroupId: parsed.connectionGroupId ?? null,
           layout: parsed.layout ?? null,
@@ -1889,8 +1949,9 @@ authed.openapi(
       const result = yield* Effect.promise(() => addCard({
         dashboardId: id,
         title: parsed.title,
-        sql: parsed.sql,
+        sql: parsed.sql ?? "",
         chartConfig: parsed.chartConfig ?? null,
+        content: kind === "text" ? parsed.content ?? null : null,
         annotations: parsed.annotations ?? [],
         cachedColumns: parsed.cachedColumns ?? null,
         cachedRows: parsed.cachedRows ?? null,
@@ -1938,10 +1999,12 @@ authed.openapi(
       const uid = user?.id;
       const routeDraft = shouldRouteToDraft(uid);
 
-      // #3207 — if this update turns on autoComparison, validate it against the
-      // card's EXISTING sql (updateCard never changes the query) + the
-      // dashboard's params. Source the SQL from the DRAFT when routing to a
-      // draft (the card may only exist in the draft), else the published row.
+      // #3207 / #4318 — if this update turns on autoComparison, validate it
+      // against the sql the card WILL have after the edit + the dashboard's
+      // params. That's `parsed.sql` when this same PATCH rewrites the query
+      // (#4318 made SQL edits reachable here), otherwise the card's existing
+      // sql. Source the existing sql from the DRAFT when routing to a draft
+      // (the card may only exist in the draft), else the published row.
       if (parsed.chartConfig?.kpi?.autoComparison) {
         let existingSql: string | undefined;
         if (routeDraft) {
@@ -1953,9 +2016,10 @@ authed.openapi(
           const existing = yield* Effect.promise(() => getCard(cardId, id));
           if (existing.ok) existingSql = existing.data.sql;
         }
-        if (existingSql !== undefined) {
+        const effectiveSql = parsed.sql ?? existingSql;
+        if (effectiveSql !== undefined) {
           const updateAutoErr = validateAutoComparison(
-            existingSql,
+            effectiveSql,
             parsed.chartConfig.kpi,
             dash.data.parameters,
           );
@@ -2046,8 +2110,34 @@ authed.openapi(removeCardRoute, async (c) => {
 
 authed.openapi(previewCardRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
-    const { requestId } = yield* RequestContext;
+    const { requestId, atlasMode } = yield* RequestContext;
+    const { orgId } = yield* AuthContext;
     const { sql, connectionId } = c.req.valid("json");
+
+    // #4318 — verify a client-supplied `connectionId` belongs to the caller's
+    // org BEFORE executing. This is the one card-execution surface that took
+    // `connectionId` on trust; `addCard` already gates `connectionGroupId` via
+    // `verifyGroupBelongsToOrg`. Fail CLOSED: an out-of-org (or unverifiable)
+    // connection 403s rather than running against another tenant's datasource.
+    // `isConnectionVisibleInMode` fails closed on a DB error and returns true
+    // for a self-hosted deploy with no internal DB, so single-tenant self-host
+    // is unaffected. Only checked when an org context is present — a self-hosted
+    // caller with no org can't cross a tenant boundary that doesn't exist.
+    if (connectionId && orgId) {
+      const visible = yield* Effect.promise(() =>
+        isConnectionVisibleInMode(orgId, connectionId, atlasMode),
+      );
+      if (!visible) {
+        return c.json(
+          {
+            error: "connection_forbidden",
+            message: "The requested connection is not available in this workspace.",
+            requestId,
+          },
+          403,
+        );
+      }
+    }
 
     const { runUserQueryPipeline } = yield* Effect.promise(() => import("@atlas/api/lib/tools/sql"));
     const outcome = yield* Effect.promise(() =>
@@ -2219,7 +2309,10 @@ authed.openapi(renderCardRoute, async (c) => {
     }
     const { format, view } = c.req.valid("query");
     const asCsv = format === "csv";
-    const { parameters: suppliedParameters } = c.req.valid("json");
+    // #4318 — a body-less render is valid: fall back to `{}` (→ every parameter
+    // resolves to its default) rather than throwing on `undefined`. Mirrors the
+    // `export` route's `?? {}`.
+    const { parameters: suppliedParameters } = c.req.valid("json") ?? {};
 
     const dash = yield* Effect.promise(() => getDashboard(id, { orgId }));
     if (!dash.ok) {

--- a/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
@@ -195,6 +195,22 @@ describe("applyChangeToDraft", () => {
     expect(result.snapshot.cards[0].sql).toBe(base.cards[0].sql);
   });
 
+  it("updateCard replaces the card's sql in place, leaving other fields (#4318)", () => {
+    const base = snapshot([card("c1", { title: "Keep", sql: "SELECT 1" })]);
+    const result = applyChangeToDraft(base, {
+      kind: "updateCard",
+      cardId: "c1",
+      updates: { sql: "SELECT 2" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.cards[0].sql).toBe("SELECT 2");
+    // Only sql changed — title (and every other field) is untouched.
+    expect(result.snapshot.cards[0].title).toBe("Keep");
+    // Pure: original snapshot unmodified.
+    expect(base.cards[0].sql).toBe("SELECT 1");
+  });
+
   it("updateCard returns unknown_card when card is missing", () => {
     const base = snapshot([card("c1")]);
     const result = applyChangeToDraft(base, {

--- a/packages/api/src/lib/dashboard-versioning.ts
+++ b/packages/api/src/lib/dashboard-versioning.ts
@@ -199,6 +199,11 @@ export type DraftChange =
       cardId: string;
       updates: {
         title?: string;
+        /** #4318 — replace the card's SQL in place (the REST update surface's
+         *  parity with the bound-editor `editSql` op). Undefined leaves the
+         *  query unchanged. The new query is validated at render/refresh time
+         *  through the full SQL pipeline, not on store — same as `editSql`. */
+        sql?: string;
         chartConfig?: DashboardChartConfig | null;
         /** #3209 — replace the card's event markers. Undefined leaves them
          *  unchanged (the draft card keeps its current annotations). */
@@ -245,6 +250,9 @@ export function applyChangeToDraft(
           ? {
               ...c,
               ...(change.updates.title !== undefined && { title: change.updates.title }),
+              // #4318 — a card-SQL edit replaces the query in place, matching
+              // the `editSql` change the stage tracker dispatches.
+              ...(change.updates.sql !== undefined && { sql: change.updates.sql }),
               ...(change.updates.chartConfig !== undefined && { chartConfig: change.updates.chartConfig }),
               ...(change.updates.annotations !== undefined && { annotations: change.updates.annotations }),
               ...(change.updates.layout !== undefined && { layout: change.updates.layout }),

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -502,6 +502,10 @@ export async function addCard(opts: {
   title: string;
   sql: string;
   chartConfig?: DashboardChartConfig | null;
+  /** #3138 / #4318 — markdown body of a text / section card. NULL/omitted for a
+   *  chart card; the card kind is DERIVED from this column's presence in
+   *  `rowToCard`. A text card stores sql = '' and content = markdown. */
+  content?: string | null;
   /** Event annotations (#3209) — dated markers on a time-series card. Defaults
    *  to none (empty array) when omitted; never null (the column is NOT NULL). */
   annotations?: DashboardCardAnnotation[];
@@ -521,8 +525,8 @@ export async function addCard(opts: {
     const nextPos = (posRows[0]?.next_pos as number) ?? 0;
 
     const rows = await internalQuery<Record<string, unknown>>(
-      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, annotations, cached_columns, cached_rows, cached_at, connection_group_id, layout)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, content, annotations, cached_columns, cached_rows, cached_at, connection_group_id, layout)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         opts.dashboardId,
@@ -530,6 +534,9 @@ export async function addCard(opts: {
         opts.title,
         opts.sql,
         opts.chartConfig ? JSON.stringify(opts.chartConfig) : null,
+        // 0117 — NULL for a chart card; markdown for a text card. `rowToCard`
+        // derives the kind from this column's presence (#3138 / #4318).
+        opts.content ?? null,
         // 0121 — the column is NOT NULL DEFAULT '[]'; pass the explicit array
         // (or '[]' when absent) so a card always persists a defined value.
         JSON.stringify(opts.annotations ?? []),
@@ -557,6 +564,10 @@ export async function updateCard(
   dashboardId: string,
   updates: {
     title?: string;
+    /** #4318 — replace the card's SQL in place (REST card-SQL edit parity).
+     *  Omitted leaves the query unchanged; the new query is validated at
+     *  render/refresh time through the full pipeline, not on store. */
+    sql?: string;
     chartConfig?: DashboardChartConfig | null;
     /** Event annotations (#3209). `null` / omitted leaves them unchanged; an
      *  explicit array (including `[]`) replaces the card's markers. */
@@ -574,6 +585,10 @@ export async function updateCard(
   if (updates.title !== undefined) {
     setClauses.push(`title = $${paramIdx++}`);
     params.push(updates.title);
+  }
+  if (updates.sql !== undefined) {
+    setClauses.push(`sql = $${paramIdx++}`);
+    params.push(updates.sql);
   }
   if (updates.chartConfig !== undefined) {
     setClauses.push(`chart_config = $${paramIdx++}`);


### PR DESCRIPTION
## Summary

Three route-surface correctness fixes on the dashboard REST card routes so the REST API matches what the draft/bound surface can do and stops mis-handling edge inputs.

- **REST/draft parity** — widen `AddCardSchema`/`UpdateCardSchema` so **text cards** (`kind` + `content`) and **card-SQL edits** (`sql`) are reachable via REST. Routing stays draft-first via `applyEditToDraft` (#4315); the `DraftChange` `updateCard.updates` type and the published `addCard`/`updateCard` CRUD are threaded for `content`/`sql` so both the draft and published paths reach parity. A `.superRefine` enforces the text/chart discriminant (text → `content` required, no `sql`/`chartConfig`; chart → `sql` required, no `content`); `kind` defaults to `"chart"` so every existing caller is unchanged.
- **preview-card org check** — verify a client-supplied `connectionId` belongs to the caller's org via `isConnectionVisibleInMode` **before executing** (fail closed → 403), mirroring `addCard`'s `connectionGroupId` gate. Self-hosted with no internal DB / no org context is unaffected (fail-open, same as the existing gate).
- **body-less render** — `POST …/render` with no body falls back to parameter defaults (`required: false` + `?? {}`) instead of throwing a 500, mirroring the `export` route.

## Test plan
- [x] Route-seam tests: text-card create + SQL-edit via REST (published + draft paths); text/chart superRefine 422s; preview-card 403 on out-of-org `connectionId` (never executes) + executes in-org; body-less render returns defaults not 500
- [x] Unit test for the new draft `updateCard` SQL-merge branch
- [x] `bun run type`, `lint`, full `test` suite green; `openapi.json` regenerated + drift gate green
- [x] Internal review panel (4 specialists) — CLEAN

Closes #4318

https://claude.ai/code/session_01S88Cgp7Kuy4n9KHNnJHX9T

---
_Generated by [Claude Code](https://claude.ai/code/session_01S88Cgp7Kuy4n9KHNnJHX9T)_