### PR TITLE
refactor(api): converge singleton installs onto the persist-form-install spine

### DIFF
--- a/packages/api/src/lib/integrations/install/__tests__/chat-integration-cap-gate.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/chat-integration-cap-gate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for {@link makeChatIntegrationCapGate} — the shared
+ * {@link SingletonInstallCapGate} the six chat-pillar singleton handlers
+ * (five static-bot + Slack OAuth) pass to `persistSingletonInstall` (#4352).
+ *
+ * The three arms pinned here (allowed → rows; cap → 429; count-failed → 503)
+ * are the cap-decision block that used to be hand-copied across all six
+ * handlers. The gate RETURNS a denial (never throws it) so the generic spine
+ * can tell it apart from a raw write-path throw, which passes straight
+ * through — pinned by the last case.
+ */
+
+import { afterEach, describe, expect, it, mock, type Mock } from "bun:test";
+import type { WorkspaceId } from "@useatlas/types";
+
+type GateResult =
+  | { allowed: true; rows: Array<Record<string, unknown>> }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+
+const mockCheckChatLimitAndInstall: Mock<
+  (
+    orgId: string | undefined,
+    catalogId: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => Promise<GateResult>
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: "row-1" }] }));
+
+// Mock every value export — a partial `mock.module()` breaks other importers
+// of the module (CLAUDE.md "mock all exports"). Only the atomic gate is used;
+// the rest are inert no-ops.
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+}));
+
+const { makeChatIntegrationCapGate } = await import("../chat-integration-cap-gate");
+
+const noopLog = { error: () => {}, info: () => {} };
+const insert = { sql: "INSERT INTO workspace_plugins ...", params: ["a", "b"] as const };
+
+function gate() {
+  return makeChatIntegrationCapGate({
+    orgId: "ws-1" as WorkspaceId,
+    catalogId: "catalog:telegram",
+    displayName: "Telegram",
+    log: noopLog,
+  });
+}
+
+afterEach(() => {
+  mockCheckChatLimitAndInstall.mockReset();
+  mockCheckChatLimitAndInstall.mockImplementation(() =>
+    Promise.resolve({ allowed: true as const, rows: [{ id: "row-1" }] }),
+  );
+});
+
+describe("makeChatIntegrationCapGate", () => {
+  it("forwards (orgId, catalogId, insert) to the atomic gate and returns its RETURNING rows on allow", async () => {
+    const result = await gate()(insert);
+    expect(result).toEqual({ ok: true, rows: [{ id: "row-1" }] });
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [org, catalog, passedInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(org).toBe("ws-1");
+    expect(catalog).toBe("catalog:telegram");
+    expect(passedInsert).toBe(insert);
+  });
+
+  it("maps a cap_reached denial to a returned (not thrown) ChatIntegrationLimitError (429)", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: false, reason: "cap_reached", errorMessage: "at cap", limit: 1 }),
+    );
+    const result = await gate()(insert);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected denial");
+    expect(result.error).toMatchObject({ _tag: "ChatIntegrationLimitError", limit: 1, workspaceId: "ws-1" });
+  });
+
+  it("maps a check_failed denial to a returned BillingCheckFailedError (503), not the 429", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: false, reason: "check_failed", errorMessage: "try again" }),
+    );
+    const result = await gate()(insert);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected denial");
+    expect(result.error).toMatchObject({ _tag: "BillingCheckFailedError", workspaceId: "ws-1" });
+  });
+
+  it("lets a raw write-path throw (routing 23505 / driver fault) propagate for the spine to classify", async () => {
+    const boom = new Error("duplicate key value violates unique constraint");
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() => Promise.reject(boom));
+    await expect(gate()(insert)).rejects.toBe(boom);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/linear-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-oauth-handler.test.ts
@@ -35,6 +35,10 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unkno
   async (sql: string): Promise<unknown[]> => {
     if (sql.includes("INSERT INTO workspace_plugins")) {
       callOrder.push("workspace_plugins.insert");
+      // The install now writes through `persistSingletonInstall`, whose SQL
+      // carries `RETURNING id`; the spine's returned-id invariant reads
+      // `rows[0].id`, so the upsert mock must surface a row (#4352).
+      return [{ id: "linear-install-row" }];
     }
     return [];
   },
@@ -141,6 +145,8 @@ beforeEach(() => {
   mockInternalQuery.mockImplementation(async (sql: string): Promise<unknown[]> => {
     if (sql.includes("INSERT INTO workspace_plugins")) {
       callOrder.push("workspace_plugins.insert");
+      // The spine's `RETURNING id` invariant reads `rows[0].id` (#4352).
+      return [{ id: "linear-install-row" }];
     }
     return [];
   });
@@ -223,6 +229,12 @@ describe("LinearOAuthInstallHandler.handleCallback — happy path", () => {
     expect(result!.workspaceId).toBe(WSID);
     expect(result!.catalogId).toBe("linear");
     expect(result!.credentialResult).toEqual({ written: true });
+    // #4352: the install id now comes from the spine's `RETURNING id`
+    // read-back — NOT the handler's own candidate UUID. The mock returns a
+    // fixed row id that can't equal any freshly-minted candidate, so this
+    // pins that the handler propagates the persisted row id (on reconnect the
+    // existing row keeps its original id; the old candidate would mismatch).
+    expect(result!.installRecord.id).toBe("linear-install-row");
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     const [tokenUrl, tokenInit] = mockFetch.mock.calls[0] as [string, RequestInit];

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install-pg.test.ts
@@ -228,6 +228,78 @@ describeIfPg("form-install spine: workspace_plugins upsert against the live sche
     expect(rows[0]?.config.chat_id).toBe(`${stamp}-rotated`);
   }, PG_TEST_TIMEOUT_MS);
 
+  it("all seven singleton-install handlers plan + execute their exact upsert against the live schema (#4352)", async () => {
+    // Every static-bot + OAuth singleton handler now writes through
+    // `persistSingletonInstall` → `buildFormInstallUpsertSql(true, pillar)`
+    // (issue #4352). Seed each platform's real catalog FK target and run the
+    // exact builder output the handler sends, proving the write path plans +
+    // executes for ALL SEVEN — the drift class the pre-spine hand-rolled
+    // copies carried, invisible behind the mock-based handler tests.
+    const PLATFORMS = [
+      // Six chat-pillar handlers (five static-bot + Slack OAuth).
+      { catalogId: "catalog:telegram", pillar: "chat" as const, type: "chat", model: "static-bot" },
+      { catalogId: "catalog:discord", pillar: "chat" as const, type: "chat", model: "static-bot" },
+      { catalogId: "catalog:teams", pillar: "chat" as const, type: "chat", model: "static-bot" },
+      { catalogId: "catalog:gchat", pillar: "chat" as const, type: "chat", model: "static-bot" },
+      { catalogId: "catalog:whatsapp", pillar: "chat" as const, type: "chat", model: "static-bot" },
+      { catalogId: "catalog:slack", pillar: "chat" as const, type: "chat", model: "static-bot" },
+      // Linear OAuth is action-pillar (Atlas writes to Linear, not chat).
+      { catalogId: "catalog:linear", pillar: "action" as const, type: "integration", model: "form" },
+    ];
+
+    const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
+    // Seed FK targets (catalog-seeder runs at boot, not via migrations, so the
+    // real rows don't exist in this migration-only test schema).
+    for (const p of PLATFORMS) {
+      const slug = p.catalogId.slice("catalog:".length);
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (id) DO NOTHING`,
+        [p.catalogId, slug, `${slug}-${stamp}`, p.type, p.pillar, p.model],
+      );
+    }
+
+    for (const p of PLATFORMS) {
+      const slug = p.catalogId.slice("catalog:".length);
+      const ws = `ws-${slug}-${stamp}`;
+      // `workspace_plugins.id` is globally unique, so each platform needs its
+      // own candidate id.
+      const candA = `cand-a-${slug}-${stamp}`;
+
+      // Fresh INSERT — returns the candidate id, which the handler reads back
+      // as the persisted `InstallRecord.id`.
+      const fresh = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true, p.pillar), [
+        candA,
+        ws,
+        p.catalogId,
+        JSON.stringify({ routing: stamp }),
+        null,
+      ]);
+      expect(fresh.rows[0]?.id).toBe(candA);
+
+      // Re-install (conflict path) — the singleton index collapses it onto the
+      // existing row: same id back, config rotated. The idempotent-reconnect
+      // invariant every singleton handler relies on.
+      const conflict = await pool.query<{ id: string }>(buildFormInstallUpsertSql(true, p.pillar), [
+        `cand-b-${slug}-${stamp}`,
+        ws,
+        p.catalogId,
+        JSON.stringify({ routing: `${stamp}-rot` }),
+        null,
+      ]);
+      expect(conflict.rows[0]?.id).toBe(candA);
+
+      const { rows } = await pool.query<{ pillar: string; config: { routing?: string } }>(
+        `SELECT pillar, config FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2`,
+        [ws, p.catalogId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.pillar).toBe(p.pillar);
+      expect(rows[0]?.config.routing).toBe(`${stamp}-rot`);
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
   it("salesforce legacy-pillar converge heals a pre-0096 datasource row so the upsert dedupes (#3362)", async () => {
     const stamp = `${Date.now()}${Math.floor(Math.random() * 1e6)}`;
     const ws = `ws-sf-converge-${stamp}`;

--- a/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/persist-form-install.test.ts
@@ -107,7 +107,7 @@ function makeLog() {
           : {},
       });
     };
-  return { log: { error: record("error"), warn: record("warn") }, calls };
+  return { log: { error: record("error"), warn: record("warn"), info: record("info") }, calls };
 }
 
 function baseParams(overrides: Partial<Parameters<typeof persistFormInstall>[0]> = {}) {

--- a/packages/api/src/lib/integrations/install/chat-integration-cap-gate.ts
+++ b/packages/api/src/lib/integrations/install/chat-integration-cap-gate.ts
@@ -1,0 +1,88 @@
+/**
+ * `makeChatIntegrationCapGate` — the shared {@link SingletonInstallCapGate}
+ * for every chat-pillar singleton handler (the five static-bot handlers +
+ * the Slack OAuth handler). Issue #4352.
+ *
+ * Each of the six used to carry its own copy of the same cap-decision block:
+ * run {@link checkChatIntegrationLimitAndInstall} (the advisory-locked
+ * check-and-UPSERT, #3001) and map its denied arm to a `429`
+ * ({@link ChatIntegrationLimitError}) or a `503`
+ * ({@link BillingCheckFailedError}). That mapping lives here now, so the six
+ * call sites shrink to one line and the generic install spine
+ * ({@link persistSingletonInstall}) stays free of billing/chat error types.
+ *
+ * A cap denial is RETURNED (via the `{ ok: false }` arm), never thrown, so the
+ * spine can tell it apart from a raw write-path throw (a routing-id `23505`, a
+ * driver fault) — the spine routes those through its
+ * {@link RoutingConflictClassifier} / persist-failure log, while a denial
+ * passes straight through to the route as its `429`/`503`. On success the gate
+ * returns the UPSERT's `RETURNING` rows for the spine's returned-id invariant.
+ *
+ * @see ./persist-form-install.ts — {@link SingletonInstallCapGate}
+ * @see ../../billing/enforcement.ts — {@link checkChatIntegrationLimitAndInstall}
+ */
+
+import type { createLogger } from "@atlas/api/lib/logger";
+import { BillingCheckFailedError, ChatIntegrationLimitError } from "@atlas/api/lib/effect/errors";
+import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
+import type { WorkspaceId } from "@useatlas/types";
+import type { SingletonInstallCapGate } from "./persist-form-install";
+
+/** The gate only logs the block reason — narrow to exactly the levels it uses. */
+type CapGateLogger = Pick<ReturnType<typeof createLogger>, "error" | "info">;
+
+export interface ChatIntegrationCapGateParams {
+  /** Workspace whose chat-integration cap is enforced (the atomic gate's `orgId`). */
+  readonly orgId: WorkspaceId;
+  /** Full `plugin_catalog.id` of the platform being installed ("catalog:telegram"). */
+  readonly catalogId: string;
+  /** Human-readable Platform name composed into the block log lines ("Telegram", "Slack"). */
+  readonly displayName: string;
+  /** The handler's own logger so the cap-block line stays attributable per platform. */
+  readonly log: CapGateLogger;
+}
+
+/**
+ * Build the {@link SingletonInstallCapGate} for one chat platform. The five
+ * static-bot handlers and the Slack OAuth handler pass the result as
+ * `persistSingletonInstall`'s `capGate` hook.
+ */
+export function makeChatIntegrationCapGate(
+  params: ChatIntegrationCapGateParams,
+): SingletonInstallCapGate {
+  const { orgId, catalogId, displayName, log } = params;
+  return async (insert) => {
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+      orgId,
+      catalogId,
+      insert,
+    );
+    if (result.allowed) return { ok: true, rows: result.rows };
+    if (result.reason === "cap_reached") {
+      // The workspace is genuinely at/over its plan cap — 429 "upgrade".
+      log.info(
+        { workspaceId: orgId, limit: result.limit },
+        `${displayName} install blocked — workspace at chat-integration cap`,
+      );
+      return {
+        ok: false,
+        error: new ChatIntegrationLimitError({
+          message: result.errorMessage,
+          workspaceId: orgId,
+          limit: result.limit,
+        }),
+      };
+    }
+    // `check_failed` — and, defensively, any future non-cap denial reason:
+    // the count couldn't be determined, so fail closed as a transient 503
+    // "try again", never a misleading 429 "upgrade your plan".
+    log.error(
+      { workspaceId: orgId },
+      `${displayName} install blocked — chat-integration count check failed (failing closed)`,
+    );
+    return {
+      ok: false,
+      error: new BillingCheckFailedError({ message: result.errorMessage, workspaceId: orgId }),
+    };
+  };
+}

--- a/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
@@ -34,13 +34,10 @@
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
-  BillingCheckFailedError,
-  ChatIntegrationLimitError,
   DiscordApiUnavailableError,
   DiscordGuildIdInvalidError,
   DiscordReachabilityError,
 } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
@@ -48,6 +45,8 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { persistSingletonInstall } from "./persist-form-install";
+import { makeChatIntegrationCapGate } from "./chat-integration-cap-gate";
 import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.discord");
@@ -301,48 +300,31 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
     // *distinct* net-new platforms installing concurrently can't both slip
     // past the cap. Reconnecting Discord (already installed) is never blocked
     // — the gate excludes Discord's own row from the count, and the UPSERT
-    // collapses the duplicate.
-    //
-    // UPSERT keyed on (workspace, catalog): candidate id on INSERT, RETURNING
-    // id so a CONFLICT lands on the existing row's id (idempotent re-install).
-    //
-    // Schema notes:
-    //   - `pillar` + `install_id` became NOT NULL in migration 0092 (#2739)
-    //     and the auto-fill trigger was dropped in 0096 (#2744). Every writer
-    //     must name both columns explicitly.
-    //   - Chat-pillar installs are singletons per (workspace, catalog),
-    //     enforced by the `workspace_plugins_singleton` partial unique index
-    //     (`WHERE pillar IN ('chat','action')` from migration 0092). We target
-    //     it via the inference clause so re-install lands on the existing row.
-    //   - For chat-pillar there's only one install per (workspace, catalog),
-    //     so `install_id` mirrors `id` — WorkspaceInstaller's datasource path
-    //     uses a caller-supplied installId; static-bot chat installs don't
-    //     have that surface, so we reuse the row id.
-    const candidateId = this.newId();
+    // collapses the duplicate. The upsert SQL, the cap-result → error mapping,
+    // the concurrent-routing-conflict re-surface, and the RETURNING invariant
+    // all live in `persistSingletonInstall` (issue #4352) — the one tested
+    // spine every singleton (chat/action) install writes through.
     const configPayload: DiscordInstallConfig = {
       guild_id: routingIdentifier,
       ...extractGuildName(extras, apiGuildName, workspaceId),
     };
 
-    let capCheck;
-    try {
-      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
-        workspaceId,
-        DISCORD_CATALOG_ID,
-        {
-          sql: `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-          params: [candidateId, workspaceId, DISCORD_CATALOG_ID, JSON.stringify(configPayload)],
-        },
-      );
-    } catch (err) {
-      if (isRoutingIdUniqueViolation(err)) {
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: DISCORD_CATALOG_ID,
+      displayName: "Discord",
+      log,
+      config: { ...configPayload },
+      newId: this.newId,
+      pillar: "chat",
+      capGate: makeChatIntegrationCapGate({
+        orgId: workspaceId,
+        catalogId: DISCORD_CATALOG_ID,
+        displayName: "Discord",
+        log,
+      }),
+      routingConflictClassifier: (err) => {
+        if (!isRoutingIdUniqueViolation(err)) return null;
         // Another workspace claimed this guild_id between our pre-check and
         // our UPSERT; the migration-0120 partial unique index rejected us
         // (#3167). Surface the same actionable error the pre-check returns
@@ -351,55 +333,11 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
           { workspaceId },
           "Discord install rejected — guild_id claimed by another workspace concurrently (unique index)",
         );
-        throw new DiscordGuildIdInvalidError({
+        return new DiscordGuildIdInvalidError({
           message: DISCORD_ROUTING_CONFLICT_MESSAGE,
         });
-      }
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Failed to persist Discord install record — aborting install",
-      );
-      throw err;
-    }
-    if (!capCheck.allowed) {
-      if (capCheck.reason === "check_failed") {
-        // Count couldn't be determined — fail closed, but as a transient
-        // 503 "try again", not a misleading 429 "upgrade your plan".
-        log.error(
-          { workspaceId },
-          "Discord install blocked — chat-integration count check failed (failing closed)",
-        );
-        throw new BillingCheckFailedError({
-          message: capCheck.errorMessage,
-          workspaceId,
-        });
-      }
-      log.info(
-        { workspaceId, limit: capCheck.limit },
-        "Discord install blocked — workspace at chat-integration cap",
-      );
-      throw new ChatIntegrationLimitError({
-        message: capCheck.errorMessage,
-        workspaceId,
-        limit: capCheck.limit,
-      });
-    }
-
-    const returned = capCheck.rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
-      // the row on both insert and update. Empty here means a driver /
-      // wrapper regression — fail loudly rather than ship a stale id back (on
-      // re-install the DB row has the existing id; falling back to the fresh
-      // candidateId would strand subsequent lookups).
-      throw new Error(
-        `workspace_plugins UPSERT returned no id for Discord install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-      );
-    }
-    const persistedId: string = returned;
+      },
+    });
 
     log.info(
       {

--- a/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
@@ -62,13 +62,10 @@ import crypto from "crypto";
 import { SignJWT, importPKCS8 } from "jose";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
-  BillingCheckFailedError,
-  ChatIntegrationLimitError,
   GchatApiUnavailableError,
   GchatReachabilityError,
   GchatWorkspaceIdInvalidError,
 } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
@@ -76,6 +73,8 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { persistSingletonInstall } from "./persist-form-install";
+import { makeChatIntegrationCapGate } from "./chat-integration-cap-gate";
 import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.gchat");
@@ -467,35 +466,31 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
     // *distinct* net-new platforms installing concurrently can't both slip
     // past the cap. Reconnecting gchat (already installed) is never blocked
     // — the gate excludes gchat's own row from the count, and the UPSERT
-    // collapses the duplicate. Identical schema + UPSERT shape to the rest
-    // of the static-bot family (see telegram/discord-static-bot-handler.ts
-    // for the full rationale on the NOT NULL columns from 0092/0096 and the
-    // singleton-index conflict target).
-    const candidateId = this.newId();
+    // collapses the duplicate. The upsert SQL, the cap-result → error
+    // mapping, the concurrent-routing-conflict re-surface, and the RETURNING
+    // invariant all live in `persistSingletonInstall` (issue #4352) — the one
+    // tested spine every singleton (chat/action) install writes through.
     const configPayload: GchatInstallConfig = {
       workspace_id: routingIdentifier,
       ...extractWorkspaceDomain(extras, workspaceId),
     };
 
-    let capCheck;
-    try {
-      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
-        workspaceId,
-        GCHAT_CATALOG_ID,
-        {
-          sql: `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-          params: [candidateId, workspaceId, GCHAT_CATALOG_ID, JSON.stringify(configPayload)],
-        },
-      );
-    } catch (err) {
-      if (isRoutingIdUniqueViolation(err)) {
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: GCHAT_CATALOG_ID,
+      displayName: "Google Chat",
+      log,
+      config: { ...configPayload },
+      newId: this.newId,
+      pillar: "chat",
+      capGate: makeChatIntegrationCapGate({
+        orgId: workspaceId,
+        catalogId: GCHAT_CATALOG_ID,
+        displayName: "Google Chat",
+        log,
+      }),
+      routingConflictClassifier: (err) => {
+        if (!isRoutingIdUniqueViolation(err)) return null;
         // Another workspace claimed this customer id between our pre-check and
         // our UPSERT; the migration-0120 partial unique index rejected us
         // (#3167). Surface the same actionable error the pre-check returns
@@ -504,55 +499,11 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
           { workspaceId },
           "Google Chat install rejected — workspace_id claimed by another workspace concurrently (unique index)",
         );
-        throw new GchatWorkspaceIdInvalidError({
+        return new GchatWorkspaceIdInvalidError({
           message: GCHAT_ROUTING_CONFLICT_MESSAGE,
         });
-      }
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Failed to persist Google Chat install record — aborting install",
-      );
-      throw err;
-    }
-    if (!capCheck.allowed) {
-      if (capCheck.reason === "check_failed") {
-        // Count couldn't be determined — fail closed, but as a transient
-        // 503 "try again", not a misleading 429 "upgrade your plan".
-        log.error(
-          { workspaceId },
-          "Google Chat install blocked — chat-integration count check failed (failing closed)",
-        );
-        throw new BillingCheckFailedError({
-          message: capCheck.errorMessage,
-          workspaceId,
-        });
-      }
-      log.info(
-        { workspaceId, limit: capCheck.limit },
-        "Google Chat install blocked — workspace at chat-integration cap",
-      );
-      throw new ChatIntegrationLimitError({
-        message: capCheck.errorMessage,
-        workspaceId,
-        limit: capCheck.limit,
-      });
-    }
-
-    const returned = capCheck.rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
-      // the row on both insert and update. Empty here means a driver /
-      // wrapper regression — fail loudly rather than ship a stale id back (on
-      // re-install the DB row has the existing id; falling back to the fresh
-      // candidateId would strand subsequent lookups).
-      throw new Error(
-        `workspace_plugins UPSERT returned no id for Google Chat install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-      );
-    }
-    const persistedId: string = returned;
+      },
+    });
 
     log.info(
       {

--- a/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
@@ -41,12 +41,11 @@
  * @see docs/adr/0005-integration-credentials-table.md
  */
 
-import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
 import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import type { WorkspaceId } from "@useatlas/types";
+import { persistSingletonInstall } from "./persist-form-install";
 import { mintOAuthStateToken } from "./oauth-state-token";
 import { verifyCallbackState } from "./oauth-callback-verify";
 import { writeCredentialWithReconnectFallback } from "./oauth-reconnect";
@@ -462,7 +461,6 @@ export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // `workspace_plugins_singleton`. Newer pattern than Jira's
     // pre-0092 trigger-derived shape (see discord-static-bot-handler.ts
     // for the same explicit-pillar idiom in newer code).
-    const installId = crypto.randomUUID();
     const installConfig: Record<string, unknown> = {
       scopes,
       status: "ok",
@@ -473,30 +471,27 @@ export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
       ...(viewer.userName ? { user_name: viewer.userName } : {}),
       ...(viewer.userEmail ? { user_email: viewer.userEmail } : {}),
     };
-    try {
-      await internalQuery(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true`,
-        [installId, workspaceId, LINEAR_CATALOG_ID, JSON.stringify(installConfig)],
-      );
-    } catch (err) {
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err.message : String(err),
-        },
+
+    // The workspace_plugins upsert + the RETURNING invariant live in
+    // `persistSingletonInstall` (issue #4352) — the one tested spine every
+    // singleton (chat/action) install writes through. Linear is action-pillar
+    // with no chat cap and no routing identifier, so it takes the bare
+    // internalQuery path (no capGate / routingConflictClassifier). Returns the
+    // PERSISTED id — on a reconnect the existing row keeps its original id, so
+    // the record now carries that id rather than the fresh candidate.
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: LINEAR_CATALOG_ID,
+      displayName: "Linear",
+      log,
+      config: installConfig,
+      pillar: "action",
+      persistFailureMessage:
         "Failed to write workspace_plugins install record — aborting Linear install",
-      );
-      throw err;
-    }
+    });
 
     const installRecord: InstallRecord = {
-      id: installId,
+      id: persistedId,
       workspaceId,
       catalogId: LINEAR_SLUG,
     };

--- a/packages/api/src/lib/integrations/install/persist-form-install.ts
+++ b/packages/api/src/lib/integrations/install/persist-form-install.ts
@@ -248,12 +248,217 @@ export interface PersistInstallRecordParams {
 }
 
 /**
+ * The `workspace_plugins` upsert the spine hands to a {@link SingletonInstallCapGate}
+ * — raw SQL + bound params, structurally the billing gate's `WorkspacePluginInsert`
+ * (kept local so the generic spine doesn't depend on the billing module).
+ */
+export interface SingletonInstallInsert {
+  readonly sql: string;
+  readonly params: readonly unknown[];
+}
+
+/**
+ * The outcome of a {@link SingletonInstallCapGate}: `ok` carries the upsert's
+ * `RETURNING` rows; the denied arm carries the already-built (and already
+ * logged) 429/503 error to throw. A cap denial is RETURNED, never thrown, so
+ * the generic spine can distinguish it from a raw write-path throw — the
+ * denial passes straight through (no persist-failure log), while a throw
+ * (routing-id `23505`, driver fault) is routed through
+ * {@link RoutingConflictClassifier} / the persist-failure log.
+ */
+export type SingletonInstallCapResult =
+  | { readonly ok: true; readonly rows: readonly { id: string }[] }
+  | { readonly ok: false; readonly error: Error };
+
+/**
+ * The atomic chat-integration cap gate, bound to `(workspaceId, catalogId)`
+ * by the caller. When supplied to {@link persistSingletonInstall} the
+ * singleton upsert runs THROUGH the gate — inside its advisory-locked
+ * transaction — instead of a bare {@link internalQuery}, so a net-new chat
+ * platform can't slip past the plan cap under concurrency (#3001).
+ *
+ * The hook OWNS the cap decision: it runs `checkChatIntegrationLimitAndInstall`
+ * and maps a denied result to the platform's 429/503 error (returned via the
+ * `{ ok: false }` arm) — so the generic spine stays free of billing/chat error
+ * types. It returns the upsert's `RETURNING` rows on success. A raw write-path
+ * throw (routing-id `23505`, driver fault) propagates OUT to the spine, which
+ * routes it through {@link RoutingConflictClassifier} / its persist-failure
+ * log. The five static-bot handlers and the Slack OAuth handler supply this;
+ * the action-pillar OAuth handlers + the form spine omit it (no chat cap).
+ */
+export type SingletonInstallCapGate = (
+  insert: SingletonInstallInsert,
+) => Promise<SingletonInstallCapResult>;
+
+/**
+ * Classifies a write-path error as a platform-specific routing-id conflict,
+ * returning the actionable error to throw (or `null` when the error is
+ * something else and should propagate as a 5xx). The five static-bot
+ * handlers pass an adapter over {@link import("./routing-id-conflict").isRoutingIdUniqueViolation}
+ * that also logs the platform's own warn line, so the specific routing-id
+ * noun ("chat_id" / "guild_id" / "tenant_id" / …) stays with the platform.
+ * Returning `null` lets {@link persistSingletonInstall} fall through to its
+ * generic persist-failure log + rethrow.
+ */
+export type RoutingConflictClassifier = (err: unknown) => Error | null;
+
+export interface PersistSingletonInstallParams {
+  readonly workspaceId: WorkspaceId;
+  /** Full `plugin_catalog.id` row key ("catalog:telegram"). */
+  readonly catalogId: string;
+  /**
+   * Human-readable Platform name composed into log lines + the invariant
+   * error ("Telegram", "Slack", "Linear").
+   */
+  readonly displayName: string;
+  /** The caller's own logger so install lines stay attributable per platform. */
+  readonly log: InstallLogger;
+  /**
+   * Config exactly as persisted to `workspace_plugins.config` — already
+   * encrypted where applicable.
+   */
+  readonly config: Record<string, unknown>;
+  /** Candidate row-id generator (handlers inject a fixed one in tests). */
+  readonly newId?: () => string;
+  /** Default `true` — see {@link buildFormInstallUpsertSql}. */
+  readonly updateConfigOnConflict?: boolean;
+  /** Default `'action'` — chat handlers pass `'chat'`. See {@link buildFormInstallUpsertSql}. */
+  readonly pillar?: "chat" | "action";
+  /**
+   * Acting user attributed as `installed_by` (first install only — never
+   * rewritten on conflict). Default `null`: the form/OAuth/static-bot
+   * handlers run below the auth seam and have no user id.
+   */
+  readonly installedBy?: string | null;
+  /**
+   * When present, the upsert runs atomically through the chat-integration
+   * cap gate (which owns the denied → 429/503 mapping and returns the
+   * `RETURNING` rows). When absent, the upsert runs via a bare
+   * {@link internalQuery} — the action-pillar OAuth handlers (Linear) + the
+   * form spine, which have no chat cap. See {@link SingletonInstallCapGate}.
+   *
+   * NOTE: `pillar` and `capGate` are independent — a `chat`-pillar caller that
+   * omits `capGate` deliberately skips the chat-integration cap (there is no
+   * such caller today; all six chat handlers pass it).
+   */
+  readonly capGate?: SingletonInstallCapGate;
+  /** See {@link RoutingConflictClassifier}. */
+  readonly routingConflictClassifier?: RoutingConflictClassifier;
+  /** Override for the persist-failure log line. */
+  readonly persistFailureMessage?: string;
+  /**
+   * Extra structured fields merged into the persist-failure log
+   * (per-Platform breadcrumbs like `teamId` / `instanceUrl`). Never
+   * secrets.
+   */
+  readonly failureLogFields?: Record<string, unknown>;
+}
+
+/**
+ * The single write path for every SINGLETON (chat/action-pillar)
+ * `workspace_plugins` install (issue #4352). Builds the one canonical
+ * upsert via {@link buildFormInstallUpsertSql}, runs it either through the
+ * chat-integration cap gate (`capGate`) or a bare {@link internalQuery},
+ * classifies a concurrent routing-id conflict, and enforces the single
+ * returned-id invariant — the block that used to be hand-copied across the
+ * five static-bot handlers, the Slack + Linear OAuth handlers, and this
+ * spine (each copy a place for the write path to drift, the exact class
+ * that produced #3357 / the pre-spine 42P10). Returns the PERSISTED row id:
+ * on a re-install the upsert's RETURNING yields the EXISTING row's id, not
+ * the fresh candidate, so callers must use this value (not their own UUID)
+ * for {@link InstallRecord.id}.
+ *
+ * Does NOT evict the lazy-loader cache — that stays with
+ * {@link persistInstallRecord} / {@link persistFormInstall}, which layer it
+ * on top. The OAuth + static-bot handlers never evicted, and this
+ * convergence preserves that (their credentials/config are re-read on the
+ * next lazy build, and adding an evict here would be a behavioural change
+ * outside this refactor's scope).
+ */
+export async function persistSingletonInstall(
+  params: PersistSingletonInstallParams,
+): Promise<string> {
+  const {
+    workspaceId,
+    catalogId,
+    displayName,
+    log,
+    config,
+    newId = () => crypto.randomUUID(),
+    updateConfigOnConflict = true,
+    pillar = "action",
+    installedBy = null,
+    capGate,
+    routingConflictClassifier,
+    persistFailureMessage = `Failed to persist ${displayName} install record — aborting install`,
+    failureLogFields = {},
+  } = params;
+
+  const candidateId = newId();
+  const insert: SingletonInstallInsert = {
+    sql: buildFormInstallUpsertSql(updateConfigOnConflict, pillar),
+    params: [candidateId, workspaceId, catalogId, JSON.stringify(config), installedBy],
+  };
+
+  // A raw write-path throw (lock/INSERT/COMMIT/driver error, or a routing-id
+  // `23505` bubbling up from the cap gate) is either the platform's routing-id
+  // conflict — re-surfaced as its actionable error — or a genuine 5xx that we
+  // log with the caller's breadcrumbs and rethrow. A cap denial is NOT a throw:
+  // the `capGate` hook returns it via `{ ok: false }`, so it never reaches here.
+  const raiseWriteError = (err: unknown): never => {
+    const routingConflict = routingConflictClassifier?.(err) ?? null;
+    if (routingConflict) throw routingConflict;
+    // Log the Error object (not `.message`) so Pino's `err` serializer keeps
+    // the type + stack of a genuine driver fault — the frame you actually need
+    // to debug the write. The serializer scrubs secrets from the stack.
+    log.error(
+      { workspaceId, ...failureLogFields, err: err instanceof Error ? err : new Error(String(err)) },
+      persistFailureMessage,
+    );
+    throw err instanceof Error ? err : new Error(String(err));
+  };
+
+  let rows: readonly { id: string }[];
+  if (capGate) {
+    const capResult = await capGate(insert).catch(raiseWriteError);
+    // Cap denial (429/503) — already built + logged by the hook. Throw it as
+    // is, without the persist-failure breadcrumb a genuine write error gets.
+    if (!capResult.ok) throw capResult.error;
+    rows = capResult.rows;
+  } else {
+    rows = await internalQuery<{ id: string }>(insert.sql, insert.params as unknown[]).catch(
+      raiseWriteError,
+    );
+  }
+
+  const returned = rows[0]?.id;
+  if (typeof returned !== "string" || returned.length === 0) {
+    // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed by
+    // Postgres (≥9.5) to emit exactly one row on both the insert and the
+    // update path. Reaching here means a structural anomaly (driver
+    // rewrite, RLS hiding the result, partial-index miss). Falling back to
+    // candidateId would silently return the WRONG id on the DO UPDATE path
+    // (the persisted row keeps its existing id, not the candidate), and
+    // downstream lookups would strand — so fail loud with a 500.
+    log.error(
+      { workspaceId, candidateId },
+      "workspace_plugins upsert returned no id — Postgres invariant violation",
+    );
+    throw new Error(
+      `workspace_plugins upsert returned no id for ${displayName} install (workspaceId=${workspaceId}). ` +
+        `RETURNING must always populate on PG ≥9.5; this indicates a driver/RLS/query-rewrite regression. Aborting install.`,
+    );
+  }
+  return returned;
+}
+
+/**
  * The persistence core shared by the form spine and the OAuth install
- * handlers: `workspace_plugins` upsert → returned-id invariant →
- * unconditional lazy-loader evict. Returns the PERSISTED row id — on a
- * re-install the upsert's RETURNING yields the existing row's id, not
- * the freshly-generated candidate, so callers must use this value (not
- * their own UUID) for {@link InstallRecord.id}.
+ * handlers: {@link persistSingletonInstall} (the `workspace_plugins` upsert
+ * + returned-id invariant) → unconditional lazy-loader evict. Returns the
+ * PERSISTED row id — on a re-install the upsert's RETURNING yields the
+ * existing row's id, not the freshly-generated candidate, so callers must
+ * use this value (not their own UUID) for {@link InstallRecord.id}.
  *
  * Extracted from {@link persistFormInstall} (#3362 review) so the four
  * OAuth handlers (GitHub App, GitHub single-tenant, Salesforce, Jira)
@@ -285,43 +490,19 @@ export async function persistInstallRecord(params: PersistInstallRecordParams): 
     failureLogFields = {},
   } = params;
 
-  const candidateId = newId();
-  let persistedId: string;
-  try {
-    const rows = await internalQuery<{ id: string }>(
-      buildFormInstallUpsertSql(updateConfigOnConflict, pillar),
-      [candidateId, workspaceId, catalogId, JSON.stringify(config), installedBy],
-    );
-    const returned = rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
-      // by Postgres to emit exactly one row on both paths. Reaching
-      // here means a structural anomaly (driver rewrite, RLS hiding
-      // the result, partial-index miss). Falling back to candidateId
-      // would silently return a WRONG id on the DO UPDATE path
-      // (persisted row keeps its existing id, not the candidate),
-      // and downstream lookups would create phantom updates. Fail
-      // loud so the operator sees the invariant break with a 500.
-      log.error(
-        { workspaceId, candidateId },
-        "workspace_plugins upsert returned no id — Postgres invariant violation",
-      );
-      throw new Error(
-        "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-      );
-    }
-    persistedId = returned;
-  } catch (err) {
-    log.error(
-      {
-        workspaceId,
-        ...failureLogFields,
-        err: err instanceof Error ? err.message : String(err),
-      },
-      persistFailureMessage,
-    );
-    throw err;
-  }
+  const persistedId = await persistSingletonInstall({
+    workspaceId,
+    catalogId,
+    displayName,
+    log,
+    config,
+    newId,
+    updateConfigOnConflict,
+    pillar,
+    installedBy,
+    persistFailureMessage,
+    failureLogFields,
+  });
 
   try {
     await lazyPluginLoader.evict(workspaceId, catalogId);

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -34,14 +34,15 @@
  * @see docs/adr/0003-two-store-chat-install-metadata-credentials.md
  */
 
-import crypto from "crypto";
 import { Data } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { slackAPI } from "@atlas/api/lib/slack/api";
 import { saveInstallation } from "@atlas/api/lib/slack/store";
 import { BillingCheckFailedError, ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimit, checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimit } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
+import { persistSingletonInstall } from "./persist-form-install";
+import { makeChatIntegrationCapGate } from "./chat-integration-cap-gate";
 import { mintOAuthStateToken } from "./oauth-state-token";
 import { verifyCallbackState } from "./oauth-callback-verify";
 import type {
@@ -245,26 +246,10 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // advisory lock, so two *distinct* net-new platforms installing
     // concurrently can't both slip past the cap. Reconnecting Slack
     // (already installed) is never blocked — the gate excludes Slack's own
-    // row from the count, and the UPSERT collapses the duplicate.
-    //
-    // Schema notes (mirrors `discord-static-bot-handler.ts`):
-    //   - `pillar` + `install_id` became NOT NULL in migration 0092
-    //     (#2739) and the auto-fill trigger was dropped in 0096 (#2744),
-    //     so every writer must name both columns explicitly — and the
-    //     chat-integration cap (#2953) counts `pillar = 'chat'` rows, so
-    //     omitting `pillar` would make Slack installs invisible to it.
-    //   - Chat-pillar installs are singletons per (workspace, catalog),
-    //     enforced by the `workspace_plugins_singleton` partial unique
-    //     index (`WHERE pillar IN ('chat','action')`). We target it via
-    //     the inference clause so re-install lands on the existing row.
-    //   - One install per (workspace, catalog) for chat, so `install_id`
-    //     mirrors `id`.
-    //   - `RETURNING id` so we hand back the PERSISTED row id, not this
-    //     candidate (#3005): on reconnect the UPSERT lands on the existing
-    //     row, which keeps its original id (ON CONFLICT DO UPDATE never
-    //     touches `id`), so the freshly-minted candidate would not match the
-    //     DB row. The gate surfaces the INSERT's RETURNING rows on success.
-    const installId = crypto.randomUUID();
+    // row from the count, and the UPSERT collapses the duplicate. The
+    // post-0092 schema shape (explicit `pillar` + `install_id`, the
+    // `workspace_plugins_singleton` partial-index conflict target) is owned
+    // by `buildFormInstallUpsertSql`'s docstring, not restated here.
     const installConfig = {
       team_id: teamId,
       team_name: teamName,
@@ -272,70 +257,30 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
       scopes,
       app_id: appId,
     };
-    let capCheck;
-    try {
-      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(workspaceId, SLACK_CATALOG_ID, {
-        sql: `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        params: [installId, workspaceId, SLACK_CATALOG_ID, JSON.stringify(installConfig)],
-      });
-    } catch (err) {
-      log.error(
-        { workspaceId, teamId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to write workspace_plugins install record — aborting install",
-      );
-      // Re-throw — the install record is the first store; without it
-      // the credential write is meaningless. Surfaced to the route as
-      // a 5xx by the runHandler bridge.
-      throw err;
-    }
-    if (!capCheck.allowed) {
-      if (capCheck.reason === "check_failed") {
-        // We couldn't read the workspace's chat-integration count, so the
-        // cap check failed closed. Surface this as a transient 503 "try
-        // again" — NOT a 429 "upgrade your plan", which would be wrong and
-        // non-actionable when the block is an internal-DB blip.
-        log.error(
-          { workspaceId },
-          "Slack install blocked — chat-integration count check failed (failing closed)",
-        );
-        throw new BillingCheckFailedError({
-          message: capCheck.errorMessage,
-          workspaceId,
-        });
-      }
-      log.info(
-        { workspaceId, limit: capCheck.limit },
-        "Slack install blocked — workspace at chat-integration cap",
-      );
-      throw new ChatIntegrationLimitError({
-        message: capCheck.errorMessage,
-        workspaceId,
-        limit: capCheck.limit,
-      });
-    }
-
-    // Read the id back from the UPSERT's RETURNING row rather than reusing the
-    // candidate `installId` (#3005). On reconnect the row already exists and
-    // keeps its ORIGINAL id, so the candidate would be wrong. Mirrors the
-    // non-empty guard in `discord-static-bot-handler.ts`.
-    const returned = capCheck.rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns the
-      // row on both insert and update. Empty here means a driver / wrapper
-      // regression — fail loudly rather than hand back a stale candidate id
-      // (on re-install the DB row has the existing id; falling back to the
-      // fresh candidate would strand subsequent lookups and the credential
-      // write below).
-      throw new Error(
-        `workspace_plugins UPSERT returned no id for Slack install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-      );
-    }
-    const persistedId: string = returned;
+    // The upsert SQL, the cap-result → error mapping, and the RETURNING
+    // invariant (read the persisted id back rather than the candidate — on
+    // reconnect the existing row keeps its ORIGINAL id, #3005) all live in
+    // `persistSingletonInstall` (issue #4352) — the one tested spine every
+    // singleton (chat/action) install writes through. Slack carries no
+    // routing identifier, so no routing-conflict classifier is passed. The
+    // install record is the first store; a write failure surfaces as a 5xx
+    // (via the spine's rethrow) so the credential write below never runs.
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: SLACK_CATALOG_ID,
+      displayName: "Slack",
+      log,
+      config: installConfig,
+      pillar: "chat",
+      capGate: makeChatIntegrationCapGate({
+        orgId: workspaceId,
+        catalogId: SLACK_CATALOG_ID,
+        displayName: "Slack",
+        log,
+      }),
+      persistFailureMessage: "Failed to write workspace_plugins install record — aborting install",
+      failureLogFields: { teamId },
+    });
 
     const installRecord: InstallRecord = {
       id: persistedId,

--- a/packages/api/src/lib/integrations/install/teams-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/teams-static-bot-handler.ts
@@ -51,13 +51,10 @@
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
-  BillingCheckFailedError,
-  ChatIntegrationLimitError,
   TeamsApiUnavailableError,
   TeamsReachabilityError,
   TeamsTenantIdInvalidError,
 } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
@@ -65,6 +62,8 @@ import type {
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { persistSingletonInstall } from "./persist-form-install";
+import { makeChatIntegrationCapGate } from "./chat-integration-cap-gate";
 import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.teams");
@@ -280,52 +279,34 @@ export class TeamsStaticBotInstallHandler implements StaticBotInstallHandler {
     await assertTenantIdUnboundElsewhere(normalizedTenantId, workspaceId);
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
-    // Mirrors the discord-static-bot-handler pattern: candidate id on
-    // INSERT, RETURNING id so a CONFLICT lands on the existing row's
-    // id (idempotent re-install).
-    const candidateId = this.newId();
+    // The upsert SQL, the cap-result → error mapping, the concurrent
+    // routing-conflict re-surface, and the RETURNING invariant all live in
+    // `persistSingletonInstall` (issue #4352) — the one tested spine every
+    // singleton (chat/action) install writes through. The cap gate (#3142)
+    // wraps the UPSERT in a per-workspace advisory-locked transaction so
+    // concurrent net-new installs can't both slip past the chat-integration
+    // cap; reconnect is grandfathered inside the gate.
     const configPayload: TeamsInstallConfig = {
       tenant_id: normalizedTenantId,
       ...extractTenantName(extras, workspaceId),
     };
 
-    let capCheck;
-    try {
-      // Schema notes:
-      //   - `pillar` + `install_id` became NOT NULL in migration 0092
-      //     (#2739) and the auto-fill trigger was dropped in 0096
-      //     (#2744). Every writer must name both columns explicitly.
-      //   - Chat-pillar installs are singletons per (workspace, catalog),
-      //     enforced by the `workspace_plugins_singleton` partial unique
-      //     index (`WHERE pillar IN ('chat','action')` from migration
-      //     0092). We target it via the inference clause
-      //     `ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat','action')`
-      //     so re-install lands on the existing row (idempotent UPSERT).
-      //   - For chat-pillar there's only one install per (workspace,
-      //     catalog), so `install_id` mirrors `id` — WorkspaceInstaller's
-      //     datasource path uses a caller-supplied installId; static-bot
-      //     chat installs don't have that surface, so we reuse the row id.
-      //   - The cap gate (#3142) wraps the UPSERT in a per-workspace
-      //     advisory-locked transaction so concurrent net-new installs
-      //     can't both slip past the chat-integration cap; reconnect is
-      //     grandfathered inside the gate.
-      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
-        workspaceId,
-        TEAMS_CATALOG_ID,
-        {
-          sql: `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-          params: [candidateId, workspaceId, TEAMS_CATALOG_ID, JSON.stringify(configPayload)],
-        },
-      );
-    } catch (err) {
-      if (isRoutingIdUniqueViolation(err)) {
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: TEAMS_CATALOG_ID,
+      displayName: "Teams",
+      log,
+      config: { ...configPayload },
+      newId: this.newId,
+      pillar: "chat",
+      capGate: makeChatIntegrationCapGate({
+        orgId: workspaceId,
+        catalogId: TEAMS_CATALOG_ID,
+        displayName: "Teams",
+        log,
+      }),
+      routingConflictClassifier: (err) => {
+        if (!isRoutingIdUniqueViolation(err)) return null;
         // Another workspace consented this tenant_id between our pre-check and
         // our UPSERT; the migration-0120 partial unique index rejected us
         // (#3167). Surface the same actionable error the pre-check returns
@@ -334,56 +315,11 @@ export class TeamsStaticBotInstallHandler implements StaticBotInstallHandler {
           { workspaceId },
           "Teams install rejected — tenant_id claimed by another workspace concurrently (unique index)",
         );
-        throw new TeamsTenantIdInvalidError({
+        return new TeamsTenantIdInvalidError({
           message: TEAMS_ROUTING_CONFLICT_MESSAGE,
         });
-      }
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Failed to persist Teams install record — aborting install",
-      );
-      throw err;
-    }
-    if (!capCheck.allowed) {
-      if (capCheck.reason === "check_failed") {
-        // Count couldn't be determined — fail closed, but as a transient
-        // 503 "try again", not a misleading 429 "upgrade your plan".
-        log.error(
-          { workspaceId },
-          "Teams install blocked — chat-integration count check failed (failing closed)",
-        );
-        throw new BillingCheckFailedError({
-          message: capCheck.errorMessage,
-          workspaceId,
-        });
-      }
-      log.info(
-        { workspaceId, limit: capCheck.limit },
-        "Teams install blocked — workspace at chat-integration cap",
-      );
-      throw new ChatIntegrationLimitError({
-        message: capCheck.errorMessage,
-        workspaceId,
-        limit: capCheck.limit,
-      });
-    }
-
-    const returned = capCheck.rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
-      // the row on both insert and update. Empty here means a driver /
-      // wrapper regression — fail loudly rather than ship a stale id back (on
-      // re-install the DB row has the existing id; falling back to the fresh
-      // candidateId would strand subsequent lookups). #2807 cemented this
-      // no-fallback posture across the static-bot family.
-      throw new Error(
-        `workspace_plugins UPSERT returned no id for Teams install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-      );
-    }
-    const persistedId: string = returned;
+      },
+    });
 
     log.info(
       {

--- a/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
@@ -44,19 +44,18 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
-  BillingCheckFailedError,
-  ChatIntegrationLimitError,
   TelegramApiUnavailableError,
   TelegramChatIdInvalidError,
   TelegramReachabilityError,
 } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { persistSingletonInstall } from "./persist-form-install";
+import { makeChatIntegrationCapGate } from "./chat-integration-cap-gate";
 import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.telegram");
@@ -243,34 +242,31 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
     // *distinct* net-new platforms installing concurrently can't both slip
     // past the cap. Reconnecting Telegram (already installed) is never blocked
     // — the gate excludes Telegram's own row from the count, and the UPSERT
-    // collapses the duplicate. Identical schema + UPSERT shape to
-    // discord-static-bot-handler.ts (see there for the full rationale on the
-    // NOT NULL columns from 0092/0096 and the singleton-index conflict target).
-    const candidateId = this.newId();
+    // collapses the duplicate. The upsert SQL, the cap-result → error mapping,
+    // the concurrent-routing-conflict re-surface, and the RETURNING invariant
+    // all live in `persistSingletonInstall` (issue #4352) — the one tested
+    // spine every singleton (chat/action) install writes through.
     const configPayload: TelegramInstallConfig = {
       chat_id: routingIdentifier,
       ...extractDisplayName(extras, workspaceId),
     };
 
-    let capCheck;
-    try {
-      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
-        workspaceId,
-        TELEGRAM_CATALOG_ID,
-        {
-          sql: `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-          params: [candidateId, workspaceId, TELEGRAM_CATALOG_ID, JSON.stringify(configPayload)],
-        },
-      );
-    } catch (err) {
-      if (isRoutingIdUniqueViolation(err)) {
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: TELEGRAM_CATALOG_ID,
+      displayName: "Telegram",
+      log,
+      config: { ...configPayload },
+      newId: this.newId,
+      pillar: "chat",
+      capGate: makeChatIntegrationCapGate({
+        orgId: workspaceId,
+        catalogId: TELEGRAM_CATALOG_ID,
+        displayName: "Telegram",
+        log,
+      }),
+      routingConflictClassifier: (err) => {
+        if (!isRoutingIdUniqueViolation(err)) return null;
         // Another workspace claimed this chat_id between our pre-check and
         // our UPSERT; the migration-0120 partial unique index rejected us
         // (#3167). Surface the same actionable error the pre-check returns
@@ -279,55 +275,11 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
           { workspaceId },
           "Telegram install rejected — chat_id claimed by another workspace concurrently (unique index)",
         );
-        throw new TelegramChatIdInvalidError({
+        return new TelegramChatIdInvalidError({
           message: TELEGRAM_ROUTING_CONFLICT_MESSAGE,
         });
-      }
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Failed to persist Telegram install record — aborting install",
-      );
-      throw err;
-    }
-    if (!capCheck.allowed) {
-      if (capCheck.reason === "check_failed") {
-        // Count couldn't be determined — fail closed, but as a transient
-        // 503 "try again", not a misleading 429 "upgrade your plan".
-        log.error(
-          { workspaceId },
-          "Telegram install blocked — chat-integration count check failed (failing closed)",
-        );
-        throw new BillingCheckFailedError({
-          message: capCheck.errorMessage,
-          workspaceId,
-        });
-      }
-      log.info(
-        { workspaceId, limit: capCheck.limit },
-        "Telegram install blocked — workspace at chat-integration cap",
-      );
-      throw new ChatIntegrationLimitError({
-        message: capCheck.errorMessage,
-        workspaceId,
-        limit: capCheck.limit,
-      });
-    }
-
-    const returned = capCheck.rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
-      // the row on both insert and update. Empty here means a driver /
-      // wrapper regression — fail loudly rather than ship a stale id back (on
-      // re-install the DB row has the existing id; falling back to the fresh
-      // candidateId would strand subsequent lookups).
-      throw new Error(
-        `workspace_plugins UPSERT returned no id for Telegram install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-      );
-    }
-    const persistedId: string = returned;
+      },
+    });
 
     log.info(
       {

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -65,19 +65,18 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
-  BillingCheckFailedError,
-  ChatIntegrationLimitError,
   WhatsAppApiUnavailableError,
   WhatsAppPhoneNumberIdInvalidError,
   WhatsAppReachabilityError,
 } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
   InstallRecord,
   StaticBotInstallHandler,
 } from "./types";
+import { persistSingletonInstall } from "./persist-form-install";
+import { makeChatIntegrationCapGate } from "./chat-integration-cap-gate";
 import { isRoutingIdUniqueViolation } from "./routing-id-conflict";
 
 const log = createLogger("integrations.install.whatsapp");
@@ -371,53 +370,34 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
     await assertPhoneNumberUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
-    // Mirrors the email-form-handler / discord-static-bot-handler /
-    // teams-static-bot-handler pattern: candidate id on INSERT,
-    // RETURNING id so a CONFLICT lands on the existing row's id
-    // (idempotent re-install).
-    const candidateId = this.newId();
+    // The upsert SQL, the cap-result → error mapping, the concurrent
+    // routing-conflict re-surface, and the RETURNING invariant all live in
+    // `persistSingletonInstall` (issue #4352) — the one tested spine every
+    // singleton (chat/action) install writes through. The cap gate (#3144)
+    // wraps the UPSERT in a per-workspace advisory-locked transaction so
+    // concurrent net-new installs can't both slip past the chat-integration
+    // cap; reconnect is grandfathered inside the gate.
     const configPayload: WhatsAppInstallConfig = {
       phone_number_id: routingIdentifier,
       ...extractDisplayPhone(extras, apiFallback, workspaceId),
     };
 
-    let capCheck;
-    try {
-      // Schema notes:
-      //   - `pillar` + `install_id` became NOT NULL in migration 0092
-      //     (#2739) and the auto-fill trigger was dropped in 0096
-      //     (#2744). Every writer must name both columns explicitly.
-      //   - Chat-pillar installs are singletons per (workspace, catalog),
-      //     enforced by the `workspace_plugins_singleton` partial unique
-      //     index (`WHERE pillar IN ('chat','action')` from migration
-      //     0092). We target it via the inference clause
-      //     `ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat','action')`
-      //     so re-install lands on the existing row (idempotent UPSERT).
-      //   - For chat-pillar there's only one install per (workspace,
-      //     catalog), so `install_id` mirrors `id` — WorkspaceInstaller's
-      //     datasource path uses a caller-supplied installId; static-bot
-      //     chat installs don't have that surface, so we reuse the row id.
-      //   - The cap gate (#3144) wraps the UPSERT in a per-workspace
-      //     advisory-locked transaction so concurrent net-new installs
-      //     can't both slip past the chat-integration cap; reconnect is
-      //     grandfathered inside the gate.
-      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
-        workspaceId,
-        WHATSAPP_CATALOG_ID,
-        {
-          sql: `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-          params: [candidateId, workspaceId, WHATSAPP_CATALOG_ID, JSON.stringify(configPayload)],
-        },
-      );
-    } catch (err) {
-      if (isRoutingIdUniqueViolation(err)) {
+    const persistedId = await persistSingletonInstall({
+      workspaceId,
+      catalogId: WHATSAPP_CATALOG_ID,
+      displayName: "WhatsApp",
+      log,
+      config: { ...configPayload },
+      newId: this.newId,
+      pillar: "chat",
+      capGate: makeChatIntegrationCapGate({
+        orgId: workspaceId,
+        catalogId: WHATSAPP_CATALOG_ID,
+        displayName: "WhatsApp",
+        log,
+      }),
+      routingConflictClassifier: (err) => {
+        if (!isRoutingIdUniqueViolation(err)) return null;
         // Another workspace claimed this phone_number_id between our pre-check
         // and our UPSERT; the migration-0120 partial unique index rejected us
         // (#3167). Surface the same actionable error the pre-check returns
@@ -426,56 +406,11 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
           { workspaceId },
           "WhatsApp install rejected — phone_number_id claimed by another workspace concurrently (unique index)",
         );
-        throw new WhatsAppPhoneNumberIdInvalidError({
+        return new WhatsAppPhoneNumberIdInvalidError({
           message: WHATSAPP_ROUTING_CONFLICT_MESSAGE,
         });
-      }
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Failed to persist WhatsApp install record — aborting install",
-      );
-      throw err;
-    }
-    if (!capCheck.allowed) {
-      if (capCheck.reason === "check_failed") {
-        // Count couldn't be determined — fail closed, but as a transient
-        // 503 "try again", not a misleading 429 "upgrade your plan".
-        log.error(
-          { workspaceId },
-          "WhatsApp install blocked — chat-integration count check failed (failing closed)",
-        );
-        throw new BillingCheckFailedError({
-          message: capCheck.errorMessage,
-          workspaceId,
-        });
-      }
-      log.info(
-        { workspaceId, limit: capCheck.limit },
-        "WhatsApp install blocked — workspace at chat-integration cap",
-      );
-      throw new ChatIntegrationLimitError({
-        message: capCheck.errorMessage,
-        workspaceId,
-        limit: capCheck.limit,
-      });
-    }
-
-    const returned = capCheck.rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
-      // the row on both insert and update. Empty here means a driver /
-      // wrapper regression — fail loudly rather than ship a stale id back (on
-      // re-install the DB row has the existing id; falling back to the fresh
-      // candidateId would strand subsequent lookups). #2807 cemented this
-      // no-fallback posture across the static-bot family.
-      throw new Error(
-        `workspace_plugins UPSERT returned no id for WhatsApp install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-      );
-    }
-    const persistedId: string = returned;
+      },
+    });
 
     log.info(
       {


### PR DESCRIPTION
## Summary

Closes #4352. Finishes ADR-0007 (unified install pipeline) — migrates the last stragglers onto the existing tested artifact.

The singleton Workspace Install upsert (`INSERT … ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat','action') … RETURNING id`) was hand-rolled in **seven** handlers — the five static-bot chat handlers (Telegram, Discord, Teams, Google Chat, WhatsApp) plus the Slack and Linear OAuth handlers — each carrying a verbatim copy of the "Postgres ≥9.5 guarantees RETURNING" invariant block. That drift class already produced real bugs (`42P10` from a stale conflict target; `#3357`), and the mock-based handler tests can't see plan-time SQL errors by construction.

This extends `persistFormInstall` into **`persistSingletonInstall`** — the single write path every chat/action-pillar `workspace_plugins` install now flows through. It owns `buildFormInstallUpsertSql`, the `capGate`/`internalQuery` execution, the routing-id-conflict classifier hook, and the **one** returned-id invariant.

- **Cap decision extracted** to `makeChatIntegrationCapGate` so the six chat handlers shrink to one line and the generic spine stays free of billing/chat error types. A cap denial is **returned** via `{ ok: false }`, never thrown, so the spine can tell it apart from a raw write-path throw (routing `23505` / driver fault) it must classify — and a legitimate 429/503 never gets a spurious "failed to persist" error log. The denial arm is exhaustive/fail-closed (any non-`cap_reached` reason → 503, never a misleading 429).
- **Linear** now reads the persisted id back from `RETURNING` instead of handing back its fresh candidate UUID — a latent bug the spine's invariant fixes (on reconnect the existing row keeps its original id; the candidate would mismatch). This is the one intentional behavioral change, and it's now pinned at the handler level.
- No other behavioral change to install/upsert semantics per platform. The `workspace_plugins` upsert converges; per-platform credential storage and reachability checks are untouched.

### Key files

- `persist-form-install.ts` — `persistSingletonInstall` + `SingletonInstall*` types; `persistInstallRecord` now delegates to it so the RETURNING invariant is genuinely single-sourced
- `chat-integration-cap-gate.ts` (new) — `makeChatIntegrationCapGate`, the shared cap decision for the six chat handlers
- `{telegram,discord,teams,gchat,whatsapp}-static-bot-handler.ts`, `slack-oauth-handler.ts`, `linear-oauth-handler.ts` — write through the spine

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated
- [x] E2E tests added/updated

- **Real-Postgres** (`persist-form-install-pg.test.ts`): extended to exercise all **seven** platforms' exact upsert against the live schema (fresh insert returns candidate id; conflict/reconnect returns the existing row id; pillar + rotated config asserted per platform) — the plan-time-SQL/FK-drift class the hand-rolled copies carried.
- **New** `chat-integration-cap-gate.test.ts`: pins the shared gate's three arms (allowed → rows, `cap_reached` → 429, `check_failed` → 503) plus the returned-vs-thrown-denial distinction and raw-throw pass-through.
- `linear-oauth-handler.test.ts`: now asserts `installRecord.id` propagates the persisted `RETURNING` id (non-tautological — the fixed mock row can't equal any candidate UUID).
- Reviewed by the internal 4-reviewer panel (error-handling, type-design, test-coverage, comments) — converged CLEAN after one round of fixes.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — full `scripts/ci-local.sh`: all 28 gates green, real-Postgres tests included
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area) — inherited from the issue (refactor, area: api, area: plugins, architecture)
- [ ] CHANGELOG.md updated — internal refactor, not user-facing

https://claude.ai/code/session_01GFDfidNGw32ijoVbTmicCz

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFDfidNGw32ijoVbTmicCz)_