### PR TITLE
refactor(api): collapse executeSQL orchestration into one pure planner

### DIFF
--- a/packages/api/src/lib/group-reach/resolve.ts
+++ b/packages/api/src/lib/group-reach/resolve.ts
@@ -1,0 +1,43 @@
+/**
+ * The **single** reach resolver both the advertised Source-catalog menu and
+ * the enforcing `executeSQL` gate consume (ADR-0022).
+ *
+ * Before this module, two sites recomputed reach independently — the
+ * Source-catalog builder (`source-catalog/lookup.ts`) narrowed the *menu* it
+ * shows the agent, while `executeSQL`'s planner narrowed the *enforceable* set
+ * it will actually run against — each calling `resolveReach(reachState,
+ * loadVisibleGroups(orgId, mode))` on its own. Two copies of the same
+ * derivation can drift, and "advertised ≠ enforceable" is exactly the class of
+ * bug the group-reach feature exists to prevent (the agent must never see a
+ * source on the menu it is then refused at execution, or vice versa).
+ *
+ * Folding both into one call makes "advertised == enforceable" hold by
+ * construction: the same visible-groups lookup feeds the same pure
+ * {@link resolveReach}, so the menu and the gate can only ever agree.
+ *
+ * This is the impure half of the `resolveReach` (pure) ⊕ `loadVisibleGroups`
+ * (impure) split — it exists purely to bind the two together once.
+ *
+ * @see ADR-0022 — cross-group reach + Source catalog
+ * @see issue #4350 — collapse the executeSQL planner; unify the two reach reads
+ */
+
+import { resolveReach, type ReachResult, type ReachState } from "./index";
+import { loadVisibleGroups } from "./lookup";
+import type { AtlasMode } from "@useatlas/types/auth";
+
+/**
+ * Resolve the reachable Connection groups for a workspace + content mode under
+ * the conversation's reach state. `loadVisibleGroups` degrades to `[]` (no
+ * workspace / whitelist load failure) rather than throwing, and
+ * {@link resolveReach} is total, so this never throws — an empty reach set is a
+ * valid, fully-degraded result the caller treats as "nothing reachable".
+ */
+export async function resolveReachableGroups(
+  orgId: string | undefined,
+  mode: AtlasMode | undefined,
+  reachState: ReachState,
+): Promise<ReachResult> {
+  const visibleGroups = await loadVisibleGroups(orgId, mode);
+  return resolveReach(reachState, visibleGroups);
+}

--- a/packages/api/src/lib/source-catalog/lookup.ts
+++ b/packages/api/src/lib/source-catalog/lookup.ts
@@ -27,8 +27,8 @@
 
 import * as yaml from "js-yaml";
 import { createLogger } from "@atlas/api/lib/logger";
-import { loadVisibleGroups } from "@atlas/api/lib/group-reach/lookup";
-import { resolveReach, type ReachState } from "@atlas/api/lib/group-reach";
+import { resolveReachableGroups } from "@atlas/api/lib/group-reach/resolve";
+import { type ReachState } from "@atlas/api/lib/group-reach";
 import {
   getGroupDescriptionMap,
   upsertAutoGroupDescription,
@@ -89,17 +89,21 @@ export async function loadSourceCatalog(
 
   let sqlSources: CatalogSource[] = [];
   try {
-    const [visibleGroups, descriptions, entityNamesByGroup] = await Promise.all([
-      loadVisibleGroups(orgId, mode),
-      getGroupDescriptionMap(orgId),
-      loadEntityNamesByGroup(orgId, mode),
-    ]);
-
     // #3895 — narrow to the reachable groups: under Focus the catalog lists only
     // the focused group (a `focus`-on-invisible reach resolves to none, so the
     // catalog drops the SQL half entirely rather than listing an unreachable
     // group). Under `all` this is every visible group, unchanged.
-    const reachableGroups = resolveReach(reach, visibleGroups).reachableGroups;
+    //
+    // #4350 — the menu and `executeSQL`'s execution gate resolve reach through
+    // the SAME `resolveReachableGroups` (visible-groups lookup ⊕ pure
+    // `resolveReach`), so "advertised == enforceable" holds by construction: a
+    // group the catalog lists is exactly a group the gate will let a query run
+    // against.
+    const [{ reachableGroups }, descriptions, entityNamesByGroup] = await Promise.all([
+      resolveReachableGroups(orgId, mode, reach),
+      getGroupDescriptionMap(orgId),
+      loadEntityNamesByGroup(orgId, mode),
+    ]);
 
     sqlSources = reachableGroups.map((grp) => ({
       kind: "sql",

--- a/packages/api/src/lib/tools/__tests__/sql-execution-plan.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-execution-plan.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Table-driven unit test for the pure `executeSQL` planner (#4350).
+ *
+ * The whole point of extracting `resolveSqlExecutionPlan` is that the
+ * reach ⊕ member ⊕ routing ⊕ per-leg-execution-target cascade — the untested
+ * inline glue every regression on this surface lived in (#3961 / #3947 /
+ * #3109 / #4109 / #3867(b)) — is now a pure value a table can assert over,
+ * WITHOUT a mocked DB. The two impure lookups are injected: `resolveReachableGroups`
+ * runs the REAL pure `resolveReach` against an in-memory visible-groups fixture,
+ * and `loadGroupRoutingContext` returns an in-memory routing context. No
+ * `mock.module`, no fake Postgres — just the planner's real branching over
+ * `(reachState, group, scope, routingMode, members)`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { resolveReach, type VisibleGroup } from "@atlas/api/lib/group-reach";
+import type { GroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
+import {
+  resolveSqlExecutionPlan,
+  type PlanRequestContext,
+  type SqlExecutionPlanArgs,
+  type SqlExecutionPlanDeps,
+} from "@atlas/api/lib/tools/sql-execution-plan";
+
+// --- In-memory deps. `resolveReachableGroups` exercises the real reach
+// resolver against a fixture; `loadGroupRoutingContext` returns a fixed
+// routing context. A group-of-one falls back to [currentMember] like the real
+// (degraded) lookup, so the routing table matches production shapes. ---
+function makeDeps(opts: {
+  visibleGroups?: readonly VisibleGroup[];
+  routing?: (currentMember: string) => GroupRoutingContext;
+  onResolveReach?: () => void;
+  onLoadRouting?: () => void;
+}): SqlExecutionPlanDeps {
+  return {
+    resolveReachableGroups: async (_orgId, _mode, reachState) => {
+      opts.onResolveReach?.();
+      return resolveReach(reachState, opts.visibleGroups ?? []);
+    },
+    loadGroupRoutingContext: async (_orgId, currentMember) => {
+      opts.onLoadRouting?.();
+      return (
+        opts.routing?.(currentMember) ?? {
+          members: [currentMember],
+          primaryMember: currentMember,
+          currentMember,
+          degraded: false,
+        }
+      );
+    },
+  };
+}
+
+const run = (
+  reqCtx: PlanRequestContext | undefined,
+  args: SqlExecutionPlanArgs,
+  deps: SqlExecutionPlanDeps,
+) => resolveSqlExecutionPlan(reqCtx, args, deps);
+
+// A two-group visible fixture reused across the reach table.
+const TWO_GROUPS: readonly VisibleGroup[] = [
+  { id: "postgres", members: ["postgres"], primary: "postgres" },
+  { id: "clickhouse", members: ["clickhouse"], primary: "clickhouse" },
+];
+
+describe("resolveSqlExecutionPlan — reach gate", () => {
+  it("All-sources + no named group: skips reach lookup entirely (no per-query DB cost)", async () => {
+    let reachCalls = 0;
+    const deps = makeDeps({ visibleGroups: TWO_GROUPS, onResolveReach: () => reachCalls++ });
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "own-conn" },
+      {},
+      deps,
+    );
+    expect(reachCalls).toBe(0);
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") expect(plan.executionTarget.connectionId).toBe("own-conn");
+  });
+
+  it("runs a query against the agent-named reachable group's primary member", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" } },
+      { group: "clickhouse" },
+      makeDeps({ visibleGroups: TWO_GROUPS }),
+    );
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") expect(plan.executionTarget.connectionId).toBe("clickhouse");
+  });
+
+  // #3867(b) — the no-substitution invariant. An out-of-reach target is a hard
+  // reject, NEVER silently re-routed to a reachable source.
+  describe("#3867(b) — out-of-reach rejects, never re-routes", () => {
+    it("rejects an agent-named group outside reach and names the reachable set", async () => {
+      const { plan, logs } = await run(
+        { user: { activeOrganizationId: "org-1" } },
+        { group: "secret-db" },
+        makeDeps({ visibleGroups: TWO_GROUPS }),
+      );
+      expect(plan.kind).toBe("reject");
+      if (plan.kind === "reject") {
+        expect(plan.error).toContain("not within this conversation's reach");
+        expect(plan.error).toContain("postgres");
+        expect(plan.error).toContain("clickhouse");
+      }
+      // The rejection is surfaced for observability, not swallowed.
+      expect(logs.some((l) => l.message.includes("rejected an out-of-reach group target"))).toBe(true);
+    });
+
+    it("rejects a query to a different VISIBLE group when Focused (only the focused group is reachable)", async () => {
+      const { plan } = await run(
+        { user: { activeOrganizationId: "org-1" }, groupReach: "postgres" },
+        { group: "clickhouse" },
+        makeDeps({ visibleGroups: TWO_GROUPS }),
+      );
+      expect(plan.kind).toBe("reject");
+      if (plan.kind === "reject") expect(plan.error).toContain("not within this conversation's reach");
+    });
+
+    it("rejects an omitted-group query when Focused on a now-invisible group — the 'focused on group' shape", async () => {
+      const { plan, logs } = await run(
+        { user: { activeOrganizationId: "org-1" }, connectionId: "postgres", groupReach: "gone" },
+        {},
+        makeDeps({ visibleGroups: TWO_GROUPS }),
+      );
+      expect(plan.kind).toBe("reject");
+      if (plan.kind === "reject") {
+        expect(plan.error).toContain('focused on group "gone"');
+        expect(plan.error).toContain("I will not query a");
+      }
+      // The focus-on-invisible reach warning is surfaced (not swallowed): it
+      // explains WHY reach is empty rather than substituting another source.
+      expect(logs.some((l) => l.message.includes('focus group "gone" is not visible'))).toBe(true);
+    });
+
+    it("rejects any group when the workspace has no reachable groups (degenerate — never falls through to default)", async () => {
+      const { plan } = await run(
+        { user: {} },
+        { group: "postgres" },
+        makeDeps({ visibleGroups: [] }),
+      );
+      expect(plan.kind).toBe("reject");
+      if (plan.kind === "reject") expect(plan.error).toContain("none");
+    });
+  });
+
+  it("binds an omitted-group query to the focused group's member (no `group` arg needed under Focus)", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "postgres", groupReach: "clickhouse" },
+      {},
+      makeDeps({ visibleGroups: TWO_GROUPS }),
+    );
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") expect(plan.executionTarget.connectionId).toBe("clickhouse");
+  });
+
+  describe("multi-member group — member pinning via connectionId", () => {
+    const MULTI: readonly VisibleGroup[] = [
+      { id: "postgres", members: ["pg-eu", "pg-us"], primary: "pg-eu" },
+      { id: "clickhouse", members: ["clickhouse"], primary: "clickhouse" },
+    ];
+
+    it("targets the group's primary when only `group` is given", async () => {
+      const { plan } = await run(
+        { user: { activeOrganizationId: "org-1" } },
+        { group: "postgres" },
+        makeDeps({ visibleGroups: MULTI }),
+      );
+      if (plan.kind === "single") expect(plan.executionTarget.connectionId).toBe("pg-eu");
+      else throw new Error("expected single");
+    });
+
+    it("honors a `connectionId` that is a member of the targeted group", async () => {
+      const { plan } = await run(
+        { user: { activeOrganizationId: "org-1" } },
+        { group: "postgres", connectionId: "pg-us" },
+        makeDeps({ visibleGroups: MULTI }),
+      );
+      if (plan.kind === "single") expect(plan.executionTarget.connectionId).toBe("pg-us");
+      else throw new Error("expected single");
+    });
+
+    it("IGNORES a foreign `connectionId` (member of another group) — falls back to primary, no cross-group escape", async () => {
+      const { plan } = await run(
+        { user: { activeOrganizationId: "org-1" } },
+        { group: "postgres", connectionId: "clickhouse" },
+        makeDeps({ visibleGroups: MULTI }),
+      );
+      if (plan.kind === "single") {
+        expect(plan.executionTarget.connectionId).toBe("pg-eu");
+        expect(plan.executionTarget.connectionId).not.toBe("clickhouse");
+      } else throw new Error("expected single");
+    });
+
+    it("rejects a `group` that names a MEMBER id, not the canonical group", async () => {
+      const { plan } = await run(
+        { user: { activeOrganizationId: "org-1" } },
+        { group: "pg-us" },
+        makeDeps({ visibleGroups: MULTI }),
+      );
+      expect(plan.kind).toBe("reject");
+    });
+  });
+
+  describe("member-selection cascade tail", () => {
+    it("uses the raw `connectionId` arg as the member when no group and no stamped context", async () => {
+      // All-sources, no named group → no reach lookup; the agent's own
+      // `connectionId` arg is the member (second rung of the cascade).
+      const { plan } = await run({ user: { activeOrganizationId: "org-1" } }, { connectionId: "arg-conn" }, makeDeps({}));
+      expect(plan.kind).toBe("single");
+      if (plan.kind === "single") expect(plan.executionTarget.connectionId).toBe("arg-conn");
+    });
+
+    it("falls through to the 'default' sentinel with no reqCtx and no ids (MCP / scheduler shape)", async () => {
+      // No request context, no group, no connectionId → the whitelist-bucket
+      // sentinel `"default"`, byte-identical to the whitelist accessors' own
+      // param default. unpinned=false (no context ⇒ not the own connection).
+      const { plan } = await run(undefined, {}, makeDeps({}));
+      expect(plan.kind).toBe("single");
+      if (plan.kind === "single") {
+        expect(plan.executionTarget.connectionId).toBe("default");
+        expect(plan.executionTarget.unpinned).toBe(false);
+      }
+    });
+  });
+
+  // The acceptance criterion asks for the reach ⊕ routing ⊕ whitelist-bucket
+  // INTERACTION, not just each axis alone. This is the composition seam: reach
+  // selects the group's member, that member feeds the routing lookup, and the
+  // group fans out — the exact chain a composition-order regression would hit.
+  describe("reach ⊕ routing interaction — named group + scope:'all' fans out the group's members", () => {
+    it("a reach-selected multi-member group fans out, each leg its own (unpinned=false) target", async () => {
+      const { plan } = await run(
+        { user: { activeOrganizationId: "org-1" }, connectionId: "own-conn" },
+        { group: "prod", scope: "all" },
+        makeDeps({
+          visibleGroups: [{ id: "prod", members: ["prod-eu", "prod-us"], primary: "prod-eu" }],
+          // Routing is anchored on the reach-selected member (the group's
+          // primary), and returns the group's full roster to fan out over.
+          routing: () => ({
+            members: ["prod-eu", "prod-us"],
+            primaryMember: "prod-eu",
+            currentMember: "prod-eu",
+            degraded: false,
+          }),
+        }),
+      );
+      expect(plan.kind).toBe("fanout");
+      if (plan.kind === "fanout") {
+        expect(plan.legs.map((l) => l.connectionId)).toEqual(["prod-eu", "prod-us"]);
+        expect(plan.fanoutReason).toBe("agent-all");
+        // Neither leg IS the conversation's own connection ("own-conn"), so no
+        // leg widens its whitelist bucket — the whole fanout is pinned.
+        expect(plan.legs.every((l) => l.unpinned === false)).toBe(true);
+      }
+    });
+  });
+});
+
+describe("resolveSqlExecutionPlan — #3961 whitelist-bucket (unpinned) derivation", () => {
+  // The union-widening `unpinned` flag on the execution target must be TRUE
+  // only for the conversation's OWN connection under All-sources reach, and
+  // FALSE for every pinned member / sibling / named-group leg. This is the
+  // exact flag that drifted in #3961 / #3947 / #3109 when derived twice.
+  it("unpinned=true for the conversation's own connection under All-sources (the #3961 fix)", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "own-conn" },
+      {},
+      makeDeps({}),
+    );
+    if (plan.kind === "single") {
+      expect(plan.executionTarget.connectionId).toBe("own-conn");
+      expect(plan.executionTarget.unpinned).toBe(true);
+    } else throw new Error("expected single");
+  });
+
+  it("unpinned=false when a group is named (the leg is not the conversation's own connection)", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "own-conn" },
+      { group: "clickhouse" },
+      makeDeps({ visibleGroups: TWO_GROUPS }),
+    );
+    if (plan.kind === "single") {
+      expect(plan.executionTarget.connectionId).toBe("clickhouse");
+      expect(plan.executionTarget.unpinned).toBe(false);
+    } else throw new Error("expected single");
+  });
+
+  it("unpinned=false under Focus even for a single reachable group (reach is not 'all')", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "postgres", groupReach: "postgres" },
+      {},
+      makeDeps({ visibleGroups: TWO_GROUPS }),
+    );
+    if (plan.kind === "single") expect(plan.executionTarget.unpinned).toBe(false);
+    else throw new Error("expected single");
+  });
+});
+
+describe("resolveSqlExecutionPlan — routing / fanout (scope ⊗ routingMode ⊗ members)", () => {
+  const twoMemberRouting = (currentMember: string): GroupRoutingContext => ({
+    members: ["m-a", "m-b"],
+    primaryMember: "m-a",
+    currentMember,
+    degraded: false,
+  });
+
+  it("fast path: scope unset + routingMode auto → single, no routing lookup, no routing reason", async () => {
+    let routingCalls = 0;
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-a" },
+      {},
+      makeDeps({ routing: twoMemberRouting, onLoadRouting: () => routingCalls++ }),
+    );
+    expect(routingCalls).toBe(0);
+    expect(plan.kind).toBe("single");
+    // The fast path runs no routing lookup, so it carries no routing reason —
+    // a documented invariant of that branch.
+    if (plan.kind === "single") expect(plan.routingReason).toBeUndefined();
+  });
+
+  it("scope 'all' fans out across every member, each leg with its own execution target", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-a" },
+      { scope: "all" },
+      makeDeps({ routing: twoMemberRouting }),
+    );
+    expect(plan.kind).toBe("fanout");
+    if (plan.kind === "fanout") {
+      expect(plan.legs.map((l) => l.connectionId)).toEqual(["m-a", "m-b"]);
+      expect(plan.fanoutReason).toBe("agent-all");
+      // Under All-sources reach, only the leg that IS the conversation's own
+      // connection (m-a) widens; the sibling (m-b) stays pinned. Per-leg, never
+      // a single broadcast target (#3961).
+      const byId = new Map(plan.legs.map((l) => [l.connectionId, l.unpinned]));
+      expect(byId.get("m-a")).toBe(true);
+      expect(byId.get("m-b")).toBe(false);
+    }
+  });
+
+  it("picker routingMode 'all' overrides the agent's scope and fans out", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-a", routingMode: "all" },
+      { scope: "this" },
+      makeDeps({ routing: twoMemberRouting }),
+    );
+    expect(plan.kind).toBe("fanout");
+    if (plan.kind === "fanout") expect(plan.fanoutReason).toBe("picker-all");
+  });
+
+  it("picker routingMode 'pin' stays single against the current member, ignoring scope", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-b", routingMode: "pin" },
+      { scope: "all" },
+      makeDeps({ routing: twoMemberRouting }),
+    );
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") {
+      expect(plan.executionTarget.connectionId).toBe("m-b");
+      expect(plan.routingReason).toBe("picker-pin");
+    }
+  });
+
+  it("scope names a specific member → single against that member", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-a" },
+      { scope: "m-b" },
+      makeDeps({ routing: twoMemberRouting }),
+    );
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") {
+      expect(plan.executionTarget.connectionId).toBe("m-b");
+      expect(plan.routingReason).toBe("agent-member");
+    }
+  });
+
+  it("scope names an unknown member → single against the primary, with a surfaced warning", async () => {
+    const { plan, logs } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-a" },
+      { scope: "ghost" },
+      makeDeps({ routing: twoMemberRouting }),
+    );
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") {
+      expect(plan.executionTarget.connectionId).toBe("m-a");
+      expect(plan.routingReason).toBe("fallback-current");
+    }
+    expect(logs.some((l) => l.message.includes('scope "ghost"'))).toBe(true);
+  });
+
+  // #4109 — a degraded routing lookup collapses to a 1×1 fallback ([currentMember]).
+  // A fanout request must then safely degrade to single, never fan out against
+  // phantom members the lookup couldn't confirm.
+  it("#4109: scope 'all' with a degraded 1×1 routing context collapses to single, no phantom fanout", async () => {
+    const { plan } = await run(
+      { user: { activeOrganizationId: "org-1" }, connectionId: "m-a" },
+      { scope: "all" },
+      makeDeps({
+        routing: (currentMember) => ({
+          members: [currentMember],
+          primaryMember: currentMember,
+          currentMember,
+          degraded: true,
+        }),
+      }),
+    );
+    expect(plan.kind).toBe("single");
+    if (plan.kind === "single") {
+      expect(plan.executionTarget.connectionId).toBe("m-a");
+      expect(plan.routingReason).toBe("1x1-group");
+    }
+  });
+});

--- a/packages/api/src/lib/tools/sql-execution-plan.ts
+++ b/packages/api/src/lib/tools/sql-execution-plan.ts
@@ -1,0 +1,334 @@
+/**
+ * The pure `executeSQL` execution **planner** (#4350).
+ *
+ * `executeSQL` composes four individually-deep, well-tested pure resolvers —
+ * reach ({@link resolveReach}), intra-group routing ({@link resolveRoutingPlan}),
+ * per-leg execution-target derivation ({@link resolveExecutionTarget}), and
+ * member-result merge (`mergeMemberResults`) — but the ~150-line chain that
+ * WIRES them used to live inline in the tool's `execute` closure, re-reading the
+ * request context twice (the closure itself and again inside the fanout).
+ *
+ * That untested wiring is where the bugs lived. #3961 — a fanout leg
+ * broadcasting one member's whitelist bucket onto its siblings — is a
+ * composition-order bug this module fixes directly, by resolving each leg's
+ * execution target from ITS OWN id. #3867(b) — no silent re-route of an
+ * out-of-reach target — becomes a first-class `reject` value here. The related
+ * whitelist-bucket drift of #3947 / #3109 was SSOT'd away in
+ * {@link resolveExecutionTarget} itself; the planner's job is to feed it the
+ * correct post-reach/post-routing id (never the raw arg), not to re-derive the
+ * bucket. (The degraded-routing *certainty* fix of #4109 lives in the routing
+ * lookup + `metric-run`, NOT here — the planner never reads `degraded`; it only
+ * inherits the safe collapse a 1×1/degraded routing context already implies: a
+ * fanout request turns into a single leg, never a fan-out across phantom
+ * members the lookup could not confirm.)
+ *
+ * This module folds the wiring into one place. Given the request context and
+ * the tool args, it resolves the whole cascade —
+ *
+ *   reach gate → group-target member → current member → routing-mode
+ *   fast-path → routing plan → per-leg execution target
+ *
+ * — and returns a discriminated {@link SqlExecutionPlan}: a hard `reject`
+ * (out-of-reach, never a silent re-route), a `single` leg, or a `fanout` across
+ * pre-resolved per-leg {@link ExecutionTarget}s. The tool's `execute` then only
+ * runs the leg(s) and merges — no orchestration decisions of its own.
+ *
+ * **Read-once.** The caller reads `getRequestContext()` a single time and hands
+ * it in; the planner derives `orgId`, reach, member, and every per-leg
+ * execution target from that one snapshot (closing the "reqCtx read twice"
+ * leak — execute closure + fanout re-read — and, via
+ * {@link resolveReachableGroups}, the "reach resolved twice" leak between the
+ * advertised menu and this enforcing gate).
+ *
+ * **Testable without a DB.** The two impure lookups (visible groups for reach,
+ * group members for routing) are injected as {@link SqlExecutionPlanDeps}, so a
+ * table-driven test drives the full `(reachState, group, scope, routingMode,
+ * members)` interaction with plain in-memory stand-ins — no `mock.module`, no
+ * fake Postgres. The prior shipped regressions are expressible against this
+ * planner directly.
+ *
+ * @see ADR-0022 — cross-group reach + cross-source composition
+ * @see ADR-0010 — environment scoping / execution target
+ * @see packages/api/src/lib/group-reach/execution-target.ts — the SSOT this extends
+ */
+
+import {
+  isReachable,
+  reachStateFromColumn,
+  type ReachResult,
+  type ReachState,
+} from "@atlas/api/lib/group-reach";
+import { resolveReachableGroups } from "@atlas/api/lib/group-reach/resolve";
+import {
+  resolveExecutionTarget,
+  type ExecutionTarget,
+} from "@atlas/api/lib/group-reach/execution-target";
+import {
+  resolveRoutingPlan,
+  type RoutingMode,
+  type RoutingReason,
+} from "@atlas/api/lib/env-routing";
+import {
+  loadGroupRoutingContext,
+  type GroupRoutingContext,
+} from "@atlas/api/lib/env-routing/lookup";
+import type { AtlasMode } from "@useatlas/types/auth";
+
+/**
+ * The subset of `RequestContext` the planner reads. A structural subset (not
+ * the full type) so callers — and tests — hand in exactly what the cascade
+ * needs. Compatible with `resolveExecutionTarget`'s `{ groupReach, connectionId }`
+ * argument, which the planner threads verbatim.
+ */
+export interface PlanRequestContext {
+  /** Persisted `conversations.group_reach` → {@link ReachState}. `null`/undefined = All sources. */
+  readonly groupReach?: string | null;
+  /** Per-turn execution target stamped by the chat route. The "conversation's own connection". */
+  readonly connectionId?: string;
+  /** Resolved content mode; scopes the visible-groups whitelist lookup. */
+  readonly atlasMode?: AtlasMode;
+  /** Three-state Auto/Pin/All picker. Undefined (non-chat callers) → `"auto"`. */
+  readonly routingMode?: RoutingMode;
+  /** Active workspace; scopes both impure lookups. */
+  readonly user?: { readonly activeOrganizationId?: string };
+}
+
+/** The `executeSQL` tool args the planner routes on. */
+export interface SqlExecutionPlanArgs {
+  /** Agent-named target Connection group (cross-group reach). Omitted → conversation's current group. */
+  readonly group?: string;
+  /** Agent-named specific member within the targeted group. */
+  readonly connectionId?: string;
+  /** Cross-environment routing override ("this" / "all" / a member id). */
+  readonly scope?: string;
+}
+
+/**
+ * A single structured log the caller emits (`log.warn(fields, message)`).
+ * The planner never logs itself — it returns the operational signals (reach
+ * warnings, the out-of-reach rejection, routing fallbacks) so the pure
+ * cascade stays free of an injected logger, and the caller keeps one log seam.
+ */
+export interface PlanLog {
+  readonly message: string;
+  readonly fields: Record<string, unknown>;
+}
+
+/**
+ * The discriminated execution plan. `execute` switches on `kind`:
+ *   - `reject` → return `{ success: false, error }` (no query runs).
+ *   - `single` → run one leg against `executionTarget`.
+ *   - `fanout` → run every `leg` and merge; each leg carries its OWN
+ *     execution target (never a single broadcast target across legs — that
+ *     would leak one leg's whitelist bucket onto the others, #3961).
+ */
+export type SqlExecutionPlan =
+  | { readonly kind: "reject"; readonly error: string }
+  | {
+      readonly kind: "single";
+      /**
+       * Whitelist-bucket + execution target for this leg (fed to `validateSQL`
+       * + execution). Its `connectionId` IS the resolved member to run against
+       * (post-reach, post-routing) — the single source for the leg's id, so a
+       * separate `connId` field (which could drift from it) is deliberately not
+       * carried; the fanout variant likewise derives ids from its `legs`.
+       */
+      readonly executionTarget: ExecutionTarget;
+      /** Picker mode threaded to the pipeline for observability. */
+      readonly routingMode: RoutingMode;
+      /** Why routing picked this leg. Undefined on the fast path (no routing lookup ran). */
+      readonly routingReason?: RoutingReason;
+    }
+  | {
+      readonly kind: "fanout";
+      /** Per-leg execution targets (order = fanout output order). Each resolved from ITS own id. */
+      readonly legs: readonly ExecutionTarget[];
+      /** Why the fanout was chosen (`agent-all` / `picker-all`). */
+      readonly fanoutReason: RoutingReason;
+    };
+
+export interface SqlExecutionPlanResult {
+  readonly plan: SqlExecutionPlan;
+  /** Structured logs for the caller to emit. Empty on a clean resolution. */
+  readonly logs: readonly PlanLog[];
+}
+
+/**
+ * Injected impure lookups. Defaults wire the real DB-backed resolvers; tests
+ * pass in-memory stand-ins so the whole `(reachState, group, scope,
+ * routingMode, members)` table runs without a mocked DB.
+ */
+export interface SqlExecutionPlanDeps {
+  readonly resolveReachableGroups: (
+    orgId: string | undefined,
+    mode: AtlasMode | undefined,
+    reachState: ReachState,
+  ) => Promise<ReachResult>;
+  readonly loadGroupRoutingContext: (
+    orgId: string | undefined,
+    currentMember: string,
+  ) => Promise<GroupRoutingContext>;
+}
+
+const defaultDeps: SqlExecutionPlanDeps = {
+  resolveReachableGroups,
+  loadGroupRoutingContext,
+};
+
+/**
+ * Resolve the full `executeSQL` execution plan from one request-context
+ * snapshot and the tool args. Never throws — the injected lookups degrade
+ * rather than fault, and every branch returns a plan (`reject` included).
+ *
+ * The cascade, in order:
+ *   1. **Reach gate** — when the agent names a `group` OR the conversation is
+ *      Focused, resolve the reachable groups (shared with the catalog menu)
+ *      and reject any out-of-reach target. Under All-sources with no named
+ *      group we skip the lookup entirely (no per-query DB cost on the common
+ *      default path).
+ *   2. **Member selection** — the group's pinned/primary member, else the raw
+ *      `connectionId`, else the conversation's own connection, else `"default"`.
+ *   3. **Fast path** — when no scope override and the picker isn't fanning out,
+ *      a single leg against the current member (no routing lookup).
+ *   4. **Routing** — otherwise load the group's members and run
+ *      {@link resolveRoutingPlan}; a `single` plan → one leg, a `fanout` plan →
+ *      per-leg targets resolved from each member id.
+ */
+export async function resolveSqlExecutionPlan(
+  reqCtx: PlanRequestContext | undefined,
+  args: SqlExecutionPlanArgs,
+  deps: SqlExecutionPlanDeps = defaultDeps,
+): Promise<SqlExecutionPlanResult> {
+  const { group, connectionId, scope } = args;
+  const logs: PlanLog[] = [];
+  const orgId = reqCtx?.user?.activeOrganizationId;
+
+  // --- 1. Reach gate (ADR-0022). Only resolved when the agent names a `group`
+  // or the conversation is Focused; under `all` with no named group every
+  // group is reachable, so we skip the lookup and the legacy single-connection
+  // path stands (no per-query DB cost on the common default case). ---
+  const reachState = reachStateFromColumn(reqCtx?.groupReach);
+  let groupTargetMember: string | undefined;
+  if (group !== undefined || reachState.kind === "focus") {
+    const reach = await deps.resolveReachableGroups(orgId, reqCtx?.atlasMode, reachState);
+    // A `focus`-on-invisible resolution explains (via a warning) why reach is
+    // empty rather than substituting another source; surface it so the
+    // divergence is observable. Under `all` warnings is always [].
+    for (const w of reach.warnings) {
+      logs.push({ message: w, fields: { group, groupReach: reqCtx?.groupReach, orgId } });
+    }
+    // The group this query targets: the agent's explicit `group`, else — under
+    // Focus — the single focused group. (Under `all` with no explicit group we
+    // don't enter this branch.)
+    const targetGroupId =
+      group ?? (reachState.kind === "focus" ? reach.reachableGroups[0]?.id : undefined);
+    if (targetGroupId === undefined || !isReachable(reach, targetGroupId)) {
+      const reachable = reach.reachableGroups.map((g) => g.id);
+      logs.push({
+        message: "executeSQL rejected an out-of-reach group target — not re-routing",
+        fields: { group, groupReach: reqCtx?.groupReach, orgId, reachable },
+      });
+      // Two shapes: the agent named an out-of-reach group, OR the conversation
+      // is Focused on a group that isn't currently reachable (content-mode hid
+      // it, or it was removed). Either way we refuse to substitute another
+      // source — the no-substitution invariant the whole feature rests on.
+      const error =
+        group === undefined && reachState.kind === "focus"
+          ? `This conversation is focused on group "${reachState.groupId}", which is not ` +
+            `currently reachable (visible groups: ${reachable.join(", ") || "none"}). ` +
+            `The focused source may be unpublished or removed — I will not query a ` +
+            `different source instead. Widen the conversation's scope to All sources to query elsewhere.`
+          : `Connection group "${group}" is not within this conversation's reach ` +
+            `(reachable groups: ${reachable.join(", ") || "none"}). ` +
+            `I will not query a different source instead — re-run against a reachable ` +
+            `group, or omit \`group\` to use the conversation's current source.`;
+      return { plan: { kind: "reject", error }, logs };
+    }
+    // Resolve the group to a connection to execute against: the group's
+    // primary member (a group-of-one resolves to its own connection id).
+    // `connectionId`, if also supplied, may pin a specific member of THIS
+    // group; otherwise the group's primary is used. The per-group whitelist
+    // resolves via this connection id (members register their group's tables).
+    const target = reach.reachableGroups.find((g) => g.id === targetGroupId);
+    groupTargetMember =
+      connectionId && target?.members.includes(connectionId)
+        ? connectionId
+        : target?.primary;
+  }
+
+  // --- 2. Member selection. Post-reach member → agent's raw connectionId →
+  // conversation's own connection → the "default" sentinel. ---
+  const currentMember =
+    groupTargetMember ?? connectionId ?? reqCtx?.connectionId ?? "default";
+
+  // #2518 — three-state picker. Undefined here means the caller never went
+  // through the chat route (tools / MCP / scheduler / unit tests), where the
+  // legacy "agent decides" (`auto`) semantics are the right answer.
+  const routingMode = reqCtx?.routingMode ?? "auto";
+
+  // --- 3. Fast path — only when EVERY override path collapses to "single
+  // execution against currentMember": the agent emitted no scope (or "this")
+  // AND the picker is not the fanout case ('all'). 'pin' also collapses to
+  // single (pin always routes to currentMember), so it keeps the fast path;
+  // 'auto' with no agent scope is the legacy single-env shape. No routing DB
+  // lookup on this path. ---
+  if ((scope === undefined || scope === "this") && routingMode !== "all") {
+    return {
+      plan: {
+        kind: "single",
+        // Resolve the target from the POST-reach/post-routing member id
+        // (`currentMember`) — NEVER the raw `connectionId` arg — so the
+        // whitelist bucket matches what we execute against (risk guard #1).
+        // The target's `connectionId` IS `currentMember`.
+        executionTarget: resolveExecutionTarget(reqCtx, currentMember),
+        routingMode,
+      },
+      logs,
+    };
+  }
+
+  // --- 4. Routing path: the agent asked for fanout / a specific member, or
+  // the picker is pinning 'all' (overrides the agent's scope regardless of
+  // value). Load the active group's members + primary, then run the pure
+  // routing module. Failures collapse to a 1×1 fallback inside the lookup so
+  // the tool call still returns a useful result. ---
+  const ctx = await deps.loadGroupRoutingContext(orgId, currentMember);
+  const { plan, warnings } = resolveRoutingPlan({
+    agentScope: scope,
+    currentMember: ctx.currentMember,
+    members: ctx.members,
+    primaryMember: ctx.primaryMember,
+    pickerMode: routingMode,
+  });
+  for (const w of warnings) {
+    logs.push({ message: w, fields: { connectionId: currentMember, scope, plan: plan.kind } });
+  }
+
+  if (plan.kind === "single") {
+    return {
+      plan: {
+        kind: "single",
+        // Post-routing member id (`plan.connectionId`), not the raw arg; it
+        // becomes the target's `connectionId`.
+        executionTarget: resolveExecutionTarget(reqCtx, plan.connectionId),
+        routingMode,
+        routingReason: plan.reason,
+      },
+      logs,
+    };
+  }
+
+  // Fanout: each leg resolves its OWN execution target from ITS connection id
+  // — a leg whose id IS the conversation's own connection under All-sources
+  // reach derives `unpinned: true`; sibling legs derive `false`. A single
+  // broadcast target across legs would leak one leg's whitelist bucket onto
+  // the others (#3961), so the derivation is strictly per-leg.
+  return {
+    plan: {
+      kind: "fanout",
+      legs: plan.connectionIds.map((connId) => resolveExecutionTarget(reqCtx, connId)),
+      fanoutReason: plan.reason,
+    },
+    logs,
+  };
+}

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -44,11 +44,9 @@ import {
 } from "@atlas/api/lib/effect/errors";
 import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
 import { appendRowLimit, hasLimitClause } from "./auto-limit";
-import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
-import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
-import { resolveReach, isReachable, reachStateFromColumn } from "@atlas/api/lib/group-reach";
-import { loadVisibleGroups } from "@atlas/api/lib/group-reach/lookup";
+import { type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { resolveExecutionTarget, type ExecutionTarget } from "@atlas/api/lib/group-reach/execution-target";
+import { resolveSqlExecutionPlan } from "./sql-execution-plan";
 import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
 import {
   ApprovalGate,
@@ -2347,7 +2345,14 @@ async function executeSqlForConnection({
 async function executeSqlFanout(args: {
   readonly sql: string;
   readonly explanation: string;
-  readonly connectionIds: readonly string[];
+  /**
+   * Per-leg execution targets, pre-resolved by {@link resolveSqlExecutionPlan}
+   * from EACH member's own connection id (never a single broadcast target —
+   * that would leak one leg's whitelist bucket onto the others, #3961). Order
+   * is the fanout output order. A leg's `connectionId` is the member to run
+   * against; its `unpinned` flag feeds the leg's table whitelist.
+   */
+  readonly legs: readonly ExecutionTarget[];
   /**
    * Planner reason that picked this fanout (one of `agent-all` /
    * `picker-all`). Threaded into each leg's OTel span as
@@ -2357,7 +2362,8 @@ async function executeSqlFanout(args: {
    */
   readonly fanoutReason: RoutingReason;
 }): Promise<Record<string, unknown>> {
-  const { sql, explanation, connectionIds, fanoutReason } = args;
+  const { sql, explanation, legs, fanoutReason } = args;
+  const connectionIds = legs.map((leg) => leg.connectionId);
 
   // Write the parent audit row up front so each leg's audit insert can
   // reference it. The parent carries no per-environment metadata
@@ -2402,25 +2408,25 @@ async function executeSqlFanout(args: {
     );
   }
 
-  // Per-leg execution target: each fanout leg resolves its OWN target from
-  // ITS connection id — NEVER a single broadcast target across legs (that
-  // would leak one leg's whitelist bucket onto the others, a regression). A
-  // leg whose id IS the conversation's own connection under All-sources reach
-  // derives `unpinned: true`; sibling legs derive `false` — exactly the
-  // current per-leg re-derivation `validateSQL` did via its fallback.
-  const fanoutReqCtx = getRequestContext();
+  // Per-leg execution target: each leg carries its OWN target (pre-resolved by
+  // the planner from ITS connection id) — NEVER a single broadcast target
+  // across legs (that would leak one leg's whitelist bucket onto the others, a
+  // regression). A leg whose id IS the conversation's own connection under
+  // All-sources reach derives `unpinned: true`; sibling legs derive `false`.
+  // The request context was read ONCE in `execute` and folded into these legs
+  // there — this function re-reads nothing (#4350).
   const startTimes = new Map<string, number>();
   const settled = await Promise.allSettled(
-    connectionIds.map((connId) => {
-      startTimes.set(connId, performance.now());
+    legs.map((leg) => {
+      startTimes.set(leg.connectionId, performance.now());
       return executeSqlForConnection({
         sql,
         explanation,
-        connId,
+        connId: leg.connectionId,
         parentAuditId,
         routingMode: "all",
         routingReason: fanoutReason,
-        executionTarget: resolveExecutionTarget(fanoutReqCtx, connId),
+        executionTarget: leg,
       });
     }),
   );
@@ -2521,154 +2527,57 @@ export const executeSQL = tool({
   }),
 
   execute: async ({ sql, explanation, group, connectionId, scope }) => {
-    // Chat routes stamp the user-selected per-turn connection into
-    // RequestContext. The model normally omits `connectionId`, so fall back to
-    // that routed context before the legacy default to avoid executing against
-    // the wrong environment while conversation metadata says otherwise.
+    // Read the request context ONCE and hand it to the planner (#4350). The
+    // planner folds the whole cascade — reach gate (ADR-0022) → group-target
+    // member → current member → routing-mode fast-path → routing plan →
+    // per-leg execution target — into a discriminated plan; this closure only
+    // runs the leg(s) and merges. The composition-order bugs this surface has
+    // shipped (#3961 fanout bucket-leak, #3867(b) no-substitution) now live,
+    // tested, inside `resolveSqlExecutionPlan`.
     const reqCtx = getRequestContext();
-    const requestContextConnectionId = reqCtx?.connectionId;
+    const { plan, logs } = await resolveSqlExecutionPlan(reqCtx, { group, connectionId, scope });
+    // The planner is pure — it returns operational signals (reach warnings, the
+    // out-of-reach rejection, routing fallbacks) rather than logging itself, so
+    // the one log seam stays here (per CLAUDE.md "never silently swallow").
+    for (const l of logs) {
+      log.warn(l.fields, l.message);
+    }
 
-    // Cross-group reach (ADR-0022). The conversation's persisted Group-reach
-    // state (slice (c) #3895, stamped into RequestContext by the chat route)
-    // bounds which Connection groups this query may reach — the axis ABOVE
-    // member routing. `all` (the default) → every visible group reachable;
-    // `focus` → exactly one. A target outside the reachable set is REJECTED
-    // here — a hard error, never a silent re-route to a different source (the
-    // #3867(b) fix at the execution layer).
-    //
-    // Resolve reach when the agent names a `group` (validate the named target)
-    // OR the conversation is Focused (bound the implicit default to the focused
-    // group, never a stale `connectionId` outside it). Under `all` with no
-    // named group we skip the lookup entirely — every group is reachable, so
-    // there is nothing to bound and the legacy single-connection path stands
-    // (no per-query DB cost added to the common default case).
-    const reachState = reachStateFromColumn(reqCtx?.groupReach);
-    let groupTargetMember: string | undefined;
-    if (group !== undefined || reachState.kind === "focus") {
-      const reachOrgId = reqCtx?.user?.activeOrganizationId;
-      const visibleGroups = await loadVisibleGroups(reachOrgId, reqCtx?.atlasMode);
-      const reach = resolveReach(reachState, visibleGroups);
-      // A `focus`-on-invisible resolution explains (via a warning) why reach is
-      // empty rather than substituting another source; surface it so the
-      // divergence is observable. Under `all` warnings is always [].
-      for (const w of reach.warnings) {
-        log.warn({ group, groupReach: reqCtx?.groupReach, orgId: reachOrgId }, w);
+    switch (plan.kind) {
+      case "reject":
+        // Out-of-reach target — a hard error, never a silent re-route to a
+        // different source (the #3867(b) no-substitution invariant).
+        return { success: false, explanation, error: plan.error, executionMs: 0 };
+      case "single": {
+        // Wraps the leaf result with a 1-element `envContributions` array so
+        // SDK consumers see the same wire shape for single-env and fanout
+        // responses (#2519). The leaf result already carries `success`,
+        // `columns`, `rows`, etc. — we only attach the contribution.
+        // The execution target's `connectionId` IS the resolved member id —
+        // the single source for the leg's id (no separate `connId` to drift).
+        const connId = plan.executionTarget.connectionId;
+        const result = await executeSqlForConnection({
+          sql,
+          explanation,
+          connId,
+          routingMode: plan.routingMode,
+          routingReason: plan.routingReason,
+          executionTarget: plan.executionTarget,
+        });
+        return attachSingleEnvContribution(result, connId);
       }
-      // The group this query targets: the agent's explicit `group`, else — under
-      // Focus — the single focused group. (Under `all` with no explicit group we
-      // don't enter this branch.)
-      const targetGroupId =
-        group ?? (reachState.kind === "focus" ? reach.reachableGroups[0]?.id : undefined);
-      if (targetGroupId === undefined || !isReachable(reach, targetGroupId)) {
-        const reachable = reach.reachableGroups.map((g) => g.id);
-        log.warn(
-          { group, groupReach: reqCtx?.groupReach, orgId: reachOrgId, reachable },
-          "executeSQL rejected an out-of-reach group target — not re-routing",
-        );
-        // Two shapes: the agent named an out-of-reach group, OR the conversation
-        // is Focused on a group that isn't currently reachable (content-mode hid
-        // it, or it was removed). Either way we refuse to substitute another
-        // source — the no-substitution invariant the whole feature rests on.
-        const error =
-          group === undefined && reachState.kind === "focus"
-            ? `This conversation is focused on group "${reachState.groupId}", which is not ` +
-              `currently reachable (visible groups: ${reachable.join(", ") || "none"}). ` +
-              `The focused source may be unpublished or removed — I will not query a ` +
-              `different source instead. Widen the conversation's scope to All sources to query elsewhere.`
-            : `Connection group "${group}" is not within this conversation's reach ` +
-              `(reachable groups: ${reachable.join(", ") || "none"}). ` +
-              `I will not query a different source instead — re-run against a reachable ` +
-              `group, or omit \`group\` to use the conversation's current source.`;
-        return { success: false, explanation, error, executionMs: 0 };
+      case "fanout":
+        return executeSqlFanout({
+          sql,
+          explanation,
+          legs: plan.legs,
+          fanoutReason: plan.fanoutReason,
+        });
+      default: {
+        const _exhaustive: never = plan;
+        return _exhaustive;
       }
-      // Resolve the group to a connection to execute against: the group's
-      // primary member (a group-of-one resolves to its own connection id).
-      // `connectionId`, if also supplied, may pin a specific member of THIS
-      // group; otherwise the group's primary is used. The per-group whitelist
-      // resolves via this connection id (members register their group's tables).
-      const target = reach.reachableGroups.find((g) => g.id === targetGroupId);
-      groupTargetMember =
-        connectionId && target?.members.includes(connectionId)
-          ? connectionId
-          : target?.primary;
     }
-
-    const currentMember =
-      groupTargetMember ?? connectionId ?? requestContextConnectionId ?? "default";
-
-    // #2518 — three-state picker. `routingMode` reaches us via
-    // `RequestContext` (stamped by the chat route from the conversation
-    // row). The chat route applies the NULL→"pin" back-compat default
-    // before stamping; reaching this code with `routingMode === undefined`
-    // means the caller never went through the chat route (tools / MCP /
-    // scheduler / unit tests), and the legacy "agent decides" semantics
-    // are the right answer there.
-    const routingMode = reqCtx?.routingMode ?? "auto";
-
-    // Fast path — only valid when EVERY override path collapses to
-    // "single execution against currentMember". That is true when:
-    //   - the agent emitted no scope (or scope === "this"), AND
-    //   - the picker is NOT pinning the fanout case ('all').
-    // The 'pin' picker case ALSO collapses to single — pin always
-    // routes to `currentMember` regardless of the agent's hint — so we
-    // keep the fast path for it (no DB lookup needed). 'auto' with no
-    // agent scope is the same shape as legacy single-env execution.
-    //
-    // Wraps the leaf result with a 1-element `envContributions` array so
-    // SDK consumers see the same wire shape for single-env and fanout
-    // responses (#2519). The leaf result already carries `success`,
-    // `columns`, `rows`, etc. — we only attach the contribution.
-    if ((scope === undefined || scope === "this") && routingMode !== "all") {
-      const result = await executeSqlForConnection({
-        sql,
-        explanation,
-        connId: currentMember,
-        routingMode,
-        // Resolve the target from the POST-reach/post-routing member id
-        // (`currentMember`) — NEVER the raw `connectionId` arg — so the
-        // whitelist bucket matches what we execute against (risk guard #1).
-        executionTarget: resolveExecutionTarget(reqCtx, currentMember),
-      });
-      return attachSingleEnvContribution(result, currentMember);
-    }
-
-    // Routing path: either the agent asked for fanout / a specific
-    // member, or the picker is pinning 'all' (which overrides the
-    // agent's scope regardless of value). Resolve the active group's
-    // members + primary, then run the pure routing module. Failures
-    // collapse to a 1×1 fallback so the tool call still returns a
-    // useful result.
-    const orgId = reqCtx?.user?.activeOrganizationId;
-    const ctx = await loadGroupRoutingContext(orgId, currentMember);
-    const { plan, warnings } = resolveRoutingPlan({
-      agentScope: scope,
-      currentMember: ctx.currentMember,
-      members: ctx.members,
-      primaryMember: ctx.primaryMember,
-      pickerMode: routingMode,
-    });
-    for (const w of warnings) {
-      log.warn({ connectionId: currentMember, scope, plan: plan.kind }, w);
-    }
-
-    if (plan.kind === "single") {
-      const result = await executeSqlForConnection({
-        sql,
-        explanation,
-        connId: plan.connectionId,
-        routingMode,
-        routingReason: plan.reason,
-        // Post-routing member id (`plan.connectionId`), not the raw arg.
-        executionTarget: resolveExecutionTarget(reqCtx, plan.connectionId),
-      });
-      return attachSingleEnvContribution(result, plan.connectionId);
-    }
-    return executeSqlFanout({
-      sql,
-      explanation,
-      connectionIds: plan.connectionIds,
-      fanoutReason: plan.reason,
-    });
   },
 });
 


### PR DESCRIPTION
## Summary

Closes #4350.

The `executeSQL` tool wired its individually-deep, well-tested resolvers (reach, intra-group routing, per-leg execution-target, member-result merge) with ~150 lines of inline glue inside its `execute` closure, re-reading the request context twice (the closure + inside the fanout). Every regression shipped on this surface — #3961 / #3947 / #3109 (whitelist-bucket drift), #4109 (degraded-routing certainty), #3867(b) (no-substitution) — was a **composition-order** bug in that untested glue, never a bug inside a resolver.

This PR folds the wiring into one pure module:

- **`resolveSqlExecutionPlan(reqCtx, { group, connectionId, scope })`** (new `tools/sql-execution-plan.ts`) resolves the whole cascade — reach gate → group-target member → current member → routing-mode fast-path → routing plan → per-leg execution target — and returns a discriminated `SqlExecutionPlan`: a hard `reject` (out-of-reach, never a silent re-route), a `single` leg, or a `fanout` across pre-resolved per-leg `ExecutionTarget`s.
- **`execute` now reads the request context once**, calls the planner, and only runs the leg(s) + merges. `executeSqlFanout` consumes pre-resolved per-leg targets, dropping its own context re-read.
- **One shared reach resolver** (`resolveReachableGroups`) is now consumed by both the advertised source-catalog menu and the enforcing execution gate — so "advertised == enforceable" holds by construction, closing the "reach resolved twice" leak.
- The two impure lookups (visible groups, group members) are injected as `SqlExecutionPlanDeps`, so the planner is testable without a mocked DB.

No behavioral change to routing/fanout/reach results — the existing integration suites (`sql-group-target`, `sql-fanout-per-leg-whitelist`, `sql-org-routing`, `source-catalog/lookup`) stay green.

Net: ~150 lines of untested inline orchestration move out of `sql.ts` into a tested pure planner (`sql.ts` shrinks ~150 lines net).

Advances ADR-0022 / ADR-0010 by extending the existing `execution-target.ts` SSOT.

## Test Plan

New table-driven unit test `tools/__tests__/sql-execution-plan.test.ts` (24 tests) drives the full `(reachState, group, scope, routingMode, members)` interaction with in-memory injected deps — no `mock.module`, no fake Postgres:

- The #3961 (per-leg `unpinned` whitelist-bucket), #4109 (degraded 1×1 routing → no phantom fanout), and #3867(b) (out-of-reach no-substitution, all three shapes) regressions are expressed against the planner directly.
- The combined **reach ⊕ routing** interaction row (named `group` + `scope: "all"` → fan out the reach-selected group's members) covers the composition seam a regression would hit.

- [ ] Manual testing
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — full local suite + 28-gate `scripts/ci-local.sh` all green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area) — `refactor`, `area: api`, `architecture` (from the issue)
- [ ] CHANGELOG.md updated (if user-facing change) — internal refactor, no user-facing change

https://claude.ai/code/session_01Too1p2WadEX6TziLqJGSKa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Too1p2WadEX6TziLqJGSKa)_