### PR TITLE
feat: Mintlify OKF importer — docs.json nav filter over the markdown-tree adapter

### DIFF
--- a/packages/okf-bundle/README.md
+++ b/packages/okf-bundle/README.md
@@ -135,6 +135,13 @@ const { bytes, stats } = await buildOkfBundle(source, { prefix: "docs", filter }
 // nav.manifestPath — which manifest won; stats.skipped.filtered — off-nav pages
 ```
 
+The reverse direction — a nav entry with **no backing file** — is tolerated,
+because Mintlify `pages` arrays legitimately carry non-file entries
+(OpenAPI-generated pages). A typo'd or renamed page therefore ships no
+document and lands in no skip bucket; when that matters, diff `nav.pages`
+against the built docs (`nav.pages` minus each doc's extension-less
+`sourcePath`) and warn on the difference.
+
 The manifest is parsed structurally as unknown JSON (no Mintlify config-type
 dependency; runtime deps stay `fflate`-only), exploiting the one invariant
 that holds across every navigation shape — tabs, anchors, dropdowns,

--- a/packages/okf-bundle/README.md
+++ b/packages/okf-bundle/README.md
@@ -3,8 +3,9 @@
 Source-neutral OKF knowledge-bundle builder + the single-homed **OKF wire
 contract**. This is the core behind every Atlas Knowledge Base importer:
 `@atlas/fumadocs-okf` is the first named adapter, the built-in
-[markdown-tree adapter](#the-markdown-tree-adapter) the second; a Mintlify
-importer later is one adapter more. (Confluence shipped as a *server-side*
+[markdown-tree adapter](#the-markdown-tree-adapter) the second, and the
+built-in [Mintlify importer](#the-mintlify-importer) (the markdown-tree
+adapter plus a `docs.json` nav filter) the third. (Confluence shipped as a *server-side*
 Knowledge Sync Connector instead — ADR-0030, #4376 — consuming collected
 documents at the ingest seam, not as a generation-side adapter here.) Private
 workspace package — not published to npm (promote to a `@useatlas/*` name only
@@ -108,12 +109,41 @@ const source = await createMarkdownTreeSource({
 const { bytes, stats } = await buildOkfBundle(source, { prefix: "docs" });
 ```
 
-"Any docs folder" works out of the box. A **Mintlify importer is this adapter
-plus a nav filter**: point `root` at the MDX tree and pass a `filter` hook
-that keeps only pages reachable from `docs.json`'s navigation (the importer
-itself is follow-up work per PRD #4372 — this adapter is the reusable part).
+"Any docs folder" works out of the box. The
+[Mintlify importer](#the-mintlify-importer) is this adapter plus a nav filter.
 The Atlas docs portal's local mode is this adapter plus portal policy
 (`apps/docs/scripts/kb-bundle-sources.ts`).
+
+## The Mintlify importer
+
+`createMintlifySource` (#4391) points the markdown-tree adapter at a Mintlify
+site and derives a `filter` predicate from the site's nav manifest —
+`docs.json`, falling back to legacy `mint.json` — so only nav-reachable pages
+collect. Pages on disk but absent from navigation (snippets, retired pages,
+drafts) are declined by the filter and land in the counted
+`skipped.filtered` bucket, never silently.
+
+```ts
+import { buildOkfBundle, createMintlifySource } from "@atlas/okf-bundle";
+import { load } from "js-yaml";
+
+const { source, filter, nav } = await createMintlifySource({
+  root: "my-mintlify-site",
+  parseYaml: load,
+});
+const { bytes, stats } = await buildOkfBundle(source, { prefix: "docs", filter });
+// nav.manifestPath — which manifest won; stats.skipped.filtered — off-nav pages
+```
+
+The manifest is parsed structurally as unknown JSON (no Mintlify config-type
+dependency; runtime deps stay `fflate`-only), exploiting the one invariant
+that holds across every navigation shape — tabs, anchors, dropdowns,
+versions, languages, arbitrarily nested groups, and the flat legacy
+`mint.json` group array: **a page path only ever appears as a string element
+of a `pages` array**. `href`/`openapi` strings are never pages. A missing,
+malformed, or zero-page manifest throws `NavManifestError` at generation time
+— the importer never falls back to collecting the whole tree (use
+`createMarkdownTreeSource` directly for an unfiltered walk).
 
 ## Hosting / ingest recipes
 

--- a/packages/okf-bundle/__tests__/mintlify.test.ts
+++ b/packages/okf-bundle/__tests__/mintlify.test.ts
@@ -1,0 +1,274 @@
+/**
+ * The Mintlify OKF importer (#4391) — the markdown-tree adapter plus a
+ * `docs.json` nav filter, exercised through the BUILD entry with real
+ * directory fixtures (the same posture as the markdown-tree tests). The nav
+ * tests pin manifest resolution (docs.json over legacy mint.json), the
+ * recursive navigation walk (tabs / anchors / dropdowns / versions /
+ * languages / nested groups), and the fail-loud posture on a malformed or
+ * unresolvable manifest — a broken manifest must never quietly produce an
+ * empty (or over-full) bundle.
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+import * as yaml from "js-yaml";
+
+import {
+  buildOkfBundle,
+  createMintlifySource,
+  NavManifestError,
+  parseMintlifyNav,
+  type ParseYaml,
+} from "../src/index";
+
+const parseYaml: ParseYaml = (raw) => yaml.load(raw);
+
+const cleanups: string[] = [];
+afterAll(async () => {
+  await Promise.all(cleanups.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function treeOf(files: Record<string, string>): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "okf-mintlify-"));
+  cleanups.push(root);
+  for (const [rel, content] of Object.entries(files)) {
+    await mkdir(join(root, rel, ".."), { recursive: true });
+    await writeFile(join(root, rel), content, "utf8");
+  }
+  return root;
+}
+
+/** A representative Mintlify site: tabs → groups → nested groups, an anchor
+ *  division, a global external anchor (href only, never a page), and pages
+ *  both in and out of nav. */
+const REPRESENTATIVE_DOCS_JSON = JSON.stringify({
+  name: "Acme Docs",
+  theme: "mint",
+  navigation: {
+    tabs: [
+      {
+        tab: "Guides",
+        groups: [
+          {
+            group: "Get Started",
+            pages: [
+              "introduction",
+              "quickstart",
+              { group: "Advanced", pages: ["advanced/config"] },
+            ],
+          },
+        ],
+      },
+      {
+        tab: "API",
+        anchors: [{ anchor: "Reference", pages: ["api/overview"] }],
+      },
+    ],
+    global: {
+      anchors: [{ anchor: "Community", href: "https://community.example.com" }],
+    },
+  },
+});
+
+const REPRESENTATIVE_TREE: Record<string, string> = {
+  "docs.json": REPRESENTATIVE_DOCS_JSON,
+  "introduction.mdx": [
+    "---",
+    'title: "Introduction"',
+    "description: What Acme is",
+    "---",
+    'import { Card } from "@mintlify/components";',
+    "",
+    "Acme introduction prose that survives the strip.",
+  ].join("\n"),
+  "quickstart.mdx": "---\ntitle: Quickstart\n---\nQuickstart prose, long enough to count.",
+  "advanced/config.mdx": "---\ntitle: Config\n---\nAdvanced configuration prose here.",
+  "api/overview.md": "---\ntitle: API Overview\n---\nOverview of the API surface.",
+  // Present on disk, absent from nav — must be skipped and COUNTED.
+  "changelog/v1.mdx": "---\ntitle: v1\n---\nOld changelog entry, not navigable.",
+  "snippets/reusable.mdx": "Reusable snippet content, never a page.",
+};
+
+describe("createMintlifySource → buildOkfBundle", () => {
+  test("collects only nav-reachable pages; off-nav pages are skipped and counted", async () => {
+    const root = await treeOf(REPRESENTATIVE_TREE);
+    const { source, filter, nav } = await createMintlifySource({ root, parseYaml });
+
+    expect(nav.manifestPath).toBe("docs.json");
+    const result = await buildOkfBundle(source, { prefix: "docs", filter, tags: ["mintlify"] });
+    expect(result.docs.map((d) => d.path)).toEqual([
+      "docs/advanced/config.md",
+      "docs/api/overview.md",
+      "docs/introduction.md",
+      "docs/quickstart.md",
+    ]);
+    // changelog/v1.mdx + snippets/reusable.mdx declined by the nav filter.
+    expect(result.stats.skipped.filtered).toBe(2);
+
+    // Mintlify frontmatter rides the shared wire split into OKF fields; the
+    // MDX module line is stripped by the existing fence-aware strip.
+    const intro = result.docs.find((d) => d.path === "docs/introduction.md");
+    expect(intro?.content).toContain('title: "Introduction"');
+    expect(intro?.content).toContain('description: "What Acme is"');
+    expect(intro?.content).toContain("Acme introduction prose");
+    expect(intro?.content).not.toContain("@mintlify/components");
+
+    // Deterministic rebuild: identical tree → identical bytes.
+    const againSource = await createMintlifySource({ root, parseYaml });
+    const again = await buildOkfBundle(againSource.source, {
+      prefix: "docs",
+      filter: againSource.filter,
+      tags: ["mintlify"],
+    });
+    expect(Buffer.from(again.bytes).equals(Buffer.from(result.bytes))).toBe(true);
+  });
+
+  test("legacy mint.json manifests are accepted when docs.json is absent", async () => {
+    const root = await treeOf({
+      "mint.json": JSON.stringify({
+        name: "Legacy",
+        navigation: [
+          {
+            group: "Docs",
+            pages: ["welcome", { group: "Nested", pages: ["deep/page"] }],
+          },
+        ],
+      }),
+      "welcome.mdx": "---\ntitle: Welcome\n---\nWelcome page prose, long enough.",
+      "deep/page.mdx": "---\ntitle: Deep\n---\nNested legacy page prose here.",
+      "orphan.mdx": "Not in the legacy nav, must be filtered.",
+    });
+    const { source, filter, nav } = await createMintlifySource({ root, parseYaml });
+    expect(nav.manifestPath).toBe("mint.json");
+    const result = await buildOkfBundle(source, { prefix: "kb", filter });
+    expect(result.docs.map((d) => d.path)).toEqual(["kb/deep/page.md", "kb/welcome.md"]);
+    expect(result.stats.skipped.filtered).toBe(1);
+  });
+
+  test("docs.json wins over a stale mint.json sitting next to it", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({ navigation: { pages: ["current"] } }),
+      "mint.json": JSON.stringify({ navigation: [{ group: "Old", pages: ["stale"] }] }),
+      "current.mdx": "---\ntitle: Current\n---\nCurrent page prose, long enough.",
+      "stale.mdx": "---\ntitle: Stale\n---\nStale page prose, long enough.",
+    });
+    const { filter, nav } = await createMintlifySource({ root, parseYaml });
+    expect(nav.manifestPath).toBe("docs.json");
+    expect(nav.pages.has("current")).toBe(true);
+    expect(nav.pages.has("stale")).toBe(false);
+    expect(filter({ path: "stale.mdx", loadBody: async () => "" })).toBe(false);
+  });
+
+  test("versions and languages divisions resolve to the union of their page sets", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({
+        navigation: {
+          versions: [
+            { version: "v2", groups: [{ group: "Docs", pages: ["v2/start"] }] },
+            {
+              version: "v1",
+              languages: [{ language: "en", pages: ["v1/en/start"] }],
+            },
+          ],
+        },
+      }),
+      "v2/start.mdx": "---\ntitle: V2\n---\nVersion two start page prose.",
+      "v1/en/start.mdx": "---\ntitle: V1 EN\n---\nVersion one english prose.",
+    });
+    const { source, filter } = await createMintlifySource({ root, parseYaml });
+    const result = await buildOkfBundle(source, { prefix: "docs", filter });
+    expect(result.docs.map((d) => d.path)).toEqual(["docs/v1/en/start.md", "docs/v2/start.md"]);
+  });
+
+  test("nav entries tolerate a leading slash and an explicit extension", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({
+        navigation: { pages: ["/slashed", "explicit.mdx"] },
+      }),
+      "slashed.mdx": "---\ntitle: Slashed\n---\nLeading-slash nav entry prose.",
+      "explicit.mdx": "---\ntitle: Explicit\n---\nExtension-carrying nav entry prose.",
+    });
+    const { source, filter } = await createMintlifySource({ root, parseYaml });
+    const result = await buildOkfBundle(source, { prefix: "docs", filter });
+    expect(result.docs.map((d) => d.path)).toEqual(["docs/explicit.md", "docs/slashed.md"]);
+  });
+});
+
+describe("fail-loud manifest handling", () => {
+  test("neither docs.json nor mint.json at root → NavManifestError naming both", async () => {
+    const root = await treeOf({
+      "page.mdx": "---\ntitle: P\n---\nSome page prose, long enough to count.",
+    });
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(NavManifestError);
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(/docs\.json.*mint\.json/);
+  });
+
+  test("malformed JSON → NavManifestError naming the manifest", async () => {
+    const root = await treeOf({
+      "docs.json": "{ not json",
+      "page.mdx": "---\ntitle: P\n---\nSome page prose, long enough to count.",
+    });
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(NavManifestError);
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(/docs\.json/);
+  });
+
+  test("a manifest whose navigation yields ZERO pages → NavManifestError, never a silent empty bundle", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({
+        navigation: {
+          global: { anchors: [{ anchor: "Only Links", href: "https://example.com" }] },
+        },
+      }),
+      "page.mdx": "---\ntitle: P\n---\nSome page prose, long enough to count.",
+    });
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(NavManifestError);
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(/no page paths/);
+  });
+
+  test("a manifest with no navigation key at all → NavManifestError", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({ name: "No Nav Here" }),
+      "page.mdx": "---\ntitle: P\n---\nSome page prose, long enough to count.",
+    });
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(NavManifestError);
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(/navigation/);
+  });
+
+  test("a non-object manifest document → NavManifestError", () => {
+    expect(() => parseMintlifyNav("[1, 2, 3]", "docs.json")).toThrow(NavManifestError);
+    expect(() => parseMintlifyNav('"just a string"', "docs.json")).toThrow(NavManifestError);
+  });
+});
+
+describe("parseMintlifyNav", () => {
+  test("walks dropdowns and collects only strings inside pages arrays (hrefs/openapi ignored)", () => {
+    const nav = parseMintlifyNav(
+      JSON.stringify({
+        navigation: {
+          dropdowns: [
+            {
+              dropdown: "SDKs",
+              openapi: "https://example.com/openapi.json",
+              groups: [{ group: "TS", pages: ["sdk/ts"], icon: "code" }],
+            },
+          ],
+          anchors: [{ anchor: "Blog", href: "https://blog.example.com" }],
+        },
+      }),
+      "docs.json",
+    );
+    expect([...nav.pages].sort()).toEqual(["sdk/ts"]);
+  });
+
+  test("external links inside a pages array are ignored, not treated as page paths", () => {
+    const nav = parseMintlifyNav(
+      JSON.stringify({
+        navigation: { pages: ["real/page", "https://example.com/external"] },
+      }),
+      "docs.json",
+    );
+    expect([...nav.pages].sort()).toEqual(["real/page"]);
+  });
+});

--- a/packages/okf-bundle/__tests__/mintlify.test.ts
+++ b/packages/okf-bundle/__tests__/mintlify.test.ts
@@ -16,6 +16,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as yaml from "js-yaml";
 
 import {
+  ArchivePathCollisionError,
   buildOkfBundle,
   createMintlifySource,
   NavManifestError,
@@ -182,6 +183,48 @@ describe("createMintlifySource → buildOkfBundle", () => {
     expect(result.docs.map((d) => d.path)).toEqual(["docs/v1/en/start.md", "docs/v2/start.md"]);
   });
 
+  test("an explicit manifest override is used exclusively — no docs.json fallback", async () => {
+    const root = await treeOf({
+      "custom.json": JSON.stringify({ navigation: { pages: ["only"] } }),
+      "docs.json": JSON.stringify({ navigation: { pages: ["never"] } }),
+      "only.mdx": "---\ntitle: Only\n---\nThe override manifest's page prose.",
+      "never.mdx": "---\ntitle: Never\n---\nThe default manifest's page prose.",
+    });
+    const { nav } = await createMintlifySource({ root, parseYaml, manifest: "custom.json" });
+    expect(nav.manifestPath).toBe("custom.json");
+    expect(nav.pages.has("only")).toBe(true);
+    expect(nav.pages.has("never")).toBe(false);
+
+    // An ABSENT override fails loud naming the override — it never quietly
+    // falls back to the docs.json sitting right there.
+    await expect(
+      createMintlifySource({ root, parseYaml, manifest: "absent.json" }),
+    ).rejects.toThrow(/absent\.json/);
+  });
+
+  test("nav entries with no backing file are tolerated — dangling entries never count as filtered", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({ navigation: { pages: ["real", "missing/page"] } }),
+      "real.mdx": "---\ntitle: Real\n---\nThe one page that exists on disk.",
+    });
+    const { source, filter } = await createMintlifySource({ root, parseYaml });
+    const result = await buildOkfBundle(source, { prefix: "docs", filter });
+    expect(result.docs.map((d) => d.path)).toEqual(["docs/real.md"]);
+    expect(result.stats.skipped.filtered).toBe(0);
+  });
+
+  test("intro.md and intro.mdx both matching one nav entry surface as an archive-path collision, never a silent overwrite", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({ navigation: { pages: ["intro"] } }),
+      "intro.md": "---\ntitle: Intro MD\n---\nMarkdown flavor of the page prose.",
+      "intro.mdx": "---\ntitle: Intro MDX\n---\nMDX flavor of the page prose.",
+    });
+    const { source, filter } = await createMintlifySource({ root, parseYaml });
+    await expect(buildOkfBundle(source, { prefix: "docs", filter })).rejects.toThrow(
+      ArchivePathCollisionError,
+    );
+  });
+
   test("nav entries tolerate a leading slash and an explicit extension", async () => {
     const root = await treeOf({
       "docs.json": JSON.stringify({
@@ -203,6 +246,25 @@ describe("fail-loud manifest handling", () => {
     });
     await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(NavManifestError);
     await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(/docs\.json.*mint\.json/);
+  });
+
+  test("an unreadable docs.json (a directory) fails loud — never a silent fallback to a stale mint.json", async () => {
+    const root = await treeOf({
+      "mint.json": JSON.stringify({ navigation: [{ group: "Stale", pages: ["stale"] }] }),
+      "stale.mdx": "---\ntitle: Stale\n---\nStale legacy page prose, long enough.",
+    });
+    await mkdir(join(root, "docs.json")); // present but unreadable (EISDIR)
+    const attempt = createMintlifySource({ root, parseYaml });
+    await expect(attempt).rejects.toThrow(NavManifestError);
+    await expect(createMintlifySource({ root, parseYaml })).rejects.toThrow(
+      /cannot read the manifest/,
+    );
+    const err = await attempt.then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(NavManifestError);
+    expect((err as NavManifestError).manifestPath).toBe("docs.json");
   });
 
   test("malformed JSON → NavManifestError naming the manifest", async () => {
@@ -265,10 +327,24 @@ describe("parseMintlifyNav", () => {
   test("external links inside a pages array are ignored, not treated as page paths", () => {
     const nav = parseMintlifyNav(
       JSON.stringify({
-        navigation: { pages: ["real/page", "https://example.com/external"] },
+        navigation: {
+          pages: ["real/page", "https://example.com/external", "//cdn.example.com/protocol-relative"],
+        },
       }),
       "docs.json",
     );
     expect([...nav.pages].sort()).toEqual(["real/page"]);
+  });
+
+  test("a division key the walker has never heard of still yields its pages (no key whitelist)", () => {
+    const nav = parseMintlifyNav(
+      JSON.stringify({
+        navigation: {
+          products: [{ product: "Cloud", groups: [{ group: "Docs", pages: ["cloud/start"] }] }],
+        },
+      }),
+      "docs.json",
+    );
+    expect([...nav.pages].sort()).toEqual(["cloud/start"]);
   });
 });

--- a/packages/okf-bundle/__tests__/mintlify.test.ts
+++ b/packages/okf-bundle/__tests__/mintlify.test.ts
@@ -225,6 +225,26 @@ describe("createMintlifySource → buildOkfBundle", () => {
     );
   });
 
+  test("a custom extensions option keeps the filter's strip in sync — failure stays accurately attributed", async () => {
+    const root = await treeOf({
+      "docs.json": JSON.stringify({ navigation: { pages: ["notes"] } }),
+      "notes.markdown": "---\ntitle: Notes\n---\nCustom-extension page prose here.",
+    });
+    const { source, filter } = await createMintlifySource({
+      root,
+      parseYaml,
+      extensions: [".markdown"],
+    });
+    // The filter must PASS the page (extension strip synced to the effective
+    // set), so the build fails downstream as InvalidPagePathError naming the
+    // page — the core's archive mapping accepts only .md/.mdx. Out of sync,
+    // the filter would drop every page and misattribute the failure as
+    // EmptyBundleError blaming the filter.
+    await expect(buildOkfBundle(source, { prefix: "docs", filter })).rejects.toThrow(
+      /notes\.markdown/,
+    );
+  });
+
   test("nav entries tolerate a leading slash and an explicit extension", async () => {
     const root = await treeOf({
       "docs.json": JSON.stringify({

--- a/packages/okf-bundle/src/errors.ts
+++ b/packages/okf-bundle/src/errors.ts
@@ -102,6 +102,30 @@ export class IngestCapExceededError extends Error {
   }
 }
 
+/**
+ * A nav manifest (Mintlify's `docs.json` / legacy `mint.json`) is missing,
+ * unparseable, or resolves to zero page paths. Fail-loud at generation time
+ * (issue #4391): a broken manifest silently yielding an empty allowed-path
+ * set would filter EVERY page out and — via `EmptyBundleError` at pack, or
+ * worse via a partial nav — ship a wrong bundle whose cause is invisible from
+ * the sync error on the Atlas side.
+ */
+export class NavManifestError extends Error {
+  /** Manifest path (relative to the source root) the failure is about. */
+  readonly manifestPath: string;
+
+  constructor(manifestPath: string, detail: string, cause?: unknown) {
+    super(
+      `Cannot resolve the navigation manifest "${manifestPath}": ${detail}. ` +
+        `The importer never falls back to collecting the whole tree — fix the manifest ` +
+        `(or use createMarkdownTreeSource directly for an unfiltered walk) and rebuild.`,
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "NavManifestError";
+    this.manifestPath = manifestPath;
+  }
+}
+
 /** A `page.path` (or configured prefix) the deterministic mapping can't accept. */
 export class InvalidPagePathError extends Error {
   readonly pagePath: string;

--- a/packages/okf-bundle/src/errors.ts
+++ b/packages/okf-bundle/src/errors.ts
@@ -104,7 +104,7 @@ export class IngestCapExceededError extends Error {
 
 /**
  * A nav manifest (Mintlify's `docs.json` / legacy `mint.json`) is missing,
- * unparseable, or resolves to zero page paths. Fail-loud at generation time
+ * unreadable, unparseable, or resolves to zero page paths. Fail-loud at generation time
  * (issue #4391): a broken manifest silently yielding an empty allowed-path
  * set would surface as a misattributed `EmptyBundleError` at pack (blaming
  * the filter, not the manifest) — or, worse, via a partial nav, ship a

--- a/packages/okf-bundle/src/errors.ts
+++ b/packages/okf-bundle/src/errors.ts
@@ -106,9 +106,9 @@ export class IngestCapExceededError extends Error {
  * A nav manifest (Mintlify's `docs.json` / legacy `mint.json`) is missing,
  * unparseable, or resolves to zero page paths. Fail-loud at generation time
  * (issue #4391): a broken manifest silently yielding an empty allowed-path
- * set would filter EVERY page out and — via `EmptyBundleError` at pack, or
- * worse via a partial nav — ship a wrong bundle whose cause is invisible from
- * the sync error on the Atlas side.
+ * set would surface as a misattributed `EmptyBundleError` at pack (blaming
+ * the filter, not the manifest) — or, worse, via a partial nav, ship a
+ * silently incomplete bundle nothing downstream can detect.
  */
 export class NavManifestError extends Error {
   /** Manifest path (relative to the source root) the failure is about. */

--- a/packages/okf-bundle/src/index.ts
+++ b/packages/okf-bundle/src/index.ts
@@ -28,6 +28,7 @@ export {
   EmptyBundleError,
   IngestCapExceededError,
   InvalidPagePathError,
+  NavManifestError,
   PageLoadError,
   type IngestCapKind,
 } from "./errors";
@@ -36,6 +37,14 @@ export {
   stripMdxModuleLines,
   type MarkdownTreeSourceOptions,
 } from "./markdown-tree";
+export {
+  createMintlifySource,
+  MINTLIFY_MANIFEST_NAMES,
+  parseMintlifyNav,
+  type MintlifyNav,
+  type MintlifySource,
+  type MintlifySourceOptions,
+} from "./mintlify";
 export {
   isContentlessBody,
   pageTags,

--- a/packages/okf-bundle/src/markdown-tree.ts
+++ b/packages/okf-bundle/src/markdown-tree.ts
@@ -63,7 +63,9 @@ export interface MarkdownTreeSourceOptions {
   readonly stripMdxModules?: boolean;
 }
 
-const DEFAULT_EXTENSIONS = [".md", ".mdx"] as const;
+/** Default page extensions — shared with the Mintlify importer so its nav
+ *  filter strips the same set the walk enumerates. */
+export const DEFAULT_EXTENSIONS = [".md", ".mdx"] as const;
 
 /** Longest multi-line ESM statement the strip will consume before deciding
  *  the "statement" is really prose (a hard-wrapped paragraph whose wrap put

--- a/packages/okf-bundle/src/markdown-tree.ts
+++ b/packages/okf-bundle/src/markdown-tree.ts
@@ -3,9 +3,9 @@
  * doc-source seam (#4374, PRD #4372), and the one every file-based docs
  * source needs: walk a tree of `.md`/`.mdx` files, split frontmatter via the
  * wire module's shared mechanics, optionally strip MDX module lines
- * fence-aware. "Any docs folder" works out of the box; a Mintlify importer is
- * this adapter plus a `docs.json` nav filter (the importer itself is
- * follow-up work per PRD #4372 — see the README's Mintlify note).
+ * fence-aware. "Any docs folder" works out of the box; the Mintlify importer
+ * (`createMintlifySource` in `./mintlify`, #4391) is this adapter plus a
+ * `docs.json` nav filter.
  *
  * Promoted from the docs portal's `localSectionSource` shim (issue #4374):
  * the portal keeps only portal policy (audience transform, section list);

--- a/packages/okf-bundle/src/mintlify.ts
+++ b/packages/okf-bundle/src/mintlify.ts
@@ -26,7 +26,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { NavManifestError } from "./errors";
-import { createMarkdownTreeSource, type MarkdownTreeSourceOptions } from "./markdown-tree";
+import {
+  createMarkdownTreeSource,
+  DEFAULT_EXTENSIONS,
+  type MarkdownTreeSourceOptions,
+} from "./markdown-tree";
 import type { DocSource, DocSourcePage } from "./types";
 
 /** Manifest filenames probed at the source root, in precedence order. */
@@ -83,12 +87,21 @@ function normalizeNavEntry(entry: string): string | null {
   return path === "" ? null : path;
 }
 
-/** Strip a trailing `.md`/`.mdx` (case-insensitive) — nav entries are
- *  extension-less by convention, tree paths carry the extension. */
-function stripPageExtension(path: string): string {
+/** Strip a trailing page extension (case-insensitive) — nav entries are
+ *  extension-less by convention, tree paths carry the extension. The filter
+ *  strips the EFFECTIVE extension set (a custom `extensions` option would
+ *  otherwise leave every enumerated path unstripped, filter everything out,
+ *  and surface as a misattributed `EmptyBundleError`); nav-entry
+ *  normalization strips the `.md`/`.mdx` convention. */
+function stripPageExtension(
+  path: string,
+  extensions: readonly string[] = DEFAULT_EXTENSIONS,
+): string {
   const lower = path.toLowerCase();
-  if (lower.endsWith(".mdx")) return path.slice(0, -4);
-  if (lower.endsWith(".md")) return path.slice(0, -3);
+  for (const ext of extensions) {
+    const suffix = ext.toLowerCase();
+    if (lower.endsWith(suffix)) return path.slice(0, -suffix.length);
+  }
   return path;
 }
 
@@ -109,6 +122,9 @@ function collectNavPages(node: unknown, out: Set<string>): void {
     return;
   }
   if (!isRecord(node)) return;
+  // A non-array `pages` value is skipped, not an error: Mintlify's schema is
+  // always an array, and throwing would false-positive on unrelated `pages`
+  // keys in arbitrary manifest metadata the full recursion visits.
   for (const [key, value] of Object.entries(node)) {
     if (key === "pages" && Array.isArray(value)) {
       for (const entry of value) {
@@ -218,9 +234,10 @@ export async function createMintlifySource(
   // NavManifestError or readdir's raw ENOENT — same mistake, two errors.
   const nav = await loadNav(options.root, manifest);
   const source = await createMarkdownTreeSource(treeOptions);
+  const extensions = options.extensions ?? DEFAULT_EXTENSIONS;
   return {
     source,
-    filter: (page) => nav.pages.has(stripPageExtension(page.path)),
+    filter: (page) => nav.pages.has(stripPageExtension(page.path, extensions)),
     nav,
   };
 }

--- a/packages/okf-bundle/src/mintlify.ts
+++ b/packages/okf-bundle/src/mintlify.ts
@@ -1,0 +1,210 @@
+/**
+ * The Mintlify OKF importer (#4391, PRD #4372) — exactly what the README
+ * promised: the markdown-tree adapter plus a nav filter keyed on Mintlify's
+ * manifest (`docs.json`, legacy `mint.json`). Only pages reachable from the
+ * configured navigation collect; everything else on disk (snippets, retired
+ * pages, drafts) is declined by the `filter` hook and lands in the core's
+ * counted `skipped.filtered` bucket — visible, never silent.
+ *
+ * The manifest is parsed STRUCTURALLY as unknown JSON — no dependency on
+ * Mintlify's config types or packages (runtime deps stay `fflate`-only). The
+ * walk exploits the one invariant that holds across every navigation shape
+ * (tabs, anchors, dropdowns, versions, languages, arbitrarily nested groups,
+ * and the flat legacy `mint.json` group array): a page path only ever appears
+ * as a STRING ELEMENT OF A `pages` ARRAY. Strings anywhere else (`href`,
+ * `openapi`, icons, division titles) are never pages, so the walker recurses
+ * through the known division keys and collects strings only under `pages`.
+ *
+ * FAIL-LOUD on a missing/malformed/unresolvable manifest
+ * ({@link NavManifestError}) — a broken manifest must fail the build where
+ * the site owner can act on it, never quietly produce an empty or over-full
+ * bundle.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { NavManifestError } from "./errors";
+import { createMarkdownTreeSource, type MarkdownTreeSourceOptions } from "./markdown-tree";
+import type { DocSource, DocSourcePage } from "./types";
+
+/** Manifest filenames probed at the source root, in precedence order. */
+export const MINTLIFY_MANIFEST_NAMES = ["docs.json", "mint.json"] as const;
+
+/** The resolved navigation of one Mintlify manifest. */
+export interface MintlifyNav {
+  /** Manifest path (relative to the source root) the navigation came from. */
+  readonly manifestPath: string;
+  /**
+   * Nav-reachable page paths, normalized to the tree adapter's shape:
+   * `/`-separated, no leading slash, no `.md`/`.mdx` extension.
+   */
+  readonly pages: ReadonlySet<string>;
+}
+
+export interface MintlifySourceOptions
+  extends Omit<MarkdownTreeSourceOptions, "root" | "parseYaml">,
+    Pick<MarkdownTreeSourceOptions, "root" | "parseYaml"> {
+  /**
+   * Manifest filename relative to `root`. Default: probe `docs.json`, then
+   * legacy `mint.json`; neither present is a {@link NavManifestError}.
+   */
+  readonly manifest?: string;
+}
+
+export interface MintlifySource {
+  /** The underlying markdown-tree doc source (full tree; the nav does not
+   *  narrow enumeration — filtering happens at collect so skips are counted). */
+  readonly source: DocSource;
+  /**
+   * The nav predicate for the core collect's `filter` hook: `true` iff the
+   * page is reachable from the manifest's navigation. Pass to
+   * `collectPages`/`buildOkfBundle` (compose manually if you have your own
+   * filter on top).
+   */
+  readonly filter: (page: DocSourcePage) => boolean;
+  /** The resolved navigation — which manifest won, and the allowed-path set. */
+  readonly nav: MintlifyNav;
+}
+
+/** Navigation division keys whose values may (transitively) hold `pages`
+ *  arrays — the docs.json navigation schema plus the legacy mint.json group
+ *  array (which arrives as the `navigation` value itself). */
+const NAV_DIVISION_KEYS = [
+  "languages",
+  "versions",
+  "tabs",
+  "anchors",
+  "dropdowns",
+  "groups",
+  "global",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Normalize one nav entry onto the tree adapter's path shape. Returns null
+ *  for entries that can never name a tree page (external links, empties). */
+function normalizeNavEntry(entry: string): string | null {
+  let path = entry.trim();
+  if (path === "" || path.includes("://")) return null;
+  while (path.startsWith("/")) path = path.slice(1);
+  path = stripPageExtension(path);
+  return path === "" ? null : path;
+}
+
+/** Strip a trailing `.md`/`.mdx` (case-insensitive) — nav entries are
+ *  extension-less by convention, tree paths carry the extension. */
+function stripPageExtension(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".mdx")) return path.slice(0, -4);
+  if (lower.endsWith(".md")) return path.slice(0, -3);
+  return path;
+}
+
+/** Recursive walk of one navigation node: collect strings under `pages`,
+ *  recurse into nested groups and every known division key. */
+function collectNavPages(node: unknown, out: Set<string>): void {
+  if (Array.isArray(node)) {
+    // The legacy mint.json navigation is a bare array of group objects; a
+    // division key's value is an array of division objects.
+    for (const element of node) collectNavPages(element, out);
+    return;
+  }
+  if (!isRecord(node)) return;
+  const pages = node.pages;
+  if (Array.isArray(pages)) {
+    for (const entry of pages) {
+      if (typeof entry === "string") {
+        const normalized = normalizeNavEntry(entry);
+        if (normalized !== null) out.add(normalized);
+      } else {
+        collectNavPages(entry, out); // nested group object
+      }
+    }
+  }
+  for (const key of NAV_DIVISION_KEYS) {
+    if (key in node) collectNavPages(node[key], out);
+  }
+}
+
+/**
+ * Parse a Mintlify manifest document (`docs.json` or legacy `mint.json`) and
+ * resolve its navigation to the set of reachable page paths. Fail-loud
+ * ({@link NavManifestError}) on unparseable JSON, a non-object document, a
+ * missing `navigation` key, or a navigation that yields zero page paths.
+ */
+export function parseMintlifyNav(raw: string, manifestPath: string): MintlifyNav {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(raw);
+  } catch (err) {
+    throw new NavManifestError(
+      manifestPath,
+      `not valid JSON (${err instanceof Error ? err.message : String(err)})`,
+      err,
+    );
+  }
+  if (!isRecord(doc)) {
+    throw new NavManifestError(manifestPath, "the manifest document is not a JSON object");
+  }
+  if (!("navigation" in doc)) {
+    throw new NavManifestError(manifestPath, 'the manifest has no "navigation" key');
+  }
+  const pages = new Set<string>();
+  collectNavPages(doc.navigation, pages);
+  if (pages.size === 0) {
+    throw new NavManifestError(
+      manifestPath,
+      "its navigation resolves to no page paths — every tree page would be filtered out",
+    );
+  }
+  return { manifestPath, pages };
+}
+
+/** Read + parse the manifest at the source root: the explicit override, or
+ *  `docs.json` falling back to legacy `mint.json`. */
+async function loadNav(root: string, manifest: string | undefined): Promise<MintlifyNav> {
+  const candidates = manifest === undefined ? MINTLIFY_MANIFEST_NAMES : [manifest];
+  for (const candidate of candidates) {
+    let raw: string;
+    try {
+      raw = await readFile(join(root, candidate), "utf8");
+    } catch {
+      // intentionally ignored: a missing candidate falls through to the next
+      // manifest name; running out of candidates fails loud below.
+      continue;
+    }
+    return parseMintlifyNav(raw, candidate);
+  }
+  throw new NavManifestError(
+    candidates.join(" / "),
+    `no readable manifest at the source root (looked for ${candidates.join(", ")})`,
+  );
+}
+
+/**
+ * Build a Mintlify doc source: {@link createMarkdownTreeSource} over `root`
+ * plus the nav `filter` derived from the site's manifest. Usage:
+ *
+ * ```ts
+ * const { source, filter } = await createMintlifySource({ root, parseYaml });
+ * const result = await buildOkfBundle(source, { prefix: "docs", filter });
+ * // result.stats.skipped.filtered — pages on disk but absent from nav
+ * ```
+ */
+export async function createMintlifySource(
+  options: MintlifySourceOptions,
+): Promise<MintlifySource> {
+  const { manifest, ...treeOptions } = options;
+  const [nav, source] = await Promise.all([
+    loadNav(options.root, manifest),
+    createMarkdownTreeSource(treeOptions),
+  ]);
+  return {
+    source,
+    filter: (page) => nav.pages.has(stripPageExtension(page.path)),
+    nav,
+  };
+}

--- a/packages/okf-bundle/src/mintlify.ts
+++ b/packages/okf-bundle/src/mintlify.ts
@@ -13,7 +13,8 @@
  * and the flat legacy `mint.json` group array): a page path only ever appears
  * as a STRING ELEMENT OF A `pages` ARRAY. Strings anywhere else (`href`,
  * `openapi`, icons, division titles) are never pages, so the walker recurses
- * through the known division keys and collects strings only under `pages`.
+ * through every object and array unconditionally (no division-key whitelist)
+ * and collects strings only under `pages`.
  *
  * FAIL-LOUD on a missing/malformed/unresolvable manifest
  * ({@link NavManifestError}) — a broken manifest must fail the build where
@@ -212,10 +213,11 @@ export async function createMintlifySource(
   options: MintlifySourceOptions,
 ): Promise<MintlifySource> {
   const { manifest, ...treeOptions } = options;
-  const [nav, source] = await Promise.all([
-    loadNav(options.root, manifest),
-    createMarkdownTreeSource(treeOptions),
-  ]);
+  // Manifest probe FIRST, sequentially: on a nonexistent root, racing the
+  // tree walk would nondeterministically surface either the contextual
+  // NavManifestError or readdir's raw ENOENT — same mistake, two errors.
+  const nav = await loadNav(options.root, manifest);
+  const source = await createMarkdownTreeSource(treeOptions);
   return {
     source,
     filter: (page) => nav.pages.has(stripPageExtension(page.path)),

--- a/packages/okf-bundle/src/mintlify.ts
+++ b/packages/okf-bundle/src/mintlify.ts
@@ -36,15 +36,14 @@ export interface MintlifyNav {
   /** Manifest path (relative to the source root) the navigation came from. */
   readonly manifestPath: string;
   /**
-   * Nav-reachable page paths, normalized to the tree adapter's shape:
-   * `/`-separated, no leading slash, no `.md`/`.mdx` extension.
+   * Nav-reachable page paths, normalized to the tree adapter's path shape
+   * minus the extension: `/`-separated, no leading slash, no `.md`/`.mdx`
+   * (the filter strips `page.path`'s extension before membership).
    */
   readonly pages: ReadonlySet<string>;
 }
 
-export interface MintlifySourceOptions
-  extends Omit<MarkdownTreeSourceOptions, "root" | "parseYaml">,
-    Pick<MarkdownTreeSourceOptions, "root" | "parseYaml"> {
+export interface MintlifySourceOptions extends MarkdownTreeSourceOptions {
   /**
    * Manifest filename relative to `root`. Default: probe `docs.json`, then
    * legacy `mint.json`; neither present is a {@link NavManifestError}.
@@ -67,19 +66,6 @@ export interface MintlifySource {
   readonly nav: MintlifyNav;
 }
 
-/** Navigation division keys whose values may (transitively) hold `pages`
- *  arrays — the docs.json navigation schema plus the legacy mint.json group
- *  array (which arrives as the `navigation` value itself). */
-const NAV_DIVISION_KEYS = [
-  "languages",
-  "versions",
-  "tabs",
-  "anchors",
-  "dropdowns",
-  "groups",
-  "global",
-] as const;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -88,7 +74,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *  for entries that can never name a tree page (external links, empties). */
 function normalizeNavEntry(entry: string): string | null {
   let path = entry.trim();
-  if (path === "" || path.includes("://")) return null;
+  // External links can never name a tree page: full protocol (`https://…`)
+  // or protocol-relative (`//host/…`).
+  if (path === "" || path.includes("://") || path.startsWith("//")) return null;
   while (path.startsWith("/")) path = path.slice(1);
   path = stripPageExtension(path);
   return path === "" ? null : path;
@@ -103,8 +91,15 @@ function stripPageExtension(path: string): string {
   return path;
 }
 
-/** Recursive walk of one navigation node: collect strings under `pages`,
- *  recurse into nested groups and every known division key. */
+/**
+ * Recursive walk of one navigation node: collect strings under `pages`
+ * arrays, recurse into EVERYTHING else. Deliberately not a division-key
+ * whitelist (tabs/anchors/dropdowns/versions/…): a key Mintlify adds later
+ * would silently drop its pages into `skipped.filtered`, misattributed to
+ * the caller's filter — while the collecting invariant (page paths only ever
+ * appear as string elements of a `pages` array) makes full recursion equally
+ * sound, since strings anywhere else are never collected.
+ */
 function collectNavPages(node: unknown, out: Set<string>): void {
   if (Array.isArray(node)) {
     // The legacy mint.json navigation is a bare array of group objects; a
@@ -113,19 +108,19 @@ function collectNavPages(node: unknown, out: Set<string>): void {
     return;
   }
   if (!isRecord(node)) return;
-  const pages = node.pages;
-  if (Array.isArray(pages)) {
-    for (const entry of pages) {
-      if (typeof entry === "string") {
-        const normalized = normalizeNavEntry(entry);
-        if (normalized !== null) out.add(normalized);
-      } else {
-        collectNavPages(entry, out); // nested group object
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "pages" && Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === "string") {
+          const normalized = normalizeNavEntry(entry);
+          if (normalized !== null) out.add(normalized);
+        } else {
+          collectNavPages(entry, out); // nested group object
+        }
       }
+    } else {
+      collectNavPages(value, out);
     }
-  }
-  for (const key of NAV_DIVISION_KEYS) {
-    if (key in node) collectNavPages(node[key], out);
   }
 }
 
@@ -163,24 +158,43 @@ export function parseMintlifyNav(raw: string, manifestPath: string): MintlifyNav
   return { manifestPath, pages };
 }
 
+/** A truly ABSENT file — the only read failure the manifest probe may fall
+ *  through. EACCES/EISDIR/EIO on a present `docs.json` must fail loud: falling
+ *  through would silently resolve a stale `mint.json` sitting next to it. */
+function isFileMissing(err: unknown): boolean {
+  return err instanceof Error && "code" in err && err.code === "ENOENT";
+}
+
 /** Read + parse the manifest at the source root: the explicit override, or
  *  `docs.json` falling back to legacy `mint.json`. */
 async function loadNav(root: string, manifest: string | undefined): Promise<MintlifyNav> {
   const candidates = manifest === undefined ? MINTLIFY_MANIFEST_NAMES : [manifest];
+  let lastMissing: unknown;
   for (const candidate of candidates) {
     let raw: string;
     try {
       raw = await readFile(join(root, candidate), "utf8");
-    } catch {
-      // intentionally ignored: a missing candidate falls through to the next
-      // manifest name; running out of candidates fails loud below.
-      continue;
+    } catch (err) {
+      if (isFileMissing(err)) {
+        // intentionally ignored: a missing candidate falls through to the next
+        // manifest name; running out of candidates fails loud below.
+        lastMissing = err;
+        continue;
+      }
+      throw new NavManifestError(
+        candidate,
+        `cannot read the manifest (${err instanceof Error ? err.message : String(err)})`,
+        err,
+      );
     }
     return parseMintlifyNav(raw, candidate);
   }
+  // manifestPath stays a real path (the first candidate) — the message
+  // carries the full probe list.
   throw new NavManifestError(
-    candidates.join(" / "),
-    `no readable manifest at the source root (looked for ${candidates.join(", ")})`,
+    candidates[0],
+    `no manifest at the source root "${root}" (looked for ${candidates.join(", ")})`,
+    lastMissing,
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #4391 — the named follow-up of PRD #4372: customers running a Mintlify site get it into the Knowledge Base without hand-producing an OKF bundle.

- **`createMintlifySource`** (`packages/okf-bundle/src/mintlify.ts`): reuses `createMarkdownTreeSource` and derives a `filter` predicate from the site's nav manifest — `docs.json`, falling back to legacy `mint.json` (an explicit `manifest` override is exclusive, never falls back). Only nav-reachable pages collect; pages on disk but absent from navigation land in the core's **counted** `skipped.filtered` bucket.
- **Structural manifest parsing** — unknown JSON, no Mintlify config-type dependency (runtime deps stay `fflate`-only). The walk exploits the invariant that a page path only ever appears as a string element of a `pages` array, recursing through every object/array unconditionally (no division-key whitelist), so tabs / anchors / dropdowns / versions / languages / nested groups — and any division key Mintlify adds later — all resolve. `href`/`openapi` strings are never pages.
- **Fail-loud** — new `NavManifestError` for a missing, unreadable (EACCES/EISDIR never silently falls back to a stale `mint.json`), unparseable, or zero-page manifest; the importer never falls back to collecting the whole tree.
- Mintlify frontmatter maps to title/description via the shared wire split; MDX module lines stripped by the existing fence-aware `stripMdxModuleLines`. Deterministic bytes across rebuilds. No `packages/api` changes, no connector, no migration — output feeds the existing `bundle-sync` connector or the admin upload route.

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — 18 new tests in `packages/okf-bundle/__tests__/mintlify.test.ts`: golden fixture over a representative tabs/groups/anchors tree, legacy `mint.json`, docs.json-over-mint.json precedence, versions/languages union, leading-slash + explicit-extension tolerance, manifest override exclusivity, dangling nav entries, filter-induced archive collision, unreadable-manifest no-fallback (EISDIR), malformed/zero-page/no-navigation manifests, unknown division key, protocol-relative links, custom-extensions attribution
- [ ] E2E tests added/updated — n/a (package-local generation tooling)

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — all 28 `ci-local.sh` gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — n/a, no dependency changes (runtime deps stay `fflate`-only)
- [x] Labels added (type + area) — mirrored from #4391 (`feature`, `area: api`, `area: docs`)
- [ ] CHANGELOG.md updated — n/a (internal workspace package; changelog entries are per-tag via `/release`)

https://claude.ai/code/session_01T4NURVgu6PvbgUuFahW83t

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4NURVgu6PvbgUuFahW83t)_