### PR TITLE
Add knowledge_documents.fts stored generated column with GIN index

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -466,6 +466,10 @@ describe("migrateAuthTables", () => {
             // 0166 (#4302) — conversations.answer_style. Atlas-internal column,
             // no FK to a Better Auth table, so it runs in every auth mode.
             { name: "0166_conversations_answer_style.sql" },
+            // 0167 (#4222) — knowledge_documents.fts stored generated tsvector
+            // + GIN index. Atlas-internal table, no FK to a Better Auth table,
+            // so it runs in every auth mode.
+            { name: "0167_knowledge_documents_fts.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3196,6 +3196,43 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     );
     expect(after.rowCount).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
+
+  it("0167: knowledge_documents.fts is a stored generated weighted tsvector with a GIN index (#4222)", async () => {
+    const cols = await pool.query<{ is_generated: string; data_type: string }>(
+      `SELECT is_generated, data_type
+         FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'knowledge_documents'
+          AND column_name = 'fts'`,
+    );
+    expect(cols.rows).toHaveLength(1);
+    // STORED, not PG 18's bare VIRTUAL default — a GIN index can't be built
+    // on a virtual column.
+    expect(cols.rows[0].is_generated).toBe("ALWAYS");
+    expect(cols.rows[0].data_type).toBe("tsvector");
+
+    const indexes = await pool.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND tablename = 'knowledge_documents'
+          AND indexname = 'idx_knowledge_documents_fts'`,
+    );
+    expect(indexes.rows).toHaveLength(1);
+    expect(indexes.rows[0].indexdef).toContain("USING gin");
+
+    // Postgres computes the vector on write with the field weights: a title
+    // lexeme carries A; a body lexeme carries the (undisplayed) default D.
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-fts-${stamp}`;
+    const { rows } = await pool.query<{ fts: string }>(
+      `INSERT INTO knowledge_documents (workspace_id, collection_id, path, title, body)
+       VALUES ($1, 'runbooks', 'fts.md', 'Alpha', 'omega')
+       RETURNING fts::text AS fts`,
+      [ws],
+    );
+    expect(rows[0]?.fts).toContain("'alpha':1A");
+    expect(rows[0]?.fts).toContain("'omega':2");
+  }, PG_TEST_TIMEOUT_MS);
 });
 
 // #2606 — source-level revert guard for the integration-store SQL formatter.

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3197,19 +3197,34 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     expect(after.rowCount).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
-  it("0167: knowledge_documents.fts is a stored generated weighted tsvector with a GIN index (#4222)", async () => {
-    const cols = await pool.query<{ is_generated: string; data_type: string }>(
-      `SELECT is_generated, data_type
+  it("0167: knowledge_documents.fts is a STORED generated weighted tsvector with a GIN index (#4222)", async () => {
+    const cols = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type
          FROM information_schema.columns
         WHERE table_schema = current_schema()
           AND table_name = 'knowledge_documents'
           AND column_name = 'fts'`,
     );
     expect(cols.rows).toHaveLength(1);
-    // STORED, not PG 18's bare VIRTUAL default — a GIN index can't be built
-    // on a virtual column.
-    expect(cols.rows[0].is_generated).toBe("ALWAYS");
     expect(cols.rows[0].data_type).toBe("tsvector");
+    // Coalesced inputs make the expression provably non-null; declared so.
+    expect(cols.rows[0].is_nullable).toBe("NO");
+
+    // STORED, not PG 18's bare VIRTUAL default — a GIN index can't be built
+    // on a virtual column. information_schema.is_generated says 'ALWAYS' for
+    // BOTH kinds, so pin pg_attribute.attgenerated: 's' = stored ('v' would
+    // be virtual on PG 18+).
+    const gen = await pool.query<{ attgenerated: string }>(
+      `SELECT a.attgenerated
+         FROM pg_attribute a
+         JOIN pg_class c ON c.oid = a.attrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relname = 'knowledge_documents'
+          AND a.attname = 'fts'`,
+    );
+    expect(gen.rows).toHaveLength(1);
+    expect(gen.rows[0].attgenerated).toBe("s");
 
     const indexes = await pool.query<{ indexdef: string }>(
       `SELECT indexdef FROM pg_indexes
@@ -3221,7 +3236,9 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     expect(indexes.rows[0].indexdef).toContain("USING gin");
 
     // Postgres computes the vector on write with the field weights: a title
-    // lexeme carries A; a body lexeme carries the (undisplayed) default D.
+    // lexeme carries A; a body lexeme carries D — explicit in the expression,
+    // undisplayed in tsvector text output because D is the display default.
+    // Exact-match the whole vector so a mis-weighted body (e.g. ':2B') fails.
     const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
     const ws = `ws-fts-${stamp}`;
     const { rows } = await pool.query<{ fts: string }>(
@@ -3230,8 +3247,7 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
        RETURNING fts::text AS fts`,
       [ws],
     );
-    expect(rows[0]?.fts).toContain("'alpha':1A");
-    expect(rows[0]?.fts).toContain("'omega':2");
+    expect(rows[0]?.fts).toBe("'alpha':1A 'omega':2");
   }, PG_TEST_TIMEOUT_MS);
 });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -208,7 +208,9 @@ describe("runMigrations", () => {
     //   the first-publish gate, #4320) = 166.
     //   Plus 0166 (conversations.answer_style — per-conversation answer-style
     //   picker, PRD #4292, #4302) = 167.
-    expect(count).toBe(167);
+    //   Plus 0167 (knowledge_documents.fts stored generated tsvector + GIN
+    //   index for the searchKnowledge lexical tier, #4222) = 168.
+    expect(count).toBe(168);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -404,6 +406,7 @@ describe("runMigrations", () => {
         "0164_knowledge_bundle_sync.sql",
         "0165_dashboard_first_published_at.sql",
         "0166_conversations_answer_style.sql",
+        "0167_knowledge_documents_fts.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0167_knowledge_documents_fts.sql
+++ b/packages/api/src/lib/db/migrations/0167_knowledge_documents_fts.sql
@@ -1,0 +1,46 @@
+-- 0167: knowledge_documents.fts — stored generated tsvector column + GIN
+-- index for the searchKnowledge lexical tier (#4222, scale follow-up to
+-- #4210 / ADR-0028 §5).
+--
+-- The lexical FTS tier previously computed the tsvector on the fly in both
+-- the `@@` match predicate and the `ts_rank` expression, seq-scanning every
+-- row passing the (workspace_id, status) filter and recomputing the vector
+-- over the full markdown body per row. This materializes the vector once
+-- per row and lets lexical queries take the GIN bitmap path.
+--
+-- A stored generated column beats a bare expression index: the planner
+-- match is trivial (`kd.fts @@ ...`) instead of requiring the code's
+-- interpolated expression to stay byte-identical to the index expression
+-- forever. `STORED` is load-bearing on Postgres 18: a bare
+-- `GENERATED ALWAYS AS (...)` defaults to VIRTUAL there, and GIN indexes
+-- cannot be built on virtual columns.
+--
+-- Field weighting is folded in while the column is being built (one table
+-- rewrite instead of two): title A, description B, body D. Lexemes from an
+-- unweighted to_tsvector already default to D, so body ranking is
+-- unchanged — title/description hits now win ties, resolving the
+-- unweighted-ranking limitation flagged at the old TS_VECTOR definition.
+-- Both to_tsvector('english', ...) (explicit regconfig) and setweight()
+-- are immutable, so the expression is legal in a generated column.
+--
+-- Operational note: ADD COLUMN ... STORED forces a full table rewrite
+-- under an ACCESS EXCLUSIVE lock, and the CREATE INDEX builds over the
+-- whole corpus (CONCURRENTLY is not an option — the migration runner
+-- wraps every migration in a transaction). Fine at the designed scale;
+-- if this ships after a workspace has grown into the trigger condition
+-- (thousands of documents), expect the boot migration to hold the lock
+-- for the duration of the rewrite.
+--
+-- Additive only — no DROP, so no two-phase-drop discipline applies.
+-- Mirrored in db/schema.ts (same commit) so a later `drizzle-kit
+-- generate` can't emit a DROP.
+
+ALTER TABLE knowledge_documents ADD COLUMN IF NOT EXISTS fts tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(body, '')), 'D')
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_documents_fts
+  ON knowledge_documents USING gin (fts);

--- a/packages/api/src/lib/db/migrations/0167_knowledge_documents_fts.sql
+++ b/packages/api/src/lib/db/migrations/0167_knowledge_documents_fts.sql
@@ -35,12 +35,14 @@
 -- Mirrored in db/schema.ts (same commit) so a later `drizzle-kit
 -- generate` can't emit a DROP.
 
+-- NOT NULL: every input is coalesced, so the expression is provably never
+-- NULL — declare the invariant rather than implying it.
 ALTER TABLE knowledge_documents ADD COLUMN IF NOT EXISTS fts tsvector
   GENERATED ALWAYS AS (
     setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
     setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
     setweight(to_tsvector('english', coalesce(body, '')), 'D')
-  ) STORED;
+  ) STORED NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_knowledge_documents_fts
   ON knowledge_documents USING gin (fts);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1811,12 +1811,15 @@ export const knowledgeDocuments = pgTable(
     // Stored generated FTS vector for the searchKnowledge lexical tier
     // (#4222, migration 0167). Weighted title A / description B / body D;
     // STORED (not VIRTUAL — PG 18's bare default) so the GIN index below
-    // can be built on it. Expression mirrors 0167 byte-for-byte.
-    fts: tsvector("fts").generatedAlwaysAs(
-      sql`setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    // can be built on it. Expression mirrors 0167 (same tokens — keep the
+    // two in lockstep; Postgres stores the normalized form).
+    fts: tsvector("fts")
+      .notNull()
+      .generatedAlwaysAs(
+        sql`setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
     setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
     setweight(to_tsvector('english', coalesce(body, '')), 'D')`,
-    ),
+      ),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -30,8 +30,18 @@ import {
   foreignKey,
   primaryKey,
   varchar,
+  customType,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
+
+// Postgres `tsvector` — no drizzle built-in. Only used for generated
+// full-text-search columns; the value is never read or written from JS
+// (Postgres computes it), so `string` is a fine wire type.
+const tsvector = customType<{ data: string }>({
+  dataType() {
+    return "tsvector";
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Core tables
@@ -1798,6 +1808,15 @@ export const knowledgeDocuments = pgTable(
     atlasIngestedAt: timestamp("atlas_ingested_at", { withTimezone: true }),
     // Content-mode lifecycle — defaults `draft` (the review gate).
     status: text("status").notNull().default("draft"),
+    // Stored generated FTS vector for the searchKnowledge lexical tier
+    // (#4222, migration 0167). Weighted title A / description B / body D;
+    // STORED (not VIRTUAL — PG 18's bare default) so the GIN index below
+    // can be built on it. Expression mirrors 0167 byte-for-byte.
+    fts: tsvector("fts").generatedAlwaysAs(
+      sql`setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(description, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(body, '')), 'D')`,
+    ),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -1808,6 +1827,8 @@ export const knowledgeDocuments = pgTable(
     index("idx_knowledge_documents_status").on(t.workspaceId, t.status),
     // GIN over the OKF `tags` array for the frontmatter-filter search tier.
     index("idx_knowledge_documents_tags").using("gin", t.tags),
+    // GIN over the generated FTS vector for the lexical search tier (0167).
+    index("idx_knowledge_documents_fts").using("gin", t.fts),
     // `path` unique per collection, not per workspace (ADR-0028 §2).
     uniqueIndex("uq_knowledge_documents_collection_path").on(
       t.workspaceId,

--- a/packages/api/src/lib/tools/__tests__/knowledge-search-pg.test.ts
+++ b/packages/api/src/lib/tools/__tests__/knowledge-search-pg.test.ts
@@ -5,10 +5,10 @@
  * bundles, and executes the REAL search + 1-hop expansion SQL against the live
  * `knowledge_documents` / `knowledge_links` schema.
  *
- * Catches the drift a mock-exec unit test can't: `websearch_to_tsquery` /
- * `to_tsvector` / `ts_headline`, `tags @> …::jsonb` against the GIN index, the
- * quoted `"timestamp"` column, the `array_agg` edge aggregation, and content-mode
- * status gating in both directions.
+ * Catches the drift a mock-exec unit test can't: `websearch_to_tsquery` against
+ * the stored generated `fts` column (0167) / `ts_headline`, `tags @> …::jsonb`
+ * against the GIN index, the quoted `"timestamp"` column, the `array_agg` edge
+ * aggregation, and content-mode status gating in both directions.
  *
  * Opt in locally with:
  *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
@@ -291,21 +291,27 @@ describeIfPg("searchKnowledge against the live schema", () => {
     expect([...shared[0].via].sort()).toEqual(["hub/a.md", "hub/b.md"]);
   }, PG_TEST_TIMEOUT_MS);
 
-  it("weighted ranking (0167): a title hit outranks a body hit for the same term", async () => {
+  it("weighted ranking (0167): title > description > body for the same term", async () => {
     // The stored generated `fts` column weights title A / description B /
-    // body D, so ts_rank must sort a title match above a body-only match.
-    // Before 0167 the vector was unweighted (everything D) and this ordering
-    // was undefined — this pins the fold-in.
+    // body D, so ts_rank must sort title > description > body matches.
+    // Discrimination matters: the body-only doc mentions the term MORE times
+    // (3) than the title doc's total occurrences (title + its H1 in body = 2),
+    // so the pre-0167 unweighted vector — where ts_rank is frequency-driven —
+    // would rank body-hit FIRST. Only the A/B/D weighting produces this order,
+    // so dropping any setweight() (or the description term) fails here.
     const docs = docsFrom({
       "weights/title-hit.md":
-        "---\ntype: Document\ntitle: Zephyrite Guide\n---\n# Zephyrite Guide\n\nNothing about the term in the body at all.",
+        "---\ntype: Document\ntitle: Zephyrite Guide\n---\n# Zephyrite Guide\n\nNothing about the term in the body prose.",
+      "weights/description-hit.md":
+        "---\ntype: Document\ntitle: Unrelated Minerals\ndescription: All about zephyrite deposits\n---\n# Unrelated Minerals\n\nBody prose without the term.",
       "weights/body-hit.md":
-        "---\ntype: Document\ntitle: Unrelated\n---\n# Unrelated\n\nA passing mention of zephyrite deep in the body.",
+        "---\ntype: Document\ntitle: Unrelated\n---\n# Unrelated\n\nzephyrite appears here, then zephyrite again, and zephyrite once more.",
     });
     await ingestBundleIntoCollection({
       client, workspaceId: ws, collectionId: "weights", source: "upload", docs,
     });
     await publish("weights", "weights/title-hit.md");
+    await publish("weights", "weights/description-hit.md");
     await publish("weights", "weights/body-hit.md");
 
     const res = await searchKnowledgeCore({
@@ -316,6 +322,7 @@ describeIfPg("searchKnowledge against the live schema", () => {
     });
     expect(res.results.map((r) => r.path)).toEqual([
       "weights/title-hit.md",
+      "weights/description-hit.md",
       "weights/body-hit.md",
     ]);
   }, PG_TEST_TIMEOUT_MS);
@@ -349,13 +356,16 @@ describeIfPg("searchKnowledge against the live schema", () => {
       limit: 10,
       expand: false,
     });
-    const explained = await pool.query(`EXPLAIN (FORMAT JSON) ${sql}`, params);
+    const explained = await pool.query<{ "QUERY PLAN": unknown }>(
+      `EXPLAIN (FORMAT JSON) ${sql}`,
+      params,
+    );
     const plan = JSON.stringify(explained.rows[0]["QUERY PLAN"]);
     expect(plan).toContain("Bitmap Index Scan");
     expect(plan).toContain("idx_knowledge_documents_fts");
 
     // And the plan is not just chosen but correct: the query itself finds
-    // exactly the one matching document among 3001.
+    // exactly the one matching document among 30,001.
     const res = await searchKnowledgeCore({
       workspaceId: wsBulk,
       mode: "published",
@@ -363,5 +373,7 @@ describeIfPg("searchKnowledge against the live schema", () => {
       exec,
     });
     expect(res.results.map((r) => r.path)).toEqual(["target.md"]);
-  }, PG_TEST_TIMEOUT_MS);
+    // 30k generated-column inserts + ANALYZE can be slow on CI Postgres —
+    // double the standard budget.
+  }, PG_TEST_TIMEOUT_MS * 2);
 });

--- a/packages/api/src/lib/tools/__tests__/knowledge-search-pg.test.ts
+++ b/packages/api/src/lib/tools/__tests__/knowledge-search-pg.test.ts
@@ -23,6 +23,7 @@ import { extractBundle } from "@atlas/api/lib/knowledge/bundle-archive";
 import { parseLenientBundle } from "@atlas/api/lib/knowledge/parse-lenient";
 import { ingestBundleIntoCollection, type IngestClient } from "@atlas/api/lib/knowledge/ingest";
 import {
+  buildSearchQuery,
   searchKnowledgeCore,
   type KnowledgeQueryExec,
 } from "@atlas/api/lib/tools/search-knowledge";
@@ -288,5 +289,79 @@ describeIfPg("searchKnowledge against the live schema", () => {
     const shared = res.neighbors.filter((n) => n.path === "hub/shared.md");
     expect(shared).toHaveLength(1);
     expect([...shared[0].via].sort()).toEqual(["hub/a.md", "hub/b.md"]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("weighted ranking (0167): a title hit outranks a body hit for the same term", async () => {
+    // The stored generated `fts` column weights title A / description B /
+    // body D, so ts_rank must sort a title match above a body-only match.
+    // Before 0167 the vector was unweighted (everything D) and this ordering
+    // was undefined — this pins the fold-in.
+    const docs = docsFrom({
+      "weights/title-hit.md":
+        "---\ntype: Document\ntitle: Zephyrite Guide\n---\n# Zephyrite Guide\n\nNothing about the term in the body at all.",
+      "weights/body-hit.md":
+        "---\ntype: Document\ntitle: Unrelated\n---\n# Unrelated\n\nA passing mention of zephyrite deep in the body.",
+    });
+    await ingestBundleIntoCollection({
+      client, workspaceId: ws, collectionId: "weights", source: "upload", docs,
+    });
+    await publish("weights", "weights/title-hit.md");
+    await publish("weights", "weights/body-hit.md");
+
+    const res = await searchKnowledgeCore({
+      workspaceId: ws,
+      mode: "published",
+      filters: { query: "zephyrite", collection: "weights", limit: 10, expand: false },
+      exec,
+    });
+    expect(res.results.map((r) => r.path)).toEqual([
+      "weights/title-hit.md",
+      "weights/body-hit.md",
+    ]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("at trigger-condition scale, lexical queries take the GIN bitmap path over idx_knowledge_documents_fts (0167)", async () => {
+    // EXPLAIN the EXACT SQL buildSearchQuery emits and assert the planner
+    // routes the `kd.fts @@ tsquery` predicate through the 0167 GIN index.
+    // At a handful of rows the (workspace_id, *) btrees always win, so this
+    // seeds a dedicated workspace at the issue's trigger-condition scale
+    // (tens of thousands of documents) — where the GIN bitmap path becomes
+    // the plan of choice with NO GUC forcing. This is what a bare-expression
+    // drift (or dropping the column back to inline to_tsvector) would break.
+    const wsBulk = `ws-bulk-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO knowledge_documents (workspace_id, collection_id, path, title, body, status)
+       SELECT $1, 'bulk', 'filler-' || g || '.md', 'Filler ' || g,
+              'routine filler content nothing special entry number ' || g, 'published'
+         FROM generate_series(1, 30000) g`,
+      [wsBulk],
+    );
+    await pool.query(
+      `INSERT INTO knowledge_documents (workspace_id, collection_id, path, title, body, status)
+       VALUES ($1, 'bulk', 'target.md', 'EU Failover',
+               'when replica lag exceeds the threshold promote the standby', 'published')`,
+      [wsBulk],
+    );
+    await pool.query(`ANALYZE knowledge_documents`);
+
+    const { sql, params } = buildSearchQuery(wsBulk, "published", {
+      query: "replica lag",
+      limit: 10,
+      expand: false,
+    });
+    const explained = await pool.query(`EXPLAIN (FORMAT JSON) ${sql}`, params);
+    const plan = JSON.stringify(explained.rows[0]["QUERY PLAN"]);
+    expect(plan).toContain("Bitmap Index Scan");
+    expect(plan).toContain("idx_knowledge_documents_fts");
+
+    // And the plan is not just chosen but correct: the query itself finds
+    // exactly the one matching document among 3001.
+    const res = await searchKnowledgeCore({
+      workspaceId: wsBulk,
+      mode: "published",
+      filters: { query: "replica lag", limit: 10, expand: false },
+      exec,
+    });
+    expect(res.results.map((r) => r.path)).toEqual(["target.md"]);
   }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/tools/__tests__/search-knowledge.test.ts
+++ b/packages/api/src/lib/tools/__tests__/search-knowledge.test.ts
@@ -39,9 +39,12 @@ describe("buildSearchQuery", () => {
   it("with a query, emits FTS match, ts_headline snippet, ts_rank, and rank-first ordering", () => {
     const { sql, params } = buildSearchQuery(WS, "published", filters({ query: "replica lag" }));
     expect(sql).toContain("websearch_to_tsquery('english', $2)");
-    expect(sql).toContain("@@");
+    // Match + rank both read the stored generated column (migration 0167),
+    // never an inline to_tsvector — that's what makes the GIN index usable.
+    expect(sql).toContain("kd.fts @@");
+    expect(sql).toContain("ts_rank(kd.fts,");
+    expect(sql).not.toContain("to_tsvector");
     expect(sql).toContain("ts_headline('english', kd.body");
-    expect(sql).toContain("ts_rank(");
     expect(sql).toMatch(/ORDER BY\s+rank DESC NULLS LAST/);
     expect(params).toContain("replica lag");
   });

--- a/packages/api/src/lib/tools/search-knowledge.ts
+++ b/packages/api/src/lib/tools/search-knowledge.ts
@@ -10,7 +10,8 @@
  *
  *   1. Structured frontmatter filter — `type`, `tags` (GIN-backed jsonb
  *      containment), `collection`, and a `since` recency bound.
- *   2. Lexical FTS — Postgres `to_tsvector` over title + description + body with
+ *   2. Lexical FTS — the stored generated `fts` tsvector (title + description +
+ *      body, weighted A/B/D, GIN-indexed — migration 0167) matched with
  *      `websearch_to_tsquery` (user-friendly, never throws on arbitrary agent
  *      input) and `ts_headline` snippets, ranked by `ts_rank`.
  *   3. 1-hop graph expansion — the seed docs' neighbors via `knowledge_links`
@@ -162,11 +163,11 @@ function toResult(row: DocRow): KnowledgeSearchResult {
 /** Shared projection (lib/knowledge/queries) — same shape drives seed + neighbor mapping. */
 const DOC_COLUMNS = knowledgeDocColumns("kd");
 
-// Full-text vector over the human-readable fields (title + description + body),
-// all terms equally weighted — no setweight()/A-B-C ranking, so ts_rank treats a
-// title hit and a body hit the same. (Field weighting is a possible follow-up.)
-const TS_VECTOR = `to_tsvector('english',
-  coalesce(kd.title, '') || ' ' || coalesce(kd.description, '') || ' ' || coalesce(kd.body, ''))`;
+// Full-text vector over the human-readable fields (title + description + body).
+// `fts` is a stored generated column (migration 0167, mirrored in db/schema.ts)
+// weighted title A / description B / body D, GIN-indexed — lexical queries take
+// the bitmap-index path instead of recomputing the vector per row (#4222).
+const TS_VECTOR = `kd.fts`;
 
 /**
  * Build the seed-search query. Every dynamic value is a bind parameter; the


### PR DESCRIPTION
## Summary

Materializes the full-text search vector for knowledge documents as a stored generated column (`fts`) with field weighting (title A / description B / body D) and a GIN index, enabling lexical queries to use the bitmap-index path instead of recomputing vectors per row.

This resolves the scale limitation flagged in #4222: at trigger-condition scale (tens of thousands of documents), the planner now routes `kd.fts @@ tsquery` through the GIN index rather than seq-scanning and recomputing `to_tsvector` for every row. Field weighting also fixes the unweighted-ranking limitation where a body-only document with more term occurrences could rank above a title match.

**Changes:**
- Migration 0167: Adds `fts` tsvector column (STORED, NOT NULL) with weighted expression and `idx_knowledge_documents_fts` GIN index
- Schema: Defines custom `tsvector` type and mirrors the generated column + index in Drizzle schema
- Search: Updates `TS_VECTOR` constant to reference the stored column instead of inline `to_tsvector` computation
- Tests: Adds integration tests verifying weighted ranking (title &gt; description &gt; body) and GIN bitmap-index plan selection at scale

No deploy-side changes needed: all three prod region internal DBs run `postgres-ssl:18.3`; everything used is core Postgres. `STORED` is load-bearing on PG 18 (bare `GENERATED ALWAYS AS` defaults to VIRTUAL there, and GIN can't index a virtual column). The `ALTER` rewrites the table under an ACCESS EXCLUSIVE lock during the boot migration — milliseconds at current scale.

Closes #4222

## Test Plan

- Added integration test `weighted ranking (0167)` in `knowledge-search-pg.test.ts` pinning title &gt; description &gt; body ordering — discriminating fixture: the body-only doc carries more term occurrences than the title doc, so the pre-0167 unweighted (frequency-driven) vector would invert the order
- Added integration test `at trigger-condition scale, lexical queries take the GIN bitmap path` seeding 30k documents and asserting EXPLAIN on the exact emitted SQL contains "Bitmap Index Scan" + "idx_knowledge_documents_fts", with no GUC forcing
- Added migration test `0167: knowledge_documents.fts is a STORED generated weighted tsvector with a GIN index` verifying column type, NOT NULL, STORED via `pg_attribute.attgenerated = 's'` (information_schema can't distinguish stored from virtual), index existence, and exact computed-vector weighting
- Updated unit test in `search-knowledge.test.ts` to assert `kd.fts @@` and `ts_rank(kd.fts,` with no inline `to_tsvector`
- Migration pins updated: count 167 → 168 + file list in `db/__tests__/migrate.test.ts`, applied-fixture entry in `auth/__tests__/migrate.test.ts`
- Full local CI gate wrapper run with `TEST_DATABASE_URL` set so the real-PG suites executed

## Checklist

- [x] Types pass
- [x] Tests pass (new integration + migration tests added)
- [x] Lint passes
- [x] Schema mirrors migration (Drizzle schema updated in same commit)
- [x] Labels match the linked issue: `refactor`, `area: api`

https://claude.ai/code/session_01LZqCr3BJicNKtb7M2acY8g