### PR TITLE
feat(auth): agent-auth OpenAPI capability breadth via createFromOpenAPI

### DIFF
--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -28,6 +28,7 @@ import { query } from "./routes/query";
 import { executeSql } from "./routes/execute-sql";
 import { staticPaths, staticTags, securitySchemes } from "./routes/openapi";
 import { registerAtlasOpenApiSource, type AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
+import { registerInProcessApiFetch } from "@atlas/api/lib/auth/in-process-api";
 import { conversations, publicConversations } from "./routes/conversations";
 import { dashboards, publicDashboards } from "./routes/dashboards";
 import { semantic } from "./routes/semantic";
@@ -834,6 +835,16 @@ app.get("/api/v1/openapi.json", (c) => c.json(buildAtlasOpenApiDocument()));
 registerAtlasOpenApiSource(
   () => buildAtlasOpenApiDocument() as unknown as AtlasOpenApiSpec,
 );
+
+// Hand the agent-auth proxy (#4410) an in-process transport to THIS app, so its
+// `onExecute` forwards derived operations through the real middleware stack with
+// no network socket. Registered here (where `app` lives) so `lib/` never imports
+// the `api/` layer.
+registerInProcessApiFetch(async (input, init) => {
+  const request =
+    input instanceof Request ? input : new Request(input instanceof URL ? input.href : input, init);
+  return app.fetch(request);
+});
 
 export { app };
 export type AppType = typeof app;

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -27,6 +27,7 @@ import { regionRouting } from "./routes/region-routing";
 import { query } from "./routes/query";
 import { executeSql } from "./routes/execute-sql";
 import { staticPaths, staticTags, securitySchemes } from "./routes/openapi";
+import { registerAtlasOpenApiSource, type AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
 import { conversations, publicConversations } from "./routes/conversations";
 import { dashboards, publicDashboards } from "./routes/dashboards";
 import { semantic } from "./routes/semantic";
@@ -780,42 +781,59 @@ app.onError((err, c) => {
 
 let cachedSpec: Record<string, unknown> | null = null;
 
-app.get("/api/v1/openapi.json", (c) => {
-  if (!cachedSpec) {
-    const auto = app.getOpenAPI31Document({
-      openapi: "3.1.0",
-      info: {
-        title: "Atlas API",
-        version: "1.0.0",
-        description:
-          "Text-to-SQL data analyst agent. Ask natural-language questions about your data and receive structured answers.",
-      },
-      servers: [
-        { url: "http://localhost:3001", description: "Standalone API (development)" },
-        { url: "http://localhost:3000", description: "Same-origin via Next.js rewrites" },
-      ],
-    });
+/**
+ * Build (once, memoized) the merged Atlas OpenAPI 3.1 document from the live
+ * route definitions + the static auth/widget entries. This is the same document
+ * `scripts/extract-openapi.ts` snapshots into `apps/docs/openapi.json`; served
+ * by `/api/v1/openapi.json` AND consumed in-process by the agent-auth OpenAPI
+ * adapter (#4410) via `registerAtlasOpenApiSource` below — the snapshot file is
+ * not copied into the runtime image, so the in-process document is the
+ * always-present source of truth.
+ */
+function buildAtlasOpenApiDocument(): Record<string, unknown> {
+  if (cachedSpec) return cachedSpec;
+  const auto = app.getOpenAPI31Document({
+    openapi: "3.1.0",
+    info: {
+      title: "Atlas API",
+      version: "1.0.0",
+      description:
+        "Text-to-SQL data analyst agent. Ask natural-language questions about your data and receive structured answers.",
+    },
+    servers: [
+      { url: "http://localhost:3001", description: "Standalone API (development)" },
+      { url: "http://localhost:3000", description: "Same-origin via Next.js rewrites" },
+    ],
+  });
 
-    // Merge static paths (auth, widget) into the auto-generated spec
-    const autoPaths = (auto.paths ?? {}) as Record<string, unknown>;
-    const mergedPaths = { ...autoPaths, ...staticPaths };
+  // Merge static paths (auth, widget) into the auto-generated spec
+  const autoPaths = (auto.paths ?? {}) as Record<string, unknown>;
+  const mergedPaths = { ...autoPaths, ...staticPaths };
 
-    // Merge static tags
-    const autoTags = (auto.tags ?? []) as Array<{ name: string; description?: string }>;
-    const autoTagNames = new Set(autoTags.map((t) => t.name));
-    const mergedTags = [...autoTags, ...staticTags.filter((t) => !autoTagNames.has(t.name))];
+  // Merge static tags
+  const autoTags = (auto.tags ?? []) as Array<{ name: string; description?: string }>;
+  const autoTagNames = new Set(autoTags.map((t) => t.name));
+  const mergedTags = [...autoTags, ...staticTags.filter((t) => !autoTagNames.has(t.name))];
 
-    // Add security schemes
-    const autoComponents = (auto.components ?? {}) as Record<string, unknown>;
-    const mergedComponents = {
-      ...autoComponents,
-      securitySchemes: { ...((autoComponents.securitySchemes as Record<string, unknown>) ?? {}), ...securitySchemes },
-    };
+  // Add security schemes
+  const autoComponents = (auto.components ?? {}) as Record<string, unknown>;
+  const mergedComponents = {
+    ...autoComponents,
+    securitySchemes: { ...((autoComponents.securitySchemes as Record<string, unknown>) ?? {}), ...securitySchemes },
+  };
 
-    cachedSpec = { ...auto, paths: mergedPaths, tags: mergedTags, components: mergedComponents };
-  }
-  return c.json(cachedSpec);
-});
+  cachedSpec = { ...auto, paths: mergedPaths, tags: mergedTags, components: mergedComponents };
+  return cachedSpec;
+}
+
+app.get("/api/v1/openapi.json", (c) => c.json(buildAtlasOpenApiDocument()));
+
+// Hand the agent-auth OpenAPI adapter (#4410) the in-process Atlas spec, lazily.
+// The thunk runs at most once, on the first agent-auth plugin build (first
+// authed request), so the ~2.5 MB document is never generated eagerly at boot.
+registerAtlasOpenApiSource(
+  () => buildAtlasOpenApiDocument() as unknown as AtlasOpenApiSpec,
+);
 
 export { app };
 export type AppType = typeof app;

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -71,6 +71,7 @@ import {
   buildAgentAuthOpenApiOptions,
 } from "@atlas/api/lib/auth/agent-auth-openapi";
 import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
+import { fromOpenAPI } from "@better-auth/agent-auth/openapi";
 
 const BASE = "http://localhost:3000";
 const ISSUER = `${BASE}/api/auth`;
@@ -118,6 +119,19 @@ describe("agent-auth OpenAPI adapter classification (#4410)", () => {
     expect(isSensitiveOperation(idx.get("getAdminAudit"))).toBe(true); // admin read
     expect(isSensitiveOperation(idx.get("getPlatformRegions"))).toBe(true); // platform read
     expect(isSensitiveOperation(undefined)).toBe(true); // fail closed
+  });
+
+  it("the operationId join holds against the REAL adapter output (fromOpenAPI)", () => {
+    // buildOperationIndex classifies caps by `cap.name === operationId`. If the
+    // adapter ever renamed/prefixed cap names, EVERY cap would miss the index
+    // and be treated as sensitive (safe, but the feature would offer nothing).
+    // Pin the join against the actual `createFromOpenAPI` capability shape.
+    const index = buildOperationIndex(FIXTURE_SPEC);
+    const derived = fromOpenAPI(FIXTURE_SPEC);
+    expect(derived.length).toBe(index.size);
+    for (const cap of derived) {
+      expect(index.has(cap.name)).toBe(true);
+    }
   });
 
   it("matches sensitive prefixes only on a segment boundary", () => {
@@ -246,16 +260,22 @@ describe("agent-auth capability execution (#4410)", () => {
   // token was minted + forwarded WITHOUT standing up the whole Atlas app.
   let lastForwarded: { url: string; headers: Record<string, string> } | null = null;
   let mintedFor: Array<{ userId: string; workspaceId: string }> = [];
+  // The proxy transport's response is configurable per test: default 200; a test
+  // can point it at a thrown transport error (sanitization branch) or a non-2xx
+  // upstream (client-error branch).
+  const okResponder = (): Response =>
+    new Response(JSON.stringify({ ok: true, from: "upstream" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  let fetchResponder: () => Response | Promise<Response> = okResponder;
   const stubFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const req = input instanceof Request ? input : new Request(String(input), init);
     lastForwarded = {
       url: req.url,
       headers: Object.fromEntries(req.headers.entries()),
     };
-    return new Response(JSON.stringify({ ok: true, from: "upstream" }), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    return fetchResponder();
   };
   const stubMint = async ({ user, workspaceId }: { user: { id: string }; workspaceId: string }) => {
     mintedFor.push({ userId: user.id, workspaceId });
@@ -274,6 +294,7 @@ describe("agent-auth capability execution (#4410)", () => {
     enabledForWorkspace = () => true;
     lastForwarded = null;
     mintedFor = [];
+    fetchResponder = okResponder;
   });
 
   afterAll(() => {
@@ -304,6 +325,9 @@ describe("agent-auth capability execution (#4410)", () => {
       deniedBy: null, grantedBy: "user_1", expiresAt: null, status: a.grantStatus,
       constraints: null, createdAt: now, updatedAt: now,
     }));
+    const plugin = buildAgentAuthPlugin({
+      spec: FIXTURE_SPEC, fetch: stubFetch, mintToken: stubMint, baseUrl: "http://internal",
+    });
     return betterAuth({
       baseURL: BASE,
       secret: "test-secret-at-least-32-characters-long!!",
@@ -312,9 +336,7 @@ describe("agent-auth capability execution (#4410)", () => {
         agent: agentRows, agentHost: [host], agentCapabilityGrant: grantRows, approvalRequest: [],
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
-      plugins: [
-        buildAgentAuthPlugin({ spec: FIXTURE_SPEC, fetch: stubFetch, mintToken: stubMint, baseUrl: "http://internal" }),
-      ] as any[],
+      plugins: [plugin] as any[],
     });
   }
 
@@ -441,5 +463,36 @@ describe("agent-auth capability execution (#4410)", () => {
     expect(body.error).toBe("unauthorized");
     expect(mintedFor).toEqual([]);
     expect(lastForwarded).toBeNull();
+  });
+
+  it("error sanitization: an opaque proxy transport failure → 500 internal_error, no raw message leaked", async () => {
+    fetchResponder = () => {
+      throw new Error("connect ECONNREFUSED secret-db-host:5432");
+    };
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(500);
+    expect(body.error).toBe("internal_error");
+    // The raw upstream/transport detail never reaches the agent; a ref does.
+    const message = JSON.stringify(body);
+    expect(message).not.toContain("ECONNREFUSED");
+    expect(message).not.toContain("secret-db-host");
+    expect(message).toContain("ref ");
+  });
+
+  it("upstream 4xx: a deterministic client error surfaces as a client envelope, no raw body, no retry advice", async () => {
+    fetchResponder = () =>
+      new Response(JSON.stringify({ error: "bad_arg", secret: "leaky-internal-detail" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      });
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(403);
+    expect(body.error).toBe("invalid_request");
+    const message = JSON.stringify(body);
+    expect(message).not.toContain("leaky-internal-detail");
+    expect(message).toContain("HTTP 403");
+    expect(message).not.toContain("Retry"); // not a transient fault
   });
 });

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -1,21 +1,22 @@
 /**
- * Agent Auth spine — plugin contract + JWT/grant verification + the Atlas-side
- * `onExecute` per-org binding (#4409, Slice 1).
+ * Agent Auth — OpenAPI adapter contract + JWT/grant verification + the
+ * Atlas-side per-org binding and error hygiene (#4410 Slice 2, building on the
+ * #4409 spine).
  *
- * These drive the REAL `buildAgentAuthPlugin()` through a real `betterAuth()`
- * instance backed by the in-memory adapter (the same harness `server.test.ts`
- * uses). The agent-auth `before` hook does full agent-JWT verification
- * (signature against the registered Ed25519 key, `aud` binding, expiry, jti
- * replay) and the capability grant check before `onExecute` runs — so hitting
- * `/api/auth/capability/execute` with crafted JWTs exercises the actual security
- * surface, not a re-implementation.
+ * These drive the REAL `buildAgentAuthPlugin()` (with injected seams — a fixture
+ * spec, a stub proxy `fetch`, and a stub token minter) through a real
+ * `betterAuth()` instance backed by the in-memory adapter (the same harness
+ * `server.test.ts` uses). The agent-auth `before` hook does full agent-JWT
+ * verification (signature against the registered Ed25519 key, `aud` binding,
+ * expiry, jti replay) and the capability grant check before `onExecute` runs —
+ * so hitting `/api/auth/capability/execute` with crafted JWTs exercises the
+ * actual security surface, not a re-implementation.
  *
- * The two `onExecute` dependencies that need an internal DB — the workspace-
- * membership lookup (`listUserWorkspaceIds`) and the org-scoped read
- * (`listEntities`) — are mocked so the happy and cross-workspace paths run
- * without Postgres; every DENIAL case (wrong aud / expired / revoked / missing
- * capability claim) fails BEFORE `onExecute`, so those assertions exercise the
- * unmocked plugin verification directly.
+ * The one `resolveHeaders` dependency that needs an internal DB — the
+ * workspace-membership lookup (`listUserWorkspaceIds`) — is mocked so the happy
+ * and cross-workspace paths run without Postgres; every DENIAL case (wrong aud /
+ * expired / revoked / missing capability claim) fails BEFORE `onExecute`, so
+ * those assertions exercise the unmocked plugin verification directly.
  *
  * Self-contained: the enable flag is set on `process.env` inside the suite and
  * restored, never at module top level.
@@ -29,7 +30,7 @@ import { generateKeyPair, exportJWK, SignJWT } from "jose";
 /** jose v6 dropped the `KeyLike` alias; infer the key type from generateKeyPair. */
 type AgentPrivateKey = Awaited<ReturnType<typeof generateKeyPair>>["privateKey"];
 
-// ── Mocks for the two internal-DB-backed onExecute dependencies ─────────────
+// ── Mocks for the internal-DB-backed resolveHeaders dependency ──────────────
 // `listUserWorkspaceIds` is the authoritative membership check the verifier
 // runs; default it to "user_1 is a member of wsA only" so the cross-workspace
 // case (an agent bound to wsB) is denied.
@@ -44,20 +45,7 @@ mock.module("@atlas/api/lib/auth/oauth-workspace-grants", () => ({
   revokeWorkspaceGrant: async () => 0,
 }));
 
-// Spread the real semantic/entities module and override only `listEntities`,
-// so "mock all exports" holds and the org-scoped read is deterministic.
-import * as entitiesReal from "@atlas/api/lib/semantic/entities";
-const defaultEntitiesForOrg = (orgId: string | undefined): entitiesReal.EntityListEntry[] =>
-  orgId === "wsA"
-    ? [{ name: "orders", table: "public.orders", description: "Orders fact", source: "default" }]
-    : [];
-let entitiesForOrg: (orgId: string | undefined) => entitiesReal.EntityListEntry[] = defaultEntitiesForOrg;
-mock.module("@atlas/api/lib/semantic/entities", () => ({
-  ...entitiesReal,
-  listEntities: async (opts: { orgId?: string } = {}) => entitiesForOrg(opts.orgId),
-}));
-
-// Spread the real gate and override only the enable check, so onExecute's
+// Spread the real gate and override only the enable check, so resolveHeaders'
 // workspace-override branch can be driven deterministically without an internal
 // DB (the gate's own env/fail-closed behavior is covered in agent-auth-gate.test.ts).
 // Default: enabled for every workspace.
@@ -71,24 +59,156 @@ mock.module("@atlas/api/lib/auth/agent-auth-gate", () => ({
 // SUT — imported AFTER the mocks are registered.
 import {
   buildAgentAuthPlugin,
-  LIST_ENTITIES_CAPABILITY,
   AGENT_WORKSPACE_METADATA_KEY,
-  AGENT_AUTH_CAPABILITIES,
+  mintWorkspaceApiKeyVia,
+  type CreateWorkspaceApiKey,
 } from "@atlas/api/lib/auth/agent-auth-plugin";
+import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import {
+  buildOperationIndex,
+  isSensitiveOperation,
+  isSensitivePath,
+  buildAgentAuthOpenApiOptions,
+} from "@atlas/api/lib/auth/agent-auth-openapi";
+import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
 
 const BASE = "http://localhost:3000";
 const ISSUER = `${BASE}/api/auth`;
 const EXECUTE_URL = `${ISSUER}/capability/execute`;
 
-// ── Contract pinning ────────────────────────────────────────────────────────
+/**
+ * A minimal fixture spec exercising every classification branch: a safe read
+ * (GET /me), a write (POST /query), a sensitive-path read (GET /admin/audit), a
+ * HEAD read, and a platform read. operationIds mirror the auto-generated
+ * `<method><Path>` shape.
+ */
+const FIXTURE_SPEC = {
+  info: { title: "Atlas API", description: "fixture" },
+  paths: {
+    "/api/v1/me": { get: { operationId: "getMe", description: "current user" } },
+    "/api/v1/query": { post: { operationId: "postQuery", description: "run a query" } },
+    "/api/v1/admin/audit": { get: { operationId: "getAdminAudit", description: "audit log" } },
+    "/api/v1/dashboards": {
+      get: { operationId: "getDashboards", description: "list dashboards" },
+      head: { operationId: "headDashboards", description: "dashboards head" },
+    },
+    "/api/v1/platform/regions": { get: { operationId: "getPlatformRegions", description: "regions" } },
+  },
+} satisfies AtlasOpenApiSpec;
 
-describe("agent-auth plugin contract (#4409)", () => {
+const SAFE_CAP = "getMe";
+
+// ── Pure adapter classification (no plugin, no auth instance) ────────────────
+
+describe("agent-auth OpenAPI adapter classification (#4410)", () => {
+  it("indexes every operationId to its method + path", () => {
+    const index = buildOperationIndex(FIXTURE_SPEC);
+    expect(index.get("getMe")).toEqual({ method: "GET", path: "/api/v1/me" });
+    expect(index.get("postQuery")).toEqual({ method: "POST", path: "/api/v1/query" });
+    expect(index.get("headDashboards")).toEqual({ method: "HEAD", path: "/api/v1/dashboards" });
+    expect(index.size).toBe(6);
+  });
+
+  it("classifies writes, admin, and platform routes as sensitive; read-only non-admin as safe", () => {
+    const idx = buildOperationIndex(FIXTURE_SPEC);
+    expect(isSensitiveOperation(idx.get("getMe"))).toBe(false); // safe read
+    expect(isSensitiveOperation(idx.get("headDashboards"))).toBe(false); // safe HEAD
+    expect(isSensitiveOperation(idx.get("getDashboards"))).toBe(false); // safe read
+    expect(isSensitiveOperation(idx.get("postQuery"))).toBe(true); // write
+    expect(isSensitiveOperation(idx.get("getAdminAudit"))).toBe(true); // admin read
+    expect(isSensitiveOperation(idx.get("getPlatformRegions"))).toBe(true); // platform read
+    expect(isSensitiveOperation(undefined)).toBe(true); // fail closed
+  });
+
+  it("matches sensitive prefixes only on a segment boundary", () => {
+    expect(isSensitivePath("/api/v1/admin")).toBe(true);
+    expect(isSensitivePath("/api/v1/admin/audit")).toBe(true);
+    expect(isSensitivePath("/api/v1/platform/regions")).toBe(true);
+    expect(isSensitivePath("/api/v1/administrators")).toBe(false); // not swept by raw prefix
+    expect(isSensitivePath("/api/v1/me")).toBe(false);
+  });
+
+  it("derives capabilities from the spec, limits defaultHostCapabilities to safe reads, blocks the rest", () => {
+    const opts = buildAgentAuthOpenApiOptions(FIXTURE_SPEC, {
+      baseUrl: "http://internal",
+      resolveHeaders: async () => ({}),
+    });
+    const capNames = (opts.capabilities ?? []).map((c) => c.name).sort();
+    // Every operation is a capability — no hand-rolled list.
+    expect(capNames).toEqual(
+      ["getAdminAudit", "getDashboards", "getMe", "getPlatformRegions", "headDashboards", "postQuery"].sort(),
+    );
+    // Auto-grant only safe reads (GET/HEAD, non-admin) — NOT admin GETs or writes.
+    expect([...(opts.defaultHostCapabilities as string[])].sort()).toEqual(
+      ["getDashboards", "getMe", "headDashboards"].sort(),
+    );
+    // Hard-block every sensitive cap from being granted/executed.
+    expect([...(opts.blockedCapabilities ?? [])].sort()).toEqual(
+      ["getAdminAudit", "getPlatformRegions", "postQuery"].sort(),
+    );
+  });
+
+  it("resolveCapabilities hides sensitive caps from discovery (list/describe)", () => {
+    const opts = buildAgentAuthOpenApiOptions(FIXTURE_SPEC, {
+      baseUrl: "http://internal",
+      resolveHeaders: async () => ({}),
+    });
+    const visible = opts.resolveCapabilities!({
+      capabilities: opts.capabilities ?? [],
+      query: null,
+      agentSession: null,
+      hostSession: null,
+    }) as Array<{ name: string }>;
+    const names = visible.map((c) => c.name).sort();
+    expect(names).toEqual(["getDashboards", "getMe", "headDashboards"].sort());
+    expect(names).not.toContain("postQuery");
+    expect(names).not.toContain("getAdminAudit");
+  });
+});
+
+// ── Per-org token minting core (AC2) ────────────────────────────────────────
+
+describe("agent-auth per-org token minting (#4410)", () => {
+  const user = createAtlasUser("user_1", "managed", "U", { activeOrganizationId: "wsA" });
+
+  it("server-side mints a workspace-scoped key: explicit userId, workspace metadata, short TTL", async () => {
+    let seen: Parameters<CreateWorkspaceApiKey>[0] | undefined;
+    const createApiKey: CreateWorkspaceApiKey = async (opts) => {
+      seen = opts;
+      return { id: "key_1", key: "wskey_secret" };
+    };
+    const token = await mintWorkspaceApiKeyVia(createApiKey, { user, workspaceId: "wsA" });
+    expect(token).toBe("wskey_secret");
+    // No request headers → server-side mint bound to the agent's owning member.
+    expect(seen?.body.userId).toBe("user_1");
+    expect(seen?.body.expiresIn).toBeGreaterThan(0);
+    expect(seen?.body.metadata).toMatchObject({ atlasWorkspaceKey: true, orgId: "wsA" });
+    // No plaintext secrets / RLS claims smuggled into metadata.
+    expect(seen?.body.metadata.claims).toBeUndefined();
+  });
+
+  it("throws a non-leaking internal error when the apiKey plugin is unavailable", async () => {
+    await expect(mintWorkspaceApiKeyVia(undefined, { user, workspaceId: "wsA" })).rejects.toMatchObject({
+      body: { error: "internal_error" },
+    });
+  });
+
+  it("throws when createApiKey returns no key material", async () => {
+    const createApiKey: CreateWorkspaceApiKey = async () => ({ id: "key_1" });
+    await expect(mintWorkspaceApiKeyVia(createApiKey, { user, workspaceId: "wsA" })).rejects.toMatchObject({
+      body: { error: "internal_error" },
+    });
+  });
+});
+
+// ── Plugin contract ─────────────────────────────────────────────────────────
+
+describe("agent-auth plugin contract (#4410)", () => {
   it("registers under id 'agent-auth' with the four spec tables", () => {
-    const plugin = buildAgentAuthPlugin();
+    const plugin = buildAgentAuthPlugin({ spec: FIXTURE_SPEC });
     expect(plugin.id).toBe("agent-auth");
     // The 0.6.2 schema names — pinned so a future bump that renames a table
-    // (docs drifted between agent/host/grant and agentHost/capabilityGrant) goes
-    // RED here rather than silently changing what auto-migrate creates.
+    // goes RED here rather than silently changing what auto-migrate creates.
     expect(Object.keys(plugin.schema ?? {}).sort()).toEqual([
       "agent",
       "agentCapabilityGrant",
@@ -97,28 +217,50 @@ describe("agent-auth plugin contract (#4409)", () => {
     ]);
   });
 
-  it("advertises exactly ONE hand-written capability (Slice 1 scope guard)", () => {
-    // The real scope guard: exactly one capability, so Slice 2's OpenAPI adapter
-    // can't silently expand the surface here. Reads the exported source list.
-    expect(AGENT_AUTH_CAPABILITIES).toHaveLength(1);
-    expect(AGENT_AUTH_CAPABILITIES[0].name).toBe(LIST_ENTITIES_CAPABILITY);
-    expect(AGENT_AUTH_CAPABILITIES[0].name).toBe("list_semantic_entities");
-    // …and the plugin exposes the execute + discovery endpoints it's built on.
-    const plugin = buildAgentAuthPlugin();
+  it("exposes the execute + discovery endpoints the adapter is built on", () => {
+    const plugin = buildAgentAuthPlugin({ spec: FIXTURE_SPEC });
     const paths = Object.values(plugin.endpoints ?? {})
       .map((e) => (e as { path?: string }).path)
       .filter(Boolean);
     expect(paths).toContain("/capability/execute");
     expect(paths).toContain("/agent-configuration");
   });
+
+  it("advertises zero capabilities when no spec is available (inert, gated surface)", () => {
+    // A non-API process (or a spec-generation failure) → null spec → empty
+    // capability set, never a crash. The surface stays default-off + 404-gated.
+    const plugin = buildAgentAuthPlugin({ spec: null });
+    expect(plugin.id).toBe("agent-auth");
+  });
 });
 
-// ── JWT / grant verification + onExecute binding ────────────────────────────
+// ── JWT / grant verification + per-org binding through the proxy ─────────────
 
-describe("agent-auth capability execution (#4409)", () => {
+describe("agent-auth capability execution (#4410)", () => {
   let privateKey: AgentPrivateKey;
   let publicJwk: Record<string, unknown>;
   const prevEnabled = process.env.ATLAS_AGENT_AUTH_ENABLED;
+
+  // The stub proxy transport captures the forwarded request (URL + headers) and
+  // returns a canned upstream response, so the happy path asserts the per-org
+  // token was minted + forwarded WITHOUT standing up the whole Atlas app.
+  let lastForwarded: { url: string; headers: Record<string, string> } | null = null;
+  let mintedFor: Array<{ userId: string; workspaceId: string }> = [];
+  const stubFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const req = input instanceof Request ? input : new Request(String(input), init);
+    lastForwarded = {
+      url: req.url,
+      headers: Object.fromEntries(req.headers.entries()),
+    };
+    return new Response(JSON.stringify({ ok: true, from: "upstream" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  const stubMint = async ({ user, workspaceId }: { user: { id: string }; workspaceId: string }) => {
+    mintedFor.push({ userId: user.id, workspaceId });
+    return `wskey_${workspaceId}`;
+  };
 
   beforeAll(async () => {
     process.env.ATLAS_AGENT_AUTH_ENABLED = "true";
@@ -127,13 +269,11 @@ describe("agent-auth capability execution (#4409)", () => {
     publicJwk = (await exportJWK(kp.publicKey)) as Record<string, unknown>;
   });
 
-  // Reset the mutable stubs after EVERY test (not just once in afterAll) so a
-  // test that repoints a stub can't bleed into a later one — the org-scoped read
-  // path is order-sensitive otherwise.
   afterEach(() => {
     workspacesForUser = () => ["wsA"];
     enabledForWorkspace = () => true;
-    entitiesForOrg = defaultEntitiesForOrg;
+    lastForwarded = null;
+    mintedFor = [];
   });
 
   afterAll(() => {
@@ -141,12 +281,6 @@ describe("agent-auth capability execution (#4409)", () => {
     else process.env.ATLAS_AGENT_AUTH_ENABLED = prevEnabled;
   });
 
-  /**
-   * Build a fresh in-memory auth instance seeded with a host, a user, and one
-   * or more agents (each with its own workspace-metadata + grant status). Rows
-   * are pre-seeded in the shape the plugin's read path expects (publicKey /
-   * metadata as JSON strings), which the scratch harness verified round-trips.
-   */
   function makeInstance(
     agents: Array<{ id: string; workspaceId: string; grantStatus: "active" | "revoked" }>,
   ) {
@@ -166,7 +300,7 @@ describe("agent-auth capability execution (#4409)", () => {
       createdAt: now, updatedAt: now,
     }));
     const grantRows = agents.map((a) => ({
-      id: `grant_${a.id}`, agentId: a.id, capability: LIST_ENTITIES_CAPABILITY,
+      id: `grant_${a.id}`, agentId: a.id, capability: SAFE_CAP,
       deniedBy: null, grantedBy: "user_1", expiresAt: null, status: a.grantStatus,
       constraints: null, createdAt: now, updatedAt: now,
     }));
@@ -178,7 +312,9 @@ describe("agent-auth capability execution (#4409)", () => {
         agent: agentRows, agentHost: [host], agentCapabilityGrant: grantRows, approvalRequest: [],
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
-      plugins: [buildAgentAuthPlugin()] as any[],
+      plugins: [
+        buildAgentAuthPlugin({ spec: FIXTURE_SPEC, fetch: stubFetch, mintToken: stubMint, baseUrl: "http://internal" }),
+      ] as any[],
     });
   }
 
@@ -189,7 +325,7 @@ describe("agent-auth capability execution (#4409)", () => {
     expired?: boolean;
   }): Promise<string> {
     const jwt = new SignJWT({
-      ...(opts.capabilities !== undefined ? { capabilities: opts.capabilities } : { capabilities: [LIST_ENTITIES_CAPABILITY] }),
+      ...(opts.capabilities !== undefined ? { capabilities: opts.capabilities } : { capabilities: [SAFE_CAP] }),
     })
       .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
       .setSubject(opts.agentId)
@@ -204,12 +340,13 @@ describe("agent-auth capability execution (#4409)", () => {
   async function execute(
     instance: ReturnType<typeof makeInstance>,
     token: string,
+    capability: string = SAFE_CAP,
   ): Promise<{ status: number; body: { error?: string; data?: unknown } }> {
     const res = await instance.handler(
       new Request(EXECUTE_URL, {
         method: "POST",
         headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-        body: JSON.stringify({ capability: LIST_ENTITIES_CAPABILITY, arguments: {} }),
+        body: JSON.stringify({ capability, arguments: {} }),
       }),
     );
     const body = (await res.json().catch(() => ({}))) as { error?: string; data?: unknown };
@@ -217,43 +354,34 @@ describe("agent-auth capability execution (#4409)", () => {
     return { status: res.status, body };
   }
 
-  it("happy path: valid aud + granted capability → 200, org-scoped result for the agent's workspace", async () => {
+  it("happy path: valid aud + granted safe capability → 200, per-org token minted + forwarded", async () => {
     workspacesForUser = () => ["wsA"];
     enabledForWorkspace = () => true;
     const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
     expect(status).toBe(200);
-    // onExecute returned the org-scoped listEntities projection for wsA, with the
-    // exact field mapping (name/table/description ?? null).
-    expect(body.data).toMatchObject({ workspaceId: "wsA", count: 1 });
-    expect((body.data as { entities: unknown[] }).entities).toEqual([
-      { name: "orders", table: "public.orders", description: "Orders fact" },
-    ]);
+    expect(body.data).toMatchObject({ ok: true, from: "upstream" });
+    // The per-org binding minted a key for the resolved (user_1, wsA) and the
+    // proxy forwarded it as x-api-key to the wsA-scoped operation path.
+    expect(mintedFor).toEqual([{ userId: "user_1", workspaceId: "wsA" }]);
+    expect(lastForwarded?.headers["x-api-key"]).toBe("wskey_wsA");
+    expect(lastForwarded?.url).toContain("/api/v1/me");
   });
 
-  it("workspace-override off: a workspace that opted out is denied even with the platform default on", async () => {
-    // Defense-in-depth beyond the raw HTTP gate: onExecute re-checks the setting
-    // for the RESOLVED workspace. wsA has it off (platform on) → denied, and the
-    // org-scoped read is never reached.
+  it("workspace-override off: a workspace that opted out is denied (404) before minting or forwarding", async () => {
     workspacesForUser = () => ["wsA"];
     enabledForWorkspace = (orgId) => orgId !== "wsA";
     const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
     expect(status).toBe(404);
     expect(body.error).toBe("unauthorized");
-    expect(body.data).toBeUndefined();
+    expect(mintedFor).toEqual([]);
+    expect(lastForwarded).toBeNull();
   });
 
-  it("workspace-override isolation: with platform on, wsA off but wsB on, wsA is 404'd while wsB executes 200", async () => {
-    // The cross-workspace half of the precedence matrix (#4419): a workspace
-    // override tightens ONLY its own execution. user_1 is a member of both; the
-    // override seals wsA and leaves wsB fully reachable.
+  it("workspace-override isolation: platform on, wsA off but wsB on → wsA 404'd, wsB executes 200", async () => {
     workspacesForUser = () => ["wsA", "wsB"];
     enabledForWorkspace = (orgId) => orgId !== "wsA"; // platform on; wsA opted out
-    entitiesForOrg = (orgId) =>
-      orgId === "wsB"
-        ? [{ name: "events", table: "public.events", description: "Events fact", source: "default" }]
-        : [];
     const instance = makeInstance([
       { id: "agent_a", workspaceId: "wsA", grantStatus: "active" },
       { id: "agent_b", workspaceId: "wsB", grantStatus: "active" },
@@ -262,11 +390,11 @@ describe("agent-auth capability execution (#4409)", () => {
     const a = await execute(instance, await mintJWT({ agentId: "agent_a" }));
     expect(a.status).toBe(404); // wsA sealed by its own override
     expect(a.body.error).toBe("unauthorized");
-    expect(a.body.data).toBeUndefined();
 
     const b = await execute(instance, await mintJWT({ agentId: "agent_b" }));
     expect(b.status).toBe(200); // wsB unaffected — override is per-org
-    expect(b.body.data).toMatchObject({ workspaceId: "wsB", count: 1 });
+    expect(mintedFor).toEqual([{ userId: "user_1", workspaceId: "wsB" }]);
+    expect(lastForwarded?.headers["x-api-key"]).toBe("wskey_wsB");
   });
 
   it("wrong audience → 401 invalid_jwt (rejected before onExecute)", async () => {
@@ -277,6 +405,7 @@ describe("agent-auth capability execution (#4409)", () => {
     );
     expect(status).toBe(401);
     expect(body.error).toBe("invalid_jwt");
+    expect(mintedFor).toEqual([]);
   });
 
   it("expired token → 401 invalid_jwt", async () => {
@@ -295,23 +424,22 @@ describe("agent-auth capability execution (#4409)", () => {
 
   it("missing capability claim (token asserts no capabilities) → 403 capability_not_granted", async () => {
     const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
-    // An empty `capabilities` claim scopes the session to zero grants — the
-    // token does not assert the capability it is trying to execute.
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1", capabilities: [] }));
     expect(status).toBe(403);
     expect(body.error).toBe("capability_not_granted");
   });
 
-  it("cross-workspace isolation: an agent bound to a workspace its owner is not a member of is denied", async () => {
+  it("cross-workspace isolation: an agent bound to a workspace its owner is not a member of is denied (403)", async () => {
     // user_1 is a member of wsA only. agent_b's metadata claims wsB.
     workspacesForUser = () => ["wsA"];
     const instance = makeInstance([{ id: "agent_b", workspaceId: "wsB", grantStatus: "active" }]);
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_b" }));
     // The JWT + grant are valid, so the plugin admits and calls onExecute; the
-    // Atlas-side membership check is what denies (403), NOT a JWT failure.
+    // Atlas-side membership check in resolveHeaders is what denies (403), and no
+    // token was minted nor request forwarded to wsB.
     expect(status).toBe(403);
     expect(body.error).toBe("unauthorized");
-    // And it never reached the org-scoped read for wsB.
-    expect(body.data).toBeUndefined();
+    expect(mintedFor).toEqual([]);
+    expect(lastForwarded).toBeNull();
   });
 });

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -543,6 +543,8 @@ describe("agent-auth capability execution (#4410)", () => {
     const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
     expect(status).toBe(429);
+    // Machine code distinguishes throttle from a genuine internal fault.
+    expect(body.error).toBe("rate_limited");
     const message = JSON.stringify(body);
     expect(message).toContain("backoff");
     expect(message).not.toContain("will not succeed"); // transient, not a permanent client error

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -26,6 +26,8 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, mock } from "bun:
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { generateKeyPair, exportJWK, SignJWT } from "jose";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 /** jose v6 dropped the `KeyLike` alias; infer the key type from generateKeyPair. */
 type AgentPrivateKey = Awaited<ReturnType<typeof generateKeyPair>>["privateKey"];
@@ -160,6 +162,41 @@ describe("agent-auth OpenAPI adapter classification (#4410)", () => {
     expect([...(opts.blockedCapabilities ?? [])].sort()).toEqual(
       ["getAdminAudit", "getPlatformRegions", "postQuery"].sort(),
     );
+  });
+
+  it("containment holds against the REAL Atlas OpenAPI spec (no write/admin auto-grantable)", () => {
+    // The classification tests above use a 6-op fixture; this pins the actual
+    // guarantee against the committed ~460-op spec. `apps/docs/openapi.json` is
+    // a dev artifact (not in the runtime image) but IS in the repo/CI checkout.
+    const specPath = resolve(import.meta.dir, "../../../../../../apps/docs/openapi.json");
+    if (!existsSync(specPath)) {
+      console.warn(`[agent-auth] real-spec containment test skipped — ${specPath} not found`);
+      return;
+    }
+    const realSpec = JSON.parse(readFileSync(specPath, "utf8")) as AtlasOpenApiSpec;
+    const index = buildOperationIndex(realSpec);
+    expect(index.size).toBeGreaterThan(300); // sanity: the real spec loaded
+
+    const opts = buildAgentAuthOpenApiOptions(realSpec, {
+      baseUrl: "http://internal",
+      resolveHeaders: async () => ({}),
+    });
+
+    // EVERY auto-grantable default host capability must be a safe read: a
+    // read-only method AND not under a sensitive prefix. One write or admin op
+    // leaking into this set is the exact capability-explosion risk this fails on.
+    for (const name of opts.defaultHostCapabilities as string[]) {
+      expect(isSensitiveOperation(index.get(name))).toBe(false);
+    }
+    // Symmetrically: every write + every /admin,/platform op is blocked.
+    const blocked = new Set(opts.blockedCapabilities ?? []);
+    for (const [name, meta] of index) {
+      if (isSensitiveOperation(meta)) {
+        expect(blocked.has(name)).toBe(true);
+      }
+    }
+    // And the real spec actually contains sensitive ops (so this isn't vacuous).
+    expect(blocked.size).toBeGreaterThan(0);
   });
 
   it("resolveCapabilities hides sensitive caps from discovery (list/describe)", () => {
@@ -493,6 +530,37 @@ describe("agent-auth capability execution (#4410)", () => {
     const message = JSON.stringify(body);
     expect(message).not.toContain("leaky-internal-detail");
     expect(message).toContain("HTTP 403");
-    expect(message).not.toContain("Retry"); // not a transient fault
+    expect(message).toContain("will not succeed"); // deterministic — correct permanent-fail guidance
+    expect(message).not.toContain("backoff"); // not a transient/throttle envelope
+  });
+
+  it("upstream 429: a throttle is retriable — status preserved, backoff advised, not 'won't succeed'", async () => {
+    fetchResponder = () =>
+      new Response(JSON.stringify({ error: "rate_limited" }), {
+        status: 429,
+        headers: { "content-type": "application/json" },
+      });
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(429);
+    const message = JSON.stringify(body);
+    expect(message).toContain("backoff");
+    expect(message).not.toContain("will not succeed"); // transient, not a permanent client error
+  });
+
+  it("upstream 5xx: an upstream 500 collapses to a non-leaking opaque 500", async () => {
+    fetchResponder = () =>
+      new Response(JSON.stringify({ error: "boom", stack: "at secretModule.ts:42 leaky-stack" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(500);
+    expect(body.error).toBe("internal_error");
+    const message = JSON.stringify(body);
+    expect(message).not.toContain("leaky-stack");
+    expect(message).not.toContain("secretModule");
+    expect(message).toContain("ref ");
   });
 });

--- a/packages/api/src/lib/auth/__tests__/atlas-openapi-source.test.ts
+++ b/packages/api/src/lib/auth/__tests__/atlas-openapi-source.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The Atlas OpenAPI source registry (#4410) — the safety valve the agent-auth
+ * adapter's "zero capabilities is safe when the spec is unavailable" argument
+ * rests on. These pin the fail-soft branches: no source registered → `null`,
+ * a source that throws → `null` (never a re-throw that would crash the
+ * auth-instance build), plus memoization and re-registration cache-clear.
+ *
+ * Self-contained: each test resets the module registry via the test-only reset.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  registerAtlasOpenApiSource,
+  getAtlasOpenApiSpec,
+  __resetAtlasOpenApiSourceForTest,
+  type AtlasOpenApiSpec,
+} from "@atlas/api/lib/auth/atlas-openapi-source";
+
+const SPEC = { info: { title: "Atlas API" }, paths: {} } satisfies AtlasOpenApiSpec;
+
+describe("atlas-openapi-source registry (#4410)", () => {
+  afterEach(() => __resetAtlasOpenApiSourceForTest());
+
+  it("returns null (fail-soft) when no source is registered", () => {
+    __resetAtlasOpenApiSourceForTest();
+    expect(getAtlasOpenApiSpec()).toBeNull();
+  });
+
+  it("returns the registered document and generates it at most once (memoized)", () => {
+    let calls = 0;
+    registerAtlasOpenApiSource(() => {
+      calls += 1;
+      return SPEC;
+    });
+    expect(getAtlasOpenApiSpec()).toBe(SPEC);
+    expect(getAtlasOpenApiSpec()).toBe(SPEC);
+    expect(calls).toBe(1); // memoized — the ~2.5MB build runs once
+  });
+
+  it("fails SOFT to null (never re-throws) when the source throws", () => {
+    registerAtlasOpenApiSource(() => {
+      throw new Error("boom: spec generation failed");
+    });
+    // Must not throw — a spec-generation failure degrades to zero capabilities,
+    // it does not crash the auth-instance build.
+    expect(getAtlasOpenApiSpec()).toBeNull();
+  });
+
+  it("re-registration clears the memoized document", () => {
+    const first = { info: { title: "first" }, paths: {} } satisfies AtlasOpenApiSpec;
+    const second = { info: { title: "second" }, paths: {} } satisfies AtlasOpenApiSpec;
+    registerAtlasOpenApiSource(() => first);
+    expect(getAtlasOpenApiSpec()).toBe(first);
+    registerAtlasOpenApiSource(() => second);
+    expect(getAtlasOpenApiSpec()).toBe(second);
+  });
+});

--- a/packages/api/src/lib/auth/agent-auth-openapi.ts
+++ b/packages/api/src/lib/auth/agent-auth-openapi.ts
@@ -22,11 +22,13 @@
  *      ONLY, so it would auto-grant admin GETs — we compute the path-aware safe
  *      set ourselves and override it.
  *
- *   2. `resolveCapabilities` — the per-request filter `GET /capability/list` and
- *      `/capability/describe` run. Hides every sensitive capability so an agent
+ *   2. `resolveCapabilities` — the discovery-time filter (`GET /capability/list`,
+ *      `/capability/describe`). Hides every sensitive capability so an agent
  *      never even discovers a write/admin route to ask for. (Visibility only —
- *      the plugin resolves execute/grant against the base `capabilities` array,
- *      not this filtered view, which is why control 3 is also required.)
+ *      the plugin resolves execute/grant against the base `capabilities` array
+ *      and consults `resolveCapabilities` only as a fallback when a cap is
+ *      ABSENT from that array, so it can never REMOVE a base cap from execution,
+ *      which is why control 3 is also required.)
  *
  *   3. `blockedCapabilities` — the hard teeth. The plugin rejects any GRANT for a
  *      blocked capability (`validateCapabilityIds` → `CAPABILITY_BLOCKED`), and

--- a/packages/api/src/lib/auth/agent-auth-openapi.ts
+++ b/packages/api/src/lib/auth/agent-auth-openapi.ts
@@ -1,0 +1,179 @@
+/**
+ * The OpenAPI → Agent-Auth capability adapter (#4410 / #2058, Slice 2).
+ *
+ * Slice 1 shipped ONE hand-written capability. Slice 2 replaces it with the
+ * `@better-auth/agent-auth` OpenAPI adapter so every documented Atlas API
+ * operation becomes an Agent-Auth capability — derived from the spec, with no
+ * hand-maintained list and no drift.
+ *
+ * ── Containing the capability explosion ─────────────────────────────────────
+ *
+ * `createFromOpenAPI` turns EVERY operation (~460 across the Atlas spec) into a
+ * capability, including every write and every operator/admin route. Exposing all
+ * of that just because it is documented is the risk this slice must contain.
+ * Three cooperating controls do so, all driven by ONE `isSensitiveOperation`
+ * predicate (method + path), so the visibility filter and the hard block can
+ * never diverge:
+ *
+ *   1. `defaultHostCapabilities` — the caps auto-granted to a newly created host.
+ *      Limited to the SAFE set: read-only methods (`GET`/`HEAD`) AND not under a
+ *      sensitive path prefix (`/api/v1/admin`, `/api/v1/platform`). NB: the
+ *      adapter's own `defaultHostCapabilities: ["GET","HEAD"]` filters by method
+ *      ONLY, so it would auto-grant admin GETs — we compute the path-aware safe
+ *      set ourselves and override it.
+ *
+ *   2. `resolveCapabilities` — the per-request filter `GET /capability/list` and
+ *      `/capability/describe` run. Hides every sensitive capability so an agent
+ *      never even discovers a write/admin route to ask for. (Visibility only —
+ *      the plugin resolves execute/grant against the base `capabilities` array,
+ *      not this filtered view, which is why control 3 is also required.)
+ *
+ *   3. `blockedCapabilities` — the hard teeth. The plugin rejects any GRANT for a
+ *      blocked capability (`validateCapabilityIds` → `CAPABILITY_BLOCKED`), and
+ *      execution requires an active grant, so a sensitive route can never be
+ *      granted OR executed even if an agent guesses its `operationId`. This is
+ *      the every-write-and-admin set.
+ *
+ * Net: the only reachable adapter-derived surface is read-only, non-admin,
+ * per-org API operations — exactly the analyst-agent surface, and nothing that
+ * mutates state or reads the operator console.
+ *
+ * ── Pure by construction ────────────────────────────────────────────────────
+ *
+ * This module is pure spec-in / options-out: no DB, no Better Auth import, no
+ * `app`. The per-org token binding (`resolveHeaders`) and the in-process proxy
+ * (`fetch`) are injected by `agent-auth-plugin.ts`, keeping the classification
+ * logic here trivially unit-testable against a fixture spec.
+ */
+
+import { createFromOpenAPI } from "@better-auth/agent-auth/openapi";
+import type { AgentAuthOptions } from "@better-auth/agent-auth";
+import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
+
+/** Read-only HTTP methods — the only ones a derived capability may be safe on. */
+export const READ_ONLY_METHODS: ReadonlySet<string> = new Set(["GET", "HEAD"]);
+
+/**
+ * Path prefixes whose operations are operator/admin surface and therefore
+ * sensitive EVEN when read-only — the admin console + platform-ops routes expose
+ * tenant config, audit, approvals, abuse controls, residency, etc. Matched on a
+ * segment boundary (`=== prefix` or `startsWith(prefix + "/")`) so a sibling
+ * like `/api/v1/administrators` (hypothetical) is not swept in by a raw prefix.
+ */
+export const SENSITIVE_PATH_PREFIXES = ["/api/v1/admin", "/api/v1/platform"] as const;
+
+/** The HTTP method + path an `operationId` maps to, recovered from the spec. */
+export interface OperationMeta {
+  readonly method: string;
+  readonly path: string;
+}
+
+/** OpenAPI path-item keys that are not HTTP operations. */
+const NON_OPERATION_KEYS = new Set(["parameters", "servers", "summary", "description"]);
+
+/**
+ * Recover `operationId → { method, path }` from the spec. `createFromOpenAPI`
+ * strips the HTTP method from the `Capability` objects it returns, so we index
+ * the spec ourselves to classify each derived capability. Mirrors the adapter's
+ * own operation walk (skip non-operation keys, require an `operationId`).
+ */
+export function buildOperationIndex(spec: AtlasOpenApiSpec): Map<string, OperationMeta> {
+  const index = new Map<string, OperationMeta>();
+  const paths = spec.paths ?? {};
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!pathItem) continue;
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (NON_OPERATION_KEYS.has(method)) continue;
+      const operationId =
+        operation && typeof operation === "object"
+          ? (operation as { operationId?: unknown }).operationId
+          : undefined;
+      if (typeof operationId !== "string" || operationId.length === 0) continue;
+      index.set(operationId, { method: method.toUpperCase(), path });
+    }
+  }
+  return index;
+}
+
+/** True when `path` sits under a sensitive (operator/admin) prefix. */
+export function isSensitivePath(path: string): boolean {
+  return SENSITIVE_PATH_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
+/**
+ * A capability is SENSITIVE (blocked + hidden) unless it is a read-only method
+ * on a non-admin path. Fails CLOSED: an operation missing from the index (no
+ * recoverable method/path) is treated as sensitive.
+ */
+export function isSensitiveOperation(meta: OperationMeta | undefined): boolean {
+  if (!meta) return true;
+  if (!READ_ONLY_METHODS.has(meta.method.toUpperCase())) return true;
+  return isSensitivePath(meta.path);
+}
+
+/** The subset of `AgentAuthOptions` this adapter produces, spreadable into `agentAuth()`. */
+export type AgentAuthOpenApiOptions = Pick<
+  AgentAuthOptions,
+  | "providerName"
+  | "providerDescription"
+  | "capabilities"
+  | "onExecute"
+  | "defaultHostCapabilities"
+  | "resolveCapabilities"
+  | "blockedCapabilities"
+>;
+
+/**
+ * The proxy transport shape. Deliberately looser than `typeof globalThis.fetch`
+ * (which, under Bun's lib types, additionally requires a `preconnect` method the
+ * in-process `app.fetch` does not implement) — only the call signature matters.
+ */
+export type ProxyFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/** Injected runtime seams — the per-org token binding and the in-process proxy transport. */
+export interface AgentAuthOpenApiDeps {
+  /** Base URL the proxy handler prefixes each operation path with. */
+  readonly baseUrl: string;
+  /** Forwards a real per-org access token as request headers (mints the `x-api-key`). */
+  readonly resolveHeaders: NonNullable<Parameters<typeof createFromOpenAPI>[1]["resolveHeaders"]>;
+  /** Transport for the proxied call — the in-process `app.fetch` in production, a stub in tests. */
+  readonly fetch?: ProxyFetch;
+}
+
+/**
+ * Build the capability set + proxy `onExecute` + the three containment controls
+ * from the Atlas OpenAPI document. Spread the result into `agentAuth({ ... })`.
+ */
+export function buildAgentAuthOpenApiOptions(
+  spec: AtlasOpenApiSpec,
+  deps: AgentAuthOpenApiDeps,
+): AgentAuthOpenApiOptions {
+  const base = createFromOpenAPI(spec, {
+    baseUrl: deps.baseUrl,
+    resolveHeaders: deps.resolveHeaders,
+    // The adapter only ever calls `fetch(url, opts)`; the cast bridges the
+    // `preconnect`-less proxy transport to its `typeof globalThis.fetch` slot.
+    ...(deps.fetch ? { fetch: deps.fetch as unknown as typeof globalThis.fetch } : {}),
+  });
+
+  const index = buildOperationIndex(spec);
+  const capabilities = base.capabilities ?? [];
+
+  const safeNames: string[] = [];
+  const sensitiveNames = new Set<string>();
+  for (const cap of capabilities) {
+    if (isSensitiveOperation(index.get(cap.name))) sensitiveNames.add(cap.name);
+    else safeNames.push(cap.name);
+  }
+
+  return {
+    ...base,
+    // Auto-grant only the read-only, non-admin surface (control 1). Overrides
+    // the adapter's method-only default, which would auto-grant admin GETs.
+    defaultHostCapabilities: safeNames,
+    // Hide sensitive caps from discovery (control 2).
+    resolveCapabilities: ({ capabilities: caps }) => caps.filter((c) => !sensitiveNames.has(c.name)),
+    // Hard-block grant/execute for sensitive caps (control 3).
+    blockedCapabilities: [...sensitiveNames],
+  };
+}

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -1,30 +1,49 @@
 /**
  * The `agentAuth()` Better Auth plugin config — the Agent Auth Protocol spine
- * (#4409 / #2058, Slice 1).
+ * (#4409 Slice 1) now driven by the OpenAPI capability adapter (#4410 / #2058,
+ * Slice 2).
  *
  * Registered UNCONDITIONALLY in `buildPlugins()` (server.ts), so the plugin's
  * routes and its `agent`/`agentHost`/`agentCapabilityGrant`/`approvalRequest`
  * schema are always present (auto-migrated by Better Auth's `ctx.runMigrations()`
- * at boot, like `twoFactor`/`passkey`/`oauthProvider` — no hand-written Atlas
- * migration). Whether the surface is *reachable* is decided per-request by the
- * `ATLAS_AGENT_AUTH_ENABLED` gate (`agent-auth-gate.ts`), NOT by conditional
- * registration — that is what buys live, no-redeploy toggling of a build-once
- * auth singleton. See the decision comment on #2058.
+ * at boot, like `twoFactor`/`passkey`/`oauthProvider`). Whether the surface is
+ * *reachable* is decided per-request by the `ATLAS_AGENT_AUTH_ENABLED` gate
+ * (`agent-auth-gate.ts`), NOT by conditional registration — that is what buys
+ * live, no-redeploy toggling of a build-once auth singleton.
  *
- * Scope for this slice is deliberately narrow: exactly ONE hand-written
- * capability (NOT the OpenAPI adapter — that is Slice 2 / #4410). Its `onExecute`
- * proxies through the in-process API under a real per-org identity — the Atlas
- * idiom for "call ourselves scoped to a workspace" (ADR-0016: bind an `AtlasUser`
- * and run the lib seam under `withRequestContext`, NOT a loopback HTTP call and
- * NOT a plaintext secret in a header). Org scoping is enforced by the resolved
- * `AtlasUser.activeOrganizationId`, so an agent can never reach another
- * workspace's data.
+ * ── Slice 2: OpenAPI adapter, not a hand-written capability ──────────────────
  *
- * Reversibility: this module and `agent-auth-verifier.ts` are the ONLY places
- * that know about agent sessions / agent JWTs. `onExecute` maps the plugin's
- * `agentSession` into the plugin-agnostic `AgentAuthIdentity` and hands it to the
- * verifier (the sixth `AtlasUser` producer). Nothing downstream — the dispatch
- * gate, RBAC, permissions — learns the agent-auth shape.
+ * Slice 1 advertised ONE hand-written capability. Slice 2 replaces it with the
+ * `createFromOpenAPI` adapter (`agent-auth-openapi.ts`): every documented Atlas
+ * API operation becomes a capability, derived from the spec with no
+ * hand-maintained list and no drift. Capability-explosion is contained to the
+ * read-only, non-admin surface by three cooperating controls (see
+ * `agent-auth-openapi.ts`).
+ *
+ * ── How execution stays org-scoped ──────────────────────────────────────────
+ *
+ * The adapter's `onExecute` PROXIES each call through the in-process Atlas API
+ * (`app.fetch`, no socket) rather than reimplementing the operation. The only
+ * Atlas-specific work happens in `resolveHeaders`, which runs per execution:
+ *
+ *   1. Map the plugin's verified `agentSession` into the plugin-agnostic
+ *      `AgentAuthIdentity` and resolve it to a membership-enforced, per-org
+ *      `AtlasUser` (`resolveAgentAuthActor`). A missing / foreign workspace, or a
+ *      lookup failure, is DENIED — this is what enforces cross-workspace
+ *      isolation for every adapter-derived capability.
+ *   2. Re-check the hot-reloadable gate for the RESOLVED workspace so a
+ *      workspace that opted out has its data sealed even when the platform
+ *      default is on (#4419, tier 2). Fail-closed.
+ *   3. Mint a short-lived, workspace-scoped Better Auth API key for that user +
+ *      org and forward it as `x-api-key`. That is a REAL per-org access token,
+ *      not a plaintext secret: the proxied request re-enters the API's normal
+ *      auth path (`resolveApiKeyAuth`), which binds the org from the key's
+ *      metadata and enforces workspace isolation itself — no org-scope bypass.
+ *
+ * Reversibility: this module, `agent-auth-openapi.ts`, and `agent-auth-verifier.ts`
+ * are the ONLY places that know about agent sessions / agent JWTs. Nothing
+ * downstream — the dispatch gate, RBAC, permissions — learns the agent-auth
+ * shape (pinned by `agent-auth-seam-quarantine.test.ts`).
  */
 
 import {
@@ -33,26 +52,31 @@ import {
   AGENT_AUTH_ERROR_CODES,
   type AgentAuthOptions,
   type AgentSession,
-  type Capability,
 } from "@better-auth/agent-auth";
+import { APIError, isAPIError } from "better-auth/api";
 
-import { withRequestContext } from "@atlas/api/lib/logger";
 import { createLogger } from "@atlas/api/lib/logger";
-import { listEntities } from "@atlas/api/lib/semantic/entities";
 import {
   resolveAgentAuthActor,
+  type AgentAuthActorResult,
   type AgentAuthIdentity,
 } from "@atlas/api/lib/auth/agent-auth-verifier";
 import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
+import {
+  buildAgentAuthOpenApiOptions,
+  type AgentAuthOpenApiOptions,
+  type ProxyFetch,
+} from "@atlas/api/lib/auth/agent-auth-openapi";
+import {
+  getAtlasOpenApiSpec,
+  type AtlasOpenApiSpec,
+} from "@atlas/api/lib/auth/atlas-openapi-source";
+import { buildApiKeyMetadata } from "@atlas/api/lib/auth/api-key-metadata";
+import { API_KEY_HEADER } from "@atlas/api/lib/auth/managed";
+import { getUserRole, clampToOrgRole } from "@atlas/api/lib/auth/permissions";
+import type { AtlasUser } from "@atlas/api/lib/auth/types";
 
 const log = createLogger("auth:agent-auth-plugin");
-
-/**
- * The single hand-written capability's name. Exported so the contract test can
- * assert the plugin advertises exactly one capability with this name (Slice 1
- * scope guard against an accidental OpenAPI-adapter expansion).
- */
-export const LIST_ENTITIES_CAPABILITY = "list_semantic_entities";
 
 /**
  * Metadata key on the agent record carrying the workspace the agent proposes to
@@ -61,33 +85,10 @@ export const LIST_ENTITIES_CAPABILITY = "list_semantic_entities";
  */
 export const AGENT_WORKSPACE_METADATA_KEY = "workspaceId";
 
-/**
- * The one capability. No `location` → clients bind the JWT `aud` to the
- * discovery document's `default_location` (the `/capability/execute` URL),
- * which is exactly what the plugin's audience check accepts.
- */
-const listEntitiesCapability: Capability = {
-  name: LIST_ENTITIES_CAPABILITY,
-  description:
-    "List the semantic-layer entities (tables the analyst agent can query) for the agent's own workspace. Read-only.",
-  input: {
-    type: "object",
-    properties: {
-      filter: {
-        type: "string",
-        description: "Optional case-insensitive substring to filter entities by name, table, or description.",
-      },
-    },
-    additionalProperties: false,
-  },
-};
-
-/**
- * The complete capability set the spine advertises. Exported so the contract
- * test can assert Slice 1 ships EXACTLY one hand-written capability — a guard
- * against Slice 2's OpenAPI adapter silently expanding the surface here.
- */
-export const AGENT_AUTH_CAPABILITIES: readonly Capability[] = [listEntitiesCapability];
+/** TTL for a minted workspace API key. Short — the key is a per-execution credential, not a stored secret. */
+const WORKSPACE_KEY_TTL_SECONDS = 15 * 60;
+/** Re-mint when a cached key has less than this remaining, so a proxied call never races expiry. */
+const WORKSPACE_KEY_REFRESH_BEFORE_MS = 2 * 60 * 1000;
 
 /**
  * Read the agent-proposed workspace id off the agent session's metadata,
@@ -113,109 +114,249 @@ function toIdentity(session: AgentSession): AgentAuthIdentity {
   };
 }
 
-/**
- * `onExecute` for the one capability. The plugin has already verified the agent
- * JWT (signature, `aud`, expiry, jti replay) and the capability grant before we
- * run; we add the Atlas-side per-org identity binding and the org-scoped call.
- */
-const onExecute: NonNullable<AgentAuthOptions["onExecute"]> = async ({
-  capability,
-  agentSession,
-  arguments: args,
-}) => {
-  const identity = toIdentity(agentSession);
+/** The typed reasons `resolveAgentAuthActor` can deny for. */
+type DenialReason = Extract<AgentAuthActorResult, { kind: "denied" }>["reason"];
 
-  // Resolve the membership-verified per-org identity. Denials (missing/foreign
-  // workspace, lookup failure) map to a spec-compliant UNAUTHORIZED envelope —
-  // never a partial or cross-workspace result.
+/** Map a resolver denial to its spec-compliant error envelope. */
+function denialError(reason: DenialReason): APIError {
+  return agentError(
+    "FORBIDDEN",
+    AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
+    reason === "not_a_member"
+      ? "Agent is not authorized for the requested workspace."
+      : "Agent identity could not be bound to a workspace.",
+  );
+}
+
+/** The per-execution binding: resolve the agent to a membership-verified per-org user + workspace. */
+async function resolveBoundActor(
+  agentSession: AgentSession,
+): Promise<{ user: AtlasUser; workspaceId: string }> {
+  const identity = toIdentity(agentSession);
   const resolved = await resolveAgentAuthActor(identity);
   if (resolved.kind === "denied") {
     log.warn(
-      { agentId: identity.agentId, capability, reason: resolved.reason },
+      { agentId: identity.agentId, reason: resolved.reason },
       "agent-auth capability execution denied",
     );
-    throw agentError(
-      "FORBIDDEN",
-      AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
-      resolved.reason === "not_a_member"
-        ? "Agent is not authorized for the requested workspace."
-        : "Agent identity could not be bound to a workspace.",
-    );
+    throw denialError(resolved.reason);
   }
 
-  // `workspaceId` is a guaranteed non-empty string on the `ok` arm (encoded in
-  // AgentAuthActorResult), so no defensive undefined-check is needed.
-  const { user, workspaceId } = resolved;
-
-  // Workspace-override precedence (#4409): the raw HTTP gate checks the platform
-  // default; here, with the workspace resolved, honor a per-workspace override.
-  // A workspace that has the feature off must not have its data reachable even
-  // when the platform default is on. Fail-closed.
-  if (!(await isAgentAuthEnabled(workspaceId))) {
+  // Workspace-override precedence (#4419, tier 2): with the workspace resolved,
+  // honor a per-workspace opt-out even when the platform default is on. Fail-closed.
+  if (!(await isAgentAuthEnabled(resolved.workspaceId))) {
     throw agentError(
       "NOT_FOUND",
       AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
       "Agent Auth is not enabled for this workspace.",
     );
   }
+  return { user: resolved.user, workspaceId: resolved.workspaceId };
+}
 
-  const filter =
-    args && typeof args.filter === "string" ? args.filter : undefined;
+/**
+ * Mint (or reuse a cached) short-lived, workspace-scoped Better Auth API key for
+ * the resolved user + org — the "real per-org access token" the proxied call
+ * carries. Server-side mint (no request headers, explicit `userId`) so the key
+ * is OWNED by the agent's owning member and traceable in the audit, exactly like
+ * an admin-minted workspace key (`admin-workspace-keys.ts` / ADR-0027 §6). The
+ * key's LIVE member role is re-resolved at use time and capped at the stored
+ * ceiling, so the agent never acts above its owner's reach.
+ *
+ * NB (documented scope): no RLS claims are threaded — an RLS-enabled workspace
+ * fails CLOSED (rows blocked) rather than leaking, deferring RLS-claim
+ * propagation to a later slice. Managed-mode assumption: the `x-api-key` path is
+ * validated only in managed auth mode (the SaaS path this feature targets);
+ * self-hosted `simple-key`/`none` deploys do not consume Better Auth keys.
+ */
+type MintWorkspaceToken = (input: { user: AtlasUser; workspaceId: string }) => Promise<string>;
 
-  // Bind the per-org identity and run the in-process, org-scoped read. Passing
-  // `orgId` explicitly AND binding the identity is belt-and-suspenders: the call
-  // is org-scoped by construction, and any deeper RLS-aware read runs under the
-  // same bound actor. No secret material is threaded — only the resolved user.
-  //
-  // The read is wrapped: an UNEXPECTED failure (internal-DB brownout, semantic
-  // load/parse error, …) must NOT (a) be silent on Atlas's side, nor (b) let the
-  // plugin's default rethrow echo the raw `err.message` back to the agent — the
-  // least-trusted actor. Log with a correlatable ref, then throw a generic,
-  // non-leaking envelope carrying only that ref. (CLAUDE.md: no silent swallow,
-  // no secrets in responses, requestId on 500s.)
-  const requestId = crypto.randomUUID();
-  try {
-    const entities = await withRequestContext({ requestId, user }, () =>
-      listEntities({ orgId: workspaceId, mode: "published", ...(filter ? { filter } : {}) }),
-    );
-    return {
-      workspaceId,
-      count: entities.length,
-      entities: entities.map((e) => ({
-        name: e.name,
-        table: e.table,
-        description: e.description ?? null,
-      })),
-    };
-  } catch (err) {
-    log.error(
-      {
-        err: err instanceof Error ? err.message : String(err),
-        requestId,
-        agentId: identity.agentId,
-        workspaceId,
-      },
-      "agent-auth capability execution failed while listing semantic entities",
-    );
+/** The Better Auth `apiKey()` plugin's server-side `createApiKey`, narrowed to what we call. */
+export type CreateWorkspaceApiKey = (opts: {
+  body: {
+    userId: string;
+    name: string;
+    metadata: Record<string, unknown>;
+    expiresIn: number;
+  };
+}) => Promise<{ id?: string; key?: string } | undefined>;
+
+/**
+ * Pure minting core (no cache, no auth-instance resolution) — exported so the
+ * per-org token contract is unit-tested directly: server-side `userId` binding,
+ * workspace-scoped metadata, the org-role ceiling, and fail-closed error
+ * envelopes. `createApiKey` is `undefined` on a deployment whose apiKey plugin
+ * didn't register it.
+ */
+export async function mintWorkspaceApiKeyVia(
+  createApiKey: CreateWorkspaceApiKey | undefined,
+  { user, workspaceId }: { user: AtlasUser; workspaceId: string },
+): Promise<string> {
+  if (!createApiKey) {
+    log.error({ workspaceId }, "apiKey plugin createApiKey unavailable — cannot mint per-org agent token");
     throw agentError(
       "INTERNAL_SERVER_ERROR",
       AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
-      `Failed to list semantic entities (ref ${requestId}). Retry; if it persists, contact your operator.`,
+      "Per-org token minting is not available on this deployment.",
     );
   }
+
+  const role = clampToOrgRole(getUserRole(user));
+  const metadata = buildApiKeyMetadata({ orgId: workspaceId, role });
+  const created = await createApiKey({
+    body: {
+      userId: user.id,
+      name: `agent-auth:${workspaceId}`,
+      metadata: metadata as unknown as Record<string, unknown>,
+      expiresIn: WORKSPACE_KEY_TTL_SECONDS,
+    },
+  });
+  if (!created?.key) {
+    throw agentError(
+      "INTERNAL_SERVER_ERROR",
+      AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+      "Could not mint the per-org agent token. Retry shortly.",
+    );
+  }
+  return created.key;
+}
+
+const tokenCache = new Map<string, { token: string; expiresAtMs: number }>();
+
+const mintWorkspaceApiKey: MintWorkspaceToken = async ({ user, workspaceId }) => {
+  const cacheKey = `${user.id}:${workspaceId}`;
+  const now = Date.now();
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAtMs - now > WORKSPACE_KEY_REFRESH_BEFORE_MS) return cached.token;
+
+  // Dynamic import: a static import of `auth/server` would pull its eager
+  // `db/internal` graph into every consumer + break partial-mock tests. Mirrors
+  // the dynamic-import pattern in `admin-workspace-keys.ts`.
+  const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+  const createApiKey = (getAuthInstance().api as { createApiKey?: unknown })
+    .createApiKey as CreateWorkspaceApiKey | undefined;
+  const token = await mintWorkspaceApiKeyVia(createApiKey, { user, workspaceId });
+  tokenCache.set(cacheKey, { token, expiresAtMs: now + WORKSPACE_KEY_TTL_SECONDS * 1000 });
+  return token;
 };
+
+/**
+ * The proxy transport for `onExecute`: route the derived operation through the
+ * in-process Atlas API via `app.fetch` (no network socket), so the real
+ * middleware stack — auth, org scoping, RLS, rate limits, the handler — runs
+ * exactly as for any client. Dynamic import breaks the `server → app` cycle.
+ */
+const inProcessFetch: ProxyFetch = async (input, init) => {
+  const { app } = await import("@atlas/api/api/index");
+  const request =
+    input instanceof Request ? input : new Request(input instanceof URL ? input.href : input, init);
+  return app.fetch(request);
+};
+
+/**
+ * Base URL the proxy prefixes each operation path with. `app.fetch` routes on
+ * the pathname, so only a valid absolute URL is required; a server-side fetch
+ * sends no `Origin`, so CORS never trips.
+ */
+function resolveInternalApiBase(): string {
+  const configured = process.env.BETTER_AUTH_URL?.trim();
+  return configured && configured.length > 0 ? configured.replace(/\/$/, "") : "http://127.0.0.1:3001";
+}
+
+/** Injected seams — real in production, stubbed in tests. */
+export interface AgentAuthPluginDeps {
+  /** The Atlas OpenAPI document capabilities are derived from. */
+  readonly spec: AtlasOpenApiSpec | null;
+  /** Proxy transport for `onExecute`. */
+  readonly fetch: ProxyFetch;
+  /** Per-org token minter. */
+  readonly mintToken: MintWorkspaceToken;
+  /** Base URL the proxy prefixes operation paths with. */
+  readonly baseUrl: string;
+}
+
+function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginDeps {
+  return {
+    spec: overrides?.spec !== undefined ? overrides.spec : getAtlasOpenApiSpec(),
+    fetch: overrides?.fetch ?? inProcessFetch,
+    mintToken: overrides?.mintToken ?? mintWorkspaceApiKey,
+    baseUrl: overrides?.baseUrl ?? resolveInternalApiBase(),
+  };
+}
+
+/**
+ * Build the adapter options (or the inert empty-capability set when no spec is
+ * available — a non-API process, or a spec-generation failure; the surface is
+ * default-off and gated, so zero capabilities is safe).
+ */
+function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
+  if (!deps.spec) {
+    return { capabilities: [], defaultHostCapabilities: [], blockedCapabilities: [] };
+  }
+
+  const resolveHeaders: NonNullable<
+    Parameters<typeof buildAgentAuthOpenApiOptions>[1]["resolveHeaders"]
+  > = async ({ agentSession }) => {
+    const { user, workspaceId } = await resolveBoundActor(agentSession);
+    const token = await deps.mintToken({ user, workspaceId });
+    return { [API_KEY_HEADER]: token };
+  };
+
+  const opts = buildAgentAuthOpenApiOptions(deps.spec, {
+    baseUrl: deps.baseUrl,
+    resolveHeaders,
+    fetch: deps.fetch,
+  });
+
+  // Wrap the adapter's proxy `onExecute` so an UNEXPECTED failure (upstream
+  // brownout, a thrown transport error) does NOT (a) go silent on Atlas's side,
+  // nor (b) echo a raw upstream error body back to the agent — the least-trusted
+  // actor. Intentional denials (`resolveHeaders` throwing an `APIError`) and the
+  // plugin's own typed errors are re-thrown unchanged so their status/envelope
+  // survive; only opaque errors are collapsed to a non-leaking ref. (CLAUDE.md:
+  // no silent swallow, no secrets in responses, requestId on 500s.)
+  const proxyExecute = opts.onExecute;
+  if (!proxyExecute) return opts;
+
+  const onExecute: NonNullable<AgentAuthOptions["onExecute"]> = async (ctx) => {
+    const requestId = crypto.randomUUID();
+    try {
+      return await proxyExecute(ctx);
+    } catch (err) {
+      // Re-throw intentional denials + the plugin's own typed errors unchanged
+      // so their status/envelope survive. `isAPIError` is a STRUCTURAL check —
+      // `agentError` builds its `APIError` from a `@better-auth/core/error` copy
+      // that may be a distinct class identity from this module's import, so a raw
+      // `instanceof` would miss it and collapse a 403/404 denial into a 500.
+      if (isAPIError(err)) throw err;
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), requestId, capability: ctx.capability },
+        "agent-auth openapi proxy execution failed",
+      );
+      throw agentError(
+        "INTERNAL_SERVER_ERROR",
+        AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+        `Failed to execute capability (ref ${requestId}). Retry; if it persists, contact your operator.`,
+      );
+    }
+  };
+
+  return { ...opts, onExecute };
+}
 
 /**
  * Build the `agentAuth()` plugin. Kept as a factory (not a module-level
  * singleton) so `buildPlugins()` composes it like every other plugin and tests
- * can construct it in isolation.
+ * can construct it in isolation with injected seams.
  */
-export function buildAgentAuthPlugin(): ReturnType<typeof agentAuth> {
+export function buildAgentAuthPlugin(
+  overrides?: Partial<AgentAuthPluginDeps>,
+): ReturnType<typeof agentAuth> {
+  const options = buildOptions(resolveDeps(overrides));
   return agentAuth({
     providerName: "Atlas",
     providerDescription:
       "Atlas — deploy-anywhere text-to-SQL data analyst agent (Agent Auth Protocol, experimental).",
-    capabilities: [...AGENT_AUTH_CAPABILITIES],
-    onExecute,
+    ...options,
   });
 }

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -71,7 +71,7 @@ import {
   getAtlasOpenApiSpec,
   type AtlasOpenApiSpec,
 } from "@atlas/api/lib/auth/atlas-openapi-source";
-import { buildApiKeyMetadata } from "@atlas/api/lib/auth/api-key-metadata";
+import { buildApiKeyMetadata, type StoredApiKeyMetadata } from "@atlas/api/lib/auth/api-key-metadata";
 import { API_KEY_HEADER } from "@atlas/api/lib/auth/managed";
 import { getUserRole, clampToOrgRole } from "@atlas/api/lib/auth/permissions";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
@@ -175,8 +175,10 @@ type MintWorkspaceToken = (input: { user: AtlasUser; workspaceId: string }) => P
 export type CreateWorkspaceApiKey = (opts: {
   body: {
     userId: string;
+    // Typed as the exact metadata we build (not a bare `Record`) so the call
+    // site assigns without an `unknown` hop and a shape change is a type error.
+    metadata: StoredApiKeyMetadata;
     name: string;
-    metadata: Record<string, unknown>;
     expiresIn: number;
   };
 }) => Promise<{ id?: string; key?: string } | undefined>;
@@ -187,17 +189,27 @@ export type CreateWorkspaceApiKey = (opts: {
  * workspace-scoped metadata, the org-role ceiling, and fail-closed error
  * envelopes. `createApiKey` is `undefined` on a deployment whose apiKey plugin
  * didn't register it.
+ *
+ * Both failure branches are 500-class. `agentError` builds an `APIError`, so it
+ * bypasses the `onExecute` wrapper's ref injection (the wrapper re-throws
+ * `APIError`s unchanged); each branch therefore logs with its OWN correlatable
+ * `ref` and stamps that `ref` into the agent-facing message, matching the
+ * wrapper's opaque-error path (CLAUDE.md: request IDs on all 500s).
  */
 export async function mintWorkspaceApiKeyVia(
   createApiKey: CreateWorkspaceApiKey | undefined,
   { user, workspaceId }: { user: AtlasUser; workspaceId: string },
 ): Promise<string> {
   if (!createApiKey) {
-    log.error({ workspaceId }, "apiKey plugin createApiKey unavailable — cannot mint per-org agent token");
+    const ref = crypto.randomUUID();
+    log.error(
+      { workspaceId, ref },
+      "apiKey plugin createApiKey unavailable — cannot mint per-org agent token",
+    );
     throw agentError(
       "INTERNAL_SERVER_ERROR",
       AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
-      "Per-org token minting is not available on this deployment.",
+      `Per-org token minting is not available on this deployment (ref ${ref}).`,
     );
   }
 
@@ -207,15 +219,20 @@ export async function mintWorkspaceApiKeyVia(
     body: {
       userId: user.id,
       name: `agent-auth:${workspaceId}`,
-      metadata: metadata as unknown as Record<string, unknown>,
+      metadata,
       expiresIn: WORKSPACE_KEY_TTL_SECONDS,
     },
   });
   if (!created?.key) {
+    const ref = crypto.randomUUID();
+    log.error(
+      { workspaceId, ref },
+      "createApiKey returned no key material — cannot mint per-org agent token",
+    );
     throw agentError(
       "INTERNAL_SERVER_ERROR",
       AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
-      "Could not mint the per-org agent token. Retry shortly.",
+      `Could not mint the per-org agent token (ref ${ref}). Retry shortly.`,
     );
   }
   return created.key;
@@ -285,9 +302,39 @@ function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginD
 }
 
 /**
+ * Recover the HTTP status the adapter embedded in its plain-`Error` message
+ * (`Upstream API error <status>: <body>`). Returns `null` for any message that
+ * doesn't match — a transport error, or an adapter message-format change on a
+ * version bump (which safely falls through to the opaque-500 path).
+ */
+function parseUpstreamStatus(err: unknown): number | null {
+  const message = err instanceof Error ? err.message : String(err);
+  const match = /^Upstream API error (\d{3}):/.exec(message);
+  return match ? Number(match[1]) : null;
+}
+
+/** Map a proxied 4xx to the agent-auth error status label that yields the same code. */
+function upstreamClientErrorLabel(
+  status: number,
+): "BAD_REQUEST" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" {
+  switch (status) {
+    case 401:
+      return "UNAUTHORIZED";
+    case 403:
+      return "FORBIDDEN";
+    case 404:
+      return "NOT_FOUND";
+    default:
+      return "BAD_REQUEST";
+  }
+}
+
+/**
  * Build the adapter options (or the inert empty-capability set when no spec is
  * available — a non-API process, or a spec-generation failure; the surface is
- * default-off and gated, so zero capabilities is safe).
+ * default-off and gated, so zero capabilities is safe). The inert branch needs
+ * no `resolveCapabilities`/`blockedCapabilities` beyond the empties: with zero
+ * base capabilities there is nothing to hide or block.
  */
 function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
   if (!deps.spec) {
@@ -329,6 +376,26 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
       // that may be a distinct class identity from this module's import, so a raw
       // `instanceof` would miss it and collapse a 403/404 denial into a 500.
       if (isAPIError(err)) throw err;
+
+      // The adapter throws a PLAIN Error (`Upstream API error <status>: <body>`)
+      // for every non-2xx proxied response, embedding the raw upstream body. A
+      // deterministic 4xx is the agent's own bad request (invalid args / not
+      // permitted), not a transient fault: surface a client-class envelope
+      // WITHOUT the raw body (no leak) and WITHOUT misleading retry guidance. A
+      // 5xx or an unparseable/transport error falls through to the opaque 500.
+      const upstreamStatus = parseUpstreamStatus(err);
+      if (upstreamStatus !== null && upstreamStatus >= 400 && upstreamStatus < 500) {
+        log.warn(
+          { status: upstreamStatus, requestId, capability: ctx.capability },
+          "agent-auth openapi proxy: upstream rejected the request (client error)",
+        );
+        throw agentError(
+          upstreamClientErrorLabel(upstreamStatus),
+          AGENT_AUTH_ERROR_CODES.INVALID_REQUEST,
+          `The Atlas API rejected this capability call (HTTP ${upstreamStatus}). Check the arguments — it will not succeed on retry unchanged (ref ${requestId}).`,
+        );
+      }
+
       log.error(
         { err: err instanceof Error ? err.message : String(err), requestId, capability: ctx.capability },
         "agent-auth openapi proxy execution failed",
@@ -354,9 +421,13 @@ export function buildAgentAuthPlugin(
 ): ReturnType<typeof agentAuth> {
   const options = buildOptions(resolveDeps(overrides));
   return agentAuth({
+    ...options,
+    // AFTER the spread: `createFromOpenAPI` derives `providerName`/
+    // `providerDescription` from the spec's `info` ("Atlas API" / the API
+    // blurb), but the discovery document should carry Atlas's own branding and
+    // the load-bearing "experimental" signal — so these literals must win.
     providerName: "Atlas",
     providerDescription:
       "Atlas — deploy-anywhere text-to-SQL data analyst agent (Agent Auth Protocol, experimental).",
-    ...options,
   });
 }

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -395,7 +395,12 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
         );
         throw agentError(
           upstreamStatus === 429 ? "TOO_MANY_REQUESTS" : "REQUEST_TIMEOUT",
-          AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+          // Machine-readable code must let an SDK branch throttle-vs-fault: 429
+          // gets the purpose-built `rate_limited`, not the `internal_error` the
+          // genuine-server-fault path uses. (408 has no dedicated code.)
+          upstreamStatus === 429
+            ? AGENT_AUTH_ERROR_CODES.RATE_LIMITED
+            : AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
           `The Atlas API is throttling or timed out (HTTP ${upstreamStatus}). Retry after a short backoff (ref ${requestId}).`,
         );
       }

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -71,6 +71,7 @@ import {
   getAtlasOpenApiSpec,
   type AtlasOpenApiSpec,
 } from "@atlas/api/lib/auth/atlas-openapi-source";
+import { getInProcessApiFetch } from "@atlas/api/lib/auth/in-process-api";
 import { buildApiKeyMetadata, type StoredApiKeyMetadata } from "@atlas/api/lib/auth/api-key-metadata";
 import { API_KEY_HEADER } from "@atlas/api/lib/auth/managed";
 import { getUserRole, clampToOrgRole } from "@atlas/api/lib/auth/permissions";
@@ -261,13 +262,24 @@ const mintWorkspaceApiKey: MintWorkspaceToken = async ({ user, workspaceId }) =>
  * The proxy transport for `onExecute`: route the derived operation through the
  * in-process Atlas API via `app.fetch` (no network socket), so the real
  * middleware stack — auth, org scoping, RLS, rate limits, the handler — runs
- * exactly as for any client. Dynamic import breaks the `server → app` cycle.
+ * exactly as for any client. The transport is obtained from the
+ * `in-process-api` registry (seeded by `api/index.ts`) rather than importing the
+ * `api/` layer here, keeping `lib/` above the route layer (CLAUDE.md). `null`
+ * only in a non-API process, where the surface is spec-less + gated so this
+ * never runs; fail closed with a ref if it somehow does.
  */
 const inProcessFetch: ProxyFetch = async (input, init) => {
-  const { app } = await import("@atlas/api/api/index");
-  const request =
-    input instanceof Request ? input : new Request(input instanceof URL ? input.href : input, init);
-  return app.fetch(request);
+  const fn = getInProcessApiFetch();
+  if (!fn) {
+    const ref = crypto.randomUUID();
+    log.error({ ref }, "in-process API transport unavailable — cannot proxy agent-auth capability");
+    throw agentError(
+      "INTERNAL_SERVER_ERROR",
+      AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+      `The in-process API transport is unavailable (ref ${ref}).`,
+    );
+  }
+  return fn(input, init);
 };
 
 /**

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -313,6 +313,9 @@ function parseUpstreamStatus(err: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
+/** Transient 4xx statuses the agent should retry after a backoff, not treat as a permanent client error. */
+const RETRIABLE_UPSTREAM_STATUS: ReadonlySet<number> = new Set([408, 429]);
+
 /** Map a proxied 4xx to the agent-auth error status label that yields the same code. */
 function upstreamClientErrorLabel(
   status: number,
@@ -378,12 +381,29 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
       if (isAPIError(err)) throw err;
 
       // The adapter throws a PLAIN Error (`Upstream API error <status>: <body>`)
-      // for every non-2xx proxied response, embedding the raw upstream body. A
-      // deterministic 4xx is the agent's own bad request (invalid args / not
-      // permitted), not a transient fault: surface a client-class envelope
-      // WITHOUT the raw body (no leak) and WITHOUT misleading retry guidance. A
-      // 5xx or an unparseable/transport error falls through to the opaque 500.
+      // for every non-2xx proxied response, embedding the raw upstream body.
       const upstreamStatus = parseUpstreamStatus(err);
+
+      // A RETRIABLE 4xx is transient — the proxy re-enters the full Atlas
+      // middleware stack via `app.fetch`, so `checkRateLimit` can return 429 and
+      // a slow handler 408. Tell the agent to back off and retry, NOT that the
+      // call is permanently bad. (Preserve the throttle/timeout status label.)
+      if (upstreamStatus !== null && RETRIABLE_UPSTREAM_STATUS.has(upstreamStatus)) {
+        log.warn(
+          { status: upstreamStatus, requestId, capability: ctx.capability },
+          "agent-auth openapi proxy: upstream throttled/timed out (retriable)",
+        );
+        throw agentError(
+          upstreamStatus === 429 ? "TOO_MANY_REQUESTS" : "REQUEST_TIMEOUT",
+          AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+          `The Atlas API is throttling or timed out (HTTP ${upstreamStatus}). Retry after a short backoff (ref ${requestId}).`,
+        );
+      }
+
+      // A DETERMINISTIC 4xx is the agent's own bad request (invalid args / not
+      // permitted): surface a client-class envelope WITHOUT the raw body (no
+      // leak) and WITHOUT misleading retry guidance. A 5xx or an unparseable/
+      // transport error falls through to the opaque 500.
       if (upstreamStatus !== null && upstreamStatus >= 400 && upstreamStatus < 500) {
         log.warn(
           { status: upstreamStatus, requestId, capability: ctx.capability },

--- a/packages/api/src/lib/auth/atlas-openapi-source.ts
+++ b/packages/api/src/lib/auth/atlas-openapi-source.ts
@@ -1,0 +1,99 @@
+/**
+ * A tiny registry that hands the agent-auth plugin the Atlas API's own OpenAPI
+ * document at plugin-build time WITHOUT a static import cycle (#4410 / #2058,
+ * Slice 2).
+ *
+ * ── Why a registry, not a disk read ─────────────────────────────────────────
+ *
+ * Slice 2 derives one Agent-Auth capability per `operationId` from the Atlas API
+ * spec (`createFromOpenAPI`). The issue points at `apps/docs/openapi.json` as
+ * "the auto-generated source of truth" — but that file is a BUILD artifact that
+ * is NOT copied into the runtime API image (see `deploy/api/Dockerfile`, which
+ * copies `packages/api` but not `apps/docs/openapi.json`). Reading it from disk
+ * at runtime would fail-closed to zero capabilities in the deployed SaaS API.
+ *
+ * The spec `apps/docs/openapi.json` is itself produced by fetching
+ * `GET /api/v1/openapi.json` from the live app (`scripts/extract-openapi.ts`).
+ * So the equivalent, always-present source is to generate the merged document
+ * IN-PROCESS from the same route definitions — which is exactly what the
+ * `/api/v1/openapi.json` handler already does. That handler lives on the `app`
+ * instance in `api/index.ts`; `agent-auth-plugin.ts` cannot statically import
+ * `app` (that module builds the app and mounts the auth handler, so the import
+ * would be circular). This registry inverts the dependency: `api/index.ts`
+ * REGISTERS a thunk that builds the document, and the plugin READS it.
+ *
+ * ── Lifecycle ───────────────────────────────────────────────────────────────
+ *
+ * `getAuthInstance()` (which calls `buildAgentAuthPlugin()`) is lazy — it first
+ * runs on a request, by which time `api/index.ts` has fully evaluated and
+ * registered the source. The thunk is invoked at most once and memoized, so the
+ * ~2.5 MB document is generated a single time on first agent-auth plugin build,
+ * never eagerly at boot (agent-auth is experimental / default-off).
+ *
+ * FAIL SOFT, LOUD: in a process that never imported `api/index.ts` (a CLI, the
+ * MCP package, a unit test that builds the auth instance in isolation) no source
+ * is registered, so `getAtlasOpenApiSpec()` returns `null` and the plugin
+ * advertises zero capabilities. That is safe — the surface is default-off and
+ * request-gated — but it is logged so a genuinely missing registration in the
+ * real API process is visible rather than silent.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { createFromOpenAPI } from "@better-auth/agent-auth/openapi";
+
+const log = createLogger("auth:atlas-openapi-source");
+
+/**
+ * The OpenAPI 3.x document shape `createFromOpenAPI` consumes. Derived from its
+ * parameter type so a `@better-auth/agent-auth` bump that reshapes the accepted
+ * spec surfaces here as a type error rather than at runtime. (`@better-auth/
+ * agent-auth/openapi` does not export the `OpenAPISpec` interface itself.)
+ */
+export type AtlasOpenApiSpec = Parameters<typeof createFromOpenAPI>[0];
+
+let source: (() => AtlasOpenApiSpec) | null = null;
+let cached: AtlasOpenApiSpec | null = null;
+
+/**
+ * Register the thunk that builds the in-process Atlas OpenAPI document. Called
+ * once from `api/index.ts` after the app + routes are defined. Registering
+ * clears any memoized document so a re-registration (only tests do this) is
+ * honored.
+ */
+export function registerAtlasOpenApiSource(fn: () => AtlasOpenApiSpec): void {
+  source = fn;
+  cached = null;
+}
+
+/**
+ * The registered Atlas OpenAPI document, generated once and memoized. Returns
+ * `null` when no source is registered or when generation throws — the plugin
+ * treats that as "zero capabilities", keeping the (default-off) surface inert
+ * rather than crashing the auth-instance build.
+ */
+export function getAtlasOpenApiSpec(): AtlasOpenApiSpec | null {
+  if (cached) return cached;
+  if (!source) {
+    log.warn(
+      "No Atlas OpenAPI source registered — agent-auth will advertise zero capabilities. " +
+        "Expected in non-API processes (CLI/MCP/isolated tests); a warning here in the API process means api/index.ts did not register the source.",
+    );
+    return null;
+  }
+  try {
+    cached = source();
+    return cached;
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Atlas OpenAPI source threw while building the spec — agent-auth will advertise zero capabilities",
+    );
+    return null;
+  }
+}
+
+/** @internal test-only — reset the registry so a suite starts from a clean slate. */
+export function __resetAtlasOpenApiSourceForTest(): void {
+  source = null;
+  cached = null;
+}

--- a/packages/api/src/lib/auth/in-process-api.ts
+++ b/packages/api/src/lib/auth/in-process-api.ts
@@ -1,0 +1,37 @@
+/**
+ * A tiny registry handing the agent-auth OpenAPI proxy an in-process transport
+ * to the Atlas API — `app.fetch`, no network socket (#4410).
+ *
+ * The adapter's `onExecute` forwards each derived operation THROUGH the real
+ * Atlas app so the normal middleware stack (auth, org scoping, RLS, rate limits,
+ * the handler) runs exactly as for any client. That transport is `app.fetch`,
+ * and `app` lives in `api/index.ts`. A `lib/` module must not import the `api/`
+ * layer (CLAUDE.md — it pulls the app graph into every consumer and breaks
+ * partial `mock.module()` mocks), so we invert the dependency exactly like
+ * `atlas-openapi-source.ts`: `api/index.ts` REGISTERS the transport, and the
+ * plugin READS it. Registration happens at module-eval of `api/index.ts` (a
+ * one-line thunk, no cost), before any request can reach the lazy auth instance.
+ *
+ * `null` when unregistered (a non-API process): the plugin surfaces a clean
+ * failure instead of executing — a process that never built the app has no
+ * in-process API to proxy to.
+ */
+
+import type { ProxyFetch } from "@atlas/api/lib/auth/agent-auth-openapi";
+
+let transport: ProxyFetch | null = null;
+
+/** Register the in-process `app.fetch` transport. Called once from `api/index.ts`. */
+export function registerInProcessApiFetch(fn: ProxyFetch): void {
+  transport = fn;
+}
+
+/** The registered in-process API transport, or `null` if none was registered. */
+export function getInProcessApiFetch(): ProxyFetch | null {
+  return transport;
+}
+
+/** @internal test-only — reset the registry. */
+export function __resetInProcessApiFetchForTest(): void {
+  transport = null;
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2835,17 +2835,21 @@ export function buildPlugins() {
     }),
   );
 
-  // Agent Auth Protocol spine (#4409 / #2058, Slice 1) — registered
-  // UNCONDITIONALLY, exactly like twoFactor/passkey above. This keeps the
-  // plugin's routes and its agent/agentHost/agentCapabilityGrant/approvalRequest
-  // schema always present (Better Auth `ctx.runMigrations()` auto-creates the
-  // tables at boot), so the build-once auth singleton never has to be rebuilt to
-  // toggle the feature. Whether the surface is *reachable* is decided per-request
-  // by the hot-reloadable `ATLAS_AGENT_AUTH_ENABLED` gate (agent-auth-gate.ts),
+  // Agent Auth Protocol spine (#4409 / #2058) — registered UNCONDITIONALLY,
+  // exactly like twoFactor/passkey above. This keeps the plugin's routes and its
+  // agent/agentHost/agentCapabilityGrant/approvalRequest schema always present
+  // (Better Auth `ctx.runMigrations()` auto-creates the tables at boot), so the
+  // build-once auth singleton never has to be rebuilt to toggle the feature.
+  // Whether the surface is *reachable* is decided per-request by the
+  // hot-reloadable `ATLAS_AGENT_AUTH_ENABLED` gate (agent-auth-gate.ts),
   // consulted in the catch-all auth router and the discovery route — default OFF,
   // fail-closed, no redeploy to flip. The `jwt()` plugin pushed above satisfies
-  // the JWT/JWKS dependency. Kept experimental (upstream spec is a moving draft);
-  // scope is ONE hand-written capability, not the OpenAPI adapter (Slice 2).
+  // the JWT/JWKS dependency. Kept experimental (upstream spec is a moving draft).
+  // Slice 2 (#4410): capabilities are DERIVED from the in-process Atlas OpenAPI
+  // spec via `createFromOpenAPI` (agent-auth-openapi.ts), contained to the
+  // read-only non-admin surface; execution proxies through the in-process API
+  // under a real per-org token. `buildAgentAuthPlugin()` reads the spec through
+  // the `atlas-openapi-source` registry seeded by `api/index.ts`.
   plugins.push(buildAgentAuthPlugin());
 
   // SCIM directory sync — enterprise only.


### PR DESCRIPTION
## Summary

Closes #4410 (Slice 2 of #2058). Replaces Slice 1's single hand-written Agent-Auth capability with the `@better-auth/agent-auth` OpenAPI adapter, so **every documented Atlas API operation becomes an Agent-Auth capability** — derived from the spec via `createFromOpenAPI`, with no hand-maintained list and no drift. Feature stays experimental and default-off behind the hot-reloadable `ATLAS_AGENT_AUTH_ENABLED` gate from #4409.

**Containing the capability explosion.** `createFromOpenAPI` turns all ~460 operations into capabilities, including every write and every operator/admin route. One `isSensitiveOperation` predicate (method + path) drives three cooperating controls so visibility and hard-block can never diverge:
- `defaultHostCapabilities` — auto-grant limited to the **safe** set: read-only (`GET`/`HEAD`) **and** not under `/api/v1/admin` or `/api/v1/platform`. (The adapter's own `["GET","HEAD"]` default filters by method only, so it would auto-grant admin GETs — we compute the path-aware set and override it.)
- `resolveCapabilities` — hides sensitive caps from discovery (`/capability/list`, `/describe`).
- `blockedCapabilities` — the teeth: the plugin rejects any grant for a blocked cap, and execution requires an active grant, so a write/admin route can never be granted or executed even if its `operationId` is guessed.

**Org-scoped execution.** The adapter's `onExecute` proxies each call **through the in-process Atlas API** (`app.fetch`, no socket) so the real middleware stack runs as for any client. `resolveHeaders` resolves the agent to a membership-verified per-org `AtlasUser`, re-checks the per-workspace enablement gate (fail-closed), and mints a short-lived workspace-scoped Better Auth API key forwarded as `x-api-key` — a real per-org token whose org scope the API's own auth path enforces (no plaintext secrets, no org-scope bypass). Unexpected proxy failures collapse to a non-leaking ref; deterministic 4xx surface a client envelope; retriable 4xx (429/408) advise backoff; intentional denials keep their 403/404 envelope.

**Spec wiring.** The Atlas spec is generated in-process (the `apps/docs/openapi.json` snapshot isn't copied into the runtime image) and handed to the plugin via two small `lib/` registries seeded by `api/index.ts` (spec source + `app.fetch` transport), so `lib/` never imports the `api/` layer.

### Key files
- `packages/api/src/lib/auth/agent-auth-openapi.ts` (new) — the pure OpenAPI→capability adapter + the three-control containment.
- `packages/api/src/lib/auth/agent-auth-plugin.ts` — swaps the hand-written capability for the adapter; `resolveHeaders` per-org binding + token mint; error-hygiene wrapper.
- `packages/api/src/lib/auth/atlas-openapi-source.ts`, `in-process-api.ts` (new) — dependency-inverting registries seeded by `api/index.ts`.

## Test Plan

- [x] Manual testing — n/a (experimental, default-off; driven end-to-end through a real `betterAuth()` instance in tests)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

Coverage (`agent-auth-plugin.test.ts`, `atlas-openapi-source.test.ts`):
- Classification branches (safe read / write / admin / platform / fail-closed); the `operationId` join pinned against real `fromOpenAPI` output.
- All three controls asserted from `buildAgentAuthOpenApiOptions`, **and** against the real ~460-op `apps/docs/openapi.json` (no write/admin op auto-grantable; every sensitive op blocked).
- JWT/grant verification matrix (wrong aud / expired / revoked / missing-claim), per-org token mint + forward, cross-workspace isolation, per-workspace override.
- Error hygiene: opaque 500 + 5xx (no raw body leak, ref present), deterministic 4xx client envelope, retriable 429 (`rate_limited`, backoff).
- Registry fail-soft branches (no source / source throws → null, memoize, re-register).

Internal review panel (silent-failure / type-design / test-coverage / comment axes) run to CLEAN over 3 rounds.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — experimental, default-off; no user-facing change yet

https://claude.ai/code/session_01CSETsWYJZG1goPq2ACFW9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSETsWYJZG1goPq2ACFW9S)_