### PR TITLE
chore(auth): pin + document Agent Auth enablement precedence (#4419)

### DIFF
--- a/apps/docs/content/docs/platform-ops/agent-auth-enablement.mdx
+++ b/apps/docs/content/docs/platform-ops/agent-auth-enablement.mdx
@@ -1,0 +1,64 @@
+---
+title: Agent Auth Enablement
+description: The two-tier on/off model for the experimental Agent Auth Protocol surface — operator kill-switch vs workspace opt-out
+---
+
+The (experimental) Agent Auth Protocol surface — the agent / host /
+capability endpoints and the `/.well-known/agent-configuration`
+discovery document — is gated by a single setting,
+`ATLAS_AGENT_AUTH_ENABLED`, which is **off by default**. When it is
+off, every agent-auth path and the discovery document return `404`.
+
+The setting is hot-reloadable: flipping it takes effect within seconds
+with no redeploy. What matters operationally is that the same key is
+enforced at **two tiers with asymmetric power** — it is *not* a flat
+"a workspace can override the platform" precedence.
+
+## The two tiers
+
+| Tier | Who controls it | Where it's read | What it governs |
+|---|---|---|---|
+| **Platform** | Operator | HTTP surface — the catch-all auth router + `/.well-known/agent-configuration`, which read the setting with **no workspace** | Reachability of the entire surface for **everyone** |
+| **Workspace** | Workspace admin | Capability **execution** (`onExecute`), where the workspace is known and membership-verified | Whether a bound agent's capability call runs against **that workspace's** data |
+
+The HTTP surface is intentionally platform-only: the workspace is not
+knowable until the agent JWT has been verified inside the plugin, and
+resolving it at the raw HTTP layer would leak token-shape knowledge
+into the gate. So the workspace tier can only be consulted at
+execution.
+
+## What each tier can do
+
+- **Operator = master on/off for everyone.** Platform-off (the
+  default) means every agent-auth path and discovery returns `404`
+  globally. A workspace **cannot** override platform-off back to on —
+  the HTTP gate never consults the workspace tier — so a tenant can
+  never enable an operator-disabled experimental feature. This is the
+  kill-switch direction.
+
+- **Workspace override can only *tighten*.** With the platform on, a
+  workspace that sets its override to `false` has its capability
+  **execution** `404`'d (its data is sealed), and **other workspaces
+  are completely unaffected** (overrides are per-org by construction).
+  A workspace override can never turn the surface *on* while the
+  platform default is off.
+
+## The disabled-workspace metadata nuance
+
+When a workspace has opted out (platform on, workspace override off),
+its **registration, discovery, and `capability/list`** endpoints stay
+reachable — those endpoints are user-scoped / workspace-agnostic and
+cannot be workspace-gated (an agent registers under a *user* who may
+belong to several workspaces; the workspace is only *proposed* per
+request and only *bound* at execute). No data flows, though: the only
+data-bearing endpoint, `capability/execute`, is `404`'d by the
+workspace-tier check. Execution is the single correct enforcement
+point, and it is gated.
+
+## If you want per-workspace enablement
+
+Letting a workspace enable the surface **independently** of the
+platform default is a distinct design change — it would require
+post-JWT-verify per-workspace gating inside the plugin lifecycle,
+not the raw HTTP layer. It is deliberately out of scope of the
+current model. File it separately if product needs it.

--- a/apps/docs/content/docs/platform-ops/meta.json
+++ b/apps/docs/content/docs/platform-ops/meta.json
@@ -15,6 +15,7 @@
     "encryption-key-rotation",
     "plugin-config-residue-audit",
     "mcp-load-test-tokens",
-    "byot-catalog-refresh"
+    "byot-catalog-refresh",
+    "agent-auth-enablement"
   ]
 }

--- a/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
+++ b/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
@@ -61,6 +61,23 @@ mock.module("@atlas/api/lib/auth/server", () => ({
   getAuthInstance: () => stubAuthInstance,
 }));
 
+// Spy on `getSettingLive` to record the orgId the REAL gate threads through on
+// each read, while keeping env as the source (no internal DB in the test, so a
+// non-delegating stub that reads process.env matches real self-hosted
+// resolution — delegating to the real fn would recurse through this same mock).
+// Spread so every other settings export stays real. This lets the state-4 guard
+// below assert the router NEVER passes a workspace to the gate — the property
+// that keeps a tenant from re-opening an operator-disabled feature (#4419).
+import * as settingsReal from "@atlas/api/lib/settings";
+const gateOrgIdCalls: Array<string | undefined> = [];
+mock.module("@atlas/api/lib/settings", () => ({
+  ...settingsReal,
+  getSettingLive: async (_key: string, orgId?: string) => {
+    gateOrgIdCalls.push(orgId);
+    return process.env.ATLAS_AGENT_AUTH_ENABLED;
+  },
+}));
+
 // SUT routers — imported AFTER the mocks.
 import { auth } from "@atlas/api/api/routes/auth";
 import { wellKnown } from "@atlas/api/api/routes/well-known";
@@ -140,6 +157,22 @@ describe("Agent Auth live-toggle (#4409)", () => {
     process.env.ATLAS_AGENT_AUTH_ENABLED = "false";
     expect((await req("POST", "/api/auth/agent/register")).status).toBe(404);
     expect((await req("GET", DISCOVERY_PATH)).status).toBe(404);
+  });
+
+  it("state 4 (#4419): the HTTP surface reads the platform tier only — a workspace can never re-open a platform-off", async () => {
+    // Platform OFF. The HTTP surface has no workspace to consult (the JWT isn't
+    // verified yet), so it MUST call the gate with no orgId — meaning a
+    // workspace override of ON is invisible here and the surface stays 404 for
+    // everyone. Assert both the 404 AND that no orgId was ever threaded, so a
+    // future refactor that leaked a workspace into the HTTP gate (which would
+    // let a tenant re-open an operator-disabled feature) goes RED here.
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    gateOrgIdCalls.length = 0;
+    expect((await req("POST", "/api/auth/agent/register")).status).toBe(404);
+    expect((await req("POST", "/api/auth/capability/execute")).status).toBe(404);
+    expect((await req("GET", DISCOVERY_PATH)).status).toBe(404);
+    expect(gateOrgIdCalls.length).toBeGreaterThan(0);
+    expect(gateOrgIdCalls.every((orgId) => orgId === undefined)).toBe(true);
   });
 
   it("the gate is scoped: a non-agent-auth auth path is never gated", async () => {

--- a/packages/api/src/lib/auth/__tests__/agent-auth-gate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-gate.test.ts
@@ -22,12 +22,21 @@ import { describe, it, expect, afterEach, mock } from "bun:test";
 // its fail-closed catch — from the settings live-cache TTL, which would
 // otherwise hold a stale value across rapid flips within one test run.
 import * as settingsReal from "@atlas/api/lib/settings";
+// `settingValue` is the PLATFORM-tier value (what resolves when no workspace
+// override applies). `workspaceOverrides` models per-org overrides, consulted
+// ONLY when an `orgId` is supplied — mirroring the real `getSettingLive`
+// precedence (workspace override > platform), which the raw HTTP surface never
+// reaches because it omits `orgId`.
 let settingValue: string | undefined;
+let workspaceOverrides: Record<string, string | undefined> = {};
 let throwOnRead = false;
 mock.module("@atlas/api/lib/settings", () => ({
   ...settingsReal,
-  getSettingLive: async (_key: string, _orgId?: string) => {
+  getSettingLive: async (_key: string, orgId?: string) => {
     if (throwOnRead) throw new Error("settings backend unavailable");
+    if (orgId !== undefined && orgId in workspaceOverrides) {
+      return workspaceOverrides[orgId];
+    }
     return settingValue;
   },
 }));
@@ -79,6 +88,7 @@ describe("isAgentAuthEnabled (fail-closed)", () => {
   afterEach(() => {
     throwOnRead = false;
     settingValue = undefined;
+    workspaceOverrides = {};
   });
 
   it("off when the setting resolves to undefined (default)", async () => {
@@ -104,5 +114,53 @@ describe("isAgentAuthEnabled (fail-closed)", () => {
     settingValue = "true"; // would be ON if it read cleanly
     throwOnRead = true;
     expect(await isAgentAuthEnabled()).toBe(false);
+  });
+});
+
+// The two-tier enablement matrix (#4419). `isAgentAuthEnabled()` (no orgId) is
+// the HTTP-surface / platform tier; `isAgentAuthEnabled(workspaceId)` is the
+// execution / workspace tier. Together they encode: operator = master on/off
+// for everyone; workspace = opt-OUT of execution only (can tighten, never
+// re-open). These assert every cell of the four-state matrix the issue enumerates.
+describe("enablement precedence matrix (#4419): platform tier vs workspace tier", () => {
+  afterEach(() => {
+    throwOnRead = false;
+    settingValue = undefined;
+    workspaceOverrides = {};
+  });
+
+  it("platform OFF + workspace unset ⇒ off at both tiers (the default kill-switch)", async () => {
+    settingValue = undefined; // platform default
+    expect(await isAgentAuthEnabled()).toBe(false); // HTTP surface
+    expect(await isAgentAuthEnabled("wsA")).toBe(false); // execution
+  });
+
+  it("platform ON + workspace unset ⇒ on at both tiers (full access)", async () => {
+    settingValue = "true";
+    expect(await isAgentAuthEnabled()).toBe(true); // HTTP surface reachable
+    expect(await isAgentAuthEnabled("wsA")).toBe(true); // execution allowed
+  });
+
+  it("platform ON + workspace OFF ⇒ tightens THAT workspace's execution only; the surface + other workspaces stay on", async () => {
+    settingValue = "true";
+    workspaceOverrides = { wsA: "false" };
+    expect(await isAgentAuthEnabled()).toBe(true); // HTTP surface unaffected (platform tier)
+    expect(await isAgentAuthEnabled("wsA")).toBe(false); // wsA sealed at execution
+    expect(await isAgentAuthEnabled("wsB")).toBe(true); // per-org override — others unaffected
+  });
+
+  it("platform OFF + workspace ON ⇒ HTTP surface still off (a workspace cannot re-open an operator-disabled feature)", async () => {
+    settingValue = undefined; // platform off
+    workspaceOverrides = { wsA: "true" };
+    // The raw HTTP gate omits orgId, so the workspace override is invisible: the
+    // surface is 404 for EVERYONE, including wsA. This is the kill-switch direction.
+    expect(await isAgentAuthEnabled()).toBe(false);
+    // Another workspace with no override also stays off (platform tier).
+    expect(await isAgentAuthEnabled("wsB")).toBe(false);
+    // The workspace tier read for wsA WOULD resolve the override to on — but that
+    // state is unreachable in practice: execution is only entered after the HTTP
+    // surface (above) admits the request, and it never does while platform is off.
+    // Asserted so the "can only tighten, never loosen" invariant is explicit.
+    expect(await isAgentAuthEnabled("wsA")).toBe(true);
   });
 });

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -21,7 +21,7 @@
  * restored, never at module top level.
  */
 
-import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, afterEach, mock } from "bun:test";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { generateKeyPair, exportJWK, SignJWT } from "jose";
@@ -47,10 +47,11 @@ mock.module("@atlas/api/lib/auth/oauth-workspace-grants", () => ({
 // Spread the real semantic/entities module and override only `listEntities`,
 // so "mock all exports" holds and the org-scoped read is deterministic.
 import * as entitiesReal from "@atlas/api/lib/semantic/entities";
-const entitiesForOrg: (orgId: string | undefined) => entitiesReal.EntityListEntry[] = (orgId) =>
+const defaultEntitiesForOrg = (orgId: string | undefined): entitiesReal.EntityListEntry[] =>
   orgId === "wsA"
-    ? ([{ name: "orders", table: "public.orders", description: "Orders fact" }] as entitiesReal.EntityListEntry[])
+    ? [{ name: "orders", table: "public.orders", description: "Orders fact", source: "default" }]
     : [];
+let entitiesForOrg: (orgId: string | undefined) => entitiesReal.EntityListEntry[] = defaultEntitiesForOrg;
 mock.module("@atlas/api/lib/semantic/entities", () => ({
   ...entitiesReal,
   listEntities: async (opts: { orgId?: string } = {}) => entitiesForOrg(opts.orgId),
@@ -126,11 +127,18 @@ describe("agent-auth capability execution (#4409)", () => {
     publicJwk = (await exportJWK(kp.publicKey)) as Record<string, unknown>;
   });
 
+  // Reset the mutable stubs after EVERY test (not just once in afterAll) so a
+  // test that repoints a stub can't bleed into a later one — the org-scoped read
+  // path is order-sensitive otherwise.
+  afterEach(() => {
+    workspacesForUser = () => ["wsA"];
+    enabledForWorkspace = () => true;
+    entitiesForOrg = defaultEntitiesForOrg;
+  });
+
   afterAll(() => {
     if (prevEnabled === undefined) delete process.env.ATLAS_AGENT_AUTH_ENABLED;
     else process.env.ATLAS_AGENT_AUTH_ENABLED = prevEnabled;
-    workspacesForUser = () => ["wsA"];
-    enabledForWorkspace = () => true;
   });
 
   /**
@@ -234,6 +242,31 @@ describe("agent-auth capability execution (#4409)", () => {
     expect(status).toBe(404);
     expect(body.error).toBe("unauthorized");
     expect(body.data).toBeUndefined();
+  });
+
+  it("workspace-override isolation: with platform on, wsA off but wsB on, wsA is 404'd while wsB executes 200", async () => {
+    // The cross-workspace half of the precedence matrix (#4419): a workspace
+    // override tightens ONLY its own execution. user_1 is a member of both; the
+    // override seals wsA and leaves wsB fully reachable.
+    workspacesForUser = () => ["wsA", "wsB"];
+    enabledForWorkspace = (orgId) => orgId !== "wsA"; // platform on; wsA opted out
+    entitiesForOrg = (orgId) =>
+      orgId === "wsB"
+        ? [{ name: "events", table: "public.events", description: "Events fact", source: "default" }]
+        : [];
+    const instance = makeInstance([
+      { id: "agent_a", workspaceId: "wsA", grantStatus: "active" },
+      { id: "agent_b", workspaceId: "wsB", grantStatus: "active" },
+    ]);
+
+    const a = await execute(instance, await mintJWT({ agentId: "agent_a" }));
+    expect(a.status).toBe(404); // wsA sealed by its own override
+    expect(a.body.error).toBe("unauthorized");
+    expect(a.body.data).toBeUndefined();
+
+    const b = await execute(instance, await mintJWT({ agentId: "agent_b" }));
+    expect(b.status).toBe(200); // wsB unaffected — override is per-org
+    expect(b.body.data).toMatchObject({ workspaceId: "wsB", count: 1 });
   });
 
   it("wrong audience → 401 invalid_jwt (rejected before onExecute)", async () => {

--- a/packages/api/src/lib/auth/agent-auth-gate.ts
+++ b/packages/api/src/lib/auth/agent-auth-gate.ts
@@ -81,12 +81,33 @@ function isTrue(value: string | undefined): boolean {
  * experimental agent-identity surface on a transient settings-DB blip is
  * strictly worse than a brief false-off, so the error path denies.
  *
- * `orgId` selects the workspace tier of the settings precedence chain
- * (workspace override > platform > env > default). Callers that know the
- * resolved workspace (e.g. capability execution) pass it for workspace-override
- * precedence; the raw HTTP surface, which can't know the workspace before the
- * agent JWT is verified without leaking token knowledge into the gate, omits it
- * and gates on the platform default.
+ * TWO ENFORCEMENT TIERS, not a flat precedence chain (#4419). Although the
+ * underlying settings key is `scope: "workspace"` (mechanically resolvable as
+ * workspace override > platform > env > default), this gate is consulted at two
+ * sites that pass DIFFERENT arguments, and that is what produces the effective
+ * semantics:
+ *
+ *   1. HTTP surface — `isAgentAuthEnabled()` with NO `orgId` (the catch-all auth
+ *      router + `/.well-known/agent-configuration`). With no `orgId` the
+ *      workspace tier is never consulted, so this reads the PLATFORM tier only.
+ *      This is the master kill-switch: platform-off ⇒ every agent-auth path +
+ *      discovery is 404 for EVERYONE, and a workspace CANNOT re-open it (its
+ *      override-on is invisible here). The HTTP layer can't know the workspace
+ *      before the agent JWT is verified, and resolving it here would leak
+ *      token-shape knowledge into the gate — which the #4408/#4409 reversible
+ *      seam forbids — so platform-only is deliberate, not a gap.
+ *
+ *   2. Execution — `isAgentAuthEnabled(workspaceId)` at capability `onExecute`,
+ *      where the workspace is known (membership-verified). Here the workspace
+ *      override is consulted, so a workspace can only ever TIGHTEN: with the
+ *      platform on, a workspace that sets its override to `false` has its data
+ *      sealed (execute 404'd) while other workspaces are unaffected (overrides
+ *      are per-org). It can never LOOSEN a platform-off, because execution is
+ *      only reached after the HTTP surface (tier 1) has already admitted the
+ *      request.
+ *
+ * Net: operator = master on/off for everyone; workspace admin = opt-OUT of
+ * execution only. See the precedence-matrix tests in `agent-auth-gate.test.ts`.
  */
 export async function isAgentAuthEnabled(orgId?: string): Promise<boolean> {
   try {

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -676,18 +676,25 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   // returns 404; when on, they become reachable — WITH NO REDEPLOY, because
   // this is a hot-reloadable settings key (NOT `requiresRestart`, NOT an env
   // var). The per-request gate reads it via `getSettingLive`/`getSettingAuto`
-  // and fails closed (any resolution error ⇒ off). `scope: "workspace"` gives
-  // the standard four-tier precedence (workspace override > platform > env >
-  // default): an operator flips the platform default, a workspace admin can
-  // override for their own workspace. Kept experimental (upstream spec is a
-  // moving `v1.0-draft`) — default OFF. See ADR-0016 §Agent Auth and the
-  // decision comment on #2058.
+  // and fails closed (any resolution error ⇒ off). `scope: "workspace"` makes
+  // the key mechanically override-able per workspace, but the enablement is
+  // enforced at TWO tiers with ASYMMETRIC power (#4419) — it is NOT a flat
+  // "workspace can override the platform" precedence:
+  //   • Operator (PLATFORM tier) = master on/off for EVERYONE. The HTTP-surface
+  //     gate reads the platform tier only (no orgId), so platform-off ⇒ 404
+  //     globally and a workspace CANNOT re-open it. This is the kill-switch.
+  //   • Workspace admin (WORKSPACE tier) = opt-OUT of EXECUTION only. With the
+  //     platform on, a workspace override of `false` seals that workspace's
+  //     capability execution (others unaffected); it can only tighten, never
+  //     turn the surface on when the platform default is off.
+  // Kept experimental (upstream spec is a moving `v1.0-draft`) — default OFF.
+  // See ADR-0016 §Agent Auth, `agent-auth-gate.ts`, and the decision on #2058.
   {
     key: "ATLAS_AGENT_AUTH_ENABLED",
     section: "MCP",
     label: "Enable Agent Auth Protocol",
     description:
-      "Expose the (experimental) Agent Auth Protocol surface: agent/host/capability endpoints and the `/.well-known/agent-configuration` discovery document. Hot-reloadable — takes effect within seconds, no redeploy. When off (default) the entire surface returns 404. Leave off unless you are piloting agent-identity clients.",
+      "Expose the (experimental) Agent Auth Protocol surface: agent/host/capability endpoints and the `/.well-known/agent-configuration` discovery document. Hot-reloadable — takes effect within seconds, no redeploy. When off (default) the entire surface returns 404. Operator master switch: setting it at the platform level turns the surface on or off for everyone, and a workspace cannot re-enable it while the platform default is off. A workspace override can only tighten — setting it to off seals that workspace's capability execution while leaving others reachable. Leave off unless you are piloting agent-identity clients.",
     type: "boolean",
     default: "false",
     envVar: "ATLAS_AGENT_AUTH_ENABLED",


### PR DESCRIPTION
## Summary

Closes #4419.

`ATLAS_AGENT_AUTH_ENABLED` is read by two gates at two different precedence tiers, but was documented misleadingly as a flat "four-tier precedence (workspace > platform > env > default)" — wording that implies a workspace can override the surface **on**, which it cannot. This PR makes the intended two-tier semantics explicit, tested, and discoverable. **No behavior change to the gate** — wording, tests, and docs only.

The effective (unchanged) semantics, now stated everywhere:

- **HTTP surface = platform tier.** `isAgentAuthEnabled()` is called with no `orgId` (catch-all auth router + `/.well-known/agent-configuration`), so it reads the platform tier only. Platform-off (the default) ⇒ every agent-auth path + discovery is 404 for everyone, and a workspace **cannot** re-open it. This is the operator kill-switch.
- **Execution = workspace tier.** `isAgentAuthEnabled(workspaceId)` at capability `onExecute`, where the workspace is membership-verified. A workspace override can only **tighten** — set it to off and that workspace's execution is 404'd (its data sealed) while other workspaces are unaffected. It can never loosen a platform-off, because execution is only reached after the HTTP surface has already admitted the request.

Changes:
- `agent-auth-gate.ts` — `isAgentAuthEnabled` docstring rewritten to state the two enforcement tiers explicitly instead of the flat precedence chain.
- `settings.ts` — the `ATLAS_AGENT_AUTH_ENABLED` registry comment + wire `description` reworded to the operator-vs-tenant model (operator = master switch; workspace admin = opt-out of execution only).
- `agent-auth-gate.test.ts` — new precedence-matrix covering all four states; the `getSettingLive` stub now models orgId-aware two-tier resolution.
- `agent-auth-plugin.test.ts` — cross-workspace override isolation (platform on, wsA off, wsB on ⇒ wsA 404, wsB 200); stub resets moved to `afterEach`; entity fixtures drop an `as` cast that omitted the required `source` field.
- `agent-auth-live-toggle.test.ts` — state-4 router-boundary guard: with platform off and a workspace override on, the HTTP surface still 404s and never threads a workspace into the gate.
- `apps/docs/content/docs/platform-ops/agent-auth-enablement.mdx` — new operator note documenting the two-tier model + the disabled-workspace metadata-surface nuance.

The remaining acceptance item — recording the decision on #2058 reconciling #4409's "a workspace admin flips it live" wording with the built reality — is posted as a comment on #2058.

## Test Plan

- [x] Manual testing — n/a (docs/wording + tests only, no runtime behavior change)
- [x] Unit tests added/updated

Precedence-matrix coverage across the four states (all green in isolation, 29 tests):
- platform **off** (default) ⇒ every agent-auth path + discovery 404 (`agent-auth-live-toggle.test.ts`).
- platform **on** + workspace **unset** ⇒ full access (gate unit + plugin execute 200).
- platform **on** + workspace **off** ⇒ that workspace's `capability/execute` denied (404) while other workspaces still execute 200 — cross-workspace isolation asserted through the real `betterAuth()` handler.
- platform **off** + workspace **on** ⇒ still 404 globally at the HTTP surface (gate unit + router-boundary guard).

Local `scripts/ci-local.sh`: 27/28 gates green (`type`, `lint`, all drift gates pass). The one failing gate is a **pre-existing, environment-specific timeout** in `admin-model-config.test.ts` (unrelated to this diff — reproduces identically on clean `origin/main` locally; `main` is green in real CI, which runs the suite against a real Postgres).

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — affected suites green; see pre-existing note above
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — no dependency changes
- [x] Labels added (type + area) — `chore`, `area: api`
- [ ] CHANGELOG.md updated — not user-facing (internal wording/tests/ops docs)

https://claude.ai/code/session_01GJycjntSxhPEs5Wek1ntWd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJycjntSxhPEs5Wek1ntWd)_