### PR TITLE
feat(knowledge): GitBook Cloud knowledge sync connector (#4393)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56648,7 +56648,8 @@
                               "upload",
                               "bundle-sync",
                               "notion",
-                              "confluence"
+                              "confluence",
+                              "gitbook"
                             ]
                           },
                           "description": {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -55,6 +55,7 @@ import {
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
 import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
 import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config";
+import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -102,7 +103,7 @@ async function loadCollection(
 }
 
 /** A synced-collection source discriminator + whether it is a connector. */
-type KnowledgeSource = "upload" | "bundle-sync" | "notion" | "confluence" | "unknown";
+type KnowledgeSource = "upload" | "bundle-sync" | "notion" | "confluence" | "gitbook" | "unknown";
 
 /**
  * Map a knowledge catalog id to the wire `source` discriminator — matching
@@ -116,12 +117,18 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === BUNDLE_SYNC_CATALOG_ID) return "bundle-sync";
   if (catalogId === NOTION_KNOWLEDGE_CATALOG_ID) return "notion";
   if (catalogId === CONFLUENCE_CATALOG_ID) return "confluence";
+  if (catalogId === GITBOOK_CATALOG_ID) return "gitbook";
   return "unknown";
 }
 
 /** True for a synced source (endpoint or connector) — has sync bookkeeping. */
 function isSyncedSource(source: KnowledgeSource): boolean {
-  return source === "bundle-sync" || source === "notion" || source === "confluence";
+  return (
+    source === "bundle-sync" ||
+    source === "notion" ||
+    source === "confluence" ||
+    source === "gitbook"
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -141,7 +148,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "gitbook"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -155,6 +155,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "bundle-sync",
       "notion-knowledge",
       "confluence",
+      "gitbook",
     ]);
   });
 
@@ -174,7 +175,13 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("reports inserted slugs on a fresh catalog and none on a re-boot", async () => {
     const fresh = await seedBuiltinKnowledgeCatalog(captureDb().db);
     expect(fresh.inserted).toBe(true);
-    expect(fresh.insertedSlugs).toEqual(["okf-upload", "bundle-sync", "notion-knowledge", "confluence"]);
+    expect(fresh.insertedSlugs).toEqual([
+      "okf-upload",
+      "bundle-sync",
+      "notion-knowledge",
+      "confluence",
+      "gitbook",
+    ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);
     expect(reboot.inserted).toBe(false);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -1,6 +1,8 @@
 /**
- * Boot-time idempotent seed pass for the built-in Knowledge Base catalog
- * rows: `okf-upload` (#4206, ADR-0028) and `bundle-sync` (#4211).
+ * Boot-time idempotent seed pass for the built-in Knowledge Base catalog rows
+ * — the upload/bundle-sync arms plus the vendor connectors (Notion, Confluence,
+ * GitBook). `BUILTIN_KNOWLEDGE_CATALOG_ROWS` is the authoritative list; adding a
+ * connector is one append there, so this header stays non-enumerating.
  *
  * The Knowledge Base lifecycle (ADR-0028 §5) started as one built-in catalog
  * row — `okf-upload`, an **explicit, degenerate form install** with no
@@ -32,6 +34,7 @@ import {
   NOTION_KNOWLEDGE_CATALOG_ID,
   NOTION_KNOWLEDGE_SLUG,
 } from "@atlas/api/lib/knowledge/notion/connector";
+import { GITBOOK_CATALOG_ID, GITBOOK_SLUG } from "@atlas/api/lib/knowledge/gitbook/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -246,12 +249,62 @@ export const BUILTIN_CONFLUENCE_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The GitBook Cloud connector Knowledge Base catalog row (#4393, ADR-0030). A
+ * form install that mirrors ONE GitBook space into a review-gated collection;
+ * the Scheduler dispatches the registered GitBook connector on a cadence
+ * (incremental + reconciliation) and every synced page lands `draft`.
+ *
+ * `api_token` is `secret: true` but is NOT stored in `workspace_plugins.config`
+ * — the install handler routes it to `knowledge_sync_credentials` (encrypted).
+ * The GitBook API host is a fixed vendor constant, so there is no base-URL field
+ * (unlike Confluence); every request still goes through the SSRF egress guard at
+ * fetch time. The id/slug are the config SSOT (`GITBOOK_CATALOG_ID` /
+ * `GITBOOK_SLUG`).
+ */
+export const BUILTIN_GITBOOK_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: GITBOOK_CATALOG_ID,
+  slug: GITBOOK_SLUG,
+  name: "Knowledge Base (GitBook)",
+  description:
+    "Mirror a GitBook Cloud space into a review-gated knowledge collection; Atlas syncs pages on a schedule (incremental + reconciliation) and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "space_id",
+      type: "string",
+      label: "GitBook space id",
+      required: true,
+      description:
+        "The id of the space to mirror (one collection per space). Copy it from your space URL: app.gitbook.com/o/…/s/<space-id>/… — you can paste the whole URL.",
+    },
+    {
+      key: "api_token",
+      type: "string",
+      secret: true,
+      label: "API token",
+      required: true,
+      description:
+        "A GitBook API token (app.gitbook.com → Settings → Developer → API tokens). Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_BUNDLE_SYNC_CATALOG_ROW,
   BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_CATALOG_ROW,
+  BUILTIN_GITBOOK_CATALOG_ROW,
 ];
 
 /**
@@ -271,8 +324,7 @@ export interface BuiltinKnowledgeCatalogSeedResult {
 }
 
 /**
- * Idempotently seed the built-in Knowledge Base catalog rows (`okf-upload`,
- * `bundle-sync`).
+ * Idempotently seed every row in `BUILTIN_KNOWLEDGE_CATALOG_ROWS`.
  *
  * Column order matches the built-in Datasource seed's VALUES block so the two
  * seeds stay structurally recognizable; `type` and `pillar` differ (`context` /

--- a/packages/api/src/lib/integrations/install/__tests__/gitbook-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/gitbook-form-handler.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for `GitbookFormInstallHandler` (#4393) — the GitBook connector
+ * install. Focus: field validation (space id / URL extraction, API token), loud
+ * credential verification at install time, credential routing (token →
+ * `knowledge_sync_credentials`, NEVER into `workspace_plugins.config`), and the
+ * multi-instance `pillar='knowledge'` upsert shape. Verification uses the REAL
+ * egress guard against an injected fixture fetch; no test touches GitBook.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:gitbook" }];
+let INSERT_RETURNS_ID = true;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { GitbookFormInstallHandler, extractSpaceId } = await import(
+  "@atlas/api/lib/integrations/install/gitbook-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = { space_id: "space-123", api_token: "gitbook-token" };
+
+/** A fixture verify-fetch: the space lookup returns an object (or a status). */
+function verifyFetch(opts: { spaceId?: string | null; status?: number } = {}): typeof fetch {
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input.toString());
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (/\/v1\/spaces\/[^/]+$/.test(url.pathname)) {
+      const id = opts.spaceId === undefined ? "space-123" : opts.spaceId;
+      return new Response(JSON.stringify(id === null ? {} : { id, title: "Docs" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+  return impl as unknown as typeof fetch;
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  return new GitbookFormInstallHandler({
+    idGenerator: () => "fixed-id",
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:gitbook" }];
+  INSERT_RETURNS_ID = true;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("extractSpaceId", () => {
+  it("returns a bare id unchanged", () => {
+    expect(extractSpaceId("space-123")).toBe("space-123");
+  });
+  it("extracts the id from an app URL", () => {
+    expect(extractSpaceId("https://app.gitbook.com/o/org1/s/AbC_123/guides/setup")).toBe("AbC_123");
+  });
+  it("returns empty for an unparseable URL", () => {
+    expect(extractSpaceId("https://app.gitbook.com/o/org1/")).toBe("");
+  });
+});
+
+describe("field validation", () => {
+  it("requires the space id", async () => {
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, space_id: "" }), "space_id");
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("requires the API token", async () => {
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, api_token: "" }), "api_token");
+    expect(msg).toMatch(/required/i);
+  });
+
+  it("rejects a token with embedded whitespace", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, api_token: "abc def" }),
+      "api_token",
+    );
+    expect(msg).toMatch(/spaces/i);
+  });
+
+  it("accepts a space URL and stores the extracted id", async () => {
+    const rec = await handler(verifyFetch()).validateConfig(WORKSPACE, {
+      ...VALID,
+      space_id: "https://app.gitbook.com/o/org1/s/space-123/guides",
+    });
+    expect(rec.credentialWritten).toBe(true);
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config.space_id).toBe("space-123");
+  });
+});
+
+describe("credential verification", () => {
+  it("blames the api_token field on a 401", async () => {
+    const msg = await fieldErrorOf(
+      handler(verifyFetch({ status: 401 })).validateConfig(WORKSPACE, VALID),
+      "api_token",
+    );
+    expect(msg).toMatch(/rejected the credentials/i);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("blames the space_id field on a 404", async () => {
+    const msg = await fieldErrorOf(
+      handler(verifyFetch({ status: 404 })).validateConfig(WORKSPACE, VALID),
+      "space_id",
+    );
+    expect(msg).toMatch(/404/);
+  });
+
+  it("blames the space_id field when the space object has no id", async () => {
+    const msg = await fieldErrorOf(
+      handler(verifyFetch({ spaceId: null })).validateConfig(WORKSPACE, VALID),
+      "space_id",
+    );
+    expect(msg).toMatch(/not found or is not visible/i);
+  });
+
+  it("routes a rate-limit (429) verification failure to a form-level error, not a field", async () => {
+    // Blaming a field on a 429 would send the admin re-entering a value that may
+    // be fine — a 429 is a transient throttle, so it belongs at the form level.
+    try {
+      await handler(verifyFetch({ status: 429 })).validateConfig(WORKSPACE, VALID);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormInstallValidationError);
+      const e = err as InstanceType<typeof FormInstallValidationError>;
+      expect(e.formErrors.length).toBeGreaterThan(0);
+      expect(Object.keys(e.fieldErrors)).toHaveLength(0);
+    }
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+});
+
+describe("successful install", () => {
+  it("verifies, writes the credential, then upserts the knowledge collection (token never in config)", async () => {
+    const rec = await handler(verifyFetch()).validateConfig(WORKSPACE, VALID);
+    expect(rec.installRecord.id).toBe("fixed-id");
+    expect(rec.credentialWritten).toBe(true);
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].sql).toContain("pillar");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toEqual({ space_id: "space-123" });
+    expect(JSON.stringify(config)).not.toContain("gitbook-token");
+  });
+
+  it("rolls back the credential when the install-row upsert fails", async () => {
+    INSERT_RETURNS_ID = false;
+    await expect(handler(verifyFetch()).validateConfig(WORKSPACE, VALID)).rejects.toThrow();
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -43,6 +43,7 @@ import {
 } from "@atlas/api/lib/knowledge/connectors";
 import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config";
 import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
+import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -139,19 +140,21 @@ describe("registerBuiltinInstallHandlers — SQL plugin datasources (#3300)", ()
   });
 });
 
-describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#4377/#4378)", () => {
+describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#4377/#4378/#4393)", () => {
   // register.ts documents the FORM handler + CONNECTOR pairing as load-bearing:
   // dropping a registerXxxKnowledgeConnector() call would ship green while every
   // install of that vendor 500s at sync time (connector_unavailable — the cycle
   // walk dispatches on the connector registry, not the form handler). Pin that
-  // one call to registerBuiltinInstallHandlers() registers both vendors'
-  // connectors alongside their form handlers. No env gate on either.
-  it("registers the Confluence and Notion knowledge sync connectors alongside their form handlers", () => {
+  // one call to registerBuiltinInstallHandlers() registers every vendor's
+  // connector alongside its form handler. No env gate on any.
+  it("registers the Confluence, Notion, and GitBook knowledge sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(GITBOOK_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "gitbook", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/gitbook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/gitbook-form-handler.ts
@@ -1,0 +1,313 @@
+/**
+ * `GitbookFormInstallHandler` — the {@link FormBasedInstallHandler} for the
+ * built-in `gitbook` Knowledge Base catalog row (#4393, ADR-0030).
+ *
+ * Installing `gitbook` creates a **synced collection** mirroring ONE GitBook
+ * Cloud space: a `pillar='knowledge'` `workspace_plugins` row (multi-instance,
+ * `install_id` = collection slug) whose config carries the space id. The
+ * Scheduler dispatches the registered GitBook connector on a cadence
+ * (`lib/knowledge/connector-sync.ts`), and every synced page lands `draft`
+ * behind the review gate.
+ *
+ * GitBook's API host is a FIXED vendor constant (`api.gitbook.com`), not a
+ * customer-supplied URL, so there is no install-time SSRF gate (the connector
+ * still routes every request through the egress guard at fetch time). Field
+ * validation accepts either a bare space id or an `app.gitbook.com/o/…/s/<id>/…`
+ * URL (the id is extracted). Beyond that it mirrors the Notion/Confluence
+ * handlers:
+ *   1. **Loud credential verification.** Before persisting anything, it resolves
+ *      the space with the supplied credentials (`verifyGitbookAccess`) — a bad
+ *      token / invalid space id fails the install with actionable guidance
+ *      instead of silently creating a collection that never syncs.
+ *   2. **The API token is a Knowledge Base credential.** It routes to the
+ *      dedicated `knowledge_sync_credentials` table (encrypted), NEVER to
+ *      `workspace_plugins.config`. Write order mirrors Confluence/Notion: verify
+ *      → SaaS keyset gate → credential row → install row (rollback on failure).
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import { EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import {
+  verifyGitbookAccess,
+  type GitbookClientDeps,
+} from "@atlas/api/lib/knowledge/gitbook/client";
+import {
+  GITBOOK_SLUG,
+  GITBOOK_CATALOG_ID,
+  type GitbookCollectionConfig,
+} from "@atlas/api/lib/knowledge/gitbook/config";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { GITBOOK_SLUG, GITBOOK_CATALOG_ID };
+
+/** Defensive upper bounds — guard against pathological pastes. */
+const SPACE_ID_INPUT_MAX = 2048;
+const SPACE_ID_MAX = 255;
+const API_TOKEN_MAX = 4096;
+
+/** GitBook space ids are opaque url-safe tokens. */
+const SPACE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export interface GitbookFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the verification fetch (no real GitBook call). */
+  readonly clientDeps?: GitbookClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to the
+ * okf-upload / bundle-sync / Confluence / Notion knowledge upserts:
+ * `status='published'` because the COLLECTION container is live immediately —
+ * the review gate is on the DOCUMENTS, which always sync in as `draft`. Exported
+ * so the real-Postgres test executes this exact string against the live schema.
+ */
+export const GITBOOK_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class GitbookFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: GitbookClientDeps;
+  private readonly log = createLogger("integrations.install.gitbook");
+
+  constructor(options: GitbookFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const collectionSlug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], GITBOOK_SLUG);
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const spaceId = validateSpaceId(rawForm.space_id);
+    const apiToken = validateApiToken(rawForm.api_token);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [GITBOOK_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "gitbook catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${GITBOOK_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+
+    // ── Verify the connection loudly BEFORE persisting anything ─────────────
+    await this.verifyConnection({ spaceId, apiToken, collectionSlug });
+
+    // ── Credential first (mirrors the Confluence/Notion write order) ────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "api_token");
+    try {
+      await saveSyncCredential(workspaceId, collectionSlug, apiToken);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install",
+      );
+      throw err;
+    }
+
+    // ── Upsert the collection container (never carries the token) ────────────
+    const config: GitbookCollectionConfig = {
+      space_id: spaceId,
+      ...(description !== null ? { description } : {}),
+    };
+
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(GITBOOK_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        collectionSlug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a failed
+      // install (its install row never landed, so uninstall would never reach
+      // it). Best-effort — a re-install overwrites it either way; a cleanup
+      // failure is logged, never masks the original error. Same block as the
+      // Confluence/Notion handlers — keep them in step.
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist gitbook collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, collectionSlug);
+      } catch (cleanupErr) {
+        this.log.error(
+          { workspaceId, collectionSlug, err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw err;
+    }
+
+    this.log.info(
+      { workspaceId, collectionSlug, rowId: persistedId, spaceId },
+      "GitBook collection install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: GITBOOK_SLUG },
+      credentialWritten: true,
+    };
+  }
+
+  /** Resolve the space with the supplied creds; map every failure to a 400. */
+  private async verifyConnection(input: {
+    spaceId: string;
+    apiToken: string;
+    collectionSlug: string;
+  }): Promise<void> {
+    try {
+      await verifyGitbookAccess(input, this.clientDeps);
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        // Defence-in-depth: the fixed GitBook host should never be blocked, but
+        // if a deploy's egress policy blocks it, surface it as a form-level error.
+        throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [err.message] });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      // Non-credential failures — a 429 (ConnectorRateLimitError) or a transport
+      // error (DNS/timeout/non-JSON; the client marks those with `cause`) — are
+      // form-level: blaming a field would send the admin re-entering a value that
+      // may be fine. All host-redacted.
+      if (err instanceof ConnectorRateLimitError || (err instanceof Error && err.cause !== undefined)) {
+        throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [message] });
+      }
+      // Auth (401/403) → the token; anything else actionable (a 404, or a space
+      // object with no id — "not found or not visible") → the space id. Both are
+      // already host-redacted + actionable.
+      const field = /rejected the credentials|\b401\b|\b403\b/.test(message) ? "api_token" : "space_id";
+      throw new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+    }
+  }
+}
+
+/**
+ * Extract a GitBook space id from a raw input. Accepts a bare id, or an
+ * `app.gitbook.com/o/<org>/s/<spaceId>/…` app URL (the `/s/<id>/` segment is the
+ * space id). Exported for the unit test.
+ */
+export function extractSpaceId(raw: string): string {
+  const trimmed = raw.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      // intentionally ignored: fall through to the "unparseable" field error.
+      return "";
+    }
+    const match = parsed.pathname.match(/\/s\/([A-Za-z0-9_-]+)/);
+    return match ? match[1] : "";
+  }
+  return trimmed;
+}
+
+/** Validate the space id: required, bounded, a bare id or extractable from a URL. */
+function validateSpaceId(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "space_id",
+      "The GitBook space id is required. Copy it from your space URL (app.gitbook.com/o/…/s/<space-id>/…), or paste the space URL.",
+    );
+  }
+  if (raw.length > SPACE_ID_INPUT_MAX) {
+    throw fieldError("space_id", `The space id must be ${SPACE_ID_INPUT_MAX} characters or fewer.`);
+  }
+  const spaceId = extractSpaceId(raw);
+  if (spaceId === "" || spaceId.length > SPACE_ID_MAX || !SPACE_ID_RE.test(spaceId)) {
+    throw fieldError(
+      "space_id",
+      "Enter a valid GitBook space id, or the space URL it appears in (app.gitbook.com/o/…/s/<space-id>/…).",
+    );
+  }
+  return spaceId;
+}
+
+function validateApiToken(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError("api_token", "An API token is required. Create one at app.gitbook.com → Settings → Developer → API tokens.");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > API_TOKEN_MAX) {
+    throw fieldError("api_token", `The API token must be ${API_TOKEN_MAX} characters or fewer.`);
+  }
+  if (/\s/.test(trimmed)) {
+    throw fieldError("api_token", "Token must not contain spaces — paste it exactly as GitBook shows it.");
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -41,6 +41,8 @@ import {
   NOTION_KNOWLEDGE_SLUG,
   registerNotionKnowledgeConnector,
 } from "@atlas/api/lib/knowledge/notion/connector";
+import { GitbookFormInstallHandler, GITBOOK_SLUG } from "./gitbook-form-handler";
+import { registerGitbookKnowledgeConnector } from "@atlas/api/lib/knowledge/gitbook/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -250,6 +252,18 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(NOTION_KNOWLEDGE_SLUG, new NotionKnowledgeFormInstallHandler());
   registerNotionKnowledgeConnector();
   log.info("Registered NotionKnowledgeFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (GitBook Cloud) — the built-in `gitbook` connector install
+  // (#4393, ADR-0030 vendor slice). Knowledge-pillar, multi-instance (one
+  // collection per space). Config = space id; the API token lands in
+  // `knowledge_sync_credentials` (encrypted), never in `workspace_plugins.config`.
+  // The API host is a fixed GitBook constant, so there is no customer-supplied
+  // base URL — every request still routes through the SSRF egress guard at fetch
+  // time. Registering the FORM handler + the CONNECTOR together (as with
+  // Confluence/Notion) keeps a half-wired deploy from having an installable card
+  // whose scheduled sync has no registered vendor client. No env gate.
+  registerFormHandler(GITBOOK_SLUG, new GitbookFormInstallHandler());
+  registerGitbookKnowledgeConnector();
+  log.info("Registered GitbookFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -37,6 +37,7 @@ import {
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
 import { NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/notion-knowledge-form-handler";
 import { CONFLUENCE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-form-handler";
+import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/gitbook-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
   CONNECTOR_SYNC_STATE_SELECT_SQL,
@@ -505,6 +506,31 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // The token is NEVER persisted in the install config.
     expect(row.rows[0]?.config).not.toHaveProperty("api_token");
     expect(row.rows[0]?.config).toMatchObject({ space_key: "ENG" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a GitBook connector collection against the live schema (#4393)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:gitbook', 'Knowledge Base (GitBook)', 'gitbook', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(GITBOOK_INSTALL_UPSERT_SQL, [
+      "row-gitbook",
+      ws,
+      "catalog:gitbook",
+      "gitbook-docs",
+      JSON.stringify({ space_id: "space-123" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-gitbook");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'gitbook-docs'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The token is NEVER persisted in the install config.
+    expect(row.rows[0]?.config).not.toHaveProperty("api_token");
+    expect(row.rows[0]?.config).toMatchObject({ space_id: "space-123" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/gitbook/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/gitbook/__tests__/client.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for the GitBook vendor client (#4393) — driven entirely through an
+ * injected fixture `fetchImpl`; NO test touches GitBook. Covers reconciliation
+ * (full crawl), incremental (updatedAt-filtered body fetch), tree walk with
+ * group/link filtering, the doc-cap over the full set, 429 →
+ * ConnectorRateLimitError, auth failure, and space verification.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createGitbookVendorClient,
+  verifyGitbookAccess,
+  parseRetryAfter,
+} from "@atlas/api/lib/knowledge/gitbook/client";
+
+const SPACE_ID = "space-123";
+
+interface FixturePage {
+  id: string;
+  title: string;
+  path: string;
+  updatedAt: string;
+  markdown: string;
+}
+
+const PAGES: FixturePage[] = [
+  { id: "p1", title: "Intro", path: "intro", updatedAt: "2026-07-01T00:00:00.000Z", markdown: "# Intro\n\nWelcome to the documentation site." },
+  { id: "p2", title: "Setup", path: "guides/setup", updatedAt: "2026-07-06T09:00:00.000Z", markdown: "Install the software by following these steps." },
+];
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+/** A content tree: a top-level group holding both doc pages + one external link. */
+function contentTree(pages: FixturePage[]): unknown {
+  return {
+    pages: [
+      {
+        id: "grp",
+        title: "Guides",
+        type: "group",
+        path: "guides",
+        pages: pages.map((p) => ({
+          id: p.id,
+          title: p.title,
+          type: "document",
+          path: p.path,
+          updatedAt: p.updatedAt,
+          urls: { app: `https://acme.gitbook.io/docs/${p.path}` },
+        })),
+      },
+      { id: "ext", title: "External", type: "link", path: "ext", urls: { app: "https://example.com" } },
+    ],
+  };
+}
+
+interface FixtureOptions {
+  readonly pages?: FixturePage[];
+  readonly failFirst?: { status: number; headers?: Record<string, string> };
+  readonly spaceMissing?: boolean;
+}
+
+function makeFetch(opts: FixtureOptions = {}) {
+  const pages = opts.pages ?? PAGES;
+  const calls: string[] = [];
+  let failed = false;
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input.toString();
+    calls.push(raw);
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    const path = url.pathname;
+
+    // Single-page markdown: /v1/spaces/{id}/content/page/{pageId}
+    const pageMatch = path.match(/\/content\/page\/([^/]+)$/);
+    if (pageMatch) {
+      const p = pages.find((x) => x.id === pageMatch[1]);
+      return jsonResponse({ markdown: p?.markdown ?? "" });
+    }
+    // Content tree: /v1/spaces/{id}/content
+    if (path.endsWith(`/spaces/${SPACE_ID}/content`)) {
+      return jsonResponse(contentTree(pages));
+    }
+    // Space: /v1/spaces/{id}
+    if (path.endsWith(`/spaces/${SPACE_ID}`)) {
+      return opts.spaceMissing ? jsonResponse({}) : jsonResponse({ id: SPACE_ID, title: "Docs" });
+    }
+    return new Response("not found", { status: 404 });
+  };
+  return { impl, calls };
+}
+
+function client(opts: FixtureOptions = {}, maxDocs?: number) {
+  const { impl, calls } = makeFetch(opts);
+  const c = createGitbookVendorClient(
+    { spaceId: SPACE_ID, apiToken: "tok", collectionSlug: "gitbook-docs" },
+    { fetchImpl: impl as unknown as typeof globalThis.fetch, ...(maxDocs !== undefined ? { maxDocs } : {}) },
+  );
+  return { c, calls };
+}
+
+/** Build a client over a bespoke raw fetch impl (for coverage/error-mapping cases). */
+function rawClient(impl: (input: string | URL | Request) => Promise<Response>) {
+  return createGitbookVendorClient(
+    { spaceId: SPACE_ID, apiToken: "tok", collectionSlug: "gitbook-docs" },
+    { fetchImpl: impl as unknown as typeof globalThis.fetch },
+  );
+}
+
+/** A raw fetch impl serving a fixed content tree + a per-page body responder. */
+function treeFetch(tree: unknown, pageBody: (pageId: string) => Response) {
+  return async (input: string | URL | Request): Promise<Response> => {
+    const path = new URL(typeof input === "string" ? input : input.toString()).pathname;
+    const pageMatch = path.match(/\/content\/page\/([^/]+)$/);
+    if (pageMatch) return pageBody(pageMatch[1]);
+    if (path.endsWith(`/spaces/${SPACE_ID}/content`)) return jsonResponse(tree);
+    return new Response("not found", { status: 404 });
+  };
+}
+
+describe("GitbookVendorClient.fetchAll (reconciliation)", () => {
+  it("enumerates every document page, skips group/link nodes, and returns docs + high-water mark", async () => {
+    const { c } = client();
+    const result = await c.fetchAll();
+    expect(result.documents).toHaveLength(2);
+    expect(result.coverageIncomplete).toBe(false);
+    // Newest page's updatedAt.
+    expect(result.highWaterMark).toBe("2026-07-06T09:00:00.000Z");
+    const paths = result.documents.map((d) => d.path).toSorted();
+    expect(paths).toEqual(["gitbook-docs/guides/setup.md", "gitbook-docs/intro.md"]);
+  });
+
+  it("stamps the atlas provenance block on each document", async () => {
+    const { c } = client();
+    const result = await c.fetchAll();
+    expect(result.documents.every((d) => d.content.includes('connector: "gitbook"'))).toBe(true);
+  });
+
+  it("throws an actionable, real-numbered error when the full set exceeds the doc cap", async () => {
+    const { c } = client({}, 1);
+    await expect(c.fetchAll()).rejects.toThrow(/has 2 pages, over the 1-document limit/);
+  });
+});
+
+describe("GitbookVendorClient.fetchChanges (incremental)", () => {
+  it("fetches bodies only for pages modified at-or-after `since`", async () => {
+    const { c, calls } = client();
+    const result = await c.fetchChanges({ since: "2026-07-05T00:00:00.000Z", cursor: null });
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].path).toBe("gitbook-docs/guides/setup.md");
+    // High-water mark still reflects the newest across ALL enumerated pages.
+    expect(result.highWaterMark).toBe("2026-07-06T09:00:00.000Z");
+    // Only the changed page's markdown was fetched (p2), not p1's.
+    expect(calls.some((u) => u.includes("/content/page/p2"))).toBe(true);
+    expect(calls.some((u) => u.includes("/content/page/p1"))).toBe(false);
+  });
+
+  it("includes a page whose updatedAt exactly equals `since` (>= boundary)", async () => {
+    // The high-water-mark contract re-emits the boundary page (overlap window),
+    // never silently drops it.
+    const { c } = client();
+    const result = await c.fetchChanges({ since: "2026-07-06T09:00:00.000Z", cursor: null });
+    expect(result.documents.map((d) => d.path)).toEqual(["gitbook-docs/guides/setup.md"]);
+  });
+
+  it("normalizes an offset-format updatedAt to a canonical instant for the filter + high-water mark", async () => {
+    // `2026-07-06T11:00:00+02:00` === `09:00:00Z`; a raw-string compare would
+    // order it wrong, so `toIsoInstant` must canonicalize it.
+    const tree = {
+      pages: [
+        {
+          id: "off",
+          title: "Offset",
+          type: "document",
+          path: "offset",
+          updatedAt: "2026-07-06T11:00:00+02:00",
+          urls: { app: "https://acme.gitbook.io/docs/offset" },
+        },
+      ],
+    };
+    const c = rawClient(treeFetch(tree, () => jsonResponse({ markdown: "Body content long enough here." })));
+    const result = await c.fetchAll();
+    expect(result.highWaterMark).toBe("2026-07-06T09:00:00.000Z");
+    // A `since` just after the normalized instant excludes it (proves canonicalization).
+    const inc = await c.fetchChanges({ since: "2026-07-06T09:00:00.001Z", cursor: null });
+    expect(inc.documents).toHaveLength(0);
+  });
+});
+
+describe("GitbookVendorClient coverage flagging (never archive a live page)", () => {
+  it("flags coverageIncomplete and emits only the good page when a document node is malformed", async () => {
+    const tree = {
+      pages: [
+        {
+          id: "good",
+          title: "Good",
+          type: "document",
+          path: "good",
+          updatedAt: "2026-07-06T09:00:00.000Z",
+          urls: { app: "https://acme.gitbook.io/docs/good" },
+        },
+        // A DOCUMENT node missing updatedAt — counted malformed, coverage flagged.
+        { id: "bad", title: "Bad", type: "document", path: "bad", urls: { app: "https://x/bad" } },
+      ],
+    };
+    const c = rawClient(treeFetch(tree, () => jsonResponse({ markdown: "Good page body, long enough here." })));
+    const result = await c.fetchAll();
+    expect(result.documents.map((d) => d.path)).toEqual(["gitbook-docs/good.md"]);
+    expect(result.coverageIncomplete).toBe(true);
+  });
+
+  it("throws (rather than silently dropping) when a page body has no markdown field", async () => {
+    // A 200 body with an absent/non-string markdown is an anomalous vendor
+    // response — coercing to "" would look like an empty page and, on
+    // reconciliation, archive a live document. It must abort the fetch instead.
+    const tree = {
+      pages: [
+        {
+          id: "p",
+          title: "P",
+          type: "document",
+          path: "p",
+          updatedAt: "2026-07-06T09:00:00.000Z",
+          urls: { app: "https://acme.gitbook.io/docs/p" },
+        },
+      ],
+    };
+    const c = rawClient(treeFetch(tree, () => jsonResponse({})));
+    await expect(c.fetchAll()).rejects.toThrow(/no markdown field/i);
+  });
+});
+
+describe("GitbookVendorClient error mapping", () => {
+  it("maps a 429 to ConnectorRateLimitError with the parsed Retry-After", async () => {
+    const { c } = client({ failFirst: { status: 429, headers: { "retry-after": "12" } } });
+    try {
+      await c.fetchAll();
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as { name?: string }).name).toBe("ConnectorRateLimitError");
+      expect((err as { retryAfterSeconds?: number }).retryAfterSeconds).toBe(12);
+    }
+  });
+
+  it("maps a 401 to an actionable credential error", async () => {
+    const { c } = client({ failFirst: { status: 401 } });
+    await expect(c.fetchAll()).rejects.toThrow(/rejected the credentials \(401\)/i);
+  });
+
+  it("maps a 404 to an actionable space-not-found error", async () => {
+    const { c } = client({ failFirst: { status: 404 } });
+    await expect(c.fetchAll()).rejects.toThrow(/returned 404/i);
+  });
+
+  it("wraps a non-JSON body in a host-redacted error carrying the cause (never the token)", async () => {
+    const c = rawClient(async () => new Response("<html>oops</html>", { status: 200, headers: { "content-type": "text/html" } }));
+    try {
+      await c.fetchAll();
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toMatch(/non-JSON response/i);
+      expect(message).toContain("api.gitbook.com");
+      expect(message).not.toContain("tok"); // the bearer token is never surfaced
+      expect((err as { cause?: unknown }).cause).toBeDefined();
+    }
+  });
+
+  it("wraps a transport failure in a host-redacted error carrying the cause", async () => {
+    const c = rawClient(async () => {
+      throw new TypeError("network down");
+    });
+    try {
+      await c.fetchAll();
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toMatch(/request to api\.gitbook\.com failed/i);
+      expect((err as { cause?: unknown }).cause).toBeDefined();
+    }
+  });
+});
+
+describe("verifyGitbookAccess", () => {
+  it("resolves when the space is visible", async () => {
+    const { impl } = makeFetch();
+    await expect(
+      verifyGitbookAccess(
+        { spaceId: SPACE_ID, apiToken: "tok", collectionSlug: "c" },
+        { fetchImpl: impl as unknown as typeof globalThis.fetch },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws a not-found error when the space object has no id", async () => {
+    const { impl } = makeFetch({ spaceMissing: true });
+    await expect(
+      verifyGitbookAccess(
+        { spaceId: SPACE_ID, apiToken: "tok", collectionSlug: "c" },
+        { fetchImpl: impl as unknown as typeof globalThis.fetch },
+      ),
+    ).rejects.toThrow(/was not found or is not visible/i);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds and rejects an HTTP-date", () => {
+    expect(parseRetryAfter("30")).toBe(30);
+    expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/knowledge/gitbook/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/gitbook/__tests__/connector.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the GitBook KnowledgeSyncConnector (#4393) — the createClient
+ * factory contract: parse stored config, read the encrypted token loudly, and
+ * build a vendor client. The credential store is mocked (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let tokenResult: string | null | (() => never) = "secret-token";
+
+mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof tokenResult === "function") return tokenResult();
+    return tokenResult;
+  },
+}));
+
+const { createGitbookConnector } = await import("@atlas/api/lib/knowledge/gitbook/connector");
+const { GITBOOK_CATALOG_ID, GITBOOK_VENDOR } = await import("@atlas/api/lib/knowledge/gitbook/config");
+
+const VALID_CONFIG = { space_id: "space-123" };
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "gitbook-docs", config };
+}
+
+afterEach(() => {
+  tokenResult = "secret-token";
+});
+
+describe("createGitbookConnector", () => {
+  it("advertises the gitbook catalog id and vendor slug", () => {
+    const connector = createGitbookConnector();
+    expect(connector.catalogId).toBe(GITBOOK_CATALOG_ID);
+    expect(connector.vendor).toBe(GITBOOK_VENDOR);
+  });
+
+  it("builds a vendor client from valid config + a stored token", async () => {
+    const connector = createGitbookConnector();
+    const client = await connector.createClient(ctx(VALID_CONFIG));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error when the stored config has no space id", async () => {
+    const connector = createGitbookConnector();
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(/no GitBook space id configured/i);
+  });
+
+  it("throws when the collection has no stored API token", async () => {
+    tokenResult = null;
+    const connector = createGitbookConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/no stored API token/i);
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    tokenResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createGitbookConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/gitbook/__tests__/content-to-markdown.test.ts
+++ b/packages/api/src/lib/knowledge/gitbook/__tests__/content-to-markdown.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Golden-fixture tests for the GitBook markdown converter (#4393). Pure — no
+ * I/O. Covers the structural block conversions (hints, code-with-title, tabs,
+ * stepper, content-ref, embed) and the honest-degradation policy (unknown
+ * paired blocks keep their inner prose under a counted placeholder; unknown
+ * standalone blocks degrade to the placeholder alone).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { convertGitbookMarkdown } from "@atlas/api/lib/knowledge/gitbook/content-to-markdown";
+
+const PAGE_URL = "https://acme.gitbook.io/docs/guides/setup";
+
+function convert(md: string) {
+  return convertGitbookMarkdown(md, { pageUrl: PAGE_URL });
+}
+
+describe("convertGitbookMarkdown — passthrough", () => {
+  it("leaves plain markdown untouched", () => {
+    const { markdown, degradations } = convert("# Title\n\nSome **bold** prose.\n");
+    expect(markdown).toBe("# Title\n\nSome **bold** prose.");
+    expect(degradations).toEqual([]);
+  });
+
+  it("keeps a fenced code block verbatim", () => {
+    const md = "```js\nconsole.log(1)\n```";
+    expect(convert(md).markdown).toBe(md);
+  });
+});
+
+describe("convertGitbookMarkdown — structural blocks", () => {
+  it("converts a hint to a labelled blockquote", () => {
+    const { markdown, degradations } = convert('{% hint style="warning" %}\nBe careful here.\n{% endhint %}');
+    expect(markdown).toBe("> **Warning**\n>\n> Be careful here.");
+    expect(degradations).toEqual([]);
+  });
+
+  it("defaults an unknown hint style to Note", () => {
+    expect(convert('{% hint style="mystery" %}\ntext\n{% endhint %}').markdown).toBe("> **Note**\n>\n> text");
+  });
+
+  it("keeps a code block's fence and prefixes its title", () => {
+    const md = '{% code title="example.js" %}\n```js\nconst x = 1;\n```\n{% endcode %}';
+    const { markdown } = convert(md);
+    expect(markdown).toBe("**example.js**\n\n```js\nconst x = 1;\n```");
+  });
+
+  it("renders tabs as labelled sections", () => {
+    const md =
+      '{% tabs %}\n{% tab title="npm" %}\nnpm install\n{% endtab %}\n{% tab title="bun" %}\nbun add\n{% endtab %}\n{% endtabs %}';
+    const { markdown } = convert(md);
+    expect(markdown).toContain("**npm**\n\nnpm install");
+    expect(markdown).toContain("**bun**\n\nbun add");
+  });
+
+  it("unwraps a stepper and labels its steps", () => {
+    const md =
+      '{% stepper %}\n{% step %}\n### First\ndo a thing\n{% endstep %}\n{% endstepper %}';
+    const { markdown } = convert(md);
+    expect(markdown).toContain("### First");
+    expect(markdown).toContain("do a thing");
+  });
+
+  it("converts a content-ref to a link", () => {
+    const md = '{% content-ref url="https://acme.gitbook.io/docs/other" %}\nSee this\n{% endcontent-ref %}';
+    expect(convert(md).markdown).toBe("[See this](https://acme.gitbook.io/docs/other)");
+  });
+
+  it("converts a standalone embed to a link", () => {
+    const md = '{% embed url="https://youtu.be/abc" %}';
+    expect(convert(md).markdown).toBe("[https://youtu.be/abc](https://youtu.be/abc)");
+  });
+});
+
+describe("convertGitbookMarkdown — degradation policy", () => {
+  it("degrades an unknown paired block to a counted placeholder, keeping inner prose", () => {
+    const md = '{% openapi src="./spec.yaml" %}\nGET /users\n{% endopenapi %}';
+    const { markdown, degradations } = convert(md);
+    expect(markdown).toContain("⚠️ Unsupported GitBook block `openapi`");
+    expect(markdown).toContain(PAGE_URL);
+    expect(markdown).toContain("GET /users"); // inner prose never dropped
+    expect(degradations).toEqual([{ name: "openapi", count: 1 }]);
+  });
+
+  it("degrades an unknown standalone block to the placeholder alone and counts it", () => {
+    const md = '{% file src="./report.pdf" %}';
+    const { markdown, degradations } = convert(md);
+    expect(markdown).toContain("⚠️ Unsupported GitBook block `file`");
+    expect(degradations).toEqual([{ name: "file", count: 1 }]);
+  });
+
+  it("counts repeated degradations of the same block", () => {
+    const md = '{% file src="a" %}\n\n{% file src="b" %}';
+    expect(convert(md).degradations).toEqual([{ name: "file", count: 2 }]);
+  });
+
+  it("handles a known block nested inside another without degrading either", () => {
+    const md =
+      '{% tabs %}\n{% tab title="Note" %}\n{% hint style="info" %}\nnested hint\n{% endhint %}\n{% endtab %}\n{% endtabs %}';
+    const { markdown, degradations } = convert(md);
+    expect(markdown).toContain("**Note**");
+    expect(markdown).toContain("> **Info**");
+    expect(markdown).toContain("nested hint");
+    expect(degradations).toEqual([]);
+  });
+
+  it("degrades an unknown block nested in a known block, keeping the surrounding structure", () => {
+    const md = '{% tabs %}\n{% tab title="API" %}\n{% swagger %}\nspec\n{% endswagger %}\n{% endtab %}\n{% endtabs %}';
+    const { markdown, degradations } = convert(md);
+    expect(markdown).toContain("**API**");
+    expect(markdown).toContain("⚠️ Unsupported GitBook block `swagger`");
+    expect(degradations).toEqual([{ name: "swagger", count: 1 }]);
+  });
+});

--- a/packages/api/src/lib/knowledge/gitbook/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/gitbook/__tests__/documents.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for GitBook page → OKF document assembly (#4393). Pure — asserts the
+ * archive path (GitBook slug path → prefixed `.md`), the `atlas:` provenance
+ * block (connector + page id + version), contentless-skip, and collision
+ * disambiguation.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleGitbookDocuments,
+  type GitbookPage,
+} from "@atlas/api/lib/knowledge/gitbook/documents";
+
+function page(overrides: Partial<GitbookPage> = {}): GitbookPage {
+  return {
+    id: "page-1",
+    title: "Setup",
+    path: "guides/setup",
+    markdown: "Install the thing.",
+    updatedAt: "2026-07-06T09:00:00.000Z",
+    url: "https://acme.gitbook.io/docs/guides/setup",
+    ...overrides,
+  };
+}
+
+describe("assembleGitbookDocuments", () => {
+  it("derives a prefixed, hierarchy-mirroring archive path from the GitBook path", () => {
+    const { documents } = assembleGitbookDocuments([page()], { collectionSlug: "gitbook-docs" });
+    expect(documents).toHaveLength(1);
+    expect(documents[0].path).toBe("gitbook-docs/guides/setup.md");
+  });
+
+  it("stamps resource, timestamp, and the atlas provenance block", () => {
+    const { documents } = assembleGitbookDocuments([page()], { collectionSlug: "gitbook-docs" });
+    const content = documents[0].content;
+    expect(content).toContain('resource: "https://acme.gitbook.io/docs/guides/setup"');
+    expect(content).toContain('timestamp: "2026-07-06T09:00:00.000Z"');
+    expect(content).toContain("atlas:");
+    expect(content).toContain('connector: "gitbook"');
+    expect(content).toContain('page_id: "page-1"');
+    expect(content).toContain('updated_at: "2026-07-06T09:00:00.000Z"');
+    expect(content).toContain("Install the thing.");
+    // No provenance `tags` line — it would re-draft on every sync (Notion posture).
+    expect(content).not.toContain("tags:");
+  });
+
+  it("carries no title line for an untitled page but still emits the document", () => {
+    const { documents } = assembleGitbookDocuments([page({ title: "  " })], {
+      collectionSlug: "c",
+    });
+    expect(documents).toHaveLength(1);
+    expect(documents[0].content).not.toContain("title:");
+  });
+
+  it("skips a contentless page rather than emitting an empty doc", () => {
+    const result = assembleGitbookDocuments([page({ markdown: "   " })], { collectionSlug: "c" });
+    expect(result.documents).toHaveLength(0);
+    expect(result.skippedContentless).toBe(1);
+  });
+
+  it("aggregates converter degradations across pages", () => {
+    const result = assembleGitbookDocuments(
+      [
+        page({ id: "a", path: "a", markdown: '{% file src="x" %}\n\ntext' }),
+        page({ id: "b", path: "b", markdown: '{% file src="y" %}\n\ntext' }),
+      ],
+      { collectionSlug: "c" },
+    );
+    expect(result.degradations).toEqual([{ name: "file", count: 2 }]);
+  });
+
+  it("disambiguates a path collision with the page id rather than clobbering", () => {
+    // Two distinct pages whose slugified paths collide (`A/B` vs `a-b`).
+    const result = assembleGitbookDocuments(
+      [
+        page({ id: "1", path: "A B", markdown: "first document body content here" }),
+        page({ id: "2", path: "a-b", markdown: "second document body content here" }),
+      ],
+      { collectionSlug: "c" },
+    );
+    expect(result.documents).toHaveLength(2);
+    expect(result.collisionsRenamed).toBe(1);
+    const paths = result.documents.map((d) => d.path);
+    expect(new Set(paths).size).toBe(2);
+    expect(paths.some((p) => p.endsWith("-2.md"))).toBe(true);
+  });
+
+  it("falls back to the title slug when the path has no usable segments", () => {
+    const { documents } = assembleGitbookDocuments([page({ path: "   ", title: "My Page" })], {
+      collectionSlug: "c",
+    });
+    expect(documents[0].path).toBe("c/my-page.md");
+  });
+});

--- a/packages/api/src/lib/knowledge/gitbook/client.ts
+++ b/packages/api/src/lib/knowledge/gitbook/client.ts
@@ -1,0 +1,408 @@
+/**
+ * The GitBook Cloud vendor client (#4393, ADR-0030) — a
+ * {@link ConnectorVendorClient} over the GitBook REST API, driven by the shared
+ * connector engine (`connector-sync.ts`). It owns ONLY enumerate + fetch +
+ * convert; scheduling, high-water marks, reconciliation cadence, 429 backoff,
+ * and caps are the engine's.
+ *
+ * Two cadences the engine decides, both served from one enumeration shape:
+ *   - `fetchChanges({ since })` (incremental) — enumerate the space's page tree
+ *     METADATA (id/title/path/updatedAt — cheap, no bodies), keep those modified
+ *     at-or-after `since`, and fetch the markdown body only for those.
+ *   - `fetchAll()` (reconciliation) — enumerate every current page and fetch all
+ *     of their bodies. The engine archives paths absent from this set, so a
+ *     deleted/unpublished page (never returned by the content tree) is treated
+ *     as absent, never an error.
+ *
+ * GitBook gives each page its full slug `path`, so hierarchy is deterministic
+ * across modes without an ancestor walk. Security + hygiene: every request goes
+ * through `guardedFetch` (the SSRF egress guard; auth stripped on cross-origin
+ * redirect) even though the host is a fixed GitBook constant. A 429 is the ONLY
+ * signal that becomes the engine's backoff (thrown as
+ * {@link ConnectorRateLimitError}); every other failure is an actionable error
+ * with the host redacted via `hostForLog` — the token lives in the
+ * `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import { getIngestMaxDocs } from "../ingest-limits";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import { GITBOOK_API_BASE } from "./config";
+import { assembleGitbookDocuments, type GitbookPage } from "./documents";
+
+const log = createLogger("knowledge.gitbook.client");
+
+/** Resolved, non-secret connection inputs plus the token. */
+export interface GitbookClientConfig {
+  /** The GitBook space id this collection mirrors. */
+  readonly spaceId: string;
+  readonly apiToken: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface GitbookClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** Test-only override of the ingest doc cap (defaults to the settings value). */
+  readonly maxDocs?: number;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * Hard anti-runaway bound on tree recursion depth — NOT a content limit. A
+ * GitBook space nested deeper than this is pathological; the descent stops and
+ * flags coverage incomplete rather than looping unbounded on a cyclic tree.
+ */
+const MAX_TREE_DEPTH = 100;
+
+// ---------------------------------------------------------------------------
+// Raw response shapes (only the fields we read; every field optional — this is
+// untrusted vendor JSON, narrowed at the use sites)
+// ---------------------------------------------------------------------------
+
+interface RawUrls {
+  readonly app?: string;
+}
+interface RawRevisionPage {
+  readonly id?: string;
+  readonly title?: string;
+  readonly path?: string;
+  readonly slug?: string;
+  readonly kind?: string;
+  readonly type?: string;
+  readonly updatedAt?: string;
+  readonly urls?: RawUrls;
+  readonly pages?: readonly RawRevisionPage[];
+}
+interface RawContent {
+  readonly pages?: readonly RawRevisionPage[];
+}
+interface RawSpace {
+  readonly id?: string;
+  readonly title?: string;
+}
+interface RawPageMarkdown {
+  readonly markdown?: string;
+}
+
+/** One enumerated page's metadata (bodies fetched separately). */
+interface EnumeratedPage {
+  readonly id: string;
+  readonly title: string;
+  readonly path: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  readonly url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a GitBook vendor client. `createClient` (the connector factory) has
+ * already decrypted the token and validated config, so this constructor does no
+ * I/O.
+ */
+export function createGitbookVendorClient(
+  config: GitbookClientConfig,
+  deps: GitbookClientDeps = {},
+): ConnectorVendorClient {
+  const api = new GitbookApi(config, deps);
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      return api.fetch({ since: params.since });
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetch({ since: null });
+    },
+  };
+}
+
+/**
+ * Verify the connection at INSTALL time — resolve the space by id with the
+ * supplied credentials. Cheap (one request) and loud: a bad token surfaces as a
+ * 401, an invalid/invisible space id as a not-found error. The install handler
+ * maps each to a field-level 400 so "invalid credentials fail the install
+ * loudly."
+ */
+export async function verifyGitbookAccess(
+  config: GitbookClientConfig,
+  deps: GitbookClientDeps = {},
+): Promise<void> {
+  await new GitbookApi(config, deps).verifyAccess();
+}
+
+class GitbookApi {
+  private readonly authHeader: string;
+  private readonly maxDocs: number;
+
+  constructor(
+    private readonly config: GitbookClientConfig,
+    private readonly deps: GitbookClientDeps,
+  ) {
+    this.authHeader = `Bearer ${config.apiToken}`;
+    this.maxDocs = deps.maxDocs ?? getIngestMaxDocs();
+  }
+
+  /** Install-time reachability + credential check (resolves the space by id). */
+  async verifyAccess(): Promise<void> {
+    const space = await this.getJson<RawSpace>(
+      `${GITBOOK_API_BASE}/v1/spaces/${encodeURIComponent(this.config.spaceId)}`,
+    );
+    if (typeof space.id !== "string" || space.id === "") {
+      throw new Error(
+        `GitBook space "${this.config.spaceId}" was not found or is not visible to this token — check the space id and the token's permissions.`,
+      );
+    }
+  }
+
+  /**
+   * Enumerate the page tree + assemble. When `since` is null this is a
+   * reconciliation crawl (every page fetched + assembled); otherwise an
+   * incremental cycle (bodies fetched only for pages modified at-or-after
+   * `since`).
+   */
+  async fetch(opts: { since: string | null }): Promise<ConnectorChanges> {
+    const reconciliation = opts.since === null;
+    const { pages: enumerated, skippedMalformed } = await this.enumeratePages();
+
+    let highWaterMark: string | null = null;
+    for (const p of enumerated) {
+      if (highWaterMark === null || p.updatedAt > highWaterMark) highWaterMark = p.updatedAt;
+    }
+
+    // `updatedAt` is a normalized ISO instant, and the engine's `since` is a
+    // toISOString — string comparisons are chronological.
+    const selected = reconciliation
+      ? enumerated
+      : enumerated.filter((p) => opts.since === null || p.updatedAt >= opts.since);
+
+    // Reject an over-cap FULL set BEFORE fetching bodies (the engine's ingest
+    // cap is the backstop, but checking here saves N markdown fetches and puts
+    // real numbers in the error — the AC's "caps validated over the full set").
+    if (reconciliation && enumerated.length > this.maxDocs) {
+      throw new Error(
+        `This GitBook space has ${enumerated.length} pages, over the ${this.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the space's scope, or raise the cap.`,
+      );
+    }
+
+    const pages: GitbookPage[] = [];
+    for (const p of selected) {
+      const markdown = await this.fetchPageMarkdown(p.id);
+      pages.push({
+        id: p.id,
+        title: p.title,
+        path: p.path,
+        markdown,
+        updatedAt: p.updatedAt,
+        url: p.url,
+      });
+    }
+
+    const assembled = assembleGitbookDocuments(pages, {
+      collectionSlug: this.config.collectionSlug,
+    });
+    if (
+      assembled.degradations.length > 0 ||
+      assembled.skippedContentless > 0 ||
+      assembled.collisionsRenamed > 0
+    ) {
+      log.info(
+        {
+          space: this.config.spaceId,
+          mode: reconciliation ? "reconciliation" : "incremental",
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+          collisionsRenamed: assembled.collisionsRenamed,
+        },
+        "GitBook conversion completed with degradations/skips",
+      );
+    }
+
+    // A warn-skipped malformed page is a KNOWN hole in the set: its document
+    // would otherwise be archived by a reconciliation off this partial crawl.
+    // The flag makes the engine upsert-only and hold the reconcile clock.
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+
+  /** Fetch + walk the space content tree into a flat list of document pages. */
+  private async enumeratePages(): Promise<{ pages: EnumeratedPage[]; skippedMalformed: number }> {
+    const content = await this.getJson<RawContent>(
+      `${GITBOOK_API_BASE}/v1/spaces/${encodeURIComponent(this.config.spaceId)}/content`,
+    );
+    const pages: EnumeratedPage[] = [];
+    let skippedMalformed = 0;
+    const seen = new Set<string>();
+
+    const walk = (nodes: readonly RawRevisionPage[], depth: number): void => {
+      if (depth > MAX_TREE_DEPTH) {
+        // A too-deep (or cyclic) tree: stop descending and flag coverage so the
+        // engine won't archive the pages we never reached.
+        skippedMalformed++;
+        log.warn(
+          { space: this.config.spaceId, depth },
+          "GitBook page tree exceeded the max depth — descent stopped; subtractive archiving is skipped this cycle",
+        );
+        return;
+      }
+      for (const raw of nodes) {
+        const normalized = this.normalizePage(raw);
+        if (normalized === null) {
+          // A group/link node carries no document; recurse into its children but
+          // don't emit or count it. A malformed DOCUMENT node is counted below.
+          if (isDocumentNode(raw)) skippedMalformed++;
+        } else if (!seen.has(normalized.id)) {
+          seen.add(normalized.id);
+          pages.push(normalized);
+        }
+        if (raw.pages && raw.pages.length > 0) walk(raw.pages, depth + 1);
+      }
+    };
+    walk(content.pages ?? [], 0);
+
+    if (skippedMalformed > 0) {
+      log.warn(
+        { space: this.config.spaceId, skippedMalformed },
+        "Skipped GitBook pages missing id/title/path/updatedAt — not ingested (coverage flagged incomplete)",
+      );
+    }
+    return { pages, skippedMalformed };
+  }
+
+  /**
+   * Fetch one page's markdown body (`?format=markdown`). A genuinely empty page
+   * returns `{ markdown: "" }` (a present string) and legitimately assembles to
+   * a contentless skip; an ABSENT/non-string `markdown` field is an anomalous
+   * vendor response, and coercing it to `""` here would look identical to an
+   * empty page — a silent contentless-skip that (unlike a malformed enumeration
+   * node) never flags `coverageIncomplete`, so a reconciliation would archive a
+   * live page. Throw instead: the fetch aborts, the engine records the
+   * collection's error, and nothing is archived (prefer errors over silent
+   * fallbacks). GitBook fetches each body in a SEPARATE request (Confluence gets
+   * it inline), so this per-page failure surface is real.
+   */
+  private async fetchPageMarkdown(pageId: string): Promise<string> {
+    const url = `${GITBOOK_API_BASE}/v1/spaces/${encodeURIComponent(this.config.spaceId)}/content/page/${encodeURIComponent(pageId)}?format=markdown`;
+    const body = await this.getJson<RawPageMarkdown>(url);
+    if (typeof body.markdown !== "string") {
+      throw new Error(
+        `GitBook returned a page body with no markdown field from ${hostForLog(GITBOOK_API_BASE)} (page ${pageId}) — unexpected vendor response.`,
+      );
+    }
+    return body.markdown;
+  }
+
+  /**
+   * Normalize a tree node into an {@link EnumeratedPage}, or null when it is not
+   * an ingestable document (a group/link) or is a malformed document (missing
+   * id/title/path/updatedAt — the caller counts the malformed case). The
+   * timestamp is normalized to a canonical ISO instant so an offset-format
+   * `updatedAt` can't compare wrong in the since-filter / high-water reduce.
+   */
+  private normalizePage(raw: RawRevisionPage): EnumeratedPage | null {
+    if (!isDocumentNode(raw)) return null;
+    const updatedAt = toIsoInstant(raw.updatedAt);
+    const path = typeof raw.path === "string" ? raw.path.trim() : "";
+    if (!raw.id || !raw.title || path === "" || updatedAt === null) return null;
+    return {
+      id: raw.id,
+      title: raw.title,
+      path,
+      updatedAt,
+      url: this.pageUrl(raw),
+    };
+  }
+
+  /** Absolute page URL from `urls.app`, or a canonical fallback from the id. */
+  private pageUrl(raw: RawRevisionPage): string {
+    const app = raw.urls?.app;
+    if (typeof app === "string" && /^https?:\/\//i.test(app)) return app;
+    return `${GITBOOK_API_BASE}/v1/spaces/${encodeURIComponent(this.config.spaceId)}/content/page/${encodeURIComponent(raw.id ?? "")}`;
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  private async getJson<T>(url: string): Promise<T> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `GitBook request to ${hostForLog(GITBOOK_API_BASE)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `GitBook rate-limited the request to ${hostForLog(GITBOOK_API_BASE)}.`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `GitBook rejected the credentials (${response.status}) for ${hostForLog(GITBOOK_API_BASE)} — re-enter the API token and confirm it can read the space.`,
+      );
+    }
+    if (response.status === 404) {
+      throw new Error(
+        `GitBook returned 404 for a request to ${hostForLog(GITBOOK_API_BASE)} — the space id may be wrong or the token can't see it.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(`GitBook returned HTTP ${response.status} from ${hostForLog(GITBOOK_API_BASE)}.`);
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new Error(
+        `GitBook returned a non-JSON response from ${hostForLog(GITBOOK_API_BASE)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/**
+ * True for a tree node that carries an ingestable document. GitBook marks a
+ * content page `type: "document"` (newer API) or `kind: "sheet"` (older); a
+ * `group` (container) / `link` (external) node is neither.
+ */
+function isDocumentNode(raw: RawRevisionPage): boolean {
+  return raw.type === "document" || raw.kind === "sheet";
+}
+
+/** Parse a `Retry-After` header (delta-seconds only; HTTP-date → null). */
+export function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}

--- a/packages/api/src/lib/knowledge/gitbook/config.ts
+++ b/packages/api/src/lib/knowledge/gitbook/config.ts
@@ -1,0 +1,51 @@
+/**
+ * GitBook connector identity + stored-config contract (#4393, ADR-0030).
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config), the
+ * connector (reads it back in `createClient`), and the admin-knowledge surface
+ * (recognizes the catalog id) share ONE definition — a field rename can't drift
+ * the three apart silently. The API token is NOT part of this config; it lives
+ * encrypted in `knowledge_sync_credentials` and is read via `readSyncCredential`.
+ *
+ * GitBook Cloud's API is a fixed vendor host (`api.gitbook.com`), so — unlike
+ * Confluence — there is no customer-supplied base URL to persist; the collection
+ * is pinned to ONE space by its id. Every request still goes through the SSRF
+ * egress guard at fetch time (defence in depth; the AC's "API host through the
+ * egress guard").
+ */
+
+/** The built-in GitBook Knowledge Base catalog slug + row id. */
+export const GITBOOK_SLUG = "gitbook";
+export const GITBOOK_CATALOG_ID = "catalog:gitbook";
+/** Vendor slug stamped into `atlas_source` as `connector:gitbook`. */
+export const GITBOOK_VENDOR = "gitbook";
+
+/** The GitBook Cloud REST base — a fixed vendor host, never customer-supplied. */
+export const GITBOOK_API_BASE = "https://api.gitbook.com";
+
+/** The non-secret config persisted on the `workspace_plugins` row. */
+export interface GitbookCollectionConfig {
+  /** The GitBook space id this collection mirrors (one space per install). */
+  readonly space_id: string;
+  readonly description?: string;
+}
+
+export type ParsedGitbookConfig =
+  | { readonly ok: true; readonly spaceId: string }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * field means someone edited the row out of band; re-installing repairs it.
+ */
+export function parseGitbookConfig(
+  config: Record<string, unknown> | null,
+): ParsedGitbookConfig {
+  const spaceId = typeof config?.space_id === "string" ? config.space_id.trim() : "";
+  if (spaceId === "") {
+    return { ok: false, error: "Collection has no GitBook space id configured — re-install it." };
+  }
+  return { ok: true, spaceId };
+}

--- a/packages/api/src/lib/knowledge/gitbook/connector.ts
+++ b/packages/api/src/lib/knowledge/gitbook/connector.ts
@@ -1,0 +1,76 @@
+/**
+ * The GitBook {@link KnowledgeSyncConnector} (#4393, ADR-0030) — the
+ * catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * three-line factory contract from ADR-0030: bind the stored config + the
+ * decrypted token into a vendor client. Scheduling, backoff, reconciliation,
+ * caps, and ingest are the shared engine's.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { createGitbookVendorClient, type GitbookClientDeps } from "./client";
+import { GITBOOK_CATALOG_ID, GITBOOK_VENDOR, parseGitbookConfig } from "./config";
+
+const log = createLogger("knowledge.gitbook.connector");
+
+export interface GitbookConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: GitbookClientDeps;
+}
+
+/** Build the GitBook connector. `deps` is test-only vendor-client injection. */
+export function createGitbookConnector(
+  deps: GitbookConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: GITBOOK_CATALOG_ID,
+    vendor: GITBOOK_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseGitbookConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiToken = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiToken === null) {
+        throw new Error(
+          "This GitBook collection has no stored API token — re-install it to re-enter the token.",
+        );
+      }
+
+      return createGitbookVendorClient(
+        {
+          spaceId: parsed.spaceId,
+          apiToken,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the GitBook connector idempotently — called from the boot seam that
+ * also registers install handlers (`registerBuiltinInstallHandlers`), and from
+ * tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog id, so
+ * gate on the registry first.
+ */
+export function registerGitbookKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(GITBOOK_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createGitbookConnector());
+  log.info({ catalogId: GITBOOK_CATALOG_ID }, "Registered GitBook knowledge sync connector");
+}

--- a/packages/api/src/lib/knowledge/gitbook/content-to-markdown.ts
+++ b/packages/api/src/lib/knowledge/gitbook/content-to-markdown.ts
@@ -1,0 +1,313 @@
+/**
+ * GitBook **markdown → honest CommonMark** converter (#4393, ADR-0030).
+ *
+ * GitBook's `?format=markdown` output is markdown-native, but carries GitBook's
+ * `{% … %}` block extensions (hints, tabs, code-with-title, steppers, embeds,
+ * content-refs, OpenAPI blocks, …). This is the pure, golden-fixture-tested
+ * heart of the GitBook connector: given one page's GitBook-flavored markdown,
+ * produce clean CommonMark plus a **counted** list of every block that degraded.
+ *
+ * The explicit **block policy** (AC — "unconvertible constructs degrade to
+ * counted placeholders, never silent drops"):
+ *   - a set of known blocks are converted structurally (hints → labelled
+ *     blockquotes; `code` → its inner fence, keeping the title; `tabs`/`tab`,
+ *     `stepper`/`step`, `columns`/`column`, `expand` → labelled/unwrapped
+ *     sections; `content-ref`/`embed` → plain links);
+ *   - every OTHER `{% … %}` block degrades to a VISIBLE placeholder pointing at
+ *     the vendor page, COUNTED by block name in
+ *     {@link ConversionResult.degradations}. A PAIRED unknown block still renders
+ *     its inner prose under the placeholder, so content is never lost; a
+ *     STANDALONE unknown block degrades to the placeholder link alone.
+ *
+ * Purity: no I/O, no vendor calls, deterministic. The only external input beyond
+ * the markdown string is the page's canonical URL, used so every placeholder is
+ * a live link back to the source page.
+ *
+ * Scope note: `{% … %}` tokens are transformed everywhere, including inside
+ * fenced code blocks. GitBook's own export escapes literal block tags in code
+ * samples, so in practice a fence never carries a real `{% … %}` block; a page
+ * that documents GitBook's own syntax is the one edge this doesn't round-trip.
+ */
+
+/** One kind of degradation and how many times it fired in a single page. */
+export interface BlockDegradation {
+  /** The GitBook block name (`{% <name> … %}`), e.g. `openapi`, `file`. */
+  readonly name: string;
+  readonly count: number;
+}
+
+export interface ConversionResult {
+  readonly markdown: string;
+  /**
+   * Every GitBook block that could not be structurally converted, counted by
+   * name. Empty when the page converted cleanly. The connector logs the
+   * aggregate so a page full of unsupported blocks is a visible signal, never a
+   * silent shrink — and each one is ALSO a placeholder line in `markdown`.
+   */
+  readonly degradations: readonly BlockDegradation[];
+}
+
+export interface ConvertOptions {
+  /** The page's canonical GitBook URL — every degradation placeholder links here. */
+  readonly pageUrl: string;
+}
+
+/** Hint styles → a blockquote label. Default (unknown style) → "Note". */
+const HINT_LABEL: Record<string, string> = {
+  info: "Info",
+  note: "Note",
+  tip: "Tip",
+  success: "Success",
+  warning: "Warning",
+  danger: "Danger",
+};
+
+/** A mutable degradation tally threaded through one page's conversion. */
+class Degradations {
+  private readonly counts = new Map<string, number>();
+  bump(name: string): void {
+    this.counts.set(name, (this.counts.get(name) ?? 0) + 1);
+  }
+  list(): BlockDegradation[] {
+    return [...this.counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .toSorted((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+interface Ctx {
+  readonly degradations: Degradations;
+  readonly pageUrl: string;
+}
+
+/** A parsed `{% name attrs %}` opening or `{% endname %}` closing tag. */
+interface Tag {
+  /** Byte offset of the `{%`. */
+  readonly start: number;
+  /** Byte offset just past the `%}`. */
+  readonly end: number;
+  /** Lower-cased tag name (without a leading `end`). */
+  readonly name: string;
+  /** True for a `{% end<name> %}` closer. */
+  readonly closing: boolean;
+  /** Raw attribute string after the name (opening tags only). */
+  readonly attrs: string;
+}
+
+const TAG_RE = /\{%\s*([\s\S]*?)\s*%\}/g;
+
+/** Parse one `{% … %}` match body into a {@link Tag}. */
+function parseTag(match: RegExpExecArray): Tag {
+  const body = match[1].trim();
+  const firstSpace = body.search(/\s/);
+  const word = (firstSpace === -1 ? body : body.slice(0, firstSpace)).toLowerCase();
+  const rest = firstSpace === -1 ? "" : body.slice(firstSpace + 1).trim();
+  if (word.startsWith("end") && word.length > 3) {
+    return { start: match.index, end: TAG_RE.lastIndex, name: word.slice(3), closing: true, attrs: "" };
+  }
+  return { start: match.index, end: TAG_RE.lastIndex, name: word, closing: false, attrs: rest };
+}
+
+/** Every `{% … %}` tag in `input`, in order. */
+function scanTags(input: string): Tag[] {
+  const tags: Tag[] = [];
+  TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TAG_RE.exec(input)) !== null) {
+    if (m[0].length === 0) {
+      TAG_RE.lastIndex++; // defensive: never spin on a zero-width match
+      continue;
+    }
+    tags.push(parseTag(m));
+  }
+  return tags;
+}
+
+/** Parse `key="value"` attributes into a map (GitBook always double-quotes). */
+function parseAttrs(attrs: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const re = /(\w[\w-]*)\s*=\s*"([^"]*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(attrs)) !== null) out[m[1].toLowerCase()] = m[2];
+  return out;
+}
+
+/**
+ * Convert one page's GitBook-flavored markdown to honest CommonMark. Text
+ * outside `{% … %}` blocks passes through unchanged; blocks are transformed or
+ * degraded (and counted) per the block policy above.
+ */
+export function convertGitbookMarkdown(
+  markdown: string,
+  options: ConvertOptions,
+): ConversionResult {
+  const degradations = new Degradations();
+  const ctx: Ctx = { degradations, pageUrl: options.pageUrl };
+  const rendered = renderSegment(markdown, ctx);
+  return { markdown: normalizeBlankLines(rendered), degradations: degradations.list() };
+}
+
+/**
+ * Render a run of markdown, transforming top-level `{% … %}` blocks. Recurses
+ * into each block's inner content so nested blocks (a hint inside a tab, …) are
+ * handled uniformly.
+ */
+function renderSegment(input: string, ctx: Ctx): string {
+  const tags = scanTags(input);
+  if (tags.length === 0) return input;
+
+  let out = "";
+  let cursor = 0;
+  let i = 0;
+  while (i < tags.length) {
+    const tag = tags[i];
+    if (tag.start < cursor) {
+      // A tag already consumed inside a previous block's span — skip it.
+      i++;
+      continue;
+    }
+    out += input.slice(cursor, tag.start);
+
+    if (tag.closing) {
+      // A stray closer with no matching opener — drop the tag, keep going.
+      cursor = tag.end;
+      i++;
+      continue;
+    }
+
+    const closerIdx = findMatchingCloser(tags, i);
+    if (closerIdx === -1) {
+      // Standalone block (embed/file/include/…) — no `{% end… %}`.
+      out += renderStandalone(tag, ctx);
+      cursor = tag.end;
+      i++;
+      continue;
+    }
+
+    const closer = tags[closerIdx];
+    const inner = input.slice(tag.end, closer.start);
+    out += renderPairedBlock(tag, inner, ctx);
+    cursor = closer.end;
+    // Advance past the closer; the `tag.start < cursor` guard skips any tags the
+    // block span already covered (handled by recursion into `inner`).
+    i = closerIdx + 1;
+  }
+  out += input.slice(cursor);
+  return out;
+}
+
+/**
+ * Index in `tags` of the `{% end<name> %}` that closes the opener at `openIdx`,
+ * balancing nested same-name openers, or -1 when there is none (a standalone
+ * block).
+ */
+function findMatchingCloser(tags: Tag[], openIdx: number): number {
+  const name = tags[openIdx].name;
+  let depth = 0;
+  for (let j = openIdx + 1; j < tags.length; j++) {
+    const t = tags[j];
+    if (t.name !== name) continue;
+    if (t.closing) {
+      if (depth === 0) return j;
+      depth--;
+    } else {
+      depth++;
+    }
+  }
+  return -1;
+}
+
+/** Transform (or degrade) a paired `{% name %}…{% endname %}` block. */
+function renderPairedBlock(tag: Tag, inner: string, ctx: Ctx): string {
+  const rendered = () => renderSegment(inner, ctx).trim();
+  const attrs = parseAttrs(tag.attrs);
+
+  switch (tag.name) {
+    case "hint": {
+      const label = HINT_LABEL[(attrs.style ?? "").toLowerCase()] ?? "Note";
+      const body = rendered();
+      return blockquote(body === "" ? `**${label}**` : `**${label}**\n\n${body}`);
+    }
+    case "code": {
+      // Inner is already a fenced code block; keep it verbatim, prefix a title.
+      const body = inner.trim();
+      const title = attrs.title;
+      return title ? `**${title}**\n\n${body}` : body;
+    }
+    case "tabs":
+      return rendered();
+    case "tab": {
+      const title = attrs.title ?? "Tab";
+      const body = rendered();
+      return body === "" ? `**${title}**` : `**${title}**\n\n${body}`;
+    }
+    case "stepper":
+      return rendered();
+    case "step": {
+      const title = attrs.title;
+      const body = rendered();
+      if (title) return body === "" ? `**${title}**` : `**${title}**\n\n${body}`;
+      return body;
+    }
+    case "columns":
+    case "column":
+      // Layout-only wrappers — unwrap, keep the prose.
+      return rendered();
+    case "expand": {
+      const title = attrs.title ?? "Details";
+      const body = rendered();
+      return body === "" ? `**${title}**` : `**${title}**\n\n${body}`;
+    }
+    case "content-ref": {
+      const url = attrs.url ?? "";
+      const label = rendered() || url;
+      return url === "" ? label : `[${label}](${url})`;
+    }
+    default:
+      // Not structurally convertible → counted, visible placeholder, prose kept.
+      return degradePaired(tag.name, rendered(), ctx);
+  }
+}
+
+/** Transform (or degrade) a standalone `{% name … %}` block (no closer). */
+function renderStandalone(tag: Tag, ctx: Ctx): string {
+  const attrs = parseAttrs(tag.attrs);
+  switch (tag.name) {
+    case "embed": {
+      const url = attrs.url ?? "";
+      return url === "" ? "" : `[${url}](${url})`;
+    }
+    case "content-ref": {
+      // A `{% content-ref url="…" /%}` self-closing variant.
+      const url = attrs.url ?? "";
+      return url === "" ? "" : `[${url}](${url})`;
+    }
+    default:
+      return degradeStandalone(tag.name, ctx);
+  }
+}
+
+/** A paired unknown block: placeholder + the inner prose (never dropped). */
+function degradePaired(name: string, inner: string, ctx: Ctx): string {
+  ctx.degradations.bump(name);
+  const placeholder = `> ⚠️ Unsupported GitBook block \`${name}\` — [view on the original page](${ctx.pageUrl})`;
+  return inner === "" ? placeholder : `${placeholder}\n\n${inner}`;
+}
+
+/** A standalone unknown block: placeholder link alone. */
+function degradeStandalone(name: string, ctx: Ctx): string {
+  ctx.degradations.bump(name);
+  return `> ⚠️ Unsupported GitBook block \`${name}\` — [view on the original page](${ctx.pageUrl})`;
+}
+
+function blockquote(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => (line === "" ? ">" : `> ${line}`))
+    .join("\n");
+}
+
+/** Collapse 3+ newlines to a paragraph break and trim edges. */
+function normalizeBlankLines(markdown: string): string {
+  return markdown.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/packages/api/src/lib/knowledge/gitbook/documents.ts
+++ b/packages/api/src/lib/knowledge/gitbook/documents.ts
@@ -1,0 +1,157 @@
+/**
+ * GitBook page → OKF `ConnectorDocument` assembly (#4393, ADR-0030).
+ *
+ * Pure, deterministic glue between the markdown converter and the connector
+ * ingest seam. For each page it:
+ *   1. builds a **hierarchy slug path** from the page's GitBook `path` (already
+ *      a root→leaf slug path, e.g. `guides/setup`), so the agent's `explore`
+ *      mirror reads a readable tree — then folds it through `@atlas/okf-bundle`'s
+ *      `deriveArchivePath` so reserved OKF basenames (`index.md`/`log.md`) can
+ *      never be silently skipped at ingest;
+ *   2. converts the GitBook-flavored markdown to honest CommonMark (counting
+ *      block degradations);
+ *   3. renders a conformant OKF document via the shared `renderOkfDocument`,
+ *      stamping **provenance that survives ingest**: `resource` = the page's
+ *      canonical URL and `timestamp` = the page's modification time, plus an
+ *      `atlas:` extension block carrying `connector` + `page_id` + `updated_at`
+ *      (vendor + page id + version). No provenance `tags`: `tags` is a mirrored
+ *      column in the lenient parser's change comparison, so stamping one would
+ *      re-draft every already-ingested GitBook document; the extension block
+ *      stays outside the comparison (the Notion connector's posture).
+ *
+ * Paths are a pure function of the page's own `path` (no ordering, no batch
+ * dependency) so the reconciliation subtractive diff stays stable: a page move
+ * reads as "old path archived + new path drafted", the documented rename-churn
+ * posture. GitBook paths are unique per space, but slugification can still
+ * collide, so a collision is disambiguated with the page id rather than one page
+ * silently overwriting the other; the count is returned so the client can
+ * surface it (the module itself stays pure).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import { GITBOOK_VENDOR } from "./config";
+import { convertGitbookMarkdown, type BlockDegradation } from "./content-to-markdown";
+
+/** A fully-fetched GitBook page ready to convert + assemble. */
+export interface GitbookPage {
+  /** GitBook page id (stable per page). */
+  readonly id: string;
+  /** Plain-text page title. */
+  readonly title: string;
+  /** The page's GitBook slug path within the space, e.g. `guides/setup`. */
+  readonly path: string;
+  /** The GitBook-flavored markdown body (`?format=markdown`). */
+  readonly markdown: string;
+  /** The page's modification time (canonical ISO instant). */
+  readonly updatedAt: string;
+  /** Canonical web URL of the page (`urls.app`), or a fallback. */
+  readonly url: string;
+}
+
+export interface AssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Block degradations aggregated across every assembled page. */
+  readonly degradations: readonly BlockDegradation[];
+  /** Pages skipped because they carried no ingestable prose (empty pages). */
+  readonly skippedContentless: number;
+  /** Pages whose path collided and were disambiguated with the page id. */
+  readonly collisionsRenamed: number;
+}
+
+/** Slugify one GitBook path segment into a single path token; `fallback` guarantees non-empty. */
+function slugifySegment(segment: string, fallback: string): string {
+  const slug = segment
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/** The collection-relative archive path for one page (prefix included). */
+function pagePath(page: GitbookPage, prefixSegments: readonly string[]): string {
+  const rawSegments = page.path
+    .split("/")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+  const segments =
+    rawSegments.length > 0
+      ? rawSegments.map((s, i) => slugifySegment(s, `section-${i}`))
+      : [slugifySegment(page.title, `page-${page.id}`)];
+  const derived = deriveArchivePath(`${segments.join("/")}.md`);
+  return [...prefixSegments, derived.path].join("/");
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched pages. `pages` is the
+ * subset to convert + emit (the changed set on an incremental cycle, the full
+ * set on reconciliation).
+ */
+export function assembleGitbookDocuments(
+  pages: readonly GitbookPage[],
+  options: { readonly collectionSlug: string },
+): AssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  const usedPaths = new Map<string, string>();
+  let skippedContentless = 0;
+  let collisionsRenamed = 0;
+
+  for (const page of pages) {
+    const { markdown, degradations } = convertGitbookMarkdown(page.markdown, {
+      pageUrl: page.url,
+    });
+    for (const d of degradations) {
+      degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+    }
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    let path = pagePath(page, prefixSegments);
+    const owner = usedPaths.get(path);
+    if (owner !== undefined && owner !== page.id) {
+      // Deterministic disambiguation — append the page id rather than let one
+      // page silently clobber another's document at ingest.
+      const withoutExt = path.replace(/\.md$/i, "");
+      path = `${withoutExt}-${page.id}.md`;
+      collisionsRenamed++;
+    }
+    usedPaths.set(path, page.id);
+
+    const title = page.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        resource: page.url,
+        timestamp: page.updatedAt,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: GITBOOK_VENDOR,
+          page_id: page.id,
+          updated_at: page.updatedAt,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless, collisionsRenamed };
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -32,10 +32,15 @@ export interface KnowledgeDocumentCounts {
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
- * `authScheme`; connector collections (`notion`, `confluence`) carry neither
- * (their credential is a token, not an endpoint).
+ * `authScheme`; connector collections (`notion`, `confluence`, `gitbook`) carry
+ * neither (their credential is a token, not an endpoint).
  */
-export type KnowledgeCollectionSource = "upload" | "bundle-sync" | "notion" | "confluence";
+export type KnowledgeCollectionSource =
+  | "upload"
+  | "bundle-sync"
+  | "notion"
+  | "confluence"
+  | "gitbook";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "gitbook"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
## Summary

Adds a `KnowledgeSyncConnector` for GitBook Cloud, following the Confluence (#4377) / Notion (#4378) precedent (ADR-0030). One collection per GitBook space; every synced page lands `draft` behind the review gate (connectors structurally cannot publish).

- **`gitbook/config.ts`** — catalog id / slug / vendor constants + stored-config parse (the SSOT the install handler, connector, and admin route share).
- **`gitbook/client.ts`** — `ConnectorVendorClient` over the GitBook REST API through the SSRF egress guard. Content-tree enumeration is a cheap metadata pass (each page carries `updatedAt` + its full slug `path`); markdown bodies are fetched per selected page (`?format=markdown`). Incremental filters off a persisted high-water mark; reconciliation crawls the full set and validates the ingest doc cap with real numbers. A malformed node or a page body with no `markdown` field flags `coverageIncomplete` / throws, so a partial crawl can never archive a live page. 429 → `ConnectorRateLimitError` for the engine's bounded backoff; every other failure is host-redacted (the token stays in the `Authorization` header).
- **`gitbook/content-to-markdown.ts`** — GitBook `{% … %}` block converter (hints, code-with-title, tabs, stepper, content-ref, embed) with **counted, honest degradation** for unknown blocks (paired blocks keep their inner prose under a placeholder; standalone blocks degrade to the placeholder alone). Golden-fixture tested.
- **`gitbook/documents.ts`** — page → OKF assembly; hierarchy path from the GitBook slug path; `atlas:` provenance carrying vendor + page id + version (no `tags`, to avoid re-draft churn — the Notion posture).
- **`gitbook/connector.ts`** — idempotent `registerGitbookKnowledgeConnector()`.
- **`install/gitbook-form-handler.ts`** — token + space id (bare id or app-URL) → encrypted `knowledge_sync_credentials`; loud verify before persist; credential rollback on install-row failure.
- Seed row (`BUILTIN_GITBOOK_CATALOG_ROW`), admin-knowledge `source` branch, register pairing (form handler + connector together), and the `KnowledgeCollectionSource` wire type + mirrored schema enums.

## Test Plan

- [x] Manual testing — n/a (no test hits the real GitBook API; all network is injected)
- [x] Unit tests added/updated — converter golden fixtures; client (incremental high-water mark, reconciliation + doc cap, coverage flagging, `getJson` error mapping, 429, `>=`/offset-timestamp boundaries); document assembly + provenance; connector decrypt-failure loudness; form-handler field classification + credential rollback; register pairing; seed catalog
- [x] E2E tests added/updated — real-Postgres block executes `GITBOOK_INSTALL_UPSERT_SQL` against the live schema

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — deferred to `/release` per the per-tag changelog process

Ran the internal review panel (2 rounds → CLEAN) and the full `scripts/ci-local.sh` (28/28 gates green, including the regenerated `apps/docs/openapi.json`).

Closes #4393

https://claude.ai/code/session_019ESFSRTcNKdqC1E3BrsN96

---
_Generated by [Claude Code](https://claude.ai/code/session_019ESFSRTcNKdqC1E3BrsN96)_