### PR TITLE
feat(dashboards): bound editor convergence — canvas-as-artifact, receipt rendering, conversation continuity (#4322)

### DIFF
--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -954,6 +954,10 @@ chat.openapi(chatRoute, async (c) => {
                 // tool's headless browser can authenticate against the
                 // bound dashboard's web route without a fresh sign-in.
                 cookieHeader?: string | null;
+                // #4322 — the conversation's content scope, so a card
+                // `addCard` mints inherits the right connection group
+                // instead of defaulting to the workspace `default`.
+                connectionGroupId?: string | null;
               };
             }
           | null = null;
@@ -1506,6 +1510,10 @@ chat.openapi(chatRoute, async (c) => {
                 // browser so it can authenticate against the dashboard's
                 // web route without doing a fresh sign-in.
                 cookieHeader: req.headers.get("cookie"),
+                // #4322 — the resolved content scope for this turn. A card
+                // added via `addCard` inherits it so it queries the
+                // conversation's group, not the workspace default.
+                connectionGroupId: effectiveConnectionGroupId ?? null,
               },
             };
           } else if (resolved.reason === "error") {

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard-drafts.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard-drafts.test.ts
@@ -252,6 +252,103 @@ describe("bound-dashboard tools — drafts flag", () => {
       expect(sqls).not.toContain("INSERT INTO dashboard_cards");
     });
 
+    // #4322 — a card added inside a conversation scoped to a connection
+    // group must inherit that group so it queries the right database, not
+    // the workspace `default`. The draft snapshot's new card carries the
+    // ctx.connectionGroupId, mirroring createDashboard's initial cards.
+    it("addCard inherits the conversation's connection group into the draft card", async () => {
+      enableInternalDB();
+      setResults(
+        { rows: [dashboardRow] },
+        { rows: [cardRow] },
+        { rows: [] }, // loadDraft empty
+        { rows: [] }, // INSERT (ON CONFLICT DO NOTHING)
+        {
+          rows: [
+            {
+              user_id: "user-1",
+              dashboard_id: "dash-1",
+              draft: { dashboardId: "dash-1", title: "Demo", description: null, cards: [] },
+              baseline: { dashboardId: "dash-1", title: "Demo", description: null, cards: [] },
+              published_baseline_at: "2026-05-17T00:00:00.000Z",
+              created_at: "2026-05-17T00:00:00.000Z",
+              updated_at: "2026-05-17T00:00:00.000Z",
+            },
+          ],
+        },
+        { rows: [{ user_id: "user-1" }] }, // saveDraft
+      );
+
+      const tools = createBoundDashboardTools({
+        dashboardId: "dash-1",
+        orgId: "org-1",
+        userId: "user-1",
+        connectionGroupId: "group-prod",
+      });
+
+      const result = await runTool<{ kind: string }>(tools.addCard, {
+        title: "Scoped card",
+        sql: "SELECT 1",
+        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+      });
+      expect(result.kind).toBe("ok");
+
+      // saveDraft's UPDATE carries the snapshot JSON as its first param.
+      const saveCall = queryCalls.find((c) => c.sql.includes("UPDATE dashboard_user_drafts"));
+      expect(saveCall).toBeDefined();
+      const snapshot = JSON.parse(saveCall!.params![0] as string) as {
+        cards: { title: string; connectionGroupId: string | null }[];
+      };
+      const added = snapshot.cards.find((c) => c.title === "Scoped card");
+      expect(added).toBeDefined();
+      expect(added!.connectionGroupId).toBe("group-prod");
+    });
+
+    // Absent scope (legacy 1×1 workspace) → the card stamps null, unchanged.
+    it("addCard stamps a null connection group when the conversation has no scope", async () => {
+      enableInternalDB();
+      setResults(
+        { rows: [dashboardRow] },
+        { rows: [cardRow] },
+        { rows: [] },
+        { rows: [] },
+        {
+          rows: [
+            {
+              user_id: "user-1",
+              dashboard_id: "dash-1",
+              draft: { dashboardId: "dash-1", title: "Demo", description: null, cards: [] },
+              baseline: { dashboardId: "dash-1", title: "Demo", description: null, cards: [] },
+              published_baseline_at: "2026-05-17T00:00:00.000Z",
+              created_at: "2026-05-17T00:00:00.000Z",
+              updated_at: "2026-05-17T00:00:00.000Z",
+            },
+          ],
+        },
+        { rows: [{ user_id: "user-1" }] },
+      );
+
+      const tools = createBoundDashboardTools({
+        dashboardId: "dash-1",
+        orgId: "org-1",
+        userId: "user-1",
+        // no connectionGroupId
+      });
+
+      await runTool(tools.addCard, {
+        title: "Unscoped card",
+        sql: "SELECT 1",
+        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+      });
+
+      const saveCall = queryCalls.find((c) => c.sql.includes("UPDATE dashboard_user_drafts"));
+      const snapshot = JSON.parse(saveCall!.params![0] as string) as {
+        cards: { title: string; connectionGroupId: string | null }[];
+      };
+      const added = snapshot.cards.find((c) => c.title === "Unscoped card");
+      expect(added!.connectionGroupId).toBeNull();
+    });
+
     // #4315 — the anonymous-bound bypass is CLOSED. With drafts ON, a bound
     // edit that can't be attributed to a user (no userId) must NOT write to
     // the published tables — the privacy hole where anonymous edits went

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -80,6 +80,17 @@ export interface BoundDashboardToolContext {
    * `ATLAS_INTERNAL_SCREENSHOT_COOKIE` (only meaningful in dev/test).
    */
   cookieHeader?: string | null;
+  /**
+   * #4322 — the conversation's content scope (its `connection_group_id`,
+   * resolved by the chat route). A card `addCard` mints inherits this so
+   * a card added inside a chat that was scoped to (say) the "prod" group
+   * queries that group's database — not the workspace `default`. Without
+   * it the draft card stamps `connectionGroupId: null` and the tile later
+   * resolves against the default datasource, the exact bug this closes
+   * (mirrors `createDashboard`'s `conversationGroupId` handling). `null`
+   * for an unscoped conversation (legacy 1×1 workspaces).
+   */
+  connectionGroupId?: string | null;
 }
 
 /**
@@ -303,7 +314,11 @@ export function createBoundDashboardTools(
           sql,
           chartConfig,
           annotations: annotations ?? [],
-          connectionGroupId: null,
+          // #4322 — inherit the conversation's content scope so the added
+          // card queries the right database. `createDashboard` already does
+          // this for its initial cards; a card added later via the bound
+          // editor must land in the same group, not the workspace default.
+          connectionGroupId: ctx.connectionGroupId ?? null,
           layout: layout ?? null,
         };
         const routed = await maybeApplyToDraft(ctx, { kind: "addCard", card: draftCard });

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -122,9 +122,21 @@ export default function DashboardViewPage() {
   // server overlays the draft only when one exists (non-forking); a viewer or
   // a board with no draft still gets published, so this never leaks.
   const [editing, setEditing] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
+  // #4322 — creation-to-bound continuity. The `createDashboard` handoff link
+  // carries the originating conversation id; the drawer resumes that
+  // conversation (its SQL + intent) instead of resetting to empty. `null`
+  // when the drawer is opened from "Edit with chat" (a fresh session).
+  const [resumeConversationId, setResumeConversationId] = useState<string | null>(null);
 
+  // #4322 — the bound chat drawer edits the DRAFT (every `addCard` lands
+  // there, per #4315), so while it's open the canvas must show the draft too:
+  // that's what makes cards materialize live during a build AND why a
+  // dashboard is non-empty on arrival from `createDashboard` (its cards were
+  // staged into the draft, and the published view is still empty).
+  const showDraftView = editing || chatOpen;
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(
-    editing ? `/api/v1/dashboards/${id}?view=draft` : `/api/v1/dashboards/${id}`,
+    showDraftView ? `/api/v1/dashboards/${id}?view=draft` : `/api/v1/dashboards/${id}`,
   );
 
   // #2365 — pending destructive stages for THIS user on THIS dashboard.
@@ -154,8 +166,9 @@ export default function DashboardViewPage() {
   // parameter / mutation errors below.
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
-  // #2363 — bound chat drawer state
-  const [chatOpen, setChatOpen] = useState(false);
+  // #2363 — bound chat drawer state (`chatOpen` / `resumeConversationId`
+  // declared above, before the dashboard fetch, so #4322's draft-view switch
+  // can key off the drawer being open).
 
   // #2521 — draft state. `useAdminFetch` powers the badge + baseline-drift
   // detection; we poll on window focus + a 30s tick so a teammate's
@@ -294,11 +307,21 @@ export default function DashboardViewPage() {
   // strip the param so a refresh doesn't keep reopening it.
   useEffect(() => {
     if (searchParams.get("openChat") !== "true") return;
+    // #4322 — the handoff link carries `conversationId` so the originating
+    // conversation carries into bound mode. Capture it before stripping the
+    // URL; absent (e.g. a hand-typed `?openChat=true`) → fresh session.
+    setResumeConversationId(searchParams.get("conversationId"));
     setChatOpen(true);
-    // Replace the URL without the flag — `router.replace` keeps the
+    // Replace the URL without the flags — `router.replace` keeps the
     // browser history clean (no "back" landing on the auto-open).
     router.replace(`/dashboards/${id}`);
   }, [searchParams, router, id]);
+
+  // Once the drawer closes, drop the resume pointer so the NEXT "Edit with
+  // chat" open is a fresh session rather than re-resuming the created one.
+  useEffect(() => {
+    if (!chatOpen) setResumeConversationId(null);
+  }, [chatOpen]);
 
   // Skip when typing in inputs.
   useEffect(() => {
@@ -1335,6 +1358,7 @@ export default function DashboardViewPage() {
           dashboardId={dashboard.id}
           dashboardTitle={dashboard.title}
           onDashboardMutated={handleStagesChanged}
+          resumeConversationId={resumeConversationId}
         />
       )}
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -29,6 +29,7 @@ import { AgentTurn } from "./chat/agent-turn";
 import { WorkingActivity, showPreStreamActivity } from "./chat/working-activity";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { SuggestionChips } from "./chat/suggestion-chips";
+import { ChatConversationProvider } from "./chat/chat-conversation-context";
 import {
   DeveloperChatEmptyState,
   shouldShowDevChatEmpty,
@@ -1231,6 +1232,10 @@ export function AtlasChat({
                     </div>
                   )}
                 >
+                {/* #4322 — expose the conversation id to CreateDashboardCard's
+                    handoff link (deeply nested under AgentTurn/ToolPart) so the
+                    bound drawer resumes THIS conversation on "Continue editing". */}
+                <ChatConversationProvider conversationId={conversationId}>
                 <div className="space-y-4 pb-4 pr-3">
                   {messages.length === 0 && !error && (
                     // #3081 — host-gated "connect data" empty state takes
@@ -1417,6 +1422,7 @@ export function AtlasChat({
                     <WorkingActivity parts={NO_PARTS} />
                   )}
                 </div>
+                </ChatConversationProvider>
                 </ErrorBoundary>
                 </ScrollArea>
 

--- a/packages/web/src/ui/components/chat/__tests__/create-dashboard-card.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/create-dashboard-card.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * #4322 — the createDashboard handoff carries the originating conversation id
+ * into bound mode. `CreateDashboardCard`'s "Continue editing" link appends
+ * `&conversationId=<id>` when a conversation is in context, and degrades to a
+ * plain `?openChat=true` outside a provider (notebook / no live conversation).
+ */
+
+import { describe, expect, test, afterEach, mock } from "bun:test";
+import React from "react";
+
+// Stub next/link to a plain anchor so we can read the href in jsdom.
+mock.module("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) =>
+    React.createElement("a", { href, ...rest }, children),
+}));
+
+import { render, cleanup } from "@testing-library/react";
+
+const { CreateDashboardCard } = await import("../create-dashboard-card");
+const { ChatConversationProvider } = await import("../chat-conversation-context");
+
+afterEach(cleanup);
+
+const okPart = {
+  type: "tool-createDashboard",
+  toolCallId: "call-1",
+  state: "output-available" as const,
+  input: {},
+  output: {
+    kind: "ok",
+    dashboardId: "dash-9",
+    title: "Sales",
+    description: null,
+    cardCount: 2,
+    draft: true,
+  },
+} as unknown;
+
+function hrefOf(container: HTMLElement): string {
+  const link = container.querySelector('a[aria-label^="Continue editing"]');
+  return link?.getAttribute("href") ?? "";
+}
+
+describe("CreateDashboardCard — continuity handoff link", () => {
+  test("inside a conversation provider → link carries conversationId", () => {
+    const { container } = render(
+      <ChatConversationProvider conversationId="conv-42">
+        <CreateDashboardCard part={okPart} />
+      </ChatConversationProvider>,
+    );
+    expect(hrefOf(container)).toBe("/dashboards/dash-9?openChat=true&conversationId=conv-42");
+  });
+
+  test("outside a provider → plain openChat link (fresh bound session)", () => {
+    const { container } = render(<CreateDashboardCard part={okPart} />);
+    expect(hrefOf(container)).toBe("/dashboards/dash-9?openChat=true");
+  });
+
+  test("URL-encodes a conversation id with reserved characters", () => {
+    const { container } = render(
+      <ChatConversationProvider conversationId="a/b?c">
+        <CreateDashboardCard part={okPart} />
+      </ChatConversationProvider>,
+    );
+    expect(hrefOf(container)).toContain(`conversationId=${encodeURIComponent("a/b?c")}`);
+  });
+});

--- a/packages/web/src/ui/components/chat/__tests__/dashboard-edit-card.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/dashboard-edit-card.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * #4322 — the bound editor's building tools get first-class receipt cards
+ * (icon + what changed) instead of the gray "Tool: addCard" fallback. These
+ * tests pin: (1) DashboardEditCard renders a labeled success/summary line,
+ * (2) the error envelope surfaces the sanitized message, and (3) ToolPart
+ * routes the building-tool names here rather than to the generic box.
+ */
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+
+const { DashboardEditCard } = await import("../dashboard-edit-card");
+const { ToolPart } = await import("../tool-part");
+
+afterEach(cleanup);
+
+function toolPart(name: string, output: unknown) {
+  return {
+    type: `tool-${name}`,
+    toolCallId: `call-${name}`,
+    state: "output-available" as const,
+    input: {},
+    output,
+  } as unknown;
+}
+
+describe("DashboardEditCard", () => {
+  test("addCard success renders the card title, not a gray box", () => {
+    const { getByTestId, queryByText } = render(
+      <DashboardEditCard
+        part={toolPart("addCard", {
+          kind: "ok",
+          card: { id: "c1", title: "Weekly signups", chartType: "bar", position: 0 },
+        })}
+      />,
+    );
+    const card = getByTestId("dashboard-edit-card");
+    expect(card.getAttribute("data-tool")).toBe("addCard");
+    expect(card.getAttribute("data-state")).toBe("ok");
+    expect(card.textContent).toContain("Added a card");
+    expect(card.textContent).toContain("Weekly signups");
+    // Never the generic fallback copy.
+    expect(queryByText(/^Tool: /)).toBeNull();
+  });
+
+  test("getDashboardState success summarizes the card count", () => {
+    const { getByTestId } = render(
+      <DashboardEditCard
+        part={toolPart("getDashboardState", {
+          kind: "ok",
+          dashboard: { title: "Sales", cardCount: 3 },
+          summary: "…",
+        })}
+      />,
+    );
+    const card = getByTestId("dashboard-edit-card");
+    expect(card.textContent).toContain("Read the dashboard");
+    expect(card.textContent).toContain("3 cards");
+  });
+
+  test("updateLayout partial failure shows the failed count", () => {
+    const { getByTestId } = render(
+      <DashboardEditCard
+        part={toolPart("updateLayout", {
+          kind: "partial",
+          results: [
+            { cardId: "a", ok: true },
+            { cardId: "b", ok: false, reason: "bad" },
+          ],
+          failedCount: 1,
+        })}
+      />,
+    );
+    const card = getByTestId("dashboard-edit-card");
+    expect(card.getAttribute("data-state")).toBe("partial");
+    expect(card.textContent).toContain("1 failed");
+  });
+
+  test("error envelope surfaces the sanitized message", () => {
+    const { getByTestId, getByRole } = render(
+      <DashboardEditCard
+        part={toolPart("addCard", {
+          kind: "err",
+          error: "SQL validation failed: syntax error. Fix the query and retry.",
+        })}
+      />,
+    );
+    expect(getByTestId("dashboard-edit-card").getAttribute("data-state")).toBe("err");
+    expect(getByRole("alert").textContent).toContain("SQL validation failed");
+  });
+
+  test("in-flight (no output) renders the active label", () => {
+    const { getByTestId } = render(
+      <DashboardEditCard
+        part={{ type: "tool-addCard", toolCallId: "c", state: "input-available", input: {} }}
+      />,
+    );
+    expect(getByTestId("dashboard-edit-card").textContent).toContain("Adding a card…");
+  });
+});
+
+describe("ToolPart routes building tools to DashboardEditCard", () => {
+  for (const name of [
+    "addCard",
+    "getDashboardState",
+    "getCardDetail",
+    "updateCard",
+    "updateLayout",
+    "updateDashboardMeta",
+  ]) {
+    test(`${name} → first-class edit card (no gray fallback)`, () => {
+      const { getByTestId, queryByText } = render(
+        <ToolPart part={toolPart(name, { kind: "ok" })} />,
+      );
+      expect(getByTestId("dashboard-edit-card").getAttribute("data-tool")).toBe(name);
+      expect(queryByText(`Tool: ${name}`)).toBeNull();
+    });
+  }
+});

--- a/packages/web/src/ui/components/chat/__tests__/follow-up-chips.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/follow-up-chips.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * #4322 — FollowUpChips gains a `disabled` mode for the read-only History
+ * transcript: the parsed <suggestions> still render, but clicking is a no-op
+ * (a finished session has no live composer). The live drawer/chat keeps them
+ * interactive.
+ */
+
+import { describe, expect, test, afterEach, mock } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+const { FollowUpChips } = await import("../follow-up-chips");
+
+afterEach(cleanup);
+
+describe("FollowUpChips", () => {
+  test("renders nothing for empty suggestions", () => {
+    const { container } = render(<FollowUpChips suggestions={[]} onSelect={() => {}} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("interactive: clicking a chip fires onSelect with its text", () => {
+    const onSelect = mock((_t: string) => {});
+    const { getByText } = render(
+      <FollowUpChips suggestions={["Add a regional card"]} onSelect={onSelect} />,
+    );
+    fireEvent.click(getByText("Add a regional card"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0]).toBe("Add a regional card");
+  });
+
+  test("disabled: chips render but clicking is a no-op", () => {
+    const onSelect = mock((_t: string) => {});
+    const { getByText } = render(
+      <FollowUpChips suggestions={["Stack the KPIs"]} onSelect={onSelect} disabled />,
+    );
+    const chip = getByText("Stack the KPIs");
+    expect(chip).toBeTruthy();
+    fireEvent.click(chip);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/ui/components/chat/__tests__/stage-change-card-readonly.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/stage-change-card-readonly.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * #4322 — a staged change replayed inside a read-only History transcript is
+ * inert: no live Accept / Discard buttons (a finished session has nothing to
+ * resolve), just a static "staged in this session" note. The live drawer keeps
+ * its interactive affordances.
+ */
+
+import { describe, expect, test, afterEach, mock } from "bun:test";
+
+mock.module("@/ui/context", () => ({
+  useAtlasConfig: () => ({ apiUrl: "", isCrossOrigin: false }),
+}));
+
+import { render, cleanup } from "@testing-library/react";
+
+const { StageChangeCard } = await import("../stage-change-card");
+const { StageProvider } = await import("@/ui/components/dashboards/stage-context");
+
+afterEach(cleanup);
+
+const stagePart = {
+  type: "tool-removeCard",
+  toolCallId: "call-1",
+  state: "output-available" as const,
+  input: {},
+  output: {
+    kind: "stage_required",
+    stageId: "stage-1",
+    stageKind: "remove_card",
+    target: { cardId: "c1", currentTitle: "Old card" },
+  },
+} as unknown;
+
+describe("StageChangeCard — read-only history", () => {
+  test("read-only: no Accept/Discard buttons, shows inert note", () => {
+    const { queryByTestId, getByTestId } = render(
+      <StageProvider value={{ dashboardId: "d1", onStagesChanged: () => {}, readOnly: true }}>
+        <StageChangeCard part={stagePart} />
+      </StageProvider>,
+    );
+    expect(queryByTestId("stage-accept-button")).toBeNull();
+    expect(queryByTestId("stage-discard-button")).toBeNull();
+    expect(getByTestId("stage-readonly").textContent).toContain("Staged in this session");
+  });
+
+  test("live drawer: Accept/Discard buttons render", () => {
+    const { getByTestId } = render(
+      <StageProvider value={{ dashboardId: "d1", onStagesChanged: () => {} }}>
+        <StageChangeCard part={stagePart} />
+      </StageProvider>,
+    );
+    expect(getByTestId("stage-accept-button")).toBeTruthy();
+    expect(getByTestId("stage-discard-button")).toBeTruthy();
+  });
+});

--- a/packages/web/src/ui/components/chat/chat-conversation-context.tsx
+++ b/packages/web/src/ui/components/chat/chat-conversation-context.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+/**
+ * Chat conversation context (#4322) — exposes the current conversation id to
+ * deeply-nested tool cards without threading a prop through the shared
+ * `AgentTurn` → `ToolPart` seam.
+ *
+ * The only consumer today is `CreateDashboardCard`: its "Continue editing"
+ * handoff link carries the originating conversation id so the bound drawer
+ * resumes that conversation (creation-to-bound continuity) instead of
+ * resetting to empty. `AtlasChat` provides the id (from the URL); the bound
+ * drawer does NOT provide it, so `createDashboard` — which the bound registry
+ * excludes anyway — never resolves an id there.
+ *
+ * Read via {@link useChatConversationId}, which returns `null` outside a
+ * provider (the notebook cell output renders the same tool cards without a
+ * live conversation) — the handoff link then degrades to `?openChat=true`.
+ */
+
+import { createContext, useContext } from "react";
+
+const ChatConversationContext = createContext<string | null>(null);
+
+export function ChatConversationProvider({
+  conversationId,
+  children,
+}: {
+  conversationId: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <ChatConversationContext.Provider value={conversationId}>
+      {children}
+    </ChatConversationContext.Provider>
+  );
+}
+
+/** The current conversation id, or `null` outside a provider. */
+export function useChatConversationId(): string | null {
+  return useContext(ChatConversationContext);
+}

--- a/packages/web/src/ui/components/chat/create-dashboard-card.tsx
+++ b/packages/web/src/ui/components/chat/create-dashboard-card.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowRight, LayoutDashboard, AlertCircle } from "lucide-react";
 import { getToolResult, isToolComplete } from "../../lib/helpers";
 import { Button } from "@/components/ui/button";
+import { useChatConversationId } from "./chat-conversation-context";
 
 /**
  * Render the result of the `createDashboard` tool (#2369).
@@ -57,6 +58,11 @@ function asCreateDashboardResult(value: unknown): CreateDashboardResult | null {
 }
 
 export function CreateDashboardCard({ part }: { part: unknown }) {
+  // #4322 — the originating conversation (if any) rides the handoff link so
+  // the bound drawer resumes it. `null` in the notebook / when unavailable →
+  // the link degrades to a plain open (fresh bound session).
+  const conversationId = useChatConversationId();
+
   if (!isToolComplete(part)) {
     return (
       <div className="my-2 inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-xs text-zinc-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
@@ -124,7 +130,11 @@ export function CreateDashboardCard({ part }: { part: unknown }) {
           className="ml-auto h-7 border-emerald-300 text-xs text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:text-emerald-200 dark:hover:bg-emerald-900/40"
         >
           <Link
-            href={`/dashboards/${result.dashboardId}?openChat=true`}
+            href={
+              conversationId
+                ? `/dashboards/${result.dashboardId}?openChat=true&conversationId=${encodeURIComponent(conversationId)}`
+                : `/dashboards/${result.dashboardId}?openChat=true`
+            }
             aria-label={`Continue editing dashboard ${result.title}`}
           >
             Continue editing

--- a/packages/web/src/ui/components/chat/dashboard-edit-card.tsx
+++ b/packages/web/src/ui/components/chat/dashboard-edit-card.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * Dashboard edit card (#4322) — first-class receipt rendering for the bound
+ * editor's building + inspection tools.
+ *
+ * Before this, `addCard` / `updateCard` / `updateLayout` /
+ * `updateDashboardMeta` / `getDashboardState` / `getCardDetail` /
+ * `screenshotDashboard` fell through `ToolPart`'s default branch to a gray
+ * "Tool: addCard" box — no signal to the user what the tool did on the
+ * canvas. The bound drawer now renders
+ * through the shared turn partitioner (activity → receipt), so these results
+ * live inside the receipt; this card gives them a labeled, glanceable line
+ * (icon + what the tool did) matching the weight of the other tool cards.
+ *
+ * The tools' `SAFE`-op envelope is `{ kind: "ok" | "err" | "partial", ... }`
+ * (see `lib/tools/bound-dashboard.ts`). We render a compact success/summary
+ * line or the sanitized error the tool returned — never a raw stack.
+ */
+
+import {
+  LayoutDashboard,
+  PlusSquare,
+  Pencil,
+  Move,
+  FileText,
+  Eye,
+  AlertCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { getToolName } from "ai";
+import { getToolResult, isToolComplete } from "../../lib/helpers";
+
+interface OkCardResult {
+  kind: "ok";
+  card?: { id?: string; title?: string; chartType?: string; position?: number };
+  dashboard?: { title?: string; cardCount?: number };
+  summary?: string;
+  cardId?: string;
+  updated?: string[];
+  results?: { cardId: string; ok: boolean }[];
+}
+
+interface ErrCardResult {
+  kind: "err";
+  error: string;
+}
+
+interface PartialCardResult {
+  kind: "partial";
+  results: { cardId: string; ok: boolean; reason?: string }[];
+  failedCount: number;
+}
+
+type EditResult = OkCardResult | ErrCardResult | PartialCardResult;
+
+function asEditResult(value: unknown): EditResult | null {
+  if (value == null || typeof value !== "object") return null;
+  const kind = (value as { kind?: unknown }).kind;
+  if (kind === "ok" || kind === "err" || kind === "partial") return value as EditResult;
+  return null;
+}
+
+const TOOL_META: Record<string, { icon: LucideIcon; verb: string; active: string }> = {
+  getDashboardState: { icon: LayoutDashboard, verb: "Read the dashboard", active: "Reading the dashboard" },
+  getCardDetail: { icon: FileText, verb: "Inspected a card", active: "Inspecting a card" },
+  addCard: { icon: PlusSquare, verb: "Added a card", active: "Adding a card" },
+  updateCard: { icon: Pencil, verb: "Updated a card", active: "Updating a card" },
+  updateLayout: { icon: Move, verb: "Rearranged the layout", active: "Rearranging the layout" },
+  updateDashboardMeta: { icon: Pencil, verb: "Updated dashboard details", active: "Updating dashboard details" },
+  screenshotDashboard: { icon: Eye, verb: "Looked at the dashboard", active: "Looking at the dashboard" },
+};
+
+/** Names this card knows how to render — `tool-part.tsx` routes on this set. */
+export const DASHBOARD_EDIT_TOOL_NAMES = new Set(Object.keys(TOOL_META));
+
+/** A short, glanceable description of what a successful edit did. */
+function summarize(name: string, result: OkCardResult): string {
+  switch (name) {
+    case "addCard":
+      return result.card?.title ? `“${result.card.title}”` : "New card staged in your draft";
+    case "getDashboardState":
+      return result.dashboard?.cardCount != null
+        ? `${result.dashboard.cardCount} card${result.dashboard.cardCount === 1 ? "" : "s"}`
+        : "Current state";
+    case "getCardDetail":
+      return result.card?.title ? `“${result.card.title}”` : "Card detail";
+    case "updateCard":
+      return result.updated?.length ? `Changed ${result.updated.join(", ")}` : "Card updated";
+    case "updateDashboardMeta":
+      return result.updated?.length ? `Changed ${result.updated.join(", ")}` : "Details updated";
+    case "updateLayout": {
+      const moved = result.results?.filter((r) => r.ok).length ?? 0;
+      return moved > 0 ? `${moved} card${moved === 1 ? "" : "s"} moved` : "Layout updated";
+    }
+    case "screenshotDashboard":
+      return "Captured the current view";
+    default:
+      return "Done";
+  }
+}
+
+export function DashboardEditCard({ part }: { part: unknown }) {
+  let name = "";
+  try {
+    name = getToolName(part as Parameters<typeof getToolName>[0]);
+  } catch {
+    // intentionally ignored: unknown tool falls back to the generic label below.
+  }
+  const meta = TOOL_META[name] ?? {
+    icon: LayoutDashboard,
+    verb: name || "Dashboard edit",
+    active: name || "Editing dashboard",
+  };
+  const Icon = meta.icon;
+
+  if (!isToolComplete(part)) {
+    return (
+      <div
+        data-testid="dashboard-edit-card"
+        data-tool={name}
+        className="my-1.5 inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-zinc-50 px-2.5 py-1.5 text-xs text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400"
+      >
+        <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+        <span>{meta.active}…</span>
+      </div>
+    );
+  }
+
+  const result = asEditResult(getToolResult(part));
+
+  if (result && result.kind === "err") {
+    return (
+      <div
+        role="alert"
+        data-testid="dashboard-edit-card"
+        data-tool={name}
+        data-state="err"
+        className="my-1.5 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-2.5 py-1.5 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400"
+      >
+        <AlertCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+        <span>{result.error}</span>
+      </div>
+    );
+  }
+
+  const isPartial = result?.kind === "partial" && result.failedCount > 0;
+  const summary = result?.kind === "ok" ? summarize(name, result) : null;
+
+  return (
+    <div
+      data-testid="dashboard-edit-card"
+      data-tool={name}
+      data-state={isPartial ? "partial" : "ok"}
+      className="my-1.5 inline-flex max-w-full items-center gap-2 rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300"
+    >
+      <Icon className="size-3.5 shrink-0 text-primary" aria-hidden="true" />
+      <span className="font-medium text-zinc-700 dark:text-zinc-200">{meta.verb}</span>
+      {summary && <span className="truncate text-zinc-500 dark:text-zinc-400">· {summary}</span>}
+      {isPartial && result?.kind === "partial" && (
+        <span className="text-amber-600 dark:text-amber-400">· {result.failedCount} failed</span>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/chat/follow-up-chips.tsx
+++ b/packages/web/src/ui/components/chat/follow-up-chips.tsx
@@ -5,9 +5,16 @@ import { Button } from "@/components/ui/button";
 export function FollowUpChips({
   suggestions,
   onSelect,
+  disabled = false,
 }: {
   suggestions: string[];
   onSelect: (text: string) => void;
+  /**
+   * #4322 — inert chips for the read-only History transcript: the parsed
+   * suggestions still render (they're part of what the session said) but
+   * clicking is a no-op, since a finished session has no live composer.
+   */
+  disabled?: boolean;
 }) {
   if (suggestions.length === 0) return null;
 
@@ -18,8 +25,9 @@ export function FollowUpChips({
           key={`${i}-${s}`}
           variant="outline"
           size="sm"
+          disabled={disabled}
           className="h-auto rounded-full border-primary/30 px-3 py-1.5 text-sm font-normal text-zinc-700 hover:border-primary/60 hover:bg-primary/5 hover:text-primary dark:text-zinc-300 dark:hover:bg-primary/10"
-          onClick={() => onSelect(s)}
+          onClick={disabled ? undefined : () => onSelect(s)}
         >
           {s}
         </Button>

--- a/packages/web/src/ui/components/chat/stage-change-card.tsx
+++ b/packages/web/src/ui/components/chat/stage-change-card.tsx
@@ -63,7 +63,7 @@ export function StageChangeCard({ part }: { part: unknown }) {
 
 function StageChangeCardInner({ stage }: { stage: StageRequiredPayload }) {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
-  const { dashboardId, onStagesChanged } = useStageContext();
+  const { dashboardId, onStagesChanged, readOnly } = useStageContext();
   // `null` until the user acts. `accepted` / `discarded` lock the card
   // (the agent won't re-prompt the user; the dashboard refetch surfaces
   // the change).
@@ -165,7 +165,17 @@ function StageChangeCardInner({ stage }: { stage: StageRequiredPayload }) {
             </div>
           )}
 
-          {resolution !== "accepted" && resolution !== "discarded" && (
+          {/* #4322 — a staged change replayed in a read-only History
+              transcript is inert: the session is over, so there's nothing
+              to accept or discard. Show a static note instead of live
+              buttons that would POST accept/discard against the current
+              draft. */}
+          {readOnly && (
+            <div className="mt-2 text-zinc-500" data-testid="stage-readonly">
+              Staged in this session.
+            </div>
+          )}
+          {!readOnly && resolution !== "accepted" && resolution !== "discarded" && (
             <div className="mt-2 flex items-center gap-2">
               <Button
                 type="button"

--- a/packages/web/src/ui/components/chat/tool-part.tsx
+++ b/packages/web/src/ui/components/chat/tool-part.tsx
@@ -9,6 +9,7 @@ import { SQLResultCard } from "./sql-result-card";
 import { ActionApprovalCard } from "../actions/action-approval-card";
 import { PythonResultCard, type PythonProgressData } from "./python-result-card";
 import { CreateDashboardCard } from "./create-dashboard-card";
+import { DashboardEditCard, DASHBOARD_EDIT_TOOL_NAMES } from "./dashboard-edit-card";
 import { StageChangeCard } from "./stage-change-card";
 import { RestWriteConfirmCard } from "./rest-write-confirm-card";
 import type { PreviousExecution } from "../notebook/types";
@@ -66,6 +67,12 @@ export const ToolPart = memo(function ToolPart({
     case "executeRestOperation":
       return <RestWriteConfirmCard part={part} />;
     default: {
+      // #4322 — bound editor building + inspection tools get a first-class
+      // receipt line (icon + what the tool did) instead of the gray
+      // "Tool: addCard" fallback.
+      if (DASHBOARD_EDIT_TOOL_NAMES.has(name)) {
+        return <DashboardEditCard part={part} />;
+      }
       const result = getToolResult(part);
       if (isActionToolResult(result)) {
         return <ActionApprovalCard part={part} />;

--- a/packages/web/src/ui/components/chat/working-activity.tsx
+++ b/packages/web/src/ui/components/chat/working-activity.tsx
@@ -31,6 +31,23 @@ function stepLabel(part: ToolTurnPart): { active: string; done: string } {
       return { active: "Running Python", done: "Ran Python" };
     case "createDashboard":
       return { active: "Creating dashboard", done: "Created dashboard" };
+    // #4322 — bound-editor building + inspection tools. First-class step copy
+    // instead of the generic "Running addCard…" fallback, so the live feed
+    // reads in the user's vocabulary as the agent composes the dashboard.
+    case "getDashboardState":
+      return { active: "Reading the dashboard", done: "Read the dashboard" };
+    case "getCardDetail":
+      return { active: "Inspecting a card", done: "Inspected a card" };
+    case "addCard":
+      return { active: "Adding a card", done: "Added a card" };
+    case "updateCard":
+      return { active: "Updating a card", done: "Updated a card" };
+    case "updateLayout":
+      return { active: "Rearranging the layout", done: "Rearranged the layout" };
+    case "updateDashboardMeta":
+      return { active: "Updating dashboard details", done: "Updated dashboard details" };
+    case "screenshotDashboard":
+      return { active: "Looking at the dashboard", done: "Looked at the dashboard" };
     // #2365 — bound-editor destructive edits stage rather than commit.
     case "removeCard":
     case "updateCardSql":

--- a/packages/web/src/ui/components/dashboards/__tests__/bound-chat-drawer.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/bound-chat-drawer.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * #4322 — the bound drawer converges onto the shared turn partitioner and
+ * carries the originating conversation into bound mode.
+ *
+ *   1. Convergence: assistant turns render through `AgentTurn` (activity →
+ *      receipt) with the live `WorkingActivity` pre-stream feed — not the old
+ *      divergent inline renderer.
+ *   2. Continuity: given `resumeConversationId`, the drawer hydrates that
+ *      conversation's transcript (no reset-to-empty) so the SQL + intent it
+ *      just produced carries in.
+ */
+
+import { describe, expect, test, mock, afterEach, beforeEach } from "bun:test";
+import React from "react";
+
+// ---- controllable useChat ------------------------------------------------
+interface FakeMsg {
+  id: string;
+  role: "user" | "assistant";
+  parts: { type: string; text?: string }[];
+}
+let chatMessages: FakeMsg[] = [];
+let chatStatus = "ready";
+const setMessagesSpy = mock((_m: unknown) => {});
+const sendMessageSpy = mock(async (_m: unknown) => {});
+
+mock.module("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: chatMessages,
+    setMessages: setMessagesSpy,
+    sendMessage: sendMessageSpy,
+    status: chatStatus,
+    error: null,
+  }),
+}));
+
+mock.module("@/ui/context", () => ({
+  useAtlasConfig: () => ({ apiUrl: "", isCrossOrigin: false }),
+}));
+
+// ---- controllable resume fetch ------------------------------------------
+let adminFetchData: unknown = null;
+let adminFetchError: { message: string } | null = null;
+let adminFetchLoading = false;
+mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: () => ({
+    data: adminFetchData,
+    loading: adminFetchLoading,
+    error: adminFetchError,
+    refetch: () => {},
+  }),
+}));
+
+// Stub the shared renderer + feed so we assert ROUTING, not their internals.
+mock.module("@/ui/components/chat/agent-turn", () => ({
+  AgentTurn: ({ streaming }: { streaming?: boolean }) =>
+    React.createElement("div", { "data-testid": "agent-turn", "data-streaming": String(!!streaming) }),
+}));
+mock.module("@/ui/components/chat/working-activity", () => ({
+  WorkingActivity: () => React.createElement("div", { "data-testid": "working-activity" }),
+  showPreStreamActivity: (loading: boolean, role: string | undefined) =>
+    loading && role !== "assistant",
+}));
+mock.module("@/ui/components/chat/follow-up-chips", () => ({
+  FollowUpChips: ({ suggestions }: { suggestions: string[] }) =>
+    React.createElement("div", { "data-testid": "chips" }, suggestions.join("|")),
+}));
+
+import { render, cleanup, waitFor } from "@testing-library/react";
+
+const { BoundChatDrawer } = await import("../bound-chat-drawer");
+
+afterEach(cleanup);
+beforeEach(() => {
+  chatMessages = [];
+  chatStatus = "ready";
+  adminFetchData = null;
+  adminFetchError = null;
+  adminFetchLoading = false;
+  setMessagesSpy.mockClear();
+  sendMessageSpy.mockClear();
+});
+
+function renderDrawer(props: Partial<React.ComponentProps<typeof BoundChatDrawer>> = {}) {
+  return render(
+    <BoundChatDrawer
+      open
+      onOpenChange={() => {}}
+      dashboardId="dash-1"
+      dashboardTitle="Sales"
+      {...props}
+    />,
+  );
+}
+
+describe("BoundChatDrawer — partitioner convergence", () => {
+  test("assistant turns render through AgentTurn, not an inline renderer", () => {
+    chatMessages = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "add a card" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "done" }] },
+    ];
+    const { getAllByTestId } = renderDrawer();
+    expect(getAllByTestId("agent-turn").length).toBe(1);
+  });
+
+  test("streaming: last assistant turn is marked streaming + pre-stream feed shows on a bare user turn", () => {
+    // A user turn mid-flight with no assistant message yet → pre-stream feed.
+    chatMessages = [{ id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] }];
+    chatStatus = "submitted";
+    const { getByTestId } = renderDrawer();
+    expect(getByTestId("working-activity")).toBeTruthy();
+  });
+});
+
+describe("BoundChatDrawer — conversation continuity", () => {
+  test("resumeConversationId hydrates the transcript (no reset-to-empty)", async () => {
+    adminFetchData = {
+      messages: [
+        {
+          id: "m1",
+          conversationId: "conv-1",
+          role: "user",
+          content: [{ type: "text", text: "build me a dashboard" }],
+          createdAt: "2026-07-04T00:00:00.000Z",
+        },
+      ],
+    };
+    renderDrawer({ resumeConversationId: "conv-1" });
+    await waitFor(() => {
+      expect(setMessagesSpy).toHaveBeenCalled();
+    });
+    // The hydrated payload was pushed into the chat (not cleared to []).
+    const lastCall = setMessagesSpy.mock.calls.at(-1)?.[0] as unknown[];
+    expect(Array.isArray(lastCall)).toBe(true);
+    expect(lastCall.length).toBe(1);
+  });
+
+  test("no resume id → fresh session clears the transcript once + shows prompts", () => {
+    const { getByText } = renderDrawer();
+    expect(getByText(/Tell the agent what to change/i)).toBeTruthy();
+    // The seed effect clears exactly once for a fresh open (the FRESH_SESSION
+    // guard prevents re-clobbering a later live turn).
+    const clears = setMessagesSpy.mock.calls.filter(
+      (c) => Array.isArray(c[0]) && (c[0] as unknown[]).length === 0,
+    );
+    expect(clears.length).toBe(1);
+  });
+
+  test("failed resume GET → fresh session + a banner, never a silent invisible pin", async () => {
+    adminFetchError = { message: "Forbidden" };
+    const { getByTestId, getByText } = renderDrawer({ resumeConversationId: "conv-x" });
+    await waitFor(() => {
+      expect(getByTestId("resume-failed-banner")).toBeTruthy();
+    });
+    // Fell back to a fresh (visible) session: transcript cleared, prompts shown.
+    expect(getByText(/Tell the agent what to change/i)).toBeTruthy();
+    const clears = setMessagesSpy.mock.calls.filter(
+      (c) => Array.isArray(c[0]) && (c[0] as unknown[]).length === 0,
+    );
+    expect(clears.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("resume still loading → skeleton, not the fresh-session prompts", () => {
+    adminFetchLoading = true;
+    const { getByTestId, queryByText } = renderDrawer({ resumeConversationId: "conv-1" });
+    expect(getByTestId("resume-loading")).toBeTruthy();
+    expect(queryByText(/Tell the agent what to change/i)).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
+++ b/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
@@ -40,12 +40,33 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Send, MessagesSquare, ArrowLeft, History, MessageCircle, User } from "lucide-react";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
-import { Markdown } from "@/ui/components/chat/markdown";
-import { ToolPart } from "@/ui/components/chat/tool-part";
-import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
+import { AgentTurn } from "@/ui/components/chat/agent-turn";
+import { WorkingActivity, showPreStreamActivity } from "@/ui/components/chat/working-activity";
+import { FollowUpChips } from "@/ui/components/chat/follow-up-chips";
+import { StageProvider } from "@/ui/components/dashboards/stage-context";
 import { parseSuggestions } from "@/ui/lib/helpers";
 import { transformMessages } from "@useatlas/types/conversation";
 import type { Message } from "@useatlas/types/conversation";
+
+/** Stable empty parts array for the pre-stream feed (avoids a new [] per render). */
+const NO_PARTS: [] = [];
+
+/** Sentinel marking that a fresh (non-resume) open has cleared its transcript. */
+const FRESH_SESSION = "__fresh__";
+
+/** Pull the last set of parsed <suggestions> chips from an assistant turn. */
+function suggestionsForMessage(message: UIMessage): string[] {
+  if (message.role !== "assistant") return [];
+  const parts = message.parts ?? [];
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i];
+    if (part.type === "text" && "text" in part) {
+      const parsed = parseSuggestions(part.text);
+      if (parsed.suggestions.length > 0) return parsed.suggestions;
+    }
+  }
+  return [];
+}
 
 interface BoundChatDrawerProps {
   open: boolean;
@@ -60,6 +81,16 @@ interface BoundChatDrawerProps {
    * smarter invalidation in a follow-up.
    */
   onDashboardMutated?: () => void;
+  /**
+   * #4322 — creation-to-bound continuity. When the drawer is opened from a
+   * `createDashboard` handoff, the originating conversation (with the SQL
+   * and intent it just produced) carries into bound mode instead of a
+   * reset-to-empty. The drawer pins this conversation id and hydrates its
+   * transcript, so the next turn appends to the same conversation — which
+   * the chat route then binds to this dashboard. `null`/undefined = the
+   * default fresh-session-per-open behavior (opened from "Edit with chat").
+   */
+  resumeConversationId?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +126,7 @@ export function BoundChatDrawer({
   dashboardId,
   dashboardTitle,
   onDashboardMutated,
+  resumeConversationId,
 }: BoundChatDrawerProps) {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const [input, setInput] = useState("");
@@ -113,14 +145,21 @@ export function BoundChatDrawer({
   // matches the PRD's "fresh conversation per drawer-open" requirement
   // (each open starts a new bound conversation; history accessible via
   // the History tab).
+  //
+  // #4322 — EXCEPT when opened from a `createDashboard` handoff: then the
+  // originating conversation carries in (pinned below + hydrated by the
+  // resume effect) rather than resetting to empty.
   useEffect(() => {
     if (open) {
-      conversationIdRef.current = null;
+      conversationIdRef.current = resumeConversationId ?? null;
       setSessionKey((k) => k + 1);
       setActiveTab("chat");
       setSelectedSessionId(null);
+      // The transcript itself (fresh-clear vs. resume-hydrate) is managed by
+      // the seed effect below — it owns `setMessages`, which isn't in scope
+      // until `useChat` is destructured.
     }
-  }, [open]);
+  }, [open, resumeConversationId]);
 
   const transport = useMemo(() => {
     return new DefaultChatTransport({
@@ -161,8 +200,18 @@ export function BoundChatDrawer({
     detail: string;
   } | null>(null);
 
-  // Clear the warning between sessions so a previous run's banner
-  // doesn't leak into the new conversation.
+  // #4322 — a failed resume GET must NOT masquerade as a fresh session. When
+  // the originating conversation can't be loaded (403 on a stale/foreign
+  // `?conversationId=`, 404 after deletion, 5xx, network error), the seed
+  // effect falls back to a genuinely fresh session (un-pins the ref so the
+  // next turn mints a new conversation the user can see) and flips this so the
+  // banner explains why — rather than silently appending to an invisible one.
+  const [resumeFailed, setResumeFailed] = useState(false);
+
+  // Clear the bind-warning between sessions so a previous run's banner
+  // doesn't leak into the new conversation. (`resumeFailed` is owned by the
+  // seed effect below, which co-locates the whole resume lifecycle — resetting
+  // it here would race that effect when `sessionKey` bumps.)
   useEffect(() => {
     if (open) setBoundUnavailable(null);
   }, [open, sessionKey]);
@@ -183,7 +232,7 @@ export function BoundChatDrawer({
     });
   }, []);
 
-  const { messages, sendMessage, status, error } = useChat({
+  const { messages, setMessages, sendMessage, status, error } = useChat({
     transport,
     // Subscribe to the same `data-context-warning` channel the main
     // chat uses so the bound flow can surface bind/resolve failures.
@@ -191,6 +240,53 @@ export function BoundChatDrawer({
   });
 
   const isLoading = status === "streaming" || status === "submitted";
+
+  // #4322 — creation-to-bound continuity. When `resumeConversationId` is
+  // set, hydrate the drawer with that conversation's transcript so the SQL +
+  // intent it just produced carries in (no reset-to-empty). Fetched only
+  // while the drawer is open AND a resume id is present; the creating user
+  // owns the conversation, so the per-user `/conversations/:id` GET resolves.
+  const resumeQuery = useAdminFetch<{ messages: Message[] }>(
+    `/api/v1/conversations/${resumeConversationId}`,
+    { enabled: open && !!resumeConversationId },
+  );
+
+  // Own the transcript lifecycle for an open: clear on a fresh open, hydrate
+  // once on a resume open. Guarded by a ref so a later live turn is never
+  // clobbered by a re-run of this effect. Reset on close so reopening re-runs.
+  const seededConversationRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!open) {
+      seededConversationRef.current = null;
+      return;
+    }
+    if (!resumeConversationId) {
+      // Fresh open → empty transcript, exactly once per open.
+      if (seededConversationRef.current !== FRESH_SESSION) {
+        setMessages([]);
+        setResumeFailed(false);
+        seededConversationRef.current = FRESH_SESSION;
+      }
+      return;
+    }
+    if (seededConversationRef.current === resumeConversationId) return;
+    // Resume GET failed — do NOT stay pinned to a conversation the user can't
+    // see. Un-pin so the next turn mints a fresh, visible conversation, clear
+    // any partial transcript, and flip the banner. Mark seeded so we don't
+    // loop on the same failing id.
+    if (resumeQuery.error) {
+      conversationIdRef.current = null;
+      setMessages([]);
+      setResumeFailed(true);
+      seededConversationRef.current = resumeConversationId;
+      return;
+    }
+    const loaded = resumeQuery.data?.messages;
+    if (!Array.isArray(loaded)) return;
+    setMessages(transformMessages(loaded) as unknown as UIMessage[]);
+    setResumeFailed(false);
+    seededConversationRef.current = resumeConversationId;
+  }, [open, resumeConversationId, resumeQuery.data, resumeQuery.error, setMessages]);
 
   // Refetch the dashboard whenever a tool result lands. The bound editor
   // tools mutate cards/title/layout — viewers expect the canvas to
@@ -229,6 +325,16 @@ export function BoundChatDrawer({
     await sendMessage({ text });
   }
 
+  // #4322 — a follow-up chip sends its text as the next turn (parity with the
+  // main chat's FollowUpChips). Guarded against firing mid-stream.
+  const handleSuggestionSelect = useCallback(
+    (text: string) => {
+      if (isLoading || !text.trim()) return;
+      void sendMessage({ text });
+    },
+    [isLoading, sendMessage],
+  );
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -266,7 +372,34 @@ export function BoundChatDrawer({
             className="flex min-h-0 flex-1 flex-col data-[state=inactive]:hidden"
           >
             <ScrollArea className="flex-1 px-4 py-3">
-              {messages.length === 0 && (
+              {/* #4322 — resuming the originating conversation: hold the space
+                  with a skeleton instead of flashing the fresh-session prompts
+                  before the transcript pops in. */}
+              {resumeConversationId && resumeQuery.loading && messages.length === 0 && (
+                <div className="space-y-3 py-2" data-testid="resume-loading">
+                  <Skeleton className="h-8 w-2/3" />
+                  <Skeleton className="h-16 w-full" />
+                  <Skeleton className="h-8 w-1/2" />
+                </div>
+              )}
+
+              {/* #4322 — a failed resume GET falls back to a fresh session
+                  (the seed effect un-pinned the conversation ref); tell the
+                  user why rather than silently starting over. */}
+              {resumeFailed && (
+                <div
+                  role="alert"
+                  data-testid="resume-failed-banner"
+                  className="my-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-300"
+                >
+                  Couldn&rsquo;t load the previous conversation — starting a fresh
+                  editing session. Your earlier work is safe in its own
+                  conversation.
+                </div>
+              )}
+
+              {messages.length === 0 &&
+                !(resumeConversationId && resumeQuery.loading) && (
                 <div className="space-y-3 py-6 text-sm text-zinc-500 dark:text-zinc-400">
                   <p>Tell the agent what to change. Examples:</p>
                   <ul className="space-y-1 pl-4">
@@ -278,13 +411,32 @@ export function BoundChatDrawer({
                 </div>
               )}
 
-              {messages.map((m: UIMessage) => (
-                <BoundChatMessage key={m.id} message={m} />
-              ))}
+              {messages.map((m: UIMessage, i) => {
+                const isLastAssistant =
+                  m.role === "assistant" && i === messages.length - 1;
+                return (
+                  <BoundChatTurn
+                    key={m.id}
+                    message={m}
+                    // #4300 — only the last assistant turn is live; it renders
+                    // the working feed and settles into the receipt as the
+                    // answer streams. Earlier turns are finished (receipt →
+                    // answer → promoted artifact).
+                    streaming={isLastAssistant && isLoading}
+                    // Follow-up chips only on the finished final assistant turn.
+                    showSuggestions={isLastAssistant && !isLoading}
+                    onSelectSuggestion={handleSuggestionSelect}
+                  />
+                );
+              })}
 
-              {isLoading && messages[messages.length - 1]?.role === "user" && (
+              {/* #4300 — the working phase begins at send, before the assistant
+                  message mounts: a standalone activity feed holds the spot the
+                  streaming turn's own feed then takes over (same component, same
+                  position), so the drawer never opens a turn with dead air. */}
+              {showPreStreamActivity(isLoading, messages[messages.length - 1]?.role) && (
                 <div className="my-2">
-                  <TypingIndicator />
+                  <WorkingActivity parts={NO_PARTS} />
                 </div>
               )}
 
@@ -461,6 +613,15 @@ function HistoryTranscriptPanel({
   );
 
   const transformed = data ? transformMessages(data.messages) : [];
+  // Index of the last assistant turn — the only one whose suggestion chips
+  // we surface (the session's closing follow-ups).
+  let lastAssistantIndex = -1;
+  for (let i = transformed.length - 1; i >= 0; i--) {
+    if (transformed[i].role === "assistant") {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -505,13 +666,25 @@ function HistoryTranscriptPanel({
           </div>
         )}
 
-        {transformed.map((m) => (
-          <BoundChatMessage
-            key={m.id}
-            message={m as unknown as UIMessage}
-            readOnly
-          />
-        ))}
+        {/* #4322 — the transcript is INERT history. The read-only stage
+            context makes any replayed `stage_required` card drop its live
+            Accept / Discard (a finished session has nothing to resolve), and
+            `BoundChatTurn` renders every turn as finished (receipt → answer)
+            with its suggestion chips shown but non-interactive. */}
+        <StageProvider
+          value={{ dashboardId, onStagesChanged: () => {}, readOnly: true }}
+        >
+          {transformed.map((m, i) => (
+            <BoundChatTurn
+              key={m.id}
+              message={m as unknown as UIMessage}
+              streaming={false}
+              // Show the final assistant turn's parsed suggestions inert.
+              showSuggestions={i === lastAssistantIndex}
+              readOnly
+            />
+          ))}
+        </StageProvider>
 
         {data && !loading && (
           <div className="mt-6 border-t border-dashed border-zinc-200 pt-3 text-[10px] uppercase tracking-wide text-zinc-400 dark:border-zinc-800">
@@ -525,24 +698,32 @@ function HistoryTranscriptPanel({
 }
 
 // ---------------------------------------------------------------------------
-// Shared message renderer (used by both live chat + read-only transcript)
+// Shared turn renderer (used by both live chat + read-only transcript)
 // ---------------------------------------------------------------------------
 
-function BoundChatMessage({
+/**
+ * #4322 — the bound drawer renders a turn through the SAME shared partitioner
+ * the main chat uses (`AgentTurn`): the activity feed settles into a collapsed
+ * receipt, the answer streams as the dominant element, and the building tools
+ * (`addCard`, `getDashboardState`, `updateLayout`, …) get first-class receipt
+ * cards instead of gray "Tool: addCard" boxes. This retires the drawer's old
+ * divergent renderer (full-weight inline tool cards, no receipt, no live feed).
+ */
+function BoundChatTurn({
   message,
+  streaming,
+  showSuggestions,
+  onSelectSuggestion,
   readOnly = false,
 }: {
   message: UIMessage;
+  streaming: boolean;
+  showSuggestions: boolean;
+  onSelectSuggestion?: (text: string) => void;
   readOnly?: boolean;
 }) {
-  const isUser = message.role === "user";
-  // Split text and tool parts so tool results render inline as cards
-  // between the assistant's text turns (matches the main AtlasChat
-  // layout convention).
-  const parts = message.parts ?? [];
-
-  if (isUser) {
-    const text = parts
+  if (message.role === "user") {
+    const text = (message.parts ?? [])
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
       .map((p) => p.text)
       .join("");
@@ -561,22 +742,20 @@ function BoundChatMessage({
     );
   }
 
+  const suggestions = showSuggestions ? suggestionsForMessage(message) : [];
+
   return (
-    <div className="my-3 space-y-2">
-      {parts.map((part, idx) => {
-        if (part.type === "text" && "text" in part) {
-          // parseSuggestions splits assistant text into the body + a
-          // trailing <suggestions> block. The bound prompt asks the
-          // agent to emit those; we render only the body in this slice
-          // — chips land in a polish pass.
-          const { text } = parseSuggestions(part.text);
-          return <Markdown key={`t-${idx}`} content={text} />;
-        }
-        if (isToolUIPart(part)) {
-          return <ToolPart key={`tool-${idx}`} part={part} />;
-        }
-        return null;
-      })}
+    <div className="my-3 space-y-2" role="article" aria-label="Message from Atlas">
+      <AgentTurn parts={message.parts} streaming={streaming} />
+      {suggestions.length > 0 && (
+        <FollowUpChips
+          suggestions={suggestions}
+          // In the read-only History transcript the chips render but don't act
+          // (no live composer); the live drawer wires them to the next turn.
+          onSelect={onSelectSuggestion ?? (() => {})}
+          disabled={readOnly || !onSelectSuggestion}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/ui/components/dashboards/stage-context.tsx
+++ b/packages/web/src/ui/components/dashboards/stage-context.tsx
@@ -21,6 +21,14 @@ export interface StageContextValue {
    * stage list so the ghost overlay updates.
    */
   onStagesChanged: () => void;
+  /**
+   * #4322 — the History tab renders past bound sessions read-only. A
+   * staged change from a finished session is inert history, not a live
+   * decision: `StageChangeCard` drops its Accept / Discard affordances and
+   * shows a static "staged in this session" note when this is set. Defaults
+   * to false (the live drawer + dashboard page).
+   */
+  readOnly?: boolean;
 }
 
 const StageContext = createContext<StageContextValue | null>(null);


### PR DESCRIPTION
## What & why

Closes #4322 — Dashboard Elevation (PRD #4313). Retires the bound editor's divergent, pre-#4292 renderer and makes the **canvas the answer-bearing artifact** for a dashboard-building turn. Depends on #4315 (draft-first spine, merged) and converges onto the shared chat turn partitioner (#4292/#4298/#4300) that already landed on `main`.

## Changes

**Rendering convergence (web)**
- The bound drawer now renders every assistant turn through the shared `AgentTurn` (activity feed → collapsed receipt), with the live `WorkingActivity` pre-stream feed and follow-up chips — no dead air, no full-weight inline tool cards. Retires the old `BoundChatMessage` inline renderer.
- New `DashboardEditCard` gives the building + inspection tools (`addCard`, `updateCard`, `updateLayout`, `updateDashboardMeta`, `getDashboardState`, `getCardDetail`, `screenshotDashboard`) first-class receipt cards instead of gray "Tool: addCard" boxes; `working-activity` gains step labels for them.

**Live canvas + non-empty on arrival (web)**
- The canvas shows the **draft** view while the drawer is open (`showDraftView = editing || chatOpen`), so cards materialize live during a build and a just-created dashboard is non-empty on arrival (its cards were staged into the draft; published is still empty).

**Conversation continuity (web)**
- The `createDashboard` "Continue editing" handoff link carries the originating conversation id (via a small `ChatConversationProvider`); the drawer resumes that transcript (`resumeConversationId`) instead of resetting to empty.
- A failed resume GET (403 on a stale/foreign `?conversationId=`, 404, 5xx, network) falls back to a **fresh, visible** session with a banner — it never silently pins to an invisible conversation. Loading shows a skeleton.

**Connection-group inheritance (api)**
- `addCard` inherits the conversation's `connectionGroupId` (plumbed through `BoundDashboardToolContext` from the chat route) instead of hardcoding `null`, so an added card queries the right database (parity with `createDashboard`).

**Read-only history (web)**
- History transcripts are inert: staged changes render read-only (read-only `StageProvider`, no live Accept/Discard) and suggestion chips render disabled.

## Tests
- API tool tests: `addCard` group inheritance + null-scope fallback.
- Web: `DashboardEditCard` rendering + `ToolPart` routing, read-only stage inertness, `FollowUpChips` disabled, `createDashboard` handoff-link (with/without conversation, URL-encoding), drawer convergence + continuity + resume-failure fallback + loading skeleton.
- Panel: 4-specialist review; the silent-failure HIGH (unhandled resume error) was fixed + covered before this PR.

## Out of scope / notes
- Page-level draft-view switch and immediate-activity→receipt are best exercised by the browser/E2E layer the issue scopes separately; the mechanism here is a typechecked one-liner plus the existing `?view=draft` overlay endpoint.

https://claude.ai/code/session_018pJ1QwLePnco1ENLT1dGJi

---
_Generated by [Claude Code](https://claude.ai/code/session_018pJ1QwLePnco1ENLT1dGJi)_