### PR TITLE
Make /ci hang-proof: disk-observable completion + launch-and-watch

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -4,34 +4,71 @@ Run the same checks CI runs. This must pass before opening a PR.
 `cd packages/api && bun run scripts/test-isolated.ts --affected` (only tests
 whose source graph your branch touched — typically 10–60s vs the full suite).
 
-## How to run it (token-aware)
+## How to run it (token-aware, hang-proof)
 
 All gates run through one wrapper: **`bash scripts/ci-local.sh`**. It runs every
 gate, redirects each one's output to `.ci-local/<gate>.log`, and prints only a
 compact PASS/FAIL table plus the tail of any *failed* gate — one small result
 instead of ~26 verbose ones. Exit code is 0 (all green) or 1 (something failed).
 
-**Delegate the run to a subagent** so even that stays out of the main thread.
-Spawn ONE `general-purpose` agent with this prompt:
+The wrapper also leaves machine-readable run state under `.ci-local/`, so
+completion is observable **from disk**, independent of any agent hand-off:
 
-> Run `bash scripts/ci-local.sh` from the repo root (it takes ~4–6 min — the
-> full test suite is the long pole; wait for it). Then, only if it exited 0,
-> run the two remote-status commands in the "Remote checks" section of
-> `.claude/commands/ci.md` and summarize them. Do NOT fix anything — you are
-> reporting only. Return: (1) the gate table verbatim if anything failed, or
-> just "local: all N gates green" if not; (2) for each failed gate, its name,
-> a one-line root cause from its `.ci-local/<gate>.log`, and the file:line to
-> fix; (3) the remote-status summary. Keep the whole reply under ~40 lines —
-> do not paste full logs.
+| File | Meaning |
+|------|---------|
+| `.ci-local/PID` | The run's pid — `kill -0 "$(cat .ci-local/PID)"` = still running |
+| `.ci-local/STATUS` | Last stage transition (install / stage 0 / 1 / 2) |
+| `.ci-local/RESULT` | The full compact report, written **atomically at the very end**. Existence = run finished; contents = the report |
 
-The subagent burns the verbose output in its own context and hands you back a
-short report. You (main thread) then apply any fixes — fixing needs the
-conversation context, so it stays here, not in the subagent.
+### Launch, then actively watch — never passively wait
+
+Historic failure mode: `/ci` was delegated to a background subagent and the
+main thread ended its turn "waiting for the report". When that completion
+hand-off was lost (subagent died or its reply never arrived), the calling loop
+(`/ship-issue`) sat idle until a human poked it. The fix is a protocol, not a
+hope: **whoever kicks off the run owns a watchdog loop, and `.ci-local/RESULT`
+on disk — not any agent's reply — is the completion signal.**
+
+1. **Launch** `bash scripts/ci-local.sh` from the repo root as a background
+   Bash task (`run_in_background: true`). Its printed output is already
+   compact — that is the wrapper's whole purpose — so no subagent wrapper is
+   needed. (If you do wrap it in a subagent, prefer a synchronous run; a
+   background subagent changes nothing below — the disk artifacts stay the
+   ground truth, never the agent's reply.)
+2. **Arm a backstop before doing anything else.** If your harness has a
+   scheduled self check-in (`send_later`, `ScheduleWakeup`, or similar),
+   schedule one ~10 min out that says "check .ci-local/RESULT for the /ci run
+   and act on it" — so even a lost completion notification can't strand the
+   session. Cancel or ignore it if the result arrives first.
+3. **Watch on a loop.** Do NOT end your turn to wait for a completion
+   notification. Check roughly every 1–2 minutes (`sleep 90` between checks
+   where foreground sleep is allowed; otherwise your harness's Monitor /
+   until-loop / background-task polling). Each check is one cheap tri-state:
+   ```bash
+   if [ -f .ci-local/RESULT ]; then cat .ci-local/RESULT
+   elif kill -0 "$(cat .ci-local/PID 2>/dev/null)" 2>/dev/null; then
+     echo "RUNNING: $(cat .ci-local/STATUS 2>/dev/null) — $(ls .ci-local/*.exit 2>/dev/null | wc -l) gates done"
+   else echo "DEAD without RESULT — the wrapper crashed"; fi
+   ```
+4. **Resolve** on the first check that isn't RUNNING:
+   - **`RESULT` exists** → that output IS the report; act on it (green →
+     remote checks; failures → fix). If a subagent/notification reports too,
+     fine — but never *require* it.
+   - **Still RUNNING past ~20 min** (a normal run is ~4–6 min; the full test
+     suite is the long pole) → treat as hung: note `.ci-local/STATUS` and which
+     gates have no `.exit` file yet, kill the run, relaunch once. Hung twice →
+     STOP and report the stuck gate to the human.
+   - **DEAD without `RESULT`** → the wrapper crashed: read the tail of the
+     newest `.ci-local/*.log`, relaunch once. Crashed twice → STOP and report.
+
+Once local gates are green, run the two commands in "Remote checks" below
+yourself (they're short, compact `gh` calls) and fold them into the report.
+You (main thread) apply any fixes — fixing needs the conversation context.
 
 After fixing a gate, re-verify just that one cheaply — e.g.
 `bash scripts/check-schema-drift.sh` or `bun run test path/to/file.test.ts` —
 rather than re-running the whole wrapper. Re-run the full `bash scripts/ci-local.sh`
-once at the end to confirm a clean green.
+once at the end (same launch-and-watch protocol) to confirm a clean green.
 
 **Env toggles** (pass to the wrapper): `CI_LOCAL_NO_TEST=1` skips the test suite
 for a fast gates-only pass (RESULT is flagged "tests skipped" — never a clean
@@ -139,6 +176,7 @@ gh api repos/AtlasDevHQ/atlas/commits/main/statuses --jq '[.[] | {context, state
 `CI gates (scripts/ci-local.sh): all pass. Remote: CI, Sync Starters, Railway staging (api-staging/web-staging/docs) — all green.`
 
 ## Rules
+- Never end a turn "waiting for the CI report". `.ci-local/RESULT` on disk is the completion signal — poll it on the watch loop above. A lost subagent reply or notification must cost you one poll interval, not a stalled session.
 - Never skip a gate or mark it "probably fine". The wrapper runs them all; don't second-guess a FAIL without reading the log.
 - If a gate fails on code you didn't write (pre-existing), still fix it — CI won't distinguish. The one exception is local-only cruft (see `plugin-count` above), which you remove, not fix.
 - If a test is flaky (passes on retry), note it but don't ignore it. The test suite runs isolated in Stage 2 specifically to reduce WSL2 flakiness — a failure there is more likely real.

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -49,6 +49,8 @@ Use `cd packages/api && bun run scripts/test-isolated.ts --affected` for the fas
 ```
 All gates must pass. Fix anything red (these are usually small). Run full `bun run test` once here even if `--affected` was green.
 
+`/ci` uses a **launch-and-watch protocol** (see `ci.md`): the wrapper runs in the background and YOU poll `.ci-local/RESULT` on a loop — never end the turn "waiting for the CI report". A lost subagent hand-off here used to stall the whole ship loop until a human poked it; `.ci-local/RESULT` on disk is the completion signal, not any agent's reply.
+
 **Step 5 — Open the PR, then drive it to merge**
 
 ```

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -8,8 +8,9 @@
 #   accumulated context on every step. This wrapper runs every gate, redirects
 #   each one's output to its own logfile under .ci-local/, and prints ONLY a
 #   compact PASS/FAIL table plus the tail of any FAILED gate. One small tool
-#   result instead of twenty large ones. Run it from a subagent (see
-#   .claude/commands/ci.md) to keep even that out of the main thread.
+#   result instead of twenty large ones. Launch it in the background and poll
+#   .ci-local/RESULT (the launch-and-watch protocol in .claude/commands/ci.md)
+#   — completion is observable from disk, never dependent on an agent hand-off.
 #
 # WHAT IT MIRRORS
 #   The required `ci` GitHub check (.github/workflows/ci.yml: drift + lint +
@@ -51,6 +52,15 @@ cd "$ROOT"
 LOG_DIR="$ROOT/.ci-local"
 rm -rf "$LOG_DIR"
 mkdir -p "$LOG_DIR"
+
+# Machine-readable run state for the launch-and-watch protocol in
+# .claude/commands/ci.md — a watcher must never depend on an agent hand-off:
+#   PID     — this run's pid; liveness = `kill -0 "$(cat .ci-local/PID)"`
+#   STATUS  — last stage transition, overwritten in place
+#   RESULT  — the full compact report, written ATOMICALLY at the very end.
+#             Its existence is the completion signal; its contents are the report.
+echo "$$" >"$LOG_DIR/PID"
+status() { printf '%s\n' "$*" | tee "$LOG_DIR/STATUS"; }
 
 JOBS="${CI_LOCAL_JOBS:-6}"
 NO_TEST="${CI_LOCAL_NO_TEST:-0}"
@@ -144,22 +154,25 @@ fi
 
 # Match CI's `bun install --frozen-lockfile`: catches a stale lockfile and
 # guarantees node_modules exists (a worktree/fresh checkout would TS2307 otherwise).
+status "install: bun install --frozen-lockfile" >/dev/null
 printf '  bun install (frozen) … '
 if bun install --frozen-lockfile >"$LOG_DIR/install.log" 2>&1; then
   echo "ok"
 else
   echo "FAILED — see .ci-local/install.log"
   tail -n "$FAIL_TAIL" "$LOG_DIR/install.log"
-  echo "RESULT: FAIL — dependency install failed; fix the lockfile before gates can run."
+  msg="RESULT: FAIL — dependency install failed; fix the lockfile before gates can run."
+  echo "$msg"
+  printf '%s\n' "$msg" >"$LOG_DIR/RESULT"
   exit 1
 fi
 
 # ---- Stage 0: the lone dist/-writer, serial ----
-echo "stage 0: type-check + SDK dist build (serial) …"
+status "stage 0: type-check + SDK dist build (serial) …"
 run_fg type g_type
 
 # ---- Stage 1: read-only gates, parallel ----
-echo "stage 1: read-only drift/lint gates (parallel, jobs=$JOBS) …"
+status "stage 1: read-only drift/lint gates (parallel, jobs=$JOBS) …"
 launch lint                      g_lint
 # Type-aware lint reads the SDK dist/ that Stage 0 just built (tsgolint
 # resolves @useatlas/* via "exports" → dist), so it must run after Stage 0 —
@@ -196,45 +209,61 @@ wait
 
 # ---- Stage 2: full test suite, isolated ----
 if [ "$NO_TEST" != "1" ]; then
-  echo "stage 2: full test suite (isolated — no parallel load) …"
+  status "stage 2: full test suite (isolated — no parallel load) …"
   run_fg test g_test
 fi
 
 # ---- Report ----
-echo ""
-printf '%-28s %-7s %5s\n' "GATE" "RESULT" "TIME"
-printf '%s\n' "------------------------------------------------"
-
+# Rendered once, printed to stdout AND written atomically (tmp + mv) to
+# .ci-local/RESULT so a watcher polling for the file can never observe it
+# half-written. RESULT's existence = run finished; its contents = the report.
 failed=()
 for name in "${GATE_NAMES[@]}"; do
   rc="$(cat "$LOG_DIR/$name.exit" 2>/dev/null || echo 1)"
-  secs="$(cat "$LOG_DIR/$name.secs" 2>/dev/null || echo '?')"
-  if [ "$rc" = "0" ]; then
-    printf '%-28s %-7s %4ss\n' "$name" "PASS" "$secs"
-  else
-    printf '%-28s %-7s %4ss\n' "$name" "FAIL" "$secs"
-    failed+=("$name")
-  fi
+  [ "$rc" = "0" ] || failed+=("$name")
 done
-printf '%s\n' "------------------------------------------------"
-
 total="${#GATE_NAMES[@]}"
-if [ "${#failed[@]}" -eq 0 ]; then
-  if [ "$NO_TEST" = "1" ]; then
-    echo "RESULT: PASS (tests skipped — Stage 2 not run; not a clean pre-PR pass)"
-  else
-    echo "RESULT: PASS — all $total gates green."
-  fi
-  exit 0
-fi
 
-echo "RESULT: FAIL — ${#failed[@]} of $total gates failed: ${failed[*]}"
-echo ""
-for name in "${failed[@]}"; do
-  echo "▼ $name  (.ci-local/$name.log — last $FAIL_TAIL lines)"
-  tail -n "$FAIL_TAIL" "$LOG_DIR/$name.log" 2>/dev/null | sed 's/^/    /'
+render_report() {
+  local name rc secs
   echo ""
-done
-echo "Full logs: .ci-local/<gate>.log   Re-run one gate, e.g.: bash scripts/check-schema-drift.sh"
-echo "Note: a 'type' failure can cascade into openapi-drift/test (incomplete SDK dist) — fix type first."
+  printf '%-28s %-7s %5s\n' "GATE" "RESULT" "TIME"
+  printf '%s\n' "------------------------------------------------"
+  for name in "${GATE_NAMES[@]}"; do
+    rc="$(cat "$LOG_DIR/$name.exit" 2>/dev/null || echo 1)"
+    secs="$(cat "$LOG_DIR/$name.secs" 2>/dev/null || echo '?')"
+    if [ "$rc" = "0" ]; then
+      printf '%-28s %-7s %4ss\n' "$name" "PASS" "$secs"
+    else
+      printf '%-28s %-7s %4ss\n' "$name" "FAIL" "$secs"
+    fi
+  done
+  printf '%s\n' "------------------------------------------------"
+
+  if [ "${#failed[@]}" -eq 0 ]; then
+    if [ "$NO_TEST" = "1" ]; then
+      echo "RESULT: PASS (tests skipped — Stage 2 not run; not a clean pre-PR pass)"
+    else
+      echo "RESULT: PASS — all $total gates green."
+    fi
+    return
+  fi
+
+  echo "RESULT: FAIL — ${#failed[@]} of $total gates failed: ${failed[*]}"
+  echo ""
+  for name in "${failed[@]}"; do
+    echo "▼ $name  (.ci-local/$name.log — last $FAIL_TAIL lines)"
+    tail -n "$FAIL_TAIL" "$LOG_DIR/$name.log" 2>/dev/null | sed 's/^/    /'
+    echo ""
+  done
+  echo "Full logs: .ci-local/<gate>.log   Re-run one gate, e.g.: bash scripts/check-schema-drift.sh"
+  echo "Note: a 'type' failure can cascade into openapi-drift/test (incomplete SDK dist) — fix type first."
+}
+
+report="$(render_report)"
+printf '%s\n' "$report"
+printf '%s\n' "$report" >"$LOG_DIR/RESULT.tmp"
+mv "$LOG_DIR/RESULT.tmp" "$LOG_DIR/RESULT"
+
+[ "${#failed[@]}" -eq 0 ] && exit 0
 exit 1


### PR DESCRIPTION
## Summary
- Fixes the `/ship-issue` stall where `/ci` was delegated to a background subagent and the caller ended its turn waiting for a reply that sometimes never arrived (observed on ship-issue 4397: the run finished green but never reported, and the session sat idle until a human poked it).
- `scripts/ci-local.sh` now writes machine-readable run state to `.ci-local/`: `PID` (liveness), `STATUS` (last stage transition), and `RESULT` — the full compact report written atomically (tmp+mv) at the very end, so its **existence is the completion signal and its contents are the report**. The install-failure early exit writes `RESULT` too.
- `.claude/commands/ci.md` replaces "delegate to a subagent and wait" with a **launch-and-watch protocol**: run the wrapper as a background task, arm a scheduled self check-in backstop, poll a cheap `RESULT`/`PID`/`STATUS` tri-state every 1–2 min, and resolve done / hung (>20 min → kill + relaunch once) / crashed (relaunch once) explicitly. New rule: never end a turn "waiting for the CI report" — disk is the completion signal, never an agent's reply.
- `.claude/commands/ship-issue.md` Step 4 points at the protocol so the ship loop can no longer strand on a lost hand-off.

## Test plan
- [x] `bash -n` on the wrapper
- [x] Full gates-only run (`CI_LOCAL_NO_TEST=1`): 26 gates PASS; `RESULT` file byte-identical to the stdout report; tests-skipped flag correctly says "not a clean pre-PR pass"
- [x] Live tri-state polling during runs reports `RUNNING: <stage> — N gates done`
- [x] Crash path: killed a run mid-stage-0 → watchdog reports `DEAD without RESULT`, `STATUS` shows the dying stage
- [x] Full `/ci` run via the new protocol itself (background launch + `send_later` backstop + Monitor watchdog): 28/29 gates green; the single `test` failure is the pre-existing env-dependent gateway-catalog flake filed as #4451 (real `getGatewayCatalog()` fetch takes ~6.8s to fall back in a proxied container, over bun's 5s test timeout; unrelated to this diff, which touches only a shell script and two command markdown files)
- [ ] Required CI green on this PR (authoritative test gate)

https://claude.ai/code/session_01FCoe5DEbXSRwwu1TYB7yKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCoe5DEbXSRwwu1TYB7yKq)_