### PR TITLE
feat(knowledge): Salesforce Knowledge sync connector — reuse the jsforce OAuth install (#4397)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56651,7 +56651,8 @@
                               "confluence",
                               "confluence-datacenter",
                               "gitbook",
-                              "zendesk"
+                              "zendesk",
+                              "salesforce-knowledge"
                             ]
                           },
                           "description": {

--- a/docs/adr/0030-knowledge-sync-connector-seam.md
+++ b/docs/adr/0030-knowledge-sync-connector-seam.md
@@ -163,3 +163,32 @@ ADR's "converter" role:
   engine's reconciliation crawl as their change detection — `fetchChanges`
   falls back to full enumeration; no engine change (the two-cadence split
   above already prices this in, just costlier cycles, documented per vendor).
+
+## Amendment (#4397): connector credentials from a reused OAuth install
+
+The Salesforce Knowledge connector (#4397) introduces the tier's second
+credential-sourcing model. Every prior connector reads a per-collection secret
+from `knowledge_sync_credentials` via `readSyncCredential(workspaceId,
+collectionSlug)` inside `createClient`. Salesforce Knowledge instead **reuses
+the workspace's existing Salesforce OAuth install** (`catalog:salesforce`,
+ADR-0014): `createClient` resolves the lazy plugin instance
+(`lazyPluginLoader.getOrInstantiate`) and drives SOQL through its
+refresh-retried surface. Consequences the pattern pins:
+
+- **No new secret path.** The install handler collects no credential, writes
+  no `knowledge_sync_credentials` row, and has no credential rollback pairing;
+  token storage, refresh, and reconnect stay single-homed in the OAuth
+  install's `integration_credentials` bundle + lazy builder.
+- **The install-time "verify loudly" step changes shape, not posture**: the
+  handler resolves the live instance (classifying loader failures to
+  actionable 400s — connect first / Reconnect / operator env missing) and
+  `describe`s the configured object before persisting, replacing the
+  credential check the other vendors run.
+- **Lifecycle coupling is deliberate**: disconnecting the Salesforce OAuth
+  install breaks the knowledge collection's sync — surfaced per cycle as that
+  collection's actionable error outcome, never a silent no-op. Uninstalling
+  the knowledge collection never touches the OAuth install.
+- A connector needing a RAW vendor surface beyond the lazy instance's
+  tool-facing `query()` extends the instance (here: `queryPage`/
+  `queryMorePage`/`describeObject` for `queryMore` pagination + body-field
+  discovery) rather than re-implementing OAuth construction.

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -1136,7 +1136,10 @@ describe("GET /api/v1/admin/model-config/catalog?provider=anthropic", () => {
     }
     expect(mockGetWorkspaceModelConfigRaw).not.toHaveBeenCalled();
     expect(mockGetAnthropicCatalog).not.toHaveBeenCalled();
-  });
+    // 15s: the real gateway fetch self-aborts at FETCH_TIMEOUT_MS (10s) and
+    // falls back — on a network that black-holes the request (sandboxed/proxied
+    // CI containers), bun's default 5s test timeout fired before the fallback.
+  }, 15_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -660,6 +660,31 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(zd?.endpointUrl).toBeNull();
     expect(zd?.sync).not.toBeNull();
   });
+
+  it("dispatches a Salesforce Knowledge collection to the connector engine and lists it as source 'salesforce-knowledge' (#4397)", async () => {
+    COLLECTION = {
+      install_id: "sf-kb",
+      catalog_id: "catalog:salesforce-knowledge",
+      status: "published",
+      config: { article_object: "Knowledge__kav", channel: "pkb" },
+    };
+    SYNC_STATES = [
+      { collection_id: "sf-kb", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/sf-kb/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const sf = body.collections.find((c) => c.slug === "sf-kb");
+    expect(sf?.source).toBe("salesforce-knowledge");
+    expect(sf?.endpointUrl).toBeNull();
+    expect(sf?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -29,6 +29,7 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import type {
   KnowledgeCollectionListResponse,
+  KnowledgeCollectionSource,
   KnowledgeDocumentListResponse,
   KnowledgeIngestSummary,
   KnowledgeSyncRunResponse,
@@ -105,17 +106,12 @@ async function loadCollection(
   return rows[0] ?? null;
 }
 
-/** A synced-collection source discriminator + whether it is a connector. */
-type KnowledgeSource =
-  | "upload"
-  | "bundle-sync"
-  | "notion"
-  | "confluence"
-  | "confluence-datacenter"
-  | "gitbook"
-  | "zendesk"
-  | "salesforce-knowledge"
-  | "unknown";
+/**
+ * A synced-collection source discriminator — the wire union plus the local
+ * fail-closed `"unknown"` (derived, not hand-duplicated, so a new wire member
+ * can't drift this file).
+ */
+type KnowledgeSource = KnowledgeCollectionSource | "unknown";
 
 /**
  * Map a knowledge catalog id to the wire `source` discriminator — matching

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -58,6 +58,7 @@ import { CONFLUENCE_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/confi
 import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/config-datacenter";
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
+import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -113,6 +114,7 @@ type KnowledgeSource =
   | "confluence-datacenter"
   | "gitbook"
   | "zendesk"
+  | "salesforce-knowledge"
   | "unknown";
 
 /**
@@ -130,6 +132,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === CONFLUENCE_DC_CATALOG_ID) return "confluence-datacenter";
   if (catalogId === GITBOOK_CATALOG_ID) return "gitbook";
   if (catalogId === ZENDESK_CATALOG_ID) return "zendesk";
+  if (catalogId === SALESFORCE_KNOWLEDGE_CATALOG_ID) return "salesforce-knowledge";
   return "unknown";
 }
 
@@ -141,7 +144,8 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "confluence" ||
     source === "confluence-datacenter" ||
     source === "gitbook" ||
-    source === "zendesk"
+    source === "zendesk" ||
+    source === "salesforce-knowledge"
   );
 }
 
@@ -162,7 +166,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -27,6 +27,7 @@ import {
   BUILTIN_CONFLUENCE_CATALOG_ROW,
   BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_ZENDESK_CATALOG_ROW,
+  BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -187,6 +188,29 @@ describe("BUILTIN_ZENDESK_CATALOG_ROW (#4396)", () => {
   });
 });
 
+describe("BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW (#4397)", () => {
+  it("is the `salesforce-knowledge` form install: scope-only config, NO secret field", () => {
+    const row = BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW;
+    expect(row.slug).toBe("salesforce-knowledge");
+    expect(row.id).toBe("catalog:salesforce-knowledge");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("channel");
+    expect(keys).toContain("article_object");
+    expect(keys).toContain("description");
+    // The tier's credential-model departure: the connector reuses the
+    // workspace's existing Salesforce OAuth install (catalog:salesforce), so
+    // this row collects NO secret and NO endpoint — zero secret fields.
+    expect(row.configSchema.filter((f) => f.secret === true)).toEqual([]);
+    expect(keys).not.toContain("api_token");
+    expect(keys).not.toContain("base_url");
+    // Every field is optional — an empty form installs the Knowledge__kav
+    // default scope.
+    expect(row.configSchema.filter((f) => f.required === true)).toEqual([]);
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -210,6 +234,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "confluence-datacenter",
       "gitbook",
       "zendesk",
+      "salesforce-knowledge",
     ]);
   });
 
@@ -237,6 +262,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "confluence-datacenter",
       "gitbook",
       "zendesk",
+      "salesforce-knowledge",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -1,8 +1,9 @@
 /**
  * Boot-time idempotent seed pass for the built-in Knowledge Base catalog rows
  * — the upload/bundle-sync arms plus the vendor connectors (Notion, Confluence
- * Cloud + Data Center, GitBook, Zendesk Guide). `BUILTIN_KNOWLEDGE_CATALOG_ROWS`
- * is the authoritative list; adding a connector is one append there.
+ * Cloud + Data Center, GitBook, Zendesk Guide, Salesforce Knowledge).
+ * `BUILTIN_KNOWLEDGE_CATALOG_ROWS` is the authoritative list; adding a
+ * connector is one append there.
  *
  * The Knowledge Base lifecycle (ADR-0028 §5) started as one built-in catalog
  * row — `okf-upload`, an **explicit, degenerate form install** with no
@@ -40,6 +41,10 @@ import {
 } from "@atlas/api/lib/knowledge/notion/connector";
 import { GITBOOK_CATALOG_ID, GITBOOK_SLUG } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID, ZENDESK_SLUG } from "@atlas/api/lib/knowledge/zendesk/config";
+import {
+  SALESFORCE_KNOWLEDGE_CATALOG_ID,
+  SALESFORCE_KNOWLEDGE_SLUG,
+} from "@atlas/api/lib/knowledge/salesforce/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -419,6 +424,53 @@ export const BUILTIN_ZENDESK_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The Salesforce Knowledge connector Knowledge Base catalog row (#4397,
+ * PRD #4395). A form install that creates one review-gated collection per
+ * article-object/channel scope; the Scheduler dispatches the registered
+ * Salesforce connector on a cadence (indexed `SystemModstamp` incremental +
+ * `queryMore` reconciliation) and every synced article version lands `draft`.
+ *
+ * The tier's one credential-model departure: NO secret field. The connector
+ * reuses the workspace's existing Salesforce OAuth install
+ * (`catalog:salesforce`, ADR-0014) via the lazy plugin loader — installing
+ * this row registers no new connected app and writes no
+ * `knowledge_sync_credentials` row. The id/slug are the config SSOT
+ * (`SALESFORCE_KNOWLEDGE_CATALOG_ID` / `SALESFORCE_KNOWLEDGE_SLUG`).
+ */
+export const BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: SALESFORCE_KNOWLEDGE_CATALOG_ID,
+  slug: SALESFORCE_KNOWLEDGE_SLUG,
+  name: "Knowledge Base (Salesforce Knowledge)",
+  description:
+    "Mirror your Salesforce Knowledge articles into a review-gated knowledge collection using the workspace's existing Salesforce connection — no extra credentials; Atlas syncs published articles on a schedule (incremental + reconciliation) and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "channel",
+      type: "string",
+      label: "Channel scope",
+      description:
+        'Optional. Mirror only articles visible on one channel: "app" (internal), "pkb" (public knowledge base), "csp" (customer portal), or "prm" (partner portal). Leave empty for every published article.',
+    },
+    {
+      key: "article_object",
+      type: "string",
+      label: "Article object",
+      description:
+        "Optional. The article-version object API name (default Knowledge__kav; Classic article types use <Type>__kav).",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -428,6 +480,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_GITBOOK_CATALOG_ROW,
   BUILTIN_ZENDESK_CATALOG_ROW,
+  BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -46,6 +46,7 @@ import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/co
 import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/connector";
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
+import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -149,18 +150,20 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Confluence DC, Notion, GitBook, and Zendesk knowledge sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, and Salesforce Knowledge sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(NOTION_KNOWLEDGE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(GITBOOK_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(ZENDESK_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(SALESFORCE_KNOWLEDGE_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "gitbook", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "zendesk", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "salesforce-knowledge", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/salesforce-knowledge-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/salesforce-knowledge-form-handler.test.ts
@@ -145,6 +145,22 @@ describe("field validation", () => {
     );
     expect(msg).toMatch(/"app", "pkb", "csp"/);
   });
+
+  it("rejects non-string field values and a non-object body with typed messages", async () => {
+    expect(
+      await fieldErrorOf(handler().validateConfig(WORKSPACE, { article_object: 42 }), "article_object"),
+    ).toMatch(/must be a string/i);
+    expect(
+      await fieldErrorOf(handler().validateConfig(WORKSPACE, { channel: ["pkb"] }), "channel"),
+    ).toMatch(/must be a string/i);
+    expect(
+      await fieldErrorOf(handler().validateConfig(WORKSPACE, { description: 7 }), "description"),
+    ).toMatch(/must be a string/i);
+    expect(await formErrorOf(handler().validateConfig(WORKSPACE, "not-an-object"))).toMatch(
+      /JSON object/i,
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
 });
 
 describe("reused-install verification (loud, pre-write)", () => {

--- a/packages/api/src/lib/integrations/install/__tests__/salesforce-knowledge-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/salesforce-knowledge-form-handler.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for `SalesforceKnowledgeFormInstallHandler` (#4397) — the
+ * Salesforce Knowledge connector install. Focus: field validation (channel
+ * enum, `*__kav` article-object pattern), the loud pre-write verification
+ * against the REUSED Salesforce OAuth install (loader failures → actionable
+ * form-level 400s; describe failures → field-level 400s), and the
+ * credential-less persistence contract: NO `knowledge_sync_credentials`
+ * write, `credentialWritten: false`, config carries scope only. Verification
+ * uses an injected fixture loader; no test touches Salesforce.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:salesforce-knowledge" }];
+let INSERT_RETURNS_ID = true;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const { SalesforceKnowledgeFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/salesforce-knowledge-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+const { LazyPluginInstallNotFoundError, LazyPluginBuilderMissingError } = await import(
+  "@atlas/api/lib/plugins/lazy-loader"
+);
+const { IntegrationReconnectRequiredError } = await import("@atlas/api/lib/effect/errors");
+type SalesforcePluginInstance =
+  import("@atlas/api/lib/integrations/salesforce/lazy-builder").SalesforcePluginInstance;
+type SalesforceInstanceLoader =
+  import("@atlas/api/lib/knowledge/salesforce/connector").SalesforceInstanceLoader;
+
+const WORKSPACE = "org-1" as WorkspaceId;
+
+function kavField(name: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name, type: "string", custom: false, ...overrides };
+}
+const KAV_FIELDS: Record<string, unknown>[] = [
+  kavField("Id"),
+  kavField("KnowledgeArticleId"),
+  kavField("ArticleNumber"),
+  kavField("Title"),
+  kavField("Language"),
+  kavField("PublishStatus"),
+  kavField("SystemModstamp"),
+  kavField("IsVisibleInPkb", { type: "boolean" }),
+  kavField("Body__c", { type: "textarea", custom: true, extraTypeInfo: "richtextarea" }),
+];
+
+function fakeInstance(overrides: Partial<SalesforcePluginInstance> = {}): SalesforcePluginInstance {
+  return {
+    id: `salesforce:${WORKSPACE}`,
+    types: ["datasource"] as const,
+    version: "0.1.0",
+    config: { instanceUrl: "https://acme.my.salesforce.com" },
+    query: async () => ({ columns: [], rows: [] }),
+    queryPage: async () => ({ records: [], done: true, nextRecordsUrl: null }),
+    queryMorePage: async () => ({ records: [], done: true, nextRecordsUrl: null }),
+    describeObject: async () => ({ fields: KAV_FIELDS }),
+    listObjects: async () => [],
+    profile: async () => ({ profiles: [] }) as never,
+    ...overrides,
+  };
+}
+
+function loaderOf(result: SalesforcePluginInstance | (() => never)): SalesforceInstanceLoader {
+  return {
+    async getOrInstantiate() {
+      if (typeof result === "function") return result();
+      return result;
+    },
+  };
+}
+
+function handler(loader: SalesforceInstanceLoader = loaderOf(fakeInstance())) {
+  let n = 0;
+  return new SalesforceKnowledgeFormInstallHandler({
+    idGenerator: () => `fixed-id-${++n}`,
+    loader,
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:salesforce-knowledge" }];
+  INSERT_RETURNS_ID = true;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+});
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+async function formErrorOf(promise: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.formErrors[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("rejects an article object that is not a *__kav name", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { article_object: "Account" }),
+      "article_object",
+    );
+    expect(msg).toMatch(/__kav/);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("rejects an unknown channel", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { channel: "twitter" }),
+      "channel",
+    );
+    expect(msg).toMatch(/"app", "pkb", "csp"/);
+  });
+});
+
+describe("reused-install verification (loud, pre-write)", () => {
+  it("surfaces a missing Salesforce install as an actionable form-level 400", async () => {
+    const msg = await formErrorOf(
+      handler(
+        loaderOf(() => {
+          throw new LazyPluginInstallNotFoundError(WORKSPACE, "catalog:salesforce");
+        }),
+      ).validateConfig(WORKSPACE, {}),
+    );
+    expect(msg).toMatch(/Salesforce is not connected/i);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("surfaces a reconnect-required install as an actionable form-level 400", async () => {
+    const msg = await formErrorOf(
+      handler(
+        loaderOf(() => {
+          throw new IntegrationReconnectRequiredError({
+            message: "refresh failed",
+            workspaceId: WORKSPACE,
+            platform: "salesforce",
+            upstreamError: "invalid_grant",
+          });
+        }),
+      ).validateConfig(WORKSPACE, {}),
+    );
+    expect(msg).toMatch(/Reconnect/);
+  });
+
+  it("surfaces a missing builder (operator env) as an actionable form-level 400", async () => {
+    const msg = await formErrorOf(
+      handler(
+        loaderOf(() => {
+          throw new LazyPluginBuilderMissingError("catalog:salesforce");
+        }),
+      ).validateConfig(WORKSPACE, {}),
+    );
+    expect(msg).toMatch(/SALESFORCE_CLIENT_ID/);
+  });
+
+  it("blames article_object when the describe fails (Knowledge not enabled)", async () => {
+    const msg = await fieldErrorOf(
+      handler(
+        loaderOf(
+          fakeInstance({
+            describeObject: async () => {
+              throw new Error("INVALID_TYPE: sObject type 'Knowledge__kav' is not supported");
+            },
+          }),
+        ),
+      ).validateConfig(WORKSPACE, {}),
+      "article_object",
+    );
+    expect(msg).toMatch(/could not describe Knowledge__kav/i);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("blames channel when the object lacks the channel's visibility field", async () => {
+    const msg = await fieldErrorOf(
+      handler(
+        loaderOf(
+          fakeInstance({
+            describeObject: async () => ({
+              fields: KAV_FIELDS.filter((f) => f.name !== "IsVisibleInPkb"),
+            }),
+          }),
+        ),
+      ).validateConfig(WORKSPACE, { channel: "pkb" }),
+      "channel",
+    );
+    expect(msg).toMatch(/no IsVisibleInPkb field/);
+  });
+});
+
+describe("credential-less persistence", () => {
+  it("persists one collection row with scope-only config and credentialWritten: false", async () => {
+    const rec = await handler().validateConfig(WORKSPACE, {
+      channel: "pkb",
+      description: "Public help center",
+    });
+    expect(rec.credentialWritten).toBe(false);
+    expect(rec.installRecord).toMatchObject({
+      workspaceId: WORKSPACE,
+      catalogId: "salesforce-knowledge",
+      id: "fixed-id-1",
+    });
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].params[3]).toBe("salesforce-knowledge");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toEqual({
+      article_object: "Knowledge__kav",
+      channel: "pkb",
+      description: "Public help center",
+    });
+    // Row lands published (the container is live; DOCUMENTS gate at draft),
+    // knowledge-pillar.
+    expect(insertCalls[0].sql).toContain("'knowledge'");
+    expect(insertCalls[0].sql).toContain("'published'");
+  });
+
+  it("defaults the article object and omits absent optional fields from config", async () => {
+    await handler().validateConfig(WORKSPACE, {});
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toEqual({ article_object: "Knowledge__kav" });
+  });
+
+  it("respects a custom collection slug via __install_id__", async () => {
+    await handler().validateConfig(WORKSPACE, { __install_id__: "support-kb" });
+    expect(insertCalls[0].params[3]).toBe("support-kb");
+  });
+
+  it("rejects a slug taken by another knowledge catalog BEFORE any write", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, {}), "__install_id__");
+    expect(msg).toMatch(/already used/i);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("fails loudly when the upsert returns no id", async () => {
+    INSERT_RETURNS_ID = false;
+    await expect(handler().validateConfig(WORKSPACE, {})).rejects.toThrow(/returned no id/i);
+  });
+});
+
+describe("catalog preconditions", () => {
+  it("fails loudly when the catalog row is missing (seed has not run)", async () => {
+    CATALOG_ROWS = [];
+    await expect(handler().validateConfig(WORKSPACE, {})).rejects.toThrow(
+      /catalog row "salesforce-knowledge" not found/i,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -311,11 +311,11 @@ export function registerBuiltinInstallHandlers(): void {
   // ADR-0014) via the lazy plugin loader. Registering the FORM handler + the
   // CONNECTOR together (as with the other knowledge vendors) keeps a
   // half-wired deploy from having an installable card whose scheduled sync has
-  // no registered vendor client. No env gate: on a deploy without the
-  // Salesforce OAuth env the install fails loudly with an actionable message —
-  // connect-Salesforce-first on a fresh deploy (no catalog:salesforce install
-  // row can exist), builder-missing when an install row outlived the env vars
-  // (same posture as the querySalesforce agent tool).
+  // no registered vendor client. No env gate: the install always fails loudly
+  // with an actionable message — builder-missing on a deploy without the
+  // Salesforce OAuth env (the loader checks the builder first),
+  // connect-Salesforce-first on a configured deploy where the workspace hasn't
+  // connected yet (same posture as the querySalesforce agent tool).
   registerFormHandler(SALESFORCE_KNOWLEDGE_SLUG, new SalesforceKnowledgeFormInstallHandler());
   registerSalesforceKnowledgeConnector();
   log.info("Registered SalesforceKnowledgeFormInstallHandler + knowledge sync connector");

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -311,9 +311,11 @@ export function registerBuiltinInstallHandlers(): void {
   // ADR-0014) via the lazy plugin loader. Registering the FORM handler + the
   // CONNECTOR together (as with the other knowledge vendors) keeps a
   // half-wired deploy from having an installable card whose scheduled sync has
-  // no registered vendor client. No env gate: on a deploy without
-  // SALESFORCE_CLIENT_ID/SECRET the install fails loudly with the actionable
-  // builder-missing message (same posture as the querySalesforce agent tool).
+  // no registered vendor client. No env gate: on a deploy without the
+  // Salesforce OAuth env the install fails loudly with an actionable message —
+  // connect-Salesforce-first on a fresh deploy (no catalog:salesforce install
+  // row can exist), builder-missing when an install row outlived the env vars
+  // (same posture as the querySalesforce agent tool).
   registerFormHandler(SALESFORCE_KNOWLEDGE_SLUG, new SalesforceKnowledgeFormInstallHandler());
   registerSalesforceKnowledgeConnector();
   log.info("Registered SalesforceKnowledgeFormInstallHandler + knowledge sync connector");

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -50,6 +50,11 @@ import { GitbookFormInstallHandler, GITBOOK_SLUG } from "./gitbook-form-handler"
 import { registerGitbookKnowledgeConnector } from "@atlas/api/lib/knowledge/gitbook/connector";
 import { ZendeskFormInstallHandler, ZENDESK_SLUG } from "./zendesk-form-handler";
 import { registerZendeskKnowledgeConnector } from "@atlas/api/lib/knowledge/zendesk/connector";
+import {
+  SalesforceKnowledgeFormInstallHandler,
+  SALESFORCE_KNOWLEDGE_SLUG,
+} from "./salesforce-knowledge-form-handler";
+import { registerSalesforceKnowledgeConnector } from "@atlas/api/lib/knowledge/salesforce/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -297,6 +302,21 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(ZENDESK_SLUG, new ZendeskFormInstallHandler());
   registerZendeskKnowledgeConnector();
   log.info("Registered ZendeskFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Salesforce Knowledge) — the built-in `salesforce-knowledge`
+  // connector install (#4397, PRD #4395). Knowledge-pillar, multi-instance:
+  // one collection per article-object/channel scope. The tier's one
+  // credential-model departure: NO secret is collected and NO
+  // `knowledge_sync_credentials` row is written — the connector reuses the
+  // workspace's existing Salesforce OAuth install (`catalog:salesforce`,
+  // ADR-0014) via the lazy plugin loader. Registering the FORM handler + the
+  // CONNECTOR together (as with the other knowledge vendors) keeps a
+  // half-wired deploy from having an installable card whose scheduled sync has
+  // no registered vendor client. No env gate: on a deploy without
+  // SALESFORCE_CLIENT_ID/SECRET the install fails loudly with the actionable
+  // builder-missing message (same posture as the querySalesforce agent tool).
+  registerFormHandler(SALESFORCE_KNOWLEDGE_SLUG, new SalesforceKnowledgeFormInstallHandler());
+  registerSalesforceKnowledgeConnector();
+  log.info("Registered SalesforceKnowledgeFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/integrations/install/salesforce-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/salesforce-knowledge-form-handler.ts
@@ -1,0 +1,296 @@
+/**
+ * `SalesforceKnowledgeFormInstallHandler` — the {@link FormBasedInstallHandler}
+ * for the built-in `salesforce-knowledge` Knowledge Base catalog row (#4397,
+ * PRD #4395).
+ *
+ * Installing `salesforce-knowledge` creates one synced collection scoped to an
+ * article-version object + optional channel; the Scheduler dispatches the
+ * registered Salesforce Knowledge connector per collection on a cadence
+ * (`lib/knowledge/connector-sync.ts`), and every synced article lands `draft`.
+ *
+ * The tier's one credential-model departure: this handler collects NO secret.
+ * The connector reuses the workspace's EXISTING Salesforce OAuth install
+ * (`catalog:salesforce`, ADR-0014, #3302) through the lazy plugin loader, so
+ * there is no `knowledge_sync_credentials` write, no rollback pairing, and no
+ * new connected-app registration. What replaces the credential check is the
+ * same loud pre-write verification the tier demands: the handler resolves the
+ * live Salesforce instance (surfacing "connect Salesforce first" /
+ * "Reconnect" as actionable 400s) and `describe`s the configured article
+ * object (surfacing "Lightning Knowledge is not enabled" / a bad channel
+ * scope as field-level 400s) BEFORE persisting anything.
+ *
+ * Multi-instance by design: a workspace installs one collection per
+ * channel/object scope (distinct `install_id`s), e.g. a public `pkb`
+ * collection next to an internal all-channels one.
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import type { SalesforcePluginInstance } from "@atlas/api/lib/integrations/salesforce/lazy-builder";
+import {
+  instanceUrlOf,
+  resolveSalesforceKnowledgeInstance,
+  type SalesforceInstanceLoader,
+} from "@atlas/api/lib/knowledge/salesforce/connector";
+import {
+  ARTICLE_OBJECT_PATTERN,
+  DEFAULT_ARTICLE_OBJECT,
+  SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS,
+  SALESFORCE_KNOWLEDGE_SLUG,
+  SALESFORCE_KNOWLEDGE_CATALOG_ID,
+  isSalesforceKnowledgeChannel,
+  type SalesforceKnowledgeChannel,
+  type SalesforceKnowledgeCollectionConfig,
+} from "@atlas/api/lib/knowledge/salesforce/config";
+import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
+import { hostForLog } from "@atlas/api/lib/openapi/egress-guard";
+import { FormInstallValidationError } from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { SALESFORCE_KNOWLEDGE_SLUG, SALESFORCE_KNOWLEDGE_CATALOG_ID };
+
+/** Defensive upper bound — guard against pathological pastes. */
+const ARTICLE_OBJECT_MAX = 120;
+
+export interface SalesforceKnowledgeFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the lazy loader (no real Salesforce call). */
+  readonly loader?: SalesforceInstanceLoader;
+}
+
+/**
+ * The synced-collection upsert. Identical shape to
+ * `ZENDESK_INSTALL_UPSERT_SQL`: `status='published'` because the COLLECTION
+ * container is live immediately — the review gate is on the DOCUMENTS, which
+ * always sync in as `draft`. Exported so the real-Postgres test executes this
+ * exact string against the live schema.
+ */
+export const SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class SalesforceKnowledgeFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly loader: SalesforceInstanceLoader;
+  private readonly log = createLogger("integrations.install.salesforce-knowledge");
+
+  constructor(options: SalesforceKnowledgeFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.loader = options.loader ?? lazyPluginLoader;
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const slug = resolveCollectionSlug(
+      rawForm[KNOWLEDGE_INSTALL_ID_FIELD],
+      SALESFORCE_KNOWLEDGE_SLUG,
+    );
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const articleObject = validateArticleObject(rawForm.article_object);
+    const channel = validateChannel(rawForm.channel);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [SALESFORCE_KNOWLEDGE_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "salesforce-knowledge catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${SALESFORCE_KNOWLEDGE_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+
+    // ── Verify the reused Salesforce connection loudly BEFORE persisting ────
+    const instance = await this.resolveInstance(workspaceId);
+    await this.verifyArticleObject(instance, articleObject, channel);
+
+    // ── Persist the collection row (no credential — the OAuth install owns it) ─
+    const config: SalesforceKnowledgeCollectionConfig = {
+      article_object: articleObject,
+      ...(channel !== null ? { channel } : {}),
+      ...(description !== null ? { description } : {}),
+    };
+    const candidateId = this.newId();
+    const rows = await internalQuery<{ id: string }>(SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL, [
+      candidateId,
+      workspaceId,
+      catalogId,
+      slug,
+      JSON.stringify(config),
+    ]);
+    const returned = rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      this.log.error(
+        { workspaceId, candidateId, collectionSlug: slug },
+        "workspace_plugins upsert returned no id — Postgres invariant violation",
+      );
+      throw new Error(
+        "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+      );
+    }
+
+    this.log.info(
+      {
+        workspaceId,
+        collectionSlug: slug,
+        articleObject,
+        channel,
+        host: hostForLog(instanceUrlOf(instance)),
+      },
+      "Salesforce Knowledge collection install completed",
+    );
+    return {
+      installRecord: { id: returned, workspaceId, catalogId: SALESFORCE_KNOWLEDGE_SLUG },
+      credentialWritten: false,
+    };
+  }
+
+  /**
+   * Resolve the workspace's live Salesforce OAuth instance, mapping every
+   * failure to an actionable form-level 400 (there is no credential field to
+   * blame — the fix is on the Integrations page or the operator's deploy).
+   */
+  private async resolveInstance(workspaceId: WorkspaceId): Promise<SalesforcePluginInstance> {
+    try {
+      return await resolveSalesforceKnowledgeInstance(this.loader, workspaceId);
+    } catch (err) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [err instanceof Error ? err.message : String(err)],
+      });
+    }
+  }
+
+  /**
+   * Describe the configured article object — the install-time connection +
+   * scope check. A failed describe blames the `article_object` field (wrong
+   * object / Knowledge not enabled); a channel whose visibility field the
+   * object lacks blames `channel`.
+   */
+  private async verifyArticleObject(
+    instance: SalesforcePluginInstance,
+    articleObject: string,
+    channel: SalesforceKnowledgeChannel | null,
+  ): Promise<void> {
+    let fields: readonly Record<string, unknown>[];
+    try {
+      fields = (await instance.describeObject(articleObject)).fields;
+    } catch (err) {
+      throw new FormInstallValidationError({
+        fieldErrors: {
+          article_object: [
+            `Salesforce could not describe ${articleObject}: ${err instanceof Error ? err.message : String(err)}. Check that Lightning Knowledge is enabled and the connected user can read the object.`,
+          ],
+        },
+        formErrors: [],
+      });
+    }
+    const names = new Set(fields.map((f) => (typeof f.name === "string" ? f.name : "")));
+    if (channel !== null) {
+      const visibilityField = SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS[channel];
+      if (!names.has(visibilityField)) {
+        throw new FormInstallValidationError({
+          fieldErrors: {
+            channel: [
+              `${articleObject} has no ${visibilityField} field — the "${channel}" channel scope cannot be applied to it.`,
+            ],
+          },
+          formErrors: [],
+        });
+      }
+    }
+    const bodyFieldCount = fields.filter(
+      (f) => f.custom === true && f.type === "textarea",
+    ).length;
+    if (bodyFieldCount === 0) {
+      // Not fatal (Title/Summary can carry prose) — but never silent.
+      this.log.warn(
+        { articleObject },
+        "Salesforce article object has no custom textarea body fields — synced documents will carry only title/summary prose",
+      );
+    }
+  }
+}
+
+/** Validate the article-version object API name (optional; defaulted). */
+function validateArticleObject(raw: unknown): string {
+  if (raw === undefined || raw === null) return DEFAULT_ARTICLE_OBJECT;
+  if (typeof raw !== "string") {
+    throw fieldError("article_object", "The article object must be a string.");
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") return DEFAULT_ARTICLE_OBJECT;
+  if (trimmed.length > ARTICLE_OBJECT_MAX || !ARTICLE_OBJECT_PATTERN.test(trimmed)) {
+    throw fieldError(
+      "article_object",
+      `Enter an article-version object API name ending in __kav (default: ${DEFAULT_ARTICLE_OBJECT}).`,
+    );
+  }
+  return trimmed;
+}
+
+/** Validate the optional channel scope. */
+function validateChannel(raw: unknown): SalesforceKnowledgeChannel | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("channel", "The channel must be a string.");
+  }
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "") return null;
+  if (!isSalesforceKnowledgeChannel(trimmed)) {
+    throw fieldError(
+      "channel",
+      'Enter one of "app", "pkb", "csp", or "prm" — or leave the channel empty to mirror every published article.',
+    );
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}

--- a/packages/api/src/lib/integrations/install/salesforce-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/salesforce-knowledge-form-handler.ts
@@ -138,6 +138,17 @@ export class SalesforceKnowledgeFormInstallHandler implements FormBasedInstallHa
 
     // ── Verify the reused Salesforce connection loudly BEFORE persisting ────
     const instance = await this.resolveInstance(workspaceId);
+    // Resolve the org URL pre-write too: a builder without one must be an
+    // actionable 400 here, not a 500 after the row already landed.
+    let instanceHost: string;
+    try {
+      instanceHost = hostForLog(instanceUrlOf(instance));
+    } catch (err) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [err instanceof Error ? err.message : String(err)],
+      });
+    }
     await this.verifyArticleObject(instance, articleObject, channel);
 
     // ── Persist the collection row (no credential — the OAuth install owns it) ─
@@ -166,13 +177,7 @@ export class SalesforceKnowledgeFormInstallHandler implements FormBasedInstallHa
     }
 
     this.log.info(
-      {
-        workspaceId,
-        collectionSlug: slug,
-        articleObject,
-        channel,
-        host: hostForLog(instanceUrlOf(instance)),
-      },
+      { workspaceId, collectionSlug: slug, articleObject, channel, host: instanceHost },
       "Salesforce Knowledge collection install completed",
     );
     return {

--- a/packages/api/src/lib/integrations/salesforce/__tests__/lazy-builder.test.ts
+++ b/packages/api/src/lib/integrations/salesforce/__tests__/lazy-builder.test.ts
@@ -308,12 +308,36 @@ describe("createSalesforceLazyBuilder — paged query surface (#4397)", () => {
     expect(mockJsforceQueryMore).toHaveBeenCalledWith("/services/data/v60.0/query/01gxx-2000");
   });
 
-  it("treats a done:false response with no locator as done (cannot continue)", async () => {
+  it("THROWS on done:false with no locator — a truncated result must never read as complete", async () => {
+    // If this were coerced to done, a reconciliation crawl would feed a
+    // partial set to subtractive archiving and mass-archive live documents.
     mockJsforceQuery.mockResolvedValueOnce({ records: [], done: false });
     const instance = await buildInstance();
+    await expect(
+      instance.queryPage("SELECT Id FROM Knowledge__kav WHERE PublishStatus = 'Online'"),
+    ).rejects.toThrow(/done:false with no nextRecordsUrl/i);
+  });
+
+  it("continues a contradictory done:true + locator page (locator presence is authoritative)", async () => {
+    mockJsforceQuery.mockResolvedValueOnce({
+      records: [{ Id: "ka0x001" }],
+      done: true,
+      nextRecordsUrl: "/services/data/v60.0/query/01gxx-2000",
+    });
+    const instance = await buildInstance();
     const page = await instance.queryPage("SELECT Id FROM Knowledge__kav WHERE PublishStatus = 'Online'");
-    expect(page.done).toBe(true);
-    expect(page.nextRecordsUrl).toBeNull();
+    expect(page.done).toBe(false);
+    expect(page.nextRecordsUrl).toBe("/services/data/v60.0/query/01gxx-2000");
+  });
+
+  it("refresh-retries queryMorePage on INVALID_SESSION_ID (the mid-crawl expiry case)", async () => {
+    mockJsforceQueryMore
+      .mockRejectedValueOnce(new Error("INVALID_SESSION_ID: Session expired or invalid"))
+      .mockResolvedValueOnce({ records: [{ Id: "ka0x004" }], done: true });
+    const instance = await buildInstance();
+    const page = await instance.queryMorePage("/services/data/v60.0/query/01gxx-2000");
+    expect(page.records).toEqual([{ Id: "ka0x004" }]);
+    expect(mockRefreshSalesforceToken).toHaveBeenCalledTimes(1);
   });
 
   it("describeObject exposes the object's field metadata over the OAuth session", async () => {

--- a/packages/api/src/lib/integrations/salesforce/__tests__/lazy-builder.test.ts
+++ b/packages/api/src/lib/integrations/salesforce/__tests__/lazy-builder.test.ts
@@ -59,8 +59,12 @@ void mock.module("@atlas/api/lib/integrations/install/salesforce-token-refresh",
 
 // Mock jsforce so the test never touches a real network. Tracks the
 // last-constructed Connection's args so assertions can inspect them.
-const mockJsforceQuery: Mock<(soql: string) => Promise<{ records?: Record<string, unknown>[] }>> =
-  mock(() => Promise.resolve({ records: [] }));
+const mockJsforceQuery: Mock<
+  (soql: string) => Promise<{ records?: Record<string, unknown>[]; done?: boolean; nextRecordsUrl?: string | null }>
+> = mock(() => Promise.resolve({ records: [] }));
+const mockJsforceQueryMore: Mock<
+  (url: string) => Promise<{ records?: Record<string, unknown>[]; done?: boolean; nextRecordsUrl?: string | null }>
+> = mock(() => Promise.resolve({ records: [], done: true }));
 const mockDescribeGlobal: Mock<() => Promise<{ sobjects?: { name?: string; queryable?: boolean }[] }>> =
   mock(() => Promise.resolve({ sobjects: [] }));
 const mockDescribe: Mock<(name: string) => Promise<{ fields?: Record<string, unknown>[] }>> =
@@ -71,6 +75,7 @@ class MockJsforceConnection {
     lastConnectionArgs = args;
   }
   query = mockJsforceQuery;
+  queryMore = mockJsforceQueryMore;
   describeGlobal = mockDescribeGlobal;
   describe = mockDescribe;
 }
@@ -128,6 +133,7 @@ beforeEach(() => {
   mockReadCredentialBundle.mockClear();
   mockRefreshSalesforceToken.mockClear();
   mockJsforceQuery.mockClear();
+  mockJsforceQueryMore.mockClear();
   mockDescribeGlobal.mockClear();
   mockDescribe.mockClear();
   lastConnectionArgs = null;
@@ -258,6 +264,76 @@ describe("createSalesforceLazyBuilder — OAuth introspection (#3667)", () => {
     expect(mockRefreshSalesforceToken).toHaveBeenCalledTimes(1);
     expect(result.profiles).toHaveLength(1);
     expect(result.profiles[0].table_name).toBe("Account");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4397 — raw paged SOQL + describeObject (the Knowledge sync surface)
+// ---------------------------------------------------------------------------
+
+describe("createSalesforceLazyBuilder — paged query surface (#4397)", () => {
+  async function buildInstance(): Promise<SalesforcePluginInstance> {
+    mockReadCredentialBundle.mockResolvedValueOnce(HAPPY_BUNDLE);
+    const build = builderMod.createSalesforceLazyBuilder(BUILDER_CONFIG);
+    return (await build({
+      workspaceId: WSID,
+      catalogId: CATALOG_ID,
+      config: { instance_url: "https://na139.my.salesforce.com", status: "ok" },
+    })) as SalesforcePluginInstance;
+  }
+
+  it("queryPage keeps jsforce's paging bookkeeping (done + nextRecordsUrl) intact", async () => {
+    mockJsforceQuery.mockResolvedValueOnce({
+      records: [{ attributes: { type: "Knowledge__kav" }, Id: "ka0x001" }],
+      done: false,
+      nextRecordsUrl: "/services/data/v60.0/query/01gxx-2000",
+    });
+    const instance = await buildInstance();
+    const page = await instance.queryPage("SELECT Id FROM Knowledge__kav WHERE PublishStatus = 'Online'");
+    expect(page.records).toHaveLength(1);
+    expect(page.done).toBe(false);
+    expect(page.nextRecordsUrl).toBe("/services/data/v60.0/query/01gxx-2000");
+  });
+
+  it("queryMorePage continues from the locator", async () => {
+    mockJsforceQueryMore.mockResolvedValueOnce({
+      records: [{ Id: "ka0x002" }],
+      done: true,
+      nextRecordsUrl: null,
+    });
+    const instance = await buildInstance();
+    const page = await instance.queryMorePage("/services/data/v60.0/query/01gxx-2000");
+    expect(page.records).toEqual([{ Id: "ka0x002" }]);
+    expect(page.done).toBe(true);
+    expect(mockJsforceQueryMore).toHaveBeenCalledWith("/services/data/v60.0/query/01gxx-2000");
+  });
+
+  it("treats a done:false response with no locator as done (cannot continue)", async () => {
+    mockJsforceQuery.mockResolvedValueOnce({ records: [], done: false });
+    const instance = await buildInstance();
+    const page = await instance.queryPage("SELECT Id FROM Knowledge__kav WHERE PublishStatus = 'Online'");
+    expect(page.done).toBe(true);
+    expect(page.nextRecordsUrl).toBeNull();
+  });
+
+  it("describeObject exposes the object's field metadata over the OAuth session", async () => {
+    mockDescribe.mockResolvedValueOnce({
+      fields: [{ name: "Id", type: "id" }, { name: "Body__c", type: "textarea", custom: true }],
+    });
+    const instance = await buildInstance();
+    const described = await instance.describeObject("Knowledge__kav");
+    expect(described.fields.map((f) => f.name)).toEqual(["Id", "Body__c"]);
+    expect(mockDescribe).toHaveBeenCalledWith("Knowledge__kav");
+  });
+
+  it("refresh-retries a paged query on INVALID_SESSION_ID like query()", async () => {
+    mockJsforceQuery
+      .mockRejectedValueOnce(new Error("INVALID_SESSION_ID: Session expired or invalid"))
+      .mockResolvedValueOnce({ records: [{ Id: "ka0x003" }], done: true });
+    const instance = await buildInstance();
+    const page = await instance.queryPage("SELECT Id FROM Knowledge__kav WHERE PublishStatus = 'Online'");
+    expect(page.records).toEqual([{ Id: "ka0x003" }]);
+    expect(mockRefreshSalesforceToken).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/lib/integrations/salesforce/lazy-builder.ts
+++ b/packages/api/src/lib/integrations/salesforce/lazy-builder.ts
@@ -72,12 +72,42 @@ export interface SalesforceQueryResult {
 }
 
 /**
+ * One raw SOQL result batch (#4397). Unlike {@link SalesforceQueryResult},
+ * this keeps jsforce's paging bookkeeping: Salesforce returns at most one
+ * batch (~2000 records, fewer for wide rows) per request, and the rest hangs
+ * off `nextRecordsUrl` via `queryMore`. `query()` above silently truncates at
+ * the first batch — fine for the agent tool (auto-LIMITed), unsound for a
+ * full enumeration like the Knowledge sync reconciliation crawl.
+ */
+export interface SalesforceQueryPage {
+  readonly records: readonly Record<string, unknown>[];
+  readonly done: boolean;
+  readonly nextRecordsUrl: string | null;
+}
+
+/** One object's `describe()` metadata — only the field list is exposed. */
+export interface SalesforceObjectDescribe {
+  readonly fields: readonly Record<string, unknown>[];
+}
+
+/**
  * Public shape exposed by the lazy-built Salesforce plugin instance.
  * Agent tooling calls `query` with a SOQL statement; the wrapper
  * handles session-expired retries via {@link refreshSalesforceToken}.
  */
 export interface SalesforcePluginInstance extends PluginLike {
   query(soql: string, timeoutMs?: number): Promise<SalesforceQueryResult>;
+  /**
+   * Raw paged SOQL (#4397, Knowledge sync connector): one batch per call with
+   * jsforce's `done`/`nextRecordsUrl` bookkeeping intact, continued via
+   * {@link queryMorePage}. Refresh-retried like `query`. Callers that need the
+   * FULL result set (sync crawls) use this pair; `query` is the one-shot,
+   * first-batch-only convenience for the auto-LIMITed agent tool.
+   */
+  queryPage(soql: string, timeoutMs?: number): Promise<SalesforceQueryPage>;
+  queryMorePage(nextRecordsUrl: string, timeoutMs?: number): Promise<SalesforceQueryPage>;
+  /** One object's field metadata over the OAuth session (refresh-retried). */
+  describeObject(objectName: string): Promise<SalesforceObjectDescribe>;
   /**
    * Introspection as a capability of the live OAuth connection (#3667, ADR-0017
    * universalization). `listObjects`/`profile` run over the SAME OAuth `jsforce`
@@ -122,11 +152,20 @@ function readInstanceUrl(config: Record<string, unknown>): string | null {
  * itself is an untyped optional peer dep loaded via {@link requireJsforce}).
  */
 interface JsforceConnection {
-  query(soql: string): Promise<{ records?: Record<string, unknown>[] }>;
+  query(soql: string): Promise<JsforceQueryResponse>;
+  /** Continue a paged SOQL result from its `nextRecordsUrl` locator (#4397). */
+  queryMore(nextRecordsUrl: string): Promise<JsforceQueryResponse>;
   // Describe surface used by the OAuth introspection (#3667). jsforce is an
   // untyped optional peer dep, so these are structural.
   describeGlobal(): Promise<{ sobjects?: ReadonlyArray<{ name?: string; queryable?: boolean }> }>;
   describe(objectName: string): Promise<{ fields?: readonly Record<string, unknown>[] }>;
+}
+
+/** jsforce's raw query/queryMore response — untrusted, every field optional. */
+interface JsforceQueryResponse {
+  readonly records?: Record<string, unknown>[];
+  readonly done?: boolean;
+  readonly nextRecordsUrl?: string | null;
 }
 
 /**
@@ -145,6 +184,34 @@ function requireJsforce(): any {
       "Salesforce integration requires the jsforce package. Install with: bun add jsforce",
     );
   }
+}
+
+/** Bound a jsforce call with the same timeout `query` has always applied. */
+async function raceTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error("Salesforce query timed out")), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer!));
+}
+
+/**
+ * Normalize jsforce's raw response into a {@link SalesforceQueryPage}. A
+ * response that claims more pages but carries no locator is treated as done —
+ * the caller can't continue it, and looping on a missing locator would spin.
+ */
+function toQueryPage(result: JsforceQueryResponse): SalesforceQueryPage {
+  const nextRecordsUrl =
+    typeof result.nextRecordsUrl === "string" && result.nextRecordsUrl !== ""
+      ? result.nextRecordsUrl
+      : null;
+  return {
+    records: result.records ?? [],
+    done: result.done !== false || nextRecordsUrl === null,
+    nextRecordsUrl,
+  };
 }
 
 function isSessionExpiredError(err: unknown): boolean {
@@ -282,16 +349,7 @@ export function createSalesforceLazyBuilder(
 
       async query(soql: string, timeoutMs = 30_000): Promise<SalesforceQueryResult> {
         return withRetry(async (c) => {
-          let timer: ReturnType<typeof setTimeout>;
-          const result = await Promise.race([
-            c.query(soql),
-            new Promise<never>((_, reject) => {
-              timer = setTimeout(
-                () => reject(new Error("Salesforce query timed out")),
-                timeoutMs,
-              );
-            }),
-          ]).finally(() => clearTimeout(timer!));
+          const result = await raceTimeout(c.query(soql), timeoutMs);
 
           const records = result.records ?? [];
           if (records.length === 0) return { columns: [], rows: [] };
@@ -302,6 +360,26 @@ export function createSalesforceLazyBuilder(
             return out;
           });
           return { columns, rows };
+        });
+      },
+
+      async queryPage(soql: string, timeoutMs = 30_000): Promise<SalesforceQueryPage> {
+        return withRetry(async (c) => toQueryPage(await raceTimeout(c.query(soql), timeoutMs)));
+      },
+
+      async queryMorePage(
+        nextRecordsUrl: string,
+        timeoutMs = 30_000,
+      ): Promise<SalesforceQueryPage> {
+        return withRetry(async (c) =>
+          toQueryPage(await raceTimeout(c.queryMore(nextRecordsUrl), timeoutMs)),
+        );
+      },
+
+      async describeObject(objectName: string): Promise<SalesforceObjectDescribe> {
+        return withRetry(async (c) => {
+          const described = await c.describe(objectName);
+          return { fields: described.fields ?? [] };
         });
       },
 

--- a/packages/api/src/lib/integrations/salesforce/lazy-builder.ts
+++ b/packages/api/src/lib/integrations/salesforce/lazy-builder.ts
@@ -199,17 +199,26 @@ async function raceTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
 
 /**
  * Normalize jsforce's raw response into a {@link SalesforceQueryPage}. A
- * response that claims more pages but carries no locator is treated as done —
- * the caller can't continue it, and looping on a missing locator would spin.
+ * response that claims more pages (`done: false`) but carries no locator is a
+ * truncation the caller cannot continue — it THROWS rather than masquerade as
+ * a complete page: a sync crawl that trusted it would feed a partial set to
+ * subtractive archiving. After that guard, locator presence is authoritative
+ * (a contradictory `done: true` + locator is continued — the safe direction,
+ * bounded by the caller's page cap).
  */
 function toQueryPage(result: JsforceQueryResponse): SalesforceQueryPage {
   const nextRecordsUrl =
     typeof result.nextRecordsUrl === "string" && result.nextRecordsUrl !== ""
       ? result.nextRecordsUrl
       : null;
+  if (result.done === false && nextRecordsUrl === null) {
+    throw new Error(
+      "Salesforce returned done:false with no nextRecordsUrl — the paged query cannot be continued; refusing to treat a truncated result as complete.",
+    );
+  }
   return {
     records: result.records ?? [],
-    done: result.done !== false || nextRecordsUrl === null,
+    done: nextRecordsUrl === null,
     nextRecordsUrl,
   };
 }
@@ -378,7 +387,9 @@ export function createSalesforceLazyBuilder(
 
       async describeObject(objectName: string): Promise<SalesforceObjectDescribe> {
         return withRetry(async (c) => {
-          const described = await c.describe(objectName);
+          // Bounded like the query paths — a hung describe would otherwise
+          // wedge the install request and the sync fiber indefinitely.
+          const described = await raceTimeout(c.describe(objectName), 30_000);
           return { fields: described.fields ?? [] };
         });
       },

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -40,6 +40,7 @@ import { CONFLUENCE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/insta
 import { CONFLUENCE_DC_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-datacenter-form-handler";
 import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/gitbook-form-handler";
 import { ZENDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/zendesk-form-handler";
+import { SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/salesforce-knowledge-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
   CONNECTOR_SYNC_STATE_SELECT_SQL,
@@ -590,6 +591,31 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // The token is NEVER persisted in the install config.
     expect(row.rows[0]?.config).not.toHaveProperty("api_token");
     expect(row.rows[0]?.config).toMatchObject({ brand_id: "42", brand_subdomain: "acme" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a Salesforce Knowledge connector collection against the live schema (#4397)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:salesforce-knowledge', 'Knowledge Base (Salesforce Knowledge)', 'salesforce-knowledge', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL, [
+      "row-sf-knowledge",
+      ws,
+      "catalog:salesforce-knowledge",
+      "sf-kb",
+      JSON.stringify({ article_object: "Knowledge__kav", channel: "pkb" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-sf-knowledge");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'sf-kb'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // Credential-less by design: the config carries scope only — the OAuth
+    // install (catalog:salesforce) owns the token; nothing secret lands here.
+    expect(row.rows[0]?.config).toEqual({ article_object: "Knowledge__kav", channel: "pkb" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/client.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for the Salesforce Knowledge vendor client (#4397) — driven entirely
+ * through an injected fixture {@link SalesforceKnowledgeApi}; NO test touches
+ * a live org. Covers describe-driven body-field discovery, the EXPLICIT
+ * PublishStatus filters (the v47+ Draft+Archived leak guard), queryMore
+ * paging + the anti-runaway page bound, the indexed SystemModstamp
+ * incremental walk (non-Online / out-of-channel rows advance the mark but
+ * emit nothing), channel visibility, malformed-row coverage flagging, and
+ * REQUEST_LIMIT_EXCEEDED → ConnectorRateLimitError governor mapping.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createSalesforceKnowledgeVendorClient,
+  type SalesforceKnowledgeApi,
+} from "@atlas/api/lib/knowledge/salesforce/client";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import type { SalesforceKnowledgeChannel } from "@atlas/api/lib/knowledge/salesforce/config";
+
+const INSTANCE_URL = "https://acme.my.salesforce.com";
+
+function field(name: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { name, type: "string", custom: false, extraTypeInfo: null, ...overrides };
+}
+
+/** A realistic Knowledge__kav describe: standard fields + two custom bodies. */
+const DEFAULT_FIELDS: Record<string, unknown>[] = [
+  field("Id", { type: "id" }),
+  field("KnowledgeArticleId", { type: "reference" }),
+  field("ArticleNumber"),
+  field("Title"),
+  field("Language", { type: "picklist" }),
+  field("PublishStatus", { type: "picklist" }),
+  field("SystemModstamp", { type: "datetime" }),
+  field("Summary", { type: "textarea" }), // standard textarea — NOT a body field
+  field("UrlName"),
+  field("VersionNumber", { type: "int" }),
+  field("IsMasterLanguage", { type: "boolean" }),
+  field("IsVisibleInApp", { type: "boolean" }),
+  field("IsVisibleInPkb", { type: "boolean" }),
+  field("IsVisibleInCsp", { type: "boolean" }),
+  field("IsVisibleInPrm", { type: "boolean" }),
+  field("Body__c", { type: "textarea", custom: true, extraTypeInfo: "richtextarea" }),
+  field("Details__c", { type: "textarea", custom: true, extraTypeInfo: "plaintextarea" }),
+];
+
+function row(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    Id: "ka0x001",
+    KnowledgeArticleId: "kA0x001",
+    ArticleNumber: "000001001",
+    Title: "Getting Started",
+    Language: "en_US",
+    PublishStatus: "Online",
+    // Salesforce's native offset format — normalization must canonicalize it.
+    SystemModstamp: "2026-07-01T10:00:00.000+0000",
+    Summary: "How to get started.",
+    VersionNumber: 3,
+    IsMasterLanguage: true,
+    IsVisibleInPkb: true,
+    Body__c: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    ...overrides,
+  };
+}
+
+interface FixturePage {
+  records: Record<string, unknown>[];
+  done?: boolean;
+  nextRecordsUrl?: string | null;
+}
+
+interface FixtureState {
+  soql: string[];
+  describeCalls: string[];
+  queryMoreCalls: string[];
+}
+
+function makeApi(opts: {
+  fields?: Record<string, unknown>[];
+  /** Batches: queryPage serves [0]; each queryMorePage serves the next. */
+  pages?: FixturePage[];
+  describeError?: unknown;
+  queryError?: unknown;
+  queryMoreError?: unknown;
+}): { api: SalesforceKnowledgeApi; state: FixtureState } {
+  const state: FixtureState = { soql: [], describeCalls: [], queryMoreCalls: [] };
+  const pages = opts.pages ?? [{ records: [row()], done: true, nextRecordsUrl: null }];
+  let served = 0;
+  const pageAt = (i: number) => {
+    const page = pages[Math.min(i, pages.length - 1)];
+    return {
+      records: page.records,
+      done: page.done !== false,
+      nextRecordsUrl: page.nextRecordsUrl ?? null,
+    };
+  };
+  const api: SalesforceKnowledgeApi = {
+    async describeObject(objectName) {
+      state.describeCalls.push(objectName);
+      if (opts.describeError !== undefined) throw opts.describeError;
+      return { fields: opts.fields ?? DEFAULT_FIELDS };
+    },
+    async queryPage(soql) {
+      state.soql.push(soql);
+      if (opts.queryError !== undefined) throw opts.queryError;
+      served = 1;
+      return pageAt(0);
+    },
+    async queryMorePage(nextRecordsUrl) {
+      state.queryMoreCalls.push(nextRecordsUrl);
+      if (opts.queryMoreError !== undefined) throw opts.queryMoreError;
+      return pageAt(served++);
+    },
+  };
+  return { api, state };
+}
+
+function client(
+  opts: Parameters<typeof makeApi>[0] = {},
+  config: { channel?: SalesforceKnowledgeChannel | null; articleObject?: string } = {},
+) {
+  const { api, state } = makeApi(opts);
+  const c = createSalesforceKnowledgeVendorClient(api, {
+    collectionSlug: "sf-kb",
+    articleObject: config.articleObject ?? "Knowledge__kav",
+    channel: config.channel ?? null,
+    instanceUrl: INSTANCE_URL,
+  });
+  return { c, state };
+}
+
+describe("fetchAll (reconciliation)", () => {
+  it("emits one document per Online version row with the max SystemModstamp as the mark", async () => {
+    const { c, state } = client({
+      pages: [
+        {
+          records: [
+            row(),
+            row({
+              Id: "ka0x002",
+              ArticleNumber: "000001002",
+              Title: "Billing FAQ",
+              SystemModstamp: "2026-07-05T08:00:00.000+0000",
+              Body__c: "<p>Billing answers for common questions live here.</p>",
+            }),
+          ],
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "sf-kb/en-us/getting-started-000001001.md",
+      "sf-kb/en-us/billing-faq-000001002.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(false);
+    expect(changes.cursor).toBeNull();
+    // Explicit published-only filter — the v47+ Draft+Archived leak guard.
+    expect(state.soql[0]).toContain("PublishStatus = 'Online'");
+    expect(state.soql[0]).toContain("FROM Knowledge__kav");
+    // Discovered custom body fields are selected; no channel clause configured.
+    expect(state.soql[0]).toContain("Body__c");
+    expect(state.soql[0]).toContain("Details__c");
+    expect(state.soql[0]).not.toContain("IsVisibleInPkb = true");
+  });
+
+  it("adds the channel visibility clause when a channel is configured", async () => {
+    const { c, state } = client({}, { channel: "pkb" });
+    await c.fetchAll();
+    expect(state.soql[0]).toContain("PublishStatus = 'Online' AND IsVisibleInPkb = true");
+  });
+
+  it("walks queryMore batches to exhaustion", async () => {
+    const { c, state } = client({
+      pages: [
+        {
+          records: [row()],
+          done: false,
+          nextRecordsUrl: "/services/data/v60.0/query/01gxx-2000",
+        },
+        {
+          records: [row({ Id: "ka0x002", ArticleNumber: "000001002", Title: "Second" })],
+          done: true,
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(2);
+    expect(state.queryMoreCalls).toEqual(["/services/data/v60.0/query/01gxx-2000"]);
+  });
+
+  it("fails loud on a locator that never terminates (page bound)", async () => {
+    const { c } = client({
+      pages: [{ records: [], done: false, nextRecordsUrl: "/services/data/v60.0/query/stuck" }],
+    });
+    await expect(c.fetchAll()).rejects.toThrow(/did not terminate/i);
+  });
+
+  it("counts a malformed row and flags coverage incomplete", async () => {
+    const { c } = client({
+      pages: [
+        {
+          records: [
+            row(),
+            row({ Id: "ka0x002", ArticleNumber: null }), // malformed — no number
+          ],
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("converts rich bodies via the shared converter and passes plain bodies through", async () => {
+    const { c } = client({
+      pages: [
+        {
+          records: [
+            row({
+              Body__c: "<p>Rich <strong>body</strong> paragraph with enough prose.</p>",
+              Details__c: "Plain details paragraph.\n\nWith a second block of text.",
+            }),
+          ],
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    const content = changes.documents[0].content;
+    expect(content).toContain("Rich **body** paragraph");
+    expect(content).toContain("Plain details paragraph.");
+    expect(content).toContain("With a second block of text.");
+  });
+
+  it("never selects a describe field whose name fails the SOQL identifier pattern", async () => {
+    const { c, state } = client({
+      fields: [
+        ...DEFAULT_FIELDS,
+        field("Weird Name__c", { type: "textarea", custom: true, extraTypeInfo: "richtextarea" }),
+      ],
+    });
+    await c.fetchAll();
+    expect(state.soql[0]).not.toContain("Weird Name__c");
+  });
+});
+
+describe("fetchChanges (incremental)", () => {
+  it("walks SystemModstamp with the explicit three-status filter (seconds precision)", async () => {
+    const { c, state } = client();
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(1);
+    // Unquoted SOQL datetime literal, milliseconds stripped.
+    expect(state.soql[0]).toContain("SystemModstamp > 2026-07-06T00:00:00Z");
+    expect(state.soql[0]).toContain("PublishStatus IN ('Online', 'Draft', 'Archived')");
+    expect(state.soql[0]).not.toContain("PublishStatus = 'Online'");
+  });
+
+  it("advances the mark for a version that flipped to Archived but emits nothing", async () => {
+    const { c } = client({
+      pages: [
+        {
+          records: [
+            row({ PublishStatus: "Archived", SystemModstamp: "2026-07-07T09:00:00.000+0000" }),
+          ],
+        },
+      ],
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(0);
+    expect(changes.highWaterMark).toBe("2026-07-07T09:00:00.000Z");
+  });
+
+  it("skips an out-of-channel row per config but still advances the mark", async () => {
+    const { c } = client(
+      { pages: [{ records: [row({ IsVisibleInPkb: false })] }] },
+      { channel: "pkb" },
+    );
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(0);
+    expect(changes.highWaterMark).toBe("2026-07-01T10:00:00.000Z");
+  });
+
+  it("serves a null since as a full crawl (defensive)", async () => {
+    const { c, state } = client();
+    const changes = await c.fetchChanges({ since: null, cursor: null });
+    expect(changes.documents).toHaveLength(1);
+    expect(state.soql[0]).toContain("PublishStatus = 'Online'");
+    expect(state.soql[0]).not.toContain("SystemModstamp >");
+  });
+
+  it("fails loud on an unparseable since instant", async () => {
+    const { c } = client();
+    await expect(c.fetchChanges({ since: "not-a-date", cursor: null })).rejects.toThrow(
+      /unparseable since instant/i,
+    );
+  });
+
+  it("returns an empty quiet cycle when nothing changed", async () => {
+    const { c } = client({ pages: [{ records: [], done: true }] });
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(0);
+    expect(changes.highWaterMark).toBeNull();
+  });
+});
+
+describe("describe-driven shape resolution", () => {
+  it("fails actionably when the object lacks the article-version fields", async () => {
+    const { c } = client({ fields: [field("Id"), field("Name")] });
+    await expect(c.fetchAll()).rejects.toThrow(/missing required article-version fields/i);
+  });
+
+  it("fails actionably when the configured channel's visibility field is absent", async () => {
+    const { c } = client(
+      { fields: DEFAULT_FIELDS.filter((f) => f.name !== "IsVisibleInPrm") },
+      { channel: "prm" },
+    );
+    await expect(c.fetchAll()).rejects.toThrow(/has no IsVisibleInPrm field/i);
+  });
+
+  it("wraps a describe failure with actionable Knowledge-enablement context", async () => {
+    const { c } = client({ describeError: new Error("INVALID_TYPE: sObject type not supported") });
+    await expect(c.fetchAll()).rejects.toThrow(/could not describe Knowledge__kav/i);
+  });
+
+  it("tolerates an org without the optional standard fields", async () => {
+    const { c, state } = client({
+      fields: DEFAULT_FIELDS.filter(
+        (f) => !["Summary", "UrlName", "VersionNumber", "IsMasterLanguage"].includes(String(f.name)),
+      ),
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(state.soql[0]).not.toContain("Summary");
+  });
+});
+
+describe("governor-limit mapping", () => {
+  it("maps a REQUEST_LIMIT_EXCEEDED message to ConnectorRateLimitError", async () => {
+    const { c } = client({
+      queryError: new Error("REQUEST_LIMIT_EXCEEDED: TotalRequests Limit exceeded."),
+    });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+  });
+
+  it("maps a jsforce errorCode REQUEST_LIMIT_EXCEEDED to ConnectorRateLimitError", async () => {
+    const limitError = Object.assign(new Error("TotalRequests Limit exceeded."), {
+      errorCode: "REQUEST_LIMIT_EXCEEDED",
+    });
+    const { c } = client({ queryMoreError: limitError, pages: [
+      { records: [row()], done: false, nextRecordsUrl: "/services/data/v60.0/query/01gxx-2000" },
+    ] });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+  });
+
+  it("wraps other query failures with actionable context (original as cause)", async () => {
+    const { c } = client({ queryError: new Error("MALFORMED_QUERY: unexpected token") });
+    await expect(c.fetchAll()).rejects.toThrow(/Salesforce Knowledge query .* failed/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/client.test.ts
@@ -2,7 +2,7 @@
  * Tests for the Salesforce Knowledge vendor client (#4397) — driven entirely
  * through an injected fixture {@link SalesforceKnowledgeApi}; NO test touches
  * a live org. Covers describe-driven body-field discovery, the EXPLICIT
- * PublishStatus filters (the v47+ Draft+Archived leak guard), queryMore
+ * PublishStatus filters (the unfiltered-query Draft+Archived leak guard), queryMore
  * paging + the anti-runaway page bound, the indexed SystemModstamp
  * incremental walk (non-Online / out-of-channel rows advance the mark but
  * emit nothing), channel visibility, malformed-row coverage flagging, and
@@ -15,6 +15,7 @@ import {
   type SalesforceKnowledgeApi,
 } from "@atlas/api/lib/knowledge/salesforce/client";
 import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
 import type { SalesforceKnowledgeChannel } from "@atlas/api/lib/knowledge/salesforce/config";
 
 const INSTANCE_URL = "https://acme.my.salesforce.com";
@@ -155,7 +156,7 @@ describe("fetchAll (reconciliation)", () => {
     expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
     expect(changes.coverageIncomplete).toBe(false);
     expect(changes.cursor).toBeNull();
-    // Explicit published-only filter — the v47+ Draft+Archived leak guard.
+    // Explicit published-only filter — the unfiltered-query Draft+Archived leak guard.
     expect(state.soql[0]).toContain("PublishStatus = 'Online'");
     expect(state.soql[0]).toContain("FROM Knowledge__kav");
     // Discovered custom body fields are selected; no channel clause configured.
@@ -210,6 +211,46 @@ describe("fetchAll (reconciliation)", () => {
     const changes = await c.fetchAll();
     expect(changes.documents).toHaveLength(1);
     expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("a malformed row can NEVER advance the high-water mark past itself", async () => {
+    // Load-bearing ordering: if the malformed row's (newer) SystemModstamp
+    // advanced the mark, the fixed row would never be refetched incrementally.
+    const { c } = client({
+      pages: [
+        {
+          records: [
+            row(),
+            row({
+              Id: "ka0x002",
+              ArticleNumber: null, // malformed — but carries the newest stamp
+              SystemModstamp: "2026-07-08T12:00:00.000+0000",
+            }),
+          ],
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.highWaterMark).toBe("2026-07-01T10:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("describes the article object once per client across both cadences (shape cache)", async () => {
+    const { c, state } = client();
+    await c.fetchAll();
+    await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(state.describeCalls).toEqual(["Knowledge__kav"]);
+  });
+
+  it("selects at most the body-field cap, warning-counted rather than silent", async () => {
+    const manyBodies = Array.from({ length: 25 }, (_, i) =>
+      field(`Body${i}__c`, { type: "textarea", custom: true, extraTypeInfo: "richtextarea" }),
+    );
+    const { c, state } = client({ fields: [...DEFAULT_FIELDS, ...manyBodies] });
+    await c.fetchAll();
+    // DEFAULT_FIELDS already carries 2 custom bodies → 18 more fit the cap of 20.
+    expect(state.soql[0]).toContain("Body17__c");
+    expect(state.soql[0]).not.toContain("Body18__c");
   });
 
   it("converts rich bodies via the shared converter and passes plain bodies through", async () => {
@@ -363,5 +404,20 @@ describe("governor-limit mapping", () => {
   it("wraps other query failures with actionable context (original as cause)", async () => {
     const { c } = client({ queryError: new Error("MALFORMED_QUERY: unexpected token") });
     await expect(c.fetchAll()).rejects.toThrow(/Salesforce Knowledge query .* failed/i);
+  });
+
+  it("passes a mid-crawl reconnect-required error through UNWRAPPED (its message is the actionable one)", async () => {
+    const reconnect = new IntegrationReconnectRequiredError({
+      message: "Salesforce install needs to be reconnected.",
+      workspaceId: "org-1",
+      platform: "salesforce",
+      upstreamError: "invalid_grant",
+    });
+    const { c } = client({ queryError: reconnect });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBe(reconnect);
   });
 });

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/connector.test.ts
@@ -37,7 +37,7 @@ function fakeInstance(overrides: Partial<SalesforcePluginInstance> = {}): Salesf
     queryMorePage: async () => ({ records: [], done: true, nextRecordsUrl: null }),
     describeObject: async () => ({ fields: [] }),
     listObjects: async () => [],
-    profile: async () => ({ profiles: [] }) as never,
+    profile: async () => ({ profiles: [], errors: [] }),
     ...overrides,
   };
 }
@@ -76,6 +76,14 @@ describe("createSalesforceKnowledgeConnector", () => {
       loader: loaderReturning(fakeInstance()),
     });
     const client = await connector.createClient(ctx({}));
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("builds the default scope from a null config (out-of-band-edited row)", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(fakeInstance()),
+    });
+    const client = await connector.createClient(ctx(null));
     expect(typeof client.fetchAll).toBe("function");
   });
 

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/connector.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for the Salesforce Knowledge KnowledgeSyncConnector (#4397) — the
+ * createClient factory contract: parse the stored scope config, resolve the
+ * workspace's EXISTING Salesforce OAuth install through the (injected) lazy
+ * loader with POSITIVE error classification, and bind it into a vendor
+ * client. No credential store is involved — that is the point of the vendor.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createSalesforceKnowledgeConnector,
+  instanceUrlOf,
+  type SalesforceInstanceLoader,
+} from "@atlas/api/lib/knowledge/salesforce/connector";
+import {
+  SALESFORCE_KNOWLEDGE_CATALOG_ID,
+  SALESFORCE_KNOWLEDGE_VENDOR,
+} from "@atlas/api/lib/knowledge/salesforce/config";
+import {
+  LazyPluginBuilderMissingError,
+  LazyPluginInstallNotFoundError,
+} from "@atlas/api/lib/plugins/lazy-loader";
+import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import type { SalesforcePluginInstance } from "@atlas/api/lib/integrations/salesforce/lazy-builder";
+
+const WSID = "org-1";
+
+function fakeInstance(overrides: Partial<SalesforcePluginInstance> = {}): SalesforcePluginInstance {
+  return {
+    id: `salesforce:${WSID}`,
+    types: ["datasource"] as const,
+    version: "0.1.0",
+    name: "Salesforce",
+    config: { instanceUrl: "https://acme.my.salesforce.com", scope: "api" },
+    query: async () => ({ columns: [], rows: [] }),
+    queryPage: async () => ({ records: [], done: true, nextRecordsUrl: null }),
+    queryMorePage: async () => ({ records: [], done: true, nextRecordsUrl: null }),
+    describeObject: async () => ({ fields: [] }),
+    listObjects: async () => [],
+    profile: async () => ({ profiles: [] }) as never,
+    ...overrides,
+  };
+}
+
+function loaderReturning(result: SalesforcePluginInstance | (() => never)): SalesforceInstanceLoader {
+  return {
+    async getOrInstantiate(_workspaceId: string, _catalogId: string) {
+      if (typeof result === "function") return result();
+      return result;
+    },
+  };
+}
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: WSID, collectionSlug: "sf-kb", config };
+}
+
+describe("createSalesforceKnowledgeConnector", () => {
+  it("advertises the salesforce-knowledge catalog id and the salesforce vendor slug", () => {
+    const connector = createSalesforceKnowledgeConnector();
+    expect(connector.catalogId).toBe(SALESFORCE_KNOWLEDGE_CATALOG_ID);
+    expect(connector.vendor).toBe(SALESFORCE_KNOWLEDGE_VENDOR);
+  });
+
+  it("builds a vendor client from a valid config + the reused OAuth instance", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(fakeInstance()),
+    });
+    const client = await connector.createClient(ctx({ article_object: "Knowledge__kav" }));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("defaults an absent article_object to Knowledge__kav and accepts an absent channel", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(fakeInstance()),
+    });
+    const client = await connector.createClient(ctx({}));
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error for a non-__kav article object", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(fakeInstance()),
+    });
+    await expect(
+      connector.createClient(ctx({ article_object: "Account" })),
+    ).rejects.toThrow(/invalid Salesforce article object/i);
+  });
+
+  it("throws an actionable error for an unknown channel", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(fakeInstance()),
+    });
+    await expect(connector.createClient(ctx({ channel: "twitter" }))).rejects.toThrow(
+      /invalid Salesforce Knowledge channel/i,
+    );
+  });
+
+  it("maps a missing Salesforce install to a connect-first message", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(() => {
+        throw new LazyPluginInstallNotFoundError(WSID, "catalog:salesforce");
+      }),
+    });
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(
+      /Salesforce is not connected — connect it under Admin → Integrations/i,
+    );
+  });
+
+  it("maps a reconnect-required install to a Reconnect message", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(() => {
+        throw new IntegrationReconnectRequiredError({
+          message: "refresh failed permanently",
+          workspaceId: WSID,
+          platform: "salesforce",
+          upstreamError: "invalid_grant",
+        });
+      }),
+    });
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(/click Reconnect/i);
+  });
+
+  it("maps a missing builder to the operator-facing env message", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(() => {
+        throw new LazyPluginBuilderMissingError("catalog:salesforce");
+      }),
+    });
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(/SALESFORCE_CLIENT_ID/);
+  });
+
+  it("propagates an unknown instantiation failure loudly (decrypt errors stay actionable)", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(() => {
+        throw new Error("failed to decrypt integration_credentials — key rotated");
+      }),
+    });
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(/failed to decrypt/i);
+  });
+
+  it("rejects an instance that lacks the paged query/describe surface", async () => {
+    const partial = fakeInstance();
+    // Simulate a custom builder registered for catalog:salesforce without the
+    // #4397 surface.
+    delete (partial as Record<string, unknown>).queryPage;
+    const connector = createSalesforceKnowledgeConnector({ loader: loaderReturning(partial) });
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(
+      /does not expose the paged query\/describe surface/i,
+    );
+  });
+
+  it("rejects an instance that carries no instance URL", async () => {
+    const connector = createSalesforceKnowledgeConnector({
+      loader: loaderReturning(fakeInstance({ config: { scope: "api" } })),
+    });
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(/no instance URL/i);
+  });
+});
+
+describe("instanceUrlOf", () => {
+  it("reads the instance URL from the plugin instance config", () => {
+    expect(instanceUrlOf(fakeInstance())).toBe("https://acme.my.salesforce.com");
+  });
+  it("throws actionably when the config is not an object", () => {
+    expect(() => instanceUrlOf(fakeInstance({ config: undefined }))).toThrow(/no instance URL/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/documents.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the Salesforce article version → ConnectorDocument assembly
+ * (#4397): the per-locale archive path
+ * (`<language>/<title-slug>-<article-number>.md`, prefixed), the `atlas:`
+ * provenance block (connector + article id + article number + version id +
+ * version + locale + updated_at — the AC's provenance fields), rich/plain
+ * body composition through the shared converter, cross-link absolutization
+ * against the instance URL, and the contentless skip. Pure — no I/O.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleSalesforceKnowledgeDocuments,
+  slugifySegment,
+  type SalesforceKnowledgeArticle,
+} from "@atlas/api/lib/knowledge/salesforce/documents";
+
+const OPTS = { collectionSlug: "sf-kb", instanceUrl: "https://acme.my.salesforce.com" };
+
+function article(
+  overrides: Partial<SalesforceKnowledgeArticle> = {},
+): SalesforceKnowledgeArticle {
+  return {
+    versionId: "ka0x001",
+    knowledgeArticleId: "kA0x001",
+    articleNumber: "000001001",
+    title: "Getting Started",
+    summary: "How to get started with the product.",
+    language: "en_us",
+    versionNumber: "3",
+    isMasterLanguage: true,
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    url: "https://acme.my.salesforce.com/lightning/r/Knowledge__kav/ka0x001/view",
+    bodyParts: [
+      {
+        field: "Body__c",
+        value: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+        rich: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("slugifySegment", () => {
+  it("lowercases and dashes non-alphanumerics (NFKD, the tier convention)", () => {
+    expect(slugifySegment("Setup & Testing Guide!", "x")).toBe("setup-testing-guide");
+    expect(slugifySegment("en_US", "locale")).toBe("en-us");
+  });
+  it("falls back when the value has no usable characters", () => {
+    expect(slugifySegment("你好", "article")).toBe("article");
+  });
+});
+
+describe("assembleSalesforceKnowledgeDocuments", () => {
+  it("emits one document per version at <prefix>/<language>/<slug>-<number>.md", () => {
+    const result = assembleSalesforceKnowledgeDocuments(
+      [
+        article(),
+        article({
+          versionId: "ka0x002",
+          language: "de",
+          title: "Erste Schritte",
+          isMasterLanguage: false,
+        }),
+      ],
+      OPTS,
+    );
+    // Translations share ArticleNumber across Language — each locale its own path.
+    expect(result.documents.map((d) => d.path)).toEqual([
+      "sf-kb/en-us/getting-started-000001001.md",
+      "sf-kb/de/erste-schritte-000001001.md",
+    ]);
+  });
+
+  it("stamps frontmatter provenance and the atlas: extension block (article id + version + locale)", () => {
+    const { documents } = assembleSalesforceKnowledgeDocuments([article()], OPTS);
+    const content = documents[0].content;
+    expect(content).toContain('title: "Getting Started"');
+    expect(content).toContain(
+      'resource: "https://acme.my.salesforce.com/lightning/r/Knowledge__kav/ka0x001/view"',
+    );
+    expect(content).toContain('timestamp: "2026-07-01T10:00:00.000Z"');
+    expect(content).toContain("atlas:");
+    expect(content).toContain('connector: "salesforce"');
+    expect(content).toContain('article_id: "kA0x001"');
+    expect(content).toContain('article_number: "000001001"');
+    expect(content).toContain('version_id: "ka0x001"');
+    expect(content).toContain('version: "3"');
+    expect(content).toContain('locale: "en_us"');
+    expect(content).toContain('is_master_language: "true"');
+    expect(content).toContain('updated_at: "2026-07-01T10:00:00.000Z"');
+    // No provenance tags — `tags` is a mirrored change-comparison column, so
+    // stamping one would re-draft every already-ingested document.
+    expect(content).not.toContain("tags:");
+  });
+
+  it("omits version/is_master_language when the org's object lacks them", () => {
+    const { documents } = assembleSalesforceKnowledgeDocuments(
+      [article({ versionNumber: null, isMasterLanguage: null })],
+      OPTS,
+    );
+    expect(documents[0].content).not.toContain("version:");
+    expect(documents[0].content).not.toContain("is_master_language:");
+  });
+
+  it("leads with the summary and keeps plain body parts verbatim after rich ones", () => {
+    const { documents } = assembleSalesforceKnowledgeDocuments(
+      [
+        article({
+          bodyParts: [
+            { field: "Body__c", value: "<p>Rich part with plenty of prose.</p>", rich: true },
+            {
+              field: "Details__c",
+              value: "Plain part, first block.\n\nPlain part, second block.",
+              rich: false,
+            },
+          ],
+        }),
+      ],
+      OPTS,
+    );
+    const content = documents[0].content;
+    const summaryAt = content.indexOf("How to get started with the product.");
+    const richAt = content.indexOf("Rich part with plenty of prose.");
+    const plainAt = content.indexOf("Plain part, first block.");
+    expect(summaryAt).toBeGreaterThan(-1);
+    expect(richAt).toBeGreaterThan(summaryAt);
+    expect(plainAt).toBeGreaterThan(richAt);
+    expect(content).toContain("Plain part, second block.");
+  });
+
+  it("absolutizes relative links against the instance URL and leaves absolute ones", () => {
+    const { documents } = assembleSalesforceKnowledgeDocuments(
+      [
+        article({
+          bodyParts: [
+            {
+              field: "Body__c",
+              value:
+                '<p>See <a href="/articles/en_US/FAQ/Billing">billing</a> and <a href="https://example.com/page">our site</a> for details.</p>',
+              rich: true,
+            },
+          ],
+        }),
+      ],
+      OPTS,
+    );
+    expect(documents[0].content).toContain(
+      "[billing](https://acme.my.salesforce.com/articles/en_US/FAQ/Billing)",
+    );
+    expect(documents[0].content).toContain("[our site](https://example.com/page)");
+  });
+
+  it("aggregates image degradations across articles", () => {
+    const { degradations } = assembleSalesforceKnowledgeDocuments(
+      [
+        article({
+          bodyParts: [
+            {
+              field: "Body__c",
+              value: '<p>Some intro text here.</p><img src="a.png"><img src="b.png">',
+              rich: true,
+            },
+          ],
+        }),
+        article({
+          versionId: "ka0x002",
+          language: "de",
+          bodyParts: [
+            { field: "Body__c", value: '<p>Etwas Text hier drin.</p><img src="c.png">', rich: true },
+          ],
+        }),
+      ],
+      OPTS,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 3 }]);
+  });
+
+  it("skips (and counts) a contentless version instead of emitting an empty doc", () => {
+    const result = assembleSalesforceKnowledgeDocuments(
+      [
+        article({ summary: null, bodyParts: [{ field: "Body__c", value: "<div><script>x()</script></div>", rich: true }] }),
+        article({ versionId: "ka0x002", language: "fr" }),
+      ],
+      OPTS,
+    );
+    expect(result.skippedContentless).toBe(1);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].path).toContain("/fr/");
+  });
+
+  it("uses the fallback segment for an unslugifiable title (number keeps it unique)", () => {
+    const { documents } = assembleSalesforceKnowledgeDocuments(
+      [article({ title: "你好" })],
+      OPTS,
+    );
+    expect(documents[0].path).toBe("sf-kb/en-us/article-000001001.md");
+  });
+});

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/documents.test.ts
@@ -188,6 +188,8 @@ describe("assembleSalesforceKnowledgeDocuments", () => {
     expect(result.skippedContentless).toBe(1);
     expect(result.documents).toHaveLength(1);
     expect(result.documents[0].path).toContain("/fr/");
+    // The WHICH, not just the count — reconciliation archives the vanished doc.
+    expect(result.contentlessArticles).toEqual(["000001001:en_us"]);
   });
 
   it("uses the fallback segment for an unslugifiable title (number keeps it unique)", () => {

--- a/packages/api/src/lib/knowledge/salesforce/client.ts
+++ b/packages/api/src/lib/knowledge/salesforce/client.ts
@@ -27,9 +27,10 @@
  *     `queryMore`/`nextRecordsUrl` batches.
  *
  * Explicit-status discipline: EVERY query filters `PublishStatus` explicitly.
- * API v47+ dropped the implicit Online-only default on `*__kav` queries —
- * an unfiltered query returns Draft + Archived versions too, which would leak
- * unpublished content into the mirror.
+ * Modern Salesforce API versions return Draft + Archived versions on an
+ * unfiltered `*__kav` query (older versions required a single-status filter
+ * outright), so an unfiltered query would leak unpublished content into the
+ * mirror — never rely on a vendor default here.
  *
  * Governor limits: Salesforce signals org-level API exhaustion with
  * `REQUEST_LIMIT_EXCEEDED` (not an HTTP 429 the guardedFetch path would see) —
@@ -216,6 +217,9 @@ class SalesforceKnowledgeClient {
     }
     const shape = await this.resolveShape();
     // SOQL datetime literals are unquoted ISO instants without milliseconds.
+    // `>` (not `>=`) is safe against the contract's "at-or-after": `since` is
+    // already mark − overlap window, and truncating the milliseconds widens
+    // the `>` window further downward.
     const soqlSince = new Date(sinceMs).toISOString().replace(/\.\d{3}Z$/, "Z");
     const where = `SystemModstamp > ${soqlSince} AND PublishStatus IN ('Online', 'Draft', 'Archived')`;
     const rows = await this.enumerate(shape, where);
@@ -243,6 +247,7 @@ class SalesforceKnowledgeClient {
     const fieldNames = new Set<string>();
     const bodyFields: SalesforceBodyField[] = [];
     let skippedUnsafeNames = 0;
+    let droppedBodyFields = 0;
     for (const raw of described.fields) {
       const name = typeof raw.name === "string" ? raw.name : "";
       if (name === "") continue;
@@ -253,7 +258,10 @@ class SalesforceKnowledgeClient {
       }
       fieldNames.add(name);
       if (raw.custom === true && raw.type === "textarea") {
-        if (bodyFields.length >= MAX_BODY_FIELDS) continue;
+        if (bodyFields.length >= MAX_BODY_FIELDS) {
+          droppedBodyFields++;
+          continue;
+        }
         bodyFields.push({ name, rich: raw.extraTypeInfo === "richtextarea" });
       }
     }
@@ -261,6 +269,14 @@ class SalesforceKnowledgeClient {
       log.warn(
         { articleObject, skippedUnsafeNames },
         "Skipped Salesforce fields whose names fail the SOQL identifier pattern — not selectable (unexpected describe metadata)",
+      );
+    }
+    if (droppedBodyFields > 0) {
+      // Never a silent shrink: documents from this org mirror only the first
+      // MAX_BODY_FIELDS custom textarea fields, in describe order.
+      log.warn(
+        { articleObject, droppedBodyFields, cap: MAX_BODY_FIELDS },
+        "Salesforce article object exceeds the custom body-field cap — later textarea fields are not mirrored",
       );
     }
 
@@ -391,6 +407,10 @@ class SalesforceKnowledgeClient {
           mode,
           degradations: assembled.degradations,
           skippedContentless: assembled.skippedContentless,
+          // Bounded article-number breadcrumbs — a reconciliation archives a
+          // previously-mirrored doc that converts to empty, so the operator
+          // needs the WHICH, not just the count.
+          contentlessArticles: assembled.contentlessArticles,
         },
         "Salesforce Knowledge conversion completed with degradations/skips",
       );
@@ -449,11 +469,10 @@ class SalesforceKnowledgeClient {
     }
 
     const summary = shape.optionalPresent.has("Summary") ? stringOf(raw.Summary) : "";
-    const versionNumber =
-      shape.optionalPresent.has("VersionNumber") && raw.VersionNumber !== null &&
-      raw.VersionNumber !== undefined
-        ? String(raw.VersionNumber)
-        : null;
+    const rawVersionNumber = shape.optionalPresent.has("VersionNumber")
+      ? stringOf(raw.VersionNumber)
+      : "";
+    const versionNumber = rawVersionNumber === "" ? null : rawVersionNumber;
     const isMasterLanguage = shape.optionalPresent.has("IsMasterLanguage")
       ? raw.IsMasterLanguage === true
       : null;
@@ -503,12 +522,15 @@ function stringOf(raw: unknown): string {
  */
 function mapSalesforceError(err: unknown, context: string): Error {
   if (err instanceof ConnectorRateLimitError) return err;
+  // Specific classes before the substring heuristic: a reconnect error whose
+  // upstream text happened to contain the governor token must stay a
+  // reconnect, not a futile backoff.
+  if (err instanceof IntegrationReconnectRequiredError) return err;
   if (isGovernorLimitError(err)) {
     return new ConnectorRateLimitError(
       "Salesforce rejected the request with REQUEST_LIMIT_EXCEEDED — the org's daily API request allocation is exhausted; the sync will back off and retry.",
     );
   }
-  if (err instanceof IntegrationReconnectRequiredError) return err;
   return new Error(`${context}: ${err instanceof Error ? err.message : String(err)}`, {
     cause: err,
   });

--- a/packages/api/src/lib/knowledge/salesforce/client.ts
+++ b/packages/api/src/lib/knowledge/salesforce/client.ts
@@ -1,0 +1,522 @@
+/**
+ * The Salesforce Knowledge vendor client (#4397, PRD #4395) — a
+ * {@link ConnectorVendorClient} running SOQL against `Knowledge__kav` (or a
+ * Classic `<Type>__kav`) over the workspace's EXISTING Salesforce OAuth
+ * connection. It owns ONLY enumerate + fetch + convert; scheduling, high-water
+ * marks, reconciliation cadence, backoff, and caps are the shared engine's
+ * (ADR-0030).
+ *
+ * The connection is the lazy-built {@link SalesforcePluginInstance} the
+ * `querySalesforce` agent tool also uses — reached here through the narrow
+ * {@link SalesforceKnowledgeApi} slice (`describeObject` + the paged query
+ * pair), NOT the agent tool itself: the tool's semantic-layer object whitelist
+ * and auto-LIMIT are agent policy, and its `query()` truncates at the first
+ * SOQL batch, which is unsound for a reconciliation crawl. OAuth refresh,
+ * token storage, and reconnect handling all live behind the instance
+ * (`lazy-builder.ts`) — this client never sees a credential.
+ *
+ * Two cadences the engine decides:
+ *   - `fetchChanges({ since })` (incremental) — one SOQL walk over the indexed
+ *     `SystemModstamp` with an EXPLICIT `PublishStatus IN (...)` filter: a row
+ *     that changed to Draft/Archived (an unpublish, a version flip) advances
+ *     the high-water mark but emits nothing — its documents are archived by
+ *     the next reconciliation crawl's subtractive diff (deletions are engine
+ *     property, invisible to incremental by design).
+ *   - `fetchAll()` (reconciliation) — enumerate every `PublishStatus =
+ *     'Online'` row (each language a distinct row = a distinct document) via
+ *     `queryMore`/`nextRecordsUrl` batches.
+ *
+ * Explicit-status discipline: EVERY query filters `PublishStatus` explicitly.
+ * API v47+ dropped the implicit Online-only default on `*__kav` queries —
+ * an unfiltered query returns Draft + Archived versions too, which would leak
+ * unpublished content into the mirror.
+ *
+ * Governor limits: Salesforce signals org-level API exhaustion with
+ * `REQUEST_LIMIT_EXCEEDED` (not an HTTP 429 the guardedFetch path would see) —
+ * mapped to {@link ConnectorRateLimitError} so the ENGINE applies its bounded
+ * backoff. Batch size is Salesforce's own (~2000 records, self-reduced for
+ * wide rows), so paging is governor-aware by construction; the page/row
+ * bounds here are anti-runaway, not throttles.
+ *
+ * Body discovery: article bodies live in per-org CUSTOM rich-text fields, so
+ * the client `describe`s the object and selects every custom `textarea` field
+ * (rich ones converted via the shared support HTML→markdown converter, plain
+ * ones passed through as prose). Field names are validated against the SOQL
+ * identifier pattern before interpolation — org metadata is data, not SQL.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { hostForLog } from "@atlas/api/lib/openapi/egress-guard";
+import { IntegrationReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import type {
+  SalesforceObjectDescribe,
+  SalesforceQueryPage,
+} from "@atlas/api/lib/integrations/salesforce/lazy-builder";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import {
+  SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS,
+  type SalesforceKnowledgeChannel,
+} from "./config";
+import {
+  assembleSalesforceKnowledgeDocuments,
+  type SalesforceKnowledgeArticle,
+  type SalesforceArticleBodyPart,
+} from "./documents";
+
+const log = createLogger("knowledge.salesforce.client");
+
+/**
+ * The narrow slice of the lazy-built Salesforce plugin instance this client
+ * drives — structural, so tests double it with fixtures and no test touches a
+ * live org. All three methods are OAuth-refresh-retried by the instance.
+ */
+export interface SalesforceKnowledgeApi {
+  describeObject(objectName: string): Promise<SalesforceObjectDescribe>;
+  queryPage(soql: string): Promise<SalesforceQueryPage>;
+  queryMorePage(nextRecordsUrl: string): Promise<SalesforceQueryPage>;
+}
+
+/** Resolved, non-secret inputs. The connector factory validated all of them. */
+export interface SalesforceKnowledgeClientConfig {
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+  /** Validated `*__kav` article-version object API name. */
+  readonly articleObject: string;
+  /** Channel scope, or null for all channels. */
+  readonly channel: SalesforceKnowledgeChannel | null;
+  /** The org's instance URL — canonical article links + link absolutization. */
+  readonly instanceUrl: string;
+}
+
+/**
+ * Hard anti-runaway bound on enumerated article versions — NOT the ingest cap
+ * (the engine owns that). A knowledge base larger than this is pathological;
+ * fail loud rather than loop unbounded on a broken locator.
+ */
+const MAX_ARTICLES = 100_000;
+/** Anti-runaway bound on `queryMore` batches walked in one enumeration. */
+const MAX_QUERY_PAGES = 1_000;
+/** Defensive cap on discovered custom body fields (orgs rarely exceed a few). */
+const MAX_BODY_FIELDS = 20;
+
+/** SOQL identifier — the only shape a field/object name may take in a query. */
+const SOQL_IDENTIFIER = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/** Standard fields every article-version object must expose. */
+const REQUIRED_FIELDS = [
+  "Id",
+  "KnowledgeArticleId",
+  "ArticleNumber",
+  "Title",
+  "Language",
+  "PublishStatus",
+  "SystemModstamp",
+] as const;
+
+/** Standard fields selected when the org's object has them. */
+const OPTIONAL_FIELDS = ["Summary", "UrlName", "VersionNumber", "IsMasterLanguage"] as const;
+
+/** One discovered custom body field. */
+export interface SalesforceBodyField {
+  readonly name: string;
+  /** True = rich text (HTML, converted); false = plain long text area. */
+  readonly rich: boolean;
+}
+
+/** The describe-resolved query shape for one collection's article object. */
+interface ArticleObjectShape {
+  readonly selectFields: readonly string[];
+  readonly bodyFields: readonly SalesforceBodyField[];
+  readonly optionalPresent: ReadonlySet<string>;
+  /** The channel-visibility field to read, when a channel is configured. */
+  readonly visibilityField: string | null;
+}
+
+/**
+ * Build a Salesforce Knowledge vendor client for ONE collection. The factory
+ * (`connector.ts`) has already resolved the plugin instance and validated the
+ * config, so construction does no I/O; the `describe` runs on first fetch.
+ */
+export function createSalesforceKnowledgeVendorClient(
+  api: SalesforceKnowledgeApi,
+  config: SalesforceKnowledgeClientConfig,
+): ConnectorVendorClient {
+  const client = new SalesforceKnowledgeClient(api, config);
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      // The engine only runs incremental with a persisted mark, but a null
+      // `since` is served defensively as a full crawl (the contract's advice).
+      if (params.since === null) return client.fetchAll();
+      return client.fetchChanges(params.since);
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return client.fetchAll();
+    },
+  };
+}
+
+/** One normalized article-version row (timestamps canonical, ids stringified). */
+interface NormalizedArticleVersion {
+  readonly versionId: string;
+  readonly knowledgeArticleId: string;
+  readonly articleNumber: string;
+  readonly title: string;
+  readonly summary: string | null;
+  readonly language: string;
+  readonly publishStatus: string;
+  readonly versionNumber: string | null;
+  readonly isMasterLanguage: boolean | null;
+  /** Canonical ISO instant (`toIsoInstant(SystemModstamp)`). */
+  readonly updatedAt: string;
+  /** Channel visibility per config (true when no channel is configured). */
+  readonly visible: boolean;
+  readonly bodyParts: readonly SalesforceArticleBodyPart[];
+}
+
+class SalesforceKnowledgeClient {
+  private shapePromise: Promise<ArticleObjectShape> | null = null;
+
+  constructor(
+    private readonly api: SalesforceKnowledgeApi,
+    private readonly config: SalesforceKnowledgeClientConfig,
+  ) {}
+
+  /** Reconciliation: enumerate every published (per-channel) version row. */
+  async fetchAll(): Promise<ConnectorChanges> {
+    const shape = await this.resolveShape();
+    const clauses = [`PublishStatus = 'Online'`];
+    // Channel scope is ALSO re-checked per row in `normalize` — the clause is
+    // a payload optimization, the row check is the correctness anchor shared
+    // with the incremental path.
+    if (shape.visibilityField !== null) clauses.push(`${shape.visibilityField} = true`);
+    const rows = await this.enumerate(shape, clauses.join(" AND "));
+    return this.assemble(shape, rows, "reconciliation");
+  }
+
+  /**
+   * Incremental: one indexed `SystemModstamp` walk with the explicit
+   * three-status filter. Non-Online changed rows (a version flip to Draft, an
+   * archive) advance the high-water mark but emit nothing — reconciliation's
+   * subtractive diff archives their paths.
+   */
+  async fetchChanges(since: string): Promise<ConnectorChanges> {
+    const sinceMs = Date.parse(since);
+    if (Number.isNaN(sinceMs)) {
+      // The engine derives `since` from its own persisted ISO mark, so this is
+      // defensive — fail loud rather than silently refetch everything.
+      throw new Error(
+        `Salesforce Knowledge incremental fetch got an unparseable since instant ("${since}").`,
+      );
+    }
+    const shape = await this.resolveShape();
+    // SOQL datetime literals are unquoted ISO instants without milliseconds.
+    const soqlSince = new Date(sinceMs).toISOString().replace(/\.\d{3}Z$/, "Z");
+    const where = `SystemModstamp > ${soqlSince} AND PublishStatus IN ('Online', 'Draft', 'Archived')`;
+    const rows = await this.enumerate(shape, where);
+    return this.assemble(shape, rows, "incremental");
+  }
+
+  /** Describe the article object once per client; validate + cache the shape. */
+  private resolveShape(): Promise<ArticleObjectShape> {
+    this.shapePromise ??= this.describeShape();
+    return this.shapePromise;
+  }
+
+  private async describeShape(): Promise<ArticleObjectShape> {
+    const { articleObject, channel } = this.config;
+    let described: SalesforceObjectDescribe;
+    try {
+      described = await this.api.describeObject(articleObject);
+    } catch (err) {
+      throw mapSalesforceError(
+        err,
+        `Salesforce could not describe ${articleObject} on ${this.hostLabel()} — check that Lightning Knowledge is enabled and the connected user can read the object.`,
+      );
+    }
+
+    const fieldNames = new Set<string>();
+    const bodyFields: SalesforceBodyField[] = [];
+    let skippedUnsafeNames = 0;
+    for (const raw of described.fields) {
+      const name = typeof raw.name === "string" ? raw.name : "";
+      if (name === "") continue;
+      if (!SOQL_IDENTIFIER.test(name)) {
+        // Never interpolate a non-identifier into SOQL — org metadata is data.
+        skippedUnsafeNames++;
+        continue;
+      }
+      fieldNames.add(name);
+      if (raw.custom === true && raw.type === "textarea") {
+        if (bodyFields.length >= MAX_BODY_FIELDS) continue;
+        bodyFields.push({ name, rich: raw.extraTypeInfo === "richtextarea" });
+      }
+    }
+    if (skippedUnsafeNames > 0) {
+      log.warn(
+        { articleObject, skippedUnsafeNames },
+        "Skipped Salesforce fields whose names fail the SOQL identifier pattern — not selectable (unexpected describe metadata)",
+      );
+    }
+
+    const missing = REQUIRED_FIELDS.filter((f) => !fieldNames.has(f));
+    if (missing.length > 0) {
+      throw new Error(
+        `Salesforce object ${articleObject} is missing required article-version fields (${missing.join(", ")}) — it does not look like a Knowledge article-version object.`,
+      );
+    }
+
+    const visibilityField = channel === null ? null : SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS[channel];
+    if (visibilityField !== null && !fieldNames.has(visibilityField)) {
+      throw new Error(
+        `Salesforce object ${articleObject} has no ${visibilityField} field — the "${channel}" channel scope cannot be applied; re-install the collection without it or pick another channel.`,
+      );
+    }
+
+    const optionalPresent = new Set(OPTIONAL_FIELDS.filter((f) => fieldNames.has(f)));
+    const selectFields = [
+      ...REQUIRED_FIELDS,
+      ...optionalPresent,
+      ...(visibilityField !== null ? [visibilityField] : []),
+      ...bodyFields.map((f) => f.name),
+    ];
+    if (bodyFields.length === 0) {
+      // Not fatal — Title + Summary can still carry prose — but an operator
+      // debugging empty documents needs the breadcrumb.
+      log.warn(
+        { articleObject },
+        "Salesforce article object has no custom textarea body fields — documents will carry only title/summary prose",
+      );
+    }
+    return { selectFields, bodyFields, optionalPresent, visibilityField };
+  }
+
+  /** Walk one SOQL result set through `queryMore` batches, bounded. */
+  private async enumerate(
+    shape: ArticleObjectShape,
+    where: string,
+  ): Promise<Record<string, unknown>[]> {
+    const soql = `SELECT ${shape.selectFields.join(", ")} FROM ${this.config.articleObject} WHERE ${where}`;
+    const rows: Record<string, unknown>[] = [];
+    let page: SalesforceQueryPage;
+    try {
+      page = await this.api.queryPage(soql);
+    } catch (err) {
+      throw mapSalesforceError(
+        err,
+        `Salesforce Knowledge query against ${this.config.articleObject} on ${this.hostLabel()} failed`,
+      );
+    }
+    for (let pages = 1; ; pages++) {
+      if (pages > MAX_QUERY_PAGES) {
+        throw new Error(
+          `Salesforce Knowledge enumeration of ${this.config.articleObject} did not terminate after ${MAX_QUERY_PAGES} query batches — unexpected vendor pagination.`,
+        );
+      }
+      rows.push(...page.records);
+      if (rows.length > MAX_ARTICLES) {
+        throw new Error(
+          `Salesforce Knowledge on ${this.hostLabel()} exceeds ${MAX_ARTICLES} article versions — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+        );
+      }
+      if (page.done || page.nextRecordsUrl === null) break;
+      try {
+        page = await this.api.queryMorePage(page.nextRecordsUrl);
+      } catch (err) {
+        throw mapSalesforceError(
+          err,
+          `Salesforce Knowledge queryMore continuation on ${this.hostLabel()} failed`,
+        );
+      }
+    }
+    return rows;
+  }
+
+  /** Normalize + convert the fetched set into `ConnectorChanges`. */
+  private assemble(
+    shape: ArticleObjectShape,
+    rawRows: readonly Record<string, unknown>[],
+    mode: "incremental" | "reconciliation",
+  ): ConnectorChanges {
+    let skippedMalformed = 0;
+    let observedNotEmitted = 0;
+    let highWaterMark: string | null = null;
+    const emitted: SalesforceKnowledgeArticle[] = [];
+
+    for (const raw of rawRows) {
+      const row = this.normalize(shape, raw);
+      if (row === null) {
+        skippedMalformed++;
+        continue;
+      }
+      // Every fetched version — emitted or not — advances the mark: its change
+      // is what this fetch observed. ISO instants compare chronologically.
+      if (highWaterMark === null || row.updatedAt > highWaterMark) {
+        highWaterMark = row.updatedAt;
+      }
+      if (row.publishStatus !== "Online" || !row.visible) {
+        // A version flip to Draft/Archived, or out-of-channel visibility:
+        // observed, never emitted — reconciliation archives its stale path.
+        observedNotEmitted++;
+        continue;
+      }
+      emitted.push({
+        versionId: row.versionId,
+        knowledgeArticleId: row.knowledgeArticleId,
+        articleNumber: row.articleNumber,
+        title: row.title,
+        summary: row.summary,
+        language: row.language,
+        versionNumber: row.versionNumber,
+        isMasterLanguage: row.isMasterLanguage,
+        updatedAt: row.updatedAt,
+        url: this.articleUrl(row.versionId),
+        bodyParts: row.bodyParts,
+      });
+    }
+
+    const assembled = assembleSalesforceKnowledgeDocuments(emitted, {
+      collectionSlug: this.config.collectionSlug,
+      instanceUrl: this.config.instanceUrl,
+    });
+    if (assembled.degradations.length > 0 || assembled.skippedContentless > 0) {
+      log.info(
+        {
+          host: this.hostLabel(),
+          mode,
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+        },
+        "Salesforce Knowledge conversion completed with degradations/skips",
+      );
+    }
+    if (observedNotEmitted > 0) {
+      log.info(
+        { host: this.hostLabel(), mode, observedNotEmitted },
+        "Observed Salesforce article versions that are not published/visible in scope — mark advanced, nothing emitted (reconciliation archives stale paths)",
+      );
+    }
+    if (skippedMalformed > 0) {
+      // A skipped version is a KNOWN hole in the set: its document would
+      // otherwise be archived by a reconciliation off this partial crawl. The
+      // flag makes the engine upsert-only and hold the reconcile clock.
+      log.warn(
+        { host: this.hostLabel(), mode, skippedMalformed },
+        "Skipped Salesforce article versions missing id/number/language/timestamp — not ingested (unexpected for published content)",
+      );
+    }
+
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+
+  /** Normalize one raw row; null = malformed (skip + count). */
+  private normalize(
+    shape: ArticleObjectShape,
+    raw: Record<string, unknown>,
+  ): NormalizedArticleVersion | null {
+    const versionId = stringOf(raw.Id);
+    const knowledgeArticleId = stringOf(raw.KnowledgeArticleId);
+    const articleNumber = stringOf(raw.ArticleNumber);
+    const language = stringOf(raw.Language).toLowerCase();
+    const publishStatus = stringOf(raw.PublishStatus);
+    const updatedAt = toIsoInstant(raw.SystemModstamp);
+    if (
+      versionId === "" ||
+      knowledgeArticleId === "" ||
+      articleNumber === "" ||
+      language === "" ||
+      updatedAt === null
+    ) {
+      return null;
+    }
+
+    const bodyParts: SalesforceArticleBodyPart[] = [];
+    for (const field of shape.bodyFields) {
+      const value = raw[field.name];
+      if (typeof value === "string" && value !== "") {
+        bodyParts.push({ field: field.name, value, rich: field.rich });
+      }
+    }
+
+    const summary = shape.optionalPresent.has("Summary") ? stringOf(raw.Summary) : "";
+    const versionNumber =
+      shape.optionalPresent.has("VersionNumber") && raw.VersionNumber !== null &&
+      raw.VersionNumber !== undefined
+        ? String(raw.VersionNumber)
+        : null;
+    const isMasterLanguage = shape.optionalPresent.has("IsMasterLanguage")
+      ? raw.IsMasterLanguage === true
+      : null;
+
+    return {
+      versionId,
+      knowledgeArticleId,
+      articleNumber,
+      title: stringOf(raw.Title),
+      summary: summary === "" ? null : summary,
+      language,
+      publishStatus,
+      versionNumber,
+      isMasterLanguage,
+      updatedAt,
+      visible: shape.visibilityField === null ? true : raw[shape.visibilityField] === true,
+      bodyParts,
+    };
+  }
+
+  /** Canonical Lightning record URL for one article version. */
+  private articleUrl(versionId: string): string {
+    const base = this.config.instanceUrl.replace(/\/+$/, "");
+    return `${base}/lightning/r/${this.config.articleObject}/${encodeURIComponent(versionId)}/view`;
+  }
+
+  /** Host-redacted label for logs + error messages. */
+  private hostLabel(): string {
+    return hostForLog(this.config.instanceUrl);
+  }
+}
+
+/** Stringify an untrusted scalar (`null`/objects/arrays = absent). */
+function stringOf(raw: unknown): string {
+  if (typeof raw === "string") return raw.trim();
+  if (typeof raw === "number") return String(raw);
+  return "";
+}
+
+/**
+ * Map a jsforce failure to the engine's vocabulary: `REQUEST_LIMIT_EXCEEDED`
+ * (org-level API governor exhaustion — Salesforce's throttle signal, not an
+ * HTTP 429) becomes {@link ConnectorRateLimitError} so the engine applies its
+ * bounded backoff; everything else is wrapped with actionable context, the
+ * original riding as `cause`. Reconnect-required errors pass through
+ * untouched — their message is already the actionable one.
+ */
+function mapSalesforceError(err: unknown, context: string): Error {
+  if (err instanceof ConnectorRateLimitError) return err;
+  if (isGovernorLimitError(err)) {
+    return new ConnectorRateLimitError(
+      "Salesforce rejected the request with REQUEST_LIMIT_EXCEEDED — the org's daily API request allocation is exhausted; the sync will back off and retry.",
+    );
+  }
+  if (err instanceof IntegrationReconnectRequiredError) return err;
+  return new Error(`${context}: ${err instanceof Error ? err.message : String(err)}`, {
+    cause: err,
+  });
+}
+
+/** Salesforce org-level API governor exhaustion, by errorCode or message. */
+function isGovernorLimitError(err: unknown): boolean {
+  if (err instanceof Error && err.message.includes("REQUEST_LIMIT_EXCEEDED")) return true;
+  const code = (err as { errorCode?: unknown } | null)?.errorCode;
+  return code === "REQUEST_LIMIT_EXCEEDED";
+}

--- a/packages/api/src/lib/knowledge/salesforce/config.ts
+++ b/packages/api/src/lib/knowledge/salesforce/config.ts
@@ -54,8 +54,12 @@ export function isSalesforceKnowledgeChannel(value: string): value is Salesforce
 export interface SalesforceKnowledgeCollectionConfig {
   /** The article-version object this collection mirrors (validated `*__kav`). */
   readonly article_object: string;
-  /** Optional channel scope (`app`/`pkb`/`csp`/`prm`); absent = all channels. */
-  readonly channel?: string;
+  /**
+   * Optional channel scope; absent = all channels. Typed as the union so a
+   * writer can't stamp an arbitrary string — the read path still re-validates
+   * (a DB row can be edited out of band).
+   */
+  readonly channel?: SalesforceKnowledgeChannel;
   readonly description?: string;
 }
 

--- a/packages/api/src/lib/knowledge/salesforce/config.ts
+++ b/packages/api/src/lib/knowledge/salesforce/config.ts
@@ -1,0 +1,102 @@
+/**
+ * Salesforce Knowledge connector identity + stored-config contract (#4397,
+ * PRD #4395).
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config),
+ * the connector (reads it back in `createClient`), and the admin-knowledge
+ * surface (recognizes the catalog id) share ONE definition.
+ *
+ * Unlike every other knowledge vendor, this connector stores NO credential of
+ * its own: it reuses the workspace's existing Salesforce OAuth install
+ * (`catalog:salesforce`, ADR-0014, #3302) via the lazy plugin loader, so there
+ * is no `knowledge_sync_credentials` row and no new secret path. The config
+ * is pure scope: which article-version object to mirror and (optionally) which
+ * channel-visibility flag gates the mirrored set.
+ */
+
+/** The built-in Salesforce Knowledge catalog slug + row id. */
+export const SALESFORCE_KNOWLEDGE_SLUG = "salesforce-knowledge";
+export const SALESFORCE_KNOWLEDGE_CATALOG_ID = "catalog:salesforce-knowledge";
+/** Vendor slug stamped into `atlas_source` as `connector:salesforce`. */
+export const SALESFORCE_KNOWLEDGE_VENDOR = "salesforce";
+
+/** The default Lightning Knowledge article-version object. */
+export const DEFAULT_ARTICLE_OBJECT = "Knowledge__kav";
+
+/**
+ * A Salesforce article-version object API name — `Knowledge__kav` (Lightning
+ * Knowledge) or a Classic article type's `<Type>__kav`. The pinned `__kav`
+ * suffix keeps the connector on article-version objects by construction, and
+ * the identifier pattern keeps the name safe to interpolate into SOQL.
+ */
+export const ARTICLE_OBJECT_PATTERN = /^[A-Za-z][A-Za-z0-9_]*__kav$/;
+
+/**
+ * Channel scopes → the article-version visibility field that gates them
+ * (the AC's "channel visibility (`IsVisibleInPkb` etc.) respected per
+ * config"). Absent channel = every published article regardless of channel.
+ */
+export const SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS = {
+  app: "IsVisibleInApp",
+  pkb: "IsVisibleInPkb",
+  csp: "IsVisibleInCsp",
+  prm: "IsVisibleInPrm",
+} as const;
+
+export type SalesforceKnowledgeChannel = keyof typeof SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS;
+
+export function isSalesforceKnowledgeChannel(value: string): value is SalesforceKnowledgeChannel {
+  return Object.hasOwn(SALESFORCE_KNOWLEDGE_CHANNEL_FIELDS, value);
+}
+
+/** The non-secret config persisted on the collection's `workspace_plugins` row. */
+export interface SalesforceKnowledgeCollectionConfig {
+  /** The article-version object this collection mirrors (validated `*__kav`). */
+  readonly article_object: string;
+  /** Optional channel scope (`app`/`pkb`/`csp`/`prm`); absent = all channels. */
+  readonly channel?: string;
+  readonly description?: string;
+}
+
+export type ParsedSalesforceKnowledgeConfig =
+  | {
+      readonly ok: true;
+      readonly articleObject: string;
+      readonly channel: SalesforceKnowledgeChannel | null;
+    }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * or invalid field means someone edited the row out of band; re-installing
+ * repairs it.
+ */
+export function parseSalesforceKnowledgeConfig(
+  config: Record<string, unknown> | null,
+): ParsedSalesforceKnowledgeConfig {
+  const rawObject =
+    typeof config?.article_object === "string" ? config.article_object.trim() : "";
+  const articleObject = rawObject === "" ? DEFAULT_ARTICLE_OBJECT : rawObject;
+  if (!ARTICLE_OBJECT_PATTERN.test(articleObject)) {
+    return {
+      ok: false,
+      error: `Collection has an invalid Salesforce article object ("${rawObject}") configured — expected an article-version object like Knowledge__kav; re-install it.`,
+    };
+  }
+
+  const rawChannel = typeof config?.channel === "string" ? config.channel.trim().toLowerCase() : "";
+  let channel: SalesforceKnowledgeChannel | null = null;
+  if (rawChannel !== "") {
+    if (!isSalesforceKnowledgeChannel(rawChannel)) {
+      return {
+        ok: false,
+        error: `Collection has an invalid Salesforce Knowledge channel ("${rawChannel}") configured — expected one of app, pkb, csp, prm (or none for all channels); re-install it.`,
+      };
+    }
+    channel = rawChannel;
+  }
+
+  return { ok: true, articleObject, channel };
+}

--- a/packages/api/src/lib/knowledge/salesforce/connector.ts
+++ b/packages/api/src/lib/knowledge/salesforce/connector.ts
@@ -66,18 +66,23 @@ export async function resolveSalesforceKnowledgeInstance(
   try {
     raw = await loader.getOrInstantiate(workspaceId, SALESFORCE_CATALOG_ID);
   } catch (err) {
+    // The original failure rides along as `cause` so the forensic detail
+    // (invalid_grant, the builder's own message) survives the remap.
     switch (classifyLazyInstantiateError(err)) {
       case "install_not_found":
         throw new Error(
           "This collection reuses the workspace's Salesforce integration, but Salesforce is not connected — connect it under Admin → Integrations, then sync again.",
+          { cause: err },
         );
       case "reconnect_required":
         throw new Error(
           "The workspace's Salesforce integration needs to be reconnected — open Admin → Integrations and click Reconnect on the Salesforce card, then sync again.",
+          { cause: err },
         );
       case "builder_missing":
         throw new Error(
-          "Salesforce integration is not configured on this deploy (SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET unset) — contact your operator.",
+          "Salesforce integration is not configured on this deploy (SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET or ATLAS_PUBLIC_API_URL unset) — contact your operator.",
+          { cause: err },
         );
       case "unknown":
         // Credential decrypt failure, missing bundle/instance_url, or
@@ -85,19 +90,29 @@ export async function resolveSalesforceKnowledgeInstance(
         throw err;
     }
   }
-  const instance = raw as SalesforcePluginInstance;
-  if (
-    typeof instance.queryPage !== "function" ||
-    typeof instance.queryMorePage !== "function" ||
-    typeof instance.describeObject !== "function"
-  ) {
+  if (!hasKnowledgeSurface(raw)) {
     // A custom/BYOC builder registered for catalog:salesforce that lacks the
     // paged-query surface — fail loud rather than truncate a crawl.
     throw new Error(
       "The workspace's Salesforce integration instance does not expose the paged query/describe surface the Knowledge connector requires.",
     );
   }
-  return instance;
+  return raw;
+}
+
+/**
+ * Structural check for the #4397 surface, run BEFORE the instance is trusted
+ * as a {@link SalesforcePluginInstance} — the loader's return type is only
+ * `PluginLike`, and a plugin/BYOC builder may have registered something else.
+ */
+function hasKnowledgeSurface(raw: unknown): raw is SalesforcePluginInstance {
+  if (raw === null || typeof raw !== "object") return false;
+  const candidate = raw as Record<string, unknown>;
+  return (
+    typeof candidate.queryPage === "function" &&
+    typeof candidate.queryMorePage === "function" &&
+    typeof candidate.describeObject === "function"
+  );
 }
 
 /** Read the instance's org URL — required for article links + provenance. */

--- a/packages/api/src/lib/knowledge/salesforce/connector.ts
+++ b/packages/api/src/lib/knowledge/salesforce/connector.ts
@@ -1,0 +1,160 @@
+/**
+ * The Salesforce Knowledge {@link KnowledgeSyncConnector} (#4397, PRD #4395) —
+ * the catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * factory contract from ADR-0030: bind the stored per-collection scope config
+ * + the workspace's EXISTING Salesforce OAuth connection into a vendor client.
+ * Scheduling, backoff, reconciliation, caps, and ingest are the shared
+ * engine's.
+ *
+ * Credential sourcing is this connector's one departure from the tier: there
+ * is NO `knowledge_sync_credentials` row. `createClient` resolves the lazy
+ * Salesforce plugin instance (`catalog:salesforce` — the same per-workspace
+ * OAuth install, refresh flow, and encrypted `integration_credentials` bundle
+ * the `querySalesforce` agent tool uses; ADR-0014, #3302), so installing this
+ * connector registers no new connected app and opens no new secret path.
+ *
+ * `createClient` is where a missing/broken Salesforce install becomes an
+ * actionable error surfaced on `/admin/knowledge`: the lazy-loader failure is
+ * classified positively (`classifyLazyInstantiateError`) and each kind maps to
+ * a message that says exactly what to fix — never a silent no-op sync.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { lazyPluginLoader, type LazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
+import { SALESFORCE_CATALOG_ID } from "@atlas/api/lib/integrations/install/salesforce-oauth-handler";
+import { classifyLazyInstantiateError } from "@atlas/api/lib/integrations/_shared/lazy-plugin-tool";
+import type { SalesforcePluginInstance } from "@atlas/api/lib/integrations/salesforce/lazy-builder";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import {
+  createSalesforceKnowledgeVendorClient,
+  type SalesforceKnowledgeApi,
+} from "./client";
+import {
+  SALESFORCE_KNOWLEDGE_CATALOG_ID,
+  SALESFORCE_KNOWLEDGE_VENDOR,
+  parseSalesforceKnowledgeConfig,
+} from "./config";
+
+const log = createLogger("knowledge.salesforce.connector");
+
+/** The loader slice the connector needs — injectable for tests. */
+export type SalesforceInstanceLoader = Pick<LazyPluginLoader, "getOrInstantiate">;
+
+export interface SalesforceKnowledgeConnectorDeps {
+  /** Injected loader for tests; defaults to the process-wide lazy loader. */
+  readonly loader?: SalesforceInstanceLoader;
+}
+
+/**
+ * Resolve the workspace's lazy Salesforce plugin instance, mapping every
+ * failure kind to an actionable, admin-facing error (they land in
+ * `knowledge_sync_state.error` — and, at install time, in the form's 400).
+ * Exported for the install handler, which runs the same resolution as its
+ * loud pre-write verification.
+ */
+export async function resolveSalesforceKnowledgeInstance(
+  loader: SalesforceInstanceLoader,
+  workspaceId: string,
+): Promise<SalesforcePluginInstance> {
+  let raw: unknown;
+  try {
+    raw = await loader.getOrInstantiate(workspaceId, SALESFORCE_CATALOG_ID);
+  } catch (err) {
+    switch (classifyLazyInstantiateError(err)) {
+      case "install_not_found":
+        throw new Error(
+          "This collection reuses the workspace's Salesforce integration, but Salesforce is not connected — connect it under Admin → Integrations, then sync again.",
+        );
+      case "reconnect_required":
+        throw new Error(
+          "The workspace's Salesforce integration needs to be reconnected — open Admin → Integrations and click Reconnect on the Salesforce card, then sync again.",
+        );
+      case "builder_missing":
+        throw new Error(
+          "Salesforce integration is not configured on this deploy (SALESFORCE_CLIENT_ID/SALESFORCE_CLIENT_SECRET unset) — contact your operator.",
+        );
+      case "unknown":
+        // Credential decrypt failure, missing bundle/instance_url, or
+        // construction error — already loud + actionable, never swallowed.
+        throw err;
+    }
+  }
+  const instance = raw as SalesforcePluginInstance;
+  if (
+    typeof instance.queryPage !== "function" ||
+    typeof instance.queryMorePage !== "function" ||
+    typeof instance.describeObject !== "function"
+  ) {
+    // A custom/BYOC builder registered for catalog:salesforce that lacks the
+    // paged-query surface — fail loud rather than truncate a crawl.
+    throw new Error(
+      "The workspace's Salesforce integration instance does not expose the paged query/describe surface the Knowledge connector requires.",
+    );
+  }
+  return instance;
+}
+
+/** Read the instance's org URL — required for article links + provenance. */
+export function instanceUrlOf(instance: SalesforcePluginInstance): string {
+  const config = instance.config;
+  const url =
+    config !== null && typeof config === "object" && !Array.isArray(config)
+      ? (config as Record<string, unknown>).instanceUrl
+      : undefined;
+  if (typeof url !== "string" || url === "") {
+    throw new Error(
+      "The workspace's Salesforce integration instance carries no instance URL — disconnect and reconnect Salesforce under Admin → Integrations.",
+    );
+  }
+  return url;
+}
+
+/** Build the Salesforce Knowledge connector. `deps` is test-only injection. */
+export function createSalesforceKnowledgeConnector(
+  deps: SalesforceKnowledgeConnectorDeps = {},
+): KnowledgeSyncConnector {
+  const loader = deps.loader ?? lazyPluginLoader;
+  return {
+    catalogId: SALESFORCE_KNOWLEDGE_CATALOG_ID,
+    vendor: SALESFORCE_KNOWLEDGE_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseSalesforceKnowledgeConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      const instance = await resolveSalesforceKnowledgeInstance(loader, ctx.workspaceId);
+      const api: SalesforceKnowledgeApi = {
+        describeObject: (objectName) => instance.describeObject(objectName),
+        queryPage: (soql) => instance.queryPage(soql),
+        queryMorePage: (nextRecordsUrl) => instance.queryMorePage(nextRecordsUrl),
+      };
+      return createSalesforceKnowledgeVendorClient(api, {
+        collectionSlug: ctx.collectionSlug,
+        articleObject: parsed.articleObject,
+        channel: parsed.channel,
+        instanceUrl: instanceUrlOf(instance),
+      });
+    },
+  };
+}
+
+/**
+ * Register the Salesforce Knowledge connector idempotently — called from the
+ * boot seam that also registers install handlers
+ * (`registerBuiltinInstallHandlers`), and from tests.
+ * `registerKnowledgeSyncConnector` throws on a duplicate catalog id, so gate
+ * on the registry first.
+ */
+export function registerSalesforceKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(SALESFORCE_KNOWLEDGE_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createSalesforceKnowledgeConnector());
+  log.info(
+    { catalogId: SALESFORCE_KNOWLEDGE_CATALOG_ID },
+    "Registered Salesforce Knowledge sync connector",
+  );
+}

--- a/packages/api/src/lib/knowledge/salesforce/documents.ts
+++ b/packages/api/src/lib/knowledge/salesforce/documents.ts
@@ -1,0 +1,194 @@
+/**
+ * Salesforce Knowledge article version → OKF `ConnectorDocument` assembly
+ * (#4397, PRD #4395).
+ *
+ * Pure, deterministic glue between the SHARED support HTML→markdown converter
+ * (`../support/html-to-markdown.ts` — this vendor deliberately owns no
+ * HTML→md logic of its own) and the connector ingest seam. Each ONLINE
+ * article-version row is a distinct document; translations share
+ * `ArticleNumber` across `Language`, so each locale is its own document (the
+ * issue's "translations share ArticleNumber across Language").
+ *
+ * Bodies are the org's custom textarea fields in describe order: rich-text
+ * fields go through the shared converter (counted degradations, cross-link
+ * absolutization against the org's instance URL); plain long-text fields are
+ * already prose and pass through as-is. The standard `Summary` leads when
+ * present.
+ *
+ * Paths are `<language>/<title-slug>-<article-number>.md` — language +
+ * ArticleNumber make them collision-free by construction (two versions never
+ * share both; ArticleNumber is stable across version flips and locales, so a
+ * republished version upserts the SAME path), and the number suffix means a
+ * basename can never be a reserved OKF name — the `deriveArchivePath` fold
+ * still runs as defence in depth. A title rename reads as "old path archived +
+ * new path drafted", the documented rename-churn posture (same as Zendesk).
+ *
+ * Provenance that survives ingest: `resource` = the version's Lightning URL,
+ * `timestamp` = its `SystemModstamp`, plus an `atlas:` extension block
+ * carrying connector + article id + article number + version id + version
+ * number + locale + updated_at (the AC's "provenance carries article id +
+ * version + locale"). No provenance `tags` — same rationale as Zendesk (a
+ * mirrored column in the lenient parser's change comparison).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import {
+  convertSupportHtmlToMarkdown,
+  type HtmlDegradation,
+} from "../support/html-to-markdown";
+import { SALESFORCE_KNOWLEDGE_VENDOR } from "./config";
+
+/** One body field's value, tagged rich (HTML) or plain (long text area). */
+export interface SalesforceArticleBodyPart {
+  readonly field: string;
+  readonly value: string;
+  readonly rich: boolean;
+}
+
+/** One ONLINE article version, ready to convert. */
+export interface SalesforceKnowledgeArticle {
+  /** The version row's Id (changes on every published version). */
+  readonly versionId: string;
+  /** The stable KnowledgeArticleId shared by every version + locale. */
+  readonly knowledgeArticleId: string;
+  /** The human article number — stable across versions AND locales. */
+  readonly articleNumber: string;
+  readonly title: string;
+  readonly summary: string | null;
+  /** Lowercased locale, e.g. `en-us`. */
+  readonly language: string;
+  readonly versionNumber: string | null;
+  /** True = the master-language row; null when the org lacks the field. */
+  readonly isMasterLanguage: boolean | null;
+  /** Canonical ISO instant (`toIsoInstant(SystemModstamp)`). */
+  readonly updatedAt: string;
+  /** Canonical Lightning record URL of this version. */
+  readonly url: string;
+  readonly bodyParts: readonly SalesforceArticleBodyPart[];
+}
+
+export interface SalesforceAssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Media degradations aggregated across every assembled article. */
+  readonly degradations: readonly HtmlDegradation[];
+  /** Articles skipped because they carried no ingestable prose. */
+  readonly skippedContentless: number;
+}
+
+/** Slugify into a single path segment; `fallback` guarantees non-empty. */
+export function slugifySegment(value: string, fallback: string): string {
+  const slug = value
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched article versions.
+ * `instanceUrl` resolves the converter's cross-link hook (relative hrefs in
+ * rich-text bodies absolutize against the org).
+ */
+export function assembleSalesforceKnowledgeDocuments(
+  articles: readonly SalesforceKnowledgeArticle[],
+  options: { readonly collectionSlug: string; readonly instanceUrl: string },
+): SalesforceAssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const instanceBase = options.instanceUrl.replace(/\/+$/, "");
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  let skippedContentless = 0;
+
+  for (const article of articles) {
+    const sections: string[] = [];
+    if (article.summary !== null && article.summary.trim() !== "") {
+      sections.push(article.summary.trim());
+    }
+    for (const part of article.bodyParts) {
+      if (part.rich) {
+        const { markdown, degradations } = convertSupportHtmlToMarkdown(part.value, {
+          pageUrl: article.url,
+          rewriteLink: (href) => rewriteInstanceLink(href, instanceBase),
+        });
+        for (const d of degradations) {
+          degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+        }
+        if (markdown.trim() !== "") sections.push(markdown.trim());
+      } else {
+        // Plain long-text areas are already prose — never routed through the
+        // HTML parser (it would eat `<` runs and collapse blank lines).
+        const text = part.value.trim();
+        if (text !== "") sections.push(text);
+      }
+    }
+    const markdown = sections.join("\n\n");
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    const segments = [
+      slugifySegment(article.language, "locale"),
+      `${slugifySegment(article.title, "article")}-${slugifySegment(article.articleNumber, "article-number")}`,
+    ];
+    const derived = deriveArchivePath(`${segments.join("/")}.md`);
+    const path = [...prefixSegments, derived.path].join("/");
+
+    const title = article.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        resource: article.url,
+        timestamp: article.updatedAt,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: SALESFORCE_KNOWLEDGE_VENDOR,
+          article_id: article.knowledgeArticleId,
+          article_number: article.articleNumber,
+          version_id: article.versionId,
+          ...(article.versionNumber !== null ? { version: article.versionNumber } : {}),
+          locale: article.language,
+          ...(article.isMasterLanguage !== null
+            ? { is_master_language: article.isMasterLanguage ? "true" : "false" }
+            : {}),
+          updated_at: article.updatedAt,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless };
+}
+
+/**
+ * The converter's cross-link hook: absolutize relative hrefs against the
+ * org's instance URL so mirrored article links stay live. Absolute and
+ * unparseable hrefs pass through untouched.
+ */
+function rewriteInstanceLink(href: string, instanceBase: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return href; // already absolute (any scheme)
+  try {
+    return new URL(href, instanceBase).toString();
+  } catch {
+    // intentionally ignored: an unparseable href renders as-is — the label
+    // text is preserved either way, and a broken org link is the org's.
+    return href;
+  }
+}

--- a/packages/api/src/lib/knowledge/salesforce/documents.ts
+++ b/packages/api/src/lib/knowledge/salesforce/documents.ts
@@ -80,7 +80,17 @@ export interface SalesforceAssembleResult {
   readonly degradations: readonly HtmlDegradation[];
   /** Articles skipped because they carried no ingestable prose. */
   readonly skippedContentless: number;
+  /**
+   * `<articleNumber>:<language>` breadcrumbs for the skipped articles (capped
+   * at {@link CONTENTLESS_BREADCRUMB_CAP}) — a reconciliation crawl archives a
+   * previously-mirrored document that converts to empty, so the operator
+   * investigating a vanished article needs more than a count.
+   */
+  readonly contentlessArticles: readonly string[];
 }
+
+/** Bound on the contentless breadcrumb list (log hygiene, not correctness). */
+export const CONTENTLESS_BREADCRUMB_CAP = 20;
 
 /** Slugify into a single path segment; `fallback` guarantees non-empty. */
 export function slugifySegment(value: string, fallback: string): string {
@@ -106,6 +116,7 @@ export function assembleSalesforceKnowledgeDocuments(
   const documents: ConnectorDocument[] = [];
   const degradationTotals = new Map<string, number>();
   let skippedContentless = 0;
+  const contentlessArticles: string[] = [];
 
   for (const article of articles) {
     const sections: string[] = [];
@@ -132,6 +143,9 @@ export function assembleSalesforceKnowledgeDocuments(
     const markdown = sections.join("\n\n");
     if (isContentlessBody(markdown)) {
       skippedContentless++;
+      if (contentlessArticles.length < CONTENTLESS_BREADCRUMB_CAP) {
+        contentlessArticles.push(`${article.articleNumber}:${article.language}`);
+      }
       continue;
     }
 
@@ -174,7 +188,7 @@ export function assembleSalesforceKnowledgeDocuments(
     .map(([name, count]) => ({ name, count }))
     .toSorted((a, b) => a.name.localeCompare(b.name));
 
-  return { documents, degradations, skippedContentless };
+  return { documents, degradations, skippedContentless, contentlessArticles };
 }
 
 /**

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -34,13 +34,18 @@ export interface KnowledgeDocumentCounts {
  *   - `zendesk` — the #4396 Knowledge Sync Connector (a scheduled pull of one
  *     Zendesk Guide brand's help center via an API token; one collection per
  *     brand, one document per published article translation).
+ *   - `salesforce-knowledge` — the #4397 Knowledge Sync Connector (a scheduled
+ *     SOQL pull of published Salesforce Knowledge article versions over the
+ *     workspace's EXISTING Salesforce OAuth install — no credential of its
+ *     own; one document per published article-version language).
  *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
  * `authScheme`; connector collections (`notion`, `confluence`,
- * `confluence-datacenter`, `gitbook`, `zendesk`) carry neither (their
- * credential is a token, not an endpoint).
+ * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`) carry
+ * neither (their credential is a token — or, for `salesforce-knowledge`, the
+ * reused OAuth install — not an endpoint).
  */
 export type KnowledgeCollectionSource =
   | "upload"
@@ -49,7 +54,8 @@ export type KnowledgeCollectionSource =
   | "confluence"
   | "confluence-datacenter"
   | "gitbook"
-  | "zendesk";
+  | "zendesk"
+  | "salesforce-knowledge";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
## Summary

Closes #4397 (PRD #4395 tier slice on the ADR-0030 connector spine).

Adds the **Salesforce Knowledge sync connector** — the knowledge tier's first vendor that sources credentials from an **existing OAuth install** instead of `knowledge_sync_credentials`:

- **`lib/knowledge/salesforce/`** — `config.ts` (identity + scope-config SSOT), `client.ts` (`ConnectorVendorClient` running SOQL over the reused jsforce connection: describe-driven custom body-field discovery with a SOQL-identifier injection guard, **explicit `PublishStatus` filters** on every query (the unfiltered-query Draft+Archived leak guard), indexed `SystemModstamp` incremental where non-Online/out-of-channel rows advance the mark but emit nothing, `queryMore` reconciliation with anti-runaway bounds, `REQUEST_LIMIT_EXCEEDED` → `ConnectorRateLimitError` engine backoff), `documents.ts` (per-locale documents keyed `ArticleNumber`+`Language`, shared support HTML→markdown converter, `atlas:` provenance with article id + version + locale), `connector.ts` (factory resolving the lazy `catalog:salesforce` instance with positively-classified, actionable errors)
- **`lazy-builder.ts` extension** — `queryPage`/`queryMorePage`/`describeObject` on `SalesforcePluginInstance` (the existing `query()` silently truncates at the first SOQL batch — unsound for a crawl); `toQueryPage` **throws** on `done:false` with no locator rather than let a truncated result feed subtractive archiving
- **Credential-less install handler** — verifies the reused OAuth install + describes the article object loudly BEFORE persisting; no secret collected, no new connected-app registration, `credentialWritten: false`
- **Wiring** — register pairing (form handler + connector together), catalog seed row, admin-knowledge source branches, `KnowledgeCollectionSource` wire union + web Zod enum, OpenAPI regen, ADR-0030 amendment documenting the reused-OAuth-install credential pattern
- Deliberately calls `connection.query()` via the lazy instance, **not** the whitelisted `querySalesforce` agent tool (whose object whitelist + auto-LIMIT are agent policy)

Internal review panel: round 1 CHANGES REQUESTED (HIGH: truncated-page coercion; 4 MEDIUM; ~15 LOW) → fixed → round 2 CLEAN.

Also fixes a pre-existing environment-dependent flake: `admin-model-config.test.ts`'s gateway backward-compat test now carries a 15s timeout (the real gateway fetch self-aborts at 10s; bun's 5s default fired first on black-holed networks).

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated — ~70 new tests: vendor client (fixture `SalesforceKnowledgeApi`, no live org), documents assembly, connector factory, form handler, lazy-builder paged surface, register pairing, catalog seed, admin-knowledge route, real-Postgres lifecycle (`SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL` against the live schema)
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`) — all 28 `ci-local.sh` gates green
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change) — changelog is per-release (`/release`), not per-PR

https://claude.ai/code/session_01EBAiMUUu853YSRRCtqovPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBAiMUUu853YSRRCtqovPj)_