### PR TITLE
docs: answer-styles concept page + chat-surface guide (v0.0.43)

### DIFF
--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -4,6 +4,8 @@
   "icon": "BookOpen",
   "pages": [
     "choosing-an-integration",
+    "chat-surface",
+    "answer-styles",
     "mcp",
     "slack",
     "proactive-chat",

--- a/apps/docs/content/self-hosted/guides/meta.json
+++ b/apps/docs/content/self-hosted/guides/meta.json
@@ -3,6 +3,8 @@
   "description": "Operator walkthroughs for self-hosted Atlas",
   "icon": "BookOpen",
   "pages": [
+    "chat-surface",
+    "answer-styles",
     "multi-tenancy",
     "plugin-marketplace",
     "onboarding-emails",

--- a/apps/docs/content/shared/guides/answer-styles.mdx
+++ b/apps/docs/content/shared/guides/answer-styles.mdx
@@ -1,0 +1,46 @@
+---
+title: Answer Styles
+description: The four answer styles — the editorial voice Atlas answers in — plus surface defaults and how a style is resolved for each turn.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+An **answer style** is the editorial voice of Atlas's answer — the final, user-facing text of a turn. It tunes the prose only: the workflow, the SQL it runs, the provenance it carries, and the follow-up suggestions are identical across styles. The same figure can be delivered as a plain sentence, an answer-first analyst paragraph, or a forwardable executive headline; the style decides which.
+
+Every style resolves to exactly one voice. Nothing else about the turn changes — so switching styles never changes *what* Atlas found, only *how it reads*.
+
+## The four styles
+
+| Style | Sounds like | Best for |
+|-------|-------------|----------|
+| **Plain English** | A few short sentences of plain prose. States the figure directly with just enough context, no headings, no jargon, no SQL. | A business user who wants the answer, not an analyst's report. |
+| **Analyst** | Answer-first: leads with the result, then the supporting detail. Length scales to the question; headings only earn their place on genuinely multi-part analyses. Tables and inline SQL stay when they carry the answer. | The default analyst-grade voice for the web chat, SDK, MCP, and the query API. |
+| **Executive** | The first line is the headline number, followed by at most three or four tight supporting points and a one-line source note ("Source: orders (Postgres), 2 queries."). Forwardable without editing. | An executive who may pass the answer along untouched. |
+| **Conversational** | One or two sentences of plain prose for a chat thread, with a closing offer to surface the SQL or full breakdown on tap. | Chat platforms (Slack, Teams). Applied automatically per turn — see below. |
+
+<Callout type="info" title="Where the voices are defined">
+  The exact wording of each style lives in the answer-style registry (`packages/api/src/lib/answer-styles.ts`) — the single source of truth. Each style there resolves to one prompt addendum appended to the agent's system prompt.
+</Callout>
+
+## Surface defaults
+
+When no one picks a style, the surface a request came from decides:
+
+- **Analyst** is the default for the web chat, the SDK, MCP, and `POST /api/v1/query` — the analyst-grade surfaces.
+- **Conversational** is the default on chat platforms (Slack `@mention`, proactive chat). Chat platforms choose it per turn — it is never persisted onto a conversation, and it is not offered as a workspace default because its voice references chat-only affordances (the "Show SQL" button).
+
+Because Conversational is applied per turn by the chat surface itself, it is not something a web user or admin selects — the web answer-style picker offers Plain English, Analyst, and Executive only.
+
+## How a style is resolved
+
+For any given turn, Atlas resolves the style through three tiers, highest precedence first:
+
+1. **Per-conversation pick.** The answer-style picker in the chat header sets the voice for *this* conversation. It rides every subsequent turn and persists on the conversation, restoring when you reopen it. An explicit pick always wins.
+2. **Workspace default (the "house voice").** Admins set a workspace-wide default under **Admin → Settings → Agent → Default Answer Style** (or the `ATLAS_DEFAULT_ANSWER_STYLE` environment variable). It applies to web conversations without a per-conversation pick and to SDK / MCP / query-API calls that send no style. See <AudienceLink saas="/guides/workspace-settings">Workspace Settings</AudienceLink> for the admin knob and [Environment Variables](/reference/environment-variables) for the env var.
+3. **Surface default.** If neither of the above applies, the surface default kicks in — Analyst for analyst-grade surfaces, Conversational for chat platforms.
+
+Chat platforms sit outside this chain: they pass their own voice (Conversational, in practice) explicitly per turn, so the workspace default never reaches them.
+
+## Choosing a style from the API
+
+API, SDK, and MCP callers set the voice per request with the `answerStyle` field on the chat request body. Accepted values are `plain-english`, `analyst`, `executive`, and `conversational`; omit the field to fall back to the workspace default, then the surface default. The full request schema, including `answerStyle`, is in the <AudienceLink saas="/api-reference/chat/postChat">interactive API Reference</AudienceLink>.

--- a/apps/docs/content/shared/guides/chat-surface.mdx
+++ b/apps/docs/content/shared/guides/chat-surface.mdx
@@ -1,0 +1,46 @@
+---
+title: The Chat Surface
+description: What the web chat looks like as you use it — the live working phase, answer-first finished turns, the composer, and how failures surface.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The web chat is built around one idea: **the answer is what you came for, so the answer is what dominates.** Everything the agent did to get there stays visible but out of the way. This guide walks through what you actually see as a turn runs and finishes.
+
+## While the agent works
+
+The moment you send a message, the **working phase** begins — there is no dead air. Atlas shows a live **activity** feed: one compact line per step, updating as the agent reads your semantic layer, runs a query, or executes Python ("Reading semantic layer", "Running query", …). Results stay collapsed while the work is in flight, and the agent's narration appears at a quieter weight than an answer.
+
+A **Stop** button replaces Send while a turn is streaming. Press it to end the turn early; the composer unlocks and you can send a new message.
+
+## When the turn finishes
+
+Once the answer begins, the turn settles into its answer-first shape, top to bottom:
+
+1. **A collapsed receipt.** The activity feed condenses to a single muted summary line — for example, *"Explored schema · 2 queries."* Click it to expand the full activity: the tool cards, the "Show SQL" affordance, the result views, and the agent's narration. The work is inspectable on demand, never ambient.
+2. **The answer.** The final text streams in as the visually dominant element of the turn.
+3. **At most one promoted artifact.** If the turn produced an answer-bearing artifact — the chart or table that *is* the answer — it appears once, directly below the answer. Intermediate queries and results stay tucked inside the receipt.
+
+<Callout type="info" title="Answer styles">
+  The editorial voice of the answer — plain, analyst, or executive — is set by the answer-style picker in the chat header. See [Answer Styles](/guides/answer-styles).
+</Callout>
+
+## The composer
+
+The composer is a multiline text box that grows with your message up to a cap, then scrolls:
+
+- **Enter** sends the message.
+- **Shift + Enter** inserts a newline — use it to draft a multi-line question without sending.
+- On mobile, the on-screen Send button is the affordance; the return key sends there too.
+
+The composer locks while a turn streams (Send becomes Stop) and while a conversation's history is loading, so a send can't race the load.
+
+## Copying an answer
+
+Every finished answer carries a **Copy** button that puts the answer text on your clipboard. It confirms with "Copied!" and reverts after a couple of seconds.
+
+## When something fails
+
+Failures surface as a **banner** rather than silently vanishing. A failed send, load, pin, or resume shows a titled banner with the server-provided detail and, when the failure is retryable, a button to re-run the action. On a 500, the banner carries a request ID you can quote to an operator for log correlation.
+
+The banner persists until you act on it — a fresh attempt supersedes it — so a failure you haven't seen yet is never erased by an unrelated one.


### PR DESCRIPTION
## Summary

Documents the two v0.0.43 headline concepts that had no prose docs (the v0.0.43 closeout docs audit gap). Two new **shared** guides — mounted into both the SaaS and self-hosted trees:

- **`answer-styles.mdx`** — the four answer styles (`plain-english` / `analyst` / `executive` / `conversational`) and what each voice sounds like, surface defaults (analyst for web/SDK/MCP/`/api/v1/query`; conversational per-turn on chat platforms), the three-level resolution precedence (per-conversation pick > workspace default > surface default), and the `answerStyle` chat-request wire field cross-linked to the API reference. Voices quoted from the registry SSOT (`packages/api/src/lib/answer-styles.ts`); the admin knob and env var are cross-linked to `workspace-settings.mdx` / the env-var reference, not duplicated.
- **`chat-surface.mdx`** — the answer-first web chat a trial user sees post-v0.0.43: the live working phase (activity feed from the moment of send) + stop button, the finished-turn shape (collapsed activity receipt → dominant answer → one promoted answer-bearing artifact), the multiline composer (Enter sends / Shift+Enter newline), the copy button, and the persistent failure banners. Uses the CONTEXT.md § Chat turn presentation vocabulary.

Both files live in `content/shared/guides/` and are wired into both `content/docs/guides/meta.json` (SaaS) and `content/self-hosted/guides/meta.json` (self-hosted). Cross-tree links to SaaS-only pages use `<AudienceLink>`; shared-to-shared links stay plain.

## Test Plan

- [x] Manual testing — `next build` passes: audience classifier green, both pages route into **both** trees (`/guides/{answer-styles,chat-surface}` and `/self-hosted/guides/{answer-styles,chat-surface}`)
- [x] Unit tests added/updated — n/a (docs-only); existing `audience-taxonomy` / `source-partition` / `llms-surface` suites pass (51/51)
- [ ] E2E tests added/updated — n/a

Fresh-context docs-accuracy review verified every claim against the registry SSOT, `settings.ts`, and the web chat components; all cross-tree links and vocabulary confirmed correct.

## Checklist

- [x] Types pass (`bun run type`) — via `scripts/ci-local.sh`, all 28 local gates green
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — n/a, no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — n/a (docs describe already-shipped v0.0.43 features)

Closes #4341

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLukcgFsUDE6WW8r7j9o6s)_