### PR TITLE
chore(ci): record tsgo parallelism verdict; fix(web): de-vacuate web type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,18 @@ jobs:
 
       # `bun run type` builds the SDK packages it needs internally
       # (@useatlas/types, plugin-sdk, sdk, react), runs tsgo --noEmit, and
-      # finishes with `@atlas/web type` — self-contained, no pre-build.
+      # finishes with `@atlas/web type` + `@atlas/www type` — self-contained,
+      # no pre-build.
+      #
+      # tsgo parallelism (--checkers/--builders) was benchmarked and declined
+      # (#4446): on this 4-vCPU runner class the tsgo default (4 checkers, as
+      # of the pinned 7.0.0-dev preview) is already optimal for the root
+      # program — ~20s vs ~34s single-checker, and 5-8 checkers regress
+      # (~21-24s, oversubscription). --builders only affects `tsc -b` build
+      # mode, which nothing here uses; the tsgo declaration-emit builds
+      # (types/sdk/plugin-sdk/webhook-publisher) and the web/www programs are
+      # sub-second. Re-benchmark before adding flags if this job moves to a
+      # higher-core runner class or tsgo's parallelism defaults change.
       - name: Type check
         run: bun run type
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
       # program — ~20s vs ~34s single-checker, and 5-8 checkers regress
       # (~21-24s, oversubscription). --builders only affects `tsc -b` build
       # mode, which nothing here uses; the tsgo declaration-emit builds
-      # (types/sdk/plugin-sdk/webhook-publisher) and the www program are
+      # (types/plugin-sdk/sdk) and the www program are
       # sub-second, and the web program (~580 files, ~8s) runs the same
       # already-optimal default. Re-benchmark before adding flags if this job
       # moves to a higher-core runner class or tsgo's parallelism defaults

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,9 +246,11 @@ jobs:
       # program — ~20s vs ~34s single-checker, and 5-8 checkers regress
       # (~21-24s, oversubscription). --builders only affects `tsc -b` build
       # mode, which nothing here uses; the tsgo declaration-emit builds
-      # (types/sdk/plugin-sdk/webhook-publisher) and the web/www programs are
-      # sub-second. Re-benchmark before adding flags if this job moves to a
-      # higher-core runner class or tsgo's parallelism defaults change.
+      # (types/sdk/plugin-sdk/webhook-publisher) and the www program are
+      # sub-second, and the web program (~580 files, ~8s) runs the same
+      # already-optimal default. Re-benchmark before adding flags if this job
+      # moves to a higher-core runner class or tsgo's parallelism defaults
+      # change.
       - name: Type check
         run: bun run type
 

--- a/docs/adr/0031-oxlint-over-eslint.md
+++ b/docs/adr/0031-oxlint-over-eslint.md
@@ -170,7 +170,14 @@ does **not** implement `no-restricted-syntax` natively.
     `packages/web/tsconfig.json`. The web `type` gate and `next build` still check the
     unchanged main config; web tests now get a real program (which surfaced one
     `no-meaningless-void-operator` error — a `void act(...)` whose callee now resolves
-    as `void`-returning; the `void` was dropped). *The last 6 findings were genuine,
+    as `void`-returning; the `void` was dropped). **Correction (#4447):** the
+    "unchanged main config" claim was wrong — because `tsconfig.test.json`'s
+    `include` claimed *all* of `src/**`, project-reference semantics redirected
+    every src file out of the referencing program, leaving the web `type` gate
+    checking zero project files (vacuously green). Fixed by narrowing the test
+    project's `include` to the test files it exists to route; a
+    `check-type-program-not-vacuous.sh` guard now runs inside the web `type`
+    script so a future config change can't silently re-empty the program. *The last 6 findings were genuine,
     not config artifacts* — wave 4's classification of the mcp/api residuals as config
     artifacts turned out wrong: they persist under fully-healthy programs
     (`packages/api`'s program already had `types: ["bun", "node"]`) because `unknown`

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "type": "tsgo --noEmit",
+    "type": "tsgo --noEmit && bash scripts/check-type-program-not-vacuous.sh",
     "test": "bun scripts/test-isolated.ts"
   },
   "exports": {

--- a/packages/web/scripts/check-type-program-not-vacuous.sh
+++ b/packages/web/scripts/check-type-program-not-vacuous.sh
@@ -45,9 +45,10 @@ case "$count" in
     ;;
 esac
 
-# The program is ~580 src files today; 100 is a generous floor — vacuation
-# drops it to ~0.
-min=100
+# The program is ~580 src files today. 450 allows real code shrinkage but
+# trips on partial vacuation (a reference claiming a whole subtree like
+# src/ui/** would drop hundreds of files), not just the total wipe-out.
+min=450
 
 if [ "$count" -lt "$min" ]; then
   echo "check-type-program-not-vacuous: FAIL — only $count packages/web/src files in the type program (expected >= $min)." >&2
@@ -55,5 +56,13 @@ if [ "$count" -lt "$min" ]; then
   echo "or tsgo's --listFilesOnly output format changed — inspect the raw file list." >&2
   exit 1
 fi
+
+# Also assert the test project (the tsgolint routing artifact the main
+# config references — see tsconfig.test.json) still loads as a program, so
+# the #4443 file->program routing can't silently break either.
+"$TSGO" -p tsconfig.test.json --listFilesOnly > /dev/null || {
+  echo "check-type-program-not-vacuous: FAIL — tsconfig.test.json no longer loads as a program (tsgolint test-file routing is broken; see #4443/#4447)." >&2
+  exit 1
+}
 
 echo "check-type-program-not-vacuous: OK ($count src files in the type program)"

--- a/packages/web/scripts/check-type-program-not-vacuous.sh
+++ b/packages/web/scripts/check-type-program-not-vacuous.sh
@@ -22,17 +22,34 @@ else
   }
 fi
 
+# Must mirror the `type` script's `tsgo --noEmit` invocation in package.json
+# (same implicit tsconfig.json) — if that ever grows `-p`/flags, change both.
 files=$("$TSGO" --noEmit --listFilesOnly) || {
   echo "check-type-program-not-vacuous: FAIL — '$TSGO --noEmit --listFilesOnly' exited non-zero." >&2
   exit 1
 }
 
-count=$(printf '%s\n' "$files" | grep -c "packages/web/src/" || true)
+# grep -c prints 0 before exiting 1 on no-match; only exit 1 is expected.
+count=$(printf '%s\n' "$files" | grep -c "packages/web/src/") || {
+  status=$?
+  if [ "$status" -gt 1 ]; then
+    echo "check-type-program-not-vacuous: FAIL — grep exited $status while counting src files; guard could not run." >&2
+    exit 1
+  fi
+}
+case "$count" in
+  '' | *[!0-9]*)
+    echo "check-type-program-not-vacuous: FAIL — non-numeric count '$count'; guard could not run." >&2
+    exit 1
+    ;;
+esac
+
 min=100
 
 if [ "$count" -lt "$min" ]; then
   echo "check-type-program-not-vacuous: FAIL — only $count packages/web/src files in the type program (expected >= $min)." >&2
-  echo "A tsconfig 'references'/include/exclude change likely re-vacuated the program; see #4447." >&2
+  echo "A tsconfig 'references'/include/exclude change likely re-vacuated the program (see #4447)," >&2
+  echo "or tsgo's --listFilesOnly output format changed — inspect the raw file list." >&2
   exit 1
 fi
 

--- a/packages/web/scripts/check-type-program-not-vacuous.sh
+++ b/packages/web/scripts/check-type-program-not-vacuous.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Guard against #4447: a tsconfig change can silently empty the main type
+# program — project-reference semantics redirect any root file that a
+# referenced composite project also claims OUT of the referencing program,
+# so an over-broad include in tsconfig.test.json once left `tsgo --noEmit`
+# checking zero project files while exiting green. Assert the program still
+# contains a healthy number of this package's source files.
+# --listFilesOnly skips the check phase, so this costs well under a second.
+
+cd "$(dirname "$0")/.."
+
+if [ -x "node_modules/.bin/tsgo" ]; then
+  TSGO="node_modules/.bin/tsgo"
+elif [ -x "../../node_modules/.bin/tsgo" ]; then
+  TSGO="../../node_modules/.bin/tsgo"
+else
+  TSGO="$(command -v tsgo)" || {
+    echo "check-type-program-not-vacuous: FAIL — tsgo not found (looked in node_modules/.bin, ../../node_modules/.bin, PATH)." >&2
+    exit 1
+  }
+fi
+
+files=$("$TSGO" --noEmit --listFilesOnly) || {
+  echo "check-type-program-not-vacuous: FAIL — '$TSGO --noEmit --listFilesOnly' exited non-zero." >&2
+  exit 1
+}
+
+count=$(printf '%s\n' "$files" | grep -c "packages/web/src/" || true)
+min=100
+
+if [ "$count" -lt "$min" ]; then
+  echo "check-type-program-not-vacuous: FAIL — only $count packages/web/src files in the type program (expected >= $min)." >&2
+  echo "A tsconfig 'references'/include/exclude change likely re-vacuated the program; see #4447." >&2
+  exit 1
+fi
+
+echo "check-type-program-not-vacuous: OK ($count src files in the type program)"

--- a/packages/web/scripts/check-type-program-not-vacuous.sh
+++ b/packages/web/scripts/check-type-program-not-vacuous.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # so an over-broad include in tsconfig.test.json once left `tsgo --noEmit`
 # checking zero project files while exiting green. Assert the program still
 # contains a healthy number of this package's source files.
-# --listFilesOnly skips the check phase, so this costs well under a second.
+# --listFilesOnly skips the check phase, so this costs a small fraction of
+# the full check.
 
 cd "$(dirname "$0")/.."
 
@@ -44,6 +45,8 @@ case "$count" in
     ;;
 esac
 
+# The program is ~580 src files today; 100 is a generous floor — vacuation
+# drops it to ~0.
 min=100
 
 if [ "$count" -lt "$min" ]; then

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -14,6 +14,12 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": [
+    "node_modules",
+    "src/test-setup.ts",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ],
   "references": [{ "path": "./tsconfig.test.json" }]
 }

--- a/packages/web/tsconfig.test.json
+++ b/packages/web/tsconfig.test.json
@@ -6,6 +6,12 @@
     "outDir": "dist/tsconfig-test-build",
     "types": ["bun", "node"]
   },
-  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "include": [
+    "src/test-setup.ts",
+    "src/**/__tests__/**/*.ts",
+    "src/**/__tests__/**/*.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ],
   "exclude": ["node_modules"]
 }

--- a/packages/web/tsconfig.test.json
+++ b/packages/web/tsconfig.test.json
@@ -1,4 +1,13 @@
 {
+  // tsgolint routing artifact, not a buildable project (#4443, #4447):
+  // this config exists so oxlint --type-aware routes test files to a real
+  // program with @/* paths + bun/node types instead of inferred per-file
+  // programs. `composite` is load-bearing for the project-reference redirect
+  // from tsconfig.json; the file list is intentionally incomplete (tests pull
+  // app code into the program unlisted), so never build this with `tsc -b`.
+  // Keep `include` narrowed to test files only — a broader include claims
+  // app src files and redirects them OUT of the main program, silently
+  // emptying the web `type` gate (#4447).
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
## Summary
- **#4446 — benchmarked tsgo GA parallelism flags (`--checkers`/`--builders`/`--singleThreaded`) for `bun run type` and declined them all**: on the 4-vCPU ubuntu-latest runner class the tsgo default (4 checkers) is already optimal for the root program (~20s vs ~34s single-checker; 5–8 checkers regress to ~21–24s from oversubscription); `--builders` is build-mode-only (nothing uses `-b`); declaration-emit builds are sub-second; tsgolint exposes no checker knob. Full matrix + CI-runner data: https://github.com/AtlasDevHQ/atlas/issues/4446#issuecomment-4929787223. The verdict + re-benchmark triggers are documented in a comment on the CI `type` job. No flags adopted ⇒ `bun run type` semantics unchanged.
- **#4447 — fixed the vacuous `packages/web` type-check** (found while benchmarking: the web program timed at 0.2s, which was implausible). #4443's project reference to a composite `tsconfig.test.json` whose `include` claimed all of `src/**` redirected every src file out of the main program, so `tsgo --noEmit` checked zero project files and passed vacuously. Fix: narrow the test project's `include` to the test files it exists to route (tsgolint file→program routing preserved — `lint:type-aware` stays green with `tsconfig-error` and `no-redundant-type-constituents` both still 0), make the two-program partition explicit (`src/test-setup.ts` in the main exclude; in-file contract comment on the routing artifact), add a `check-type-program-not-vacuous.sh` guard to the web `type` script (≥450 src files in the main program via `--listFilesOnly`, test project must still load, fails loudly and distinctly on every can't-run path), and correct the ADR-0031 wave-5 claim that the main config was unchanged.

Follow-up filed from panel review: #4450 — web *test* files have never been type-checked by any gate (pre-existing, ~184-error backlog; composite routing artifact can't compile standalone by design).

## Test plan
- [x] `bun run type` green end-to-end, with the guard reporting 577 src files in the web program
- [x] Deliberate type error in `packages/web/src` fails `tsgo --noEmit` again (was silently green before the fix)
- [x] Guard adversarially tested: FAILs on the regressed (broad-include) config, OK on the fixed one, fails loudly when tsgo is missing / tsgo exits non-zero / grep hard-fails / count is non-numeric
- [x] `bun run lint:type-aware` exit 0, zero errors (the routing #4443 built the reference for still works)
- [x] Web test suite: 283/283 files pass
- [x] Local CI gates (`scripts/ci-local.sh`): 28/29 green; the one failure is `admin-model-config.test.ts`'s gateway-catalog test, which live-fetches the AI gateway and deterministically times out behind this container's network policy — unrelated (same code green on main run 7603)
- [x] Internal review panel: round 1 clean on the benchmark commit; round 2 on the fix — 1 HIGH (guard grep fall-through) + accuracy/config findings, all addressed in follow-up commits; out-of-scope finding filed as #4450
- [ ] CI green on this PR

Closes #4446
Closes #4447

https://claude.ai/code/session_01E1vjfm3JrvoQ3X6RS7ELW9