### PR TITLE
fix: v0.0.43 review-panel aggregate findings — house-voice curation, failure-policy hook, byte-identity pin

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -147,7 +147,11 @@ mock.module("@atlas/api/lib/plugins/secrets", () => ({
 
 // #3044 — the group_id assignment guard calls verifyGroupBelongsToOrg; mock it
 // so the existence verdict is controllable without seeding the db recorder.
+// Spread the real exports (per CLAUDE.md "mock all exports") so a route later
+// importing another conversations export doesn't hit "Export named X not found".
+const realConversations = await import("@atlas/api/lib/conversations");
 mock.module("@atlas/api/lib/conversations", () => ({
+  ...realConversations,
   verifyGroupBelongsToOrg: async () => mockGroupVerdict,
 }));
 

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -409,11 +409,13 @@ export const ChatRequestSchema = z.object({
    * `lib/answer-styles.ts`. Sent by the chat header's style picker; the
    * route persists it onto the conversation row AND feeds it into prompt
    * assembly for this turn. Omitted turns inherit the conversation's stored
-   * value; a stored NULL (or a brand-new conversation) resolves to the
-   * surface default (`analyst`) at prompt assembly. The Zod enum derives
-   * from `ANSWER_STYLE_NAMES` — the registry is the single source of truth
-   * for acceptable values; there's no DB-layer CHECK constraint (see
-   * migration 0165, same rationale as `routingMode`/0077).
+   * value; a stored NULL (or a brand-new conversation) resolves to the live
+   * default at prompt assembly — the workspace default
+   * (`ATLAS_DEFAULT_ANSWER_STYLE`, #4303) when set, else the surface
+   * default (`analyst`). The Zod enum derives from `ANSWER_STYLE_NAMES` —
+   * the registry is the single source of truth for acceptable values;
+   * there's no DB-layer CHECK constraint (see migration 0166, same
+   * rationale as `routingMode`/0077).
    */
   answerStyle: z.enum(ANSWER_STYLE_NAMES).optional(),
   /**
@@ -1279,22 +1281,40 @@ chat.openapi(chatRoute, async (c) => {
             ) {
               // Fire-and-forget, same contract as routing-mode / REST scope /
               // Group reach above: the runtime honours the body's style for
-              // this turn even if the persist fails; the helper logs its own
-              // failures.
+              // this turn even if the persist fails. The helper never rejects
+              // (it catches internally and returns a CrudResult), so inspect
+              // the RESOLUTION: an `ok: false` that isn't the logged `error`
+              // arm — `not_found` (conversation deleted mid-turn, or an
+              // ownership-scope miss) — would otherwise be silent at both
+              // layers, and a style pin that didn't stick reverts the voice
+              // on reopen with zero breadcrumb.
               updateConversationAnswerStyle(
                 conversationId,
                 parsed.data.answerStyle,
                 authResult.user?.id,
                 authResult.user?.activeOrganizationId,
-              ).catch((err: unknown) => {
-                log.warn(
-                  {
-                    err: err instanceof Error ? err.message : String(err),
-                    conversationId,
-                  },
-                  "updateConversationAnswerStyle rejected",
-                );
-              });
+              ).then(
+                (result) => {
+                  if (!result.ok) {
+                    log.warn(
+                      { conversationId, reason: result.reason },
+                      "answer-style persist did not apply — the conversation will revert to its stored voice on reopen",
+                    );
+                  }
+                },
+                (err: unknown) => {
+                  // Contract breach only: the helper catches internally, so a
+                  // rejection means that changed — log it rather than letting a
+                  // fire-and-forget path emit an unhandled rejection.
+                  log.warn(
+                    {
+                      err: err instanceof Error ? err.message : String(err),
+                      conversationId,
+                    },
+                    "updateConversationAnswerStyle rejected",
+                  );
+                },
+              );
             }
             // F-77 — aggregate per-conversation step ceiling. The per-request
             // caps (stepCountIs(25), 180s wall-clock) bound a single agent
@@ -1419,7 +1439,8 @@ chat.openapi(chatRoute, async (c) => {
                 groupReach: effectiveGroupReach ?? null,
                 // #4302 — persist the answer style the user picked at
                 // creation. Undefined ⇒ NULL (no explicit choice — the row
-                // keeps tracking the surface default at prompt assembly).
+                // keeps tracking the live default at prompt assembly: the
+                // workspace default #4303 when set, else the surface default).
                 answerStyle: effectiveAnswerStyle ?? null,
                 orgId: authResult.user?.activeOrganizationId,
               });

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -126,13 +126,15 @@ const ConversationSchema = z.object({
   /**
    * Per-conversation answer style (#4302, PRD #4292) — the editorial voice
    * of the agent's answers (lib/answer-styles.ts registry). `null` = no
-   * explicit choice: prompt assembly resolves the surface default
-   * (`analyst` for web). Genuinely nullable; optional so pre-#4302 rows /
-   * SDK consumers need not supply it. Mirrors the `Conversation` wire type
-   * — `GET /conversations/:id` carries it so the header picker restores the
-   * persisted style on reopen. `conversational` is a legal persisted value
-   * (accepted from API/SDK callers), though the web picker doesn't offer it
-   * and chat platforms apply that voice per-turn, leaving their rows NULL.
+   * explicit choice: prompt assembly resolves the live default — the
+   * workspace default (`ATLAS_DEFAULT_ANSWER_STYLE`, #4303) when set, else
+   * the surface default (`analyst` for web). Genuinely nullable; optional
+   * so pre-#4302 rows / SDK consumers need not supply it. Mirrors the
+   * `Conversation` wire type — `GET /conversations/:id` carries it so the
+   * header picker restores the persisted style on reopen. `conversational`
+   * is a legal persisted value (accepted from API/SDK callers), though the
+   * web picker doesn't offer it and chat platforms apply that voice
+   * per-turn, leaving their rows NULL.
    */
   answerStyle: z.enum(ANSWER_STYLE_NAMES).nullable().optional(),
   starred: z.boolean(),

--- a/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
@@ -202,12 +202,27 @@ describe("resolveWorkspaceDefaultAnswerStyle (#4303)", () => {
     expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
   });
 
-  it("accepts every registered style — including conversational (registry-total; curation lives at the admin options seam)", async () => {
-    const { ANSWER_STYLE_NAMES } = await import("@atlas/api/lib/answer-styles");
-    for (const style of ANSWER_STYLE_NAMES) {
+  it("accepts every OFFERED house voice and rejects conversational — curation is enforced at resolution, not only the admin options seam", async () => {
+    const { WORKSPACE_DEFAULT_STYLE_OPTIONS } = await import(
+      "@atlas/api/lib/answer-styles"
+    );
+    for (const style of WORKSPACE_DEFAULT_STYLE_OPTIONS) {
       await setSetting(KEY, style, "test", ORG);
       expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBe(style);
     }
+    // The env-var ingress bypasses the admin select's write validation, so a
+    // registered-but-non-offered style must take the same warn-and-fall-back
+    // path as an unknown token: `conversational`'s addendum instructs the
+    // agent to reference Slack affordances ("Show SQL" buttons) that don't
+    // exist on the analyst-grade surfaces this default applies to.
+    process.env[KEY] = "conversational";
+    _resetSettingsCache();
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
+    // A DB-stored value gets the same treatment (defense in depth — today's
+    // admin route can't store it, but the resolver must not trust that).
+    delete process.env[KEY];
+    await setSetting(KEY, "conversational", "test", ORG);
+    expect(resolveWorkspaceDefaultAnswerStyle(ORG)).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/__tests__/agent-answer-style.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style.test.ts
@@ -76,6 +76,29 @@ describe("answer-style registry (#4299)", () => {
     }
   });
 
+  it("the conversational addendum is pinned verbatim — the #4299 byte-identity rider (no Slack regression)", () => {
+    // Full-string pin, not markers: the marker tests above catch a missing
+    // heading or phrase, but an edit to an UNPINNED line (the closing-CTA
+    // formatting rule, the "bare numbers" phrasing) would pass them all
+    // while changing the live Slack voice — and the retired #2705 constant
+    // this addendum was byte-compared against is deleted, so that check
+    // can't be re-run. Editing this string is legal, but must be a
+    // deliberate chat-platform voice change made HERE, eyes open.
+    expect(resolveAnswerStyleAddendum("conversational")).toBe(
+      `## Presentation mode — conversational
+
+You are answering inside a chat platform (Slack/Teams/etc.) where the audience is a non-analyst teammate skimming a thread. Override the standard formatting guidance with the following rules:
+
+- Keep the answer to **1-2 sentences of plain English prose**. No headings, no bullet lists, no preamble.
+- **Do NOT include SQL** in the response body. The chat surface attaches a "Show SQL" button that surfaces the query on demand.
+- **Do NOT use markdown tables.** Express small comparisons as prose ("3 in the US, 1 in EU, 1 in APAC"); use bare numbers, not formatted tables. For larger result sets, summarize the top line in prose and let the "Show details" button surface the breakdown.
+- **Skip the glossary lecture.** Assume the reader already knows what a customer / order / MRR is. Don't define terms.
+- Cite figures inline in the prose, with units. ("Revenue grew to $1.2M in March, up 14% from February.")
+- End with a single short line offering the analyst view: "Want the SQL or full breakdown? Tap the button below." Do NOT use markdown formatting on this closing line.
+`,
+    );
+  });
+
   it("isAnswerStyle accepts every registered name and rejects everything else", () => {
     for (const style of ANSWER_STYLE_NAMES) {
       expect(isAnswerStyle(style)).toBe(true);

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -89,11 +89,12 @@ import { ModelRouter } from "./effect/services";
 import { runEnterprise } from "./effect/enterprise-layer";
 import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
 import {
-  ANSWER_STYLE_NAMES,
   DEFAULT_ANSWER_STYLE,
-  isAnswerStyle,
+  isWorkspaceDefaultAnswerStyle,
   resolveAnswerStyleAddendum,
+  WORKSPACE_DEFAULT_STYLE_OPTIONS,
   type AnswerStyle,
+  type WorkspaceDefaultAnswerStyle,
 } from "./answer-styles";
 
 const log = createLogger("agent");
@@ -152,28 +153,33 @@ const warnedAnswerStyleDefaults = new Set<string>();
  * chat-platform surfaces — whose entrypoints both map `presentationMode` to
  * an explicit style every turn (`executeQuery` in core, the proactive
  * answer adapter in /ee) — are structurally unaffected. Returns `undefined`
- * when unset, cleared, or empty (legal silent states), and for an
- * unrecognized token — the one case that warns, once per (workspace, value):
- * fail-soft to the surface default, because a stale DB/env token must never
- * crash a turn.
+ * when unset, cleared, or empty (legal silent states), and for a token that
+ * isn't an offered house voice — the one case that warns, once per
+ * (workspace, value): fail-soft to the surface default, because a stale
+ * DB/env token must never crash a turn. Non-offered registry styles
+ * (`conversational` — see `NON_HOUSE_VOICE_STYLES`) take the same
+ * warn-and-fall-back path as unknown tokens: the admin select can't store
+ * them, but the env-var ingress bypasses that write validation, and the
+ * Slack-tuned addendum must never become the house voice for analyst-grade
+ * surfaces.
  *
  * `orgId` threads the workspace tier; when omitted it falls back to the
  * request context's active organization (#3406 shape).
  */
 export function resolveWorkspaceDefaultAnswerStyle(
   orgId?: string,
-): AnswerStyle | undefined {
+): WorkspaceDefaultAnswerStyle | undefined {
   const effectiveOrgId = orgId ?? getRequestContext()?.user?.activeOrganizationId;
   const raw = getSetting("ATLAS_DEFAULT_ANSWER_STYLE", effectiveOrgId)?.trim();
   // Unset or empty (the admin select stores "" as a legal value) — no house
   // voice configured; the surface default applies.
   if (!raw) return undefined;
-  if (!isAnswerStyle(raw)) {
+  if (!isWorkspaceDefaultAnswerStyle(raw)) {
     const dedupeKey = `${effectiveOrgId ?? "platform"}:${raw}`;
     if (!warnedAnswerStyleDefaults.has(dedupeKey)) {
       log.warn(
         { value: raw, orgId: effectiveOrgId ?? null },
-        `Unrecognized ATLAS_DEFAULT_ANSWER_STYLE value — using the surface default answer style (valid: ${ANSWER_STYLE_NAMES.join(", ")})`,
+        `ATLAS_DEFAULT_ANSWER_STYLE value is not an offered house voice — using the surface default answer style (valid: ${WORKSPACE_DEFAULT_STYLE_OPTIONS.join(", ")})`,
       );
       warnedAnswerStyleDefaults.add(dedupeKey);
     }

--- a/packages/api/src/lib/answer-styles.ts
+++ b/packages/api/src/lib/answer-styles.ts
@@ -28,11 +28,13 @@
  * `@useatlas/types` (lifted by #4302) because the style crosses the HTTP
  * boundary on the chat request + conversation record. The workspace default
  * ("house voice", #4303) builds on it too, from the OTHER side: the
- * `ATLAS_DEFAULT_ANSWER_STYLE` settings-registry entry derives its admin
- * options from {@link ANSWER_STYLE_NAMES} (minus `conversational`), and
- * `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts) validates the stored
- * value with {@link isAnswerStyle} — precedence: explicit style > workspace
- * default > surface default.
+ * `ATLAS_DEFAULT_ANSWER_STYLE` settings-registry entry offers
+ * {@link WORKSPACE_DEFAULT_STYLE_OPTIONS} (the registry minus
+ * {@link NON_HOUSE_VOICE_STYLES}), and `resolveWorkspaceDefaultAnswerStyle`
+ * (lib/agent.ts) validates the stored value with
+ * {@link isWorkspaceDefaultAnswerStyle} at every ingress (admin write AND
+ * env var) — precedence: explicit style > workspace default > surface
+ * default.
  */
 
 import type { AnswerStyle } from "@useatlas/types/conversation";
@@ -94,6 +96,51 @@ export function isAnswerStyle(value: unknown): value is AnswerStyle {
     (ANSWER_STYLE_NAMES as readonly string[]).includes(value)
   );
 }
+
+/**
+ * Styles never offered as the workspace default ("house voice", #4303):
+ * `conversational` is a chat-platform voice — its addendum references Slack
+ * affordances ("Show SQL" / "Tap the button below") that don't exist on
+ * analyst-grade surfaces. This constant is the single statement of that
+ * curation: the settings knob's admin `options` and the resolution-side
+ * guard ({@link isWorkspaceDefaultAnswerStyle}, used by
+ * `resolveWorkspaceDefaultAnswerStyle` in lib/agent.ts) both derive from it,
+ * so the env-var ingress (`ATLAS_DEFAULT_ANSWER_STYLE` set as an env var,
+ * which bypasses the admin write validation) cannot install a non-offered
+ * voice either.
+ */
+export const NON_HOUSE_VOICE_STYLES = [
+  "conversational",
+] as const satisfies readonly AnswerStyle[];
+
+/** An answer style legal as the workspace default ("house voice", #4303). */
+export type WorkspaceDefaultAnswerStyle = Exclude<
+  AnswerStyle,
+  (typeof NON_HOUSE_VOICE_STYLES)[number]
+>;
+
+/**
+ * Guard for the workspace-default ingress points (admin select write, env
+ * var read): a registered style that is also offered as a house voice.
+ */
+export function isWorkspaceDefaultAnswerStyle(
+  value: unknown,
+): value is WorkspaceDefaultAnswerStyle {
+  return (
+    isAnswerStyle(value) &&
+    !(NON_HOUSE_VOICE_STYLES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * The styles offered as a workspace default, in registry order — the
+ * `ATLAS_DEFAULT_ANSWER_STYLE` setting's `options` list. Derived (not
+ * hand-listed) so a future registry style is house-voice-eligible by
+ * default; opting one out is an explicit {@link NON_HOUSE_VOICE_STYLES}
+ * entry, never a second list to keep in sync.
+ */
+export const WORKSPACE_DEFAULT_STYLE_OPTIONS: readonly WorkspaceDefaultAnswerStyle[] =
+  ANSWER_STYLE_NAMES.filter(isWorkspaceDefaultAnswerStyle);
 
 const PLAIN_ENGLISH_ADDENDUM = `## Answer style — plain English
 
@@ -172,10 +219,10 @@ const ANSWER_STYLE_ADDENDA: Record<AnswerStyle, string> = {
  * pin that a built system param contains its style's addendum and no other.
  *
  * Fails loud on an out-of-vocabulary value: the type makes that unreachable
- * for in-repo callers, but the style will start crossing validated wire
- * boundaries with #4302, and a route that forgets the {@link isAnswerStyle}
- * guard must surface as an error — never as the literal text "undefined"
- * silently appended to the system prompt.
+ * for in-repo callers, but the style crosses validated wire boundaries
+ * (#4302), and a route that forgets the {@link isAnswerStyle} guard must
+ * surface as an error — never as the literal text "undefined" silently
+ * appended to the system prompt.
  */
 export function resolveAnswerStyleAddendum(style: AnswerStyle): string {
   const addendum = ANSWER_STYLE_ADDENDA[style];

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -145,7 +145,12 @@ const mockGetConversation: Mock<(id: string) => Promise<unknown>> = mock(() =>
 );
 const mockGenerateTitle: Mock<(q: string) => string> = mock((q) => q.slice(0, 80));
 
+// Spread the real exports and override only what these tests exercise (per
+// CLAUDE.md "mock all exports" — a partial factory breaks with "Export named
+// X not found" the moment executeQuery.ts imports another export).
+const realConversations = await import("@atlas/api/lib/conversations");
 mock.module("@atlas/api/lib/conversations", () => ({
+  ...realConversations,
   createConversation: mockCreateConversation,
   addMessage: mockAddMessage,
   getConversation: mockGetConversation,

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -163,8 +163,11 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
     // default — the workspace default #4303 when set, else the surface
     // default, DEFAULT_ANSWER_STYLE for web). The guard keeps an unknown DB
     // string (a style retired from the registry, a manual edit) from leaking
-    // into the typed union — it reads as null, i.e. "track the default".
-    answerStyle: isAnswerStyle(r.answer_style) ? r.answer_style : null,
+    // into the typed union — it reads as null, i.e. "track the default",
+    // with a breadcrumb (mirroring the web ingress guard's console.debug):
+    // if a style is ever retired, every conversation pinned to it silently
+    // reverting to the default voice must be diagnosable from logs.
+    answerStyle: readAnswerStyleColumn(r),
     starred: r.starred === true,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
@@ -172,6 +175,34 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
       ? (r.notebook_state as Conversation["notebookState"])
       : null,
   };
+}
+
+// Once-per-value breadcrumb dedupe for unknown persisted answer styles —
+// rowToConversation runs per list row, so a retired style must not log per
+// row. Module-private (NOT exported: a new export here breaks every partial
+// mock of this module). Bounded: values come from the DB column, which only
+// ever held registry names.
+const loggedUnknownAnswerStyles = new Set<string>();
+
+/**
+ * Read the `answer_style` column: NULL stays null (the legal "track the
+ * default" state, no log); an unknown string (a style retired from the
+ * registry, a manual edit) degrades to null WITH a breadcrumb — the server
+ * twin of the web ingress guard's console.debug (`isKnownAnswerStyle`).
+ */
+function readAnswerStyleColumn(r: Record<string, unknown>): AnswerStyle | null {
+  const raw = r.answer_style;
+  if (raw == null) return null;
+  if (isAnswerStyle(raw)) return raw;
+  const key = String(raw);
+  if (!loggedUnknownAnswerStyles.has(key)) {
+    log.debug(
+      { answerStyle: key },
+      "Unknown persisted answer_style — reading as null (track the default)",
+    );
+    loggedUnknownAnswerStyles.add(key);
+  }
+  return null;
 }
 
 /** Type guard — keeps an unknown DB string from leaking into a typed union. */
@@ -442,7 +473,10 @@ export async function updateConversationAnswerStyle(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "updateConversationAnswerStyle failed");
+    log.error(
+      { err: errorMessage(err), conversationId: id },
+      "updateConversationAnswerStyle failed",
+    );
     return { ok: false, reason: "error" };
   }
 }

--- a/packages/api/src/lib/db/migrations/0166_conversations_answer_style.sql
+++ b/packages/api/src/lib/db/migrations/0166_conversations_answer_style.sql
@@ -1,4 +1,4 @@
--- 0165 — Per-conversation answer style (PRD #4292, issue #4302).
+-- 0166 — Per-conversation answer style (PRD #4292, issue #4302).
 --
 -- Adds `conversations.answer_style` to record the answer style (the
 -- editorial voice of the agent's answers — lib/answer-styles.ts) the user
@@ -11,10 +11,11 @@
 --                       value but not offered by the web picker.
 --
 -- Nullable on purpose. NULL means "no explicit choice": prompt assembly
--- resolves it to the surface default (`analyst` for web via
--- DEFAULT_ANSWER_STYLE; chat-platform surfaces pass `conversational`
--- explicitly), so pre-#4302 rows and untouched pickers keep tracking the
--- default rather than freezing a copy of it.
+-- resolves it to the live default — the workspace default
+-- (ATLAS_DEFAULT_ANSWER_STYLE, #4303) when set, else the surface default
+-- (`analyst` for web via DEFAULT_ANSWER_STYLE; chat-platform surfaces pass
+-- `conversational` explicitly) — so pre-#4302 rows and untouched pickers
+-- keep tracking the default rather than freezing a copy of it.
 --
 -- No CHECK constraint at the DB layer. Validation lives in the chat
 -- route's Zod schema (z.enum over ANSWER_STYLE_NAMES — single source of

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -152,15 +152,17 @@ export const conversations = pgTable(
     // resolver (#3893) so Focus actually bounds executeSQL. Existing group-bound
     // rows were backfilled to Focus (behavior-preserving).
     groupReach: text("group_reach"),
-    // 0165 — per-conversation answer style (#4302, PRD #4292). Which
+    // 0166 — per-conversation answer style (#4302, PRD #4292). Which
     // answer-style registry entry (lib/answer-styles.ts) voices the agent's
     // answers in this conversation: 'plain-english' / 'analyst' /
     // 'executive' / 'conversational'. NULL (the default) = no explicit
-    // choice — prompt assembly resolves the surface default ('analyst' for
-    // web; chat-platform callers pass 'conversational' explicitly), so
-    // untouched rows keep tracking the default. Validation lives in the
-    // chat route's Zod schema (single source of truth) rather than a CHECK
-    // here — same rationale as routing_mode (0077).
+    // choice — prompt assembly resolves the live default (the workspace
+    // default ATLAS_DEFAULT_ANSWER_STYLE #4303 when set, else the surface
+    // default: 'analyst' for web; chat-platform callers pass
+    // 'conversational' explicitly), so untouched rows keep tracking the
+    // default. Validation lives in the chat route's Zod schema (single
+    // source of truth) rather than a CHECK here — same rationale as
+    // routing_mode (0077).
     answerStyle: text("answer_style"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -25,7 +25,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { EMAIL_PROVIDERS } from "@atlas/api/lib/integrations/types";
 import { SaasImmutableSettingError } from "@atlas/api/lib/settings-errors";
-import { ANSWER_STYLE_NAMES } from "@atlas/api/lib/answer-styles";
+import { WORKSPACE_DEFAULT_STYLE_OPTIONS } from "@atlas/api/lib/answer-styles";
 
 const log = createLogger("settings");
 
@@ -358,19 +358,23 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     // the description documents. Resolution seam:
     // `resolveWorkspaceDefaultAnswerStyle` (lib/agent.ts).
     //
-    // Options derive from the answer-style registry minus `conversational`:
-    // that addendum is written for chat platforms (it references the Slack
-    // "Show SQL" progressive-disclosure buttons), so it isn't offered as a
-    // house voice for analyst-grade surfaces. No `default` on purpose — unset
-    // means "track the surface default" (analyst), not a frozen copy of it.
-    // Hot-reloadable: read per turn through the settings cache, no restart.
+    // Options are the registry's offered house voices
+    // (`WORKSPACE_DEFAULT_STYLE_OPTIONS` — the registry minus
+    // `NON_HOUSE_VOICE_STYLES`): `conversational` is excluded because its
+    // addendum is written for chat platforms (it references the Slack
+    // "Show SQL" progressive-disclosure buttons). The read-side resolver
+    // (`resolveWorkspaceDefaultAnswerStyle`, lib/agent.ts) enforces the same
+    // list, so the env-var ingress can't smuggle a non-offered voice past
+    // this select. No `default` on purpose — unset means "track the surface
+    // default" (analyst), not a frozen copy of it. Hot-reloadable: read per
+    // turn through the settings cache, no restart.
     key: "ATLAS_DEFAULT_ANSWER_STYLE",
     section: "Agent",
     label: "Default Answer Style",
     description:
       "Workspace default answer style (the house voice) for surfaces that don't explicitly choose one — web chat conversations without a per-conversation pick, and SDK/MCP/query API calls that send no style. A per-conversation pick always wins. Chat platforms (Slack mentions, proactive chat) choose their own voice per turn and are not affected. Reset to fall back to the built-in default (analyst).",
     type: "select",
-    options: ANSWER_STYLE_NAMES.filter((s) => s !== "conversational"),
+    options: [...WORKSPACE_DEFAULT_STYLE_OPTIONS],
     envVar: "ATLAS_DEFAULT_ANSWER_STYLE",
     scope: "workspace",
   },

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -128,12 +128,13 @@ export interface Conversation {
    * Per-conversation answer style (#4302, PRD #4292) — the editorial voice
    * of the agent's answers in this conversation. Genuinely nullable: the
    * column is plain nullable `text` and `null` is the meaningful "no
-   * explicit choice" state, resolved to the surface default at prompt
-   * assembly (`analyst` for web; chat-platform surfaces pass
-   * `conversational` explicitly). The header picker persists an explicit
-   * value; `null` rows keep tracking the default. Optional so pre-#4302
-   * fixtures / SDK consumers can omit it; the runtime treats missing the
-   * same as `null`.
+   * explicit choice" state, resolved at prompt assembly to the live default
+   * — the workspace default (`ATLAS_DEFAULT_ANSWER_STYLE`, #4303) when the
+   * admin set one, else the surface default (`analyst` for web;
+   * chat-platform surfaces pass `conversational` explicitly). The header
+   * picker persists an explicit value; `null` rows keep tracking the
+   * default. Optional so pre-#4302 fixtures / SDK consumers can omit it;
+   * the runtime treats missing the same as `null`.
    */
   answerStyle?: AnswerStyle | null;
   starred: boolean;

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -13,12 +13,8 @@ import { useAtlasTransport } from "../hooks/use-atlas-transport";
 import { useConversations, transformMessages } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
 import { ChatComposer } from "./chat/chat-composer";
-import {
-  ErrorBanner,
-  ActionErrorBanner,
-  clearFailureOfKind,
-  type StoredActionFailure,
-} from "./chat/error-banner";
+import { ErrorBanner, ActionErrorBanner } from "./chat/error-banner";
+import { useChatFailures } from "../hooks/use-chat-failures";
 import { ContextWarningBanner } from "./chat/context-warning-banner";
 import { ResumeBanner } from "./chat/resume-banner";
 import { useRunStatus } from "../hooks/use-run-status";
@@ -216,13 +212,13 @@ export function AtlasChat({
   // conversation id, so this value is NOT used to target a resume.
   const runIdRef = useRef<string | null>(null);
   // #4297 — real failures (send / load / pin / unpin / resume) surface as a
-  // persistent structured banner (`ActionErrorBanner`): visible until retried,
-  // superseded by a newer user action (including "+ New"), or explicitly
-  // dismissed. Machine-initiated paths (auto-resume) clear only their own
-  // `kind`, so they can't erase a failure the user hasn't seen. Genuinely
-  // informational transients (pin success / already-pinned) go through
-  // `useTransientNotice` — successes may whisper; failures must not.
-  const [actionFailure, setActionFailure] = useState<StoredActionFailure | null>(null);
+  // persistent structured banner (`ActionErrorBanner`). The clear-scoping
+  // policy — deliberate attempts supersede unscoped, machine-initiated /
+  // implicit clears are kind-scoped — lives (documented and unit-tested) in
+  // `useChatFailures`. Genuinely informational transients (pin success /
+  // already-pinned) go through `useTransientNotice` — successes may whisper;
+  // failures must not.
+  const failures = useChatFailures();
   const { notice: transientNotice, showNotice: showTransientNotice } = useTransientNotice();
   const [loadingConversation, setLoadingConversation] = useState(false);
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
@@ -250,7 +246,8 @@ export function AtlasChat({
   // #4302 — the conversation's answer style (the header picker). `null` = no
   // explicit choice: the trigger shows the web default ("Analyst") and the
   // transport omits the field so the server inherits the row / applies the
-  // surface default. Deliberately NOT part of `useConversationScope`: it has
+  // live default (workspace default #4303, else surface default).
+  // Deliberately NOT part of `useConversationScope`: it has
   // no sticky preference, no group validation, and no provenance races — a
   // plain state + latest-value ref (for the transport's fetch-time getter)
   // covers restore-on-open and reset-on-new-chat at the same two call sites
@@ -313,7 +310,8 @@ export function AtlasChat({
     // widen back to All sources nulls the row instead of inheriting stale Focus.
     getGroupReach: () => scopeRef.current.groupReach,
     // #4302 — forward the picker's answer style (omitted when null — the
-    // server inherits the row's stored style / applies the surface default).
+    // server inherits the row's stored style / applies the live default:
+    // workspace default #4303, else surface default).
     getAnswerStyle: () => answerStyleRef.current,
     // #3749 / #4294 — onRunId: capture the active run id; it targets the
     // explicit stop endpoint (not a resume — a resume targets the bound
@@ -510,13 +508,13 @@ export function AtlasChat({
     // without retrying. Kind-scoped because auto-resume is machine-initiated:
     // it must not clear an unrelated failure the user hasn't seen.
     onStart: () => {
-      setActionFailure(clearFailureOfKind("resume"));
+      failures.clearKind("resume");
     },
     onError: (message, detail) => {
       // #4297 — a failed resume is a real failure: persistent banner, not a
       // fading whisper. Retry through the ref — this callback is constructed
       // before `handleResume` exists (same seam as `handleParkedResolved`).
-      setActionFailure({
+      failures.report({
         kind: "resume",
         title: message,
         detail,
@@ -621,7 +619,7 @@ export function AtlasChat({
   async function handlePin(text: string) {
     if (!text.trim()) return;
     // A fresh attempt supersedes any earlier failure banner (#4297).
-    setActionFailure(null);
+    failures.supersede();
     setPinningText(text);
     try {
       const res = await fetch(`${apiUrl}/api/v1/starter-prompts/favorites`, {
@@ -660,7 +658,7 @@ export function AtlasChat({
           requestId ?? "(no requestId — non-JSON body)",
           detail,
         );
-        setActionFailure({
+        failures.report({
           kind: "pin",
           title: "Couldn't pin starter prompt",
           detail,
@@ -693,7 +691,7 @@ export function AtlasChat({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("pin request failed:", msg);
-      setActionFailure({
+      failures.report({
         kind: "pin",
         title: "Couldn't pin starter prompt",
         retry: () => {
@@ -713,7 +711,7 @@ export function AtlasChat({
       ? favoriteId.slice("favorite:".length)
       : favoriteId;
     // A fresh attempt supersedes any earlier failure banner (#4297).
-    setActionFailure(null);
+    failures.supersede();
     try {
       const res = await fetch(
         `${apiUrl}/api/v1/starter-prompts/favorites/${encodeURIComponent(raw)}`,
@@ -742,7 +740,7 @@ export function AtlasChat({
           requestId ?? "(no requestId — non-JSON body)",
           detail,
         );
-        setActionFailure({
+        failures.report({
           kind: "unpin",
           title: "Couldn't unpin starter prompt",
           detail,
@@ -759,7 +757,7 @@ export function AtlasChat({
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn("unpin request failed:", msg);
-      setActionFailure({
+      failures.report({
         kind: "unpin",
         title: "Couldn't unpin starter prompt",
         retry: () => {
@@ -782,7 +780,7 @@ export function AtlasChat({
     // race a second stream. Guard BEFORE the clear, like every other path.
     if (isLoading) return;
     // A fresh attempt supersedes any earlier failure banner (#4297).
-    setActionFailure(null);
+    failures.supersede();
     const saved = text;
     setInput("");
     // Drop any unattached warnings from a stalled earlier turn so they
@@ -795,7 +793,7 @@ export function AtlasChat({
     sendMessage({ text: saved }).catch((err: unknown) => {
       console.error("Failed to send message:", err instanceof Error ? err.message : String(err));
       setInput(saved);
-      setActionFailure({
+      failures.report({
         kind: "send",
         title: "Message failed to send",
         detail: "Your message was put back in the composer.",
@@ -839,7 +837,7 @@ export function AtlasChat({
     // stale check below stops that in-flight load from committing over this one.
     if (loadingConversation) return;
     // A fresh attempt supersedes any earlier failure banner (#4297).
-    setActionFailure(null);
+    failures.supersede();
     // Mark bound for the open effect's dedup once we actually begin loading: a
     // redundant dispatch is then a no-op, and a load that fails below isn't
     // retried on every render.
@@ -905,7 +903,7 @@ export function AtlasChat({
       warningCtl.reset();
     } catch (err: unknown) {
       console.warn("Failed to load conversation:", err instanceof Error ? err.message : String(err));
-      setActionFailure({
+      failures.report({
         kind: "load",
         title: "Couldn't load the conversation",
         // Retry through the ref so a later attempt uses the freshest handler
@@ -935,7 +933,7 @@ export function AtlasChat({
     setMessages([]);
     // #4297 — a fresh chat supersedes any failure banner (e.g. a "Couldn't
     // load the conversation" whose retry targets the just-abandoned id).
-    setActionFailure(null);
+    failures.supersede();
     // #3068 — clear the bound + most-recently-requested refs and the URL
     // (`?id=`) so the open effect re-seeds a fresh chat instead of treating the
     // just-left conversation as still loaded. Clearing the requested ref also
@@ -1426,10 +1424,10 @@ export function AtlasChat({
                     dismissed. Distinct from the ErrorBanner below, which owns
                     errors from the chat turn itself (request + stream failures
                     surfaced by useChat). */}
-                {actionFailure && (
+                {failures.failure && (
                   <ActionErrorBanner
-                    failure={actionFailure}
-                    onDismiss={() => setActionFailure(null)}
+                    failure={failures.failure}
+                    onDismiss={failures.dismiss}
                   />
                 )}
 
@@ -1479,7 +1477,7 @@ export function AtlasChat({
                       // stale "Try again" (which resends the ORIGINAL text)
                       // from clobbering the edit. Send-kind only — typing must
                       // not dismiss an unrelated pin/load/resume failure.
-                      setActionFailure(clearFailureOfKind("send"));
+                      failures.clearKind("send");
                     }}
                     onSend={handleSend}
                     streaming={isLoading}

--- a/packages/web/src/ui/components/chat/answer-style-picker.tsx
+++ b/packages/web/src/ui/components/chat/answer-style-picker.tsx
@@ -65,7 +65,7 @@ interface AnswerStyleOption {
  * `conversational` is deliberately absent — it stays auto-selected by
  * chat-platform surfaces (Slack) and is not a web choice.
  */
-const ANSWER_STYLE_OPTIONS: readonly AnswerStyleOption[] = [
+const ANSWER_STYLE_OPTIONS = [
   {
     value: "plain-english",
     label: "Plain English",
@@ -84,7 +84,30 @@ const ANSWER_STYLE_OPTIONS: readonly AnswerStyleOption[] = [
     subtitle: "Headline, key drivers, provenance",
     icon: Briefcase,
   },
-];
+] as const satisfies readonly AnswerStyleOption[];
+
+/**
+ * The styles this surface deliberately does NOT offer. A type-level mirror
+ * of the API's `NON_HOUSE_VOICE_STYLES` (lib/answer-styles.ts) — the same
+ * acceptable web↔api duplication class as `DEFAULT_WEB_ANSWER_STYLE` (the
+ * frontend is a pure HTTP client and cannot import api-internal constants).
+ */
+type NonOfferedAnswerStyle = "conversational";
+
+// Compile-time coverage tripwire (the picker-side twin of the registry's
+// `_everyWireStyleRegistered`): the hand-listed menu above is opt-in, so
+// without this, a style added to the wire union would silently never be
+// offered here while the API's workspace-default options (filter-out)
+// auto-offer it. If `@useatlas/types` adds a style, this stops compiling
+// until it is either added to `ANSWER_STYLE_OPTIONS` or explicitly declared
+// `NonOfferedAnswerStyle` — an offered/not-offered decision, never drift.
+const _everyStyleOfferedOrDeclaredNonOffered: Exclude<
+  AnswerStyle,
+  (typeof ANSWER_STYLE_OPTIONS)[number]["value"] | NonOfferedAnswerStyle
+> extends never
+  ? true
+  : never = true;
+void _everyStyleOfferedOrDeclaredNonOffered;
 
 /** Display metadata for every persistable style — including the non-offered
  * `conversational` (persistable via API/SDK callers; chat platforms apply it

--- a/packages/web/src/ui/components/chat/turn-partitioner.ts
+++ b/packages/web/src/ui/components/chat/turn-partitioner.ts
@@ -1,9 +1,10 @@
 /**
- * Turn partitioner (#4298) — the single seam that decides how a finished agent
- * turn is presented, per CONTEXT.md § Chat turn presentation. A pure function
- * (no React, no DOM) so both the chat transcript and the notebook renderer
- * (#4301) partition identically, and the live working phase (#4300) can settle
- * into the same shape.
+ * Turn partitioner (#4298) — the single seam that decides how an agent turn is
+ * presented, streaming or finished, per CONTEXT.md § Chat turn presentation. A
+ * pure function (no React, no DOM) so the chat transcript, the notebook
+ * renderer (#4301), and the live working phase (#4300) — which partitions
+ * mid-flight to detect the answer's start and settle into the receipt — all
+ * partition identically.
  *
  * Boundary rules (v1 — all of them live here, nowhere else):
  * - Everything up to and including the last tool part is **activity** (tool
@@ -53,7 +54,7 @@ export interface IndexedTurnPart<P extends TurnPart = TurnPart> {
   readonly index: number;
 }
 
-/** The three presentation buckets of a finished turn. */
+/** The three presentation buckets of a turn — streaming or finished. */
 export interface PartitionedTurn {
   /**
    * What the agent did on the way to the answer — tool parts plus narration

--- a/packages/web/src/ui/components/chat/turn-receipt.tsx
+++ b/packages/web/src/ui/components/chat/turn-receipt.tsx
@@ -15,7 +15,8 @@ import {
 import type { PythonProgressData } from "./python-result-card";
 
 /**
- * The collapsed receipt a finished turn's activity settles into (#4298):
+ * The collapsed receipt a turn's activity settles into (#4298) — rendered
+ * once the answer starts streaming (mid-stream, #4300) and after finish:
  * one muted summary line ("Explored schema · 2 queries") that expands on
  * click to the full activity — tool cards with today's affordances (Show
  * SQL, result views) plus the agent's narration at sub-answer weight.

--- a/packages/web/src/ui/hooks/__tests__/use-chat-failures.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-chat-failures.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+import { useChatFailures } from "../use-chat-failures";
+import type { StoredActionFailure } from "../../components/chat/error-banner";
+
+const sendFailure: StoredActionFailure = {
+  kind: "send",
+  title: "Message failed to send",
+};
+const pinFailure: StoredActionFailure = {
+  kind: "pin",
+  title: "Couldn't pin starter prompt",
+};
+const resumeFailure: StoredActionFailure = {
+  kind: "resume",
+  title: "Couldn't resume the turn",
+};
+
+describe("useChatFailures (#4297) — the failure-banner clear-scoping policy", () => {
+  test("starts with no banner and stores a reported failure", () => {
+    const { result } = renderHook(() => useChatFailures());
+    expect(result.current.failure).toBeNull();
+
+    act(() => result.current.report(sendFailure));
+    expect(result.current.failure).toEqual(sendFailure);
+  });
+
+  test("a newer failure replaces the current banner (single slot — the newest is actionable)", () => {
+    const { result } = renderHook(() => useChatFailures());
+    act(() => result.current.report(sendFailure));
+    act(() => result.current.report(pinFailure));
+    expect(result.current.failure).toEqual(pinFailure);
+  });
+
+  test("supersede clears ANY kind — a deliberate user attempt supersedes whatever banner is up", () => {
+    const { result } = renderHook(() => useChatFailures());
+    for (const failure of [sendFailure, pinFailure, resumeFailure]) {
+      act(() => result.current.report(failure));
+      act(() => result.current.supersede());
+      expect(result.current.failure).toBeNull();
+    }
+  });
+
+  test("clearKind clears only its own kind — a machine-initiated clear can't erase an unseen unrelated failure", () => {
+    const { result } = renderHook(() => useChatFailures());
+
+    // The composer-edit path (clearKind("send")) must not dismiss a pin
+    // failure the user hasn't acted on…
+    act(() => result.current.report(pinFailure));
+    act(() => result.current.clearKind("send"));
+    expect(result.current.failure).toEqual(pinFailure);
+
+    // …and auto-resume (clearKind("resume")) must not dismiss a send failure…
+    act(() => result.current.report(sendFailure));
+    act(() => result.current.clearKind("resume"));
+    expect(result.current.failure).toEqual(sendFailure);
+
+    // …while each DOES clear its own kind.
+    act(() => result.current.clearKind("send"));
+    expect(result.current.failure).toBeNull();
+    act(() => result.current.report(resumeFailure));
+    act(() => result.current.clearKind("resume"));
+    expect(result.current.failure).toBeNull();
+  });
+
+  test("clearKind on an empty slot stays empty (no-op, no crash)", () => {
+    const { result } = renderHook(() => useChatFailures());
+    act(() => result.current.clearKind("load"));
+    expect(result.current.failure).toBeNull();
+  });
+
+  test("dismiss (the banner's ✕) clears the banner", () => {
+    const { result } = renderHook(() => useChatFailures());
+    act(() => result.current.report(sendFailure));
+    act(() => result.current.dismiss());
+    expect(result.current.failure).toBeNull();
+  });
+
+  test("the transition callbacks are referentially stable across state changes (safe in effect deps / memoized children)", () => {
+    const { result } = renderHook(() => useChatFailures());
+    const first = {
+      report: result.current.report,
+      supersede: result.current.supersede,
+      clearKind: result.current.clearKind,
+      dismiss: result.current.dismiss,
+    };
+    act(() => result.current.report(sendFailure));
+    expect(result.current.report).toBe(first.report);
+    expect(result.current.supersede).toBe(first.supersede);
+    expect(result.current.clearKind).toBe(first.clearKind);
+    expect(result.current.dismiss).toBe(first.dismiss);
+  });
+});

--- a/packages/web/src/ui/hooks/__tests__/use-stop-handler.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-stop-handler.test.tsx
@@ -104,17 +104,29 @@ describe("useStopHandler (#4294)", () => {
     }
   });
 
-  test("a network failure never blocks or throws — the client stop already delivered the outcome", async () => {
+  test("a network failure never blocks or throws — and logs a console.warn (same token-burn consequence as an HTTP failure)", async () => {
     const fetchMock = mock(() => Promise.reject(new Error("offline")));
     globalThis.fetch = fetchMock as unknown as typeof fetch;
-    const opts = makeOpts();
-    const { result } = renderHook(() => useStopHandler(opts));
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const opts = makeOpts();
+      const { result } = renderHook(() => useStopHandler(opts));
 
-    act(() => {
-      result.current.stopTurn();
-    });
+      act(() => {
+        result.current.stopTurn();
+      });
 
-    expect(opts.stop).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      expect(opts.stop).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(
+          warnSpy.mock.calls.some((c) =>
+            String(c[0]).includes("Server-side stop failed (network)"),
+          ),
+        ).toBe(true),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/web/src/ui/hooks/use-atlas-transport.ts
+++ b/packages/web/src/ui/hooks/use-atlas-transport.ts
@@ -100,10 +100,11 @@ export interface ChatRoutingInputs {
   /**
    * #4302 — per-conversation answer style. Omitted when `null` (no explicit
    * choice — the server inherits the row's stored style, or applies the
-   * surface default for a NULL row), like `routingMode`. The getter returns
-   * a style once its state holds one — picked this session or restored from
-   * the row on reopen — so every turn re-sends it; only a genuine change
-   * burns an UPDATE server-side (the route's skip-UPDATE gate).
+   * live default for a NULL row: workspace default #4303, else surface
+   * default), like `routingMode`. The getter returns a style once its state
+   * holds one — picked this session or restored from the row on reopen — so
+   * every turn re-sends it; only a genuine change burns an UPDATE
+   * server-side (the route's skip-UPDATE gate).
    */
   answerStyle?: AnswerStyle | null;
 }
@@ -213,7 +214,8 @@ export interface UseAtlasTransportOptions {
   /**
    * #4302 — the conversation's answer style from the header picker (`null` =
    * no explicit choice). Omitted from the body when null so the server
-   * inherits the row's stored style (or applies the surface default).
+   * inherits the row's stored style (or applies the live default: workspace
+   * default #4303, else surface default).
    */
   getAnswerStyle?: () => AnswerStyle | null;
 }

--- a/packages/web/src/ui/hooks/use-chat-failures.ts
+++ b/packages/web/src/ui/hooks/use-chat-failures.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  clearFailureOfKind,
+  type ChatActionKind,
+  type StoredActionFailure,
+} from "../components/chat/error-banner";
+
+/**
+ * #4297 — the chat surface's failure-banner state machine, extracted from
+ * `AtlasChat` (like `useStopHandler`) so the clear-scoping policy is
+ * unit-testable without the full chat harness.
+ *
+ * One failure is stored at a time (the banner surface is single-slot); the
+ * POLICY is in which transitions may replace or clear it:
+ *
+ * - {@link ChatFailuresApi.report report} — a failed action stores its
+ *   failure (tagged with its `kind`), replacing whatever banner is up: the
+ *   newest failure is the one the user can act on.
+ * - {@link ChatFailuresApi.supersede supersede} — a DELIBERATE user attempt
+ *   (send, pin, unpin, opening a conversation, "+ New") clears unscoped:
+ *   a fresh attempt supersedes whatever banner is up.
+ * - {@link ChatFailuresApi.clearKind clearKind} — machine-initiated
+ *   (auto-resume start) and implicit (composer edit) clears are scoped to
+ *   their own `kind`, so neither can erase an unrelated failure the user
+ *   hasn't seen. Identity-preserving on a non-matching kind (React bails
+ *   out of the re-render).
+ * - {@link ChatFailuresApi.dismiss dismiss} — the banner's explicit ✕.
+ *
+ * Failures render as a persistent `ActionErrorBanner` — never an
+ * auto-dismissing transient (`useTransientNotice` is for informational
+ * successes only): successes may whisper; failures must not.
+ */
+export interface ChatFailuresApi {
+  /** The failure the banner renders, or `null` (no banner). */
+  failure: StoredActionFailure | null;
+  /** Store a failed action's failure — replaces any current banner. */
+  report: (failure: StoredActionFailure) => void;
+  /** A deliberate user attempt supersedes any banner (unscoped clear). */
+  supersede: () => void;
+  /**
+   * Kind-scoped clear for machine-initiated / implicit paths — clears the
+   * banner only when it belongs to `kind`, never an unseen unrelated one.
+   */
+  clearKind: (kind: ChatActionKind) => void;
+  /** The banner's explicit dismiss affordance (unscoped clear). */
+  dismiss: () => void;
+}
+
+export function useChatFailures(): ChatFailuresApi {
+  const [failure, setFailure] = useState<StoredActionFailure | null>(null);
+  const report = useCallback((next: StoredActionFailure) => {
+    setFailure(next);
+  }, []);
+  const supersede = useCallback(() => {
+    setFailure(null);
+  }, []);
+  const clearKind = useCallback((kind: ChatActionKind) => {
+    setFailure(clearFailureOfKind(kind));
+  }, []);
+  return { failure, report, supersede, clearKind, dismiss: supersede };
+}

--- a/packages/web/src/ui/hooks/use-stop-handler.ts
+++ b/packages/web/src/ui/hooks/use-stop-handler.ts
@@ -35,10 +35,11 @@ export interface UseStopHandlerReturn {
  *   2. fire-and-forget `POST /chat/runs/:runId/stop` so generation stops
  *      server-side too (token spend ends at the abort, not the step cap).
  *      A 404 is the expected race (run already finished, or streaming on
- *      another instance) and is tolerated silently; any OTHER HTTP failure
- *      gets a console.warn — a persistent 401/500 means tokens burn on every
- *      stop and should not wear the benign-race label. Nothing is surfaced to
- *      the user either way: the visible outcome (stream stopped) already
+ *      another instance) and is tolerated silently; any OTHER failure — HTTP
+ *      or network-level — gets a console.warn, because both have the same
+ *      consequence: a persistent failure means tokens burn on every stop and
+ *      should not wear the benign-race label. Nothing is surfaced to the
+ *      user either way: the visible outcome (stream stopped) already
  *      happened.
  *   3. no run id yet (stopped in the pre-header sliver) ⇒ client-only stop.
  */
@@ -72,10 +73,11 @@ export function useStopHandler(opts: UseStopHandlerOptions): UseStopHandlerRetur
         console.warn(`Server-side stop failed: HTTP ${res.status} — generation may run to its budget`);
       })
       .catch((err: unknown) => {
-        // Network-level failure; the client-side stop already delivered the
-        // user-visible outcome.
-        console.debug(
-          "Server-side stop skipped:",
+        // Network-level failure — same token-burn consequence as a non-404
+        // HTTP failure, so the same severity. The client-side stop already
+        // delivered the user-visible outcome.
+        console.warn(
+          "Server-side stop failed (network) — generation may run to its budget:",
           err instanceof Error ? err.message : String(err),
         );
       });


### PR DESCRIPTION
## Summary

Closes out every finding from the **milestone-wide review panel** run over the combined v0.0.43 — The Analyst Voice diff (`0cd18f981...main`, all 10 slices reviewed in aggregate by the four tuned specialists). The panel verdict was **CLEAN** (no must-fix); this PR lands the banked MEDIUMs and LOWs before `/release` tags the train.

### Behavioral fixes
- **`conversational` can no longer become the house voice via the env-var ingress** *(flagged independently by silent-failure + type-design)*. `ATLAS_DEFAULT_ANSWER_STYLE=conversational` as an env var bypassed the admin select's write validation and silently installed the Slack-tuned addendum (which references "Show SQL" buttons that don't exist) on every web/SDK/MCP turn. Curation now lives once in the registry — `NON_HOUSE_VOICE_STYLES` → `WorkspaceDefaultAnswerStyle` type + `isWorkspaceDefaultAnswerStyle` guard + `WORKSPACE_DEFAULT_STYLE_OPTIONS` — enforced at resolution (warn-once + fall back to the surface default) with the settings `options` derived from the same constant.
- **The answer-style persist's dead `.catch` replaced with a real result check.** The helper never rejects (it returns a `CrudResult`), so a `not_found` resolution (conversation deleted mid-turn / scope race) was silent at both layers — a style pin that didn't stick reverted the voice on reopen with zero breadcrumb. Kept a contract-breach rejection handler so the fire-and-forget path can never emit an unhandled rejection.
- `updateConversationAnswerStyle` failure log now carries `conversationId`; `rowToConversation` leaves a once-per-value debug breadcrumb when an unknown persisted style degrades to null (server twin of the web ingress guard). The helper is module-private — no new export, so no partial-mock breakage.
- `useStopHandler`: network-level stop failures now `console.warn` like non-404 HTTP failures — same token-burn consequence, same severity (+ test).

### Type-level tripwire
- The web picker's hand-listed style menu gains a compile-time coverage tripwire: a style added to `@useatlas/types` stops compiling until it's either offered in the menu or explicitly declared `NonOfferedAnswerStyle` — the picker (opt-in) and the API's workspace-default options (filter-out) can no longer silently drift on a future registry addition.

### Test gaps closed
- **`useChatFailures` hook** extracted from `AtlasChat` (the same move as `useStopHandler`): `report` / `supersede` / `clearKind` / `dismiss`, with unit tests pinning the #4297 clear-scoping policy — machine-initiated clears (auto-resume, composer edit) can never erase an unseen unrelated failure. 11 call sites rewired mechanically; behavior unchanged.
- **Full-verbatim pin of the conversational addendum** — the #4299 "byte-identical, no Slack regression" rider was pinned only by marker phrases; an edit to an unpinned line would have passed every test while changing the live Slack voice, and the retired #2705 constant it was originally byte-compared against is deleted.
- The deliberate old behavior test ("accepts every registered style including conversational — curation lives at the admin options seam") is **inverted** to pin the new resolution-side curation, covering both the env-var and DB-stored ingress.
- `execute-query.test.ts` + `admin-openapi-datasources.test.ts` partial mocks of `lib/conversations` now spread the real exports (mock-all-exports rule; the file's own established pattern).

### Comment rot (two aggregate clusters)
- `migration 0165` → `0166` in the SQL header, `schema.ts` mirror, and chat-route JSDoc (parallel-dashboard-stream renumber artifact; the migration runner tracks by filename only — verified — so editing the applied file's comment is safe).
- The #4339 workspace-default tier added to every NULL-resolution doc written before it landed (wire type SDK consumers read, both routes, migration, schema, transport, atlas-chat) — they all claimed NULL resolves straight to the surface default. Partitioner/receipt headers updated for #4337's mid-stream reality; stale future tense fixed.

## Verification
- `bun run type` — clean
- `bun run lint` — 0 errors (1 pre-existing warning in an untouched file)
- `packages/api` `--affected`: **182/182 files pass**
- 10 touched web test files: **119/119 pass** (incl. the new `use-chat-failures` + network-warn tests)

## Review provenance
Four fresh-context specialist reviews (silent-failure-hunter, type-design-analyzer, pr-test-analyzer, comment-analyzer) over the milestone's combined diff; findings deduped and all addressed here. Explicitly NOT changed: the `chunkMs` inactivity-abort mislabel (already banked), the pre-existing dead-`.catch` shape on the older routing-mode/REST/reach persists (out of the milestone's diff — same fix applies if wanted later).

https://claude.ai/code/session_01T5otsm6xk3RsP93EzTjJhL