### PR TITLE
feat(knowledge): Confluence Data Center/Server sync connector

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56649,6 +56649,7 @@
                               "bundle-sync",
                               "notion",
                               "confluence",
+                              "confluence-datacenter",
                               "gitbook"
                             ]
                           },

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -602,6 +602,33 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(conf?.endpointUrl).toBeNull();
     expect(conf?.sync).not.toBeNull();
   });
+
+  it("dispatches a Confluence Data Center collection to the connector engine and lists it as source 'confluence-datacenter' (#4394)", async () => {
+    COLLECTION = {
+      install_id: "runbooks",
+      catalog_id: "catalog:confluence-datacenter",
+      status: "published",
+      config: { base_url: "https://confluence.acme.com", space_key: "ENG" },
+    };
+    SYNC_STATES = [
+      { collection_id: "runbooks", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/runbooks/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const conf = body.collections.find((c) => c.slug === "runbooks");
+    // A future edit dropping this from isSyncedSource would silently strip the
+    // collection's sync bookkeeping / "Sync now" — the wire enum wouldn't catch it.
+    expect(conf?.source).toBe("confluence-datacenter");
+    expect(conf?.endpointUrl).toBeNull();
+    expect(conf?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -55,6 +55,7 @@ import {
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
 import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
 import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config";
+import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config-datacenter";
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
@@ -103,7 +104,14 @@ async function loadCollection(
 }
 
 /** A synced-collection source discriminator + whether it is a connector. */
-type KnowledgeSource = "upload" | "bundle-sync" | "notion" | "confluence" | "gitbook" | "unknown";
+type KnowledgeSource =
+  | "upload"
+  | "bundle-sync"
+  | "notion"
+  | "confluence"
+  | "confluence-datacenter"
+  | "gitbook"
+  | "unknown";
 
 /**
  * Map a knowledge catalog id to the wire `source` discriminator — matching
@@ -117,6 +125,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === BUNDLE_SYNC_CATALOG_ID) return "bundle-sync";
   if (catalogId === NOTION_KNOWLEDGE_CATALOG_ID) return "notion";
   if (catalogId === CONFLUENCE_CATALOG_ID) return "confluence";
+  if (catalogId === CONFLUENCE_DC_CATALOG_ID) return "confluence-datacenter";
   if (catalogId === GITBOOK_CATALOG_ID) return "gitbook";
   return "unknown";
 }
@@ -127,6 +136,7 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "bundle-sync" ||
     source === "notion" ||
     source === "confluence" ||
+    source === "confluence-datacenter" ||
     source === "gitbook"
   );
 }
@@ -148,7 +158,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "gitbook"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -25,6 +25,7 @@ import {
   BUILTIN_BUNDLE_SYNC_CATALOG_ROW,
   BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_CATALOG_ROW,
+  BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -135,6 +136,30 @@ describe("BUILTIN_CONFLUENCE_CATALOG_ROW (#4377)", () => {
   });
 });
 
+describe("BUILTIN_CONFLUENCE_DC_CATALOG_ROW (#4394)", () => {
+  it("is the `confluence-datacenter` form install: base URL + space key + secret PAT, NO email", () => {
+    const row = BUILTIN_CONFLUENCE_DC_CATALOG_ROW;
+    expect(row.slug).toBe("confluence-datacenter");
+    expect(row.id).toBe("catalog:confluence-datacenter");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("base_url");
+    expect(keys).toContain("space_key");
+    expect(keys).toContain("api_token");
+    // A Server/DC PAT is a Bearer credential with no paired username — the
+    // Cloud-only email field must be absent.
+    expect(keys).not.toContain("email");
+    // Exactly one secret field: the PAT (never echoed).
+    expect(row.configSchema.filter((f) => f.secret === true).map((f) => f.key)).toEqual([
+      "api_token",
+    ]);
+    for (const key of ["base_url", "space_key", "api_token"]) {
+      expect(row.configSchema.find((f) => f.key === key)?.required).toBe(true);
+    }
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -155,6 +180,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "bundle-sync",
       "notion-knowledge",
       "confluence",
+      "confluence-datacenter",
       "gitbook",
     ]);
   });
@@ -180,6 +206,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "bundle-sync",
       "notion-knowledge",
       "confluence",
+      "confluence-datacenter",
       "gitbook",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -1,8 +1,8 @@
 /**
  * Boot-time idempotent seed pass for the built-in Knowledge Base catalog rows
- * — the upload/bundle-sync arms plus the vendor connectors (Notion, Confluence,
- * GitBook). `BUILTIN_KNOWLEDGE_CATALOG_ROWS` is the authoritative list; adding a
- * connector is one append there, so this header stays non-enumerating.
+ * — the upload/bundle-sync arms plus the vendor connectors (Notion, Confluence
+ * Cloud + Data Center, GitBook). `BUILTIN_KNOWLEDGE_CATALOG_ROWS` is the
+ * authoritative list; adding a connector is one append there.
  *
  * The Knowledge Base lifecycle (ADR-0028 §5) started as one built-in catalog
  * row — `okf-upload`, an **explicit, degenerate form install** with no

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -31,6 +31,10 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import { CONFLUENCE_CATALOG_ID, CONFLUENCE_SLUG } from "@atlas/api/lib/knowledge/confluence/config";
 import {
+  CONFLUENCE_DC_CATALOG_ID,
+  CONFLUENCE_DC_SLUG,
+} from "@atlas/api/lib/knowledge/confluence/config-datacenter";
+import {
   NOTION_KNOWLEDGE_CATALOG_ID,
   NOTION_KNOWLEDGE_SLUG,
 } from "@atlas/api/lib/knowledge/notion/connector";
@@ -250,6 +254,64 @@ export const BUILTIN_CONFLUENCE_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
 };
 
 /**
+ * The Confluence Data Center / Server connector Knowledge Base catalog row
+ * (#4394, PRD #4375). The self-managed sibling of the Cloud row: a form install
+ * that mirrors ONE Confluence Server/DC space into a review-gated collection;
+ * the Scheduler dispatches the registered Confluence DC connector on a cadence
+ * (incremental + reconciliation) and every synced page lands `draft`.
+ *
+ * `api_token` (a Personal Access Token) is `secret: true` but is NOT stored in
+ * `workspace_plugins.config` — the install handler routes it to
+ * `knowledge_sync_credentials` (encrypted). The base URL is customer-supplied,
+ * so every fetch goes through the SSRF egress guard. There is no email field
+ * (unlike Cloud): a Server/DC PAT is a Bearer credential with no paired
+ * username. The id/slug are the config SSOT (`CONFLUENCE_DC_CATALOG_ID` /
+ * `CONFLUENCE_DC_SLUG`).
+ */
+export const BUILTIN_CONFLUENCE_DC_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: CONFLUENCE_DC_CATALOG_ID,
+  slug: CONFLUENCE_DC_SLUG,
+  name: "Knowledge Base (Confluence Data Center)",
+  description:
+    "Mirror a self-managed Confluence Data Center/Server space into a review-gated knowledge collection; Atlas syncs pages on a schedule (incremental + reconciliation) and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "base_url",
+      type: "string",
+      label: "Confluence base URL",
+      required: true,
+      description:
+        "Your self-managed Confluence base URL, e.g. https://confluence.your-company.com. Fetched server-side through the SSRF egress guard.",
+    },
+    {
+      key: "space_key",
+      type: "string",
+      label: "Space key",
+      required: true,
+      description: "The key of the space to mirror (one collection per space), e.g. ENG.",
+    },
+    {
+      key: "api_token",
+      type: "string",
+      secret: true,
+      label: "Personal Access Token",
+      required: true,
+      description:
+        "A Confluence Server/DC Personal Access Token (Profile → Personal Access Tokens). Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
+/**
  * The GitBook Cloud connector Knowledge Base catalog row (#4393, ADR-0030). A
  * form install that mirrors ONE GitBook space into a review-gated collection;
  * the Scheduler dispatches the registered GitBook connector on a cadence
@@ -304,6 +366,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_BUNDLE_SYNC_CATALOG_ROW,
   BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_CATALOG_ROW,
+  BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_GITBOOK_CATALOG_ROW,
 ];
 

--- a/packages/api/src/lib/integrations/install/__tests__/confluence-datacenter-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/confluence-datacenter-form-handler.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for `ConfluenceDatacenterFormInstallHandler` (#4394) — the
+ * Confluence Data Center connector install. Focus: field validation (base URL +
+ * SSRF gate, space key, PAT — NO email), loud credential verification at install
+ * time, the credential routing (PAT → `knowledge_sync_credentials`, NEVER into
+ * `workspace_plugins.config`), and the multi-instance `pillar='knowledge'` upsert
+ * shape. The SSRF check + verification use the REAL egress guard against an
+ * injected fixture fetch; no test touches a real Confluence.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:confluence-datacenter" }];
+let INSERT_RETURNS_ID = true;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { ConfluenceDatacenterFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/confluence-datacenter-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = {
+  base_url: "https://confluence.acme.com",
+  space_key: "ENG",
+  api_token: "pat-token",
+};
+
+/** A fixture verify-fetch: the space probe returns `spaceResults` (or a status). */
+function verifyFetch(opts: { spaceResults?: unknown[]; status?: number } = {}) {
+  return async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input.toString());
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (url.pathname.endsWith("/rest/api/space")) {
+      return new Response(JSON.stringify({ results: opts.spaceResults ?? [{ key: "ENG", id: 100 }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  return new ConfluenceDatacenterFormInstallHandler({
+    idGenerator: () => "fixed-id",
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:confluence-datacenter" }];
+  INSERT_RETURNS_ID = true;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("requires the base URL", async () => {
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, base_url: "" }), "base_url");
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-https base URL", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, base_url: "http://confluence.acme.com" }),
+      "base_url",
+    );
+    expect(msg).toMatch(/https/i);
+  });
+
+  it("blocks an SSRF base URL as a field error, not a 500", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, base_url: "https://169.254.169.254" }),
+      "base_url",
+    );
+    expect(msg).toMatch(/private|internal|Refusing/i);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("requires the space key and the Personal Access Token", async () => {
+    expect(await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, space_key: "" }), "space_key")).toMatch(/required/i);
+    expect(await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, api_token: "" }), "api_token")).toMatch(/token is required/i);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("rejects credentials embedded in the base URL (the token belongs in the encrypted field)", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, base_url: "https://user:pass@confluence.acme.com" }),
+      "base_url",
+    );
+    expect(msg).toMatch(/Remove the credentials from the URL/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed base URL", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, base_url: "not a url" }),
+      "base_url",
+    );
+    expect(msg).toMatch(/well-formed/i);
+  });
+
+  it("rejects a slug already taken by another knowledge catalog, before any write", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    await expect(
+      handler(verifyFetch() as unknown as typeof fetch).validateConfig(WORKSPACE, VALID),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+});
+
+describe("credential verification + persistence", () => {
+  it("installs on valid config: verifies, stores the PAT, persists config WITHOUT the token", async () => {
+    const result = await handler(verifyFetch() as unknown as typeof fetch).validateConfig(WORKSPACE, VALID);
+
+    expect(result.installRecord).toMatchObject({ id: "fixed-id", catalogId: "confluence-datacenter" });
+    expect(result.credentialWritten).toBe(true);
+    // The token was routed to the credential store.
+    expect(saveSyncCredential).toHaveBeenCalledWith(WORKSPACE, "confluence-datacenter", "pat-token");
+    // The persisted config carries base_url/space_key — NEVER the token, NEVER an email.
+    expect(insertCalls).toHaveLength(1);
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toMatchObject({ base_url: VALID.base_url, space_key: "ENG" });
+    expect(config).not.toHaveProperty("api_token");
+    expect(config).not.toHaveProperty("email");
+  });
+
+  it("fails the install loudly on a bad token (401), persisting nothing", async () => {
+    const msg = await fieldErrorOf(
+      handler(verifyFetch({ status: 401 }) as unknown as typeof fetch).validateConfig(WORKSPACE, VALID),
+      "api_token",
+    );
+    expect(msg).toMatch(/rejected the credentials \(401\)/i);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("routes a rate-limit (429) verification failure to a form-level error, not the api_token field", async () => {
+    let caught: unknown;
+    try {
+      await handler(verifyFetch({ status: 429 }) as unknown as typeof fetch).validateConfig(WORKSPACE, VALID);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const validation = caught as InstanceType<typeof FormInstallValidationError>;
+    expect(validation.formErrors[0]).toMatch(/rate-limited/i);
+    expect(validation.fieldErrors.api_token).toBeUndefined();
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("routes a transport (DNS/timeout) verification failure to a form-level error, not the api_token field", async () => {
+    const dnsFailure = (async () => {
+      throw new Error("getaddrinfo ENOTFOUND confluence.acme.com");
+    }) as unknown as typeof fetch;
+    let caught: unknown;
+    try {
+      await handler(dnsFailure).validateConfig(WORKSPACE, VALID);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const validation = caught as InstanceType<typeof FormInstallValidationError>;
+    expect(validation.formErrors[0]).toMatch(/failed/i);
+    expect(validation.fieldErrors.api_token).toBeUndefined();
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("fails the install when the space key is not visible to the token", async () => {
+    const msg = await fieldErrorOf(
+      handler(verifyFetch({ spaceResults: [] }) as unknown as typeof fetch).validateConfig(WORKSPACE, VALID),
+      "api_token",
+    );
+    expect(msg).toMatch(/space "ENG" was not found or is not visible/i);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("rolls back the just-written credential when the install-row upsert returns no id", async () => {
+    INSERT_RETURNS_ID = false;
+    await expect(
+      handler(verifyFetch() as unknown as typeof fetch).validateConfig(WORKSPACE, VALID),
+    ).rejects.toThrow(/returned no id/i);
+    // The credential was written, then rolled back so no secret outlives the
+    // failed install (its install row never landed).
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential).toHaveBeenCalledWith(WORKSPACE, "confluence-datacenter");
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -42,6 +42,7 @@ import {
   getKnowledgeSyncConnector,
 } from "@atlas/api/lib/knowledge/connectors";
 import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config";
+import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config-datacenter";
 import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 
@@ -147,12 +148,14 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Notion, and GitBook knowledge sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, and GitBook knowledge sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(GITBOOK_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "gitbook", install_model: "form" }).kind).toBe("form");
   });

--- a/packages/api/src/lib/integrations/install/confluence-datacenter-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/confluence-datacenter-form-handler.ts
@@ -1,0 +1,324 @@
+/**
+ * `ConfluenceDatacenterFormInstallHandler` — the {@link FormBasedInstallHandler}
+ * for the built-in `confluence-datacenter` Knowledge Base catalog row (#4394,
+ * PRD #4375). The self-managed sibling of the Cloud handler
+ * (`confluence-form-handler.ts`).
+ *
+ * Installing `confluence-datacenter` creates a **synced collection** mirroring
+ * ONE Confluence Server/DC space: a `pillar='knowledge'` `workspace_plugins` row
+ * (multi-instance, `install_id` = collection slug) whose config carries the base
+ * URL + space key. The Scheduler dispatches the registered Confluence DC
+ * connector on a cadence (`lib/knowledge/connector-sync.ts`), and every synced
+ * page lands `draft` behind the review gate.
+ *
+ * It mirrors the Cloud handler's three properties, differing only in the
+ * credential shape — a Personal Access Token (Bearer), with no paired email:
+ *   1. **SSRF gate at install time.** The base URL is admin-supplied and Atlas
+ *      fetches it server-side on a schedule — so it is validated through
+ *      `assertBaseUrlAllowed` here and re-validated by `guardedFetch` on every
+ *      request. A blocked target is a field-level 400.
+ *   2. **Loud credential verification.** Before persisting anything, it resolves
+ *      the space with the supplied PAT (`verifyConfluenceDatacenterAccess`) — a
+ *      bad token / invalid space key fails the install with actionable guidance
+ *      instead of silently creating a collection that never syncs.
+ *   3. **The PAT is a Knowledge Base credential.** It routes to the dedicated
+ *      `knowledge_sync_credentials` table (encrypted), NEVER to
+ *      `workspace_plugins.config`. Write order mirrors the Cloud handler: verify
+ *      → SaaS keyset gate → credential row → install row (rollback on failure).
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  assertBaseUrlAllowed,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import {
+  verifyConfluenceDatacenterAccess,
+  type ConfluenceDcClientDeps,
+} from "@atlas/api/lib/knowledge/confluence/client-datacenter";
+import {
+  CONFLUENCE_DC_SLUG,
+  CONFLUENCE_DC_CATALOG_ID,
+  type ConfluenceDcCollectionConfig,
+} from "@atlas/api/lib/knowledge/confluence/config-datacenter";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config-datacenter.ts.
+export { CONFLUENCE_DC_SLUG, CONFLUENCE_DC_CATALOG_ID };
+
+/** Defensive upper bounds — guard against pathological pastes. */
+const BASE_URL_MAX = 2048;
+const SPACE_KEY_MAX = 255;
+const API_TOKEN_MAX = 4096;
+
+export interface ConfluenceDatacenterFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the verification fetch (no real Confluence call). */
+  readonly clientDeps?: ConfluenceDcClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to the Cloud
+ * handler's `CONFLUENCE_INSTALL_UPSERT_SQL`: `status='published'` because the
+ * COLLECTION container is live immediately — the review gate is on the
+ * DOCUMENTS, which always sync in as `draft`. Exported so the real-Postgres test
+ * executes this exact string against the live schema.
+ */
+export const CONFLUENCE_DC_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class ConfluenceDatacenterFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: ConfluenceDcClientDeps;
+  private readonly log = createLogger("integrations.install.confluence-datacenter");
+
+  constructor(options: ConfluenceDatacenterFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const collectionSlug = resolveCollectionSlug(
+      rawForm[KNOWLEDGE_INSTALL_ID_FIELD],
+      CONFLUENCE_DC_SLUG,
+    );
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const baseUrl = validateBaseUrl(rawForm.base_url);
+    const spaceKey = validateSpaceKey(rawForm.space_key);
+    const apiToken = validateApiToken(rawForm.api_token);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [CONFLUENCE_DC_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "confluence-datacenter catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${CONFLUENCE_DC_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+
+    // ── Verify the connection loudly BEFORE persisting anything ─────────────
+    await this.verifyConnection({ baseUrl, apiToken, spaceKey, collectionSlug });
+
+    // ── Credential first (mirrors the Cloud handler's write order) ──────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "api_token");
+    try {
+      await saveSyncCredential(workspaceId, collectionSlug, apiToken);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install",
+      );
+      throw err;
+    }
+
+    // ── Upsert the collection container (never carries the token) ────────────
+    const config: ConfluenceDcCollectionConfig = {
+      base_url: baseUrl,
+      space_key: spaceKey,
+      ...(description !== null ? { description } : {}),
+    };
+
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(CONFLUENCE_DC_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        collectionSlug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a failed
+      // install (its install row never landed, so uninstall would never reach
+      // it). Best-effort — a re-install overwrites it either way; a cleanup
+      // failure is logged, never masks the original error.
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist confluence-datacenter collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, collectionSlug);
+      } catch (cleanupErr) {
+        this.log.error(
+          { workspaceId, collectionSlug, err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw err;
+    }
+
+    this.log.info(
+      { workspaceId, collectionSlug, rowId: persistedId, siteHost: hostForLog(baseUrl), spaceKey },
+      "Confluence Data Center collection install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: CONFLUENCE_DC_SLUG },
+      credentialWritten: true,
+    };
+  }
+
+  /** Resolve the space with the supplied PAT; map every failure to a 400. */
+  private async verifyConnection(input: {
+    baseUrl: string;
+    apiToken: string;
+    spaceKey: string;
+    collectionSlug: string;
+  }): Promise<void> {
+    try {
+      await verifyConfluenceDatacenterAccess(input, this.clientDeps);
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { base_url: [err.message] },
+          formErrors: [],
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      // Non-credential failures — a 429 (ConnectorRateLimitError) or a transport
+      // error (DNS/timeout/non-JSON; the client marks those with `cause`) — are
+      // form-level: blaming the api_token field would send the admin re-entering
+      // a token that may be fine. All host-redacted.
+      if (err instanceof ConnectorRateLimitError || (err instanceof Error && err.cause !== undefined)) {
+        throw new FormInstallValidationError({
+          fieldErrors: {},
+          formErrors: [message],
+        });
+      }
+      // Auth (401/403) / space-not-found — actionable, already host-redacted.
+      throw new FormInstallValidationError({
+        fieldErrors: { api_token: [message] },
+        formErrors: [],
+      });
+    }
+  }
+}
+
+/** Validate the site base URL: required, https, bounded, SSRF-allowed. */
+function validateBaseUrl(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError("base_url", "The Confluence base URL is required (e.g. https://confluence.your-company.com).");
+  }
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  if (trimmed.length > BASE_URL_MAX) {
+    throw fieldError("base_url", `The Confluence base URL must be ${BASE_URL_MAX} characters or fewer.`);
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // intentionally ignored: the URL constructor throw is the negative signal.
+    throw fieldError("base_url", "The Confluence base URL must be a well-formed URL (e.g. https://confluence.your-company.com).");
+  }
+  if (parsed.protocol !== "https:") {
+    throw fieldError("base_url", "The Confluence base URL must be https.");
+  }
+  if (parsed.username !== "" || parsed.password !== "") {
+    throw fieldError("base_url", "Remove the credentials from the URL — use the Personal Access Token field instead (the token is stored encrypted).");
+  }
+  try {
+    assertBaseUrlAllowed(trimmed);
+  } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      throw fieldError("base_url", err.message);
+    }
+    throw err;
+  }
+  return trimmed;
+}
+
+function validateSpaceKey(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError("space_key", "The Confluence space key is required (e.g. ENG).");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > SPACE_KEY_MAX) {
+    throw fieldError("space_key", `The space key must be ${SPACE_KEY_MAX} characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function validateApiToken(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError("api_token", "A Personal Access Token is required. Create one in Confluence → Profile → Personal Access Tokens.");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > API_TOKEN_MAX) {
+    throw fieldError("api_token", `The Personal Access Token must be ${API_TOKEN_MAX} characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -36,6 +36,11 @@ import { OkfUploadFormInstallHandler, OKF_UPLOAD_SLUG } from "./okf-upload-form-
 import { BundleSyncFormInstallHandler, BUNDLE_SYNC_SLUG } from "./bundle-sync-form-handler";
 import { ConfluenceFormInstallHandler, CONFLUENCE_SLUG } from "./confluence-form-handler";
 import { registerConfluenceKnowledgeConnector } from "@atlas/api/lib/knowledge/confluence/connector";
+import {
+  ConfluenceDatacenterFormInstallHandler,
+  CONFLUENCE_DC_SLUG,
+} from "./confluence-datacenter-form-handler";
+import { registerConfluenceDatacenterKnowledgeConnector } from "@atlas/api/lib/knowledge/confluence/connector-datacenter";
 import { NotionKnowledgeFormInstallHandler } from "./notion-knowledge-form-handler";
 import {
   NOTION_KNOWLEDGE_SLUG,
@@ -240,6 +245,19 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(CONFLUENCE_SLUG, new ConfluenceFormInstallHandler());
   registerConfluenceKnowledgeConnector();
   log.info("Registered ConfluenceFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Confluence Data Center/Server) — the built-in
+  // `confluence-datacenter` connector install (#4394, ADR-0030 vendor slice).
+  // The self-managed sibling of Confluence Cloud: same collection model + shared
+  // storage→markdown converter, but Confluence REST v1 + a Personal Access Token
+  // (Bearer) instead of Cloud REST v2 + Basic auth. Config = base URL + space
+  // key; the PAT lands in `knowledge_sync_credentials` (encrypted), never in
+  // `workspace_plugins.config`. The base URL is customer-supplied → SSRF gated.
+  // Registering the FORM handler + the CONNECTOR together (as with Cloud) keeps
+  // a half-wired deploy from having an installable card whose scheduled sync has
+  // no registered vendor client. No env gate.
+  registerFormHandler(CONFLUENCE_DC_SLUG, new ConfluenceDatacenterFormInstallHandler());
+  registerConfluenceDatacenterKnowledgeConnector();
+  log.info("Registered ConfluenceDatacenterFormInstallHandler + knowledge sync connector");
   // Knowledge Base (Notion) — the built-in `notion-knowledge` synced-collection
   // install (#4378, PRD #4375). Knowledge-pillar, multi-instance. Config = an
   // optional description; the internal-integration token lands in the dedicated

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -37,6 +37,7 @@ import {
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
 import { NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/notion-knowledge-form-handler";
 import { CONFLUENCE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-form-handler";
+import { CONFLUENCE_DC_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-datacenter-form-handler";
 import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/gitbook-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
@@ -506,6 +507,32 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // The token is NEVER persisted in the install config.
     expect(row.rows[0]?.config).not.toHaveProperty("api_token");
     expect(row.rows[0]?.config).toMatchObject({ space_key: "ENG" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a Confluence Data Center connector collection against the live schema (#4394)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:confluence-datacenter', 'Knowledge Base (Confluence Data Center)', 'confluence-datacenter', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(CONFLUENCE_DC_INSTALL_UPSERT_SQL, [
+      "row-confluence-dc",
+      ws,
+      "catalog:confluence-datacenter",
+      "confluence-dc-eng",
+      JSON.stringify({ base_url: "https://confluence.acme.com", space_key: "ENG" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-confluence-dc");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'confluence-dc-eng'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The token is NEVER persisted in the install config; neither is a Cloud email.
+    expect(row.rows[0]?.config).not.toHaveProperty("api_token");
+    expect(row.rows[0]?.config).not.toHaveProperty("email");
+    expect(row.rows[0]?.config).toMatchObject({ base_url: "https://confluence.acme.com", space_key: "ENG" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("installs a GitBook connector collection against the live schema (#4393)", async () => {

--- a/packages/api/src/lib/knowledge/confluence/__tests__/client-datacenter.test.ts
+++ b/packages/api/src/lib/knowledge/confluence/__tests__/client-datacenter.test.ts
@@ -250,6 +250,39 @@ describe("failure handling", () => {
   });
 });
 
+describe("context path", () => {
+  it("preserves a Server/DC context path in page URLs via `_links.base`", async () => {
+    // Self-managed Confluence commonly lives under a context path
+    // (e.g. …/confluence). `_links.base` reflects it, and `pageUrl`
+    // concatenates (not URL-resolves) so the context path is never dropped.
+    const CTX_BASE = "https://confluence.acme.com/confluence";
+    const impl = async (input: string | URL | Request): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (url.pathname.endsWith("/rest/api/space")) {
+        return jsonResponse({ results: [{ key: "ENG", id: 100 }] });
+      }
+      return jsonResponse({
+        results: [
+          {
+            id: "2",
+            title: "Oncall",
+            type: "page",
+            ancestors: [],
+            version: { when: "2026-07-06T09:00:00.000Z", number: 1 },
+            _links: { webui: "/display/ENG/Oncall", base: CTX_BASE },
+            body: { storage: { value: "<p>Oncall prose here.</p>", representation: "storage" } },
+          },
+        ],
+        _links: { base: CTX_BASE },
+      });
+    };
+    const changes = await client({ baseUrl: CTX_BASE }, impl as unknown as typeof fetch).fetchAll();
+    expect(changes.documents[0].content).toContain(
+      'resource: "https://confluence.acme.com/confluence/display/ENG/Oncall"',
+    );
+  });
+});
+
 describe("auth", () => {
   it("sends the PAT as a Bearer token (never Basic, never in the URL)", async () => {
     const seen: { authorization: string | null; url: string }[] = [];

--- a/packages/api/src/lib/knowledge/confluence/__tests__/client-datacenter.test.ts
+++ b/packages/api/src/lib/knowledge/confluence/__tests__/client-datacenter.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the Confluence Data Center vendor client (#4394) — driven entirely
+ * through an injected fixture `fetchImpl`; NO test touches a real Confluence.
+ * Covers reconciliation (full v1 crawl with bodies), incremental (metadata pass
+ * + changed-body fetch), `_links.next` pagination, 429 → ConnectorRateLimitError,
+ * auth failure, space-not-found, the SSRF guard rejecting a private base URL, and
+ * that the SHARED converter produces the same markdown as Cloud for identical
+ * storage XHTML (the AC's "identical markdown" property).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
+import { createConfluenceDatacenterVendorClient } from "@atlas/api/lib/knowledge/confluence/client-datacenter";
+
+const BASE = "https://confluence.acme.com";
+
+interface FixturePage {
+  id: string;
+  title: string;
+  /** Root-first ancestor ids (v1 returns the full chain inline). */
+  ancestorIds: string[];
+  modifiedAt: string;
+  body: string;
+}
+
+const PAGES: FixturePage[] = [
+  { id: "1", title: "Engineering", ancestorIds: [], modifiedAt: "2026-07-01T00:00:00.000Z", body: "<p>Root prose here.</p>" },
+  { id: "2", title: "Oncall", ancestorIds: ["1"], modifiedAt: "2026-07-06T09:00:00.000Z", body: "<p>Oncall prose here.</p>" },
+];
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function titleFor(id: string): string {
+  return PAGES.find((p) => p.id === id)?.title ?? `Page ${id}`;
+}
+
+function contentObject(p: FixturePage, withBody: boolean): Record<string, unknown> {
+  return {
+    id: p.id,
+    title: p.title,
+    type: "page",
+    ancestors: p.ancestorIds.map((id) => ({ id, title: titleFor(id) })),
+    version: { when: p.modifiedAt, number: 1 },
+    _links: { webui: `/display/ENG/${p.id}`, base: BASE },
+    ...(withBody ? { body: { storage: { value: p.body, representation: "storage" } } } : {}),
+  };
+}
+
+interface FixtureOptions {
+  readonly pages?: FixturePage[];
+  readonly spaceResults?: unknown[];
+  /** Reject with this status on the FIRST call, then behave normally. */
+  readonly failFirst?: { status: number; headers?: Record<string, string> };
+  /** Paginate the content list into two responses (`_links.next` driven). */
+  readonly paginate?: boolean;
+}
+
+/** Build a fixture fetchImpl + a call log. */
+function makeFetch(opts: FixtureOptions = {}) {
+  const pages = opts.pages ?? PAGES;
+  const calls: string[] = [];
+  let failed = false;
+  const impl = async (input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input.toString();
+    calls.push(raw);
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    const path = url.pathname;
+
+    // Space visibility probe: /rest/api/space?spaceKey=…
+    if (path.endsWith("/rest/api/space")) {
+      return jsonResponse({ results: opts.spaceResults ?? [{ key: "ENG", id: 100, name: "Engineering" }] });
+    }
+    // Single content: /rest/api/content/{id}
+    const singleMatch = path.match(/\/rest\/api\/content\/([^/]+)$/);
+    if (singleMatch) {
+      const p = pages.find((x) => x.id === singleMatch[1]);
+      if (!p) return jsonResponse({}, 404);
+      return jsonResponse(contentObject(p, true));
+    }
+    // Content list: /rest/api/content
+    if (path.endsWith("/rest/api/content")) {
+      const withBody = (url.searchParams.get("expand") ?? "").includes("body.storage");
+      const start = Number(url.searchParams.get("start") ?? "0");
+      if (opts.paginate) {
+        if (start === 0) {
+          return jsonResponse({
+            results: [contentObject(pages[0], withBody)],
+            _links: {
+              base: BASE,
+              next: `/rest/api/content?spaceKey=ENG&type=page&status=current&start=1&limit=100&expand=${encodeURIComponent(withBody ? "version,ancestors,body.storage" : "version,ancestors")}`,
+            },
+          });
+        }
+        return jsonResponse({ results: pages.slice(1).map((p) => contentObject(p, withBody)), _links: { base: BASE } });
+      }
+      return jsonResponse({ results: pages.map((p) => contentObject(p, withBody)), _links: { base: BASE } });
+    }
+    throw new Error(`fixture: unexpected URL ${raw}`);
+  };
+  return { impl, calls };
+}
+
+function client(over: Partial<Parameters<typeof createConfluenceDatacenterVendorClient>[0]> = {}, fetchImpl?: typeof fetch) {
+  return createConfluenceDatacenterVendorClient(
+    { baseUrl: BASE, apiToken: "pat-secret-token", spaceKey: "ENG", collectionSlug: "confluence-dc-eng", ...over },
+    fetchImpl ? { fetchImpl } : {},
+  );
+}
+
+describe("fetchAll (reconciliation)", () => {
+  it("crawls the full space with bodies and returns assembled OKF documents", async () => {
+    const { impl, calls } = makeFetch();
+    const changes = await client({}, impl as unknown as typeof fetch).fetchAll();
+
+    expect(changes.documents.map((d) => d.path).toSorted()).toEqual([
+      "confluence-dc-eng/engineering.md",
+      "confluence-dc-eng/engineering/oncall.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-06T09:00:00.000Z");
+    // A clean crawl never flags its coverage — the engine may archive off it.
+    expect(changes.coverageIncomplete).toBe(false);
+    // Bodies came from the enumeration pass — no per-page body fetch.
+    expect(calls.some((c) => /\/rest\/api\/content\/\d+/.test(c))).toBe(false);
+    // The oncall doc carries provenance + converted body (shared converter).
+    const oncall = changes.documents.find((d) => d.path.endsWith("oncall.md"));
+    expect(oncall?.content).toContain('resource: "https://confluence.acme.com/display/ENG/2"');
+    expect(oncall?.content).toContain("Oncall prose here.");
+  });
+
+  it("follows `_links.next` pagination across content-list responses", async () => {
+    const { impl } = makeFetch({ paginate: true });
+    const changes = await client({}, impl as unknown as typeof fetch).fetchAll();
+    expect(changes.documents).toHaveLength(2);
+  });
+});
+
+describe("fetchChanges (incremental)", () => {
+  it("enumerates metadata, fetches bodies only for pages modified at/after since", async () => {
+    const { impl, calls } = makeFetch();
+    const changes = await client({}, impl as unknown as typeof fetch).fetchChanges({
+      since: "2026-07-05T00:00:00.000Z",
+      cursor: null,
+    });
+    // Only page 2 (2026-07-06) changed; page 1 (2026-07-01) filtered out.
+    expect(changes.documents.map((d) => d.path)).toEqual(["confluence-dc-eng/engineering/oncall.md"]);
+    // High-water mark still reflects the newest page across the whole space.
+    expect(changes.highWaterMark).toBe("2026-07-06T09:00:00.000Z");
+    // Exactly one per-page body fetch (the changed page).
+    expect(calls.filter((c) => /\/rest\/api\/content\/2(\?|$)/.test(c))).toHaveLength(1);
+    expect(calls.some((c) => /\/rest\/api\/content\/1(\?|$)/.test(c))).toBe(false);
+  });
+});
+
+describe("failure handling", () => {
+  it("maps a 429 to ConnectorRateLimitError carrying the parsed Retry-After", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 429, headers: { "retry-after": "7" } } });
+    await expect(client({}, impl as unknown as typeof fetch).fetchAll()).rejects.toMatchObject({
+      name: "ConnectorRateLimitError",
+      retryAfterSeconds: 7,
+    });
+  });
+
+  it("maps a 401 to an actionable, host-redacted error (never the token)", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 401 } });
+    await expect(client({}, impl as unknown as typeof fetch).fetchAll()).rejects.toThrow(
+      /rejected the credentials \(401\).*re-enter/i,
+    );
+  });
+
+  it("errors clearly when the space key is not visible to the token", async () => {
+    const { impl } = makeFetch({ spaceResults: [] });
+    await expect(client({}, impl as unknown as typeof fetch).fetchAll()).rejects.toThrow(
+      /space "ENG" was not found or is not visible/i,
+    );
+  });
+
+  it("rejects a private/loopback base URL through the SSRF egress guard", async () => {
+    const { impl, calls } = makeFetch();
+    await expect(
+      client({ baseUrl: "https://169.254.169.254" }, impl as unknown as typeof fetch).fetchAll(),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    // The guard blocks BEFORE any request is made.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("maps a generic non-2xx (500) to an actionable, host-redacted error", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 500 } });
+    await expect(client({}, impl as unknown as typeof fetch).fetchAll()).rejects.toThrow(/HTTP 500/);
+  });
+
+  it("treats a 403 as a credential/permission error (token can't read the space)", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 403 } });
+    await expect(client({}, impl as unknown as typeof fetch).fetchAll()).rejects.toThrow(
+      /rejected the credentials \(403\)/i,
+    );
+  });
+
+  it("maps a non-JSON response to an actionable, host-redacted error", async () => {
+    const impl = async (): Promise<Response> =>
+      new Response("<html>not json</html>", { status: 200, headers: { "content-type": "text/html" } });
+    await expect(client({}, impl as unknown as typeof fetch).fetchAll()).rejects.toThrow(/non-JSON response/i);
+  });
+
+  it("warn-skips a malformed page (no version) and flags the crawl's coverage incomplete", async () => {
+    const impl = async (input: string | URL | Request): Promise<Response> => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (url.pathname.endsWith("/rest/api/space")) {
+        return jsonResponse({ results: [{ key: "ENG", id: 100 }] });
+      }
+      // One good page + one malformed (missing version) — the malformed one is
+      // dropped (logged), never emitted as a document.
+      return jsonResponse({
+        results: [
+          contentObject(PAGES[0], true),
+          { id: "999", title: "Broken", ancestors: [], _links: { webui: "/x", base: BASE }, body: { storage: { value: "<p>x</p>" } } },
+        ],
+        _links: { base: BASE },
+      });
+    };
+    const changes = await client({}, impl as unknown as typeof fetch).fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual(["confluence-dc-eng/engineering.md"]);
+    // The skipped page's document must not be archived off this partial set —
+    // the flag makes the engine defer deletions to a clean crawl.
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("normalizes an offset-format version timestamp to a canonical ISO instant", async () => {
+    // Raw offset strings compare lexicographically wrong against the engine's
+    // toISOString `since`; normalization happens at page construction.
+    const offsetPage: FixturePage = {
+      id: "7",
+      title: "Offset",
+      ancestorIds: [],
+      modifiedAt: "2026-07-06T11:00:00+05:00",
+      body: "<p>Offset prose here.</p>",
+    };
+    const { impl } = makeFetch({ pages: [offsetPage] });
+    const changes = await client({}, impl as unknown as typeof fetch).fetchAll();
+    expect(changes.highWaterMark).toBe("2026-07-06T06:00:00.000Z");
+    expect(changes.documents[0].content).toContain('timestamp: "2026-07-06T06:00:00.000Z"');
+  });
+});
+
+describe("auth", () => {
+  it("sends the PAT as a Bearer token (never Basic, never in the URL)", async () => {
+    const seen: { authorization: string | null; url: string }[] = [];
+    const impl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const headers = new Headers(init?.headers);
+      seen.push({ authorization: headers.get("authorization"), url });
+      const path = new URL(url).pathname;
+      if (path.endsWith("/rest/api/space")) return jsonResponse({ results: [{ key: "ENG" }] });
+      return jsonResponse({ results: PAGES.map((p) => contentObject(p, true)), _links: { base: BASE } });
+    };
+    await client({}, impl as unknown as typeof fetch).fetchAll();
+    expect(seen.length).toBeGreaterThan(0);
+    for (const s of seen) {
+      expect(s.authorization).toBe("Bearer pat-secret-token");
+      expect(s.url).not.toContain("pat-secret-token");
+    }
+  });
+});

--- a/packages/api/src/lib/knowledge/confluence/__tests__/connector-datacenter.test.ts
+++ b/packages/api/src/lib/knowledge/confluence/__tests__/connector-datacenter.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the Confluence Data Center KnowledgeSyncConnector (#4394) — the
+ * createClient factory contract: parse stored config, read the encrypted PAT
+ * loudly, and build a vendor client. The credential store is mocked
+ * (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let tokenResult: string | null | (() => never) = "pat-secret-token";
+
+mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof tokenResult === "function") return tokenResult();
+    return tokenResult;
+  },
+}));
+
+const { createConfluenceDatacenterConnector } = await import(
+  "@atlas/api/lib/knowledge/confluence/connector-datacenter"
+);
+const { CONFLUENCE_DC_CATALOG_ID, CONFLUENCE_DC_VENDOR } = await import(
+  "@atlas/api/lib/knowledge/confluence/config-datacenter"
+);
+
+const VALID_CONFIG = {
+  base_url: "https://confluence.acme.com",
+  space_key: "ENG",
+};
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "confluence-dc-eng", config };
+}
+
+afterEach(() => {
+  tokenResult = "pat-secret-token";
+});
+
+describe("createConfluenceDatacenterConnector", () => {
+  it("advertises the confluence-datacenter catalog id and vendor slug", () => {
+    const connector = createConfluenceDatacenterConnector();
+    expect(connector.catalogId).toBe(CONFLUENCE_DC_CATALOG_ID);
+    expect(connector.vendor).toBe(CONFLUENCE_DC_VENDOR);
+  });
+
+  it("builds a vendor client from valid config + a stored PAT", async () => {
+    const connector = createConfluenceDatacenterConnector();
+    const client = await connector.createClient(ctx(VALID_CONFIG));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error when the stored config is missing the base URL", async () => {
+    const connector = createConfluenceDatacenterConnector();
+    await expect(connector.createClient(ctx({ space_key: "ENG" }))).rejects.toThrow(
+      /no Confluence base URL configured/i,
+    );
+  });
+
+  it("throws an actionable error when the stored config is missing the space key", async () => {
+    const connector = createConfluenceDatacenterConnector();
+    await expect(
+      connector.createClient(ctx({ base_url: "https://confluence.acme.com" })),
+    ).rejects.toThrow(/no Confluence space key configured/i);
+  });
+
+  it("throws when the collection has no stored Personal Access Token", async () => {
+    tokenResult = null;
+    const connector = createConfluenceDatacenterConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(
+      /no stored Personal Access Token/i,
+    );
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    tokenResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createConfluenceDatacenterConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/confluence/client-datacenter.ts
+++ b/packages/api/src/lib/knowledge/confluence/client-datacenter.ts
@@ -1,0 +1,431 @@
+/**
+ * The Confluence Data Center / Server vendor client (#4394, PRD #4375) — a
+ * {@link ConnectorVendorClient} over the Confluence REST **v1** API with a
+ * Personal Access Token (Bearer auth), driven by the shared connector engine
+ * (`connector-sync.ts`). It is the self-managed sibling of the Cloud client
+ * (`client.ts`): it swaps ONLY the client layer (v1 REST paths, Bearer PAT) and
+ * reuses the exact same converter + assembly (`documents.ts` →
+ * `storage-to-markdown.ts`), so identical storage XHTML produces identical
+ * markdown across Cloud and DC.
+ *
+ * Two cadences the engine decides, both served from one enumeration shape (the
+ * same design as Cloud):
+ *   - `fetchChanges({ since })` (incremental) — enumerate the space's page
+ *     METADATA (id/title/ancestors/version — cheap, no bodies), keep those
+ *     modified at-or-after `since`, and fetch the storage body only for those.
+ *     The full metadata pass keeps hierarchy paths deterministic across modes
+ *     (ancestors always resolve) while keeping body bandwidth to the changed set.
+ *   - `fetchAll()` (reconciliation) — enumerate every current page WITH its
+ *     storage body in one paginated pass and assemble all. The engine archives
+ *     paths absent from this set, so a restricted/deleted page is treated as
+ *     absent, never an error.
+ *
+ * v1 vs Cloud v2, the only differences this file owns:
+ *   - Auth is `Authorization: Bearer <PAT>` (a Server/DC Personal Access Token),
+ *     not Basic `email:token`.
+ *   - Enumeration is `/rest/api/content?spaceKey=…&type=page` with
+ *     `expand=version,ancestors[,body.storage]`; a single body is
+ *     `/rest/api/content/{id}?expand=body.storage`; the space is resolved via
+ *     `/rest/api/space?spaceKey=…`.
+ *   - The parent id comes from v1's inline `ancestors` array (immediate parent =
+ *     last ancestor), and the modification time is `version.when`.
+ *
+ * Security + hygiene mirror Cloud exactly: every request goes through
+ * `guardedFetch` (customer base URL → SSRF egress guard; auth stripped on
+ * cross-origin redirect). A 429 is the ONLY signal that becomes the engine's
+ * backoff (thrown as {@link ConnectorRateLimitError}); every other failure is an
+ * actionable error with the host redacted via `hostForLog` — the PAT lives in
+ * the `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import {
+  assembleConfluenceDocuments,
+  type ConfluencePage,
+  type ConfluencePageNode,
+} from "./documents";
+// The Retry-After parser is auth/version-agnostic — share the Cloud one rather
+// than duplicate the delta-seconds discipline.
+import { parseRetryAfter } from "./client";
+
+const log = createLogger("knowledge.confluence.datacenter.client");
+
+/** Resolved, non-secret connection inputs plus the PAT. */
+export interface ConfluenceDcClientConfig {
+  /** Server/DC base, e.g. `https://confluence.acme.com` (no trailing slash). */
+  readonly baseUrl: string;
+  /** A Confluence Server/DC Personal Access Token (Bearer auth). */
+  readonly apiToken: string;
+  readonly spaceKey: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface ConfluenceDcClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Page-list page size. */
+const PAGE_LIMIT = 100;
+/**
+ * Hard anti-runaway bound on pagination — NOT the ingest cap (the engine owns
+ * that, and surfaces the real over-limit numbers). A space larger than this is
+ * pathological; we fail loud rather than loop unbounded on a broken `next`.
+ */
+const MAX_PAGES = 100_000;
+
+// ---------------------------------------------------------------------------
+// Raw v1 response shapes (only the fields we read)
+// ---------------------------------------------------------------------------
+
+// Every field is optional: this is untrusted vendor JSON, so `id`/`title`/
+// `version.when` are narrowed at the use site (`normalizePage`) rather than
+// asserted here.
+interface V1Version {
+  readonly when?: string;
+}
+interface V1Ancestor {
+  readonly id?: string;
+  readonly title?: string;
+}
+interface V1Links {
+  readonly webui?: string;
+  readonly base?: string;
+  readonly next?: string;
+}
+interface V1Content {
+  readonly id?: string;
+  readonly title?: string;
+  readonly ancestors?: readonly V1Ancestor[];
+  readonly version?: V1Version;
+  readonly body?: { readonly storage?: { readonly value?: string } };
+  readonly _links?: V1Links;
+}
+interface V1ContentList {
+  readonly results?: readonly V1Content[];
+  readonly _links?: V1Links;
+}
+interface V1Space {
+  readonly key?: string;
+}
+interface V1SpaceList {
+  readonly results?: readonly V1Space[];
+}
+
+/** One enumerated page, normalized. `storageBody` is present only when fetched. */
+interface EnumeratedPage extends ConfluencePageNode {
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly modifiedAt: string;
+  readonly webui: string;
+  readonly storageBody: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Confluence Data Center vendor client. `createClient` (the connector
+ * factory) has already decrypted the token and validated config, so this
+ * constructor does no I/O — the first fetch verifies the space lazily.
+ */
+export function createConfluenceDatacenterVendorClient(
+  config: ConfluenceDcClientConfig,
+  deps: ConfluenceDcClientDeps = {},
+): ConnectorVendorClient {
+  const api = new ConfluenceDcApi(config, deps);
+
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      return api.fetch({ since: params.since });
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetch({ since: null });
+    },
+  };
+}
+
+/**
+ * Verify the connection at INSTALL time — resolve the space by key with the
+ * supplied PAT. Cheap (one request) and loud: a bad token surfaces as a 401
+ * error, an invalid/invisible space key as a not-found error, a private base URL
+ * as an `EgressBlockedError`. The install handler maps each to a field-level 400
+ * so "invalid credentials fail the install loudly."
+ */
+export async function verifyConfluenceDatacenterAccess(
+  config: ConfluenceDcClientConfig,
+  deps: ConfluenceDcClientDeps = {},
+): Promise<void> {
+  await new ConfluenceDcApi(config, deps).verifyAccess();
+}
+
+class ConfluenceDcApi {
+  private readonly base: string;
+  private readonly authHeader: string;
+  private spaceVerified = false;
+  private siteBase: string;
+
+  constructor(
+    private readonly config: ConfluenceDcClientConfig,
+    private readonly deps: ConfluenceDcClientDeps,
+  ) {
+    this.base = config.baseUrl.replace(/\/+$/, "");
+    this.siteBase = this.base;
+    // Server/DC Personal Access Token → Bearer auth (introduced in Confluence
+    // 7.9). Unlike Cloud, no email/username is paired with the token.
+    this.authHeader = `Bearer ${config.apiToken}`;
+  }
+
+  /**
+   * Enumerate + assemble. When `since` is null this is a reconciliation crawl
+   * (bodies fetched in the enumeration pass, all pages assembled); otherwise an
+   * incremental cycle (metadata-only enumeration, bodies fetched for the changed
+   * subset only).
+   */
+  async fetch(opts: { since: string | null }): Promise<ConnectorChanges> {
+    const reconciliation = opts.since === null;
+    // Resolve the space FIRST: an invisible/renamed space must fail loudly, not
+    // enumerate zero pages — a reconciliation off an empty crawl would archive
+    // the whole collection.
+    await this.ensureSpace();
+
+    const { pages: enumerated, skippedMalformed } = await this.enumeratePages({
+      withBody: reconciliation,
+    });
+
+    const byId = new Map<string, ConfluencePageNode>();
+    let highWaterMark: string | null = null;
+    // `modifiedAt` is normalized to an ISO instant at `normalizePage`, and the
+    // engine's `since` is a toISOString — string comparisons are chronological.
+    for (const p of enumerated) {
+      byId.set(p.id, { id: p.id, title: p.title, parentId: p.parentId });
+      if (highWaterMark === null || p.modifiedAt > highWaterMark) highWaterMark = p.modifiedAt;
+    }
+
+    const selected = reconciliation
+      ? enumerated
+      : enumerated.filter((p) => opts.since === null || p.modifiedAt >= opts.since);
+
+    const pages: ConfluencePage[] = [];
+    for (const p of selected) {
+      const storageBody = p.storageBody ?? (await this.fetchPageBody(p.id));
+      pages.push({
+        id: p.id,
+        title: p.title,
+        parentId: p.parentId,
+        storageBody,
+        modifiedAt: p.modifiedAt,
+        url: this.pageUrl(p.webui),
+      });
+    }
+
+    const assembled = assembleConfluenceDocuments(pages, byId, {
+      collectionSlug: this.config.collectionSlug,
+    });
+    if (
+      assembled.degradations.length > 0 ||
+      assembled.skippedContentless > 0 ||
+      assembled.collisionsRenamed > 0
+    ) {
+      log.info(
+        {
+          host: hostForLog(this.base),
+          space: this.config.spaceKey,
+          mode: reconciliation ? "reconciliation" : "incremental",
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+          collisionsRenamed: assembled.collisionsRenamed,
+        },
+        "Confluence Data Center conversion completed with degradations/skips",
+      );
+    }
+
+    // A warn-skipped malformed page is a KNOWN hole in the set: its document
+    // would otherwise be archived by a reconciliation off this partial crawl.
+    // The flag makes the engine upsert-only and hold the reconcile clock.
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+
+  /** Install-time reachability + credential check (resolves the space by key). */
+  async verifyAccess(): Promise<void> {
+    await this.ensureSpace();
+  }
+
+  /**
+   * Resolve + confirm the space is visible to the PAT (v1 has no space-id
+   * requirement for content enumeration — the key drives the query — so this is
+   * purely a visibility/credential probe, cached after the first success).
+   */
+  private async ensureSpace(): Promise<void> {
+    if (this.spaceVerified) return;
+    const url = `${this.base}/rest/api/space?spaceKey=${encodeURIComponent(this.config.spaceKey)}&limit=1`;
+    const body = await this.getJson<V1SpaceList>(url);
+    const space = body.results?.[0];
+    if (!space) {
+      throw new Error(
+        `Confluence space "${this.config.spaceKey}" was not found or is not visible to this token on ${hostForLog(this.base)} — check the space key and the token's permissions.`,
+      );
+    }
+    this.spaceVerified = true;
+  }
+
+  /** Paginate the space's pages; include storage bodies when `withBody`. */
+  private async enumeratePages(opts: {
+    withBody: boolean;
+  }): Promise<{ pages: EnumeratedPage[]; skippedMalformed: number }> {
+    const expand = opts.withBody ? "version,ancestors,body.storage" : "version,ancestors";
+    const params = new URLSearchParams({
+      spaceKey: this.config.spaceKey,
+      type: "page",
+      status: "current",
+      start: "0",
+      limit: String(PAGE_LIMIT),
+      expand,
+    });
+    let nextUrl: string | null = `${this.base}/rest/api/content?${params}`;
+
+    const pages: EnumeratedPage[] = [];
+    let skippedMalformed = 0;
+    while (nextUrl !== null) {
+      // Annotate `body` explicitly: `nextUrl` is reassigned below from a value
+      // derived from `body`, which is fetched with `nextUrl` — an inference cycle
+      // TS otherwise gives up on (TS7022). The annotation breaks it.
+      const body: V1ContentList = await this.getJson<V1ContentList>(nextUrl);
+      if (body._links?.base) this.siteBase = body._links.base.replace(/\/+$/, "");
+      for (const raw of body.results ?? []) {
+        const normalized = this.normalizePage(raw, opts.withBody);
+        if (normalized !== null) pages.push(normalized);
+        else skippedMalformed++;
+      }
+      if (pages.length > MAX_PAGES) {
+        throw new Error(
+          `Confluence space "${this.config.spaceKey}" exceeds ${MAX_PAGES} pages — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+        );
+      }
+      const rel: string | undefined = body._links?.next;
+      nextUrl = rel ? new URL(rel, this.base).toString() : null;
+    }
+    if (skippedMalformed > 0) {
+      // Never a silent drop: a page missing id/title/version isn't ingested, and
+      // if it was an ancestor its descendants' paths shorten — surface it loudly
+      // so an operator can see the hole rather than infer it from a smaller tree.
+      // The count also flags the fetch's coverage as incomplete (see `fetch`).
+      log.warn(
+        { host: hostForLog(this.base), space: this.config.spaceKey, skippedMalformed },
+        "Skipped Confluence pages missing id/title/version — not ingested (unexpected for current pages)",
+      );
+    }
+    return { pages, skippedMalformed };
+  }
+
+  /** Fetch one page's storage body (incremental path — changed pages only). */
+  private async fetchPageBody(pageId: string): Promise<string> {
+    const url = `${this.base}/rest/api/content/${encodeURIComponent(pageId)}?expand=body.storage`;
+    const body = await this.getJson<V1Content>(url);
+    return body.body?.storage?.value ?? "";
+  }
+
+  private normalizePage(raw: V1Content, withBody: boolean): EnumeratedPage | null {
+    // A page with no id/title/version is unusable — skip defensively rather than
+    // emit a malformed document (v1 always populates these for a current page).
+    // The timestamp is normalized to a canonical ISO instant so an offset-format
+    // `when` can't compare wrong in the since-filter / high-water reduce; an
+    // unparseable one counts as malformed (same skip, same coverage flag).
+    const modifiedAt = toIsoInstant(raw.version?.when);
+    if (!raw.id || !raw.title || modifiedAt === null) return null;
+    // v1 returns the full ancestor chain inline (root → immediate parent); the
+    // immediate parent is the last element. `documents.ts` walks parentId across
+    // the full byId map to rebuild the path, exactly as the Cloud client does.
+    const ancestors = raw.ancestors ?? [];
+    const parent = ancestors.length > 0 ? ancestors[ancestors.length - 1] : undefined;
+    const parentId = typeof parent?.id === "string" && parent.id !== "" ? parent.id : null;
+    return {
+      id: raw.id,
+      title: raw.title,
+      parentId,
+      modifiedAt,
+      webui: raw._links?.webui ?? "",
+      storageBody: withBody ? raw.body?.storage?.value ?? "" : null,
+    };
+  }
+
+  /**
+   * Absolute page URL from a `_links.webui`. Confluence's `webui` is an absolute
+   * PATH (`/display/…` or `/spaces/…`) whose canonical URL is `_links.base` +
+   * `webui` (the site base already includes any context path) — so this
+   * concatenates rather than URL-resolves, which would drop the context path.
+   */
+  private pageUrl(webui: string): string {
+    if (webui === "") return this.base;
+    if (/^https?:\/\//i.test(webui)) return webui;
+    return `${this.siteBase}${webui.startsWith("/") ? "" : "/"}${webui}`;
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  private async getJson<T>(url: string): Promise<T> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `Confluence request to ${hostForLog(this.base)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `Confluence rate-limited the request to ${hostForLog(this.base)}.`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `Confluence rejected the credentials (${response.status}) for ${hostForLog(this.base)} — re-enter the Personal Access Token and confirm it can read the space.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Confluence returned HTTP ${response.status} from ${hostForLog(this.base)}.`,
+      );
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new Error(
+        `Confluence returned a non-JSON response from ${hostForLog(this.base)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+}

--- a/packages/api/src/lib/knowledge/confluence/client-datacenter.ts
+++ b/packages/api/src/lib/knowledge/confluence/client-datacenter.ts
@@ -286,6 +286,16 @@ class ConfluenceDcApi {
         `Confluence space "${this.config.spaceKey}" was not found or is not visible to this token on ${hostForLog(this.base)} — check the space key and the token's permissions.`,
       );
     }
+    // Fail loud on a truthy-but-empty element rather than treat a malformed
+    // vendor response as a verified space (untrusted JSON — `key` is optional).
+    // Mirrors the Cloud client's "unexpected vendor response" guard; DC drives
+    // enumeration off the admin-supplied spaceKey, so no garbage reaches a URL,
+    // but the fail-loud posture stays consistent across the two clients.
+    if (typeof space.key !== "string" || space.key === "") {
+      throw new Error(
+        `Confluence returned a space for "${this.config.spaceKey}" with no key from ${hostForLog(this.base)} — unexpected vendor response.`,
+      );
+    }
     this.spaceVerified = true;
   }
 

--- a/packages/api/src/lib/knowledge/confluence/config-datacenter.ts
+++ b/packages/api/src/lib/knowledge/confluence/config-datacenter.ts
@@ -1,0 +1,60 @@
+/**
+ * Confluence Data Center / Server connector identity + stored-config contract
+ * (#4394, PRD #4375). The self-managed sibling of the Cloud connector
+ * (`config.ts`): same collection model (one per space), same shared
+ * storage-XHTML→markdown converter, but a different client layer — Confluence
+ * Server/DC REST **v1** with a Personal Access Token (Bearer auth) instead of
+ * Cloud REST v2 with Basic auth.
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config), the
+ * connector (reads it back in `createClient`), and the admin-knowledge surface
+ * (recognizes the catalog id) share ONE definition — a field rename can't drift
+ * the three apart silently. The PAT is NOT part of this config; it lives
+ * encrypted in `knowledge_sync_credentials` and is read via `readSyncCredential`.
+ *
+ * Deliberately a SEPARATE catalog row from Cloud (`confluence`), not a
+ * `deployment: cloud | datacenter` discriminator threaded through the shared
+ * config: the two clients speak different REST versions + auth schemes, so a
+ * distinct row keeps the pairing test clean, the provenance vendor slug
+ * unambiguous (`connector:confluence-datacenter`), and the install form free of
+ * a Cloud-only email field.
+ */
+
+/** The built-in Confluence Data Center Knowledge Base catalog slug + row id. */
+export const CONFLUENCE_DC_SLUG = "confluence-datacenter";
+export const CONFLUENCE_DC_CATALOG_ID = "catalog:confluence-datacenter";
+/** Vendor slug stamped into `atlas_source` as `connector:confluence-datacenter`. */
+export const CONFLUENCE_DC_VENDOR = "confluence-datacenter";
+
+/** The non-secret config persisted on the `workspace_plugins` row. */
+export interface ConfluenceDcCollectionConfig {
+  /** Server/DC base URL, e.g. `https://confluence.acme.com` (context path incl.). */
+  readonly base_url: string;
+  /** The Confluence space key this collection mirrors (one space per install). */
+  readonly space_key: string;
+  readonly description?: string;
+}
+
+export type ParsedConfluenceDcConfig =
+  | { readonly ok: true; readonly baseUrl: string; readonly spaceKey: string }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * field means someone edited the row out of band; re-installing repairs it.
+ */
+export function parseConfluenceDcConfig(
+  config: Record<string, unknown> | null,
+): ParsedConfluenceDcConfig {
+  const baseUrl = typeof config?.base_url === "string" ? config.base_url.trim() : "";
+  const spaceKey = typeof config?.space_key === "string" ? config.space_key.trim() : "";
+  if (baseUrl === "") {
+    return { ok: false, error: "Collection has no Confluence base URL configured — re-install it." };
+  }
+  if (spaceKey === "") {
+    return { ok: false, error: "Collection has no Confluence space key configured — re-install it." };
+  }
+  return { ok: true, baseUrl, spaceKey };
+}

--- a/packages/api/src/lib/knowledge/confluence/connector-datacenter.ts
+++ b/packages/api/src/lib/knowledge/confluence/connector-datacenter.ts
@@ -1,0 +1,88 @@
+/**
+ * The Confluence Data Center {@link KnowledgeSyncConnector} (#4394, PRD #4375) —
+ * the catalog-id-keyed adapter the sync cycle dispatches on, the self-managed
+ * sibling of the Cloud connector (`connector.ts`). It owns only the three-line
+ * factory contract from ADR-0030: bind the stored config + the decrypted PAT
+ * into a vendor client. Scheduling, backoff, reconciliation, caps, and ingest
+ * are the shared engine's.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import {
+  createConfluenceDatacenterVendorClient,
+  type ConfluenceDcClientDeps,
+} from "./client-datacenter";
+import {
+  CONFLUENCE_DC_CATALOG_ID,
+  CONFLUENCE_DC_VENDOR,
+  parseConfluenceDcConfig,
+} from "./config-datacenter";
+
+const log = createLogger("knowledge.confluence.datacenter.connector");
+
+export interface ConfluenceDcConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: ConfluenceDcClientDeps;
+}
+
+/** Build the Confluence Data Center connector. `deps` is test-only injection. */
+export function createConfluenceDatacenterConnector(
+  deps: ConfluenceDcConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: CONFLUENCE_DC_CATALOG_ID,
+    vendor: CONFLUENCE_DC_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseConfluenceDcConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiToken = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiToken === null) {
+        throw new Error(
+          "This Confluence collection has no stored Personal Access Token — re-install it to re-enter the token.",
+        );
+      }
+
+      return createConfluenceDatacenterVendorClient(
+        {
+          baseUrl: parsed.baseUrl,
+          apiToken,
+          spaceKey: parsed.spaceKey,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the Confluence Data Center connector idempotently — called from the
+ * boot seam that also registers install handlers (`registerBuiltinInstallHandlers`),
+ * and from tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog
+ * id, so gate on the registry first.
+ */
+export function registerConfluenceDatacenterKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createConfluenceDatacenterConnector());
+  log.info(
+    { catalogId: CONFLUENCE_DC_CATALOG_ID },
+    "Registered Confluence Data Center knowledge sync connector",
+  );
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -28,18 +28,23 @@ export interface KnowledgeDocumentCounts {
  *     Notion workspace via an internal-integration token).
  *   - `confluence` — the #4377 Knowledge Sync Connector (a scheduled pull of a
  *     Confluence Cloud space via an API token).
+ *   - `confluence-datacenter` — the #4394 Knowledge Sync Connector (a scheduled
+ *     pull of a self-managed Confluence Data Center/Server space via a Personal
+ *     Access Token; REST v1 instead of Cloud's v2).
  *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
- * `authScheme`; connector collections (`notion`, `confluence`, `gitbook`) carry
- * neither (their credential is a token, not an endpoint).
+ * `authScheme`; connector collections (`notion`, `confluence`,
+ * `confluence-datacenter`, `gitbook`) carry neither (their credential is a
+ * token, not an endpoint).
  */
 export type KnowledgeCollectionSource =
   | "upload"
   | "bundle-sync"
   | "notion"
   | "confluence"
+  | "confluence-datacenter"
   | "gitbook";
 
 /**

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "gitbook"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
## Summary

Closes #4394.

Adds a self-managed **Confluence Data Center/Server** knowledge sync connector — the sibling of the shipped Confluence **Cloud** connector (#4377). It reuses the exact same storage-XHTML→markdown converter and document assembly (`documents.ts` → `storage-to-markdown.ts`, ~518 LOC) and swaps **only the client layer**: Confluence REST **v1** with a Personal Access Token (Bearer auth) instead of Cloud REST v2 with Basic auth.

Modeled as a **separate `confluence-datacenter` catalog row** (not a `deployment: cloud | datacenter` discriminator on the Cloud row): the two clients speak different REST versions + auth schemes, so a distinct row keeps the pairing test clean, the provenance vendor slug unambiguous (`connector:confluence-datacenter`), and the install form free of the Cloud-only email field.

**New files** (all under `packages/api/src/lib/knowledge/confluence/`):
- `config-datacenter.ts` — catalog id/slug/vendor SSOT + `ConfluenceDcCollectionConfig` (base_url + space_key) + parse
- `client-datacenter.ts` — v1 REST vendor client (Bearer PAT, `/rest/api/content?spaceKey=…`, inline-`ancestors` parent derivation, `version.when` timestamps), incremental + reconciliation, 429→`ConnectorRateLimitError`, SSRF-guarded, PAT never in a URL/message
- `connector-datacenter.ts` — the `KnowledgeSyncConnector` factory + idempotent register
- `integrations/install/confluence-datacenter-form-handler.ts` — base URL + PAT form install; install-time SSRF gate + loud credential verification; PAT routed to encrypted `knowledge_sync_credentials`, never `workspace_plugins.config`; verify → keyset gate → credential → install-row (rollback on failure)

**Wiring:** `register.ts` (form handler + connector pairing), `seed-builtin-knowledge-catalog.ts` (catalog row), `admin-knowledge.ts` + `@useatlas/types` + web schema (`confluence-datacenter` source discriminator), OpenAPI spec regenerated.

## Test Plan

- [x] Manual testing — n/a (no live Confluence DC instance); every path is exercised through injected fixture `fetchImpl`
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

New/updated tests:
- `client-datacenter.test.ts` — v1 fixtures: reconciliation (full crawl w/ bodies), incremental (metadata pass + changed-body fetch), `_links.next` pagination, 429/401/403/500/non-JSON, space-not-found, SSRF block, malformed-page coverage flag, offset-timestamp normalization, Bearer-not-Basic auth, and **context-path URL assembly** (`_links.base` under `/confluence`)
- `connector-datacenter.test.ts` — factory contract (config parse, loud missing/undecryptable PAT)
- `confluence-datacenter-form-handler.test.ts` — field validation (base URL + SSRF, space key, PAT; no email), loud verification, PAT-never-in-config, credential rollback
- `register.test.ts` — connector + form-handler pairing
- `seed-builtin-knowledge-catalog.test.ts` — DC row shape (base_url + space_key + secret PAT, no email)
- `admin-knowledge.test.ts` — DC collection classifies as source `confluence-datacenter` with sync bookkeeping
- `knowledge-lifecycle-pg.test.ts` — DC install against the live schema

Internal review panel (silent-failure / type-design / test-coverage / comment) ran clean; four low-severity suggestions applied. Local `scripts/ci-local.sh`: all 28 gates green.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — via `scripts/ci-local.sh` (Stage 2 isolated suite)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area) — inherited from the issue (feature, area: api, area: docs)
- [ ] CHANGELOG.md updated — connector is operator-facing; no changelog entry required pre-launch

https://claude.ai/code/session_01VeMtWTTNrsjaNqzXWh3SWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeMtWTTNrsjaNqzXWh3SWr)_