### PR TITLE
perf(www): address PageSpeed audit findings on the landing page

### DIFF
--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -40,8 +40,13 @@ TypeScript, Hono (API), Next.js (frontend), Effect.ts (backend services), Vercel
 
 ## Links
 
-- Website: https://www.useatlas.dev
-- Documentation: https://docs.useatlas.dev
-- GitHub: https://github.com/AtlasDevHQ/atlas
-- Cloud: https://app.useatlas.dev
-- npm packages: @useatlas/sdk, @useatlas/react, @useatlas/types, @useatlas/plugin-sdk
+- [Website](https://www.useatlas.dev): Product overview and landing page
+- [Documentation](https://docs.useatlas.dev): Guides, API reference, and self-hosting instructions
+- [GitHub](https://github.com/AtlasDevHQ/atlas): Source code, open source under AGPL-3.0
+- [Atlas Cloud](https://app.useatlas.dev): Managed hosting with a 14-day free trial
+
+## Optional
+
+- [npm: @useatlas/sdk](https://www.npmjs.com/package/@useatlas/sdk): TypeScript SDK for the Atlas API
+- [npm: @useatlas/react](https://www.npmjs.com/package/@useatlas/react): Embeddable React chat component and headless hooks
+- [npm: @useatlas/plugin-sdk](https://www.npmjs.com/package/@useatlas/plugin-sdk): Plugin type definitions and definePlugin()

--- a/apps/www/serve.test.ts
+++ b/apps/www/serve.test.ts
@@ -163,3 +163,22 @@ describe("apex agent discovery — markdown twins", () => {
     expect(await html.text()).toContain("<!doctype html>");
   });
 });
+
+describe("static asset caching", () => {
+  beforeAll(() => {
+    mkdirSync(join(fixtureDir, "_next", "static", "chunks"), { recursive: true });
+    writeFileSync(join(fixtureDir, "_next", "static", "chunks", "app.js"), "export const x = 1;");
+  });
+
+  it("caches content-hashed /_next/static/ assets immutably for a year", async () => {
+    const res = await req("/_next/static/chunks/app.js");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+  });
+
+  it("does not long-cache the HTML shell, so a new deploy is picked up", async () => {
+    const res = await req("/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control") ?? "").not.toContain("immutable");
+  });
+});

--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -313,6 +313,16 @@ export async function handleRequest(req: Request): Promise<Response> {
         if (pathname === "/" || pathname === "/index.html" || suffix === "/index.html") {
           headers["Link"] = HOMEPAGE_LINK_HEADER;
         }
+        // Everything under /_next/static/ is content-hashed by Next's build
+        // (chunks, CSS, `media/*.woff2`), so the URL changes whenever the bytes
+        // do — safe to cache immutably for a year. Without this the origin sends
+        // no Cache-Control and Cloudflare falls back to a 4h default, which
+        // Lighthouse flagged ("Use efficient cache lifetimes", ~170 KiB
+        // re-fetched on repeat visits). HTML is deliberately left uncached so a
+        // new deploy is picked up immediately.
+        if (pathname.startsWith("/_next/static/")) {
+          headers["Cache-Control"] = "public, max-age=31536000, immutable";
+        }
         return new Response(file, { headers });
       }
     }

--- a/apps/www/src/app/globals.css
+++ b/apps/www/src/app/globals.css
@@ -22,7 +22,11 @@
   --bg-sunken: var(--atlas-paper-sunken);
   --fg: var(--atlas-ink); /* near-black ink, faint forest */
   --fg-muted: var(--atlas-ink-muted);
-  --fg-faint: oklch(0.565 0.02 158);
+  /* L=0.50 keeps this the faintest ink in the ramp while clearing WCAG AA for
+   * normal text on both paper (5.2:1) and raised surfaces (4.7:1). At the prior
+   * 0.565 it was ~3.6–4:1 — below AA — which Lighthouse flagged as a contrast
+   * failure on faint text (footer meta, comparison table). */
+  --fg-faint: oklch(0.5 0.02 158);
   --border: oklch(0.245 0.03 158 / 0.16);
   --border-soft: oklch(0.245 0.03 158 / 0.09);
   --border-strong: oklch(0.245 0.03 158 / 0.3);

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -69,11 +69,11 @@ function AnswerCard() {
           <span className="flex items-center gap-1.5 text-brand">
             <span aria-hidden>✓</span> 7 validators
           </span>
-          <span className="text-zinc-700">·</span>
+          <span aria-hidden className="text-zinc-700">·</span>
           <span>read-only</span>
-          <span className="text-zinc-700">·</span>
+          <span aria-hidden className="text-zinc-700">·</span>
           <span>row-limited</span>
-          <span className="text-zinc-700">·</span>
+          <span aria-hidden className="text-zinc-700">·</span>
           <span>audited</span>
         </div>
       </div>
@@ -137,9 +137,20 @@ export function Hero() {
         }}
       />
 
+      {/*
+        The above-the-fold hero text (h1, subhead, CTAs, trial note) paints
+        immediately — no `animate-fade-in-up`. That keyframe starts at
+        `opacity: 0`, and Chrome's LCP algorithm won't register an element
+        painted transparent as an LCP candidate at its paint time. With the
+        headline (the mobile LCP element) fading in, Lighthouse mobile reported
+        `NO_LCP` and an inflated Speed Index (content still settling ~2.6s after
+        FCP). Entrance polish stays on below-the-fold / non-LCP surfaces
+        (PipelineStrip); the decorative AnswerCard also paints immediately so it
+        can't become a late LCP candidate on narrow viewports.
+      */}
       <div className="relative grid gap-10 md:grid-cols-2 md:items-center md:gap-12">
         <div className="max-w-[520px]">
-          <h1 className="animate-fade-in-up m-0 text-[44px] sm:text-[56px] md:text-[64px] font-semibold leading-[1.02] tracking-[-0.035em] text-fg">
+          <h1 className="m-0 text-[44px] sm:text-[56px] md:text-[64px] font-semibold leading-[1.02] tracking-[-0.035em] text-fg">
             {HEADLINE_LINES.map((line, i) => (
               <span key={line} className="block">
                 {i === ITALIC_LINE_INDEX ? (
@@ -150,8 +161,8 @@ export function Hero() {
               </span>
             ))}
           </h1>
-          <p className="animate-fade-in-up delay-100 mt-6 max-w-[460px] text-base leading-[1.6] text-fg-muted">{SUBHEAD}</p>
-          <div className="animate-fade-in-up delay-200 mt-7 flex flex-wrap gap-2.5">
+          <p className="mt-6 max-w-[460px] text-base leading-[1.6] text-fg-muted">{SUBHEAD}</p>
+          <div className="mt-7 flex flex-wrap gap-2.5">
             <a
               href="https://app.useatlas.dev/signup"
               className="inline-flex items-center gap-2 rounded-lg bg-accent px-[18px] py-[11px] text-[13.5px] font-semibold text-accent-ink transition-colors hover:bg-accent-hover"
@@ -165,13 +176,13 @@ export function Hero() {
               Try the live demo →
             </a>
           </div>
-          <p className="animate-fade-in-up delay-300 mt-3.5 text-[13px] text-fg-muted">
+          <p className="mt-3.5 text-[13px] text-fg-muted">
             14-day trial, no credit card. Or self-host — free and open source:{" "}
             <code className="font-mono text-[12px] text-fg">bun create atlas-agent</code>
           </p>
         </div>
 
-        <div className="animate-fade-in-up delay-200 relative">
+        <div className="relative">
           <AnswerCard />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes from the Jul 4 PageSpeed reports for `useatlas.dev` (mobile 96 / desktop 100). Every fix was verified against the real `apps/www` source and the build/tests.

- **Mobile `NO_LCP` + inflated Speed Index** — the hero's above-the-fold text (h1, subhead, CTAs, trial note) and the AnswerCard animated in from `opacity: 0`. Chrome won't register a transparent-painted element as an LCP candidate, so Lighthouse mobile reported `NO_LCP` and a Speed Index of ~4.3s (content still settling ~2.6s after FCP). These now paint immediately; entrance polish stays on below-the-fold surfaces (PipelineStrip). — `hero.tsx`
- **Cache lifetimes (~170 KiB)** — the origin sent no `Cache-Control` on content-hashed `/_next/static/` assets, so Cloudflare's 4h default applied and Lighthouse flagged re-fetching on repeat visits. Now `public, max-age=31536000, immutable` for those fingerprinted assets; HTML stays uncached so deploys are picked up. — `serve.ts`
- **Accessibility contrast (96)** — darkened `--fg-faint` (L 0.565 → 0.50) to clear WCAG AA on paper (5.2:1) and raised surfaces (4.7:1); it was ~3.6–4:1. Marked the decorative `·` separators `aria-hidden` (matching the existing `→`/`✓` pattern) so the 1.9:1 zinc-700 dots leave the contrast audit. — `globals.css`, `hero.tsx`
- **Agentic Browsing 2/3 → 3/3** — the `llms.txt` "Links" section used bare URLs; the audit needs markdown links. Converted to `[text](url)` links plus an `## Optional` section. — `llms.txt`

**Not shipped — Legacy JavaScript (~14 KiB, unscored):** I tried a modern `browserslist` but an A/B build proved it inert (788 KB with vs 780 KB without — hash noise, not a reduction). Next 16's Turbopack build doesn't drop those polyfills via browserslist; it's a fixed Next polyfill set. Reverted rather than ship a config that doesn't do what its comment claims.

## Test Plan

- [x] Manual testing — `next build` succeeds (static export), `bun run type` clean, `bunx eslint` clean, `syncpack lint` clean
- [x] Unit tests added/updated — new `static asset caching` suite in `serve.test.ts` asserts the immutable `Cache-Control` on `/_next/static/` and that HTML is not long-cached (14/14 pass)
- [ ] E2E tests added/updated — n/a
- [ ] Re-run PageSpeed post-deploy to confirm mobile LCP now resolves

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun test serve.test.ts`)
- [x] Lint passes (`eslint` on changed files)
- [x] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — n/a (marketing-site polish, not a product change)

https://claude.ai/code/session_01Q9kN9WuCXUdwVSqvUugrK4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9kN9WuCXUdwVSqvUugrK4)_