### PR TITLE
chore(lint): resolve type-aware await-thenable (753 → 0), promote to error

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,7 +12,7 @@
     "typescript/no-explicit-any": "warn",
     "no-unsafe-optional-chaining": "warn",
     "typescript/no-floating-promises": "error",
-    "typescript/await-thenable": "warn",
+    "typescript/await-thenable": "error",
     "typescript/no-base-to-string": "warn",
     "typescript/no-redundant-type-constituents": "warn",
     "typescript/unbound-method": "warn",

--- a/bun.lock
+++ b/bun.lock
@@ -937,6 +937,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "bun-types@1.3.14": "patches/bun-types@1.3.14.patch",
+  },
   "packages": {
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.119", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.85", "@ai-sdk/openai": "3.0.73", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DgJugGl0Euja2g+60p3eV+2k4kQvtLtJFeYskVrAlt0KgpVGYot0XEPCOBgjDsn6aAEuyibWDSIddxJU8k9wug=="],
 

--- a/deploy/api-apac/railway.json
+++ b/deploy/api-apac/railway.json
@@ -7,6 +7,7 @@
     "watchPatterns": [
       "bun.lock",
       "package.json",
+      "patches/**",
       "packages/api/**",
       "packages/react/**",
       "packages/types/**",

--- a/deploy/api-eu/railway.json
+++ b/deploy/api-eu/railway.json
@@ -7,6 +7,7 @@
     "watchPatterns": [
       "bun.lock",
       "package.json",
+      "patches/**",
       "packages/api/**",
       "packages/react/**",
       "packages/types/**",

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -10,6 +10,9 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
+# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
+# present in the build context for `bun ci` to apply it during install.
+COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json
 COPY packages/cli/package.json packages/cli/package.json

--- a/deploy/api/railway.json
+++ b/deploy/api/railway.json
@@ -7,6 +7,7 @@
     "watchPatterns": [
       "bun.lock",
       "package.json",
+      "patches/**",
       "packages/api/**",
       "packages/react/**",
       "packages/types/**",

--- a/deploy/docs/Dockerfile
+++ b/deploy/docs/Dockerfile
@@ -23,6 +23,9 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
+# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
+# present in the build context for `bun ci` to apply it during install.
+COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json
 COPY packages/cli/package.json packages/cli/package.json

--- a/deploy/docs/railway.json
+++ b/deploy/docs/railway.json
@@ -7,6 +7,7 @@
     "watchPatterns": [
       "bun.lock",
       "package.json",
+      "patches/**",
       "brand.css",
       "apps/docs/**",
       "deploy/docs/**",

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -10,6 +10,9 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
+# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
+# present in the build context for `bun ci` to apply it during install.
+COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json
 COPY packages/cli/package.json packages/cli/package.json

--- a/deploy/web/railway.json
+++ b/deploy/web/railway.json
@@ -7,6 +7,7 @@
     "watchPatterns": [
       "bun.lock",
       "package.json",
+      "patches/**",
       "packages/web/**",
       "packages/api/**",
       "packages/react/**",

--- a/docs/adr/0031-oxlint-over-eslint.md
+++ b/docs/adr/0031-oxlint-over-eslint.md
@@ -78,6 +78,31 @@ does **not** implement `no-restricted-syntax` natively.
     `warn` → `error`** (now 0 repo-wide): `no-floating-promises`,
     `require-array-sort-compare`, `no-useless-default-assignment`,
     `no-duplicate-type-constituents`.
+  - **Wave 3 (`await-thenable`, 753 → 0, #4437).** The 753 sites were all
+    `await expect(...).rejects/.resolves.X()` false positives: `bun-types` declares
+    the matcher methods reached through `.resolves`/`.rejects` as returning `void`
+    (they share the synchronous `MatchersBuiltin` interface), so tsgolint sees
+    `await <void>` and flags the `await` as redundant — even though at runtime those
+    methods return a real thenable that MUST be awaited to enforce the assertion.
+    Not a bun-1.4 bump (that is a runtime rewrite; the matcher return types on bun
+    `main` are still `void`). **Fix: a repo-side `bun` patch** (`patches/bun-types@1.3.14.patch`
+    via `patchedDependencies`) that rewrites only the async matcher path — a mapped type
+    repoints `resolves`/`rejects` so every matcher method returns `Promise<void>`, leaving
+    the synchronous `expect(x).toBe(y)` path (`void`) untouched. We chose the patch over a
+    repo-side `declare module` augmentation because the augmentation only applies to files
+    in a program that includes it, and the repo's programs diverge (several packages have
+    no tsconfig; `packages/web` *excludes* its tests, so tsgolint builds inferred per-file
+    programs for them) — the patch propagates to every test program uniformly and stays
+    correct for future test files, with no per-package wiring. Because the sync path is
+    preserved, `no-floating-promises` (now `error`) newly catches a missing `await` before a
+    `.rejects`/`.resolves` assertion — which surfaced one real latent bug (an un-awaited,
+    never-enforced rejection assertion in `lazy-loader.test.ts`). After the patch, 15
+    genuine residual redundant-awaits remained (previously masked by the 753 noise) and were
+    removed: `await registry.registerDirect(...)` ×11 (`registerDirect` returns `void`) and
+    `await validate!(...)` ×4 (synchronous mock returns). **Promoted `await-thenable`
+    `warn` → `error`** (0 repo-wide). *Caveat:* the patch is pinned to `bun-types@1.3.14`;
+    a version bump that changes `test.d.ts` will fail to apply at install time (a loud,
+    CI-caught failure) and the patch must be regenerated (`bun patch bun-types@<v>`).
 
 ## Consequences
 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -3,6 +3,9 @@ FROM oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da0
 FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
+# The bun-types patch (patchedDependencies in package.json/bun.lock) must be
+# present in the build context for `bun ci` to apply it during install.
+COPY patches patches
 COPY packages/api/package.json packages/api/package.json
 COPY packages/web/package.json packages/web/package.json
 COPY packages/cli/package.json packages/cli/package.json

--- a/package.json
+++ b/package.json
@@ -145,5 +145,8 @@
     "snowflake-sdk": "^2.4.3",
     "tailwindcss": "^4.3.1",
     "zustand": "^5.0.14"
+  },
+  "patchedDependencies": {
+    "bun-types@1.3.14": "patches/bun-types@1.3.14.patch"
   }
 }

--- a/packages/api/src/lib/db/__tests__/registry-health.test.ts
+++ b/packages/api/src/lib/db/__tests__/registry-health.test.ts
@@ -55,7 +55,7 @@ describe("ConnectionRegistry health checks", () => {
   }
 
   it("healthy on successful health check", async () => {
-    await registry.registerDirect("test", mockConn(), "postgres");
+    registry.registerDirect("test", mockConn(), "postgres");
     const result = await registry.healthCheck("test");
     expect(result.status).toBe("healthy");
     expect(result.latencyMs).toBeGreaterThanOrEqual(0);
@@ -63,7 +63,7 @@ describe("ConnectionRegistry health checks", () => {
   });
 
   it("degraded after 1 failure", async () => {
-    await registry.registerDirect("test", mockConn({ failQuery: true }), "postgres");
+    registry.registerDirect("test", mockConn({ failQuery: true }), "postgres");
     const result = await registry.healthCheck("test");
     expect(result.status).toBe("degraded");
     expect(result.message).toContain("connection refused");
@@ -71,7 +71,7 @@ describe("ConnectionRegistry health checks", () => {
 
   it("unhealthy after 3 failures spanning > 5 minutes", async () => {
     const conn = mockConn({ failQuery: true });
-    await registry.registerDirect("test", conn, "postgres");
+    registry.registerDirect("test", conn, "postgres");
 
     // Simulate 3 failures over 5+ minutes
     await registry.healthCheck("test"); // failure 1
@@ -97,7 +97,7 @@ describe("ConnectionRegistry health checks", () => {
       async close() {},
     };
 
-    await registry.registerDirect("test", conn, "postgres");
+    registry.registerDirect("test", conn, "postgres");
 
     // Make it unhealthy
     const entries = (registry as unknown as { entries: Map<string, { firstFailureAt: number | null; consecutiveFailures: number }> }).entries;
@@ -115,7 +115,7 @@ describe("ConnectionRegistry health checks", () => {
   });
 
   it("describe() includes health status", async () => {
-    await registry.registerDirect("test", mockConn(), "postgres", "Test DB");
+    registry.registerDirect("test", mockConn(), "postgres", "Test DB");
     await registry.healthCheck("test");
 
     const meta = registry.describe();
@@ -125,7 +125,7 @@ describe("ConnectionRegistry health checks", () => {
   });
 
   it("describe() omits health when no check has been run", async () => {
-    await registry.registerDirect("test", mockConn(), "postgres");
+    registry.registerDirect("test", mockConn(), "postgres");
     const meta = registry.describe();
     expect(meta[0].health).toBeUndefined();
   });

--- a/packages/api/src/lib/db/__tests__/registry.test.ts
+++ b/packages/api/src/lib/db/__tests__/registry.test.ts
@@ -120,7 +120,7 @@ describe("ConnectionRegistry", () => {
         async query() { return { columns: [], rows: [] }; },
         async close() {},
       };
-      await connections.registerDirect("bench", mockConn, "postgres");
+      connections.registerDirect("bench", mockConn, "postgres");
       expect(connections.get("bench")).toBe(mockConn);
       expect(connections.getDBType("bench")).toBe("postgres");
     });
@@ -136,8 +136,8 @@ describe("ConnectionRegistry", () => {
         async close() {},
       };
 
-      await connections.registerDirect("bench", firstConn, "postgres");
-      await connections.registerDirect("bench", secondConn, "postgres");
+      connections.registerDirect("bench", firstConn, "postgres");
+      connections.registerDirect("bench", secondConn, "postgres");
 
       expect(closeCalled).toBe(1);
       expect(connections.get("bench")).toBe(secondConn);
@@ -148,7 +148,7 @@ describe("ConnectionRegistry", () => {
         async query() { return { columns: [], rows: [] }; },
         async close() {},
       };
-      await connections.registerDirect("bench", mockConn, "duckdb", "Benchmark DB");
+      connections.registerDirect("bench", mockConn, "duckdb", "Benchmark DB");
 
       const meta = connections.describe();
       const benchMeta = meta.find((m) => m.id === "bench");
@@ -253,7 +253,7 @@ describe("ConnectionRegistry", () => {
 
     it("returns correct type for plugin-registered connection", async () => {
       const conn = { async query() { return { columns: [], rows: [] }; }, async close() {} };
-      await connections.registerDirect("ch", conn, "clickhouse");
+      connections.registerDirect("ch", conn, "clickhouse");
       expect(connections.getDBType("ch")).toBe("clickhouse");
     });
 

--- a/packages/api/src/lib/plugins/__tests__/lazy-loader.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/lazy-loader.test.ts
@@ -310,7 +310,7 @@ describe("LazyPluginLoader.evict", () => {
 });
 
 describe("LazyPluginLoader readInstallConfig", () => {
-  test("treats workspace_plugins.enabled = false as not-installed (filter is in the SQL)", () => {
+  test("treats workspace_plugins.enabled = false as not-installed (filter is in the SQL)", async () => {
     const loader = new LazyPluginLoader();
     loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) =>
       buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
@@ -319,7 +319,7 @@ describe("LazyPluginLoader readInstallConfig", () => {
     // The mocked `internalQuery` returns rows only when `mockRowsByKey`
     // has an entry — by not staging a row we model a disabled install
     // being filtered out. The assertion that matters is the SQL itself.
-    expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
+    await expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
       /no enabled install/i,
     );
 

--- a/packages/plugin-sdk/src/__tests__/types.test.ts
+++ b/packages/plugin-sdk/src/__tests__/types.test.ts
@@ -770,8 +770,8 @@ describe("datasource plugin entities and dialect", () => {
     } satisfies AtlasDatasourcePlugin);
 
     expect(plugin.connection.validate).toBeDefined();
-    expect(await plugin.connection.validate!("SELECT Id FROM Account")).toEqual({ valid: true });
-    expect(await plugin.connection.validate!("DELETE FROM Account")).toEqual({ valid: false, reason: "Only SELECT queries allowed" });
+    expect(plugin.connection.validate!("SELECT Id FROM Account")).toEqual({ valid: true });
+    expect(plugin.connection.validate!("DELETE FROM Account")).toEqual({ valid: false, reason: "Only SELECT queries allowed" });
   });
 
   test("accepts async connection.validate function", async () => {
@@ -871,8 +871,8 @@ describe("datasource plugin entities and dialect", () => {
 
     const instance = sfPlugin({ instanceUrl: "https://example.my.salesforce.com" });
     expect(instance.connection.validate).toBeDefined();
-    expect(await instance.connection.validate!("SELECT Id FROM Account")).toEqual({ valid: true });
-    expect(await instance.connection.validate!("DESCRIBE Account")).toEqual({ valid: false, reason: "Must start with SELECT" });
+    expect(instance.connection.validate!("SELECT Id FROM Account")).toEqual({ valid: true });
+    expect(instance.connection.validate!("DESCRIBE Account")).toEqual({ valid: false, reason: "Must start with SELECT" });
   });
 
   test("accepts parserDialect string", () => {

--- a/patches/bun-types@1.3.14.patch
+++ b/patches/bun-types@1.3.14.patch
@@ -1,0 +1,47 @@
+diff --git a/test.d.ts b/test.d.ts
+index 6c3dfe7760ced9444cf1dce7e7432da0c47b63b4..9a11eb39834e049aa2df04fba1511735c3c30e1e 100644
+--- a/test.d.ts
++++ b/test.d.ts
+@@ -897,6 +897,24 @@ declare module "bun:test" {
+     closeTo(num: number, numDigits?: number): AsymmetricMatcher;
+   }
+ 
++  /**
++   * Atlas patch (#4437): the matcher methods reached through `.resolves` / `.rejects`
++   * are declared to return `void` upstream, even though at runtime they return a real
++   * thenable that MUST be awaited for the assertion to be enforced. That mismatch makes
++   * tsgolint's `typescript/await-thenable` rule flag every
++   * `await expect(...).rejects/.resolves.X()` as a redundant await (~740 false positives),
++   * and stripping the `await` would silently disable the assertion. We rewrite the async
++   * matcher path to return `Promise<void>` so `await` is honored; the synchronous matcher
++   * path (`expect(x).toBe(y)`) is untouched, so `no-floating-promises` still (correctly)
++   * fires on a missing `await` before a `.rejects` / `.resolves` assertion.
++   */
++  type AsyncMatchers<T = unknown> = {
++    [K in keyof MatchersBuiltin<T>]: MatchersBuiltin<T>[K] extends (
++      ...args: infer A
++    ) => unknown
++      ? (...args: A) => Promise<void>
++      : AsyncMatchers<T>;
++  };
+   export interface MatchersBuiltin<T = unknown> {
+     /**
+      * Negates the result of a subsequent assertion.
+@@ -918,7 +936,7 @@ declare module "bun:test" {
+      * @example
+      * expect(Promise.resolve(1)).resolves.toBe(1);
+      */
+-    resolves: Matchers<Awaited<T>>;
++    resolves: AsyncMatchers<Awaited<T>>;
+ 
+     /**
+      * Expects the value to be a promise that rejects.
+@@ -926,7 +944,7 @@ declare module "bun:test" {
+      * @example
+      * expect(Promise.reject("error")).rejects.toBe("error");
+      */
+-    rejects: Matchers<unknown>;
++    rejects: AsyncMatchers<unknown>;
+ 
+     /**
+      * Assertion which passes.


### PR DESCRIPTION
## Summary

Closes #4437. Clears the last big lever in the oxlint type-aware burndown: `await-thenable` (753 findings, 79% of the post-wave-2 remainder) → **0 repo-wide**, promoted `warn` → `error`.

Every one of the 753 sites was `await expect(...).rejects/.resolves.X()`. `bun-types` declares the matcher methods reached through `.resolves`/`.rejects` as returning `void` (they share the synchronous `MatchersBuiltin` interface), so tsgolint sees `await <void>` and flags the `await` as redundant — even though at runtime those methods return a real thenable that **must** be awaited to enforce the assertion. Stripping the `await` would silently disable the assertion (the false-green trap), so the sites can't be fixed in the tests. This is not fixed by a bun 1.4 bump (that's a runtime rewrite; the matcher return types on bun `main` are still `void`).

**Fix — a repo-side `bun` patch** (`patches/bun-types@1.3.14.patch` via `patchedDependencies`): a mapped type repoints `resolves`/`rejects` so every matcher method returns `Promise<void>`, leaving the synchronous `expect(x).toBe(y)` path (`void`) untouched.

Chosen over a repo-side `declare module` augmentation because the augmentation only applies to files in a program that includes it, and the repo's programs diverge (several packages have no tsconfig; `packages/web` *excludes* its tests, so tsgolint builds inferred per-file programs for them). The patch propagates to every test program uniformly and stays correct for future test files, with no per-package wiring.

### What else this surfaced / cleaned up

- **1 real latent bug fixed.** Because the sync path is preserved, `no-floating-promises` (already `error`) now catches a missing `await` before a `.rejects`/`.resolves` assertion — which flagged an un-awaited, never-enforced rejection assertion in `lazy-loader.test.ts` (made the test `async` + `await`; it now enforces and passes).
- **15 genuine residual redundant-awaits removed** (previously masked by the 753 noise): `await registry.registerDirect(...)` ×11 (`registerDirect` returns `void`) and `await validate!(...)` ×4 (synchronous mock returns).
- **ADR-0031** gets a Wave 3 entry documenting the decision and the version-bump caveat (the patch is pinned to `bun-types@1.3.14`; a bump that changes `test.d.ts` fails loudly at install/CI and must be regenerated with `bun patch`).

Scoped to #4437 only — the sibling config-artifact follow-ups (#4433 `@types/json-schema`, #4434 sdk/react type-aware program) are independent and untouched.

## Test Plan

- [x] Manual testing
- [x] Unit tests added/updated

- `bun run type` (root, sanctioned) — ✓ exit 0
- `bun run lint` — ✓ pre-existing warnings only
- Full isolated api suite (834 files) — 833 pass; the 1 failure is the documented pre-existing flake (`admin-model-config` gateway-catalog 5s timeout, red on clean `main`), unrelated to this diff
- Repo-wide type-aware `await-thenable` and `no-floating-promises` — both **0**
- The 4 edited test files pass in isolation (74 + 86 assertions green)

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent — `patchedDependencies` added; `bun.lock` updated
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated (not user-facing — lint/CI hygiene)

https://claude.ai/code/session_01QtRFJuHymCVbYW9UKzJXMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtRFJuHymCVbYW9UKzJXMV)_