### PR TITLE
feat(auth): agent-auth spine behind ATLAS_AGENT_AUTH_ENABLED (default off)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -201,6 +201,7 @@
         "@atlas/mcp": "workspace:*",
         "@atlas/okf-bundle": "workspace:*",
         "@aws-sdk/client-bedrock": "^3.1075.0",
+        "@better-auth/agent-auth": "0.6.2",
         "@better-auth/api-key": "^1.6.20",
         "@better-auth/oauth-provider": "^1.6.20",
         "@better-auth/passkey": "^1.6.20",
@@ -1148,6 +1149,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@better-auth/agent-auth": ["@better-auth/agent-auth@0.6.2", "", { "dependencies": { "@simplewebauthn/server": "^13.3.0", "better-call": "1.3.2", "jose": "^6.0.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": ">=1.4.0", "better-auth": ">=1.4.0" } }, "sha512-bXJ31rkZtCd27TuUfaAqNLbeZOMfJih5fO9HGq8mrU/23E9ljxScCkIPA3RJmUJ0SBGtaHA9GKVwIlFce0slvg=="],
 
     "@better-auth/api-key": ["@better-auth/api-key@1.6.20", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.20", "@better-auth/utils": "0.4.2", "better-auth": "^1.6.20", "better-call": "1.3.6" } }, "sha512-BgyhJ74m8z3wKODJV348Qr19cG3jnJT/r7yBe6YpOnirAImFt1IzmERUDOXylizMrFWOb8SM4PbVuq5hKSCe4g=="],
 
@@ -4269,6 +4272,8 @@
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@better-auth/agent-auth/better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
+
     "@daytonaio/sdk/@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/otlp-transformer": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ=="],
 
     "@daytonaio/sdk/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.217.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.217.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ=="],
@@ -4736,6 +4741,8 @@
     "@azure/identity/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@better-auth/agent-auth/better-call/@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@daytonaio/sdk/@opentelemetry/exporter-trace-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.217.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "protobufjs": "8.0.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -28,6 +28,7 @@
     "@useatlas/twenty": "^0.0.6",
     "@useatlas/types": "^0.5.0",
     "@useatlas/webhook-publisher": "^0.0.1",
+    "@better-auth/agent-auth": "0.6.2",
     "@better-auth/api-key": "^1.6.20",
     "@better-auth/oauth-provider": "^1.6.20",
     "@better-auth/passkey": "^1.6.20",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -26,6 +26,7 @@
     "@useatlas/types": "^0.5.0",
     "@useatlas/webhook-publisher": "^0.0.1",
     "ai": "^6.0.208",
+    "@better-auth/agent-auth": "0.6.2",
     "@better-auth/api-key": "^1.6.20",
     "@better-auth/oauth-provider": "^1.6.20",
     "@better-auth/passkey": "^1.6.20",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -51,6 +51,7 @@
     "@atlas/okf-bundle": "workspace:*",
     "@atlas/mcp": "workspace:*",
     "@aws-sdk/client-bedrock": "^3.1075.0",
+    "@better-auth/agent-auth": "0.6.2",
     "@better-auth/api-key": "^1.6.20",
     "@better-auth/oauth-provider": "^1.6.20",
     "@better-auth/passkey": "^1.6.20",

--- a/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
+++ b/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Live-toggle integration test for the Agent Auth surface (#4409).
+ *
+ * The headline guarantee of Slice 1: with `ATLAS_AGENT_AUTH_ENABLED` OFF (the
+ * default) every agent-auth path AND the `/.well-known/agent-configuration`
+ * discovery document return 404; flipping the setting ON — with NO process
+ * restart and NO rebuild of the (build-once) auth singleton — makes the whole
+ * surface reachable; flipping it back returns it to 404. And a non-agent-auth
+ * auth path is never gated, so the gate is scoped, not a blanket kill-switch.
+ *
+ * This drives the REAL catch-all auth router (`routes/auth.ts`) and the REAL
+ * `.well-known` router (`routes/well-known.ts`) — i.e. the actual gate wiring.
+ * Only two boundaries are stubbed so the test needn't build the full heavy auth
+ * singleton: `detectAuthMode` (→ managed) and `getAuthInstance` (→ a stub whose
+ * `.handler` returns a 200 marker). The gate sits IN FRONT of both, so "off →
+ * 404" is decided before either stub is consulted; "on → reachable" means the
+ * request reaches the stub (200), never 404. The real plugin's JWT/grant
+ * behavior is covered separately in `agent-auth-plugin.test.ts`.
+ *
+ * No-restart proof: the same mounted app + same stub is reused across the
+ * off→on→off sequence; only `process.env.ATLAS_AGENT_AUTH_ENABLED` changes
+ * between requests, and `getSettingLive` (no internal DB in the test → reads env
+ * fresh) picks it up per request. Self-contained: env saved and restored.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+import { Hono } from "hono";
+
+// Stub the auth-mode detector → managed, and the auth singleton → a light stub.
+// Both are consulted via dynamic import inside the routers, so mock.module
+// intercepts them; neither router statically imports these modules.
+import * as detectReal from "@atlas/api/lib/auth/detect";
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  ...detectReal,
+  detectAuthMode: () => "managed",
+}));
+
+const AGENT_CONFIG_DOC = { version: "1.0-draft", provider_name: "Atlas", endpoints: {} };
+const stubAuthInstance = {
+  handler: async (req: Request): Promise<Response> => {
+    const path = new URL(req.url).pathname;
+    if (path === "/api/auth/agent-configuration") {
+      return new Response(JSON.stringify(AGENT_CONFIG_DOC), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    // Any other reached path → 200 marker ("reachable, not 404").
+    return new Response(JSON.stringify({ reached: path }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  },
+};
+mock.module("@atlas/api/lib/auth/server", () => ({
+  getAuthInstance: () => stubAuthInstance,
+}));
+
+// SUT routers — imported AFTER the mocks.
+import { auth } from "@atlas/api/api/routes/auth";
+import { wellKnown } from "@atlas/api/api/routes/well-known";
+
+const app = new Hono();
+app.route("/api/auth", auth);
+app.route("/.well-known", wellKnown);
+
+/** Every path the gate must 404 when off / admit when on. */
+const AGENT_AUTH_PATHS = [
+  { method: "POST", path: "/api/auth/agent/register" },
+  { method: "GET", path: "/api/auth/agent/list" },
+  { method: "POST", path: "/api/auth/host/enroll" },
+  { method: "POST", path: "/api/auth/host/create" },
+  { method: "GET", path: "/api/auth/capability/list" },
+  { method: "POST", path: "/api/auth/capability/execute" },
+  { method: "GET", path: "/api/auth/agent-configuration" },
+] as const;
+
+const DISCOVERY_PATH = "/.well-known/agent-configuration";
+
+async function req(method: string, path: string): Promise<Response> {
+  return app.request(path, { method });
+}
+
+describe("Agent Auth live-toggle (#4409)", () => {
+  const prev = process.env.ATLAS_AGENT_AUTH_ENABLED;
+
+  beforeAll(() => {
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED; // default = off
+  });
+  afterAll(() => {
+    if (prev === undefined) delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    else process.env.ATLAS_AGENT_AUTH_ENABLED = prev;
+  });
+
+  it("OFF (default): every agent-auth path returns 404", async () => {
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    for (const { method, path } of AGENT_AUTH_PATHS) {
+      const res = await req(method, path);
+      expect({ path, status: res.status }).toEqual({ path, status: 404 });
+    }
+  });
+
+  it("OFF (default): the discovery document returns 404", async () => {
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    const res = await req("GET", DISCOVERY_PATH);
+    expect(res.status).toBe(404);
+  });
+
+  it("ON (flipped live, no restart): every agent-auth path is reachable (not 404)", async () => {
+    process.env.ATLAS_AGENT_AUTH_ENABLED = "true";
+    for (const { method, path } of AGENT_AUTH_PATHS) {
+      const res = await req(method, path);
+      expect({ path, status: res.status }).toEqual({ path, status: 200 });
+    }
+  });
+
+  it("ON: the discovery document is served (the plugin's canonical doc, proxied)", async () => {
+    process.env.ATLAS_AGENT_AUTH_ENABLED = "true";
+    const res = await req("GET", DISCOVERY_PATH);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { version?: string };
+    expect(body.version).toBe("1.0-draft");
+  });
+
+  it("flipped back OFF: the surface returns to 404 (no restart)", async () => {
+    // Same app, same singleton — only the setting changed.
+    process.env.ATLAS_AGENT_AUTH_ENABLED = "true";
+    expect((await req("POST", "/api/auth/capability/execute")).status).toBe(200);
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    expect((await req("POST", "/api/auth/capability/execute")).status).toBe(404);
+    expect((await req("GET", DISCOVERY_PATH)).status).toBe(404);
+  });
+
+  it("fail-closed: an explicitly false value is off", async () => {
+    process.env.ATLAS_AGENT_AUTH_ENABLED = "false";
+    expect((await req("POST", "/api/auth/agent/register")).status).toBe(404);
+    expect((await req("GET", DISCOVERY_PATH)).status).toBe(404);
+  });
+
+  it("the gate is scoped: a non-agent-auth auth path is never gated", async () => {
+    // sign-in is not an agent-auth path, so it reaches the auth handler
+    // regardless of the setting.
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    expect((await req("POST", "/api/auth/sign-in/email")).status).toBe(200);
+    process.env.ATLAS_AGENT_AUTH_ENABLED = "true";
+    expect((await req("POST", "/api/auth/sign-in/email")).status).toBe(200);
+  });
+});

--- a/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
+++ b/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
@@ -52,6 +52,11 @@ const stubAuthInstance = {
     });
   },
 };
+// Intentional wholesale replace (NOT a spread of the real module, unlike the
+// `detect` mock above): building the real auth singleton is heavy, and both
+// routers consume ONLY `getAuthInstance` from this module — and only via dynamic
+// `import()` inside their handlers — so a light stub is sufficient and nothing
+// else in this test's graph needs the module's other exports.
 mock.module("@atlas/api/lib/auth/server", () => ({
   getAuthInstance: () => stubAuthInstance,
 }));

--- a/packages/api/src/api/routes/auth.ts
+++ b/packages/api/src/api/routes/auth.ts
@@ -11,6 +11,7 @@ import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createLogger } from "@atlas/api/lib/logger";
 import { normalizeSignupResponseBody } from "@atlas/api/lib/auth/signup-response";
+import { isAgentAuthPath, isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
 
 const log = createLogger("auth-route");
 
@@ -83,6 +84,25 @@ auth.all("/*", async (c) => {
           "endpoint is disabled.",
       },
       403,
+    );
+  }
+
+  // #4409 / #2058 — Agent Auth Protocol surface gate. The `agentAuth()` plugin is
+  // registered unconditionally (schema + routes always present), so its endpoints
+  // (`/api/auth/agent/*`, `/api/auth/host/*`, `/api/auth/capability/*`) and the
+  // discovery endpoint (`/api/auth/agent-configuration`) would otherwise be live
+  // by default. Gate them per-request on the hot-reloadable
+  // `ATLAS_AGENT_AUTH_ENABLED` setting so the whole surface returns 404 when off
+  // (the default) and becomes reachable — with NO redeploy — when an operator
+  // flips it on. Fail-closed (any resolution error ⇒ off). Gated on the platform
+  // default here (the workspace isn't known until the agent JWT is verified, and
+  // resolving it at this raw layer would leak token knowledge into the gate);
+  // per-workspace override precedence is honored downstream at capability
+  // execution. Mirrors the native-admin block above and `shouldExposeCanonicalPrompts`.
+  if (isAgentAuthPath(c.req.path) && !(await isAgentAuthEnabled())) {
+    return c.json(
+      { error: "not_found", message: "Not found" },
+      404,
     );
   }
 

--- a/packages/api/src/api/routes/well-known.ts
+++ b/packages/api/src/api/routes/well-known.ts
@@ -435,6 +435,73 @@ wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", async (c) => {
   }
 });
 
+// ── /.well-known/agent-configuration ────────────────────────────────
+// Agent Auth Protocol discovery document (§6.1), gated by #4409's
+// hot-reloadable `ATLAS_AGENT_AUTH_ENABLED` setting. Served FROM THE API
+// (not a packages/web Next.js route) precisely because the gate decision
+// needs `getSettingLive`, which a web route can't reach (#2058 §5's
+// web-route sketch is stale).
+//
+// The document itself is the `agentAuth()` plugin's own canonical
+// `/api/auth/agent-configuration` output, proxied through the Better Auth
+// handler so the discovery doc can never drift from the endpoints the plugin
+// actually serves. When the setting is off (default) — or managed auth is not
+// configured — this returns 404, exactly like every other agent-auth path.
+//
+// Fail-closed: the gate resolves to off on any settings error, and a
+// handler/proxy failure surfaces as 503 with a requestId rather than a
+// misleading 404.
+wellKnown.get("/agent-configuration", async (c) => {
+  const requestId = crypto.randomUUID();
+
+  // Gate first — when off, the surface does not exist. Checked before auth-mode
+  // detection so an off deployment reveals nothing about managed-auth state.
+  const { isAgentAuthEnabled } = await import("@atlas/api/lib/auth/agent-auth-gate");
+  if (!(await isAgentAuthEnabled())) return notFoundAgentConfig();
+
+  const outcome = await loadAuthAndHelpers();
+  if (outcome.kind === "not-managed") return notFoundAgentConfig();
+  if (outcome.kind === "load-failed") {
+    return loadFailedResponse(requestId, outcome.reason);
+  }
+
+  try {
+    // Proxy the plugin's own discovery endpoint. The agent-auth before-hook
+    // only fires for `/agent/ /capability/ /host/` paths carrying a bearer, so
+    // this bare GET reaches the discovery handler directly (public, no auth).
+    const origin = new URL(c.req.url).origin;
+    const upstream = await outcome.helpers.auth.handler(
+      new Request(`${origin}/api/auth/agent-configuration`, { method: "GET" }),
+    );
+    if (!upstream.ok) {
+      log.error(
+        { requestId, status: upstream.status },
+        "agent-configuration proxy returned non-2xx",
+      );
+      return metadataUnavailableResponse(requestId);
+    }
+    return await withMetadataHeaders(upstream);
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err), requestId },
+      "agent-configuration discovery generation failed",
+    );
+    return metadataUnavailableResponse(requestId);
+  }
+});
+
+/** 404 for the agent-configuration surface — shape mirrors `notManagedResponse`. */
+function notFoundAgentConfig(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "not_found",
+      message:
+        "The Agent Auth discovery document is not available on this deployment.",
+    }),
+    { status: 404, headers: { "Content-Type": "application/json" } },
+  );
+}
+
 // CORS preflight — MCP Inspector and some browser MCP UIs probe before
 // fetching. Same shape as the production response, no body.
 wellKnown.options("/*", (c) => {

--- a/packages/api/src/lib/auth/__tests__/agent-auth-gate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-gate.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Agent Auth gate — path matcher, fail-closed resolution, and the
+ * plugin↔gate prefix CONTRACT (#4409).
+ *
+ * The contract test is the one the gate's own docstring promises: the gate's
+ * `isAgentAuthPath` prefix list is a hand copy of the plugin's internal
+ * (non-exported) prefixes, so a `@better-auth/agent-auth` bump that adds a route
+ * under a NEW prefix would silently escape the gate and be reachable while the
+ * feature is off. This enumerates every path the real plugin advertises and
+ * asserts the gate matches each — turning that drift into a RED test.
+ *
+ * Self-contained: the enable flag is set on `process.env` per-test and restored;
+ * the settings module is spread-mocked so the fail-closed error path can be
+ * driven without an internal DB.
+ */
+
+import { describe, it, expect, afterEach, mock } from "bun:test";
+
+// Spread the real settings module and override only getSettingLive with a
+// controllable stub. Driving the raw string return directly (rather than env +
+// the real resolver) isolates the gate's OWN logic — its `isTrue` coercion and
+// its fail-closed catch — from the settings live-cache TTL, which would
+// otherwise hold a stale value across rapid flips within one test run.
+import * as settingsReal from "@atlas/api/lib/settings";
+let settingValue: string | undefined;
+let throwOnRead = false;
+mock.module("@atlas/api/lib/settings", () => ({
+  ...settingsReal,
+  getSettingLive: async (_key: string, _orgId?: string) => {
+    if (throwOnRead) throw new Error("settings backend unavailable");
+    return settingValue;
+  },
+}));
+
+import {
+  isAgentAuthPath,
+  isAgentAuthEnabled,
+  AGENT_AUTH_MOUNT,
+  AGENT_AUTH_CONFIGURATION_PATH,
+} from "@atlas/api/lib/auth/agent-auth-gate";
+import { buildAgentAuthPlugin } from "@atlas/api/lib/auth/agent-auth-plugin";
+
+describe("isAgentAuthPath", () => {
+  it("matches every functional group + the discovery path", () => {
+    expect(isAgentAuthPath("/api/auth/agent/register")).toBe(true);
+    expect(isAgentAuthPath("/api/auth/agent/device/code")).toBe(true);
+    expect(isAgentAuthPath("/api/auth/host/enroll")).toBe(true);
+    expect(isAgentAuthPath("/api/auth/capability/execute")).toBe(true);
+    expect(isAgentAuthPath(AGENT_AUTH_CONFIGURATION_PATH)).toBe(true);
+  });
+
+  it("does NOT match non-agent-auth auth paths (gate is scoped)", () => {
+    expect(isAgentAuthPath("/api/auth/sign-in/email")).toBe(false);
+    expect(isAgentAuthPath("/api/auth/token")).toBe(false);
+    expect(isAgentAuthPath("/api/auth/device/code")).toBe(false); // the OTHER device flow (RFC 8628), not agent-auth
+    expect(isAgentAuthPath("/api/v1/chat")).toBe(false);
+  });
+});
+
+// THE CONTRACT: the gate must match every path the plugin actually mounts.
+describe("plugin↔gate prefix contract (#4409)", () => {
+  it("every path the agent-auth plugin advertises is gated by isAgentAuthPath", () => {
+    const plugin = buildAgentAuthPlugin();
+    const paths = Object.values(plugin.endpoints ?? {})
+      .map((e) => (e as { path?: string }).path)
+      .filter((p): p is string => typeof p === "string");
+
+    expect(paths.length).toBeGreaterThan(0);
+    const escaped = paths.filter((p) => !isAgentAuthPath(`${AGENT_AUTH_MOUNT}${p}`));
+    expect(
+      escaped,
+      `these plugin routes are NOT covered by the gate and would be reachable while the ` +
+        `feature is off — extend AGENT_AUTH_PREFIXES in agent-auth-gate.ts: ${escaped.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("isAgentAuthEnabled (fail-closed)", () => {
+  afterEach(() => {
+    throwOnRead = false;
+    settingValue = undefined;
+  });
+
+  it("off when the setting resolves to undefined (default)", async () => {
+    settingValue = undefined;
+    expect(await isAgentAuthEnabled()).toBe(false);
+  });
+
+  it("on when the setting is exactly 'true' (trimmed / case-insensitive)", async () => {
+    for (const v of ["true", "TRUE", " true "]) {
+      settingValue = v;
+      expect({ v, on: await isAgentAuthEnabled() }).toEqual({ v, on: true });
+    }
+  });
+
+  it("off for any non-'true' value (a malformed override cannot open the surface)", async () => {
+    for (const v of ["false", "0", "1", "yes", "on", "enabled", ""]) {
+      settingValue = v;
+      expect({ v, on: await isAgentAuthEnabled() }).toEqual({ v, on: false });
+    }
+  });
+
+  it("fail-closed: a settings-resolution error resolves to off (never opens)", async () => {
+    settingValue = "true"; // would be ON if it read cleanly
+    throwOnRead = true;
+    expect(await isAgentAuthEnabled()).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Agent Auth spine — plugin contract + JWT/grant verification + the Atlas-side
+ * `onExecute` per-org binding (#4409, Slice 1).
+ *
+ * These drive the REAL `buildAgentAuthPlugin()` through a real `betterAuth()`
+ * instance backed by the in-memory adapter (the same harness `server.test.ts`
+ * uses). The agent-auth `before` hook does full agent-JWT verification
+ * (signature against the registered Ed25519 key, `aud` binding, expiry, jti
+ * replay) and the capability grant check before `onExecute` runs — so hitting
+ * `/api/auth/capability/execute` with crafted JWTs exercises the actual security
+ * surface, not a re-implementation.
+ *
+ * The two `onExecute` dependencies that need an internal DB — the workspace-
+ * membership lookup (`listUserWorkspaceIds`) and the org-scoped read
+ * (`listEntities`) — are mocked so the happy and cross-workspace paths run
+ * without Postgres; every DENIAL case (wrong aud / expired / revoked / missing
+ * capability claim) fails BEFORE `onExecute`, so those assertions exercise the
+ * unmocked plugin verification directly.
+ *
+ * Self-contained: the enable flag is set on `process.env` inside the suite and
+ * restored, never at module top level.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { generateKeyPair, exportJWK, SignJWT } from "jose";
+
+/** jose v6 dropped the `KeyLike` alias; infer the key type from generateKeyPair. */
+type AgentPrivateKey = Awaited<ReturnType<typeof generateKeyPair>>["privateKey"];
+
+// ── Mocks for the two internal-DB-backed onExecute dependencies ─────────────
+// `listUserWorkspaceIds` is the authoritative membership check the verifier
+// runs; default it to "user_1 is a member of wsA only" so the cross-workspace
+// case (an agent bound to wsB) is denied.
+let workspacesForUser: (userId: string) => string[] = () => ["wsA"];
+mock.module("@atlas/api/lib/auth/oauth-workspace-grants", () => ({
+  getOAuthClientScope: async () => "single",
+  hasWorkspaceGrant: async () => false,
+  userIsWorkspaceMember: async () => false,
+  listUserWorkspaceIds: async (userId: string) => workspacesForUser(userId),
+  listWorkspaceGrantsForClient: async () => [],
+  setWorkspaceScopeAndGrants: async () => undefined,
+  revokeWorkspaceGrant: async () => 0,
+}));
+
+// Spread the real semantic/entities module and override only `listEntities`,
+// so "mock all exports" holds and the org-scoped read is deterministic.
+import * as entitiesReal from "@atlas/api/lib/semantic/entities";
+const entitiesForOrg: (orgId: string | undefined) => entitiesReal.EntityListEntry[] = (orgId) =>
+  orgId === "wsA"
+    ? ([{ name: "orders", table: "public.orders", description: "Orders fact" }] as entitiesReal.EntityListEntry[])
+    : [];
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  ...entitiesReal,
+  listEntities: async (opts: { orgId?: string } = {}) => entitiesForOrg(opts.orgId),
+}));
+
+// SUT — imported AFTER the mocks are registered.
+import {
+  buildAgentAuthPlugin,
+  LIST_ENTITIES_CAPABILITY,
+  AGENT_WORKSPACE_METADATA_KEY,
+} from "@atlas/api/lib/auth/agent-auth-plugin";
+
+const BASE = "http://localhost:3000";
+const ISSUER = `${BASE}/api/auth`;
+const EXECUTE_URL = `${ISSUER}/capability/execute`;
+
+// ── Contract pinning ────────────────────────────────────────────────────────
+
+describe("agent-auth plugin contract (#4409)", () => {
+  it("registers under id 'agent-auth' with the four spec tables", () => {
+    const plugin = buildAgentAuthPlugin();
+    expect(plugin.id).toBe("agent-auth");
+    // The 0.6.2 schema names — pinned so a future bump that renames a table
+    // (docs drifted between agent/host/grant and agentHost/capabilityGrant) goes
+    // RED here rather than silently changing what auto-migrate creates.
+    expect(Object.keys(plugin.schema ?? {}).sort()).toEqual([
+      "agent",
+      "agentCapabilityGrant",
+      "agentHost",
+      "approvalRequest",
+    ]);
+  });
+
+  it("advertises exactly ONE hand-written capability (Slice 1 scope guard)", () => {
+    // The plugin does not surface its options directly, so assert through the
+    // capabilities the discovery/list path is configured with: build a probe
+    // instance and read the registered capability off the execute path via a
+    // round-trip is overkill — instead pin the exported name + that the plugin
+    // exposes the execute + discovery endpoints.
+    const plugin = buildAgentAuthPlugin();
+    const paths = Object.values(plugin.endpoints ?? {})
+      .map((e) => (e as { path?: string }).path)
+      .filter(Boolean);
+    expect(paths).toContain("/capability/execute");
+    expect(paths).toContain("/agent-configuration");
+    expect(LIST_ENTITIES_CAPABILITY).toBe("list_semantic_entities");
+  });
+});
+
+// ── JWT / grant verification + onExecute binding ────────────────────────────
+
+describe("agent-auth capability execution (#4409)", () => {
+  let privateKey: AgentPrivateKey;
+  let publicJwk: Record<string, unknown>;
+  const prevEnabled = process.env.ATLAS_AGENT_AUTH_ENABLED;
+
+  beforeAll(async () => {
+    process.env.ATLAS_AGENT_AUTH_ENABLED = "true";
+    const kp = await generateKeyPair("EdDSA", { crv: "Ed25519", extractable: true });
+    privateKey = kp.privateKey;
+    publicJwk = (await exportJWK(kp.publicKey)) as Record<string, unknown>;
+  });
+
+  afterAll(() => {
+    if (prevEnabled === undefined) delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    else process.env.ATLAS_AGENT_AUTH_ENABLED = prevEnabled;
+    workspacesForUser = () => ["wsA"];
+  });
+
+  /**
+   * Build a fresh in-memory auth instance seeded with a host, a user, and one
+   * or more agents (each with its own workspace-metadata + grant status). Rows
+   * are pre-seeded in the shape the plugin's read path expects (publicKey /
+   * metadata as JSON strings), which the scratch harness verified round-trips.
+   */
+  function makeInstance(
+    agents: Array<{ id: string; workspaceId: string; grantStatus: "active" | "revoked" }>,
+  ) {
+    const now = new Date();
+    const host = {
+      id: "host_1", name: "h", userId: "user_1", defaultCapabilities: "[]",
+      publicKey: null, kid: null, jwksUrl: null, enrollmentTokenHash: null,
+      enrollmentTokenExpiresAt: null, status: "active", activatedAt: now,
+      expiresAt: null, lastUsedAt: null, createdAt: now, updatedAt: now,
+    };
+    const user = { id: "user_1", name: "U", email: "u@example.com", emailVerified: true, createdAt: now, updatedAt: now };
+    const agentRows = agents.map((a) => ({
+      id: a.id, name: a.id, userId: "user_1", hostId: "host_1", status: "active",
+      mode: "delegated", publicKey: JSON.stringify(publicJwk), kid: null, jwksUrl: null,
+      lastUsedAt: null, activatedAt: now, expiresAt: null,
+      metadata: JSON.stringify({ [AGENT_WORKSPACE_METADATA_KEY]: a.workspaceId }),
+      createdAt: now, updatedAt: now,
+    }));
+    const grantRows = agents.map((a) => ({
+      id: `grant_${a.id}`, agentId: a.id, capability: LIST_ENTITIES_CAPABILITY,
+      deniedBy: null, grantedBy: "user_1", expiresAt: null, status: a.grantStatus,
+      constraints: null, createdAt: now, updatedAt: now,
+    }));
+    return betterAuth({
+      baseURL: BASE,
+      secret: "test-secret-at-least-32-characters-long!!",
+      database: memoryAdapter({
+        user: [user], session: [], account: [], verification: [],
+        agent: agentRows, agentHost: [host], agentCapabilityGrant: grantRows, approvalRequest: [],
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
+      plugins: [buildAgentAuthPlugin()] as any[],
+    });
+  }
+
+  async function mintJWT(opts: {
+    agentId: string;
+    aud?: string;
+    capabilities?: string[];
+    expired?: boolean;
+  }): Promise<string> {
+    const jwt = new SignJWT({
+      ...(opts.capabilities !== undefined ? { capabilities: opts.capabilities } : { capabilities: [LIST_ENTITIES_CAPABILITY] }),
+    })
+      .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
+      .setSubject(opts.agentId)
+      .setIssuer("host_1")
+      .setAudience(opts.aud ?? EXECUTE_URL)
+      .setJti(`jti_${opts.agentId}_${crypto.randomUUID()}`)
+      .setIssuedAt(opts.expired ? Math.floor(Date.now() / 1000) - 3600 : undefined)
+      .setExpirationTime(opts.expired ? Math.floor(Date.now() / 1000) - 1800 : "2m");
+    return jwt.sign(privateKey);
+  }
+
+  async function execute(
+    instance: ReturnType<typeof makeInstance>,
+    token: string,
+  ): Promise<{ status: number; body: { error?: string; data?: unknown } }> {
+    const res = await instance.handler(
+      new Request(EXECUTE_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ capability: LIST_ENTITIES_CAPABILITY, arguments: {} }),
+      }),
+    );
+    const body = (await res.json().catch(() => ({}))) as { error?: string; data?: unknown };
+    await instance.$context.catch(() => {});
+    return { status: res.status, body };
+  }
+
+  it("happy path: valid aud + granted capability → 200, org-scoped result for the agent's workspace", async () => {
+    workspacesForUser = () => ["wsA"];
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(200);
+    // onExecute returned the org-scoped listEntities projection for wsA.
+    expect(body.data).toMatchObject({ workspaceId: "wsA", count: 1 });
+    expect((body.data as { entities: unknown[] }).entities).toHaveLength(1);
+  });
+
+  it("wrong audience → 401 invalid_jwt (rejected before onExecute)", async () => {
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(
+      instance,
+      await mintJWT({ agentId: "agent_1", aud: "https://attacker.example.com/execute" }),
+    );
+    expect(status).toBe(401);
+    expect(body.error).toBe("invalid_jwt");
+  });
+
+  it("expired token → 401 invalid_jwt", async () => {
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1", expired: true }));
+    expect(status).toBe(401);
+    expect(body.error).toBe("invalid_jwt");
+  });
+
+  it("revoked grant → 403 grant_revoked", async () => {
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "revoked" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(403);
+    expect(body.error).toBe("grant_revoked");
+  });
+
+  it("missing capability claim (token asserts no capabilities) → 403 capability_not_granted", async () => {
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    // An empty `capabilities` claim scopes the session to zero grants — the
+    // token does not assert the capability it is trying to execute.
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1", capabilities: [] }));
+    expect(status).toBe(403);
+    expect(body.error).toBe("capability_not_granted");
+  });
+
+  it("cross-workspace isolation: an agent bound to a workspace its owner is not a member of is denied", async () => {
+    // user_1 is a member of wsA only. agent_b's metadata claims wsB.
+    workspacesForUser = () => ["wsA"];
+    const instance = makeInstance([{ id: "agent_b", workspaceId: "wsB", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_b" }));
+    // The JWT + grant are valid, so the plugin admits and calls onExecute; the
+    // Atlas-side membership check is what denies (403), NOT a JWT failure.
+    expect(status).toBe(403);
+    expect(body.error).toBe("unauthorized");
+    // And it never reached the org-scoped read for wsB.
+    expect(body.data).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -56,11 +56,23 @@ mock.module("@atlas/api/lib/semantic/entities", () => ({
   listEntities: async (opts: { orgId?: string } = {}) => entitiesForOrg(opts.orgId),
 }));
 
+// Spread the real gate and override only the enable check, so onExecute's
+// workspace-override branch can be driven deterministically without an internal
+// DB (the gate's own env/fail-closed behavior is covered in agent-auth-gate.test.ts).
+// Default: enabled for every workspace.
+import * as gateReal from "@atlas/api/lib/auth/agent-auth-gate";
+let enabledForWorkspace: (orgId?: string) => boolean = () => true;
+mock.module("@atlas/api/lib/auth/agent-auth-gate", () => ({
+  ...gateReal,
+  isAgentAuthEnabled: async (orgId?: string) => enabledForWorkspace(orgId),
+}));
+
 // SUT — imported AFTER the mocks are registered.
 import {
   buildAgentAuthPlugin,
   LIST_ENTITIES_CAPABILITY,
   AGENT_WORKSPACE_METADATA_KEY,
+  AGENT_AUTH_CAPABILITIES,
 } from "@atlas/api/lib/auth/agent-auth-plugin";
 
 const BASE = "http://localhost:3000";
@@ -85,18 +97,18 @@ describe("agent-auth plugin contract (#4409)", () => {
   });
 
   it("advertises exactly ONE hand-written capability (Slice 1 scope guard)", () => {
-    // The plugin does not surface its options directly, so assert through the
-    // capabilities the discovery/list path is configured with: build a probe
-    // instance and read the registered capability off the execute path via a
-    // round-trip is overkill — instead pin the exported name + that the plugin
-    // exposes the execute + discovery endpoints.
+    // The real scope guard: exactly one capability, so Slice 2's OpenAPI adapter
+    // can't silently expand the surface here. Reads the exported source list.
+    expect(AGENT_AUTH_CAPABILITIES).toHaveLength(1);
+    expect(AGENT_AUTH_CAPABILITIES[0].name).toBe(LIST_ENTITIES_CAPABILITY);
+    expect(AGENT_AUTH_CAPABILITIES[0].name).toBe("list_semantic_entities");
+    // …and the plugin exposes the execute + discovery endpoints it's built on.
     const plugin = buildAgentAuthPlugin();
     const paths = Object.values(plugin.endpoints ?? {})
       .map((e) => (e as { path?: string }).path)
       .filter(Boolean);
     expect(paths).toContain("/capability/execute");
     expect(paths).toContain("/agent-configuration");
-    expect(LIST_ENTITIES_CAPABILITY).toBe("list_semantic_entities");
   });
 });
 
@@ -118,6 +130,7 @@ describe("agent-auth capability execution (#4409)", () => {
     if (prevEnabled === undefined) delete process.env.ATLAS_AGENT_AUTH_ENABLED;
     else process.env.ATLAS_AGENT_AUTH_ENABLED = prevEnabled;
     workspacesForUser = () => ["wsA"];
+    enabledForWorkspace = () => true;
   });
 
   /**
@@ -198,12 +211,29 @@ describe("agent-auth capability execution (#4409)", () => {
 
   it("happy path: valid aud + granted capability → 200, org-scoped result for the agent's workspace", async () => {
     workspacesForUser = () => ["wsA"];
+    enabledForWorkspace = () => true;
     const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
     expect(status).toBe(200);
-    // onExecute returned the org-scoped listEntities projection for wsA.
+    // onExecute returned the org-scoped listEntities projection for wsA, with the
+    // exact field mapping (name/table/description ?? null).
     expect(body.data).toMatchObject({ workspaceId: "wsA", count: 1 });
-    expect((body.data as { entities: unknown[] }).entities).toHaveLength(1);
+    expect((body.data as { entities: unknown[] }).entities).toEqual([
+      { name: "orders", table: "public.orders", description: "Orders fact" },
+    ]);
+  });
+
+  it("workspace-override off: a workspace that opted out is denied even with the platform default on", async () => {
+    // Defense-in-depth beyond the raw HTTP gate: onExecute re-checks the setting
+    // for the RESOLVED workspace. wsA has it off (platform on) → denied, and the
+    // org-scoped read is never reached.
+    workspacesForUser = () => ["wsA"];
+    enabledForWorkspace = (orgId) => orgId !== "wsA";
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(404);
+    expect(body.error).toBe("unauthorized");
+    expect(body.data).toBeUndefined();
   });
 
   it("wrong audience → 401 invalid_jwt (rejected before onExecute)", async () => {

--- a/packages/api/src/lib/auth/__tests__/agent-auth-seam-quarantine.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-seam-quarantine.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Reversibility guard for the Agent Auth seam (#4409 AC / #4408 AC4).
+ *
+ * The load-bearing invariant: Agent Auth plugs into the identity layer as a new
+ * `AtlasUser` producer, and NO agent-auth / token / discovery knowledge leaks
+ * into the enforcement core — the MCP dispatch gate, its declarative contract,
+ * or RBAC/permissions. So a future switch to an OAuth-native (ID-JAG / auth.md)
+ * agent-identity flow replaces the producer and touches none of those files.
+ *
+ * This is grep-assertable and is asserted here: the three quarantined files must
+ * contain none of the agent-auth vocabulary. If a future change threads a token
+ * shape or `/.well-known/agent-configuration` assumption into the gate, this
+ * test goes RED and names the leak.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// packages/api/src/lib/auth/__tests__ → repo root is six levels up
+// (__tests__ → auth → lib → src → api → packages → root).
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..", "..", "..");
+
+/**
+ * The enforcement-core files that must stay ignorant of agent-auth. Paths are
+ * repo-relative so the failure message points a maintainer straight at the file.
+ */
+const QUARANTINED_FILES = [
+  "packages/mcp/src/dispatch-gate.ts",
+  "packages/api/src/lib/mcp/dispatch-gate-contract.ts",
+  "packages/api/src/lib/auth/permissions.ts",
+] as const;
+
+/**
+ * Vocabulary that would signal an agent-auth leak into the enforcement core.
+ * Case-insensitive. `agent-configuration` / `agentAuth` / the package name are
+ * the discovery + plugin identifiers; the token/session/grant terms are the
+ * shapes that must stay quarantined in the verifier + plugin.
+ */
+const FORBIDDEN_TERMS = [
+  "agent-auth",
+  "agentauth",
+  "@better-auth/agent-auth",
+  "agent-configuration",
+  "agent-auth-verifier",
+  "agent-auth-plugin",
+  "agentsession",
+  "capabilitygrant",
+  "verifyagentrequest",
+  "agent_auth",
+] as const;
+
+describe("agent-auth seam quarantine (#4409 reversibility)", () => {
+  for (const rel of QUARANTINED_FILES) {
+    it(`${rel} contains no agent-auth vocabulary`, () => {
+      const source = readFileSync(join(REPO_ROOT, rel), "utf8").toLowerCase();
+      const leaks = FORBIDDEN_TERMS.filter((term) => source.includes(term.toLowerCase()));
+      expect(
+        leaks,
+        `${rel} leaked agent-auth vocabulary: ${leaks.join(", ")}. The enforcement ` +
+          `core must consume only the AtlasUser abstraction — keep agent-auth ` +
+          `knowledge inside the verifier + plugin.`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/packages/api/src/lib/auth/__tests__/agent-auth-verifier.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-verifier.test.ts
@@ -55,6 +55,8 @@ describe("resolveAgentAuthActor (#4409 sixth AtlasUser producer)", () => {
     expect(result.user.id).toBe("user_1");
     expect(result.user.mode).toBe("managed");
     expect(result.user.activeOrganizationId).toBe("wsA");
+    // The `ok` arm carries the bound workspace explicitly (guaranteed string).
+    expect(result.workspaceId).toBe("wsA");
     expect(result.user.role).toBe("member");
     expect(result.user.claims).toMatchObject({ agent_auth: true, agent_id: "agent_1", active_organization_id: "wsA" });
     // Frozen — createAtlasUser hardens the object.

--- a/packages/api/src/lib/auth/__tests__/agent-auth-verifier.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-verifier.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the Agent-Auth → AtlasUser producer (#4409 reversible seam).
+ *
+ * `resolveAgentAuthActor` is the sixth producer of `AtlasUser` and the single
+ * place the agent-auth workspace binding + trust boundary are enforced. These
+ * pin the branches that are awkward to reach through the full plugin: the
+ * fail-closed denials and the org-role-only (withhold-`platform_admin`)
+ * boundary. The end-to-end happy + cross-workspace paths are additionally
+ * covered through the real plugin in `agent-auth-plugin.test.ts`.
+ *
+ * `resolveEffectiveRole` and `listUserWorkspaceIds` are mocked (both hit the
+ * internal DB in production); the tests drive their return values per-case.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+let workspacesFor: (userId: string) => Promise<string[]> = async () => ["wsA"];
+mock.module("@atlas/api/lib/auth/oauth-workspace-grants", () => ({
+  getOAuthClientScope: async () => "single",
+  hasWorkspaceGrant: async () => false,
+  userIsWorkspaceMember: async () => false,
+  listUserWorkspaceIds: (userId: string) => workspacesFor(userId),
+  listWorkspaceGrantsForClient: async () => [],
+  setWorkspaceScopeAndGrants: async () => undefined,
+  revokeWorkspaceGrant: async () => 0,
+}));
+
+// Capture the arguments the verifier passes to resolveEffectiveRole so we can
+// assert the org-role-only boundary (userRole must be undefined).
+const roleCalls: Array<[unknown, string, string | undefined]> = [];
+let roleResult: unknown = undefined;
+mock.module("@atlas/api/lib/auth/effective-role", () => ({
+  resolveEffectiveRole: async (userRole: unknown, userId: string, orgId: string | undefined) => {
+    roleCalls.push([userRole, userId, orgId]);
+    return roleResult;
+  },
+}));
+
+import { resolveAgentAuthActor } from "@atlas/api/lib/auth/agent-auth-verifier";
+
+const baseIdentity = {
+  userId: "user_1",
+  requestedWorkspaceId: "wsA",
+  agentId: "agent_1",
+  label: "Agent One",
+};
+
+describe("resolveAgentAuthActor (#4409 sixth AtlasUser producer)", () => {
+  it("happy: owning user is a member → binds an AtlasUser scoped to that workspace", async () => {
+    workspacesFor = async () => ["wsA", "wsOther"];
+    roleResult = "member";
+    const result = await resolveAgentAuthActor(baseIdentity);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("unreachable");
+    expect(result.user.id).toBe("user_1");
+    expect(result.user.mode).toBe("managed");
+    expect(result.user.activeOrganizationId).toBe("wsA");
+    expect(result.user.role).toBe("member");
+    expect(result.user.claims).toMatchObject({ agent_auth: true, agent_id: "agent_1", active_organization_id: "wsA" });
+    // Frozen — createAtlasUser hardens the object.
+    expect(Object.isFrozen(result.user)).toBe(true);
+  });
+
+  it("threads the resolved org role onto the AtlasUser", async () => {
+    workspacesFor = async () => ["wsA"];
+    roleResult = "admin";
+    const result = await resolveAgentAuthActor(baseIdentity);
+    expect(result.kind === "ok" && result.user.role).toBe("admin");
+  });
+
+  it("org-role-only: never passes a user-level role to resolveEffectiveRole (withholds platform_admin)", async () => {
+    roleCalls.length = 0;
+    workspacesFor = async () => ["wsA"];
+    roleResult = "member";
+    await resolveAgentAuthActor(baseIdentity);
+    // Exactly the hosted/cli boundary: userRole arg is undefined.
+    expect(roleCalls).toHaveLength(1);
+    expect(roleCalls[0][0]).toBeUndefined();
+    expect(roleCalls[0]).toEqual([undefined, "user_1", "wsA"]);
+  });
+
+  it("cross-workspace isolation: owning user not a member of the requested workspace → denied", async () => {
+    workspacesFor = async () => ["wsA"]; // not wsB
+    const result = await resolveAgentAuthActor({ ...baseIdentity, requestedWorkspaceId: "wsB" });
+    expect(result).toEqual({ kind: "denied", reason: "not_a_member" });
+  });
+
+  it("missing workspace binding → denied without a membership lookup", async () => {
+    let called = false;
+    workspacesFor = async () => {
+      called = true;
+      return ["wsA"];
+    };
+    const result = await resolveAgentAuthActor({ ...baseIdentity, requestedWorkspaceId: undefined });
+    expect(result).toEqual({ kind: "denied", reason: "missing_workspace" });
+    expect(called).toBe(false);
+  });
+
+  it("fail-closed: a membership-lookup error denies (never a broader identity)", async () => {
+    workspacesFor = async () => {
+      throw new Error("internal DB down");
+    };
+    const result = await resolveAgentAuthActor(baseIdentity);
+    expect(result).toEqual({ kind: "denied", reason: "membership_lookup_failed" });
+  });
+
+  it("no resolved role → AtlasUser omits role (downstream defaults to least privilege)", async () => {
+    workspacesFor = async () => ["wsA"];
+    roleResult = undefined;
+    const result = await resolveAgentAuthActor(baseIdentity);
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("unreachable");
+    expect(result.user.role).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/agent-auth-gate.ts
+++ b/packages/api/src/lib/auth/agent-auth-gate.ts
@@ -20,7 +20,7 @@
  * document knowledge lives here — only the on/off decision and the path shape.
  */
 
-import { getSettingAuto, getSettingLive } from "@atlas/api/lib/settings";
+import { getSettingLive } from "@atlas/api/lib/settings";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("auth:agent-auth-gate");
@@ -31,13 +31,17 @@ export const AGENT_AUTH_ENABLED_SETTING = "ATLAS_AGENT_AUTH_ENABLED";
 /**
  * Better Auth mounts every plugin endpoint under `/api/auth`. The agent-auth
  * plugin contributes routes under these three functional prefixes plus the one
- * public discovery endpoint. Kept in lockstep with the plugin's own
- * `AGENT_AUTH_PREFIXES` (`/agent/`, `/capability/`, `/host/`) + the
- * `/agent-configuration` discovery path — a future plugin route outside these
- * would silently escape the gate, so the contract test pins this list against
- * the plugin's advertised paths.
+ * public discovery endpoint. These mirror the plugin's OWN (internal,
+ * non-exported) `AGENT_AUTH_PREFIXES` (`/agent/`, `/capability/`, `/host/`) +
+ * the `/agent-configuration` discovery path — a hand copy with no compile-time
+ * coupling, so a future plugin route outside these would silently escape the
+ * gate and be reachable while the feature is off. The
+ * `agent-auth-gate.test.ts` contract test guards exactly that: it enumerates
+ * every path the real plugin advertises and asserts `isAgentAuthPath` matches
+ * each, so a `@better-auth/agent-auth` bump that adds a new route prefix goes
+ * RED here instead of opening a hole.
  */
-const AGENT_AUTH_MOUNT = "/api/auth";
+export const AGENT_AUTH_MOUNT = "/api/auth";
 const AGENT_AUTH_PREFIXES = [
   `${AGENT_AUTH_MOUNT}/agent/`,
   `${AGENT_AUTH_MOUNT}/capability/`,
@@ -91,22 +95,6 @@ export async function isAgentAuthEnabled(orgId?: string): Promise<boolean> {
     log.warn(
       { err: err instanceof Error ? err.message : String(err), orgId },
       "agent-auth gate: settings resolution failed — failing closed (off)",
-    );
-    return false;
-  }
-}
-
-/**
- * Synchronous variant for hot-path callers that already run inside a warm
- * settings cache (mirrors `getSettingAuto`). Same fail-closed contract.
- */
-export function isAgentAuthEnabledSync(orgId?: string): boolean {
-  try {
-    return isTrue(getSettingAuto(AGENT_AUTH_ENABLED_SETTING, orgId));
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err), orgId },
-      "agent-auth gate (sync): settings resolution failed — failing closed (off)",
     );
     return false;
   }

--- a/packages/api/src/lib/auth/agent-auth-gate.ts
+++ b/packages/api/src/lib/auth/agent-auth-gate.ts
@@ -1,0 +1,113 @@
+/**
+ * Request-time gate for the Agent Auth Protocol surface (#4409 / #2058).
+ *
+ * The `agentAuth()` plugin is registered UNCONDITIONALLY in `buildPlugins()`
+ * (its routes + `agent`/`agentHost`/`agentCapabilityGrant`/`approvalRequest`
+ * schema are always present — the same tradeoff `twoFactor`/`passkey` make), so
+ * the better-auth build-once singleton never has to be rebuilt to toggle the
+ * feature. What *is* toggled — with no redeploy — is whether the reachable HTTP
+ * surface answers: this module is the single place that decision is made.
+ *
+ * Precedent this mirrors: `shouldExposeCanonicalPrompts`
+ * (`packages/mcp/src/prompts/gating.ts`) — read a hot-reloadable settings key,
+ * fail closed. The catch-all auth router (`api/routes/auth.ts`) and the
+ * `/.well-known/agent-configuration` discovery route (`api/routes/well-known.ts`)
+ * both consult this before dispatching, and 404 when it says off.
+ *
+ * Deliberately settings-only imports: the two HTTP surfaces that gate on this
+ * must not have to load better-auth (or the agent-auth plugin) to decide
+ * whether to 404. No token / agent-session / `/.well-known/agent-configuration`
+ * document knowledge lives here — only the on/off decision and the path shape.
+ */
+
+import { getSettingAuto, getSettingLive } from "@atlas/api/lib/settings";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("auth:agent-auth-gate");
+
+/** Settings-registry key (registered in `lib/settings.ts`). */
+export const AGENT_AUTH_ENABLED_SETTING = "ATLAS_AGENT_AUTH_ENABLED";
+
+/**
+ * Better Auth mounts every plugin endpoint under `/api/auth`. The agent-auth
+ * plugin contributes routes under these three functional prefixes plus the one
+ * public discovery endpoint. Kept in lockstep with the plugin's own
+ * `AGENT_AUTH_PREFIXES` (`/agent/`, `/capability/`, `/host/`) + the
+ * `/agent-configuration` discovery path — a future plugin route outside these
+ * would silently escape the gate, so the contract test pins this list against
+ * the plugin's advertised paths.
+ */
+const AGENT_AUTH_MOUNT = "/api/auth";
+const AGENT_AUTH_PREFIXES = [
+  `${AGENT_AUTH_MOUNT}/agent/`,
+  `${AGENT_AUTH_MOUNT}/capability/`,
+  `${AGENT_AUTH_MOUNT}/host/`,
+] as const;
+/** The plugin's discovery endpoint, mounted under the auth base. */
+export const AGENT_AUTH_CONFIGURATION_PATH = `${AGENT_AUTH_MOUNT}/agent-configuration`;
+
+/**
+ * True when `path` (a request path like `/api/auth/capability/execute`) targets
+ * the agent-auth plugin surface. Used by the catch-all auth router to decide
+ * which requests the gate applies to. Exact-match on the discovery path,
+ * prefix-match on the three functional groups (so `/agent/device/code`,
+ * `/capability/execute`, `/host/enroll`, … are all covered).
+ */
+export function isAgentAuthPath(path: string): boolean {
+  if (path === AGENT_AUTH_CONFIGURATION_PATH) return true;
+  return AGENT_AUTH_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+/**
+ * Coerce a settings string into the boolean the gate needs. Only the exact
+ * string `"true"` (case-insensitive, trimmed) enables — every other value,
+ * including `undefined`, disables. Fail-safe by construction: a malformed
+ * override can never accidentally open the surface.
+ */
+function isTrue(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+/**
+ * Whether the agent-auth surface is enabled — the authoritative, hot-reloaded
+ * read. `getSettingLive` refreshes the settings cache from the DB within its
+ * short TTL so an operator's toggle takes effect in seconds with no restart.
+ *
+ * FAIL CLOSED: any resolution error resolves to `false` (off). Enabling an
+ * experimental agent-identity surface on a transient settings-DB blip is
+ * strictly worse than a brief false-off, so the error path denies.
+ *
+ * `orgId` selects the workspace tier of the settings precedence chain
+ * (workspace override > platform > env > default). Callers that know the
+ * resolved workspace (e.g. capability execution) pass it for workspace-override
+ * precedence; the raw HTTP surface, which can't know the workspace before the
+ * agent JWT is verified without leaking token knowledge into the gate, omits it
+ * and gates on the platform default.
+ */
+export async function isAgentAuthEnabled(orgId?: string): Promise<boolean> {
+  try {
+    return isTrue(await getSettingLive(AGENT_AUTH_ENABLED_SETTING, orgId));
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "agent-auth gate: settings resolution failed — failing closed (off)",
+    );
+    return false;
+  }
+}
+
+/**
+ * Synchronous variant for hot-path callers that already run inside a warm
+ * settings cache (mirrors `getSettingAuto`). Same fail-closed contract.
+ */
+export function isAgentAuthEnabledSync(orgId?: string): boolean {
+  try {
+    return isTrue(getSettingAuto(AGENT_AUTH_ENABLED_SETTING, orgId));
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "agent-auth gate (sync): settings resolution failed — failing closed (off)",
+    );
+    return false;
+  }
+}

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -83,6 +83,13 @@ const listEntitiesCapability: Capability = {
 };
 
 /**
+ * The complete capability set the spine advertises. Exported so the contract
+ * test can assert Slice 1 ships EXACTLY one hand-written capability — a guard
+ * against Slice 2's OpenAPI adapter silently expanding the surface here.
+ */
+export const AGENT_AUTH_CAPABILITIES: readonly Capability[] = [listEntitiesCapability];
+
+/**
  * Read the agent-proposed workspace id off the agent session's metadata,
  * coerced to a non-empty string (metadata values are `string|number|boolean|null`).
  */
@@ -136,18 +143,9 @@ const onExecute: NonNullable<AgentAuthOptions["onExecute"]> = async ({
     );
   }
 
-  const user = resolved.user;
-  const workspaceId = user.activeOrganizationId;
-  if (!workspaceId) {
-    // Unreachable: resolveAgentAuthActor only returns `ok` with a bound
-    // workspace. Guard defensively rather than pass `undefined` into the
-    // org-scoped seam (which would hard-fail on a multi-tenant deployment).
-    throw agentError(
-      "FORBIDDEN",
-      AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
-      "Agent identity resolved without a workspace binding.",
-    );
-  }
+  // `workspaceId` is a guaranteed non-empty string on the `ok` arm (encoded in
+  // AgentAuthActorResult), so no defensive undefined-check is needed.
+  const { user, workspaceId } = resolved;
 
   // Workspace-override precedence (#4409): the raw HTTP gate checks the platform
   // default; here, with the workspace resolved, honor a per-workspace override.
@@ -168,20 +166,43 @@ const onExecute: NonNullable<AgentAuthOptions["onExecute"]> = async ({
   // `orgId` explicitly AND binding the identity is belt-and-suspenders: the call
   // is org-scoped by construction, and any deeper RLS-aware read runs under the
   // same bound actor. No secret material is threaded — only the resolved user.
-  const entities = await withRequestContext(
-    { requestId: crypto.randomUUID(), user },
-    () => listEntities({ orgId: workspaceId, mode: "published", ...(filter ? { filter } : {}) }),
-  );
-
-  return {
-    workspaceId,
-    count: entities.length,
-    entities: entities.map((e) => ({
-      name: e.name,
-      table: e.table,
-      description: e.description ?? null,
-    })),
-  };
+  //
+  // The read is wrapped: an UNEXPECTED failure (internal-DB brownout, semantic
+  // load/parse error, …) must NOT (a) be silent on Atlas's side, nor (b) let the
+  // plugin's default rethrow echo the raw `err.message` back to the agent — the
+  // least-trusted actor. Log with a correlatable ref, then throw a generic,
+  // non-leaking envelope carrying only that ref. (CLAUDE.md: no silent swallow,
+  // no secrets in responses, requestId on 500s.)
+  const requestId = crypto.randomUUID();
+  try {
+    const entities = await withRequestContext({ requestId, user }, () =>
+      listEntities({ orgId: workspaceId, mode: "published", ...(filter ? { filter } : {}) }),
+    );
+    return {
+      workspaceId,
+      count: entities.length,
+      entities: entities.map((e) => ({
+        name: e.name,
+        table: e.table,
+        description: e.description ?? null,
+      })),
+    };
+  } catch (err) {
+    log.error(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        requestId,
+        agentId: identity.agentId,
+        workspaceId,
+      },
+      "agent-auth capability execution failed while listing semantic entities",
+    );
+    throw agentError(
+      "INTERNAL_SERVER_ERROR",
+      AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+      `Failed to list semantic entities (ref ${requestId}). Retry; if it persists, contact your operator.`,
+    );
+  }
 };
 
 /**
@@ -194,7 +215,7 @@ export function buildAgentAuthPlugin(): ReturnType<typeof agentAuth> {
     providerName: "Atlas",
     providerDescription:
       "Atlas — deploy-anywhere text-to-SQL data analyst agent (Agent Auth Protocol, experimental).",
-    capabilities: [listEntitiesCapability],
+    capabilities: [...AGENT_AUTH_CAPABILITIES],
     onExecute,
   });
 }

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -1,0 +1,200 @@
+/**
+ * The `agentAuth()` Better Auth plugin config — the Agent Auth Protocol spine
+ * (#4409 / #2058, Slice 1).
+ *
+ * Registered UNCONDITIONALLY in `buildPlugins()` (server.ts), so the plugin's
+ * routes and its `agent`/`agentHost`/`agentCapabilityGrant`/`approvalRequest`
+ * schema are always present (auto-migrated by Better Auth's `ctx.runMigrations()`
+ * at boot, like `twoFactor`/`passkey`/`oauthProvider` — no hand-written Atlas
+ * migration). Whether the surface is *reachable* is decided per-request by the
+ * `ATLAS_AGENT_AUTH_ENABLED` gate (`agent-auth-gate.ts`), NOT by conditional
+ * registration — that is what buys live, no-redeploy toggling of a build-once
+ * auth singleton. See the decision comment on #2058.
+ *
+ * Scope for this slice is deliberately narrow: exactly ONE hand-written
+ * capability (NOT the OpenAPI adapter — that is Slice 2 / #4410). Its `onExecute`
+ * proxies through the in-process API under a real per-org identity — the Atlas
+ * idiom for "call ourselves scoped to a workspace" (ADR-0016: bind an `AtlasUser`
+ * and run the lib seam under `withRequestContext`, NOT a loopback HTTP call and
+ * NOT a plaintext secret in a header). Org scoping is enforced by the resolved
+ * `AtlasUser.activeOrganizationId`, so an agent can never reach another
+ * workspace's data.
+ *
+ * Reversibility: this module and `agent-auth-verifier.ts` are the ONLY places
+ * that know about agent sessions / agent JWTs. `onExecute` maps the plugin's
+ * `agentSession` into the plugin-agnostic `AgentAuthIdentity` and hands it to the
+ * verifier (the sixth `AtlasUser` producer). Nothing downstream — the dispatch
+ * gate, RBAC, permissions — learns the agent-auth shape.
+ */
+
+import {
+  agentAuth,
+  agentError,
+  AGENT_AUTH_ERROR_CODES,
+  type AgentAuthOptions,
+  type AgentSession,
+  type Capability,
+} from "@better-auth/agent-auth";
+
+import { withRequestContext } from "@atlas/api/lib/logger";
+import { createLogger } from "@atlas/api/lib/logger";
+import { listEntities } from "@atlas/api/lib/semantic/entities";
+import {
+  resolveAgentAuthActor,
+  type AgentAuthIdentity,
+} from "@atlas/api/lib/auth/agent-auth-verifier";
+import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
+
+const log = createLogger("auth:agent-auth-plugin");
+
+/**
+ * The single hand-written capability's name. Exported so the contract test can
+ * assert the plugin advertises exactly one capability with this name (Slice 1
+ * scope guard against an accidental OpenAPI-adapter expansion).
+ */
+export const LIST_ENTITIES_CAPABILITY = "list_semantic_entities";
+
+/**
+ * Metadata key on the agent record carrying the workspace the agent proposes to
+ * act in. Honored only if the agent's owning user is a live member of it (see
+ * `resolveAgentAuthActor`) — never claim-trusted.
+ */
+export const AGENT_WORKSPACE_METADATA_KEY = "workspaceId";
+
+/**
+ * The one capability. No `location` → clients bind the JWT `aud` to the
+ * discovery document's `default_location` (the `/capability/execute` URL),
+ * which is exactly what the plugin's audience check accepts.
+ */
+const listEntitiesCapability: Capability = {
+  name: LIST_ENTITIES_CAPABILITY,
+  description:
+    "List the semantic-layer entities (tables the analyst agent can query) for the agent's own workspace. Read-only.",
+  input: {
+    type: "object",
+    properties: {
+      filter: {
+        type: "string",
+        description: "Optional case-insensitive substring to filter entities by name, table, or description.",
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+/**
+ * Read the agent-proposed workspace id off the agent session's metadata,
+ * coerced to a non-empty string (metadata values are `string|number|boolean|null`).
+ */
+function workspaceIdFromSession(session: AgentSession): string | undefined {
+  const raw = session.agent.metadata?.[AGENT_WORKSPACE_METADATA_KEY];
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}
+
+/**
+ * Map the plugin's verified `agentSession` into the plugin-agnostic identity the
+ * verifier consumes. `userId` prefers the canonical owning account
+ * (`session.userId`), falling back to the runtime `user.id` for autonomous
+ * agents (out of scope for this slice, but the fallback keeps the mapping total).
+ */
+function toIdentity(session: AgentSession): AgentAuthIdentity {
+  return {
+    userId: session.userId ?? session.user.id,
+    requestedWorkspaceId: workspaceIdFromSession(session),
+    agentId: session.agentId,
+    label: session.agent.name || session.user.name || undefined,
+  };
+}
+
+/**
+ * `onExecute` for the one capability. The plugin has already verified the agent
+ * JWT (signature, `aud`, expiry, jti replay) and the capability grant before we
+ * run; we add the Atlas-side per-org identity binding and the org-scoped call.
+ */
+const onExecute: NonNullable<AgentAuthOptions["onExecute"]> = async ({
+  capability,
+  agentSession,
+  arguments: args,
+}) => {
+  const identity = toIdentity(agentSession);
+
+  // Resolve the membership-verified per-org identity. Denials (missing/foreign
+  // workspace, lookup failure) map to a spec-compliant UNAUTHORIZED envelope —
+  // never a partial or cross-workspace result.
+  const resolved = await resolveAgentAuthActor(identity);
+  if (resolved.kind === "denied") {
+    log.warn(
+      { agentId: identity.agentId, capability, reason: resolved.reason },
+      "agent-auth capability execution denied",
+    );
+    throw agentError(
+      "FORBIDDEN",
+      AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
+      resolved.reason === "not_a_member"
+        ? "Agent is not authorized for the requested workspace."
+        : "Agent identity could not be bound to a workspace.",
+    );
+  }
+
+  const user = resolved.user;
+  const workspaceId = user.activeOrganizationId;
+  if (!workspaceId) {
+    // Unreachable: resolveAgentAuthActor only returns `ok` with a bound
+    // workspace. Guard defensively rather than pass `undefined` into the
+    // org-scoped seam (which would hard-fail on a multi-tenant deployment).
+    throw agentError(
+      "FORBIDDEN",
+      AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
+      "Agent identity resolved without a workspace binding.",
+    );
+  }
+
+  // Workspace-override precedence (#4409): the raw HTTP gate checks the platform
+  // default; here, with the workspace resolved, honor a per-workspace override.
+  // A workspace that has the feature off must not have its data reachable even
+  // when the platform default is on. Fail-closed.
+  if (!(await isAgentAuthEnabled(workspaceId))) {
+    throw agentError(
+      "NOT_FOUND",
+      AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
+      "Agent Auth is not enabled for this workspace.",
+    );
+  }
+
+  const filter =
+    args && typeof args.filter === "string" ? args.filter : undefined;
+
+  // Bind the per-org identity and run the in-process, org-scoped read. Passing
+  // `orgId` explicitly AND binding the identity is belt-and-suspenders: the call
+  // is org-scoped by construction, and any deeper RLS-aware read runs under the
+  // same bound actor. No secret material is threaded — only the resolved user.
+  const entities = await withRequestContext(
+    { requestId: crypto.randomUUID(), user },
+    () => listEntities({ orgId: workspaceId, mode: "published", ...(filter ? { filter } : {}) }),
+  );
+
+  return {
+    workspaceId,
+    count: entities.length,
+    entities: entities.map((e) => ({
+      name: e.name,
+      table: e.table,
+      description: e.description ?? null,
+    })),
+  };
+};
+
+/**
+ * Build the `agentAuth()` plugin. Kept as a factory (not a module-level
+ * singleton) so `buildPlugins()` composes it like every other plugin and tests
+ * can construct it in isolation.
+ */
+export function buildAgentAuthPlugin(): ReturnType<typeof agentAuth> {
+  return agentAuth({
+    providerName: "Atlas",
+    providerDescription:
+      "Atlas — deploy-anywhere text-to-SQL data analyst agent (Agent Auth Protocol, experimental).",
+    capabilities: [listEntitiesCapability],
+    onExecute,
+  });
+}

--- a/packages/api/src/lib/auth/agent-auth-verifier.ts
+++ b/packages/api/src/lib/auth/agent-auth-verifier.ts
@@ -9,11 +9,14 @@
  * `AtlasUser` is already produced by five mechanisms (managed session, API key,
  * simple key, hosted OAuth bearer, cli device bearer). Agent Auth plugs in here
  * as the sixth: this module — and the `agentAuth()` plugin's `onExecute` that
- * calls it — are the ONLY places that know about agent sessions, agent JWTs, or
- * the `/.well-known/agent-configuration` surface. Everything downstream sees a
- * plain `AtlasUser`. So a future switch to an OAuth-native (ID-JAG / `auth.md`)
- * agent-identity flow replaces this producer and touches nothing in
- * `dispatch-gate.ts`, `dispatch-gate-contract.ts`, or `permissions.ts`.
+ * calls it — are the ONLY places that know about the agent-session / agent-JWT
+ * *shapes*. Everything downstream sees a plain `AtlasUser`. So a future switch
+ * to an OAuth-native (ID-JAG / `auth.md`) agent-identity flow replaces this
+ * producer and touches nothing in the enforcement core (`dispatch-gate.ts`,
+ * `dispatch-gate-contract.ts`, `permissions.ts`) — the invariant the
+ * `agent-auth-seam-quarantine` test pins. (The discovery route + the gate
+ * naturally know the surface exists; the quarantine is about the *enforcement
+ * core*, not every file.)
  *
  * ── Trust boundary ──────────────────────────────────────────────────────────
  *
@@ -75,7 +78,11 @@ export interface AgentAuthIdentity {
  * the cause.
  */
 export type AgentAuthActorResult =
-  | { readonly kind: "ok"; readonly user: AtlasUser }
+  // `workspaceId` is carried explicitly (not just implied by
+  // `user.activeOrganizationId`, which is typed `string | undefined`) so the
+  // caller reads a guaranteed `string` — encoding "an `ok` always has a bound
+  // workspace" in the type instead of a downstream runtime guard.
+  | { readonly kind: "ok"; readonly user: AtlasUser; readonly workspaceId: string }
   | {
       readonly kind: "denied";
       readonly reason: "missing_workspace" | "not_a_member" | "membership_lookup_failed";
@@ -146,5 +153,5 @@ export async function resolveAgentAuthActor(
     },
   );
 
-  return { kind: "ok", user };
+  return { kind: "ok", user, workspaceId };
 }

--- a/packages/api/src/lib/auth/agent-auth-verifier.ts
+++ b/packages/api/src/lib/auth/agent-auth-verifier.ts
@@ -1,0 +1,150 @@
+/**
+ * Agent-Auth identity → `AtlasUser` — the SIXTH producer of the single
+ * identity abstraction the MCP dispatch gate (`runMcpDispatchGate`) and RBAC
+ * (`meetsRoleRequirement`) consume (#4409, reversibility constraint from
+ * #4408 AC4).
+ *
+ * ── Why this is the reversible seam ─────────────────────────────────────────
+ *
+ * `AtlasUser` is already produced by five mechanisms (managed session, API key,
+ * simple key, hosted OAuth bearer, cli device bearer). Agent Auth plugs in here
+ * as the sixth: this module — and the `agentAuth()` plugin's `onExecute` that
+ * calls it — are the ONLY places that know about agent sessions, agent JWTs, or
+ * the `/.well-known/agent-configuration` surface. Everything downstream sees a
+ * plain `AtlasUser`. So a future switch to an OAuth-native (ID-JAG / `auth.md`)
+ * agent-identity flow replaces this producer and touches nothing in
+ * `dispatch-gate.ts`, `dispatch-gate-contract.ts`, or `permissions.ts`.
+ *
+ * ── Trust boundary ──────────────────────────────────────────────────────────
+ *
+ * An agent credential is a delegated, portable bearer — strictly less trusted
+ * than the local operator. It resolves ORG (member) role ONLY, withholding
+ * `platform_admin`, exactly like the `hosted` and `cli` transports. That rule
+ * is DECLARED canonically by the `"agent"` arm of `resolveMcpActorRole`
+ * (`packages/mcp/src/bind-actor.ts`) and pinned by `bind-actor.test`. This
+ * module reaches the SAME `resolveEffectiveRole(undefined, …)` boundary directly
+ * rather than calling `resolveMcpActorRole` at runtime — the identical pattern
+ * the stdio production path uses (it reaches `resolveEffectiveRole` through
+ * `loadActorUser`, not through the switch) and required here to avoid a static
+ * `@atlas/api → @atlas/mcp` import (the api bundle loads `@atlas/mcp` only via
+ * lazy dynamic `import()`; see `api/index.ts`). The trust arm remains the
+ * canonical declaration; this is a same-boundary reach.
+ *
+ * ── Workspace binding is membership-enforced, never claim-trusted ────────────
+ *
+ * The agent proposes a workspace (carried in `agent.metadata.workspaceId`), but
+ * it is honored ONLY if the agent's owning Atlas user is a live member of that
+ * workspace — the same authoritative-membership posture the hosted MCP edge
+ * uses (`bindFactoryContext`). A leaked/misconfigured agent claiming a workspace
+ * its owner can't reach is DENIED. This is what enforces cross-workspace
+ * isolation: an agent registered under a user who belongs only to workspace A
+ * can never resolve an identity scoped to workspace B.
+ *
+ * Fail-closed throughout: a missing workspace, a non-member owner, or a
+ * membership-lookup error all resolve to `denied`, never a broader identity.
+ */
+
+import { createAtlasUser, type AtlasUser } from "@atlas/api/lib/auth/types";
+import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
+import { listUserWorkspaceIds } from "@atlas/api/lib/auth/oauth-workspace-grants";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("auth:agent-auth-verifier");
+
+/**
+ * The minimal, plugin-agnostic identity shape this producer maps to an
+ * `AtlasUser`. Deliberately NOT `@better-auth/agent-auth`'s `AgentSession` — the
+ * seam depends only on these fields, so swapping the underlying agent-identity
+ * library never reshapes this contract. The `agentAuth()` plugin's `onExecute`
+ * adapts its `agentSession` into this shape at the boundary.
+ */
+export interface AgentAuthIdentity {
+  /** The real Atlas user the agent acts for (`agentSession.userId ?? user.id`). */
+  readonly userId: string;
+  /** Workspace the agent proposes to act in (from `agent.metadata.workspaceId`). */
+  readonly requestedWorkspaceId: string | undefined;
+  /** Agent id — carried into claims/label for audit correlation. */
+  readonly agentId: string;
+  /** Display label for the bound actor (defaults to the user id). */
+  readonly label?: string;
+}
+
+/**
+ * Discriminated outcome. `denied` carries a machine reason so the `onExecute`
+ * caller can map it to the right agent-auth error envelope without re-deriving
+ * the cause.
+ */
+export type AgentAuthActorResult =
+  | { readonly kind: "ok"; readonly user: AtlasUser }
+  | {
+      readonly kind: "denied";
+      readonly reason: "missing_workspace" | "not_a_member" | "membership_lookup_failed";
+    };
+
+/**
+ * Resolve an `AtlasUser` for an agent-auth identity, or a typed denial.
+ *
+ * The plugin has already verified the agent JWT (signature, `aud`, expiry, jti
+ * replay) and the capability grant before `onExecute` runs — this producer adds
+ * the Atlas-side identity binding: which workspace, which role, membership-gated.
+ */
+export async function resolveAgentAuthActor(
+  identity: AgentAuthIdentity,
+): Promise<AgentAuthActorResult> {
+  const workspaceId = identity.requestedWorkspaceId?.trim();
+  if (!workspaceId) {
+    // No workspace binding → nothing to scope to. The org-scoped lib seam would
+    // hard-fail anyway; denying here yields a precise, actionable reason.
+    return { kind: "denied", reason: "missing_workspace" };
+  }
+
+  // Authoritative membership check — the agent-proposed workspace is honored
+  // ONLY if the owning user is a live member. Never trust the claim itself.
+  let memberships: string[];
+  try {
+    memberships = await listUserWorkspaceIds(identity.userId);
+  } catch (err) {
+    log.error(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        userId: identity.userId,
+        workspaceId,
+      },
+      "agent-auth: workspace membership lookup failed — denying (fail closed)",
+    );
+    return { kind: "denied", reason: "membership_lookup_failed" };
+  }
+
+  if (!memberships.includes(workspaceId)) {
+    log.warn(
+      { userId: identity.userId, workspaceId, agentId: identity.agentId },
+      "agent-auth: owning user is not a member of the requested workspace — denying (cross-workspace isolation)",
+    );
+    return { kind: "denied", reason: "not_a_member" };
+  }
+
+  // ORG (member) role only — withhold platform_admin. Same boundary the
+  // `"agent"` arm of `resolveMcpActorRole` declares. Fails closed: a member-
+  // table read error yields `undefined`, so downstream defaults to least
+  // privilege (`member`), never escalates.
+  const role = await resolveEffectiveRole(undefined, identity.userId, workspaceId);
+
+  const user = createAtlasUser(
+    identity.userId,
+    "managed",
+    identity.label ?? identity.userId,
+    {
+      ...(role !== undefined ? { role } : {}),
+      activeOrganizationId: workspaceId,
+      // Minimal, non-secret claims for RLS/audit correlation. No agent JWT or
+      // token material is threaded through — only the resolved identifiers.
+      claims: {
+        agent_auth: true,
+        agent_id: identity.agentId,
+        active_organization_id: workspaceId,
+      },
+    },
+  );
+
+  return { kind: "ok", user };
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -95,6 +95,7 @@ import { getConfig } from "@atlas/api/lib/config";
 import { SaasCrm } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import { getSignupOrigin } from "@atlas/api/lib/auth/signup-origin";
+import { buildAgentAuthPlugin } from "@atlas/api/lib/auth/agent-auth-plugin";
 import { Effect } from "effect";
 
 /**
@@ -2833,6 +2834,19 @@ export function buildPlugins() {
       schema: {},
     }),
   );
+
+  // Agent Auth Protocol spine (#4409 / #2058, Slice 1) — registered
+  // UNCONDITIONALLY, exactly like twoFactor/passkey above. This keeps the
+  // plugin's routes and its agent/agentHost/agentCapabilityGrant/approvalRequest
+  // schema always present (Better Auth `ctx.runMigrations()` auto-creates the
+  // tables at boot), so the build-once auth singleton never has to be rebuilt to
+  // toggle the feature. Whether the surface is *reachable* is decided per-request
+  // by the hot-reloadable `ATLAS_AGENT_AUTH_ENABLED` gate (agent-auth-gate.ts),
+  // consulted in the catch-all auth router and the discovery route — default OFF,
+  // fail-closed, no redeploy to flip. The `jwt()` plugin pushed above satisfies
+  // the JWT/JWKS dependency. Kept experimental (upstream spec is a moving draft);
+  // scope is ONE hand-written capability, not the OpenAPI adapter (Slice 2).
+  plugins.push(buildAgentAuthPlugin());
 
   // SCIM directory sync — enterprise only.
   // No try/catch: if the plugin fails to initialize (missing dep, bad config),

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -668,6 +668,31 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS",
     scope: "workspace",
   },
+  // #4409 / #2058 — Agent Auth Protocol spine kill-switch. The `agentAuth()`
+  // plugin is registered UNCONDITIONALLY in buildPlugins() (schema + routes
+  // always present, like twoFactor/passkey), so the ONLY thing this key
+  // controls is whether the reachable HTTP surface answers: when off (the
+  // default), every agent-auth endpoint + `/.well-known/agent-configuration`
+  // returns 404; when on, they become reachable — WITH NO REDEPLOY, because
+  // this is a hot-reloadable settings key (NOT `requiresRestart`, NOT an env
+  // var). The per-request gate reads it via `getSettingLive`/`getSettingAuto`
+  // and fails closed (any resolution error ⇒ off). `scope: "workspace"` gives
+  // the standard four-tier precedence (workspace override > platform > env >
+  // default): an operator flips the platform default, a workspace admin can
+  // override for their own workspace. Kept experimental (upstream spec is a
+  // moving `v1.0-draft`) — default OFF. See ADR-0016 §Agent Auth and the
+  // decision comment on #2058.
+  {
+    key: "ATLAS_AGENT_AUTH_ENABLED",
+    section: "MCP",
+    label: "Enable Agent Auth Protocol",
+    description:
+      "Expose the (experimental) Agent Auth Protocol surface: agent/host/capability endpoints and the `/.well-known/agent-configuration` discovery document. Hot-reloadable — takes effect within seconds, no redeploy. When off (default) the entire surface returns 404. Leave off unless you are piloting agent-identity clients.",
+    type: "boolean",
+    default: "false",
+    envVar: "ATLAS_AGENT_AUTH_ENABLED",
+    scope: "workspace",
+  },
 
   // Appearance
   {

--- a/packages/mcp/src/__tests__/bind-actor.test.ts
+++ b/packages/mcp/src/__tests__/bind-actor.test.ts
@@ -112,4 +112,25 @@ describe("resolveMcpActorRole — trust-boundary fork (#3603, ADR-0016)", () => 
     // Mock returns the userRole it was given (undefined for the cli arm).
     expect(role).toBeUndefined();
   });
+
+  it("agent arm withholds the user-level role (org role only — never platform_admin) (#4409)", async () => {
+    const role = await resolveMcpActorRole({
+      transport: "agent",
+      userId: "user-5",
+      activeOrganizationId: "org-5",
+      // An Agent Auth JWT is a delegated, portable bearer — strictly less
+      // trusted than the local operator. Even a wrongly-passed platform_admin
+      // userRole must NOT be forwarded.
+      userRole: "platform_admin",
+    });
+
+    // The invariant: agent forwards `undefined`, never the user-level role —
+    // the canonical declaration of the boundary the Agent Auth verifier reaches
+    // via resolveEffectiveRole directly.
+    expect(resolveCalls).toHaveLength(1);
+    expect(resolveCalls[0].userRole).toBeUndefined();
+    expect(resolveCalls[0].userId).toBe("user-5");
+    expect(resolveCalls[0].activeOrganizationId).toBe("org-5");
+    expect(role).toBeUndefined();
+  });
 });

--- a/packages/mcp/src/bind-actor.ts
+++ b/packages/mcp/src/bind-actor.ts
@@ -61,15 +61,21 @@ import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
  * REGARDLESS of deploy mode (a copied-off credential file is never the
  * trusted local operator).
  *
- * SCOPE NOTE: the `cli` arm is a forward-declaration — no runtime caller binds
- * `transport: "cli"` yet (only `hosted.ts` calls this, with `"hosted"`). The
- * device-flow credential is a getSession session bearer, so its runtime
- * downgrade happens in `buildCustomSessionPayload` (REST path, keyed on
- * `session.origin === "cli"`), NOT here. This arm reserves the same trust
- * boundary for the day the cli bearer reaches MCP dispatch; `bind-actor.test`
- * proves it resolves org-role-only (it does NOT exercise the gate chain).
+ * SCOPE NOTE: the `cli` and `agent` arms are forward-declarations — no runtime
+ * caller binds `transport: "cli"` or `"agent"` here yet (only `hosted.ts` calls
+ * this, with `"hosted"`). The device-flow credential is a getSession session
+ * bearer, so its runtime downgrade happens in `buildCustomSessionPayload` (REST
+ * path, keyed on `session.origin === "cli"`), NOT here. The `agent` arm's
+ * runtime producer is the Agent Auth verifier
+ * (`@atlas/api/lib/auth/agent-auth-verifier`), which reaches the SAME
+ * `resolveEffectiveRole(undefined, …)` boundary directly (the identical pattern
+ * the stdio path uses through `loadActorUser`) — required because the api
+ * bundle loads `@atlas/mcp` only via lazy dynamic `import()`, so a static call
+ * back into this switch is not available there. Both arms reserve the trust
+ * boundary as the canonical declaration; `bind-actor.test` proves each resolves
+ * org-role-only (it does NOT exercise the gate chain).
  */
-export type McpTransportTrust = "stdio" | "hosted" | "cli";
+export type McpTransportTrust = "stdio" | "hosted" | "cli" | "agent";
 
 export interface ResolveMcpActorRoleArgs {
   /** The trust boundary this binding is happening under. */
@@ -118,6 +124,15 @@ export function resolveMcpActorRole(
       // a stolen `~/.atlas/credentials` can never act past its org/member role
       // for the bound workspace. Distinct case (not a fall-through) so the
       // trust boundary is named, audited, and pinned independently of hosted.
+      return resolveEffectiveRole(undefined, args.userId, args.activeOrganizationId);
+    case "agent":
+      // Agent Auth Protocol identity (#4409): ORG role ONLY, like `hosted`/`cli`.
+      // An agent JWT is a delegated, portable bearer — strictly less trusted
+      // than the local operator — so `platform_admin` is withheld and it acts
+      // with the owning user's member role for the bound (membership-verified)
+      // workspace. Distinct case (not a fall-through) so the boundary is named,
+      // audited, and pinned independently. Canonical declaration of the rule the
+      // Agent Auth verifier reaches via `resolveEffectiveRole` directly.
       return resolveEffectiveRole(undefined, args.userId, args.activeOrganizationId);
     default: {
       // Exhaustiveness guard — a new transport must declare its trust boundary


### PR DESCRIPTION
## Summary

Slice 1 of the Agent Auth Protocol work — the flag-gated, reversible **tracer-bullet spine** (parent #2058; decision gate #4408 resolved GO — build reversibly). Everything is **default OFF**: when off there is *no reachable surface* (every agent-auth path + the discovery doc return 404); when on, an agent can register, request one capability, receive a capability-bound JWT, and invoke it — scoped to its own workspace and no other.

Two load-bearing constraints, both honored:

- **SaaS-first enablement, no redeploy.** `agentAuth({...})` is registered **unconditionally** in `buildPlugins()` (schema + routes always present, like `twoFactor`/`passkey`), so the build-once auth singleton never needs rebuilding. The reachable HTTP surface is gated **per-request** on the hot-reloadable `ATLAS_AGENT_AUTH_ENABLED` settings key (`getSettingLive`/`getSettingAuto`, **fail-closed**), mirroring `shouldExposeCanonicalPrompts`. Flipping it on/off takes effect in seconds with no restart.
- **Reversible seam.** Agent-Auth identity → `AtlasUser` via a dedicated verifier (the sixth `AtlasUser` producer) + a new `"agent"` trust arm in `resolveMcpActorRole` (org-role-only, withholds `platform_admin`). **No** agent-auth / token / `/.well-known/agent-configuration` knowledge leaks into `dispatch-gate.ts`, `dispatch-gate-contract.ts`, or `permissions.ts` — grep-asserted by a test — so a future switch to an OAuth-native (ID-JAG / `auth.md`) flow never touches the enforcement core.

Key points:
- Pin `@better-auth/agent-auth@0.6.2` **exact** (+ `bun.lock`). Its pinned `better-call@1.3.2` nests cleanly beside the main tree's `1.3.6` — no hoist collision. Generated schema tables are `agent` / `agentHost` / `agentCapabilityGrant` / `approvalRequest` (docs had drifted); they auto-migrate via Better Auth's `ctx.runMigrations()` at boot — **no** hand migration, **no** `schema.ts` mirror (verified against `check-schema-drift.sh` + `migrate-pg.test.ts`).
- `/.well-known/agent-configuration` is served **from the API** (`routes/well-known.ts`), proxying the plugin's own canonical doc, gated by the same setting. Not a `packages/web` route (a web route can't reach `getSettingAuto`).
- **One** hand-written capability (`list_semantic_entities`), not the OpenAPI adapter (that's a follow-on slice). Its `onExecute` binds a membership-verified per-org `AtlasUser` and runs the org-scoped lib seam under `withRequestContext` (ADR-0016 — not a loopback HTTP call, no plaintext secrets, no org-scope bypass).
- The exact dep pin is propagated to the `docker` + `nextjs-standalone` templates (they vendor the API source, so Deploy Validation's build needs it).

Closes #4409

## Test Plan

- [x] **JWT `aud` matrix** (`agent-auth-plugin.test.ts`, real plugin + in-memory adapter, jose-minted agent JWTs): happy path, wrong audience, expired, revoked grant, missing capability claim.
- [x] **Cross-workspace isolation**: real `onExecute` denies an agent whose owning user isn't a member of the requested workspace (403), plus a focused verifier unit test.
- [x] **Live-toggle integration** (`agent-auth-live-toggle.test.ts`, real catch-all auth router + `.well-known` router): off (default) → 404 on every agent-auth path + discovery; flip on with no restart → reachable; flip back → 404; scoped (a non-agent-auth auth path is never gated); fail-closed on an explicit `false`.
- [x] **Verifier** fail-closed branches + org-role-only boundary (`agent-auth-verifier.test.ts`).
- [x] **Seam quarantine** grep guard (`agent-auth-seam-quarantine.test.ts`) + the new `"agent"` arm pinned in `bind-actor.test.ts`.
- [x] Manual testing (scratch harness verified the full register-seed → mint JWT → execute path end-to-end before formalizing).

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass — full `scripts/ci-local.sh`: **27 / 28 gates green**. The one red gate is a **pre-existing, environment-caused** failure unrelated to this diff: `admin-model-config.test.ts` times out (5000ms) fetching an upstream provider model catalog over network egress that's blocked in this sandbox — it fails **identically on the clean tree** with all changes stashed. GitHub CI (with egress) runs it fine.
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent (`syncpack lint` — exact pin consistent across `packages/api` + both templates)
- [ ] Labels added (type + area) — inherits `feature` / `area: api` / `area: mcp` from #4409
- [ ] CHANGELOG.md updated — not applicable: experimental, default-off; the docs changelog is release-managed (`/release`), and Slice 6 (#4415) owns the docs page.

https://claude.ai/code/session_01UCN2XSC6NnAQKQkTyJMbHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCN2XSC6NnAQKQkTyJMbHN)_