### PR TITLE
chore(lint): clear tsconfig-error + no-redundant-type-constituents, promote to error (#4432 closeout)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,7 +14,7 @@
     "typescript/no-floating-promises": "error",
     "typescript/await-thenable": "error",
     "typescript/no-base-to-string": "warn",
-    "typescript/no-redundant-type-constituents": "warn",
+    "typescript/no-redundant-type-constituents": "error",
     "typescript/unbound-method": "warn",
     "typescript/restrict-template-expressions": "warn",
     "typescript/require-array-sort-compare": "error",

--- a/docs/adr/0031-oxlint-over-eslint.md
+++ b/docs/adr/0031-oxlint-over-eslint.md
@@ -141,6 +141,51 @@ does **not** implement `no-restricted-syntax` natively.
     repo-wide (residuals in `packages/web`, `plugins/mcp`, `packages/oauth-helper`,
     `packages/api` test files + the one genuine react finding), so both stay `warn` —
     promotion to `error` is gated on 0 **repo-wide**, not 0 in the touched packages.
+  - **Wave 5 (closeout: `tsconfig-error` 16 → 0, `no-redundant-type-constituents`
+    17 → 0, #4432).** *tsconfig-error (16 → 0):* every finding was a plugin
+    `tsconfig.json` extending `../../../tsconfig.json` — one level above the repo
+    root, a path that doesn't exist — so tsgolint couldn't load the base config and
+    skipped type-aware analysis of those plugins entirely. Fixed to
+    `../../tsconfig.json` (16 plugins; `plugins/chat` was already correct). No plugin
+    has a `build`/`type` script, so the wrong depth had been invisible outside the
+    linter. **Fixing the depth un-hid the same config-artifact class inside plugins**:
+    unresolved `URL`/`Request`/`RequestInit`/`Buffer` globals (root config is
+    `lib: ["esnext"]` with no `types`, and tsgolint doesn't auto-include `@types/bun`)
+    plus 16 previously-masked `no-floating-promises` errors, all top-level
+    `mock.module(...)` (wave-2 class, fixed with `void`) except one genuinely-floating
+    `plugin.initialize!(...)` in the email-digest tests whose completion gates
+    `schemaReady` — that helper became `async` and its 19 call sites `await`. Fix for
+    the globals: `types: ["bun", "node"]` in all 16 plugin tsconfigs (mirroring
+    `packages/api` and the wave-4 sdk fix), plus a new `plugins/mcp/tsconfig.json`
+    (mcp had none, so its files fell under the root program's `lib: ["esnext"]`).
+    `packages/oauth-helper` got the same `types` addition (its 2 `URL`/`Request`
+    findings were this class). *packages/web (9 → 0):* web's tsconfig excludes tests,
+    so tsgolint built inferred per-file programs for them — no `@/*` paths mapping, so
+    `FetchError`/`DashboardCard`/`KnowledgeCollectionListResponse` resolved to
+    error-types-as-`any` and absorbed union members. tsgolint honors **project
+    references** for file→program routing: a new `packages/web/tsconfig.test.json`
+    (extends the web config, adds `types: ["bun", "node"]`, includes tests; `composite:
+    true` + an emit target under gitignored `dist/` only because TS validates
+    references against TS6306/TS6310 — nothing ever builds it) referenced from
+    `packages/web/tsconfig.json`. The web `type` gate and `next build` still check the
+    unchanged main config; web tests now get a real program (which surfaced one
+    `no-meaningless-void-operator` error — a `void act(...)` whose callee now resolves
+    as `void`-returning; the `void` was dropped). *The last 6 findings were genuine,
+    not config artifacts* — wave 4's classification of the mcp/api residuals as config
+    artifacts turned out wrong: they persist under fully-healthy programs
+    (`packages/api`'s program already had `types: ["bun", "node"]`) because `unknown`
+    genuinely absorbs any union partner. All six were simplified to the type-identical
+    form per the wave-4 genuine-finding carve-out: `unknown | "pending"` → `unknown`
+    (react), `unknown | FetchStub` ×3 → `unknown` (mcp test helper; the doc comment
+    keeps the either-body-or-stub intent), `{…} | unknown` → the already-`unknown`
+    initializer and `unknown | null` → `unknown` (api tests). **Promoted
+    `no-redundant-type-constituents` `warn` → `error`** (0 repo-wide);
+    `tsconfig-error` isn't a configurable rule (it already reports at `error`
+    severity when a program fails to load) and is now also 0 repo-wide. The
+    healthier programs grew the permanent-`warn` tallies (`no-base-to-string`
+    75 → 113, `unbound-method` 50 → 65, `restrict-template-expressions` 5 → 10) —
+    same genuine-`unknown`/save-restore classes, newly visible, still not burndown
+    targets. This closes #4432.
 
 ## Consequences
 

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -167,7 +167,7 @@ void mock.module("effect", () => {
       // execute the generator synchronously so `yield* RolesPolicy` and
       // `yield* roles.checkPermission(...)` resolve under the same shim
       // semantics the rest of this file relies on.
-      const v = value as { _tag?: string; genFn?: () => Generator } | unknown;
+      const v = value;
       if (v && typeof v === "object" && (v as { _tag?: string })._tag === "EffectGen") {
         const gen = (v as { genFn: () => Generator }).genFn();
         let next = gen.next();

--- a/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
@@ -171,7 +171,7 @@ function snapshotRaw(rows: CatalogDbRow[]): Array<{
   install_model: string;
   saas_eligible: boolean;
   implementation_status: string;
-  config_schema: unknown | null;
+  config_schema: unknown;
 }> {
   return rows.map((r) => ({
     slug: r.slug,

--- a/packages/oauth-helper/tsconfig.json
+++ b/packages/oauth-helper/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun", "node"]
+  },
   "include": ["src", "__tests__"]
 }

--- a/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
+++ b/packages/react/src/components/__tests__/atlas-chat.empty-state-fallback.test.tsx
@@ -30,7 +30,7 @@ import { DEFAULT_STARTER_PROMPT_TEXTS } from "../../lib/fallback-starter-prompts
 
 let resolveStarter: ((res: Response) => void) | null = null;
 
-function makeFetch(starterBody: unknown | "pending", starterStatus = 200) {
+function makeFetch(starterBody: unknown, starterStatus = 200) {
   return function fetchImpl(input: string | URL | Request): Promise<Response> {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 

--- a/packages/web/src/ui/hooks/__tests__/use-run-status.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-run-status.test.tsx
@@ -121,7 +121,7 @@ describe("useRunStatus (#3749)", () => {
       useRunStatus({ ...baseOpts, conversationId: "conv-1", enabled: true }),
     );
     await waitFor(() => expect(result.current.runStatus?.status).toBe("running"));
-    void act(() => result.current.clear());
+    act(() => result.current.clear());
     expect(result.current.runStatus).toBeNull();
   });
 

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -14,5 +14,6 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": ["node_modules", "src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
+  "references": [{ "path": "./tsconfig.test.json" }]
 }

--- a/packages/web/tsconfig.test.json
+++ b/packages/web/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "outDir": "dist/tsconfig-test-build",
+    "types": ["bun", "node"]
+  },
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/plugins/bigquery/__tests__/bigquery.test.ts
+++ b/plugins/bigquery/__tests__/bigquery.test.ts
@@ -13,7 +13,7 @@ const mockBigQuery = mock(() => ({
   query: mockQuery,
 }));
 
-mock.module("@google-cloud/bigquery", () => ({
+void mock.module("@google-cloud/bigquery", () => ({
   BigQuery: mockBigQuery,
 }));
 

--- a/plugins/bigquery/__tests__/cost-estimator.test.ts
+++ b/plugins/bigquery/__tests__/cost-estimator.test.ts
@@ -31,7 +31,7 @@ const mockBigQuery = mock(() => ({
   query: mockQuery,
 }));
 
-mock.module("@google-cloud/bigquery", () => ({
+void mock.module("@google-cloud/bigquery", () => ({
   BigQuery: mockBigQuery,
 }));
 

--- a/plugins/bigquery/__tests__/profiler.test.ts
+++ b/plugins/bigquery/__tests__/profiler.test.ts
@@ -87,7 +87,7 @@ const mockQuery = mock((opts: { query: string }) => {
 
 const mockBigQuery = mock(() => ({ query: mockQuery }));
 
-mock.module("@google-cloud/bigquery", () => ({ BigQuery: mockBigQuery }));
+void mock.module("@google-cloud/bigquery", () => ({ BigQuery: mockBigQuery }));
 
 import { listBigQueryObjects, profileBigQuery } from "../src/profiler";
 

--- a/plugins/bigquery/tsconfig.json
+++ b/plugins/bigquery/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/clickhouse/__tests__/clickhouse.test.ts
+++ b/plugins/clickhouse/__tests__/clickhouse.test.ts
@@ -17,7 +17,7 @@ const mockCreateClient = mock(() => ({
   close: mockClose,
 }));
 
-mock.module("@clickhouse/client", () => ({
+void mock.module("@clickhouse/client", () => ({
   createClient: mockCreateClient,
 }));
 

--- a/plugins/clickhouse/__tests__/profiler.test.ts
+++ b/plugins/clickhouse/__tests__/profiler.test.ts
@@ -62,7 +62,7 @@ const mockQuery = mock((opts: { query: string; clickhouse_settings?: Record<stri
 const mockClose = mock(() => Promise.resolve());
 const mockCreateClient = mock(() => ({ query: mockQuery, close: mockClose }));
 
-mock.module("@clickhouse/client", () => ({ createClient: mockCreateClient }));
+void mock.module("@clickhouse/client", () => ({ createClient: mockCreateClient }));
 
 import { listClickHouseObjects, profileClickHouse } from "../src/profiler";
 

--- a/plugins/clickhouse/tsconfig.json
+++ b/plugins/clickhouse/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/duckdb/__tests__/duckdb.test.ts
+++ b/plugins/duckdb/__tests__/duckdb.test.ts
@@ -24,7 +24,7 @@ const mockCreate = mock((_path: string, _opts?: Record<string, string>) =>
   }),
 );
 
-mock.module("@duckdb/node-api", () => ({
+void mock.module("@duckdb/node-api", () => ({
   DuckDBInstance: {
     create: mockCreate,
   },
@@ -40,7 +40,7 @@ mock.module("@duckdb/node-api", () => ({
 const listSpy = mock(async (_o: unknown) => [] as unknown[]);
 const profileSpy = mock(async (_o: unknown) => ({ profiles: [], errors: [] }));
 const realProfiler = await import("../src/profiler");
-mock.module("../src/profiler", () => ({
+void mock.module("../src/profiler", () => ({
   ...realProfiler,
   listDuckDBObjects: listSpy,
   profileDuckDB: profileSpy,

--- a/plugins/duckdb/__tests__/profiler.test.ts
+++ b/plugins/duckdb/__tests__/profiler.test.ts
@@ -68,7 +68,7 @@ const mockCreate = mock((_path: string, opts?: Record<string, string>) => {
   return Promise.resolve({ connect: mockConnect, closeSync: mockCloseSync });
 });
 
-mock.module("@duckdb/node-api", () => ({ DuckDBInstance: { create: mockCreate } }));
+void mock.module("@duckdb/node-api", () => ({ DuckDBInstance: { create: mockCreate } }));
 
 import { listDuckDBObjects, profileDuckDB } from "../src/profiler";
 

--- a/plugins/duckdb/tsconfig.json
+++ b/plugins/duckdb/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/elasticsearch/__tests__/built-connection-introspection.test.ts
+++ b/plugins/elasticsearch/__tests__/built-connection-introspection.test.ts
@@ -19,7 +19,7 @@ import { describe, test, expect, mock } from "bun:test";
 const listSpy = mock(async (_o: unknown) => [] as unknown[]);
 const profileSpy = mock(async (_o: unknown) => ({ profiles: [], errors: [] }));
 const realProfiler = await import("../src/profiler");
-mock.module("../src/profiler", () => ({
+void mock.module("../src/profiler", () => ({
   ...realProfiler,
   listElasticsearchObjects: listSpy,
   profileElasticsearchObjects: profileSpy,

--- a/plugins/elasticsearch/tsconfig.json
+++ b/plugins/elasticsearch/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/email-digest/__tests__/email-digest.test.ts
+++ b/plugins/email-digest/__tests__/email-digest.test.ts
@@ -127,10 +127,10 @@ function createMockCtx(db?: ReturnType<typeof createMockDb>["db"]) {
   };
 }
 
-function createTestApp(config: EmailDigestPluginConfig, db?: ReturnType<typeof createMockDb>["db"]): Hono {
+async function createTestApp(config: EmailDigestPluginConfig, db?: ReturnType<typeof createMockDb>["db"]): Promise<Hono> {
   const plugin = buildEmailDigestPlugin(config);
   const mockCtx = createMockCtx(db);
-  plugin.initialize!(mockCtx.ctx as never);
+  await plugin.initialize!(mockCtx.ctx as never);
   const app = new Hono();
   plugin.routes!(app);
   return app;
@@ -421,7 +421,7 @@ describe("sendEmail", () => {
 describe("routes — subscription CRUD", () => {
   test("POST /digest/subscriptions creates a subscription", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "POST",
@@ -449,7 +449,7 @@ describe("routes — subscription CRUD", () => {
 
   test("POST rejects empty metrics array", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "POST",
@@ -472,7 +472,7 @@ describe("routes — subscription CRUD", () => {
 
   test("POST rejects invalid frequency", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "POST",
@@ -485,7 +485,7 @@ describe("routes — subscription CRUD", () => {
 
   test("POST rejects invalid deliveryHour", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "POST",
@@ -498,7 +498,7 @@ describe("routes — subscription CRUD", () => {
 
   test("POST rejects missing email", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "POST",
@@ -511,7 +511,7 @@ describe("routes — subscription CRUD", () => {
 
   test("POST rejects invalid JSON body", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "POST",
@@ -539,7 +539,7 @@ describe("routes — subscription CRUD", () => {
       updated_at: "2026-03-16T00:00:00Z",
     });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "GET",
@@ -567,7 +567,7 @@ describe("routes — subscription CRUD", () => {
       enabled: true,
     });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "GET",
@@ -592,7 +592,7 @@ describe("routes — subscription CRUD", () => {
       enabled: true,
     });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-del", {
       method: "DELETE",
@@ -606,7 +606,7 @@ describe("routes — subscription CRUD", () => {
 
   test("DELETE returns 404 for non-existent subscription", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/nonexistent", {
       method: "DELETE",
@@ -617,7 +617,7 @@ describe("routes — subscription CRUD", () => {
   });
 
   test("returns 503 when internal DB is not available", async () => {
-    const app = createTestApp(createMockConfig());
+    const app = await createTestApp(createMockConfig());
 
     const resp = await app.request("/digest/subscriptions", {
       method: "GET",
@@ -629,7 +629,7 @@ describe("routes — subscription CRUD", () => {
 
   test("returns 401 when user ID header is missing", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions", {
       method: "GET",
@@ -659,7 +659,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
       enabled: true,
     });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-up", {
       method: "PUT",
@@ -676,7 +676,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
     const { db, rows } = createMockDb();
     rows.push({ id: "sub-other", user_id: "user-2", email: "x@t.com", metrics: "[]", frequency: "daily", delivery_hour: 9, timezone: "UTC", enabled: true });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-other", {
       method: "PUT",
@@ -691,7 +691,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
     const { db, rows } = createMockDb();
     rows.push({ id: "sub-x", user_id: "user-1", email: "x@t.com", metrics: "[]", frequency: "daily", delivery_hour: 9, timezone: "UTC", enabled: true });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-x", {
       method: "PUT",
@@ -708,7 +708,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
     const { db, rows } = createMockDb();
     rows.push({ id: "sub-x", user_id: "user-1", email: "x@t.com", metrics: "[]", frequency: "daily", delivery_hour: 9, timezone: "UTC", enabled: true });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-x", {
       method: "PUT",
@@ -723,7 +723,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
     const { db, rows } = createMockDb();
     rows.push({ id: "sub-tog", user_id: "user-1", email: "x@t.com", metrics: "[]", frequency: "daily", delivery_hour: 9, timezone: "UTC", enabled: true });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-tog", {
       method: "PUT",
@@ -738,7 +738,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
     const { db, rows } = createMockDb();
     rows.push({ id: "sub-v", user_id: "user-1", email: "x@t.com", metrics: "[]", frequency: "daily", delivery_hour: 9, timezone: "UTC", enabled: true });
 
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp1 = await app.request("/digest/subscriptions/sub-v", {
       method: "PUT",
@@ -757,7 +757,7 @@ describe("routes — PUT /digest/subscriptions/:id", () => {
 
   test("returns 401 without user ID header", async () => {
     const { db } = createMockDb();
-    const app = createTestApp(createMockConfig(), db);
+    const app = await createTestApp(createMockConfig(), db);
 
     const resp = await app.request("/digest/subscriptions/sub-x", {
       method: "PUT",

--- a/plugins/email/tsconfig.json
+++ b/plugins/email/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/plugins/jira/tsconfig.json
+++ b/plugins/jira/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -118,9 +118,9 @@ const EXPECTED_VERIFIER = (() => {
 type FetchStub = (req: Request) => Response | Promise<Response>;
 interface FetchStubBehavior {
   /** Either the JSON body to return or a function that throws/returns. */
-  discovery?: unknown | FetchStub;
-  registration?: unknown | FetchStub;
-  token?: unknown | FetchStub;
+  discovery?: unknown;
+  registration?: unknown;
+  token?: unknown;
 }
 
 function fakeFetch(behavior: FetchStubBehavior): typeof fetch {

--- a/plugins/mcp/tsconfig.json
+++ b/plugins/mcp/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist",
     "types": ["bun", "node"]
   },
   "include": ["src/**/*.ts", "__tests__/**/*.ts"]

--- a/plugins/mysql/__tests__/mysql.test.ts
+++ b/plugins/mysql/__tests__/mysql.test.ts
@@ -20,7 +20,7 @@ const mockCreatePool = mock(() => ({
   end: mockEnd,
 }));
 
-mock.module("mysql2/promise", () => ({
+void mock.module("mysql2/promise", () => ({
   createPool: mockCreatePool,
 }));
 

--- a/plugins/mysql/tsconfig.json
+++ b/plugins/mysql/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/obsidian-reader/tsconfig.json
+++ b/plugins/obsidian-reader/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/plugins/salesforce/__tests__/built-connection-introspection.test.ts
+++ b/plugins/salesforce/__tests__/built-connection-introspection.test.ts
@@ -13,7 +13,7 @@ import { describe, test, expect, mock } from "bun:test";
 const listSpy = mock(async (_o: unknown) => [] as unknown[]);
 const profileSpy = mock(async (_o: unknown) => ({ profiles: [], errors: [] }));
 const realProfiler = await import("../src/profiler");
-mock.module("../src/profiler", () => ({
+void mock.module("../src/profiler", () => ({
   ...realProfiler,
   listSalesforceObjects: listSpy,
   profileSalesforce: profileSpy,
@@ -22,7 +22,7 @@ mock.module("../src/profiler", () => ({
 // Mock the jsforce-backed connection so createFromConfig doesn't open a session;
 // keep parseSalesforceURL real so the url is validated as the plugin would.
 const realConn = await import("../src/connection");
-mock.module("../src/connection", () => ({
+void mock.module("../src/connection", () => ({
   ...realConn,
   createSalesforceConnection: mock(() => ({
     query: mock(async () => ({ columns: [], rows: [] })),

--- a/plugins/salesforce/__tests__/profiler.test.ts
+++ b/plugins/salesforce/__tests__/profiler.test.ts
@@ -79,7 +79,7 @@ const mockDescribeGlobal = mock(() =>
   }),
 );
 
-mock.module("jsforce", () => ({
+void mock.module("jsforce", () => ({
   Connection: class MockConnection {
     login = mockLogin;
     logout = mockLogout;

--- a/plugins/salesforce/__tests__/salesforce.test.ts
+++ b/plugins/salesforce/__tests__/salesforce.test.ts
@@ -47,7 +47,7 @@ const mockDescribeGlobal = mock(() =>
   }),
 );
 
-mock.module("jsforce", () => ({
+void mock.module("jsforce", () => ({
   Connection: class MockConnection {
     query = mockQuery;
     login = mockLogin;

--- a/plugins/salesforce/tsconfig.json
+++ b/plugins/salesforce/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/snowflake/__tests__/plugin.test.ts
+++ b/plugins/snowflake/__tests__/plugin.test.ts
@@ -26,7 +26,7 @@ const mockCreatePool = mock(() => ({
 }));
 const mockConfigure = mock(() => {});
 
-mock.module("snowflake-sdk", () => ({
+void mock.module("snowflake-sdk", () => ({
   createPool: mockCreatePool,
   configure: mockConfigure,
 }));

--- a/plugins/snowflake/__tests__/profiler.test.ts
+++ b/plugins/snowflake/__tests__/profiler.test.ts
@@ -54,7 +54,7 @@ const mockCreatePool = mock(() => ({
 }));
 const mockConfigure = mock(() => {});
 
-mock.module("snowflake-sdk", () => ({
+void mock.module("snowflake-sdk", () => ({
   createPool: mockCreatePool,
   configure: mockConfigure,
 }));

--- a/plugins/snowflake/tsconfig.json
+++ b/plugins/snowflake/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }

--- a/plugins/teams/tsconfig.json
+++ b/plugins/teams/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["src/**/*.ts", "__tests__/**/*.ts"]
 }

--- a/plugins/twenty/tsconfig.json
+++ b/plugins/twenty/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/plugins/webhook-action/tsconfig.json
+++ b/plugins/webhook-action/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/plugins/webhook/tsconfig.json
+++ b/plugins/webhook/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["bun", "node"]
   },
   "include": ["src/**/*.ts", "__tests__/**/*.ts"]
 }

--- a/plugins/yaml-context/tsconfig.json
+++ b/plugins/yaml-context/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["bun", "node"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Final slice of the oxlint type-aware burndown. Clears the last two targets repo-wide and promotes the rule. Closes #4432.

**tsconfig-error 16 → 0.** Every finding was a plugin `tsconfig.json` extending `../../../tsconfig.json` — one level *above* the repo root, a path that doesn't exist — so tsgolint couldn't load the base config for those 16 plugins (only `plugins/chat` was correct). Corrected to `../../tsconfig.json`. No plugin has a `build`/`type` script (root `tsgo` covers plugin sources), so the wrong depth was invisible outside the linter. The now-loading programs **un-hid two masked classes**:

- Unresolved `URL`/`Request`/`RequestInit`/`Buffer` globals (root config is `lib: ["esnext"]` with no `types`; tsgolint doesn't auto-include `@types/bun`) → `types: ["bun", "node"]` in all 16 plugin tsconfigs, mirroring `packages/api` and the #4434 sdk fix. `plugins/mcp` gained a tsconfig (it had none, so its files fell under the root program).
- 16 masked `no-floating-promises` **errors** — 15 top-level `mock.module(...)` (wave-2 class → `void`), plus one genuinely-floating `plugin.initialize!(...)` in the email-digest tests whose completion gates `schemaReady`: its `createTestApp` helper is now `async` and awaited at all 19 call sites, removing a latent microtask-timing assumption.

**no-redundant-type-constituents 17 → 0.**

- *oauth-helper (2)*: config artifacts — `types: ["bun", "node"]`.
- *web (9)*: web's tsconfig excludes tests, so tsgolint built inferred per-file programs with no `@/*` paths mapping — `FetchError`/`DashboardCard`/`KnowledgeCollectionListResponse` resolved to error-types-as-`any`. tsgolint honors **project references** for file→program routing, so a new `packages/web/tsconfig.test.json` (extends the web config, adds bun/node types, includes tests; `composite: true` + a gitignored emit target only to satisfy TS6306/TS6310 — nothing ever builds it) is referenced from the main config. The web `type` gate and `next build` are unchanged and verified green. The real program surfaced one `no-meaningless-void-operator` error (`void act(...)` whose callee now resolves as `void`-returning) — the `void` was dropped.
- *react (1), mcp (3), api (2)*: **deviation from the task brief** — the brief classified the mcp/api residuals as config artifacts, but they persist under fully-healthy programs (api's program already had `types: ["bun", "node"]` before this PR): `unknown` genuinely absorbs any union partner. All six were simplified to the type-identical form under the same genuine-finding carve-out as the sanctioned react edit (`unknown | "pending"` → `unknown`, `unknown | FetchStub` → `unknown`, `{…} | unknown` cast → the already-`unknown` value, `unknown | null` → `unknown`).

**Promotion:** `typescript/no-redundant-type-constituents` `warn` → `error` (0 repo-wide, verified via the live-count command). `tsconfig-error` isn't a configurable rule (it already reports at `error` severity when a program fails to load) and is also 0 repo-wide. ADR-0031 gains the Wave 5 log entry.

Note: the healthier programs grew the permanent-`warn` tallies (`no-base-to-string` 75 → 113, `unbound-method` 50 → 65, `restrict-template-expressions` 5 → 10) — same documented genuine-`unknown`/save-restore classes, newly visible in plugin/web-test programs, still not burndown targets.

## Test Plan

- [x] Live count: `oxlint --type-aware` repo-wide → 0 `tsconfig-error`, 0 `no-redundant-type-constituents`, exit 0 with the promoted rule
- [x] Unit tests added/updated — all 9 touched plugin suites green; web full isolated suite 283/283; react/oauth-helper/api targeted files green
- [x] Full isolated api suite: 831/834 — the 3 red files are the documented pre-existing `admin-model-config` gateway-catalog 5s-timeout flake plus two teams files that flaked under concurrent-suite load and pass in isolation
- [ ] E2E tests added/updated — n/a (lint/config-only)

## Checklist

- [x] Types pass (`bun run type`) — includes web (`tsgo --noEmit`) and a local `next build` to validate the tsconfig references
- [x] Tests pass (`bun run test`) — see Test Plan
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — n/a (not user-facing)

https://claude.ai/code/session_01YNoRJ36da5mT74d73oENXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNoRJ36da5mT74d73oENXL)_