### PR TITLE
feat: first-class Fumadocs → KB OKF importer over the source-loader surface

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,6 +23,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@atlas/fumadocs-okf": "workspace:*",
     "@types/node": "^25.9.4",
     "@shikijs/transformers": "^4.2.0",
     "@tailwindcss/postcss": "^4.3.1",

--- a/apps/docs/scripts/README-kb-bundle.md
+++ b/apps/docs/scripts/README-kb-bundle.md
@@ -1,44 +1,33 @@
-# Docs → Knowledge Base staging-ingestion test
+# Docs → Knowledge Base bundle
 
-A throwaway helper for exercising the KB upload-ingest pipeline (ADR-0028) end to
-end in **staging**, using the docs portal as a realistic prose corpus.
+Builds the docs portal's Knowledge Base bundle — a `.tar.gz` OKF tree of clean
+markdown (one file = one document, `title`/`description`/`tags` frontmatter)
+for the KB ingest seam (ADR-0028).
 
-`build-docs-kb-bundle.ts` turns the portal content into a `.tar.gz` OKF tree of
-clean markdown (one file = one document, `title`/`description`/`tags`
-frontmatter) that the upload-ingest seam accepts directly. It has two modes:
+Since #4367 this script is the **dogfood consumer of `@atlas/fumadocs-okf`**
+(`packages/fumadocs-okf` — see its README for the adapter contract and the
+bundle-sync hosting recipe). The adapter owns OKF rendering, deterministic
+archive paths, generation-time ingest-cap validation, and deterministic
+packing; this script supplies only the portal-specific parts:
 
-- **local** (default) — build from the repo `content/` tree. No network, no
-  build; approximates the processed surface (fence-aware ESM strip + audience
-  strip). Best for a reproducible, offline bundle.
-- **`--from-deployed <base-url>`** — build from a *deployed* docs site's
-  `llms.txt` index + per-page `.mdx` twins over HTTP. Bodies are byte-faithful to
-  fumadocs' `getText("processed")` (the same content the on-page "copy markdown"
-  button yields), titles/descriptions come from the index, and no local build is
-  needed. Use it to A/B the body fidelity against the local bundle.
+- **source shims** (`kb-bundle-sources.ts`): the portal's real Fumadocs loader
+  lives behind the Next bundler (`.source/server.ts` imports
+  `*.mdx?collection=…` modules bun can't resolve), so local mode walks
+  `content/` and approximates the processed surface (fence-aware ESM strip),
+  and deployed mode reads the live site's `llms.txt` + `.mdx` twins
+  (byte-faithful bodies);
+- the **audience transform** via the adapter's body-transform hook: the
+  portal's own `stripInactiveAudienceBlocks` resolves
+  `<WhenSaaS>`/`<WhenSelfHosted>`/`<AudienceLink>` per mount and fails closed,
+  so a SaaS bundle is structurally incapable of carrying self-hosted branches
+  (pinned by `src/lib/__tests__/kb-bundle.test.ts`). A page the strip can't
+  fully resolve is skipped, never emitted.
 
-## What it produces
-
-Mirrors the SaaS `source` composition (`src/lib/source.ts`): `content/docs`
-(minus the 473 auto-generated `api-reference/` stubs) + `content/shared`, scoped
-to the `saas` audience. ~165 documents, ~0.7 MB — comfortably under the ingest
-caps (1000 docs / 1 MB per doc / 25 MB per bundle).
-
-Pages whose content is entirely component-rendered at build time (e.g.
-`changelog.mdx` is just `<ChangelogTimeline />`) carry no static prose, so they
-ingest as contentless KB docs and are skipped. MDX `import`/`export` module
-lines are stripped fence-aware — an `import` inside a ``` code block is a code
-*example* and is preserved, only the top-of-file component imports are removed.
-
-Faithfulness: the leak-safety-critical transform — resolving
-`<WhenSaaS>` / `<WhenSelfHosted>` / `<AudienceLink>` for the target audience — is
-done by importing the portal's own pure `stripInactiveAudienceBlocks` (the same
-function `getLLMText` uses), so a SaaS bundle is structurally incapable of
-carrying self-hosted branches. It does **not** run fumadocs' `getText("processed")`
-MDX pass; since that preserves component tags verbatim anyway the gap is minor
-(the odd leftover `<Callout>` tag), and MDX `import`/`export` module lines are
-stripped here so the body reads as prose. For a byte-faithful bundle instead,
-harvest the `.md` twins a full `next build` emits under `out/` — this script is
-the lightweight, reproducible stand-in.
+Reserved-basename fix (#4367): the ingest parser silently skips `index.md` /
+`log.md`, which used to drop all 8 section-landing pages (165 built → 157
+ingested, `rejected=0`). The adapter now folds `…/index.mdx` onto the section
+slug (`shared/comparisons/index.mdx` → `shared/comparisons.md`) in BOTH modes,
+so built count == ingested count; the summary prints any reserved renames.
 
 ## 1. Generate the bundle
 
@@ -55,10 +44,18 @@ bun run scripts/build-docs-kb-bundle.ts --include-api-reference
 bun run scripts/build-docs-kb-bundle.ts --from-deployed https://docs.useatlas.dev --out /tmp/docs-kb-deployed.tar.gz
 ```
 
-`--from-deployed` reads each page's URL *path* from the index and re-roots it onto
-the base URL you pass, so it works against staging or a preview deployment, not
-just prod. It filters `api-reference/` and contentless pages the same way local
-mode does.
+`--from-deployed` reads each page's URL *path* from the index and re-roots it
+onto the base URL you pass, so it works against staging or a preview
+deployment. It is **surface-dependent**: it only works on a site that has
+opted into the hand-authored `llms.txt` + `.mdx`-twin routes (ours has). Local
+mode's archive paths are prefixed per section (`docs/…`, `shared/…`,
+`self-hosted/…`); deployed mode uses a single `portal/…` prefix. Twin-fetch
+failures are fail-loud (unlike the #4366 spike): a silently partial bundle fed
+to a bundle-sync collection would archive the missing pages' documents via the
+subtractive diff.
+
+The summary line `Documents: N` is a reconcile contract — expect the SAME
+count ingested. A smaller ingest count means silent drops; investigate.
 
 ## 2. Create an upload collection (staging)
 
@@ -106,9 +103,11 @@ Published docs are mirrored to the agent's sandboxed `explore` view
 (`.orgs/{orgId}/modes/published/knowledge/...`); drafts appear only in developer
 mode. A good final check is asking the agent something only these docs answer.
 
-## 5. (Fast follow) bundle-sync instead of upload
+## 5. bundle-sync instead of upload
 
-The portal already publishes `https://docs.useatlas.dev/llms-full.txt` and
-per-page `.mdx` twins. Once the upload path looks right, a `bundle-sync`
-collection pointed at that surface tests the scheduled-pull path — synced content
-always queues for review (no publish shortcut, enforced at the seam).
+For the scheduled-pull path (synced content always queues for review — no
+publish shortcut, enforced at the seam), host the generated archive at an
+endpoint and point a `bundle-sync` collection at it. The full recipe — static
+artifact vs route handler, the bearer-protected variant, the SSRF egress-guard
+reachability constraints, and the cap-settings knobs — lives in
+`packages/fumadocs-okf/README.md`.

--- a/apps/docs/scripts/build-docs-kb-bundle.ts
+++ b/apps/docs/scripts/build-docs-kb-bundle.ts
@@ -1,41 +1,50 @@
 /**
- * Build a Knowledge Base ingest bundle from the docs portal content.
+ * Build a Knowledge Base ingest bundle from the docs portal content — the
+ * dogfood consumer of the `@atlas/fumadocs-okf` adapter (issue #4367; the
+ * #4366 spike, refit). The adapter owns everything bundle-shaped: OKF
+ * rendering, deterministic archive paths (including the reserved-basename
+ * fold that used to silently drop every `index.md` section landing at
+ * ingest), generation-time ingest-cap validation, and the deterministic
+ * `.tar.gz` packing. This script only supplies the portal-specific parts:
  *
- * Produces a `.tar.gz` OKF tree of clean markdown (one file = one document,
- * `title`/`description`/`tags` frontmatter) suitable for the KB upload-ingest
- * seam (`POST /api/v1/admin/knowledge/{slug}/ingest`, ADR-0028). This is a
- * throwaway staging-test helper — the intended production source for the same
- * content is the portal's own `llms-full.txt` / per-page `.mdx` twin surfaces.
- *
- * Faithfulness: the substantive, leak-safety-critical transform — resolving
- * `<WhenSaaS>` / `<WhenSelfHosted>` / `<AudienceLink>` for the target audience —
- * is done by importing the portal's OWN pure `stripInactiveAudienceBlocks`
- * (`src/lib/audience-markdown.ts`), the same function `getLLMText` uses. So a
- * SaaS bundle is structurally incapable of carrying self-hosted branches, exactly
- * like the deployed machine surface. What this DOESN'T replicate is fumadocs'
- * `getText("processed")` MDX pass; since that preserves custom component tags
- * verbatim anyway, the gap is minor (leftover `<Callout>`/`<Tabs>` tags), and we
- * strip MDX `import`/`export` module lines here so the body reads as prose.
- *
- * Mirrors the SaaS `source` composition (`src/lib/source.ts`): `content/docs`
- * (minus the auto-generated `api-reference/` stubs) + `content/shared`, scoped
- * to `"saas"`. Pass `--audience self-hosted` for the `content/self-hosted` +
- * `content/shared` surface instead.
+ *   - the two source shims (`kb-bundle-sources.ts`) — the local `content/`
+ *     walk and the deployed `llms.txt` + `.mdx`-twin fetch — because the
+ *     portal's real Fumadocs loader lives behind the Next bundler;
+ *   - the leak-safety-critical audience transform, passed through the
+ *     adapter's body-transform hook: a SaaS bundle is structurally incapable
+ *     of carrying self-hosted branches (`stripInactiveAudienceBlocks` fails
+ *     closed; an unresolved page is skipped, never emitted).
  *
  *   bun run scripts/build-docs-kb-bundle.ts                       # SaaS bundle
  *   bun run scripts/build-docs-kb-bundle.ts --audience self-hosted
  *   bun run scripts/build-docs-kb-bundle.ts --out /tmp/kb.tar.gz --include-api-reference
+ *   bun run scripts/build-docs-kb-bundle.ts --from-deployed https://docs.useatlas.dev
  */
 
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join, dirname } from "node:path";
-import { Glob } from "bun";
-import { stripInactiveAudienceBlocks } from "../src/lib/audience-markdown";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  buildFumadocsOkfBundle,
+  collectFumadocsPages,
+  mergeCollectResults,
+  packOkfBundle,
+  type BuildResult,
+  type CollectResult,
+} from "@atlas/fumadocs-okf";
 import type { Audience } from "../src/lib/audience";
+import {
+  deployedSource,
+  localSectionSource,
+  parseLlmsIndex,
+  portalAudienceTransform,
+  sectionsFor,
+} from "./kb-bundle-sources";
 
 const DOCS_ROOT = join(import.meta.dir, "..");
 const CONTENT_DIR = join(DOCS_ROOT, "content");
+
+/** Stable top-level prefix for deployed-mode bundles (local mode prefixes per section). */
+const DEPLOYED_PREFIX = "portal";
 
 interface Args {
   audience: Audience;
@@ -77,255 +86,47 @@ function parseArgs(argv: string[]): Args {
   return { audience, out, includeApiReference, fromDeployed };
 }
 
-/** The content collections composing each audience's surface (mirrors
- * `buildSectionSource` in `src/lib/source.ts`). `shared` is mounted into both. */
-function sectionsFor(audience: Audience): string[] {
-  return audience === "saas" ? ["docs", "shared"] : ["self-hosted", "shared"];
-}
+/** LOCAL mode: one adapter collect per section (prefix = section name), packed
+ * as ONE archive so the caps are validated over the merged set. */
+async function buildLocal(args: Args): Promise<BuildResult> {
+  const transform = portalAudienceTransform(args.audience, (pagePath, reason) => {
+    console.warn(`  skip (audience strip) ${pagePath}: ${reason}`);
+  });
 
-interface Frontmatter {
-  title?: string;
-  description?: string;
-  tags?: string[];
-}
-
-/**
- * Split leading `---\n…\n---` frontmatter from the body and pull the scalar
- * fields we mirror into OKF. Deliberately minimal — the docs frontmatter is
- * clean (`title`/`description`, occasionally `audience`/`fork`/`tags`), so a
- * line-scan for top-level scalars beats pulling in a YAML dependency. Unparsed
- * fields are simply ignored; a missing title falls back to the first `# heading`
- * or the filename downstream (matching the ingest seam's own lenient behaviour).
- */
-function splitFrontmatter(raw: string): { fm: Frontmatter; body: string } {
-  const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
-  if (!m) return { fm: {}, body: raw };
-  const body = raw.slice(m[0].length);
-  const fm: Frontmatter = {};
-  const lines = m[1].split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const kv = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
-    if (!kv) continue;
-    const key = kv[1];
-    const rawVal = kv[2].trim();
-    if (key === "title" || key === "description") {
-      fm[key] = unquote(rawVal);
-    } else if (key === "tags") {
-      fm.tags = parseTags(rawVal, lines, i);
-    }
-  }
-  return { fm, body };
-}
-
-function unquote(v: string): string {
-  if (
-    (v.startsWith('"') && v.endsWith('"')) ||
-    (v.startsWith("'") && v.endsWith("'"))
-  ) {
-    return v.slice(1, -1);
-  }
-  return v;
-}
-
-/** Handle both flow (`[a, b]`) and block (`\n  - a\n  - b`) YAML tag lists. */
-function parseTags(inline: string, lines: string[], idx: number): string[] {
-  if (inline.startsWith("[") && inline.endsWith("]")) {
-    return inline
-      .slice(1, -1)
-      .split(",")
-      .map((t) => unquote(t.trim()))
-      .filter(Boolean);
-  }
-  const tags: string[] = [];
-  for (let j = idx + 1; j < lines.length; j++) {
-    const item = /^\s*-\s*(.+)$/.exec(lines[j]);
-    if (!item) break;
-    tags.push(unquote(item[1].trim()));
-  }
-  return tags;
-}
-
-/**
- * Drop MDX module syntax (top-level `import …` / `export …`) so the body reads
- * as prose — mirroring what fumadocs' `getText("processed")` removes. Must be
- * FENCE-AWARE: `import`/`export` lines inside a ``` code block are code
- * *examples* (e.g. the SDK reference's `import type { AtlasClient } …`), not
- * module syntax — stripping them corrupts the example, and a multi-line one
- * would leave a dangling `} from "…"`. So only column-0 ESM statements OUTSIDE a
- * fence are removed, consuming continuation lines of a multi-line statement.
- */
-function stripMdxModuleLines(body: string): string {
-  const lines = body.split("\n");
-  const out: string[] = [];
-  let fence: string | null = null; // the opening fence's marker while open
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(line);
-    if (fenceMatch) {
-      const marker = fenceMatch[1];
-      if (fence === null) fence = marker[0].repeat(3); // open (track char)
-      else if (marker.startsWith(fence)) fence = null; // close on same char
-      out.push(line);
-      continue;
-    }
-    // A real MDX ESM statement is at column 0 and outside any fence.
-    if (fence === null && /^(import|export)\s/.test(line)) {
-      // Consume continuation lines ONLY when the line clearly opens a multi-line
-      // construct (trailing `{`/`(`/`[`/`,`) — so a single-line `export default
-      // Foo` with no terminator can never run the scan away into the prose that
-      // follows. The corpus has no top-level multi-line ESM today (all such
-      // statements live inside fences, handled above); this stays correct if one
-      // is added later.
-      if (/[{([,]\s*$/.test(line)) {
-        i++;
-        while (i < lines.length && !/([)}\]]|["'`]|;)\s*;?\s*$/.test(lines[i])) i++;
-      }
-      continue;
-    }
-    out.push(line);
-  }
-  return out.join("\n").replace(/^\n+/, "");
-}
-
-/**
- * True when the processed body carries no ingestable prose — a page whose
- * content is entirely component-rendered at build time (e.g. `changelog.mdx` is
- * just `<ChangelogTimeline />`). Such a page ingests as a contentless KB doc, so
- * we skip it. Conservative: any fenced code block counts as content, and only a
- * body with almost no text once JSX/HTML tags are removed is treated as empty.
- */
-function isContentless(body: string): boolean {
-  if (/```[\s\S]*?```/.test(body)) return false; // a code-only page is content
-  const text = body
-    .replace(/<[^>]+>/g, " ") // drop JSX / HTML tags
-    .replace(/\s+/g, " ")
-    .trim();
-  return text.length < 16;
-}
-
-/** Serialize OKF frontmatter. String values are JSON-encoded (valid YAML
- * double-quoted scalars) so colons/quotes in descriptions can't break parsing. */
-function renderOkf(fm: Frontmatter, tags: string[], body: string): string {
-  const lines = ["---", "type: Document"];
-  if (fm.title) lines.push(`title: ${JSON.stringify(fm.title)}`);
-  if (fm.description) lines.push(`description: ${JSON.stringify(fm.description)}`);
-  if (tags.length > 0) {
-    lines.push(`tags: [${tags.map((t) => JSON.stringify(t)).join(", ")}]`);
-  }
-  lines.push("---", "", body.trimEnd(), "");
-  return lines.join("\n");
-}
-
-interface Summary {
-  written: number;
-  skippedApiRef: number;
-  skippedEmpty: number;
-  skippedAudience: number;
-}
-
-function emptySummary(): Summary {
-  return { written: 0, skippedApiRef: 0, skippedEmpty: 0, skippedAudience: 0 };
-}
-
-/** Should this content path be excluded from the bundle? The 473 auto-generated
- * OpenAPI stubs are `<APIPage>` shells with no prose — worthless as KB content
- * and a waste of the doc-count cap. Shared across both modes. */
-function isApiReference(path: string): boolean {
-  return path.startsWith("api-reference/") || path.startsWith("/api-reference/");
-}
-
-/** LOCAL mode: build from the repo `content/` tree, approximating the processed
- * surface (fence-aware ESM strip + audience strip). */
-async function collectLocal(staging: string, args: Args): Promise<Summary> {
-  const summary = emptySummary();
+  const collects: CollectResult[] = [];
   for (const section of sectionsFor(args.audience)) {
-    const sectionDir = join(CONTENT_DIR, section);
-    const glob = new Glob("**/*.mdx");
-    for await (const rel of glob.scan(sectionDir)) {
-      if (!args.includeApiReference && section === "docs" && isApiReference(rel)) {
-        summary.skippedApiRef++;
-        continue;
-      }
-
-      const raw = await Bun.file(join(sectionDir, rel)).text();
-      const { fm, body } = splitFrontmatter(raw);
-
-      let processed: string;
-      try {
-        // Fail-soft per file (mirrors `renderLlmsFullText`): a residual
-        // audience tag throws; skip rather than abort the whole bundle.
-        processed = stripInactiveAudienceBlocks(stripMdxModuleLines(body), args.audience);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn(`  skip (audience strip) ${section}/${rel}: ${msg}`);
-        summary.skippedAudience++;
-        continue;
-      }
-
-      if (isContentless(processed)) {
-        summary.skippedEmpty++;
-        continue;
-      }
-
-      // Provenance tags make the bundle's origin legible in the review UI.
-      const tags = [...new Set(["docs-portal", section, ...(fm.tags ?? [])])];
-      const outRel = join(section, rel.replace(/\.mdx$/, ".md"));
-      await writeDoc(staging, outRel, renderOkf(fm, tags, processed));
-      summary.written++;
-    }
+    const source = await localSectionSource(join(CONTENT_DIR, section));
+    collects.push(
+      await collectFumadocsPages(source, {
+        prefix: section,
+        transform,
+        // Provenance tags make the bundle's origin legible in the review UI.
+        tags: ["docs-portal", section],
+        skipApiReference: !args.includeApiReference,
+      }),
+    );
   }
-  return summary;
+  const merged = mergeCollectResults(collects);
+  const { bytes, totalDocBytes } = packOkfBundle(merged.docs);
+  return {
+    bytes,
+    docs: merged.docs,
+    stats: {
+      documents: merged.docs.length,
+      totalDocBytes,
+      archiveBytes: bytes.length,
+      skipped: merged.skipped,
+      renamedReserved: merged.renamedReserved,
+    },
+  };
 }
 
-const FETCH_CONCURRENCY = 8;
-
-interface IndexEntry {
-  title: string;
-  path: string;
-  description?: string;
-}
-
-/**
- * Parse a deployed `llms.txt` index (`- [Title](url): description` lines) into
- * page entries. Reads each link's URL PATH — not the host — because the index
- * absolutizes every URL to the hardcoded `docs.useatlas.dev` regardless of which
- * deployment served it, so we re-root the path onto the `--from-deployed` base.
- */
-function parseLlmsIndex(indexText: string): IndexEntry[] {
-  const out: IndexEntry[] = [];
-  for (const line of indexText.split("\n")) {
-    const m = /^\s*-\s*\[([^\]]+)\]\(([^)]+)\)\s*(?::\s*(.*\S))?\s*$/.exec(line);
-    if (!m) continue;
-    const [, title, url, description] = m;
-    let path: string;
-    try {
-      path = new URL(url).pathname;
-    } catch {
-      path = url.startsWith("/") ? url : `/${url}`;
-    }
-    out.push({ title: title.trim(), path, description: description?.trim() || undefined });
-  }
-  return out;
-}
-
-/** `getLLMText` prepends `# Title (url)` to every twin; drop that leading H1
- * (the title goes into OKF frontmatter) so the body starts at real content. */
-function stripTwinHeading(body: string): string {
-  return body.replace(/^#\s+.*(?:\r?\n)+/, "");
-}
-
-/** Map a deployed page path to a bundle-relative `.md` path. A section-index
- * path (trailing slash) becomes `<section>/index.md`. */
-function deployedOutRel(path: string): string {
-  return `${path.replace(/^\//, "").replace(/\/$/, "/index")}.md`;
-}
-
-/** DEPLOYED mode: build from a live site's `llms.txt` index + per-page `.mdx`
- * twins over HTTP. Twins are already audience-resolved by `getLLMText`, so no
- * re-strip; descriptions come from the index (the twins carry none). */
-async function collectDeployed(staging: string, args: Args, base: string): Promise<Summary> {
+/** DEPLOYED mode: pages from the site's `llms.txt`, bodies from the `.mdx`
+ * twins (already audience-resolved — no transform). A twin fetch failure is
+ * FAIL-LOUD (unlike the #4366 spike's warn-and-skip): a silently partial
+ * bundle fed to a bundle-sync collection would ARCHIVE the missing pages'
+ * previously-reviewed documents via the subtractive diff. */
+async function buildDeployed(args: Args, base: string): Promise<BuildResult> {
   const indexPath = args.audience === "saas" ? "/llms.txt" : "/self-hosted/llms.txt";
   const indexUrl = `${base}${indexPath}`;
 
@@ -333,99 +134,51 @@ async function collectDeployed(staging: string, args: Args, base: string): Promi
   if (!res.ok) {
     throw new Error(`Fetch ${indexUrl} → ${res.status} ${res.statusText}`);
   }
-  const index = parseLlmsIndex(await res.text());
-  if (index.length === 0) throw new Error(`No pages parsed from ${indexUrl}`);
+  const entries = parseLlmsIndex(await res.text()).filter(
+    // The bare site root ("/") is skipped as in #4366: its twin URL shape is
+    // not a page twin. The docs landing content still arrives via local mode.
+    (entry) => entry.path !== "/" && entry.path !== indexPath,
+  );
+  if (entries.length === 0) throw new Error(`No pages parsed from ${indexUrl}`);
 
-  const summary = emptySummary();
-  const pages = index.filter((p) => {
-    if (p.path === "/" || p.path === indexPath) return false;
-    if (!args.includeApiReference && isApiReference(p.path)) {
-      summary.skippedApiRef++;
-      return false;
-    }
-    return true;
+  return buildFumadocsOkfBundle(deployedSource(base, entries), {
+    prefix: DEPLOYED_PREFIX,
+    tags: ["docs-portal", "deployed"],
+    skipApiReference: !args.includeApiReference,
   });
-
-  // Bounded-concurrency fetch pool. `cursor++` and the `summary` mutations are
-  // safe under Bun's single-threaded event loop (no interleaving mid-statement).
-  let cursor = 0;
-  const worker = async () => {
-    for (let i = cursor++; i < pages.length; i = cursor++) {
-      const p = pages[i];
-      const twinUrl = `${base}${p.path}.mdx`;
-      let body: string;
-      try {
-        const r = await fetch(twinUrl);
-        if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
-        body = stripTwinHeading(await r.text());
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn(`  skip (fetch) ${p.path}.mdx: ${msg}`);
-        continue;
-      }
-      if (isContentless(body)) {
-        summary.skippedEmpty++;
-        continue;
-      }
-      const okf = renderOkf(
-        { title: p.title, description: p.description },
-        ["docs-portal", "deployed"],
-        body,
-      );
-      await writeDoc(staging, deployedOutRel(p.path), okf);
-      summary.written++;
-    }
-  };
-  await Promise.all(Array.from({ length: FETCH_CONCURRENCY }, worker));
-  return summary;
-}
-
-/** Write one staged doc, creating parent dirs. */
-async function writeDoc(staging: string, outRel: string, okf: string): Promise<void> {
-  const outAbs = join(staging, outRel);
-  await mkdir(dirname(outAbs), { recursive: true });
-  await writeFile(outAbs, okf, "utf8");
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const staging = await mkdtemp(join(tmpdir(), "docs-kb-"));
 
-  try {
-    const summary = args.fromDeployed
-      ? await collectDeployed(staging, args, args.fromDeployed)
-      : await collectLocal(staging, args);
+  const result = args.fromDeployed
+    ? await buildDeployed(args, args.fromDeployed)
+    : await buildLocal(args);
 
-    if (summary.written === 0) {
-      throw new Error("No documents collected — nothing to bundle.");
-    }
+  if (result.stats.documents === 0) {
+    throw new Error("No documents collected — nothing to bundle.");
+  }
 
-    // Tar the staged tree so archive paths are the OKF tree at the root.
-    await mkdir(dirname(args.out), { recursive: true });
-    const proc = Bun.spawn(["tar", "-czf", args.out, "-C", staging, "."], {
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    const code = await proc.exited;
-    if (code !== 0) throw new Error(`tar exited with code ${code}`);
+  await mkdir(dirname(args.out), { recursive: true });
+  await writeFile(args.out, result.bytes);
 
-    const bytes = (await Bun.file(args.out).stat()).size;
-    console.log("");
-    console.log(`Bundle:    ${args.out}`);
-    console.log(
-      args.fromDeployed
-        ? `Source:    ${args.fromDeployed}  (deployed llms.txt + .mdx twins, ${args.audience})`
-        : `Source:    local content/  (${args.audience}: ${sectionsFor(args.audience).join(", ")})`,
-    );
-    console.log(`Documents: ${summary.written}`);
-    console.log(`Size:      ${(bytes / 1_000_000).toFixed(2)} MB`);
-    if (summary.skippedApiRef > 0) console.log(`Skipped:   ${summary.skippedApiRef} api-reference stubs`);
-    if (summary.skippedEmpty > 0) console.log(`Skipped:   ${summary.skippedEmpty} contentless (component-only) pages`);
-    if (summary.skippedAudience > 0) console.log(`Skipped:   ${summary.skippedAudience} files (audience strip)`);
-    console.log("");
-    console.log("Caps: 1000 docs / 1 MB per doc / 25 MB per bundle.");
-  } finally {
-    await rm(staging, { recursive: true, force: true });
+  const { stats } = result;
+  console.log("");
+  console.log(`Bundle:    ${args.out}`);
+  console.log(
+    args.fromDeployed
+      ? `Source:    ${args.fromDeployed}  (deployed llms.txt + .mdx twins, ${args.audience})`
+      : `Source:    local content/  (${args.audience}: ${sectionsFor(args.audience).join(", ")})`,
+  );
+  console.log(`Documents: ${stats.documents}  (expect the SAME count ingested — a smaller`);
+  console.log(`           ingest count means silent drops; investigate, don't shrug)`);
+  console.log(`Size:      ${(stats.archiveBytes / 1_000_000).toFixed(2)} MB compressed, ${(stats.totalDocBytes / 1_000_000).toFixed(2)} MB decoded`);
+  if (stats.skipped.apiReference > 0) console.log(`Skipped:   ${stats.skipped.apiReference} api-reference stubs`);
+  if (stats.skipped.contentless > 0) console.log(`Skipped:   ${stats.skipped.contentless} contentless (component-only) pages`);
+  if (stats.skipped.transformSkipped > 0) console.log(`Skipped:   ${stats.skipped.transformSkipped} pages (audience strip — see warnings above)`);
+  if (stats.renamedReserved.length > 0) {
+    console.log(`Renamed:   ${stats.renamedReserved.length} reserved-basename pages (index/log → ingestable paths):`);
+    for (const r of stats.renamedReserved) console.log(`             ${r.from} → ${r.to}`);
   }
 }
 

--- a/apps/docs/scripts/build-docs-kb-bundle.ts
+++ b/apps/docs/scripts/build-docs-kb-bundle.ts
@@ -36,7 +36,7 @@ import {
   deployedSource,
   localSectionSource,
   parseLlmsIndex,
-  portalAudienceTransform,
+  portalSectionCollectOptions,
   sectionsFor,
 } from "./kb-bundle-sources";
 
@@ -70,7 +70,9 @@ function parseArgs(argv: string[]): Args {
       }
       audience = v;
     } else if (a === "--out") {
-      out = argv[++i];
+      const v = argv[++i];
+      if (!v) throw new Error("--out needs a file path");
+      out = v;
     } else if (a === "--include-api-reference") {
       includeApiReference = true;
     } else if (a === "--from-deployed") {
@@ -87,23 +89,21 @@ function parseArgs(argv: string[]): Args {
 }
 
 /** LOCAL mode: one adapter collect per section (prefix = section name), packed
- * as ONE archive so the caps are validated over the merged set. */
+ * as ONE archive so the caps + cross-section path uniqueness are validated
+ * over the merged set. Every section's options come from
+ * `portalSectionCollectOptions`, so the audience transform cannot be
+ * forgotten for one section. */
 async function buildLocal(args: Args): Promise<BuildResult> {
-  const transform = portalAudienceTransform(args.audience, (pagePath, reason) => {
-    console.warn(`  skip (audience strip) ${pagePath}: ${reason}`);
-  });
-
   const collects: CollectResult[] = [];
   for (const section of sectionsFor(args.audience)) {
     const source = await localSectionSource(join(CONTENT_DIR, section));
     collects.push(
-      await collectFumadocsPages(source, {
-        prefix: section,
-        transform,
-        // Provenance tags make the bundle's origin legible in the review UI.
-        tags: ["docs-portal", section],
-        skipApiReference: !args.includeApiReference,
-      }),
+      await collectFumadocsPages(
+        source,
+        portalSectionCollectOptions(section, args.audience, {
+          includeApiReference: args.includeApiReference,
+        }),
+      ),
     );
   }
   const merged = mergeCollectResults(collects);
@@ -136,7 +136,8 @@ async function buildDeployed(args: Args, base: string): Promise<BuildResult> {
   }
   const entries = parseLlmsIndex(await res.text()).filter(
     // The bare site root ("/") is skipped as in #4366: its twin URL shape is
-    // not a page twin. The docs landing content still arrives via local mode.
+    // not a page twin, so deployed-mode bundles simply do not include the
+    // site-root landing page (local mode does, as <section>/overview.md).
     (entry) => entry.path !== "/" && entry.path !== indexPath,
   );
   if (entries.length === 0) throw new Error(`No pages parsed from ${indexUrl}`);

--- a/apps/docs/scripts/kb-bundle-sources.ts
+++ b/apps/docs/scripts/kb-bundle-sources.ts
@@ -30,8 +30,15 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Glob } from "bun";
-import type { FumadocsOkfPage, FumadocsOkfSource } from "@atlas/fumadocs-okf";
-import { stripInactiveAudienceBlocks } from "../src/lib/audience-markdown";
+import type {
+  CollectOptions,
+  FumadocsOkfPage,
+  FumadocsOkfSource,
+} from "@atlas/fumadocs-okf";
+import {
+  ResidualAudienceTagError,
+  stripInactiveAudienceBlocks,
+} from "../src/lib/audience-markdown";
 import type { Audience } from "../src/lib/audience";
 
 // ---------------------------------------------------------------------------
@@ -151,29 +158,58 @@ export function stripMdxModuleLines(body: string): string {
 /**
  * The adapter body-transform resolving audience conditionals for one mount.
  * Fail-SOFT per page, fail-CLOSED per body: `stripInactiveAudienceBlocks`
- * throws when any raw audience construct survives, and this hook maps that
- * throw to `null` (skip the page, count it, log it) — the page is dropped
- * from the bundle rather than ever emitted with an unresolved branch.
+ * throws `ResidualAudienceTagError` when any raw audience construct survives,
+ * and this hook maps EXACTLY that throw to `null` (skip the page, count it,
+ * log it) — the page is dropped from the bundle rather than ever emitted
+ * with an unresolved branch. Any OTHER throw is a bug in the strip itself
+ * and is rethrown: a systemic failure must abort the build, not quietly thin
+ * the bundle page by page (a thinner bundle fed to bundle-sync would archive
+ * the missing pages' documents via the subtractive diff).
  */
 export function portalAudienceTransform(
   audience: Audience,
   onSkip?: (pagePath: string, reason: string) => void,
 ): (body: string, page: FumadocsOkfPage) => string | null {
+  const reportSkip =
+    onSkip ??
+    ((pagePath: string, reason: string) => {
+      console.warn(`  skip (audience strip) ${pagePath}: ${reason}`);
+    });
   return (body, page) => {
     try {
       return stripInactiveAudienceBlocks(body, audience);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      onSkip?.(page.path, msg);
+      if (!(err instanceof ResidualAudienceTagError)) throw err;
+      reportSkip(page.path, err.message);
       return null;
     }
   };
 }
 
-/** The content collections composing each audience's surface (mirrors
- * `buildSectionSource` in `src/lib/source.ts`). `shared` is mounted into both. */
+/** The content collections composing each audience's surface — mirrors the
+ * `buildSectionSource` (`src/lib/compose.ts`) compositions in
+ * `src/lib/source.ts`. `shared` is mounted into both. */
 export function sectionsFor(audience: Audience): string[] {
   return audience === "saas" ? ["docs", "shared"] : ["self-hosted", "shared"];
+}
+
+/**
+ * The adapter options every LOCAL-mode section collect uses — one function so
+ * the audience transform cannot be forgotten for a section (the leak-safety
+ * wiring is pinned by `src/lib/__tests__/kb-bundle.test.ts` through here).
+ */
+export function portalSectionCollectOptions(
+  section: string,
+  audience: Audience,
+  opts: { includeApiReference?: boolean; onSkip?: (pagePath: string, reason: string) => void } = {},
+): CollectOptions {
+  return {
+    prefix: section,
+    transform: portalAudienceTransform(audience, opts.onSkip),
+    // Provenance tags make the bundle's origin legible in the review UI.
+    tags: ["docs-portal", section],
+    skipApiReference: !(opts.includeApiReference ?? false),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -252,6 +288,8 @@ export function parseLlmsIndex(indexText: string): DeployedIndexEntry[] {
     try {
       path = new URL(url).pathname;
     } catch {
+      // intentionally ignored: not an absolute URL — treat it as a
+      // site-relative path; a garbage path fails loud at the twin fetch.
       path = url.startsWith("/") ? url : `/${url}`;
     }
     out.push({ title: title.trim(), path, description: description?.trim() || undefined });

--- a/apps/docs/scripts/kb-bundle-sources.ts
+++ b/apps/docs/scripts/kb-bundle-sources.ts
@@ -1,0 +1,303 @@
+/**
+ * Source-like shims feeding the `@atlas/fumadocs-okf` adapter from the docs
+ * portal — the dogfood refit of #4366's throwaway builder (issue #4367).
+ *
+ * Why shims instead of the real `src/lib/source.ts` loaders: the generated
+ * `.source/server.ts` imports `*.mdx?collection=…` modules only the Next
+ * bundler can resolve, so a plain `bun run scripts/…` CLI cannot load the
+ * portal's actual Fumadocs source (see `src/lib/compose.ts`). These shims
+ * implement the adapter's structural loader contract instead:
+ *
+ *   - {@link localSectionSource} — walk one `content/<section>` tree;
+ *     `getText("processed")` returns the fence-aware ESM-strip APPROXIMATION
+ *     of fumadocs' processed markdown (same fidelity note as #4366). An
+ *     in-Next consumer would pass the real loader and get byte-faithful
+ *     bodies — the approximation lives HERE, not in the adapter.
+ *   - {@link deployedSource} — read a deployed site's `llms.txt` index and
+ *     serve each page's `.mdx` twin as its processed text (byte-faithful,
+ *     already audience-resolved by `getLLMText`; no transform needed).
+ *
+ * The leak-safety-critical transform — resolving `<WhenSaaS>` /
+ * `<WhenSelfHosted>` / `<AudienceLink>` for the target audience — rides the
+ * adapter's body-transform hook ({@link portalAudienceTransform}), importing
+ * the portal's OWN `stripInactiveAudienceBlocks` (the function `getLLMText`
+ * uses). Its fail-closed residual-tag check means a page that cannot be
+ * fully resolved is SKIPPED (transform → null), never emitted with the other
+ * audience's branch — so a SaaS bundle remains structurally incapable of
+ * carrying self-hosted content.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Glob } from "bun";
+import type { FumadocsOkfPage, FumadocsOkfSource } from "@atlas/fumadocs-okf";
+import { stripInactiveAudienceBlocks } from "../src/lib/audience-markdown";
+import type { Audience } from "../src/lib/audience";
+
+// ---------------------------------------------------------------------------
+// Shared frontmatter/body helpers (ported from the #4366 builder)
+// ---------------------------------------------------------------------------
+
+export interface PortalFrontmatter {
+  title?: string;
+  description?: string;
+  tags?: string[];
+}
+
+/**
+ * Split leading `---\n…\n---` frontmatter from the body and pull the scalar
+ * fields we mirror into OKF. Deliberately minimal — the docs frontmatter is
+ * clean (`title`/`description`, occasionally `audience`/`fork`/`tags`), so a
+ * line-scan for top-level scalars beats pulling in a YAML dependency. Unparsed
+ * fields are simply ignored; a missing title falls back to the first `# heading`
+ * or the filename downstream (matching the ingest seam's own lenient behaviour).
+ */
+export function splitFrontmatter(raw: string): { fm: PortalFrontmatter; body: string } {
+  const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
+  if (!m) return { fm: {}, body: raw };
+  const body = raw.slice(m[0].length);
+  const fm: PortalFrontmatter = {};
+  const lines = m[1].split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const kv = /^([A-Za-z0-9_]+):\s*(.*)$/.exec(line);
+    if (!kv) continue;
+    const key = kv[1];
+    const rawVal = kv[2].trim();
+    if (key === "title" || key === "description") {
+      fm[key] = unquote(rawVal);
+    } else if (key === "tags") {
+      fm.tags = parseTags(rawVal, lines, i);
+    }
+  }
+  return { fm, body };
+}
+
+function unquote(v: string): string {
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/** Handle both flow (`[a, b]`) and block (`\n  - a\n  - b`) YAML tag lists. */
+function parseTags(inline: string, lines: string[], idx: number): string[] {
+  if (inline.startsWith("[") && inline.endsWith("]")) {
+    return inline
+      .slice(1, -1)
+      .split(",")
+      .map((t) => unquote(t.trim()))
+      .filter(Boolean);
+  }
+  const tags: string[] = [];
+  for (let j = idx + 1; j < lines.length; j++) {
+    const item = /^\s*-\s*(.+)$/.exec(lines[j]);
+    if (!item) break;
+    tags.push(unquote(item[1].trim()));
+  }
+  return tags;
+}
+
+/**
+ * Drop MDX module syntax (top-level `import …` / `export …`) so the body reads
+ * as prose — mirroring what fumadocs' `getText("processed")` removes. Must be
+ * FENCE-AWARE: `import`/`export` lines inside a ``` code block are code
+ * *examples* (e.g. the SDK reference's `import type { AtlasClient } …`), not
+ * module syntax — stripping them corrupts the example, and a multi-line one
+ * would leave a dangling `} from "…"`. So only column-0 ESM statements OUTSIDE a
+ * fence are removed, consuming continuation lines of a multi-line statement.
+ */
+export function stripMdxModuleLines(body: string): string {
+  const lines = body.split("\n");
+  const out: string[] = [];
+  let fence: string | null = null; // the opening fence's marker while open
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (fence === null) fence = marker[0].repeat(3); // open (track char)
+      else if (marker.startsWith(fence)) fence = null; // close on same char
+      out.push(line);
+      continue;
+    }
+    // A real MDX ESM statement is at column 0 and outside any fence.
+    if (fence === null && /^(import|export)\s/.test(line)) {
+      // Consume continuation lines ONLY when the line clearly opens a multi-line
+      // construct (trailing `{`/`(`/`[`/`,`) — so a single-line `export default
+      // Foo` with no terminator can never run the scan away into the prose that
+      // follows. The corpus has no top-level multi-line ESM today (all such
+      // statements live inside fences, handled above); this stays correct if one
+      // is added later.
+      if (/[{([,]\s*$/.test(line)) {
+        i++;
+        while (i < lines.length && !/([)}\]]|["'`]|;)\s*;?\s*$/.test(lines[i])) i++;
+      }
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join("\n").replace(/^\n+/, "");
+}
+
+// ---------------------------------------------------------------------------
+// Audience transform hook (leak-safety critical)
+// ---------------------------------------------------------------------------
+
+/**
+ * The adapter body-transform resolving audience conditionals for one mount.
+ * Fail-SOFT per page, fail-CLOSED per body: `stripInactiveAudienceBlocks`
+ * throws when any raw audience construct survives, and this hook maps that
+ * throw to `null` (skip the page, count it, log it) — the page is dropped
+ * from the bundle rather than ever emitted with an unresolved branch.
+ */
+export function portalAudienceTransform(
+  audience: Audience,
+  onSkip?: (pagePath: string, reason: string) => void,
+): (body: string, page: FumadocsOkfPage) => string | null {
+  return (body, page) => {
+    try {
+      return stripInactiveAudienceBlocks(body, audience);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      onSkip?.(page.path, msg);
+      return null;
+    }
+  };
+}
+
+/** The content collections composing each audience's surface (mirrors
+ * `buildSectionSource` in `src/lib/source.ts`). `shared` is mounted into both. */
+export function sectionsFor(audience: Audience): string[] {
+  return audience === "saas" ? ["docs", "shared"] : ["self-hosted", "shared"];
+}
+
+// ---------------------------------------------------------------------------
+// LOCAL mode shim — walk one content/<section> tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a source-like over `content/<section>`: one page per `.mdx` file,
+ * frontmatter mirrored into `data`, `getText("processed")` returning the
+ * ESM-strip approximation. Page paths are section-relative — pass the section
+ * name as the adapter's `prefix` so archive paths come out `docs/…`,
+ * `shared/…`, `self-hosted/…`.
+ */
+export async function localSectionSource(sectionDir: string): Promise<FumadocsOkfSource> {
+  const glob = new Glob("**/*.mdx");
+  const relPaths: string[] = [];
+  for await (const rel of glob.scan(sectionDir)) relPaths.push(rel);
+  relPaths.sort();
+
+  const pages: FumadocsOkfPage[] = relPaths.map((rel) => ({
+    path: rel,
+    data: {
+      // Frontmatter + body resolve lazily per hit, so a filtered page (e.g.
+      // the 473 api-reference stubs) costs a directory entry, not a read.
+      get title(): string | undefined {
+        return readSplit(sectionDir, rel).fm.title;
+      },
+      get description(): string | undefined {
+        return readSplit(sectionDir, rel).fm.description;
+      },
+      get tags(): string[] | undefined {
+        return readSplit(sectionDir, rel).fm.tags;
+      },
+      getText: async () => stripMdxModuleLines(readSplit(sectionDir, rel).body),
+    },
+  }));
+  return { getPages: () => pages };
+}
+
+/** Per-file cache so title/description/tags/getText share one read+parse. */
+const splitCache = new Map<string, { fm: PortalFrontmatter; body: string }>();
+
+function readSplit(sectionDir: string, rel: string): { fm: PortalFrontmatter; body: string } {
+  const key = join(sectionDir, rel);
+  const cached = splitCache.get(key);
+  if (cached) return cached;
+  const raw = readFileSync(key, "utf8");
+  const split = splitFrontmatter(raw);
+  splitCache.set(key, split);
+  return split;
+}
+
+// ---------------------------------------------------------------------------
+// DEPLOYED mode shim — llms.txt index + per-page .mdx twins over HTTP
+// ---------------------------------------------------------------------------
+
+export interface DeployedIndexEntry {
+  title: string;
+  path: string;
+  description?: string;
+}
+
+/**
+ * Parse a deployed `llms.txt` index (`- [Title](url): description` lines) into
+ * page entries. Reads each link's URL PATH — not the host — because the index
+ * absolutizes every URL to the hardcoded `docs.useatlas.dev` regardless of which
+ * deployment served it, so we re-root the path onto the deployed base.
+ */
+export function parseLlmsIndex(indexText: string): DeployedIndexEntry[] {
+  const out: DeployedIndexEntry[] = [];
+  for (const line of indexText.split("\n")) {
+    const m = /^\s*-\s*\[([^\]]+)\]\(([^)]+)\)\s*(?::\s*(.*\S))?\s*$/.exec(line);
+    if (!m) continue;
+    const [, title, url, description] = m;
+    let path: string;
+    try {
+      path = new URL(url).pathname;
+    } catch {
+      path = url.startsWith("/") ? url : `/${url}`;
+    }
+    out.push({ title: title.trim(), path, description: description?.trim() || undefined });
+  }
+  return out;
+}
+
+/** `getLLMText` prepends `# Title (url)` to every twin; drop that leading H1
+ * (the title goes into OKF frontmatter) so the body starts at real content. */
+export function stripTwinHeading(body: string): string {
+  return body.replace(/^#\s+.*(?:\r?\n)+/, "");
+}
+
+/**
+ * Map a deployed URL path onto a synthetic `page.path` for the adapter. A
+ * section-landing path (trailing slash) becomes `<section>/index.mdx`, which
+ * the adapter FOLDS onto the section slug — closing the reserved-basename
+ * drop the #4366 spike's `deployedOutRel` (`…/index.md`) walked into.
+ */
+export function deployedPagePath(urlPath: string): string {
+  return `${urlPath.replace(/^\//, "").replace(/\/$/, "/index")}.mdx`;
+}
+
+/**
+ * Build a source-like over a DEPLOYED docs site: pages from the `llms.txt`
+ * index, bodies fetched lazily from each page's `.mdx` twin (byte-faithful to
+ * `getText("processed")`, already audience-resolved — no transform needed).
+ * A twin fetch failure throws with the page named; the adapter surfaces it
+ * (fail-loud) rather than emitting a partial bundle silently.
+ */
+export function deployedSource(base: string, entries: readonly DeployedIndexEntry[]): FumadocsOkfSource {
+  const pages: FumadocsOkfPage[] = entries.map((entry) => ({
+    path: deployedPagePath(entry.path),
+    url: entry.path,
+    data: {
+      title: entry.title,
+      description: entry.description,
+      getText: async () => {
+        const twinUrl = `${base}${entry.path}.mdx`;
+        const res = await fetch(twinUrl);
+        if (!res.ok) {
+          throw new Error(`Fetch ${twinUrl} → ${res.status} ${res.statusText}`);
+        }
+        return stripTwinHeading(await res.text());
+      },
+    },
+  }));
+  return { getPages: () => pages };
+}

--- a/apps/docs/src/lib/__tests__/kb-bundle.test.ts
+++ b/apps/docs/src/lib/__tests__/kb-bundle.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The docs → KB bundle refit (issue #4367): the portal script consumes the
+ * `@atlas/fumadocs-okf` adapter, supplying audience stripping via the
+ * body-transform hook. These tests PIN the leak-safety property PR #4366
+ * carried — a SaaS bundle is structurally incapable of carrying self-hosted
+ * branches — now expressed through the adapter pipeline:
+ *
+ *   1. the transform resolves `<WhenSaaS>`/`<WhenSelfHosted>`/`<AudienceLink>`
+ *      for the target audience (inactive branch REMOVED, active branch
+ *      unwrapped);
+ *   2. a page the strip cannot fully resolve is SKIPPED (transform → null),
+ *      never emitted with a residual branch;
+ *   3. a full adapter build over an audience-forked fixture yields bundle
+ *      bodies with zero opposite-audience content.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { buildFumadocsOkfBundle } from "@atlas/fumadocs-okf";
+import type { FumadocsOkfPage, FumadocsOkfSource } from "@atlas/fumadocs-okf";
+import {
+  deployedPagePath,
+  parseLlmsIndex,
+  portalAudienceTransform,
+  splitFrontmatter,
+  stripMdxModuleLines,
+  stripTwinHeading,
+} from "../../../scripts/kb-bundle-sources";
+
+const FORKED_BODY = [
+  "Shared intro prose for every audience.",
+  "",
+  "<WhenSaaS>",
+  "Use the hosted console at console.example.com.",
+  "</WhenSaaS>",
+  "",
+  "<WhenSelfHosted>",
+  "Edit your docker-compose.yml and restart the stack.",
+  "</WhenSelfHosted>",
+].join("\n");
+
+function pageOf(path: string, body: string, title = "Page"): FumadocsOkfPage {
+  return {
+    path,
+    data: { title, getText: async () => body },
+  };
+}
+
+function sourceOf(pages: readonly FumadocsOkfPage[]): FumadocsOkfSource {
+  return { getPages: () => pages };
+}
+
+describe("portalAudienceTransform (leak safety)", () => {
+  test("SaaS transform strips the self-hosted branch and unwraps the SaaS one", () => {
+    const out = portalAudienceTransform("saas")(FORKED_BODY, pageOf("x.mdx", FORKED_BODY));
+    expect(out).toContain("hosted console");
+    expect(out).not.toContain("docker-compose");
+    expect(out).not.toContain("WhenSelfHosted");
+    expect(out).not.toContain("<WhenSaaS>");
+  });
+
+  test("an unresolvable page is skipped (null), never emitted with a residual tag", () => {
+    // Single-line inline form — unsupported by the block strip, so the
+    // fail-closed post-condition throws; the hook maps that to a skip.
+    const inline = "Inline <WhenSelfHosted>secret self-hosted step</WhenSelfHosted> here.";
+    const skips: string[] = [];
+    const out = portalAudienceTransform("saas", (p) => skips.push(p))(
+      inline,
+      pageOf("broken.mdx", inline),
+    );
+    expect(out).toBeNull();
+    expect(skips).toEqual(["broken.mdx"]);
+  });
+
+  test("adapter build over a forked fixture: SaaS bundle carries zero self-hosted content", async () => {
+    const source = sourceOf([
+      pageOf("guide.mdx", FORKED_BODY, "Guide"),
+      pageOf("plain.mdx", "Plain shared prose, no conditionals at all.", "Plain"),
+    ]);
+    const result = await buildFumadocsOkfBundle(source, {
+      prefix: "docs",
+      transform: portalAudienceTransform("saas"),
+    });
+    expect(result.stats.documents).toBe(2);
+    for (const doc of result.docs) {
+      expect(doc.content).not.toContain("docker-compose");
+      expect(doc.content).not.toContain("WhenSelfHosted");
+    }
+    // And the inverse mount: the self-hosted bundle carries no SaaS branch.
+    const sh = await buildFumadocsOkfBundle(source, {
+      prefix: "docs",
+      transform: portalAudienceTransform("self-hosted"),
+    });
+    const guide = sh.docs.find((d) => d.path === "docs/guide.md");
+    expect(guide?.content).toContain("docker-compose");
+    expect(guide?.content).not.toContain("hosted console");
+  });
+});
+
+describe("kb-bundle source shims", () => {
+  test("splitFrontmatter pulls title/description/tags and leaves the body intact", () => {
+    const { fm, body } = splitFrontmatter(
+      '---\ntitle: "Quickstart"\ndescription: Zero to one\ntags: [a, b]\n---\n# Hello\n',
+    );
+    expect(fm).toEqual({ title: "Quickstart", description: "Zero to one", tags: ["a", "b"] });
+    expect(body).toBe("# Hello\n");
+  });
+
+  test("stripMdxModuleLines removes top-level ESM but preserves fenced examples", () => {
+    const input = [
+      'import { Callout } from "fumadocs-ui/components/callout";',
+      "",
+      "Prose here.",
+      "",
+      "```ts",
+      'import type { AtlasClient } from "@useatlas/sdk";',
+      "```",
+    ].join("\n");
+    const out = stripMdxModuleLines(input);
+    expect(out).not.toContain("fumadocs-ui/components");
+    expect(out).toContain('import type { AtlasClient } from "@useatlas/sdk";');
+  });
+
+  test("deployedPagePath folds section landings so the adapter can dodge index.md", () => {
+    expect(deployedPagePath("/quickstart")).toBe("quickstart.mdx");
+    expect(deployedPagePath("/guides/")).toBe("guides/index.mdx");
+  });
+
+  test("parseLlmsIndex reads paths off absolutized URLs and keeps descriptions", () => {
+    const entries = parseLlmsIndex(
+      [
+        "- [Quickstart](https://docs.useatlas.dev/quickstart): Zero to one",
+        "- [Guides](https://docs.useatlas.dev/guides/)",
+        "not a link line",
+      ].join("\n"),
+    );
+    expect(entries).toEqual([
+      { title: "Quickstart", path: "/quickstart", description: "Zero to one" },
+      { title: "Guides", path: "/guides/", description: undefined },
+    ]);
+  });
+
+  test("stripTwinHeading drops the injected `# Title (url)` line only", () => {
+    expect(stripTwinHeading("# Title (/x)\n\nBody starts.")).toBe("Body starts.");
+    expect(stripTwinHeading("No heading body.")).toBe("No heading body.");
+  });
+});

--- a/apps/docs/src/lib/__tests__/kb-bundle.test.ts
+++ b/apps/docs/src/lib/__tests__/kb-bundle.test.ts
@@ -14,14 +14,20 @@
  *      bodies with zero opposite-audience content.
  */
 
-import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
 
-import { buildFumadocsOkfBundle } from "@atlas/fumadocs-okf";
+import { buildFumadocsOkfBundle, collectFumadocsPages } from "@atlas/fumadocs-okf";
 import type { FumadocsOkfPage, FumadocsOkfSource } from "@atlas/fumadocs-okf";
 import {
   deployedPagePath,
+  localSectionSource,
   parseLlmsIndex,
   portalAudienceTransform,
+  portalSectionCollectOptions,
+  sectionsFor,
   splitFrontmatter,
   stripMdxModuleLines,
   stripTwinHeading,
@@ -94,6 +100,76 @@ describe("portalAudienceTransform (leak safety)", () => {
     const guide = sh.docs.find((d) => d.path === "docs/guide.md");
     expect(guide?.content).toContain("docker-compose");
     expect(guide?.content).not.toContain("hosted console");
+  });
+});
+
+describe("section composition (leak-safety leg 2)", () => {
+  test("a SaaS bundle mounts only docs + shared — never the self-hosted tree", () => {
+    expect(sectionsFor("saas")).toEqual(["docs", "shared"]);
+    expect(sectionsFor("self-hosted")).toEqual(["self-hosted", "shared"]);
+  });
+
+  test("every section's collect options carry the audience transform (wiring pin)", async () => {
+    for (const audience of ["saas", "self-hosted"] as const) {
+      for (const section of sectionsFor(audience)) {
+        const options = portalSectionCollectOptions(section, audience);
+        expect(options.prefix).toBe(section);
+        expect(options.skipApiReference).toBe(true);
+        // The transform must actually strip: run the forked body through it.
+        const out = await options.transform?.(FORKED_BODY, pageOf("x.mdx", FORKED_BODY));
+        if (audience === "saas") {
+          expect(out).toContain("hosted console");
+          expect(out).not.toContain("docker-compose");
+        } else {
+          expect(out).toContain("docker-compose");
+          expect(out).not.toContain("hosted console");
+        }
+      }
+    }
+  });
+});
+
+describe("localSectionSource", () => {
+  let dir: string | null = null;
+  afterAll(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  test("walks a content tree: frontmatter into data, ESM-stripped body from getText", async () => {
+    dir = await mkdtemp(join(tmpdir(), "kb-shim-"));
+    await mkdir(join(dir, "guides"), { recursive: true });
+    await writeFile(
+      join(dir, "guides", "setup.mdx"),
+      [
+        "---",
+        'title: "Setup"',
+        "description: Getting started",
+        "tags: [install]",
+        "---",
+        'import { Callout } from "fumadocs-ui/components/callout";',
+        "",
+        "Real setup prose that survives.",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const source = await localSectionSource(dir);
+    const pages = source.getPages();
+    expect(pages.map((p) => p.path)).toEqual(["guides/setup.mdx"]);
+    expect(pages[0].data.title).toBe("Setup");
+    expect(pages[0].data.description).toBe("Getting started");
+    expect(pages[0].data.tags).toEqual(["install"]);
+    const body = await pages[0].data.getText?.("processed");
+    expect(body).toContain("Real setup prose");
+    expect(body).not.toContain("fumadocs-ui/components");
+
+    // And through the adapter with the portal options: one doc, tagged, prefixed.
+    const collected = await collectFumadocsPages(
+      source,
+      portalSectionCollectOptions("docs", "saas"),
+    );
+    expect(collected.docs.map((d) => d.path)).toEqual(["docs/guides/setup.md"]);
+    expect(collected.docs[0].content).toContain('tags: ["docs-portal", "docs", "install"]');
   });
 });
 

--- a/apps/docs/src/lib/audience-markdown.ts
+++ b/apps/docs/src/lib/audience-markdown.ts
@@ -55,6 +55,24 @@ export function resolveAudienceLinks(
   });
 }
 
+/**
+ * The fail-closed post-condition failure: a raw `<When…>` / `<AudienceLink>`
+ * construct survived the strip (malformed/unclosed block, unsupported inline
+ * form, or a future MDX-emit change). A TYPED class so callers that must
+ * distinguish "this page has an unresolvable audience construct" from an
+ * unexpected bug in the strip itself (e.g. the KB bundle transform, which
+ * skips the former and rethrows the latter) can use `instanceof` instead of
+ * message matching.
+ */
+export class ResidualAudienceTagError extends Error {
+  constructor(audience: string) {
+    super(
+      `[docs] audience strip left a residual <When…> / <AudienceLink> tag while resolving "${audience}" — a branch or cross-link was not resolved. <When…> conditionals must be BLOCK-form (opening/closing tags each on their own line); <AudienceLink> must be a single well-formed element. Also check for malformed/unclosed tags.`,
+    );
+    this.name = "ResidualAudienceTagError";
+  }
+}
+
 /** Mask fenced and inline code spans (their raw tag MENTIONS must be spared) so
  * the residual check only sees real tags. Returns text safe to scan, not to emit. */
 function maskCodeSpans(markdown: string): string {
@@ -138,9 +156,7 @@ export function stripInactiveAudienceBlocks(
   // the inline resolver could not close — any must fail the build/page rather
   // than silently leak the other audience's prose or link target.
   if (RESIDUAL_AUDIENCE_TAG.test(maskCodeSpans(out))) {
-    throw new Error(
-      `[docs] audience strip left a residual <When…> / <AudienceLink> tag while resolving "${audience}" — a branch or cross-link was not resolved. <When…> conditionals must be BLOCK-form (opening/closing tags each on their own line); <AudienceLink> must be a single well-formed element. Also check for malformed/unclosed tags.`,
-    );
+    throw new ResidualAudienceTagError(audience);
   }
   return out;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@atlas/fumadocs-okf": "workspace:*",
         "@shikijs/transformers": "^4.2.0",
         "@tailwindcss/postcss": "^4.3.1",
         "@types/node": "^25.9.4",
@@ -292,6 +293,16 @@
         "@clack/prompts": "^1.6.0",
         "@types/pg": "^8.20.0",
         "picocolors": "^1.1.1",
+      },
+    },
+    "packages/fumadocs-okf": {
+      "name": "@atlas/fumadocs-okf",
+      "version": "0.0.0",
+      "dependencies": {
+        "fflate": "^0.8.2",
+      },
+      "devDependencies": {
+        "@atlas/api": "workspace:*",
       },
     },
     "packages/mcp": {
@@ -943,6 +954,8 @@
     "@atlas/ee": ["@atlas/ee@workspace:ee"],
 
     "@atlas/embedded-mcp-onboarding-example": ["@atlas/embedded-mcp-onboarding-example@workspace:examples/embedded-mcp-onboarding"],
+
+    "@atlas/fumadocs-okf": ["@atlas/fumadocs-okf@workspace:packages/fumadocs-okf"],
 
     "@atlas/mcp": ["@atlas/mcp@workspace:packages/mcp"],
 

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -22,6 +22,7 @@ COPY packages/react/package.json packages/react/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/schemas/package.json packages/schemas/package.json
 COPY packages/webhook-publisher/package.json packages/webhook-publisher/package.json
+COPY packages/fumadocs-okf/package.json packages/fumadocs-okf/package.json
 COPY apps/docs/package.json apps/docs/package.json
 COPY apps/www/package.json apps/www/package.json
 COPY examples/nextjs-standalone/package.json examples/nextjs-standalone/package.json

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -22,6 +22,7 @@ COPY packages/react/package.json packages/react/package.json
 COPY packages/types/package.json packages/types/package.json
 COPY packages/schemas/package.json packages/schemas/package.json
 COPY packages/webhook-publisher/package.json packages/webhook-publisher/package.json
+COPY packages/fumadocs-okf/package.json packages/fumadocs-okf/package.json
 COPY apps/docs/package.json apps/docs/package.json
 COPY apps/www/package.json apps/www/package.json
 COPY examples/nextjs-standalone/package.json examples/nextjs-standalone/package.json

--- a/packages/fumadocs-okf/README.md
+++ b/packages/fumadocs-okf/README.md
@@ -1,0 +1,231 @@
+# `@atlas/fumadocs-okf` — Fumadocs → Atlas Knowledge Base bundles
+
+Turn any [Fumadocs](https://fumadocs.dev) site into an OKF `.tar.gz` the Atlas
+Knowledge Base ingests — through the **existing** `bundle-sync` connector (pull
+on a schedule) or the admin upload route. No `packages/api` changes, no new
+connector: the adapter's whole job is producing an archive the ingest seam
+already accepts (issue #4367; ADR-0028 §5 deliberately defers any
+connector/adapter framework).
+
+**Unpublished by design.** This package is internal (`private: true`), consumed
+in-repo by the docs portal and by third parties via copy. Publishing to npm is
+deferred until the API survives a real non-Atlas consumer — at which point it
+needs an explicit `fumadocs-core` peerDependency range pinned to the majors
+actually tested, and the `0.0.x` exact-pin publish sequencing from the root
+CLAUDE.md applies.
+
+## Requirements
+
+The site's `source.config.ts` must enable processed-markdown output on each
+collection the bundle draws from:
+
+```ts
+export const docs = defineDocs({
+  dir: "content/docs",
+  docs: {
+    postprocess: { includeProcessedMarkdown: true },
+  },
+});
+```
+
+That one line is the only opt-in. Without it a page has no
+`getText("processed")` body and the build **fails with an error naming this
+config** — the adapter never falls back to raw MDX (a raw body would carry
+unstripped `import`/`export` lines and un-expanded component content: quietly
+worse documents).
+
+## Usage
+
+```ts
+import { loader } from "fumadocs-core/source";
+import { buildFumadocsOkfBundle } from "@atlas/fumadocs-okf";
+
+export const source = loader({ baseUrl: "/docs", source: docs.toFumadocsSource() });
+
+const result = await buildFumadocsOkfBundle(source, {
+  prefix: "docs",                        // stable top-level dir — see "Path stability"
+  tags: ["acme-docs"],                   // provenance tags, visible in the review UI
+  filter: (page) => !page.path.startsWith("internal/"),   // page-filter hook
+  transform: (body, page) => body,       // body-transform hook (return null to skip a page)
+});
+
+await Bun.write("site-kb.tar.gz", result.bytes);
+console.log(result.stats); // documents, byte totals, skips, reserved renames
+```
+
+The input is typed **structurally** against the loader surface
+(`getPages()`, `page.path`, `page.data.{title,description,getText}`), so this
+package has no `fumadocs-core` dependency — a real `loader()` output satisfies
+it, and so does a hand-built shim where the bundler-generated source isn't
+loadable (see `apps/docs/scripts/kb-bundle-sources.ts` for both a filesystem
+shim and a deployed-site shim).
+
+Multi-section sites compose collects and pack once, so the ingest caps are
+validated over the merged set:
+
+```ts
+import { collectFumadocsPages, mergeCollectResults, packOkfBundle } from "@atlas/fumadocs-okf";
+
+const merged = mergeCollectResults([
+  await collectFumadocsPages(docsSource, { prefix: "docs" }),
+  await collectFumadocsPages(blogSource, { prefix: "blog" }),
+]);
+const { bytes } = packOkfBundle(merged.docs);
+```
+
+### Built-in skips (they ride the same hooks)
+
+- **`api-reference/` stubs** (`skipApiReference`, default on) — auto-generated
+  OpenAPI shells with no prose; a waste of the doc-count cap.
+- **Contentless pages** (`skipContentless`, default on) — pages that are
+  entirely component-rendered (e.g. a body of just `<ChangelogTimeline />`).
+
+Both are counted in `stats.skipped`, never silent, and can be disabled or
+replaced by your own `filter`.
+
+### What the path mapping guarantees
+
+Archive paths derive **deterministically from `page.path`** — no hashing, no
+ordering dependence — under your stable `prefix`:
+
+| page                    | archive path        | why                                            |
+| ----------------------- | ------------------- | ---------------------------------------------- |
+| `guides/setup.mdx`      | `guides/setup.md`   | 1:1                                            |
+| `guides/index.mdx`      | `guides.md`         | landing folds onto the section slug            |
+| `index.mdx` (root)      | `overview.md`       | root landing                                   |
+| `ops/log.mdx`           | `ops/log-doc.md`    | reserved OKF basename — renamed, never dropped |
+
+The fold/rename matters: the KB ingest parser **silently skips** the reserved
+OKF basenames `index.md`/`log.md` (navigation/history in hand-authored OKF
+trees). Fumadocs uses `index.mdx` for real section-landing content, so without
+the fold a site's biggest overview pages vanish without even a rejection row —
+that exact 8-of-165 gap is what motivated this mapping (#4367). Every rename is
+reported in `stats.renamedReserved`.
+
+**Reconcile guardrail:** `stats.documents` is the count Atlas should report as
+ingested. Because reserved basenames are renamed at generation, a smaller
+ingest count is a signal to investigate, never expected shrinkage.
+
+## Path stability & rename churn
+
+The bundle-sync subtractive diff (`archiveAbsent`) keys on **full bundle
+paths**. Consequences:
+
+- Keep `prefix` constant across builds (never a build number or commit SHA) —
+  a changed prefix reads as "everything absent + everything new" and
+  re-archives/re-drafts the whole collection.
+- Renaming a page's slug or directory reads as "old path absent + new path
+  added": the old document is **archived** and the new one lands as a fresh
+  **draft** for review. That churn is *expected and safe* (synced content never
+  hard-deletes), but it is visible in review queues — plan slug renames
+  accordingly.
+
+## Ingest caps (validated at generation time)
+
+Atlas rejects bundles over its knowledge-ingest caps. The adapter validates at
+**generation** time and fails with the actual numbers, so the site owner sees
+the overflow where they can act on it — not as a recurring per-sync ingest
+error on the Atlas side they can't see into.
+
+| cap                | default | server setting                            |
+| ------------------ | ------- | ----------------------------------------- |
+| documents / bundle | 1000    | `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS`         |
+| bytes / document   | 1 MB    | `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES`    |
+| bytes / bundle     | 25 MB   | `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` |
+
+The settings are runtime-tunable by a platform operator from the Admin console
+(settings registry — no redeploy). If the target workspace runs raised caps,
+pass the raised values via the `caps` option; the defaults here are pinned to
+the server defaults by this package's round-trip test.
+
+## Hosting recipe — feeding a `bundle-sync` collection
+
+A `bundle-sync` collection is a Knowledge Base install whose config carries an
+`endpoint_url` + `auth_scheme` (`none | bearer | basic`). On a schedule, Atlas
+pulls the endpoint and re-ingests: new/changed pages land as **drafts** for
+review, pages that left the bundle are archived (the subtractive diff). Synced
+content always queues for review — there is no publish shortcut at this seam.
+
+### 1. Generate the archive in your build
+
+```jsonc
+// package.json
+{ "scripts": { "build:kb": "bun run scripts/build-kb-bundle.ts" } }
+```
+
+Run it in CI next to your site build so the artifact always matches the
+deployed content. Output is **byte-deterministic** for identical content
+(sorted entries, fixed timestamps), so an unchanged site produces an unchanged
+artifact — content-addressed hosting and honest artifact diffs both work.
+
+### 2. Serve it
+
+Any of these work — the endpoint just has to return the raw `.tar.gz` bytes:
+
+- **Static artifact**: copy `site-kb.tar.gz` into your static output
+  (`public/`), served at `https://docs.example.com/site-kb.tar.gz`.
+- **Next.js route handler** (bearer-protected variant shown below).
+
+**Reachability constraints (read this before picking a host).** Atlas fetches
+the endpoint through its SSRF egress guard:
+
+- The URL must be **publicly routable**. Private, loopback, link-local, and
+  internal-DNS targets are blocked — at the initial URL *and at every redirect
+  hop*. An internal-only artifact host won't work.
+- On a **cross-origin redirect the auth header is stripped**. If the endpoint
+  is authenticated, any redirects must stay same-origin (best: serve 200s
+  directly, no redirects).
+- The endpoint is validated at install time too — a blocked target is a
+  field-level error when configuring the collection, not a silent dead sync.
+
+### 3. The bearer-protected variant, end to end
+
+Protect the route — compare against a long random token you mint:
+
+```ts
+// app/kb-bundle/route.ts
+import { timingSafeEqual } from "node:crypto";
+
+export async function GET(req: Request) {
+  const token = process.env.KB_BUNDLE_TOKEN!;
+  const got = req.headers.get("authorization") ?? "";
+  const want = `Bearer ${token}`;
+  const a = Buffer.from(got);
+  const b = Buffer.from(want);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return new Response("unauthorized", { status: 401 });
+  }
+  const bytes = await Bun.file("./artifacts/site-kb.tar.gz").arrayBuffer();
+  return new Response(bytes, {
+    headers: { "content-type": "application/gzip" },
+  });
+}
+```
+
+Then configure the collection (Admin → Knowledge → add a Bundle Sync
+collection, or the install API) with:
+
+- `endpoint_url`: `https://docs.example.com/kb-bundle`
+- `auth_scheme`: `bearer`
+- auth secret: the token
+
+The secret is stored encrypted at rest in Atlas's dedicated
+`knowledge_sync_credentials` table (never in plugin config); switching the
+scheme back to `none` deletes the credential row. `basic` works the same with
+a `user:password` secret.
+
+### 4. Verify the first sync
+
+Trigger a sync (or wait for the schedule), then check the collection's
+documents: the ingested count should **equal** `stats.documents` from your
+build, and every synced doc sits in `draft` awaiting review. If the counts
+differ, something dropped — see the reconcile guardrail above.
+
+## Dogfood consumer
+
+`apps/docs/scripts/build-docs-kb-bundle.ts` builds the Atlas docs portal's own
+bundle through this adapter — including a leak-safety-critical body transform
+(audience stripping) supplied via the `transform` hook, and shims for both a
+local content walk and a deployed `llms.txt` + `.mdx`-twin surface. It's the
+reference for adapting sites whose real loader isn't importable outside the
+Next bundler.

--- a/packages/fumadocs-okf/README.md
+++ b/packages/fumadocs-okf/README.md
@@ -60,8 +60,9 @@ it, and so does a hand-built shim where the bundler-generated source isn't
 loadable (see `apps/docs/scripts/kb-bundle-sources.ts` for both a filesystem
 shim and a deployed-site shim).
 
-Multi-section sites compose collects and pack once, so the ingest caps are
-validated over the merged set:
+Multi-section sites compose collects and pack once — the ingest caps AND
+cross-section path uniqueness are validated over the merged set at pack (a
+duplicate archive path is refused, never silently last-write-wins):
 
 ```ts
 import { collectFumadocsPages, mergeCollectResults, packOkfBundle } from "@atlas/fumadocs-okf";
@@ -183,8 +184,9 @@ the endpoint through its SSRF egress guard:
 Protect the route — compare against a long random token you mint:
 
 ```ts
-// app/kb-bundle/route.ts
+// app/kb-bundle/route.ts  (plain Node APIs — works on any Next.js host)
 import { timingSafeEqual } from "node:crypto";
+import { readFile } from "node:fs/promises";
 
 export async function GET(req: Request) {
   const token = process.env.KB_BUNDLE_TOKEN!;
@@ -195,8 +197,8 @@ export async function GET(req: Request) {
   if (a.length !== b.length || !timingSafeEqual(a, b)) {
     return new Response("unauthorized", { status: 401 });
   }
-  const bytes = await Bun.file("./artifacts/site-kb.tar.gz").arrayBuffer();
-  return new Response(bytes, {
+  const bytes = await readFile("./artifacts/site-kb.tar.gz");
+  return new Response(new Uint8Array(bytes), {
     headers: { "content-type": "application/gzip" },
   });
 }

--- a/packages/fumadocs-okf/__tests__/adapter.test.ts
+++ b/packages/fumadocs-okf/__tests__/adapter.test.ts
@@ -8,9 +8,12 @@ import {
   IngestCapExceededError,
   InvalidPagePathError,
   isContentlessBody,
+  mergeCollectResults,
   packOkfBundle,
+  PageLoadError,
   ProcessedTextUnavailableError,
   splitUstarPath,
+  type FumadocsOkfPage,
 } from "../src/index";
 import { acmeSource, page, sourceOf } from "./fixture";
 
@@ -64,6 +67,7 @@ describe("collectFumadocsPages", () => {
     const result = await collectFumadocsPages(acmeSource(), { prefix: "acme" });
 
     expect(result.docs.map((d) => d.path).toSorted()).toEqual([
+      "acme/faq.md",
       "acme/guides.md", // guides/index.mdx folded
       "acme/guides/dashboards.md",
       "acme/ops/log-doc.md", // reserved basename renamed
@@ -136,6 +140,52 @@ describe("collectFumadocsPages", () => {
     );
   });
 
+  test("a non-config load failure is a PageLoadError — no misdirected config guidance", async () => {
+    const flaky: FumadocsOkfPage = {
+      path: "guides/net.mdx",
+      data: {
+        title: "Net",
+        getText: async () => {
+          throw new Error("Fetch https://docs.example.com/guides/net.mdx → 404 Not Found");
+        },
+      },
+    };
+    const promise = collectFumadocsPages(sourceOf([flaky]), { prefix: "acme" });
+    await expect(promise).rejects.toThrow(PageLoadError);
+    try {
+      await collectFumadocsPages(sourceOf([flaky]), { prefix: "acme" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain("404 Not Found");
+      expect(message).not.toContain("includeProcessedMarkdown");
+    }
+  });
+
+  test("filters run before body resolution — a skipped page never loads its body", async () => {
+    let loads = 0;
+    const counting = (path: string): FumadocsOkfPage => ({
+      path,
+      data: {
+        title: path,
+        getText: async () => {
+          loads++;
+          return "A real prose body that would count as content.";
+        },
+      },
+    });
+    const source = sourceOf([
+      counting("api-reference/stub.mdx"), // built-in skip
+      counting("internal/notes.mdx"), // caller filter skip
+      counting("kept.mdx"),
+    ]);
+    const result = await collectFumadocsPages(source, {
+      prefix: "acme",
+      filter: (p) => !p.path.startsWith("internal/"),
+    });
+    expect(result.docs.map((d) => d.path)).toEqual(["acme/kept.md"]);
+    expect(loads).toBe(1);
+  });
+
   test("archive-path collision is a hard error naming both pages", async () => {
     const colliding = sourceOf([
       page("guide.mdx", "a standalone page with plenty of prose", { title: "A" }),
@@ -144,6 +194,21 @@ describe("collectFumadocsPages", () => {
     await expect(collectFumadocsPages(colliding, { prefix: "acme" })).rejects.toThrow(
       ArchivePathCollisionError,
     );
+  });
+
+  test("cross-collect collisions are refused at pack — merge never last-write-wins", async () => {
+    // Two collects with the SAME prefix producing the same archive path:
+    // within-collect checks can't see this; packOkfBundle must.
+    const a = await collectFumadocsPages(
+      sourceOf([page("setup.mdx", "prose from the first section collect")]),
+      { prefix: "kb" },
+    );
+    const b = await collectFumadocsPages(
+      sourceOf([page("setup.mdx", "prose from the second section collect")]),
+      { prefix: "kb" },
+    );
+    const merged = mergeCollectResults([a, b]);
+    expect(() => packOkfBundle(merged.docs)).toThrow(ArchivePathCollisionError);
   });
 
   test("skipApiReference: false keeps the stubs (and contentless still applies)", async () => {
@@ -201,7 +266,7 @@ describe("deterministic packing", () => {
   test("stats reconcile: documents == emitted docs, skips accounted", async () => {
     const result = await buildFumadocsOkfBundle(acmeSource(), { prefix: "acme" });
     expect(result.stats.documents).toBe(result.docs.length);
-    expect(result.stats.documents).toBe(5);
+    expect(result.stats.documents).toBe(6);
     expect(result.stats.skipped.apiReference + result.stats.skipped.contentless).toBe(2);
     expect(result.stats.totalDocBytes).toBe(result.docs.reduce((n, d) => n + d.bytes, 0));
     expect(result.stats.archiveBytes).toBe(result.bytes.length);
@@ -220,7 +285,8 @@ describe("splitUstarPath", () => {
     expect(split.name).toBe(`${"f".repeat(60)}.md`);
   });
 
-  test("an unsplittable path throws instead of truncating", () => {
+  test("an unsplittable path throws typed instead of truncating", () => {
+    expect(() => splitUstarPath("x".repeat(160))).toThrow(InvalidPagePathError);
     expect(() => splitUstarPath("x".repeat(160))).toThrow(/ustar/);
   });
 });

--- a/packages/fumadocs-okf/__tests__/adapter.test.ts
+++ b/packages/fumadocs-okf/__tests__/adapter.test.ts
@@ -297,4 +297,14 @@ describe("isContentlessBody", () => {
     expect(isContentlessBody("Real prose that should be kept for the KB.")).toBe(false);
     expect(isContentlessBody("```sql\nSELECT 1;\n```")).toBe(false);
   });
+
+  test("a long run of unclosed '<' resolves in linear time (no polynomial ReDoS)", () => {
+    // Guards the js/polynomial-redos fix: the tag-strip regex must not blow up
+    // on a pathological body of many `<` with no closing `>`. The strip leaves
+    // the literal `<` run intact, so the body reads as content — the property
+    // under test is that it returns *quickly*, not what it returns.
+    const start = performance.now();
+    expect(isContentlessBody("<".repeat(200_000))).toBe(false);
+    expect(performance.now() - start).toBeLessThan(1000);
+  });
 });

--- a/packages/fumadocs-okf/__tests__/adapter.test.ts
+++ b/packages/fumadocs-okf/__tests__/adapter.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ArchivePathCollisionError,
+  buildFumadocsOkfBundle,
+  collectFumadocsPages,
+  deriveArchivePath,
+  IngestCapExceededError,
+  InvalidPagePathError,
+  isContentlessBody,
+  packOkfBundle,
+  ProcessedTextUnavailableError,
+  splitUstarPath,
+} from "../src/index";
+import { acmeSource, page, sourceOf } from "./fixture";
+
+describe("deriveArchivePath", () => {
+  test("plain page maps 1:1 with .md extension", () => {
+    expect(deriveArchivePath("guides/setup.mdx")).toEqual({
+      path: "guides/setup.md",
+      renamedFromReserved: false,
+    });
+  });
+
+  test("section landing folds onto the section slug (reserved-basename trap)", () => {
+    expect(deriveArchivePath("plugins/index.mdx").path).toBe("plugins.md");
+    expect(deriveArchivePath("plugins/datasources/index.mdx").path).toBe(
+      "plugins/datasources.md",
+    );
+  });
+
+  test("root landing becomes overview.md", () => {
+    expect(deriveArchivePath("index.mdx").path).toBe("overview.md");
+    expect(deriveArchivePath("INDEX.mdx").path).toBe("overview.md");
+  });
+
+  test("a page literally named log gets -doc so ingest can never silently drop it", () => {
+    const derived = deriveArchivePath("ops/log.mdx");
+    expect(derived.path).toBe("ops/log-doc.md");
+    expect(derived.renamedFromReserved).toBe(true);
+  });
+
+  test("an index that survives folding still moves off the reserved basename", () => {
+    // `a/index/index.mdx` folds to `a/index.md` — reserved, so renamed.
+    const derived = deriveArchivePath("a/index/index.mdx");
+    expect(derived.path).toBe("a/index-doc.md");
+    expect(derived.renamedFromReserved).toBe(true);
+  });
+
+  test("deterministic: same input, same output, no ordering dependence", () => {
+    expect(deriveArchivePath("guides/setup.mdx")).toEqual(deriveArchivePath("guides/setup.mdx"));
+  });
+
+  test("rejects traversal, absolute, and non-page paths", () => {
+    expect(() => deriveArchivePath("../escape.mdx")).toThrow(InvalidPagePathError);
+    expect(() => deriveArchivePath("/abs/page.mdx")).toThrow(InvalidPagePathError);
+    expect(() => deriveArchivePath("image.png")).toThrow(InvalidPagePathError);
+    expect(() => deriveArchivePath("")).toThrow(InvalidPagePathError);
+  });
+});
+
+describe("collectFumadocsPages", () => {
+  test("collects the Acme fixture with built-in skips and reserved renames", async () => {
+    const result = await collectFumadocsPages(acmeSource(), { prefix: "acme" });
+
+    expect(result.docs.map((d) => d.path).toSorted()).toEqual([
+      "acme/guides.md", // guides/index.mdx folded
+      "acme/guides/dashboards.md",
+      "acme/ops/log-doc.md", // reserved basename renamed
+      "acme/overview.md", // root index.mdx
+      "acme/quickstart.md",
+    ]);
+    expect(result.skipped.apiReference).toBe(1);
+    expect(result.skipped.contentless).toBe(1);
+    expect(result.renamedReserved).toEqual([
+      { from: "ops/log.mdx", to: "acme/ops/log-doc.md" },
+    ]);
+  });
+
+  test("frontmatter carries title/description/tags; body is byte-faithful", async () => {
+    const result = await collectFumadocsPages(acmeSource(), {
+      prefix: "acme",
+      tags: ["acme-docs"],
+    });
+    const quickstart = result.docs.find((d) => d.path === "acme/quickstart.md");
+    expect(quickstart?.content).toBe(
+      [
+        "---",
+        "type: Document",
+        'title: "Quickstart"',
+        'description: "Zero to first query"',
+        'tags: ["acme-docs", "setup"]',
+        "---",
+        "",
+        "## Install",
+        "",
+        "Run `acme init` and follow the prompts.",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("filter hook drops pages and is counted, not silent", async () => {
+    const result = await collectFumadocsPages(acmeSource(), {
+      prefix: "acme",
+      filter: (p) => !p.path.startsWith("guides/"),
+    });
+    expect(result.docs.some((d) => d.path.startsWith("acme/guides"))).toBe(false);
+    expect(result.skipped.filtered).toBe(2);
+  });
+
+  test("transform hook rewrites bodies; returning null skips fail-soft", async () => {
+    const result = await collectFumadocsPages(acmeSource(), {
+      prefix: "acme",
+      transform: (body, p) =>
+        p.path === "quickstart.mdx" ? null : body.replaceAll("Acme", "ACME"),
+    });
+    expect(result.docs.some((d) => d.path === "acme/quickstart.md")).toBe(false);
+    expect(result.skipped.transformSkipped).toBe(1);
+    expect(result.docs.find((d) => d.path === "acme/overview.md")?.content).toContain(
+      "ACME turns your warehouse",
+    );
+  });
+
+  test("missing processed text fails loud, naming the config — never raw-MDX fallback", async () => {
+    const broken = sourceOf([
+      page("no-postprocess.mdx", "body", { title: "X", missingProcessed: true }),
+    ]);
+    await expect(collectFumadocsPages(broken, { prefix: "acme" })).rejects.toThrow(
+      /includeProcessedMarkdown/,
+    );
+
+    const noMethod = sourceOf([page("no-method.mdx", "body", { noGetText: true })]);
+    await expect(collectFumadocsPages(noMethod, { prefix: "acme" })).rejects.toThrow(
+      ProcessedTextUnavailableError,
+    );
+  });
+
+  test("archive-path collision is a hard error naming both pages", async () => {
+    const colliding = sourceOf([
+      page("guide.mdx", "a standalone page with plenty of prose", { title: "A" }),
+      page("guide/index.mdx", "a landing that folds onto guide.md", { title: "B" }),
+    ]);
+    await expect(collectFumadocsPages(colliding, { prefix: "acme" })).rejects.toThrow(
+      ArchivePathCollisionError,
+    );
+  });
+
+  test("skipApiReference: false keeps the stubs (and contentless still applies)", async () => {
+    const result = await collectFumadocsPages(acmeSource(), {
+      prefix: "acme",
+      skipApiReference: false,
+      skipContentless: false,
+    });
+    expect(result.docs.some((d) => d.path === "acme/api-reference/create-widget.md")).toBe(true);
+    expect(result.docs.some((d) => d.path === "acme/changelog.md")).toBe(true);
+  });
+});
+
+describe("caps validation", () => {
+  test("doc-count overflow reports the actual numbers and the settings knob", async () => {
+    const many = sourceOf(
+      Array.from({ length: 5 }, (_, i) => page(`p${i}.mdx`, `Body of page number ${i}.`)),
+    );
+    await expect(
+      buildFumadocsOkfBundle(many, { prefix: "acme", caps: { maxDocs: 3 } }),
+    ).rejects.toThrow(/maxDocs: 5 documents > 3 documents.*ATLAS_KNOWLEDGE_INGEST_MAX_DOCS/s);
+  });
+
+  test("per-doc byte overflow names the document", async () => {
+    const big = sourceOf([page("big.mdx", "x".repeat(2000), { title: "Big" })]);
+    await expect(
+      buildFumadocsOkfBundle(big, { prefix: "acme", caps: { maxDocBytes: 100 } }),
+    ).rejects.toThrow(IngestCapExceededError);
+    await expect(
+      buildFumadocsOkfBundle(big, { prefix: "acme", caps: { maxDocBytes: 100 } }),
+    ).rejects.toThrow(/acme\/big\.md/);
+  });
+
+  test("decoded-total overflow trips maxBundleBytes", async () => {
+    const docs = Array.from({ length: 4 }, (_, i) => ({
+      path: `acme/p${i}.md`,
+      content: "y".repeat(400),
+      bytes: 400,
+      sourcePath: `p${i}.mdx`,
+    }));
+    expect(() =>
+      packOkfBundle(docs, { maxDocs: 100, maxDocBytes: 1000, maxBundleBytes: 1000 }),
+    ).toThrow(/maxBundleBytes: 1600 bytes > 1000 bytes/);
+  });
+});
+
+describe("deterministic packing", () => {
+  test("same source builds byte-identical archives, regardless of page order", async () => {
+    const pages = acmeSource().getPages();
+    const a = await buildFumadocsOkfBundle(sourceOf(pages), { prefix: "acme" });
+    const b = await buildFumadocsOkfBundle(sourceOf([...pages].reverse()), { prefix: "acme" });
+    expect(Buffer.from(a.bytes).equals(Buffer.from(b.bytes))).toBe(true);
+  });
+
+  test("stats reconcile: documents == emitted docs, skips accounted", async () => {
+    const result = await buildFumadocsOkfBundle(acmeSource(), { prefix: "acme" });
+    expect(result.stats.documents).toBe(result.docs.length);
+    expect(result.stats.documents).toBe(5);
+    expect(result.stats.skipped.apiReference + result.stats.skipped.contentless).toBe(2);
+    expect(result.stats.totalDocBytes).toBe(result.docs.reduce((n, d) => n + d.bytes, 0));
+    expect(result.stats.archiveBytes).toBe(result.bytes.length);
+  });
+});
+
+describe("splitUstarPath", () => {
+  test("short paths stay in name", () => {
+    expect(splitUstarPath("docs/a.md")).toEqual({ name: "docs/a.md", prefix: "" });
+  });
+
+  test("long paths split at a slash boundary", () => {
+    const dir = "d".repeat(90);
+    const split = splitUstarPath(`${dir}/${"f".repeat(60)}.md`);
+    expect(split.prefix).toBe(dir);
+    expect(split.name).toBe(`${"f".repeat(60)}.md`);
+  });
+
+  test("an unsplittable path throws instead of truncating", () => {
+    expect(() => splitUstarPath("x".repeat(160))).toThrow(/ustar/);
+  });
+});
+
+describe("isContentlessBody", () => {
+  test("component-only body is contentless; prose and code are content", () => {
+    expect(isContentlessBody("<ChangelogTimeline />")).toBe(true);
+    expect(isContentlessBody("Real prose that should be kept for the KB.")).toBe(false);
+    expect(isContentlessBody("```sql\nSELECT 1;\n```")).toBe(false);
+  });
+});

--- a/packages/fumadocs-okf/__tests__/fixture.ts
+++ b/packages/fumadocs-okf/__tests__/fixture.ts
@@ -1,0 +1,83 @@
+/**
+ * A synthetic NON-ATLAS Fumadocs site ("Acme Metrics" product docs) — the
+ * acceptance-criteria fixture proving the adapter works from the loader
+ * surface alone, not from the Atlas portal's content layout. The shapes
+ * mirror what `loader()` + fumadocs-mdx produce: `path` relative to the
+ * content dir, `url`, `data.{title,description,tags}` and the
+ * `getText("processed")` doc method.
+ */
+
+import type { FumadocsOkfPage, FumadocsOkfSource } from "../src/index";
+
+export function page(
+  path: string,
+  body: string,
+  data: {
+    title?: string;
+    description?: string;
+    tags?: unknown;
+    /** Simulate a site without `postprocess.includeProcessedMarkdown`. */
+    missingProcessed?: boolean;
+    /** Drop `getText` entirely (a non-fumadocs-mdx source). */
+    noGetText?: boolean;
+  } = {},
+): FumadocsOkfPage {
+  const { missingProcessed, noGetText, ...fm } = data;
+  return {
+    path,
+    url: `/${path.replace(/\.(mdx|md)$/i, "").replace(/(^|\/)index$/i, "")}`,
+    data: {
+      ...fm,
+      getText: noGetText
+        ? undefined
+        : async (type: "processed" | "raw") => {
+            if (type === "processed" && missingProcessed) {
+              // fumadocs-mdx's verbatim error for the missing config opt-in.
+              throw new Error(
+                "getText('processed') requires `includeProcessedMarkdown` to be enabled in your collection config.",
+              );
+            }
+            return body;
+          },
+    },
+  };
+}
+
+export function sourceOf(pages: readonly FumadocsOkfPage[]): FumadocsOkfSource {
+  return { getPages: () => pages };
+}
+
+/** The default Acme fixture: landings, nested sections, reserved names, stubs. */
+export function acmeSource(): FumadocsOkfSource {
+  return sourceOf([
+    page("index.mdx", "# Acme Metrics\n\nAcme turns your warehouse into answers.", {
+      title: "Acme Metrics",
+      description: "Product overview",
+    }),
+    page("quickstart.mdx", "## Install\n\nRun `acme init` and follow the prompts.", {
+      title: "Quickstart",
+      description: "Zero to first query",
+      tags: ["setup"],
+    }),
+    page(
+      "guides/index.mdx",
+      "All guides live here, organized by workload.",
+      { title: "Guides" },
+    ),
+    page(
+      "guides/dashboards.mdx",
+      "Dashboards are built from saved queries.\n\n```sql\nSELECT 1;\n```",
+      { title: "Dashboards", tags: ["viz", "setup"] },
+    ),
+    // A real content page that happens to carry a reserved OKF basename.
+    page("ops/log.mdx", "How Acme writes an audit log entry for every query.", {
+      title: "Audit log",
+    }),
+    // Auto-generated API-reference stub (built-in skip).
+    page("api-reference/create-widget.mdx", "<APIPage operations={[1]} />", {
+      title: "POST /widgets",
+    }),
+    // Component-only page (contentless skip).
+    page("changelog.mdx", "<ChangelogTimeline />", { title: "Changelog" }),
+  ]);
+}

--- a/packages/fumadocs-okf/__tests__/fixture.ts
+++ b/packages/fumadocs-okf/__tests__/fixture.ts
@@ -73,6 +73,12 @@ export function acmeSource(): FumadocsOkfSource {
     page("ops/log.mdx", "How Acme writes an audit log entry for every query.", {
       title: "Audit log",
     }),
+    // Hostile frontmatter: quotes, colons, and a backslash must survive the
+    // OKF serialization round-trip (the JSON-encoded-scalar claim in okf.ts).
+    page("faq.mdx", 'Q: does `"SELECT *"` count? A: yes\\no, it depends.', {
+      title: 'FAQ: "gotchas", edge: cases',
+      description: 'Answers to: "why?", "how?" — and C:\\paths too',
+    }),
     // Auto-generated API-reference stub (built-in skip).
     page("api-reference/create-widget.mdx", "<APIPage operations={[1]} />", {
       title: "POST /widgets",

--- a/packages/fumadocs-okf/__tests__/roundtrip.test.ts
+++ b/packages/fumadocs-okf/__tests__/roundtrip.test.ts
@@ -19,9 +19,14 @@ import { describe, expect, test } from "bun:test";
 
 import { extractBundle } from "@atlas/api/lib/knowledge/bundle-archive";
 import { parseLenientBundle } from "@atlas/api/lib/knowledge/parse-lenient";
+import { RESERVED_BASENAMES } from "@atlas/api/lib/semantic/okf/md-utils";
 
-import { buildFumadocsOkfBundle, DEFAULT_INGEST_CAPS } from "../src/index";
-import { acmeSource } from "./fixture";
+import {
+  buildFumadocsOkfBundle,
+  DEFAULT_INGEST_CAPS,
+  RESERVED_OKF_BASENAMES,
+} from "../src/index";
+import { acmeSource, page, sourceOf } from "./fixture";
 
 describe("bundle-sync round-trip (no packages/api changes)", () => {
   test("every built doc survives extract + lenient parse — zero silent drops", async () => {
@@ -76,6 +81,42 @@ describe("bundle-sync round-trip (no packages/api changes)", () => {
     expect(guides?.title).toBe("Guides");
     // The reserved-named page ingests under its -doc rename.
     expect(parsed.docs.some((d) => d.path === "acme/ops/log-doc.md")).toBe(true);
+  });
+
+  test("hostile frontmatter (quotes/colons/backslashes) survives the round-trip byte-faithfully", async () => {
+    const built = await buildFumadocsOkfBundle(acmeSource(), { prefix: "acme" });
+    const parsed = parseLenientBundle(
+      extractBundle(built.bytes, {
+        maxDocBytes: DEFAULT_INGEST_CAPS.maxDocBytes,
+        maxTotalBytes: DEFAULT_INGEST_CAPS.maxBundleBytes,
+      }).files,
+    );
+    const faq = parsed.docs.find((d) => d.path === "acme/faq.md");
+    expect(faq).toBeDefined();
+    expect(faq?.title).toBe('FAQ: "gotchas", edge: cases');
+    expect(faq?.description).toBe('Answers to: "why?", "how?" — and C:\\paths too');
+    expect(faq?.body.trim()).toBe('Q: does `"SELECT *"` count? A: yes\\no, it depends.');
+  });
+
+  test("a prefix-split (>100-byte) archive path round-trips intact through the real USTAR reader", async () => {
+    const deepDir = `${"section-".repeat(8)}nested`; // 71 chars
+    const longStem = `${"page-".repeat(10)}leaf`; // 54 chars → full path > 100
+    const source = sourceOf([
+      page(`${deepDir}/${longStem}.mdx`, "Deeply nested prose that must keep its path."),
+    ]);
+    const built = await buildFumadocsOkfBundle(source, { prefix: "acme" });
+    const extracted = extractBundle(built.bytes, {
+      maxDocBytes: DEFAULT_INGEST_CAPS.maxDocBytes,
+      maxTotalBytes: DEFAULT_INGEST_CAPS.maxBundleBytes,
+    });
+    expect(extracted.errors).toEqual([]);
+    expect(extracted.files.map((f) => f.path)).toEqual([`acme/${deepDir}/${longStem}.md`]);
+  });
+
+  test("reserved-basename set stays equal to the server's RESERVED_BASENAMES", () => {
+    // A drift here (e.g. the API side reserving a new basename) would
+    // reintroduce the silent-drop class this package exists to close.
+    expect([...RESERVED_OKF_BASENAMES].toSorted()).toEqual([...RESERVED_BASENAMES].toSorted());
   });
 
   test("adapter default caps stay equal to the server ingest-limit defaults", async () => {

--- a/packages/fumadocs-okf/__tests__/roundtrip.test.ts
+++ b/packages/fumadocs-okf/__tests__/roundtrip.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Round-trip: the generated archive through the REAL Atlas ingest pipeline
+ * stages — `extractBundle` (magic-byte container detection, traversal/size
+ * guards) → `parseLenientBundle` (frontmatter, reserved basenames, links) —
+ * imported from `@atlas/api` as a dev dependency, with ZERO changes to
+ * `packages/api` (issue #4367 acceptance criterion). These are exactly the
+ * stages `ingestBundle()` runs before its transaction, and the ones
+ * bundle-sync feeds after `guardedFetch` pulls the endpoint; the
+ * transactional tail (draft rows → review → publish) is `packages/api`'s own
+ * tested territory.
+ *
+ * The headline assertion is the reconcile guardrail from the issue: EVERY
+ * document the adapter reports built must come out of the lenient parser —
+ * no silent reserved-basename drops (the 8-of-165 `index.md` gap that
+ * motivated the rename mapping), no rejections, no non-markdown skips.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { extractBundle } from "@atlas/api/lib/knowledge/bundle-archive";
+import { parseLenientBundle } from "@atlas/api/lib/knowledge/parse-lenient";
+
+import { buildFumadocsOkfBundle, DEFAULT_INGEST_CAPS } from "../src/index";
+import { acmeSource } from "./fixture";
+
+describe("bundle-sync round-trip (no packages/api changes)", () => {
+  test("every built doc survives extract + lenient parse — zero silent drops", async () => {
+    const built = await buildFumadocsOkfBundle(acmeSource(), {
+      prefix: "acme",
+      tags: ["acme-docs"],
+    });
+
+    const extracted = extractBundle(built.bytes, {
+      maxDocBytes: DEFAULT_INGEST_CAPS.maxDocBytes,
+      maxTotalBytes: DEFAULT_INGEST_CAPS.maxBundleBytes,
+    });
+    expect(extracted.format).toBe("tar.gz");
+    expect(extracted.errors).toEqual([]);
+    expect(extracted.files.length).toBe(built.stats.documents);
+
+    const parsed = parseLenientBundle(extracted.files);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.skippedNonMarkdown).toBe(0);
+    // The reconcile guardrail: built N === parsed N. Reserved basenames were
+    // renamed at generation, so the parser's silent index.md/log.md skip can
+    // never eat a document.
+    expect(parsed.docs.length).toBe(built.stats.documents);
+    expect(parsed.docs.map((d) => d.path).toSorted()).toEqual(
+      built.docs.map((d) => d.path).toSorted(),
+    );
+  });
+
+  test("frontmatter fidelity: title/description/tags/type land as authored", async () => {
+    const built = await buildFumadocsOkfBundle(acmeSource(), {
+      prefix: "acme",
+      tags: ["acme-docs"],
+    });
+    const extracted = extractBundle(built.bytes, {
+      maxDocBytes: DEFAULT_INGEST_CAPS.maxDocBytes,
+      maxTotalBytes: DEFAULT_INGEST_CAPS.maxBundleBytes,
+    });
+    const parsed = parseLenientBundle(extracted.files);
+
+    const quickstart = parsed.docs.find((d) => d.path === "acme/quickstart.md");
+    expect(quickstart).toBeDefined();
+    expect(quickstart?.type).toBe("Document");
+    expect(quickstart?.title).toBe("Quickstart");
+    expect(quickstart?.description).toBe("Zero to first query");
+    expect(quickstart?.tags).toEqual(["acme-docs", "setup"]);
+    expect(quickstart?.body.trim()).toBe(
+      "## Install\n\nRun `acme init` and follow the prompts.",
+    );
+
+    // The folded section landing ingests as a real document.
+    const guides = parsed.docs.find((d) => d.path === "acme/guides.md");
+    expect(guides?.title).toBe("Guides");
+    // The reserved-named page ingests under its -doc rename.
+    expect(parsed.docs.some((d) => d.path === "acme/ops/log-doc.md")).toBe(true);
+  });
+
+  test("adapter default caps stay equal to the server ingest-limit defaults", async () => {
+    // Import lazily: ingest-limits pulls the settings/logger modules, which is
+    // fine to load but kept out of the shared top-level imports above.
+    const limits = await import("@atlas/api/lib/knowledge/ingest-limits");
+    expect(DEFAULT_INGEST_CAPS.maxDocs).toBe(limits.DEFAULT_INGEST_MAX_DOCS);
+    expect(DEFAULT_INGEST_CAPS.maxDocBytes).toBe(limits.DEFAULT_INGEST_MAX_DOC_BYTES);
+    expect(DEFAULT_INGEST_CAPS.maxBundleBytes).toBe(limits.DEFAULT_INGEST_MAX_BUNDLE_BYTES);
+  });
+});

--- a/packages/fumadocs-okf/package.json
+++ b/packages/fumadocs-okf/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@atlas/fumadocs-okf",
+  "version": "0.0.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "description": "Fumadocs → OKF knowledge-bundle generator: turns any Fumadocs content-source loader into an Atlas Knowledge Base .tar.gz for the bundle-sync connector. Internal-only — not published to npm (promote only after the API survives a real non-Atlas consumer).",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./errors": "./src/errors.ts",
+    "./paths": "./src/paths.ts",
+    "./okf": "./src/okf.ts",
+    "./tar": "./src/tar.ts",
+    "./collect": "./src/collect.ts",
+    "./build": "./src/build.ts"
+  },
+  "scripts": {
+    "test": "bun test __tests__/"
+  },
+  "dependencies": {
+    "fflate": "^0.8.2"
+  },
+  "devDependencies": {
+    "@atlas/api": "workspace:*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtlasDevHQ/atlas",
+    "directory": "packages/fumadocs-okf"
+  }
+}

--- a/packages/fumadocs-okf/src/build.ts
+++ b/packages/fumadocs-okf/src/build.ts
@@ -3,13 +3,13 @@
  *
  * `validateIngestCaps` + `packOkfBundle` are exported separately so a
  * multi-section site (like the Atlas docs portal) can run several collects
- * with different prefixes and pack them as ONE archive — caps are then
- * validated once, over the merged document set, exactly as the ingest seam
- * will see it.
+ * with different prefixes and pack them as ONE archive — caps AND path
+ * uniqueness are then validated once, over the merged document set, exactly
+ * as the ingest seam will see it.
  */
 
 import { collectFumadocsPages } from "./collect";
-import { IngestCapExceededError } from "./errors";
+import { ArchivePathCollisionError, IngestCapExceededError } from "./errors";
 import { createDeterministicTarGz } from "./tar";
 import {
   DEFAULT_INGEST_CAPS,
@@ -64,11 +64,26 @@ export function validateIngestCaps(
  * Pack collected documents into a deterministic `.tar.gz`, validating the
  * caps over the full set first (including the compressed-size cap the ingest
  * route applies to the raw upload body).
+ *
+ * This is ALSO where the path-uniqueness invariant is enforced over the
+ * whole set: `collectFumadocsPages` catches collisions within one collect,
+ * but merged multi-section sets (overlapping prefixes, the same collect
+ * passed twice) would otherwise pack two tar entries at one path and let
+ * the ingest upsert silently last-write-win. Every pack path goes through
+ * here, so a bundle is either collision-free or refused.
  */
 export function packOkfBundle(
   docs: readonly CollectedDoc[],
   caps: IngestCaps = DEFAULT_INGEST_CAPS,
 ): { bytes: Uint8Array; totalDocBytes: number } {
+  const byPath = new Map<string, string>();
+  for (const doc of docs) {
+    const existing = byPath.get(doc.path);
+    if (existing !== undefined) {
+      throw new ArchivePathCollisionError(doc.path, existing, doc.sourcePath);
+    }
+    byPath.set(doc.path, doc.sourcePath);
+  }
   const { totalDocBytes } = validateIngestCaps(docs, caps);
   const bytes = createDeterministicTarGz(docs);
   if (bytes.length > caps.maxBundleBytes) {
@@ -82,7 +97,11 @@ export function packOkfBundle(
   return { bytes, totalDocBytes };
 }
 
-/** Merge per-collect results for multi-section packing (portal dogfood path). */
+/**
+ * Merge per-collect results for multi-section packing (portal dogfood path).
+ * Merging itself does not re-check path collisions across collects —
+ * `packOkfBundle` does, so a cross-section duplicate is refused at pack.
+ */
 export function mergeCollectResults(results: readonly CollectResult[]): CollectResult {
   return {
     docs: results.flatMap((r) => r.docs),

--- a/packages/fumadocs-okf/src/build.ts
+++ b/packages/fumadocs-okf/src/build.ts
@@ -1,0 +1,122 @@
+/**
+ * One-shot build: collect → validate against the ingest caps → pack.
+ *
+ * `validateIngestCaps` + `packOkfBundle` are exported separately so a
+ * multi-section site (like the Atlas docs portal) can run several collects
+ * with different prefixes and pack them as ONE archive — caps are then
+ * validated once, over the merged document set, exactly as the ingest seam
+ * will see it.
+ */
+
+import { collectFumadocsPages } from "./collect";
+import { IngestCapExceededError } from "./errors";
+import { createDeterministicTarGz } from "./tar";
+import {
+  DEFAULT_INGEST_CAPS,
+  type BuildOptions,
+  type BuildResult,
+  type CollectedDoc,
+  type CollectResult,
+  type FumadocsOkfSource,
+  type IngestCaps,
+} from "./types";
+
+/**
+ * Generation-time mirror of the checks Atlas's ingest seam applies
+ * (`ingestBundle` → doc count / per-doc bytes / decoded-total bytes).
+ * Throws {@link IngestCapExceededError} with the actual numbers.
+ */
+export function validateIngestCaps(
+  docs: readonly CollectedDoc[],
+  caps: IngestCaps = DEFAULT_INGEST_CAPS,
+): { totalDocBytes: number } {
+  if (docs.length > caps.maxDocs) {
+    throw new IngestCapExceededError({
+      cap: "maxDocs",
+      actual: docs.length,
+      limit: caps.maxDocs,
+    });
+  }
+  let totalDocBytes = 0;
+  for (const doc of docs) {
+    if (doc.bytes > caps.maxDocBytes) {
+      throw new IngestCapExceededError({
+        cap: "maxDocBytes",
+        actual: doc.bytes,
+        limit: caps.maxDocBytes,
+        docPath: doc.path,
+      });
+    }
+    totalDocBytes += doc.bytes;
+  }
+  if (totalDocBytes > caps.maxBundleBytes) {
+    throw new IngestCapExceededError({
+      cap: "maxBundleBytes",
+      actual: totalDocBytes,
+      limit: caps.maxBundleBytes,
+      detail: "decoded document total (the ingest decompression guard sees this)",
+    });
+  }
+  return { totalDocBytes };
+}
+
+/**
+ * Pack collected documents into a deterministic `.tar.gz`, validating the
+ * caps over the full set first (including the compressed-size cap the ingest
+ * route applies to the raw upload body).
+ */
+export function packOkfBundle(
+  docs: readonly CollectedDoc[],
+  caps: IngestCaps = DEFAULT_INGEST_CAPS,
+): { bytes: Uint8Array; totalDocBytes: number } {
+  const { totalDocBytes } = validateIngestCaps(docs, caps);
+  const bytes = createDeterministicTarGz(docs);
+  if (bytes.length > caps.maxBundleBytes) {
+    throw new IngestCapExceededError({
+      cap: "maxBundleBytes",
+      actual: bytes.length,
+      limit: caps.maxBundleBytes,
+      detail: "compressed archive size (the ingest route caps the raw upload body)",
+    });
+  }
+  return { bytes, totalDocBytes };
+}
+
+/** Merge per-collect results for multi-section packing (portal dogfood path). */
+export function mergeCollectResults(results: readonly CollectResult[]): CollectResult {
+  return {
+    docs: results.flatMap((r) => r.docs),
+    skipped: {
+      filtered: results.reduce((n, r) => n + r.skipped.filtered, 0),
+      apiReference: results.reduce((n, r) => n + r.skipped.apiReference, 0),
+      contentless: results.reduce((n, r) => n + r.skipped.contentless, 0),
+      transformSkipped: results.reduce((n, r) => n + r.skipped.transformSkipped, 0),
+    },
+    renamedReserved: results.flatMap((r) => r.renamedReserved),
+  };
+}
+
+/**
+ * Turn a Fumadocs source into an OKF `.tar.gz` bundle for the Atlas KB
+ * bundle-sync connector (or the upload-ingest route) — collect, validate
+ * against the ingest caps, pack.
+ */
+export async function buildFumadocsOkfBundle(
+  source: FumadocsOkfSource,
+  options: BuildOptions,
+): Promise<BuildResult> {
+  const collected = await collectFumadocsPages(source, options);
+  const caps: IngestCaps = { ...DEFAULT_INGEST_CAPS, ...options.caps };
+  const { bytes, totalDocBytes } = packOkfBundle(collected.docs, caps);
+  return {
+    bytes,
+    docs: collected.docs,
+    stats: {
+      documents: collected.docs.length,
+      totalDocBytes,
+      archiveBytes: bytes.length,
+      skipped: collected.skipped,
+      renamedReserved: collected.renamedReserved,
+    },
+  };
+}

--- a/packages/fumadocs-okf/src/collect.ts
+++ b/packages/fumadocs-okf/src/collect.ts
@@ -11,6 +11,7 @@
 
 import {
   ArchivePathCollisionError,
+  PageLoadError,
   ProcessedTextUnavailableError,
 } from "./errors";
 import { isContentlessBody, pageTags, renderOkfDocument } from "./okf";
@@ -40,13 +41,16 @@ async function processedBody(page: FumadocsOkfPage): Promise<string> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (FUMADOCS_MISSING_PROCESSED.test(message)) {
+      // The config case — prescribe the one-line source.config.ts fix.
       throw new ProcessedTextUnavailableError(page.path);
     }
-    // Any other load failure still fails the build — with the page named.
-    throw new ProcessedTextUnavailableError(page.path, message);
+    // Any other failure (a shim's HTTP fetch, a file read) is a LOAD error:
+    // still fail-loud with the page named, but without misdiagnosing it as
+    // the missing-config case.
+    throw new PageLoadError(page.path, message, err);
   }
   if (typeof body !== "string") {
-    throw new ProcessedTextUnavailableError(page.path, "getText(\"processed\") returned a non-string");
+    throw new PageLoadError(page.path, 'getText("processed") returned a non-string');
   }
   return body;
 }
@@ -59,32 +63,35 @@ function tagsFor(
   return [...new Set([...configured, ...pageTags(page.data.tags)])];
 }
 
-interface PageOutcome {
-  readonly doc?: CollectedDoc;
-  readonly rename?: ReservedRename;
-  readonly skip?: "filtered" | "apiReference" | "contentless" | "transformSkipped";
-}
+/** One page's outcome — a doc or a counted skip, never neither/both. */
+type PageOutcome =
+  | { readonly kind: "skip"; readonly reason: keyof CollectResult["skipped"] }
+  | { readonly kind: "doc"; readonly doc: CollectedDoc; readonly rename?: ReservedRename };
 
 async function collectPage(
   page: FumadocsOkfPage,
   prefixSegments: readonly string[],
   options: CollectOptions,
 ): Promise<PageOutcome> {
+  // Filters run BEFORE the body resolves — a skipped page must never cost a
+  // twin fetch / file read (473 api-reference stubs are a directory listing,
+  // not 473 reads), and a skipped page with a broken body must not fail the
+  // build.
   if ((options.skipApiReference ?? true) && isApiReferencePage(page.path)) {
-    return { skip: "apiReference" };
+    return { kind: "skip", reason: "apiReference" };
   }
   if (options.filter && !(await options.filter(page))) {
-    return { skip: "filtered" };
+    return { kind: "skip", reason: "filtered" };
   }
 
   let body = await processedBody(page);
   if (options.transform) {
     const transformed = await options.transform(body, page);
-    if (transformed === null) return { skip: "transformSkipped" };
+    if (transformed === null) return { kind: "skip", reason: "transformSkipped" };
     body = transformed;
   }
   if ((options.skipContentless ?? true) && isContentlessBody(body)) {
-    return { skip: "contentless" };
+    return { kind: "skip", reason: "contentless" };
   }
 
   const derived = deriveArchivePath(page.path);
@@ -95,6 +102,7 @@ async function collectPage(
     body,
   );
   return {
+    kind: "doc",
     doc: {
       path,
       content,
@@ -107,9 +115,10 @@ async function collectPage(
 
 /**
  * Collect every eligible page of a source into OKF documents. Throws
- * {@link ProcessedTextUnavailableError} / {@link ArchivePathCollisionError} /
- * `InvalidPagePathError` — a bundle is either right or refused, never
- * silently partial (skips are counted and returned, not hidden).
+ * {@link ProcessedTextUnavailableError} / {@link PageLoadError} /
+ * {@link ArchivePathCollisionError} / `InvalidPagePathError` — a bundle is
+ * either right or refused, never silently partial (skips are counted and
+ * returned, not hidden).
  */
 export async function collectFumadocsPages(
   source: FumadocsOkfSource,
@@ -120,7 +129,13 @@ export async function collectFumadocsPages(
   const outcomes: PageOutcome[] = new Array<PageOutcome>(pages.length);
 
   // Bounded-concurrency pool; outcomes land by index so ordering is stable.
-  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
+  // A non-finite/sub-1 concurrency value clamps to the default rather than
+  // producing zero workers (Array.from({length: NaN}) is empty).
+  const requested = options.concurrency;
+  const concurrency =
+    typeof requested === "number" && Number.isFinite(requested) && requested >= 1
+      ? Math.floor(requested)
+      : DEFAULT_CONCURRENCY;
   let cursor = 0;
   const worker = async (): Promise<void> => {
     for (let i = cursor++; i < pages.length; i = cursor++) {
@@ -134,12 +149,19 @@ export async function collectFumadocsPages(
   const skipped = { filtered: 0, apiReference: 0, contentless: 0, transformSkipped: 0 };
   const byPath = new Map<string, string>();
 
-  for (const outcome of outcomes) {
-    if (outcome.skip) {
-      skipped[outcome.skip]++;
+  for (let i = 0; i < outcomes.length; i++) {
+    const outcome: PageOutcome | undefined = outcomes[i];
+    if (outcome === undefined) {
+      // A hole here means the worker pool skipped an index — an internal bug
+      // that must never read as a silently smaller bundle.
+      throw new Error(
+        `internal: page ${i} ("${pages[i]?.path}") produced no outcome — collect-pool index bug`,
+      );
+    }
+    if (outcome.kind === "skip") {
+      skipped[outcome.reason]++;
       continue;
     }
-    if (!outcome.doc) continue; // unreachable: every outcome is a skip or a doc
     const existing = byPath.get(outcome.doc.path);
     if (existing !== undefined) {
       throw new ArchivePathCollisionError(outcome.doc.path, existing, outcome.doc.sourcePath);

--- a/packages/fumadocs-okf/src/collect.ts
+++ b/packages/fumadocs-okf/src/collect.ts
@@ -1,0 +1,153 @@
+/**
+ * Walk a Fumadocs source and collect OKF documents — the adapter's core.
+ *
+ * Per page: filter hooks (built-in + caller) → `getText("processed")`
+ * (fail-loud when unavailable, never a raw-MDX fallback) → body-transform
+ * hook → contentless check → OKF render → deterministic archive path.
+ * Bodies resolve under bounded concurrency (a shim's `getText` may be an
+ * HTTP fetch), but the result is ordered by the source's page order and the
+ * packer sorts by path, so output never depends on completion timing.
+ */
+
+import {
+  ArchivePathCollisionError,
+  ProcessedTextUnavailableError,
+} from "./errors";
+import { isContentlessBody, pageTags, renderOkfDocument } from "./okf";
+import { deriveArchivePath, isApiReferencePage, normalizePrefix } from "./paths";
+import type {
+  CollectedDoc,
+  CollectOptions,
+  CollectResult,
+  FumadocsOkfPage,
+  FumadocsOkfSource,
+  ReservedRename,
+} from "./types";
+
+const DEFAULT_CONCURRENCY = 8;
+
+/** fumadocs-mdx's own error message when `includeProcessedMarkdown` is off. */
+const FUMADOCS_MISSING_PROCESSED = /includeProcessedMarkdown/;
+
+async function processedBody(page: FumadocsOkfPage): Promise<string> {
+  const getText = page.data.getText;
+  if (typeof getText !== "function") {
+    throw new ProcessedTextUnavailableError(page.path, "page.data.getText is not available");
+  }
+  let body: unknown;
+  try {
+    body = await getText("processed");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (FUMADOCS_MISSING_PROCESSED.test(message)) {
+      throw new ProcessedTextUnavailableError(page.path);
+    }
+    // Any other load failure still fails the build — with the page named.
+    throw new ProcessedTextUnavailableError(page.path, message);
+  }
+  if (typeof body !== "string") {
+    throw new ProcessedTextUnavailableError(page.path, "getText(\"processed\") returned a non-string");
+  }
+  return body;
+}
+
+function tagsFor(
+  page: FumadocsOkfPage,
+  option: CollectOptions["tags"],
+): string[] {
+  const configured = typeof option === "function" ? option(page) : (option ?? []);
+  return [...new Set([...configured, ...pageTags(page.data.tags)])];
+}
+
+interface PageOutcome {
+  readonly doc?: CollectedDoc;
+  readonly rename?: ReservedRename;
+  readonly skip?: "filtered" | "apiReference" | "contentless" | "transformSkipped";
+}
+
+async function collectPage(
+  page: FumadocsOkfPage,
+  prefixSegments: readonly string[],
+  options: CollectOptions,
+): Promise<PageOutcome> {
+  if ((options.skipApiReference ?? true) && isApiReferencePage(page.path)) {
+    return { skip: "apiReference" };
+  }
+  if (options.filter && !(await options.filter(page))) {
+    return { skip: "filtered" };
+  }
+
+  let body = await processedBody(page);
+  if (options.transform) {
+    const transformed = await options.transform(body, page);
+    if (transformed === null) return { skip: "transformSkipped" };
+    body = transformed;
+  }
+  if ((options.skipContentless ?? true) && isContentlessBody(body)) {
+    return { skip: "contentless" };
+  }
+
+  const derived = deriveArchivePath(page.path);
+  const path = [...prefixSegments, derived.path].join("/");
+  const content = renderOkfDocument(
+    { title: page.data.title, description: page.data.description },
+    tagsFor(page, options.tags),
+    body,
+  );
+  return {
+    doc: {
+      path,
+      content,
+      bytes: new TextEncoder().encode(content).length,
+      sourcePath: page.path,
+    },
+    rename: derived.renamedFromReserved ? { from: page.path, to: path } : undefined,
+  };
+}
+
+/**
+ * Collect every eligible page of a source into OKF documents. Throws
+ * {@link ProcessedTextUnavailableError} / {@link ArchivePathCollisionError} /
+ * `InvalidPagePathError` — a bundle is either right or refused, never
+ * silently partial (skips are counted and returned, not hidden).
+ */
+export async function collectFumadocsPages(
+  source: FumadocsOkfSource,
+  options: CollectOptions,
+): Promise<CollectResult> {
+  const prefixSegments = normalizePrefix(options.prefix);
+  const pages = source.getPages();
+  const outcomes: PageOutcome[] = new Array<PageOutcome>(pages.length);
+
+  // Bounded-concurrency pool; outcomes land by index so ordering is stable.
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY);
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    for (let i = cursor++; i < pages.length; i = cursor++) {
+      outcomes[i] = await collectPage(pages[i], prefixSegments, options);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, pages.length || 1) }, worker));
+
+  const docs: CollectedDoc[] = [];
+  const renamedReserved: ReservedRename[] = [];
+  const skipped = { filtered: 0, apiReference: 0, contentless: 0, transformSkipped: 0 };
+  const byPath = new Map<string, string>();
+
+  for (const outcome of outcomes) {
+    if (outcome.skip) {
+      skipped[outcome.skip]++;
+      continue;
+    }
+    if (!outcome.doc) continue; // unreachable: every outcome is a skip or a doc
+    const existing = byPath.get(outcome.doc.path);
+    if (existing !== undefined) {
+      throw new ArchivePathCollisionError(outcome.doc.path, existing, outcome.doc.sourcePath);
+    }
+    byPath.set(outcome.doc.path, outcome.doc.sourcePath);
+    docs.push(outcome.doc);
+    if (outcome.rename) renamedReserved.push(outcome.rename);
+  }
+
+  return { docs, skipped, renamedReserved };
+}

--- a/packages/fumadocs-okf/src/errors.ts
+++ b/packages/fumadocs-okf/src/errors.ts
@@ -11,11 +11,14 @@
  */
 
 /**
- * A page has no `getText("processed")` body — the site's `source.config.ts`
- * hasn't enabled `postprocess: { includeProcessedMarkdown: true }` on the
- * collection (or the page failed to load). Raw MDX is NOT an acceptable
- * fallback: it carries unstripped `import`/`export` module lines and
- * un-expanded component content — quietly worse documents.
+ * A page has no `getText("processed")` body because the site's
+ * `source.config.ts` hasn't enabled `postprocess: { includeProcessedMarkdown:
+ * true }` on the collection (the method is missing, or fumadocs reported the
+ * config as absent). Raw MDX is NOT an acceptable fallback: it carries
+ * unstripped `import`/`export` module lines and un-expanded component
+ * content — quietly worse documents. A body that fails to LOAD for some
+ * other reason is a {@link PageLoadError} instead — same fail-loud posture,
+ * without misprescribing the config fix.
  */
 export class ProcessedTextUnavailableError extends Error {
   readonly pagePath: string;
@@ -28,6 +31,27 @@ export class ProcessedTextUnavailableError extends Error {
         `(a raw body would carry unstripped import/export lines and un-expanded component content).`,
     );
     this.name = "ProcessedTextUnavailableError";
+    this.pagePath = pagePath;
+  }
+}
+
+/**
+ * A page's processed body failed to load for a non-config reason — a shim's
+ * HTTP twin fetch failed, a file read errored, or `getText` returned a
+ * non-string. Fail-loud with the page named: a silently partial bundle fed
+ * to a bundle-sync collection would archive the missing pages' documents via
+ * the subtractive diff. The original failure rides `cause`.
+ */
+export class PageLoadError extends Error {
+  readonly pagePath: string;
+
+  constructor(pagePath: string, detail: string, cause?: unknown) {
+    super(
+      `Failed to load the processed markdown for page "${pagePath}": ${detail}. ` +
+        `The adapter never falls back to raw MDX — fix the load failure and rebuild.`,
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "PageLoadError";
     this.pagePath = pagePath;
   }
 }
@@ -90,7 +114,7 @@ export class IngestCapExceededError extends Error {
         `${actual} ${unit} > ${limit} ${unit}` +
         (docPath ? ` (document "${docPath}")` : "") +
         (detail ? ` — ${detail}` : "") +
-        `. Trim the bundle (filter hook), or have the workspace operator raise the ` +
+        `. Trim the bundle (filter hook), or have the Atlas platform operator raise the ` +
         `${CAP_SETTING[cap]} setting and pass the raised value via the caps option.`,
     );
     this.name = "IngestCapExceededError";

--- a/packages/fumadocs-okf/src/errors.ts
+++ b/packages/fumadocs-okf/src/errors.ts
@@ -1,0 +1,113 @@
+/**
+ * Typed failures for the Fumadocs → OKF adapter. Plain `Error` subclasses
+ * (not Effect `Data.TaggedError`): they cross ordinary function boundaries in
+ * build scripts and CLIs, never Effect's typed-error channel, and this
+ * package deliberately has no runtime dependency on `@atlas/api`.
+ *
+ * Every failure mode here is FAIL-LOUD by design (issue #4367): a page
+ * without processed text must never silently fall back to raw MDX, a cap
+ * overflow must surface at generation time with the actual numbers, and a
+ * path collision must never let one document silently overwrite another.
+ */
+
+/**
+ * A page has no `getText("processed")` body — the site's `source.config.ts`
+ * hasn't enabled `postprocess: { includeProcessedMarkdown: true }` on the
+ * collection (or the page failed to load). Raw MDX is NOT an acceptable
+ * fallback: it carries unstripped `import`/`export` module lines and
+ * un-expanded component content — quietly worse documents.
+ */
+export class ProcessedTextUnavailableError extends Error {
+  readonly pagePath: string;
+
+  constructor(pagePath: string, detail?: string) {
+    super(
+      `Page "${pagePath}" has no processed markdown${detail ? ` (${detail})` : ""}. ` +
+        `Enable it in the site's source.config.ts collection config: ` +
+        `postprocess: { includeProcessedMarkdown: true } — the adapter never falls back to raw MDX ` +
+        `(a raw body would carry unstripped import/export lines and un-expanded component content).`,
+    );
+    this.name = "ProcessedTextUnavailableError";
+    this.pagePath = pagePath;
+  }
+}
+
+/**
+ * Two pages mapped to the same archive path. Deterministic path derivation
+ * means this is a real content-layout conflict (e.g. `guide.mdx` next to a
+ * post-rename `guide/index.mdx` fold target) — refusing beats one document
+ * silently shadowing the other in the collection.
+ */
+export class ArchivePathCollisionError extends Error {
+  readonly archivePath: string;
+  readonly pages: readonly [string, string];
+
+  constructor(archivePath: string, firstPagePath: string, secondPagePath: string) {
+    super(
+      `Pages "${firstPagePath}" and "${secondPagePath}" both map to archive path "${archivePath}". ` +
+        `Rename one of the source pages — archive paths derive deterministically from page.path, ` +
+        `so a collision would make one document silently overwrite the other at ingest.`,
+    );
+    this.name = "ArchivePathCollisionError";
+    this.archivePath = archivePath;
+    this.pages = [firstPagePath, secondPagePath];
+  }
+}
+
+/** Which ingest cap a bundle overflowed, with the server-side settings knob that raises it. */
+export type IngestCapKind = "maxDocs" | "maxDocBytes" | "maxBundleBytes";
+
+const CAP_SETTING: Record<IngestCapKind, string> = {
+  maxDocs: "ATLAS_KNOWLEDGE_INGEST_MAX_DOCS",
+  maxDocBytes: "ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES",
+  maxBundleBytes: "ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES",
+};
+
+/**
+ * The generated bundle would be rejected by Atlas's KB ingest caps. Raised at
+ * GENERATION time, with the actual numbers, so the site owner sees the
+ * overflow where they can fix it — not as a recurring per-sync ingest error
+ * on the Atlas side they can't see into.
+ */
+export class IngestCapExceededError extends Error {
+  readonly cap: IngestCapKind;
+  readonly actual: number;
+  readonly limit: number;
+  /** The document that tripped a per-doc cap, when one did. */
+  readonly docPath?: string;
+
+  constructor(params: {
+    cap: IngestCapKind;
+    actual: number;
+    limit: number;
+    docPath?: string;
+    detail?: string;
+  }) {
+    const { cap, actual, limit, docPath, detail } = params;
+    const unit = cap === "maxDocs" ? "documents" : "bytes";
+    super(
+      `Bundle exceeds the Atlas knowledge-ingest cap ${cap}: ` +
+        `${actual} ${unit} > ${limit} ${unit}` +
+        (docPath ? ` (document "${docPath}")` : "") +
+        (detail ? ` — ${detail}` : "") +
+        `. Trim the bundle (filter hook), or have the workspace operator raise the ` +
+        `${CAP_SETTING[cap]} setting and pass the raised value via the caps option.`,
+    );
+    this.name = "IngestCapExceededError";
+    this.cap = cap;
+    this.actual = actual;
+    this.limit = limit;
+    this.docPath = docPath;
+  }
+}
+
+/** A `page.path` (or configured prefix) the deterministic mapping can't accept. */
+export class InvalidPagePathError extends Error {
+  readonly pagePath: string;
+
+  constructor(pagePath: string, reason: string) {
+    super(`Cannot derive an archive path for "${pagePath}": ${reason}`);
+    this.name = "InvalidPagePathError";
+    this.pagePath = pagePath;
+  }
+}

--- a/packages/fumadocs-okf/src/index.ts
+++ b/packages/fumadocs-okf/src/index.ts
@@ -4,8 +4,9 @@
  * Turns any Fumadocs content-source loader (or a structurally-compatible
  * shim) into an OKF `.tar.gz` the Atlas Knowledge Base ingests via the
  * existing `bundle-sync` connector or the upload route — zero `packages/api`
- * changes required to consume the output (issue #4367, ADR-0028 §5: no new
- * connector, no `IngestSource` framework).
+ * changes required to consume the output (issue #4367: no new connector and
+ * no `IngestSource` adapter framework, per ADR-0028 §5's connectors-are-
+ * deliberate-follow-ups posture).
  *
  * See `README.md` for the hosting recipe (serving the archive for a
  * bundle-sync collection, the bearer-protected variant, and the egress-guard
@@ -23,6 +24,7 @@ export {
   ArchivePathCollisionError,
   IngestCapExceededError,
   InvalidPagePathError,
+  PageLoadError,
   ProcessedTextUnavailableError,
   type IngestCapKind,
 } from "./errors";

--- a/packages/fumadocs-okf/src/index.ts
+++ b/packages/fumadocs-okf/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * `@atlas/fumadocs-okf` — Fumadocs → OKF knowledge-bundle generator.
+ *
+ * Turns any Fumadocs content-source loader (or a structurally-compatible
+ * shim) into an OKF `.tar.gz` the Atlas Knowledge Base ingests via the
+ * existing `bundle-sync` connector or the upload route — zero `packages/api`
+ * changes required to consume the output (issue #4367, ADR-0028 §5: no new
+ * connector, no `IngestSource` framework).
+ *
+ * See `README.md` for the hosting recipe (serving the archive for a
+ * bundle-sync collection, the bearer-protected variant, and the egress-guard
+ * reachability constraints).
+ */
+
+export {
+  buildFumadocsOkfBundle,
+  mergeCollectResults,
+  packOkfBundle,
+  validateIngestCaps,
+} from "./build";
+export { collectFumadocsPages } from "./collect";
+export {
+  ArchivePathCollisionError,
+  IngestCapExceededError,
+  InvalidPagePathError,
+  ProcessedTextUnavailableError,
+  type IngestCapKind,
+} from "./errors";
+export { isContentlessBody, pageTags, renderOkfDocument, type OkfFrontmatter } from "./okf";
+export {
+  deriveArchivePath,
+  firstSegment,
+  isApiReferencePage,
+  normalizePrefix,
+  RESERVED_OKF_BASENAMES,
+  ROOT_INDEX_STEM,
+  type DerivedArchivePath,
+} from "./paths";
+export {
+  createDeterministicTar,
+  createDeterministicTarGz,
+  splitUstarPath,
+  type TarEntry,
+} from "./tar";
+export {
+  DEFAULT_INGEST_CAPS,
+  type BuildOptions,
+  type BuildResult,
+  type BuildStats,
+  type CollectedDoc,
+  type CollectOptions,
+  type CollectResult,
+  type CollectSkips,
+  type FumadocsOkfPage,
+  type FumadocsOkfSource,
+  type IngestCaps,
+  type ReservedRename,
+} from "./types";

--- a/packages/fumadocs-okf/src/okf.ts
+++ b/packages/fumadocs-okf/src/okf.ts
@@ -41,7 +41,11 @@ export function renderOkfDocument(
 export function isContentlessBody(body: string): boolean {
   if (/```[\s\S]*?```/.test(body)) return false; // a code-only page is content
   const text = body
-    .replace(/<[^>]+>/g, " ") // drop JSX / HTML tags
+    // Drop JSX / HTML tags. The character class excludes `<` (not just `>`)
+    // so a run of unclosed `<<<<` can't be re-scanned from every position —
+    // that overlap is what makes the naive `<[^>]+>` quadratic (js/polynomial-redos)
+    // on library-supplied bodies. A real tag never contains a literal `<`.
+    .replace(/<[^<>]+>/g, " ")
     .replace(/\s+/g, " ")
     .trim();
   return text.length < 16;

--- a/packages/fumadocs-okf/src/okf.ts
+++ b/packages/fumadocs-okf/src/okf.ts
@@ -1,0 +1,57 @@
+/**
+ * OKF document rendering + the contentless-page heuristic — ported from the
+ * #4366 portal prototype so every consumer of the adapter emits the same
+ * conformant shape the KB lenient ingest parser expects
+ * (`packages/api/src/lib/knowledge/parse-lenient.ts`).
+ */
+
+export interface OkfFrontmatter {
+  readonly title?: string;
+  readonly description?: string;
+}
+
+/**
+ * Serialize an OKF document: `type: Document` frontmatter, optional
+ * title/description, tags, then the body. String values are JSON-encoded
+ * (valid YAML double-quoted scalars) so colons/quotes in descriptions can't
+ * break parsing.
+ */
+export function renderOkfDocument(
+  fm: OkfFrontmatter,
+  tags: readonly string[],
+  body: string,
+): string {
+  const lines = ["---", "type: Document"];
+  if (fm.title) lines.push(`title: ${JSON.stringify(fm.title)}`);
+  if (fm.description) lines.push(`description: ${JSON.stringify(fm.description)}`);
+  if (tags.length > 0) {
+    lines.push(`tags: [${tags.map((t) => JSON.stringify(t)).join(", ")}]`);
+  }
+  lines.push("---", "", body.trimEnd(), "");
+  return lines.join("\n");
+}
+
+/**
+ * True when a body carries no ingestable prose — a page whose content is
+ * entirely component-rendered at build time (e.g. a page that is just
+ * `<ChangelogTimeline />`). Such a page would ingest as a contentless KB doc.
+ * Conservative: any fenced code block counts as content, and only a body with
+ * almost no text once JSX/HTML tags are removed is treated as empty.
+ */
+export function isContentlessBody(body: string): boolean {
+  if (/```[\s\S]*?```/.test(body)) return false; // a code-only page is content
+  const text = body
+    .replace(/<[^>]+>/g, " ") // drop JSX / HTML tags
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length < 16;
+}
+
+/** Narrow a page's frontmatter `tags` value to a clean string list. */
+export function pageTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => t.trim())
+    .filter((t) => t !== "");
+}

--- a/packages/fumadocs-okf/src/paths.ts
+++ b/packages/fumadocs-okf/src/paths.ts
@@ -27,7 +27,8 @@ import { InvalidPagePathError } from "./errors";
 /** Reserved OKF basenames the ingest parser skips (compared case-insensitively). */
 export const RESERVED_OKF_BASENAMES: ReadonlySet<string> = new Set(["index.md", "log.md"]);
 
-/** The archive path a folded ROOT `index` page lands on (`index.mdx` at the collection root). */
+/** The archive-path STEM a folded ROOT `index` page lands on — `index.mdx`
+ *  at the collection root becomes `<prefix>/overview.md`. */
 export const ROOT_INDEX_STEM = "overview";
 
 /** Page extensions a Fumadocs collection can contain. */

--- a/packages/fumadocs-okf/src/paths.ts
+++ b/packages/fumadocs-okf/src/paths.ts
@@ -1,0 +1,132 @@
+/**
+ * Deterministic `page.path` → archive-path derivation.
+ *
+ * The bundle-sync subtractive diff (`archiveAbsent`) keys on FULL bundle
+ * paths, so this mapping must be a pure function of the page's own path — no
+ * hashing, no ordering dependence, no per-build components. A slug rename
+ * therefore reads as "old path absent + new path added" → archive + fresh
+ * draft; that churn is expected, safe (never a hard delete), and documented.
+ *
+ * Two OKF realities shape the mapping:
+ *   1. The ingest parser SILENTLY skips reserved basenames (`index.md`,
+ *      `log.md` — navigation/history in a hand-authored OKF tree). Fumadocs
+ *      uses `index.mdx` for real section-landing content, so a naive mapping
+ *      drops a site's biggest overview pages without even a rejection row
+ *      (issue #4367: 8 of 165 portal docs vanished this way). A section
+ *      landing is therefore FOLDED onto its section's own slug
+ *      (`plugins/index.mdx` → `plugins.md`) — collision-free by construction
+ *      for a valid Fumadocs site, because `plugins/index.mdx` and
+ *      `plugins.mdx` already collide at the same URL there.
+ *   2. Anything else that still lands on a reserved basename (a page
+ *      literally named `log.mdx`, or an `index` that survives folding) gets a
+ *      `-doc` suffix so it can never be silently dropped.
+ */
+
+import { InvalidPagePathError } from "./errors";
+
+/** Reserved OKF basenames the ingest parser skips (compared case-insensitively). */
+export const RESERVED_OKF_BASENAMES: ReadonlySet<string> = new Set(["index.md", "log.md"]);
+
+/** The archive path a folded ROOT `index` page lands on (`index.mdx` at the collection root). */
+export const ROOT_INDEX_STEM = "overview";
+
+/** Page extensions a Fumadocs collection can contain. */
+const PAGE_EXTENSION = /\.(mdx|md)$/i;
+
+/**
+ * Normalize and validate a path into clean segments. Rejects traversal,
+ * absolute paths, and empty input — the archive must extract under the
+ * collection's relative tree (mirrors the ingest side's `normalizeBundlePath`
+ * posture, but fails loud at generation instead of rejecting at ingest).
+ */
+function toSegments(raw: string, what: string): string[] {
+  const unified = raw.replace(/\\/g, "/").trim();
+  if (unified === "") throw new InvalidPagePathError(raw, `${what} is empty`);
+  if (unified.startsWith("/") || /^[A-Za-z]:\//.test(unified)) {
+    throw new InvalidPagePathError(raw, `${what} must be relative, got an absolute path`);
+  }
+  const segments: string[] = [];
+  for (const segment of unified.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      throw new InvalidPagePathError(raw, `${what} contains a ".." traversal segment`);
+    }
+    segments.push(segment);
+  }
+  if (segments.length === 0) throw new InvalidPagePathError(raw, `${what} has no path segments`);
+  return segments;
+}
+
+/** Validate a bundle prefix (one or more plain path segments). Returns clean segments. */
+export function normalizePrefix(prefix: string): string[] {
+  return toSegments(prefix, "prefix");
+}
+
+export interface DerivedArchivePath {
+  /** Archive-relative `.md` path (prefix NOT included). */
+  readonly path: string;
+  /** Set when the basename had to move off a reserved OKF name. */
+  readonly renamedFromReserved: boolean;
+}
+
+/**
+ * Derive the archive-relative `.md` path for a page path, deterministically:
+ *
+ *   `guides/setup.mdx`      → `guides/setup.md`
+ *   `plugins/index.mdx`     → `plugins.md`        (section landing folds to the section slug)
+ *   `index.mdx`             → `overview.md`       (root landing)
+ *   `ops/log.mdx`           → `ops/log-doc.md`    (reserved basename — never silently droppable)
+ */
+export function deriveArchivePath(pagePath: string): DerivedArchivePath {
+  const segments = toSegments(pagePath, "page.path");
+
+  const last = segments[segments.length - 1];
+  if (!PAGE_EXTENSION.test(last)) {
+    throw new InvalidPagePathError(
+      pagePath,
+      `expected a .mdx/.md page file, got "${last}" — is this a page from a Fumadocs source loader?`,
+    );
+  }
+  const stem = last.replace(PAGE_EXTENSION, "");
+  if (stem === "") {
+    throw new InvalidPagePathError(pagePath, "page filename has no stem");
+  }
+
+  // Fold a section landing onto the section's own slug — matches Fumadocs URL
+  // semantics (`plugins/index.mdx` and `plugins.mdx` share a slug there, so
+  // the fold target cannot belong to another page on a valid site).
+  let outSegments: string[];
+  if (stem.toLowerCase() === "index") {
+    outSegments = segments.slice(0, -1);
+    if (outSegments.length === 0) outSegments = [ROOT_INDEX_STEM];
+  } else {
+    outSegments = [...segments.slice(0, -1), stem];
+  }
+
+  // Anything still landing on a reserved basename (`log.mdx`; an `index`
+  // directory name that became the basename after folding) gets `-doc` so the
+  // ingest parser can never silently skip it.
+  let renamedFromReserved = false;
+  const basename = `${outSegments[outSegments.length - 1]}.md`;
+  if (RESERVED_OKF_BASENAMES.has(basename.toLowerCase())) {
+    outSegments[outSegments.length - 1] = `${outSegments[outSegments.length - 1]}-doc`;
+    renamedFromReserved = true;
+  }
+
+  return { path: `${outSegments.join("/")}.md`, renamedFromReserved };
+}
+
+/** First path segment of a normalized page path, lower-cased ("" when invalid). */
+export function firstSegment(pagePath: string): string {
+  const unified = pagePath.replace(/\\/g, "/").trim().replace(/^\.?\//, "");
+  const idx = unified.indexOf("/");
+  return (idx === -1 ? unified : unified.slice(0, idx)).toLowerCase();
+}
+
+/**
+ * True for auto-generated API-reference stub pages (`api-reference/…`) — the
+ * built-in page-filter predicate behind `skipApiReference`.
+ */
+export function isApiReferencePage(pagePath: string): boolean {
+  return firstSegment(pagePath) === "api-reference";
+}

--- a/packages/fumadocs-okf/src/tar.ts
+++ b/packages/fumadocs-okf/src/tar.ts
@@ -15,6 +15,8 @@
 
 import { gzipSync } from "fflate";
 
+import { InvalidPagePathError } from "./errors";
+
 const BLOCK = 512;
 const NAME_FIELD = 100;
 const PREFIX_FIELD = 155;
@@ -43,8 +45,8 @@ export function splitUstarPath(path: string): { name: string; prefix: string } {
   const bytes = encoder.encode(path);
   if (bytes.length <= NAME_FIELD) return { name: path, prefix: "" };
 
-  // Find the split point closest to the start that keeps name ≤ 100 — i.e.
-  // the LAST '/' whose right side fits in the name field.
+  // Scan left to right and take the FIRST '/' whose right side fits the
+  // 100-byte name field (longest name, shortest prefix).
   for (let i = 0; i < path.length; i++) {
     if (path[i] !== "/") continue;
     const prefix = path.slice(0, i);
@@ -56,9 +58,10 @@ export function splitUstarPath(path: string): { name: string; prefix: string } {
       return { name, prefix };
     }
   }
-  throw new Error(
-    `Archive path "${path}" cannot be stored in a ustar header (a segment exceeds 100 bytes ` +
-      `or the path exceeds 255 bytes) — shorten the page path or prefix.`,
+  throw new InvalidPagePathError(
+    path,
+    `cannot be stored in a ustar header (a segment exceeds 100 bytes ` +
+      `or the path exceeds 255 bytes) — shorten the page path or prefix`,
   );
 }
 

--- a/packages/fumadocs-okf/src/tar.ts
+++ b/packages/fumadocs-okf/src/tar.ts
@@ -1,0 +1,130 @@
+/**
+ * Deterministic USTAR + gzip packing.
+ *
+ * The KB ingest side magic-byte-detects the container and hand-parses USTAR
+ * (`packages/api/src/lib/knowledge/bundle-archive.ts`), so this writer emits
+ * plain POSIX ustar: regular files only, `name`(100)/`prefix`(155) split for
+ * long paths, no PAX/GNU extensions.
+ *
+ * Determinism is a feature: entries are sorted by path, every header stamps
+ * mtime 0 / uid 0 / gid 0 / mode 0644, and the gzip layer writes mtime 0 — so
+ * the same content produces the same bytes on every build, and an unchanged
+ * site produces an unchanged artifact (nice for content-addressed hosting and
+ * honest diffs; the bundle-sync path diff itself keys on paths, not bytes).
+ */
+
+import { gzipSync } from "fflate";
+
+const BLOCK = 512;
+const NAME_FIELD = 100;
+const PREFIX_FIELD = 155;
+
+const encoder = new TextEncoder();
+
+/** Write an ASCII string into a fixed field (NUL-padded). Caller guarantees fit. */
+function writeString(block: Uint8Array, offset: number, value: string): void {
+  const bytes = encoder.encode(value);
+  block.set(bytes, offset);
+}
+
+/** Write a tar octal numeric field: zero-padded octal + trailing NUL. */
+function writeOctal(block: Uint8Array, offset: number, length: number, value: number): void {
+  const octal = value.toString(8).padStart(length - 1, "0");
+  writeString(block, offset, octal); // leaves the final byte NUL
+}
+
+/**
+ * Split an archive path into ustar `name`/`prefix` fields at a `/` boundary.
+ * Throws when no valid split exists (a single segment over 100 bytes, or a
+ * path whose prefix side exceeds 155) — loud beats a silently-truncated path
+ * that would corrupt the bundle-sync diff.
+ */
+export function splitUstarPath(path: string): { name: string; prefix: string } {
+  const bytes = encoder.encode(path);
+  if (bytes.length <= NAME_FIELD) return { name: path, prefix: "" };
+
+  // Find the split point closest to the start that keeps name ≤ 100 — i.e.
+  // the LAST '/' whose right side fits in the name field.
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] !== "/") continue;
+    const prefix = path.slice(0, i);
+    const name = path.slice(i + 1);
+    if (
+      encoder.encode(name).length <= NAME_FIELD &&
+      encoder.encode(prefix).length <= PREFIX_FIELD
+    ) {
+      return { name, prefix };
+    }
+  }
+  throw new Error(
+    `Archive path "${path}" cannot be stored in a ustar header (a segment exceeds 100 bytes ` +
+      `or the path exceeds 255 bytes) — shorten the page path or prefix.`,
+  );
+}
+
+function headerFor(path: string, size: number): Uint8Array {
+  const { name, prefix } = splitUstarPath(path);
+  const header = new Uint8Array(BLOCK);
+
+  writeString(header, 0, name);
+  writeOctal(header, 100, 8, 0o644); // mode
+  writeOctal(header, 108, 8, 0); // uid
+  writeOctal(header, 116, 8, 0); // gid
+  writeOctal(header, 124, 12, size);
+  writeOctal(header, 136, 12, 0); // mtime — fixed for determinism
+  header[156] = "0".charCodeAt(0); // typeflag: regular file
+  writeString(header, 257, "ustar"); // magic (POSIX: "ustar\0", version "00")
+  header[262] = 0;
+  writeString(header, 263, "00");
+  writeString(header, 345, prefix);
+
+  // Checksum: computed with the checksum field itself read as spaces, then
+  // stored as six octal digits + NUL + space.
+  header.fill(0x20, 148, 156);
+  let sum = 0;
+  for (const byte of header) sum += byte;
+  writeString(header, 148, sum.toString(8).padStart(6, "0"));
+  header[154] = 0;
+  header[155] = 0x20;
+
+  return header;
+}
+
+/** One file to pack. Content is UTF-8 text (OKF markdown documents). */
+export interface TarEntry {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** Build a deterministic uncompressed USTAR archive from the entries (sorted by path). */
+export function createDeterministicTar(entries: readonly TarEntry[]): Uint8Array {
+  const sorted = entries.toSorted((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
+  const parts: Uint8Array[] = [];
+  let total = 0;
+  for (const entry of sorted) {
+    const data = encoder.encode(entry.content);
+    const header = headerFor(entry.path, data.length);
+    const padded = new Uint8Array(Math.ceil(data.length / BLOCK) * BLOCK);
+    padded.set(data, 0);
+    parts.push(header, padded);
+    total += header.length + padded.length;
+  }
+  // End-of-archive marker: two zero blocks.
+  const terminator = new Uint8Array(BLOCK * 2);
+  parts.push(terminator);
+  total += terminator.length;
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/** Pack entries into a deterministic `.tar.gz` (gzip mtime 0, max compression). */
+export function createDeterministicTarGz(entries: readonly TarEntry[]): Uint8Array {
+  return gzipSync(createDeterministicTar(entries), { level: 9, mtime: 0 });
+}

--- a/packages/fumadocs-okf/src/types.ts
+++ b/packages/fumadocs-okf/src/types.ts
@@ -1,0 +1,192 @@
+/**
+ * The adapter's ONLY input contract: the Fumadocs content-source loader
+ * surface, typed STRUCTURALLY so this package needs no `fumadocs-core`
+ * dependency at all (issue #4367 constraint 4 — the loader surface *is* the
+ * compatibility contract; a real `LoaderOutput` from `loader()` satisfies
+ * these shapes as-is, and so does a synthetic test fixture or a CLI shim for
+ * a site the Next bundler isn't around to load).
+ *
+ * The fields mirror fumadocs-core's `Page` (`path`, `url`, `data.title`,
+ * `data.description`) plus fumadocs-mdx's doc method `getText("processed")`,
+ * which only exists when the site's `source.config.ts` enables
+ * `postprocess: { includeProcessedMarkdown: true }` on the collection.
+ */
+
+/** The per-page surface the adapter reads. Satisfied by a fumadocs `Page`. */
+export interface FumadocsOkfPage {
+  /**
+   * Virtualized file path relative to the collection's content directory,
+   * e.g. `guides/getting-started.mdx`. Archive paths derive deterministically
+   * from this (no hashing, no ordering dependence) so the bundle-sync
+   * subtractive diff stays stable across builds.
+   */
+  readonly path: string;
+  /** Rendered URL, e.g. `/guides/getting-started`. Optional — used only in messages. */
+  readonly url?: string;
+  readonly data: {
+    readonly title?: string;
+    readonly description?: string;
+    /** Frontmatter tags, when the site's schema carries them. Non-string entries are ignored. */
+    readonly tags?: unknown;
+    /**
+     * fumadocs-mdx doc method. `getText("processed")` returns the
+     * byte-faithful processed markdown when `includeProcessedMarkdown` is
+     * enabled; absent or throwing otherwise — which this adapter surfaces as
+     * an actionable error, never a raw-MDX fallback.
+     */
+    readonly getText?: (type: "processed" | "raw") => Promise<string>;
+  };
+}
+
+/** The source surface the adapter walks. Satisfied by fumadocs' `loader()` output. */
+export interface FumadocsOkfSource {
+  getPages(): readonly FumadocsOkfPage[];
+}
+
+/**
+ * Ingest caps mirrored from Atlas's KB ingest seam
+ * (`packages/api/src/lib/knowledge/ingest-limits.ts`). Validated at
+ * GENERATION time so a site owner sees the overflow with real numbers where
+ * they can act on it, instead of as a recurring per-sync ingest error on the
+ * Atlas side. Runtime-tunable server-side via the settings registry
+ * (`ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` / `_MAX_DOC_BYTES` / `_MAX_BUNDLE_BYTES`);
+ * pass matching values here when an operator has raised them.
+ */
+export interface IngestCaps {
+  /** Max concept documents per bundle. */
+  readonly maxDocs: number;
+  /** Max decoded size of any single document, in bytes. */
+  readonly maxDocBytes: number;
+  /** Max bundle size, in bytes — applied to BOTH the decoded total and the compressed archive. */
+  readonly maxBundleBytes: number;
+}
+
+/**
+ * Default caps — kept equal to the `DEFAULT_INGEST_MAX_*` constants in
+ * `@atlas/api/lib/knowledge/ingest-limits` (pinned by this package's
+ * round-trip test, so they cannot drift silently).
+ */
+export const DEFAULT_INGEST_CAPS: IngestCaps = {
+  maxDocs: 1000,
+  maxDocBytes: 1_000_000,
+  maxBundleBytes: 25_000_000,
+};
+
+/** One page's collected OKF document, ready to pack. */
+export interface CollectedDoc {
+  /** Archive path (prefix included), derived deterministically from `page.path`. */
+  readonly path: string;
+  /** Full rendered OKF document (frontmatter + body). */
+  readonly content: string;
+  /** UTF-8 byte length of `content` — what the per-doc ingest cap sees. */
+  readonly bytes: number;
+  /** The originating `page.path`, for reconciliation and error messages. */
+  readonly sourcePath: string;
+}
+
+/** Why pages were left out of the bundle — surfaced, never silent. */
+export interface CollectSkips {
+  /** Pages the caller's `filter` hook declined. */
+  readonly filtered: number;
+  /** Auto-generated API-reference stub pages (built-in skip, `skipApiReference`). */
+  readonly apiReference: number;
+  /** Pages whose transformed body carried no ingestable prose (built-in skip, `skipContentless`). */
+  readonly contentless: number;
+  /** Pages the `transform` hook skipped by returning `null`. */
+  readonly transformSkipped: number;
+}
+
+/** A reserved-basename rename applied on the way out (e.g. `docs/index.mdx` → `docs.md`). */
+export interface ReservedRename {
+  readonly from: string;
+  readonly to: string;
+}
+
+export interface CollectResult {
+  readonly docs: readonly CollectedDoc[];
+  readonly skipped: CollectSkips;
+  /**
+   * Every emitted path that had to move off a reserved OKF basename
+   * (`index.md` / `log.md` — the ingest parser silently skips those, issue
+   * #4367 comment: 8 of 165 portal docs vanished this way). Emitting them
+   * renamed means built-count == ingested-count by construction.
+   */
+  readonly renamedReserved: readonly ReservedRename[];
+}
+
+export interface CollectOptions {
+  /**
+   * Stable top-level directory every archive path lives under (the
+   * bundle-sync subtractive diff keys on full paths — a per-build prefix
+   * would re-archive everything on every sync). One or more plain path
+   * segments, e.g. `"docs"` or `"kb/site"`.
+   */
+  readonly prefix: string;
+  /**
+   * Page-filter hook: return `false` to leave a page out of the bundle.
+   * Runs before the page's body is resolved. Composes with (does not
+   * replace) the built-in skips.
+   */
+  readonly filter?: (page: FumadocsOkfPage) => boolean | Promise<boolean>;
+  /**
+   * Body-transform hook, applied to the processed markdown before the
+   * contentless check and OKF rendering. Return `null` to skip the page
+   * (counted in `skipped.transformSkipped`) — the fail-soft escape for a
+   * transform that must never emit an unprocessed body (e.g. the docs
+   * portal's audience strip).
+   */
+  readonly transform?: (body: string, page: FumadocsOkfPage) => string | null | Promise<string | null>;
+  /**
+   * Provenance tags stamped into every document's OKF frontmatter (merged
+   * with the page's own frontmatter tags, de-duplicated). A function
+   * receives the page for per-page tagging.
+   */
+  readonly tags?: readonly string[] | ((page: FumadocsOkfPage) => readonly string[]);
+  /**
+   * Skip pages under a top-level `api-reference/` segment (auto-generated
+   * OpenAPI stubs — `<APIPage>` shells with no prose, worthless as KB
+   * content and a waste of the doc-count cap). Default `true`. This is the
+   * built-in expression of the filter hook; disable and supply your own
+   * `filter` to change the policy.
+   */
+  readonly skipApiReference?: boolean;
+  /**
+   * Skip pages whose transformed body has no ingestable prose (entirely
+   * component-rendered pages). Default `true`.
+   */
+  readonly skipContentless?: boolean;
+  /**
+   * How many pages resolve their body concurrently (a shim's `getText` may
+   * be an HTTP fetch). Default 8. Output is deterministic regardless.
+   */
+  readonly concurrency?: number;
+}
+
+export interface BuildStats {
+  /** Documents in the archive — also the count Atlas should report as ingested.
+   *  Reserved basenames are renamed at generation, so a smaller ingest count
+   *  is a signal to investigate, not expected shrinkage. */
+  readonly documents: number;
+  /** Sum of decoded document bytes (the total the ingest bomb-guard sees). */
+  readonly totalDocBytes: number;
+  /** Compressed `.tar.gz` size (the raw upload-size cap sees this). */
+  readonly archiveBytes: number;
+  readonly skipped: CollectSkips;
+  readonly renamedReserved: readonly ReservedRename[];
+}
+
+export interface BuildResult {
+  /** The `.tar.gz` archive, byte-for-byte deterministic for identical input. */
+  readonly bytes: Uint8Array;
+  readonly docs: readonly CollectedDoc[];
+  readonly stats: BuildStats;
+}
+
+export interface BuildOptions extends CollectOptions {
+  /**
+   * Generation-time ingest-cap overrides. Defaults to Atlas's server
+   * defaults ({@link DEFAULT_INGEST_CAPS}); pass the raised values when the
+   * target workspace's operator has tuned `ATLAS_KNOWLEDGE_INGEST_MAX_*`.
+   */
+  readonly caps?: Partial<IngestCaps>;
+}

--- a/packages/fumadocs-okf/src/types.ts
+++ b/packages/fumadocs-okf/src/types.ts
@@ -96,7 +96,13 @@ export interface CollectSkips {
   readonly transformSkipped: number;
 }
 
-/** A reserved-basename rename applied on the way out (e.g. `docs/index.mdx` → `docs.md`). */
+/**
+ * A `-doc` suffix rename applied because a page would otherwise land on a
+ * reserved OKF basename the ingest parser silently skips (e.g. `ops/log.mdx`
+ * → `docs/ops/log-doc.md`). Ordinary `index` folds (`guides/index.mdx` →
+ * `guides.md`) are the NORMAL mapping and are not reported here. `from` is
+ * the source `page.path`; `to` is the full archive path (prefix included).
+ */
 export interface ReservedRename {
   readonly from: string;
   readonly to: string;
@@ -106,10 +112,12 @@ export interface CollectResult {
   readonly docs: readonly CollectedDoc[];
   readonly skipped: CollectSkips;
   /**
-   * Every emitted path that had to move off a reserved OKF basename
-   * (`index.md` / `log.md` — the ingest parser silently skips those, issue
-   * #4367 comment: 8 of 165 portal docs vanished this way). Emitting them
-   * renamed means built-count == ingested-count by construction.
+   * The `-doc` suffix renames applied so no emitted path lands on a reserved
+   * OKF basename (`index.md` / `log.md` — the ingest parser silently skips
+   * those; issue #4367: 8 of 165 portal docs vanished that way). Together
+   * with the ordinary `index` fold, this makes built-count == ingested-count
+   * by construction. Folds are not listed here — only the rarer suffix
+   * renames, which a site owner may want to know about.
    */
   readonly renamedReserved: readonly ReservedRename[];
 }


### PR DESCRIPTION
## Summary

Closes #4367.

Promotes the #4366 staging spike into **`@atlas/fumadocs-okf`** (`packages/fumadocs-okf`) — a reusable bundle generator that turns any Fumadocs content-source loader into an OKF `.tar.gz` for the Knowledge Base, consumed through the **existing** `bundle-sync` connector / upload route with **zero `packages/api` changes**. No `catalog:fumadocs` connector and no `IngestSource` framework (deferred per ADR-0028 §5).

**Adapter** (unpublished, `private: true`):
- Structurally-typed loader contract (`getPages()` / `page.path` / `data.{title,description,getText}`) — deliberately **no `fumadocs-core` dependency**; a real `loader()` output or a shim both satisfy it
- **Page-filter + body-transform hooks**; built-in api-reference/contentless skips ride the same mechanism, counted never silent
- **Deterministic archive paths** from `page.path` under a stable prefix. Section landings fold onto the section slug (`guides/index.mdx` → `guides.md`), closing the reserved-basename silent drop from the issue comment (165 built → 157 ingested, `rejected=0`); remaining reserved basenames get `-doc` and are reported. Verified on the real portal corpus: **165/165 now survive `parseLenientBundle`** (was 157/165)
- A page without `getText("processed")` **fails with guidance naming `postprocess: { includeProcessedMarkdown: true }`** — never a raw-MDX fallback; non-config load failures are a distinct `PageLoadError` (cause preserved)
- **Generation-time cap validation** (doc count / per-doc bytes / decoded + compressed bundle bytes) with the actual numbers and the `ATLAS_KNOWLEDGE_INGEST_MAX_*` knobs in the error; defaults drift-pinned to `ingest-limits.ts` by test
- Deterministic USTAR+gzip packing (sorted entries, fixed mtimes) — byte-identical archives for identical content; pack-time cross-collect path-collision guard
- **Round-trip test through `@atlas/api`'s real `extractBundle` + `parseLenientBundle`** (dev-dep only): built N == parsed N, zero silent drops; reserved-basename set drift-pinned; >100-byte ustar prefix-split path round-trips

**Dogfood refit** (`apps/docs`): `build-docs-kb-bundle.ts` now consumes the adapter; the bespoke OKF render / tar spawn / path mapping retire. Local + deployed modes are source shims (`kb-bundle-sources.ts`) because the portal's real `.source/server` loader only resolves under the Next bundler. Audience stripping rides the transform hook via a new typed `ResidualAudienceTagError` (skip-on-residual, rethrow on unexpected bugs); the leak-safety property — a SaaS bundle carries zero self-hosted branches — is pinned by `kb-bundle.test.ts` in both directions, plus per-section wiring pins. Deployed-mode twin fetches are now **fail-loud** (a silently partial bundle would archive reviewed docs via the subtractive diff). `--from-deployed` retained, documented as dependent on the site's llms/twin routes.

**Hosting recipe** (`packages/fumadocs-okf/README.md`): serving the archive for a bundle-sync collection — static artifact or route handler, the **bearer-protected variant end to end**, the egress-guard reachability constraints (publicly routable; auth header stripped on cross-origin redirect), the cap knobs, and rename→archive/redraft churn expectations.

**Packaging decision (recorded per AC):** unpublished private workspace package under `packages/` (the `@atlas/oauth-helper` precedent) rather than a `create-atlas`-adjacent copy — it must be importable by `apps/docs` for the dogfood refit, and structural typing removes the `fumadocs-core` peer-range question entirely. Promote to a published package only after the API survives a real non-Atlas consumer (then: pinned `fumadocs-core` peer range + `0.0.x` exact-pin publish sequencing).

Internal review panel: 2 rounds — round 1 CHANGES REQUESTED (pack-time collision guard, typed errors, drift pins, doc accuracy), all addressed; round 2 CLEAN. Advisory leftovers (not blocking): no timeout on deployed-mode twin fetches; CLI prints message-only for unexpected internal errors.

## Test Plan

- [x] Unit tests added/updated — `packages/fumadocs-okf/__tests__` (32 tests: non-Atlas "Acme" fixture, hooks, caps, determinism, collisions, ustar round-trip, drift pins) + `apps/docs/src/lib/__tests__/kb-bundle.test.ts` (leak-safety + shim coverage; docs suite 174 green)
- [x] Manual testing — rebuilt the real portal bundles (saas 165 docs / self-hosted 106 docs), verified 165/165 parse through the real ingest pipeline stages, zero residual audience tags outside code-span mentions, byte-identical rebuilds
- [ ] E2E tests added/updated — n/a (the transactional ingest tail is `packages/api`'s existing tested territory; this PR changes no API code)

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test` — new suites auto-discovered by `test-others.ts`)
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent — new workspace package + `fflate` pinned to the api's range; Dockerfile COPY lines added (`check-dockerfile-workspace.sh` green)
- [ ] Labels added (type + area) — feature / area: api, area: docs (from the issue)
- [ ] CHANGELOG.md updated — n/a (internal tooling; no user-facing product change)

https://claude.ai/code/session_01PujakE1NMMgLiZwrma3zpE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PujakE1NMMgLiZwrma3zpE)_