### PR TITLE
feat(auth): agent-auth consent + device-approval UI

### DIFF
--- a/packages/api/src/lib/auth/__tests__/agent-approval-page.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-approval-page.test.ts
@@ -1,0 +1,37 @@
+/**
+ * `resolveAgentApprovalPage` — the `deviceAuthorizationPage` URL for the Agent
+ * Auth device-approval flow (#4411). Mirrors `device-verification-uri.test.ts`:
+ * an absolute web-origin URL when the origin resolves, the bare relative path
+ * only for a genuinely single-origin embedded deploy.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveAgentApprovalPage,
+  AGENT_APPROVAL_PATH,
+} from "@atlas/api/lib/auth/agent-approval-page";
+
+describe("resolveAgentApprovalPage (#4411)", () => {
+  it("returns an absolute web-origin URL when the web origin resolves", () => {
+    expect(resolveAgentApprovalPage("https://app.useatlas.dev")).toBe(
+      "https://app.useatlas.dev/agent/approve",
+    );
+  });
+
+  it("targets the WEB origin, not the API origin (the page 404s on api.*)", () => {
+    const uri = resolveAgentApprovalPage("https://app.staging.useatlas.dev");
+    expect(uri).toBe("https://app.staging.useatlas.dev/agent/approve");
+    expect(uri).not.toContain("api.");
+  });
+
+  it("strips a trailing slash so the URL never doubles up (`//agent/approve`)", () => {
+    expect(resolveAgentApprovalPage("http://localhost:3000/")).toBe(
+      "http://localhost:3000/agent/approve",
+    );
+  });
+
+  it("falls back to the bare relative path for a single-origin embedded deploy (null origin)", () => {
+    expect(resolveAgentApprovalPage(null)).toBe(AGENT_APPROVAL_PATH);
+    expect(AGENT_APPROVAL_PATH).toBe("/agent/approve");
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/agent-auth-device-approval.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-device-approval.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Agent Auth device-authorization approval round-trip (#4411 Slice 3).
+ *
+ * Drives the REAL `buildAgentAuthPlugin()` through a real `betterAuth()`
+ * instance (in-memory adapter, the same harness `agent-auth-plugin.test.ts`
+ * uses) to prove the browser-approval half of the device flow end-to-end:
+ *
+ *   - APPROVE: a signed-in human POSTs `/agent/approve-capability` with the
+ *     device `user_code` + `action: "approve"` → the pending capability grant
+ *     transitions to `active` (the capability is now executable). This is the
+ *     "request → approve → grant active" acceptance path.
+ *   - DENY: the same POST with `action: "deny"` transitions the pending grant
+ *     to `denied` and never activates it → the grant is left UNUSABLE. This is
+ *     the "deny leaves the grant unusable" acceptance path.
+ *   - USER-CODE BINDING: an approve with the WRONG code is rejected
+ *     (`invalid_user_code`) and the grant stays pending — the device round-trip
+ *     can't be completed without the code shown to the human.
+ *
+ * The approval endpoint is the plugin's own (`use: [sessionMiddleware]`), so a
+ * genuine Better Auth session is minted via `signUpEmail` and its cookie is
+ * forwarded — this exercises the real ownership + user-code checks, not a
+ * re-implementation. The agent/host/grant/approval rows are created through the
+ * live adapter AFTER signup so they reference the freshly-minted user id.
+ *
+ * Self-contained: `ATLAS_AGENT_AUTH_ENABLED` is not touched (the plugin's
+ * approval handler is not gated by it — the HTTP router is, and that
+ * setting-off→404 fail-closed gate is covered by
+ * `src/api/__tests__/agent-auth-live-toggle.test.ts` +
+ * `agent-auth-gate.test.ts`).
+ */
+
+import { describe, it, expect, beforeAll } from "bun:test";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { createHash } from "node:crypto";
+import { buildAgentAuthPlugin } from "@atlas/api/lib/auth/agent-auth-plugin";
+import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
+
+const BASE = "http://localhost:3000";
+const APPROVE_URL = `${BASE}/api/auth/agent/approve-capability`;
+const WEB_APPROVAL_PAGE = "http://localhost:4000/agent/approve";
+
+/** A safe (non-blocked) read capability the pending grant targets. */
+const SAFE_CAP = "getMe";
+
+const FIXTURE_SPEC = {
+  info: { title: "Atlas API", description: "fixture" },
+  paths: {
+    "/api/v1/me": { get: { operationId: "getMe", description: "current user" } },
+  },
+} satisfies AtlasOpenApiSpec;
+
+/**
+ * The plugin stores `hashToken(userCode)` = base64url(SHA-256(userCode)) with no
+ * padding — identical to Node's `digest("base64url")`. Seeding the same hash
+ * lets us submit the plaintext code and hit the real match path.
+ */
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("base64url");
+}
+
+/** Matches the plugin's `generateUserCode()` shape (`XXXX-XXXX`), stable for the seed. */
+const USER_CODE = "ABCD-2345";
+
+interface SignedUpUser {
+  userId: string;
+  cookie: string;
+}
+
+/** Build a fresh instance so each test gets an isolated in-memory store. */
+function makeInstance() {
+  const plugin = buildAgentAuthPlugin({
+    spec: FIXTURE_SPEC,
+    fetch: async () => new Response("{}", { status: 200 }),
+    mintToken: async () => "unused-token",
+    baseUrl: "http://internal",
+    deviceAuthorizationPage: WEB_APPROVAL_PAGE,
+  });
+  return betterAuth({
+    baseURL: BASE,
+    secret: "test-secret-at-least-32-characters-long!!",
+    emailAndPassword: { enabled: true },
+    database: memoryAdapter({
+      user: [], session: [], account: [], verification: [],
+      agent: [], agentHost: [], agentCapabilityGrant: [], approvalRequest: [],
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
+    plugins: [plugin] as any[],
+  });
+}
+
+type Instance = ReturnType<typeof makeInstance>;
+
+/** Sign up a user and return its id + a forwardable Cookie header. */
+async function signUp(instance: Instance, email: string): Promise<SignedUpUser> {
+  const { headers, response } = await instance.api.signUpEmail({
+    body: { email, password: "password123", name: "Approver" },
+    returnHeaders: true,
+  });
+  const cookie = headers
+    .getSetCookie()
+    .map((c) => c.split(";")[0])
+    .join("; ");
+  return { userId: response.user.id, cookie };
+}
+
+/**
+ * Seed a device-authorization approval scenario for `userId`: an active
+ * delegated agent, its host, a PENDING grant for {@link SAFE_CAP}, and a pending
+ * `device_authorization` approval request whose `userCodeHash` matches
+ * {@link USER_CODE}. Returns the agent id.
+ */
+async function seedPendingApproval(instance: Instance, userId: string): Promise<string> {
+  const ctx = await instance.$context;
+  const now = new Date();
+  const host = await ctx.adapter.create<Record<string, unknown>>({
+    model: "agentHost",
+    data: {
+      name: "h", userId, defaultCapabilities: "[]", publicKey: null, kid: null,
+      jwksUrl: null, enrollmentTokenHash: null, enrollmentTokenExpiresAt: null,
+      status: "active", activatedAt: now, expiresAt: null, lastUsedAt: null,
+      createdAt: now, updatedAt: now,
+    },
+  });
+  const hostId = host.id as string;
+  const agent = await ctx.adapter.create<Record<string, unknown>>({
+    model: "agent",
+    data: {
+      name: "reporting-agent", userId, hostId, status: "active", mode: "delegated",
+      publicKey: "{}", kid: null, jwksUrl: null, lastUsedAt: null, activatedAt: now,
+      expiresAt: null, metadata: null, createdAt: now, updatedAt: now,
+    },
+  });
+  const agentId = agent.id as string;
+  await ctx.adapter.create({
+    model: "agentCapabilityGrant",
+    data: {
+      agentId, capability: SAFE_CAP, deniedBy: null, grantedBy: userId,
+      expiresAt: null, status: "pending", constraints: null, createdAt: now, updatedAt: now,
+    },
+  });
+  await ctx.adapter.create({
+    model: "approvalRequest",
+    data: {
+      method: "device_authorization", agentId, hostId, userId, capabilities: null,
+      status: "pending", userCodeHash: hashToken(USER_CODE), loginHint: null,
+      bindingMessage: null, clientNotificationToken: null, clientNotificationEndpoint: null,
+      deliveryMode: null, interval: 5, lastPolledAt: null,
+      expiresAt: new Date(now.getTime() + 300_000), createdAt: now, updatedAt: now,
+    },
+  });
+  return agentId;
+}
+
+/** GET the signed-in user's pending approvals (device + CIBA). */
+async function getPending(
+  instance: Instance,
+  cookie: string,
+): Promise<{ status: number; requests: Array<Record<string, unknown>> }> {
+  const res = await instance.handler(
+    new Request(`${BASE}/api/auth/agent/ciba/pending`, {
+      method: "GET",
+      headers: { cookie },
+    }),
+  );
+  const parsed = (await res.json().catch(() => ({}))) as { requests?: Array<Record<string, unknown>> };
+  await instance.$context.catch(() => {});
+  return { status: res.status, requests: parsed.requests ?? [] };
+}
+
+async function grantStatus(instance: Instance, agentId: string): Promise<string | undefined> {
+  const ctx = await instance.$context;
+  const grant = await ctx.adapter.findOne<{ status?: string }>({
+    model: "agentCapabilityGrant",
+    where: [{ field: "agentId", value: agentId }],
+  });
+  return grant?.status;
+}
+
+async function postApproval(
+  instance: Instance,
+  cookie: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; body: { status?: string; error?: string } }> {
+  const res = await instance.handler(
+    new Request(APPROVE_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(body),
+    }),
+  );
+  const parsed = (await res.json().catch(() => ({}))) as { status?: string; error?: string };
+  await instance.$context.catch(() => {});
+  return { status: res.status, body: parsed };
+}
+
+describe("Agent Auth device-approval round-trip (#4411)", () => {
+  let instance: Instance;
+  let approver: SignedUpUser;
+
+  beforeAll(() => {
+    // Sanity: the plugin defaults the page to /device/capabilities; we inject
+    // the Atlas web page so the whole surface points at src/app/agent/approve.
+    expect(WEB_APPROVAL_PAGE).toContain("/agent/approve");
+  });
+
+  it("GET /agent/ciba/pending returns the device request in the snake_case shape the web resolver reads", async () => {
+    // Pins the wire contract `resolvePendingApproval` (packages/web) depends on:
+    // the field NAMES + the `method: "device_authorization"` discriminant.
+    // A @better-auth/agent-auth bump that renamed any of these would go RED here
+    // instead of silently making the approval page show "no pending request".
+    instance = makeInstance();
+    approver = await signUp(instance, "pending@example.com");
+    const agentId = await seedPendingApproval(instance, approver.userId);
+
+    const { status, requests } = await getPending(instance, approver.cookie);
+    expect(status).toBe(200);
+    const req = requests.find((r) => r.agent_id === agentId);
+    expect(req).toBeDefined();
+    expect(req?.method).toBe("device_authorization");
+    expect(typeof req?.approval_id).toBe("string");
+    // Every field the web resolver maps must be present under its snake_case key.
+    for (const key of [
+      "approval_id",
+      "method",
+      "agent_id",
+      "agent_name",
+      "binding_message",
+      "capabilities",
+      "capability_reasons",
+      "expires_in",
+    ]) {
+      expect(req && key in req).toBe(true);
+    }
+  });
+
+  it("approve with the correct user code → pending grant becomes active (executable)", async () => {
+    instance = makeInstance();
+    approver = await signUp(instance, "approve@example.com");
+    const agentId = await seedPendingApproval(instance, approver.userId);
+    expect(await grantStatus(instance, agentId)).toBe("pending");
+
+    const { status, body } = await postApproval(instance, approver.cookie, {
+      agent_id: agentId,
+      user_code: USER_CODE,
+      action: "approve",
+    });
+
+    expect(status).toBe(200);
+    expect(body.status).toBe("approved");
+    expect(await grantStatus(instance, agentId)).toBe("active");
+  });
+
+  it("deny leaves the grant UNUSABLE — it transitions to denied, never active", async () => {
+    instance = makeInstance();
+    approver = await signUp(instance, "deny@example.com");
+    const agentId = await seedPendingApproval(instance, approver.userId);
+
+    const { status, body } = await postApproval(instance, approver.cookie, {
+      agent_id: agentId,
+      action: "deny",
+    });
+
+    expect(status).toBe(200);
+    expect(body.status).toBe("denied");
+    expect(await grantStatus(instance, agentId)).toBe("denied");
+    expect(await grantStatus(instance, agentId)).not.toBe("active");
+  });
+
+  it("approve with the WRONG user code is rejected and the grant stays pending", async () => {
+    instance = makeInstance();
+    approver = await signUp(instance, "wrongcode@example.com");
+    const agentId = await seedPendingApproval(instance, approver.userId);
+
+    const { status, body } = await postApproval(instance, approver.cookie, {
+      agent_id: agentId,
+      user_code: "ZZZZ-9999",
+      action: "approve",
+    });
+
+    expect(status).toBeGreaterThanOrEqual(400);
+    expect(body.error).toBe("invalid_user_code");
+    expect(await grantStatus(instance, agentId)).toBe("pending");
+  });
+});

--- a/packages/api/src/lib/auth/agent-approval-page.ts
+++ b/packages/api/src/lib/auth/agent-approval-page.ts
@@ -1,0 +1,42 @@
+/**
+ * Resolve the `deviceAuthorizationPage` for the Agent Auth Protocol
+ * device-authorization approval flow (#4411 / #2058, Slice 3).
+ *
+ * When an agent requests a capability whose approval strength requires user
+ * presence, the `@better-auth/agent-auth` device-code flow returns a
+ * `verification_uri` (+ `verification_uri_complete`) pointing at this page. A
+ * signed-in human opens it, sees the pending capability request, and
+ * approves/denies. The plugin does NOT serve the page — Atlas implements it in
+ * `packages/web` at `src/app/agent/approve/page.tsx`.
+ *
+ * Exactly the same web-origin problem the CLI device flow solves in
+ * `resolveDeviceVerificationUri`: the approval page lives on the WEB origin
+ * (`app.<env>.useatlas.dev`), but the agent-auth plugin resolves a *relative*
+ * `deviceAuthorizationPage` against its own base URL (the API origin), so a bare
+ * `"/agent/approve"` becomes `https://api.<env>.useatlas.dev/agent/approve`,
+ * which 404s (there is no such route on the API host). Handing the plugin an
+ * ABSOLUTE web-app URL makes both `verification_uri` and
+ * `verification_uri_complete` (base + `?agent_id=&code=`) resolve to the page
+ * that actually renders.
+ *
+ * `getWebOrigin()` is the same region/env-aware source `resolveDeviceVerificationUri`
+ * uses, so the agent-approval URL stays consistent with the CLI `/device` URL
+ * across regions. It is null only when NONE of `ATLAS_CORS_ORIGIN`,
+ * `BETTER_AUTH_TRUSTED_ORIGINS`, or a region resolves — a genuinely
+ * single-origin embedded deploy (e.g. `nextjs-standalone` with the Hono API
+ * mounted on the web app's own origin), where the relative `/agent/approve`
+ * resolves correctly against that shared origin.
+ *
+ * The `.replace(/\/+$/, "")` makes the module own its own no-trailing-slash
+ * precondition (avoids `//agent/approve`) rather than trusting every caller —
+ * even though `getWebOrigin()` already strips trailing slashes today.
+ */
+
+/** The web route (in `packages/web`) that renders the approval page. */
+export const AGENT_APPROVAL_PATH = "/agent/approve";
+
+export function resolveAgentApprovalPage(webOrigin: string | null): string {
+  return webOrigin
+    ? `${webOrigin.replace(/\/+$/, "")}${AGENT_APPROVAL_PATH}`
+    : AGENT_APPROVAL_PATH;
+}

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -62,6 +62,8 @@ import {
   type AgentAuthIdentity,
 } from "@atlas/api/lib/auth/agent-auth-verifier";
 import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
+import { resolveAgentApprovalPage } from "@atlas/api/lib/auth/agent-approval-page";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import {
   buildAgentAuthOpenApiOptions,
   type AgentAuthOpenApiOptions,
@@ -302,6 +304,13 @@ export interface AgentAuthPluginDeps {
   readonly mintToken: MintWorkspaceToken;
   /** Base URL the proxy prefixes operation paths with. */
   readonly baseUrl: string;
+  /**
+   * The device-authorization approval page (#4411). Absolute WEB-origin URL so
+   * the plugin's `verification_uri` resolves to the page that actually renders
+   * (`packages/web` `src/app/agent/approve/page.tsx`) rather than a 404 on the
+   * API host — see `resolveAgentApprovalPage`.
+   */
+  readonly deviceAuthorizationPage: string;
 }
 
 function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginDeps {
@@ -310,6 +319,8 @@ function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginD
     fetch: overrides?.fetch ?? inProcessFetch,
     mintToken: overrides?.mintToken ?? mintWorkspaceApiKey,
     baseUrl: overrides?.baseUrl ?? resolveInternalApiBase(),
+    deviceAuthorizationPage:
+      overrides?.deviceAuthorizationPage ?? resolveAgentApprovalPage(getWebOrigin()),
   };
 }
 
@@ -456,9 +467,16 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
 export function buildAgentAuthPlugin(
   overrides?: Partial<AgentAuthPluginDeps>,
 ): ReturnType<typeof agentAuth> {
-  const options = buildOptions(resolveDeps(overrides));
+  const deps = resolveDeps(overrides);
+  const options = buildOptions(deps);
   return agentAuth({
     ...options,
+    // Point the device-authorization approval flow (#4411) at the Atlas web
+    // page. Absolute WEB-origin URL — a bare path would resolve against the API
+    // origin and 404 (see `resolveAgentApprovalPage`). Set outside the OpenAPI
+    // `options` spread because it's a top-level plugin option, not an adapter
+    // field; the adapter never touches it, so ordering is immaterial.
+    deviceAuthorizationPage: deps.deviceAuthorizationPage,
     // AFTER the spread: `createFromOpenAPI` derives `providerName`/
     // `providerDescription` from the spec's `info` ("Atlas API" / the API
     // blurb), but the discovery document should carry Atlas's own branding and

--- a/packages/web/src/app/agent/approve/layout.tsx
+++ b/packages/web/src/app/agent/approve/layout.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Approve an agent — Atlas",
+  description:
+    "Review the capability an AI agent is requesting and approve or deny access to your workspace.",
+  // The agent-approval screen carries a one-shot device code + capability
+  // request and must never be indexed or cached (#4411 / #2058), exactly like
+  // the OAuth consent and CLI device screens it mirrors.
+  robots: { index: false, follow: false },
+};
+
+export default function AgentApproveLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main
+      id="main"
+      className="relative flex min-h-dvh items-center justify-center overflow-hidden bg-background p-4"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10
+          bg-[radial-gradient(60%_50%_at_50%_0%,color-mix(in_oklch,var(--primary)_10%,transparent)_0%,transparent_70%)]"
+      />
+      <div className="w-full max-w-md">{children}</div>
+    </main>
+  );
+}

--- a/packages/web/src/app/agent/approve/page.test.tsx
+++ b/packages/web/src/app/agent/approve/page.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Coverage for the Agent Auth device-approval page (#4411).
+ *
+ * Pins the browser round-trip: render the pending capability request, POST the
+ * user's decision to `/agent/approve-capability` with the right body, and render
+ * the terminal state. Also pins the fail-closed gate (404 → "not available"),
+ * the not-signed-in login bounce, and the expired/handled ("no pending request")
+ * path.
+ *
+ * `mock.module(...)` covers every named export it stubs (repo rule) so a sibling
+ * test importing a different export doesn't trip a partial-mock error.
+ */
+
+import {
+  describe,
+  expect,
+  test,
+  mock,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import {
+  render,
+  fireEvent,
+  waitFor,
+  cleanup,
+  screen,
+} from "@testing-library/react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+type Session = {
+  isPending: boolean;
+  data: { user: { id: string; email: string } } | null;
+};
+const sessionStore: { value: Session } = {
+  value: { isPending: false, data: { user: { id: "user_1", email: "dev@useatlas.dev" } } },
+};
+
+mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => sessionStore.value,
+  },
+}));
+
+const searchParamsStore: Record<string, string | null> = {
+  agent_id: "agent_1",
+  code: "ABCD-2345",
+};
+mock.module("next/navigation", () => ({
+  useSearchParams: () => ({ get: (k: string) => searchParamsStore[k] ?? null }),
+}));
+
+// Spread the real module so every named export stays present (repo rule),
+// overriding only `getApiUrl` to a fixed cross-origin API host.
+import * as apiUrlReal from "@/lib/api-url";
+mock.module("@/lib/api-url", () => ({
+  ...apiUrlReal,
+  getApiUrl: () => "https://api.useatlas.dev",
+}));
+
+import AgentApprovePage from "./page";
+
+// ── fetch stub ──────────────────────────────────────────────────────────
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: Record<string, unknown> | null;
+}
+const fetchCalls: FetchCall[] = [];
+
+/** Response the pending-list GET returns; overridable per test. */
+let pendingResponder: () => Response = () =>
+  jsonResponse(200, {
+    requests: [
+      {
+        approval_id: "appr_1",
+        method: "device_authorization",
+        agent_id: "agent_1",
+        agent_name: "Reporting Agent",
+        binding_message: "Weekly revenue report",
+        capabilities: ["getMe"],
+        capability_reasons: { getMe: "Identify the caller" },
+        expires_in: 300,
+      },
+    ],
+  });
+/** Response the approve/deny POST returns; overridable per test. */
+let approveResponder: () => Response = () => jsonResponse(200, { status: "approved" });
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  sessionStore.value = {
+    isPending: false,
+    data: { user: { id: "user_1", email: "dev@useatlas.dev" } },
+  };
+  searchParamsStore.agent_id = "agent_1";
+  searchParamsStore.code = "ABCD-2345";
+  pendingResponder = () =>
+    jsonResponse(200, {
+      requests: [
+        {
+          approval_id: "appr_1",
+          method: "device_authorization",
+          agent_id: "agent_1",
+          agent_name: "Reporting Agent",
+          binding_message: "Weekly revenue report",
+          capabilities: ["getMe"],
+          capability_reasons: { getMe: "Identify the caller" },
+          expires_in: 300,
+        },
+      ],
+    });
+  approveResponder = () => jsonResponse(200, { status: "approved" });
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : null;
+    fetchCalls.push({ url, method, body });
+    if (url.includes("/agent/approve-capability")) return approveResponder();
+    if (url.includes("/agent/ciba/pending")) return pendingResponder();
+    throw new Error(`unexpected fetch: ${method} ${url}`);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("agent approval page (#4411)", () => {
+  test("renders the pending capability request for the signed-in user", async () => {
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Reporting Agent")).toBeDefined());
+    expect(screen.getByText("Weekly revenue report")).toBeDefined();
+    expect(screen.getByText("getMe")).toBeDefined();
+    expect(screen.getByText("dev@useatlas.dev")).toBeDefined();
+    // The pending list was fetched with the credentialed GET.
+    expect(fetchCalls.some((c) => c.url.includes("/agent/ciba/pending") && c.method === "GET")).toBe(
+      true,
+    );
+  });
+
+  test("approve POSTs action:approve with the user code, then shows approved", async () => {
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Approve")).toBeDefined());
+    fireEvent.click(screen.getByText("Approve"));
+
+    await waitFor(() => expect(screen.getByText("Capability approved")).toBeDefined());
+    const post = fetchCalls.find((c) => c.url.includes("/agent/approve-capability"));
+    expect(post).toBeDefined();
+    expect(post?.method).toBe("POST");
+    expect(post?.body).toEqual({ agent_id: "agent_1", user_code: "ABCD-2345", action: "approve" });
+  });
+
+  test("deny POSTs action:deny and shows the denied terminal state", async () => {
+    approveResponder = () => jsonResponse(200, { status: "denied" });
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Deny")).toBeDefined());
+    fireEvent.click(screen.getByText("Deny"));
+
+    await waitFor(() => expect(screen.getByText("Request denied")).toBeDefined());
+    const post = fetchCalls.find((c) => c.url.includes("/agent/approve-capability"));
+    expect(post?.body).toEqual({ agent_id: "agent_1", user_code: "ABCD-2345", action: "deny" });
+  });
+
+  test("a rejected decision surfaces the server message and stays on the form", async () => {
+    approveResponder = () =>
+      jsonResponse(403, { error: "invalid_user_code", message: "That code is invalid or expired." });
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Approve")).toBeDefined());
+    fireEvent.click(screen.getByText("Approve"));
+
+    await waitFor(() =>
+      expect(screen.getByText("That code is invalid or expired.")).toBeDefined(),
+    );
+    // Not a false success — the form is still shown.
+    expect(screen.getByText("Approve")).toBeDefined();
+  });
+
+  test("404 on the pending list → the fail-closed 'not available' state (gate off)", async () => {
+    pendingResponder = () => jsonResponse(404, { error: "not_found" });
+    render(<AgentApprovePage />);
+    await waitFor(() =>
+      expect(screen.getByText("Agent approvals are not available")).toBeDefined(),
+    );
+    // No approve control is offered when the surface is gated off.
+    expect(screen.queryByText("Approve")).toBeNull();
+  });
+
+  test("POST-time gate 404 (surface toggled off mid-flow) → 'not available'", async () => {
+    approveResponder = () => jsonResponse(404, { error: "not_found" });
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Approve")).toBeDefined());
+    fireEvent.click(screen.getByText("Approve"));
+    await waitFor(() =>
+      expect(screen.getByText("Agent approvals are not available")).toBeDefined(),
+    );
+  });
+
+  test("POST-time stale-agent 404 → an error message, NOT the 'not available' screen", async () => {
+    approveResponder = () =>
+      jsonResponse(404, { error: "agent_not_found", message: "This agent was revoked." });
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Approve")).toBeDefined());
+    fireEvent.click(screen.getByText("Approve"));
+    await waitFor(() => expect(screen.getByText("This agent was revoked.")).toBeDefined());
+    // Not mislabeled as the feature being disabled.
+    expect(screen.queryByText("Agent approvals are not available")).toBeNull();
+    // Still on the form so the user can retry with a fresh link.
+    expect(screen.getByText("Approve")).toBeDefined();
+  });
+
+  test("no matching pending request → the expired/handled state", async () => {
+    pendingResponder = () => jsonResponse(200, { requests: [] });
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("No pending request")).toBeDefined());
+  });
+
+  test("not signed in → bounce to login carrying a redirect back to this URL", () => {
+    sessionStore.value = { isPending: false, data: null };
+    render(<AgentApprovePage />);
+    const signIn = screen.getByText("Sign in").closest("a");
+    expect(signIn?.getAttribute("href")).toContain("/login?redirect=");
+    expect(decodeURIComponent(signIn?.getAttribute("href") ?? "")).toContain(
+      "/agent/approve?agent_id=agent_1&code=ABCD-2345",
+    );
+    // No agent-auth call is made until the user is signed in.
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  test("missing agent_id/code → an actionable 'open from your agent' state", async () => {
+    searchParamsStore.agent_id = null;
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Open this from your agent")).toBeDefined());
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/packages/web/src/app/agent/approve/page.tsx
+++ b/packages/web/src/app/agent/approve/page.tsx
@@ -1,0 +1,510 @@
+"use client";
+
+/**
+ * Agent Auth device-authorization approval screen (#4411 / #2058, Slice 3).
+ *
+ * When an AI agent requests a capability whose approval strength requires a
+ * present user, the `@better-auth/agent-auth` device-code flow returns a
+ * `verification_uri_complete` pointing here:
+ * `/agent/approve?agent_id=<id>&code=<user_code>` (Atlas wires that URL via
+ * `deviceAuthorizationPage` → `resolveAgentApprovalPage`). A signed-in human
+ * lands on this page, reviews the pending capability request (what the agent is,
+ * which capabilities, and why), and approves or denies. Approve activates the
+ * pending grant; deny leaves it unusable.
+ *
+ * This reuses the OAuth-consent / CLI-device UI primitives (Card, Button,
+ * Skeleton, lucide icons, the centered radial-gradient layout) rather than
+ * hand-rolling a second consent surface.
+ *
+ * Gating: every agent-auth endpoint is 404 when `ATLAS_AGENT_AUTH_ENABLED` is
+ * off (the #4409 request-time, fail-closed gate). So when the feature is off,
+ * the pending-request fetch and the approve/deny POST both return 404, and this
+ * page renders the "not available" state — the page has no reachable surface,
+ * exactly like the rest of agent-auth.
+ *
+ * Not signed in? We render a sign-in prompt linking to /login with a redirect
+ * back to this exact URL (agent_id + code ride in the query), so the user
+ * returns here to finish approving — the plugin's `/agent/approve-capability`
+ * requires a session. (There is no auto-redirect; the user clicks through.)
+ */
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { authClient } from "@/lib/auth/client";
+import { getApiUrl } from "@/lib/api-url";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertCircle,
+  Bot,
+  CheckCircle2,
+  Loader2,
+  ShieldCheck,
+  XCircle,
+} from "lucide-react";
+import {
+  resolvePendingApproval,
+  type PendingApprovalRequest,
+} from "./resolve-pending-approval";
+import { resolveApprovalOutcome } from "./resolve-approval-outcome";
+
+function getApiBase(): string {
+  const url = getApiUrl();
+  if (url) return url;
+  if (typeof window !== "undefined") return window.location.origin;
+  return "http://localhost:3000";
+}
+
+/** The page's data-load phase. */
+type LoadState =
+  | "loading"
+  | "ready"
+  | "not-found"
+  | "unavailable"
+  | "missing-params"
+  | "error";
+
+function AgentApproval() {
+  const searchParams = useSearchParams();
+  const session = authClient.useSession();
+
+  const agentId = searchParams.get("agent_id") ?? "";
+  const code = searchParams.get("code") ?? "";
+
+  const [load, setLoad] = useState<LoadState>("loading");
+  const [request, setRequest] = useState<PendingApprovalRequest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState<"approve" | "deny" | null>(null);
+  const [outcome, setOutcome] = useState<"approved" | "denied" | null>(null);
+
+  const userId = session.data?.user?.id;
+
+  // Fetch the pending request once a signed-in user is present. `GET
+  // /agent/ciba/pending` returns the user's pending approvals across BOTH
+  // methods; `resolvePendingApproval` selects the device request for this
+  // `agent_id`. A 404 means the whole agent-auth surface is gated off.
+  useEffect(() => {
+    // No authenticated user yet (session still loading, or signed out) — the
+    // render shows the skeleton or the sign-in prompt, so don't fetch.
+    if (!userId) return;
+    if (!agentId || !code) {
+      setLoad("missing-params");
+      return;
+    }
+    const controller = new AbortController();
+    setLoad("loading");
+    setError(null);
+    fetch(`${getApiBase()}/api/auth/agent/ciba/pending`, {
+      credentials: "include",
+      signal: controller.signal,
+    })
+      .then(async (r) => {
+        if (controller.signal.aborted) return;
+        if (r.status === 404) {
+          setLoad("unavailable");
+          return;
+        }
+        if (r.status === 401) {
+          setError(
+            "Your session expired. Sign in again to approve this request.",
+          );
+          setLoad("error");
+          return;
+        }
+        if (!r.ok) {
+          setError(
+            `Could not load the pending request (HTTP ${r.status}). Refresh to try again.`,
+          );
+          setLoad("error");
+          return;
+        }
+        let payload: unknown;
+        try {
+          payload = await r.json();
+        } catch (parseErr) {
+          // A non-JSON 200 body (proxy HTML, truncated stream) can't be a
+          // pending list — surface an actionable message instead of letting the
+          // raw SyntaxError escape, and log the cause so an operator can tell a
+          // proxy interstitial from a genuinely malformed plugin body.
+          console.debug(
+            "agent-approve pending parse failed",
+            parseErr instanceof Error ? parseErr.message : String(parseErr),
+          );
+          setError("Could not load the pending request. Refresh to try again.");
+          setLoad("error");
+          return;
+        }
+        const lookup = resolvePendingApproval(payload, agentId);
+        if (lookup.kind === "ready") {
+          setRequest(lookup.request);
+          setLoad("ready");
+        } else {
+          setLoad("not-found");
+        }
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name === "AbortError") return;
+        setError(
+          err instanceof TypeError
+            ? "Couldn't reach Atlas. Check your connection and try again."
+            : err instanceof Error
+              ? err.message
+              : "Could not load the pending request.",
+        );
+        setLoad("error");
+      });
+    return () => controller.abort();
+  }, [userId, agentId, code]);
+
+  async function decide(action: "approve" | "deny") {
+    if (!agentId || !code) return;
+    setSubmitting(action);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${getApiBase()}/api/auth/agent/approve-capability`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ agent_id: agentId, user_code: code, action }),
+        },
+      );
+      let body: unknown = null;
+      try {
+        body = await res.json();
+      } catch {
+        // intentionally ignored: a non-JSON body (empty 204, gateway HTML) is
+        // expected on some error paths; resolveApprovalOutcome degrades to an
+        // actionable default from the HTTP status alone.
+        body = null;
+      }
+      const result = resolveApprovalOutcome({ status: res.status, body });
+      if (result.kind === "resolved") {
+        setOutcome(result.decision);
+      } else if (result.kind === "unavailable") {
+        setLoad("unavailable");
+      } else {
+        setError(result.message);
+      }
+    } catch (err) {
+      setError(
+        err instanceof TypeError
+          ? "Couldn't reach Atlas. Check your connection and try again."
+          : err instanceof Error
+            ? err.message
+            : "Could not record your decision.",
+      );
+    } finally {
+      setSubmitting(null);
+    }
+  }
+
+  // ── Loading session ──────────────────────────────────────────────
+  if (session.isPending) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-10 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Not signed in → sign-in prompt linking to /login (returns here) ──
+  if (!session.data) {
+    const returnTo = `/agent/approve?agent_id=${encodeURIComponent(agentId)}&code=${encodeURIComponent(code)}`;
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Sign in to continue</CardTitle>
+          <CardDescription>
+            Sign in to Atlas to review the capability an agent is requesting.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild className="w-full">
+            <Link href={`/login?redirect=${encodeURIComponent(returnTo)}`}>
+              Sign in
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Decision recorded ────────────────────────────────────────────
+  if (outcome === "approved") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CheckCircle2 className="size-5 text-primary" aria-hidden />
+            Capability approved
+          </CardTitle>
+          <CardDescription>
+            The agent can now use this capability in your workspace. You can
+            close this page and return to your agent.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+  if (outcome === "denied") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <XCircle className="size-5 text-destructive" aria-hidden />
+            Request denied
+          </CardTitle>
+          <CardDescription>
+            The agent was not granted this capability. You can close this page.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // ── Surface gated off (agent auth disabled) ──────────────────────
+  if (load === "unavailable") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Agent approvals are not available</CardTitle>
+          <CardDescription>
+            Agent authorization is not enabled on this workspace. Ask your
+            workspace admin to enable it, then reopen the link from your agent.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // ── Missing / stale link ─────────────────────────────────────────
+  if (load === "missing-params") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Open this from your agent</CardTitle>
+          <CardDescription>
+            This approval link is missing its agent and code. Reopen the link
+            your agent provided to review the request.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // ── No matching pending request (expired / already handled) ──────
+  if (load === "not-found") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>No pending request</CardTitle>
+          <CardDescription>
+            This request has expired or was already handled. Ask your agent to
+            request the capability again to get a fresh approval link.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // ── Failed to load the pending request ───────────────────────────
+  if (load === "error") {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Couldn&apos;t load the request</CardTitle>
+          <CardDescription
+            className="flex items-start gap-2 text-destructive"
+            role="alert"
+          >
+            <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+            {error ?? "Couldn't load the request. Refresh to try again."}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // ── Loading the pending request ──────────────────────────────────
+  if (load === "loading" || !request) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-16 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Approval form ────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col items-center">
+      <div className="mb-6 flex flex-col items-center text-center">
+        <div className="mb-3 flex size-12 items-center justify-center rounded-lg bg-primary/10">
+          <Bot className="size-6 text-primary" aria-hidden />
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Authorize an agent
+        </h1>
+        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+          An AI agent is requesting a capability in your workspace. Review it
+          before granting access.
+        </p>
+      </div>
+
+      <Card className="w-full">
+        <CardHeader className="flex flex-row items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-muted">
+            <Bot className="size-5 text-muted-foreground" aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <CardTitle className="truncate text-lg">
+              {request.agentName ?? "Unknown agent"}
+            </CardTitle>
+            <CardDescription className="truncate">
+              Requesting access as{" "}
+              <span className="font-medium text-foreground">
+                {session.data.user?.email}
+              </span>
+            </CardDescription>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {request.bindingMessage ? (
+            <p className="rounded-md border bg-muted/40 p-3 text-sm">
+              {request.bindingMessage}
+            </p>
+          ) : null}
+
+          <div>
+            <p className="text-sm font-medium">Requested capabilities</p>
+            <ul className="mt-2 space-y-2">
+              {request.capabilities.length === 0 ? (
+                <li className="text-sm text-muted-foreground">
+                  No specific capabilities requested.
+                </li>
+              ) : (
+                request.capabilities.map((capability) => (
+                  <li
+                    key={capability}
+                    className="flex items-start gap-2 text-sm"
+                  >
+                    <ShieldCheck
+                      className="mt-0.5 size-4 shrink-0 text-primary"
+                      aria-hidden
+                    />
+                    <span>
+                      <span className="font-mono">{capability}</span>
+                      {request.capabilityReasons[capability] ? (
+                        <span className="text-muted-foreground">
+                          {" "}
+                          — {request.capabilityReasons[capability]}
+                        </span>
+                      ) : null}
+                    </span>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+
+          {request.expiresIn > 0 ? (
+            <p className="text-xs text-muted-foreground">
+              This request expires in about {Math.ceil(request.expiresIn / 60)}{" "}
+              minute{Math.ceil(request.expiresIn / 60) === 1 ? "" : "s"} — approve
+              or deny before then.
+            </p>
+          ) : null}
+
+          {error ? (
+            <div
+              className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              <AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden />
+              <span>{error}</span>
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-2 pt-2">
+            <Button
+              onClick={() => decide("approve")}
+              disabled={submitting !== null}
+              className="w-full"
+            >
+              {submitting === "approve" ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                  Approving
+                </>
+              ) : (
+                "Approve"
+              )}
+            </Button>
+            <Button
+              onClick={() => decide("deny")}
+              disabled={submitting !== null}
+              variant="outline"
+              className="w-full"
+            >
+              {submitting === "deny" ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                  Denying
+                </>
+              ) : (
+                "Deny"
+              )}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <p className="mt-4 max-w-sm text-center text-xs text-muted-foreground">
+        Approving lets this agent use the listed capabilities in your workspace
+        only. You can revoke access at any time from your workspace settings.
+      </p>
+    </div>
+  );
+}
+
+export default function AgentApprovePage() {
+  // useSearchParams requires a Suspense boundary for static prerender.
+  return (
+    <Suspense
+      fallback={
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-10 w-full" />
+          </CardContent>
+        </Card>
+      }
+    >
+      <AgentApproval />
+    </Suspense>
+  );
+}

--- a/packages/web/src/app/agent/approve/resolve-approval-outcome.test.ts
+++ b/packages/web/src/app/agent/approve/resolve-approval-outcome.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "bun:test";
+import { resolveApprovalOutcome } from "./resolve-approval-outcome";
+
+describe("resolveApprovalOutcome (#4411)", () => {
+  it("200 { status: approved } → resolved/approved", () => {
+    expect(resolveApprovalOutcome({ status: 200, body: { status: "approved" } })).toEqual({
+      kind: "resolved",
+      decision: "approved",
+    });
+  });
+
+  it("200 { status: denied } → resolved/denied", () => {
+    expect(resolveApprovalOutcome({ status: 200, body: { status: "denied" } })).toEqual({
+      kind: "resolved",
+      decision: "denied",
+    });
+  });
+
+  it("gate 404 { error: not_found } → unavailable (the surface was toggled off mid-flow)", () => {
+    expect(resolveApprovalOutcome({ status: 404, body: { error: "not_found" } })).toEqual({
+      kind: "unavailable",
+    });
+  });
+
+  it("stale-agent 404 { error: agent_not_found } → error, NOT unavailable", () => {
+    const out = resolveApprovalOutcome({
+      status: 404,
+      body: { error: "agent_not_found", message: "Agent has been revoked." },
+    });
+    // A revoked/stale link must not read as "the feature is disabled".
+    expect(out).toEqual({ kind: "error", message: "Agent has been revoked." });
+  });
+
+  it("401 → an actionable 'session expired, sign in again' error", () => {
+    const out = resolveApprovalOutcome({ status: 401, body: { error: "unauthorized" } });
+    expect(out.kind).toBe("error");
+    if (out.kind === "error") expect(out.message.toLowerCase()).toContain("sign in");
+  });
+
+  it("4xx error envelope → error carrying the server message", () => {
+    const out = resolveApprovalOutcome({
+      status: 403,
+      body: { error: "invalid_user_code", message: "That code is invalid or expired." },
+    });
+    expect(out).toEqual({ kind: "error", message: "That code is invalid or expired." });
+  });
+
+  it("4xx with only an error code → error carrying the code", () => {
+    expect(resolveApprovalOutcome({ status: 400, body: { error: "invalid_request" } })).toEqual({
+      kind: "error",
+      message: "invalid_request",
+    });
+  });
+
+  it("non-JSON / empty error body → actionable fallback message", () => {
+    const out = resolveApprovalOutcome({ status: 500, body: null });
+    expect(out.kind).toBe("error");
+    if (out.kind === "error") expect(out.message.length).toBeGreaterThan(0);
+  });
+
+  it("2xx with an unexpected status value → error, not a false success", () => {
+    const out = resolveApprovalOutcome({ status: 200, body: { status: "weird" } });
+    expect(out.kind).toBe("error");
+  });
+});

--- a/packages/web/src/app/agent/approve/resolve-approval-outcome.ts
+++ b/packages/web/src/app/agent/approve/resolve-approval-outcome.ts
@@ -1,0 +1,87 @@
+/**
+ * Map the `POST /api/auth/agent/approve-capability` response to the approval
+ * page's terminal state (#4411).
+ *
+ * The plugin returns `{ status: "approved" | "denied" }` on success and a
+ * `{ error, message }` envelope on a rejected decision (`invalid_user_code`,
+ * `approval_expired`, `agent_not_found`, …). Discriminating on `kind` lets the
+ * page reach `decision` only on success and `message` only on error.
+ *
+ * 404 is ambiguous on this endpoint and must NOT be blanket-mapped to
+ * "unavailable": the #4409 request-time gate 404s the WHOLE surface with the
+ * exact envelope `{ error: "not_found" }` when Agent Auth is off, but the plugin
+ * ALSO 404s an individual stale/revoked agent with `{ error: "agent_not_found" }`
+ * even when the feature is fully enabled. Only the gate envelope means the
+ * surface is unavailable; a stale-agent 404 is a per-request error (the link is
+ * no longer valid), so it flows to the error branch with the server's message.
+ */
+
+/** The exact error code the #4409 request-time gate returns (routes/auth.ts). */
+const GATE_OFF_ERROR = "not_found";
+
+export type ApprovalOutcome =
+  | { kind: "resolved"; decision: "approved" | "denied" }
+  | { kind: "unavailable" }
+  | { kind: "error"; message: string };
+
+/** The parts of a `fetch` result this resolver needs. */
+export interface ApprovalHttpResult {
+  readonly status: number;
+  /** Parsed JSON body (or `null` when the body wasn't JSON). */
+  readonly body: unknown;
+}
+
+function errorCode(body: unknown): string | undefined {
+  if (body && typeof body === "object") {
+    const code = (body as { error?: unknown }).error;
+    if (typeof code === "string") return code;
+  }
+  return undefined;
+}
+
+function messageFrom(body: unknown, fallback: string): string {
+  if (body && typeof body === "object") {
+    const b = body as Record<string, unknown>;
+    if (typeof b.message === "string" && b.message) return b.message;
+    if (typeof b.error === "string" && b.error) return b.error;
+  }
+  return fallback;
+}
+
+export function resolveApprovalOutcome(res: ApprovalHttpResult): ApprovalOutcome {
+  if (res.status >= 200 && res.status < 300) {
+    const status =
+      res.body && typeof res.body === "object"
+        ? (res.body as { status?: unknown }).status
+        : undefined;
+    if (status === "approved") return { kind: "resolved", decision: "approved" };
+    if (status === "denied") return { kind: "resolved", decision: "denied" };
+    return {
+      kind: "error",
+      message: "The approval completed with an unexpected response. Refresh and try again.",
+    };
+  }
+
+  // Session lapsed between page load and the decision — give the same
+  // actionable "sign in again" copy the pending-fetch path uses on a 401.
+  if (res.status === 401) {
+    return {
+      kind: "error",
+      message: "Your session expired. Sign in again to record your decision.",
+    };
+  }
+
+  // ONLY the gate's whole-surface 404 means "unavailable". A stale/revoked
+  // agent (`agent_not_found`) also 404s but is a per-request error.
+  if (res.status === 404 && errorCode(res.body) === GATE_OFF_ERROR) {
+    return { kind: "unavailable" };
+  }
+
+  return {
+    kind: "error",
+    message: messageFrom(
+      res.body,
+      "Could not record your decision. Refresh the page and try again.",
+    ),
+  };
+}

--- a/packages/web/src/app/agent/approve/resolve-pending-approval.test.ts
+++ b/packages/web/src/app/agent/approve/resolve-pending-approval.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "bun:test";
+import { resolvePendingApproval } from "./resolve-pending-approval";
+
+const deviceRequest = (overrides: Record<string, unknown> = {}) => ({
+  approval_id: "appr_1",
+  method: "device_authorization",
+  agent_id: "agent_1",
+  agent_name: "Reporting Agent",
+  binding_message: "Weekly revenue report",
+  capabilities: ["getMe", "getDashboards"],
+  capability_reasons: { getMe: "Identify the caller", getDashboards: "Read your dashboards" },
+  expires_in: 300,
+  created_at: "2026-07-08T00:00:00Z",
+  ...overrides,
+});
+
+describe("resolvePendingApproval (#4411)", () => {
+  it("returns the matching device-authorization request, normalized", () => {
+    const out = resolvePendingApproval({ requests: [deviceRequest()] }, "agent_1");
+    expect(out.kind).toBe("ready");
+    if (out.kind !== "ready") throw new Error("expected ready");
+    expect(out.request).toEqual({
+      approvalId: "appr_1",
+      agentId: "agent_1",
+      agentName: "Reporting Agent",
+      bindingMessage: "Weekly revenue report",
+      capabilities: ["getMe", "getDashboards"],
+      capabilityReasons: { getMe: "Identify the caller", getDashboards: "Read your dashboards" },
+      expiresIn: 300,
+    });
+  });
+
+  it("picks the request for the requested agent when several are pending", () => {
+    const out = resolvePendingApproval(
+      {
+        requests: [
+          deviceRequest({ approval_id: "appr_other", agent_id: "agent_2" }),
+          deviceRequest({ approval_id: "appr_mine", agent_id: "agent_1" }),
+        ],
+      },
+      "agent_1",
+    );
+    expect(out.kind).toBe("ready");
+    if (out.kind === "ready") expect(out.request.approvalId).toBe("appr_mine");
+  });
+
+  it("ignores CIBA requests — only device_authorization is approvable here", () => {
+    const out = resolvePendingApproval(
+      { requests: [deviceRequest({ method: "ciba" })] },
+      "agent_1",
+    );
+    expect(out.kind).toBe("not-found");
+  });
+
+  it("not-found when no request matches the agent id", () => {
+    const out = resolvePendingApproval({ requests: [deviceRequest()] }, "agent_999");
+    expect(out.kind).toBe("not-found");
+  });
+
+  it("not-found (never throws) on a malformed payload", () => {
+    expect(resolvePendingApproval(null, "agent_1").kind).toBe("not-found");
+    expect(resolvePendingApproval({}, "agent_1").kind).toBe("not-found");
+    expect(resolvePendingApproval({ requests: "nope" }, "agent_1").kind).toBe("not-found");
+    expect(resolvePendingApproval({ requests: [42, null] }, "agent_1").kind).toBe("not-found");
+  });
+
+  it("not-found when the agent id is empty", () => {
+    expect(resolvePendingApproval({ requests: [deviceRequest()] }, "").kind).toBe("not-found");
+  });
+
+  it("tolerates missing optional fields (null agent_name / reasons / message)", () => {
+    const out = resolvePendingApproval(
+      {
+        requests: [
+          {
+            approval_id: "appr_1",
+            method: "device_authorization",
+            agent_id: "agent_1",
+            agent_name: null,
+            binding_message: null,
+            capabilities: ["getMe"],
+            capability_reasons: null,
+            expires_in: 300,
+          },
+        ],
+      },
+      "agent_1",
+    );
+    expect(out.kind).toBe("ready");
+    if (out.kind === "ready") {
+      expect(out.request.agentName).toBeNull();
+      expect(out.request.bindingMessage).toBeNull();
+      expect(out.request.capabilityReasons).toEqual({});
+    }
+  });
+});

--- a/packages/web/src/app/agent/approve/resolve-pending-approval.ts
+++ b/packages/web/src/app/agent/approve/resolve-pending-approval.ts
@@ -1,0 +1,101 @@
+/**
+ * Map the Agent Auth pending-approvals payload to the one request the approval
+ * page should render (#4411).
+ *
+ * The device-authorization approval page is opened at
+ * `/agent/approve?agent_id=<id>&code=<user_code>` (the plugin's
+ * `verification_uri_complete`). To render the pending capability request we read
+ * the signed-in user's pending approvals from `GET /api/auth/agent/ciba/pending`
+ * — despite the CIBA-flavoured path, the plugin returns BOTH `ciba` and
+ * `device_authorization` pending requests there — and pick the one that belongs
+ * to this `agent_id`.
+ *
+ * `user_code` is deliberately NOT in the listing (only its hash is stored
+ * server-side), so we match on `agent_id` + `method === "device_authorization"`.
+ * The code still round-trips to the server on approve, where it is verified
+ * against the stored hash — this resolver only chooses what to display.
+ *
+ * Defensive parse: an unexpected shape degrades to `not-found` rather than
+ * throwing, so a plugin-version response drift shows the recoverable "no pending
+ * request" screen instead of a crash.
+ */
+
+/** One pending capability request, as rendered by the approval page. */
+export interface PendingApprovalRequest {
+  readonly approvalId: string;
+  readonly agentId: string;
+  readonly agentName: string | null;
+  readonly bindingMessage: string | null;
+  readonly capabilities: readonly string[];
+  readonly capabilityReasons: Readonly<Record<string, string>>;
+  readonly expiresIn: number;
+}
+
+export type PendingApprovalLookup =
+  | { kind: "ready"; request: PendingApprovalRequest }
+  | { kind: "not-found" };
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function asReasonMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Find the device-authorization request for `agentId` in the pending payload.
+ * Returns `ready` with a normalized request, or `not-found` (no match, wrong
+ * method, or malformed payload).
+ */
+export function resolvePendingApproval(
+  payload: unknown,
+  agentId: string,
+): PendingApprovalLookup {
+  if (!agentId) return { kind: "not-found" };
+  const requests =
+    payload && typeof payload === "object" && Array.isArray((payload as { requests?: unknown }).requests)
+      ? ((payload as { requests: unknown[] }).requests)
+      : [];
+
+  for (const raw of requests) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    if (r.method !== "device_authorization") continue;
+    if (asString(r.agent_id) !== agentId) continue;
+    const approvalId = asString(r.approval_id);
+    if (!approvalId) continue;
+    return {
+      kind: "ready",
+      request: {
+        approvalId,
+        agentId,
+        agentName: asString(r.agent_name),
+        bindingMessage: asString(r.binding_message),
+        capabilities: asStringArray(r.capabilities),
+        capabilityReasons: asReasonMap(r.capability_reasons),
+        expiresIn: typeof r.expires_in === "number" ? r.expires_in : 0,
+      },
+    };
+  }
+  // A non-empty list with no match on our fields is the signature of a plugin
+  // response-shape drift (a renamed `agent_id`/`approval_id`/`method`), which
+  // would otherwise present identically to a legitimately-empty list ("no
+  // pending request"). Leave a breadcrumb so a drift outage is traceable
+  // without changing the recoverable UX.
+  if (requests.length > 0) {
+    console.debug(
+      `resolvePendingApproval: ${requests.length} pending request(s) but none matched agent ${agentId} — check for @better-auth/agent-auth response drift`,
+    );
+  }
+  return { kind: "not-found" };
+}


### PR DESCRIPTION
## Summary

Adds the browser approval round-trip for the Agent Auth Protocol device-authorization flow — Slice 3 of #2058, building on the #4409 spine. When an agent requests a capability whose approval strength requires a present user, the device-code flow now sends the user to a real `/agent/approve` page where they review the pending capability request and approve or deny.

Closes #4411.

**What changed**
- **`deviceAuthorizationPage` wiring** (`packages/api`): `buildAgentAuthPlugin()` now sets the plugin's `deviceAuthorizationPage` to a new `/agent/approve` web route via `resolveAgentApprovalPage(getWebOrigin())` — an absolute web-origin URL, so the CLI/agent-printed `verification_uri` resolves to the page that renders instead of 404ing on the API host. This mirrors the CLI device flow's `resolveDeviceVerificationUri`.
- **`/agent/approve` page** (`packages/web`): reuses the existing OAuth-consent / CLI-device UI primitives (Card, Button, Skeleton, the centered radial-gradient layout) — no duplicated consent surface. Reads `agent_id` + `code`, fetches the pending request from `/agent/ciba/pending`, renders the agent + requested capabilities (with reasons) + workspace context, and posts the decision to the plugin's `/agent/approve-capability`.
- **Fail-closed gating**: the page's pending-request fetch and the decision POST both hit the #4409 request-time gate, so the whole surface returns 404 → "not available" when `ATLAS_AGENT_AUTH_ENABLED` is off (the default). Live-toggleable with no redeploy.
- **404 discrimination**: `resolveApprovalOutcome` distinguishes the gate-off envelope (`{ error: "not_found" }` → "unavailable") from a stale/revoked-agent 404 (`{ error: "agent_not_found" }` → per-request error), so a stale link is never mislabeled as "the feature is disabled".

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated
- [x] E2E tests added/updated

- `agent-auth-device-approval.test.ts` — drives a **real Better Auth + agent-auth plugin** instance (memory adapter): approve → grant becomes `active`; deny → grant becomes `denied` (unusable, never active); wrong user code → `invalid_user_code`, grant stays pending; and a `/agent/ciba/pending` wire-contract assertion so a plugin field rename fails loudly instead of silently showing "no pending request".
- `agent-approval-page.test.ts` — `resolveAgentApprovalPage` absolute-URL / single-origin-fallback.
- `page.test.tsx` (RTL) — renders the request, approve/deny post the right body, gate-off 404 → "not available", stale-agent 404 → error, login bounce, not-found, missing params.
- `resolve-pending-approval.test.ts` / `resolve-approval-outcome.test.ts` — pure resolver coverage incl. malformed payloads and the 404/401 discrimination.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — local `scripts/ci-local.sh`: all 28 gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area) — issue carries `feature` / `area: api` / `area: web`
- [ ] CHANGELOG.md updated — n/a: feature is experimental and default-off; the changelog is per-release-tag

https://claude.ai/code/session_01Urd7rZuWyFnbjtVxBQF7gZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Urd7rZuWyFnbjtVxBQF7gZ)_