### PR TITLE
feat(dashboards): concurrency cap + dead-browser relaunch for headless renders (#4319)

### DIFF
--- a/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Dashboard render resource-discipline tests (#4319).
+ *
+ * The shared headless Chromium behind dashboard screenshots + PDF/PNG export
+ * must:
+ *   1. Cap simultaneous renders with a semaphore — excess requests QUEUE and
+ *      still complete, rather than each spawning its own browser context.
+ *   2. Detect a dead/crashed browser and relaunch it on the next acquire,
+ *      instead of serving the cached dead instance forever (every export
+ *      failing until an API restart).
+ *
+ * Both are exercised through injectable seams (`_setRenderFn`,
+ * `_setBrowserLauncher`) so the suite never downloads or launches real
+ * Chromium — the real Playwright path stays in the opt-in smoke spec.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import {
+  screenshotDashboard,
+  _resetScreenshotCache,
+  _resetScreenshotBrowserState,
+  _setRenderFn,
+  _setRenderConcurrency,
+  _setBrowserLauncher,
+  _acquireScreenshotBrowser,
+  _renderInFlight,
+  type LaunchedBrowser,
+} from "../dashboard-screenshot";
+
+// Stub getDashboard so the snapshot-hash step doesn't touch the internal DB.
+// Mock-all-exports: anything the module exports but we don't call is `never`.
+mock.module("@atlas/api/lib/dashboards", () => ({
+  getDashboard: mock(async () => ({
+    ok: true,
+    data: {
+      id: "dash-1",
+      title: "Demo",
+      description: null,
+      updatedAt: "2026-07-04",
+      cards: [
+        {
+          id: "card-1",
+          title: "Signups",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+          layout: null,
+          position: 0,
+        },
+      ],
+    },
+  })),
+  createDashboard: undefined as never,
+  listDashboards: undefined as never,
+  updateDashboard: undefined as never,
+  deleteDashboard: undefined as never,
+  addCard: undefined as never,
+  updateCard: undefined as never,
+  removeCard: undefined as never,
+  refreshCard: undefined as never,
+  getCard: undefined as never,
+  shareDashboard: undefined as never,
+  unshareDashboard: undefined as never,
+  getShareStatus: undefined as never,
+  getSharedDashboard: undefined as never,
+  setRefreshSchedule: undefined as never,
+  CardLayoutSchema: { safeParse: () => ({ success: false }) },
+  resolveCardConnectionId: undefined as never,
+  NoGroupMembersError: class {},
+}));
+
+const PNG = Buffer.from("FAKE-PNG", "utf8");
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor: condition never became true");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("dashboard render concurrency cap (#4319)", () => {
+  beforeEach(() => {
+    _resetScreenshotCache();
+    _setRenderConcurrency(null);
+  });
+
+  afterEach(() => {
+    _setRenderFn(null);
+    _setRenderConcurrency(null);
+    _resetScreenshotCache();
+  });
+
+  it("caps simultaneous renders and queues the excess, which still complete", async () => {
+    _setRenderConcurrency(2);
+
+    let active = 0;
+    let peak = 0;
+    let started = 0;
+    let completed = 0;
+    // One resolver per parked render; resolving it lets that render finish.
+    const gates: Array<() => void> = [];
+
+    _setRenderFn(async () => {
+      started += 1;
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise<void>((resolve) => gates.push(resolve));
+      active -= 1;
+      completed += 1;
+      return PNG;
+    });
+
+    // Fire 5 renders at once. Distinct userIds ⇒ 5 distinct cache keys ⇒ all
+    // 5 actually render (none served from cache).
+    const all = Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        screenshotDashboard({ dashboardId: "dash-1", userId: `user-${i}`, orgId: "org-1" }),
+      ),
+    );
+
+    // Only the cap (2) may be in flight; the other 3 queue.
+    await waitFor(() => started === 2);
+    // Give any erroneously-admitted 3rd render a chance to show up.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(started).toBe(2);
+    expect(_renderInFlight()).toBe(2);
+    expect(peak).toBe(2);
+
+    // Drain: release one render at a time; each completion admits exactly one
+    // queued render. The cap must never be exceeded during the drain.
+    while (completed < 5) {
+      await waitFor(() => gates.length > 0);
+      const before = completed;
+      gates.shift()?.();
+      await waitFor(() => completed === before + 1);
+      expect(_renderInFlight()).toBeLessThanOrEqual(2);
+    }
+
+    const results = await all;
+    expect(results).toHaveLength(5);
+    expect(results.every((r) => r.ok)).toBe(true);
+    // The queued excess completed without ever breaching the cap.
+    expect(peak).toBe(2);
+    expect(started).toBe(5);
+    expect(_renderInFlight()).toBe(0);
+  });
+
+  it("serializes to a single render when the cap is 1", async () => {
+    _setRenderConcurrency(1);
+
+    let active = 0;
+    let peak = 0;
+    const gates: Array<() => void> = [];
+    _setRenderFn(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise<void>((resolve) => gates.push(resolve));
+      active -= 1;
+      return PNG;
+    });
+
+    const all = Promise.all(
+      Array.from({ length: 3 }, (_, i) =>
+        screenshotDashboard({ dashboardId: "dash-1", userId: `solo-${i}`, orgId: "org-1" }),
+      ),
+    );
+
+    await waitFor(() => gates.length === 1);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(_renderInFlight()).toBe(1);
+
+    // Release renders until all three complete.
+    for (let i = 0; i < 3; i++) {
+      await waitFor(() => gates.length > 0);
+      gates.shift()?.();
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const results = await all;
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(peak).toBe(1);
+  });
+});
+
+describe("dashboard headless browser liveness + relaunch (#4319)", () => {
+  beforeEach(() => {
+    _resetScreenshotBrowserState();
+  });
+
+  afterEach(() => {
+    _setBrowserLauncher(null);
+    _resetScreenshotBrowserState();
+  });
+
+  const makeFakeBrowser = (isAlive: () => boolean, onClose: (id: number) => void, id: number): LaunchedBrowser => ({
+    isConnected: isAlive,
+    close: async () => {
+      onClose(id);
+    },
+    // Never reached in the lifecycle tests — they drive getBrowser() directly.
+    newContext: async () => {
+      throw new Error("fake browser: newContext not used in lifecycle tests");
+    },
+  });
+
+  it("reuses a live cached browser without relaunching", async () => {
+    let launches = 0;
+    _setBrowserLauncher(async () => {
+      launches += 1;
+      return makeFakeBrowser(() => true, () => {}, launches);
+    });
+
+    const first = await _acquireScreenshotBrowser();
+    const second = await _acquireScreenshotBrowser();
+    expect(launches).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  it("relaunches a dead browser on next acquire instead of serving the cached dead instance", async () => {
+    let launches = 0;
+    let alive = true;
+    const closed: number[] = [];
+    _setBrowserLauncher(async () => {
+      launches += 1;
+      return makeFakeBrowser(() => alive, (id) => closed.push(id), launches);
+    });
+
+    const first = await _acquireScreenshotBrowser();
+    expect(launches).toBe(1);
+
+    // Simulate a crash: the cached browser reports disconnected.
+    alive = false;
+
+    const relaunched = await _acquireScreenshotBrowser();
+    expect(launches).toBe(2); // a fresh browser was launched
+    expect(relaunched).not.toBe(first); // not the dead cached instance
+    expect(closed).toEqual([1]); // the dead handle was closed, not leaked
+
+    // The relaunched instance is live (shared flag restored) and gets reused
+    // on subsequent acquires — no second relaunch.
+    alive = true;
+    const again = await _acquireScreenshotBrowser();
+    expect(again).toBe(relaunched);
+    expect(launches).toBe(2);
+  });
+
+  it("relaunches even when closing the dead handle throws", async () => {
+    let launches = 0;
+    let alive = true;
+    _setBrowserLauncher(async () => {
+      launches += 1;
+      const thisLaunch = launches;
+      return {
+        isConnected: () => (thisLaunch === 1 ? alive : true),
+        close: async () => {
+          if (thisLaunch === 1) throw new Error("close failed on dead handle");
+        },
+        newContext: async () => {
+          throw new Error("unused");
+        },
+      } satisfies LaunchedBrowser;
+    });
+
+    await _acquireScreenshotBrowser();
+    expect(launches).toBe(1);
+
+    alive = false; // first browser now dead; its close() will throw
+    const relaunched = await _acquireScreenshotBrowser();
+    // A throw while closing the dead handle must not block the relaunch.
+    expect(launches).toBe(2);
+    expect(relaunched).toBeDefined();
+  });
+
+  it("single-flights concurrent acquires into one launch", async () => {
+    let launches = 0;
+    _setBrowserLauncher(async () => {
+      launches += 1;
+      // Defer so both acquires overlap before the first launch resolves.
+      await new Promise((r) => setTimeout(r, 15));
+      return makeFakeBrowser(() => true, () => {}, launches);
+    });
+
+    const [a, b] = await Promise.all([_acquireScreenshotBrowser(), _acquireScreenshotBrowser()]);
+    expect(launches).toBe(1); // both shared one launch
+    expect(a).toBe(b);
+  });
+});

--- a/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
@@ -17,9 +17,12 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   screenshotDashboard,
+  exportDashboard,
+  clampRenderConcurrency,
   _resetScreenshotCache,
   _resetScreenshotBrowserState,
   _setRenderFn,
+  _setExportRenderFn,
   _setRenderConcurrency,
   _setBrowserLauncher,
   _acquireScreenshotBrowser,
@@ -65,6 +68,13 @@ mock.module("@atlas/api/lib/dashboards", () => ({
   setRefreshSchedule: undefined as never,
   CardLayoutSchema: { safeParse: () => ({ success: false }) },
   resolveCardConnectionId: undefined as never,
+  rowToCard: undefined as never,
+  loadGroupSnapshot: undefined as never,
+  buildSharedParameterSummary: undefined as never,
+  projectSharedDashboardView: undefined as never,
+  getDashboardsDueForRefresh: undefined as never,
+  lockDashboardForRefresh: undefined as never,
+  refreshDashboardCards: undefined as never,
   NoGroupMembersError: class {},
 }));
 
@@ -180,6 +190,117 @@ describe("dashboard render concurrency cap (#4319)", () => {
     expect(results.every((r) => r.ok)).toBe(true);
     expect(peak).toBe(1);
   });
+
+  it("releases the permit when a render FAILS, so the semaphore never starves", async () => {
+    // Regression guard for the exact deadlock class #4319 exists to kill: if
+    // `RenderSemaphore.run` ever released only on success, every failed render
+    // would leak a permit and — because screenshot/export swallow errors into
+    // `{ ok: false }` — silently starve ALL renders until an API restart.
+    _setRenderConcurrency(1);
+
+    // First render rejects. screenshotDashboard maps the throw to ok:false.
+    _setRenderFn(async () => {
+      throw new Error("nav timeout");
+    });
+    const failed = await screenshotDashboard({
+      dashboardId: "dash-1",
+      userId: "user-fail",
+      orgId: "org-1",
+    });
+    expect(failed.ok).toBe(false);
+    // The permit was returned despite the failure.
+    expect(_renderInFlight()).toBe(0);
+
+    // A subsequent render is admitted and completes — no starvation.
+    _setRenderFn(async () => PNG);
+    const next = await screenshotDashboard({
+      dashboardId: "dash-1",
+      userId: "user-ok",
+      orgId: "org-1",
+    });
+    expect(next.ok).toBe(true);
+    expect(_renderInFlight()).toBe(0);
+  });
+
+  it("exports share the same semaphore and acquire the permit BEFORE the render timeout starts", async () => {
+    // The export path deliberately wraps `withTimeout(fn(...))` INSIDE
+    // `renderSemaphore.run(...)`, so time spent queueing for a permit is not
+    // charged against the render budget. Park a screenshot render to hold the
+    // sole permit, fire an export behind it with a tiny timeout, and prove the
+    // export neither starts nor times out while queued.
+    _setRenderConcurrency(1);
+
+    let exportStarted = false;
+    const screenshotGate: Array<() => void> = [];
+    _setRenderFn(async () => {
+      await new Promise<void>((resolve) => screenshotGate.push(resolve));
+      return PNG;
+    });
+    _setExportRenderFn(async () => {
+      exportStarted = true;
+      return { bytes: PNG, contentType: "image/png", partial: false };
+    });
+
+    // Hold the permit with a screenshot render.
+    const shot = screenshotDashboard({ dashboardId: "dash-1", userId: "holder", orgId: "org-1" });
+    await waitFor(() => screenshotGate.length === 1);
+    expect(_renderInFlight()).toBe(1);
+
+    // Fire the export with a 30ms render budget. If the budget were counted
+    // during the queue wait, this would time out; instead it must simply wait.
+    const exp = exportDashboard({
+      dashboardId: "dash-1",
+      userId: "exporter",
+      orgId: "org-1",
+      format: "png",
+      timeoutMs: 30,
+    });
+
+    // Stay queued well past its own render budget without starting or failing.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(exportStarted).toBe(false);
+
+    // Release the screenshot → the export is admitted, its clock starts fresh.
+    screenshotGate.shift()?.();
+    const shotResult = await shot;
+    const expResult = await exp;
+    expect(shotResult.ok).toBe(true);
+    expect(exportStarted).toBe(true);
+    expect(expResult.ok).toBe(true); // did not time out — budget started after admission
+    expect(_renderInFlight()).toBe(0);
+
+    _setExportRenderFn(null);
+  });
+});
+
+describe("clampRenderConcurrency boundaries (#4319)", () => {
+  it("falls back to the default (3) for unset / empty / non-numeric input", () => {
+    expect(clampRenderConcurrency(null)).toBe(3);
+    expect(clampRenderConcurrency(undefined)).toBe(3);
+    expect(clampRenderConcurrency("")).toBe(3);
+    expect(clampRenderConcurrency("abc")).toBe(3);
+    expect(clampRenderConcurrency(Number.NaN)).toBe(3);
+  });
+
+  it("clamps to the floor of 1 for zero / negative (a 0 cap would deadlock)", () => {
+    expect(clampRenderConcurrency("0")).toBe(1);
+    expect(clampRenderConcurrency(0)).toBe(1);
+    expect(clampRenderConcurrency("-5")).toBe(1);
+    expect(clampRenderConcurrency(-5)).toBe(1);
+  });
+
+  it("clamps to the ceiling of 16 for oversized input", () => {
+    expect(clampRenderConcurrency("17")).toBe(16);
+    expect(clampRenderConcurrency(1000)).toBe(16);
+  });
+
+  it("truncates fractional values and passes valid ones through", () => {
+    expect(clampRenderConcurrency("3.9")).toBe(3);
+    expect(clampRenderConcurrency(4.2)).toBe(4);
+    expect(clampRenderConcurrency("1")).toBe(1);
+    expect(clampRenderConcurrency("16")).toBe(16);
+    expect(clampRenderConcurrency(8)).toBe(8);
+  });
 });
 
 describe("dashboard headless browser liveness + relaunch (#4319)", () => {
@@ -269,6 +390,35 @@ describe("dashboard headless browser liveness + relaunch (#4319)", () => {
     // A throw while closing the dead handle must not block the relaunch.
     expect(launches).toBe(2);
     expect(relaunched).toBeDefined();
+  });
+
+  it("treats a browser whose isConnected() THROWS as dead and relaunches", async () => {
+    // A crashed browser's transport can make isConnected() throw rather than
+    // return false; that must still be read as dead, not propagated.
+    let launches = 0;
+    let transportGone = false;
+    _setBrowserLauncher(async () => {
+      launches += 1;
+      const thisLaunch = launches;
+      return {
+        isConnected: () => {
+          if (thisLaunch === 1 && transportGone) throw new Error("transport closed");
+          return true;
+        },
+        close: async () => {},
+        newContext: async () => {
+          throw new Error("unused");
+        },
+      } satisfies LaunchedBrowser;
+    });
+
+    const first = await _acquireScreenshotBrowser();
+    expect(launches).toBe(1);
+
+    transportGone = true; // first browser's isConnected() now throws
+    const relaunched = await _acquireScreenshotBrowser();
+    expect(launches).toBe(2); // a throwing liveness probe forced a relaunch
+    expect(relaunched).not.toBe(first);
   });
 
   it("single-flights concurrent acquires into one launch", async () => {

--- a/packages/api/src/lib/dashboard-screenshot.ts
+++ b/packages/api/src/lib/dashboard-screenshot.ts
@@ -207,30 +207,74 @@ async function computeSnapshotHash(
 // users may not install browsers).
 let cachedBrowser: unknown | null = null;
 let browserShuttingDown = false;
+// Single-flight guard: N concurrent renders that find the cache empty (or a
+// dead handle) share ONE (close-dead + launch) instead of each spawning its
+// own Chromium and leaking all but one. Cleared once the acquire settles.
+let browserAcquire: Promise<unknown> | null = null;
 
 interface PlaywrightChromium {
-  launch: (opts?: Record<string, unknown>) => Promise<{
-    newContext: (opts?: Record<string, unknown>) => Promise<{
-      newPage: () => Promise<{
-        goto: (url: string, opts?: Record<string, unknown>) => Promise<unknown>;
-        waitForSelector: (sel: string, opts?: Record<string, unknown>) => Promise<unknown>;
-        waitForFunction: (fn: string | (() => boolean), opts?: Record<string, unknown>) => Promise<unknown>;
-        evaluate: <T>(fn: string | (() => T)) => Promise<T>;
-        screenshot: (opts?: Record<string, unknown>) => Promise<Buffer>;
-        close: () => Promise<void>;
-      }>;
-      addCookies: (cookies: unknown[]) => Promise<void>;
-      setExtraHTTPHeaders: (headers: Record<string, string>) => Promise<void>;
+  launch: (opts?: Record<string, unknown>) => Promise<LaunchedBrowser>;
+}
+
+/**
+ * Minimal lifecycle surface of a launched browser. `isConnected()` is
+ * Playwright's liveness signal — it flips to `false` the moment the underlying
+ * Chromium process dies or the transport drops, which is exactly the
+ * dead-instance-cached-forever failure (#4319) we relaunch on.
+ */
+export interface LaunchedBrowser {
+  isConnected?: () => boolean;
+  close: () => Promise<void>;
+  newContext: (opts?: Record<string, unknown>) => Promise<{
+    newPage: () => Promise<{
+      goto: (url: string, opts?: Record<string, unknown>) => Promise<unknown>;
+      waitForSelector: (sel: string, opts?: Record<string, unknown>) => Promise<unknown>;
+      waitForFunction: (fn: string | (() => boolean), opts?: Record<string, unknown>) => Promise<unknown>;
+      evaluate: <T>(fn: string | (() => T)) => Promise<T>;
+      screenshot: (opts?: Record<string, unknown>) => Promise<Buffer>;
       close: () => Promise<void>;
     }>;
+    addCookies: (cookies: unknown[]) => Promise<void>;
+    setExtraHTTPHeaders: (headers: Record<string, string>) => Promise<void>;
     close: () => Promise<void>;
   }>;
 }
 
-async function getBrowser(): Promise<unknown> {
-  if (cachedBrowser) return cachedBrowser;
-  if (browserShuttingDown) throw new Error("Screenshot browser is shutting down");
+/** Injectable launcher — the real one lazy-imports Playwright. */
+type BrowserLauncher = () => Promise<LaunchedBrowser>;
 
+let browserLauncherOverride: BrowserLauncher | null = null;
+
+/**
+ * @internal — test seam. Swap in a fake browser launcher so the launch /
+ * liveness / relaunch lifecycle is testable without downloading Chromium.
+ * Pass `null` to restore the real Playwright launcher.
+ */
+export function _setBrowserLauncher(fn: BrowserLauncher | null): void {
+  browserLauncherOverride = fn;
+}
+
+/**
+ * @internal — test-only. Reset the browser cache + single-flight guard between
+ * tests (the cache and shutdown flag are module-level singletons).
+ */
+export function _resetScreenshotBrowserState(): void {
+  cachedBrowser = null;
+  browserShuttingDown = false;
+  browserAcquire = null;
+}
+
+/**
+ * @internal — test-only. Force-acquire the shared browser through the real
+ * `getBrowser()` path (liveness check + relaunch + single-flight), so the
+ * lifecycle can be asserted directly.
+ */
+export function _acquireScreenshotBrowser(): Promise<unknown> {
+  return getBrowser();
+}
+
+/** The real launcher: lazy-import Playwright and launch headless Chromium. */
+async function launchViaPlaywright(): Promise<LaunchedBrowser> {
   // Lazy import — surface a graceful error if Playwright isn't installed.
   let chromium: PlaywrightChromium;
   try {
@@ -243,11 +287,68 @@ async function getBrowser(): Promise<unknown> {
     log.warn({ err: errorMessage(err) }, "Playwright not available — screenshot tool disabled");
     throw new Error("playwright_not_installed", { cause: err });
   }
-
-  cachedBrowser = await chromium.launch({
+  return chromium.launch({
     headless: true,
     args: ["--no-sandbox", "--disable-dev-shm-usage"],
   });
+}
+
+/**
+ * Liveness check. A cached browser whose process has crashed reports
+ * `isConnected() === false`; serving it would fail every render until an API
+ * restart (#4319). A handle that doesn't expose `isConnected` (a stub, or an
+ * older Playwright) is treated as alive — we can't prove it's dead. A throw
+ * from `isConnected()` means the transport is gone → treat as dead.
+ */
+function isBrowserAlive(b: LaunchedBrowser): boolean {
+  if (typeof b.isConnected !== "function") return true;
+  try {
+    return b.isConnected();
+  } catch (err) {
+    log.debug({ err: errorMessage(err) }, "browser isConnected() threw — treating as dead");
+    return false;
+  }
+}
+
+async function getBrowser(): Promise<unknown> {
+  if (browserShuttingDown) throw new Error("Screenshot browser is shutting down");
+
+  // Fast path: a live cached browser.
+  if (cachedBrowser && isBrowserAlive(cachedBrowser as LaunchedBrowser)) {
+    return cachedBrowser;
+  }
+
+  // Slow path: no browser, or the cached one is dead. Single-flight the
+  // (close-dead + launch) so concurrent renders share one relaunch.
+  if (!browserAcquire) {
+    browserAcquire = acquireBrowser().finally(() => {
+      browserAcquire = null;
+    });
+  }
+  return browserAcquire;
+}
+
+async function acquireBrowser(): Promise<unknown> {
+  // Re-check inside the single-flight — a racing caller may have already
+  // relaunched a live browser while we were queued behind it.
+  if (cachedBrowser && isBrowserAlive(cachedBrowser as LaunchedBrowser)) {
+    return cachedBrowser;
+  }
+
+  // A dead handle is cached: best-effort close so we don't leak the crashed
+  // process, then drop it. A throw here must not block the relaunch.
+  if (cachedBrowser) {
+    log.warn("Cached headless Chromium is disconnected — relaunching");
+    try {
+      await (cachedBrowser as LaunchedBrowser).close();
+    } catch (err) {
+      log.debug({ err: errorMessage(err) }, "closing dead browser handle failed (ignored)");
+    }
+    cachedBrowser = null;
+  }
+
+  const launch = browserLauncherOverride ?? launchViaPlaywright;
+  cachedBrowser = await launch();
   log.info("Headless Chromium launched for dashboard screenshots");
   return cachedBrowser;
 }
@@ -258,7 +359,10 @@ async function getBrowser(): Promise<unknown> {
  */
 export async function closeScreenshotBrowser(): Promise<void> {
   browserShuttingDown = true;
-  if (!cachedBrowser) return;
+  if (!cachedBrowser) {
+    browserShuttingDown = false;
+    return;
+  }
   try {
     const browser = cachedBrowser as { close: () => Promise<void> };
     await browser.close();
@@ -269,6 +373,96 @@ export async function closeScreenshotBrowser(): Promise<void> {
     cachedBrowser = null;
     browserShuttingDown = false;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Render concurrency semaphore (#4319)
+// ---------------------------------------------------------------------------
+//
+// One shared headless Chromium serves every screenshot AND export. Without a
+// bound, a burst of export requests each opens its own browser context/page in
+// parallel, and memory (each ~1920×2160 or 1600×2000 @2× render) climbs
+// unbounded until the process OOMs. The semaphore caps simultaneous renders;
+// excess requests QUEUE (FIFO) and run as permits free up, rather than being
+// rejected or spawning unbounded contexts.
+
+const RENDER_CONCURRENCY_DEFAULT = 3;
+const RENDER_CONCURRENCY_MIN = 1;
+const RENDER_CONCURRENCY_MAX = 16;
+
+let renderConcurrencyOverride: number | null = null;
+
+/**
+ * @internal — test seam. Pin the concurrency cap so the queueing behaviour is
+ * deterministic without reaching into the settings registry. `null` restores
+ * the registry-backed value.
+ */
+export function _setRenderConcurrency(n: number | null): void {
+  renderConcurrencyOverride = n;
+}
+
+/** Effective cap: test override > platform DB override > env > default. */
+function getRenderConcurrency(): number {
+  if (renderConcurrencyOverride !== null) return renderConcurrencyOverride;
+  const raw = getSettingAuto("ATLAS_DASHBOARD_RENDER_CONCURRENCY");
+  if (!raw) return RENDER_CONCURRENCY_DEFAULT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return RENDER_CONCURRENCY_DEFAULT;
+  return Math.min(RENDER_CONCURRENCY_MAX, Math.max(RENDER_CONCURRENCY_MIN, Math.trunc(parsed)));
+}
+
+/**
+ * Minimal FIFO counting semaphore. The limit is read live on every admission
+ * decision (via `getLimit`) so a settings hot-reload takes effect for the next
+ * queued waiter without a restart.
+ */
+class RenderSemaphore {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(private readonly getLimit: () => number) {}
+
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const tryAdmit = (): void => {
+        if (this.active < this.getLimit()) {
+          this.active += 1;
+          resolve();
+        } else {
+          // Over the cap — queue and re-attempt when a permit frees up.
+          this.waiters.push(tryAdmit);
+        }
+      };
+      tryAdmit();
+    });
+  }
+
+  private release(): void {
+    this.active -= 1;
+    const next = this.waiters.shift();
+    if (next) next();
+  }
+
+  /** @internal — test-only. Current in-flight render count. */
+  get inFlight(): number {
+    return this.active;
+  }
+}
+
+const renderSemaphore = new RenderSemaphore(getRenderConcurrency);
+
+/** @internal — test-only. Current in-flight render count (semaphore probe). */
+export function _renderInFlight(): number {
+  return renderSemaphore.inFlight;
 }
 
 // ---------------------------------------------------------------------------
@@ -466,13 +660,17 @@ export async function screenshotDashboard(opts: ScreenshotOpts): Promise<Screens
   let png: Buffer;
   try {
     const fn = renderImpl ?? defaultRender;
-    png = await fn({
-      dashboardId: opts.dashboardId,
-      userId: opts.userId,
-      orgId: opts.orgId,
-      cookieHeader: opts.cookieHeader ?? null,
-      baseUrl,
-    });
+    // Bound simultaneous headless renders — excess requests queue here rather
+    // than each opening its own browser context (#4319).
+    png = await renderSemaphore.run(() =>
+      fn({
+        dashboardId: opts.dashboardId,
+        userId: opts.userId,
+        orgId: opts.orgId,
+        cookieHeader: opts.cookieHeader ?? null,
+        baseUrl,
+      }),
+    );
   } catch (err) {
     const msg = errorMessage(err);
     if (msg === "playwright_not_installed") {
@@ -772,21 +970,26 @@ export async function exportDashboard(opts: ExportOpts): Promise<ExportResult> {
   let rendered: ExportRenderOutput;
   try {
     const fn = exportRenderImpl ?? defaultExportRender;
-    rendered = await withTimeout(
-      fn({
-        dashboardId: opts.dashboardId,
-        userId: opts.userId,
-        orgId: opts.orgId,
-        cookieHeader: opts.cookieHeader ?? null,
-        baseUrl,
-        apiBaseUrl: opts.apiBaseUrl,
-        format: opts.format,
-        parameters: opts.parameters ?? null,
-        title,
-        generatedAt: formatDisplayStamp(now),
+    // Bound simultaneous headless renders (shared with the screenshot path).
+    // The permit is acquired BEFORE the render timeout starts, so time spent
+    // queueing for a permit doesn't count against the render budget (#4319).
+    rendered = await renderSemaphore.run(() =>
+      withTimeout(
+        fn({
+          dashboardId: opts.dashboardId,
+          userId: opts.userId,
+          orgId: opts.orgId,
+          cookieHeader: opts.cookieHeader ?? null,
+          baseUrl,
+          apiBaseUrl: opts.apiBaseUrl,
+          format: opts.format,
+          parameters: opts.parameters ?? null,
+          title,
+          generatedAt: formatDisplayStamp(now),
+          timeoutMs,
+        }),
         timeoutMs,
-      }),
-      timeoutMs,
+      ),
     );
   } catch (err) {
     const msg = errorMessage(err);

--- a/packages/api/src/lib/dashboard-screenshot.ts
+++ b/packages/api/src/lib/dashboard-screenshot.ts
@@ -401,14 +401,25 @@ export function _setRenderConcurrency(n: number | null): void {
   renderConcurrencyOverride = n;
 }
 
-/** Effective cap: test override > platform DB override > env > default. */
-function getRenderConcurrency(): number {
-  if (renderConcurrencyOverride !== null) return renderConcurrencyOverride;
-  const raw = getSettingAuto("ATLAS_DASHBOARD_RENDER_CONCURRENCY");
-  if (!raw) return RENDER_CONCURRENCY_DEFAULT;
+/**
+ * Clamp a raw setting value to a valid concurrency cap. Pure + exported so the
+ * boundary behaviour is unit-testable without the settings registry:
+ *   - unset / empty / non-numeric → default (3)
+ *   - below the floor (incl. 0 / negative) → 1  (a 0 cap would deadlock all renders)
+ *   - above the ceiling → 16
+ *   - fractional → truncated
+ */
+export function clampRenderConcurrency(raw: string | number | null | undefined): number {
+  if (raw === null || raw === undefined || raw === "") return RENDER_CONCURRENCY_DEFAULT;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) return RENDER_CONCURRENCY_DEFAULT;
   return Math.min(RENDER_CONCURRENCY_MAX, Math.max(RENDER_CONCURRENCY_MIN, Math.trunc(parsed)));
+}
+
+/** Effective cap: test override > platform DB override > env > default. */
+function getRenderConcurrency(): number {
+  if (renderConcurrencyOverride !== null) return renderConcurrencyOverride;
+  return clampRenderConcurrency(getSettingAuto("ATLAS_DASHBOARD_RENDER_CONCURRENCY"));
 }
 
 /**

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1363,6 +1363,23 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     saasVisible: false,
   },
 
+  // Dashboards — max simultaneous headless renders (screenshot + PDF/PNG
+  // export share one Chromium). Hot-reloadable: `getRenderConcurrency()` reads
+  // per acquire. Excess requests queue rather than spawning unbounded browser
+  // contexts. Clamped to [1, 16].
+  {
+    key: "ATLAS_DASHBOARD_RENDER_CONCURRENCY",
+    section: "Dashboards",
+    label: "Headless Render Concurrency",
+    description:
+      "Max simultaneous dashboard screenshot/export renders on the shared headless Chromium; excess requests queue (default 3, clamped to 1–16).",
+    type: "number",
+    default: "3",
+    envVar: "ATLAS_DASHBOARD_RENDER_CONCURRENCY",
+    scope: "platform",
+    saasVisible: false,
+  },
+
   // Observability — plugin-health probe cache TTL. Hot-reloadable:
   // `getPluginHealthCacheTtlMs()` reads per health probe. (OTEL exporter
   // endpoint/headers are intentionally NOT here — see the block header above.)


### PR DESCRIPTION
## What & why

The shared headless Chromium behind dashboard screenshots and PDF/PNG export previously served every request from one long-lived instance with **no concurrency bound**, and cached a **crashed browser forever** — every export failing until an API restart (#4319).

## Changes

**1. Concurrency semaphore** (`packages/api/src/lib/dashboard-screenshot.ts`)
- A FIFO counting semaphore caps simultaneous renders. Screenshot + export share one Chromium, so they share one semaphore. Excess requests **queue and still complete** rather than each spawning its own browser context and driving memory unbounded.
- Cap is platform-settings-driven: `ATLAS_DASHBOARD_RENDER_CONCURRENCY` (default 3, clamped 1–16), resolved through the settings registry (`getSettingAuto`, precedence workspace > platform > env > default, hot-reloadable). **No new env var** — env is only the registry's default layer.
- The limit is re-read on every admission decision, so a settings hot-reload applies to the next queued waiter without a restart.
- Export acquires its permit **before** the render timeout starts, so queue time isn't charged against the render budget.

**2. Liveness check + relaunch**
- `getBrowser()` checks `isConnected()` on the cached browser; a dead handle (returns false, or throws) is best-effort closed and relaunched on the next acquire, instead of serving the cached dead instance forever.
- Concurrent acquires single-flight into one launch (`browserAcquire` guard) so N parallel renders share one relaunch instead of leaking browsers.

## Tests (`dashboard-render-resource.test.ts`, 13 cases)
- Concurrency cap: excess requests queue, complete, and never breach the cap; serialized at cap=1; **permit is released on render FAILURE** (regression guard for the exact starvation/deadlock class #4319 exists to kill).
- Export shares the semaphore and its timeout clock starts only after admission.
- Relaunch-on-dead-instance: relaunch, dead-handle close, close-throws tolerance, `isConnected()`-throws tolerance, single-flight.
- `clampRenderConcurrency` boundaries (NaN/empty→default, 0/negative→1, >16→16, truncation).
- All via injectable seams — no real Chromium.

## Acceptance criteria
- [x] Concurrent headless renders are capped by a semaphore; excess requests queue and complete
- [x] A crashed browser is detected and relaunched on the next render, not served from cache
- [x] Tests cover the relaunch-on-dead-instance path and the concurrency cap

Local gates: `type`, `lint`, `syncpack`, `settings-readers`, `openapi-drift`, `test-discipline` and all other read-only gates PASS. No routes changed → no OpenAPI regen. Affected api test suite (83 files) green.

Closes #4319

https://claude.ai/code/session_01S88Cgp7Kuy4n9KHNnJHX9T

---
_Generated by [Claude Code](https://claude.ai/code/session_01S88Cgp7Kuy4n9KHNnJHX9T)_