### PR TITLE
docs(mcp): record #4314 decision — decline WorkOS agent_auth, defer to #2058

### DIFF
--- a/packages/api/scripts/check-auth-md-discovery-parity.ts
+++ b/packages/api/scripts/check-auth-md-discovery-parity.ts
@@ -97,6 +97,13 @@ const HOST_FIXTURES = [
  * backstop unit tests (`lib/mcp/__tests__/auth-md.test.ts`) as defense in
  * depth — the parity guard fails the build in the SAME job as the other drift
  * gates, independent of the per-file test shard running.
+ *
+ * These stay forbidden by decision #4314: Atlas declined the WorkOS
+ * `agent_auth` flow (no `@better-auth/agent-auth`-style library path for the
+ * WorkOS id-jag/claim/events surface, which overlaps #2058's Agent Auth
+ * Protocol — the chosen vehicle if Atlas ever ships agent-verified
+ * registration). See the decision note in `lib/mcp/auth-md.ts`. Do not relax
+ * this list to appease an agent-readiness scanner.
  */
 export const FORBIDDEN_FRAGMENTS = [
   "/agent/identity",

--- a/packages/api/src/lib/mcp/__tests__/auth-md.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/auth-md.test.ts
@@ -154,6 +154,9 @@ describe("buildAuthMd — content contract", () => {
     // The required backstop (#3824 § Testing): the doc must never advertise an
     // endpoint Atlas does not serve. `/agent/identity`, `identity_assertion`,
     // and the `urn:workos:*` grant types are explicitly Out of Scope.
+    // #4314 formally kept it that way: the WorkOS `agent_auth` flow was
+    // declined in favor of #2058's Agent Auth Protocol (see the decision note
+    // in `../auth-md.ts`), so these fragments remain asserted-absent.
     const md = buildAuthMd(BASE_OPTS);
     expect(md).not.toContain("/agent/identity");
     expect(md).not.toContain("identity_assertion");

--- a/packages/api/src/lib/mcp/auth-md.ts
+++ b/packages/api/src/lib/mcp/auth-md.ts
@@ -21,6 +21,20 @@
  * Scope; the WorkOS-verified flow is a deliberately deferred future
  * direction noted as prose only.)
  *
+ * Decision (#4314): Atlas DECLINES the WorkOS `agent_auth` block and folds
+ * any future agent-verified registration into #2058's Agent Auth Protocol
+ * — not this WorkOS flow. Rationale: the two are distinct protocols on
+ * distinct discovery surfaces (WorkOS puts `agent_auth` inside
+ * `/.well-known/oauth-authorization-server` with an id-jag/claim/events
+ * build; the Agent Auth Protocol uses a separate `/.well-known/agent-configuration`).
+ * Only the latter has a real library path (`@better-auth/agent-auth`), so
+ * serving the WorkOS block would mean a from-scratch, per-region
+ * id-jag/claim/`event/notify` build with no library support, purely to
+ * satisfy an agent-readiness scanner — advertising exactly the endpoints
+ * this file (and the parity guard) deliberately withhold. The scanner
+ * finding is accepted as intentional non-conformance until/unless #2058
+ * ships. The forbidden-fragment guard therefore stays as-is.
+ *
  * Drift safety: this is a PURE builder. It hard-codes no host and no scope.
  * The route feeds it the SAME resolved auth-server issuer URI and MCP
  * resource host that back the `.well-known` discovery documents


### PR DESCRIPTION
## Summary

`Closes #4314`.

An [isitagentready.com](https://isitagentready.com) scan flags a missing WorkOS `agent_auth` block in `/.well-known/oauth-authorization-server`. #4314 required a **human product decision** before any code — adopt the WorkOS agent-verified flow, or decline. **Decision: decline the WorkOS flow and defer any future agent-verified registration into #2058's Agent Auth Protocol.** This PR records that decision in code (comment-only); it makes no behavior change.

**Why (researched Better-Auth's current state to inform the call):**

| | WorkOS `auth.md` — what #4314 wanted | Agent Auth Protocol — #2058 |
|---|---|---|
| Discovery | `agent_auth` block **inside** `/.well-known/oauth-authorization-server` | separate `/.well-known/agent-configuration` |
| Endpoints | `/agent/identity`, `/agent/identity/claim`, `/agent/event/notify` | `/capability/execute`, `/capability/list`, `/agent/session` |
| Token | ID-JAG (`urn:ietf:params:oauth:token-type:id-jag`), identity assertion | short-lived aud-bound capability JWTs |
| **Library path** | **none** | **`@better-auth/agent-auth`** (0.6.x) |

`@better-auth/agent-auth` implements the **Agent Auth Protocol** (#2058), not the WorkOS `auth.md` flow — its docs have zero mention of WorkOS, `auth.md`, `identity_assertion`, `id-jag`, or the `agent_auth` block. So serving #4314's block would be a from-scratch, per-region id-jag/claim/events build with no library support, purely to satisfy a scanner — and it would advertise exactly the endpoints `auth-md.ts` and the parity guard deliberately withhold (the no-404-in-discovery principle from #3824). The scanner finding is accepted as intentional non-conformance until/unless #2058 ships.

**What changed:** comment-only rationale notes in the two files the issue named (`lib/mcp/auth-md.ts` + `scripts/check-auth-md-discovery-parity.ts`) plus the mirror test (`__tests__/auth-md.test.ts`), so the decision is found wherever a maintainer lands. The `FORBIDDEN_FRAGMENTS` guard and its mirror test are unchanged — the block stays forbidden.

## Test Plan

- [x] Manual testing — parity guard prints `OK` (2 region fixtures) and exits 0 without the dev-only pino-pretty transport; mirror unit test `auth-md.test.ts` is 14/14 green.
- [ ] Unit tests added/updated — n/a (comment-only decision record; no behavior change)
- [ ] E2E tests added/updated — n/a

## Checklist

- [x] Types pass (`bun run type`)
- [x] Lint passes (`bun run lint`)
- [ ] Tests pass (`bun run test`) — affected `auth-md` test + parity guard verified green; comment-only diff
- [ ] Deps consistent — n/a (no dependency changes)
- [x] Labels added (type + area) — inherited from #4314 (feature, area: api, area: mcp, architecture)
- [ ] CHANGELOG.md updated — n/a (no user-facing change)

https://claude.ai/code/session_01Bkca4zT99tY3PgY8zKzpgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bkca4zT99tY3PgY8zKzpgf)_