### PR TITLE
fix(www): landing accessibility — eyebrow contrast + trial-CTA link parity

### DIFF
--- a/apps/www/src/components/landing/deploy.tsx
+++ b/apps/www/src/components/landing/deploy.tsx
@@ -175,7 +175,7 @@ function CloudCard() {
       </ul>
 
       <a
-        href="https://app.useatlas.dev"
+        href="https://app.useatlas.dev/signup"
         className="mt-auto inline-flex items-center justify-center rounded-lg bg-accent px-4 py-3 text-[13.5px] font-semibold text-accent-ink transition-colors hover:bg-accent-hover"
       >
         start free trial →

--- a/apps/www/src/components/landing/knowledge-base.tsx
+++ b/apps/www/src/components/landing/knowledge-base.tsx
@@ -81,7 +81,7 @@ export function KnowledgeBase() {
     >
       <div className="grid gap-10 md:grid-cols-2 md:items-center">
         <div>
-          <p className="mb-3 font-mono text-[11px] tracking-[0.06em] text-brand">
+          <p className="mb-3 font-mono text-[11px] tracking-[0.06em] text-accent">
             // knowledge base
           </p>
           <h2 className="m-0 mb-4 text-[36px] md:text-[46px] font-semibold leading-[1.05] tracking-[-0.03em] text-fg">


### PR DESCRIPTION
## Summary

Two landing-page fixes surfaced by a Lighthouse audit of `useatlas.dev`:

- **Contrast (Accessibility flag):** the `// knowledge base` eyebrow used `text-brand`, which the www adapter maps to the teal *spark* (`--atlas-spark`, `#23CE9E`). Per ADR-0023 the teal spark is only legible on dark code panes, but this eyebrow sits on the cream paper section background (`bg-bg`) — failing WCAG AA. Switched to `text-accent` (deep forest `#1F5C45`), matching the sibling light-surface eyebrows (e.g. `deploy.tsx` `// atlas cloud`) and clearing AA comfortably (~7:1).
- **Identical links, differing purpose (Best-Practices flag):** the Atlas Cloud card's "start free trial →" CTA linked to `app.useatlas.dev` (app root) while the two other identical "Start free trial →" CTAs (hero, end-cta) link to `/signup`. Unified the destination on `/signup` — the correct landing for a trial CTA.

No tracking issue — surfaced directly from the Lighthouse report.

## Test Plan

- [x] Manual testing — verified against the failing Lighthouse elements; the flagged eyebrow now renders forest on cream, and all three trial CTAs resolve to `/signup`
- [ ] Unit tests added/updated — n/a (static className / href change, no logic)
- [ ] E2E tests added/updated — n/a

## Checklist

- [x] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`) — n/a; no behavior change (CI runs the full suite)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — n/a; landing-page polish, not a product-surface change

https://claude.ai/code/session_014oADumnvmZgymZDAU8Jnhw

---
_Generated by [Claude Code](https://claude.ai/code/session_014oADumnvmZgymZDAU8Jnhw)_