### PR TITLE
feat(ee): gate WebAuthn step-up approval strength behind enterprise flag

### DIFF
--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -61,15 +61,21 @@ mock.module("@atlas/api/lib/auth/agent-auth-gate", () => ({
 // SUT — imported AFTER the mocks are registered.
 import {
   buildAgentAuthPlugin,
+  buildAgentAuthPluginOptions,
+  resolveDeps,
   AGENT_WORKSPACE_METADATA_KEY,
   mintWorkspaceApiKeyVia,
   type CreateWorkspaceApiKey,
+  type AgentAuthPluginDeps,
 } from "@atlas/api/lib/auth/agent-auth-plugin";
+import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import {
   buildOperationIndex,
   isSensitiveOperation,
   isSensitivePath,
+  isWriteOperation,
   buildAgentAuthOpenApiOptions,
 } from "@atlas/api/lib/auth/agent-auth-openapi";
 import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
@@ -214,6 +220,186 @@ describe("agent-auth OpenAPI adapter classification (#4410)", () => {
     expect(names).toEqual(["getDashboards", "getMe", "headDashboards"].sort());
     expect(names).not.toContain("postQuery");
     expect(names).not.toContain("getAdminAudit");
+  });
+});
+
+// ── WebAuthn step-up strength gating (#4413, Slice 5a) ──────────────────────
+//
+// The /ee license controls step-up STRENGTH: with enterprise on, write-method
+// capabilities require a WebAuthn assertion (physical presence) before approval
+// and the plugin's `proofOfPresence` is enabled; core (AGPL) leaves writes at the
+// library-default "session" strength with no proof-of-presence. Writes are still
+// contained (blocked from the derived surface), so this asserts the enforcement
+// POLICY the capabilities carry + the plugin option that turns it on — the
+// library enforces the ceremony itself once a webauthn-strength cap is reachable.
+
+describe("agent-auth WebAuthn step-up strength gating (#4413)", () => {
+  /** Full plugin deps with injected seams; enterprise off by default. */
+  function makeStepUpDeps(overrides: Partial<AgentAuthPluginDeps> = {}): AgentAuthPluginDeps {
+    return {
+      spec: FIXTURE_SPEC,
+      fetch: async () => new Response("{}", { status: 200 }),
+      mintToken: async () => "wskey",
+      baseUrl: "http://internal",
+      deviceAuthorizationPage: "https://app.example.com/agent/approve",
+      stepUpWrites: false,
+      webauthnRpId: "app.example.com",
+      webauthnOrigin: "https://app.example.com",
+      ...overrides,
+    };
+  }
+
+  it("isWriteOperation keys off the method — writes true, reads (even admin reads) false, unknown false", () => {
+    const idx = buildOperationIndex(FIXTURE_SPEC);
+    expect(isWriteOperation(idx.get("postQuery"))).toBe(true); // write
+    expect(isWriteOperation(idx.get("getMe"))).toBe(false); // safe read
+    expect(isWriteOperation(idx.get("headDashboards"))).toBe(false); // HEAD read
+    // Admin/platform READS are sensitive (blocked) but NOT writes — they keep the
+    // session default; only the METHOD promotes to webauthn.
+    expect(isWriteOperation(idx.get("getAdminAudit"))).toBe(false);
+    expect(isWriteOperation(idx.get("getPlatformRegions"))).toBe(false);
+    expect(isWriteOperation(undefined)).toBe(false); // unknown → not claimed as a write
+  });
+
+  it("core adapter (no writeApprovalStrength): every capability keeps the default strength (unstamped)", () => {
+    const opts = buildAgentAuthOpenApiOptions(FIXTURE_SPEC, {
+      baseUrl: "http://internal",
+      resolveHeaders: async () => ({}),
+    });
+    for (const cap of opts.capabilities ?? []) {
+      expect(cap.approvalStrength).toBeUndefined(); // library default is "session"
+    }
+  });
+
+  it("enterprise adapter (writeApprovalStrength=webauthn): writes stamped webauthn, reads left at session default", () => {
+    const opts = buildAgentAuthOpenApiOptions(FIXTURE_SPEC, {
+      baseUrl: "http://internal",
+      resolveHeaders: async () => ({}),
+      writeApprovalStrength: "webauthn",
+    });
+    const byName = new Map((opts.capabilities ?? []).map((c) => [c.name, c] as const));
+    // The one write in the fixture is bumped to the strongest step-up.
+    expect(byName.get("postQuery")?.approvalStrength).toBe("webauthn");
+    // Reads — including admin/platform reads — are NOT bumped (GET → session).
+    expect(byName.get("getMe")?.approvalStrength).toBeUndefined();
+    expect(byName.get("getDashboards")?.approvalStrength).toBeUndefined();
+    expect(byName.get("headDashboards")?.approvalStrength).toBeUndefined();
+    expect(byName.get("getAdminAudit")?.approvalStrength).toBeUndefined();
+    expect(byName.get("getPlatformRegions")?.approvalStrength).toBeUndefined();
+    // Stamping the strength does not disturb the containment set — names only.
+    expect((opts.capabilities ?? []).map((c) => c.name).sort()).toEqual(
+      ["getAdminAudit", "getDashboards", "getMe", "getPlatformRegions", "headDashboards", "postQuery"].sort(),
+    );
+  });
+
+  it("enterprise plugin options (AC1): proofOfPresence enabled + write caps require webauthn", () => {
+    const opts = buildAgentAuthPluginOptions(
+      makeStepUpDeps({
+        stepUpWrites: true,
+        webauthnRpId: "app.example.com",
+        webauthnOrigin: "https://app.example.com",
+      }),
+    );
+    // The plugin-level switch that makes the library ENFORCE the webauthn
+    // ceremony (blocks approval until a physical-presence assertion is provided),
+    // with the RP mirroring the passkey plugin's enrollment RP.
+    expect(opts.proofOfPresence).toEqual({
+      enabled: true,
+      rpId: "app.example.com",
+      origin: "https://app.example.com",
+    });
+    const post = (opts.capabilities ?? []).find((c) => c.name === "postQuery");
+    expect(post?.approvalStrength).toBe("webauthn");
+  });
+
+  it("core plugin options (AC2): no proofOfPresence, writes fall back to the core session strength", () => {
+    const opts = buildAgentAuthPluginOptions(makeStepUpDeps({ stepUpWrites: false }));
+    expect(opts.proofOfPresence).toBeUndefined();
+    for (const cap of opts.capabilities ?? []) {
+      expect(cap.approvalStrength).toBeUndefined(); // no webauthn enforcement without /ee
+    }
+  });
+
+  it("enterprise with no configured web origin: origin omitted so the plugin derives it from baseURL", () => {
+    const opts = buildAgentAuthPluginOptions(
+      makeStepUpDeps({ stepUpWrites: true, webauthnRpId: "fallback.rp", webauthnOrigin: null }),
+    );
+    expect(opts.proofOfPresence).toEqual({ enabled: true, rpId: "fallback.rp" });
+  });
+
+  it("containment + stamping hold together against the REAL spec: every write webauthn-stamped, every read left default", () => {
+    // The fixture has one write; pin the write-classification-drives-stamping
+    // guarantee at spec scale (mirrors the containment real-spec test above).
+    const specPath = resolve(import.meta.dir, "../../../../../../apps/docs/openapi.json");
+    if (!existsSync(specPath)) {
+      console.warn(`[agent-auth] real-spec stamping test skipped — ${specPath} not found`);
+      return;
+    }
+    const realSpec = JSON.parse(readFileSync(specPath, "utf8")) as AtlasOpenApiSpec;
+    const index = buildOperationIndex(realSpec);
+    const opts = buildAgentAuthOpenApiOptions(realSpec, {
+      baseUrl: "http://internal",
+      resolveHeaders: async () => ({}),
+      writeApprovalStrength: "webauthn",
+    });
+    const byName = new Map((opts.capabilities ?? []).map((c) => [c.name, c] as const));
+    let stampedWrites = 0;
+    for (const [name, meta] of index) {
+      const cap = byName.get(name);
+      if (!cap) continue;
+      if (isWriteOperation(meta)) {
+        expect(cap.approvalStrength).toBe("webauthn");
+        stampedWrites++;
+      } else {
+        expect(cap.approvalStrength).toBeUndefined(); // reads stay at session default
+      }
+    }
+    expect(stampedWrites).toBeGreaterThan(0); // non-vacuous — the real spec has writes
+  });
+});
+
+// ── resolveDeps default-resolution wiring (#4413 AC3) ───────────────────────
+//
+// The step-up tests above inject `stepUpWrites` directly; these pin the seam
+// that actually connects the enterprise decision to the feature. `resolveDeps`
+// reads the flag through the core `enterprise-config.ts` mirror, which (with
+// config unloaded in unit tests) resolves from `ATLAS_ENTERPRISE_ENABLED` —
+// driven here via env, self-contained (set inside the suite, restored after).
+
+describe("resolveDeps enterprise-flag wiring (#4413 AC3)", () => {
+  const prevEnterprise = process.env.ATLAS_ENTERPRISE_ENABLED;
+  afterEach(() => {
+    if (prevEnterprise === undefined) delete process.env.ATLAS_ENTERPRISE_ENABLED;
+    else process.env.ATLAS_ENTERPRISE_ENABLED = prevEnterprise;
+  });
+
+  it("stepUpWrites resolves true when enterprise is enabled (read via the core mirror, not @atlas/ee)", () => {
+    process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+    expect(resolveDeps({ spec: FIXTURE_SPEC }).stepUpWrites).toBe(true);
+  });
+
+  it("stepUpWrites resolves false when enterprise is disabled — writes stay at the core session strength", () => {
+    process.env.ATLAS_ENTERPRISE_ENABLED = "false";
+    expect(resolveDeps({ spec: FIXTURE_SPEC }).stepUpWrites).toBe(false);
+  });
+
+  it("an explicit stepUpWrites override wins over the enterprise flag", () => {
+    process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+    expect(resolveDeps({ spec: FIXTURE_SPEC, stepUpWrites: false }).stepUpWrites).toBe(false);
+  });
+
+  it("webauthnRpId is resolved from the shared passkey RP resolver (resolvePasskeyRpId + getWebOrigin)", () => {
+    // Pins that `resolveDeps` derives the step-up RP from the SAME exported
+    // helper + args the passkey plugin uses — so the two can only agree by both
+    // calling `resolvePasskeyRpId(process.env, getWebOrigin())`. This guards
+    // internal drift in `resolveDeps` (swapping the resolver/args here goes red);
+    // it does NOT re-verify `server.ts`'s own `passkey({ rpID: ... })` call,
+    // which is the passkey feature's contract. Shared helper = agreement by
+    // construction; a step-up assertion against an enrolled passkey would be
+    // RP-mismatched only if BOTH sites diverged from this helper.
+    expect(resolveDeps({ spec: FIXTURE_SPEC }).webauthnRpId).toBe(
+      resolvePasskeyRpId(process.env, getWebOrigin()),
+    );
   });
 });
 

--- a/packages/api/src/lib/auth/agent-auth-openapi.ts
+++ b/packages/api/src/lib/auth/agent-auth-openapi.ts
@@ -49,7 +49,7 @@
  */
 
 import { createFromOpenAPI } from "@better-auth/agent-auth/openapi";
-import type { AgentAuthOptions } from "@better-auth/agent-auth";
+import type { AgentAuthOptions, ApprovalStrength } from "@better-auth/agent-auth";
 import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
 
 /** Read-only HTTP methods — the only ones a derived capability may be safe on. */
@@ -113,6 +113,20 @@ export function isSensitiveOperation(meta: OperationMeta | undefined): boolean {
   return isSensitivePath(meta.path);
 }
 
+/**
+ * True when `meta` is a WRITE operation — a non-read-only method
+ * (`POST`/`PUT`/`PATCH`/`DELETE`/…). Distinct from {@link isSensitiveOperation},
+ * which ALSO flags admin/platform READS: step-up approval strength (#4413) keys
+ * off the METHOD, so an admin GET is sensitive-but-not-a-write and keeps the
+ * session default. A cap with no recoverable method is NOT treated as a write —
+ * it is already blocked by {@link isSensitiveOperation}, so its approval strength
+ * is moot; leaving it at the default avoids over-claiming a strength it never
+ * exercises.
+ */
+export function isWriteOperation(meta: OperationMeta | undefined): boolean {
+  return meta !== undefined && !READ_ONLY_METHODS.has(meta.method.toUpperCase());
+}
+
 /** The subset of `AgentAuthOptions` this adapter produces, spreadable into `agentAuth()`. */
 export type AgentAuthOpenApiOptions = Pick<
   AgentAuthOptions,
@@ -140,6 +154,18 @@ export interface AgentAuthOpenApiDeps {
   readonly resolveHeaders: NonNullable<Parameters<typeof createFromOpenAPI>[1]["resolveHeaders"]>;
   /** Transport for the proxied call — the in-process `app.fetch` in production, a stub in tests. */
   readonly fetch?: ProxyFetch;
+  /**
+   * When set, stamp this approval strength on every WRITE-method capability
+   * ({@link isWriteOperation}). Enterprise (#4413) passes `"webauthn"` to require
+   * a WebAuthn step-up (physical presence) before a write can be approved —
+   * unbypassable by an autonomous agent with browser control. Core (AGPL) leaves
+   * it unset so writes keep the library default (`"session"`). Read-only caps are
+   * never restamped — they stay at the session default (#4413: `GET → session`).
+   * Orthogonal to the containment controls: writes remain blocked from the
+   * derived surface today, so this stamps the enforcement policy the caps carry
+   * for when they become reachable.
+   */
+  readonly writeApprovalStrength?: ApprovalStrength;
 }
 
 /**
@@ -159,17 +185,36 @@ export function buildAgentAuthOpenApiOptions(
   });
 
   const index = buildOperationIndex(spec);
-  const capabilities = base.capabilities ?? [];
+  const baseCapabilities = base.capabilities ?? [];
 
   const safeNames: string[] = [];
   const sensitiveNames = new Set<string>();
-  for (const cap of capabilities) {
+  for (const cap of baseCapabilities) {
     if (isSensitiveOperation(index.get(cap.name))) sensitiveNames.add(cap.name);
     else safeNames.push(cap.name);
   }
 
+  // Stamp step-up strength on write-method capabilities when requested (#4413,
+  // enterprise). Reads are left untouched so they keep the library default
+  // ("session"). No-op passthrough when `writeApprovalStrength` is unset (core).
+  // Hoisted to a `const` local: TS PRESERVES the truthy-branch narrowing of a
+  // `const` (`ApprovalStrength | undefined` → `ApprovalStrength`) into the nested
+  // `.map` closure, but DROPS narrowing of a property access
+  // (`deps.writeApprovalStrength`) at the closure boundary. The hoist therefore
+  // gives the closure a provably-`ApprovalStrength` value rather than relying on
+  // `Capability.approvalStrength` being optional to swallow a stray `undefined`.
+  const writeStrength = deps.writeApprovalStrength;
+  const capabilities = writeStrength
+    ? baseCapabilities.map((cap) =>
+        isWriteOperation(index.get(cap.name)) ? { ...cap, approvalStrength: writeStrength } : cap,
+      )
+    : baseCapabilities;
+
   return {
     ...base,
+    // Capabilities carrying the step-up strength stamp (#4413) — overrides the
+    // adapter's un-stamped set. Names/inputs are otherwise identical to `base`.
+    capabilities,
     // Auto-grant only the read-only, non-admin surface (control 1). Overrides
     // the adapter's method-only default, which would auto-grant admin GETs.
     defaultHostCapabilities: safeNames,

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -65,6 +65,8 @@ import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
 import { auditAgentAuthEvent } from "@atlas/api/lib/auth/agent-auth-audit";
 import { resolveAgentApprovalPage } from "@atlas/api/lib/auth/agent-approval-page";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
+import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
 import {
   buildAgentAuthOpenApiOptions,
   type AgentAuthOpenApiOptions,
@@ -312,9 +314,41 @@ export interface AgentAuthPluginDeps {
    * API host — see `resolveAgentApprovalPage`.
    */
   readonly deviceAuthorizationPage: string;
+  /**
+   * Enterprise (#4413, Slice 5a): when `true`, WRITE-method capabilities are
+   * stamped with `approvalStrength: "webauthn"` and the plugin's
+   * `proofOfPresence` is enabled, so a write requires a WebAuthn step-up
+   * (physical presence) before approval — unbypassable by an autonomous agent
+   * with browser control. When `false` (core / AGPL) writes keep the library
+   * default (`"session"`) and no proof-of-presence is required. Resolved from the
+   * core `enterprise-config.ts` mirror, never a direct `@atlas/ee` import, so
+   * `check-ee-imports.sh` stays green. Orthogonal to `ATLAS_AGENT_AUTH_ENABLED`
+   * (#4409), which gates whether the surface is reachable at all.
+   */
+  readonly stepUpWrites: boolean;
+  /**
+   * WebAuthn RP id + origin for `proofOfPresence`. `webauthnRpId` MUST match the
+   * passkey plugin's enrollment RP — `server.ts` registers
+   * `passkey({ rpID: resolvePasskeyRpId(process.env, getWebOrigin()) })` — or an
+   * assertion made against an enrolled passkey would be rejected as RP-mismatched;
+   * it is always a non-empty string (`resolvePasskeyRpId` falls back to
+   * `DEFAULT_RP_ID`). `webauthnOrigin` is `null` when no web origin is configured,
+   * in which case only the ORIGIN is omitted and the plugin derives it from its
+   * `baseURL` — `rpId` is always supplied.
+   */
+  readonly webauthnRpId: string;
+  readonly webauthnOrigin: string | null;
 }
 
-function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginDeps {
+/**
+ * Resolve the injected seams to their production defaults, honoring any
+ * overrides. Exported so the flag→feature wiring is directly testable — in
+ * particular that `stepUpWrites` reads the enterprise decision through the core
+ * `enterprise-config.ts` mirror (#4413 AC3) and that `webauthnRpId` matches the
+ * passkey plugin's enrollment RP by construction (same resolver + args as
+ * `server.ts`). Callers that want the plugin should use `buildAgentAuthPlugin`.
+ */
+export function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginDeps {
   return {
     spec: overrides?.spec !== undefined ? overrides.spec : getAtlasOpenApiSpec(),
     fetch: overrides?.fetch ?? inProcessFetch,
@@ -322,6 +356,14 @@ function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuthPluginD
     baseUrl: overrides?.baseUrl ?? resolveInternalApiBase(),
     deviceAuthorizationPage:
       overrides?.deviceAuthorizationPage ?? resolveAgentApprovalPage(getWebOrigin()),
+    // Read the enterprise flag through the core mirror (getConfig() → env), NOT a
+    // direct @atlas/ee import. Defaults false whenever config is unloaded / the
+    // env flag is unset (e.g. isolated unit tests), keeping core behavior unless
+    // enterprise is explicitly on.
+    stepUpWrites: overrides?.stepUpWrites ?? isEnterpriseEnabled(),
+    webauthnRpId: overrides?.webauthnRpId ?? resolvePasskeyRpId(process.env, getWebOrigin()),
+    webauthnOrigin:
+      overrides?.webauthnOrigin !== undefined ? overrides.webauthnOrigin : getWebOrigin(),
   };
 }
 
@@ -380,6 +422,9 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
     baseUrl: deps.baseUrl,
     resolveHeaders,
     fetch: deps.fetch,
+    // Enterprise-only (#4413): require a WebAuthn step-up on writes. Omitted in
+    // core, so writes keep the library default ("session").
+    ...(deps.stepUpWrites ? { writeApprovalStrength: "webauthn" as const } : {}),
   });
 
   // Wrap the adapter's proxy `onExecute` so an UNEXPECTED failure (upstream
@@ -461,16 +506,17 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
 }
 
 /**
- * Build the `agentAuth()` plugin. Kept as a factory (not a module-level
- * singleton) so `buildPlugins()` composes it like every other plugin and tests
- * can construct it in isolation with injected seams.
+ * Assemble the full `agentAuth()` options object from resolved deps — the
+ * capability set + proxy `onExecute` (from {@link buildOptions}) plus the
+ * top-level plugin options (device-authorization page, enterprise step-up,
+ * audit, branding). Extracted from {@link buildAgentAuthPlugin} so the
+ * enterprise-gated `proofOfPresence` + the write-capability strength stamps are
+ * assertable directly (the constructed plugin object hides its options), without
+ * standing up a `betterAuth()` instance.
  */
-export function buildAgentAuthPlugin(
-  overrides?: Partial<AgentAuthPluginDeps>,
-): ReturnType<typeof agentAuth> {
-  const deps = resolveDeps(overrides);
+export function buildAgentAuthPluginOptions(deps: AgentAuthPluginDeps): AgentAuthOptions {
   const options = buildOptions(deps);
-  return agentAuth({
+  return {
     ...options,
     // Point the device-authorization approval flow (#4411) at the Atlas web
     // page. Absolute WEB-origin URL — a bare path would resolve against the API
@@ -478,6 +524,29 @@ export function buildAgentAuthPlugin(
     // `options` spread because it's a top-level plugin option, not an adapter
     // field; the adapter never touches it, so ordering is immaterial.
     deviceAuthorizationPage: deps.deviceAuthorizationPage,
+    // #4413 Slice 5a — WebAuthn step-up enforcement, ENTERPRISE-ONLY. When /ee is
+    // enabled (`stepUpWrites`), write-method capabilities carry
+    // `approvalStrength: "webauthn"` (stamped in `buildOptions`) and
+    // proof-of-presence is REQUIRED before a write is approved — so even an
+    // autonomous agent with browser control cannot self-approve a write; a human
+    // with a physical authenticator must. `rpId` mirrors the passkey plugin's
+    // enrollment RP (`server.ts`) so an assertion made against an enrolled passkey
+    // validates; `origin` is the configured web origin. When the web origin is
+    // unset, `origin` is omitted and the plugin derives it from its `baseURL`
+    // (`rpId` is always supplied). Omitted entirely in core, where writes keep the
+    // library-default "session" strength and no proof-of-presence is required.
+    // The enterprise decision is read via the core `enterprise-config.ts` mirror
+    // (no `@atlas/ee` import here). This is orthogonal to `ATLAS_AGENT_AUTH_ENABLED`
+    // (#4409), which gates whether the surface is reachable at all.
+    ...(deps.stepUpWrites
+      ? {
+          proofOfPresence: {
+            enabled: true,
+            rpId: deps.webauthnRpId,
+            ...(deps.webauthnOrigin ? { origin: deps.webauthnOrigin } : {}),
+          },
+        }
+      : {}),
     // #4412 Slice 4 — record the grant/approval/execute lifecycle in the admin
     // audit catalog (`ADMIN_ACTIONS.agent.*`). The bridge fails closed on the
     // `ATLAS_AGENT_AUTH_ENABLED` master switch, summarizes high-volume executes
@@ -493,5 +562,29 @@ export function buildAgentAuthPlugin(
     providerName: "Atlas",
     providerDescription:
       "Atlas — deploy-anywhere text-to-SQL data analyst agent (Agent Auth Protocol, experimental).",
-  });
+  };
+}
+
+/**
+ * Build the `agentAuth()` plugin. Kept as a factory (not a module-level
+ * singleton) so `buildPlugins()` composes it like every other plugin and tests
+ * can construct it in isolation with injected seams.
+ */
+export function buildAgentAuthPlugin(
+  overrides?: Partial<AgentAuthPluginDeps>,
+): ReturnType<typeof agentAuth> {
+  const deps = resolveDeps(overrides);
+  // Loud, non-secret signal of the resolved step-up posture (#4413) so an
+  // operator can confirm from logs whether WebAuthn enforcement is active on a
+  // licensed deploy — not infer it. If config loads late (unresolved → false),
+  // this line is the only trace that writes built at the weaker "session"
+  // strength. rpId + booleans are not secrets (CLAUDE.md: no secrets in logs).
+  log.info(
+    {
+      stepUpWrites: deps.stepUpWrites,
+      webauthnRpId: deps.stepUpWrites ? deps.webauthnRpId : undefined,
+    },
+    "agent-auth: resolved WebAuthn step-up enforcement posture",
+  );
+  return agentAuth(buildAgentAuthPluginOptions(deps));
 }


### PR DESCRIPTION
## Summary

Slice 5a of #2058 (the WebAuthn half of the former Slice 5). Gates WebAuthn step-up **enforcement** behind `isEnterpriseEnabled()`, following the enterprise-inversion pattern:

- **`agent-auth-openapi.ts`** — new pure `isWriteOperation()` (method-based, distinct from `isSensitiveOperation`, which also flags admin/platform *reads*) and an optional `writeApprovalStrength` dep. When set, write-method capabilities are stamped `approvalStrength: "webauthn"`; reads keep the library default (`"session"`). Reused `READ_ONLY_METHODS` as the single method-classification SSOT so containment and stamping can't diverge.
- **`agent-auth-plugin.ts`** — `stepUpWrites` (resolved from the core `enterprise-config.ts` mirror, **not** a direct `@atlas/ee` import) drives both the `writeApprovalStrength: "webauthn"` stamp and the plugin's `proofOfPresence` (RP mirrors the passkey plugin's enrollment RP via `resolvePasskeyRpId`). Core/AGPL omits both, so writes fall back to the session default. Extracted `buildAgentAuthPluginOptions()` so the assembled options (incl. `proofOfPresence`) are assertable without standing up `betterAuth()`. Added a loud, non-secret boot log of the resolved enforcement posture.
- Orthogonal to `ATLAS_AGENT_AUTH_ENABLED` (#4409): the `/ee` license controls step-up *strength*; the hot-reloadable setting controls surface *reachability* (fail-closed 404 when off, independent of `/ee`).

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

New tests in `agent-auth-plugin.test.ts`:
- `isWriteOperation` classification (writes true; reads, admin reads, HEAD, unknown → false).
- Adapter stamping: enterprise stamps writes `webauthn`, leaves reads at session default, and doesn't disturb the containment name-set; core stamps nothing. Verified at fixture and real-`openapi.json` scale.
- Plugin options: enterprise ⇒ `proofOfPresence` enabled + write caps `webauthn` (AC1); core ⇒ no `proofOfPresence`, writes fall back to session (AC2); null web origin ⇒ origin omitted (plugin derives from `baseURL`).
- `resolveDeps` wiring (AC3): `stepUpWrites` follows `ATLAS_ENTERPRISE_ENABLED` on/off through the core mirror; explicit override wins; `webauthnRpId` resolved from the shared passkey RP resolver.

Reviewed by the internal specialist panel (2 rounds → clean). `bash scripts/ci-local.sh`: 27/28 gates green; the one `test` failure was a confirmed-flaky 5008ms boot-test timeout in the unrelated `startup-first-run.test.ts` (passes in isolation), not this change.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — experimental/default-off `/ee` internals, not a user-facing surface yet

Closes #4413

https://claude.ai/code/session_01XtPfxvzXEvp4SxaDMkY4cU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtPfxvzXEvp4SxaDMkY4cU)_