### PR TITLE
Fix polynomial regex backtracking in parseSuggestions

### DIFF
--- a/packages/react/src/lib/__tests__/helpers.test.ts
+++ b/packages/react/src/lib/__tests__/helpers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { parseSuggestions } from "../helpers";
+
+describe("parseSuggestions", () => {
+  test("extracts suggestions and strips the block from text", () => {
+    const content = `Here is the answer.\n\n<suggestions>\nWhat is the trend?\nHow does this break down?\nWhich accounts matter most?\n</suggestions>`;
+    const result = parseSuggestions(content);
+    expect(result.text).toBe("Here is the answer.");
+    expect(result.suggestions).toEqual([
+      "What is the trend?",
+      "How does this break down?",
+      "Which accounts matter most?",
+    ]);
+  });
+
+  test("returns empty suggestions when no block present", () => {
+    const content = "Just a normal response.";
+    const result = parseSuggestions(content);
+    expect(result.text).toBe("Just a normal response.");
+    expect(result.suggestions).toEqual([]);
+  });
+
+  test("handles extra whitespace inside suggestions block", () => {
+    const content = `Answer.\n\n<suggestions>\n  Spaced question?  \n\n  Another one?  \n</suggestions>`;
+    const result = parseSuggestions(content);
+    expect(result.suggestions).toEqual(["Spaced question?", "Another one?"]);
+  });
+
+  test("strips block even when inline with text", () => {
+    const content = `Some text before <suggestions>\nQ1?\nQ2?\n</suggestions> and after`;
+    const result = parseSuggestions(content);
+    expect(result.text).toBe("Some text before  and after");
+    expect(result.suggestions).toEqual(["Q1?", "Q2?"]);
+  });
+
+  test("strips all blocks when multiple exist and merges suggestions", () => {
+    const content = `Answer\n<suggestions>\nQ1?\n</suggestions>\nMore text\n<suggestions>\nQ2?\n</suggestions>`;
+    const result = parseSuggestions(content);
+    expect(result.text).toBe("Answer\n\nMore text");
+    expect(result.suggestions).toEqual(["Q1?", "Q2?"]);
+  });
+
+  test("returns empty suggestions for empty content", () => {
+    const result = parseSuggestions("");
+    expect(result.text).toBe("");
+    expect(result.suggestions).toEqual([]);
+  });
+
+  test("unclosed suggestions tag is not matched (streaming partial)", () => {
+    const content = "Answer\n\n<suggestions>\nQ1?\nQ2?";
+    const result = parseSuggestions(content);
+    expect(result.text).toBe(content);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  test("caps suggestions at 5", () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `Question ${i + 1}?`).join("\n");
+    const content = `Answer\n<suggestions>\n${lines}\n</suggestions>`;
+    const result = parseSuggestions(content);
+    expect(result.suggestions).toHaveLength(5);
+    expect(result.suggestions[0]).toBe("Question 1?");
+    expect(result.suggestions[4]).toBe("Question 5?");
+  });
+
+  test("all-whitespace block yields no suggestions and leaves text untouched", () => {
+    const content = "Answer\n<suggestions>   \n\t \n</suggestions>";
+    const result = parseSuggestions(content);
+    expect(result.text).toBe(content);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  // CodeQL js/polynomial-redos regression: the old regex
+  // /<suggestions>\s*([\s\S]*?)\s*<\/suggestions>/g backtracked quadratically on
+  // an unclosed tag followed by a long whitespace run (minutes at this size).
+  test("unclosed tag followed by a long whitespace run stays linear", () => {
+    const content = "<suggestions>" + "\t".repeat(100_000);
+    const start = performance.now();
+    const result = parseSuggestions(content);
+    expect(performance.now() - start).toBeLessThan(1_000);
+    expect(result.text).toBe(content);
+    expect(result.suggestions).toEqual([]);
+  });
+});

--- a/packages/react/src/lib/helpers.ts
+++ b/packages/react/src/lib/helpers.ts
@@ -211,22 +211,31 @@ export async function downloadExcel(
   }
 }
 
-const SUGGESTIONS_RE = /<suggestions>\s*([\s\S]*?)\s*<\/suggestions>/g;
+const SUGGESTIONS_OPEN = "<suggestions>";
+const SUGGESTIONS_CLOSE = "</suggestions>";
 
 /** Extract follow-up suggestions from assistant message content and return the cleaned text + suggestions.
- *  All `<suggestions>` blocks are stripped; suggestions from all blocks are merged. */
+ *  All `<suggestions>` blocks are stripped; suggestions from all blocks are merged.
+ *  Scanned with indexOf rather than a regex: content is model/library input, and the previous
+ *  regex backtracked polynomially on an unclosed tag followed by long whitespace runs
+ *  (CodeQL js/polynomial-redos). */
 export function parseSuggestions(content: string): { text: string; suggestions: string[] } {
   const suggestions: string[] = [];
-  let match;
-  while ((match = SUGGESTIONS_RE.exec(content)) !== null) {
-    const lines = match[1].split("\n").map((l) => l.trim()).filter(Boolean);
-    suggestions.push(...lines);
+  let text = "";
+  let cursor = 0;
+  for (;;) {
+    const open = content.indexOf(SUGGESTIONS_OPEN, cursor);
+    if (open === -1) break;
+    const close = content.indexOf(SUGGESTIONS_CLOSE, open + SUGGESTIONS_OPEN.length);
+    if (close === -1) break; // unclosed block (streaming partial) — leave it in the text
+    const inner = content.slice(open + SUGGESTIONS_OPEN.length, close);
+    suggestions.push(...inner.split("\n").map((l) => l.trim()).filter(Boolean));
+    text += content.slice(cursor, open);
+    cursor = close + SUGGESTIONS_CLOSE.length;
   }
-  SUGGESTIONS_RE.lastIndex = 0;
   if (suggestions.length === 0) return { text: content, suggestions: [] };
-  const text = content.replace(SUGGESTIONS_RE, "").trimEnd();
-  SUGGESTIONS_RE.lastIndex = 0;
-  return { text, suggestions: suggestions.slice(0, 5) };
+  text += content.slice(cursor);
+  return { text: text.trimEnd(), suggestions: suggestions.slice(0, 5) };
 }
 
 /**

--- a/packages/web/src/ui/__tests__/helpers.test.ts
+++ b/packages/web/src/ui/__tests__/helpers.test.ts
@@ -280,6 +280,18 @@ describe("parseSuggestions", () => {
     expect(result.suggestions[0]).toBe("Question 1?");
     expect(result.suggestions[4]).toBe("Question 5?");
   });
+
+  // CodeQL js/polynomial-redos regression: the old regex
+  // /<suggestions>\s*([\s\S]*?)\s*<\/suggestions>/g backtracked quadratically on
+  // an unclosed tag followed by a long whitespace run (minutes at this size).
+  test("unclosed tag followed by a long whitespace run stays linear", () => {
+    const content = "<suggestions>" + "\t".repeat(100_000);
+    const start = performance.now();
+    const result = parseSuggestions(content);
+    expect(performance.now() - start).toBeLessThan(1_000);
+    expect(result.text).toBe(content);
+    expect(result.suggestions).toEqual([]);
+  });
 });
 
 /* ------------------------------------------------------------------ */

--- a/packages/web/src/ui/lib/helpers.ts
+++ b/packages/web/src/ui/lib/helpers.ts
@@ -192,22 +192,31 @@ export async function downloadExcel(
   }
 }
 
-const SUGGESTIONS_RE = /<suggestions>\s*([\s\S]*?)\s*<\/suggestions>/g;
+const SUGGESTIONS_OPEN = "<suggestions>";
+const SUGGESTIONS_CLOSE = "</suggestions>";
 
 /** Extract follow-up suggestions from assistant message content and return the cleaned text + suggestions.
- *  All `<suggestions>` blocks are stripped; suggestions from all blocks are merged. */
+ *  All `<suggestions>` blocks are stripped; suggestions from all blocks are merged.
+ *  Scanned with indexOf rather than a regex: content is model/library input, and the previous
+ *  regex backtracked polynomially on an unclosed tag followed by long whitespace runs
+ *  (CodeQL js/polynomial-redos). */
 export function parseSuggestions(content: string): { text: string; suggestions: string[] } {
   const suggestions: string[] = [];
-  let match;
-  while ((match = SUGGESTIONS_RE.exec(content)) !== null) {
-    const lines = match[1].split("\n").map((l) => l.trim()).filter(Boolean);
-    suggestions.push(...lines);
+  let text = "";
+  let cursor = 0;
+  for (;;) {
+    const open = content.indexOf(SUGGESTIONS_OPEN, cursor);
+    if (open === -1) break;
+    const close = content.indexOf(SUGGESTIONS_CLOSE, open + SUGGESTIONS_OPEN.length);
+    if (close === -1) break; // unclosed block (streaming partial) — leave it in the text
+    const inner = content.slice(open + SUGGESTIONS_OPEN.length, close);
+    suggestions.push(...inner.split("\n").map((l) => l.trim()).filter(Boolean));
+    text += content.slice(cursor, open);
+    cursor = close + SUGGESTIONS_CLOSE.length;
   }
-  SUGGESTIONS_RE.lastIndex = 0;
   if (suggestions.length === 0) return { text: content, suggestions: [] };
-  const text = content.replace(SUGGESTIONS_RE, "").trimEnd();
-  SUGGESTIONS_RE.lastIndex = 0;
-  return { text, suggestions: suggestions.slice(0, 5) };
+  text += content.slice(cursor);
+  return { text: text.trimEnd(), suggestions: suggestions.slice(0, 5) };
 }
 
 /**


### PR DESCRIPTION
## Summary

Replace regex-based parsing in `parseSuggestions` with linear-time `indexOf` scanning to fix a CodeQL js/polynomial-redos vulnerability. The previous regex `/<suggestions>\s*([\s\S]*?)\s*<\/suggestions>/g` exhibited quadratic backtracking behavior when encountering an unclosed tag followed by long whitespace runs, causing severe performance degradation (minutes for 100KB of whitespace).

The new implementation uses `indexOf` to locate opening and closing tags, which is O(n) and immune to catastrophic backtracking. Behavior is preserved: all `<suggestions>` blocks are stripped, suggestions are merged and capped at 5, and unclosed blocks (streaming partials) are left in the text.

## Test Plan

- Added comprehensive test suite in `packages/react/src/lib/__tests__/helpers.test.ts` covering:
  - Basic extraction and stripping
  - Empty/missing blocks
  - Whitespace handling
  - Multiple blocks
  - Edge cases (empty content, all-whitespace blocks)
  - **Regression test**: Unclosed tag + 100KB whitespace completes in <1s (previously minutes)
- Updated existing test in `packages/web/src/ui/__tests__/helpers.test.ts` with the same regression test
- Applied identical fix to both `packages/react/src/lib/helpers.ts` and `packages/web/src/ui/lib/helpers.ts`

## Checklist

- [x] Types pass
- [x] Tests pass (new + existing)
- [x] Lint passes
- [x] No dependency changes

https://claude.ai/code/session_01HcPTM9xQEU2iTGeuAbDWPK