### PR TITLE
feat: copy button on assistant answers (#4296)

### DIFF
--- a/e2e/browser/copy-answer.spec.ts
+++ b/e2e/browser/copy-answer.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { askQuestion, ensureChatReady } from "./helpers";
+
+/**
+ * #4296 — copy button on assistant answers. A finished turn's answer exposes
+ * a "Copy answer" affordance (hover-revealed on desktop) that writes the
+ * answer's markdown SOURCE to the clipboard with the <suggestions> block
+ * stripped — the follow-up chips render separately and must never ride along.
+ */
+test.describe("Copy answer @llm", () => {
+  // LLM turns take 60-120s via gateway.
+  test.describe.configure({ timeout: 300_000, mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+    await ensureChatReady(page);
+  });
+
+  test("copying an answer puts its text on the clipboard without suggestions markup", async ({ page }) => {
+    await askQuestion(page, "how many companies are there?");
+
+    // The finished answer is on screen; the copy button starts hover-hidden
+    // on desktop. Playwright's toBeVisible() ignores opacity, so pin the
+    // reveal via computed style: 0 before hover, 1 after (toHaveCSS retries,
+    // letting the transition settle).
+    const answer = page.getByTestId("turn-answer").last();
+    await expect(answer).toBeVisible({ timeout: 10_000 });
+
+    const copyButton = page.getByRole("button", { name: "Copy answer" });
+    await expect(copyButton.locator("..")).toHaveCSS("opacity", "0");
+    await answer.hover();
+    await expect(copyButton.locator("..")).toHaveCSS("opacity", "1");
+    await copyButton.click();
+
+    // The existing CopyButton feedback confirms the write went through.
+    await expect(page.getByRole("button", { name: "Copied!" })).toBeVisible({ timeout: 5_000 });
+
+    // The root tsconfig (which type-checks e2e/) has no DOM lib, and
+    // @types/node's Navigator lacks `clipboard` — narrow the browser-side
+    // global explicitly.
+    const clipboard = await page.evaluate(() =>
+      (navigator as unknown as { clipboard: { readText(): Promise<string> } }).clipboard.readText(),
+    );
+
+    // The clipboard holds the answer, not the suggestions markup.
+    expect(clipboard.trim().length).toBeGreaterThan(0);
+    expect(clipboard).not.toContain("<suggestions>");
+    expect(clipboard).not.toContain("</suggestions>");
+
+    // And it is THIS answer: the copied markdown source and the rendered
+    // answer share vocabulary even after markdown formatting is applied.
+    const rendered = (await answer.textContent()) ?? "";
+    const words = clipboard.split(/\s+/).filter((w) => /^[a-zA-Z]{5,}$/.test(w));
+    expect(words.length).toBeGreaterThan(0);
+    expect(words.some((w) => rendered.includes(w))).toBe(true);
+  });
+});

--- a/e2e/browser/copy-answer.spec.ts
+++ b/e2e/browser/copy-answer.spec.ts
@@ -21,15 +21,25 @@ test.describe("Copy answer @llm", () => {
 
     // The finished answer is on screen; the copy button starts hover-hidden
     // on desktop. Playwright's toBeVisible() ignores opacity, so pin the
-    // reveal via computed style: 0 before hover, 1 after (toHaveCSS retries,
-    // letting the transition settle).
+    // reveal via computed style on the button's parent — AgentTurn's reveal
+    // wrapper carries the opacity classes; CopyButton renders the bare
+    // button. 0 before hover, 1 after (toHaveCSS retries, letting the
+    // transition settle).
     const answer = page.getByTestId("turn-answer").last();
     await expect(answer).toBeVisible({ timeout: 10_000 });
 
     const copyButton = page.getByRole("button", { name: "Copy answer" });
-    await expect(copyButton.locator("..")).toHaveCSS("opacity", "0");
+    const copyWrapper = copyButton.locator("..");
+    await expect(copyWrapper).toHaveCSS("opacity", "0");
+
+    // Keyboard path: focusing the button reveals it too (group-focus-within).
+    await copyButton.focus();
+    await expect(copyWrapper).toHaveCSS("opacity", "1");
+    await copyButton.blur();
+    await expect(copyWrapper).toHaveCSS("opacity", "0");
+
     await answer.hover();
-    await expect(copyButton.locator("..")).toHaveCSS("opacity", "1");
+    await expect(copyWrapper).toHaveCSS("opacity", "1");
     await copyButton.click();
 
     // The existing CopyButton feedback confirms the write went through.
@@ -53,5 +63,11 @@ test.describe("Copy answer @llm", () => {
     const words = clipboard.split(/\s+/).filter((w) => /^[a-zA-Z]{5,}$/.test(w));
     expect(words.length).toBeGreaterThan(0);
     expect(words.some((w) => rendered.includes(w))).toBe(true);
+
+    // Below the md: breakpoint the button is always visible — no hover needed
+    // (the mouse is parked away first so a lingering hover can't fake this).
+    await page.mouse.move(0, 0);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(copyWrapper).toHaveCSS("opacity", "1");
   });
 });

--- a/packages/web/src/ui/components/chat/__tests__/agent-turn-copy.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/agent-turn-copy.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copy affordance on finished assistant answers (#4296): every finished turn
+ * with answer text exposes a CopyButton that copies the answer's markdown
+ * SOURCE with the <suggestions> block stripped. No answer text → no button;
+ * still-streaming turns → no button (the answer is incomplete). Shared by the
+ * chat transcript and the notebook cell output via AgentTurn.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import React from "react";
+import type { TurnPart } from "../turn-partitioner";
+
+// Stub the heavy leaf renderers — this test pins the copy affordance, not
+// card internals. CLAUDE.md "Mock all exports": tool-part.tsx exports only
+// ToolPart; markdown.tsx exports only Markdown.
+mock.module("@/ui/components/chat/tool-part", () => ({
+  ToolPart: ({ part }: { part: unknown }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "tool-part-stub" },
+      String((part as { type?: string }).type),
+    ),
+}));
+mock.module("@/ui/components/chat/markdown", () => ({
+  Markdown: ({ content }: { content: string }) =>
+    React.createElement("div", null, content),
+}));
+
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+const { AgentTurn } = await import("../agent-turn");
+
+const writeTextMock = mock((_text: string) => Promise.resolve());
+
+beforeEach(() => {
+  writeTextMock.mockClear();
+  // Use defineProperty to override readonly clipboard
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: writeTextMock },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(cleanup);
+
+let nextCallId = 0;
+
+function text(t: string): TurnPart {
+  return { type: "text", text: t };
+}
+
+function sql(): TurnPart {
+  return {
+    type: "tool-executeSQL",
+    toolCallId: `call-${nextCallId++}`,
+    state: "output-available",
+    input: { sql: "SELECT 1", explanation: "test" },
+    output: { success: true, columns: ["n"], rows: [{ n: 1 }] },
+  } as TurnPart;
+}
+
+function copyButton(container: HTMLElement): HTMLButtonElement | null {
+  return Array.from(container.querySelectorAll("button")).find(
+    (b) => b.textContent === "Copy answer",
+  ) ?? null;
+}
+
+describe("AgentTurn copy affordance", () => {
+  test("answer with a <suggestions> block copies the markdown source without it", async () => {
+    const answer =
+      "US leads with **$200**.\n\n| region | sum |\n| --- | --- |\n| US | 200 |";
+    // Narration BEFORE the tool part must never ride into the clipboard —
+    // the copy source is the partitioner's answer bucket, not every text part.
+    const { container } = render(
+      <AgentTurn
+        parts={[
+          text("Looking at the data..."),
+          sql(),
+          text(`${answer}\n<suggestions>\nBreak down by month\n</suggestions>`),
+        ]}
+      />,
+    );
+
+    const button = copyButton(container);
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(answer);
+    });
+    const copied = writeTextMock.mock.calls[0][0];
+    expect(copied).not.toContain("<suggestions>");
+    expect(copied).not.toContain("Break down by month");
+    expect(copied).not.toContain("Looking at the data...");
+  });
+
+  test("multi-part answer copies all parts joined with a blank line", async () => {
+    const { container } = render(
+      <AgentTurn
+        parts={[
+          text("First paragraph."),
+          text("Second paragraph.\n<suggestions>\nMore\n</suggestions>"),
+        ]}
+      />,
+    );
+
+    const button = copyButton(container);
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(
+        "First paragraph.\n\nSecond paragraph.",
+      );
+    });
+  });
+
+  test("exactly one copy button per turn even with multiple answer parts", () => {
+    const { container } = render(
+      <AgentTurn parts={[text("One."), text("Two.")]} />,
+    );
+    const buttons = Array.from(container.querySelectorAll("button")).filter(
+      (b) => b.textContent === "Copy answer",
+    );
+    expect(buttons.length).toBe(1);
+  });
+
+  test("no copy button while the turn is still streaming (settled answer, open stream)", () => {
+    // #4300's settled-streaming state renders answer text before the stream
+    // closes — copying then would hand out a truncated answer.
+    const { container } = render(
+      <AgentTurn parts={[sql(), text("US leads so far")]} streaming />,
+    );
+    expect(copyButton(container)).toBeNull();
+  });
+
+  test("no copy button when the turn has no answer text (interrupted stream)", () => {
+    const { container } = render(<AgentTurn parts={[sql()]} />);
+    expect(copyButton(container)).toBeNull();
+  });
+
+  test("no copy button when the answer is all <suggestions> block", () => {
+    const { container } = render(
+      <AgentTurn
+        parts={[text("<suggestions>\nOnly chips\n</suggestions>")]}
+      />,
+    );
+    expect(copyButton(container)).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/chat/__tests__/agent-turn-copy.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/agent-turn-copy.test.tsx
@@ -116,6 +116,26 @@ describe("AgentTurn copy affordance", () => {
     });
   });
 
+  test("mixed answer parts: an all-suggestions part contributes nothing to the copy", async () => {
+    const { container } = render(
+      <AgentTurn
+        parts={[
+          text("Real answer."),
+          text("<suggestions>\nOnly chips\n</suggestions>"),
+        ]}
+      />,
+    );
+
+    const button = copyButton(container);
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+
+    await waitFor(() => {
+      // No trailing blank-line join from the empty stripped part.
+      expect(writeTextMock).toHaveBeenCalledWith("Real answer.");
+    });
+  });
+
   test("exactly one copy button per turn even with multiple answer parts", () => {
     const { container } = render(
       <AgentTurn parts={[text("One."), text("Two.")]} />,

--- a/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/turn-receipt.test.tsx
@@ -142,7 +142,9 @@ describe("AgentTurn", () => {
       />,
     );
 
-    const receipt = getByRole("button");
+    // The receipt toggle is the only button carrying aria-expanded — the
+    // answer's CopyButton (#4296) shares the turn now.
+    const receipt = getByRole("button", { expanded: false });
     const answer = getByTestId("turn-answer");
     const artifact = getByTestId("answer-artifact");
     expect(answer.textContent).toContain("Revenue was $1.2M.");
@@ -171,10 +173,14 @@ describe("AgentTurn", () => {
   });
 
   test("zero-tool turn renders the answer with no receipt", () => {
-    const { queryByRole, getByTestId } = render(
+    const { queryByRole, getByRole, getByTestId } = render(
       <AgentTurn parts={[text("Just an answer.")]} />,
     );
-    expect(queryByRole("button")).toBeNull();
+    // No receipt toggle (nothing carries aria-expanded) — the only button is
+    // the answer's copy affordance (#4296).
+    expect(queryByRole("button", { expanded: true })).toBeNull();
+    expect(queryByRole("button", { expanded: false })).toBeNull();
+    expect(getByRole("button", { name: "Copy answer" })).not.toBeNull();
     expect(getByTestId("turn-answer").textContent).toContain("Just an answer.");
   });
 
@@ -209,7 +215,7 @@ describe("AgentTurn", () => {
     const { getByRole, queryAllByTestId, getByTestId } = render(
       <AgentTurn parts={[pendingApproval, text("I need your approval to send this.")]} />,
     );
-    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    expect(getByRole("button", { expanded: true })).not.toBeNull();
     expect(queryAllByTestId("tool-part-stub")).toHaveLength(1);
     expect(getByTestId("turn-answer").textContent).toContain("I need your approval");
   });
@@ -225,6 +231,6 @@ describe("AgentTurn", () => {
     const { getByRole } = render(
       <AgentTurn parts={[executed, text("The email went out.")]} />,
     );
-    expect(getByRole("button").getAttribute("aria-expanded")).toBe("false");
+    expect(getByRole("button", { expanded: false })).not.toBeNull();
   });
 });

--- a/packages/web/src/ui/components/chat/__tests__/working-phase.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/working-phase.test.tsx
@@ -208,8 +208,11 @@ describe("AgentTurn (streaming)", () => {
     );
     rerender(<AgentTurn parts={parts} streaming={false} />);
     expect(getByTestId("answer-artifact")).not.toBeNull();
-    expect(getByRole("button").textContent).toContain("Explored schema");
-    expect(getByRole("button").textContent).not.toContain("query");
+    // Settling also reveals the answer's CopyButton (#4296) — locate the
+    // receipt toggle by its aria-expanded state, not as the only button.
+    const settledToggle = getByRole("button", { expanded: false });
+    expect(settledToggle.textContent).toContain("Explored schema");
+    expect(settledToggle.textContent).not.toContain("query");
   });
 
   test("a receipt expanded mid-stream stays expanded when the stream settles", () => {
@@ -222,7 +225,9 @@ describe("AgentTurn (streaming)", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
 
     rerender(<AgentTurn parts={parts} streaming={false} />);
-    expect(getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    // Settling also reveals the answer's CopyButton (#4296) — locate the
+    // receipt toggle by its aria-expanded state, not as the only button.
+    expect(getByRole("button", { expanded: true })).not.toBeNull();
     // Expanded receipt (explore card) + the now-promoted artifact.
     expect(queryAllByTestId("tool-part-stub")).toHaveLength(2);
   });

--- a/packages/web/src/ui/components/chat/agent-turn.tsx
+++ b/packages/web/src/ui/components/chat/agent-turn.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CopyButton } from "./copy-button";
 import { Markdown } from "./markdown";
 import { ToolPart } from "./tool-part";
 import { parseSuggestions } from "../../lib/helpers";
@@ -62,6 +63,14 @@ export function AgentTurn({
     ({ part }) => parseSuggestions(part.text).text.trim(),
   );
 
+  // What the copy affordance writes (#4296): the answer's markdown SOURCE with
+  // the <suggestions> block stripped — the same text the Markdown blocks below
+  // render, joined across parts, not the rendered DOM text.
+  const answerCopyText = answer
+    .map(({ part }) => parseSuggestions(part.text).text.trim())
+    .filter(Boolean)
+    .join("\n\n");
+
   // Working phase: the answer hasn't begun, the live feed is the whole turn.
   if (streaming && !hasRenderedAnswer) {
     return <WorkingActivity parts={parts ?? []} pythonProgress={pythonProgress} />;
@@ -91,19 +100,39 @@ export function AgentTurn({
           activityAwaitsUser(receiptActivity)
         }
       />
-      {answer.map(({ part, index }) => {
-        const displayText = parseSuggestions(part.text).text;
-        if (!displayText.trim()) return null;
-        return (
-          <div
-            key={index}
-            data-testid="turn-answer"
-            className="max-w-[90%] text-[0.9375rem] leading-relaxed text-zinc-800 dark:text-zinc-200"
-          >
-            <Markdown content={displayText} />
-          </div>
-        );
-      })}
+      {hasRenderedAnswer && (
+        // Named group so the hover reveal can't be hijacked by a bare `group`
+        // ancestor — notebook-cell.tsx's root has one (same guard as
+        // conversations/conversation-item.tsx). space-y-2 matches the spacing
+        // both consumers' containers put between answer parts. The wrapper is
+        // unconditional across the stream settling so the answer blocks keep
+        // their DOM position (no remount) when the copy row appears.
+        <div className="group/turn-answer space-y-2">
+          {answer.map(({ part, index }) => {
+            const displayText = parseSuggestions(part.text).text;
+            if (!displayText.trim()) return null;
+            return (
+              <div
+                key={index}
+                data-testid="turn-answer"
+                className="max-w-[90%] text-[0.9375rem] leading-relaxed text-zinc-800 dark:text-zinc-200"
+              >
+                <Markdown content={displayText} />
+              </div>
+            );
+          })}
+          {/* #4296 — copy the answer's markdown source. Finished turns only:
+              a still-streaming answer is incomplete, so offering to copy it
+              would hand out a truncated snapshot. Always visible below the
+              md: breakpoint (proxy for touch layouts); revealed on
+              hover/focus from md: up. */}
+          {!streaming && (
+            <div className="opacity-100 transition-opacity md:opacity-0 md:group-focus-within/turn-answer:opacity-100 md:group-hover/turn-answer:opacity-100">
+              <CopyButton text={answerCopyText} label="Copy answer" />
+            </div>
+          )}
+        </div>
+      )}
       {!streaming && answerBearingArtifact && (
         <div className="max-w-[95%]" data-testid="answer-artifact">
           <ToolPart

--- a/packages/web/src/ui/components/chat/agent-turn.tsx
+++ b/packages/web/src/ui/components/chat/agent-turn.tsx
@@ -64,8 +64,9 @@ export function AgentTurn({
   );
 
   // What the copy affordance writes (#4296): the answer's markdown SOURCE with
-  // the <suggestions> block stripped — the same text the Markdown blocks below
-  // render, joined across parts, not the rendered DOM text.
+  // the <suggestions> block stripped — the same source text the Markdown
+  // blocks below render (trimmed per part), joined across parts, not the
+  // rendered DOM text.
   const answerCopyText = answer
     .map(({ part }) => parseSuggestions(part.text).text.trim())
     .filter(Boolean)

--- a/packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx
+++ b/packages/web/src/ui/components/notebook/__tests__/notebook-cell-output.test.tsx
@@ -83,6 +83,9 @@ test("finished cell renders receipt → answer → promoted artifact via the sha
   // Receipt is collapsed: activity narration stays hidden until expanded.
   expect(container.textContent).not.toContain("Let me check the schema.");
   expect(getByRole("button", { name: /Explored schema/ })).toBeTruthy();
+  // The answer's copy affordance (#4296) ships on the notebook surface too —
+  // AgentTurn is the shared seam.
+  expect(getByRole("button", { name: "Copy answer" })).toBeTruthy();
   // Notebook chrome: everything sits inside the AssistantTurn gutter.
   const gutter = container.querySelector('[data-slot="assistant-turn"]');
   expect(gutter).not.toBeNull();


### PR DESCRIPTION
## Summary
- Every finished assistant turn with answer text now exposes the existing `CopyButton` below the answer, copying the answer's **markdown source** with the `<suggestions>` block stripped (the follow-up chips render separately and never ride along)
- Lives in `AgentTurn` — the shared seam from #4337 — so the chat transcript **and** the notebook cell output get the affordance consistently; gated on `!streaming` so a still-open stream can't hand out a truncated answer
- Hover/focus-revealed from the `md:` breakpoint up (named group `group/turn-answer` — notebook-cell's bare `group` root would hijack an unnamed one); always visible below `md:` as the touch tap-target

## Test plan
- [x] `agent-turn-copy.test.tsx` — copies markdown source (bold + table pipes intact) excluding `<suggestions>` AND pre-tool narration (exact-equality clipboard assertion); multi-part answers join with a blank line; mixed all-suggestions part contributes nothing; exactly one button per turn; no button while streaming / with no rendered answer
- [x] `turn-receipt.test.tsx` + `working-phase.test.tsx` — receipt toggle located by `aria-expanded` now that it's no longer the only button
- [x] `notebook-cell-output.test.tsx` — the affordance ships on the notebook surface too
- [x] Full local CI wrapper green (28 gates), root + web typecheck, lint
- [ ] `e2e/browser/copy-answer.spec.ts` (@llm) — hover/focus reveal pinned via computed opacity, mobile always-visible below `md:`, clipboard holds the answer text without suggestions markup (runs in the browser-test suite, not per-PR CI)

Closes #4296