### PR TITLE
feat(knowledge): Notion sync connector — token install, markdown endpoint, crawl-union enumeration (#4378)

### DIFF
--- a/apps/docs/content/docs/api-reference/admin-knowledge/postAdminKnowledgeByCollectionSlugSync.mdx
+++ b/apps/docs/content/docs/api-reference/admin-knowledge/postAdminKnowledgeByCollectionSlugSync.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sync a bundle-sync collection now
+title: Sync a synced collection now
 full: true
 _openapi:
   method: POST
@@ -9,11 +9,12 @@ _openapi:
     headings: []
     contents:
       - content: >-
-          Manually pull a synced collection's bundle endpoint and apply the diff
-          immediately (the same run the scheduled sync performs — daily by
-          default, operator-tunable). Changed and new documents land as `draft`
-          for review — synced content has no publish shortcut; paths absent from
-          the fetched bundle are archived, never hard-deleted. Returns the
+          Manually pull a synced collection's source (a bundle endpoint, or a
+          connector like Notion) and apply the diff immediately (the same run
+          the scheduled sync performs — daily by default, operator-tunable).
+          Changed and new documents land as `draft` for review — synced content
+          has no publish shortcut; on a full reconciliation, paths absent from
+          the fetched set are archived, never hard-deleted. Returns the
           attempt's outcome; a failed fetch/ingest is reported as `status:
           "error"` with an actionable message (also recorded on the collection's
           sync status).

--- a/apps/docs/content/docs/guides/connect-notion.mdx
+++ b/apps/docs/content/docs/guides/connect-notion.mdx
@@ -1,0 +1,80 @@
+---
+title: Connect Notion
+description: Sync a Notion workspace into a review-gated Knowledge Base collection — the pages you share with an integration become knowledge documents the agent reads alongside your semantic layer.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Connecting Notion turns the pages you share with a Notion integration into a [Knowledge Base](/guides/knowledge-base) collection: Atlas pulls them on a schedule, converts each to markdown, and queues every change as a **draft** for review before it can reach the agent. It is one of the Knowledge Base's synced sources — like the endpoint sync, but the source is a Notion workspace instead of a bundle URL.
+
+<Callout title="What syncs — and what doesn't">
+**Only the pages you explicitly share with the integration sync.** Notion integrations start with access to *nothing*; you grant access page by page. Sharing a parent page includes its whole subtree. This is the model to internalize before you connect — see [The sharing model](#the-sharing-model) below.
+</Callout>
+
+---
+
+## Create a Notion integration
+
+1. Go to [notion.so/my-integrations](https://www.notion.so/my-integrations) and create a new **internal integration** in the workspace whose pages you want to sync.
+2. Give it read access — Atlas never writes to Notion. **Read content** capability is all it needs.
+3. Copy the integration's **internal-integration token** (it looks like `ntn_…`). You'll paste it into Atlas once.
+
+An internal integration is scoped to a single Notion workspace, which is why each Atlas connection maps to **one workspace per authorization**.
+
+---
+
+## Share the pages you want synced
+
+This is the step people miss. Creating the integration grants it access to nothing. In Notion, open each page (or the top of each subtree) you want in Atlas, use the page's **•••** menu → **Connections** → **Connect to**, and pick your integration.
+
+- **Share a parent to include its subtree.** Sharing the "Engineering" page shares every page nested under it. You do not need to share children individually.
+- **Databases work too.** Sharing a database shares its rows (each row is a page).
+- **Nothing else is visible.** A page you didn't share — even one linked from a shared page — will not sync.
+
+---
+
+## Connect it in Atlas
+
+Navigate to **Admin → Knowledge Base** (`/admin/knowledge`), choose **New collection**, and pick the **Notion** tab. Give the collection a slug, paste the internal-integration token, and (optionally) a description. The token is encrypted at rest and never shown again.
+
+Creating the collection kicks off the first sync immediately. Every page lands as a **draft** — see [Review and publish](/guides/knowledge-base#review-and-publish); nothing a connector pulls is ever auto-published.
+
+---
+
+## The sharing model
+
+Notion's permission model is *opt-in per subtree*, and Atlas mirrors it exactly: the set of pages shared with the integration **is** the collection's scope. There is no space picker or path filter — you curate what syncs by curating what you share in Notion.
+
+Two consequences follow, and both are intentional:
+
+- **To add pages,** share them (or their parent) with the integration in Notion. They appear on the next sync — no change in Atlas.
+- **To remove pages,** unshare them in Notion. On the next full reconciliation, the pages that are no longer reachable are **archived** in Atlas (never hard-deleted; a re-share brings them back as drafts for re-review).
+
+### "Why is my page missing?"
+
+Nine times out of ten, a page that didn't sync was never shared with the integration. Notion's own **search is deliberately non-exhaustive**, so Atlas doesn't rely on it alone — every scheduled full reconciliation also walks the tree of shared pages to find children that search misses. But a page that is not shared at all (directly or via an ancestor) is invisible to the integration, and therefore to Atlas. If a page is missing:
+
+1. Open it in Notion and confirm the integration appears under **•••** → **Connections**. If not, share it (or a parent).
+2. Give it until the next sync, or press **Sync now** on the collection card.
+
+Newly shared pages appear on the next **full reconciliation** (which also handles removals), not necessarily the next incremental cycle — reconciliation is the connector's correctness anchor.
+
+---
+
+## How syncing behaves
+
+- **Incremental cycles** run often and cheaply: they pick up pages edited since the last sync.
+- **Full reconciliation** runs on a slower cadence (weekly by default) and is authoritative: it enumerates the entire shared set, so it's where newly-shared pages are discovered and unshared pages are archived.
+- **Rate limits** are respected automatically — Atlas throttles to Notion's ~3 requests/second per token and backs off on `429`s, so a large workspace can't burn your API budget.
+- **Content is text-first.** Page bodies are converted to markdown via Notion's official page-markdown endpoint. Images and file attachments are **not** mirrored (their Notion URLs expire within the hour); each is replaced with a link back to the Notion page.
+- **Every change is review-gated.** New and changed pages land as drafts; an already-published page whose Notion content changed is demoted back to draft so the edit is re-reviewed. Connectors structurally cannot publish.
+
+<Callout type="info" title="Provenance">
+Every synced document carries an `atlas:` provenance block — the vendor (`notion`), the Notion page id, its `last_edited_time`, and the sync time — plus a `resource` link to the source page, so any answer traces back to the Notion page it came from.
+</Callout>
+
+---
+
+## Uninstalling
+
+Uninstalling a Notion collection **archives** its documents (never hard-deletes them) and removes the stored token. Re-connecting and syncing restores the shared pages as drafts for re-review. See [Uninstalling a collection](/guides/knowledge-base#uninstalling-a-collection).

--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -33,6 +33,7 @@ Navigate to **Admin → Knowledge Base** (`/admin/knowledge`) and choose **New c
 
 - **Upload** — you push bundles by hand. No credentials; just a slug and an optional description.
 - **Sync from endpoint** — Atlas pulls a bundle from a URL on a schedule. Provide the endpoint URL and an auth scheme (`none`, `bearer`, or `basic`); the secret is encrypted at rest and never shown again. Credentials embedded in the URL itself (`user:pass@`) are rejected — use the auth fields.
+- **Notion** — Atlas pulls the pages you share with a Notion integration, on the same schedule. Provide an internal-integration token; the pages shared with the integration *are* the scope. See [Connect Notion](/guides/connect-notion) for the sharing model and its one gotcha.
 
 The endpoint can be anything that serves a tarball or zip, including git-forge repository-archive URLs (e.g. a GitHub `archive/refs/heads/main.tar.gz` link), so "sync my docs repo" needs no dedicated connector. Prefer a **branch** archive URL: tag and commit archives change their top-level folder name on every release, which makes every document path look new on each pull. Creating a synced collection in the admin console kicks off the first sync immediately; collections installed through the API wait for the schedule or a manual sync trigger.
 

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -21,6 +21,7 @@
     "semantic-editor",
     "semantic-expert",
     "knowledge-base",
+    "connect-notion",
     "developer-mode",
     "demo-mode",
     "guided-tour",

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56646,7 +56646,8 @@
                             "type": "string",
                             "enum": [
                               "upload",
-                              "bundle-sync"
+                              "bundle-sync",
+                              "notion"
                             ]
                           },
                           "description": {
@@ -57231,8 +57232,8 @@
         "tags": [
           "Admin — Knowledge"
         ],
-        "summary": "Sync a bundle-sync collection now",
-        "description": "Manually pull a synced collection's bundle endpoint and apply the diff immediately (the same run the scheduled sync performs — daily by default, operator-tunable). Changed and new documents land as `draft` for review — synced content has no publish shortcut; paths absent from the fetched bundle are archived, never hard-deleted. Returns the attempt's outcome; a failed fetch/ingest is reported as `status: \"error\"` with an actionable message (also recorded on the collection's sync status).",
+        "summary": "Sync a synced collection now",
+        "description": "Manually pull a synced collection's source (a bundle endpoint, or a connector like Notion) and apply the diff immediately (the same run the scheduled sync performs — daily by default, operator-tunable). Changed and new documents land as `draft` for review — synced content has no publish shortcut; on a full reconciliation, paths absent from the fetched set are archived, never hard-deleted. Returns the attempt's outcome; a failed fetch/ingest is reported as `status: \"error\"` with an actionable message (also recorded on the collection's sync status).",
         "parameters": [
           {
             "schema": {
@@ -57372,7 +57373,7 @@
             }
           },
           "400": {
-            "description": "Not a synced collection (upload collections have no endpoint to sync)",
+            "description": "Not a synced collection (upload collections have no source to pull)",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -216,6 +216,10 @@ const syncConnectorCollection = mock(async (params: { collectionSlug: string }) 
   rejected: [],
   highWaterMark: "2026-07-01T00:00:00.000Z",
 }));
+// Partial mock, justified: the router reaches exactly one symbol from
+// connector-sync (`syncConnectorCollection`); the isolated per-file runner
+// prevents cross-file leaks, and any other export reached later would fail
+// loudly as `undefined is not a function`.
 mock.module("@atlas/api/lib/knowledge/connector-sync", () => ({
   syncConnectorCollection,
 }));

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -179,6 +179,47 @@ mock.module("@atlas/api/lib/integrations/install/bundle-sync-form-handler", () =
   parseBundleSyncConfig: () => ({ ok: true, endpointUrl: "https://kb.example.com/bundle.zip", authScheme: "none" }),
 }));
 
+// Notion connector dispatch (#4378). Stub the heavier notion client stack out
+// (only the catalog-id constant is consumed), and spy the registry +
+// connector engine so the route tests assert dispatch + the fail-closed
+// `connector_unavailable` branch only. `NOTION_CONNECTOR` is read live by the
+// registry mock so a test can null it to simulate a missing registration.
+let NOTION_CONNECTOR: unknown = {
+  catalogId: "catalog:notion-knowledge",
+  vendor: "notion",
+  createClient: () => ({}),
+};
+mock.module("@atlas/api/lib/knowledge/notion/connector", () => ({
+  NOTION_KNOWLEDGE_CATALOG_ID: "catalog:notion-knowledge",
+  NOTION_KNOWLEDGE_SLUG: "notion-knowledge",
+  NOTION_VENDOR: "notion",
+  notionKnowledgeConnector: NOTION_CONNECTOR,
+  registerNotionKnowledgeConnector: () => {},
+}));
+const getKnowledgeSyncConnector = mock((_id: string) => NOTION_CONNECTOR);
+class ConnectorRateLimitError extends Error {}
+mock.module("@atlas/api/lib/knowledge/connectors", () => ({
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector: () => {},
+  listKnowledgeSyncConnectorCatalogIds: () => ["catalog:notion-knowledge"],
+  _resetKnowledgeSyncConnectors: () => {},
+  ConnectorRateLimitError,
+}));
+const syncConnectorCollection = mock(async (params: { collectionSlug: string }) => ({
+  collection: params.collectionSlug,
+  status: "success" as const,
+  mode: "reconciliation" as const,
+  syncedAt: "2026-07-02T02:00:00.000Z",
+  error: null,
+  documents: { created: 3, updated: 0, demoted: 0, resurrected: 0, unchanged: 0, total: 3 },
+  archivedAbsent: 1,
+  rejected: [],
+  highWaterMark: "2026-07-01T00:00:00.000Z",
+}));
+mock.module("@atlas/api/lib/knowledge/connector-sync", () => ({
+  syncConnectorCollection,
+}));
+
 // Partial mock, justified: this file's import graph reaches only the exports
 // stubbed below; the isolated per-file runner prevents cross-file leaks, and an
 // unmocked export reached later fails loudly as `undefined is not a function`.
@@ -233,8 +274,21 @@ beforeEach(() => {
   invalidateCalls.length = 0;
   internalQuery.mockClear();
   syncCollection.mockClear();
+  syncConnectorCollection.mockClear();
+  getKnowledgeSyncConnector.mockClear();
+  NOTION_CONNECTOR = { catalogId: "catalog:notion-knowledge", vendor: "notion", createClient: () => ({}) };
 });
 afterEach(() => internalQuery.mockClear());
+
+/** Switch the resolved collection to a Notion connector install (#4378). */
+function useNotionCollection(): void {
+  COLLECTION = {
+    install_id: "runbooks",
+    catalog_id: "catalog:notion-knowledge",
+    status: "published",
+    config: {},
+  };
+}
 
 /** Switch the resolved collection to a bundle-sync install (#4211). */
 function useSyncedCollection(): void {
@@ -448,6 +502,61 @@ describe("POST /{collectionSlug}/sync — manual Sync now (#4211)", () => {
     const res = await adminKnowledge.request("/runbooks/sync", { method: "POST" });
     expect(res.status).toBe(404);
     expect(syncCollection).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => {
+  it("dispatches a Notion collection to the connector engine, not the bundle engine", async () => {
+    useNotionCollection();
+    const res = await adminKnowledge.request("/runbooks/sync", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+    const body = (await res.json()) as {
+      collection: string;
+      status: string;
+      format: string | null;
+      linksWritten: number | null;
+      archivedAbsent: number | null;
+      documents: { total: number };
+    };
+    // The connector outcome maps to the shared wire shape — no bundle `format`
+    // or `linksWritten`, but the ingest counts + archivedAbsent carry through.
+    expect(body).toMatchObject({
+      collection: "runbooks",
+      status: "success",
+      format: null,
+      linksWritten: null,
+      archivedAbsent: 1,
+    });
+    expect(body.documents.total).toBe(3);
+  });
+
+  it("500s connector_unavailable when the catalog has no registered connector", async () => {
+    useNotionCollection();
+    NOTION_CONNECTOR = undefined; // getKnowledgeSyncConnector → undefined
+    const res = await adminKnowledge.request("/runbooks/sync", { method: "POST" });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; requestId: string };
+    expect(body.error).toBe("connector_unavailable");
+    expect(body.requestId).toBeDefined();
+    expect(syncConnectorCollection).not.toHaveBeenCalled();
+  });
+
+  it("lists a Notion collection as source 'notion' with sync bookkeeping", async () => {
+    useNotionCollection();
+    SYNC_STATES = [
+      { collection_id: "runbooks", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const res = await adminKnowledge.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const notion = body.collections.find((c) => c.slug === "runbooks");
+    expect(notion?.source).toBe("notion");
+    expect(notion?.endpointUrl).toBeNull(); // connector has a token, not an endpoint
+    expect(notion?.sync).not.toBeNull();
   });
 });
 

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -53,7 +53,10 @@ import {
   BUNDLE_SYNC_AUTH_SCHEMES,
   BUNDLE_SYNC_CATALOG_ID,
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
+import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
+import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
+import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
@@ -97,17 +100,26 @@ async function loadCollection(
   return rows[0] ?? null;
 }
 
+/** A synced-collection source discriminator + whether it is a connector. */
+type KnowledgeSource = "upload" | "bundle-sync" | "notion" | "unknown";
+
 /**
  * Map a knowledge catalog id to the wire `source` discriminator — matching
- * each KNOWN catalog explicitly so a future third knowledge catalog can never
- * default into a privileged branch (`upload` is the source that inherits the
- * upload-&-publish ingest route, ADR-0028 §4). Both gated routes reject
+ * each KNOWN catalog explicitly so a future knowledge catalog can never default
+ * into a privileged branch (`upload` is the source that inherits the
+ * upload-&-publish ingest route, ADR-0028 §4). The gated routes reject
  * `"unknown"` outright; only the list rendering maps it to a wire label.
  */
-function sourceOf(catalogId: string): "upload" | "bundle-sync" | "unknown" {
+function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === OKF_UPLOAD_CATALOG_ID) return "upload";
   if (catalogId === BUNDLE_SYNC_CATALOG_ID) return "bundle-sync";
+  if (catalogId === NOTION_KNOWLEDGE_CATALOG_ID) return "notion";
   return "unknown";
+}
+
+/** True for a synced source (endpoint or connector) — has sync bookkeeping. */
+function isSyncedSource(source: KnowledgeSource): boolean {
+  return source === "bundle-sync" || source === "notion";
 }
 
 // ---------------------------------------------------------------------------
@@ -127,7 +139,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync"]),
+      source: z.enum(["upload", "bundle-sync", "notion"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),
@@ -299,11 +311,12 @@ const syncRoute = createRoute({
   method: "post",
   path: "/{collectionSlug}/sync",
   tags: ["Admin — Knowledge"],
-  summary: "Sync a bundle-sync collection now",
+  summary: "Sync a synced collection now",
   description:
-    "Manually pull a synced collection's bundle endpoint and apply the diff immediately (the same " +
-    "run the scheduled sync performs — daily by default, operator-tunable). Changed and new documents land as `draft` for review — " +
-    "synced content has no publish shortcut; paths absent from the fetched bundle are archived, " +
+    "Manually pull a synced collection's source (a bundle endpoint, or a connector like Notion) and " +
+    "apply the diff immediately (the same run the scheduled sync performs — daily by default, " +
+    "operator-tunable). Changed and new documents land as `draft` for review — synced content has no " +
+    "publish shortcut; on a full reconciliation, paths absent from the fetched set are archived, " +
     "never hard-deleted. Returns the attempt's outcome; a failed fetch/ingest is reported as " +
     "`status: \"error\"` with an actionable message (also recorded on the collection's sync status).",
   request: {
@@ -317,7 +330,7 @@ const syncRoute = createRoute({
       content: { "application/json": { schema: SyncRunResponseSchema } },
     },
     400: {
-      description: "Not a synced collection (upload collections have no endpoint to sync)",
+      description: "Not a synced collection (upload collections have no source to pull)",
       content: { "application/json": { schema: ErrorSchema } },
     },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
@@ -467,7 +480,9 @@ adminKnowledge.openapi(listRoute, async (c) =>
                     ? (rawAuthScheme as (typeof BUNDLE_SYNC_AUTH_SCHEMES)[number])
                     : ("none" as const)
                   : null,
-              sync: source === "bundle-sync" ? syncBySlug.get(r.install_id) ?? null : null,
+              // Every synced source (endpoint or connector) carries last-sync
+              // bookkeeping; only upload collections have none.
+              sync: isSyncedSource(source) ? syncBySlug.get(r.install_id) ?? null : null,
               documents: countsBySlug.get(r.install_id) ?? { draft: 0, published: 0, archived: 0 },
             },
           ];
@@ -712,51 +727,34 @@ adminKnowledge.openapi(syncRoute, async (c) =>
         404,
       );
     }
-    if (sourceOf(collection.catalog_id) !== "bundle-sync") {
+    const source = sourceOf(collection.catalog_id);
+    if (!isSyncedSource(source)) {
       return c.json(
         {
           error: "not_synced_collection",
-          message: `"${collectionSlug}" is not a synced collection — only bundle-sync collections have an endpoint to sync.`,
+          message: `"${collectionSlug}" is not a synced collection — only synced collections (endpoint or connector) have a source to pull.`,
           requestId,
         },
         400,
       );
     }
 
-    // `syncCollection` never throws: fetch hardening, ingest, archive-absent,
-    // and the knowledge_sync_state upsert all happen inside. A failed attempt
-    // comes back as `status: "error"` with a host-redacted, actionable message.
-    const outcome = await syncCollection({
-      workspaceId: orgId,
-      collectionSlug,
-      config: collection.config,
-    });
-
-    logAdminAction({
-      actionType: ADMIN_ACTIONS.knowledge.sync,
-      targetType: "knowledge",
-      targetId: collectionSlug,
-      scope: "workspace",
-      status: outcome.status === "success" ? "success" : "failure",
-      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-      metadata: {
+    // Both engines never throw: fetch hardening, ingest, archive-absent, and the
+    // knowledge_sync_state upsert all happen inside. A failed attempt comes back
+    // as `status: "error"` with a host-redacted, actionable message. Bundle-sync
+    // pulls an endpoint; a connector (Notion) drives its registered vendor
+    // client. Both map to the one sync-run wire shape — connectors carry no
+    // bundle `format` / `linksWritten`, so those are null. Typed as the route
+    // schema's inferred (mutable) shape; the module-level producer-drift guard
+    // keeps it assignable to `KnowledgeSyncRunResponse`.
+    let wire: z.infer<typeof SyncRunResponseSchema>;
+    if (source === "bundle-sync") {
+      const outcome = await syncCollection({
+        workspaceId: orgId,
         collectionSlug,
-        status: outcome.status,
-        error: outcome.error,
-        format: outcome.format,
-        ...(outcome.documents ?? {}),
-        archivedAbsent: outcome.archivedAbsent,
-        rejected: outcome.rejected.length,
-      },
-    });
-
-    log.info(
-      { requestId, orgId, collectionSlug, status: outcome.status, error: outcome.error },
-      "Knowledge collection manual sync completed",
-    );
-
-    return c.json(
-      {
+        config: collection.config,
+      });
+      wire = {
         collection: outcome.collection,
         status: outcome.status,
         syncedAt: outcome.syncedAt,
@@ -766,9 +764,69 @@ adminKnowledge.openapi(syncRoute, async (c) =>
         archivedAbsent: outcome.archivedAbsent,
         linksWritten: outcome.linksWritten,
         rejected: [...outcome.rejected],
-      } satisfies KnowledgeSyncRunResponse,
-      200,
+      };
+    } else {
+      const connector = getKnowledgeSyncConnector(collection.catalog_id);
+      if (connector === undefined) {
+        // The source came from the same catalog-id map the connector registers
+        // under, so this is only reachable if boot registration failed — a real
+        // server misconfig, surfaced (not a silent success).
+        log.error(
+          { requestId, orgId, collectionSlug, catalogId: collection.catalog_id },
+          "Synced collection has no registered connector — the boot registration did not run",
+        );
+        return c.json(
+          {
+            error: "connector_unavailable",
+            message: `"${collectionSlug}" cannot sync — its connector is not registered on this server. Contact your operator.`,
+            requestId,
+          },
+          500,
+        );
+      }
+      const outcome = await syncConnectorCollection({
+        connector,
+        workspaceId: orgId,
+        collectionSlug,
+        config: collection.config,
+      });
+      wire = {
+        collection: outcome.collection,
+        status: outcome.status,
+        syncedAt: outcome.syncedAt,
+        error: outcome.error,
+        format: null,
+        documents: outcome.documents,
+        archivedAbsent: outcome.archivedAbsent,
+        linksWritten: null,
+        rejected: [...outcome.rejected],
+      };
+    }
+
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.knowledge.sync,
+      targetType: "knowledge",
+      targetId: collectionSlug,
+      scope: "workspace",
+      status: wire.status === "success" ? "success" : "failure",
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+      metadata: {
+        collectionSlug,
+        source,
+        status: wire.status,
+        error: wire.error,
+        ...(wire.documents ?? {}),
+        archivedAbsent: wire.archivedAbsent,
+        rejected: wire.rejected.length,
+      },
+    });
+
+    log.info(
+      { requestId, orgId, collectionSlug, source, status: wire.status, error: wire.error },
+      "Knowledge collection manual sync completed",
     );
+
+    return c.json(wire satisfies KnowledgeSyncRunResponse, 200);
   }),
 );
 

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -23,6 +23,7 @@ import {
   seedBuiltinKnowledgeCatalog,
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_BUNDLE_SYNC_CATALOG_ROW,
+  BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -89,6 +90,27 @@ describe("BUILTIN_BUNDLE_SYNC_CATALOG_ROW (#4211)", () => {
   });
 });
 
+describe("BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW (#4378)", () => {
+  it("is the `notion-knowledge` form install: required token (secret), optional description", () => {
+    const row = BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW;
+    expect(row.slug).toBe("notion-knowledge");
+    expect(row.id).toBe("catalog:notion-knowledge");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("integration_token");
+    expect(keys).toContain("description");
+    // No endpoint/auth-scheme fields — the shared pages ARE the scope.
+    expect(keys).not.toContain("endpoint_url");
+    // Exactly one secret field: the integration token (password input, never
+    // echoed), and it is required.
+    expect(row.configSchema.filter((f) => f.secret === true).map((f) => f.key)).toEqual([
+      "integration_token",
+    ]);
+    expect(row.configSchema.find((f) => f.key === "integration_token")?.required).toBe(true);
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -104,7 +126,11 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       expect(q.sql).not.toContain("ON CONFLICT (slug)");
       expect(q.sql).toContain("RETURNING slug");
     }
-    expect(captured.map((q) => q.params[2])).toEqual(["okf-upload", "bundle-sync"]);
+    expect(captured.map((q) => q.params[2])).toEqual([
+      "okf-upload",
+      "bundle-sync",
+      "notion-knowledge",
+    ]);
   });
 
   it("binds each row's 8 params and serializes config_schema as JSON", async () => {
@@ -123,7 +149,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("reports inserted slugs on a fresh catalog and none on a re-boot", async () => {
     const fresh = await seedBuiltinKnowledgeCatalog(captureDb().db);
     expect(fresh.inserted).toBe(true);
-    expect(fresh.insertedSlugs).toEqual(["okf-upload", "bundle-sync"]);
+    expect(fresh.insertedSlugs).toEqual(["okf-upload", "bundle-sync", "notion-knowledge"]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);
     expect(reboot.inserted).toBe(false);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -137,10 +137,52 @@ export const BUILTIN_BUNDLE_SYNC_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The Notion Knowledge Sync Connector catalog row (#4378, PRD #4375). A form
+ * install whose only inputs are an internal-integration token and an optional
+ * description — Notion's scope IS the set of pages the customer shares with the
+ * integration (one collection per authorization), so there is no space/endpoint
+ * field. Atlas syncs on the Scheduler via the shared connector engine; every
+ * synced page lands `draft` behind the review gate.
+ *
+ * The `integration_token` field is `secret: true` but is NOT stored in
+ * `workspace_plugins.config` — the install handler routes it to the dedicated
+ * `knowledge_sync_credentials` table (encrypted). The flag tells the admin form
+ * to render a password input and never echo the value back.
+ */
+export const BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: "catalog:notion-knowledge",
+  slug: "notion-knowledge",
+  name: "Knowledge Base (Notion)",
+  description:
+    "Connect a Notion workspace with an internal-integration token; the pages you share with the integration sync as review-gated knowledge documents. Share a parent page to include its whole subtree.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "integration_token",
+      type: "string",
+      secret: true,
+      label: "Internal-integration token",
+      required: true,
+      description:
+        "A Notion internal-integration token (notion.so/my-integrations). Share the pages you want synced with this integration. Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_BUNDLE_SYNC_CATALOG_ROW,
+  BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/notion-knowledge-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/notion-knowledge-form-handler.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for `NotionKnowledgeFormInstallHandler` (#4378) — the Notion
+ * synced-collection install.
+ *
+ * Focus: token validation, the credential routing (token →
+ * `knowledge_sync_credentials` via the store, NEVER into
+ * `workspace_plugins.config`), the multi-instance `pillar='knowledge'` upsert
+ * shape, and the cross-catalog slug guard. The internal DB is a
+ * SQL-string-dispatching mock; the live INSERT is pinned against real Postgres
+ * in the shared install `-pg` smoke.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:notion-knowledge" }];
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    insertCalls.push({ sql, params });
+    return [{ id: params[0] }];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT INTO knowledge_sync_credentials …",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { NotionKnowledgeFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/notion-knowledge-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+
+function handler() {
+  return new NotionKnowledgeFormInstallHandler({ idGenerator: () => "fixed-id" });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:notion-knowledge" }];
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+});
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("NotionKnowledgeFormInstallHandler — token validation", () => {
+  it("requires a token", async () => {
+    const err = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { __install_id__: "notion" }),
+      "integration_token",
+    );
+    expect(err).toMatch(/token is required/i);
+  });
+
+  it("rejects a token with embedded whitespace", async () => {
+    const err = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { __install_id__: "notion", integration_token: "ntn_ a b" }),
+      "integration_token",
+    );
+    expect(err).toMatch(/must not contain spaces/i);
+  });
+
+  it("rejects a pathologically long token", async () => {
+    const err = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, {
+        __install_id__: "notion",
+        integration_token: "n".repeat(600),
+      }),
+      "integration_token",
+    );
+    expect(err).toMatch(/characters or fewer/i);
+  });
+});
+
+describe("NotionKnowledgeFormInstallHandler — install", () => {
+  it("routes the token to the credential store and NEVER into config", async () => {
+    const result = await handler().validateConfig(WORKSPACE, {
+      __install_id__: "runbooks",
+      integration_token: "ntn_secret-token",
+      description: "Product runbooks",
+    });
+
+    expect(saveSyncCredential).toHaveBeenCalledWith(WORKSPACE, "runbooks", "ntn_secret-token");
+    expect(result.credentialWritten).toBe(true);
+    expect(result.installRecord).toEqual({
+      id: "fixed-id",
+      workspaceId: WORKSPACE,
+      catalogId: "notion-knowledge",
+    });
+
+    // The persisted config carries the description but NOT the token.
+    expect(insertCalls).toHaveLength(1);
+    const configJson = insertCalls[0].params[4] as string;
+    expect(JSON.parse(configJson)).toEqual({ description: "Product runbooks" });
+    expect(configJson).not.toContain("ntn_secret-token");
+    // Upsert is the knowledge-pillar, published-container shape.
+    expect(insertCalls[0].sql).toContain("'knowledge'");
+    expect(insertCalls[0].sql).toContain("'published'");
+  });
+
+  it("fails loudly when the catalog row is missing (seed not run)", async () => {
+    CATALOG_ROWS = [];
+    await expect(
+      handler().validateConfig(WORKSPACE, {
+        __install_id__: "notion",
+        integration_token: "ntn_x",
+      }),
+    ).rejects.toThrow(/not found or disabled/);
+    // Never persisted a credential for an install that can't complete.
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a slug already taken by another knowledge catalog", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:okf-upload" }];
+    await expect(
+      handler().validateConfig(WORKSPACE, {
+        __install_id__: "runbooks",
+        integration_token: "ntn_x",
+      }),
+    ).rejects.toBeDefined();
+    expect(insertCalls).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/notion-knowledge-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/notion-knowledge-form-handler.test.ts
@@ -153,4 +153,19 @@ describe("NotionKnowledgeFormInstallHandler — install", () => {
     ).rejects.toBeDefined();
     expect(insertCalls).toHaveLength(0);
   });
+
+  it("aborts (no install row) when the credential write fails — never a half-install", async () => {
+    saveSyncCredential.mockImplementationOnce(async () => {
+      throw new Error("encryption keyset unavailable");
+    });
+    await expect(
+      handler().validateConfig(WORKSPACE, {
+        __install_id__: "runbooks",
+        integration_token: "ntn_x",
+      }),
+    ).rejects.toThrow(/encryption keyset unavailable/);
+    // Credential-first write order: a failed credential means NO workspace_plugins
+    // row (no installable card whose scheduled sync then 401s).
+    expect(insertCalls).toHaveLength(0);
+  });
 });

--- a/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
@@ -1,0 +1,226 @@
+/**
+ * `NotionKnowledgeFormInstallHandler` — the {@link FormBasedInstallHandler} for
+ * the built-in `notion-knowledge` catalog row (#4378, PRD #4375). Installing it
+ * creates a **synced knowledge collection** whose content comes from Notion via
+ * an internal-integration token.
+ *
+ * ONE COLLECTION PER AUTHORIZATION: the pages a customer shares with the
+ * integration ARE the scope — there is no space/endpoint field to configure
+ * (unlike bundle-sync). Install is therefore just a token + optional
+ * description. The token is the load-bearing artefact: it routes to the shared
+ * `knowledge_sync_credentials` table (encrypted via `db/secret-encryption.ts`,
+ * an `INTEGRATION_TABLES` participant), NEVER to `workspace_plugins.config`.
+ * Write order mirrors the bundle-sync handler: SaaS keyset gate → credential
+ * row → install row (re-running the install heals a half-completed pair).
+ *
+ * There is no SSRF surface here (the API host is a fixed Notion constant, not a
+ * customer-supplied URL), so no egress guard — the only field validation is a
+ * non-empty, bounded, whitespace-free token. Re-installing an existing slug
+ * edits the description in place and re-stores the token (secrets are never
+ * echoed back, so a token is required on every save — same posture as
+ * bundle-sync's required secret).
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import { saveSyncCredential } from "@atlas/api/lib/knowledge/sync-credentials";
+import { NOTION_KNOWLEDGE_SLUG } from "@atlas/api/lib/knowledge/notion/connector";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+/** Defensive upper bound — a Notion token is ~50 chars; guard against a paste. */
+const TOKEN_MAX = 512;
+
+/** The non-secret config persisted on the `workspace_plugins` row (no token). */
+export interface NotionKnowledgeCollectionConfig {
+  readonly description?: string;
+}
+
+/**
+ * The multi-instance synced-collection upsert (identical shape to the
+ * okf-upload / bundle-sync knowledge upserts): `status='published'` because the
+ * COLLECTION container is live immediately — the review gate is on the
+ * DOCUMENTS, which always sync in as `draft`. Exported so the real-Postgres
+ * test executes this exact string against the live schema.
+ */
+export const NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export interface NotionKnowledgeFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+}
+
+export class NotionKnowledgeFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly log = createLogger("integrations.install.notion-knowledge");
+
+  constructor(options: NotionKnowledgeFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const collectionSlug = resolveCollectionSlug(
+      rawForm[KNOWLEDGE_INSTALL_ID_FIELD],
+      NOTION_KNOWLEDGE_SLUG,
+    );
+
+    const token = validateToken(rawForm.integration_token);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled so a seed misconfig surfaces
+    // as a clear 500 rather than an opaque FK error on the INSERT below.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [NOTION_KNOWLEDGE_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "notion-knowledge catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${NOTION_KNOWLEDGE_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    // A slug taken by another knowledge catalog (okf-upload / bundle-sync) would
+    // merge document trees — reject before any write.
+    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+
+    // ── Credential first (mirrors the bundle-sync / Twenty write order) ────────
+    // SaaS keyset gate BEFORE any credential byte is persisted — a misconfigured
+    // SaaS deploy must fail closed, never store plaintext.
+    assertSaasEncryptionKeyset(this.log, workspaceId, "integration_token");
+    try {
+      await saveSyncCredential(workspaceId, collectionSlug, token);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install",
+      );
+      throw err;
+    }
+
+    // ── Upsert the collection container (never carries the token) ──────────────
+    const config: NotionKnowledgeCollectionConfig = {
+      ...(description !== null ? { description } : {}),
+    };
+
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        collectionSlug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist notion-knowledge collection install — aborting install (the credential write is idempotent; retrying the install is safe)",
+      );
+      throw err;
+    }
+
+    this.log.info(
+      { workspaceId, collectionSlug, rowId: persistedId },
+      "Notion knowledge collection install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: NOTION_KNOWLEDGE_SLUG },
+      credentialWritten: true,
+    };
+  }
+}
+
+/**
+ * Validate the internal-integration token: required, bounded, no internal
+ * whitespace (a Notion token is a single opaque string — an embedded space is a
+ * paste error). The token is never echoed, so it is required on every save.
+ */
+function validateToken(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        integration_token: [
+          "A Notion internal-integration token is required. Create one at notion.so/my-integrations and share your pages with it.",
+        ],
+      },
+      formErrors: [],
+    });
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > TOKEN_MAX) {
+    throw new FormInstallValidationError({
+      fieldErrors: { integration_token: [`Token must be ${TOKEN_MAX} characters or fewer.`] },
+      formErrors: [],
+    });
+  }
+  if (/\s/.test(trimmed)) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        integration_token: ["Token must not contain spaces — paste the token exactly as Notion shows it."],
+      },
+      formErrors: [],
+    });
+  }
+  return trimmed;
+}
+
+/** Optional human description — same rule as the bundle-sync handler. */
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw new FormInstallValidationError({
+      fieldErrors: { description: ["Description must be a string."] },
+      formErrors: [],
+    });
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -34,6 +34,11 @@ import { DatasourceFormInstallHandler } from "./datasource-form-handler";
 import { ObsidianFormInstallHandler } from "./obsidian-form-handler";
 import { OkfUploadFormInstallHandler, OKF_UPLOAD_SLUG } from "./okf-upload-form-handler";
 import { BundleSyncFormInstallHandler, BUNDLE_SYNC_SLUG } from "./bundle-sync-form-handler";
+import { NotionKnowledgeFormInstallHandler } from "./notion-knowledge-form-handler";
+import {
+  NOTION_KNOWLEDGE_SLUG,
+  registerNotionKnowledgeConnector,
+} from "@atlas/api/lib/knowledge/notion/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -220,6 +225,18 @@ export function registerBuiltinInstallHandlers(): void {
   // gate — the customer admin supplies the endpoint at install time.
   registerFormHandler(BUNDLE_SYNC_SLUG, new BundleSyncFormInstallHandler());
   log.info("Registered BundleSyncFormInstallHandler");
+  // Knowledge Base (Notion) — the built-in `notion-knowledge` synced-collection
+  // install (#4378, PRD #4375). Knowledge-pillar, multi-instance. Config = an
+  // optional description; the internal-integration token lands in the dedicated
+  // `knowledge_sync_credentials` table (encrypted), never in
+  // `workspace_plugins.config`. Registering the FORM handler and the CONNECTOR
+  // together keeps a half-wired deploy from having an installable card whose
+  // scheduled sync has no registered vendor client (the connector is what the
+  // sync cycle dispatches on). No env gate — the customer admin supplies the
+  // token at install time.
+  registerFormHandler(NOTION_KNOWLEDGE_SLUG, new NotionKnowledgeFormInstallHandler());
+  registerNotionKnowledgeConnector();
+  log.info("Registered NotionKnowledgeFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -35,6 +35,7 @@ import {
   BUNDLE_SYNC_CATALOG_ID,
   BUNDLE_SYNC_INSTALL_UPSERT_SQL,
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
+import { NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/notion-knowledge-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
   CONNECTOR_SYNC_STATE_SELECT_SQL,
@@ -452,6 +453,32 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     expect(projection.rows).toHaveLength(1);
     expect(projection.rows[0]?.collection_id).toBe("synced-docs");
     expect(projection.rows[0]?.last_sync_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a notion-knowledge connector collection against the live schema (#4378)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:notion-knowledge', 'Knowledge Base (Notion)', 'notion-knowledge', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    // The exported upsert string runs against real Postgres — a future divergence
+    // from the shared knowledge-install shape fails here, not silently at deploy.
+    const installed = await pool.query<{ id: string }>(NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL, [
+      "row-notion",
+      ws,
+      "catalog:notion-knowledge",
+      "notion-docs",
+      JSON.stringify({ description: "Product knowledge from Notion" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-notion");
+    // The connector's token rides the same credential store as bundle-sync.
+    await pool.query(SYNC_CREDENTIAL_UPSERT_SQL, [ws, "notion-docs", "enc:v1:ntn", 1]);
+    const creds = await pool.query<{ collection_id: string }>(
+      `SELECT collection_id FROM knowledge_sync_credentials
+        WHERE workspace_id = $1 AND collection_id = 'notion-docs'`,
+      [ws],
+    );
+    expect(creds.rows).toHaveLength(1);
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/notion/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/notion/__tests__/connector.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The Notion connector registration + `createClient` credential seam (#4378).
+ * The credential store is mocked (all exports) so no test touches the DB; the
+ * connectors registry is reset per-test (never mutated at module top-level).
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+let storedToken: string | null = "ntn_workspace-token";
+mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT INTO knowledge_sync_credentials …",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => storedToken,
+}));
+
+const {
+  registerNotionKnowledgeConnector,
+  notionKnowledgeConnector,
+  NOTION_KNOWLEDGE_CATALOG_ID,
+  NOTION_VENDOR,
+} = await import("@atlas/api/lib/knowledge/notion/connector");
+const { getKnowledgeSyncConnector, _resetKnowledgeSyncConnectors } = await import(
+  "@atlas/api/lib/knowledge/connectors"
+);
+const { NotionVendorClient } = await import("@atlas/api/lib/knowledge/notion/client");
+
+beforeEach(() => {
+  _resetKnowledgeSyncConnectors();
+  storedToken = "ntn_workspace-token";
+});
+
+describe("registerNotionKnowledgeConnector", () => {
+  it("registers the connector under the catalog id, idempotently", () => {
+    expect(getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID)).toBeUndefined();
+    registerNotionKnowledgeConnector();
+    const got = getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID);
+    expect(got).toBe(notionKnowledgeConnector);
+    expect(got?.vendor).toBe(NOTION_VENDOR);
+    // Second call is a no-op (the registry throws on a duplicate — the helper
+    // gates on it), never a throw.
+    expect(() => registerNotionKnowledgeConnector()).not.toThrow();
+  });
+
+  it("stamps the vendor slug as `notion` (→ atlas_source `connector:notion`)", () => {
+    expect(notionKnowledgeConnector.vendor).toBe("notion");
+  });
+});
+
+describe("notionKnowledgeConnector.createClient", () => {
+  const ctx = { workspaceId: "ws1", collectionSlug: "notion", config: null };
+
+  it("builds a NotionVendorClient from the stored integration token", async () => {
+    const built = await notionKnowledgeConnector.createClient(ctx);
+    expect(built).toBeInstanceOf(NotionVendorClient);
+  });
+
+  it("throws an actionable error when the collection has no stored token", async () => {
+    storedToken = null;
+    await expect(notionKnowledgeConnector.createClient(ctx)).rejects.toThrow(
+      /no integration token stored/,
+    );
+  });
+});

--- a/packages/api/src/lib/knowledge/notion/__tests__/notion.test.ts
+++ b/packages/api/src/lib/knowledge/notion/__tests__/notion.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Notion Knowledge Sync Connector — vendor client, HTTP seam, markdown
+ * normalizer, and document builder (#4378). Every network call is a doubled
+ * `fetch`; NO test reaches Notion (AC). The engine integration
+ * (incremental/reconcile/backoff/archive) is already covered by
+ * `connector-sync.test.ts` with a fixture connector — these tests own the
+ * Notion-specific enumeration, content, and normalization logic.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import {
+  NotionHttpClient,
+  NOTION_API_VERSION,
+  NOTION_MIN_REQUEST_INTERVAL_MS,
+} from "@atlas/api/lib/knowledge/notion/http";
+import { normalizeNotionMarkdown } from "@atlas/api/lib/knowledge/notion/markdown";
+import {
+  notionArchivePath,
+  renderNotionOkfDocument,
+  slugifyTitle,
+} from "@atlas/api/lib/knowledge/notion/document";
+import { NotionVendorClient } from "@atlas/api/lib/knowledge/notion/client";
+
+// ── A doubled Notion API ──────────────────────────────────────────────────────
+
+interface FakeNotionState {
+  /** Page objects returned by `POST /search` (filter object=page), in order. */
+  readonly searchPages?: Array<Record<string, unknown>>;
+  /** Data-source rows returned by `POST /search` (filter object=data_source). */
+  readonly dataSources?: Array<Record<string, unknown>>;
+  /** `POST /data_sources/:id/query` → page objects. */
+  readonly dataSourcePages?: Record<string, Array<Record<string, unknown>>>;
+  /** `GET /databases/:id` → `{ data_sources: [...] }`. */
+  readonly databases?: Record<string, Record<string, unknown>>;
+  /** `GET /blocks/:id/children` → block list. */
+  readonly blocks?: Record<string, Array<Record<string, unknown>>>;
+  /** `GET /pages/:id/markdown` → response, or "throw" to fail the endpoint. */
+  readonly markdown?: Record<
+    string,
+    { markdown?: string; truncated?: boolean; unknown_block_ids?: string[] } | "throw"
+  >;
+  /** Number of leading requests that answer 429 before succeeding. */
+  rateLimit?: number;
+}
+
+interface RecordedCall {
+  readonly method: string;
+  readonly path: string;
+  readonly headers: Record<string, string>;
+  readonly body: unknown;
+}
+
+/** Wrap a bare fetch fn as Bun's `fetch` type (adds the unused `preconnect`). */
+function asFetch(
+  fn: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
+): typeof globalThis.fetch {
+  return Object.assign(fn, { preconnect: async () => {} }) as typeof globalThis.fetch;
+}
+
+function makeFakeNotion(state: FakeNotionState) {
+  const calls: RecordedCall[] = [];
+  const json = (body: unknown, status = 200): Response =>
+    new Response(JSON.stringify(body), { status });
+
+  const fetchImpl = asFetch(async (input, init) => {
+    const url = new URL(String(input));
+    const path = url.pathname.replace(/^\/v1/, "");
+    const method = init?.method ?? "GET";
+    const headers = Object.fromEntries(
+      Object.entries((init?.headers ?? {}) as Record<string, string>),
+    );
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ method, path, headers, body });
+
+    if (state.rateLimit && state.rateLimit > 0) {
+      state.rateLimit--;
+      return new Response(JSON.stringify({ object: "error", code: "rate_limited" }), {
+        status: 429,
+        headers: { "Retry-After": "7" },
+      });
+    }
+
+    if (path === "/search") {
+      const value = body?.filter?.value;
+      const results = value === "data_source" ? state.dataSources ?? [] : state.searchPages ?? [];
+      return json({ object: "list", results, has_more: false, next_cursor: null });
+    }
+    const dsQuery = path.match(/^\/data_sources\/([^/]+)\/query$/);
+    if (dsQuery) {
+      return json({
+        object: "list",
+        results: state.dataSourcePages?.[dsQuery[1]] ?? [],
+        has_more: false,
+        next_cursor: null,
+      });
+    }
+    const db = path.match(/^\/databases\/([^/]+)$/);
+    if (db) return json(state.databases?.[db[1]] ?? { data_sources: [] });
+
+    const blocks = path.match(/^\/blocks\/([^/]+)\/children$/);
+    if (blocks) {
+      return json({
+        object: "list",
+        results: state.blocks?.[blocks[1]] ?? [],
+        has_more: false,
+        next_cursor: null,
+      });
+    }
+    const md = path.match(/^\/pages\/([^/]+)\/markdown$/);
+    if (md) {
+      const entry = state.markdown?.[md[1]];
+      if (entry === "throw" || entry === undefined) {
+        return json({ object: "error", code: "object_not_found", message: "not served" }, 400);
+      }
+      return json({ object: "page_markdown", id: md[1], markdown: "", ...entry });
+    }
+    return json({ object: "error", code: "not_found" }, 404);
+  });
+
+  return { fetchImpl, calls };
+}
+
+/** A minimal page object as `POST /search` returns one. */
+function pageObject(opts: {
+  id: string;
+  title: string;
+  lastEditedTime: string;
+  url?: string;
+  archived?: boolean;
+}): Record<string, unknown> {
+  return {
+    object: "page",
+    id: opts.id,
+    last_edited_time: opts.lastEditedTime,
+    url: opts.url ?? `https://www.notion.so/${opts.id.replace(/-/g, "")}`,
+    archived: opts.archived ?? false,
+    properties: {
+      Name: { type: "title", title: [{ plain_text: opts.title }] },
+    },
+  };
+}
+
+function client(state: FakeNotionState, maxDocs = 1000): { vendor: NotionVendorClient; calls: RecordedCall[] } {
+  const { fetchImpl, calls } = makeFakeNotion(state);
+  const http = new NotionHttpClient({
+    token: "ntn_secret-token",
+    fetchImpl,
+    now: () => 0, // frozen clock — the throttle never actually waits in these tests
+    sleep: async () => {},
+  });
+  return { vendor: new NotionVendorClient({ http, maxDocs }), calls };
+}
+
+// ── HTTP seam ─────────────────────────────────────────────────────────────────
+
+describe("NotionHttpClient", () => {
+  it("pins the recorded Notion-Version header and sends the bearer token on every call", async () => {
+    const { fetchImpl, calls } = makeFakeNotion({ searchPages: [] });
+    const http = new NotionHttpClient({ token: "ntn_abc", fetchImpl, now: () => 0, sleep: async () => {} });
+    await http.post("/search", { filter: { property: "object", value: "page" } });
+    expect(NOTION_API_VERSION).toBe("2026-03-11");
+    expect(calls[0].headers["Notion-Version"]).toBe("2026-03-11");
+    expect(calls[0].headers.Authorization).toBe("Bearer ntn_abc");
+  });
+
+  it("throttles request starts by the documented ~3 req/s interval", async () => {
+    const { fetchImpl } = makeFakeNotion({ searchPages: [] });
+    const sleeps: number[] = [];
+    let clock = 0;
+    const http = new NotionHttpClient({
+      token: "ntn_abc",
+      fetchImpl,
+      now: () => clock,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        clock += ms;
+      },
+    });
+    await http.get("/blocks/a/children");
+    await http.get("/blocks/b/children");
+    await http.get("/blocks/c/children");
+    // First call never waits; the next two are spaced by the interval.
+    expect(sleeps).toEqual([NOTION_MIN_REQUEST_INTERVAL_MS, NOTION_MIN_REQUEST_INTERVAL_MS]);
+  });
+
+  it("maps 429 to ConnectorRateLimitError carrying the parsed Retry-After", async () => {
+    const { fetchImpl } = makeFakeNotion({ rateLimit: 1 });
+    const http = new NotionHttpClient({ token: "ntn_abc", fetchImpl, now: () => 0, sleep: async () => {} });
+    const err = await http.get("/search").catch((e) => e);
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+    expect((err as ConnectorRateLimitError).retryAfterSeconds).toBe(7);
+  });
+
+  it("surfaces Notion's error code/message but never the token on a non-2xx", async () => {
+    const fetchImpl = asFetch(async () =>
+      new Response(JSON.stringify({ code: "unauthorized", message: "API token is invalid." }), {
+        status: 401,
+      }),
+    );
+    const http = new NotionHttpClient({ token: "ntn_super-secret", fetchImpl, now: () => 0, sleep: async () => {} });
+    const err = (await http.get("/pages/x/markdown").catch((e) => e)) as Error;
+    expect(err.message).toContain("unauthorized");
+    expect(err.message).toContain("API token is invalid");
+    expect(err.message).not.toContain("ntn_super-secret");
+  });
+
+  it("rejects a blank token at construction", () => {
+    expect(() => new NotionHttpClient({ token: "   " })).toThrow(/non-empty integration token/);
+  });
+});
+
+// ── Markdown normalizer (goldens) ──────────────────────────────────────────────
+
+describe("normalizeNotionMarkdown", () => {
+  const ctx = { pageUrl: "https://www.notion.so/deadbeef" };
+
+  it("downgrades a callout fence to a blockquote", () => {
+    const out = normalizeNotionMarkdown("```callout\n💡 Heads up\nBe careful\n```", ctx);
+    expect(out).toBe("> 💡 Heads up\n> Be careful\n");
+  });
+
+  it("leaves a real code fence untouched (never rewrites its body)", () => {
+    const src = "```ts\nconst x = 1;\n<column>\n```";
+    expect(normalizeNotionMarkdown(src, ctx)).toBe("```ts\nconst x = 1;\n<column>\n```\n");
+  });
+
+  it("strips column tags and flattens columns vertically", () => {
+    const src = "<columns>\n<column>\nLeft\n</column>\n<column>\nRight\n</column>\n</columns>";
+    expect(normalizeNotionMarkdown(src, ctx)).toBe("Left\n\nRight\n");
+  });
+
+  it("unwraps details and turns the summary into a bold lead line", () => {
+    const src = "<details>\n<summary>More info</summary>\nHidden body\n</details>";
+    expect(normalizeNotionMarkdown(src, ctx)).toBe("**More info**\nHidden body\n");
+  });
+
+  it("replaces an expiring S3 image with a link to the stable page", () => {
+    const src =
+      "![diagram](https://prod-files-secure.s3.us-west-2.amazonaws.com/x?X-Amz-Signature=abc)";
+    expect(normalizeNotionMarkdown(src, ctx)).toBe(
+      "[diagram — view in Notion](https://www.notion.so/deadbeef)\n",
+    );
+  });
+
+  it("replaces an expiring media LINK (non-image) too, and leaves a normal link alone", () => {
+    const expiring = "[attachment](https://file.notion.so/f/secret.pdf?X-Amz-Expires=3600)";
+    expect(normalizeNotionMarkdown(expiring, ctx)).toBe(
+      "[attachment](https://www.notion.so/deadbeef)\n",
+    );
+    const normal = "[docs](https://example.com/guide)";
+    expect(normalizeNotionMarkdown(normal, ctx)).toBe("[docs](https://example.com/guide)\n");
+  });
+});
+
+// ── Document builder ───────────────────────────────────────────────────────────
+
+describe("notion document builder", () => {
+  const idA = "11111111-2222-3333-4444-555555555555";
+  const idB = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+  it("derives a readable, deterministic, collision-free path", () => {
+    expect(slugifyTitle("On-Call Runbook!")).toBe("on-call-runbook");
+    const p = notionArchivePath(idA, "On-Call Runbook");
+    expect(p).toBe("on-call-runbook-11111111222233334444555555555555.md");
+    // Same-titled distinct pages never collide (id token disambiguates).
+    expect(notionArchivePath(idA, "Same")).not.toBe(notionArchivePath(idB, "Same"));
+    // Deterministic.
+    expect(notionArchivePath(idA, "Same")).toBe(notionArchivePath(idA, "Same"));
+  });
+
+  it("falls back to `untitled` for an empty/punctuation title", () => {
+    expect(slugifyTitle("")).toBe("untitled");
+    expect(slugifyTitle("!!!")).toBe("untitled");
+  });
+
+  it("renders conformant OKF frontmatter with atlas provenance, and no sync-time churn", () => {
+    const doc = renderNotionOkfDocument({
+      id: idA,
+      title: "Runbook",
+      lastEditedTime: "2026-07-01T00:00:00.000Z",
+      url: "https://www.notion.so/runbook",
+      body: "Body text",
+    });
+    expect(doc).toContain("type: Document");
+    expect(doc).toContain('title: "Runbook"');
+    expect(doc).toContain('resource: "https://www.notion.so/runbook"');
+    expect(doc).toContain('timestamp: "2026-07-01T00:00:00.000Z"');
+    expect(doc).toContain("atlas:");
+    expect(doc).toContain("connector: notion");
+    expect(doc).toContain(`page_id: "${idA}"`);
+    // Body is a pure function of the page version — no per-sync timestamp that
+    // would flip the change comparison and force needless re-review.
+    expect(doc).not.toContain("synced_at");
+    expect(doc.endsWith("Body text\n")).toBe(true);
+  });
+});
+
+// ── Vendor client: enumeration + content ───────────────────────────────────────
+
+describe("NotionVendorClient.fetchAll (reconciliation)", () => {
+  it("unions search with descent — an inheritance-only child page is found", async () => {
+    const parent = pageObject({ id: "parent-id", title: "Parent", lastEditedTime: "2026-07-01T00:00:00.000Z" });
+    const { vendor } = client({
+      // Search returns ONLY the parent (the child is invisible to search).
+      searchPages: [parent],
+      blocks: {
+        "parent-id": [
+          {
+            object: "block",
+            id: "child-id",
+            type: "child_page",
+            last_edited_time: "2026-07-02T00:00:00.000Z",
+            has_children: false,
+            child_page: { title: "Child Runbook" },
+          },
+        ],
+        "child-id": [],
+      },
+      markdown: {
+        "parent-id": { markdown: "Parent body" },
+        "child-id": { markdown: "Child body" },
+      },
+    });
+    const changes = await vendor.fetchAll();
+    const paths = changes.documents.map((d) => d.path).sort();
+    expect(paths.some((p) => p.startsWith("parent-"))).toBe(true);
+    expect(paths.some((p) => p.startsWith("child-runbook-"))).toBe(true);
+    // High-water mark is the newest last_edited_time across the full set.
+    expect(changes.highWaterMark).toBe("2026-07-02T00:00:00.000Z");
+  });
+
+  it("skips archived/trashed pages", async () => {
+    const { vendor } = client({
+      searchPages: [
+        pageObject({ id: "live", title: "Live", lastEditedTime: "2026-07-01T00:00:00.000Z" }),
+        pageObject({ id: "gone", title: "Gone", lastEditedTime: "2026-07-01T00:00:00.000Z", archived: true }),
+      ],
+      blocks: { live: [] },
+      markdown: { live: { markdown: "hi" } },
+    });
+    const changes = await vendor.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.documents[0].path).toContain("live-");
+  });
+
+  it("throws (never truncates) when the shared set exceeds the doc cap", async () => {
+    const { vendor } = client(
+      {
+        searchPages: [
+          pageObject({ id: "a", title: "A", lastEditedTime: "2026-07-01T00:00:00.000Z" }),
+          pageObject({ id: "b", title: "B", lastEditedTime: "2026-07-01T00:00:00.000Z" }),
+        ],
+        blocks: { a: [], b: [] },
+      },
+      1, // maxDocs
+    );
+    await expect(vendor.fetchAll()).rejects.toThrow(/over the 1-document limit/);
+  });
+
+  it("normalizes content and stamps provenance in the built document", async () => {
+    const { vendor } = client({
+      searchPages: [pageObject({ id: "p", title: "Doc", lastEditedTime: "2026-07-01T00:00:00.000Z" })],
+      blocks: { p: [] },
+      markdown: { p: { markdown: "```callout\nNote\n```" } },
+    });
+    const changes = await vendor.fetchAll();
+    expect(changes.documents[0].content).toContain("> Note");
+    expect(changes.documents[0].content).toContain("connector: notion");
+  });
+});
+
+describe("NotionVendorClient.fetchChanges (incremental)", () => {
+  it("collects pages at/after `since` and stops at the first older one", async () => {
+    const { vendor, calls } = client({
+      // Sorted descending by last_edited_time (as the client requests).
+      searchPages: [
+        pageObject({ id: "new", title: "New", lastEditedTime: "2026-07-05T00:00:00.000Z" }),
+        pageObject({ id: "old", title: "Old", lastEditedTime: "2026-07-01T00:00:00.000Z" }),
+      ],
+      markdown: { new: { markdown: "fresh" } },
+    });
+    const changes = await vendor.fetchChanges({ since: "2026-07-03T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.documents[0].path).toContain("new-");
+    // Never fetched content for the older page (walk stopped).
+    expect(calls.some((c) => c.path === "/pages/old/markdown")).toBe(false);
+    // Incremental does NOT descend block trees (that's reconciliation's job).
+    expect(calls.some((c) => c.path.endsWith("/children"))).toBe(false);
+  });
+});
+
+describe("NotionVendorClient content edge cases", () => {
+  it("completes a truncated page by re-fetching its unknown_block_ids", async () => {
+    const { vendor } = client({
+      searchPages: [pageObject({ id: "big", title: "Big", lastEditedTime: "2026-07-01T00:00:00.000Z" })],
+      blocks: { big: [] },
+      markdown: {
+        big: { markdown: "part one", truncated: true, unknown_block_ids: ["sub"] },
+        sub: { markdown: "part two", truncated: false },
+      },
+    });
+    const changes = await vendor.fetchAll();
+    expect(changes.documents[0].content).toContain("part one");
+    expect(changes.documents[0].content).toContain("part two");
+  });
+
+  it("falls back to a block-walk render when the markdown endpoint cannot serve a page", async () => {
+    const { vendor } = client({
+      searchPages: [pageObject({ id: "hard", title: "Hard", lastEditedTime: "2026-07-01T00:00:00.000Z" })],
+      blocks: {
+        hard: [
+          { object: "block", id: "b1", type: "heading_1", has_children: false, heading_1: { rich_text: [{ plain_text: "Title" }] } },
+          { object: "block", id: "b2", type: "paragraph", has_children: false, paragraph: { rich_text: [{ plain_text: "Prose here" }] } },
+        ],
+      },
+      markdown: { hard: "throw" },
+    });
+    const changes = await vendor.fetchAll();
+    expect(changes.documents[0].content).toContain("# Title");
+    expect(changes.documents[0].content).toContain("Prose here");
+  });
+
+  it("propagates a 429 during enumeration (the engine owns the backoff)", async () => {
+    const { vendor } = client({ searchPages: [], rateLimit: 1 });
+    await expect(vendor.fetchAll()).rejects.toBeInstanceOf(ConnectorRateLimitError);
+  });
+});

--- a/packages/api/src/lib/knowledge/notion/__tests__/notion.test.ts
+++ b/packages/api/src/lib/knowledge/notion/__tests__/notion.test.ts
@@ -35,10 +35,11 @@ interface FakeNotionState {
   readonly databases?: Record<string, Record<string, unknown>>;
   /** `GET /blocks/:id/children` → block list. */
   readonly blocks?: Record<string, Array<Record<string, unknown>>>;
-  /** `GET /pages/:id/markdown` → response, or "throw" to fail the endpoint. */
+  /** `GET /pages/:id/markdown` → response, "throw" (endpoint failure → block-walk
+   *  fallback), or "throw-429" (rate limit on the content path). */
   readonly markdown?: Record<
     string,
-    { markdown?: string; truncated?: boolean; unknown_block_ids?: string[] } | "throw"
+    { markdown?: string; truncated?: boolean; unknown_block_ids?: string[] } | "throw" | "throw-429"
   >;
   /** Number of leading requests that answer 429 before succeeding. */
   rateLimit?: number;
@@ -110,6 +111,12 @@ function makeFakeNotion(state: FakeNotionState) {
     const md = path.match(/^\/pages\/([^/]+)\/markdown$/);
     if (md) {
       const entry = state.markdown?.[md[1]];
+      if (entry === "throw-429") {
+        return new Response(JSON.stringify({ object: "error", code: "rate_limited" }), {
+          status: 429,
+          headers: { "Retry-After": "3" },
+        });
+      }
       if (entry === "throw" || entry === undefined) {
         return json({ object: "error", code: "object_not_found", message: "not served" }, 400);
       }
@@ -294,6 +301,19 @@ describe("notion document builder", () => {
     expect(doc).not.toContain("synced_at");
     expect(doc.endsWith("Body text\n")).toBe(true);
   });
+
+  it("keeps frontmatter valid YAML when the title/URL contain colons and quotes", () => {
+    const doc = renderNotionOkfDocument({
+      id: idA,
+      title: 'Q3: "Revenue" — plan',
+      lastEditedTime: "2026-07-01T00:00:00.000Z",
+      url: 'https://www.notion.so/x?q="a:b"',
+      body: "b",
+    });
+    // JSON-encoded scalars keep the colon/quote from breaking the YAML block.
+    expect(doc).toContain('title: "Q3: \\"Revenue\\" — plan"');
+    expect(doc).toContain('resource: "https://www.notion.so/x?q=\\"a:b\\""');
+  });
 });
 
 // ── Vendor client: enumeration + content ───────────────────────────────────────
@@ -368,6 +388,76 @@ describe("NotionVendorClient.fetchAll (reconciliation)", () => {
     expect(changes.documents[0].content).toContain("> Note");
     expect(changes.documents[0].content).toContain("connector: notion");
   });
+
+  it("enumerates pages of a shared database via the data-source query path", async () => {
+    const { vendor } = client({
+      searchPages: [], // no loose pages — everything lives in the database
+      dataSources: [{ object: "data_source", id: "ds-1" }],
+      dataSourcePages: {
+        "ds-1": [pageObject({ id: "row-1", title: "DB Row", lastEditedTime: "2026-07-03T00:00:00.000Z" })],
+      },
+      blocks: { "row-1": [] },
+      markdown: { "row-1": { markdown: "row body" } },
+    });
+    const changes = await vendor.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.documents[0].path).toContain("db-row-");
+  });
+
+  it("descends a child_database block into its data source's pages", async () => {
+    const { vendor } = client({
+      searchPages: [pageObject({ id: "parent", title: "Parent", lastEditedTime: "2026-07-01T00:00:00.000Z" })],
+      blocks: {
+        parent: [{ object: "block", id: "db-1", type: "child_database", has_children: false, child_database: { title: "Tasks" } }],
+        "row-x": [],
+      },
+      databases: { "db-1": { object: "database", id: "db-1", data_sources: [{ id: "ds-x" }] } },
+      dataSourcePages: {
+        "ds-x": [pageObject({ id: "row-x", title: "Task One", lastEditedTime: "2026-07-04T00:00:00.000Z" })],
+      },
+      markdown: { parent: { markdown: "p" }, "row-x": { markdown: "task" } },
+    });
+    const changes = await vendor.fetchAll();
+    const paths = changes.documents.map((d) => d.path);
+    expect(paths.some((p) => p.startsWith("task-one-"))).toBe(true);
+  });
+
+  it("de-duplicates a page reachable via BOTH search and descent (one document)", async () => {
+    const dupId = "dupdupdup-1111-2222-3333-444444444444";
+    const { vendor } = client({
+      // Same page id appears in search AND as a child_page under itself's parent.
+      searchPages: [
+        pageObject({ id: "root", title: "Root", lastEditedTime: "2026-07-01T00:00:00.000Z" }),
+        pageObject({ id: dupId, title: "Dup", lastEditedTime: "2026-07-01T00:00:00.000Z" }),
+      ],
+      blocks: {
+        root: [{ object: "block", id: dupId, type: "child_page", has_children: false, last_edited_time: "2026-07-01T00:00:00.000Z", child_page: { title: "Dup" } }],
+        [dupId]: [],
+      },
+      markdown: { root: { markdown: "r" }, [dupId]: { markdown: "d" } },
+    });
+    const changes = await vendor.fetchAll();
+    const dupPaths = changes.documents.filter((d) => d.path.startsWith("dup-"));
+    expect(dupPaths).toHaveLength(1);
+  });
+
+  it("throws when the vendor reports more pages but omits the next cursor (never a partial set)", async () => {
+    const { fetchImpl } = makeFakeNotion({});
+    // Override: a search response that claims has_more but returns no cursor.
+    const badFetch = asFetch(async (input) => {
+      const path = new URL(String(input)).pathname.replace(/^\/v1/, "");
+      if (path === "/search") {
+        return new Response(
+          JSON.stringify({ object: "list", results: [], has_more: true, next_cursor: null }),
+          { status: 200 },
+        );
+      }
+      return fetchImpl(input);
+    });
+    const http = new NotionHttpClient({ token: "ntn_x", fetchImpl: badFetch, now: () => 0, sleep: async () => {} });
+    const vendor = new NotionVendorClient({ http, maxDocs: 1000 });
+    await expect(vendor.fetchAll()).rejects.toThrow(/incomplete/i);
+  });
 });
 
 describe("NotionVendorClient.fetchChanges (incremental)", () => {
@@ -423,6 +513,15 @@ describe("NotionVendorClient content edge cases", () => {
 
   it("propagates a 429 during enumeration (the engine owns the backoff)", async () => {
     const { vendor } = client({ searchPages: [], rateLimit: 1 });
+    await expect(vendor.fetchAll()).rejects.toBeInstanceOf(ConnectorRateLimitError);
+  });
+
+  it("propagates a 429 from the CONTENT path (never swallowed into a fallback)", async () => {
+    const { vendor } = client({
+      searchPages: [pageObject({ id: "p", title: "P", lastEditedTime: "2026-07-01T00:00:00.000Z" })],
+      blocks: { p: [] },
+      markdown: { p: "throw-429" },
+    });
     await expect(vendor.fetchAll()).rejects.toBeInstanceOf(ConnectorRateLimitError);
   });
 });

--- a/packages/api/src/lib/knowledge/notion/client.ts
+++ b/packages/api/src/lib/knowledge/notion/client.ts
@@ -57,7 +57,12 @@ const MAX_ENUMERATED_PAGES = 10_000;
 /** Bound the truncation continuation so a pathological page can't fan out unboundedly. */
 const MAX_TRUNCATION_CONTINUATIONS = 50;
 
-/** Bound block-walk recursion depth (the fallback render). */
+/**
+ * Bound block-walk recursion depth — governs BOTH the enumeration
+ * container-descent (`walkBlocks`, where exceeding it is logged, since a missed
+ * subpage could be archived) and the fallback content render
+ * (`blockWalkMarkdown`). Tune with both in mind.
+ */
 const MAX_BLOCK_WALK_DEPTH = 6;
 
 // ---------------------------------------------------------------------------
@@ -74,6 +79,41 @@ function asArray(value: unknown): unknown[] {
 }
 function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+/**
+ * A Notion list/query response must be a JSON object — a 2xx body that isn't
+ * (proxy HTML, an edge hiccup, a contract violation) is NOT "no more pages". In
+ * an enumeration loop, treating "couldn't understand the response" as "done"
+ * returns a partial set, and a partial reconciliation set makes the engine
+ * archive the pages we never reached. Throw instead — the engine turns it into
+ * the collection's sync error (exactly as {@link MAX_ENUMERATED_PAGES} does).
+ */
+function requireResponseObject(value: unknown, what: string): Record<string, unknown> {
+  const obj = asRecord(value);
+  if (obj === null) {
+    throw new Error(
+      `Notion ${what} returned an unexpected non-object response — refusing to treat enumeration as complete (a partial set would archive live pages).`,
+    );
+  }
+  return obj;
+}
+
+/**
+ * Advance a Notion pagination cursor, or return null when the vendor says the
+ * listing is complete (`has_more !== true`). THROWS when the vendor reports
+ * more pages (`has_more === true`) but returns no usable `next_cursor` — that is
+ * a known-incomplete listing, and stopping silently would archive live pages.
+ */
+function advancePageCursor(res: Record<string, unknown>, what: string): string | null {
+  if (res.has_more !== true) return null;
+  const next = asString(res.next_cursor);
+  if (next === "") {
+    throw new Error(
+      `Notion ${what} reported more results (has_more) but returned no next_cursor — enumeration is incomplete; refusing to archive on a partial set.`,
+    );
+  }
+  return next;
 }
 
 /** A page's title from its `properties` (the one `type: "title"` property). */
@@ -216,9 +256,8 @@ export class NotionVendorClient implements ConnectorVendorClient {
         page_size: 100,
         ...(cursor !== null ? { start_cursor: cursor } : {}),
       };
-      const res = asRecord(await this.http.post("/search", body));
-      const results = asArray(res?.results);
-      for (const raw of results) {
+      const res = requireResponseObject(await this.http.post("/search", body), "page search");
+      for (const raw of asArray(res.results)) {
         const obj = asRecord(raw);
         if (obj === null || obj.object !== "page" || isArchived(obj)) continue;
         const id = asString(obj.id);
@@ -231,9 +270,8 @@ export class NotionVendorClient implements ConnectorVendorClient {
         };
         if (opts.onPage(ref) === "stop") return;
       }
-      if (res?.has_more !== true) return;
-      const next = asString(res.next_cursor);
-      if (next === "") return;
+      const next = advancePageCursor(res, "page search");
+      if (next === null) return;
       cursor = next;
     }
   }
@@ -254,15 +292,14 @@ export class NotionVendorClient implements ConnectorVendorClient {
         page_size: 100,
         ...(cursor !== null ? { start_cursor: cursor } : {}),
       };
-      const res = asRecord(await this.http.post("/search", body));
-      for (const raw of asArray(res?.results)) {
+      const res = requireResponseObject(await this.http.post("/search", body), "data-source search");
+      for (const raw of asArray(res.results)) {
         const ds = asRecord(raw);
         const dsId = asString(ds?.id);
         if (dsId !== "") await this.queryDataSourcePages(dsId, addRef, roots);
       }
-      if (res?.has_more !== true) return;
-      const next = asString(res.next_cursor);
-      if (next === "") return;
+      const next = advancePageCursor(res, "data-source search");
+      if (next === null) return;
       cursor = next;
     }
   }
@@ -279,8 +316,11 @@ export class NotionVendorClient implements ConnectorVendorClient {
         page_size: 100,
         ...(cursor !== null ? { start_cursor: cursor } : {}),
       };
-      const res = asRecord(await this.http.post(`/data_sources/${dataSourceId}/query`, body));
-      for (const raw of asArray(res?.results)) {
+      const res = requireResponseObject(
+        await this.http.post(`/data_sources/${dataSourceId}/query`, body),
+        "data-source query",
+      );
+      for (const raw of asArray(res.results)) {
         const obj = asRecord(raw);
         if (obj === null || obj.object !== "page" || isArchived(obj)) continue;
         const id = asString(obj.id);
@@ -293,9 +333,8 @@ export class NotionVendorClient implements ConnectorVendorClient {
         });
         roots.push(id);
       }
-      if (res?.has_more !== true) return;
-      const next = asString(res.next_cursor);
-      if (next === "") return;
+      const next = advancePageCursor(res, "data-source query");
+      if (next === null) return;
       cursor = next;
     }
   }
@@ -333,8 +372,8 @@ export class NotionVendorClient implements ConnectorVendorClient {
       const path =
         `/blocks/${blockId}/children?page_size=100` +
         (cursor !== null ? `&start_cursor=${encodeURIComponent(cursor)}` : "");
-      const res = asRecord(await this.http.get(path));
-      for (const raw of asArray(res?.results)) {
+      const res = requireResponseObject(await this.http.get(path), `block children of ${blockId}`);
+      for (const raw of asArray(res.results)) {
         const block = asRecord(raw);
         if (block === null) continue;
         const type = asString(block.type);
@@ -352,15 +391,24 @@ export class NotionVendorClient implements ConnectorVendorClient {
           pageQueue.push(id);
         } else if (type === "child_database" && id !== "") {
           await this.enumerateDatabaseBlock(id, addRef, pageQueue);
-        } else if (block.has_children === true && id !== "" && depth < MAX_BLOCK_WALK_DEPTH) {
-          // A container block (toggle, column, callout, …) may hold a subpage —
-          // recurse into it, bounded by depth.
-          await this.walkBlocks(id, addRef, pageQueue, depth + 1);
+        } else if (block.has_children === true && id !== "") {
+          if (depth < MAX_BLOCK_WALK_DEPTH) {
+            // A container block (toggle, column, callout, …) may hold a subpage —
+            // recurse into it, bounded by depth.
+            await this.walkBlocks(id, addRef, pageQueue, depth + 1);
+          } else {
+            // Counted, never silent (matches the truncation/fallback logging): a
+            // subpage buried past the depth cap could be an inheritance-only page
+            // the reconciliation would then archive — surface the coverage gap.
+            log.warn(
+              { blockId: id, depth },
+              "Notion block descent hit the depth cap — a subpage nested this deep in one page is not enumerated",
+            );
+          }
         }
       }
-      if (res?.has_more !== true) return;
-      const next = asString(res.next_cursor);
-      if (next === "") return;
+      const next = advancePageCursor(res, `block children of ${blockId}`);
+      if (next === null) return;
       cursor = next;
     }
   }
@@ -371,8 +419,11 @@ export class NotionVendorClient implements ConnectorVendorClient {
     addRef: (ref: NotionPageRef) => void,
     pageQueue: string[],
   ): Promise<void> {
-    const db = asRecord(await this.http.get(`/databases/${databaseId}`));
-    const dataSources = asArray(db?.data_sources);
+    const db = requireResponseObject(
+      await this.http.get(`/databases/${databaseId}`),
+      `database ${databaseId}`,
+    );
+    const dataSources = asArray(db.data_sources);
     if (dataSources.length === 0) return;
     for (const raw of dataSources) {
       const dsId = asString(asRecord(raw)?.id);

--- a/packages/api/src/lib/knowledge/notion/client.ts
+++ b/packages/api/src/lib/knowledge/notion/client.ts
@@ -1,0 +1,554 @@
+/**
+ * The Notion `ConnectorVendorClient` (#4378) — enumerate + fetch, behind the
+ * per-vendor interface the shared engine (`connector-sync.ts`) drives. The
+ * engine owns scheduling, high-water marks, 429 backoff, caps, and ingest; this
+ * client owns ONLY Notion's two documented awkwardnesses:
+ *
+ *   ENUMERATION is non-trivial because Notion search is officially
+ *   non-exhaustive and visibility is opt-in per shared subtree. So:
+ *     - `fetchAll` (RECONCILIATION, the correctness anchor) unions SEARCH with a
+ *       RECURSIVE DESCENT of every shared root's block tree — a page reachable
+ *       only by inheritance (its parent was shared, but search never returned
+ *       it) is still found via its parent's `child_page`/`child_database`
+ *       blocks. Deletions/unshares surface here as paths absent from the full
+ *       set; the engine archives them. An INCOMPLETE enumeration must THROW
+ *       (never return a partial set) — a silent under-count would let the engine
+ *       archive live pages.
+ *     - `fetchChanges` (INCREMENTAL, cheap) walks SEARCH sorted by
+ *       `last_edited_time` descending and stops once older than `since`. The
+ *       engine's overlap window absorbs Notion's minute-granularity timestamps;
+ *       inheritance-only pages and deletions are reconciliation's job, not this
+ *       cycle's.
+ *
+ *   CONTENT is the official page-markdown endpoint (one request per page). A
+ *   `truncated` page (over Notion's ~20k-block limit) is completed by
+ *   re-fetching its `unknown_block_ids` as page ids; a page the endpoint can't
+ *   serve falls back to a block-walk render. Both are COUNTED and logged, never
+ *   silent (AC). Expiring media URLs are replaced with the stable page link by
+ *   the normalizer.
+ *
+ * Every network call is the injected {@link NotionHttpClient}; no test reaches
+ * Notion.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getIngestMaxDocs } from "../ingest-limits";
+import { ConnectorRateLimitError } from "../connectors";
+import type {
+  ConnectorChanges,
+  ConnectorDocument,
+  ConnectorFetchSince,
+  ConnectorVendorClient,
+} from "../connectors";
+import { NotionHttpClient } from "./http";
+import { normalizeNotionMarkdown } from "./markdown";
+import { buildNotionConnectorDocument, compactPageId, type NotionPageDocument } from "./document";
+
+const log = createLogger("knowledge.notion.client");
+
+/**
+ * Hard ceiling on pages enumerated in one reconciliation — a runaway guard well
+ * above the ingest doc cap (which produces the actionable "narrow scope" error
+ * first). Hitting THIS throws rather than truncating: a capped enumeration is
+ * incomplete, and an incomplete reconciliation must never archive the overflow.
+ */
+const MAX_ENUMERATED_PAGES = 10_000;
+
+/** Bound the truncation continuation so a pathological page can't fan out unboundedly. */
+const MAX_TRUNCATION_CONTINUATIONS = 50;
+
+/** Bound block-walk recursion depth (the fallback render). */
+const MAX_BLOCK_WALK_DEPTH = 6;
+
+// ---------------------------------------------------------------------------
+// Narrowing helpers for the untyped Notion JSON (the read sites own the shape)
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** A page's title from its `properties` (the one `type: "title"` property). */
+function extractTitle(properties: unknown): string {
+  const props = asRecord(properties);
+  if (props === null) return "";
+  for (const key of Object.keys(props)) {
+    const prop = asRecord(props[key]);
+    if (prop?.type === "title") {
+      return asArray(prop.title)
+        .map((rt) => asString(asRecord(rt)?.plain_text))
+        .join("");
+    }
+  }
+  return "";
+}
+
+/** A page's stable URL from its object, or a canonical fallback from the id. */
+function pageUrl(pageObject: Record<string, unknown>, id: string): string {
+  const url = asString(pageObject.url);
+  return url !== "" ? url : `https://www.notion.so/${compactPageId(id)}`;
+}
+
+/** The vendor-neutral page reference the enumerator accumulates. */
+interface NotionPageRef {
+  readonly id: string;
+  readonly title: string;
+  readonly lastEditedTime: string;
+  readonly url: string;
+}
+
+/** True for a page object that is trashed/archived (treat as absent). */
+function isArchived(pageObject: Record<string, unknown>): boolean {
+  return pageObject.archived === true || pageObject.in_trash === true;
+}
+
+export interface NotionVendorClientOptions {
+  readonly http: NotionHttpClient;
+  /** Test-only override of the ingest doc cap (defaults to the settings value). */
+  readonly maxDocs?: number;
+}
+
+export class NotionVendorClient implements ConnectorVendorClient {
+  private readonly http: NotionHttpClient;
+  private readonly maxDocs: number;
+
+  constructor(options: NotionVendorClientOptions) {
+    this.http = options.http;
+    this.maxDocs = options.maxDocs ?? getIngestMaxDocs();
+  }
+
+  /** INCREMENTAL: search walk-until-older. */
+  async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+    // The engine only routes here with a non-null `since`; a defensive null
+    // means "treat everything as changed" (equivalent to a reconciliation of
+    // the search-visible set) rather than silently fetching nothing.
+    const since = params.since;
+    const changed: NotionPageRef[] = [];
+    let newestSeen: string | null = null;
+
+    await this.searchPages({
+      direction: "descending",
+      onPage: (ref) => {
+        if (newestSeen === null || ref.lastEditedTime > newestSeen) newestSeen = ref.lastEditedTime;
+        if (since === null || ref.lastEditedTime >= since) {
+          changed.push(ref);
+          return "continue";
+        }
+        // Sorted descending: the first page older than `since` means every
+        // remaining result is older too — stop paginating.
+        return "stop";
+      },
+    });
+
+    const documents = await this.buildDocuments(changed);
+    return { documents, highWaterMark: newestSeen, cursor: null };
+  }
+
+  /** RECONCILIATION: search ∪ recursive descent — the exhaustive set. */
+  async fetchAll(): Promise<ConnectorChanges> {
+    const refs = new Map<string, NotionPageRef>();
+    const addRef = (ref: NotionPageRef): void => {
+      if (!refs.has(ref.id)) refs.set(ref.id, ref);
+      if (refs.size > MAX_ENUMERATED_PAGES) {
+        // Incomplete-by-cap: throwing keeps the engine from archiving the pages
+        // we never reached. Actionable — the operator narrows the shared scope.
+        throw new Error(
+          `This Notion integration shares more than ${MAX_ENUMERATED_PAGES} pages — narrow what is shared with the integration, or split it across collections.`,
+        );
+      }
+    };
+
+    // Roots: everything search returns (pages + data-source rows). Descent then
+    // fills in the inheritance-only pages search missed.
+    const roots: string[] = [];
+    await this.searchPages({
+      direction: "descending",
+      onPage: (ref) => {
+        addRef(ref);
+        roots.push(ref.id);
+        return "continue";
+      },
+    });
+    await this.enumerateDataSources(addRef, roots);
+    await this.descend(roots, addRef);
+
+    const highWaterMark = [...refs.values()].reduce<string | null>(
+      (max, ref) => (max === null || ref.lastEditedTime > max ? ref.lastEditedTime : max),
+      null,
+    );
+
+    // Reject an over-cap set BEFORE fetching content (the engine's ingest cap is
+    // the backstop, but checking here saves thousands of markdown fetches).
+    if (refs.size > this.maxDocs) {
+      throw new Error(
+        `This Notion integration shares ${refs.size} pages, over the ${this.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow what is shared with the integration, or raise the cap.`,
+      );
+    }
+
+    const documents = await this.buildDocuments([...refs.values()]);
+    return { documents, highWaterMark, cursor: null };
+  }
+
+  // ── Enumeration ────────────────────────────────────────────────────────────
+
+  /**
+   * Page every `POST /v1/search` result of type `page`, invoking `onPage` per
+   * live page. `onPage` returns `"stop"` to end pagination (the incremental
+   * walk-until-older). Archived/trashed pages are skipped.
+   */
+  private async searchPages(opts: {
+    readonly direction: "ascending" | "descending";
+    readonly onPage: (ref: NotionPageRef) => "continue" | "stop";
+  }): Promise<void> {
+    let cursor: string | null = null;
+    for (;;) {
+      const body: Record<string, unknown> = {
+        filter: { property: "object", value: "page" },
+        sort: { direction: opts.direction, timestamp: "last_edited_time" },
+        page_size: 100,
+        ...(cursor !== null ? { start_cursor: cursor } : {}),
+      };
+      const res = asRecord(await this.http.post("/search", body));
+      const results = asArray(res?.results);
+      for (const raw of results) {
+        const obj = asRecord(raw);
+        if (obj === null || obj.object !== "page" || isArchived(obj)) continue;
+        const id = asString(obj.id);
+        if (id === "") continue;
+        const ref: NotionPageRef = {
+          id,
+          title: extractTitle(obj.properties),
+          lastEditedTime: asString(obj.last_edited_time),
+          url: pageUrl(obj, id),
+        };
+        if (opts.onPage(ref) === "stop") return;
+      }
+      if (res?.has_more !== true) return;
+      const next = asString(res.next_cursor);
+      if (next === "") return;
+      cursor = next;
+    }
+  }
+
+  /**
+   * Search for data sources and enqueue each of their pages as a root — search
+   * for `object: "page"` does not surface database rows, so a shared database's
+   * pages arrive here (and via `child_database` descent).
+   */
+  private async enumerateDataSources(
+    addRef: (ref: NotionPageRef) => void,
+    roots: string[],
+  ): Promise<void> {
+    let cursor: string | null = null;
+    for (;;) {
+      const body: Record<string, unknown> = {
+        filter: { property: "object", value: "data_source" },
+        page_size: 100,
+        ...(cursor !== null ? { start_cursor: cursor } : {}),
+      };
+      const res = asRecord(await this.http.post("/search", body));
+      for (const raw of asArray(res?.results)) {
+        const ds = asRecord(raw);
+        const dsId = asString(ds?.id);
+        if (dsId !== "") await this.queryDataSourcePages(dsId, addRef, roots);
+      }
+      if (res?.has_more !== true) return;
+      const next = asString(res.next_cursor);
+      if (next === "") return;
+      cursor = next;
+    }
+  }
+
+  /** Query every page in one data source, enqueueing each as a root to descend. */
+  private async queryDataSourcePages(
+    dataSourceId: string,
+    addRef: (ref: NotionPageRef) => void,
+    roots: string[],
+  ): Promise<void> {
+    let cursor: string | null = null;
+    for (;;) {
+      const body: Record<string, unknown> = {
+        page_size: 100,
+        ...(cursor !== null ? { start_cursor: cursor } : {}),
+      };
+      const res = asRecord(await this.http.post(`/data_sources/${dataSourceId}/query`, body));
+      for (const raw of asArray(res?.results)) {
+        const obj = asRecord(raw);
+        if (obj === null || obj.object !== "page" || isArchived(obj)) continue;
+        const id = asString(obj.id);
+        if (id === "") continue;
+        addRef({
+          id,
+          title: extractTitle(obj.properties),
+          lastEditedTime: asString(obj.last_edited_time),
+          url: pageUrl(obj, id),
+        });
+        roots.push(id);
+      }
+      if (res?.has_more !== true) return;
+      const next = asString(res.next_cursor);
+      if (next === "") return;
+      cursor = next;
+    }
+  }
+
+  /**
+   * Recursively descend the block tree of each root, collecting nested
+   * `child_page` (→ a page, recurse) and `child_database` (→ query its pages).
+   * A visited set keeps a cyclic/shared tree from looping; container blocks
+   * (`has_children`) are traversed so a subpage nested inside a toggle/column is
+   * still found.
+   */
+  private async descend(
+    roots: readonly string[],
+    addRef: (ref: NotionPageRef) => void,
+  ): Promise<void> {
+    const visited = new Set<string>();
+    const queue = [...roots];
+    while (queue.length > 0) {
+      const pageId = queue.shift()!;
+      if (visited.has(pageId)) continue;
+      visited.add(pageId);
+      await this.walkBlocks(pageId, addRef, queue, 0);
+    }
+  }
+
+  /** Walk one block subtree, collecting subpages/databases. */
+  private async walkBlocks(
+    blockId: string,
+    addRef: (ref: NotionPageRef) => void,
+    pageQueue: string[],
+    depth: number,
+  ): Promise<void> {
+    let cursor: string | null = null;
+    for (;;) {
+      const path =
+        `/blocks/${blockId}/children?page_size=100` +
+        (cursor !== null ? `&start_cursor=${encodeURIComponent(cursor)}` : "");
+      const res = asRecord(await this.http.get(path));
+      for (const raw of asArray(res?.results)) {
+        const block = asRecord(raw);
+        if (block === null) continue;
+        const type = asString(block.type);
+        const id = asString(block.id);
+        if (type === "child_page" && id !== "") {
+          const child = asRecord(block.child_page);
+          addRef({
+            id,
+            title: asString(child?.title),
+            lastEditedTime: asString(block.last_edited_time),
+            url: `https://www.notion.so/${compactPageId(id)}`,
+          });
+          // Enqueue unconditionally — the `descend` visited-set dedupes; a page
+          // already in `refs` may still have un-walked subpages of its own.
+          pageQueue.push(id);
+        } else if (type === "child_database" && id !== "") {
+          await this.enumerateDatabaseBlock(id, addRef, pageQueue);
+        } else if (block.has_children === true && id !== "" && depth < MAX_BLOCK_WALK_DEPTH) {
+          // A container block (toggle, column, callout, …) may hold a subpage —
+          // recurse into it, bounded by depth.
+          await this.walkBlocks(id, addRef, pageQueue, depth + 1);
+        }
+      }
+      if (res?.has_more !== true) return;
+      const next = asString(res.next_cursor);
+      if (next === "") return;
+      cursor = next;
+    }
+  }
+
+  /** Resolve a `child_database` block to its data sources and enqueue their pages. */
+  private async enumerateDatabaseBlock(
+    databaseId: string,
+    addRef: (ref: NotionPageRef) => void,
+    pageQueue: string[],
+  ): Promise<void> {
+    const db = asRecord(await this.http.get(`/databases/${databaseId}`));
+    const dataSources = asArray(db?.data_sources);
+    if (dataSources.length === 0) return;
+    for (const raw of dataSources) {
+      const dsId = asString(asRecord(raw)?.id);
+      if (dsId !== "") await this.queryDataSourcePages(dsId, addRef, pageQueue);
+    }
+  }
+
+  // ── Content ──────────────────────────────────────────────────────────────
+
+  /** Fetch + normalize content for each ref into a `ConnectorDocument`. */
+  private async buildDocuments(refs: readonly NotionPageRef[]): Promise<ConnectorDocument[]> {
+    const documents: ConnectorDocument[] = [];
+    let truncatedCount = 0;
+    let fallbackCount = 0;
+    for (const ref of refs) {
+      const content = await this.fetchContent(ref.id);
+      if (content.truncated) truncatedCount++;
+      if (content.usedFallback) fallbackCount++;
+      const page: NotionPageDocument = {
+        id: ref.id,
+        title: ref.title,
+        lastEditedTime: ref.lastEditedTime,
+        url: ref.url,
+        body: normalizeNotionMarkdown(content.markdown, { pageUrl: ref.url }),
+      };
+      documents.push(buildNotionConnectorDocument(page));
+    }
+    if (truncatedCount > 0 || fallbackCount > 0) {
+      // Counted, never silent (AC): a page that needed continuation or the
+      // block-walk fallback is reported so an operator can see coverage gaps.
+      log.info(
+        { pages: refs.length, truncatedCompleted: truncatedCount, blockWalkFallback: fallbackCount },
+        "Notion content fetch used truncation continuation / block-walk fallback",
+      );
+    }
+    return documents;
+  }
+
+  /**
+   * One page's markdown via the official endpoint, completing a `truncated`
+   * page by re-fetching its `unknown_block_ids` as page ids. If the endpoint
+   * cannot serve the page at all, fall back to a block-walk render.
+   */
+  private async fetchContent(
+    pageId: string,
+  ): Promise<{ markdown: string; truncated: boolean; usedFallback: boolean }> {
+    let root: Record<string, unknown> | null;
+    try {
+      root = asRecord(await this.http.get(`/pages/${pageId}/markdown`));
+    } catch (err) {
+      // A 429 must propagate to the engine's backoff — re-throw it untouched.
+      if (err instanceof ConnectorRateLimitError) throw err;
+      log.warn(
+        { pageId, err: err instanceof Error ? err.message : String(err) },
+        "Notion page-markdown endpoint failed — falling back to block-walk",
+      );
+      return { markdown: await this.blockWalkMarkdown(pageId, 0), truncated: false, usedFallback: true };
+    }
+
+    const parts = [asString(root?.markdown)];
+    let truncated = root?.truncated === true;
+    const seen = new Set<string>([pageId]);
+    let queue = uniqueStrings(root?.unknown_block_ids).filter((id) => !seen.has(id));
+    let continuations = 0;
+
+    while (truncated && queue.length > 0 && continuations < MAX_TRUNCATION_CONTINUATIONS) {
+      const blockId = queue.shift()!;
+      if (seen.has(blockId)) continue;
+      seen.add(blockId);
+      continuations++;
+      try {
+        const sub = asRecord(await this.http.get(`/pages/${blockId}/markdown`));
+        parts.push(asString(sub?.markdown));
+        const more = uniqueStrings(sub?.unknown_block_ids).filter((id) => !seen.has(id));
+        queue = [...queue, ...more];
+        // A subtree that itself reports not-truncated has been fully retrieved;
+        // `truncated` stays true only while some subtree remains unresolved.
+        if (queue.length === 0 && sub?.truncated !== true) truncated = false;
+      } catch (err) {
+        if (err instanceof ConnectorRateLimitError) throw err;
+        // A subtree we cannot fetch stays a gap — logged via the fallback count.
+        log.warn(
+          { pageId, blockId, err: err instanceof Error ? err.message : String(err) },
+          "Notion truncation continuation sub-fetch failed — leaving the subtree out",
+        );
+      }
+    }
+    return { markdown: parts.join("\n\n"), truncated, usedFallback: false };
+  }
+
+  /**
+   * Minimal block-walk render — the fallback when the markdown endpoint can't
+   * serve a page. Extracts prose from the common text block types; text-first,
+   * so non-text blocks degrade to a note rather than being mirrored.
+   */
+  private async blockWalkMarkdown(blockId: string, depth: number): Promise<string> {
+    if (depth > MAX_BLOCK_WALK_DEPTH) return "";
+    const out: string[] = [];
+    let cursor: string | null = null;
+    for (;;) {
+      const path =
+        `/blocks/${blockId}/children?page_size=100` +
+        (cursor !== null ? `&start_cursor=${encodeURIComponent(cursor)}` : "");
+      const res = asRecord(await this.http.get(path));
+      for (const raw of asArray(res?.results)) {
+        const block = asRecord(raw);
+        if (block === null) continue;
+        const rendered = renderBlock(block);
+        if (rendered !== null) out.push(rendered);
+        if (block.has_children === true && asString(block.type) !== "child_page") {
+          const nested = await this.blockWalkMarkdown(asString(block.id), depth + 1);
+          if (nested.trim() !== "") out.push(indent(nested));
+        }
+      }
+      if (res?.has_more !== true) break;
+      const next = asString(res.next_cursor);
+      if (next === "") break;
+      cursor = next;
+    }
+    return out.join("\n\n");
+  }
+}
+
+/** Dedup + string-narrow an unknown array (the `unknown_block_ids` field). */
+function uniqueStrings(value: unknown): string[] {
+  const seen = new Set<string>();
+  for (const item of asArray(value)) {
+    const s = asString(item);
+    if (s !== "") seen.add(s);
+  }
+  return [...seen];
+}
+
+/** Plain text of a block's `rich_text` array. */
+function richText(value: unknown): string {
+  return asArray(value)
+    .map((rt) => asString(asRecord(rt)?.plain_text))
+    .join("");
+}
+
+/** Render one block to markdown, or null when it carries no prose. */
+function renderBlock(block: Record<string, unknown>): string | null {
+  const type = asString(block.type);
+  const data = asRecord(block[type]);
+  if (data === null) return null;
+  const text = richText(data.rich_text);
+  switch (type) {
+    case "paragraph":
+      return text === "" ? null : text;
+    case "heading_1":
+      return `# ${text}`;
+    case "heading_2":
+      return `## ${text}`;
+    case "heading_3":
+      return `### ${text}`;
+    case "bulleted_list_item":
+      return `- ${text}`;
+    case "numbered_list_item":
+      return `1. ${text}`;
+    case "to_do":
+      return `- [${data.checked === true ? "x" : " "}] ${text}`;
+    case "quote":
+      return `> ${text}`;
+    case "callout":
+      return `> ${text}`;
+    case "code":
+      return `\`\`\`${asString(data.language)}\n${text}\n\`\`\``;
+    default:
+      return text === "" ? null : text;
+  }
+}
+
+/** Indent a nested block-walk render one list level. */
+function indent(block: string): string {
+  return block
+    .split("\n")
+    .map((line) => (line === "" ? line : `  ${line}`))
+    .join("\n");
+}

--- a/packages/api/src/lib/knowledge/notion/client.ts
+++ b/packages/api/src/lib/knowledge/notion/client.ts
@@ -483,10 +483,21 @@ export class NotionVendorClient implements ConnectorVendorClient {
       return { markdown: await this.blockWalkMarkdown(pageId, 0), truncated: false, usedFallback: true };
     }
 
-    const parts = [asString(root?.markdown)];
-    let truncated = root?.truncated === true;
+    // A 2xx body that isn't an object (contract violation) would otherwise
+    // narrow to an empty, uncounted body — treat it as an endpoint failure and
+    // fall back to the block-walk (counted), never a silently blank page.
+    if (root === null) {
+      log.warn(
+        { pageId },
+        "Notion page-markdown endpoint returned a non-object body — falling back to block-walk",
+      );
+      return { markdown: await this.blockWalkMarkdown(pageId, 0), truncated: false, usedFallback: true };
+    }
+
+    const parts = [asString(root.markdown)];
+    let truncated = root.truncated === true;
     const seen = new Set<string>([pageId]);
-    let queue = uniqueStrings(root?.unknown_block_ids).filter((id) => !seen.has(id));
+    let queue = uniqueStrings(root.unknown_block_ids).filter((id) => !seen.has(id));
     let continuations = 0;
 
     while (truncated && queue.length > 0 && continuations < MAX_TRUNCATION_CONTINUATIONS) {

--- a/packages/api/src/lib/knowledge/notion/connector.ts
+++ b/packages/api/src/lib/knowledge/notion/connector.ts
@@ -1,0 +1,67 @@
+/**
+ * The Notion Knowledge Sync Connector registration (#4378, ADR-0030) — binds
+ * the `catalog:notion-knowledge` catalog row to the {@link NotionVendorClient}
+ * the shared engine drives. The engine (`connector-sync.ts`) owns everything
+ * else; this file is only the catalog↔client seam plus the vendor's identity
+ * constants (the one home the install handler, catalog seed, and admin route
+ * all import).
+ *
+ * `createClient` reads the workspace's internal-integration token from the
+ * shared `knowledge_sync_credentials` store (the bundle-sync credential seam,
+ * reused per PRD #4375) and constructs a version-pinned HTTP client. A missing
+ * or undecryptable credential throws with an actionable message — the engine
+ * surfaces it on `/admin/knowledge` as that collection's error, never a silent
+ * unauthenticated fetch.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { NotionHttpClient } from "./http";
+import { NotionVendorClient } from "./client";
+
+const log = createLogger("knowledge.notion.connector");
+
+/** The plugin_catalog slug (distinct from the `notion-data` REST datasource). */
+export const NOTION_KNOWLEDGE_SLUG = "notion-knowledge";
+/** The catalog row id = the cycle-walk dispatch key. */
+export const NOTION_KNOWLEDGE_CATALOG_ID = "catalog:notion-knowledge";
+/** The vendor slug stamped into `atlas_source` as `connector:notion`. */
+export const NOTION_VENDOR = "notion";
+
+/** Build the vendor client for one installed Notion collection. */
+async function createNotionClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+  // Throws on decrypt failure (rotated key / corrupt ciphertext) — the sync
+  // must fail loudly, never fetch unauthenticated (a 401 would mask the cause).
+  const token = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+  if (token === null || token.trim() === "") {
+    throw new Error(
+      "This Notion collection has no integration token stored — re-install it with a valid internal-integration token (Admin → Integrations → Notion).",
+    );
+  }
+  return new NotionVendorClient({ http: new NotionHttpClient({ token }) });
+}
+
+/** The registered connector for the built-in Notion knowledge catalog row. */
+export const notionKnowledgeConnector: KnowledgeSyncConnector = {
+  catalogId: NOTION_KNOWLEDGE_CATALOG_ID,
+  vendor: NOTION_VENDOR,
+  createClient: createNotionClient,
+};
+
+/**
+ * Register the Notion connector idempotently — safe to call from the boot seam
+ * that also registers install handlers (and from tests). `registerKnowledge...`
+ * throws on a duplicate catalog id, so gate on the registry first.
+ */
+export function registerNotionKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(notionKnowledgeConnector);
+  log.info({ catalogId: NOTION_KNOWLEDGE_CATALOG_ID }, "Registered Notion knowledge sync connector");
+}

--- a/packages/api/src/lib/knowledge/notion/document.ts
+++ b/packages/api/src/lib/knowledge/notion/document.ts
@@ -1,0 +1,108 @@
+/**
+ * Build the OKF `ConnectorDocument` (path + full markdown) for one Notion page
+ * (#4378). PURE — the vendor client fetches + normalizes; this shapes the
+ * result the ingest seam stores.
+ *
+ * PATH — `<title-slug>-<compact-page-id>.md`, flat. Requirements the
+ * `ConnectorDocument` contract places on it: deterministic per vendor page (the
+ * upsert-by-path diff and the reconciliation subtractive archive both key on
+ * it) and collision-free. Notion page titles are non-unique and its search is
+ * non-exhaustive, so a purely title-derived path would (a) collide between two
+ * same-titled pages and (b) differ between an incremental subset and a full
+ * reconciliation if it encoded ancestry. Appending the page's own stable id
+ * makes the path a pure function of the page ALONE — collision-free and
+ * batch-independent — while the leading title slug keeps it readable in the
+ * agent's explore mirror. A title edit reads as archive-old + fresh-draft, the
+ * same documented rename posture as bundle-sync. (Full ancestry-mirroring paths
+ * are a deferred follow-up: Notion's partial-sharing model makes a page's
+ * ancestor chain resolvable only with extra, sometimes-forbidden reads.)
+ *
+ * PROVENANCE — the frontmatter carries `atlas:` (connector, page id,
+ * last_edited_time), plus top-level `resource` (the stable page URL) and
+ * `timestamp` (last_edited_time). The lenient ingest parser strips ALL
+ * frontmatter into columns/discard before the change comparison, which runs on
+ * the BODY + mirrored fields only — so provenance never causes re-review churn,
+ * and a page re-fetched unchanged no-ops in the upsert. Sync time lives in the
+ * `atlas_ingested_at` column the ingest stamps, deliberately NOT in the body,
+ * so content stays a pure function of the page version.
+ */
+
+import type { ConnectorDocument } from "../connectors";
+
+/** The vendor-neutral projection of a Notion page the document layer consumes. */
+export interface NotionPageDocument {
+  /** Notion page id (dashed UUID). */
+  readonly id: string;
+  /** Plain-text page title (may be empty for an untitled page). */
+  readonly title: string;
+  /** ISO-8601 `last_edited_time` from the page object. */
+  readonly lastEditedTime: string;
+  /** The page's stable Notion URL (from the page object's `url`). */
+  readonly url: string;
+  /** The normalized (plain) markdown body. */
+  readonly body: string;
+}
+
+const SLUG_MAX = 80;
+
+/** Compact a Notion id (dashed UUID) to bare lowercase hex — the path token. */
+export function compactPageId(id: string): string {
+  return id.replace(/-/g, "").toLowerCase();
+}
+
+/**
+ * Slugify a title to `[a-z0-9-]`, collapsed and trimmed, capped at
+ * {@link SLUG_MAX}. Empty / punctuation-only titles fall back to `untitled` so
+ * the path is never just the id token.
+ */
+export function slugifyTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, SLUG_MAX)
+    .replace(/-+$/g, "");
+  return slug === "" ? "untitled" : slug;
+}
+
+/** The deterministic, collision-free archive path for a page. */
+export function notionArchivePath(id: string, title: string): string {
+  return `${slugifyTitle(title)}-${compactPageId(id)}.md`;
+}
+
+/** Encode a YAML double-quoted scalar (JSON strings are valid YAML scalars). */
+function yamlScalar(value: string): string {
+  return JSON.stringify(value);
+}
+
+/**
+ * Render the full OKF document for a page: conformant frontmatter (with `atlas:`
+ * provenance) + the normalized body. String scalars are JSON-encoded so a
+ * title/URL containing a colon or quote can't break the YAML.
+ */
+export function renderNotionOkfDocument(page: NotionPageDocument): string {
+  const lines = [
+    "---",
+    "type: Document",
+    ...(page.title.trim() !== "" ? [`title: ${yamlScalar(page.title.trim())}`] : []),
+    `resource: ${yamlScalar(page.url)}`,
+    `timestamp: ${yamlScalar(page.lastEditedTime)}`,
+    "atlas:",
+    "  connector: notion",
+    `  page_id: ${yamlScalar(page.id)}`,
+    `  last_edited_time: ${yamlScalar(page.lastEditedTime)}`,
+    "---",
+    "",
+    page.body.trimEnd(),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+/** Assemble the `ConnectorDocument` (path + content) for one page. */
+export function buildNotionConnectorDocument(page: NotionPageDocument): ConnectorDocument {
+  return {
+    path: notionArchivePath(page.id, page.title),
+    content: renderNotionOkfDocument(page),
+  };
+}

--- a/packages/api/src/lib/knowledge/notion/http.ts
+++ b/packages/api/src/lib/knowledge/notion/http.ts
@@ -1,0 +1,205 @@
+/**
+ * The Notion REST seam for the Knowledge Sync Connector (#4378, PRD #4375,
+ * ADR-0030). One thin client owns every cross-cutting concern the connector's
+ * enumeration + content fetch must not re-remember per call:
+ *
+ *   1. AUTH + VERSION HEADERS — a `Bearer` internal-integration token and a
+ *      DELIBERATELY PINNED `Notion-Version`. The 2025-09-03 release split
+ *      databases into data sources and bifurcated older code paths; the page
+ *      markdown endpoint (Feb 2026) requires `2026-03-11`, which post-dates the
+ *      split — so pinning one version keeps search, block descent, and the
+ *      markdown endpoint on the same side of the fork. The value is recorded in
+ *      {@link NOTION_API_VERSION} and asserted by the client's tests (AC:
+ *      "`Notion-Version` header pinned and recorded").
+ *   2. THROTTLE — Notion documents ~3 requests/second per token. A connector
+ *      that enumerates a large workspace makes many sub-requests, so the client
+ *      spaces request STARTS by {@link NOTION_MIN_REQUEST_INTERVAL_MS}; the
+ *      engine's own 429 backoff is the safety net, not the primary limiter.
+ *   3. 429 → {@link ConnectorRateLimitError} — the ONE exception the engine's
+ *      bounded backoff retries. A 429 carries Notion's `Retry-After` (integer
+ *      seconds); every other non-2xx is a plain, actionable error.
+ *   4. REDACTION — errors never carry the token. Notion's own error envelope
+ *      (`{ code, message }`) is safe to surface (it names the misconfig, e.g.
+ *      `unauthorized`, `restricted_resource`) and is; the `Authorization`
+ *      header never is. The base host is a fixed Notion constant, not a
+ *      customer-supplied URL, so there is no SSRF surface here (unlike
+ *      bundle-sync's endpoint) — plain `fetch`, no egress guard.
+ *
+ * `fetch`, the clock, and the sleep are all injected so the vendor client is
+ * fully test-doubled: no test reaches the network (AC: "no test calls Notion").
+ */
+
+import { ConnectorRateLimitError } from "../connectors";
+
+/**
+ * The pinned Notion API version. `2026-03-11` is the first version carrying the
+ * page-markdown endpoint; it post-dates the 2025-09-03 data-source split, so
+ * search (`filter.value: "data_source"`), block descent, and the markdown
+ * endpoint all speak the same dialect under it. Bump deliberately — a version
+ * change can reshape search filters and the database/data-source model.
+ */
+export const NOTION_API_VERSION = "2026-03-11";
+
+/** The Notion REST base — a fixed vendor host, never customer-supplied. */
+export const NOTION_API_BASE = "https://api.notion.com/v1";
+
+/**
+ * Minimum spacing between request starts: Notion allows ~3 req/s per token, so
+ * one request every ~334 ms keeps a full-workspace crawl under the average
+ * without leaning on the engine's 429 backoff for routine pacing.
+ */
+export const NOTION_MIN_REQUEST_INTERVAL_MS = Math.ceil(1000 / 3);
+
+/** Cap a pathological `Retry-After` echoed into the error (the engine also caps its wait). */
+const RETRY_AFTER_MAX_SECONDS = 3600;
+
+type FetchImpl = typeof globalThis.fetch;
+type Now = () => number;
+type Sleep = (ms: number) => Promise<void>;
+
+export interface NotionHttpClientOptions {
+  /** The workspace's internal-integration token (decrypted). Never logged. */
+  readonly token: string;
+  /** Injected for tests; defaults to the global fetch. */
+  readonly fetchImpl?: FetchImpl;
+  /** Injected monotonic clock (ms) for the throttle; defaults to `Date.now`. */
+  readonly now?: Now;
+  /** Injected sleep for the throttle; defaults to a real timer. */
+  readonly sleep?: Sleep;
+}
+
+/** A Notion error envelope — safe to surface (names the misconfig, no secrets). */
+interface NotionErrorBody {
+  readonly object?: string;
+  readonly status?: number;
+  readonly code?: string;
+  readonly message?: string;
+}
+
+/**
+ * A minimal Notion REST client: throttled, version-pinned, 429-aware, and
+ * token-redacting. `get`/`post` return the parsed JSON as `unknown` — the
+ * enumeration/content layers narrow it at their read sites (the one place that
+ * knows the shape it asked for).
+ */
+export class NotionHttpClient {
+  private readonly token: string;
+  private readonly fetchImpl: FetchImpl;
+  private readonly now: Now;
+  private readonly sleep: Sleep;
+  /** Start time (ms) of the most recent request — the throttle's only state. */
+  private lastRequestStartedAt: number | null = null;
+
+  constructor(options: NotionHttpClientOptions) {
+    if (options.token.trim() === "") {
+      // A blank token would 401 on the first call with a confusing "unauthorized"
+      // — fail here with the actionable cause instead.
+      throw new Error("NotionHttpClient requires a non-empty integration token");
+    }
+    this.token = options.token;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.now = options.now ?? (() => Date.now());
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  /** GET a Notion resource path (relative to {@link NOTION_API_BASE}). */
+  async get(path: string): Promise<unknown> {
+    return this.request("GET", path, undefined);
+  }
+
+  /** POST a JSON body to a Notion resource path. */
+  async post(path: string, body: Record<string, unknown>): Promise<unknown> {
+    return this.request("POST", path, body);
+  }
+
+  private async request(
+    method: "GET" | "POST",
+    path: string,
+    body: Record<string, unknown> | undefined,
+  ): Promise<unknown> {
+    await this.throttle();
+    const url = `${NOTION_API_BASE}${path}`;
+    let res: Response;
+    try {
+      res = await this.fetchImpl(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Notion-Version": NOTION_API_VERSION,
+          ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    } catch (err) {
+      // Network / DNS / abort — a transport failure, not a vendor rejection.
+      // The path (not the token) is safe context.
+      throw new Error(
+        `Notion API ${method} ${path} could not be reached: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (res.status === 429) {
+      throw new ConnectorRateLimitError(
+        "Notion is rate limiting this integration token (HTTP 429).",
+        parseRetryAfter(res.headers.get("Retry-After")),
+      );
+    }
+
+    if (!res.ok) {
+      const detail = await this.readErrorDetail(res);
+      throw new Error(`Notion API ${method} ${path} failed (HTTP ${res.status})${detail}`);
+    }
+
+    try {
+      return (await res.json()) as unknown;
+    } catch (err) {
+      throw new Error(
+        `Notion API ${method} ${path} returned a non-JSON body: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Space request starts by {@link NOTION_MIN_REQUEST_INTERVAL_MS}. Records the
+   * start time AFTER sleeping so back-to-back calls stay one interval apart even
+   * under the injected clock (which tests advance deterministically).
+   */
+  private async throttle(): Promise<void> {
+    const last = this.lastRequestStartedAt;
+    if (last !== null) {
+      const elapsed = this.now() - last;
+      const wait = NOTION_MIN_REQUEST_INTERVAL_MS - elapsed;
+      if (wait > 0) await this.sleep(wait);
+    }
+    this.lastRequestStartedAt = this.now();
+  }
+
+  /** Read Notion's error envelope for an actionable, secret-free suffix. */
+  private async readErrorDetail(res: Response): Promise<string> {
+    try {
+      const parsed = (await res.json()) as NotionErrorBody;
+      const code = typeof parsed.code === "string" ? parsed.code : null;
+      const message = typeof parsed.message === "string" ? parsed.message : null;
+      if (code && message) return `: ${code} — ${message}`;
+      if (code) return `: ${code}`;
+      if (message) return `: ${message}`;
+      return "";
+    } catch {
+      // A non-JSON error body (proxy HTML, empty) carries no safe detail worth
+      // surfacing — the status code above is the signal.
+      return "";
+    }
+  }
+}
+
+/**
+ * Parse a `Retry-After` header (integer seconds per Notion's docs) into a
+ * bounded number, or null when absent/unparseable (the engine then picks its
+ * default wait). A negative / pathological value clamps rather than wedging.
+ */
+function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return Math.min(seconds, RETRY_AFTER_MAX_SECONDS);
+}

--- a/packages/api/src/lib/knowledge/notion/http.ts
+++ b/packages/api/src/lib/knowledge/notion/http.ts
@@ -133,9 +133,10 @@ export class NotionHttpClient {
       });
     } catch (err) {
       // Network / DNS / abort — a transport failure, not a vendor rejection.
-      // The path (not the token) is safe context.
+      // The path (not the token) is safe context; `cause` preserves the original.
       throw new Error(
         `Notion API ${method} ${path} could not be reached: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
     }
 
@@ -156,6 +157,7 @@ export class NotionHttpClient {
     } catch (err) {
       throw new Error(
         `Notion API ${method} ${path} returned a non-JSON body: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
     }
   }

--- a/packages/api/src/lib/knowledge/notion/http.ts
+++ b/packages/api/src/lib/knowledge/notion/http.ts
@@ -62,7 +62,8 @@ export interface NotionHttpClientOptions {
   readonly token: string;
   /** Injected for tests; defaults to the global fetch. */
   readonly fetchImpl?: FetchImpl;
-  /** Injected monotonic clock (ms) for the throttle; defaults to `Date.now`. */
+  /** Injected clock (ms) for the throttle; defaults to `Date.now`. Only the
+   *  elapsed-since-last-request delta is used, so a wall clock is fine. */
   readonly now?: Now;
   /** Injected sleep for the throttle; defaults to a real timer. */
   readonly sleep?: Sleep;
@@ -177,16 +178,22 @@ export class NotionHttpClient {
   /** Read Notion's error envelope for an actionable, secret-free suffix. */
   private async readErrorDetail(res: Response): Promise<string> {
     try {
-      const parsed = (await res.json()) as NotionErrorBody;
-      const code = typeof parsed.code === "string" ? parsed.code : null;
-      const message = typeof parsed.message === "string" ? parsed.message : null;
+      // `res.json()` is `any` and a vendor error body could be a primitive /
+      // array / null — narrow to an object before reading fields.
+      const parsed: unknown = await res.json();
+      const body: NotionErrorBody =
+        typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+          ? (parsed as NotionErrorBody)
+          : {};
+      const code = typeof body.code === "string" ? body.code : null;
+      const message = typeof body.message === "string" ? body.message : null;
       if (code && message) return `: ${code} — ${message}`;
       if (code) return `: ${code}`;
       if (message) return `: ${message}`;
       return "";
     } catch {
-      // A non-JSON error body (proxy HTML, empty) carries no safe detail worth
-      // surfacing — the status code above is the signal.
+      // intentionally ignored: a non-JSON error body (proxy HTML, empty) carries
+      // no safe detail worth surfacing — the status code above is the signal.
       return "";
     }
   }

--- a/packages/api/src/lib/knowledge/notion/markdown.ts
+++ b/packages/api/src/lib/knowledge/notion/markdown.ts
@@ -1,0 +1,197 @@
+/**
+ * Normalize Notion "enhanced Markdown" (the page-markdown endpoint's output)
+ * into the plain Markdown the KB ingest stores (#4378). A PURE function —
+ * golden-fixture tested (AC: "Markdown endpoint output normalized to plain
+ * markdown (goldens)").
+ *
+ * Three enhanced constructs are downgraded; everything else passes through
+ * untouched (real fenced code, standard headings/lists/links):
+ *
+ *   1. CALLOUT FENCES — an enhanced ```` ```callout ```` block becomes a
+ *      Markdown blockquote, so the note reads as prose, not a code listing.
+ *   2. COLUMN TAGS — `<columns>` / `<column>` layout wrappers are dropped and
+ *      their contents concatenated top-to-bottom (a linear document has no
+ *      columns); a blank line separates what were side-by-side columns.
+ *   3. DETAILS / SUMMARY (toggles) — `<details>` wrappers are dropped and the
+ *      `<summary>` becomes a bold lead line, so the toggle's hidden body is
+ *      always present in the ingested text (an agent can't expand a toggle).
+ *
+ * Separately, EXPIRING MEDIA URLs are replaced with a link to the vendor page
+ * (AC: "expiring media URLs never persist into documents"). Notion serves
+ * images/files from short-lived pre-signed S3 URLs; persisting one guarantees a
+ * dead link within the hour, so `![alt](signed-url)` and `[text](signed-url)`
+ * collapse to a "view in Notion" link at the page's stable URL. Text-first v1:
+ * the media itself is not mirrored.
+ */
+
+/** Everything the normalizer needs about the page beyond its markdown. */
+export interface NotionMarkdownContext {
+  /** The page's stable Notion URL — the replacement target for expiring media. */
+  readonly pageUrl: string;
+}
+
+const FENCE = /^(\s*)(`{3,}|~{3,})\s*([^\s`~]*)/;
+
+/**
+ * Convert enhanced Markdown to plain Markdown. Line-oriented so a real code
+ * fence is never rewritten and the tag/callout transforms never reach inside
+ * one.
+ */
+export function normalizeNotionMarkdown(raw: string, ctx: NotionMarkdownContext): string {
+  const withCallouts = convertCalloutFences(raw);
+  const withoutLayoutTags = stripLayoutTags(withCallouts);
+  const withStableMedia = replaceExpiringMedia(withoutLayoutTags, ctx.pageUrl);
+  // Collapse 3+ blank lines the transforms can leave behind into the Markdown
+  // paragraph break (exactly one blank line).
+  return withStableMedia.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}
+
+/**
+ * Rewrite ```` ```callout ```` fenced blocks as blockquotes. A non-callout
+ * fence (real code) is copied verbatim, including its body — so callout/tag
+ * processing never corrupts a code sample that happens to contain `<column>` or
+ * a `> ` line.
+ */
+function convertCalloutFences(input: string): string {
+  const lines = input.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const match = line.match(FENCE);
+    if (match === null) {
+      out.push(line);
+      i++;
+      continue;
+    }
+    const marker = match[2];
+    const info = match[3];
+    // Find the matching closing fence (same marker char, ≥ same length).
+    const closeIdx = findFenceClose(lines, i + 1, marker[0], marker.length);
+    const bodyLines = lines.slice(i + 1, closeIdx === -1 ? lines.length : closeIdx);
+    if (info.toLowerCase() === "callout") {
+      // Blockquote each body line; an empty body line stays a bare `>` so the
+      // quote block doesn't break into two.
+      for (const body of bodyLines) {
+        out.push(body === "" ? ">" : `> ${body}`);
+      }
+    } else {
+      // A real fenced block — emit it unchanged (open, body, close).
+      out.push(line, ...bodyLines);
+      if (closeIdx !== -1) out.push(lines[closeIdx]);
+    }
+    i = closeIdx === -1 ? lines.length : closeIdx + 1;
+  }
+  return out.join("\n");
+}
+
+/** Index of the closing fence at/after `from`, or -1 if the block is unterminated. */
+function findFenceClose(lines: string[], from: number, char: string, minLen: number): number {
+  for (let i = from; i < lines.length; i++) {
+    const m = lines[i].match(FENCE);
+    if (m !== null && m[2][0] === char && m[2].length >= minLen && m[3] === "") return i;
+  }
+  return -1;
+}
+
+/**
+ * Drop Notion's layout tags and flatten their contents. `<columns>`/`<column>`
+ * become plain vertical flow; `<details>` is unwrapped and its `<summary>`
+ * becomes a bold lead line. Block-level tags (a line that is only the tag) are
+ * removed; an inline `<summary>…</summary>` on its own line is converted.
+ */
+function stripLayoutTags(input: string): string {
+  const out: string[] = [];
+  // Track code-fence state so a tag INSIDE a real code sample is never stripped.
+  let fence: { char: string; len: number } | null = null;
+  for (const line of input.split("\n")) {
+    const fenceMatch = line.match(FENCE);
+    if (fenceMatch !== null) {
+      const marker = fenceMatch[2];
+      if (fence === null) {
+        fence = { char: marker[0], len: marker.length };
+      } else if (marker[0] === fence.char && marker.length >= fence.len && fenceMatch[3] === "") {
+        fence = null;
+      }
+      out.push(line);
+      continue;
+    }
+    if (fence !== null) {
+      out.push(line);
+      continue;
+    }
+    const trimmed = line.trim();
+
+    // `<summary>Heading</summary>` → a bold lead line (the toggle's label).
+    const summary = trimmed.match(/^<summary>([\s\S]*?)<\/summary>$/i);
+    if (summary !== null) {
+      const label = summary[1].trim();
+      out.push(label === "" ? "" : `**${label}**`);
+      continue;
+    }
+
+    // Column boundary: a new column starts a new vertical section — one blank
+    // line so the previously side-by-side blocks don't run together.
+    if (/^<column(\s[^>]*)?>$/i.test(trimmed) || /^<\/column>$/i.test(trimmed)) {
+      if (out.length > 0 && out[out.length - 1] !== "") out.push("");
+      continue;
+    }
+
+    // Pure wrapper tags carry no content — drop them.
+    if (
+      /^<\/?columns(\s[^>]*)?>$/i.test(trimmed) ||
+      /^<\/?details(\s[^>]*)?>$/i.test(trimmed)
+    ) {
+      continue;
+    }
+
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/** Notion's short-lived file hosts — a URL served from one is expiring media. */
+function isExpiringMediaUrl(rawUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    // A relative or malformed target is not an expiring absolute media URL.
+    return false;
+  }
+  const host = url.hostname.toLowerCase();
+  // AWS pre-signed params are the surest signal, host-agnostic.
+  if (url.searchParams.has("X-Amz-Signature") || url.searchParams.has("X-Amz-Expires")) {
+    return true;
+  }
+  return (
+    host.endsWith(".amazonaws.com") ||
+    host === "file.notion.so" ||
+    host.includes("notion-static")
+  );
+}
+
+/**
+ * Replace image/link targets pointing at expiring Notion media with a link to
+ * the stable page. Runs over image syntax first (`![alt](url)`) then plain
+ * links (`[text](url)`); both regexes are single-pass with disjoint character
+ * classes (no nested quantifiers) so they stay linear on untrusted bodies.
+ */
+function replaceExpiringMedia(input: string, pageUrl: string): string {
+  const withImages = input.replace(
+    /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
+    (whole, alt: string, url: string) => {
+      if (!isExpiringMediaUrl(url)) return whole;
+      const label = alt.trim() === "" ? "image" : alt.trim();
+      return `[${label} — view in Notion](${pageUrl})`;
+    },
+  );
+  return withImages.replace(
+    /\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g,
+    (whole, text: string, url: string) => {
+      if (!isExpiringMediaUrl(url)) return whole;
+      const label = text.trim() === "" ? "view in Notion" : text.trim();
+      return `[${label}](${pageUrl})`;
+    },
+  );
+}

--- a/packages/api/src/lib/knowledge/notion/markdown.ts
+++ b/packages/api/src/lib/knowledge/notion/markdown.ts
@@ -156,7 +156,8 @@ function isExpiringMediaUrl(rawUrl: string): boolean {
   try {
     url = new URL(rawUrl);
   } catch {
-    // A relative or malformed target is not an expiring absolute media URL.
+    // intentionally ignored: a relative or malformed target is not an expiring
+    // absolute media URL — the parse failure IS the negative signal.
     return false;
   }
   const host = url.hostname.toLowerCase();

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -20,11 +20,20 @@ export interface KnowledgeDocumentCounts {
 }
 
 /**
- * How a collection's content arrives: `upload` (the `okf-upload` catalog row —
- * explicit admin bundle uploads) or `bundle-sync` (the #4211 catalog row — a
- * scheduled pull of a configured bundle endpoint).
+ * How a collection's content arrives:
+ *   - `upload` — the `okf-upload` catalog row (explicit admin bundle uploads);
+ *   - `bundle-sync` — the #4211 catalog row (a scheduled pull of a configured
+ *     bundle endpoint);
+ *   - `notion` — the #4378 Knowledge Sync Connector (a scheduled pull of a
+ *     Notion workspace via an internal-integration token).
+ *
+ * Every value except `upload` is a "synced" collection: its content is owned by
+ * an external source, it has last-sync bookkeeping, and it can be re-pulled with
+ * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
+ * `authScheme`; connector collections (`notion`) carry neither (their credential
+ * is a token, not an endpoint).
  */
-export type KnowledgeCollectionSource = "upload" | "bundle-sync";
+export type KnowledgeCollectionSource = "upload" | "bundle-sync" | "notion";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/app/admin/knowledge/create-collection-dialog.tsx
+++ b/packages/web/src/app/admin/knowledge/create-collection-dialog.tsx
@@ -39,6 +39,11 @@ import type { KnowledgeCollectionSource, KnowledgeSyncAuthScheme } from "@/ui/li
  *      server-side (never echoed back). Atlas pulls the endpoint on a schedule
  *      (daily by default, operator-tunable) and queues changes for review;
  *      "Sync now" runs a pull on demand.
+ *    - Notion (`notion-knowledge`, #4378): config carries only an optional
+ *      description; the internal-integration token is encrypted at rest
+ *      server-side (never echoed back). The pages the customer shares with the
+ *      integration ARE the scope — Atlas pulls them on the same schedule and
+ *      queues changes for review.
  *
  *  Edit mode (`edit` prop) re-drives the SAME install pipeline with the
  *  existing slug — the server upserts the container config in place and
@@ -88,6 +93,7 @@ export function CreateCollectionDialog({
   const [endpointUrl, setEndpointUrl] = useState("");
   const [authScheme, setAuthScheme] = useState<AuthScheme>("none");
   const [authSecret, setAuthSecret] = useState("");
+  const [integrationToken, setIntegrationToken] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -99,6 +105,7 @@ export function CreateCollectionDialog({
       setEndpointUrl(edit?.endpointUrl ?? "");
       setAuthScheme(edit?.authScheme ?? "none");
       setAuthSecret("");
+      setIntegrationToken("");
       setError(null);
     }
   }, [open, edit]);
@@ -108,8 +115,10 @@ export function CreateCollectionDialog({
   // Editing targets an existing slug by design; only creation rejects dupes.
   const isDuplicate = !isEdit && existingSlugs.includes(trimmedSlug);
   const isSync = source === "bundle-sync";
+  const isNotion = source === "notion";
   const endpointValid = !isSync || endpointUrl.trim().length > 0;
   const secretValid = !isSync || authScheme === "none" || authSecret.trim().length > 0;
+  const tokenValid = !isNotion || integrationToken.trim().length > 0;
 
   async function handleSubmit() {
     if (!slugValid) {
@@ -128,6 +137,10 @@ export function CreateCollectionDialog({
       setError("An auth secret is required for bearer/basic authentication.");
       return;
     }
+    if (isNotion && !tokenValid) {
+      setError("A Notion internal-integration token is required.");
+      return;
+    }
     setSaving(true);
     setError(null);
 
@@ -138,7 +151,10 @@ export function CreateCollectionDialog({
       body.auth_scheme = authScheme;
       if (authScheme !== "none") body.auth_secret = authSecret.trim();
     }
-    const catalogSlug = isSync ? "bundle-sync" : "okf-upload";
+    if (isNotion) {
+      body.integration_token = integrationToken.trim();
+    }
+    const catalogSlug = isSync ? "bundle-sync" : isNotion ? "notion-knowledge" : "okf-upload";
 
     try {
       const res = await fetch(`${getApiUrl()}/api/v1/integrations/${catalogSlug}/install-form`, {
@@ -187,13 +203,21 @@ export function CreateCollectionDialog({
 
         <div className="space-y-3">
           {!isEdit ? (
-            <Tabs value={source} onValueChange={(v) => setSource(v === "bundle-sync" ? "bundle-sync" : "upload")}>
-              <TabsList className="grid w-full grid-cols-2">
+            <Tabs
+              value={source}
+              onValueChange={(v) =>
+                setSource(v === "bundle-sync" ? "bundle-sync" : v === "notion" ? "notion" : "upload")
+              }
+            >
+              <TabsList className="grid w-full grid-cols-3">
                 <TabsTrigger value="upload" data-testid="source-upload">
                   Upload
                 </TabsTrigger>
                 <TabsTrigger value="bundle-sync" data-testid="source-bundle-sync">
-                  Sync from endpoint
+                  Endpoint
+                </TabsTrigger>
+                <TabsTrigger value="notion" data-testid="source-notion">
+                  Notion
                 </TabsTrigger>
               </TabsList>
             </Tabs>
@@ -278,6 +302,27 @@ export function CreateCollectionDialog({
             </>
           ) : null}
 
+          {isNotion ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="collection-notion-token">Internal-integration token</Label>
+              <Input
+                id="collection-notion-token"
+                type="password"
+                autoComplete="off"
+                placeholder="ntn_…"
+                value={integrationToken}
+                onChange={(e) => setIntegrationToken(e.target.value)}
+                data-testid="collection-notion-token"
+              />
+              <p className="text-xs text-muted-foreground">
+                Create an internal integration at notion.so/my-integrations, then{" "}
+                <strong>share the pages you want synced with it</strong> — only pages shared with the
+                integration sync. Share a parent page to include its whole subtree. Stored encrypted;
+                never shown again. Synced changes always land as drafts for review.
+              </p>
+            </div>
+          ) : null}
+
           <div className="space-y-1.5">
             <Label htmlFor="collection-description">Description (optional)</Label>
             <Textarea
@@ -298,7 +343,7 @@ export function CreateCollectionDialog({
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={saving || !slugValid || isDuplicate || !endpointValid || !secretValid}
+            disabled={saving || !slugValid || isDuplicate || !endpointValid || !secretValid || !tokenValid}
             data-testid="create-collection-submit"
           >
             {saving ? (

--- a/packages/web/src/app/admin/knowledge/page.tsx
+++ b/packages/web/src/app/admin/knowledge/page.tsx
@@ -200,9 +200,10 @@ export default function KnowledgePage() {
         onCreated={(slug, source) => {
           setCreateOpen(false);
           void refetch();
-          if (source === "bundle-sync") {
-            // Initial full ingest: kick the first pull right away rather than
-            // waiting for the scheduled sync (daily by default).
+          if (source !== "upload") {
+            // Initial full ingest for any synced source (endpoint or connector):
+            // kick the first pull right away rather than waiting for the
+            // scheduled sync (daily by default).
             void handleSyncNow(slug);
           } else {
             setUploadTarget(slug);
@@ -260,8 +261,8 @@ export default function KnowledgePage() {
               {uninstallTarget
                 ? describeArchive(uninstallTarget)
                 : ""}{" "}
-              {uninstallTarget?.source === "bundle-sync"
-                ? "Documents are archived, never deleted — but re-installing this synced collection pulls its endpoint again, which restores them as drafts for re-review."
+              {uninstallTarget && uninstallTarget.source !== "upload"
+                ? "Documents are archived, never deleted — but re-installing this synced collection pulls its source again, which restores them as drafts for re-review."
                 : "Documents are archived, never deleted — re-installing alone does not resurrect them; only re-uploading a bundle with the same paths brings them back, as drafts."}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -305,7 +306,9 @@ export function describeArchive(collection: KnowledgeCollection): string {
  * attempt, else the last attempt's outcome. Exported for tests.
  */
 export function describeSync(collection: KnowledgeCollection): "synced" | "sync-failed" | "never-synced" | null {
-  if (collection.source !== "bundle-sync") return null;
+  // Every non-upload source is synced (endpoint or connector) and carries
+  // last-sync bookkeeping; only upload collections have no sync footer.
+  if (collection.source === "upload") return null;
   if (!collection.sync) return "never-synced";
   return collection.sync.status === "success" ? "synced" : "sync-failed";
 }
@@ -328,7 +331,11 @@ function CollectionCard({
   onUninstall: () => void;
 }) {
   const { draft, published } = collection.documents;
-  const isSynced = collection.source === "bundle-sync";
+  const isSynced = collection.source !== "upload";
+  // Endpoint / auth are editable only for bundle-sync; a connector collection
+  // (Notion) has a token, not an endpoint, so it gets "Sync now" but no
+  // endpoint-edit dialog.
+  const isEndpointEditable = collection.source === "bundle-sync";
   const syncState = describeSync(collection);
   return (
     <Card>
@@ -390,10 +397,11 @@ function CollectionCard({
                 <RefreshCw className={`mr-1 size-3.5 ${syncing ? "animate-spin" : ""}`} />
                 {syncing ? "Syncing…" : "Sync now"}
               </Button>
-              {collection.authScheme !== undefined ? (
-                // Hidden during a web-before-API deploy-overlap window (an
-                // older API omits authScheme): pre-filling "None" there would
-                // delete the stored credential on a routine save.
+              {isEndpointEditable && collection.authScheme !== undefined ? (
+                // Endpoint/auth edit is bundle-sync-only (a connector has no
+                // endpoint). Also hidden during a web-before-API deploy-overlap
+                // window (an older API omits authScheme): pre-filling "None"
+                // there would delete the stored credential on a routine save.
                 <Button
                   variant="ghost"
                   size="sm"

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -664,7 +664,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync"]),
+  source: z.enum(["upload", "bundle-sync", "notion"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
Closes #4378. Slice 3 of PRD #4375 — the first concrete **Knowledge Sync Connector** on the #4376 spine. A `notion-knowledge` catalog row installs a synced collection from a Notion internal-integration token; the shared engine drives it, and every synced page lands `draft` behind the review gate.

## What's here

**Vendor client** (`packages/api/src/lib/knowledge/notion/`)
- Version-pinned HTTP seam (`Notion-Version: 2026-03-11`, verified against Notion's docs — post-dates the 2025-09-03 data-source split): ≤3 req/s throttle, `429 → ConnectorRateLimitError` (parsed `Retry-After`), token redaction, injected fetch/clock/sleep.
- Enumeration = **search ∪ recursive `child_page`/`child_database` descent** (dedupe by id; an inheritance-only page search misses is still found). Reconciliation is the correctness anchor: an **incomplete enumeration throws** (a partial set would archive live pages) — every pagination loop fails loud on a contract-violating response.
- Incremental = `last_edited_time` walk-until-older (engine overlap window absorbs minute granularity).
- Content via the official page-markdown endpoint with **truncated continuation** (`unknown_block_ids` re-fetch) + **block-walk fallback**, both counted/logged. Enhanced-markdown normalizer (callout fences, columns/details tags) → plain markdown; expiring media URLs → vendor page links (text-first v1).

**Provenance & paths** — readable, deterministic, collision-free path (`<title-slug>-<page-id>.md`); `atlas:` provenance (vendor, page id, `last_edited_time`) + `resource`/`timestamp`. Churn-free: frontmatter is stripped at ingest and no sync-time rides in the body, so an unchanged page never re-reviews.

**Install & wiring** — internal-integration token form handler → `knowledge_sync_credentials` (encrypted, never in `config`); `catalog:notion-knowledge` seed row; form handler + connector registered at boot.

**Admin & web** — list/sync/uninstall recognize connector collections; sync route dispatches to `syncConnectorCollection` (fail-closed `connector_unavailable` 500 if unregistered); wire `source` widened to `notion` (+ web mirror + a Notion tab in the create-collection dialog documenting the sharing model).

**Docs** — [Connect Notion](apps/docs/content/docs/guides/connect-notion.mdx) guide: integration creation, the sharing model + "why is my page missing" pitfall, review-gate flow.

## Tests

Fully test-doubled — **no test calls Notion**. Normalizer goldens; enumeration (search∪descent, data-source/database, dedup, incremental walk-until-older, over-cap-throws, incomplete-pagination-throws); content (truncation, block-walk fallback, 429 propagation on both enumeration and content paths); http (version pin, throttle spacing, 429, redaction); document (path determinism/collision-free, provenance, YAML-injection safety, churn-free); install (token→credentials-not-config, catalog-missing, slug collision, credential-write-abort); connector registration; admin route dispatch + list; real-Postgres upsert smoke.

## Gates

- `bun run type` ✅ (api + web + www)
- All affected api + web suites ✅ (isolated per-file runner)
- OpenAPI spec + api-reference regenerated ✅
- Internal review panel run pre-PR; round-1 findings addressed (the HIGH enumeration-completeness fix above).

## Notes / deferred

- OAuth install (both vendors) is the sibling slice **#4379** (staging app registration, human-gated) — this slice is token-only.
- Full ancestry-mirroring paths are a documented v1 follow-up (Notion's partial-sharing model makes a page's ancestor chain not always resolvable); v1 uses flat readable slugs + a stable id token.