### PR TITLE
feat(knowledge): Zendesk Guide sync connector + shared support HTML→markdown converter

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56650,7 +56650,8 @@
                               "notion",
                               "confluence",
                               "confluence-datacenter",
-                              "gitbook"
+                              "gitbook",
+                              "zendesk"
                             ]
                           },
                           "description": {

--- a/docs/adr/0030-knowledge-sync-connector-seam.md
+++ b/docs/adr/0030-knowledge-sync-connector-seam.md
@@ -138,3 +138,28 @@ bookkeeping — the same reason `knowledge_sync_state` exists at all (migration
   the new state SQL (COALESCE-forward semantics) and migration 0168 against a
   live schema.
 - CONTEXT.md gains the **Knowledge Sync Connector** term.
+
+## Amendment (#4396): the shared support HTML→markdown converter sub-seam
+
+PRD #4395 extends the connector family to **support/help-center platforms**
+(Zendesk Guide, Intercom, Help Scout, Freshdesk, Front, Zoho Desk, ServiceNow,
+Salesforce Knowledge). The vendor research found the tier homogeneous in one
+load-bearing way: **every viable support platform returns article bodies as
+plain HTML** — unlike Confluence's storage-XHTML dialect or GitBook's extended
+markdown. So the tier gets ONE shared converter, named as a sub-seam of this
+ADR's "converter" role:
+
+- `lib/knowledge/support/html-to-markdown.ts` — pure, golden-fixture-tested
+  HTML→markdown with the same degradation policy the per-vendor converters
+  established (unconvertible constructs → counted, visible placeholders
+  linking back to the vendor page; never silent drops), plus a **cross-link
+  rewriting hook** vendors use to absolutize relative article links.
+- A support connector must NOT fork its own HTML→markdown pass; per-vendor
+  shaping (titles, paths, provenance, locale fan-out) stays in the vendor's
+  `documents.ts`.
+- Built with the anchor slice (#4396 Zendesk Guide — token auth + the tier's
+  only native incremental feed); consumed by every subsequent support vendor.
+- Delta-less vendors in the tier (Intercom, Freshdesk, Front) lean on the
+  engine's reconciliation crawl as their change detection — `fetchChanges`
+  falls back to full enumeration; no engine change (the two-cadence split
+  above already prices this in, just costlier cycles, documented per vendor).

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -629,6 +629,37 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(conf?.endpointUrl).toBeNull();
     expect(conf?.sync).not.toBeNull();
   });
+
+  it("dispatches a Zendesk collection to the connector engine and lists it as source 'zendesk' (#4396)", async () => {
+    COLLECTION = {
+      install_id: "runbooks",
+      catalog_id: "catalog:zendesk",
+      status: "published",
+      config: {
+        subdomain: "acme",
+        email: "ops@acme.test",
+        brand_id: "10",
+        brand_subdomain: "acme",
+        brand_name: "Acme",
+      },
+    };
+    SYNC_STATES = [
+      { collection_id: "runbooks", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/runbooks/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const zd = body.collections.find((c) => c.slug === "runbooks");
+    expect(zd?.source).toBe("zendesk");
+    expect(zd?.endpointUrl).toBeNull();
+    expect(zd?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -57,6 +57,7 @@ import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/con
 import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config";
 import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config-datacenter";
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
+import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -111,6 +112,7 @@ type KnowledgeSource =
   | "confluence"
   | "confluence-datacenter"
   | "gitbook"
+  | "zendesk"
   | "unknown";
 
 /**
@@ -127,6 +129,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === CONFLUENCE_CATALOG_ID) return "confluence";
   if (catalogId === CONFLUENCE_DC_CATALOG_ID) return "confluence-datacenter";
   if (catalogId === GITBOOK_CATALOG_ID) return "gitbook";
+  if (catalogId === ZENDESK_CATALOG_ID) return "zendesk";
   return "unknown";
 }
 
@@ -137,7 +140,8 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "notion" ||
     source === "confluence" ||
     source === "confluence-datacenter" ||
-    source === "gitbook"
+    source === "gitbook" ||
+    source === "zendesk"
   );
 }
 
@@ -158,7 +162,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -26,6 +26,7 @@ import {
   BUILTIN_NOTION_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
+  BUILTIN_ZENDESK_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -160,6 +161,32 @@ describe("BUILTIN_CONFLUENCE_DC_CATALOG_ROW (#4394)", () => {
   });
 });
 
+describe("BUILTIN_ZENDESK_CATALOG_ROW (#4396)", () => {
+  it("is the `zendesk` form install: subdomain + email + secret token, NO base URL", () => {
+    const row = BUILTIN_ZENDESK_CATALOG_ROW;
+    expect(row.slug).toBe("zendesk");
+    expect(row.id).toBe("catalog:zendesk");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("subdomain");
+    expect(keys).toContain("email");
+    expect(keys).toContain("api_token");
+    // Hosts are composed `*.zendesk.com` labels — no free-form URL field, and
+    // no brand field: brands are enumerated at install time (one collection
+    // per help-center-enabled brand).
+    expect(keys).not.toContain("base_url");
+    expect(keys).not.toContain("brand_id");
+    // Exactly one secret field: the API token (never echoed).
+    expect(row.configSchema.filter((f) => f.secret === true).map((f) => f.key)).toEqual([
+      "api_token",
+    ]);
+    for (const key of ["subdomain", "email", "api_token"]) {
+      expect(row.configSchema.find((f) => f.key === key)?.required).toBe(true);
+    }
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -182,6 +209,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "confluence",
       "confluence-datacenter",
       "gitbook",
+      "zendesk",
     ]);
   });
 
@@ -208,6 +236,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "confluence",
       "confluence-datacenter",
       "gitbook",
+      "zendesk",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -1,8 +1,8 @@
 /**
  * Boot-time idempotent seed pass for the built-in Knowledge Base catalog rows
  * — the upload/bundle-sync arms plus the vendor connectors (Notion, Confluence
- * Cloud + Data Center, GitBook). `BUILTIN_KNOWLEDGE_CATALOG_ROWS` is the
- * authoritative list; adding a connector is one append there.
+ * Cloud + Data Center, GitBook, Zendesk Guide). `BUILTIN_KNOWLEDGE_CATALOG_ROWS`
+ * is the authoritative list; adding a connector is one append there.
  *
  * The Knowledge Base lifecycle (ADR-0028 §5) started as one built-in catalog
  * row — `okf-upload`, an **explicit, degenerate form install** with no
@@ -39,6 +39,7 @@ import {
   NOTION_KNOWLEDGE_SLUG,
 } from "@atlas/api/lib/knowledge/notion/connector";
 import { GITBOOK_CATALOG_ID, GITBOOK_SLUG } from "@atlas/api/lib/knowledge/gitbook/config";
+import { ZENDESK_CATALOG_ID, ZENDESK_SLUG } from "@atlas/api/lib/knowledge/zendesk/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -360,6 +361,64 @@ export const BUILTIN_GITBOOK_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The Zendesk Guide connector Knowledge Base catalog row (#4396, PRD #4395 —
+ * the support tier's anchor slice). A form install that enumerates the
+ * account's help-center-enabled BRANDS and creates one review-gated collection
+ * per brand; the Scheduler dispatches the registered Zendesk connector on a
+ * cadence (native incremental feed + reconciliation) and every synced article
+ * translation lands `draft`.
+ *
+ * `api_token` is `secret: true` but is NOT stored in `workspace_plugins.config`
+ * — the install handler routes it to `knowledge_sync_credentials` (encrypted,
+ * one row per brand collection). Hosts are composed from the validated
+ * subdomain label (`*.zendesk.com`), so there is no free-form base-URL field;
+ * every request still goes through the SSRF egress guard. The id/slug are the
+ * config SSOT (`ZENDESK_CATALOG_ID` / `ZENDESK_SLUG`).
+ */
+export const BUILTIN_ZENDESK_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: ZENDESK_CATALOG_ID,
+  slug: ZENDESK_SLUG,
+  name: "Knowledge Base (Zendesk Guide)",
+  description:
+    "Mirror your Zendesk Guide help center into review-gated knowledge collections (one per brand); Atlas syncs published articles on a schedule (incremental + reconciliation) and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "subdomain",
+      type: "string",
+      label: "Zendesk subdomain",
+      required: true,
+      description:
+        'The "acme" in acme.zendesk.com (you can paste the full URL). Brands are discovered automatically — one collection per help center.',
+    },
+    {
+      key: "email",
+      type: "string",
+      label: "Zendesk account email",
+      required: true,
+      description: "The account email paired with the API token for token authentication.",
+    },
+    {
+      key: "api_token",
+      type: "string",
+      secret: true,
+      label: "API token",
+      required: true,
+      description:
+        "A Zendesk API token (Admin Center → Apps and integrations → Zendesk API). Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -368,6 +427,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_CONFLUENCE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_GITBOOK_CATALOG_ROW,
+  BUILTIN_ZENDESK_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -45,6 +45,7 @@ import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/confi
 import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config-datacenter";
 import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
+import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -148,16 +149,18 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Confluence DC, Notion, and GitBook knowledge sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, GitBook, and Zendesk knowledge sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(GITBOOK_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(ZENDESK_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "gitbook", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "zendesk", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/zendesk-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/zendesk-form-handler.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for `ZendeskFormInstallHandler` (#4396) — the Zendesk Guide
+ * connector install. Focus: field validation (subdomain label extraction,
+ * email, API token), loud brand-enumeration verification at install time, the
+ * PER-BRAND FAN-OUT (one collection per help-center-enabled brand; base slug
+ * for a single brand, suffixed slugs for multi-brand), credential routing
+ * (token → `knowledge_sync_credentials`, one row per brand collection, NEVER
+ * into `workspace_plugins.config`), and the credential rollback on a failed
+ * row write. Verification uses the REAL egress guard against an injected
+ * fixture fetch; no test touches Zendesk.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:zendesk" }];
+let INSERT_RETURNS_ID = true;
+let INSERT_FAIL_ON_SLUG: string | null = null;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    if (INSERT_FAIL_ON_SLUG !== null && params[3] === INSERT_FAIL_ON_SLUG) {
+      throw new Error("simulated row-write failure");
+    }
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { ZendeskFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/zendesk-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = { subdomain: "acme", email: "ops@acme.test", api_token: "zd-token" };
+
+interface FixtureBrand {
+  id?: number;
+  name?: string;
+  subdomain?: string;
+  has_help_center?: boolean;
+  active?: boolean;
+}
+
+const ONE_BRAND: FixtureBrand[] = [
+  { id: 10, name: "Acme", subdomain: "acme", has_help_center: true, active: true },
+];
+const TWO_BRANDS: FixtureBrand[] = [
+  ...ONE_BRAND,
+  { id: 11, name: "Beta", subdomain: "acme-beta", has_help_center: true, active: true },
+];
+
+/** A fixture brands-endpoint fetch (or a fixed failure status). */
+function brandsFetch(opts: { brands?: FixtureBrand[]; status?: number } = {}): typeof fetch {
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url);
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (url.pathname.endsWith("/api/v2/brands.json")) {
+      return new Response(
+        JSON.stringify({ brands: opts.brands ?? ONE_BRAND, meta: { has_more: false }, links: { next: null } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+  return impl as unknown as typeof fetch;
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  let n = 0;
+  return new ZendeskFormInstallHandler({
+    idGenerator: () => `fixed-id-${++n}`,
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:zendesk" }];
+  INSERT_RETURNS_ID = true;
+  INSERT_FAIL_ON_SLUG = null;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+async function formErrorOf(promise: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.formErrors[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("requires the subdomain", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, subdomain: "" }),
+      "subdomain",
+    );
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("reduces a pasted URL / host to the bare label", async () => {
+    for (const paste of ["https://acme.zendesk.com/hc/en-us", "acme.zendesk.com", "ACME"]) {
+      insertCalls.length = 0;
+      const rec = await handler(brandsFetch()).validateConfig(WORKSPACE, { ...VALID, subdomain: paste });
+      expect(rec.credentialWritten).toBe(true);
+      const config = JSON.parse(insertCalls[0].params[4] as string);
+      expect(config.subdomain).toBe("acme");
+    }
+  });
+
+  it("rejects a subdomain that is not a host label", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { ...VALID, subdomain: "acme_corp!" }),
+      "subdomain",
+    );
+    expect(msg).toMatch(/bare Zendesk subdomain/i);
+  });
+
+  it("requires a plausible email and an API token", async () => {
+    expect(
+      await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, email: "nope" }), "email"),
+    ).toMatch(/valid/i);
+    expect(
+      await fieldErrorOf(handler().validateConfig(WORKSPACE, { ...VALID, api_token: "" }), "api_token"),
+    ).toMatch(/required/i);
+  });
+});
+
+describe("brand enumeration (install-time verification)", () => {
+  it("blames the api_token field on a 401", async () => {
+    const msg = await fieldErrorOf(
+      handler(brandsFetch({ status: 401 })).validateConfig(WORKSPACE, VALID),
+      "api_token",
+    );
+    expect(msg).toMatch(/rejected the credentials/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 429 as a form-level error (the token may be fine)", async () => {
+    const msg = await formErrorOf(handler(brandsFetch({ status: 429 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/rate-limited/i);
+  });
+
+  it("rejects an account with no help-center-enabled brand", async () => {
+    const msg = await formErrorOf(
+      handler(
+        brandsFetch({ brands: [{ id: 1, name: "X", subdomain: "x", has_help_center: false, active: true }] }),
+      ).validateConfig(WORKSPACE, VALID),
+    );
+    expect(msg).toMatch(/no active brand with a Help Center/i);
+  });
+});
+
+describe("per-brand fan-out", () => {
+  it("single brand: one collection under the base slug", async () => {
+    const rec = await handler(brandsFetch()).validateConfig(WORKSPACE, VALID);
+    expect(rec.installRecord).toMatchObject({ workspaceId: WORKSPACE, catalogId: "zendesk" });
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].params[3]).toBe("zendesk");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toMatchObject({
+      subdomain: "acme",
+      email: "ops@acme.test",
+      brand_id: "10",
+      brand_subdomain: "acme",
+      brand_name: "Acme",
+    });
+    // The token NEVER lands in the install config…
+    expect(config).not.toHaveProperty("api_token");
+    // …it lands in knowledge_sync_credentials, keyed by the collection slug.
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(saveSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "zendesk", "zd-token"]);
+  });
+
+  it("respects a custom collection slug via __install_id__", async () => {
+    await handler(brandsFetch()).validateConfig(WORKSPACE, { ...VALID, __install_id__: "support-kb" });
+    expect(insertCalls[0].params[3]).toBe("support-kb");
+  });
+
+  it("multi-brand: one collection per brand under suffixed slugs, one credential each", async () => {
+    const rec = await handler(brandsFetch({ brands: TWO_BRANDS })).validateConfig(WORKSPACE, VALID);
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["zendesk-acme", "zendesk-acme-beta"]);
+    const configs = insertCalls.map((c) => JSON.parse(c.params[4] as string));
+    expect(configs.map((c) => c.brand_subdomain)).toEqual(["acme", "acme-beta"]);
+    expect(saveSyncCredential.mock.calls.map((c) => c[1])).toEqual(["zendesk-acme", "zendesk-acme-beta"]);
+    // The returned record is the first brand's row.
+    expect(rec.installRecord.id).toBe("fixed-id-1");
+  });
+
+  it("skips inactive and non-help-center brands in the fan-out", async () => {
+    await handler(
+      brandsFetch({
+        brands: [
+          ...TWO_BRANDS,
+          { id: 12, name: "Dead", subdomain: "acme-dead", has_help_center: true, active: false },
+          { id: 13, name: "NoHC", subdomain: "acme-nohc", has_help_center: false, active: true },
+        ],
+      }),
+    ).validateConfig(WORKSPACE, VALID);
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["zendesk-acme", "zendesk-acme-beta"]);
+  });
+
+  it("rejects a fan-out slug taken by another knowledge catalog BEFORE any write", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const msg = await fieldErrorOf(
+      handler(brandsFetch({ brands: TWO_BRANDS })).validateConfig(WORKSPACE, VALID),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/already used/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the failed brand's credential and leaves earlier brands installed", async () => {
+    INSERT_FAIL_ON_SLUG = "zendesk-acme-beta";
+    await expect(
+      handler(brandsFetch({ brands: TWO_BRANDS })).validateConfig(WORKSPACE, VALID),
+    ).rejects.toThrow(/simulated row-write failure/);
+    // First brand fully installed…
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["zendesk-acme"]);
+    // …the failed brand's orphaned credential rolled back (and only that one).
+    expect(deleteSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "zendesk-acme-beta"]);
+  });
+});
+
+describe("catalog preconditions", () => {
+  it("fails loudly when the catalog row is missing (seed has not run)", async () => {
+    CATALOG_ROWS = [];
+    await expect(handler(brandsFetch()).validateConfig(WORKSPACE, VALID)).rejects.toThrow(
+      /catalog row "zendesk" not found/i,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/zendesk-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/zendesk-form-handler.test.ts
@@ -187,6 +187,19 @@ describe("brand enumeration (install-time verification)", () => {
     expect(msg).toMatch(/rate-limited/i);
   });
 
+  it("blames the subdomain field on a 404 (wrong subdomain)", async () => {
+    const msg = await fieldErrorOf(
+      handler(brandsFetch({ status: 404 })).validateConfig(WORKSPACE, VALID),
+      "subdomain",
+    );
+    expect(msg).toMatch(/404/);
+  });
+
+  it("surfaces a vendor 5xx as a form-level error, never blaming the token", async () => {
+    const msg = await formErrorOf(handler(brandsFetch({ status: 503 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/vendor-side error/i);
+  });
+
   it("rejects an account with no help-center-enabled brand", async () => {
     const msg = await formErrorOf(
       handler(
@@ -244,6 +257,20 @@ describe("per-brand fan-out", () => {
       }),
     ).validateConfig(WORKSPACE, VALID);
     expect(insertCalls.map((c) => c.params[3])).toEqual(["zendesk-acme", "zendesk-acme-beta"]);
+  });
+
+  it("rejects a fan-out slug that would exceed the collection-slug bound BEFORE any write", async () => {
+    const longBase = "z".repeat(120); // valid alone; overflows once "-acme-beta" is appended
+    const msg = await fieldErrorOf(
+      handler(brandsFetch({ brands: TWO_BRANDS })).validateConfig(WORKSPACE, {
+        ...VALID,
+        __install_id__: longBase,
+      }),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/exceeds 128 characters/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
   });
 
   it("rejects a fan-out slug taken by another knowledge catalog BEFORE any write", async () => {

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -48,6 +48,8 @@ import {
 } from "@atlas/api/lib/knowledge/notion/connector";
 import { GitbookFormInstallHandler, GITBOOK_SLUG } from "./gitbook-form-handler";
 import { registerGitbookKnowledgeConnector } from "@atlas/api/lib/knowledge/gitbook/connector";
+import { ZendeskFormInstallHandler, ZENDESK_SLUG } from "./zendesk-form-handler";
+import { registerZendeskKnowledgeConnector } from "@atlas/api/lib/knowledge/zendesk/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -282,6 +284,19 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(GITBOOK_SLUG, new GitbookFormInstallHandler());
   registerGitbookKnowledgeConnector();
   log.info("Registered GitbookFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Zendesk Guide) — the built-in `zendesk` connector install
+  // (#4396, PRD #4395 anchor slice). Knowledge-pillar, multi-instance: ONE
+  // install fans out to one collection per help-center-enabled BRAND. Config =
+  // account subdomain + email + per-brand binding; the API token lands in
+  // `knowledge_sync_credentials` (encrypted, one row per brand collection),
+  // never in `workspace_plugins.config`. Hosts are composed `*.zendesk.com`
+  // labels → SSRF gated at install and fetch. Registering the FORM handler +
+  // the CONNECTOR together (as with Confluence/Notion/GitBook) keeps a
+  // half-wired deploy from having an installable card whose scheduled sync has
+  // no registered vendor client. No env gate.
+  registerFormHandler(ZENDESK_SLUG, new ZendeskFormInstallHandler());
+  registerZendeskKnowledgeConnector();
+  log.info("Registered ZendeskFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
@@ -6,9 +6,10 @@
  * BRAND (the PRD's "each brand maps to a collection"): the handler enumerates
  * the account's brands with the supplied credentials and upserts one
  * `pillar='knowledge'` `workspace_plugins` row per brand, each config pinned
- * to that brand's `*.zendesk.com` subdomain. A single-brand account (the
- * common case) gets exactly the chosen collection slug; a multi-brand account
- * fans out to `<slug>-<brand-subdomain>`. The Scheduler dispatches the
+ * to that brand's `*.zendesk.com` subdomain. A single INSTALLABLE brand (the
+ * common case; installable = active + Help Center enabled + valid host label)
+ * gets exactly the chosen collection slug; multiple installable brands fan
+ * out to `<slug>-<brand-subdomain>`. The Scheduler dispatches the
  * registered Zendesk connector per collection on a cadence
  * (`lib/knowledge/connector-sync.ts`), and every synced article lands `draft`.
  *
@@ -43,9 +44,10 @@ import {
   saveSyncCredential,
   deleteSyncCredential,
 } from "@atlas/api/lib/knowledge/sync-credentials";
-import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
 import {
   listZendeskBrands,
+  ZendeskAuthError,
+  ZendeskNotFoundError,
   type ZendeskBrand,
   type ZendeskClientDeps,
 } from "@atlas/api/lib/knowledge/zendesk/client";
@@ -155,12 +157,12 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
 
     // ── Enumerate brands = verify the connection loudly BEFORE persisting ────
     const brands = await this.enumerateBrands({ subdomain, email, apiToken });
-    const installable = brands.filter(
-      (b) => b.active && b.hasHelpCenter && ZENDESK_SUBDOMAIN_PATTERN.test(b.subdomain),
-    );
-    const skippedBadSubdomain = brands.filter(
-      (b) => b.active && b.hasHelpCenter && !ZENDESK_SUBDOMAIN_PATTERN.test(b.subdomain),
-    );
+    // Brand subdomains come from vendor JSON: same label validation as the
+    // admin-supplied one (pattern + DNS-label bound) before a host is composed.
+    const validLabel = (b: ZendeskBrand) =>
+      b.subdomain.length <= SUBDOMAIN_LABEL_MAX && ZENDESK_SUBDOMAIN_PATTERN.test(b.subdomain);
+    const installable = brands.filter((b) => b.active && b.hasHelpCenter && validLabel(b));
+    const skippedBadSubdomain = brands.filter((b) => b.active && b.hasHelpCenter && !validLabel(b));
     if (skippedBadSubdomain.length > 0) {
       // Never silent: a brand whose subdomain fails the host-label pattern
       // cannot get a composed host, so it cannot be installed.
@@ -252,7 +254,7 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
         { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
         "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed brand collections stay installed)",
       );
-      throw err;
+      throw retryableInstallError(slug, err);
     }
 
     const candidateId = this.newId();
@@ -301,11 +303,18 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
           "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
         );
       }
-      throw err;
+      throw retryableInstallError(slug, err);
     }
   }
 
-  /** Enumerate brands with the supplied creds; map every failure to a 400. */
+  /**
+   * Enumerate brands with the supplied creds; map every failure to a 400.
+   * Classification is POSITIVE, by `instanceof` on the client's typed errors —
+   * never by message text or `cause`-presence sniffing — so only a failure the
+   * client KNOWS is credential-shaped blames the api_token field; a Zendesk
+   * outage or transport error stays form-level (re-entering a fine token
+   * would be the wrong guidance). All messages host-redacted by the client.
+   */
   private async enumerateBrands(input: {
     subdomain: string;
     email: string;
@@ -321,20 +330,23 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
         });
       }
       const message = err instanceof Error ? err.message : String(err);
-      // Non-credential failures — a 429 (ConnectorRateLimitError) or a
-      // transport error (DNS/timeout/non-JSON; the client marks those with
-      // `cause`) — are form-level: blaming the api_token field would send the
-      // admin re-entering a token that may be fine. All host-redacted.
-      if (err instanceof ConnectorRateLimitError || (err instanceof Error && err.cause !== undefined)) {
+      if (err instanceof ZendeskAuthError) {
         throw new FormInstallValidationError({
-          fieldErrors: {},
-          formErrors: [message],
+          fieldErrors: { api_token: [message] },
+          formErrors: [],
         });
       }
-      // Auth (401/403) / wrong subdomain (404) — actionable, host-redacted.
+      if (err instanceof ZendeskNotFoundError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { subdomain: [message] },
+          formErrors: [],
+        });
+      }
+      // Everything else — 429 (ConnectorRateLimitError), vendor 5xx,
+      // transport/DNS/non-JSON — is form-level.
       throw new FormInstallValidationError({
-        fieldErrors: { api_token: [message] },
-        formErrors: [],
+        fieldErrors: {},
+        formErrors: [message],
       });
     }
   }
@@ -425,4 +437,16 @@ function validateDescription(raw: unknown): string | null {
 
 function fieldError(field: string, message: string): FormInstallValidationError {
   return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}
+
+/**
+ * Wrap a mid-fan-out persistence failure with the retry guidance the admin
+ * needs: all writes are idempotent upserts converging on the same slugs, so
+ * re-running the install is always safe. The original failure rides as cause.
+ */
+function retryableInstallError(slug: string, err: unknown): Error {
+  return new Error(
+    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed brand collections are simply updated in place.`,
+    { cause: err },
+  );
 }

--- a/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
@@ -1,0 +1,428 @@
+/**
+ * `ZendeskFormInstallHandler` — the {@link FormBasedInstallHandler} for the
+ * built-in `zendesk` Knowledge Base catalog row (#4396, PRD #4395).
+ *
+ * Installing `zendesk` creates one synced collection PER help-center-enabled
+ * BRAND (the PRD's "each brand maps to a collection"): the handler enumerates
+ * the account's brands with the supplied credentials and upserts one
+ * `pillar='knowledge'` `workspace_plugins` row per brand, each config pinned
+ * to that brand's `*.zendesk.com` subdomain. A single-brand account (the
+ * common case) gets exactly the chosen collection slug; a multi-brand account
+ * fans out to `<slug>-<brand-subdomain>`. The Scheduler dispatches the
+ * registered Zendesk connector per collection on a cadence
+ * (`lib/knowledge/connector-sync.ts`), and every synced article lands `draft`.
+ *
+ * Beyond the Confluence precedent it inherits (SSRF gate, loud credential
+ * verification, token routed to `knowledge_sync_credentials` — never
+ * `workspace_plugins.config`), two Zendesk-specific choices:
+ *
+ *   1. **Hosts are composed, never pasted.** The admin supplies a SUBDOMAIN
+ *      (a bare label; a pasted `acme.zendesk.com` / full URL is reduced to
+ *      its label), so every host is `https://<label>.zendesk.com` by
+ *      construction — then still egress-guard-checked at install and fetch.
+ *   2. **Fan-out is validated fully before any write.** Every per-brand slug
+ *      is availability-checked first; writes then run per brand
+ *      (credential → row). A mid-fan-out failure leaves earlier brands fully
+ *      installed and working; the thrown error says retrying is safe (all
+ *      writes are idempotent upserts converging on the same slugs). The one
+ *      transition caveat: a single-brand install that later becomes
+ *      multi-brand re-fans-out under suffixed slugs — the old base-slug
+ *      collection stays behind and should be uninstalled by the admin.
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  assertBaseUrlAllowed,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import {
+  listZendeskBrands,
+  type ZendeskBrand,
+  type ZendeskClientDeps,
+} from "@atlas/api/lib/knowledge/zendesk/client";
+import {
+  ZENDESK_SLUG,
+  ZENDESK_CATALOG_ID,
+  ZENDESK_SUBDOMAIN_PATTERN,
+  zendeskHostFor,
+  type ZendeskCollectionConfig,
+} from "@atlas/api/lib/knowledge/zendesk/config";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  COLLECTION_SLUG_MAX,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { ZENDESK_SLUG, ZENDESK_CATALOG_ID };
+
+/** Defensive upper bounds — guard against pathological pastes. */
+const SUBDOMAIN_INPUT_MAX = 2048; // a pasted URL is allowed; the label is extracted
+const SUBDOMAIN_LABEL_MAX = 63; // DNS label bound
+const EMAIL_MAX = 320;
+const API_TOKEN_MAX = 4096;
+
+export interface ZendeskFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the brand-enumeration fetch (no real Zendesk call). */
+  readonly clientDeps?: ZendeskClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to
+ * `CONFLUENCE_INSTALL_UPSERT_SQL`: `status='published'` because the COLLECTION
+ * container is live immediately — the review gate is on the DOCUMENTS, which
+ * always sync in as `draft`. Exported so the real-Postgres test executes this
+ * exact string against the live schema.
+ */
+export const ZENDESK_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: ZendeskClientDeps;
+  private readonly log = createLogger("integrations.install.zendesk");
+
+  constructor(options: ZendeskFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const baseSlug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], ZENDESK_SLUG);
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const subdomain = validateSubdomain(rawForm.subdomain);
+    const email = validateEmail(rawForm.email);
+    const apiToken = validateApiToken(rawForm.api_token);
+    const description = validateDescription(rawForm.description);
+
+    // SSRF gate on the composed account host (defence in depth — `*.zendesk.com`
+    // by construction; `guardedFetch` re-validates on every request).
+    assertAccountHostAllowed(subdomain);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [ZENDESK_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "zendesk catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${ZENDESK_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    // ── Enumerate brands = verify the connection loudly BEFORE persisting ────
+    const brands = await this.enumerateBrands({ subdomain, email, apiToken });
+    const installable = brands.filter(
+      (b) => b.active && b.hasHelpCenter && ZENDESK_SUBDOMAIN_PATTERN.test(b.subdomain),
+    );
+    const skippedBadSubdomain = brands.filter(
+      (b) => b.active && b.hasHelpCenter && !ZENDESK_SUBDOMAIN_PATTERN.test(b.subdomain),
+    );
+    if (skippedBadSubdomain.length > 0) {
+      // Never silent: a brand whose subdomain fails the host-label pattern
+      // cannot get a composed host, so it cannot be installed.
+      this.log.warn(
+        { workspaceId, skipped: skippedBadSubdomain.map((b) => b.id) },
+        "Skipped Zendesk brands with non-label subdomains — cannot compose their help-center host",
+      );
+    }
+    if (installable.length === 0) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [
+          `The Zendesk account "${subdomain}" has no active brand with a Help Center enabled — activate a Guide help center, then re-install.`,
+        ],
+      });
+    }
+
+    // ── Compute + validate every per-brand slug BEFORE any write ─────────────
+    const planned = installable.map((brand) => ({
+      brand,
+      slug: installable.length === 1 ? baseSlug : `${baseSlug}-${brand.subdomain}`,
+    }));
+    for (const { slug } of planned) {
+      if (slug.length > COLLECTION_SLUG_MAX) {
+        throw new FormInstallValidationError({
+          fieldErrors: {
+            [KNOWLEDGE_INSTALL_ID_FIELD]: [
+              `Collection id "${slug}" (the per-brand fan-out of "${baseSlug}") exceeds ${COLLECTION_SLUG_MAX} characters — choose a shorter collection id.`,
+            ],
+          },
+          formErrors: [],
+        });
+      }
+      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+    }
+
+    // ── Per-brand writes: credential first, then the collection row ──────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "api_token");
+    let firstRecord: InstallRecord | null = null;
+    for (const { brand, slug } of planned) {
+      const record = await this.installBrandCollection({
+        workspaceId,
+        catalogId,
+        slug,
+        brand,
+        config: {
+          subdomain,
+          email,
+          brand_id: brand.id,
+          brand_subdomain: brand.subdomain,
+          brand_name: brand.name,
+          ...(description !== null ? { description } : {}),
+        },
+        apiToken,
+      });
+      firstRecord ??= record;
+    }
+
+    this.log.info(
+      {
+        workspaceId,
+        accountHost: hostForLog(zendeskHostFor(subdomain)),
+        collections: planned.map((p) => p.slug),
+        brands: planned.length,
+      },
+      "Zendesk collection install completed",
+    );
+    // `firstRecord` is set on the first loop iteration (planned is non-empty).
+    if (firstRecord === null) {
+      throw new Error("Zendesk install produced no collection record — invariant violation");
+    }
+    return { installRecord: firstRecord, credentialWritten: true };
+  }
+
+  /** Write one brand's credential + collection row, Confluence rollback posture. */
+  private async installBrandCollection(input: {
+    workspaceId: WorkspaceId;
+    catalogId: string;
+    slug: string;
+    brand: ZendeskBrand;
+    config: ZendeskCollectionConfig;
+    apiToken: string;
+  }): Promise<InstallRecord> {
+    const { workspaceId, catalogId, slug, brand, config, apiToken } = input;
+    try {
+      await saveSyncCredential(workspaceId, slug, apiToken);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed brand collections stay installed)",
+      );
+      throw err;
+    }
+
+    const candidateId = this.newId();
+    try {
+      const rows = await internalQuery<{ id: string }>(ZENDESK_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        slug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug: slug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      return { id: returned, workspaceId, catalogId: ZENDESK_SLUG };
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a
+      // failed install (this brand's install row never landed, so uninstall
+      // would never reach it). Best-effort — a re-install overwrites it either
+      // way; a cleanup failure is logged, never masks the original error.
+      this.log.error(
+        {
+          workspaceId,
+          collectionSlug: slug,
+          brandId: brand.id,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to persist zendesk collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, slug);
+      } catch (cleanupErr) {
+        this.log.error(
+          {
+            workspaceId,
+            collectionSlug: slug,
+            err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw err;
+    }
+  }
+
+  /** Enumerate brands with the supplied creds; map every failure to a 400. */
+  private async enumerateBrands(input: {
+    subdomain: string;
+    email: string;
+    apiToken: string;
+  }): Promise<ZendeskBrand[]> {
+    try {
+      return await listZendeskBrands(input, this.clientDeps);
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { subdomain: [err.message] },
+          formErrors: [],
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      // Non-credential failures — a 429 (ConnectorRateLimitError) or a
+      // transport error (DNS/timeout/non-JSON; the client marks those with
+      // `cause`) — are form-level: blaming the api_token field would send the
+      // admin re-entering a token that may be fine. All host-redacted.
+      if (err instanceof ConnectorRateLimitError || (err instanceof Error && err.cause !== undefined)) {
+        throw new FormInstallValidationError({
+          fieldErrors: {},
+          formErrors: [message],
+        });
+      }
+      // Auth (401/403) / wrong subdomain (404) — actionable, host-redacted.
+      throw new FormInstallValidationError({
+        fieldErrors: { api_token: [message] },
+        formErrors: [],
+      });
+    }
+  }
+}
+
+/**
+ * Validate the account subdomain: required, reduced to a bare label (a pasted
+ * `acme.zendesk.com` or full URL is accepted and reduced), bounded, matching
+ * the DNS-label pattern the host is composed from.
+ */
+function validateSubdomain(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "subdomain",
+      'The Zendesk subdomain is required — the "acme" in acme.zendesk.com (you can paste the full URL).',
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > SUBDOMAIN_INPUT_MAX) {
+    throw fieldError("subdomain", `The subdomain must be ${SUBDOMAIN_INPUT_MAX} characters or fewer.`);
+  }
+  let label = trimmed.toLowerCase();
+  // Accept a pasted URL or host and reduce it to the leading label.
+  label = label.replace(/^https?:\/\//, "");
+  const zendeskHost = /^([a-z0-9-]+)\.zendesk\.com(?:[/:?#].*)?$/.exec(label);
+  if (zendeskHost) label = zendeskHost[1];
+  else label = label.split(/[/:?#]/, 1)[0];
+  if (label.length > SUBDOMAIN_LABEL_MAX || !ZENDESK_SUBDOMAIN_PATTERN.test(label)) {
+    throw fieldError(
+      "subdomain",
+      'Enter the bare Zendesk subdomain — the "acme" in acme.zendesk.com (letters, digits, and dashes).',
+    );
+  }
+  return label;
+}
+
+/** SSRF-gate the composed account host, mapping a block to a field-level 400. */
+function assertAccountHostAllowed(subdomain: string): void {
+  try {
+    assertBaseUrlAllowed(zendeskHostFor(subdomain));
+  } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      throw new FormInstallValidationError({
+        fieldErrors: { subdomain: [err.message] },
+        formErrors: [],
+      });
+    }
+    throw err;
+  }
+}
+
+function validateEmail(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError("email", "The Zendesk account email is required.");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > EMAIL_MAX) {
+    throw fieldError("email", `The email must be ${EMAIL_MAX} characters or fewer.`);
+  }
+  if (!trimmed.includes("@")) {
+    throw fieldError("email", "Enter a valid Zendesk account email.");
+  }
+  return trimmed;
+}
+
+function validateApiToken(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "api_token",
+      "An API token is required. Create one in Admin Center → Apps and integrations → Zendesk API.",
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > API_TOKEN_MAX) {
+    throw fieldError("api_token", `The API token must be ${API_TOKEN_MAX} characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -39,6 +39,7 @@ import { NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations
 import { CONFLUENCE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-form-handler";
 import { CONFLUENCE_DC_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-datacenter-form-handler";
 import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/gitbook-form-handler";
+import { ZENDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/zendesk-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
   CONNECTOR_SYNC_STATE_SELECT_SQL,
@@ -558,6 +559,37 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // The token is NEVER persisted in the install config.
     expect(row.rows[0]?.config).not.toHaveProperty("api_token");
     expect(row.rows[0]?.config).toMatchObject({ space_id: "space-123" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a Zendesk per-brand connector collection against the live schema (#4396)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:zendesk', 'Knowledge Base (Zendesk Guide)', 'zendesk', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(ZENDESK_INSTALL_UPSERT_SQL, [
+      "row-zendesk",
+      ws,
+      "catalog:zendesk",
+      "zendesk-acme",
+      JSON.stringify({
+        subdomain: "acme",
+        email: "ops@acme.test",
+        brand_id: "42",
+        brand_subdomain: "acme",
+        brand_name: "Acme",
+      }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-zendesk");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'zendesk-acme'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The token is NEVER persisted in the install config.
+    expect(row.rows[0]?.config).not.toHaveProperty("api_token");
+    expect(row.rows[0]?.config).toMatchObject({ brand_id: "42", brand_subdomain: "acme" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/support/__tests__/html-to-markdown.test.ts
+++ b/packages/api/src/lib/knowledge/support/__tests__/html-to-markdown.test.ts
@@ -63,8 +63,13 @@ describe("links", () => {
     );
   });
 
-  it("drops javascript: hrefs but keeps the anchor text", () => {
+  it("drops javascript:/data:/vbscript: hrefs but keeps the anchor text", () => {
     expect(md('<p><a href="javascript:alert(1)">click me</a></p>')).toBe("click me");
+    expect(md('<p><a href="data:text/html,<script>x()</script>">click me</a></p>')).toBe("click me");
+    expect(md('<p><a href="vbscript:MsgBox(1)">click me</a></p>')).toBe("click me");
+    // Control chars / whitespace inside the scheme must not defeat the check.
+    expect(md('<p><a href="java\nscript:alert(1)">click me</a></p>')).toBe("click me");
+    expect(md('<p><a href=" DATA:text/html,x">click me</a></p>')).toBe("click me");
   });
 
   it("passes every href through the cross-link rewriting hook", () => {

--- a/packages/api/src/lib/knowledge/support/__tests__/html-to-markdown.test.ts
+++ b/packages/api/src/lib/knowledge/support/__tests__/html-to-markdown.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Golden tests for the shared support-center HTML → markdown converter
+ * (#4396, PRD #4395). The corpus covers every AC-named shape — safe-tag
+ * handling, tables/code/links, inline formatting, lists, definition lists —
+ * and the degradation policy: images/media/embeds degrade to a VISIBLE
+ * placeholder and a COUNTED bucket, and prose is never silently dropped.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { convertSupportHtmlToMarkdown } from "@atlas/api/lib/knowledge/support/html-to-markdown";
+
+const PAGE_URL = "https://acme.zendesk.com/hc/en-us/articles/123-Getting-Started";
+
+/** Convenience: convert with the shared page URL and return the markdown only. */
+function md(html: string): string {
+  return convertSupportHtmlToMarkdown(html, { pageUrl: PAGE_URL }).markdown;
+}
+
+describe("headings and inline formatting", () => {
+  it("renders headings h1–h6", () => {
+    expect(md("<h1>One</h1><h2>Two</h2><h3>Three</h3><h6>Six</h6>")).toBe(
+      "# One\n\n## Two\n\n### Three\n\n###### Six",
+    );
+  });
+
+  it("renders bold, italic, code, and strikethrough inline", () => {
+    expect(
+      md("<p>Hello <strong>world</strong> and <em>you</em> and <code>x=1</code> and <del>gone</del>.</p>"),
+    ).toBe("Hello **world** and *you* and `x=1` and ~~gone~~.");
+  });
+
+  it("decodes HTML entities exactly once", () => {
+    expect(md("<p>Fish &amp; chips &lt;here&gt; &mdash; also a literal &amp;nbsp;</p>")).toBe(
+      "Fish & chips <here> — also a literal &nbsp;",
+    );
+  });
+
+  it("collapses non-breaking spaces and whitespace runs", () => {
+    expect(md("<p>a&nbsp;&nbsp;b\n   c</p>")).toBe("a b c");
+  });
+
+  it("turns <br> into a hard line break", () => {
+    expect(md("<p>line one<br>line two</p>")).toBe("line one\nline two");
+  });
+
+  it("renders kbd/samp as inline code and unwraps span/u/sub/sup/mark", () => {
+    expect(md("<p>Press <kbd>Ctrl</kbd> in <span>the</span> <u>editor</u><sub>1</sub></p>")).toBe(
+      "Press `Ctrl` in the editor1",
+    );
+  });
+});
+
+describe("links", () => {
+  it("renders an external anchor", () => {
+    expect(md('<p>See <a href="https://example.com/docs">the docs</a>.</p>')).toBe(
+      "See [the docs](https://example.com/docs).",
+    );
+  });
+
+  it("uses the href as the label when the anchor has no text", () => {
+    expect(md('<p><a href="https://example.com"></a></p>')).toBe(
+      "[https://example.com](https://example.com)",
+    );
+  });
+
+  it("drops javascript: hrefs but keeps the anchor text", () => {
+    expect(md('<p><a href="javascript:alert(1)">click me</a></p>')).toBe("click me");
+  });
+
+  it("passes every href through the cross-link rewriting hook", () => {
+    const { markdown } = convertSupportHtmlToMarkdown(
+      '<p><a href="/hc/en-us/articles/456">related</a></p>',
+      {
+        pageUrl: PAGE_URL,
+        rewriteLink: (href) => new URL(href, "https://acme.zendesk.com").toString(),
+      },
+    );
+    expect(markdown).toBe("[related](https://acme.zendesk.com/hc/en-us/articles/456)");
+  });
+});
+
+describe("lists", () => {
+  it("renders nested unordered lists with two-space indents", () => {
+    expect(md("<ul><li>One<ul><li>Sub</li></ul></li><li>Two</li></ul>")).toBe(
+      "- One\n  - Sub\n- Two",
+    );
+  });
+
+  it("renders ordered lists", () => {
+    expect(md("<ol><li>First</li><li>Second</li></ol>")).toBe("1. First\n2. Second");
+  });
+
+  it("renders a definition list with bold terms", () => {
+    expect(md("<dl><dt>API key</dt><dd>Your secret token</dd></dl>")).toBe(
+      "**API key**\n: Your secret token",
+    );
+  });
+});
+
+describe("tables", () => {
+  it("renders a table with a header row", () => {
+    expect(
+      md(
+        "<table><thead><tr><th>Name</th><th>Value</th></tr></thead>" +
+          "<tbody><tr><td>a</td><td>1</td></tr><tr><td>b</td><td>2</td></tr></tbody></table>",
+      ),
+    ).toBe("| Name | Value |\n| --- | --- |\n| a | 1 |\n| b | 2 |");
+  });
+
+  it("emits an empty header for a headerless table and pads ragged rows", () => {
+    expect(md("<table><tr><td>a</td><td>1</td></tr><tr><td>b</td></tr></table>")).toBe(
+      "|  |  |\n| --- | --- |\n| a | 1 |\n| b |  |",
+    );
+  });
+
+  it("escapes backslashes and pipes in cells so they cannot split columns", () => {
+    expect(md("<table><tr><td>a\\|b</td></tr></table>")).toBe(
+      "|  |\n| --- |\n| a\\\\\\|b |",
+    );
+  });
+});
+
+describe("code blocks", () => {
+  it("renders <pre> as a fence", () => {
+    expect(md("<pre>const x = 1;\nconst y = 2;</pre>")).toBe(
+      "```\nconst x = 1;\nconst y = 2;\n```",
+    );
+  });
+
+  it("sniffs the language from <pre><code class=\"language-…\">", () => {
+    expect(md('<pre><code class="language-python">print("hi")</code></pre>')).toBe(
+      '```python\nprint("hi")\n```',
+    );
+  });
+
+  it("does not entity-mangle code content", () => {
+    expect(md("<pre>if (a &lt; b &amp;&amp; c) {}</pre>")).toBe(
+      "```\nif (a < b && c) {}\n```",
+    );
+  });
+});
+
+describe("blockquotes, rules, details", () => {
+  it("renders a blockquote", () => {
+    expect(md("<blockquote><p>Wise words</p></blockquote>")).toBe("> Wise words");
+  });
+
+  it("renders <hr> as a thematic break", () => {
+    expect(md("<p>a</p><hr><p>b</p>")).toBe("a\n\n---\n\nb");
+  });
+
+  it("renders details/summary as a bold label plus its body", () => {
+    expect(md("<details><summary>More info</summary><p>Hidden text</p></details>")).toBe(
+      "**More info**\n\nHidden text",
+    );
+  });
+});
+
+describe("degradation policy — counted placeholders, never silent drops", () => {
+  it("degrades an image to a counted placeholder linking to the article", () => {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(
+      '<p>Step one:</p><img src="https://cdn.example.com/shots/step1.png" alt="Step one screenshot">',
+      { pageUrl: PAGE_URL },
+    );
+    expect(markdown).toBe(
+      `Step one:\n\n[Image: Step one screenshot — view on the original page](${PAGE_URL})`,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 1 }]);
+  });
+
+  it("labels an alt-less image by its src basename", () => {
+    const { markdown } = convertSupportHtmlToMarkdown(
+      '<img src="https://cdn.example.com/a/diagram.png?w=100">',
+      { pageUrl: PAGE_URL },
+    );
+    expect(markdown).toBe(`[Image: diagram.png — view on the original page](${PAGE_URL})`);
+  });
+
+  it("counts each media kind under its own bucket", () => {
+    const { degradations } = convertSupportHtmlToMarkdown(
+      '<img src="a.png"><img src="b.png"><iframe src="https://youtube.com/embed/x"></iframe>' +
+        "<video src='v.mp4'></video><svg><circle/></svg>",
+      { pageUrl: PAGE_URL },
+    );
+    expect(degradations).toEqual([
+      { name: "#iframe", count: 1 },
+      { name: "#image", count: 2 },
+      { name: "#svg", count: 1 },
+      { name: "#video", count: 1 },
+    ]);
+  });
+
+  it("degrades an inline image inside a paragraph without dropping the prose", () => {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(
+      '<p>Click <img src="icon.png" alt="the gear icon"> to open settings.</p>',
+      { pageUrl: PAGE_URL },
+    );
+    expect(markdown).toBe(
+      `Click [Image: the gear icon — view on the original page](${PAGE_URL}) to open settings.`,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 1 }]);
+  });
+});
+
+describe("safe-tag handling", () => {
+  it("removes script/style/noscript bodies entirely (not prose, not counted)", () => {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(
+      "<p>before</p><script>alert(1)</script><style>p{color:red}</style><noscript>enable js</noscript><p>after</p>",
+      { pageUrl: PAGE_URL },
+    );
+    expect(markdown).toBe("before\n\nafter");
+    expect(degradations).toEqual([]);
+  });
+
+  it("renders the children of unknown wrappers so prose is never dropped", () => {
+    expect(md('<section><article><custom-widget><p>Real prose</p></custom-widget></article></section>')).toBe(
+      "Real prose",
+    );
+  });
+
+  it("survives malformed real-world HTML (unclosed tags)", () => {
+    expect(md("<p>one<p>two<div>three")).toBe("one\n\ntwo\n\nthree");
+  });
+});
+
+describe("whole-article golden fixture", () => {
+  it("converts a representative help-center article", () => {
+    const html = `
+      <h1>Getting started</h1>
+      <p>Welcome! This guide covers <strong>setup</strong> and <em>first steps</em>.</p>
+      <h2>Install</h2>
+      <ol><li>Download the CLI</li><li>Run <code>init</code></li></ol>
+      <pre><code class="language-bash">atlas init --profile</code></pre>
+      <table><thead><tr><th>Flag</th><th>Meaning</th></tr></thead>
+        <tbody><tr><td><code>--profile</code></td><td>Profile the DB</td></tr></tbody></table>
+      <img src="https://cdn.example.com/setup.png" alt="Setup wizard">
+      <p>Questions? See <a href="/hc/en-us/articles/456">the FAQ</a>.</p>
+    `;
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(html, {
+      pageUrl: PAGE_URL,
+      rewriteLink: (href) => new URL(href, "https://acme.zendesk.com").toString(),
+    });
+    expect(markdown).toBe(
+      [
+        "# Getting started",
+        "",
+        "Welcome! This guide covers **setup** and *first steps*.",
+        "",
+        "## Install",
+        "",
+        "1. Download the CLI",
+        "2. Run `init`",
+        "",
+        "```bash",
+        "atlas init --profile",
+        "```",
+        "",
+        "| Flag | Meaning |",
+        "| --- | --- |",
+        "| `--profile` | Profile the DB |",
+        "",
+        `[Image: Setup wizard — view on the original page](${PAGE_URL})`,
+        "",
+        "Questions? See [the FAQ](https://acme.zendesk.com/hc/en-us/articles/456).",
+      ].join("\n"),
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 1 }]);
+  });
+});

--- a/packages/api/src/lib/knowledge/support/html-to-markdown.ts
+++ b/packages/api/src/lib/knowledge/support/html-to-markdown.ts
@@ -56,9 +56,10 @@ export interface HtmlConvertOptions {
   /** The article's canonical vendor URL — every degradation placeholder links here. */
   readonly pageUrl: string;
   /**
-   * Cross-link rewriting hook: every `<a href>` is passed through it before
-   * rendering. Vendors absolutize relative article links here (e.g. resolve
-   * `/hc/en-us/articles/123` against the brand host). Default: identity.
+   * Cross-link rewriting hook: every RENDERED `<a href>` is passed through it
+   * before rendering (empty and `javascript:` hrefs are dropped first and
+   * never reach it). Vendors absolutize relative article links here (e.g.
+   * resolve `/hc/en-us/articles/123` against the brand host). Default: identity.
    */
   readonly rewriteLink?: (href: string) => string;
 }
@@ -292,9 +293,8 @@ function renderList(listEl: Element, ctx: Ctx, depth: number): string {
     const nested: Element[] = [];
     const leadNodes: ChildNode[] = [];
     for (const child of li.children) {
-      const childName = isElement(child) ? child.name.toLowerCase() : "";
-      if (childName === "ul" || childName === "ol") {
-        nested.push(child as Element);
+      if (isElement(child) && (child.name.toLowerCase() === "ul" || child.name.toLowerCase() === "ol")) {
+        nested.push(child);
       } else {
         leadNodes.push(child);
       }
@@ -446,7 +446,7 @@ function collapseInlineWhitespace(text: string): string {
   return text.replace(/\u00a0/g, " ").replace(/[ \t\r\n]+/g, " ");
 }
 
-/** Collapse 3+ newlines to a paragraph break and trim trailing whitespace. */
+/** Collapse 3+ newlines to a paragraph break and trim the result. */
 function normalizeBlankLines(markdown: string): string {
   return markdown.replace(/\n{3,}/g, "\n\n").trim();
 }

--- a/packages/api/src/lib/knowledge/support/html-to-markdown.ts
+++ b/packages/api/src/lib/knowledge/support/html-to-markdown.ts
@@ -57,9 +57,10 @@ export interface HtmlConvertOptions {
   readonly pageUrl: string;
   /**
    * Cross-link rewriting hook: every RENDERED `<a href>` is passed through it
-   * before rendering (empty and `javascript:` hrefs are dropped first and
-   * never reach it). Vendors absolutize relative article links here (e.g.
-   * resolve `/hc/en-us/articles/123` against the brand host). Default: identity.
+   * before rendering (empty and unsafe-scheme hrefs — `javascript:`, `data:`,
+   * `vbscript:` — are dropped first and never reach it). Vendors absolutize
+   * relative article links here (e.g. resolve `/hc/en-us/articles/123`
+   * against the brand host). Default: identity.
    */
   readonly rewriteLink?: (href: string) => string;
 }
@@ -411,7 +412,7 @@ function renderInlineNode(node: ChildNode, ctx: Ctx): string {
     case "a": {
       const href = node.attribs.href?.trim() ?? "";
       const text = inner().trim();
-      if (href === "" || href.toLowerCase().startsWith("javascript:")) return text;
+      if (href === "" || hasUnsafeLinkScheme(href)) return text;
       return `[${text || href}](${ctx.rewriteLink(href)})`;
     }
     default:
@@ -424,6 +425,24 @@ function renderInlineNode(node: ChildNode, ctx: Ctx): string {
 // ---------------------------------------------------------------------------
 // Text utilities
 // ---------------------------------------------------------------------------
+
+/**
+ * True for hrefs whose scheme executes or smuggles content when the mirrored
+ * markdown is later rendered in a web surface — `javascript:`, `data:`, and
+ * `vbscript:` links are dropped (their anchor TEXT is kept, so no prose is
+ * lost). Control characters and whitespace are stripped before the check
+ * because HTML parsers ignore them inside a scheme (`java\nscript:` is live
+ * in a browser), so a naive prefix test would be bypassable.
+ */
+function hasUnsafeLinkScheme(href: string): boolean {
+  // oxlint-disable-next-line no-control-regex -- stripping control chars from an untrusted href IS the point (browsers ignore them inside a scheme)
+  const normalized = href.replace(/[\u0000-\u0020]+/g, "").toLowerCase();
+  return (
+    normalized.startsWith("javascript:") ||
+    normalized.startsWith("data:") ||
+    normalized.startsWith("vbscript:")
+  );
+}
 
 function wrapNonEmpty(inner: string, delim: string): string {
   const trimmed = inner.trim();

--- a/packages/api/src/lib/knowledge/support/html-to-markdown.ts
+++ b/packages/api/src/lib/knowledge/support/html-to-markdown.ts
@@ -1,0 +1,452 @@
+/**
+ * Shared **support-center HTML → Markdown** converter (#4396, PRD #4395).
+ *
+ * Every viable support/help-center platform (Zendesk Guide, Intercom Articles,
+ * Help Scout, Freshdesk, Front, Zoho Desk, ServiceNow, Salesforce Knowledge)
+ * returns article bodies as plain HTML — unlike Confluence's storage-XHTML
+ * dialect — so the tier gets ONE converter, built with the anchor slice
+ * (Zendesk) and consumed by every subsequent vendor. A support connector must
+ * never fork its own HTML→markdown pass; vendor-specific shaping belongs in
+ * the vendor's `documents.ts` (titles, paths, provenance), not here.
+ *
+ * The explicit **degradation policy** (PRD AC — "unconvertible constructs
+ * degrade to counted placeholders, never silent drops"):
+ *   - a set of known-safe tags are converted structurally (headings,
+ *     paragraphs, lists, tables, code fences, blockquotes, links, inline
+ *     formatting, definition lists);
+ *   - images/media/embeds are text-first v1: not mirrored, replaced by a
+ *     VISIBLE placeholder linking back to the vendor article, COUNTED under
+ *     synthetic buckets (`#image`, `#iframe`, `#video`, …) in
+ *     {@link HtmlConversionResult.degradations};
+ *   - non-content machinery (`script`, `style`, `noscript`, `template`,
+ *     comments) is removed outright — it carries no prose, so removal is safe
+ *     handling, not a degradation;
+ *   - every OTHER element renders its children, so prose is never dropped.
+ *
+ * Purity: no I/O, no vendor calls, deterministic. The only external inputs
+ * beyond the HTML string are the article's canonical URL (every placeholder is
+ * a live link back to the source) and the optional **cross-link rewriting
+ * hook** — vendors use it to absolutize relative hrefs (e.g. Zendesk `/hc/…`
+ * paths) against their article host.
+ */
+
+import { parseDocument } from "htmlparser2";
+import type { ChildNode, Element } from "domhandler";
+import { isTag, isText } from "domhandler";
+
+/** One kind of degradation and how many times it fired in a single article. */
+export interface HtmlDegradation {
+  /** A synthetic bucket: `#image`, `#iframe`, `#video`, `#audio`, `#embed`, `#svg`. */
+  readonly name: string;
+  readonly count: number;
+}
+
+export interface HtmlConversionResult {
+  readonly markdown: string;
+  /**
+   * Every image/media/embed that could not be structurally converted, counted
+   * by bucket. Empty when the article converted cleanly. The connector logs
+   * the aggregate so a media-heavy article is a visible signal, never a silent
+   * shrink — and each one is ALSO a placeholder line in `markdown`.
+   */
+  readonly degradations: readonly HtmlDegradation[];
+}
+
+export interface HtmlConvertOptions {
+  /** The article's canonical vendor URL — every degradation placeholder links here. */
+  readonly pageUrl: string;
+  /**
+   * Cross-link rewriting hook: every `<a href>` is passed through it before
+   * rendering. Vendors absolutize relative article links here (e.g. resolve
+   * `/hc/en-us/articles/123` against the brand host). Default: identity.
+   */
+  readonly rewriteLink?: (href: string) => string;
+}
+
+/** A mutable degradation tally threaded through one article's conversion. */
+class Degradations {
+  private readonly counts = new Map<string, number>();
+  bump(name: string): void {
+    this.counts.set(name, (this.counts.get(name) ?? 0) + 1);
+  }
+  list(): HtmlDegradation[] {
+    return [...this.counts.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .toSorted((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+/** Convert one article's HTML body to markdown. */
+export function convertSupportHtmlToMarkdown(
+  html: string,
+  options: HtmlConvertOptions,
+): HtmlConversionResult {
+  const degradations = new Degradations();
+  // HTML mode (not xmlMode): help-center bodies are real-world HTML — named
+  // entities, unclosed tags, case-insensitive names. htmlparser2 decodes
+  // entities during tokenization here, so text/attribute reads are already
+  // plain text (no second decode anywhere — a literal `&amp;nbsp;` in the
+  // source stays `&nbsp;` as prose).
+  const doc = parseDocument(html);
+  const ctx: Ctx = {
+    degradations,
+    pageUrl: options.pageUrl,
+    rewriteLink: options.rewriteLink ?? ((href) => href),
+  };
+  const markdown = renderBlocks(doc.children, ctx);
+  return {
+    markdown: normalizeBlankLines(markdown),
+    degradations: degradations.list(),
+  };
+}
+
+interface Ctx {
+  readonly degradations: Degradations;
+  readonly pageUrl: string;
+  readonly rewriteLink: (href: string) => string;
+}
+
+// ---------------------------------------------------------------------------
+// Node helpers
+// ---------------------------------------------------------------------------
+
+function isElement(node: ChildNode): node is Element {
+  return isTag(node);
+}
+
+/** Concatenated text of a node subtree (entities already decoded at parse). */
+function textOf(node: ChildNode): string {
+  if (isText(node)) return node.data;
+  if (isElement(node)) return node.children.map((c) => textOf(c)).join("");
+  return "";
+}
+
+/**
+ * Non-content machinery removed outright — no prose lives here, so removal is
+ * the SAFE handling (rendering a `<script>` body as prose would be worse than
+ * dropping it), and it is deliberately not counted as a degradation.
+ */
+const REMOVED_TAGS = new Set(["script", "style", "noscript", "template", "head", "meta", "link", "title", "base"]);
+
+/** Media/embed tags degraded to a counted placeholder (text-first v1). */
+const MEDIA_BUCKETS: Record<string, string> = {
+  img: "#image",
+  picture: "#image",
+  svg: "#svg",
+  iframe: "#iframe",
+  video: "#video",
+  audio: "#audio",
+  embed: "#embed",
+  object: "#embed",
+  canvas: "#embed",
+};
+
+// ---------------------------------------------------------------------------
+// Block rendering
+// ---------------------------------------------------------------------------
+
+const HEADINGS: Record<string, number> = { h1: 1, h2: 2, h3: 3, h4: 4, h5: 5, h6: 6 };
+
+/** Render a sequence of nodes as block-level markdown, blank-line separated. */
+function renderBlocks(nodes: readonly ChildNode[], ctx: Ctx): string {
+  const blocks: string[] = [];
+  for (const node of nodes) {
+    const block = renderBlock(node, ctx);
+    if (block.trim() !== "") blocks.push(block.trimEnd());
+  }
+  return blocks.join("\n\n");
+}
+
+function renderBlock(node: ChildNode, ctx: Ctx): string {
+  if (isText(node)) {
+    const text = collapseInlineWhitespace(node.data);
+    return text.trim() === "" ? "" : text.trim();
+  }
+  if (!isElement(node)) return "";
+
+  const name = node.name.toLowerCase();
+  if (REMOVED_TAGS.has(name)) return "";
+  if (name in HEADINGS) {
+    return `${"#".repeat(HEADINGS[name])} ${renderInline(node.children, ctx).trim()}`;
+  }
+  if (name in MEDIA_BUCKETS) return degradeMedia(node, name, ctx);
+  switch (name) {
+    case "p":
+    case "div":
+      return renderInline(node.children, ctx).trim();
+    case "ul":
+    case "ol":
+      return renderList(node, ctx, 0);
+    case "table":
+      return renderTable(node, ctx);
+    case "blockquote":
+      return blockquote(renderBlocks(node.children, ctx));
+    case "pre":
+      return renderPre(node);
+    case "hr":
+      return "---";
+    case "dl":
+      return renderDefinitionList(node, ctx);
+    case "figure":
+      return renderBlocks(node.children, ctx);
+    case "details":
+      return renderDetails(node, ctx);
+    default:
+      // Unknown/structural block element (section, article, main, aside, …):
+      // render its children so prose is never dropped.
+      return renderBlocks(node.children, ctx);
+  }
+}
+
+/** `<pre>` → a fenced block; language sniffed from `class="language-x"`. */
+function renderPre(el: Element): string {
+  let language = languageFromClass(el.attribs.class);
+  if (language === "") {
+    const code = el.children.find((c): c is Element => isElement(c) && c.name.toLowerCase() === "code");
+    if (code) language = languageFromClass(code.attribs.class);
+  }
+  return fence(language, textOf(el).replace(/\n$/, ""));
+}
+
+/** Extract a fence language from a `language-x` / `lang-x` class token. */
+function languageFromClass(cls: string | undefined): string {
+  if (!cls) return "";
+  const match = /(?:^|\s)(?:language|lang)-([\w#+-]+)/.exec(cls);
+  return match ? match[1] : "";
+}
+
+/** `<dl>` — terms bold, definitions indented under them. */
+function renderDefinitionList(el: Element, ctx: Ctx): string {
+  const lines: string[] = [];
+  for (const child of el.children) {
+    if (!isElement(child)) continue;
+    const name = child.name.toLowerCase();
+    if (name === "dt") {
+      const term = renderInline(child.children, ctx).trim();
+      if (term !== "") lines.push(`**${term}**`);
+    } else if (name === "dd") {
+      const def = renderInline(child.children, ctx).trim();
+      if (def !== "") lines.push(`: ${def}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/** `<details>`/`<summary>` — bold summary line, body rendered under it. */
+function renderDetails(el: Element, ctx: Ctx): string {
+  const summaryEl = el.children.find(
+    (c): c is Element => isElement(c) && c.name.toLowerCase() === "summary",
+  );
+  const rest = el.children.filter((c) => c !== summaryEl);
+  const summary = summaryEl ? renderInline(summaryEl.children, ctx).trim() : "";
+  const inner = renderBlocks(rest, ctx);
+  if (summary === "") return inner;
+  return inner === "" ? `**${summary}**` : `**${summary}**\n\n${inner}`;
+}
+
+/**
+ * Degrade a media/embed element to a visible placeholder that links back to
+ * the vendor article — counted, never a silent drop (text-first v1: no media
+ * mirroring, same posture as the Confluence/Notion connectors).
+ */
+function degradeMedia(el: Element, name: string, ctx: Ctx): string {
+  const bucket = MEDIA_BUCKETS[name];
+  ctx.degradations.bump(bucket);
+  const label = mediaLabel(el, name);
+  return `[${label} — view on the original page](${ctx.pageUrl})`;
+}
+
+/** A human label for a degraded media element (alt/title/src basename). */
+function mediaLabel(el: Element, name: string): string {
+  const kind =
+    name === "img" || name === "picture" ? "Image"
+    : name === "svg" ? "Image"
+    : name === "video" ? "Video"
+    : name === "audio" ? "Audio"
+    : name === "iframe" ? "Embedded content"
+    : "Embedded content";
+  const alt = el.attribs.alt?.trim();
+  const title = el.attribs.title?.trim();
+  const detail = alt || title || srcBasename(el.attribs.src);
+  return detail ? `${kind}: ${detail}` : kind;
+}
+
+/** The final path segment of a `src` URL, sans query — or empty. */
+function srcBasename(src: string | undefined): string {
+  if (!src) return "";
+  const path = src.split(/[?#]/, 1)[0];
+  const segment = path.split("/").filter((s) => s !== "").at(-1) ?? "";
+  // A bare host (no path) is noise, not a filename.
+  return segment.includes(".") ? segment : "";
+}
+
+function renderList(listEl: Element, ctx: Ctx, depth: number): string {
+  const ordered = listEl.name.toLowerCase() === "ol";
+  const indent = "  ".repeat(depth);
+  const lines: string[] = [];
+  let index = 1;
+  for (const li of listEl.children) {
+    if (!isElement(li) || li.name.toLowerCase() !== "li") continue;
+    const marker = ordered ? `${index}.` : "-";
+    // Split the <li> into inline lead content and any nested lists.
+    const nested: Element[] = [];
+    const leadNodes: ChildNode[] = [];
+    for (const child of li.children) {
+      const childName = isElement(child) ? child.name.toLowerCase() : "";
+      if (childName === "ul" || childName === "ol") {
+        nested.push(child as Element);
+      } else {
+        leadNodes.push(child);
+      }
+    }
+    const lead = renderInline(leadNodes, ctx).trim() || " ";
+    lines.push(`${indent}${marker} ${lead}`);
+    for (const sub of nested) lines.push(renderList(sub, ctx, depth + 1));
+    index++;
+  }
+  return lines.join("\n");
+}
+
+function renderTable(tableEl: Element, ctx: Ctx): string {
+  // Help centers wrap rows in <tbody> (and sometimes <thead>); gather every <tr>.
+  const rows: Element[] = [];
+  const collectRows = (el: Element) => {
+    for (const child of el.children) {
+      if (!isElement(child)) continue;
+      const name = child.name.toLowerCase();
+      if (name === "tr") rows.push(child);
+      else if (name === "thead" || name === "tbody" || name === "tfoot") {
+        collectRows(child);
+      }
+    }
+  };
+  collectRows(tableEl);
+  if (rows.length === 0) return "";
+
+  const renderRow = (tr: Element): string[] =>
+    tr.children
+      .filter((c): c is Element => {
+        if (!isElement(c)) return false;
+        const name = c.name.toLowerCase();
+        return name === "td" || name === "th";
+      })
+      .map((cell) => cellText(cell, ctx));
+
+  const firstIsHeader = rows[0].children.some(
+    (c) => isElement(c) && c.name.toLowerCase() === "th",
+  );
+  const bodyRows = firstIsHeader ? rows.slice(1) : rows;
+  const headerCells = firstIsHeader ? renderRow(rows[0]) : [];
+  const columnCount = Math.max(
+    headerCells.length,
+    ...bodyRows.map((r) => renderRow(r).length),
+    1,
+  );
+
+  const pad = (cells: string[]) => {
+    const out = [...cells];
+    while (out.length < columnCount) out.push("");
+    return out;
+  };
+  const header = firstIsHeader ? pad(headerCells) : new Array<string>(columnCount).fill("");
+  const lines = [
+    `| ${header.join(" | ")} |`,
+    `| ${new Array<string>(columnCount).fill("---").join(" | ")} |`,
+  ];
+  for (const row of bodyRows) lines.push(`| ${pad(renderRow(row)).join(" | ")} |`);
+  return lines.join("\n");
+}
+
+/** A table cell: inline markdown with pipes escaped and newlines flattened. */
+function cellText(cell: Element, ctx: Ctx): string {
+  return renderInline(cell.children, ctx)
+    .replace(/\r?\n+/g, "<br>")
+    // Escape backslashes FIRST: text nodes are emitted raw, so a source `\`
+    // reaches here unescaped. Escaping only `|` would let `a\|b` become
+    // `a\\|b` — a literal backslash + a LIVE pipe that splits/injects a table
+    // column. GFM undoes `\\`→`\` and `\|`→`|` before inline/code-span
+    // parsing, so escaping both (backslash before pipe) is the composable
+    // transform. (Same reasoning as the Confluence converter.)
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Inline rendering
+// ---------------------------------------------------------------------------
+
+function renderInline(nodes: readonly ChildNode[], ctx: Ctx): string {
+  let out = "";
+  for (const node of nodes) out += renderInlineNode(node, ctx);
+  return out;
+}
+
+function renderInlineNode(node: ChildNode, ctx: Ctx): string {
+  if (isText(node)) return collapseInlineWhitespace(node.data);
+  if (!isElement(node)) return "";
+
+  const name = node.name.toLowerCase();
+  if (REMOVED_TAGS.has(name)) return "";
+  if (name in MEDIA_BUCKETS) return degradeMedia(node, name, ctx);
+
+  const inner = () => renderInline(node.children, ctx);
+  switch (name) {
+    case "strong":
+    case "b":
+      return wrapNonEmpty(inner(), "**");
+    case "em":
+    case "i":
+      return wrapNonEmpty(inner(), "*");
+    case "code":
+    case "kbd":
+    case "samp":
+      return wrapNonEmpty(textOf(node), "`");
+    case "s":
+    case "del":
+    case "strike":
+      return wrapNonEmpty(inner(), "~~");
+    case "br":
+      return "\n";
+    case "a": {
+      const href = node.attribs.href?.trim() ?? "";
+      const text = inner().trim();
+      if (href === "" || href.toLowerCase().startsWith("javascript:")) return text;
+      return `[${text || href}](${ctx.rewriteLink(href)})`;
+    }
+    default:
+      // span/u/sub/sup/small/mark/abbr/time/font and anything unknown: render
+      // children so prose is never dropped.
+      return inner();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Text utilities
+// ---------------------------------------------------------------------------
+
+function wrapNonEmpty(inner: string, delim: string): string {
+  const trimmed = inner.trim();
+  return trimmed === "" ? "" : `${delim}${trimmed}${delim}`;
+}
+
+function fence(language: string, body: string): string {
+  return `\`\`\`${language}\n${body}\n\`\`\``;
+}
+
+function blockquote(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => (line === "" ? ">" : `> ${line}`))
+    .join("\n");
+}
+
+/** Collapse runs of inline whitespace (incl. NBSP) to single spaces. */
+function collapseInlineWhitespace(text: string): string {
+  return text.replace(/\u00a0/g, " ").replace(/[ \t\r\n]+/g, " ");
+}
+
+/** Collapse 3+ newlines to a paragraph break and trim trailing whitespace. */
+function normalizeBlankLines(markdown: string): string {
+  return markdown.replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/packages/api/src/lib/knowledge/zendesk/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/zendesk/__tests__/client.test.ts
@@ -181,6 +181,22 @@ describe("fetchAll (reconciliation)", () => {
     await expect(c.fetchAll()).rejects.toThrow(/pointing off|refusing to follow/i);
   });
 
+  it("fails loud on a stuck cursor that keeps returning empty pages (page bound)", async () => {
+    // A same-origin `next` with has_more forever and zero articles never grows
+    // the article count — only the page-count bound stops the walk.
+    const impl = (async (): Promise<Response> =>
+      jsonResponse({
+        articles: [],
+        meta: { has_more: true },
+        links: { next: `${BASE}/api/v2/help_center/articles.json?page[after]=stuck` },
+      })) as unknown as typeof globalThis.fetch;
+    const c = createZendeskVendorClient(
+      { brandSubdomain: "acme", email: "ops@acme.test", apiToken: "tok", collectionSlug: "zendesk-acme" },
+      { fetchImpl: impl },
+    );
+    await expect(c.fetchAll()).rejects.toThrow(/did not terminate/i);
+  });
+
   it("skips draft articles and draft translations (unpublish = absent = archived)", async () => {
     const { c } = client({
       articles: [

--- a/packages/api/src/lib/knowledge/zendesk/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/zendesk/__tests__/client.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for the Zendesk vendor client (#4396) — driven entirely through an
+ * injected fixture `fetchImpl`; NO test touches Zendesk. Covers reconciliation
+ * (cursor-paginated list + translations sideload + fallback), incremental (the
+ * native start_time feed + per-article translations), draft semantics, the
+ * high-water mark, malformed-item coverage flagging, 429 →
+ * ConnectorRateLimitError, auth failure, same-origin pagination pinning, and
+ * the brand enumeration used at install time.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createZendeskVendorClient,
+  listZendeskBrands,
+  parseRetryAfter,
+} from "@atlas/api/lib/knowledge/zendesk/client";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+
+const BASE = "https://acme.zendesk.com";
+
+interface FixtureTranslation {
+  locale?: string;
+  title?: string;
+  body?: string;
+  draft?: boolean;
+  updated_at?: string;
+  html_url?: string;
+}
+interface FixtureArticle {
+  id?: number;
+  title?: string;
+  draft?: boolean;
+  updated_at?: string;
+  html_url?: string;
+  translations?: FixtureTranslation[];
+}
+
+function tr(overrides: FixtureTranslation = {}): FixtureTranslation {
+  return {
+    locale: "en-us",
+    title: "Getting Started",
+    body: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    draft: false,
+    updated_at: "2026-07-01T10:00:00Z",
+    html_url: `${BASE}/hc/en-us/articles/1-getting-started`,
+    ...overrides,
+  };
+}
+
+const ARTICLES: FixtureArticle[] = [
+  { id: 1, draft: false, updated_at: "2026-07-01T10:00:00Z", translations: [tr()] },
+  {
+    id: 2,
+    draft: false,
+    updated_at: "2026-07-05T08:00:00Z",
+    translations: [
+      tr({ title: "Billing FAQ", html_url: `${BASE}/hc/en-us/articles/2-billing-faq`, updated_at: "2026-07-05T08:00:00Z" }),
+      tr({ locale: "de", title: "Abrechnung FAQ", html_url: `${BASE}/hc/de/articles/2`, updated_at: "2026-07-04T08:00:00Z" }),
+    ],
+  },
+];
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+interface FixtureState {
+  calls: string[];
+}
+
+/**
+ * A fixture Zendesk API. `articles` serves the cursor list (optionally split
+ * into two pages); `incremental` serves the start_time feed pages in order;
+ * `translationsById` serves per-article translation fetches.
+ */
+function makeFetch(opts: {
+  articles?: FixtureArticle[];
+  splitList?: boolean;
+  incremental?: Array<{ articles: FixtureArticle[]; next_page?: string | null; end_time?: number }>;
+  translationsById?: Record<string, FixtureTranslation[]>;
+  failFirst?: { status: number; headers?: Record<string, string> };
+  offOriginNext?: boolean;
+}): { impl: typeof globalThis.fetch; state: FixtureState } {
+  const state: FixtureState = { calls: [] };
+  const articles = opts.articles ?? ARTICLES;
+  let failed = false;
+  let incrementalServed = 0;
+  const impl = (async (input: string | URL | Request): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    state.calls.push(raw);
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    const path = url.pathname;
+
+    if (path.endsWith("/api/v2/help_center/incremental/articles.json")) {
+      const page = opts.incremental?.[incrementalServed] ?? { articles: [] };
+      incrementalServed++;
+      return jsonResponse({
+        articles: page.articles,
+        next_page: page.next_page ?? null,
+        end_time: page.end_time,
+        count: page.articles.length,
+      });
+    }
+    const translationMatch = path.match(/\/api\/v2\/help_center\/articles\/(\d+)\/translations\.json$/);
+    if (translationMatch) {
+      const list = opts.translationsById?.[translationMatch[1]] ?? [];
+      return jsonResponse({ translations: list, next_page: null });
+    }
+    if (path.endsWith("/api/v2/help_center/articles.json")) {
+      if (opts.splitList) {
+        const isSecondPage = url.searchParams.get("page[after]") === "cursor-2";
+        const next = opts.offOriginNext
+          ? "https://evil.example.com/api/v2/help_center/articles.json?page[after]=cursor-2"
+          : `${BASE}/api/v2/help_center/articles.json?include=translations&page[size]=100&page[after]=cursor-2`;
+        return jsonResponse({
+          articles: isSecondPage ? articles.slice(1) : articles.slice(0, 1),
+          meta: { has_more: !isSecondPage },
+          links: { next: isSecondPage ? null : next },
+        });
+      }
+      return jsonResponse({ articles, meta: { has_more: false }, links: { next: null } });
+    }
+    if (path.endsWith("/api/v2/brands.json")) {
+      return jsonResponse({
+        brands: [
+          { id: 10, name: "Acme", subdomain: "acme", has_help_center: true, active: true },
+          { id: 11, name: "Beta", subdomain: "acme-beta", has_help_center: true, active: true },
+          { id: 12, name: "NoHC", subdomain: "acme-nohc", has_help_center: false, active: true },
+          { id: 13, subdomain: "" }, // malformed — skipped
+        ],
+        meta: { has_more: false },
+        links: { next: null },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, state };
+}
+
+function client(opts: Parameters<typeof makeFetch>[0] = {}) {
+  const { impl, state } = makeFetch(opts);
+  const c = createZendeskVendorClient(
+    { brandSubdomain: "acme", email: "ops@acme.test", apiToken: "tok", collectionSlug: "zendesk-acme" },
+    { fetchImpl: impl },
+  );
+  return { c, state };
+}
+
+describe("fetchAll (reconciliation)", () => {
+  it("emits one document per published translation with the max updated_at as the mark", async () => {
+    const { c } = client();
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "zendesk-acme/en-us/getting-started-1.md",
+      "zendesk-acme/en-us/billing-faq-2.md",
+      "zendesk-acme/de/abrechnung-faq-2.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(false);
+    expect(changes.cursor).toBeNull();
+  });
+
+  it("follows cursor pagination across pages", async () => {
+    const { c, state } = client({ splitList: true });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(3);
+    expect(state.calls.filter((u) => u.includes("/articles.json"))).toHaveLength(2);
+  });
+
+  it("refuses an off-origin pagination link rather than forward credentials", async () => {
+    const { c } = client({ splitList: true, offOriginNext: true });
+    await expect(c.fetchAll()).rejects.toThrow(/pointing off|refusing to follow/i);
+  });
+
+  it("skips draft articles and draft translations (unpublish = absent = archived)", async () => {
+    const { c } = client({
+      articles: [
+        { id: 1, draft: true, updated_at: "2026-07-06T00:00:00Z", translations: [tr()] },
+        {
+          id: 2,
+          draft: false,
+          updated_at: "2026-07-02T00:00:00Z",
+          translations: [tr({ updated_at: "2026-07-02T00:00:00Z" }), tr({ locale: "fr", draft: true })],
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual(["zendesk-acme/en-us/getting-started-2.md"]);
+    // The draft article still advances the mark — its change was observed.
+    expect(changes.highWaterMark).toBe("2026-07-06T00:00:00.000Z");
+  });
+
+  it("falls back to a per-article translations fetch when the sideload is absent", async () => {
+    const { c, state } = client({
+      articles: [{ id: 7, draft: false, updated_at: "2026-07-01T00:00:00Z" }],
+      translationsById: { "7": [tr({ html_url: `${BASE}/hc/en-us/articles/7` })] },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(state.calls.some((u) => u.includes("/articles/7/translations.json"))).toBe(true);
+  });
+
+  it("counts a malformed article/translation and flags coverage incomplete", async () => {
+    const { c } = client({
+      articles: [
+        { title: "no id", updated_at: "2026-07-01T00:00:00Z" }, // malformed article
+        {
+          id: 2,
+          draft: false,
+          updated_at: "2026-07-02T00:00:00Z",
+          translations: [tr({ updated_at: "2026-07-02T00:00:00Z" }), tr({ locale: undefined })],
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("builds a fallback URL for a translation missing html_url", async () => {
+    const { c } = client({
+      articles: [
+        { id: 3, draft: false, updated_at: "2026-07-01T00:00:00Z", translations: [tr({ html_url: undefined })] },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents[0].content).toContain(`resource: "${BASE}/hc/en-us/articles/3"`);
+  });
+});
+
+describe("fetchChanges (incremental)", () => {
+  it("walks the start_time feed and fetches translations per changed article", async () => {
+    const { c, state } = client({
+      incremental: [
+        {
+          articles: [{ id: 1, draft: false, updated_at: "2026-07-06T10:00:00Z" }],
+          next_page: `${BASE}/api/v2/help_center/incremental/articles.json?start_time=1783418400`,
+          end_time: 1783418400,
+        },
+        { articles: [], end_time: 1783418400, next_page: null },
+      ],
+      translationsById: { "1": [tr({ updated_at: "2026-07-06T10:00:00Z" })] },
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.highWaterMark).toBe("2026-07-06T10:00:00.000Z");
+    const incrementalCalls = state.calls.filter((u) => u.includes("/incremental/articles.json"));
+    expect(incrementalCalls).toHaveLength(2);
+    // The second page's start_time is the first response's end_time.
+    expect(incrementalCalls[1]).toContain("start_time=1783418400");
+  });
+
+  it("dedupes an article that appears on multiple feed pages (newest wins)", async () => {
+    const { c, state } = client({
+      incremental: [
+        {
+          articles: [{ id: 1, draft: false, updated_at: "2026-07-06T10:00:00Z" }],
+          next_page: "next",
+          end_time: 1783418400,
+        },
+        {
+          articles: [{ id: 1, draft: false, updated_at: "2026-07-06T11:00:00Z" }],
+          next_page: null,
+          end_time: 1783422000,
+        },
+      ],
+      translationsById: { "1": [tr({ updated_at: "2026-07-06T11:00:00Z" })] },
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(1);
+    expect(state.calls.filter((u) => u.includes("/translations.json"))).toHaveLength(1);
+    expect(changes.highWaterMark).toBe("2026-07-06T11:00:00.000Z");
+  });
+
+  it("emits nothing for an article that became draft but still advances the mark", async () => {
+    const { c, state } = client({
+      incremental: [
+        { articles: [{ id: 1, draft: true, updated_at: "2026-07-06T10:00:00Z" }], next_page: null, end_time: 1783418400 },
+      ],
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(0);
+    expect(changes.highWaterMark).toBe("2026-07-06T10:00:00.000Z");
+    // No translations fetch for an unpublished article.
+    expect(state.calls.some((u) => u.includes("/translations.json"))).toBe(false);
+  });
+
+  it("returns an empty quiet cycle when the feed has no changes", async () => {
+    const { c } = client({ incremental: [{ articles: [], end_time: 1783418400, next_page: null }] });
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(0);
+    expect(changes.highWaterMark).toBeNull();
+  });
+
+  it("serves a null since as a full crawl (defensive)", async () => {
+    const { c, state } = client();
+    const changes = await c.fetchChanges({ since: null, cursor: null });
+    expect(changes.documents).toHaveLength(3);
+    expect(state.calls.some((u) => u.includes("/incremental/"))).toBe(false);
+  });
+});
+
+describe("vendor failure mapping", () => {
+  it("throws ConnectorRateLimitError with the parsed Retry-After on a 429", async () => {
+    const { c } = client({ failFirst: { status: 429, headers: { "retry-after": "37" } } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+    expect((err as ConnectorRateLimitError).retryAfterSeconds).toBe(37);
+  });
+
+  it("maps a 401 to an actionable, host-redacted credentials error", async () => {
+    const { c } = client({ failFirst: { status: 401 } });
+    await expect(c.fetchAll()).rejects.toThrow(/rejected the credentials \(401\)/i);
+  });
+
+  it("maps a 404 to an actionable subdomain/help-center error", async () => {
+    const { c } = client({ failFirst: { status: 404 } });
+    await expect(c.fetchAll()).rejects.toThrow(/404/);
+  });
+
+  it("never leaks the token in an error message", async () => {
+    const { c } = client({ failFirst: { status: 500 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain("tok");
+  });
+});
+
+describe("listZendeskBrands (install-time enumeration + credential check)", () => {
+  it("maps brands, normalizes subdomains, and skips malformed entries", async () => {
+    const { impl } = makeFetch({});
+    const brands = await listZendeskBrands(
+      { subdomain: "acme", email: "ops@acme.test", apiToken: "tok" },
+      { fetchImpl: impl },
+    );
+    expect(brands.map((b) => b.subdomain)).toEqual(["acme", "acme-beta", "acme-nohc"]);
+    expect(brands.map((b) => b.hasHelpCenter)).toEqual([true, true, false]);
+    expect(brands[0]).toMatchObject({ id: "10", name: "Acme", active: true });
+  });
+
+  it("propagates an auth failure loudly", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 401 } });
+    await expect(
+      listZendeskBrands({ subdomain: "acme", email: "e@x.test", apiToken: "bad" }, { fetchImpl: impl }),
+    ).rejects.toThrow(/rejected the credentials/i);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds and rejects HTTP-dates/garbage", () => {
+    expect(parseRetryAfter("42")).toBe(42);
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/knowledge/zendesk/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/zendesk/__tests__/client.test.ts
@@ -69,6 +69,7 @@ function jsonResponse(obj: unknown, status = 200, headers: Record<string, string
 
 interface FixtureState {
   calls: string[];
+  authHeaders: Array<string | null>;
 }
 
 /**
@@ -84,13 +85,14 @@ function makeFetch(opts: {
   failFirst?: { status: number; headers?: Record<string, string> };
   offOriginNext?: boolean;
 }): { impl: typeof globalThis.fetch; state: FixtureState } {
-  const state: FixtureState = { calls: [] };
+  const state: FixtureState = { calls: [], authHeaders: [] };
   const articles = opts.articles ?? ARTICLES;
   let failed = false;
   let incrementalServed = 0;
-  const impl = (async (input: string | URL | Request): Promise<Response> => {
+  const impl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     state.calls.push(raw);
+    state.authHeaders.push(new Headers(init?.headers).get("authorization"));
     if (opts.failFirst && !failed) {
       failed = true;
       return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
@@ -253,8 +255,25 @@ describe("fetchChanges (incremental)", () => {
     expect(changes.highWaterMark).toBe("2026-07-06T10:00:00.000Z");
     const incrementalCalls = state.calls.filter((u) => u.includes("/incremental/articles.json"));
     expect(incrementalCalls).toHaveLength(2);
+    // The FIRST request's start_time is `since` in epoch SECONDS — a ms/s
+    // regression here would silently sync nothing against real Zendesk.
+    expect(incrementalCalls[0]).toContain("start_time=1783296000");
     // The second page's start_time is the first response's end_time.
     expect(incrementalCalls[1]).toContain("start_time=1783418400");
+  });
+
+  it("stops on a stuck cursor (end_time did not advance) instead of looping", async () => {
+    const { c, state } = client({
+      incremental: [
+        {
+          articles: [{ id: 1, draft: true, updated_at: "2026-07-06T10:00:00Z" }],
+          next_page: "next",
+          end_time: 1783296000, // equals the request's start_time — no progress
+        },
+      ],
+    });
+    await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(state.calls.filter((u) => u.includes("/incremental/articles.json"))).toHaveLength(1);
   });
 
   it("dedupes an article that appears on multiple feed pages (newest wins)", async () => {
@@ -304,6 +323,16 @@ describe("fetchChanges (incremental)", () => {
     const changes = await c.fetchChanges({ since: null, cursor: null });
     expect(changes.documents).toHaveLength(3);
     expect(state.calls.some((u) => u.includes("/incremental/"))).toBe(false);
+  });
+});
+
+describe("authentication", () => {
+  it("sends Zendesk token auth: Basic base64('{email}/token:{apiToken}')", async () => {
+    const { c, state } = client();
+    await c.fetchAll();
+    const expected = `Basic ${Buffer.from("ops@acme.test/token:tok").toString("base64")}`;
+    expect(state.authHeaders.length).toBeGreaterThan(0);
+    for (const header of state.authHeaders) expect(header).toBe(expected);
   });
 });
 

--- a/packages/api/src/lib/knowledge/zendesk/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/zendesk/__tests__/connector.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the Zendesk KnowledgeSyncConnector (#4396) — the createClient
+ * factory contract: parse the stored per-brand config, read the encrypted
+ * token loudly, and build a vendor client. The credential store is mocked
+ * (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let tokenResult: string | null | (() => never) = "secret-token";
+
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof tokenResult === "function") return tokenResult();
+    return tokenResult;
+  },
+}));
+
+const { createZendeskConnector } = await import("@atlas/api/lib/knowledge/zendesk/connector");
+const { ZENDESK_CATALOG_ID, ZENDESK_VENDOR } = await import(
+  "@atlas/api/lib/knowledge/zendesk/config"
+);
+
+const VALID_CONFIG = {
+  subdomain: "acme",
+  email: "ops@acme.test",
+  brand_id: "10",
+  brand_subdomain: "acme",
+  brand_name: "Acme",
+};
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "zendesk-acme", config };
+}
+
+afterEach(() => {
+  tokenResult = "secret-token";
+});
+
+describe("createZendeskConnector", () => {
+  it("advertises the zendesk catalog id and vendor slug", () => {
+    const connector = createZendeskConnector();
+    expect(connector.catalogId).toBe(ZENDESK_CATALOG_ID);
+    expect(connector.vendor).toBe(ZENDESK_VENDOR);
+  });
+
+  it("builds a vendor client from valid per-brand config + a stored token", async () => {
+    const connector = createZendeskConnector();
+    const client = await connector.createClient(ctx(VALID_CONFIG));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error when the stored config is missing the brand", async () => {
+    const connector = createZendeskConnector();
+    await expect(
+      connector.createClient(ctx({ subdomain: "acme", email: "ops@acme.test" })),
+    ).rejects.toThrow(/no Zendesk brand configured/i);
+  });
+
+  it("throws when the brand subdomain fails the host-label pattern", async () => {
+    const connector = createZendeskConnector();
+    await expect(
+      connector.createClient(ctx({ ...VALID_CONFIG, brand_subdomain: "evil.example.com/x" })),
+    ).rejects.toThrow(/no valid Zendesk brand subdomain/i);
+  });
+
+  it("throws when the collection has no stored API token", async () => {
+    tokenResult = null;
+    const connector = createZendeskConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/no stored API token/i);
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    tokenResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createZendeskConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/zendesk/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/zendesk/__tests__/documents.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the Zendesk translation → ConnectorDocument assembly (#4396): the
+ * per-locale archive path (`<locale>/<title-slug>-<id>.md`, prefixed), the
+ * `atlas:` provenance block (connector + brand + article id + locale +
+ * updated_at), the shared-converter integration (cross-link rewriting, counted
+ * image degradations), and the contentless skip. Pure — no I/O.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleZendeskDocuments,
+  slugifyTitle,
+  type ZendeskArticleTranslation,
+} from "@atlas/api/lib/knowledge/zendesk/documents";
+
+const OPTS = { collectionSlug: "zendesk-acme", brandSubdomain: "acme" };
+
+function translation(overrides: Partial<ZendeskArticleTranslation> = {}): ZendeskArticleTranslation {
+  return {
+    articleId: "123",
+    locale: "en-us",
+    title: "Getting Started",
+    bodyHtml: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    url: "https://acme.zendesk.com/hc/en-us/articles/123-Getting-Started",
+    ...overrides,
+  };
+}
+
+describe("slugifyTitle", () => {
+  it("lowercases and dashes non-alphanumerics (NFKD, the Confluence convention)", () => {
+    expect(slugifyTitle("Setup & Testing Guide!", "x")).toBe("setup-testing-guide");
+  });
+  it("falls back when the title has no usable characters", () => {
+    expect(slugifyTitle("你好", "article")).toBe("article");
+  });
+});
+
+describe("assembleZendeskDocuments", () => {
+  it("emits one document per translation at <prefix>/<locale>/<slug>-<id>.md", () => {
+    const result = assembleZendeskDocuments(
+      [translation(), translation({ locale: "de", title: "Erste Schritte", articleId: "123" })],
+      OPTS,
+    );
+    expect(result.documents.map((d) => d.path)).toEqual([
+      "zendesk-acme/en-us/getting-started-123.md",
+      "zendesk-acme/de/erste-schritte-123.md",
+    ]);
+  });
+
+  it("stamps frontmatter provenance and the atlas: extension block", () => {
+    const { documents } = assembleZendeskDocuments([translation()], OPTS);
+    const content = documents[0].content;
+    expect(content).toContain('title: "Getting Started"');
+    expect(content).toContain(
+      'resource: "https://acme.zendesk.com/hc/en-us/articles/123-Getting-Started"',
+    );
+    expect(content).toContain('timestamp: "2026-07-01T10:00:00.000Z"');
+    expect(content).toContain("atlas:");
+    expect(content).toContain('connector: "zendesk"');
+    expect(content).toContain('brand: "acme"');
+    expect(content).toContain('article_id: "123"');
+    expect(content).toContain('locale: "en-us"');
+    expect(content).toContain('updated_at: "2026-07-01T10:00:00.000Z"');
+    // No provenance tags — `tags` is a mirrored change-comparison column, so
+    // stamping one would re-draft every already-ingested document.
+    expect(content).not.toContain("tags:");
+  });
+
+  it("rewrites relative help-center links against the brand host", () => {
+    const { documents } = assembleZendeskDocuments(
+      [translation({ bodyHtml: '<p>See <a href="/hc/en-us/articles/456">the FAQ</a> for details.</p>' })],
+      OPTS,
+    );
+    expect(documents[0].content).toContain(
+      "[the FAQ](https://acme.zendesk.com/hc/en-us/articles/456)",
+    );
+  });
+
+  it("leaves absolute links untouched", () => {
+    const { documents } = assembleZendeskDocuments(
+      [translation({ bodyHtml: '<p>Visit <a href="https://example.com/page">our site</a> for more info.</p>' })],
+      OPTS,
+    );
+    expect(documents[0].content).toContain("[our site](https://example.com/page)");
+  });
+
+  it("aggregates image degradations across translations", () => {
+    const { degradations } = assembleZendeskDocuments(
+      [
+        translation({ bodyHtml: '<p>Some intro text here.</p><img src="a.png"><img src="b.png">' }),
+        translation({ locale: "de", bodyHtml: '<p>Etwas Text hier drin.</p><img src="c.png">' }),
+      ],
+      OPTS,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 3 }]);
+  });
+
+  it("skips (and counts) a contentless translation instead of emitting an empty doc", () => {
+    const result = assembleZendeskDocuments(
+      [translation({ bodyHtml: "<div><script>x()</script></div>" }), translation({ locale: "fr" })],
+      OPTS,
+    );
+    expect(result.skippedContentless).toBe(1);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].path).toContain("/fr/");
+  });
+
+  it("uses the fallback segment for an unslugifiable title (id keeps it unique)", () => {
+    const { documents } = assembleZendeskDocuments(
+      [translation({ title: "你好", articleId: "9" })],
+      OPTS,
+    );
+    expect(documents[0].path).toBe("zendesk-acme/en-us/article-9.md");
+  });
+});

--- a/packages/api/src/lib/knowledge/zendesk/client.ts
+++ b/packages/api/src/lib/knowledge/zendesk/client.ts
@@ -1,0 +1,567 @@
+/**
+ * The Zendesk Guide vendor client (#4396, PRD #4395) — a
+ * {@link ConnectorVendorClient} over the Zendesk Help Center REST API, driven
+ * by the shared connector engine (`connector-sync.ts`). It owns ONLY
+ * enumerate + fetch + convert; scheduling, high-water marks, reconciliation
+ * cadence, 429 backoff, and caps are the engine's (ADR-0030).
+ *
+ * Two cadences the engine decides:
+ *   - `fetchChanges({ since })` (incremental) — walk the NATIVE incremental
+ *     feed (`/api/v2/help_center/incremental/articles?start_time=`, the reason
+ *     Zendesk anchors the support tier), paging by the response's `end_time`
+ *     as the next `start_time` cursor, then fetch each changed article's
+ *     per-locale translations. Zendesk caps this endpoint at 10 req/min — a
+ *     429 is thrown as {@link ConnectorRateLimitError} and the ENGINE applies
+ *     the bounded backoff (never a client-side sleep).
+ *   - `fetchAll()` (reconciliation) — cursor-paginate the full article list
+ *     with translations sideloaded (`include=translations`), one document per
+ *     published translation. The engine archives paths absent from this set,
+ *     so a deleted or unpublished (`draft: true`) article/translation is
+ *     treated as absent, never an error.
+ *
+ * Draft semantics: a `draft: true` article (and a `draft: true` translation)
+ * is UNPUBLISHED — never emitted. An article that BECOMES draft simply stops
+ * appearing in the emitted set; the reconciliation crawl's subtractive diff
+ * archives its documents (the AC's "draft flag + archive semantics detect
+ * unpublish/delete").
+ *
+ * Security + hygiene: hosts are composed from validated `*.zendesk.com`
+ * subdomain labels and every request goes through `guardedFetch` (SSRF egress
+ * guard; auth stripped on cross-origin redirect). A 429 is the ONLY signal
+ * that becomes the engine's backoff; every other failure is an actionable
+ * error with the host redacted via `hostForLog` — the token lives in the
+ * `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import { zendeskHostFor } from "./config";
+import { assembleZendeskDocuments, type ZendeskArticleTranslation } from "./documents";
+
+const log = createLogger("knowledge.zendesk.client");
+
+/** Resolved, non-secret connection inputs plus the token. One brand per client. */
+export interface ZendeskClientConfig {
+  /** The BRAND's validated subdomain label — the help-center host to fetch. */
+  readonly brandSubdomain: string;
+  readonly email: string;
+  readonly apiToken: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface ZendeskClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Article-list page size (cursor pagination). */
+const PAGE_SIZE = 100;
+/**
+ * Hard anti-runaway bound on enumerated articles — NOT the ingest cap (the
+ * engine owns that, and surfaces the real over-limit numbers). A help center
+ * larger than this is pathological; we fail loud rather than loop unbounded
+ * on a broken `next` link.
+ */
+const MAX_ARTICLES = 100_000;
+/** Anti-runaway bound on incremental feed pages walked in one fetch. */
+const MAX_INCREMENTAL_PAGES = 1_000;
+/** Anti-runaway bound on one article's translation pages (locales are few). */
+const MAX_TRANSLATION_PAGES = 20;
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (only the fields we read; untrusted vendor JSON —
+// every field optional, narrowed at the use sites)
+// ---------------------------------------------------------------------------
+
+interface RawTranslation {
+  readonly locale?: string;
+  readonly title?: string;
+  readonly body?: string | null;
+  readonly draft?: boolean;
+  readonly updated_at?: string;
+  readonly html_url?: string;
+}
+interface RawArticle {
+  readonly id?: number | string;
+  readonly title?: string;
+  readonly draft?: boolean;
+  readonly updated_at?: string;
+  readonly html_url?: string;
+  readonly translations?: readonly RawTranslation[];
+}
+interface CursorLinks {
+  readonly next?: string | null;
+}
+interface CursorMeta {
+  readonly has_more?: boolean;
+}
+interface ArticleListResponse {
+  readonly articles?: readonly RawArticle[];
+  readonly links?: CursorLinks;
+  readonly meta?: CursorMeta;
+}
+interface IncrementalResponse {
+  readonly articles?: readonly RawArticle[];
+  readonly next_page?: string | null;
+  readonly end_time?: number;
+}
+interface TranslationListResponse {
+  readonly translations?: readonly RawTranslation[];
+  readonly next_page?: string | null;
+}
+interface RawBrand {
+  readonly id?: number | string;
+  readonly name?: string;
+  readonly subdomain?: string;
+  readonly has_help_center?: boolean;
+  readonly active?: boolean;
+}
+interface BrandListResponse {
+  readonly brands?: readonly RawBrand[];
+  readonly links?: CursorLinks;
+  readonly meta?: CursorMeta;
+}
+
+/** One enumerated article, normalized (timestamps canonical, id stringified). */
+interface NormalizedArticle {
+  readonly id: string;
+  readonly draft: boolean;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  readonly translations: readonly RawTranslation[] | null;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Zendesk vendor client for ONE brand's help center. `createClient`
+ * (the connector factory) has already decrypted the token and validated
+ * config, so this constructor does no I/O.
+ */
+export function createZendeskVendorClient(
+  config: ZendeskClientConfig,
+  deps: ZendeskClientDeps = {},
+): ConnectorVendorClient {
+  const api = new ZendeskApi(config, deps);
+
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      // The engine only runs incremental with a persisted mark, but a null
+      // `since` is served defensively as a full crawl (the contract's advice).
+      if (params.since === null) return api.fetchAll();
+      return api.fetchChanges(params.since);
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetchAll();
+    },
+  };
+}
+
+/** One Zendesk brand, normalized for the install handler's fan-out. */
+export interface ZendeskBrand {
+  /** Stringified numeric brand id. */
+  readonly id: string;
+  readonly name: string;
+  /** The brand's own `*.zendesk.com` subdomain label. */
+  readonly subdomain: string;
+  /** True when the brand has a help center to mirror. */
+  readonly hasHelpCenter: boolean;
+  readonly active: boolean;
+}
+
+export interface ZendeskAccountParams {
+  /** The ACCOUNT subdomain (validated label) to enumerate brands from. */
+  readonly subdomain: string;
+  readonly email: string;
+  readonly apiToken: string;
+}
+
+/**
+ * Enumerate the account's brands — ALSO the install-time credential check
+ * (one authenticated request; loud on every failure). A bad token surfaces as
+ * a 401 error, a wrong subdomain typically as a 404, both actionable and
+ * host-redacted; the install handler maps them to field-level 400s so
+ * "invalid credentials fail the install loudly."
+ */
+export async function listZendeskBrands(
+  params: ZendeskAccountParams,
+  deps: ZendeskClientDeps = {},
+): Promise<ZendeskBrand[]> {
+  const base = zendeskHostFor(params.subdomain);
+  const http = new ZendeskHttp(base, params.email, params.apiToken, deps);
+  const brands: ZendeskBrand[] = [];
+  let skippedMalformed = 0;
+  let url: string | null = `${base}/api/v2/brands.json?page[size]=${PAGE_SIZE}`;
+  let pages = 0;
+  while (url !== null) {
+    if (++pages > MAX_INCREMENTAL_PAGES) {
+      throw new Error(
+        `Zendesk brand listing on ${hostForLog(base)} did not terminate after ${MAX_INCREMENTAL_PAGES} pages — unexpected vendor pagination.`,
+      );
+    }
+    const body: BrandListResponse = await http.getJson<BrandListResponse>(url);
+    for (const raw of body.brands ?? []) {
+      const id = raw.id === undefined ? "" : String(raw.id);
+      const subdomain = typeof raw.subdomain === "string" ? raw.subdomain.trim().toLowerCase() : "";
+      if (id === "" || subdomain === "") {
+        skippedMalformed++;
+        continue;
+      }
+      brands.push({
+        id,
+        name: typeof raw.name === "string" && raw.name.trim() !== "" ? raw.name.trim() : subdomain,
+        subdomain,
+        hasHelpCenter: raw.has_help_center === true,
+        active: raw.active !== false,
+      });
+    }
+    const next = body.links?.next;
+    url =
+      body.meta?.has_more === true && typeof next === "string" && next !== ""
+        ? sameOriginPageUrl(next, base)
+        : null;
+  }
+  if (skippedMalformed > 0) {
+    log.warn(
+      { host: hostForLog(base), skippedMalformed },
+      "Skipped Zendesk brands missing id/subdomain — not installable (unexpected vendor response)",
+    );
+  }
+  return brands;
+}
+
+/**
+ * Resolve a vendor-supplied pagination link against the client's base and pin
+ * it to the SAME origin. Pagination URLs come from response bodies and are
+ * fetched with the `Authorization` header — an off-origin link (broken or
+ * malicious vendor payload) must fail loudly rather than forward credentials
+ * (the egress guard blocks private hosts, this closes the public-host case).
+ */
+function sameOriginPageUrl(rawNext: string, base: string): string {
+  let resolved: URL;
+  try {
+    resolved = new URL(rawNext, base);
+  } catch {
+    // intentionally ignored: the URL constructor throw is the negative signal.
+    throw new Error(
+      `Zendesk returned an unparseable pagination link from ${hostForLog(base)} — unexpected vendor response.`,
+    );
+  }
+  if (resolved.origin !== new URL(base).origin) {
+    throw new Error(
+      `Zendesk returned a pagination link pointing off ${hostForLog(base)} — refusing to follow it with credentials.`,
+    );
+  }
+  return resolved.toString();
+}
+
+class ZendeskApi {
+  private readonly base: string;
+  private readonly http: ZendeskHttp;
+
+  constructor(
+    private readonly config: ZendeskClientConfig,
+    deps: ZendeskClientDeps,
+  ) {
+    this.base = zendeskHostFor(config.brandSubdomain);
+    this.http = new ZendeskHttp(this.base, config.email, config.apiToken, deps);
+  }
+
+  /**
+   * Reconciliation: cursor-paginate the FULL article list with translations
+   * sideloaded. One document per published translation of a published article.
+   */
+  async fetchAll(): Promise<ConnectorChanges> {
+    const articles: NormalizedArticle[] = [];
+    let skippedMalformed = 0;
+    let url: string | null = `${this.base}/api/v2/help_center/articles.json?include=translations&page[size]=${PAGE_SIZE}`;
+    while (url !== null) {
+      const body: ArticleListResponse = await this.http.getJson<ArticleListResponse>(url);
+      for (const raw of body.articles ?? []) {
+        const normalized = normalizeArticle(raw);
+        if (normalized !== null) articles.push(normalized);
+        else skippedMalformed++;
+      }
+      if (articles.length > MAX_ARTICLES) {
+        throw new Error(
+          `Zendesk help center on ${hostForLog(this.base)} exceeds ${MAX_ARTICLES} articles — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+        );
+      }
+      const next = body.links?.next;
+      url =
+        body.meta?.has_more === true && typeof next === "string" && next !== ""
+          ? sameOriginPageUrl(next, this.base)
+          : null;
+    }
+    return this.assemble(articles, skippedMalformed, "reconciliation");
+  }
+
+  /**
+   * Incremental: walk the native feed since the engine's `since` instant. The
+   * feed pages by time — each response's `end_time` is the next request's
+   * `start_time` — and reports whole changed ARTICLES; the per-locale
+   * translations are then fetched per changed article.
+   */
+  async fetchChanges(since: string): Promise<ConnectorChanges> {
+    const sinceMs = Date.parse(since);
+    if (Number.isNaN(sinceMs)) {
+      // The engine derives `since` from its own persisted ISO mark, so this is
+      // defensive — fail loud rather than silently refetch everything.
+      throw new Error(`Zendesk incremental fetch got an unparseable since instant ("${since}").`);
+    }
+    let startTime = Math.max(0, Math.floor(sinceMs / 1000));
+
+    // Later pages override earlier ones so an article touched twice inside the
+    // walk keeps its newest snapshot.
+    const changedById = new Map<string, NormalizedArticle>();
+    let skippedMalformed = 0;
+    for (let page = 1; ; page++) {
+      if (page > MAX_INCREMENTAL_PAGES) {
+        throw new Error(
+          `Zendesk incremental feed on ${hostForLog(this.base)} did not terminate after ${MAX_INCREMENTAL_PAGES} pages — unexpected vendor pagination.`,
+        );
+      }
+      const url = `${this.base}/api/v2/help_center/incremental/articles.json?start_time=${startTime}`;
+      const body = await this.http.getJson<IncrementalResponse>(url);
+      const raws = body.articles ?? [];
+      for (const raw of raws) {
+        const normalized = normalizeArticle(raw);
+        if (normalized !== null) changedById.set(normalized.id, normalized);
+        else skippedMalformed++;
+      }
+      // The feed's cursor is time-shaped: `end_time` is the next `start_time`.
+      // Stop on an empty page, a missing/absent next page, or a cursor that
+      // did not advance (guards an infinite loop on a stuck feed).
+      const endTime = typeof body.end_time === "number" ? body.end_time : null;
+      const hasNext = typeof body.next_page === "string" && body.next_page !== "";
+      if (raws.length === 0 || !hasNext || endTime === null || endTime <= startTime) break;
+      startTime = endTime;
+    }
+
+    // The changed set is article-level; translations are per-locale documents,
+    // fetched per changed article (bounded by the changed set's size, the
+    // incremental feed's whole point).
+    const articles: NormalizedArticle[] = [];
+    for (const article of changedById.values()) {
+      if (article.draft) {
+        // Unpublished: contributes its timestamp to the high-water mark but
+        // emits no documents; reconciliation archives its stale paths.
+        articles.push(article);
+        continue;
+      }
+      const translations = await this.fetchTranslations(article.id);
+      articles.push({ ...article, translations });
+    }
+    return this.assemble(articles, skippedMalformed, "incremental");
+  }
+
+  /** One article's translations (paginated defensively; locales are few). */
+  private async fetchTranslations(articleId: string): Promise<RawTranslation[]> {
+    const translations: RawTranslation[] = [];
+    let url: string | null =
+      `${this.base}/api/v2/help_center/articles/${encodeURIComponent(articleId)}/translations.json`;
+    let pages = 0;
+    while (url !== null) {
+      if (++pages > MAX_TRANSLATION_PAGES) {
+        throw new Error(
+          `Zendesk translations for one article on ${hostForLog(this.base)} did not terminate after ${MAX_TRANSLATION_PAGES} pages — unexpected vendor pagination.`,
+        );
+      }
+      const body: TranslationListResponse = await this.http.getJson<TranslationListResponse>(url);
+      translations.push(...(body.translations ?? []));
+      const next = body.next_page;
+      url = typeof next === "string" && next !== "" ? sameOriginPageUrl(next, this.base) : null;
+    }
+    return translations;
+  }
+
+  /** Normalize + convert the fetched set into `ConnectorChanges`. */
+  private async assemble(
+    articles: readonly NormalizedArticle[],
+    skippedMalformedArticles: number,
+    mode: "incremental" | "reconciliation",
+  ): Promise<ConnectorChanges> {
+    let skippedMalformed = skippedMalformedArticles;
+    let highWaterMark: string | null = null;
+    const emitted: ZendeskArticleTranslation[] = [];
+
+    for (const article of articles) {
+      // Every article — draft or not — advances the mark: its change is what
+      // this fetch observed. ISO instants compare chronologically as strings.
+      if (highWaterMark === null || article.updatedAt > highWaterMark) {
+        highWaterMark = article.updatedAt;
+      }
+      if (article.draft) continue;
+
+      // Reconciliation sideloads translations; a response missing the sideload
+      // entirely (vendor quirk) falls back to the per-article fetch so the
+      // crawl's coverage stays honest rather than silently emitting nothing.
+      const rawTranslations =
+        article.translations ?? (await this.fetchTranslations(article.id));
+
+      for (const raw of rawTranslations) {
+        if (raw.draft === true) continue; // unpublished locale — never emitted
+        const locale = typeof raw.locale === "string" ? raw.locale.trim().toLowerCase() : "";
+        const updatedAt = toIsoInstant(raw.updated_at);
+        if (locale === "" || updatedAt === null) {
+          // Never a silent drop: a translation we can't place (no locale) or
+          // order (no timestamp) is counted, flags coverage as incomplete, and
+          // is surfaced in the log below.
+          skippedMalformed++;
+          continue;
+        }
+        const title = typeof raw.title === "string" ? raw.title : "";
+        emitted.push({
+          articleId: article.id,
+          locale,
+          title,
+          bodyHtml: typeof raw.body === "string" ? raw.body : "",
+          updatedAt,
+          url:
+            typeof raw.html_url === "string" && raw.html_url !== ""
+              ? raw.html_url
+              : `${this.base}/hc/${locale}/articles/${article.id}`,
+        });
+      }
+    }
+
+    const assembled = assembleZendeskDocuments(emitted, {
+      collectionSlug: this.config.collectionSlug,
+      brandSubdomain: this.config.brandSubdomain,
+    });
+    if (assembled.degradations.length > 0 || assembled.skippedContentless > 0) {
+      log.info(
+        {
+          host: hostForLog(this.base),
+          mode,
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+        },
+        "Zendesk conversion completed with degradations/skips",
+      );
+    }
+    if (skippedMalformed > 0) {
+      // A skipped article/translation is a KNOWN hole in the set: its document
+      // would otherwise be archived by a reconciliation off this partial
+      // crawl. The flag makes the engine upsert-only and hold the reconcile
+      // clock.
+      log.warn(
+        { host: hostForLog(this.base), mode, skippedMalformed },
+        "Skipped Zendesk articles/translations missing id/locale/timestamp — not ingested (unexpected for published content)",
+      );
+    }
+
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+}
+
+/** Normalize one raw article; null = malformed (skip + count). */
+function normalizeArticle(raw: RawArticle): NormalizedArticle | null {
+  const id = raw.id === undefined ? "" : String(raw.id);
+  const updatedAt = toIsoInstant(raw.updated_at);
+  if (id === "" || updatedAt === null) return null;
+  return {
+    id,
+    draft: raw.draft === true,
+    updatedAt,
+    translations: Array.isArray(raw.translations) ? raw.translations : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP (shared by the per-brand client and the account-level brand listing)
+// ---------------------------------------------------------------------------
+
+class ZendeskHttp {
+  private readonly authHeader: string;
+
+  constructor(
+    private readonly base: string,
+    email: string,
+    apiToken: string,
+    private readonly deps: ZendeskClientDeps,
+  ) {
+    // Zendesk token auth is Basic with the `{email}/token` username form.
+    // Buffer.from handles any UTF-8 in the email (unlike btoa).
+    this.authHeader = `Basic ${Buffer.from(`${email}/token:${apiToken}`).toString("base64")}`;
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  async getJson<T>(url: string): Promise<T> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `Zendesk request to ${hostForLog(this.base)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `Zendesk rate-limited the request to ${hostForLog(this.base)} (the incremental feed allows 10 requests/minute).`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `Zendesk rejected the credentials (${response.status}) for ${hostForLog(this.base)} — re-enter the email + API token (Admin Center → Apps and integrations → Zendesk API) and confirm token access is enabled.`,
+      );
+    }
+    if (response.status === 404) {
+      throw new Error(
+        `Zendesk returned 404 from ${hostForLog(this.base)} — check the subdomain, and that the brand's Help Center is activated.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(`Zendesk returned HTTP ${response.status} from ${hostForLog(this.base)}.`);
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new Error(
+        `Zendesk returned a non-JSON response from ${hostForLog(this.base)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/** Parse a `Retry-After` header (delta-seconds only; HTTP-date → null). */
+export function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}

--- a/packages/api/src/lib/knowledge/zendesk/client.ts
+++ b/packages/api/src/lib/knowledge/zendesk/client.ts
@@ -51,6 +51,27 @@ import { assembleZendeskDocuments, type ZendeskArticleTranslation } from "./docu
 
 const log = createLogger("knowledge.zendesk.client");
 
+/**
+ * Zendesk rejected the credentials (401/403). A distinct class — not a
+ * `cause`-presence side channel — so the install handler can blame the
+ * `api_token` field with `instanceof` (the `ConnectorRateLimitError`
+ * precedent; plain subclass, this is not Effect code).
+ */
+export class ZendeskAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ZendeskAuthError";
+  }
+}
+
+/** Zendesk returned 404 — wrong subdomain, or the brand has no Help Center. */
+export class ZendeskNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ZendeskNotFoundError";
+  }
+}
+
 /** Resolved, non-secret connection inputs plus the token. One brand per client. */
 export interface ZendeskClientConfig {
   /** The BRAND's validated subdomain label — the help-center host to fetch. */
@@ -77,8 +98,12 @@ const PAGE_SIZE = 100;
  * on a broken `next` link.
  */
 const MAX_ARTICLES = 100_000;
-/** Anti-runaway bound on incremental feed pages walked in one fetch. */
-const MAX_INCREMENTAL_PAGES = 1_000;
+/**
+ * Anti-runaway bound on pages walked in one paginated enumeration — the
+ * article list, the incremental feed, AND the brand listing all share it, so
+ * every walk fails loud on a stuck `next` cursor rather than looping forever.
+ */
+const MAX_FEED_PAGES = 1_000;
 /** Anti-runaway bound on one article's translation pages (locales are few). */
 const MAX_TRANSLATION_PAGES = 20;
 
@@ -210,14 +235,14 @@ export async function listZendeskBrands(
   let url: string | null = `${base}/api/v2/brands.json?page[size]=${PAGE_SIZE}`;
   let pages = 0;
   while (url !== null) {
-    if (++pages > MAX_INCREMENTAL_PAGES) {
+    if (++pages > MAX_FEED_PAGES) {
       throw new Error(
-        `Zendesk brand listing on ${hostForLog(base)} did not terminate after ${MAX_INCREMENTAL_PAGES} pages — unexpected vendor pagination.`,
+        `Zendesk brand listing on ${hostForLog(base)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
       );
     }
     const body: BrandListResponse = await http.getJson<BrandListResponse>(url);
     for (const raw of body.brands ?? []) {
-      const id = raw.id === undefined ? "" : String(raw.id);
+      const id = idOf(raw.id);
       const subdomain = typeof raw.subdomain === "string" ? raw.subdomain.trim().toLowerCase() : "";
       if (id === "" || subdomain === "") {
         skippedMalformed++;
@@ -257,10 +282,12 @@ function sameOriginPageUrl(rawNext: string, base: string): string {
   let resolved: URL;
   try {
     resolved = new URL(rawNext, base);
-  } catch {
-    // intentionally ignored: the URL constructor throw is the negative signal.
+  } catch (err) {
+    // Translate-and-rethrow: the raw link must not reach the message (it is
+    // untrusted vendor payload), but the parse failure rides along as cause.
     throw new Error(
       `Zendesk returned an unparseable pagination link from ${hostForLog(base)} — unexpected vendor response.`,
+      { cause: err },
     );
   }
   if (resolved.origin !== new URL(base).origin) {
@@ -291,7 +318,16 @@ class ZendeskApi {
     const articles: NormalizedArticle[] = [];
     let skippedMalformed = 0;
     let url: string | null = `${this.base}/api/v2/help_center/articles.json?include=translations&page[size]=${PAGE_SIZE}`;
+    let pages = 0;
     while (url !== null) {
+      // Page-count bound, not just the article-count one below: a stuck
+      // cursor that keeps returning EMPTY pages never grows `articles`, and
+      // an unbounded loop here would silently wedge the sync fiber.
+      if (++pages > MAX_FEED_PAGES) {
+        throw new Error(
+          `Zendesk article listing on ${hostForLog(this.base)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+        );
+      }
       const body: ArticleListResponse = await this.http.getJson<ArticleListResponse>(url);
       for (const raw of body.articles ?? []) {
         const normalized = normalizeArticle(raw);
@@ -332,9 +368,9 @@ class ZendeskApi {
     const changedById = new Map<string, NormalizedArticle>();
     let skippedMalformed = 0;
     for (let page = 1; ; page++) {
-      if (page > MAX_INCREMENTAL_PAGES) {
+      if (page > MAX_FEED_PAGES) {
         throw new Error(
-          `Zendesk incremental feed on ${hostForLog(this.base)} did not terminate after ${MAX_INCREMENTAL_PAGES} pages — unexpected vendor pagination.`,
+          `Zendesk incremental feed on ${hostForLog(this.base)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
         );
       }
       const url = `${this.base}/api/v2/help_center/incremental/articles.json?start_time=${startTime}`;
@@ -398,6 +434,7 @@ class ZendeskApi {
     mode: "incremental" | "reconciliation",
   ): Promise<ConnectorChanges> {
     let skippedMalformed = skippedMalformedArticles;
+    let sideloadFallbacks = 0;
     let highWaterMark: string | null = null;
     const emitted: ZendeskArticleTranslation[] = [];
 
@@ -412,6 +449,11 @@ class ZendeskApi {
       // Reconciliation sideloads translations; a response missing the sideload
       // entirely (vendor quirk) falls back to the per-article fetch so the
       // crawl's coverage stays honest rather than silently emitting nothing.
+      // Counted + logged below: the fallback flips the request profile from
+      // ~1/100 articles to N+1, and an operator debugging sudden 429s needs
+      // that breadcrumb. (On the incremental path the per-article fetch IS
+      // the design, so the counter only ticks during reconciliation.)
+      if (article.translations === null && mode === "reconciliation") sideloadFallbacks++;
       const rawTranslations =
         article.translations ?? (await this.fetchTranslations(article.id));
 
@@ -466,6 +508,12 @@ class ZendeskApi {
         "Skipped Zendesk articles/translations missing id/locale/timestamp — not ingested (unexpected for published content)",
       );
     }
+    if (sideloadFallbacks > 0) {
+      log.warn(
+        { host: hostForLog(this.base), mode, sideloadFallbacks },
+        "Zendesk article list returned no translations sideload — fell back to per-article translation fetches (N+1 request profile)",
+      );
+    }
 
     return {
       documents: assembled.documents,
@@ -476,9 +524,14 @@ class ZendeskApi {
   }
 }
 
+/** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */
+function idOf(raw: number | string | undefined): string {
+  return typeof raw === "number" || typeof raw === "string" ? String(raw) : "";
+}
+
 /** Normalize one raw article; null = malformed (skip + count). */
 function normalizeArticle(raw: RawArticle): NormalizedArticle | null {
-  const id = raw.id === undefined ? "" : String(raw.id);
+  const id = idOf(raw.id);
   const updatedAt = toIsoInstant(raw.updated_at);
   if (id === "" || updatedAt === null) return null;
   return {
@@ -531,18 +584,23 @@ class ZendeskHttp {
 
     if (response.status === 429) {
       throw new ConnectorRateLimitError(
-        `Zendesk rate-limited the request to ${hostForLog(this.base)} (the incremental feed allows 10 requests/minute).`,
+        `Zendesk rate-limited the request to ${hostForLog(this.base)} (Zendesk rate limits apply — the incremental feed is capped at 10 requests/minute).`,
         parseRetryAfter(response.headers.get("retry-after")),
       );
     }
     if (response.status === 401 || response.status === 403) {
-      throw new Error(
+      throw new ZendeskAuthError(
         `Zendesk rejected the credentials (${response.status}) for ${hostForLog(this.base)} — re-enter the email + API token (Admin Center → Apps and integrations → Zendesk API) and confirm token access is enabled.`,
       );
     }
     if (response.status === 404) {
-      throw new Error(
+      throw new ZendeskNotFoundError(
         `Zendesk returned 404 from ${hostForLog(this.base)} — check the subdomain, and that the brand's Help Center is activated.`,
+      );
+    }
+    if (response.status >= 500) {
+      throw new Error(
+        `Zendesk returned HTTP ${response.status} from ${hostForLog(this.base)} — a vendor-side error; the next scheduled sync (or retrying the install) will usually succeed.`,
       );
     }
     if (!response.ok) {

--- a/packages/api/src/lib/knowledge/zendesk/client.ts
+++ b/packages/api/src/lib/knowledge/zendesk/client.ts
@@ -219,7 +219,8 @@ export interface ZendeskAccountParams {
 
 /**
  * Enumerate the account's brands — ALSO the install-time credential check
- * (one authenticated request; loud on every failure). A bad token surfaces as
+ * (the first authenticated request doubles as it; loud on every failure). A
+ * bad token surfaces as
  * a 401 error, a wrong subdomain typically as a 404, both actionable and
  * host-redacted; the install handler maps them to field-level 400s so
  * "invalid credentials fail the install loudly."
@@ -382,8 +383,8 @@ class ZendeskApi {
         else skippedMalformed++;
       }
       // The feed's cursor is time-shaped: `end_time` is the next `start_time`.
-      // Stop on an empty page, a missing/absent next page, or a cursor that
-      // did not advance (guards an infinite loop on a stuck feed).
+      // Stop on an empty page, a missing next page, or a time cursor that is
+      // absent or did not advance (guards an infinite loop on a stuck feed).
       const endTime = typeof body.end_time === "number" ? body.end_time : null;
       const hasNext = typeof body.next_page === "string" && body.next_page !== "";
       if (raws.length === 0 || !hasNext || endTime === null || endTime <= startTime) break;
@@ -584,7 +585,7 @@ class ZendeskHttp {
 
     if (response.status === 429) {
       throw new ConnectorRateLimitError(
-        `Zendesk rate-limited the request to ${hostForLog(this.base)} (Zendesk rate limits apply — the incremental feed is capped at 10 requests/minute).`,
+        `Zendesk rate-limited the request to ${hostForLog(this.base)} (Zendesk rate limits apply; the incremental feed in particular is capped at 10 requests/minute).`,
         parseRetryAfter(response.headers.get("retry-after")),
       );
     }
@@ -604,7 +605,9 @@ class ZendeskHttp {
       );
     }
     if (!response.ok) {
-      throw new Error(`Zendesk returned HTTP ${response.status} from ${hostForLog(this.base)}.`);
+      throw new Error(
+        `Zendesk returned HTTP ${response.status} from ${hostForLog(this.base)} — an unexpected Zendesk API response; if it persists, re-install the collection or check Zendesk's API status.`,
+      );
     }
     try {
       return (await response.json()) as T;

--- a/packages/api/src/lib/knowledge/zendesk/config.ts
+++ b/packages/api/src/lib/knowledge/zendesk/config.ts
@@ -1,0 +1,89 @@
+/**
+ * Zendesk Guide connector identity + stored-config contract (#4396, PRD #4395).
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config),
+ * the connector (reads it back in `createClient`), and the admin-knowledge
+ * surface (recognizes the catalog id) share ONE definition — a field rename
+ * can't drift the three apart silently. The API token is NOT part of this
+ * config; it lives encrypted in `knowledge_sync_credentials` and is read via
+ * `readSyncCredential`.
+ *
+ * Zendesk is the tier's first MULTI-BRAND vendor: one install enumerates the
+ * account's help-center-enabled brands and creates one collection per brand
+ * (the PRD's "each brand maps to a collection"). Each collection's config is
+ * therefore BRAND-scoped: it pins the brand's own `*.zendesk.com` subdomain
+ * (the article host its client fetches) alongside the account subdomain the
+ * install enumerated from. Hosts are always composed from a validated
+ * subdomain label — never a customer-supplied URL — and every fetch still
+ * goes through the SSRF egress guard.
+ */
+
+/** The built-in Zendesk Guide Knowledge Base catalog slug + row id. */
+export const ZENDESK_SLUG = "zendesk";
+export const ZENDESK_CATALOG_ID = "catalog:zendesk";
+/** Vendor slug stamped into `atlas_source` as `connector:zendesk`. */
+export const ZENDESK_VENDOR = "zendesk";
+
+/**
+ * A Zendesk subdomain label (`acme` in `acme.zendesk.com`). Composing hosts
+ * from this validated label (rather than accepting a URL) keeps the egress
+ * surface to `*.zendesk.com` by construction.
+ */
+export const ZENDESK_SUBDOMAIN_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/** The API base for a Zendesk subdomain. `subdomain` MUST be pre-validated. */
+export function zendeskHostFor(subdomain: string): string {
+  return `https://${subdomain}.zendesk.com`;
+}
+
+/** The non-secret config persisted on each per-brand `workspace_plugins` row. */
+export interface ZendeskCollectionConfig {
+  /** The ACCOUNT subdomain the install enumerated brands from. */
+  readonly subdomain: string;
+  /** Zendesk account email — the Basic-auth username (`{email}/token`). */
+  readonly email: string;
+  /** The brand this collection mirrors (stringified numeric brand id). */
+  readonly brand_id: string;
+  /** The BRAND's subdomain — the help-center host this collection fetches. */
+  readonly brand_subdomain: string;
+  /** Human brand name, for the admin surface. */
+  readonly brand_name: string;
+  readonly description?: string;
+}
+
+export type ParsedZendeskConfig =
+  | {
+      readonly ok: true;
+      readonly email: string;
+      readonly brandId: string;
+      readonly brandSubdomain: string;
+    }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * field means someone edited the row out of band; re-installing repairs it.
+ */
+export function parseZendeskConfig(
+  config: Record<string, unknown> | null,
+): ParsedZendeskConfig {
+  const email = typeof config?.email === "string" ? config.email.trim() : "";
+  const brandId = typeof config?.brand_id === "string" ? config.brand_id.trim() : "";
+  const brandSubdomain =
+    typeof config?.brand_subdomain === "string" ? config.brand_subdomain.trim().toLowerCase() : "";
+  if (email === "") {
+    return { ok: false, error: "Collection has no Zendesk account email configured — re-install it." };
+  }
+  if (brandId === "") {
+    return { ok: false, error: "Collection has no Zendesk brand configured — re-install it." };
+  }
+  if (brandSubdomain === "" || !ZENDESK_SUBDOMAIN_PATTERN.test(brandSubdomain)) {
+    return {
+      ok: false,
+      error: "Collection has no valid Zendesk brand subdomain configured — re-install it.",
+    };
+  }
+  return { ok: true, email, brandId, brandSubdomain };
+}

--- a/packages/api/src/lib/knowledge/zendesk/connector.ts
+++ b/packages/api/src/lib/knowledge/zendesk/connector.ts
@@ -1,0 +1,81 @@
+/**
+ * The Zendesk Guide {@link KnowledgeSyncConnector} (#4396, PRD #4395) — the
+ * catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * factory contract from ADR-0030: bind the stored per-brand config + the
+ * decrypted token into a vendor client. Scheduling, backoff, reconciliation,
+ * caps, and ingest are the shared engine's.
+ *
+ * One Zendesk install fans out to one collection PER BRAND (the install
+ * handler's job); each collection row carries its brand's subdomain, so this
+ * factory builds a client scoped to exactly one brand's help center.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { createZendeskVendorClient, type ZendeskClientDeps } from "./client";
+import { ZENDESK_CATALOG_ID, ZENDESK_VENDOR, parseZendeskConfig } from "./config";
+
+const log = createLogger("knowledge.zendesk.connector");
+
+export interface ZendeskConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: ZendeskClientDeps;
+}
+
+/** Build the Zendesk connector. `deps` is test-only vendor-client injection. */
+export function createZendeskConnector(
+  deps: ZendeskConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: ZENDESK_CATALOG_ID,
+    vendor: ZENDESK_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseZendeskConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiToken = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiToken === null) {
+        throw new Error(
+          "This Zendesk collection has no stored API token — re-install it to re-enter the token.",
+        );
+      }
+
+      return createZendeskVendorClient(
+        {
+          brandSubdomain: parsed.brandSubdomain,
+          email: parsed.email,
+          apiToken,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the Zendesk connector idempotently — called from the boot seam
+ * that also registers install handlers (`registerBuiltinInstallHandlers`), and
+ * from tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog
+ * id, so gate on the registry first.
+ */
+export function registerZendeskKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(ZENDESK_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createZendeskConnector());
+  log.info({ catalogId: ZENDESK_CATALOG_ID }, "Registered Zendesk knowledge sync connector");
+}

--- a/packages/api/src/lib/knowledge/zendesk/documents.ts
+++ b/packages/api/src/lib/knowledge/zendesk/documents.ts
@@ -1,0 +1,156 @@
+/**
+ * Zendesk article translation → OKF `ConnectorDocument` assembly (#4396,
+ * PRD #4395).
+ *
+ * Pure, deterministic glue between the SHARED support HTML→markdown converter
+ * (`../support/html-to-markdown.ts` — this vendor deliberately owns no
+ * HTML→md logic of its own) and the connector ingest seam. Each PUBLISHED
+ * translation of a published article is a distinct document (the PRD's
+ * "per-locale translations are distinct documents"); draft articles and draft
+ * translations are never emitted, so an unpublish reads as "path absent" and
+ * the reconciliation crawl archives it.
+ *
+ * Paths are `<locale>/<title-slug>-<article-id>.md` — locale + article id make
+ * them collision-free by construction (two translations never share both),
+ * and the id suffix means a basename can never be a reserved OKF name — the
+ * `deriveArchivePath` fold still runs as defence in depth. A title rename
+ * reads as "old path archived + new path drafted", the documented rename-churn
+ * posture (same as Confluence/GitBook).
+ *
+ * Provenance that survives ingest: `resource` = the translation's canonical
+ * help-center URL, `timestamp` = its modification time, plus an `atlas:`
+ * extension block carrying connector + brand + article id + locale +
+ * updated_at (the AC's provenance fields). No provenance `tags`: `tags` is a
+ * mirrored column in the lenient parser's change comparison, so stamping one
+ * would re-draft every already-ingested document; the extension block stays
+ * outside the comparison (the GitBook/Notion posture).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import {
+  convertSupportHtmlToMarkdown,
+  type HtmlDegradation,
+} from "../support/html-to-markdown";
+import { ZENDESK_VENDOR, zendeskHostFor } from "./config";
+
+/** One PUBLISHED translation of a PUBLISHED article, ready to convert. */
+export interface ZendeskArticleTranslation {
+  /** Stringified numeric article id (stable across renames/locales). */
+  readonly articleId: string;
+  /** Translation locale, e.g. `en-us` (Zendesk locales are lowercase). */
+  readonly locale: string;
+  readonly title: string;
+  /** The translation's HTML body. */
+  readonly bodyHtml: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  /** Canonical help-center URL of this translation. */
+  readonly url: string;
+}
+
+export interface ZendeskAssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Media degradations aggregated across every assembled translation. */
+  readonly degradations: readonly HtmlDegradation[];
+  /** Translations skipped because they carried no ingestable prose. */
+  readonly skippedContentless: number;
+}
+
+/** Slugify a title into a single path segment; `fallback` guarantees non-empty. */
+export function slugifyTitle(title: string, fallback: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched translations.
+ * `brandSubdomain` is the collection's brand host label — it resolves the
+ * converter's cross-link hook (relative `/hc/…` hrefs absolutize against the
+ * brand's help center) and lands in the `atlas:` provenance block.
+ */
+export function assembleZendeskDocuments(
+  translations: readonly ZendeskArticleTranslation[],
+  options: { readonly collectionSlug: string; readonly brandSubdomain: string },
+): ZendeskAssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const brandBase = zendeskHostFor(options.brandSubdomain);
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  let skippedContentless = 0;
+
+  for (const t of translations) {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(t.bodyHtml, {
+      pageUrl: t.url,
+      rewriteLink: (href) => rewriteBrandLink(href, brandBase),
+    });
+    for (const d of degradations) {
+      degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+    }
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    const segments = [
+      slugifyTitle(t.locale, "locale"),
+      `${slugifyTitle(t.title, "article")}-${t.articleId}`,
+    ];
+    const derived = deriveArchivePath(`${segments.join("/")}.md`);
+    const path = [...prefixSegments, derived.path].join("/");
+
+    const title = t.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        resource: t.url,
+        timestamp: t.updatedAt,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: ZENDESK_VENDOR,
+          brand: options.brandSubdomain,
+          article_id: t.articleId,
+          locale: t.locale,
+          updated_at: t.updatedAt,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless };
+}
+
+/**
+ * The converter's cross-link hook: absolutize relative help-center hrefs
+ * against the brand host so a mirrored article's `/hc/en-us/articles/…` links
+ * stay live. Absolute and unparseable hrefs pass through untouched.
+ */
+function rewriteBrandLink(href: string, brandBase: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return href; // already absolute (any scheme)
+  try {
+    return new URL(href, brandBase).toString();
+  } catch {
+    // intentionally ignored: an unparseable href renders as-is — the label
+    // text is preserved either way, and a broken vendor link is the vendor's.
+    return href;
+  }
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -31,13 +31,16 @@ export interface KnowledgeDocumentCounts {
  *   - `confluence-datacenter` — the #4394 Knowledge Sync Connector (a scheduled
  *     pull of a self-managed Confluence Data Center/Server space via a Personal
  *     Access Token; REST v1 instead of Cloud's v2).
+ *   - `zendesk` — the #4396 Knowledge Sync Connector (a scheduled pull of one
+ *     Zendesk Guide brand's help center via an API token; one collection per
+ *     brand, one document per published article translation).
  *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
  * `authScheme`; connector collections (`notion`, `confluence`,
- * `confluence-datacenter`, `gitbook`) carry neither (their credential is a
- * token, not an endpoint).
+ * `confluence-datacenter`, `gitbook`, `zendesk`) carry neither (their
+ * credential is a token, not an endpoint).
  */
 export type KnowledgeCollectionSource =
   | "upload"
@@ -45,7 +48,8 @@ export type KnowledgeCollectionSource =
   | "notion"
   | "confluence"
   | "confluence-datacenter"
-  | "gitbook";
+  | "gitbook"
+  | "zendesk";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
## Summary

Closes #4396 — the anchor slice of the support-center connector tier (PRD #4395), on the ADR-0030 connector spine.

- **New shared converter** `packages/api/src/lib/knowledge/support/html-to-markdown.ts` — pure, golden-fixture-tested HTML→markdown for the whole support tier: safe-tag handling, tables/code/links, image/media degradation to counted placeholders (never silent drops), and a cross-link rewriting hook. ADR-0030 gains an amendment recording the sub-seam; later support slices (Salesforce Knowledge, Intercom, Help Scout, …) consume this converter instead of forking their own.
- **New `knowledge/zendesk/` vendor package**: `config.ts` (per-brand collection contract), `documents.ts` (each published article *translation* is a distinct document at `<locale>/<title-slug>-<id>.md` with an `atlas:` provenance block carrying connector + brand + article id + locale + updated_at), `client.ts` (native incremental feed with the `end_time`→`start_time` cursor, cursor-paginated reconciliation with translations sideload + per-article fallback, 429 → `ConnectorRateLimitError` for the engine's bounded backoff, same-origin pagination pinning so credentialed requests can never follow an off-host link), `connector.ts` (`registerZendeskKnowledgeConnector`).
- **Install**: `zendesk-form-handler.ts` enumerates the account's brands with the supplied token (loud verification; typed `ZendeskAuthError`/`ZendeskNotFoundError` drive field-level attribution) and fans out **one collection per help-center-enabled brand**. Hosts are composed `*.zendesk.com` labels through the SSRF egress guard; the API token is encrypted per collection in `knowledge_sync_credentials`, never in `workspace_plugins.config`.
- **Wiring**: `register.ts` pairing (form handler + connector registered together), built-in knowledge catalog seed row, `admin-knowledge` source branches, `KnowledgeCollectionSource` wire type + web schema, OpenAPI regen, real-Postgres upsert smoke.
- Draft-only ingest holds structurally: every synced translation lands `draft` via `ingestDocuments` with `source: connector:zendesk`; subtractive archiving only on reconciliation, so unpublish/delete (Zendesk `draft` flag) reads as path-absent → archived.

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — golden-fixture converter suite (32 tests), vendor client via injected fixture fetch (22 — incl. epoch-seconds `start_time` pin, stuck-cursor + page-bound termination, auth-header form, off-origin pagination refusal), documents assembly (9), connector factory (6), install fan-out (17 — incl. per-brand credential rollback), admin-knowledge route branches, register pairing, seed shape, real-Postgres upsert smoke
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — 838/839 locally; the one failure is a pre-existing sandbox-only network timeout in `admin-model-config.test.ts` (untouched by this diff; live gateway-catalog fetch hangs through the local egress proxy)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change)

Internal review panel (4 specialist reviewers) ran pre-PR: round 1 CHANGES REQUESTED (unbounded `fetchAll` pagination, `cause`-sniffing error attribution — both fixed), round 2 CLEAN.

https://claude.ai/code/session_01VJzpzZYWUNtDyrCewQcgtf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJzpzZYWUNtDyrCewQcgtf)_