### PR TITLE
chore(lint): clear type-aware config artifacts in cli/sdk/react (#4433, #4434)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@playwright/test": "^1.60.0",
         "@types/bun": "^1.3.14",
+        "@types/json-schema": "^7.0.15",
         "@types/node": "^25.9.4",
         "@types/pg": "^8.20.0",
         "@types/react": "^19.2.15",
@@ -2096,6 +2097,8 @@
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw=="],
 

--- a/docs/adr/0031-oxlint-over-eslint.md
+++ b/docs/adr/0031-oxlint-over-eslint.md
@@ -103,6 +103,44 @@ does **not** implement `no-restricted-syntax` natively.
     `warn` → `error`** (0 repo-wide). *Caveat:* the patch is pinned to `bun-types@1.3.14`;
     a version bump that changes `test.d.ts` will fail to apply at install time (a loud,
     CI-caught failure) and the patch must be regenerated (`bun patch bun-types@<v>`).
+  - **Wave 4 (config-artifact tail: `no-redundant-type-constituents` 42 → 17, #4433 + #4434).**
+    Two independent fixes, each clearing findings that were *config artifacts* of the
+    per-package type-aware program — not code smells the sanctioned `bun run type` (root
+    tsgo) ever saw. **#4433 — `@types/json-schema` (2 findings).** `ai` re-exports
+    `JSONSchema7` from `@ai-sdk/provider` ← `json-schema`, but `@types/json-schema` was
+    installed nowhere in the tree (only as a nested devDep of `@ai-sdk/provider`), so
+    `JSONSchema7` resolved to an **error type that acts as `any`** — which absorbed the
+    `undefined` in `(t.inputSchema as JSONSchema7 | undefined) ?? {…}` at
+    `canonical-eval-mcp-llm.ts:308` / `canonical-eval-tool-selection.ts:307`, tripping
+    `no-redundant-type-constituents`. Fix: add `@types/json-schema` as a **root
+    devDependency**; `JSONSchema7` resolves to the real interface, both findings clear
+    honestly, and `bun run type` stays green (the real type introduced no new errors —
+    `jsonSchema(schema)` already accepted the shape). **#4434 — sdk/react per-package
+    programs (25 findings, 23 cleared).** *sdk (21 → 0):* `packages/sdk/tsconfig.json`
+    extended the root config (`lib: ["esnext"]`, no `types`), and tsgolint's per-package
+    program did **not** auto-include `@types/bun`, so the `URL`/`Request`/`Response` globals
+    in the fetch-mock test unions (`string | URL | Request`, `Promise<Response>`) resolved
+    to error-types-as-`any`. The unions themselves are **correct** — the fix is
+    `compilerOptions.types: ["bun", "node"]` (mirroring `packages/api`), which makes the
+    globals resolve; no test source touched. This surfaced 2 previously-masked genuine
+    `no-base-to-string` warnings (`String(calls[0]?.[0])` on a now-`string | URL | Request`
+    fetch arg) — left as `warn` (permanent genuine-`unknown` category). *react (3 → 1):*
+    react's tsconfig already carries `lib: ["dom", …]`, so its globals resolve — these were
+    **not** global-resolution findings. 2 were `AtlasMcpError` from `@useatlas/sdk`
+    resolving to an error type because the standalone type-aware program (no prior build)
+    hit the unbuilt `dist/index.d.ts`; fix: a `paths` mapping (`@useatlas/sdk` →
+    `../sdk/src/index.ts`) so the program resolves sdk to **source**, build-order-independent
+    and matching what the root program does (it includes sdk source directly). The library
+    build already externalizes `@useatlas/sdk`, so the mapping only redirects the
+    self-contained widget bundle to source (identical code) and the dts keeps the external
+    import by name — no source leak. The 3rd react finding (`unknown | "pending"` in a
+    mock-fetch signature) is a **genuine** redundant constituent — `unknown` swallows the
+    `"pending"` sentinel in *any* program, config or not — so it is **not** a config
+    artifact; left as `warn` per this wave's no-test-source-edits rule. **Not promoted:**
+    `no-redundant-type-constituents` (17) and `tsconfig-error` (16) remain non-zero
+    repo-wide (residuals in `packages/web`, `plugins/mcp`, `packages/oauth-helper`,
+    `packages/api` test files + the one genuine react finding), so both stay `warn` —
+    promotion to `error` is gated on 0 **repo-wide**, not 0 in the touched packages.
 
 ## Consequences
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@playwright/test": "^1.60.0",
     "@types/bun": "^1.3.14",
+    "@types/json-schema": "^7.0.15",
     "@types/node": "^25.9.4",
     "@types/pg": "^8.20.0",
     "@types/react": "^19.2.15",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,7 +9,11 @@
     "declarationMap": true,
     "sourceMap": true,
     "noEmit": true,
-    "incremental": false
+    "incremental": false,
+    "paths": {
+      "@useatlas/sdk": ["../sdk/src/index.ts"],
+      "@useatlas/sdk/*": ["../sdk/src/*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun", "node"]
+  },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Tail of the oxlint type-aware burndown (#4432). Clears the config-artifact `no-redundant-type-constituents` findings — **42 → 17 repo-wide**. Every finding cleared was a per-package type-aware program failing to resolve a type the sanctioned root `bun run type` (tsgo) already sees; no code smells, no runtime changes.

- **#4433 — `@types/json-schema` (cli/bin 2 → 0).** `ai` re-exports `JSONSchema7` from `@ai-sdk/provider` ← `json-schema`, but `@types/json-schema` was installed nowhere in the tree, so `JSONSchema7` resolved to an *error type acting as `any`* and absorbed the `undefined` in `(t.inputSchema as JSONSchema7 | undefined) ?? {…}` at `canonical-eval-mcp-llm.ts:308` / `canonical-eval-tool-selection.ts:307`. Added it as a root devDependency → real interface resolves, both findings clear honestly, `bun run type` stays green (no new errors).
- **#4434 — sdk/react per-package tsconfig fixes (24 → 1, no test-source edits).**
  - *sdk (21 → 0):* the per-package program didn't auto-include `@types/bun`, so the `URL`/`Request`/`Response` globals in the (correct) fetch-mock unions resolved to error-types. Fix: `compilerOptions.types: ["bun", "node"]` (mirrors `packages/api`). Honestly surfaces 2 previously-masked `no-base-to-string` warnings (permanent-warn category) — no behavior change.
  - *react (3 → 1):* react's findings were **not** DOM globals (its tsconfig already carries `lib: ["dom"]`). 2 were `AtlasMcpError` from `@useatlas/sdk` resolving against the unbuilt `dist`; fix: a `paths` mapping to sdk **source** (`../sdk/src`), build-order-independent and matching the root program. The library build externalizes `@useatlas/sdk` and the dts keeps the import by name, so the published contract is unchanged.

Recorded as Wave 4 in `docs/adr/0031-oxlint-over-eslint.md`. Neither `no-redundant-type-constituents` (17) nor `tsconfig-error` (16) reaches 0 repo-wide (residuals in web, plugins/mcp, oauth-helper, api test files), so **no rules promoted** this wave — promotion is gated on 0 repo-wide.

### ⚠️ One deviation from #4434's AC (react not fully 0)

#4434 assumed 100% of react's findings were fetch/DOM globals. Investigation showed that's not the case: react already resolves DOM globals via its own `lib`. Its 3 findings were 2× `AtlasMcpError` (config artifacts, fixed) and 1× `unknown | "pending"` in a mock-fetch signature. That last one is a **genuine** redundant constituent — `unknown` swallows the `"pending"` sentinel in *any* program, config or not — so it is not a config artifact. Per this wave's explicit "no test-source edits" rule it's **left as `warn`** rather than edited. This is why react is 3 → 1, not 3 → 0; documented in the ADR so a future wave doesn't retry it as a config fix.

## Test Plan

- [x] Manual testing — verified fresh-clone (no `dist`) `oxlint --type-aware` counts: sdk 0, cli/bin 0, react 1 (the genuine finding)
- [x] Unit tests added/updated — none needed (config + docs only); existing suites re-run
- [ ] E2E tests added/updated — n/a

Verification: `bun run type` ✓ · `bun run lint` ✓ (warnings only) · `syncpack lint` ✓ · published/unpublished-symbol guards ✓ · sdk 213/213 ✓ · react 17/17 ✓ · cli 47/47 ✓ · api isolated 833/834 (sole failure = pre-existing `admin-model-config` gateway-catalog 5s-timeout flake) · full `scripts/ci-local.sh` = 27/28 gates green (only that flake red).

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [x] Deps consistent (`bun run deps:lint`) — `@types/json-schema` added; syncpack clean
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — n/a (no user-facing change)

Closes #4433
Closes #4434

https://claude.ai/code/session_011LQNkNsqE5e1Tq8AUThEVm

---
_Generated by [Claude Code](https://claude.ai/code/session_011LQNkNsqE5e1Tq8AUThEVm)_