### PR TITLE
feat: workspace default answer style setting (#4303)

### DIFF
--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -1003,8 +1003,9 @@ chat.openapi(chatRoute, async (c) => {
         // #4302 — per-conversation answer style. Body value (this turn, from
         // the header picker) > stored value on the row. `undefined` all the
         // way down means "no explicit choice anywhere" — `runAgent` then
-        // applies the surface default (`analyst`) at prompt assembly, so a
-        // NULL row keeps tracking the default rather than freezing a copy.
+        // applies the workspace default (#4303 settings registry), else the
+        // surface default (`analyst`), at prompt assembly, so a NULL row
+        // keeps tracking the live default rather than freezing a copy.
         let effectiveAnswerStyle: AnswerStyle | undefined =
           parsed.data.answerStyle;
 
@@ -1149,7 +1150,8 @@ chat.openapi(chatRoute, async (c) => {
             // #4302 — inherit the answer style from the row when the body
             // omits it. A NULL row stays `undefined` here (there is no
             // explicit choice to inherit) so prompt assembly keeps applying
-            // the live surface default.
+            // the live default (workspace default #4303, else the surface
+            // default).
             if (effectiveAnswerStyle === undefined && existing.data.answerStyle) {
               effectiveAnswerStyle = existing.data.answerStyle;
             }
@@ -1721,8 +1723,9 @@ chat.openapi(chatRoute, async (c) => {
                 }),
                 // #4302 — the conversation's answer style (body > row).
                 // Stripped when undefined so prompt assembly applies the
-                // surface default (`analyst`) for no-explicit-choice
-                // conversations instead of pinning a frozen copy of it.
+                // live default (workspace default #4303, else the `analyst`
+                // surface default) for no-explicit-choice conversations
+                // instead of pinning a frozen copy of it.
                 ...(effectiveAnswerStyle && { answerStyle: effectiveAnswerStyle }),
                 // #4294 — the pre-minted id + its stop signal (see above).
                 runId: turnRunId,
@@ -2198,8 +2201,9 @@ chat.openapi(chatResumeRoute, async (c) => {
             // checkpoint stores the message transcript, not the system
             // param), so re-thread the conversation's pinned style from the
             // row loaded for the ownership check above. NULL stays stripped
-            // — the resumed prompt applies the surface default, exactly as
-            // the original turn did.
+            // — the resumed prompt applies the live default (workspace
+            // default #4303, else the surface default), exactly as the
+            // original turn did.
             ...(existing.data.answerStyle && {
               answerStyle: existing.data.answerStyle,
             }),

--- a/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
@@ -1,0 +1,311 @@
+/**
+ * #4303 (PRD #4292) — workspace default answer style ("house voice").
+ *
+ * A workspace admin can set a default answer style in the settings registry
+ * (`ATLAS_DEFAULT_ANSWER_STYLE`, workspace-scoped, hot-reloadable). Precedence:
+ *
+ *   explicit `answerStyle` (per-conversation pick #4302, or a chat-platform
+ *   surface's explicit "conversational") > workspace default > surface
+ *   default (`DEFAULT_ANSWER_STYLE`, analyst).
+ *
+ * Two seams are pinned here:
+ *
+ *   1. `resolveWorkspaceDefaultAnswerStyle` — the settings-tier resolution
+ *      (workspace override > platform override > env > unset), the
+ *      empty/invalid-value fail-soft, and the request-context orgId fallback
+ *      (same shape as `getAgentMaxSteps`, #3406).
+ *   2. `runAgent` — the real agent loop, spying-mock-model harness (borrowed
+ *      from agent-answer-style-prompt-shape.test.ts): a turn with no explicit
+ *      style renders the workspace default's addendum; an explicit style
+ *      still wins (including the Slack path's explicit "conversational", so
+ *      chat-platform surfaces are structurally unaffected); clearing the
+ *      default falls back to the analyst surface default without a restart.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// ---------------------------------------------------------------------------
+// Module mocks — deterministic single-connection workspace. runAgent runs with
+// NO request context here, so every org-scoped loader short-circuits; the
+// workspace-default reads below exercise the PLATFORM settings tier (the same
+// getSetting chain, without waking the org-gated context loaders).
+// ---------------------------------------------------------------------------
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      describe: () => [{ id: "default", dbType: "postgres" as const }],
+    },
+  }),
+);
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => [],
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  buildRetrievalQuery: () => "",
+  getRetrievalTurns: () => 3,
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+// #3633 — agent.ts assembles the org-knowledge block via this module.
+mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
+const { runAgent, resolveWorkspaceDefaultAnswerStyle } = await import(
+  "@atlas/api/lib/agent"
+);
+const { withRequestContext } = await import("@atlas/api/lib/logger");
+const { _resetPool } = await import("@atlas/api/lib/db/internal");
+type InternalPool = import("@atlas/api/lib/db/internal").InternalPool;
+const { setSetting, deleteSetting, _resetSettingsCache } = await import(
+  "@atlas/api/lib/settings"
+);
+
+const ORG = "org-answer-style-default-test";
+const KEY = "ATLAS_DEFAULT_ANSWER_STYLE";
+
+// Same in-memory internal-DB stand-in as agent-max-steps.test.ts (#3406):
+// setSetting/deleteSetting persist through this no-op pool and maintain the
+// in-process cache the resolver reads.
+const mockPool: InternalPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+const origDbUrl = process.env.DATABASE_URL;
+const origEnvDefault = process.env[KEY];
+
+beforeEach(() => {
+  delete process.env[KEY];
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+  _resetSettingsCache();
+});
+
+afterEach(() => {
+  if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+  else delete process.env.DATABASE_URL;
+  if (origEnvDefault !== undefined) process.env[KEY] = origEnvDefault;
+  else delete process.env[KEY];
+  _resetPool(null);
+  _resetSettingsCache();
+});
+
+// ---------------------------------------------------------------------------
+// 1) The settings-tier resolver
+// ---------------------------------------------------------------------------
+
+describe("resolveWorkspaceDefaultAnswerStyle (#4303)", () => {
+  it("returns undefined when nothing is configured (surface default applies)", () => {
+    expect(resolveWorkspaceDefaultAnswerStyle()).toBeUndefined();
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
+  });
+
+  it("returns the workspace override for that org — and does not leak to others", async () => {
+    await setSetting(KEY, "plain-english", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe("plain-english");
+    expect(resolveWorkspaceDefaultAnswerStyle("org-other")).toBeUndefined();
+  });
+
+  it("falls back to the platform override when the org has none", async () => {
+    await setSetting(KEY, "executive", "test");
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe("executive");
+    expect(resolveWorkspaceDefaultAnswerStyle()).toBe("executive");
+  });
+
+  it("resolves the active org from the request context when no orgId is passed (#3406 shape)", async () => {
+    await setSetting(KEY, "executive", "test", ORG);
+    const inRequest = withRequestContext(
+      {
+        requestId: "req-4303",
+        user: {
+          id: "u1",
+          mode: "managed",
+          label: "u1@example.com",
+          activeOrganizationId: ORG,
+        },
+      },
+      () => resolveWorkspaceDefaultAnswerStyle(),
+    );
+    expect(inRequest).toBe("executive");
+    // Out-of-request callers see no workspace tier.
+    expect(resolveWorkspaceDefaultAnswerStyle()).toBeUndefined();
+  });
+
+  it("a cleared override resolves to undefined again (set → delete)", async () => {
+    await setSetting(KEY, "executive", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe("executive");
+    await deleteSetting(KEY, "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
+  });
+
+  it("treats an empty-string override as unset (the select route stores \"\" as a legal value)", async () => {
+    await setSetting(KEY, "", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace before validating", async () => {
+    await setSetting(KEY, "  analyst  ", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe("analyst");
+  });
+
+  it("ignores an out-of-vocabulary value (fail-soft to the surface default, never a crashed turn)", async () => {
+    await setSetting(KEY, "sarcastic", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
+  });
+
+  it("accepts every registered style — including conversational (registry-total; curation lives at the admin options seam)", async () => {
+    const { ANSWER_STYLE_NAMES } = await import("@atlas/api/lib/answer-styles");
+    for (const style of ANSWER_STYLE_NAMES) {
+      await setSetting(KEY, style, "test", ORG);
+      expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe(style);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2) runAgent precedence — real agent loop, spying mock model
+// ---------------------------------------------------------------------------
+
+let lastSystemPrompt: string | undefined;
+
+function extractSystemPrompt(opts: unknown): string | undefined {
+  const prompt = (opts as { prompt?: ReadonlyArray<{ role: string; content: unknown }> })?.prompt;
+  const systemMsg = Array.isArray(prompt) ? prompt.find((p) => p.role === "system") : undefined;
+  if (!systemMsg) return undefined;
+  const content = systemMsg.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((c) => (c as { text?: string })?.text ?? "").join("");
+  }
+  return "";
+}
+
+function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
+  const parts: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "The EU region grew the most, up 14%." },
+    {
+      type: "finish",
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 20, text: 20, reasoning: undefined },
+      },
+      finishReason: { unified: "stop", raw: "end_turn" },
+    },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async (opts: unknown) => {
+      const content = extractSystemPrompt(opts);
+      if (content) lastSystemPrompt = content;
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+async function runTurn(
+  answerStyle?: import("@atlas/api/lib/answer-styles").AnswerStyle,
+): Promise<string> {
+  lastSystemPrompt = undefined;
+  const result = await runAgent({
+    messages: [
+      {
+        id: "msg-1",
+        role: "user" as const,
+        parts: [
+          { type: "text" as const, text: "Which region grew the most last quarter?" },
+        ],
+      },
+    ] satisfies UIMessage[],
+    aiModel: {
+      model: makeSpyingModel(),
+      providerType: "openai",
+      modelId: "mock-workspace-default-model",
+    },
+    ...(answerStyle ? { answerStyle } : {}),
+  });
+  await result.text; // drain the stream so doStream ran
+  expect(lastSystemPrompt).toBeDefined();
+  return lastSystemPrompt ?? "";
+}
+
+describe("runAgent — workspace default answer style precedence (#4303)", () => {
+  it("a turn with no explicit style renders the workspace default's addendum", async () => {
+    await setSetting(KEY, "executive", "test");
+    const prompt = await runTurn();
+    expect(prompt).toContain("## Answer style — executive");
+    expect(prompt).not.toContain("## Answer style — analyst");
+  });
+
+  it("an explicit per-conversation style beats the workspace default", async () => {
+    await setSetting(KEY, "executive", "test");
+    const prompt = await runTurn("plain-english");
+    expect(prompt).toContain("## Answer style — plain English");
+    expect(prompt).not.toContain("## Answer style — executive");
+  });
+
+  it("the chat-platform surface's explicit conversational voice is unaffected by the workspace default", async () => {
+    // Slack/proactive always pass an explicit style (executeQuery.ts maps
+    // presentationMode → answerStyle), so the workspace default can never
+    // reach a chat-platform turn — the no-Slack-regression half of #4303.
+    await setSetting(KEY, "executive", "test");
+    const prompt = await runTurn("conversational");
+    expect(prompt).toContain("## Presentation mode — conversational");
+    expect(prompt).not.toContain("## Answer style — executive");
+  });
+
+  it("no workspace default ⇒ the analyst surface default still applies", async () => {
+    const prompt = await runTurn();
+    expect(prompt).toContain("## Answer style — analyst");
+  });
+
+  it("clearing the workspace default falls back to the surface default without a restart (hot reload)", async () => {
+    await setSetting(KEY, "executive", "test");
+    expect(await runTurn()).toContain("## Answer style — executive");
+    await deleteSetting(KEY, "test");
+    const prompt = await runTurn();
+    expect(prompt).toContain("## Answer style — analyst");
+    expect(prompt).not.toContain("## Answer style — executive");
+  });
+
+  it("an invalid stored value fails soft to the surface default (never a crashed turn)", async () => {
+    await setSetting(KEY, "sarcastic", "test");
+    const prompt = await runTurn();
+    expect(prompt).toContain("## Answer style — analyst");
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
@@ -11,9 +11,10 @@
  * Two seams are pinned here:
  *
  *   1. `resolveWorkspaceDefaultAnswerStyle` — the settings-tier resolution
- *      (workspace override > platform override > env > unset), the
- *      empty/invalid-value fail-soft, and the request-context orgId fallback
- *      (same shape as `getAgentMaxSteps`, #3406).
+ *      (workspace override > platform override > env var > unset, each tier
+ *      exercised below), the empty/invalid-value fail-soft, and the
+ *      request-context orgId fallback (same shape as `getAgentMaxSteps`,
+ *      #3406).
  *   2. `runAgent` — the real agent loop, spying-mock-model harness (borrowed
  *      from agent-answer-style-prompt-shape.test.ts): a turn with no explicit
  *      style renders the workspace default's addendum; an explicit style
@@ -149,6 +150,17 @@ describe("resolveWorkspaceDefaultAnswerStyle (#4303)", () => {
     expect(resolveWorkspaceDefaultAnswerStyle()).toBe("executive");
   });
 
+  it("falls back to the env tier when no DB override exists — and a DB override beats it", async () => {
+    // The env tier exists mechanically for every registry entry (this key is
+    // registry-managed, not env-first: nothing requires the var to be set),
+    // and this pins the registry entry's `envVar` spelling for self-hosted
+    // deployments that do use it.
+    process.env[KEY] = "plain-english";
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe("plain-english");
+    await setSetting(KEY, "executive", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe("executive");
+  });
+
   it("resolves the active org from the request context when no orgId is passed (#3406 shape)", async () => {
     await setSetting(KEY, "executive", "test", ORG);
     const inRequest = withRequestContext(
@@ -280,9 +292,10 @@ describe("runAgent — workspace default answer style precedence (#4303)", () =>
   });
 
   it("the chat-platform surface's explicit conversational voice is unaffected by the workspace default", async () => {
-    // Slack/proactive always pass an explicit style (executeQuery.ts maps
-    // presentationMode → answerStyle), so the workspace default can never
-    // reach a chat-platform turn — the no-Slack-regression half of #4303.
+    // Both chat-platform entrypoints map presentationMode → an explicit
+    // answerStyle every turn (executeQuery.ts in core, the proactive answer
+    // adapter in /ee), so the workspace default can never reach a
+    // chat-platform turn — the no-Slack-regression half of #4303.
     await setSetting(KEY, "executive", "test");
     const prompt = await runTurn("conversational");
     expect(prompt).toContain("## Presentation mode — conversational");

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -22,6 +22,7 @@ import {
   SECURITY_SENSITIVE_KEYS,
   _resetSettingsCache,
 } from "../settings";
+import { ANSWER_STYLE_NAMES, isAnswerStyle } from "../answer-styles";
 
 // ---------------------------------------------------------------------------
 // Mock pool
@@ -713,6 +714,42 @@ describe("settings module", () => {
 
       const provider = settings.find((s) => s.key === "ATLAS_PROVIDER");
       expect(provider!.requiresRestart).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // ATLAS_DEFAULT_ANSWER_STYLE — the workspace "house voice" (#4303, PRD #4292)
+  // ---------------------------------------------------------------------------
+
+  describe("ATLAS_DEFAULT_ANSWER_STYLE registry entry (#4303)", () => {
+    it("is a workspace-scoped, hot-reloadable select with no built-in default", () => {
+      const def = getSettingDefinition("ATLAS_DEFAULT_ANSWER_STYLE");
+      expect(def).toBeDefined();
+      expect(def!.scope).toBe("workspace");
+      expect(def!.type).toBe("select");
+      // Hot-reloadable: the agent loop reads it per turn through the settings
+      // cache — a restart hint would contradict the no-redeploy contract.
+      expect(def!.requiresRestart).toBeFalsy();
+      // No registry default: unset means "fall through to the surface
+      // default" (analyst for web/SDK/MCP, conversational for chat
+      // platforms), NOT a frozen copy of one of them.
+      expect(def!.default).toBeUndefined();
+    });
+
+    it("offers every registered style except conversational (drift lock against the answer-style registry)", () => {
+      const def = getSettingDefinition("ATLAS_DEFAULT_ANSWER_STYLE");
+      // conversational is the chat-platform voice — its addendum references
+      // Slack progressive-disclosure buttons that don't exist on the
+      // analyst-grade surfaces this default applies to, so it is not offered
+      // as a house voice. Everything else in the registry is.
+      expect(def!.options).toEqual(
+        ANSWER_STYLE_NAMES.filter((s) => s !== "conversational"),
+      );
+      // Every offered option must be a registry style — a token the resolver
+      // would reject can never be a legal admin choice.
+      for (const opt of def!.options ?? []) {
+        expect(isAnswerStyle(opt)).toBe(true);
+      }
     });
   });
 

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -727,6 +727,9 @@ describe("settings module", () => {
       expect(def).toBeDefined();
       expect(def!.scope).toBe("workspace");
       expect(def!.type).toBe("select");
+      // Pins the env-tier spelling for self-hosted deployments (the registry
+      // requires an envVar; nothing requires the var to be set).
+      expect(def!.envVar).toBe("ATLAS_DEFAULT_ANSWER_STYLE");
       // Hot-reloadable: the agent loop reads it per turn through the settings
       // cache — a restart hint would contradict the no-redeploy contract.
       expect(def!.requiresRestart).toBeFalsy();

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -136,9 +136,11 @@ export interface ExecuteAgentQueryOptions {
    * reply renders as 1-2 sentences of prose with the SQL and tables
    * surfaced via progressive-disclosure buttons (#2705).
    *
-   * Optional, defaulting to `"analyst"` (the answer-first analyst voice)
-   * so the synchronous JSON `/api/v1/query` route, MCP, and any other
-   * non-chat caller get the analyst-grade body.
+   * Optional. When absent, `runAgent` resolves the workspace default
+   * answer style (#4303, the `ATLAS_DEFAULT_ANSWER_STYLE` setting), else
+   * `"analyst"` (the answer-first analyst voice) — so the synchronous JSON
+   * `/api/v1/query` route, MCP, and any other non-chat caller get the
+   * workspace's house voice, defaulting to the analyst-grade body.
    */
   answerStyle?: AnswerStyle;
 }

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -90,6 +90,7 @@ import { runEnterprise } from "./effect/enterprise-layer";
 import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
 import {
   DEFAULT_ANSWER_STYLE,
+  isAnswerStyle,
   resolveAnswerStyleAddendum,
   type AnswerStyle,
 } from "./answer-styles";
@@ -126,6 +127,49 @@ export function getAgentMaxSteps(orgId?: string): number {
     return DEFAULT_MAX_STEPS;
   }
   return n;
+}
+
+let lastWarnedAnswerStyleDefault: string | undefined;
+
+/**
+ * #4303 (PRD #4292) — the workspace default answer style ("house voice"),
+ * read from the settings registry (`ATLAS_DEFAULT_ANSWER_STYLE`, workspace
+ * DB override > platform DB override > env var; no registry default). The
+ * middle tier of the answer-style precedence chain:
+ *
+ *   explicit `answerStyle` (per-conversation pick #4302, or a chat-platform
+ *   surface's explicit "conversational") > THIS workspace default > surface
+ *   default (`DEFAULT_ANSWER_STYLE`, applied by `buildSystemParam`).
+ *
+ * `runAgent` consults it only when the caller passed no style, so
+ * chat-platform surfaces — which always pass one (`executeQuery` maps
+ * `presentationMode` explicitly) — are structurally unaffected. Returns
+ * `undefined` when unset, cleared, empty, or unrecognized: fail-soft to the
+ * surface default (a stale DB/env token must never crash a turn), with a
+ * once-per-value warn breadcrumb (same shape as `getAgentMaxSteps`).
+ *
+ * `orgId` threads the workspace tier; when omitted it falls back to the
+ * request context's active organization (#3406 shape).
+ */
+export function resolveWorkspaceDefaultAnswerStyle(
+  orgId?: string,
+): AnswerStyle | undefined {
+  const effectiveOrgId = orgId ?? getRequestContext()?.user?.activeOrganizationId;
+  const raw = getSetting("ATLAS_DEFAULT_ANSWER_STYLE", effectiveOrgId)?.trim();
+  // Unset or empty (the admin select stores "" as a legal value) — no house
+  // voice configured; the surface default applies.
+  if (!raw) return undefined;
+  if (!isAnswerStyle(raw)) {
+    if (raw !== lastWarnedAnswerStyleDefault) {
+      log.warn(
+        { value: raw },
+        "Unrecognized ATLAS_DEFAULT_ANSWER_STYLE value — using the surface default answer style",
+      );
+      lastWarnedAnswerStyleDefault = raw;
+    }
+    return undefined;
+  }
+  return raw;
 }
 
 const SYSTEM_PROMPT_PREFIX = `You are Atlas, an expert data analyst AI. You answer questions about data by exploring a semantic layer, writing SQL, and interpreting results.
@@ -597,7 +641,10 @@ export interface BuildSystemParamOptions {
    * #4299 — the answer's editorial voice. Resolves through the answer-style
    * registry (lib/answer-styles.ts); exactly one style's addendum is appended.
    * Defaults to {@link DEFAULT_ANSWER_STYLE} (`"analyst"`, the answer-first
-   * web voice). Chat-platform callers pass `"conversational"`.
+   * web voice). Chat-platform callers pass `"conversational"`. `runAgent`
+   * resolves the workspace default (`ATLAS_DEFAULT_ANSWER_STYLE`, #4303)
+   * before calling this, so the fallback here is the SURFACE default — the
+   * last tier of the precedence chain, not the whole of it.
    */
   readonly answerStyle?: AnswerStyle;
   /**
@@ -1015,6 +1062,13 @@ export async function runAgent({
    *   buttons that surface the SQL and full result tables on demand.
    * - `"plain-english"` / `"executive"`: selectable voices for the
    *   per-conversation picker (#4302); no surface auto-selects them yet.
+   *
+   * #4303 — when ABSENT, the workspace default answer style (the
+   * `ATLAS_DEFAULT_ANSWER_STYLE` setting, resolved per turn via
+   * {@link resolveWorkspaceDefaultAnswerStyle}) applies before the surface
+   * default. Passing an explicit style always wins — which is what keeps
+   * chat-platform surfaces (always explicit) outside the workspace
+   * default's reach.
    */
   answerStyle?: AnswerStyle;
   /**
@@ -1588,7 +1642,14 @@ export async function runAgent({
     learnedPatternsSection,
     routingContext: scopeRoutingContext,
     boundDashboardContext,
-    answerStyle,
+    // #4303 — answer-style precedence: the caller's explicit style (the
+    // #4302 per-conversation pick, or a chat-platform surface's explicit
+    // "conversational") > the workspace default from the settings registry
+    // > the surface default (`DEFAULT_ANSWER_STYLE`, applied inside
+    // `buildSystemParam` when this resolves to undefined). Re-read per turn
+    // through the settings cache, so an admin's change (or clear) takes
+    // effect on the next turn without a restart.
+    answerStyle: answerStyle ?? resolveWorkspaceDefaultAnswerStyle(orgId),
     restRepresentation,
     modelId: resolvedModelId,
     memoryBlock,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -89,6 +89,7 @@ import { ModelRouter } from "./effect/services";
 import { runEnterprise } from "./effect/enterprise-layer";
 import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
 import {
+  ANSWER_STYLE_NAMES,
   DEFAULT_ANSWER_STYLE,
   isAnswerStyle,
   resolveAnswerStyleAddendum,
@@ -129,7 +130,13 @@ export function getAgentMaxSteps(orgId?: string): number {
   return n;
 }
 
-let lastWarnedAnswerStyleDefault: string | undefined;
+// Once-per-(workspace, value) warn dedupe. Keyed per org — not a single
+// process-global slot like `lastWarnedMaxSteps` — because this is a
+// workspace-scoped setting in a multi-tenant process: org B's stale token
+// must still leave a breadcrumb after org A warned for the same value.
+// Bounded in practice: entries come from admin/env config, so cardinality is
+// (misconfigured workspaces × distinct bad tokens), effectively tiny.
+const warnedAnswerStyleDefaults = new Set<string>();
 
 /**
  * #4303 (PRD #4292) — the workspace default answer style ("house voice"),
@@ -138,15 +145,17 @@ let lastWarnedAnswerStyleDefault: string | undefined;
  * middle tier of the answer-style precedence chain:
  *
  *   explicit `answerStyle` (per-conversation pick #4302, or a chat-platform
- *   surface's explicit "conversational") > THIS workspace default > surface
- *   default (`DEFAULT_ANSWER_STYLE`, applied by `buildSystemParam`).
+ *   surface's explicit style) > THIS workspace default > surface default
+ *   (`DEFAULT_ANSWER_STYLE`, applied by `buildSystemParam`).
  *
  * `runAgent` consults it only when the caller passed no style, so
- * chat-platform surfaces — which always pass one (`executeQuery` maps
- * `presentationMode` explicitly) — are structurally unaffected. Returns
- * `undefined` when unset, cleared, empty, or unrecognized: fail-soft to the
- * surface default (a stale DB/env token must never crash a turn), with a
- * once-per-value warn breadcrumb (same shape as `getAgentMaxSteps`).
+ * chat-platform surfaces — whose entrypoints both map `presentationMode` to
+ * an explicit style every turn (`executeQuery` in core, the proactive
+ * answer adapter in /ee) — are structurally unaffected. Returns `undefined`
+ * when unset, cleared, or empty (legal silent states), and for an
+ * unrecognized token — the one case that warns, once per (workspace, value):
+ * fail-soft to the surface default, because a stale DB/env token must never
+ * crash a turn.
  *
  * `orgId` threads the workspace tier; when omitted it falls back to the
  * request context's active organization (#3406 shape).
@@ -160,12 +169,13 @@ export function resolveWorkspaceDefaultAnswerStyle(
   // voice configured; the surface default applies.
   if (!raw) return undefined;
   if (!isAnswerStyle(raw)) {
-    if (raw !== lastWarnedAnswerStyleDefault) {
+    const dedupeKey = `${effectiveOrgId ?? "platform"}:${raw}`;
+    if (!warnedAnswerStyleDefaults.has(dedupeKey)) {
       log.warn(
-        { value: raw },
-        "Unrecognized ATLAS_DEFAULT_ANSWER_STYLE value — using the surface default answer style",
+        { value: raw, orgId: effectiveOrgId ?? null },
+        `Unrecognized ATLAS_DEFAULT_ANSWER_STYLE value — using the surface default answer style (valid: ${ANSWER_STYLE_NAMES.join(", ")})`,
       );
-      lastWarnedAnswerStyleDefault = raw;
+      warnedAnswerStyleDefaults.add(dedupeKey);
     }
     return undefined;
   }
@@ -1061,7 +1071,8 @@ export async function runAgent({
    *   #2705 binary. The chat plugin pairs this with progressive-disclosure
    *   buttons that surface the SQL and full result tables on demand.
    * - `"plain-english"` / `"executive"`: selectable voices for the
-   *   per-conversation picker (#4302); no surface auto-selects them yet.
+   *   per-conversation picker (#4302); no surface auto-selects them,
+   *   though a workspace default (#4303, below) can.
    *
    * #4303 — when ABSENT, the workspace default answer style (the
    * `ATLAS_DEFAULT_ANSWER_STYLE` setting, resolved per turn via

--- a/packages/api/src/lib/answer-styles.ts
+++ b/packages/api/src/lib/answer-styles.ts
@@ -26,7 +26,13 @@
  * builds on this seam: {@link ANSWER_STYLE_NAMES} is the vocabulary the
  * chat route validates against, and the `AnswerStyle` union lives in
  * `@useatlas/types` (lifted by #4302) because the style crosses the HTTP
- * boundary on the chat request + conversation record.
+ * boundary on the chat request + conversation record. The workspace default
+ * ("house voice", #4303) builds on it too, from the OTHER side: the
+ * `ATLAS_DEFAULT_ANSWER_STYLE` settings-registry entry derives its admin
+ * options from {@link ANSWER_STYLE_NAMES}, and
+ * `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts) validates the stored
+ * value with {@link isAnswerStyle} — precedence: explicit style > workspace
+ * default > surface default.
  */
 
 import type { AnswerStyle } from "@useatlas/types/conversation";
@@ -71,10 +77,13 @@ void _everyWireStyleRegistered;
 export type { AnswerStyle };
 
 /**
- * Default style when a caller doesn't select one: the analyst voice, the
- * answer-first default for the web chat and analyst-grade callers (SDK, MCP,
- * `/api/v1/query`). Chat-platform surfaces pass `"conversational"` explicitly
- * (see `answerStyleForPresentationMode`).
+ * The SURFACE default — the last tier of the precedence chain: the analyst
+ * voice, the answer-first default for the web chat and analyst-grade callers
+ * (SDK, MCP, `/api/v1/query`). Chat-platform surfaces pass `"conversational"`
+ * explicitly (see `answerStyleForPresentationMode`). A workspace default
+ * (#4303, the `ATLAS_DEFAULT_ANSWER_STYLE` setting) applies before this one
+ * when no explicit style is chosen — see
+ * `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts).
  */
 export const DEFAULT_ANSWER_STYLE = "analyst" satisfies AnswerStyle;
 

--- a/packages/api/src/lib/answer-styles.ts
+++ b/packages/api/src/lib/answer-styles.ts
@@ -29,7 +29,7 @@
  * boundary on the chat request + conversation record. The workspace default
  * ("house voice", #4303) builds on it too, from the OTHER side: the
  * `ATLAS_DEFAULT_ANSWER_STYLE` settings-registry entry derives its admin
- * options from {@link ANSWER_STYLE_NAMES}, and
+ * options from {@link ANSWER_STYLE_NAMES} (minus `conversational`), and
  * `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts) validates the stored
  * value with {@link isAnswerStyle} — precedence: explicit style > workspace
  * default > surface default.

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -159,8 +159,9 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
     // as null, matching the column's "All sources" default.
     groupReach: (r.group_reach as string) ?? null,
     // #4302 — per-conversation answer style. Plain nullable text column:
-    // NULL → null = no explicit choice (prompt assembly resolves the surface
-    // default — DEFAULT_ANSWER_STYLE for web). The guard keeps an unknown DB
+    // NULL → null = no explicit choice (prompt assembly resolves the live
+    // default — the workspace default #4303 when set, else the surface
+    // default, DEFAULT_ANSWER_STYLE for web). The guard keeps an unknown DB
     // string (a style retired from the registry, a manual edit) from leaking
     // into the typed union — it reads as null, i.e. "track the default".
     answerStyle: isAnswerStyle(r.answer_style) ? r.answer_style : null,

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -25,6 +25,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { EMAIL_PROVIDERS } from "@atlas/api/lib/integrations/types";
 import { SaasImmutableSettingError } from "@atlas/api/lib/settings-errors";
+import { ANSWER_STYLE_NAMES } from "@atlas/api/lib/answer-styles";
 
 const log = createLogger("settings");
 
@@ -345,6 +346,32 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: "number",
     default: "500",
     envVar: "ATLAS_CONVERSATION_STEP_CAP",
+    scope: "workspace",
+  },
+  {
+    // #4303 (PRD #4292) — the workspace "house voice". Applies wherever no
+    // explicit answer style is chosen (web conversations without a #4302
+    // per-conversation pick; SDK / MCP / /api/v1/query calls that send no
+    // style). Chat-platform surfaces (Slack @mention, proactive) always pass
+    // their own explicit conversational voice per turn, so this default
+    // structurally never reaches them — the surface-scoping decision the
+    // description documents. Resolution seam:
+    // `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts).
+    //
+    // Options derive from the answer-style registry minus `conversational`:
+    // that addendum is written for chat platforms (it references the Slack
+    // "Show SQL" progressive-disclosure buttons), so it isn't offered as a
+    // house voice for analyst-grade surfaces. No `default` on purpose — unset
+    // means "track the surface default" (analyst), not a frozen copy of it.
+    // Hot-reloadable: read per turn through the settings cache, no restart.
+    key: "ATLAS_DEFAULT_ANSWER_STYLE",
+    section: "Agent",
+    label: "Default Answer Style",
+    description:
+      "Workspace default answer style (the house voice) for surfaces that don't explicitly choose one — web chat conversations without a per-conversation pick, and SDK/MCP/query API calls that send no style. A per-conversation pick always wins. Chat platforms (Slack mentions, proactive chat) keep their conversational voice and are not affected. Reset to fall back to the built-in default (analyst).",
+    type: "select",
+    options: ANSWER_STYLE_NAMES.filter((s) => s !== "conversational"),
+    envVar: "ATLAS_DEFAULT_ANSWER_STYLE",
     scope: "workspace",
   },
   // Context Compaction (#3759 — PRD #3751). When a turn's assembled context

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -353,9 +353,9 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     // explicit answer style is chosen (web conversations without a #4302
     // per-conversation pick; SDK / MCP / /api/v1/query calls that send no
     // style). Chat-platform surfaces (Slack @mention, proactive) always pass
-    // their own explicit conversational voice per turn, so this default
-    // structurally never reaches them — the surface-scoping decision the
-    // description documents. Resolution seam:
+    // an explicit style per turn (conversational in practice), so this
+    // default structurally never reaches them — the surface-scoping decision
+    // the description documents. Resolution seam:
     // `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts).
     //
     // Options derive from the answer-style registry minus `conversational`:
@@ -368,7 +368,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     section: "Agent",
     label: "Default Answer Style",
     description:
-      "Workspace default answer style (the house voice) for surfaces that don't explicitly choose one — web chat conversations without a per-conversation pick, and SDK/MCP/query API calls that send no style. A per-conversation pick always wins. Chat platforms (Slack mentions, proactive chat) keep their conversational voice and are not affected. Reset to fall back to the built-in default (analyst).",
+      "Workspace default answer style (the house voice) for surfaces that don't explicitly choose one — web chat conversations without a per-conversation pick, and SDK/MCP/query API calls that send no style. A per-conversation pick always wins. Chat platforms (Slack mentions, proactive chat) choose their own voice per turn and are not affected. Reset to fall back to the built-in default (analyst).",
     type: "select",
     options: ANSWER_STYLE_NAMES.filter((s) => s !== "conversational"),
     envVar: "ATLAS_DEFAULT_ANSWER_STYLE",

--- a/packages/web/src/ui/components/chat/answer-style-picker.tsx
+++ b/packages/web/src/ui/components/chat/answer-style-picker.tsx
@@ -43,7 +43,13 @@ export type { AnswerStyle };
  * `effectiveMode` mirroring `resolveRoutingMode` (the frontend is a pure
  * HTTP client and cannot import api-internal constants). Drift is a UX bug
  * (mislabeled trigger), not a correctness bug: the server resolves the
- * actual default at prompt assembly.
+ * actual default at prompt assembly. Known limitation of the same class: a
+ * workspace admin can set a workspace default answer style (#4303, the
+ * `ATLAS_DEFAULT_ANSWER_STYLE` setting) that the server applies to
+ * no-explicit-choice conversations — this trigger still labels those with
+ * the static web default because the workspace default isn't threaded to
+ * the client. An explicit pick (which is what this picker emits) always
+ * beats the workspace default, so the menu's semantics are unaffected.
  */
 export const DEFAULT_WEB_ANSWER_STYLE: AnswerStyle = "analyst";
 


### PR DESCRIPTION
## Summary

Final slice of PRD #4292 — the workspace-scoped **default answer style** ("house voice"), completing the precedence chain:

> per-conversation pick (#4302) > **workspace default (this PR)** > surface default (analyst web / conversational chat platforms)

- **`ATLAS_DEFAULT_ANSWER_STYLE` settings-registry entry** (`lib/settings.ts`): workspace-scoped, hot-reloadable `select` — runtime-controllable from the Admin console per the SaaS-first configuration rule (no redeploy; the registry-mandated env tier exists mechanically but nothing requires the var, and it's deliberately not added to `.env.example`). Options derive from `ANSWER_STYLE_NAMES` minus `conversational` (that addendum references Slack-only progressive-disclosure buttons). No registry default — unset means "track the surface default", not a frozen copy.
- **`resolveWorkspaceDefaultAnswerStyle`** (`lib/agent.ts`, mirrors the `getAgentMaxSteps` #3406 shape): workspace override > platform override > env tier; trims, treats `""` as unset (the admin select's legal clear value), and fail-softs unrecognized tokens to the surface default with a once-per-(workspace, value) warn carrying `orgId`.
- **Wiring**: one line in `runAgent` — `answerStyle: answerStyle ?? resolveWorkspaceDefaultAnswerStyle(orgId)`. The default is consulted only when the caller passed no style, so **chat-platform surfaces are structurally unaffected** (both entrypoints — `executeQuery` in core and the proactive answer adapter in /ee — pass an explicit style every turn). Web chat, SDK, MCP, and `/api/v1/query` inherit the house voice when no explicit style is sent.

### Admin surface decision
The setting auto-surfaces on **`/admin/settings` → Agent** via the registry-driven page (Edit dialog with select, Reset to clear) — the shared admin hooks (`useAdminFetch`/`useAdminMutation`) that page is built on. A bespoke `useConfigForm` page for a single select would duplicate the registry surface, so none was added (the AC's intent — admins set/clear from the console with shared plumbing, no hand-rolled fetch — is met; noting the deviation from the AC's letter explicitly).

### Known limitation (documented in-code)
The #4302 picker's trigger still labels a no-explicit-choice conversation with the static web default ("Analyst") even when a workspace default is set — the workspace default isn't threaded to the client. Explicit picks (what the picker emits) always win, so menu semantics are unaffected.

## Test plan
- [x] `resolveWorkspaceDefaultAnswerStyle` tier tests: workspace > platform > env > unset, cross-org non-leakage, request-context fallback, set→delete lifecycle, `""`/whitespace/invalid fail-soft, registry-total acceptance (new `agent-answer-style-workspace-default.test.ts`)
- [x] Real-`runAgent` prompt precedence with a spying mock LLM: workspace default applies when no explicit style; explicit pick wins; explicit conversational (Slack path) unaffected; clear falls back hot (no restart); invalid token fail-softs to analyst
- [x] Registry-shape drift locks in `settings.test.ts`: workspace scope, select type, hot-reloadable, no default, `envVar` spelling, options = `ANSWER_STYLE_NAMES` minus `conversational`
- [x] `/review-panel` round 1: CLEAN (0 must-fix; 3 MEDIUMs fixed in-branch)
- [x] `scripts/ci-local.sh`: all 28 gates green on the rebased SHA

Closes #4303