### PR TITLE
chore(lint): post-cutover oxlint tightening — restore no-explicit-any + no-control-regex

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,8 +9,8 @@
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "@next/next/no-html-link-for-pages": "off",
-    "no-unsafe-optional-chaining": "warn",
-    "no-control-regex": "warn"
+    "typescript/no-explicit-any": "warn",
+    "no-unsafe-optional-chaining": "warn"
   },
   "overrides": [
     {

--- a/create-atlas/templates/docker/.oxlintrc.json
+++ b/create-atlas/templates/docker/.oxlintrc.json
@@ -4,5 +4,8 @@
   "categories": {
     "correctness": "error"
   },
+  "rules": {
+    "typescript/no-explicit-any": "warn"
+  },
   "ignorePatterns": ["**/.next/", "node_modules/", "**/dist/"]
 }

--- a/create-atlas/templates/nextjs-standalone/.oxlintrc.json
+++ b/create-atlas/templates/nextjs-standalone/.oxlintrc.json
@@ -4,5 +4,8 @@
   "categories": {
     "correctness": "error"
   },
+  "rules": {
+    "typescript/no-explicit-any": "warn"
+  },
   "ignorePatterns": ["**/.next/", "node_modules/", "**/dist/"]
 }

--- a/docs/adr/0031-oxlint-over-eslint.md
+++ b/docs/adr/0031-oxlint-over-eslint.md
@@ -53,13 +53,19 @@ does **not** implement `no-restricted-syntax` natively.
   reimplementations of `no-unsafe-optional-chaining` and `no-control-regex` are
   stricter than ESLint's and flagged 5 sites that ESLint passed clean. Rather
   than rewrite working, ESLint-green code to satisfy a stricter reimplementation
-  mid-swap, both rules are set to `warn` (surfaced, non-blocking). One genuine
-  redundancy oxlint's parser caught — a duplicate `import type React` in
-  `admin-layout.test.tsx` — was removed.
-- **Signal loss to revisit:** `@typescript-eslint/no-explicit-any` was a
-  *warning* under `tseslint.recommended`; it is not in oxlint's `correctness`
-  set, so the `any` lint signal is gone (type-check + review still cover it).
-  Re-adding `typescript/no-explicit-any: warn` is a candidate follow-up.
+  mid-swap, both rules were initially set to `warn`. One genuine redundancy
+  oxlint's parser caught — a duplicate `import type React` in
+  `admin-layout.test.tsx` — was removed. **Follow-up (post-cutover):**
+  `no-control-regex` was restored to `error` after switching the one flagged
+  site (tar NUL-padding strip in `bundle-archive.ts`) to a `\u0000` escape with
+  a justified `oxlint-disable-next-line`. `no-unsafe-optional-chaining` stays
+  `warn` — its 4 remaining sites are benign test assertions not worth the
+  non-null-assertion churn.
+- **Signal loss, now restored:** `@typescript-eslint/no-explicit-any` was a
+  *warning* under `tseslint.recommended` and is not in oxlint's `correctness`
+  set. **Follow-up (post-cutover):** re-added as `typescript/no-explicit-any:
+  warn` (root + template configs), reproducing the pre-oxlint signal — existing
+  `oxlint-disable` comments are honored, and new undisabled `any` warns again.
 - Scaffolded projects copy `.oxlintrc.json` (create-atlas's `copyDirRecursive`
   includes dotfiles) and depend on `oxlint`; `bun run lint` works standalone.
 - `typescript@6` stays for `.d.ts` emit (`packages/{types,sdk,plugin-sdk,

--- a/examples/nextjs-standalone/.oxlintrc.json
+++ b/examples/nextjs-standalone/.oxlintrc.json
@@ -4,5 +4,8 @@
   "categories": {
     "correctness": "error"
   },
+  "rules": {
+    "typescript/no-explicit-any": "warn"
+  },
   "ignorePatterns": ["**/.next/", "node_modules/", "**/dist/"]
 }

--- a/packages/api/src/lib/knowledge/bundle-archive.ts
+++ b/packages/api/src/lib/knowledge/bundle-archive.ts
@@ -294,7 +294,8 @@ function extractTar(
 
     // GNU long-name extension: this entry's data IS the next entry's full name.
     if (typeChar === "L") {
-      longName = readString(bytes, dataStart, size).replace(/\0+$/, "");
+      // oxlint-disable-next-line no-control-regex -- tar long-name fields are NUL-padded; matching \u0000 to strip the padding is intended.
+      longName = readString(bytes, dataStart, size).replace(/\u0000+$/, "");
       continue;
     }
     // pax extended headers ('x'/'g') and directories ('5') carry no concept file.


### PR DESCRIPTION
## Summary

Follow-up to the ESLint→oxlint cutover (#4428, ADR-0031), closing the two divergences that PR documented as post-cutover work:

1. **Restore the `no-explicit-any` signal.** Re-add `typescript/no-explicit-any: warn` to the root config + both `create-atlas` templates + `examples/nextjs-standalone`. This reproduces the warning `tseslint.recommended` gave pre-cutover. Existing `oxlint-disable` comments are honored (verified); a *new* undisabled `any` warns again. Confirmed the rule is active via probe.
2. **Re-tighten `no-control-regex` to `error`.** Drop the temporary `warn` downgrade. The one site it flagged — stripping NUL padding from tar long-name fields in `bundle-archive.ts` — carried a **raw NUL byte in the regex source**. Replaced it with a `` Unicode escape (a genuine source-hygiene improvement, behavior-identical) plus a justified `oxlint-disable-next-line` for the intentional control-char match. The rest of the codebase now enforces the rule at `error`.

`no-unsafe-optional-chaining` intentionally **stays `warn`** — its 4 remaining sites are benign test assertions, and "fixing" them means non-null-assertion churn that conflicts with the minimize-`!` guideline. Recorded in the ADR.

Relates to #3870, #3873. ADR-0031 consequences updated to record both follow-ups landing.

## Test Plan

- `bun run lint` → **exit 0** (no-control-regex at `error` passes on the fixed site; no-explicit-any warnings are honored-or-surfaced, non-blocking).
- `bun run test src/lib/knowledge/__tests__/bundle-archive.test.ts` → **PASS** (the `` regex change is behavior-identical; tar parsing intact).
- Verified `no-explicit-any` fires on an undisabled-`any` probe and is suppressed by existing `oxlint-disable` comments.
- Confirmed 0 literal NUL bytes remain in `bundle-archive.ts`.

- [x] Manual testing (`bun run lint`, targeted test, probes)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`) — no type surface changed (regex-literal + config + docs)
- [x] Tests pass (`bun run test`) — bundle-archive suite verified; full suite via CI
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — internal tooling change, no user-facing surface

https://claude.ai/code/session_012XPZWkCUKyibRBah7cTcqS

---
_Generated by [Claude Code](https://claude.ai/code/session_012XPZWkCUKyibRBah7cTcqS)_