### PR TITLE
feat(ee): gate CIBA backchannel approval behind enterprise flag

### DIFF
--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -245,6 +245,7 @@ describe("agent-auth WebAuthn step-up strength gating (#4413)", () => {
       stepUpWrites: false,
       webauthnRpId: "app.example.com",
       webauthnOrigin: "https://app.example.com",
+      cibaApproval: false,
       ...overrides,
     };
   }
@@ -358,6 +359,81 @@ describe("agent-auth WebAuthn step-up strength gating (#4413)", () => {
   });
 });
 
+// ── CIBA backchannel approval gating (#4414, Slice 5b) ──────────────────────
+//
+// The /ee license controls whether the Atlas-internal CIBA (backchannel)
+// approval method is OFFERED. With enterprise on, `approval_methods` advertises
+// both `device_authorization` and `ciba` and the library accepts
+// `/agent/ciba/authorize`; core (AGPL) offers ONLY `device_authorization` — the
+// library omits `ciba` from the discovery document and hard-rejects the CIBA
+// endpoint. This asserts the plugin OPTION that drives the library gate plus the
+// end-to-end advertised method set through a real `betterAuth()` instance.
+
+describe("agent-auth CIBA backchannel approval gating (#4414)", () => {
+  /** Full plugin deps with injected seams; CIBA (enterprise) off by default. */
+  function makeCibaDeps(overrides: Partial<AgentAuthPluginDeps> = {}): AgentAuthPluginDeps {
+    return {
+      spec: FIXTURE_SPEC,
+      fetch: async () => new Response("{}", { status: 200 }),
+      mintToken: async () => "wskey",
+      baseUrl: "http://internal",
+      deviceAuthorizationPage: "https://app.example.com/agent/approve",
+      stepUpWrites: false,
+      webauthnRpId: "app.example.com",
+      webauthnOrigin: "https://app.example.com",
+      cibaApproval: false,
+      ...overrides,
+    };
+  }
+
+  it("core plugin options (AC2): device-authorization only, CIBA not offered", () => {
+    const opts = buildAgentAuthPluginOptions(makeCibaDeps({ cibaApproval: false }));
+    // Set EXPLICITLY, not left to the library default (["ciba","device_authorization"])
+    // — leaving it unset would offer CIBA in core.
+    expect(opts.approvalMethods).toEqual(["device_authorization"]);
+    expect(opts.approvalMethods).not.toContain("ciba");
+  });
+
+  it("enterprise plugin options (AC1): CIBA offered alongside device-authorization", () => {
+    const opts = buildAgentAuthPluginOptions(makeCibaDeps({ cibaApproval: true }));
+    expect(opts.approvalMethods).toContain("ciba");
+    expect(opts.approvalMethods).toContain("device_authorization");
+  });
+
+  // The advertised method set through a REAL betterAuth() instance: the discovery
+  // document (§6.1) is exactly what an agent reads to learn which approval methods
+  // the server accepts, and the library derives `/agent/ciba/authorize`'s own gate
+  // from the same list — so this is the load-bearing "offered / not offered" proof.
+  async function discoveryApprovalMethods(cibaApproval: boolean): Promise<string[]> {
+    const plugin = buildAgentAuthPlugin({ spec: FIXTURE_SPEC, cibaApproval });
+    const instance = betterAuth({
+      baseURL: BASE,
+      secret: "test-secret-at-least-32-characters-long!!",
+      database: memoryAdapter({
+        user: [], session: [], account: [], verification: [],
+        agent: [], agentHost: [], agentCapabilityGrant: [], approvalRequest: [],
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
+      plugins: [plugin] as any[],
+    });
+    const res = await instance.handler(
+      new Request(`${ISSUER}/agent-configuration`, { method: "GET" }),
+    );
+    const body = (await res.json()) as { approval_methods?: string[] };
+    return body.approval_methods ?? [];
+  }
+
+  it("core discovery document advertises device-authorization only (no ciba) — end-to-end", async () => {
+    expect(await discoveryApprovalMethods(false)).toEqual(["device_authorization"]);
+  });
+
+  it("enterprise discovery document advertises the CIBA backchannel — end-to-end", async () => {
+    const methods = await discoveryApprovalMethods(true);
+    expect(methods).toContain("ciba");
+    expect(methods).toContain("device_authorization");
+  });
+});
+
 // ── resolveDeps default-resolution wiring (#4413 AC3) ───────────────────────
 //
 // The step-up tests above inject `stepUpWrites` directly; these pin the seam
@@ -386,6 +462,21 @@ describe("resolveDeps enterprise-flag wiring (#4413 AC3)", () => {
   it("an explicit stepUpWrites override wins over the enterprise flag", () => {
     process.env.ATLAS_ENTERPRISE_ENABLED = "true";
     expect(resolveDeps({ spec: FIXTURE_SPEC, stepUpWrites: false }).stepUpWrites).toBe(false);
+  });
+
+  it("cibaApproval resolves true when enterprise is enabled (read via the core mirror, not @atlas/ee)", () => {
+    process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+    expect(resolveDeps({ spec: FIXTURE_SPEC }).cibaApproval).toBe(true);
+  });
+
+  it("cibaApproval resolves false when enterprise is disabled — core offers only device-authorization", () => {
+    process.env.ATLAS_ENTERPRISE_ENABLED = "false";
+    expect(resolveDeps({ spec: FIXTURE_SPEC }).cibaApproval).toBe(false);
+  });
+
+  it("an explicit cibaApproval override wins over the enterprise flag", () => {
+    process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+    expect(resolveDeps({ spec: FIXTURE_SPEC, cibaApproval: false }).cibaApproval).toBe(false);
   });
 
   it("webauthnRpId is resolved from the shared passkey RP resolver (resolvePasskeyRpId + getWebOrigin)", () => {

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -400,13 +400,10 @@ describe("agent-auth CIBA backchannel approval gating (#4414)", () => {
     expect(opts.approvalMethods).toContain("device_authorization");
   });
 
-  // The advertised method set through a REAL betterAuth() instance: the discovery
-  // document (§6.1) is exactly what an agent reads to learn which approval methods
-  // the server accepts, and the library derives `/agent/ciba/authorize`'s own gate
-  // from the same list — so this is the load-bearing "offered / not offered" proof.
-  async function discoveryApprovalMethods(cibaApproval: boolean): Promise<string[]> {
+  /** A real `betterAuth()` instance with only the agent-auth plugin, CIBA gated by `cibaApproval`. */
+  function makeCibaInstance(cibaApproval: boolean) {
     const plugin = buildAgentAuthPlugin({ spec: FIXTURE_SPEC, cibaApproval });
-    const instance = betterAuth({
+    return betterAuth({
       baseURL: BASE,
       secret: "test-secret-at-least-32-characters-long!!",
       database: memoryAdapter({
@@ -416,12 +413,60 @@ describe("agent-auth CIBA backchannel approval gating (#4414)", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
       plugins: [plugin] as any[],
     });
-    const res = await instance.handler(
+  }
+
+  // The advertised method set through a REAL betterAuth() instance: the discovery
+  // document (§6.1) is exactly what an agent reads to learn which approval methods
+  // the server accepts, and the library derives `/agent/ciba/authorize`'s own gate
+  // from the same list — so this is the load-bearing "offered / not offered" proof.
+  async function discoveryApprovalMethods(cibaApproval: boolean): Promise<string[]> {
+    const res = await makeCibaInstance(cibaApproval).handler(
       new Request(`${ISSUER}/agent-configuration`, { method: "GET" }),
     );
+    // A non-200 here (a regressed discovery endpoint) would otherwise surface as an
+    // empty method list; assert the status so a break reads as "endpoint broke",
+    // not "methods list is empty".
+    expect(res.status).toBe(200);
     const body = (await res.json()) as { approval_methods?: string[] };
     return body.approval_methods ?? [];
   }
+
+  // The ENFORCEMENT endpoint, end-to-end — not just the advertisement. The library
+  // runs `approvalMethods.includes("ciba")` as the FIRST line of
+  // `/agent/ciba/authorize`, before it even checks for a host session, so an
+  // unauthenticated POST cleanly separates the two postures: core rejects with
+  // `invalid_request` (CIBA is not offered), while enterprise passes the method gate
+  // and only THEN demands host auth (`unauthorized`). This pins the actual gate
+  // against a future library bump that might decouple the endpoint from
+  // `approval_methods` — a decoupling that would keep the advertising tests green
+  // while core silently accepted a backchannel approval (an enterprise-gate bypass).
+  async function cibaAuthorize(
+    cibaApproval: boolean,
+  ): Promise<{ status: number; error?: string }> {
+    const res = await makeCibaInstance(cibaApproval).handler(
+      new Request(`${ISSUER}/agent/ciba/authorize`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ login_hint: "user@example.com" }),
+      }),
+    );
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    return { status: res.status, error: body.error };
+  }
+
+  it("core /agent/ciba/authorize is hard-rejected (invalid_request) — enforcement, not just advertising", async () => {
+    const { status, error } = await cibaAuthorize(false);
+    expect(status).toBe(400);
+    expect(error).toBe("invalid_request");
+  });
+
+  it("enterprise /agent/ciba/authorize passes the method gate, then demands host auth (unauthorized)", async () => {
+    // Not `invalid_request`: the CIBA method IS offered, so the library advances
+    // past the gate to the host-auth check — which an unauthenticated request fails.
+    const { status, error } = await cibaAuthorize(true);
+    expect(status).toBe(401);
+    expect(error).toBe("unauthorized");
+  });
 
   it("core discovery document advertises device-authorization only (no ciba) — end-to-end", async () => {
     expect(await discoveryApprovalMethods(false)).toEqual(["device_authorization"]);

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -338,6 +338,24 @@ export interface AgentAuthPluginDeps {
    */
   readonly webauthnRpId: string;
   readonly webauthnOrigin: string | null;
+  /**
+   * Enterprise (#4414, Slice 5b): when `true`, the Atlas-internal CIBA
+   * (backchannel) approval method (§9) is advertised in the discovery document
+   * and accepted by `/agent/ciba/authorize`, in addition to the core
+   * device-authorization path. When `false` (core / AGPL) only
+   * `device_authorization` is offered: the library omits `ciba` from
+   * `approval_methods` and hard-rejects `/agent/ciba/authorize`
+   * (`invalid_request`), and `resolveApprovalMethod` falls back to
+   * `device_authorization` even for an agent that asks for
+   * `preferredMethod: "ciba"`. Only Atlas-internal CIBA is in scope — the
+   * library resolves the user from its own internal adapter by email login-hint;
+   * native third-party-IdP CIBA integrations stay out of scope (#2058). Resolved
+   * from the core `enterprise-config.ts` mirror, never a direct `@atlas/ee`
+   * import, so `check-ee-imports.sh` stays green. Orthogonal to
+   * `ATLAS_AGENT_AUTH_ENABLED` (#4409), which gates whether the surface is
+   * reachable at all.
+   */
+  readonly cibaApproval: boolean;
 }
 
 /**
@@ -364,6 +382,11 @@ export function resolveDeps(overrides?: Partial<AgentAuthPluginDeps>): AgentAuth
     webauthnRpId: overrides?.webauthnRpId ?? resolvePasskeyRpId(process.env, getWebOrigin()),
     webauthnOrigin:
       overrides?.webauthnOrigin !== undefined ? overrides.webauthnOrigin : getWebOrigin(),
+    // #4414 Slice 5b — read the same enterprise decision through the core mirror
+    // (never a direct @atlas/ee import). Defaults false whenever config is
+    // unloaded / the env flag is unset, so core offers only device-authorization
+    // unless enterprise is explicitly on.
+    cibaApproval: overrides?.cibaApproval ?? isEnterpriseEnabled(),
   };
 }
 
@@ -524,6 +547,25 @@ export function buildAgentAuthPluginOptions(deps: AgentAuthPluginDeps): AgentAut
     // `options` spread because it's a top-level plugin option, not an adapter
     // field; the adapter never touches it, so ordering is immaterial.
     deviceAuthorizationPage: deps.deviceAuthorizationPage,
+    // #4414 Slice 5b — CIBA (backchannel) approval, ENTERPRISE-ONLY. Core (AGPL)
+    // offers ONLY device-authorization approval; the Atlas-internal CIBA
+    // backchannel (§9.2) is advertised + accepted only when /ee is enabled. The
+    // library gates its own CIBA surface on THIS list: `/agent/ciba/authorize`
+    // hard-rejects (`invalid_request`) and `/agent-configuration` omits `ciba`
+    // from `approval_methods` whenever `"ciba"` is absent — so a core deploy
+    // cannot initiate a backchannel flow even if an agent asks for
+    // `preferredMethod: "ciba"` (`resolveApprovalMethod` falls back to
+    // `device_authorization`). This must be set explicitly: the library default
+    // is `["ciba", "device_authorization"]`, i.e. CIBA-on, so leaving it unset
+    // would offer CIBA in core. Native third-party-IdP CIBA integrations stay out
+    // of scope (#2058) — this is Atlas-internal CIBA only (the library resolves
+    // the user via its own internal adapter by email login-hint, not an external
+    // IdP). The enterprise decision is read via the core `enterprise-config.ts`
+    // mirror (no `@atlas/ee` import here). Orthogonal to `ATLAS_AGENT_AUTH_ENABLED`
+    // (#4409), which gates whether the surface is reachable at all.
+    approvalMethods: deps.cibaApproval
+      ? ["device_authorization", "ciba"]
+      : ["device_authorization"],
     // #4413 Slice 5a — WebAuthn step-up enforcement, ENTERPRISE-ONLY. When /ee is
     // enabled (`stepUpWrites`), write-method capabilities carry
     // `approvalStrength: "webauthn"` (stamped in `buildOptions`) and
@@ -574,17 +616,19 @@ export function buildAgentAuthPlugin(
   overrides?: Partial<AgentAuthPluginDeps>,
 ): ReturnType<typeof agentAuth> {
   const deps = resolveDeps(overrides);
-  // Loud, non-secret signal of the resolved step-up posture (#4413) so an
-  // operator can confirm from logs whether WebAuthn enforcement is active on a
-  // licensed deploy — not infer it. If config loads late (unresolved → false),
-  // this line is the only trace that writes built at the weaker "session"
-  // strength. rpId + booleans are not secrets (CLAUDE.md: no secrets in logs).
+  // Loud, non-secret signal of the resolved enterprise approval posture (#4413
+  // WebAuthn step-up + #4414 CIBA) so an operator can confirm from logs which
+  // enterprise controls are active on a licensed deploy — not infer them. If
+  // config loads late (unresolved → false), this line is the only trace that
+  // writes built at the weaker "session" strength / that CIBA is not offered.
+  // rpId + booleans are not secrets (CLAUDE.md: no secrets in logs).
   log.info(
     {
       stepUpWrites: deps.stepUpWrites,
       webauthnRpId: deps.stepUpWrites ? deps.webauthnRpId : undefined,
+      cibaApproval: deps.cibaApproval,
     },
-    "agent-auth: resolved WebAuthn step-up enforcement posture",
+    "agent-auth: resolved enterprise approval posture (WebAuthn step-up + CIBA)",
   );
   return agentAuth(buildAgentAuthPluginOptions(deps));
 }


### PR DESCRIPTION
## Summary

Slice 5b of #2058 — gate the CIBA (backchannel) agent-auth approval method behind the enterprise flag. Core (AGPL) keeps device-authorization approval; the Atlas-internal CIBA approval method is offered only when `/ee` is enabled. Mirrors the #4413 (Slice 5a) WebAuthn step-up gating in the same file.

- Adds a `cibaApproval` dep to `AgentAuthPluginDeps`, resolved in `resolveDeps` from `isEnterpriseEnabled()` via the core `enterprise-config.ts` mirror — never a direct `@atlas/ee` import (keeps `check-ee-imports.sh` green).
- Sets `approvalMethods` **explicitly** in `buildAgentAuthPluginOptions`: `["device_authorization"]` in core, `+ "ciba"` under enterprise. This must be explicit — the `@better-auth/agent-auth@0.6.2` default is `["ciba", "device_authorization"]` (CIBA-on), so leaving it unset would offer CIBA in core.
- The library derives its own CIBA surface from that list: `/agent/ciba/authorize` hard-rejects (`invalid_request`) and `/agent-configuration` omits `ciba` from `approval_methods` whenever `"ciba"` is absent; `resolveApprovalMethod` falls back to `device_authorization` even for an agent that asks for `preferredMethod: "ciba"`.
- Third-party-IdP CIBA stays **out of scope** (#2058): only Atlas-internal CIBA is offered (the library resolves the user via its own internal adapter by email login-hint, not an external IdP). Documented in the `cibaApproval` field JSDoc and the option-site comment.
- Orthogonal to `ATLAS_AGENT_AUTH_ENABLED` (#4409): the `/ee` license controls the approval *method*, while the hot-reloadable request-time gate controls surface *reachability* (fail-closed 404 when off, covered by the existing `agent-auth-gate` / `agent-auth-live-toggle` tests).

Closes #4414

## Test Plan

New tests in `agent-auth-plugin.test.ts`, driven through the real `buildAgentAuthPlugin()` + a real `betterAuth()` instance:

- **Advertising** (discovery document, end-to-end): core advertises `["device_authorization"]` only; enterprise advertises both `device_authorization` and `ciba`.
- **Enforcement** (`/agent/ciba/authorize`, end-to-end): core is hard-rejected `400 invalid_request` (CIBA not offered); enterprise passes the method gate and only then demands host auth (`401 unauthorized`) — pinning the endpoint gate against a future library bump that might decouple it from `approval_methods`.
- **Plugin options** (unit): core `approvalMethods` omits `ciba`; enterprise includes it.
- **`resolveDeps` wiring**: `cibaApproval` reads the enterprise decision via the `enterprise-config.ts` mirror (true when `ATLAS_ENTERPRISE_ENABLED=true`, false when disabled, explicit override wins).

Internal review panel (silent-failure / type-design / test-coverage / comment) run pre-PR: clean after one round (the test-coverage finding — enforcement untested, only advertising — was addressed by the `/agent/ciba/authorize` E2E cases above).

- [ ] Manual testing
- [x] Unit tests added/updated
- [x] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — all 28 local `ci-local.sh` gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [x] Labels added (type + area) — `feature`, `area: api`, `area: mcp` (inherited from the issue)
- [ ] CHANGELOG.md updated — not user-facing (enterprise-internal gating of an experimental surface)

https://claude.ai/code/session_01HQsYjsyFLWeKoZ2RFj7mhW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQsYjsyFLWeKoZ2RFj7mhW)_