### PR TITLE
feat(dashboards): first-impression polish + accessibility pass (#4323)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -9,7 +9,7 @@ import { MessagesSquare, Plus, Sparkles, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BoundChatDrawer } from "@/ui/components/dashboards/bound-chat-drawer";
 import { Card } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
+import { DashboardDetailSkeleton } from "@/ui/components/dashboards/dashboard-skeleton";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -1098,18 +1098,7 @@ export default function DashboardViewPage() {
         className="flex h-full flex-1 flex-col overflow-auto"
         data-dashboard-export-ready={exportReady ? "1" : "0"}
       >
-        {loading && (
-          <div className="space-y-4 px-4 py-6 sm:px-6">
-            <Skeleton className="h-8 w-1/3" />
-            <Skeleton className="h-4 w-1/4" />
-            <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
-              <Skeleton className="h-64 w-full" />
-              <Skeleton className="h-64 w-full" />
-              <Skeleton className="h-64 w-full" />
-              <Skeleton className="h-64 w-full" />
-            </div>
-          </div>
-        )}
+        {loading && <DashboardDetailSkeleton />}
 
         {!loading && error && (
           <div className="m-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400">

--- a/packages/web/src/app/(workspace)/dashboards/loading.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/loading.tsx
@@ -1,3 +1,8 @@
+import { DashboardDetailSkeleton } from "@/ui/components/dashboards/dashboard-skeleton";
+
+// Route-level fallback for a hard navigation into /dashboards. Renders the
+// same layout-matching skeleton the detail page shows during its client fetch
+// (#4323) so the surface never flashes a blank frame before content lands.
 export default function Loading() {
-  return null;
+  return <DashboardDetailSkeleton />;
 }

--- a/packages/web/src/app/(workspace)/dashboards/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { DashboardsEmptyState } from "./empty-state";
+import { DashboardListSkeleton } from "@/ui/components/dashboards/dashboard-skeleton";
 import { selectMostRecentDashboardId } from "./select-recent";
 import type { Dashboard } from "@/ui/lib/types";
 
@@ -49,9 +50,11 @@ export default function DashboardsPage() {
     }
   }, [isAuthError, targetId, router]);
 
-  // Auth bounce or dashboard redirect in flight — render nothing rather than
-  // flashing the empty/error chrome before navigation lands.
-  if (isAuthError || targetId) return null;
+  // Auth bounce or dashboard redirect in flight — show the layout-matching
+  // skeleton (not a blank frame) so the redirect never flashes an empty screen
+  // (#4323). The empty/error chrome is still gated below so it can't flash
+  // before navigation lands.
+  if (isAuthError || targetId) return <DashboardListSkeleton />;
 
   if (error) {
     return (
@@ -74,9 +77,9 @@ export default function DashboardsPage() {
     );
   }
 
-  // Still loading the list (no data yet) — render nothing; the route's
-  // loading.tsx and the workspace shell already provide chrome.
-  if (loading || !data) return null;
+  // Still loading the list (no data yet) — show the skeleton rather than a
+  // blank frame while the fetch is in flight.
+  if (loading || !data) return <DashboardListSkeleton />;
 
   // Loaded with no dashboards.
   return <DashboardsEmptyState />;

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -201,21 +201,9 @@
   background-position: 7px 7px;
 }
 
-/* Fullscreen tile sits on a fully opaque backdrop so the underlying grid
- * (and any stale chart bleed) cannot show through the inset gutter. */
-.dash-tile-wrapper.is-fullscreen {
-  position: fixed !important;
-  inset: 0 !important;
-  width: auto !important;
-  height: auto !important;
-  transform: none !important;
-  z-index: 100;
-  background: var(--background);
-  padding: 14px;
-}
-.dash-tile-wrapper.is-fullscreen > .dash-tile {
-  box-shadow: 0 14px 32px oklch(0 0 0 / 0.18);
-}
+/* #4323 — the fullscreen tile is a real Radix dialog (see DashboardGrid); its
+ * backdrop, sizing, and focus trap are owned by <DialogContent>, so the old
+ * `.is-fullscreen` fixed-position hack was removed. */
 
 .dash-mobile-tile {
   width: 100%;

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -84,6 +84,31 @@ describe("DashboardGrid", () => {
     expect(screen.getByTestId("rgl-root")).toBeTruthy();
   });
 
+  test("fullscreen opens a real modal dialog (focus trap / backdrop / aria-modal), not a CSS overlay", () => {
+    widthOverride = 1024;
+    render(<DashboardGrid {...baseProps} />);
+    // No dialog until a tile is maximized.
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fullscreen" }));
+
+    // #4323 — a real modal dialog (Radix): a dialog role + an opaque backdrop
+    // overlay (click-away) replace the old fixed-position CSS overlay.
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeTruthy();
+    expect(document.querySelector('[data-slot="dialog-overlay"]')).toBeTruthy();
+    // The maximized tile lives inside the dialog and offers the exit affordance.
+    expect(screen.getByRole("button", { name: "Exit fullscreen" })).toBeTruthy();
+  });
+
+  test("the fullscreen dialog closes when its Exit-fullscreen button is clicked", () => {
+    widthOverride = 1024;
+    render(<DashboardGrid {...baseProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "Fullscreen" }));
+    fireEvent.click(screen.getByRole("button", { name: "Exit fullscreen" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
   test("Esc closes a fullscreen tile and prevents the page-level handler from also firing", () => {
     widthOverride = 1024;
     render(<DashboardGrid {...baseProps} />);

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-parameter-bar.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-parameter-bar.test.tsx
@@ -62,4 +62,40 @@ describe("DashboardParameterBar", () => {
     const { container } = render(<DashboardParameterBar parameters={[]} onChange={onChange} />);
     expect(container.firstChild).toBeNull();
   });
+
+  // #4323 — a malformed number is surfaced inline, not silently coerced to "no
+  // override" (the old `Number("abc")` → NaN → dropped path).
+  test("a malformed number shows a per-control error and does NOT commit", () => {
+    const onChange = mock((_: Record<string, string | number | null>) => {});
+    render(<DashboardParameterBar parameters={[NUM]} onChange={onChange} />);
+    // Mount fires once with the empty override map (use defaults).
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({});
+
+    const input = screen.getByLabelText("Top N") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "12x" } });
+    fireEvent.blur(input);
+
+    // The error renders in place, the input is flagged invalid, and no new
+    // override was committed (still only the mount call).
+    expect(screen.getByRole("alert").textContent).toContain("Enter a valid number");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("correcting a malformed number clears the error and commits the valid value", () => {
+    const onChange = mock((_: Record<string, string | number | null>) => {});
+    render(<DashboardParameterBar parameters={[NUM]} onChange={onChange} />);
+
+    const input = screen.getByLabelText("Top N") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "12x" } });
+    fireEvent.blur(input);
+    expect(screen.queryByRole("alert")).not.toBeNull();
+
+    // Editing the field clears the error immediately; a valid blur commits.
+    fireEvent.change(input, { target: { value: "50" } });
+    expect(screen.queryByRole("alert")).toBeNull();
+    fireEvent.blur(input);
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual({ limit_n: 50 });
+  });
 });

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-skeleton.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-skeleton.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Dashboard loading skeletons (#4323).
+ *
+ * The skeletons exist to kill CLS + blank `null` screens: they reserve the
+ * top-bar, banner, and tile-grid regions so the real content lands in place.
+ * These tests pin that they render a non-empty, layout-shaped placeholder.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import {
+  DashboardDetailSkeleton,
+  DashboardListSkeleton,
+} from "../dashboard-skeleton";
+
+describe("dashboard skeletons (#4323)", () => {
+  afterEach(cleanup);
+
+  test("the detail skeleton reserves a top-bar, a banner strip, and a tile grid", () => {
+    const { container } = render(<DashboardDetailSkeleton />);
+    expect(screen.getByTestId("dashboard-detail-skeleton")).toBeTruthy();
+    // Four tile placeholders matching the default 2-up grid.
+    const tiles = container.querySelectorAll(".rounded-xl.border");
+    expect(tiles.length).toBe(4);
+    // It's a real placeholder, not a blank null frame.
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(4);
+  });
+
+  test("the list skeleton renders a top-bar and tile grid", () => {
+    const { container } = render(<DashboardListSkeleton />);
+    expect(screen.getByTestId("dashboard-list-skeleton")).toBeTruthy();
+    expect(container.querySelectorAll(".rounded-xl.border").length).toBe(4);
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -409,6 +409,48 @@ describe("DashboardTile — drilldown (#3212)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Keyboard drilldown (#4323)
+// ---------------------------------------------------------------------------
+
+describe("DashboardTile — keyboard drilldown (#4323)", () => {
+  afterEach(cleanup);
+
+  // Radix DropdownMenu opens on a real PointerEvent — activate via keyboard
+  // (Enter on the focused trigger), mirroring the CSV-menu tests. This is also
+  // exactly the keyboard path the feature exists to provide.
+  function openDrilldownMenu() {
+    const trigger = screen.getByRole("button", { name: "Drill down" });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+  }
+
+  test("a chart drilldown card exposes a keyboard-navigable Drill down menu of its categories", async () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    const onDrilldown = mock((_param: string, _value: string) => {});
+    render(<DashboardTile {...baseProps} card={barDrillCard} onDrilldown={onDrilldown} />);
+
+    openDrilldownMenu();
+    // Distinct category values from the card's `stage` column become menu items.
+    expect(await screen.findByRole("menuitem", { name: /Discovery/ })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: /Closed Won/ }));
+    expect(onDrilldown).toHaveBeenCalledTimes(1);
+    expect(onDrilldown.mock.calls[0]).toEqual(["stage", "Closed Won"]);
+  });
+
+  test("no Drill down menu on a chart card without a drilldown target", () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    render(<DashboardTile {...baseProps} card={baseCard} />);
+    expect(screen.queryByRole("button", { name: "Drill down" })).toBeNull();
+  });
+
+  test("the Drill down menu is hidden while editing (the chart is a drag surface)", () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    render(<DashboardTile {...baseProps} card={barDrillCard} editing onDrilldown={() => {}} />);
+    expect(screen.queryByRole("button", { name: "Drill down" })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Per-card CSV export (#3210)
 // ---------------------------------------------------------------------------
 

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -57,7 +57,7 @@ mock.module("@/ui/hooks/use-dark-mode", () => ({
   useDarkMode: () => false,
 }));
 
-import { DashboardTile } from "../dashboard-tile";
+import { DashboardTile, distinctCategoryValues, DRILLDOWN_MENU_CAP } from "../dashboard-tile";
 
 const noop = () => {};
 
@@ -447,6 +447,36 @@ describe("DashboardTile — keyboard drilldown (#4323)", () => {
     (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
     render(<DashboardTile {...baseProps} card={barDrillCard} editing onDrilldown={() => {}} />);
     expect(screen.queryByRole("button", { name: "Drill down" })).toBeNull();
+  });
+
+  test("no Drill down menu in table view — table rows are already keyboard-drillable", () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    // A table-type card with a drilldown target renders the DataTable (keyboard
+    // rows), so the chart-only dropdown must not appear.
+    render(<DashboardTile {...baseProps} card={tableDrillCard} onDrilldown={() => {}} />);
+    expect(screen.queryByRole("button", { name: "Drill down" })).toBeNull();
+  });
+});
+
+describe("distinctCategoryValues (#4323)", () => {
+  test("dedupes, skips null/empty cells, and preserves first-seen order", () => {
+    const rows = [
+      { stage: "Discovery" },
+      { stage: "Discovery" },
+      { stage: "" },
+      { stage: null },
+      { stage: "Closed Won" },
+    ];
+    expect(distinctCategoryValues(rows, "stage")).toEqual(["Discovery", "Closed Won"]);
+  });
+
+  test("caps the list so a high-cardinality column can't render an unbounded menu", () => {
+    const rows = Array.from({ length: DRILLDOWN_MENU_CAP + 150 }, (_, i) => ({ stage: `s${i}` }));
+    expect(distinctCategoryValues(rows, "stage").length).toBe(DRILLDOWN_MENU_CAP);
+  });
+
+  test("returns an empty list when the category column is unset", () => {
+    expect(distinctCategoryValues([{ stage: "A" }], "")).toEqual([]);
   });
 });
 

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar-touch.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar-touch.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * DashboardTopBar — viewing-first on touch (#4323).
+ *
+ * On a coarse (touch) pointer the layout-Edit affordance is HIDDEN with a
+ * one-line "editing is desktop-only" explanation, rather than shown-and-inert
+ * (the grid is a read-only stack on touch anyway). A fine pointer keeps the
+ * View/Edit toggle. `useCoarsePointer` is mocked through a mutable flag so both
+ * pointer classes are exercised.
+ */
+import { describe, expect, test, afterEach, mock } from "bun:test";
+import type { ReactNode } from "react";
+
+let coarse = false;
+mock.module("@/ui/hooks/use-coarse-pointer", () => ({
+  useCoarsePointer: () => coarse,
+}));
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  usePathname: () => "/dashboards/d-1",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ id: "d-1" }),
+  redirect: () => {},
+  notFound: () => {},
+}));
+
+mock.module("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import { render, cleanup, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import { DashboardTopBar } from "../dashboard-topbar";
+import type { Density } from "../grid-constants";
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null }),
+};
+
+const noop = () => {};
+
+const baseProps = {
+  dashboardId: "d-1",
+  title: "Revenue overview",
+  cardCount: 3,
+  description: null,
+  onTitleChange: noop as (next: string) => void,
+  refreshing: false,
+  refreshSchedule: null,
+  onScheduleChange: noop as (v: string) => void,
+  onRefreshAll: noop,
+  onSuggest: noop,
+  suggesting: false,
+  onExport: noop as (format: "png" | "pdf") => void,
+  exporting: false,
+  onDelete: noop,
+  shareSlot: <button type="button">Share</button>,
+  editing: false,
+  onEditingChange: noop as (next: boolean) => void,
+  density: "comfortable" as Density,
+  onDensityChange: noop as (next: Density) => void,
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <AtlasProvider
+        config={{
+          apiUrl: "http://localhost:3001",
+          isCrossOrigin: false as const,
+          authClient: stubAuthClient,
+        }}
+      >
+        {children}
+      </AtlasProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("DashboardTopBar — touch (#4323)", () => {
+  afterEach(() => {
+    cleanup();
+    coarse = false;
+  });
+
+  test("a fine pointer shows the View/Edit mode toggle", () => {
+    coarse = false;
+    render(<DashboardTopBar {...baseProps} />, { wrapper });
+    expect(screen.getByRole("group", { name: "Mode" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Edit/ })).toBeTruthy();
+    expect(screen.queryByTestId("edit-desktop-only-hint")).toBeNull();
+  });
+
+  test("a coarse (touch) pointer hides the toggle and explains editing is desktop-only", () => {
+    coarse = true;
+    render(<DashboardTopBar {...baseProps} />, { wrapper });
+    expect(screen.queryByRole("group", { name: "Mode" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Edit/ })).toBeNull();
+    const hint = screen.getByTestId("edit-desktop-only-hint");
+    expect(hint.textContent).toContain("Editing is desktop-only");
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/draft-status-banner.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/draft-status-banner.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Draft status banner — discard confirm behaviour (#4323).
+ *
+ * The discard confirm must stay open until its async request resolves (Radix
+ * otherwise auto-dismisses an AlertDialogAction on click, before the mutation
+ * settles) and surface a failure IN PLACE rather than letting the dialog vanish
+ * with the error appearing in a banner the user is no longer looking at.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { DraftStatusBanner } from "../draft-status-banner";
+import type { FetchError } from "@/ui/lib/fetch-error";
+
+const noop = () => {};
+
+const baseProps = {
+  hasDraft: true,
+  staleBaseline: false,
+  editing: false,
+  discardOpen: false,
+  onDiscardOpenChange: noop,
+  onPublish: noop,
+  onDiscardConfirm: noop,
+  onRebase: noop,
+  publishing: false,
+  discarding: false,
+  rebasing: false,
+  error: null as FetchError | null,
+} as const;
+
+describe("DraftStatusBanner — discard confirm (#4323)", () => {
+  afterEach(cleanup);
+
+  test("confirming discard fires onDiscardConfirm but does NOT auto-dismiss the dialog", () => {
+    const onDiscardConfirm = mock(() => {});
+    const onDiscardOpenChange = mock((_open: boolean) => {});
+    render(
+      <DraftStatusBanner
+        {...baseProps}
+        discardOpen
+        onDiscardConfirm={onDiscardConfirm}
+        onDiscardOpenChange={onDiscardOpenChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("draft-discard-confirm"));
+
+    expect(onDiscardConfirm).toHaveBeenCalledTimes(1);
+    // The dialog stays open — the parent closes it explicitly on success, not
+    // Radix's default click-to-close.
+    expect(onDiscardOpenChange).not.toHaveBeenCalled();
+  });
+
+  test("a discard failure surfaces inside the open dialog, not in the outer banner", () => {
+    const error: FetchError = { message: "Draft is locked by another editor." };
+    render(<DraftStatusBanner {...baseProps} discardOpen error={error} />);
+
+    expect(screen.getByTestId("draft-discard-error").textContent).toContain(
+      "Draft is locked by another editor.",
+    );
+    // While the dialog owns the failure surface, the banner-level error is
+    // suppressed so the message isn't shown twice.
+    expect(screen.queryByTestId("draft-error-banner")).toBeNull();
+  });
+
+  test("with the dialog closed, an error still renders in the banner", () => {
+    const error: FetchError = { message: "Publish failed." };
+    render(<DraftStatusBanner {...baseProps} discardOpen={false} error={error} />);
+    expect(screen.getByTestId("draft-error-banner").textContent).toContain("Publish failed.");
+  });
+});

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -273,9 +273,10 @@ export function DashboardGrid({
       {/* #4323 — fullscreen tile as a REAL dialog: Radix gives focus trap +
           return, an opaque backdrop with click-away, and aria-modal. The tile
           renders again here (not moved) so the grid underneath keeps its place;
-          the in-grid Maximize button opens it, the tile's own Exit-fullscreen
-          button / Esc / backdrop close it. Rendered for the RGL grid only —
-          the mobile stack is already a single-column read-only view. */}
+          a Maximize button opens it, the tile's own Exit-fullscreen button /
+          Esc / backdrop close it. The dialog is shared — reachable from BOTH
+          the desktop grid and the mobile stack, since each wires its tile's
+          Maximize to `setFullscreenId`. */}
       <Dialog
         open={!!fullscreenCard}
         onOpenChange={(open) => {

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -10,6 +10,11 @@ import {
 } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import { cn } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import type { DashboardCard, DashboardCardLayout, KpiComparisonResult, StagedChange } from "@/ui/lib/types";
 import type { TileRenderPhase } from "./tile-status";
 import { COLS, ROW_H, GAP, MIN_W, MIN_H, MOBILE_BREAKPOINT } from "./grid-constants";
@@ -116,8 +121,12 @@ export function DashboardGrid({
     }
   }
 
-  // Esc must exit fullscreen *before* the page-level handler exits edit mode,
-  // so the user gets one Esc per dialog-like layer.
+  // #4323 — the fullscreen tile is now a real modal dialog (focus trap + return,
+  // backdrop / click-away, aria-modal via Radix). This capture-phase Esc handler
+  // still runs FIRST (window capture) so one Esc closes the fullscreen layer and
+  // `stopPropagation` keeps the page-level handler from ALSO exiting edit mode —
+  // one Esc per layer. Because it stops propagation before Radix's own document
+  // listener sees the key, closing stays single-sourced through `setFullscreenId`.
   useEffect(() => {
     if (!fullscreenId) return;
     const onKey = (e: KeyboardEvent) => {
@@ -129,6 +138,12 @@ export function DashboardGrid({
     window.addEventListener("keydown", onKey, { capture: true });
     return () => window.removeEventListener("keydown", onKey, { capture: true });
   }, [fullscreenId]);
+
+  // The card shown in the fullscreen dialog (if any). Resolved from `placed` so
+  // it tracks layout/data updates while open.
+  const fullscreenCard = fullscreenId
+    ? (placed.find((p) => p.id === fullscreenId) ?? null)
+    : null;
 
   const layout: Layout = placed.map((p) => ({
     i: p.id,
@@ -185,7 +200,7 @@ export function DashboardGrid({
               <DashboardTile
                 card={card}
                 editing={false}
-                fullscreen={fullscreenId === card.id}
+                fullscreen={false}
                 isRefreshing={refreshingId === card.id}
                 stage={stagesByCardId.get(card.id) ?? null}
                 comparison={comparisons?.[card.id] ?? null}
@@ -229,17 +244,11 @@ export function DashboardGrid({
           onResizeStop={handleRGLDragOrResizeStop}
         >
           {placed.map((card) => (
-            <div
-              key={card.id}
-              className={cn(
-                "dash-tile-wrapper",
-                fullscreenId === card.id && "is-fullscreen",
-              )}
-            >
+            <div key={card.id} className="dash-tile-wrapper">
               <DashboardTile
                 card={card}
                 editing={editing}
-                fullscreen={fullscreenId === card.id}
+                fullscreen={false}
                 isRefreshing={refreshingId === card.id}
                 stage={stagesByCardId.get(card.id) ?? null}
                 comparison={comparisons?.[card.id] ?? null}
@@ -260,6 +269,55 @@ export function DashboardGrid({
           ))}
         </GridLayout>
       )}
+
+      {/* #4323 — fullscreen tile as a REAL dialog: Radix gives focus trap +
+          return, an opaque backdrop with click-away, and aria-modal. The tile
+          renders again here (not moved) so the grid underneath keeps its place;
+          the in-grid Maximize button opens it, the tile's own Exit-fullscreen
+          button / Esc / backdrop close it. Rendered for the RGL grid only —
+          the mobile stack is already a single-column read-only view. */}
+      <Dialog
+        open={!!fullscreenCard}
+        onOpenChange={(open) => {
+          if (!open) setFullscreenId(null);
+        }}
+      >
+        <DialogContent
+          showCloseButton={false}
+          className="flex h-[92vh] w-[96vw] max-w-[96vw] flex-col gap-0 p-3 sm:max-w-[96vw]"
+          data-testid="tile-fullscreen-dialog"
+        >
+          {/* Titles the modal for screen readers without duplicating the tile's
+              own visible header. */}
+          <DialogTitle className="sr-only">
+            {fullscreenCard?.title ?? "Tile"}
+          </DialogTitle>
+          {fullscreenCard && (
+            <div className="min-h-0 flex-1">
+              <DashboardTile
+                card={fullscreenCard}
+                editing={false}
+                fullscreen
+                isRefreshing={refreshingId === fullscreenCard.id}
+                stage={stagesByCardId.get(fullscreenCard.id) ?? null}
+                comparison={comparisons?.[fullscreenCard.id] ?? null}
+                onDrilldown={onDrilldown}
+                incompatible={incompatibleCardIds?.has(fullscreenCard.id)}
+                selectedValue={selectedValues?.[fullscreenCard.id]}
+                renderPhase={renderPhases?.[fullscreenCard.id]}
+                pendingRefresh={pendingRefreshIds?.has(fullscreenCard.id)}
+                onRetry={onRetryCard}
+                onFullscreen={(id) => setFullscreenId((prev) => (prev === id ? null : id))}
+                onRefresh={onRefresh}
+                onDuplicate={onDuplicate}
+                onDelete={onDelete}
+                onUpdateTitle={onUpdateTitle}
+                onExportCsv={onExportCsv}
+              />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/web/src/ui/components/dashboards/dashboard-parameter-bar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-parameter-bar.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/date-picker";
+import { cn } from "@/lib/utils";
 import type { DashboardParameter } from "@/ui/lib/types";
 // The override map is shared with click-to-drilldown (#3212) — both read/write
 // the same nuqs key via these helpers, so the key + (de)serialization stay
@@ -139,11 +140,19 @@ function ParameterControl({
   // Local mirror for free-text / number inputs so we commit on blur/Enter,
   // not on every keystroke. Date pickers commit immediately on select.
   const [draft, setDraft] = useState(value == null ? "" : String(value));
+  // #4323 — inline validation. A malformed number is surfaced as a per-control
+  // error rather than silently coerced to "no override" (the old `Number("x")`
+  // → NaN → dropped path). Reset whenever the committed value changes (a URL /
+  // drilldown / Reset update supersedes any local error).
+  const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     setDraft(value == null ? "" : String(value));
+    setError(null);
   }, [value]);
 
   if (param.type === "date") {
+    // The DatePicker is calendar-only, so it cannot produce a malformed date —
+    // there is nothing to validate inline here.
     return (
       <DatePicker
         id={`param-${param.key}`}
@@ -159,28 +168,59 @@ function ParameterControl({
   const commitDraft = () => {
     const trimmed = draft.trim();
     if (trimmed === "") {
+      setError(null);
       onCommit(null);
       return;
     }
-    onCommit(param.type === "number" ? Number(trimmed) : trimmed);
+    if (param.type === "number") {
+      const n = Number(trimmed);
+      if (!Number.isFinite(n)) {
+        // Keep the malformed text visible + flag it; do NOT commit (which would
+        // drop the override), so the user can correct it in place.
+        setError("Enter a valid number");
+        return;
+      }
+      setError(null);
+      onCommit(n);
+      return;
+    }
+    setError(null);
+    onCommit(trimmed);
   };
 
+  const errorId = `param-${param.key}-error`;
   return (
-    <Input
-      id={`param-${param.key}`}
-      type={param.type === "number" ? "number" : "text"}
-      value={draft}
-      placeholder={param.label}
-      aria-label={param.label}
-      disabled={disabled}
-      className="h-9 w-40"
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commitDraft}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.currentTarget.blur();
-        }
-      }}
-    />
+    <>
+      {/* `type="text"` + `inputMode` (not `type="number"`) so a malformed entry
+          can actually be typed and validated inline, rather than being silently
+          swallowed by the native number input. */}
+      <Input
+        id={`param-${param.key}`}
+        type="text"
+        inputMode={param.type === "number" ? "decimal" : undefined}
+        value={draft}
+        placeholder={param.label}
+        aria-label={param.label}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
+        disabled={disabled}
+        className={cn("h-9 w-40", error && "border-red-500 focus-visible:ring-red-500/40 dark:border-red-500")}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          if (error) setError(null);
+        }}
+        onBlur={commitDraft}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.currentTarget.blur();
+          }
+        }}
+      />
+      {error && (
+        <p id={errorId} role="alert" className="text-[11px] text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </>
   );
 }

--- a/packages/web/src/ui/components/dashboards/dashboard-skeleton.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-skeleton.tsx
@@ -1,0 +1,99 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading skeletons for the dashboard surface (#4323 — first-impression polish).
+ *
+ * The point is CLS, not decoration: the skeleton reserves the SAME vertical
+ * regions the loaded page occupies — a sticky top-bar row, a banner-strip row,
+ * and a tile grid — so the real content lands in place instead of the grid
+ * jumping down as the top bar, draft banner, and tiles paint in. Replaces the
+ * blank `null` / bare-list loading states the route rendered before.
+ */
+
+/** A single tile placeholder that mirrors the real tile chrome: head row,
+ *  body, and footer caption — so the grid doesn't reflow when tiles arrive. */
+function TileSkeleton() {
+  return (
+    <div className="flex h-64 flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex items-center gap-2 border-b border-zinc-100 px-3 py-2 dark:border-zinc-800/80">
+        <Skeleton className="h-4 flex-1" />
+        <Skeleton className="size-6 shrink-0 rounded" />
+      </div>
+      <div className="min-h-0 flex-1 p-4">
+        <Skeleton className="h-full w-full" />
+      </div>
+      <div className="flex items-center justify-between border-t border-zinc-100 px-3 py-1.5 dark:border-zinc-800/80">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-3 w-10" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full detail-page skeleton: a top-bar row, a reserved banner strip, and a
+ * grid of tile skeletons. Used by the `/dashboards/[id]` loading branch AND
+ * the route-level `loading.tsx`, so a hard navigation and a client fetch show
+ * the same layout-matching placeholder.
+ */
+export function DashboardDetailSkeleton() {
+  return (
+    <div
+      className="flex h-full flex-1 flex-col overflow-hidden"
+      data-testid="dashboard-detail-skeleton"
+      aria-hidden="true"
+    >
+      {/* Top bar — mirrors the sticky DashboardTopBar row (title + actions). */}
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800 sm:px-6">
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-24 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+      </div>
+
+      {/* Reserved banner strip — the draft / parameter / filter rows land here
+          once their async data arrives, so the grid below doesn't jump. */}
+      <div className="px-4 pt-3 sm:px-6">
+        <Skeleton className="h-9 w-full rounded-md" />
+      </div>
+
+      {/* Tile grid — 2-up on desktop, matching the default 12-col tiles. */}
+      <div className="grid flex-1 grid-cols-1 gap-4 px-3 py-4 sm:px-5 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <TileSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact skeleton for the redirect-only `/dashboards` index. It forwards to
+ * the most-recent board, but the fetch is a real round-trip — this fills the
+ * gap with a top-bar + tile-grid placeholder instead of a blank frame so the
+ * redirect never flashes an empty screen.
+ */
+export function DashboardListSkeleton() {
+  return (
+    <div
+      className="flex h-full flex-1 flex-col overflow-hidden"
+      data-testid="dashboard-list-skeleton"
+      aria-hidden="true"
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800 sm:px-6">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-8 w-24 rounded-md" />
+      </div>
+      <div className="grid flex-1 grid-cols-1 gap-4 px-3 py-4 sm:px-5 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <TileSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -236,8 +236,8 @@ function drilldownValueFromRow(
  * column can't render a thousand-item menu (drilldown is for a handful of
  * categories; the table view remains the path for long tails).
  */
-const DRILLDOWN_MENU_CAP = 100;
-function distinctCategoryValues(
+export const DRILLDOWN_MENU_CAP = 100;
+export function distinctCategoryValues(
   rows: Record<string, unknown>[],
   categoryColumn: string,
   cap: number = DRILLDOWN_MENU_CAP,

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -20,6 +20,7 @@ import {
   Inbox,
   CircleDashed,
   Loader2,
+  ListFilter,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -228,6 +229,35 @@ function drilldownValueFromRow(
 }
 
 /**
+ * #4323 — the distinct, non-empty category values a chart tile can drill into,
+ * pulled from its `categoryColumn`. Backs the keyboard drilldown menu: a
+ * Recharts click is mouse-only, so a chart card exposes the SAME drilldown
+ * targets through a keyboard-navigable dropdown. Capped so a high-cardinality
+ * column can't render a thousand-item menu (drilldown is for a handful of
+ * categories; the table view remains the path for long tails).
+ */
+const DRILLDOWN_MENU_CAP = 100;
+function distinctCategoryValues(
+  rows: Record<string, unknown>[],
+  categoryColumn: string,
+  cap: number = DRILLDOWN_MENU_CAP,
+): string[] {
+  if (!categoryColumn) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const row of rows) {
+    const value = row[categoryColumn];
+    if (value == null || value === "") continue;
+    const s = String(value);
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+/**
  * Tile dispatcher (#3138). A `text` / section-block card renders markdown with
  * no chart, data fetch, or refresh chrome; everything else is a SQL-backed
  * chart tile. Kept hook-free so each concrete tile owns a stable hook order.
@@ -320,6 +350,23 @@ function ChartTile({
           if (value != null) onDrilldown(drilldownParam, value);
         }
       : undefined;
+
+  // #4323 — a keyboard path to drilldown / cross-filter. A Recharts click is
+  // mouse-only, so when a chart card is showing its (mouse-driven) chart body we
+  // surface the same drilldown targets through a keyboard-navigable dropdown
+  // (Tab to the trigger, arrows to move, Enter to select). Table view already
+  // has keyboard-accessible rows (`onRowClick` fires on Enter/Space), so the
+  // menu is offered only in chart view, and only when a target param is bound.
+  const drilldownCategories =
+    drillEnabled &&
+    drilldownParam !== null &&
+    onDrilldown &&
+    categoryColumn &&
+    hasChartConfig &&
+    viewMode === "chart" &&
+    showData
+      ? distinctCategoryValues(rows, categoryColumn)
+      : [];
 
   function commitTitle() {
     const next = titleDraft.trim();
@@ -457,6 +504,36 @@ function ChartTile({
 
         {!titleEditing && (
           <div className="flex shrink-0 items-center gap-0.5">
+            {drilldownCategories.length > 0 && drilldownParam !== null && onDrilldown && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Drill down"
+                  >
+                    <ListFilter className="size-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto text-xs">
+                  {drilldownCategories.map((value) => {
+                    const isSelected = selectedValue === value;
+                    return (
+                      <DropdownMenuItem
+                        key={value}
+                        onSelect={() => onDrilldown(drilldownParam, value)}
+                        className={cn(isSelected && "font-medium text-primary")}
+                        aria-checked={isSelected}
+                      >
+                        {isSelected && <Check className="mr-2 size-3.5" aria-hidden="true" />}
+                        <span className={cn("truncate", !isSelected && "pl-[1.375rem]")}>{value}</span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
             <Button
               variant="ghost"
               size="icon"

--- a/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
@@ -96,8 +96,9 @@ export function DashboardTopBar({
 
   // #4323 — the dashboard is viewing-first on touch. Editing means dragging /
   // resizing tiles on a 24-col grid, which needs a fine pointer; on a coarse
-  // (touch) pointer the grid renders a read-only stack anyway, so we HIDE the
-  // View/Edit toggle rather than show it inert, and explain why in one line.
+  // (touch) pointer we HIDE the View/Edit toggle rather than show it inert, and
+  // explain in one line where to edit. (Tracks the INPUT, not the viewport — a
+  // wide touch tablet still can't usefully drag-arrange.)
   const coarsePointer = useCoarsePointer();
 
   // Resync the draft when the canonical title changes (e.g. after a server save

--- a/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { useCoarsePointer } from "@/ui/hooks/use-coarse-pointer";
 import { DashboardSwitcher } from "./dashboard-switcher";
 import type { Density } from "./grid-constants";
 
@@ -92,6 +93,12 @@ export function DashboardTopBar({
 }: DashboardTopBarProps) {
   const [titleEditing, setTitleEditing] = useState(false);
   const [draft, setDraft] = useState(title);
+
+  // #4323 — the dashboard is viewing-first on touch. Editing means dragging /
+  // resizing tiles on a 24-col grid, which needs a fine pointer; on a coarse
+  // (touch) pointer the grid renders a read-only stack anyway, so we HIDE the
+  // View/Edit toggle rather than show it inert, and explain why in one line.
+  const coarsePointer = useCoarsePointer();
 
   // Resync the draft when the canonical title changes (e.g. after a server save
   // resolves) so a subsequent edit starts from the up-to-date value.
@@ -163,40 +170,52 @@ export function DashboardTopBar({
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        <div
-          role="group"
-          aria-label="Mode"
-          className="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-100/60 p-0.5 dark:border-zinc-800 dark:bg-zinc-900"
-        >
-          <button
-            type="button"
-            className={cn(
-              "inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
-              !editing
-                ? "bg-background text-foreground shadow-sm"
-                : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
-            )}
-            onClick={() => onEditingChange(false)}
-            aria-pressed={!editing}
+        {coarsePointer ? (
+          // #4323 — viewing-first on touch: the Edit affordance is hidden (not
+          // shown-and-inert) with a one-line explanation of where to edit.
+          <span
+            data-testid="edit-desktop-only-hint"
+            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 bg-zinc-100/60 px-2 py-1 text-xs text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400"
           >
-            <Eye className="size-3.5" />
-            View
-          </button>
-          <button
-            type="button"
-            className={cn(
-              "inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
-              editing
-                ? "bg-background text-foreground shadow-sm"
-                : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
-            )}
-            onClick={() => onEditingChange(true)}
-            aria-pressed={editing}
+            <Eye className="size-3.5" aria-hidden="true" />
+            Editing is desktop-only
+          </span>
+        ) : (
+          <div
+            role="group"
+            aria-label="Mode"
+            className="inline-flex items-center rounded-md border border-zinc-200 bg-zinc-100/60 p-0.5 dark:border-zinc-800 dark:bg-zinc-900"
           >
-            <Pencil className="size-3.5" />
-            Edit
-          </button>
-        </div>
+            <button
+              type="button"
+              className={cn(
+                "inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
+                !editing
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
+              )}
+              onClick={() => onEditingChange(false)}
+              aria-pressed={!editing}
+            >
+              <Eye className="size-3.5" />
+              View
+            </button>
+            <button
+              type="button"
+              className={cn(
+                "inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors",
+                editing
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100",
+              )}
+              onClick={() => onEditingChange(true)}
+              aria-pressed={editing}
+            >
+              <Pencil className="size-3.5" />
+              Edit
+            </button>
+          </div>
+        )}
 
         <div
           role="group"

--- a/packages/web/src/ui/components/dashboards/draft-status-banner.tsx
+++ b/packages/web/src/ui/components/dashboards/draft-status-banner.tsx
@@ -144,7 +144,13 @@ export function DraftStatusBanner({
               size="sm"
               variant="outline"
               className="h-7 border-amber-300 bg-white text-amber-900 hover:bg-amber-100 dark:border-amber-800 dark:bg-zinc-900 dark:text-amber-100 dark:hover:bg-amber-900/30"
-              onClick={() => onDiscardOpenChange(true)}
+              onClick={() => {
+                // #4323 — clear any prior publish/rebase/discard error so the
+                // dialog's in-place error surface opens clean, rather than
+                // showing a stale message from an earlier attempt.
+                onDismissError?.();
+                onDiscardOpenChange(true);
+              }}
               disabled={discarding || publishing}
               data-testid="draft-discard-button"
             >

--- a/packages/web/src/ui/components/dashboards/draft-status-banner.tsx
+++ b/packages/web/src/ui/components/dashboards/draft-status-banner.tsx
@@ -193,7 +193,9 @@ export function DraftStatusBanner({
         </div>
       )}
 
-      {error && (
+      {/* While the discard confirm is open, its own inline error owns the
+          failure surface (#4323) — don't also render it in the banner. */}
+      {error && !discardOpen && (
         <div
           role="alert"
           data-testid="draft-error-banner"
@@ -223,10 +225,32 @@ export function DraftStatusBanner({
               published dashboard is unaffected. This cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {/* #4323 — surface a discard FAILURE in place. The confirm below stays
+              open until the request resolves (the parent closes it only on
+              success), so a failed discard shows its reason right here instead
+              of the dialog vanishing before the async settles. */}
+          {error && (
+            <div
+              role="alert"
+              data-testid="draft-discard-error"
+              className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50/70 px-3 py-2 text-xs text-red-700 dark:border-red-900/40 dark:bg-red-950/20 dark:text-red-300"
+            >
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+              <span className="min-w-0 flex-1">{friendlyError(error)}</span>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={discarding}>Cancel</AlertDialogCancel>
+            {/* #4323 — `preventDefault` stops Radix from auto-dismissing the
+                dialog on click (its default), so it survives the in-flight
+                request; the parent dismisses it explicitly once the discard
+                succeeds. Without this the dialog vanished before the async
+                settled and a failure had nowhere to render. */}
             <AlertDialogAction
-              onClick={onDiscardConfirm}
+              onClick={(e) => {
+                e.preventDefault();
+                void onDiscardConfirm();
+              }}
               disabled={discarding}
               className="bg-red-600 text-white hover:bg-red-700"
               data-testid="draft-discard-confirm"

--- a/packages/web/src/ui/hooks/__tests__/use-coarse-pointer.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-coarse-pointer.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * useCoarsePointer (#4323).
+ *
+ * The hook is the mechanism behind the dashboard's viewing-first-on-touch
+ * behaviour, so its contract is pinned directly: it reflects the live
+ * `(pointer: coarse)` match, subscribes/unsubscribes to `matchMedia`, and is
+ * SSR-safe. `window.matchMedia` is stubbed since jsdom doesn't implement it.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { useCoarsePointer } from "../use-coarse-pointer";
+
+type Listener = () => void;
+
+function stubMatchMedia(matches: boolean) {
+  const listeners = new Set<Listener>();
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: (_: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_: string, cb: Listener) => listeners.delete(cb),
+    addListener: (cb: Listener) => listeners.add(cb),
+    removeListener: (cb: Listener) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  })) as typeof window.matchMedia;
+  return {
+    listenerCount: () => listeners.size,
+    restore: () => {
+      window.matchMedia = original;
+    },
+  };
+}
+
+function Probe({ onValue }: { onValue: (v: boolean) => void }) {
+  onValue(useCoarsePointer());
+  return null;
+}
+
+describe("useCoarsePointer (#4323)", () => {
+  afterEach(cleanup);
+
+  test("returns true when the primary pointer is coarse", () => {
+    const mm = stubMatchMedia(true);
+    let value: boolean | null = null;
+    render(<Probe onValue={(v) => { value = v; }} />);
+    expect(value).toBe(true);
+    mm.restore();
+  });
+
+  test("returns false when the primary pointer is fine", () => {
+    const mm = stubMatchMedia(false);
+    let value: boolean | null = null;
+    render(<Probe onValue={(v) => { value = v; }} />);
+    expect(value).toBe(false);
+    mm.restore();
+  });
+
+  test("subscribes on mount and cleans up its listener on unmount", () => {
+    const mm = stubMatchMedia(false);
+    const { unmount } = render(<Probe onValue={() => {}} />);
+    expect(mm.listenerCount()).toBe(1);
+    unmount();
+    expect(mm.listenerCount()).toBe(0);
+    mm.restore();
+  });
+});

--- a/packages/web/src/ui/hooks/use-coarse-pointer.ts
+++ b/packages/web/src/ui/hooks/use-coarse-pointer.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Whether the device's primary pointer is COARSE — i.e. a touch screen with no
+ * precise cursor. Backs the dashboard's "viewing-first on touch" behaviour
+ * (#4323): the layout-Edit affordance is hidden on touch (drag-to-arrange needs
+ * a fine pointer) rather than shown-and-inert.
+ *
+ * Uses `(pointer: coarse)` rather than a width breakpoint so a narrow desktop
+ * window (fine pointer) still gets the editor, while a large tablet (coarse
+ * pointer) does not — the affordance tracks the INPUT, not the viewport. Mirrors
+ * the `useSyncExternalStore` + `matchMedia` pattern in `use-dark-mode.ts`, and
+ * is SSR-safe (`getServerSnapshot` returns `false`, so the editor renders on the
+ * server and only collapses on a real touch device after hydration).
+ */
+
+const QUERY = "(pointer: coarse)";
+
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const mq = window.matchMedia(QUERY);
+  mq.addEventListener("change", onChange);
+  return () => mq.removeEventListener("change", onChange);
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/** Returns `true` when the primary pointer is coarse (touch). */
+export function useCoarsePointer(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## Summary

Dashboard first-impression polish + accessibility pass (milestone: Dashboard Elevation, PRD #4313). Frontend-only. Closes #4323.

- **Loading / CLS** — new shared `DashboardDetailSkeleton` / `DashboardListSkeleton` reserve the top-bar, banner-strip, and tile-grid regions so the surface no longer flashes a blank `null` screen or jumps as content paints in. Wired into the `/dashboards/[id]` loading branch, the route-level `loading.tsx`, and the redirect-only `/dashboards` index.
- **Mobile viewing-first** — new `useCoarsePointer` hook (tracks the *input* via `(pointer: coarse)`, not the viewport). On touch the layout-Edit toggle is **hidden** with a one-line "Editing is desktop-only" explanation instead of shown-and-inert.
- **Fullscreen tile is a real dialog** — replaced the `.is-fullscreen` fixed-position CSS hack with a Radix `Dialog`: focus trap + return, opaque backdrop / click-away, `aria-modal`. The capture-phase Esc handler is retained so one Esc closes one layer.
- **Keyboard drilldown** — chart tiles now expose their drilldown categories through a keyboard-navigable dropdown (a Recharts click is mouse-only; table rows were already keyboard-drillable, so the menu is offered only in chart view).
- **Inline parameter validation** — number controls validate inline (`type="text"` + `inputMode`, `Number.isFinite` guard) and surface a per-control error (`role="alert"`, `aria-invalid`) instead of silently coercing a malformed entry to "no override".
- **Discard-draft dialog** — stays open until its request resolves (`preventDefault` stops Radix's auto-dismiss; the parent closes it on success) and surfaces a failure **in place**; a stale prior error is cleared when the dialog re-opens.

## Test Plan

- [x] Unit tests added/updated — parameter validation (malformed → error, no commit; recovery commits), discard-dialog stays-open + in-place error matrix, fullscreen real-dialog (role + overlay) + Esc single-layer, keyboard drilldown menu (chart-only, editing-hidden, table-absent), `distinctCategoryValues` (dedup / null-skip / cap), `useCoarsePointer` (value + listener cleanup), skeleton layout regions, topbar touch vs fine pointer.
- [x] Ran the dashboard suites via the isolated runner (all green) plus the `/dashboards` route tests.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (isolated runner, dashboard + route suites)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [x] Labels present (feature, area: web, design)
- [ ] CHANGELOG — deferred (per-tag changelog is added at `/release`, not per-PR)

https://claude.ai/code/session_018pJ1QwLePnco1ENLT1dGJi

---
_Generated by [Claude Code](https://claude.ai/code/session_018pJ1QwLePnco1ENLT1dGJi)_