### PR TITLE
Docs → KB staging-ingestion test helper

### DIFF
--- a/apps/docs/scripts/README-kb-bundle.md
+++ b/apps/docs/scripts/README-kb-bundle.md
@@ -5,7 +5,16 @@ end in **staging**, using the docs portal as a realistic prose corpus.
 
 `build-docs-kb-bundle.ts` turns the portal content into a `.tar.gz` OKF tree of
 clean markdown (one file = one document, `title`/`description`/`tags`
-frontmatter) that the upload-ingest seam accepts directly.
+frontmatter) that the upload-ingest seam accepts directly. It has two modes:
+
+- **local** (default) — build from the repo `content/` tree. No network, no
+  build; approximates the processed surface (fence-aware ESM strip + audience
+  strip). Best for a reproducible, offline bundle.
+- **`--from-deployed <base-url>`** — build from a *deployed* docs site's
+  `llms.txt` index + per-page `.mdx` twins over HTTP. Bodies are byte-faithful to
+  fumadocs' `getText("processed")` (the same content the on-page "copy markdown"
+  button yields), titles/descriptions come from the index, and no local build is
+  needed. Use it to A/B the body fidelity against the local bundle.
 
 ## What it produces
 
@@ -35,12 +44,21 @@ the lightweight, reproducible stand-in.
 
 ```bash
 cd apps/docs
+# local (default): build from the repo content/ tree
 bun run scripts/build-docs-kb-bundle.ts --out /tmp/docs-kb-saas.tar.gz
 # self-hosted surface (content/self-hosted + content/shared):
 bun run scripts/build-docs-kb-bundle.ts --audience self-hosted --out /tmp/docs-kb-sh.tar.gz
 # keep the api-reference stubs (usually don't — they're empty <APIPage> shells):
 bun run scripts/build-docs-kb-bundle.ts --include-api-reference
+
+# from a deployed site: fetch llms.txt + .mdx twins (byte-faithful bodies, no build)
+bun run scripts/build-docs-kb-bundle.ts --from-deployed https://docs.useatlas.dev --out /tmp/docs-kb-deployed.tar.gz
 ```
+
+`--from-deployed` reads each page's URL *path* from the index and re-roots it onto
+the base URL you pass, so it works against staging or a preview deployment, not
+just prod. It filters `api-reference/` and contentless pages the same way local
+mode does.
 
 ## 2. Create an upload collection (staging)
 

--- a/apps/docs/scripts/README-kb-bundle.md
+++ b/apps/docs/scripts/README-kb-bundle.md
@@ -1,0 +1,90 @@
+# Docs → Knowledge Base staging-ingestion test
+
+A throwaway helper for exercising the KB upload-ingest pipeline (ADR-0028) end to
+end in **staging**, using the docs portal as a realistic prose corpus.
+
+`build-docs-kb-bundle.ts` turns the portal content into a `.tar.gz` OKF tree of
+clean markdown (one file = one document, `title`/`description`/`tags`
+frontmatter) that the upload-ingest seam accepts directly.
+
+## What it produces
+
+Mirrors the SaaS `source` composition (`src/lib/source.ts`): `content/docs`
+(minus the 473 auto-generated `api-reference/` stubs) + `content/shared`, scoped
+to the `saas` audience. ~166 documents, ~0.7 MB — comfortably under the ingest
+caps (1000 docs / 1 MB per doc / 25 MB per bundle).
+
+Faithfulness: the leak-safety-critical transform — resolving
+`<WhenSaaS>` / `<WhenSelfHosted>` / `<AudienceLink>` for the target audience — is
+done by importing the portal's own pure `stripInactiveAudienceBlocks` (the same
+function `getLLMText` uses), so a SaaS bundle is structurally incapable of
+carrying self-hosted branches. It does **not** run fumadocs' `getText("processed")`
+MDX pass; since that preserves component tags verbatim anyway the gap is minor
+(the odd leftover `<Callout>` tag), and MDX `import`/`export` module lines are
+stripped here so the body reads as prose. For a byte-faithful bundle instead,
+harvest the `.md` twins a full `next build` emits under `out/` — this script is
+the lightweight, reproducible stand-in.
+
+## 1. Generate the bundle
+
+```bash
+cd apps/docs
+bun run scripts/build-docs-kb-bundle.ts --out /tmp/docs-kb-saas.tar.gz
+# self-hosted surface (content/self-hosted + content/shared):
+bun run scripts/build-docs-kb-bundle.ts --audience self-hosted --out /tmp/docs-kb-sh.tar.gz
+# keep the api-reference stubs (usually don't — they're empty <APIPage> shells):
+bun run scripts/build-docs-kb-bundle.ts --include-api-reference
+```
+
+## 2. Create an upload collection (staging)
+
+A collection is a `pillar='knowledge'` install of the `catalog:okf-upload`
+catalog. Easiest path is the admin UI:
+
+**Admin → Knowledge → add an OKF upload collection.** Note the collection slug
+(its `install_id`) — you need it for the ingest call.
+
+## 3. Ingest the bundle
+
+Upload the raw bytes as `application/octet-stream` to the ingest route. Requires
+an authenticated **admin session** (reuse your browser session cookie against the
+staging API, or an admin API credential):
+
+```bash
+curl -sS -X POST \
+  "$STAGING_API/api/v1/admin/knowledge/$COLLECTION_SLUG/ingest" \
+  -H "Content-Type: application/octet-stream" \
+  -H "Cookie: $ADMIN_SESSION_COOKIE" \
+  --data-binary @/tmp/docs-kb-saas.tar.gz
+```
+
+Everything lands as **`draft`**. Review it:
+
+```bash
+curl -sS "$STAGING_API/api/v1/admin/knowledge/$COLLECTION_SLUG/documents" \
+  -H "Cookie: $ADMIN_SESSION_COOKIE" | jq '.documents | length'
+```
+
+## 4. Publish
+
+⚠️ **`?publish=true` on the ingest call, and `POST /api/v1/admin/publish`, are
+BOTH workspace-wide** — they promote every pending draft across all content-mode
+tables (entities, connections, prompts, knowledge), not just these docs. For a
+clean staging test, either use a throwaway workspace, or ingest without publish,
+confirm no other drafts are pending, then publish deliberately.
+
+```bash
+# publish this workspace's pending drafts (includes the just-ingested docs):
+curl -sS -X POST "$STAGING_API/api/v1/admin/publish/" -H "Cookie: $ADMIN_SESSION_COOKIE"
+```
+
+Published docs are mirrored to the agent's sandboxed `explore` view
+(`.orgs/{orgId}/modes/published/knowledge/...`); drafts appear only in developer
+mode. A good final check is asking the agent something only these docs answer.
+
+## 5. (Fast follow) bundle-sync instead of upload
+
+The portal already publishes `https://docs.useatlas.dev/llms-full.txt` and
+per-page `.mdx` twins. Once the upload path looks right, a `bundle-sync`
+collection pointed at that surface tests the scheduled-pull path — synced content
+always queues for review (no publish shortcut, enforced at the seam).

--- a/apps/docs/scripts/README-kb-bundle.md
+++ b/apps/docs/scripts/README-kb-bundle.md
@@ -11,8 +11,14 @@ frontmatter) that the upload-ingest seam accepts directly.
 
 Mirrors the SaaS `source` composition (`src/lib/source.ts`): `content/docs`
 (minus the 473 auto-generated `api-reference/` stubs) + `content/shared`, scoped
-to the `saas` audience. ~166 documents, ~0.7 MB — comfortably under the ingest
+to the `saas` audience. ~165 documents, ~0.7 MB — comfortably under the ingest
 caps (1000 docs / 1 MB per doc / 25 MB per bundle).
+
+Pages whose content is entirely component-rendered at build time (e.g.
+`changelog.mdx` is just `<ChangelogTimeline />`) carry no static prose, so they
+ingest as contentless KB docs and are skipped. MDX `import`/`export` module
+lines are stripped fence-aware — an `import` inside a ``` code block is a code
+*example* and is preserved, only the top-of-file component imports are removed.
 
 Faithfulness: the leak-safety-critical transform — resolving
 `<WhenSaaS>` / `<WhenSelfHosted>` / `<AudienceLink>` for the target audience — is

--- a/apps/docs/scripts/build-docs-kb-bundle.ts
+++ b/apps/docs/scripts/build-docs-kb-bundle.ts
@@ -1,0 +1,245 @@
+/**
+ * Build a Knowledge Base ingest bundle from the docs portal content.
+ *
+ * Produces a `.tar.gz` OKF tree of clean markdown (one file = one document,
+ * `title`/`description`/`tags` frontmatter) suitable for the KB upload-ingest
+ * seam (`POST /api/v1/admin/knowledge/{slug}/ingest`, ADR-0028). This is a
+ * throwaway staging-test helper — the intended production source for the same
+ * content is the portal's own `llms-full.txt` / per-page `.mdx` twin surfaces.
+ *
+ * Faithfulness: the substantive, leak-safety-critical transform — resolving
+ * `<WhenSaaS>` / `<WhenSelfHosted>` / `<AudienceLink>` for the target audience —
+ * is done by importing the portal's OWN pure `stripInactiveAudienceBlocks`
+ * (`src/lib/audience-markdown.ts`), the same function `getLLMText` uses. So a
+ * SaaS bundle is structurally incapable of carrying self-hosted branches, exactly
+ * like the deployed machine surface. What this DOESN'T replicate is fumadocs'
+ * `getText("processed")` MDX pass; since that preserves custom component tags
+ * verbatim anyway, the gap is minor (leftover `<Callout>`/`<Tabs>` tags), and we
+ * strip MDX `import`/`export` module lines here so the body reads as prose.
+ *
+ * Mirrors the SaaS `source` composition (`src/lib/source.ts`): `content/docs`
+ * (minus the auto-generated `api-reference/` stubs) + `content/shared`, scoped
+ * to `"saas"`. Pass `--audience self-hosted` for the `content/self-hosted` +
+ * `content/shared` surface instead.
+ *
+ *   bun run scripts/build-docs-kb-bundle.ts                       # SaaS bundle
+ *   bun run scripts/build-docs-kb-bundle.ts --audience self-hosted
+ *   bun run scripts/build-docs-kb-bundle.ts --out /tmp/kb.tar.gz --include-api-reference
+ */
+
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname, relative } from "node:path";
+import { Glob } from "bun";
+import { stripInactiveAudienceBlocks } from "../src/lib/audience-markdown";
+import type { Audience } from "../src/lib/audience";
+
+const DOCS_ROOT = join(import.meta.dir, "..");
+const CONTENT_DIR = join(DOCS_ROOT, "content");
+
+interface Args {
+  audience: Audience;
+  out: string;
+  includeApiReference: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  let audience: Audience = "saas";
+  let out = join(process.cwd(), "docs-kb-bundle.tar.gz");
+  let includeApiReference = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--audience") {
+      const v = argv[++i];
+      if (v !== "saas" && v !== "self-hosted") {
+        throw new Error(`--audience must be "saas" or "self-hosted", got "${v}"`);
+      }
+      audience = v;
+    } else if (a === "--out") {
+      out = argv[++i];
+    } else if (a === "--include-api-reference") {
+      includeApiReference = true;
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return { audience, out, includeApiReference };
+}
+
+/** The content collections composing each audience's surface (mirrors
+ * `buildSectionSource` in `src/lib/source.ts`). `shared` is mounted into both. */
+function sectionsFor(audience: Audience): string[] {
+  return audience === "saas" ? ["docs", "shared"] : ["self-hosted", "shared"];
+}
+
+interface Frontmatter {
+  title?: string;
+  description?: string;
+  tags?: string[];
+}
+
+/**
+ * Split leading `---\n…\n---` frontmatter from the body and pull the scalar
+ * fields we mirror into OKF. Deliberately minimal — the docs frontmatter is
+ * clean (`title`/`description`, occasionally `audience`/`fork`/`tags`), so a
+ * line-scan for top-level scalars beats pulling in a YAML dependency. Unparsed
+ * fields are simply ignored; a missing title falls back to the first `# heading`
+ * or the filename downstream (matching the ingest seam's own lenient behaviour).
+ */
+function splitFrontmatter(raw: string): { fm: Frontmatter; body: string } {
+  const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
+  if (!m) return { fm: {}, body: raw };
+  const body = raw.slice(m[0].length);
+  const fm: Frontmatter = {};
+  const lines = m[1].split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const kv = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
+    if (!kv) continue;
+    const key = kv[1];
+    const rawVal = kv[2].trim();
+    if (key === "title" || key === "description") {
+      fm[key] = unquote(rawVal);
+    } else if (key === "tags") {
+      fm.tags = parseTags(rawVal, lines, i);
+    }
+  }
+  return { fm, body };
+}
+
+function unquote(v: string): string {
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/** Handle both flow (`[a, b]`) and block (`\n  - a\n  - b`) YAML tag lists. */
+function parseTags(inline: string, lines: string[], idx: number): string[] {
+  if (inline.startsWith("[") && inline.endsWith("]")) {
+    return inline
+      .slice(1, -1)
+      .split(",")
+      .map((t) => unquote(t.trim()))
+      .filter(Boolean);
+  }
+  const tags: string[] = [];
+  for (let j = idx + 1; j < lines.length; j++) {
+    const item = /^\s*-\s*(.+)$/.exec(lines[j]);
+    if (!item) break;
+    tags.push(unquote(item[1].trim()));
+  }
+  return tags;
+}
+
+/** Drop MDX module syntax (`import …`, `export …`) so the body is prose. The
+ * audience-strip runs after, on the same shape it expects (processed markdown
+ * keeps component tags but not imports). */
+function stripMdxModuleLines(body: string): string {
+  return body
+    .split("\n")
+    .filter((l) => !/^\s*(import|export)\s/.test(l))
+    .join("\n")
+    .replace(/^\n+/, "");
+}
+
+/** Serialize OKF frontmatter. String values are JSON-encoded (valid YAML
+ * double-quoted scalars) so colons/quotes in descriptions can't break parsing. */
+function renderOkf(fm: Frontmatter, tags: string[], body: string): string {
+  const lines = ["---", "type: Document"];
+  if (fm.title) lines.push(`title: ${JSON.stringify(fm.title)}`);
+  if (fm.description) lines.push(`description: ${JSON.stringify(fm.description)}`);
+  if (tags.length > 0) {
+    lines.push(`tags: [${tags.map((t) => JSON.stringify(t)).join(", ")}]`);
+  }
+  lines.push("---", "", body.trimEnd(), "");
+  return lines.join("\n");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const sections = sectionsFor(args.audience);
+
+  const staging = await mkdtemp(join(tmpdir(), "docs-kb-"));
+  let written = 0;
+  let skippedApiRef = 0;
+  let skippedAudience = 0;
+
+  try {
+    for (const section of sections) {
+      const sectionDir = join(CONTENT_DIR, section);
+      const glob = new Glob("**/*.mdx");
+      for await (const rel of glob.scan(sectionDir)) {
+        // The 473 auto-generated OpenAPI stubs are `<APIPage>` shells with no
+        // prose — worthless as KB content and a waste of the doc-count cap.
+        if (
+          !args.includeApiReference &&
+          section === "docs" &&
+          rel.startsWith("api-reference/")
+        ) {
+          skippedApiRef++;
+          continue;
+        }
+
+        const abs = join(sectionDir, rel);
+        const raw = await Bun.file(abs).text();
+        const { fm, body } = splitFrontmatter(raw);
+
+        let processed: string;
+        try {
+          // Fail-soft per file (mirrors `renderLlmsFullText`): a residual
+          // audience tag throws; skip rather than abort the whole bundle.
+          processed = stripInactiveAudienceBlocks(
+            stripMdxModuleLines(body),
+            args.audience,
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`  skip (audience strip) ${section}/${rel}: ${msg}`);
+          skippedAudience++;
+          continue;
+        }
+
+        // Provenance tags make the bundle's origin legible in the review UI.
+        const tags = [...new Set(["docs-portal", section, ...(fm.tags ?? [])])];
+        const okf = renderOkf(fm, tags, processed);
+
+        const outRel = join(section, rel.replace(/\.mdx$/, ".md"));
+        const outAbs = join(staging, outRel);
+        await mkdir(dirname(outAbs), { recursive: true });
+        await writeFile(outAbs, okf, "utf8");
+        written++;
+      }
+    }
+
+    // Tar the staged tree so archive paths are `docs/…`, `shared/…` at the root.
+    await mkdir(dirname(args.out), { recursive: true });
+    const proc = Bun.spawn(
+      ["tar", "-czf", args.out, "-C", staging, "."],
+      { stdout: "inherit", stderr: "inherit" },
+    );
+    const code = await proc.exited;
+    if (code !== 0) throw new Error(`tar exited with code ${code}`);
+
+    const bytes = (await Bun.file(args.out).stat()).size;
+    console.log("");
+    console.log(`Bundle:    ${args.out}`);
+    console.log(`Audience:  ${args.audience}  (sections: ${sections.join(", ")})`);
+    console.log(`Documents: ${written}`);
+    console.log(`Size:      ${(bytes / 1_000_000).toFixed(2)} MB`);
+    if (skippedApiRef > 0) console.log(`Skipped:   ${skippedApiRef} api-reference stubs`);
+    if (skippedAudience > 0) console.log(`Skipped:   ${skippedAudience} files (audience strip)`);
+    console.log("");
+    console.log("Caps: 1000 docs / 1 MB per doc / 25 MB per bundle.");
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/apps/docs/scripts/build-docs-kb-bundle.ts
+++ b/apps/docs/scripts/build-docs-kb-bundle.ts
@@ -135,15 +135,63 @@ function parseTags(inline: string, lines: string[], idx: number): string[] {
   return tags;
 }
 
-/** Drop MDX module syntax (`import …`, `export …`) so the body is prose. The
- * audience-strip runs after, on the same shape it expects (processed markdown
- * keeps component tags but not imports). */
+/**
+ * Drop MDX module syntax (top-level `import …` / `export …`) so the body reads
+ * as prose — mirroring what fumadocs' `getText("processed")` removes. Must be
+ * FENCE-AWARE: `import`/`export` lines inside a ``` code block are code
+ * *examples* (e.g. the SDK reference's `import type { AtlasClient } …`), not
+ * module syntax — stripping them corrupts the example, and a multi-line one
+ * would leave a dangling `} from "…"`. So only column-0 ESM statements OUTSIDE a
+ * fence are removed, consuming continuation lines of a multi-line statement.
+ */
 function stripMdxModuleLines(body: string): string {
-  return body
-    .split("\n")
-    .filter((l) => !/^\s*(import|export)\s/.test(l))
-    .join("\n")
-    .replace(/^\n+/, "");
+  const lines = body.split("\n");
+  const out: string[] = [];
+  let fence: string | null = null; // the opening fence's marker while open
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (fence === null) fence = marker[0].repeat(3); // open (track char)
+      else if (marker.startsWith(fence)) fence = null; // close on same char
+      out.push(line);
+      continue;
+    }
+    // A real MDX ESM statement is at column 0 and outside any fence.
+    if (fence === null && /^(import|export)\s/.test(line)) {
+      // Consume continuation lines ONLY when the line clearly opens a multi-line
+      // construct (trailing `{`/`(`/`[`/`,`) — so a single-line `export default
+      // Foo` with no terminator can never run the scan away into the prose that
+      // follows. The corpus has no top-level multi-line ESM today (all such
+      // statements live inside fences, handled above); this stays correct if one
+      // is added later.
+      if (/[{([,]\s*$/.test(line)) {
+        i++;
+        while (i < lines.length && !/([)}\]]|["'`]|;)\s*;?\s*$/.test(lines[i])) i++;
+      }
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join("\n").replace(/^\n+/, "");
+}
+
+/**
+ * True when the processed body carries no ingestable prose — a page whose
+ * content is entirely component-rendered at build time (e.g. `changelog.mdx` is
+ * just `<ChangelogTimeline />`). Such a page ingests as a contentless KB doc, so
+ * we skip it. Conservative: any fenced code block counts as content, and only a
+ * body with almost no text once JSX/HTML tags are removed is treated as empty.
+ */
+function isContentless(body: string): boolean {
+  if (/```[\s\S]*?```/.test(body)) return false; // a code-only page is content
+  const text = body
+    .replace(/<[^>]+>/g, " ") // drop JSX / HTML tags
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length < 16;
 }
 
 /** Serialize OKF frontmatter. String values are JSON-encoded (valid YAML
@@ -167,6 +215,7 @@ async function main() {
   let written = 0;
   let skippedApiRef = 0;
   let skippedAudience = 0;
+  let skippedEmpty = 0;
 
   try {
     for (const section of sections) {
@@ -203,6 +252,11 @@ async function main() {
           continue;
         }
 
+        if (isContentless(processed)) {
+          skippedEmpty++;
+          continue;
+        }
+
         // Provenance tags make the bundle's origin legible in the review UI.
         const tags = [...new Set(["docs-portal", section, ...(fm.tags ?? [])])];
         const okf = renderOkf(fm, tags, processed);
@@ -231,6 +285,7 @@ async function main() {
     console.log(`Documents: ${written}`);
     console.log(`Size:      ${(bytes / 1_000_000).toFixed(2)} MB`);
     if (skippedApiRef > 0) console.log(`Skipped:   ${skippedApiRef} api-reference stubs`);
+    if (skippedEmpty > 0) console.log(`Skipped:   ${skippedEmpty} contentless (component-only) pages`);
     if (skippedAudience > 0) console.log(`Skipped:   ${skippedAudience} files (audience strip)`);
     console.log("");
     console.log("Caps: 1000 docs / 1 MB per doc / 25 MB per bundle.");

--- a/apps/docs/scripts/build-docs-kb-bundle.ts
+++ b/apps/docs/scripts/build-docs-kb-bundle.ts
@@ -41,12 +41,17 @@ interface Args {
   audience: Audience;
   out: string;
   includeApiReference: boolean;
+  /** When set, build from a DEPLOYED docs site's `llms.txt` + `.mdx` twins over
+   * HTTP instead of the local `content/` tree — no build, bodies byte-faithful
+   * to `getText("processed")`. Value is the site base URL. */
+  fromDeployed?: string;
 }
 
 function parseArgs(argv: string[]): Args {
   let audience: Audience = "saas";
   let out = join(process.cwd(), "docs-kb-bundle.tar.gz");
   let includeApiReference = false;
+  let fromDeployed: string | undefined;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--audience") {
@@ -59,11 +64,17 @@ function parseArgs(argv: string[]): Args {
       out = argv[++i];
     } else if (a === "--include-api-reference") {
       includeApiReference = true;
+    } else if (a === "--from-deployed") {
+      const v = argv[++i];
+      if (!v || !/^https?:\/\//.test(v)) {
+        throw new Error(`--from-deployed needs an http(s) base URL, got "${v}"`);
+      }
+      fromDeployed = v.replace(/\/$/, "");
     } else {
       throw new Error(`Unknown argument: ${a}`);
     }
   }
-  return { audience, out, includeApiReference };
+  return { audience, out, includeApiReference, fromDeployed };
 }
 
 /** The content collections composing each audience's surface (mirrors
@@ -207,86 +218,210 @@ function renderOkf(fm: Frontmatter, tags: string[], body: string): string {
   return lines.join("\n");
 }
 
+interface Summary {
+  written: number;
+  skippedApiRef: number;
+  skippedEmpty: number;
+  skippedAudience: number;
+}
+
+function emptySummary(): Summary {
+  return { written: 0, skippedApiRef: 0, skippedEmpty: 0, skippedAudience: 0 };
+}
+
+/** Should this content path be excluded from the bundle? The 473 auto-generated
+ * OpenAPI stubs are `<APIPage>` shells with no prose — worthless as KB content
+ * and a waste of the doc-count cap. Shared across both modes. */
+function isApiReference(path: string): boolean {
+  return path.startsWith("api-reference/") || path.startsWith("/api-reference/");
+}
+
+/** LOCAL mode: build from the repo `content/` tree, approximating the processed
+ * surface (fence-aware ESM strip + audience strip). */
+async function collectLocal(staging: string, args: Args): Promise<Summary> {
+  const summary = emptySummary();
+  for (const section of sectionsFor(args.audience)) {
+    const sectionDir = join(CONTENT_DIR, section);
+    const glob = new Glob("**/*.mdx");
+    for await (const rel of glob.scan(sectionDir)) {
+      if (!args.includeApiReference && section === "docs" && isApiReference(rel)) {
+        summary.skippedApiRef++;
+        continue;
+      }
+
+      const raw = await Bun.file(join(sectionDir, rel)).text();
+      const { fm, body } = splitFrontmatter(raw);
+
+      let processed: string;
+      try {
+        // Fail-soft per file (mirrors `renderLlmsFullText`): a residual
+        // audience tag throws; skip rather than abort the whole bundle.
+        processed = stripInactiveAudienceBlocks(stripMdxModuleLines(body), args.audience);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`  skip (audience strip) ${section}/${rel}: ${msg}`);
+        summary.skippedAudience++;
+        continue;
+      }
+
+      if (isContentless(processed)) {
+        summary.skippedEmpty++;
+        continue;
+      }
+
+      // Provenance tags make the bundle's origin legible in the review UI.
+      const tags = [...new Set(["docs-portal", section, ...(fm.tags ?? [])])];
+      const outRel = join(section, rel.replace(/\.mdx$/, ".md"));
+      await writeDoc(staging, outRel, renderOkf(fm, tags, processed));
+      summary.written++;
+    }
+  }
+  return summary;
+}
+
+const FETCH_CONCURRENCY = 8;
+
+interface IndexEntry {
+  title: string;
+  path: string;
+  description?: string;
+}
+
+/**
+ * Parse a deployed `llms.txt` index (`- [Title](url): description` lines) into
+ * page entries. Reads each link's URL PATH — not the host — because the index
+ * absolutizes every URL to the hardcoded `docs.useatlas.dev` regardless of which
+ * deployment served it, so we re-root the path onto the `--from-deployed` base.
+ */
+function parseLlmsIndex(indexText: string): IndexEntry[] {
+  const out: IndexEntry[] = [];
+  for (const line of indexText.split("\n")) {
+    const m = /^\s*-\s*\[([^\]]+)\]\(([^)]+)\)\s*(?::\s*(.*\S))?\s*$/.exec(line);
+    if (!m) continue;
+    const [, title, url, description] = m;
+    let path: string;
+    try {
+      path = new URL(url).pathname;
+    } catch {
+      path = url.startsWith("/") ? url : `/${url}`;
+    }
+    out.push({ title: title.trim(), path, description: description?.trim() || undefined });
+  }
+  return out;
+}
+
+/** `getLLMText` prepends `# Title (url)` to every twin; drop that leading H1
+ * (the title goes into OKF frontmatter) so the body starts at real content. */
+function stripTwinHeading(body: string): string {
+  return body.replace(/^#\s+.*(?:\r?\n)+/, "");
+}
+
+/** Map a deployed page path to a bundle-relative `.md` path. A section-index
+ * path (trailing slash) becomes `<section>/index.md`. */
+function deployedOutRel(path: string): string {
+  return `${path.replace(/^\//, "").replace(/\/$/, "/index")}.md`;
+}
+
+/** DEPLOYED mode: build from a live site's `llms.txt` index + per-page `.mdx`
+ * twins over HTTP. Twins are already audience-resolved by `getLLMText`, so no
+ * re-strip; descriptions come from the index (the twins carry none). */
+async function collectDeployed(staging: string, args: Args, base: string): Promise<Summary> {
+  const indexPath = args.audience === "saas" ? "/llms.txt" : "/self-hosted/llms.txt";
+  const indexUrl = `${base}${indexPath}`;
+
+  const res = await fetch(indexUrl);
+  if (!res.ok) {
+    throw new Error(`Fetch ${indexUrl} → ${res.status} ${res.statusText}`);
+  }
+  const index = parseLlmsIndex(await res.text());
+  if (index.length === 0) throw new Error(`No pages parsed from ${indexUrl}`);
+
+  const summary = emptySummary();
+  const pages = index.filter((p) => {
+    if (p.path === "/" || p.path === indexPath) return false;
+    if (!args.includeApiReference && isApiReference(p.path)) {
+      summary.skippedApiRef++;
+      return false;
+    }
+    return true;
+  });
+
+  // Bounded-concurrency fetch pool. `cursor++` and the `summary` mutations are
+  // safe under Bun's single-threaded event loop (no interleaving mid-statement).
+  let cursor = 0;
+  const worker = async () => {
+    for (let i = cursor++; i < pages.length; i = cursor++) {
+      const p = pages[i];
+      const twinUrl = `${base}${p.path}.mdx`;
+      let body: string;
+      try {
+        const r = await fetch(twinUrl);
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+        body = stripTwinHeading(await r.text());
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`  skip (fetch) ${p.path}.mdx: ${msg}`);
+        continue;
+      }
+      if (isContentless(body)) {
+        summary.skippedEmpty++;
+        continue;
+      }
+      const okf = renderOkf(
+        { title: p.title, description: p.description },
+        ["docs-portal", "deployed"],
+        body,
+      );
+      await writeDoc(staging, deployedOutRel(p.path), okf);
+      summary.written++;
+    }
+  };
+  await Promise.all(Array.from({ length: FETCH_CONCURRENCY }, worker));
+  return summary;
+}
+
+/** Write one staged doc, creating parent dirs. */
+async function writeDoc(staging: string, outRel: string, okf: string): Promise<void> {
+  const outAbs = join(staging, outRel);
+  await mkdir(dirname(outAbs), { recursive: true });
+  await writeFile(outAbs, okf, "utf8");
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const sections = sectionsFor(args.audience);
-
   const staging = await mkdtemp(join(tmpdir(), "docs-kb-"));
-  let written = 0;
-  let skippedApiRef = 0;
-  let skippedAudience = 0;
-  let skippedEmpty = 0;
 
   try {
-    for (const section of sections) {
-      const sectionDir = join(CONTENT_DIR, section);
-      const glob = new Glob("**/*.mdx");
-      for await (const rel of glob.scan(sectionDir)) {
-        // The 473 auto-generated OpenAPI stubs are `<APIPage>` shells with no
-        // prose — worthless as KB content and a waste of the doc-count cap.
-        if (
-          !args.includeApiReference &&
-          section === "docs" &&
-          rel.startsWith("api-reference/")
-        ) {
-          skippedApiRef++;
-          continue;
-        }
+    const summary = args.fromDeployed
+      ? await collectDeployed(staging, args, args.fromDeployed)
+      : await collectLocal(staging, args);
 
-        const abs = join(sectionDir, rel);
-        const raw = await Bun.file(abs).text();
-        const { fm, body } = splitFrontmatter(raw);
-
-        let processed: string;
-        try {
-          // Fail-soft per file (mirrors `renderLlmsFullText`): a residual
-          // audience tag throws; skip rather than abort the whole bundle.
-          processed = stripInactiveAudienceBlocks(
-            stripMdxModuleLines(body),
-            args.audience,
-          );
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.warn(`  skip (audience strip) ${section}/${rel}: ${msg}`);
-          skippedAudience++;
-          continue;
-        }
-
-        if (isContentless(processed)) {
-          skippedEmpty++;
-          continue;
-        }
-
-        // Provenance tags make the bundle's origin legible in the review UI.
-        const tags = [...new Set(["docs-portal", section, ...(fm.tags ?? [])])];
-        const okf = renderOkf(fm, tags, processed);
-
-        const outRel = join(section, rel.replace(/\.mdx$/, ".md"));
-        const outAbs = join(staging, outRel);
-        await mkdir(dirname(outAbs), { recursive: true });
-        await writeFile(outAbs, okf, "utf8");
-        written++;
-      }
+    if (summary.written === 0) {
+      throw new Error("No documents collected — nothing to bundle.");
     }
 
-    // Tar the staged tree so archive paths are `docs/…`, `shared/…` at the root.
+    // Tar the staged tree so archive paths are the OKF tree at the root.
     await mkdir(dirname(args.out), { recursive: true });
-    const proc = Bun.spawn(
-      ["tar", "-czf", args.out, "-C", staging, "."],
-      { stdout: "inherit", stderr: "inherit" },
-    );
+    const proc = Bun.spawn(["tar", "-czf", args.out, "-C", staging, "."], {
+      stdout: "inherit",
+      stderr: "inherit",
+    });
     const code = await proc.exited;
     if (code !== 0) throw new Error(`tar exited with code ${code}`);
 
     const bytes = (await Bun.file(args.out).stat()).size;
     console.log("");
     console.log(`Bundle:    ${args.out}`);
-    console.log(`Audience:  ${args.audience}  (sections: ${sections.join(", ")})`);
-    console.log(`Documents: ${written}`);
+    console.log(
+      args.fromDeployed
+        ? `Source:    ${args.fromDeployed}  (deployed llms.txt + .mdx twins, ${args.audience})`
+        : `Source:    local content/  (${args.audience}: ${sectionsFor(args.audience).join(", ")})`,
+    );
+    console.log(`Documents: ${summary.written}`);
     console.log(`Size:      ${(bytes / 1_000_000).toFixed(2)} MB`);
-    if (skippedApiRef > 0) console.log(`Skipped:   ${skippedApiRef} api-reference stubs`);
-    if (skippedEmpty > 0) console.log(`Skipped:   ${skippedEmpty} contentless (component-only) pages`);
-    if (skippedAudience > 0) console.log(`Skipped:   ${skippedAudience} files (audience strip)`);
+    if (summary.skippedApiRef > 0) console.log(`Skipped:   ${summary.skippedApiRef} api-reference stubs`);
+    if (summary.skippedEmpty > 0) console.log(`Skipped:   ${summary.skippedEmpty} contentless (component-only) pages`);
+    if (summary.skippedAudience > 0) console.log(`Skipped:   ${summary.skippedAudience} files (audience strip)`);
     console.log("");
     console.log("Caps: 1000 docs / 1 MB per doc / 25 MB per bundle.");
   } finally {

--- a/apps/docs/scripts/build-docs-kb-bundle.ts
+++ b/apps/docs/scripts/build-docs-kb-bundle.ts
@@ -29,7 +29,7 @@
 
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, dirname, relative } from "node:path";
+import { join, dirname } from "node:path";
 import { Glob } from "bun";
 import { stripInactiveAudienceBlocks } from "../src/lib/audience-markdown";
 import type { Audience } from "../src/lib/audience";


### PR DESCRIPTION
## Summary

Adds a throwaway helper for exercising the Knowledge Base upload-ingest pipeline ([ADR-0028](../blob/main/docs/adr/0028-knowledge-base-fourth-pillar.md)) end to end in **staging**, using the docs portal as a realistic prose corpus. It turns the portal into a `.tar.gz` OKF tree of clean markdown (one file = one document, `title`/`description`/`tags` frontmatter) that the upload-ingest seam (`POST /api/v1/admin/knowledge/{slug}/ingest`) accepts directly.

Two modes:

- **local** (default) — build from the repo `content/` tree. No network, no build. Mirrors the SaaS `source` composition (`content/docs` minus the 473 auto-generated `api-reference/` stubs + `content/shared`), scoped to the target audience. Reuses the portal's own pure `stripInactiveAudienceBlocks` (the same function `getLLMText` uses), so a SaaS bundle is structurally incapable of carrying self-hosted branches. **~165 docs, ~0.7 MB** — well under the ingest caps (1000 docs / 1 MB per doc / 25 MB per bundle).
- **`--from-deployed <base-url>`** — build from a deployed docs site's `llms.txt` index + per-page `.mdx` twins over HTTP (the same surface behind the on-page "copy markdown" button). Bodies are byte-faithful to fumadocs' `getText("processed")`; titles/descriptions are recovered from the index; the leading `# Title (url)` H1 is stripped into OKF frontmatter. Reads each link's URL *path* and re-roots it onto the passed base, so it works against staging/preview, not just prod.

Quality handling shared by both modes: `api-reference/` stubs excluded, contentless component-only pages (e.g. `changelog.mdx` = `<ChangelogTimeline />`) skipped, and MDX `import`/`export` stripping is **fence-aware** — an `import` inside a ``` code block is a code *example* and is preserved; only top-of-file component imports are removed.

Scope: two new files under `apps/docs/scripts/` (the builder + a runbook README). No product code touched. This is a staging test tool, not a shipped feature.

## Test Plan

- [x] Manual testing
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

**Local mode** — ran against the repo; 165 docs, 0.67 MB. Verified extracted output: clean OKF frontmatter, audience-strip leaves zero real self-hosted branches (only an inline-code `` `<WhenSaaS>` `` mention in a page documenting the feature survives, as intended), all multi-line code examples intact (`opens == closes` per file, zero orphans after the fence-aware fix), every doc carries a description, all sizes within caps.

**Deployed mode** — captured the real `docs.useatlas.dev` `llms.txt` + all 163 twins via curl, served them on localhost, and ran `--from-deployed` against it: 162 clean docs, every one with title + description, H1 stripped, api-reference (473) and contentless (1) skipped. (The live-site fetch can't run from the CI sandbox because bun's `fetch` doesn't use the outbound proxy — a sandbox constraint, not a script issue; the localhost run exercises the identical code path.)

**Note on CI gates below:** `node_modules` isn't installed in this environment, so I could not run `bun run type` / `test` / `lint` locally — the script is runtime-verified via bun instead. Please let the CI checks confirm.

## Checklist

- [ ] Types pass (`bun run type`) — not run locally (see note)
- [ ] Tests pass (`bun run test`) — no tests added; not run locally
- [ ] Lint passes (`bun run lint`) — not run locally (see note)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — not user-facing (internal test tooling)

https://claude.ai/code/session_01J9kVa8kDXMfi97q5AufMcB

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9kVa8kDXMfi97q5AufMcB)_