### PR TITLE
feat(audit): agent.* audit action catalog via agent-auth onEvent

### DIFF
--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -904,6 +904,46 @@ export const ADMIN_ACTIONS = {
   mcpActionPolicy: {
     update: "mcp_action_policy.update",
   },
+  /**
+   * Agent Auth Protocol lifecycle (#4412 / #2058, Slice 4). The
+   * `@better-auth/agent-auth` plugin emits an `onEvent` for every significant
+   * mutation across the register → enroll → request → approve/deny → execute →
+   * revoke lifecycle; `lib/auth/agent-auth-audit.ts` maps the audited subset onto
+   * these actions so the grant/approval trail is queryable in `admin_action_log`
+   * alongside every other admin surface. `targetType` is the domain prefix
+   * `agent` for all of them (see {@link AdminTargetType}); the sub-domain
+   * (`host` / `capability`) lives in the action verb, not a nested target type.
+   *
+   * `logAdminAction` resolves the `actor_id` / `org_id` COLUMNS only from the
+   * ambient Atlas request context, which is absent on the Better Auth catch-all
+   * these events fire from — so those columns are `unknown`/`null` regardless of
+   * what the event carries. The trustworthy forensic identifiers travel in
+   * `metadata` instead: `actorId` (the owning/approving user), `actorType`,
+   * `agentId`, `hostId`, and `orgId` when the event carries one (execute rows add
+   * `userId`) — exactly as the `mcp_session.*` rows carry `clientId`/`userId`
+   * there. Capability `arguments` / `output` are DELIBERATELY never recorded
+   * (they can carry customer SQL / PII); only the capability name + outcome are.
+   *
+   * `capabilityExecute` is the one high-volume verb, so it is NOT written
+   * per-call: successful executes are SUMMARIZED — one row per
+   * `EXECUTE_SUMMARY_INTERVAL` calls per `(agent, capability)`, with
+   * `metadata.representedExecuteCount` recording how many the row stands for and
+   * `metadata.sampled: true` marking it a summary. Execute FAILURES bypass the
+   * sampler and always emit (`status: failure`) — they are rare and the
+   * load-bearing signal. When `ATLAS_AGENT_AUTH_ENABLED` resolves off (fail
+   * closed), NO agent-auth row is emitted at all.
+   */
+  agent: {
+    register: "agent.register",
+    revoke: "agent.revoke",
+    hostEnroll: "agent.host.enroll",
+    hostRevoke: "agent.host.revoke",
+    capabilityRequest: "agent.capability.request",
+    capabilityApprove: "agent.capability.approve",
+    capabilityDeny: "agent.capability.deny",
+    capabilityRevoke: "agent.capability.revoke",
+    capabilityExecute: "agent.capability.execute",
+  },
 } as const;
 
 /** Union of all admin action type string values. */

--- a/packages/api/src/lib/auth/__tests__/agent-auth-audit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-audit.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Agent Auth → admin-action audit bridge (#4412 / #2058, Slice 4).
+ *
+ * Drives {@link createAgentAuthAuditor} with fully-injected seams — a spy
+ * `emit`, a controllable `isEnabled`, and a small `executeSummaryInterval` — so
+ * every assertion is self-contained with no settings DB, no Better Auth, and no
+ * top-level singleton mutation. The mappings are asserted against the SAME
+ * `ADMIN_ACTIONS.agent.*` catalog production uses, so a catalog rename is a RED
+ * test rather than a silent drift.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { AgentAuthEvent } from "@better-auth/agent-auth";
+
+import {
+  createAgentAuthAuditor,
+  type AgentAuthAuditor,
+} from "@atlas/api/lib/auth/agent-auth-audit";
+import { ADMIN_ACTIONS, type AdminActionEntry, type AdminActionType } from "@atlas/api/lib/audit";
+
+/** Build an auditor whose emitted rows land in `rows`, enabled unless overridden. */
+function harness(
+  overrides: { enabled?: boolean; interval?: number; maxTrackedKeys?: number } = {},
+): { auditor: AgentAuthAuditor; rows: AdminActionEntry[] } {
+  const rows: AdminActionEntry[] = [];
+  const auditor = createAgentAuthAuditor({
+    emit: (entry) => rows.push(entry),
+    isEnabled: async () => overrides.enabled ?? true,
+    executeSummaryInterval: overrides.interval,
+    maxTrackedKeys: overrides.maxTrackedKeys,
+  });
+  return { auditor, rows };
+}
+
+const executeEvent = (
+  over: Partial<Extract<AgentAuthEvent, { type: "capability.executed" }>> = {},
+): AgentAuthEvent => ({
+  type: "capability.executed",
+  capability: "getReports",
+  agentId: "agent_1",
+  status: "success",
+  ...over,
+});
+
+describe("agent-auth audit — lifecycle mappings", () => {
+  const cases: Array<{ event: AgentAuthEvent; action: AdminActionType; targetId: string }> = [
+    {
+      event: { type: "agent.created", actorId: "user_1", agentId: "agent_1", hostId: "host_1" },
+      action: ADMIN_ACTIONS.agent.register,
+      targetId: "agent_1",
+    },
+    {
+      event: { type: "agent.revoked", actorId: "user_1", agentId: "agent_1", hostId: "host_1" },
+      action: ADMIN_ACTIONS.agent.revoke,
+      targetId: "agent_1",
+    },
+    {
+      event: { type: "host.enrolled", hostId: "host_1", actorType: "system" },
+      action: ADMIN_ACTIONS.agent.hostEnroll,
+      targetId: "host_1",
+    },
+    {
+      event: { type: "host.revoked", actorId: "user_1", hostId: "host_1" },
+      action: ADMIN_ACTIONS.agent.hostRevoke,
+      targetId: "host_1",
+    },
+    {
+      event: { type: "capability.requested", actorType: "agent", actorId: "user_1", agentId: "agent_1" },
+      action: ADMIN_ACTIONS.agent.capabilityRequest,
+      targetId: "agent_1",
+    },
+    {
+      event: { type: "capability.approved", actorId: "user_1", agentId: "agent_1" },
+      action: ADMIN_ACTIONS.agent.capabilityApprove,
+      targetId: "agent_1",
+    },
+    {
+      event: { type: "capability.denied", actorId: "user_1", agentId: "agent_1" },
+      action: ADMIN_ACTIONS.agent.capabilityDeny,
+      targetId: "agent_1",
+    },
+    {
+      event: { type: "capability.revoked", actorId: "user_1", agentId: "agent_1", hostId: "host_1" },
+      action: ADMIN_ACTIONS.agent.capabilityRevoke,
+      targetId: "agent_1",
+    },
+  ];
+
+  for (const { event, action, targetId } of cases) {
+    it(`maps ${event.type} → ${action}`, async () => {
+      const { auditor, rows } = harness();
+      await auditor.handleEvent(event);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.actionType).toBe(action);
+      expect(rows[0]!.targetType).toBe("agent");
+      expect(rows[0]!.targetId).toBe(targetId);
+      // Lifecycle rows default to success (a deny is a decision, not a failure).
+      expect(rows[0]!.status).toBeUndefined();
+    });
+  }
+
+  it("lifts the trustworthy identity fields into metadata and nests plugin metadata under detail", async () => {
+    const { auditor, rows } = harness();
+    await auditor.handleEvent({
+      type: "capability.denied",
+      actorId: "user_1",
+      actorType: "user",
+      agentId: "agent_1",
+      metadata: { capabilities: ["getReports"], reason: "not needed" },
+    });
+    expect(rows[0]!.metadata).toEqual({
+      actorId: "user_1",
+      actorType: "user",
+      agentId: "agent_1",
+      detail: { capabilities: ["getReports"], reason: "not needed" },
+    });
+  });
+
+  it("ignores event types that are not in the audited catalog", async () => {
+    const { auditor, rows } = harness();
+    for (const type of [
+      "agent.updated",
+      "agent.claimed",
+      "host.created",
+      "capability.granted",
+      "approval.created",
+    ] as const) {
+      await auditor.handleEvent({ type, agentId: "agent_1" } as AgentAuthEvent);
+    }
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("agent-auth audit — execute sampling (AC #3)", () => {
+  it("summarizes successful executes: one row per interval, not per call", async () => {
+    const { auditor, rows } = harness({ interval: 3 });
+
+    await auditor.handleEvent(executeEvent());
+    await auditor.handleEvent(executeEvent());
+    expect(rows).toHaveLength(0); // below the interval — no per-call rows
+
+    await auditor.handleEvent(executeEvent());
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.actionType).toBe(ADMIN_ACTIONS.agent.capabilityExecute);
+    expect(rows[0]!.status).toBe("success");
+    expect(rows[0]!.metadata).toMatchObject({
+      capability: "getReports",
+      sampled: true,
+      representedExecuteCount: 3,
+    });
+
+    // Counter reset after a flush — the next two don't emit again.
+    await auditor.handleEvent(executeEvent());
+    await auditor.handleEvent(executeEvent());
+    expect(rows).toHaveLength(1);
+  });
+
+  it("counts each capability independently", async () => {
+    const { auditor, rows } = harness({ interval: 2 });
+    await auditor.handleEvent(executeEvent({ capability: "getReports" }));
+    await auditor.handleEvent(executeEvent({ capability: "listUsers" }));
+    expect(rows).toHaveLength(0); // one of each — neither pair hit 2 yet
+    await auditor.handleEvent(executeEvent({ capability: "getReports" }));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.metadata).toMatchObject({ capability: "getReports" });
+  });
+
+  it("counts each agentId independently for the same capability", async () => {
+    const { auditor, rows } = harness({ interval: 2 });
+    // Two different agents hammering the SAME capability must NOT be co-counted —
+    // a regression that dropped the agentId half of the sampler key would emit a
+    // spurious summary here.
+    await auditor.handleEvent(executeEvent({ agentId: "agent_1", capability: "getReports" }));
+    await auditor.handleEvent(executeEvent({ agentId: "agent_2", capability: "getReports" }));
+    expect(rows).toHaveLength(0);
+    // agent_1's second execute closes agent_1's window only.
+    await auditor.handleEvent(executeEvent({ agentId: "agent_1", capability: "getReports" }));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.metadata).toMatchObject({ agentId: "agent_1", representedExecuteCount: 2 });
+  });
+
+  it("always emits a failure row for a failed execute, bypassing the sampler", async () => {
+    const { auditor, rows } = harness({ interval: 100 });
+    await auditor.handleEvent(
+      executeEvent({ status: "error", error: "Upstream API error 500", durationMs: 42 }),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.status).toBe("failure");
+    expect(rows[0]!.metadata).toMatchObject({
+      executeStatus: "error",
+      sampled: false,
+      representedExecuteCount: 1,
+      error: "Upstream API error 500",
+      durationMs: 42,
+    });
+  });
+
+  it("scrubs a connection string out of a failure's error before persisting it", async () => {
+    const { auditor, rows } = harness({ interval: 100 });
+    await auditor.handleEvent(
+      executeEvent({
+        status: "error",
+        error: "connect failed: postgres://svc:s3cr3t@10.0.0.4:5432/prod is unreachable",
+      }),
+    );
+    expect(rows).toHaveLength(1);
+    const persisted = String(rows[0]!.metadata?.error ?? "");
+    expect(persisted).not.toContain("s3cr3t");
+    expect(persisted).toContain("postgres://***@");
+  });
+
+  it("bounds sampler memory by clearing counters when the tracked-key cap is exceeded", async () => {
+    // interval high enough that no pair flushes on its own; cap of 2 so the 3rd
+    // distinct pair trips the wholesale clear. The sampler must keep working
+    // (not corrupt) afterwards — a fresh pair still counts up and flushes.
+    const { auditor, rows } = harness({ interval: 2, maxTrackedKeys: 2 });
+    await auditor.handleEvent(executeEvent({ capability: "a" }));
+    await auditor.handleEvent(executeEvent({ capability: "b" }));
+    await auditor.handleEvent(executeEvent({ capability: "c" })); // size now 3 > cap → cleared
+    expect(rows).toHaveLength(0);
+    // Post-clear the sampler is intact: two executes of one pair still summarize.
+    await auditor.handleEvent(executeEvent({ capability: "d" }));
+    await auditor.handleEvent(executeEvent({ capability: "d" }));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.metadata).toMatchObject({ capability: "d", representedExecuteCount: 2 });
+  });
+
+  it("never records capability arguments or output in the audit metadata", async () => {
+    const { auditor, rows } = harness({ interval: 1 });
+    await auditor.handleEvent(
+      executeEvent({
+        arguments: { sql: "SELECT ssn FROM customers" },
+        output: [{ ssn: "123-45-6789" }],
+      }),
+    );
+    expect(rows).toHaveLength(1);
+    const meta = rows[0]!.metadata ?? {};
+    expect(meta).not.toHaveProperty("arguments");
+    expect(meta).not.toHaveProperty("output");
+    expect(JSON.stringify(meta)).not.toContain("123-45-6789");
+  });
+});
+
+describe("agent-auth audit — fail-closed master gate (AC #4)", () => {
+  it("emits no rows for any event when ATLAS_AGENT_AUTH_ENABLED is off", async () => {
+    const { auditor, rows } = harness({ enabled: false, interval: 1 });
+    await auditor.handleEvent({ type: "agent.created", agentId: "agent_1" });
+    await auditor.handleEvent({ type: "capability.approved", actorId: "user_1", agentId: "agent_1" });
+    await auditor.handleEvent(executeEvent());
+    await auditor.handleEvent(executeEvent({ status: "error", error: "boom" }));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/auth/agent-auth-audit.ts
+++ b/packages/api/src/lib/auth/agent-auth-audit.ts
@@ -1,0 +1,318 @@
+/**
+ * Agent Auth Protocol → admin-action audit bridge (#4412 / #2058, Slice 4).
+ *
+ * The `@better-auth/agent-auth` plugin exposes a single `onEvent(event)` hook
+ * that fires after every significant mutation in the agent lifecycle (§12 of the
+ * protocol). This module is the one place that hook is turned into rows in the
+ * existing `admin_action_log` catalog (`ADMIN_ACTIONS.agent.*`), so the
+ * register → enroll → request → approve/deny → execute → revoke trail is
+ * queryable next to every other admin surface — no bespoke agent-audit table.
+ *
+ * Three things this bridge is careful about:
+ *
+ *  1. **Fail-closed on the master switch.** Every call first consults the
+ *     platform-tier `ATLAS_AGENT_AUTH_ENABLED` gate (`isAgentAuthEnabled()`, no
+ *     orgId ⇒ platform tier — the master kill-switch). When off, NOTHING is
+ *     emitted. In practice the HTTP surface already 404s when off so no event
+ *     fires, but a direct `auth.api.*` server call would bypass that gate; this
+ *     check makes "no rows when off" a guaranteed, directly-testable contract
+ *     (issue AC #4) rather than an emergent property of the HTTP layer.
+ *
+ *  2. **Execute is summarized, never per-call.** `capability.executed` is the
+ *     high-volume verb — a single agent session can drive thousands. Successful
+ *     executes are counted per `(agentId, capability)` and only every
+ *     {@link EXECUTE_SUMMARY_INTERVAL}-th one emits a row, which records how many
+ *     it stands for (`metadata.representedExecuteCount`) and that it is a summary
+ *     (`metadata.sampled: true`). Execute FAILURES skip the sampler and always
+ *     emit (`status: "failure"`) — rare and forensically load-bearing.
+ *
+ *  3. **No sensitive payloads, honest attribution.** `logAdminAction` resolves
+ *     the `actor_id` / `org_id` COLUMNS only from the ambient Atlas request
+ *     context, which is absent on the Better Auth catch-all — so those columns
+ *     are `unknown`/`null` here regardless of what the event carries. The real
+ *     forensic identifiers travel in `metadata` instead: `actorId`, `actorType`,
+ *     `agentId`, `hostId`, and `orgId` when the event carries one (it is optional
+ *     on the event and not always present); execute rows add `userId`. Same shape
+ *     `mcp_session.*` uses. Capability `arguments` / `output` are never recorded
+ *     (they can hold customer SQL / PII), and the plugin's per-event `metadata` is
+ *     allowlisted into `detail` (not copied wholesale) so an upstream version bump
+ *     can't silently start persisting a new sensitive field. A failure's `error`
+ *     string is run through {@link errorMessage} (connection-string scrub +
+ *     truncation) before it lands in the row.
+ *
+ * Reversibility: like the rest of the agent-auth seam, only this file, the
+ * plugin factory, the verifier and the gate know the agent-auth event shape.
+ * Nothing downstream learns it.
+ */
+
+import type {
+  AgentAuthEvent,
+  AgentAuthAuditEvent,
+  AgentAuthAuditEventType,
+  AgentAuthCapabilityExecutionEvent,
+} from "@better-auth/agent-auth";
+
+import {
+  ADMIN_ACTIONS,
+  errorMessage,
+  logAdminAction,
+  type AdminActionEntry,
+  type AdminActionType,
+} from "@atlas/api/lib/audit";
+import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("auth:agent-auth-audit");
+
+/**
+ * One `agent.capability.execute` audit row is written per this many SUCCESSFUL
+ * executes of the same `(agentId, capability)` pair. Chosen to keep a high-QPS
+ * agent from flooding the admin trail while still leaving a periodic breadcrumb
+ * that execution is happening. A plain constant (not a settings key) — it is a
+ * fine-grained sampling knob, not an operator-facing control. Injectable via
+ * {@link createAgentAuthAuditor} for deterministic tests.
+ */
+export const EXECUTE_SUMMARY_INTERVAL = 25;
+
+/**
+ * Coarse memory bound on the per-`(agentId, capability)` success counters. A
+ * counter is deleted the moment it flushes, so the live set is normally just the
+ * currently-active agent×capability pairs; this cap only matters under a flood of
+ * distinct pairs that each execute fewer than {@link EXECUTE_SUMMARY_INTERVAL}
+ * times and never again. On overflow the counters are cleared wholesale (a few
+ * pending summaries are lost — acceptable for a sampled trail).
+ */
+export const EXECUTE_TRACKED_KEYS_CAP = 5000;
+
+/** How an audited event maps onto the catalog + which id is the audit target. */
+interface AuditMapping {
+  readonly action: AdminActionType;
+  /** Whether the row's `targetId` is the host id or the agent id. */
+  readonly target: "agent" | "host";
+}
+
+/**
+ * The audited subset of `AgentAuthAuditEventType`. The plugin emits many more
+ * event types (`agent.updated`, `agent.claimed`, `host.created`,
+ * `capability.granted`, `approval.created`, key-rotations, …); those are
+ * deliberately NOT in the catalog for this slice and fall through unaudited.
+ * `capability.executed` is handled by its own sampled path, not here.
+ */
+const AUDIT_MAPPINGS: Partial<Record<AgentAuthAuditEventType, AuditMapping>> = {
+  "agent.created": { action: ADMIN_ACTIONS.agent.register, target: "agent" },
+  "agent.revoked": { action: ADMIN_ACTIONS.agent.revoke, target: "agent" },
+  "host.enrolled": { action: ADMIN_ACTIONS.agent.hostEnroll, target: "host" },
+  "host.revoked": { action: ADMIN_ACTIONS.agent.hostRevoke, target: "host" },
+  "capability.requested": { action: ADMIN_ACTIONS.agent.capabilityRequest, target: "agent" },
+  "capability.approved": { action: ADMIN_ACTIONS.agent.capabilityApprove, target: "agent" },
+  "capability.denied": { action: ADMIN_ACTIONS.agent.capabilityDeny, target: "agent" },
+  "capability.revoked": { action: ADMIN_ACTIONS.agent.capabilityRevoke, target: "agent" },
+};
+
+/**
+ * The plugin per-event `metadata` keys we copy into the audit row's `detail`.
+ * An ALLOWLIST, not a blanket spread: every key here is a known-benign label /
+ * count / id-list (`name`, capability names, grant ids, revoked counts, a
+ * decision `reason`). A future `@better-auth/agent-auth` version that adds a new
+ * field to `event.metadata` (rotated key material, a raw claim set, …) is dropped
+ * by construction rather than silently persisted into `admin_action_log`.
+ */
+const DETAIL_ALLOWLIST: ReadonlySet<string> = new Set([
+  "name",
+  "mode",
+  "capabilities",
+  "pendingCapabilities",
+  "forceApproval",
+  "autoApproved",
+  "pending",
+  "reason",
+  "grantIds",
+  "agentsRevoked",
+]);
+
+/** Project the plugin's per-event metadata down to the {@link DETAIL_ALLOWLIST}. Returns undefined when nothing survives. */
+function allowlistedDetail(raw: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!raw) return undefined;
+  const detail: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (DETAIL_ALLOWLIST.has(key)) detail[key] = value;
+  }
+  return Object.keys(detail).length > 0 ? detail : undefined;
+}
+
+/** Pick the audit row's `targetId` — the host or agent id per the mapping, with a total fallback chain. */
+function pickTargetId(event: AgentAuthAuditEvent, target: "agent" | "host"): string {
+  const preferred = target === "host" ? event.hostId : event.agentId;
+  return preferred ?? event.agentId ?? event.hostId ?? event.targetId ?? "unknown";
+}
+
+/**
+ * The trustworthy identity fields, lifted into metadata under stable keys so
+ * forensic queries can pivot (`metadata->>'agentId'`, …). The plugin's own
+ * per-event metadata (`name`, `capabilities`, `reason`, `agentsRevoked`, …) is
+ * nested under `detail` so it can never clobber these keys.
+ */
+function auditMetadata(event: AgentAuthAuditEvent): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  if (event.actorId) metadata.actorId = event.actorId;
+  if (event.actorType) metadata.actorType = event.actorType;
+  if (event.agentId) metadata.agentId = event.agentId;
+  if (event.hostId) metadata.hostId = event.hostId;
+  if (event.orgId) metadata.orgId = event.orgId;
+  if (event.targetType) metadata.eventTargetType = event.targetType;
+  const detail = allowlistedDetail(event.metadata);
+  if (detail) metadata.detail = detail;
+  return metadata;
+}
+
+/** Build the metadata for a `capability.executed` row — identity + capability + outcome, never args/output. */
+function executeMetadata(
+  event: AgentAuthCapabilityExecutionEvent,
+  representedExecuteCount: number,
+  sampled: boolean,
+): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {
+    capability: event.capability,
+    executeStatus: event.status,
+    representedExecuteCount,
+    sampled,
+  };
+  if (event.agentId) metadata.agentId = event.agentId;
+  if (event.hostId) metadata.hostId = event.hostId;
+  if (event.userId) metadata.userId = event.userId;
+  if (event.agentName) metadata.agentName = event.agentName;
+  if (event.provider) metadata.provider = event.provider;
+  if (typeof event.durationMs === "number") metadata.durationMs = event.durationMs;
+  // Scrub + truncate before persisting: a driver/proxy error string can echo a
+  // connection string (password) or overflow the JSONB column. `errorMessage` is
+  // the same audit-metadata hygiene the rest of the catalog uses.
+  if (event.error) metadata.error = errorMessage(event.error);
+  // NB: event.arguments / event.output are intentionally omitted — they can
+  // carry customer SQL and query results (PII). Only the capability name and the
+  // outcome are auditable.
+  return metadata;
+}
+
+/** Injected seams — real in production, stubbed in tests. */
+export interface AgentAuthAuditorOptions {
+  /** Sink for finished rows. Defaults to the fire-and-forget {@link logAdminAction}. */
+  readonly emit?: (entry: AdminActionEntry) => void;
+  /** Master-switch resolver. Defaults to the platform-tier {@link isAgentAuthEnabled}. */
+  readonly isEnabled?: () => Promise<boolean>;
+  /** Successful executes per emitted summary row. Defaults to {@link EXECUTE_SUMMARY_INTERVAL}. */
+  readonly executeSummaryInterval?: number;
+  /** Coarse cap on live per-key counters. Defaults to {@link EXECUTE_TRACKED_KEYS_CAP}. */
+  readonly maxTrackedKeys?: number;
+}
+
+export interface AgentAuthAuditor {
+  /**
+   * The `onEvent` callback. Never rejects — every failure path (gate resolver,
+   * emit, enrichment) is caught internally and logged, so it is safe to run
+   * fire-and-forget / in the background.
+   */
+  handleEvent(event: AgentAuthEvent): Promise<void>;
+}
+
+/**
+ * Build an auditor with its own encapsulated sampler state. Kept a factory (not a
+ * bare module function) so the per-`(agentId, capability)` counters stay private
+ * and tests can drive a fresh instance with injected seams — no top-level
+ * singleton mutation (CLAUDE.md testing rule).
+ */
+export function createAgentAuthAuditor(options: AgentAuthAuditorOptions = {}): AgentAuthAuditor {
+  const emit = options.emit ?? logAdminAction;
+  const isEnabled = options.isEnabled ?? (() => isAgentAuthEnabled());
+  const interval = Math.max(1, Math.floor(options.executeSummaryInterval ?? EXECUTE_SUMMARY_INTERVAL));
+  const maxKeys = Math.max(1, Math.floor(options.maxTrackedKeys ?? EXECUTE_TRACKED_KEYS_CAP));
+
+  /** count of successful executes since the last emitted summary, per `${agentId}::${capability}`. */
+  const executeCounts = new Map<string, number>();
+
+  function handleExecute(event: AgentAuthCapabilityExecutionEvent): void {
+    // Failures bypass the sampler — rare and load-bearing. Always one row.
+    if (event.status === "error") {
+      emit({
+        actionType: ADMIN_ACTIONS.agent.capabilityExecute,
+        targetType: "agent",
+        targetId: event.agentId ?? "unknown",
+        status: "failure",
+        metadata: executeMetadata(event, 1, false),
+      });
+      return;
+    }
+
+    // Summarize successes: one row per `interval` executes of the same pair.
+    const key = `${event.agentId ?? "unknown"}::${event.capability}`;
+    const next = (executeCounts.get(key) ?? 0) + 1;
+    if (next >= interval) {
+      executeCounts.delete(key);
+      emit({
+        actionType: ADMIN_ACTIONS.agent.capabilityExecute,
+        targetType: "agent",
+        targetId: event.agentId ?? "unknown",
+        status: "success",
+        metadata: executeMetadata(event, interval, true),
+      });
+      return;
+    }
+    executeCounts.set(key, next);
+
+    // Coarse memory bound — see EXECUTE_TRACKED_KEYS_CAP.
+    if (executeCounts.size > maxKeys) {
+      log.debug(
+        { trackedKeys: executeCounts.size, cap: maxKeys },
+        "agent-auth execute audit: tracked-key cap exceeded — clearing sampler counters",
+      );
+      executeCounts.clear();
+    }
+  }
+
+  return {
+    async handleEvent(event: AgentAuthEvent): Promise<void> {
+      // Honor the "never throws" contract in this module rather than leaning on
+      // the plugin's generic console.error swallow — a future enrichment that
+      // throws (or a rejecting gate resolver) stays inside Atlas's structured
+      // logging and drops just this one event.
+      try {
+        // AC #4 — fail-closed master gate. No agent-auth rows when the platform
+        // switch is off, independent of how the event reached us.
+        if (!(await isEnabled())) return;
+
+        if (event.type === "capability.executed") {
+          handleExecute(event);
+          return;
+        }
+
+        const mapping = AUDIT_MAPPINGS[event.type];
+        if (!mapping) return; // an unaudited lifecycle event — no catalog action
+
+        // A deny is a normal decision outcome (like `approval.deny`), not an
+        // operation failure — status stays the default "success".
+        emit({
+          actionType: mapping.action,
+          targetType: "agent",
+          targetId: pickTargetId(event, mapping.target),
+          metadata: auditMetadata(event),
+        });
+      } catch (err: unknown) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), eventType: event.type },
+          "agent-auth audit bridge failed — event dropped",
+        );
+      }
+    },
+  };
+}
+
+/**
+ * The process-wide auditor wired into the `agentAuth()` plugin. Constructed once
+ * at module load (never mutated at test top level — tests build their own via
+ * {@link createAgentAuthAuditor}).
+ */
+const defaultAuditor = createAgentAuthAuditor();
+
+/** The `onEvent` callback passed to `agentAuth({ onEvent })` in the plugin factory. */
+export function auditAgentAuthEvent(event: AgentAuthEvent): Promise<void> {
+  return defaultAuditor.handleEvent(event);
+}

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -62,6 +62,7 @@ import {
   type AgentAuthIdentity,
 } from "@atlas/api/lib/auth/agent-auth-verifier";
 import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
+import { auditAgentAuthEvent } from "@atlas/api/lib/auth/agent-auth-audit";
 import { resolveAgentApprovalPage } from "@atlas/api/lib/auth/agent-approval-page";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import {
@@ -477,6 +478,14 @@ export function buildAgentAuthPlugin(
     // `options` spread because it's a top-level plugin option, not an adapter
     // field; the adapter never touches it, so ordering is immaterial.
     deviceAuthorizationPage: deps.deviceAuthorizationPage,
+    // #4412 Slice 4 — record the grant/approval/execute lifecycle in the admin
+    // audit catalog (`ADMIN_ACTIONS.agent.*`). The bridge fails closed on the
+    // `ATLAS_AGENT_AUTH_ENABLED` master switch, summarizes high-volume executes
+    // (never one row per call), and never records capability args/output. See
+    // `agent-auth-audit.ts`. The plugin's own `onEvent` dispatch is fire-and-forget
+    // (`.catch`-logged), and the bridge additionally never rejects, so a
+    // slow/failing audit write can never break an agent-auth request.
+    onEvent: auditAgentAuthEvent,
     // AFTER the spread: `createFromOpenAPI` derives `providerName`/
     // `providerDescription` from the spec's `info` ("Atlas API" / the API
     // blurb), but the discovery document should carry Atlas's own branding and


### PR DESCRIPTION
## Summary

Slice 4 of 7 for the Agent Auth Protocol (#2058). Wires the `@better-auth/agent-auth` `onEvent` hook into the existing `admin_action_log` catalog so the grant / approval / execution lifecycle is recorded under a new `agent` domain following the `domain.verb` convention.

Closes #4412.

**What's added**
- New `agent.*` actions in `ADMIN_ACTIONS` (`packages/api/src/lib/audit/actions.ts`): `agent.register`, `agent.revoke`, `agent.host.enroll`, `agent.host.revoke`, `agent.capability.{request,approve,deny,revoke,execute}`. `action_type`/`target_type` are free-text columns, so no migration is needed; `AdminTargetType` picks up the new `agent` domain automatically.
- New `packages/api/src/lib/auth/agent-auth-audit.ts` — maps the audited subset of agent-auth events onto the catalog and is wired in via `onEvent: auditAgentAuthEvent` in the plugin factory (`agent-auth-plugin.ts`). Unaudited lifecycle events (`agent.updated`, `capability.granted`, `approval.created`, …) fall through by design.

**Behavioral guarantees**
- **Execute is summarized, never per-call** — successful `capability.execute` events are counted per `(agentId, capability)` and emit one row per N (default 25), recording `representedExecuteCount` + `sampled: true`. Execute failures bypass the sampler and always emit (`status: failure`). Sampler memory is bounded.
- **Fail-closed** — every event first consults the platform-tier `ATLAS_AGENT_AUTH_ENABLED` master switch; when off, no rows are emitted at all.
- **No sensitive payloads** — capability `arguments`/`output` are never recorded (customer SQL / PII); the plugin's per-event metadata is allowlisted into `detail` (not copied wholesale); error strings are scrubbed + truncated via `errorMessage`.
- **Reversible seam preserved** — only the audit bridge, plugin factory, verifier, and gate know the agent-auth event shape; nothing downstream learns it (seam-quarantine test stays green).

## Test Plan

New `agent-auth-audit.test.ts` (18 tests) drives `createAgentAuthAuditor` through fully-injected seams (spy `emit`, controllable `isEnabled`, small interval) — self-contained, no settings DB / Better Auth / singleton mutation. Covers: every lifecycle mapping, unaudited-type fall-through, execute summarization + counter reset, per-`(agentId, capability)` keying, failure-always-emits, memory-cap clear, connection-string scrub, args/output never recorded, and the fail-closed master gate. The real `buildAgentAuthPlugin` plugin test also exercises the wired `onEvent` end-to-end.

- [x] Manual testing
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — full `scripts/ci-local.sh`: all 28 local gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area) — `feature`, `area: api` (inherited from issue)
- [ ] CHANGELOG.md updated — internal audit-catalog wiring for a default-off experimental surface; not a user-facing changelog entry

https://claude.ai/code/session_017cT7Sk5CDx7Q5VJgN5LkHv

---
_Generated by [Claude Code](https://claude.ai/code/session_017cT7Sk5CDx7Q5VJgN5LkHv)_