### PR TITLE
fix(agent-auth): review-panel punch-list — fail-closed hardening + coverage

### DIFF
--- a/apps/docs/content/docs/agent-auth/index.mdx
+++ b/apps/docs/content/docs/agent-auth/index.mdx
@@ -95,9 +95,9 @@ execution the incoming JWT is validated (signature, `aud`, expiry, `jti` replay)
 requested capability is checked against the agent's recorded grants. A missing, expired, or
 revoked grant fails closed — the capability does not run.
 
-Grants are workspace-scoped by construction. An agent registers under a **user** (who may
-belong to several workspaces) and *proposes* a workspace per request; the proposal is
-honored only if that owning user is a live member of it. So an agent bound to workspace A
+Data access is workspace-scoped by construction. An agent registers under a **user** (who
+may belong to several workspaces) and carries a *proposed* workspace on its agent record;
+at each execution the proposal is honored only if that owning user is a live member of it. So an agent bound to workspace A
 can never resolve a capability that reads workspace B's data. That isolation is enforced at
 capability **execution** (`onExecute`), which is the point where the workspace is known and
 membership-verified — see the enforcement discussion in

--- a/apps/docs/content/docs/platform-ops/agent-auth-enablement.mdx
+++ b/apps/docs/content/docs/platform-ops/agent-auth-enablement.mdx
@@ -49,8 +49,8 @@ When a workspace has opted out (platform on, workspace override off),
 its **registration, discovery, and `capability/list`** endpoints stay
 reachable — those endpoints are user-scoped / workspace-agnostic and
 cannot be workspace-gated (an agent registers under a *user* who may
-belong to several workspaces; the workspace is only *proposed* per
-request and only *bound* at execute). No data flows, though: the only
+belong to several workspaces; the workspace is only *proposed* on the
+agent's record and only *bound*, membership-checked, at execute). No data flows, though: the only
 data-bearing endpoint, `capability/execute`, is `404`'d by the
 workspace-tier check. Execution is the single correct enforcement
 point, and it is gated.

--- a/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
+++ b/packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts
@@ -19,8 +19,9 @@
  *
  * No-restart proof: the same mounted app + same stub is reused across the
  * off→on→off sequence; only `process.env.ATLAS_AGENT_AUTH_ENABLED` changes
- * between requests, and `getSettingLive` (no internal DB in the test → reads env
- * fresh) picks it up per request. Self-contained: env saved and restored.
+ * between requests, and the `getSettingLive` stub (which mirrors real
+ * no-internal-DB resolution: an env read per call — see the stub-site comment)
+ * picks it up per request. Self-contained: env saved and restored.
  */
 
 import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
@@ -120,6 +121,20 @@ describe("Agent Auth live-toggle (#4409)", () => {
       const res = await req(method, path);
       expect({ path, status: res.status }).toEqual({ path, status: 404 });
     }
+  });
+
+  it("OFF: the gate 404 carries the exact `{ error: \"not_found\" }` envelope the web approval page keys on", async () => {
+    // Cross-package wire contract: `resolve-approval-outcome.ts` (packages/web)
+    // discriminates "surface gated off" from a per-request 404 (e.g.
+    // `agent_not_found`) by this literal. The constant can't be shared until the
+    // next `@useatlas/types` publish window (scaffold-bound source may only use
+    // published symbols), so this pin + the web-side test are the drift guard.
+    // If you change this envelope, update GATE_OFF_ERROR there in the same PR.
+    delete process.env.ATLAS_AGENT_AUTH_ENABLED;
+    const res = await req("POST", "/api/auth/agent/approve-capability");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("not_found");
   });
 
   it("OFF (default): the discovery document returns 404", async () => {

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -832,17 +832,31 @@ app.get("/api/v1/openapi.json", (c) => c.json(buildAtlasOpenApiDocument()));
 // Hand the agent-auth OpenAPI adapter (#4410) the in-process Atlas spec, lazily.
 // The thunk runs at most once, on the first agent-auth plugin build (first
 // authed request), so the ~2.5 MB document is never generated eagerly at boot.
-registerAtlasOpenApiSource(
-  () => buildAtlasOpenApiDocument() as unknown as AtlasOpenApiSpec,
-);
+registerAtlasOpenApiSource(() => {
+  const doc = buildAtlasOpenApiDocument();
+  // Structural assert at the unchecked-cast boundary: a shape regression here
+  // must surface as the source module's loud fail-soft (zero capabilities,
+  // logged at error, not memoized), never as a silently-empty operation index.
+  if (!doc.paths || typeof doc.paths !== "object") {
+    throw new Error("Atlas OpenAPI document has no paths object — cannot derive agent-auth capabilities");
+  }
+  return doc as unknown as AtlasOpenApiSpec;
+});
 
 // Hand the agent-auth proxy (#4410) an in-process transport to THIS app, so its
 // `onExecute` forwards derived operations through the real middleware stack with
 // no network socket. Registered here (where `app` lives) so `lib/` never imports
 // the `api/` layer.
 registerInProcessApiFetch(async (input, init) => {
+  // `new Request(input, init)` when both are present: a caller passing
+  // `fetch(request, init)` must not have its init (method/headers — potentially
+  // the minted x-api-key) silently dropped.
   const request =
-    input instanceof Request ? input : new Request(input instanceof URL ? input.href : input, init);
+    input instanceof Request
+      ? init
+        ? new Request(input, init)
+        : input
+      : new Request(input instanceof URL ? input.href : input, init);
   return app.fetch(request);
 });
 

--- a/packages/api/src/lib/auth/__tests__/agent-auth-audit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-audit.test.ts
@@ -116,6 +116,25 @@ describe("agent-auth audit — lifecycle mappings", () => {
     });
   });
 
+  it("drops non-primitive values under allowlisted detail keys (value guard pairs with the key allowlist)", async () => {
+    const { auditor, rows } = harness();
+    await auditor.handleEvent({
+      type: "capability.denied",
+      actorId: "user_1",
+      agentId: "agent_1",
+      metadata: {
+        reason: { verbose: "object smuggled under an allowlisted key", claims: { ssn: "123-45-6789" } },
+        name: "ok-label",
+        capabilities: ["getReports"],
+      },
+    });
+    expect(rows).toHaveLength(1);
+    const detail = (rows[0]!.metadata?.detail ?? {}) as Record<string, unknown>;
+    // Primitive + flat-array values survive; the nested object is dropped whole.
+    expect(detail).toEqual({ name: "ok-label", capabilities: ["getReports"] });
+    expect(JSON.stringify(rows[0]!.metadata)).not.toContain("123-45-6789");
+  });
+
   it("ignores event types that are not in the audited catalog", async () => {
     const { auditor, rows } = harness();
     for (const type of [
@@ -248,6 +267,48 @@ describe("agent-auth audit — fail-closed master gate (AC #4)", () => {
     await auditor.handleEvent({ type: "capability.approved", actorId: "user_1", agentId: "agent_1" });
     await auditor.handleEvent(executeEvent());
     await auditor.handleEvent(executeEvent({ status: "error", error: "boom" }));
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// The interface's stated contract: `handleEvent` NEVER rejects — a slow/failing
+// audit path must not be able to break an agent-auth request.
+describe("agent-auth audit — never-rejects contract", () => {
+  it("resolves (and keeps processing later events) when emit throws", async () => {
+    const rows: AdminActionEntry[] = [];
+    let failNext = true;
+    const auditor = createAgentAuthAuditor({
+      emit: (entry) => {
+        if (failNext) {
+          failNext = false;
+          throw new Error("admin_action_log insert failed");
+        }
+        rows.push(entry);
+      },
+      isEnabled: async () => true,
+    });
+    // The throwing emit is swallowed + logged, never rejected to the caller…
+    await expect(
+      auditor.handleEvent({ type: "agent.created", agentId: "agent_1" }),
+    ).resolves.toBeUndefined();
+    // …and the auditor is not poisoned: the next event still lands.
+    await auditor.handleEvent({ type: "agent.revoked", agentId: "agent_1" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.actionType).toBe(ADMIN_ACTIONS.agent.revoke);
+  });
+
+  it("resolves AND emits nothing when the gate resolver rejects (fail-closed, not fail-open)", async () => {
+    const rows: AdminActionEntry[] = [];
+    const auditor = createAgentAuthAuditor({
+      emit: (entry) => rows.push(entry),
+      isEnabled: async () => {
+        throw new Error("settings backend unavailable");
+      },
+    });
+    await expect(
+      auditor.handleEvent({ type: "agent.created", agentId: "agent_1" }),
+    ).resolves.toBeUndefined();
+    // A gate error must read as OFF (no rows), never as ON.
     expect(rows).toHaveLength(0);
   });
 });

--- a/packages/api/src/lib/auth/__tests__/agent-auth-device-approval.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-device-approval.test.ts
@@ -32,8 +32,12 @@
 import { describe, it, expect, beforeAll } from "bun:test";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
+import { passkey } from "@better-auth/passkey";
 import { createHash } from "node:crypto";
-import { buildAgentAuthPlugin } from "@atlas/api/lib/auth/agent-auth-plugin";
+import {
+  buildAgentAuthPlugin,
+  type AgentAuthPluginDeps,
+} from "@atlas/api/lib/auth/agent-auth-plugin";
 import type { AtlasOpenApiSpec } from "@atlas/api/lib/auth/atlas-openapi-source";
 
 const BASE = "http://localhost:3000";
@@ -68,13 +72,14 @@ interface SignedUpUser {
 }
 
 /** Build a fresh instance so each test gets an isolated in-memory store. */
-function makeInstance() {
+function makeInstance(overrides: Partial<AgentAuthPluginDeps> = {}) {
   const plugin = buildAgentAuthPlugin({
     spec: FIXTURE_SPEC,
     fetch: async () => new Response("{}", { status: 200 }),
     mintToken: async () => "unused-token",
     baseUrl: "http://internal",
     deviceAuthorizationPage: WEB_APPROVAL_PAGE,
+    ...overrides,
   });
   return betterAuth({
     baseURL: BASE,
@@ -83,9 +88,14 @@ function makeInstance() {
     database: memoryAdapter({
       user: [], session: [], account: [], verification: [],
       agent: [], agentHost: [], agentCapabilityGrant: [], approvalRequest: [],
+      passkey: [],
     }),
+    // The passkey plugin mirrors server.ts — it is LOAD-BEARING for the step-up
+    // test: without it the agent-auth plugin's proofOfPresence enforcement is
+    // silently inert (no challenge cache), and an approval that should demand a
+    // WebAuthn assertion would just succeed.
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
-    plugins: [plugin] as any[],
+    plugins: [plugin, passkey({ rpID: "localhost" })] as any[],
   });
 }
 
@@ -280,6 +290,37 @@ describe("Agent Auth device-approval round-trip (#4411)", () => {
 
     expect(status).toBeGreaterThanOrEqual(400);
     expect(body.error).toBe("invalid_user_code");
+    expect(await grantStatus(instance, agentId)).toBe("pending");
+  });
+
+  it("enterprise step-up (#4413): with proofOfPresence on, an approve WITHOUT a WebAuthn assertion is rejected and the grant stays pending", async () => {
+    // The options-level tests (agent-auth-plugin.test.ts) pin that /ee turns
+    // proofOfPresence on; this pins that the library then actually ENFORCES the
+    // ceremony end-to-end: a signed-in user with no passkey (and no assertion in
+    // the POST) cannot complete an approval — the grant never activates. This is
+    // the "an autonomous agent with browser control cannot self-approve" half.
+    instance = makeInstance({
+      stepUpWrites: true,
+      webauthnRpId: "localhost",
+      webauthnOrigin: BASE,
+    });
+    approver = await signUp(instance, "stepup@example.com");
+    const agentId = await seedPendingApproval(instance, approver.userId);
+
+    const { body } = await postApproval(instance, approver.cookie, {
+      agent_id: agentId,
+      user_code: USER_CODE,
+      action: "approve",
+    });
+
+    // No enrolled passkey → the ceremony cannot even start; with one enrolled
+    // the library instead returns `webauthn_required` + a challenge. Either way
+    // the approval does NOT complete without proof of presence. (0.6.2 quirk:
+    // this branch uses `ctx.json(body, { status: 403 })`, whose status is not
+    // honored through the handler — the ERROR BODY + the grant staying pending
+    // are the enforced contract, so those are what this pins.)
+    expect(body.error).toBe("webauthn_not_enrolled");
+    expect(body.status).toBeUndefined(); // never "approved"
     expect(await grantStatus(instance, agentId)).toBe("pending");
   });
 });

--- a/packages/api/src/lib/auth/__tests__/agent-auth-gate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-gate.test.ts
@@ -44,8 +44,10 @@ void mock.module("@atlas/api/lib/settings", () => ({
 import {
   isAgentAuthPath,
   isAgentAuthEnabled,
+  resolveAgentAuthEnablement,
   AGENT_AUTH_MOUNT,
   AGENT_AUTH_CONFIGURATION_PATH,
+  AGENT_AUTH_ENABLED_SETTING,
 } from "@atlas/api/lib/auth/agent-auth-gate";
 import { buildAgentAuthPlugin } from "@atlas/api/lib/auth/agent-auth-plugin";
 
@@ -114,6 +116,51 @@ describe("isAgentAuthEnabled (fail-closed)", () => {
     settingValue = "true"; // would be ON if it read cleanly
     throwOnRead = true;
     expect(await isAgentAuthEnabled()).toBe(false);
+  });
+});
+
+// The tri-state under the boolean: `indeterminate` (a failed settings read)
+// stays distinguishable for the execution tier, which surfaces it as a
+// ref-stamped 500 instead of a 404 that would falsely claim a workspace opt-out.
+describe("resolveAgentAuthEnablement (tri-state)", () => {
+  afterEach(() => {
+    throwOnRead = false;
+    settingValue = undefined;
+    workspaceOverrides = {};
+  });
+
+  it("resolves on / off from the setting value", async () => {
+    settingValue = "true";
+    expect(await resolveAgentAuthEnablement()).toBe("on");
+    settingValue = "false";
+    expect(await resolveAgentAuthEnablement()).toBe("off");
+    settingValue = undefined;
+    expect(await resolveAgentAuthEnablement()).toBe("off");
+  });
+
+  it("a settings-resolution error is 'indeterminate' — distinguishable from a deliberate off", async () => {
+    settingValue = "true";
+    throwOnRead = true;
+    expect(await resolveAgentAuthEnablement("wsA")).toBe("indeterminate");
+    // The boolean view of the same state stays fail-closed.
+    expect(await isAgentAuthEnabled("wsA")).toBe(false);
+  });
+});
+
+// Pin the load-bearing registry-definition fields. Every behavioral test above
+// stubs `getSettingLive`, so nothing else goes red if the DEFINITION drifts —
+// e.g. default flipped to "true" (fleet-wide silent enable), `requiresRestart`
+// added (kills the no-redeploy guarantee), or the workspace scope dropped
+// (breaks tier 2 of the #4419 precedence).
+describe("ATLAS_AGENT_AUTH_ENABLED settings-registry definition pin", () => {
+  it("is a hot-reloadable, workspace-scoped boolean defaulting OFF", () => {
+    const def = settingsReal.getSettingDefinition(AGENT_AUTH_ENABLED_SETTING);
+    expect(def).toBeDefined();
+    expect(def?.type).toBe("boolean");
+    expect(def?.default).toBe("false");
+    expect(def?.scope).toBe("workspace");
+    expect(def?.envVar).toBe("ATLAS_AGENT_AUTH_ENABLED");
+    expect(def?.requiresRestart ?? false).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/agent-auth-plugin.test.ts
@@ -24,6 +24,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, afterEach, mock } from "bun:test";
 import { betterAuth } from "better-auth";
+import { apiKey as apiKeyPlugin } from "@better-auth/api-key";
 import { memoryAdapter } from "better-auth/adapters/memory";
 import { generateKeyPair, exportJWK, SignJWT } from "jose";
 import { existsSync, readFileSync } from "node:fs";
@@ -47,15 +48,26 @@ void mock.module("@atlas/api/lib/auth/oauth-workspace-grants", () => ({
   revokeWorkspaceGrant: async () => 0,
 }));
 
-// Spread the real gate and override only the enable check, so resolveHeaders'
+// Spread the real gate and override only the enablement reads, so resolveHeaders'
 // workspace-override branch can be driven deterministically without an internal
 // DB (the gate's own env/fail-closed behavior is covered in agent-auth-gate.test.ts).
-// Default: enabled for every workspace.
+// Default: enabled for every workspace. `enablementForWorkspace` (when set)
+// drives the tri-state directly — used to exercise the `indeterminate` (settings
+// read failed) branch, which must surface as a 500, not a workspace opt-out 404.
 import * as gateReal from "@atlas/api/lib/auth/agent-auth-gate";
+import type { AgentAuthEnablement } from "@atlas/api/lib/auth/agent-auth-gate";
 let enabledForWorkspace: (orgId?: string) => boolean = () => true;
+let enablementForWorkspace: ((orgId?: string) => AgentAuthEnablement) | null = null;
+const resolveStubEnablement = (orgId?: string): AgentAuthEnablement =>
+  enablementForWorkspace
+    ? enablementForWorkspace(orgId)
+    : enabledForWorkspace(orgId)
+      ? "on"
+      : "off";
 void mock.module("@atlas/api/lib/auth/agent-auth-gate", () => ({
   ...gateReal,
-  isAgentAuthEnabled: async (orgId?: string) => enabledForWorkspace(orgId),
+  isAgentAuthEnabled: async (orgId?: string) => resolveStubEnablement(orgId) === "on",
+  resolveAgentAuthEnablement: async (orgId?: string) => resolveStubEnablement(orgId),
 }));
 
 // SUT — imported AFTER the mocks are registered.
@@ -63,11 +75,13 @@ import {
   buildAgentAuthPlugin,
   buildAgentAuthPluginOptions,
   resolveDeps,
+  createWorkspaceTokenMinter,
   AGENT_WORKSPACE_METADATA_KEY,
   mintWorkspaceApiKeyVia,
   type CreateWorkspaceApiKey,
   type AgentAuthPluginDeps,
 } from "@atlas/api/lib/auth/agent-auth-plugin";
+import { auditAgentAuthEvent } from "@atlas/api/lib/auth/agent-auth-audit";
 import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
@@ -176,6 +190,12 @@ describe("agent-auth OpenAPI adapter classification (#4410)", () => {
     // a dev artifact (not in the runtime image) but IS in the repo/CI checkout.
     const specPath = resolve(import.meta.dir, "../../../../../../apps/docs/openapi.json");
     if (!existsSync(specPath)) {
+      // In CI this file is the strongest containment guarantee in the suite — a
+      // docs-repo reorg must not silently drop it. Locally (partial checkouts)
+      // skipping stays fine.
+      if (process.env.CI) {
+        throw new Error(`real-spec containment test requires ${specPath} in the CI checkout`);
+      }
       console.warn(`[agent-auth] real-spec containment test skipped — ${specPath} not found`);
       return;
     }
@@ -333,6 +353,9 @@ describe("agent-auth WebAuthn step-up strength gating (#4413)", () => {
     // guarantee at spec scale (mirrors the containment real-spec test above).
     const specPath = resolve(import.meta.dir, "../../../../../../apps/docs/openapi.json");
     if (!existsSync(specPath)) {
+      if (process.env.CI) {
+        throw new Error(`real-spec stamping test requires ${specPath} in the CI checkout`);
+      }
       console.warn(`[agent-auth] real-spec stamping test skipped — ${specPath} not found`);
       return;
     }
@@ -410,7 +433,7 @@ describe("agent-auth CIBA backchannel approval gating (#4414)", () => {
         user: [], session: [], account: [], verification: [],
         agent: [], agentHost: [], agentCapabilityGrant: [], approvalRequest: [],
       }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Better Auth plugin union types
       plugins: [plugin] as any[],
     });
   }
@@ -494,6 +517,16 @@ describe("resolveDeps enterprise-flag wiring (#4413 AC3)", () => {
     else process.env.ATLAS_ENTERPRISE_ENABLED = prevEnterprise;
   });
 
+  it("UNSET flag (config unloaded) fails closed: stepUpWrites AND cibaApproval default false", () => {
+    // The comments in resolveDeps promise "defaults false whenever config is
+    // unloaded / the env flag is unset" — the true/false cases below don't
+    // exercise that default; this does.
+    delete process.env.ATLAS_ENTERPRISE_ENABLED;
+    const deps = resolveDeps({ spec: FIXTURE_SPEC });
+    expect(deps.stepUpWrites).toBe(false);
+    expect(deps.cibaApproval).toBe(false);
+  });
+
   it("stepUpWrites resolves true when enterprise is enabled (read via the core mirror, not @atlas/ee)", () => {
     process.env.ATLAS_ENTERPRISE_ENABLED = "true";
     expect(resolveDeps({ spec: FIXTURE_SPEC }).stepUpWrites).toBe(true);
@@ -572,6 +605,61 @@ describe("agent-auth per-org token minting (#4410)", () => {
       body: { error: "internal_error" },
     });
   });
+
+  it("upstream contract: minting through the REAL apiKey plugin stores the expiry + workspace metadata on the key row", async () => {
+    // The stub-based tests above pin what Atlas SENDS; this pins what Better
+    // Auth STORES — the half a `better-auth` bump could break while every stub
+    // test stayed green (e.g. a renamed `expiresIn` silently ignored).
+    const now = new Date();
+    const userRow = {
+      id: "user_1", name: "U", email: "u@example.com", emailVerified: true,
+      createdAt: now, updatedAt: now,
+    };
+    const apikeyRows: Array<Record<string, unknown>> = [];
+    const instance = betterAuth({
+      baseURL: BASE,
+      secret: "test-secret-at-least-32-characters-long!!",
+      database: memoryAdapter({
+        user: [userRow], session: [], account: [], verification: [], apikey: apikeyRows,
+      }),
+      // MIRROR of server.ts's apiKey() registration (metadata + the 15-minute
+      // minExpiresIn are both load-bearing: without the latter, the plugin's
+      // 1-DAY default minimum rejects the agent TTL with EXPIRES_IN_IS_TOO_SMALL
+      // — the exact production regression this test exists to catch).
+      plugins: [
+        apiKeyPlugin({
+          enableMetadata: true,
+          enableSessionForAPIKeys: true,
+          keyExpiration: { minExpiresIn: 15 / (60 * 24) },
+        }),
+      ],
+    });
+    const rawCreate = (instance.api as { createApiKey?: unknown }).createApiKey;
+    // The exact surface the production runtime-narrowing trusts.
+    expect(typeof rawCreate).toBe("function");
+    const token = await mintWorkspaceApiKeyVia(rawCreate as CreateWorkspaceApiKey, {
+      user,
+      workspaceId: "wsA",
+    });
+    expect(token.length).toBeGreaterThan(0);
+    // Read the STORED row back through the adapter (the memory adapter copies
+    // its seed arrays, so the row must be queried, not observed by reference).
+    const ctx = await instance.$context;
+    const rows = (await ctx.adapter.findMany({
+      model: "apikey",
+    })) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    // The plugin stores the owning user under `referenceId`.
+    expect(row.referenceId).toBe("user_1");
+    // The 15-min TTL actually landed on the stored row (a silently-ignored
+    // `expiresIn` would leave a never-expiring credential).
+    const expiresAt = new Date(String(row.expiresAt)).getTime();
+    const createdAt = new Date(String(row.createdAt)).getTime();
+    expect(expiresAt - createdAt).toBe(15 * 60 * 1000);
+    const meta = typeof row.metadata === "string" ? JSON.parse(row.metadata) : row.metadata;
+    expect(meta).toMatchObject({ atlasWorkspaceKey: true, orgId: "wsA" });
+  });
 });
 
 // ── Plugin contract ─────────────────────────────────────────────────────────
@@ -604,6 +692,103 @@ describe("agent-auth plugin contract (#4410)", () => {
     // capability set, never a crash. The surface stays default-off + 404-gated.
     const plugin = buildAgentAuthPlugin({ spec: null });
     expect(plugin.id).toBe("agent-auth");
+  });
+
+  it("wires the audit bridge as onEvent (drop that line and the whole agent.* trail silently disappears)", () => {
+    const opts = buildAgentAuthPluginOptions(
+      resolveDeps({
+        spec: FIXTURE_SPEC,
+        fetch: async () => new Response("{}", { status: 200 }),
+        mintToken: async () => "wskey",
+        baseUrl: "http://internal",
+        deviceAuthorizationPage: "https://app.example.com/agent/approve",
+        stepUpWrites: false,
+        webauthnRpId: "app.example.com",
+        webauthnOrigin: "https://app.example.com",
+        cibaApproval: false,
+      }),
+    );
+    // Identity, not shape: the audit unit tests all drive createAgentAuthAuditor
+    // directly, so ONLY this assertion goes red if the plugin factory stops
+    // passing the bridge ("unit-tested but unwired").
+    expect(opts.onEvent).toBe(auditAgentAuthEvent);
+  });
+});
+
+// ── Workspace token cache (createWorkspaceTokenMinter) ──────────────────────
+//
+// The cache sits between resolveHeaders and the Better Auth mint. Its one
+// unforgivable failure mode is key confusion: returning workspace A's cached
+// token for a workspace-B execution would be a cross-workspace credential leak.
+
+describe("agent-auth workspace token cache", () => {
+  const cacheUser = createAtlasUser("user_1", "managed", "U", { activeOrganizationId: "wsA" });
+  const otherUser = createAtlasUser("user_2", "managed", "V", { activeOrganizationId: "wsA" });
+
+  function cacheHarness(opts?: { ttlSeconds?: number; refreshBeforeMs?: number; maxEntries?: number }) {
+    let clock = 0;
+    const minted: string[] = [];
+    const minter = createWorkspaceTokenMinter(
+      async ({ user: u, workspaceId }) => {
+        const token = `tok_${u.id}_${workspaceId}_${minted.length}`;
+        minted.push(token);
+        return token;
+      },
+      { ...opts, now: () => clock },
+    );
+    return { minter, minted, advance: (ms: number) => (clock += ms) };
+  }
+
+  it("caches per (user, workspace): repeat calls reuse the token, no re-mint", async () => {
+    const { minter, minted } = cacheHarness({ ttlSeconds: 900, refreshBeforeMs: 120_000 });
+    const first = await minter({ user: cacheUser, workspaceId: "wsA" });
+    const second = await minter({ user: cacheUser, workspaceId: "wsA" });
+    expect(second).toBe(first);
+    expect(minted).toHaveLength(1);
+  });
+
+  it("NEVER returns one workspace's token for another workspace (cache-key isolation)", async () => {
+    const { minter, minted } = cacheHarness({ ttlSeconds: 900, refreshBeforeMs: 120_000 });
+    const a = await minter({ user: cacheUser, workspaceId: "wsA" });
+    const b = await minter({ user: cacheUser, workspaceId: "wsB" });
+    expect(b).not.toBe(a);
+    expect(b).toContain("wsB");
+    expect(minted).toHaveLength(2);
+    // …and per-user too: same workspace, different owning user ⇒ distinct token.
+    const c = await minter({ user: otherUser, workspaceId: "wsA" });
+    expect(c).not.toBe(a);
+    expect(c).toContain("user_2");
+  });
+
+  it("re-mints when the cached token is inside the refresh-before-expiry window", async () => {
+    const { minter, minted, advance } = cacheHarness({ ttlSeconds: 900, refreshBeforeMs: 120_000 });
+    const first = await minter({ user: cacheUser, workspaceId: "wsA" });
+    // Just before the window: still cached.
+    advance(900_000 - 120_000 - 1);
+    expect(await minter({ user: cacheUser, workspaceId: "wsA" })).toBe(first);
+    // Into the window: a proxied call must never race expiry — re-mint.
+    advance(2);
+    const refreshed = await minter({ user: cacheUser, workspaceId: "wsA" });
+    expect(refreshed).not.toBe(first);
+    expect(minted).toHaveLength(2);
+  });
+
+  it("stays bounded: overflowing maxEntries sweeps stale entries and keeps working", async () => {
+    const { minter, minted, advance } = cacheHarness({
+      ttlSeconds: 900,
+      refreshBeforeMs: 120_000,
+      maxEntries: 2,
+    });
+    await minter({ user: cacheUser, workspaceId: "ws1" });
+    await minter({ user: cacheUser, workspaceId: "ws2" });
+    // Let both go stale, then a third distinct pair triggers the sweep.
+    advance(900_000);
+    await minter({ user: cacheUser, workspaceId: "ws3" });
+    expect(minted).toHaveLength(3);
+    // Post-sweep the cache is intact: ws3 is cached, the stale pair re-mints.
+    expect(await minter({ user: cacheUser, workspaceId: "ws3" })).toBe(minted[2]);
+    const ws1Again = await minter({ user: cacheUser, workspaceId: "ws1" });
+    expect(ws1Again).toBe(minted[3]);
   });
 });
 
@@ -651,6 +836,7 @@ describe("agent-auth capability execution (#4410)", () => {
   afterEach(() => {
     workspacesForUser = () => ["wsA"];
     enabledForWorkspace = () => true;
+    enablementForWorkspace = null;
     lastForwarded = null;
     mintedFor = [];
     fetchResponder = okResponder;
@@ -662,7 +848,13 @@ describe("agent-auth capability execution (#4410)", () => {
   });
 
   function makeInstance(
-    agents: Array<{ id: string; workspaceId: string; grantStatus: "active" | "revoked" }>,
+    agents: Array<{
+      id: string;
+      workspaceId: string;
+      grantStatus: "active" | "revoked";
+      /** Capability the grant is for — defaults to the safe read. A BLOCKED name here models a grant that exists despite the policy (the execute-time re-check target). */
+      capability?: string;
+    }>,
   ) {
     const now = new Date();
     const host = {
@@ -680,7 +872,7 @@ describe("agent-auth capability execution (#4410)", () => {
       createdAt: now, updatedAt: now,
     }));
     const grantRows = agents.map((a) => ({
-      id: `grant_${a.id}`, agentId: a.id, capability: SAFE_CAP,
+      id: `grant_${a.id}`, agentId: a.id, capability: a.capability ?? SAFE_CAP,
       deniedBy: null, grantedBy: "user_1", expiresAt: null, status: a.grantStatus,
       constraints: null, createdAt: now, updatedAt: now,
     }));
@@ -704,6 +896,8 @@ describe("agent-auth capability execution (#4410)", () => {
     aud?: string;
     capabilities?: string[];
     expired?: boolean;
+    /** Sign with a DIFFERENT key than the registered one (forged-signature case). */
+    signWith?: AgentPrivateKey;
   }): Promise<string> {
     const jwt = new SignJWT({
       ...(opts.capabilities !== undefined ? { capabilities: opts.capabilities } : { capabilities: [SAFE_CAP] }),
@@ -715,7 +909,7 @@ describe("agent-auth capability execution (#4410)", () => {
       .setJti(`jti_${opts.agentId}_${crypto.randomUUID()}`)
       .setIssuedAt(opts.expired ? Math.floor(Date.now() / 1000) - 3600 : undefined)
       .setExpirationTime(opts.expired ? Math.floor(Date.now() / 1000) - 1800 : "2m");
-    return jwt.sign(privateKey);
+    return jwt.sign(opts.signWith ?? privateKey);
   }
 
   async function execute(
@@ -796,6 +990,79 @@ describe("agent-auth capability execution (#4410)", () => {
     expect(body.error).toBe("invalid_jwt");
   });
 
+  it("forged signature: a JWT signed by a foreign keypair → 401 invalid_jwt", async () => {
+    const forged = await generateKeyPair("EdDSA", { crv: "Ed25519", extractable: true });
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(
+      instance,
+      await mintJWT({ agentId: "agent_1", signWith: forged.privateKey }),
+    );
+    expect(status).toBe(401);
+    expect(body.error).toBe("invalid_jwt");
+    expect(mintedFor).toEqual([]);
+  });
+
+  it("jti replay: presenting the same token twice → second execute 401 jti_replay", async () => {
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const token = await mintJWT({ agentId: "agent_1" });
+    const first = await execute(instance, token);
+    expect(first.status).toBe(200);
+    const replay = await execute(instance, token);
+    expect(replay.status).toBe(401);
+    expect(replay.body.error).toBe("jti_replay");
+    // Only the first (legitimate) execute minted + forwarded.
+    expect(mintedFor).toHaveLength(1);
+  });
+
+  it("blocked capability with a seeded ACTIVE grant → 403 capability_blocked before mint/forward (execute-time re-check)", async () => {
+    // As of 0.6.2 the library enforces `blockedCapabilities` at grant/approve
+    // time but NOT at execute — this drives the grant-exists-anyway state
+    // (seeded directly into the adapter, exactly how SAFE_CAP grants are seeded)
+    // and pins Atlas's own execute-time re-check: the containment set must hold
+    // regardless of grant state, or a write/admin op reaches the in-process
+    // proxy under a real per-org key.
+    workspacesForUser = () => ["wsA"];
+    const instance = makeInstance([
+      { id: "agent_1", workspaceId: "wsA", grantStatus: "active", capability: "postQuery" },
+    ]);
+    const { status, body } = await execute(
+      instance,
+      await mintJWT({ agentId: "agent_1", capabilities: ["postQuery"] }),
+      "postQuery",
+    );
+    expect(status).toBe(403);
+    expect(body.error).toBe("capability_blocked");
+    expect(mintedFor).toEqual([]);
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("membership lookup FAILURE → retriable 500 with a ref, never a 403 denial (infra ≠ authorization)", async () => {
+    workspacesForUser = () => {
+      throw new Error("internal DB unreachable at secret-db-host:5432");
+    };
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(500);
+    expect(body.error).toBe("internal_error");
+    const message = JSON.stringify(body);
+    expect(message).toContain("ref ");
+    expect(message).toContain("Retry"); // transient guidance, not "not authorized"
+    expect(message).not.toContain("secret-db-host"); // no infra detail leaked
+    expect(mintedFor).toEqual([]);
+    expect(lastForwarded).toBeNull();
+  });
+
+  it("workspace enablement INDETERMINATE (settings read failed) → retriable 500, not a 404 claiming an opt-out", async () => {
+    enablementForWorkspace = () => "indeterminate";
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(500);
+    expect(body.error).toBe("internal_error");
+    expect(JSON.stringify(body)).toContain("ref ");
+    expect(mintedFor).toEqual([]);
+    expect(lastForwarded).toBeNull();
+  });
+
   it("revoked grant → 403 grant_revoked", async () => {
     const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "revoked" }]);
     const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
@@ -870,6 +1137,22 @@ describe("agent-auth capability execution (#4410)", () => {
     const message = JSON.stringify(body);
     expect(message).toContain("backoff");
     expect(message).not.toContain("will not succeed"); // transient, not a permanent client error
+  });
+
+  it("upstream 408: a timeout is retriable — status preserved, backoff advised (the other RETRIABLE_UPSTREAM_STATUS arm)", async () => {
+    fetchResponder = () =>
+      new Response(JSON.stringify({ error: "request_timeout" }), {
+        status: 408,
+        headers: { "content-type": "application/json" },
+      });
+    const instance = makeInstance([{ id: "agent_1", workspaceId: "wsA", grantStatus: "active" }]);
+    const { status, body } = await execute(instance, await mintJWT({ agentId: "agent_1" }));
+    expect(status).toBe(408);
+    // 408 has no dedicated machine code — it carries internal_error, unlike 429's rate_limited.
+    expect(body.error).toBe("internal_error");
+    const message = JSON.stringify(body);
+    expect(message).toContain("backoff");
+    expect(message).not.toContain("will not succeed");
   });
 
   it("upstream 5xx: an upstream 500 collapses to a non-leaking opaque 500", async () => {

--- a/packages/api/src/lib/auth/agent-auth-audit.ts
+++ b/packages/api/src/lib/auth/agent-auth-audit.ts
@@ -40,9 +40,10 @@
  *     string is run through {@link errorMessage} (connection-string scrub +
  *     truncation) before it lands in the row.
  *
- * Reversibility: like the rest of the agent-auth seam, only this file, the
- * plugin factory, the verifier and the gate know the agent-auth event shape.
- * Nothing downstream learns it.
+ * Reversibility: this file (and the plugin factory that wires it) is where the
+ * agent-auth EVENT shape is quarantined — the authoritative per-shape
+ * enumeration lives in the `agent-auth-verifier.ts` header. Nothing downstream
+ * learns it.
  */
 
 import type {
@@ -130,12 +131,37 @@ const DETAIL_ALLOWLIST: ReadonlySet<string> = new Set([
   "agentsRevoked",
 ]);
 
-/** Project the plugin's per-event metadata down to the {@link DETAIL_ALLOWLIST}. Returns undefined when nothing survives. */
+/** A detail value we allow into JSONB: a primitive label/count/flag, or a flat array of them. */
+type BenignDetailValue = string | number | boolean | Array<string | number | boolean>;
+
+/**
+ * Value-level guard paired with the key allowlist: a future plugin version
+ * nesting a large or sensitive OBJECT under an allowlisted key (`reason`,
+ * `name`, …) is dropped rather than persisted wholesale.
+ */
+function benignDetailValue(value: unknown): BenignDetailValue | undefined {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (
+    Array.isArray(value) &&
+    value.every(
+      (v) => typeof v === "string" || typeof v === "number" || typeof v === "boolean",
+    )
+  ) {
+    return value as Array<string | number | boolean>;
+  }
+  return undefined;
+}
+
+/** Project the plugin's per-event metadata down to the {@link DETAIL_ALLOWLIST} (keys) + {@link benignDetailValue} (values). Returns undefined when nothing survives. */
 function allowlistedDetail(raw: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (!raw) return undefined;
   const detail: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(raw)) {
-    if (DETAIL_ALLOWLIST.has(key)) detail[key] = value;
+    if (!DETAIL_ALLOWLIST.has(key)) continue;
+    const benign = benignDetailValue(value);
+    if (benign !== undefined) detail[key] = benign;
   }
   return Object.keys(detail).length > 0 ? detail : undefined;
 }

--- a/packages/api/src/lib/auth/agent-auth-gate.ts
+++ b/packages/api/src/lib/auth/agent-auth-gate.ts
@@ -102,21 +102,39 @@ function isTrue(value: string | undefined): boolean {
  *      override is consulted, so a workspace can only ever TIGHTEN: with the
  *      platform on, a workspace that sets its override to `false` has its data
  *      sealed (execute 404'd) while other workspaces are unaffected (overrides
- *      are per-org). It can never LOOSEN a platform-off, because execution is
- *      only reached after the HTTP surface (tier 1) has already admitted the
- *      request.
+ *      are per-org). It can never LOOSEN a platform-off for HTTP-reached
+ *      execution, because that path passes the tier-1 surface gate first. A
+ *      direct server-side `auth.api.*` call bypasses tier 1, which is why the
+ *      audit bridge (`agent-auth-audit.ts`) independently re-checks the
+ *      platform tier before emitting.
  *
  * Net: operator = master on/off for everyone; workspace admin = opt-OUT of
  * execution only. See the precedence-matrix tests in `agent-auth-gate.test.ts`.
  */
 export async function isAgentAuthEnabled(orgId?: string): Promise<boolean> {
+  return (await resolveAgentAuthEnablement(orgId)) === "on";
+}
+
+/**
+ * The tri-state the boolean gate is built on. `indeterminate` means the
+ * settings read itself failed — for the HTTP surface + audit bridge that is
+ * indistinguishable from `off` (fail closed, via {@link isAgentAuthEnabled}),
+ * but the capability-execution tier surfaces it as a ref-stamped 500 instead of
+ * a 404 that would falsely claim the workspace opted out (an infra blip must
+ * not read as a permanent policy decision — CLAUDE.md: return 500, not a false
+ * negative).
+ */
+export type AgentAuthEnablement = "on" | "off" | "indeterminate";
+
+/** The authoritative enablement read behind {@link isAgentAuthEnabled} — same tiers, same fail-closed logging, but errors stay distinguishable. */
+export async function resolveAgentAuthEnablement(orgId?: string): Promise<AgentAuthEnablement> {
   try {
-    return isTrue(await getSettingLive(AGENT_AUTH_ENABLED_SETTING, orgId));
+    return isTrue(await getSettingLive(AGENT_AUTH_ENABLED_SETTING, orgId)) ? "on" : "off";
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err), orgId },
       "agent-auth gate: settings resolution failed — failing closed (off)",
     );
-    return false;
+    return "indeterminate";
   }
 }

--- a/packages/api/src/lib/auth/agent-auth-plugin.ts
+++ b/packages/api/src/lib/auth/agent-auth-plugin.ts
@@ -40,10 +40,10 @@
  *      auth path (`resolveApiKeyAuth`), which binds the org from the key's
  *      metadata and enforces workspace isolation itself — no org-scope bypass.
  *
- * Reversibility: this module, `agent-auth-openapi.ts`, and `agent-auth-verifier.ts`
- * are the ONLY places that know about agent sessions / agent JWTs. Nothing
- * downstream — the dispatch gate, RBAC, permissions — learns the agent-auth
- * shape (pinned by `agent-auth-seam-quarantine.test.ts`).
+ * Reversibility: the verifier (`agent-auth-verifier.ts`) header carries the
+ * authoritative enumeration of which files may know which agent-auth shapes.
+ * Nothing downstream — the dispatch gate, RBAC, permissions — learns the
+ * agent-auth shape (pinned by `agent-auth-seam-quarantine.test.ts`).
  */
 
 import {
@@ -61,7 +61,8 @@ import {
   type AgentAuthActorResult,
   type AgentAuthIdentity,
 } from "@atlas/api/lib/auth/agent-auth-verifier";
-import { isAgentAuthEnabled } from "@atlas/api/lib/auth/agent-auth-gate";
+import { resolveAgentAuthEnablement } from "@atlas/api/lib/auth/agent-auth-gate";
+import { errorMessage } from "@atlas/api/lib/audit";
 import { auditAgentAuthEvent } from "@atlas/api/lib/auth/agent-auth-audit";
 import { resolveAgentApprovalPage } from "@atlas/api/lib/auth/agent-approval-page";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
@@ -123,8 +124,29 @@ function toIdentity(session: AgentSession): AgentAuthIdentity {
 /** The typed reasons `resolveAgentAuthActor` can deny for. */
 type DenialReason = Extract<AgentAuthActorResult, { kind: "denied" }>["reason"];
 
-/** Map a resolver denial to its spec-compliant error envelope. */
+/**
+ * Map a resolver denial to its spec-compliant error envelope.
+ *
+ * `membership_lookup_failed` is NOT an authorization decision — it means the
+ * membership READ itself failed (internal-DB blip, pool exhaustion). Dressing
+ * that as a 403 would tell the agent's operator "this agent is not authorized"
+ * for a transient infra fault, so it surfaces as a ref-stamped, retriable
+ * 500 instead (CLAUDE.md: return 500, not a false negative; request IDs on all
+ * 500s). The deny direction stays fail-closed either way — nothing executes.
+ */
 function denialError(reason: DenialReason): APIError {
+  if (reason === "membership_lookup_failed") {
+    const ref = crypto.randomUUID();
+    log.error(
+      { ref },
+      "agent-auth: membership lookup failed — surfacing a retriable 500, not a denial",
+    );
+    return agentError(
+      "INTERNAL_SERVER_ERROR",
+      AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+      `Could not verify workspace membership (ref ${ref}). Retry shortly.`,
+    );
+  }
   return agentError(
     "FORBIDDEN",
     AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
@@ -149,8 +171,28 @@ async function resolveBoundActor(
   }
 
   // Workspace-override precedence (#4419, tier 2): with the workspace resolved,
-  // honor a per-workspace opt-out even when the platform default is on. Fail-closed.
-  if (!(await isAgentAuthEnabled(resolved.workspaceId))) {
+  // honor a per-workspace opt-out even when the platform default is on. The
+  // tri-state keeps a settings-read failure distinguishable from a deliberate
+  // opt-out: an infra blip is a retriable 500, never a 404 claiming the
+  // workspace disabled the feature. Both directions fail closed.
+  const enablement = await resolveAgentAuthEnablement(resolved.workspaceId);
+  if (enablement === "indeterminate") {
+    const ref = crypto.randomUUID();
+    log.error(
+      { workspaceId: resolved.workspaceId, agentId: identity.agentId, ref },
+      "agent-auth: workspace enablement could not be resolved — failing closed with a retriable 500",
+    );
+    throw agentError(
+      "INTERNAL_SERVER_ERROR",
+      AGENT_AUTH_ERROR_CODES.INTERNAL_ERROR,
+      `Could not verify Agent Auth enablement for this workspace (ref ${ref}). Retry shortly.`,
+    );
+  }
+  if (enablement === "off") {
+    log.warn(
+      { workspaceId: resolved.workspaceId, agentId: identity.agentId },
+      "agent-auth capability execution sealed by workspace enablement override (tier 2)",
+    );
     throw agentError(
       "NOT_FOUND",
       AGENT_AUTH_ERROR_CODES.UNAUTHORIZED,
@@ -175,7 +217,10 @@ async function resolveBoundActor(
  * validated only in managed auth mode (the SaaS path this feature targets);
  * self-hosted `simple-key`/`none` deploys do not consume Better Auth keys.
  */
-type MintWorkspaceToken = (input: { user: AtlasUser; workspaceId: string }) => Promise<string>;
+export type MintWorkspaceToken = (input: {
+  user: AtlasUser;
+  workspaceId: string;
+}) => Promise<string>;
 
 /** The Better Auth `apiKey()` plugin's server-side `createApiKey`, narrowed to what we call. */
 export type CreateWorkspaceApiKey = (opts: {
@@ -244,24 +289,73 @@ export async function mintWorkspaceApiKeyVia(
   return created.key;
 }
 
-const tokenCache = new Map<string, { token: string; expiresAtMs: number }>();
+/**
+ * Coarse bound on live cached tokens (`user × workspace` keys). Expired/stale
+ * entries are evicted on the write path, so this cap only matters under a flood
+ * of distinct pairs; on overflow the stale sweep runs and, if still full, the
+ * cache clears wholesale — a re-mint is cheap, unbounded key material in process
+ * memory is not. Mirrors the audit sampler's `EXECUTE_TRACKED_KEYS_CAP` posture.
+ */
+const TOKEN_CACHE_MAX_ENTRIES = 1000;
 
-const mintWorkspaceApiKey: MintWorkspaceToken = async ({ user, workspaceId }) => {
-  const cacheKey = `${user.id}:${workspaceId}`;
-  const now = Date.now();
-  const cached = tokenCache.get(cacheKey);
-  if (cached && cached.expiresAtMs - now > WORKSPACE_KEY_REFRESH_BEFORE_MS) return cached.token;
+/**
+ * Caching wrapper around a token minter. Exported as a factory (mirroring
+ * `createAgentAuthAuditor`) so the cache contract is directly testable: the
+ * `${user.id}:${workspaceId}` key can never hand workspace A's token to a
+ * workspace-B execution, entries refresh before expiry
+ * ({@link WORKSPACE_KEY_REFRESH_BEFORE_MS}), and the cache stays bounded.
+ */
+export function createWorkspaceTokenMinter(
+  mint: MintWorkspaceToken,
+  opts?: {
+    ttlSeconds?: number;
+    refreshBeforeMs?: number;
+    maxEntries?: number;
+    now?: () => number;
+  },
+): MintWorkspaceToken {
+  const ttlMs = (opts?.ttlSeconds ?? WORKSPACE_KEY_TTL_SECONDS) * 1000;
+  const refreshBeforeMs = opts?.refreshBeforeMs ?? WORKSPACE_KEY_REFRESH_BEFORE_MS;
+  const maxEntries = opts?.maxEntries ?? TOKEN_CACHE_MAX_ENTRIES;
+  const now = opts?.now ?? Date.now;
+  const cache = new Map<string, { token: string; expiresAtMs: number }>();
 
-  // Dynamic import: a static import of `auth/server` would pull its eager
-  // `db/internal` graph into every consumer + break partial-mock tests. Mirrors
-  // the dynamic-import pattern in `admin-workspace-keys.ts`.
-  const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
-  const createApiKey = (getAuthInstance().api as { createApiKey?: unknown })
-    .createApiKey as CreateWorkspaceApiKey | undefined;
-  const token = await mintWorkspaceApiKeyVia(createApiKey, { user, workspaceId });
-  tokenCache.set(cacheKey, { token, expiresAtMs: now + WORKSPACE_KEY_TTL_SECONDS * 1000 });
-  return token;
-};
+  return async ({ user, workspaceId }) => {
+    const cacheKey = `${user.id}:${workspaceId}`;
+    const t = now();
+    const cached = cache.get(cacheKey);
+    if (cached && cached.expiresAtMs - t > refreshBeforeMs) return cached.token;
+    if (cached) cache.delete(cacheKey); // stale — evict rather than overwrite later
+
+    const token = await mint({ user, workspaceId });
+    if (cache.size >= maxEntries) {
+      for (const [key, entry] of cache) {
+        if (entry.expiresAtMs - t <= refreshBeforeMs) cache.delete(key);
+      }
+      if (cache.size >= maxEntries) cache.clear();
+    }
+    cache.set(cacheKey, { token, expiresAtMs: t + ttlMs });
+    return token;
+  };
+}
+
+const mintWorkspaceApiKey: MintWorkspaceToken = createWorkspaceTokenMinter(
+  async ({ user, workspaceId }) => {
+    // Dynamic import: a static import of `auth/server` would pull its eager
+    // `db/internal` graph into every consumer + break partial-mock tests. Mirrors
+    // the dynamic-import pattern in `admin-workspace-keys.ts`.
+    const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+    const rawCreateApiKey = (getAuthInstance().api as { createApiKey?: unknown }).createApiKey;
+    // Runtime-narrow before trusting the third-party surface: a Better Auth bump
+    // that reshapes/renames `createApiKey` must land on the loud fail-closed
+    // branch in `mintWorkspaceApiKeyVia`, not be blind-cast and fail late.
+    const createApiKey =
+      typeof rawCreateApiKey === "function"
+        ? (rawCreateApiKey as CreateWorkspaceApiKey)
+        : undefined;
+    return mintWorkspaceApiKeyVia(createApiKey, { user, workspaceId });
+  },
+);
 
 /**
  * The proxy transport for `onExecute`: route the derived operation through the
@@ -458,10 +552,37 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
   // survive; only opaque errors are collapsed to a non-leaking ref. (CLAUDE.md:
   // no silent swallow, no secrets in responses, requestId on 500s.)
   const proxyExecute = opts.onExecute;
-  if (!proxyExecute) return opts;
+  if (!proxyExecute) {
+    // An adapter bump that stops returning `onExecute` would build a capability
+    // surface with no execute path AND no protective wrapper — make that drift
+    // loud instead of silent.
+    log.error(
+      "agent-auth openapi adapter returned no onExecute — capabilities will not execute",
+    );
+    return opts;
+  }
+
+  // Defense-in-depth for the containment set: as of 0.6.2 the library enforces
+  // `blockedCapabilities` at grant/request/approve time but NOT at
+  // `/capability/execute` — an active grant that exists anyway (seeded directly,
+  // or a future library path that skips the block) would execute. Re-check at
+  // the execute seam Atlas controls, so a blocked (write/admin) capability can
+  // never reach the in-process proxy regardless of grant state.
+  const blockedSet = new Set(opts.blockedCapabilities ?? []);
 
   const onExecute: NonNullable<AgentAuthOptions["onExecute"]> = async (ctx) => {
     const requestId = crypto.randomUUID();
+    if (blockedSet.has(ctx.capability)) {
+      log.warn(
+        { capability: ctx.capability, requestId },
+        "agent-auth: execute of a blocked capability rejected (execute-time re-check)",
+      );
+      throw agentError(
+        "FORBIDDEN",
+        AGENT_AUTH_ERROR_CODES.CAPABILITY_BLOCKED,
+        `Capability "${ctx.capability}" is blocked by server policy.`,
+      );
+    }
     try {
       return await proxyExecute(ctx);
     } catch (err) {
@@ -482,7 +603,10 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
       // call is permanently bad. (Preserve the throttle/timeout status label.)
       if (upstreamStatus !== null && RETRIABLE_UPSTREAM_STATUS.has(upstreamStatus)) {
         log.warn(
-          { status: upstreamStatus, requestId, capability: ctx.capability },
+          // `errorMessage` scrubs connection strings + truncates — the raw
+          // upstream body embedded in the adapter's message is Atlas-log-only
+          // and must be diagnosable without being persisted verbatim.
+          { status: upstreamStatus, requestId, capability: ctx.capability, errMessage: errorMessage(err) },
           "agent-auth openapi proxy: upstream throttled/timed out (retriable)",
         );
         throw agentError(
@@ -503,7 +627,9 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
       // transport error falls through to the opaque 500.
       if (upstreamStatus !== null && upstreamStatus >= 400 && upstreamStatus < 500) {
         log.warn(
-          { status: upstreamStatus, requestId, capability: ctx.capability },
+          // Withheld from the agent (least-trusted actor), but logged scrubbed —
+          // otherwise a 400-class capability failure is undiagnosable server-side.
+          { status: upstreamStatus, requestId, capability: ctx.capability, errMessage: errorMessage(err) },
           "agent-auth openapi proxy: upstream rejected the request (client error)",
         );
         throw agentError(
@@ -514,7 +640,9 @@ function buildOptions(deps: AgentAuthPluginDeps): AgentAuthOpenApiOptions {
       }
 
       log.error(
-        { err: err instanceof Error ? err.message : String(err), requestId, capability: ctx.capability },
+        // Scrub before logging: a driver-level error echoed through an upstream
+        // 500 body can carry a connection string (same hygiene as the audit bridge).
+        { err: errorMessage(err), requestId, capability: ctx.capability },
         "agent-auth openapi proxy execution failed",
       );
       throw agentError(

--- a/packages/api/src/lib/auth/agent-auth-verifier.ts
+++ b/packages/api/src/lib/auth/agent-auth-verifier.ts
@@ -18,6 +18,17 @@
  * naturally know the surface exists; the quarantine is about the *enforcement
  * core*, not every file.)
  *
+ * AUTHORITATIVE shape-quarantine enumeration (other module headers point here;
+ * scope each claim by shape, not by "agent-auth" at large):
+ *   - Agent SESSION / agent-JWT shapes: `agent-auth-plugin.ts` (adapts
+ *     `agentSession` at the boundary) and `agent-auth-openapi.ts` (adapter
+ *     options). This module deliberately does NOT know `AgentSession` — it
+ *     consumes only the plugin-agnostic `AgentAuthIdentity` below.
+ *   - Agent-auth EVENT shapes: `agent-auth-audit.ts` (the `onEvent` bridge) and
+ *     the plugin factory that wires it.
+ *   - On/off decision + path shape ONLY (no token/session/event knowledge):
+ *     `agent-auth-gate.ts` and the two HTTP surfaces that consult it.
+ *
  * ── Trust boundary ──────────────────────────────────────────────────────────
  *
  * An agent credential is a delegated, portable bearer — strictly less trusted
@@ -70,6 +81,20 @@ export interface AgentAuthIdentity {
   readonly agentId: string;
   /** Display label for the bound actor (defaults to the user id). */
   readonly label?: string;
+}
+
+/**
+ * The compile-checked key set of the claims bag this producer stamps onto the
+ * resolved `AtlasUser`. `AtlasUser.claims` stays a wide
+ * `Record<string, unknown>` (it is shared by every producer), but building the
+ * bag through `satisfies AgentAuthClaims` means a consumer typing these keys by
+ * hand (RLS, audit) has one declaration to import and a producer-side typo is a
+ * compile error, not silent claim loss.
+ */
+export interface AgentAuthClaims {
+  readonly agent_auth: true;
+  readonly agent_id: string;
+  readonly active_organization_id: string;
 }
 
 /**
@@ -149,7 +174,7 @@ export async function resolveAgentAuthActor(
         agent_auth: true,
         agent_id: identity.agentId,
         active_organization_id: workspaceId,
-      },
+      } satisfies AgentAuthClaims,
     },
   );
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2431,7 +2431,20 @@ export function buildPlugins() {
     // key; the device-flow session bearer stays on `Authorization: Bearer`, so the
     // two credential classes never collide). The legacy `ATLAS_API_KEY` god-key is
     // a SEPARATE auth path (`simple-key.ts`) and is untouched.
-    apiKey({ enableMetadata: true, enableSessionForAPIKeys: true }),
+    //  - `keyExpiration.minExpiresIn` is in DAYS (plugin default 1). The
+    //    agent-auth proxy mints 15-MINUTE workspace keys
+    //    (`WORKSPACE_KEY_TTL_SECONDS`, agent-auth-plugin.ts); with the default
+    //    minimum every real capability execution would throw
+    //    EXPIRES_IN_IS_TOO_SMALL at first mint. 15/(60*24) admits exactly that
+    //    TTL and nothing shorter; the admin workspace-key route keeps its own
+    //    stricter ≥1-day schema (`expiresInDays: int().positive()`), so this
+    //    relaxation does not loosen operator-facing keys. Pinned by the
+    //    "upstream contract" mint test in agent-auth-plugin.test.ts.
+    apiKey({
+      enableMetadata: true,
+      enableSessionForAPIKeys: true,
+      keyExpiration: { minExpiresIn: 15 / (60 * 24) },
+    }),
     // Business-email-only signup (#3650, ADR-0018). `emailHarmony` contributes
     // the unique `normalizedEmail` column + `+alias`/dot/case normalization —
     // the teeth behind one-trial-per-user — and ships the `mailchecker`

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -670,16 +670,19 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   },
   // #4409 / #2058 — Agent Auth Protocol spine kill-switch. The `agentAuth()`
   // plugin is registered UNCONDITIONALLY in buildPlugins() (schema + routes
-  // always present, like twoFactor/passkey), so the ONLY thing this key
-  // controls is whether the reachable HTTP surface answers: when off (the
-  // default), every agent-auth endpoint + `/.well-known/agent-configuration`
-  // returns 404; when on, they become reachable — WITH NO REDEPLOY, because
-  // this is a hot-reloadable settings key (NOT `requiresRestart`, NOT an env
-  // var). The per-request gate reads it via `getSettingLive`/`getSettingAuto`
-  // and fails closed (any resolution error ⇒ off). `scope: "workspace"` makes
-  // the key mechanically override-able per workspace, but the enablement is
-  // enforced at TWO tiers with ASYMMETRIC power (#4419) — it is NOT a flat
-  // "workspace can override the platform" precedence:
+  // always present, like twoFactor/passkey) — this key never toggles plugin
+  // registration or schema. What it DOES gate: surface reachability (platform
+  // tier — when off, the default, every agent-auth endpoint +
+  // `/.well-known/agent-configuration` returns 404), capability EXECUTION
+  // (workspace tier), and agent-audit emission (`agent-auth-audit.ts`).
+  // Toggling needs NO REDEPLOY: this is a hot-reloadable settings key (not
+  // `requiresRestart`; the `envVar` below is only the tier-3 fallback under
+  // the hot-reloading DB tiers). The per-request gate reads it via
+  // `getSettingLive` and fails closed (any resolution error ⇒ off).
+  // `scope: "workspace"` makes the key mechanically override-able per
+  // workspace, but the enablement is enforced at TWO tiers with ASYMMETRIC
+  // power (#4419) — it is NOT a flat "workspace can override the platform"
+  // precedence:
   //   • Operator (PLATFORM tier) = master on/off for EVERYONE. The HTTP-surface
   //     gate reads the platform tier only (no orgId), so platform-off ⇒ 404
   //     globally and a workspace CANNOT re-open it. This is the kill-switch.
@@ -688,7 +691,9 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   //     capability execution (others unaffected); it can only tighten, never
   //     turn the surface on when the platform default is off.
   // Kept experimental (upstream spec is a moving `v1.0-draft`) — default OFF.
-  // See ADR-0016 §Agent Auth, `agent-auth-gate.ts`, and the decision on #2058.
+  // Design + precedence rationale: `agent-auth-gate.ts`, the #4419 decision
+  // recorded on #2058, and the operator doc
+  // `apps/docs/content/docs/platform-ops/agent-auth-enablement.mdx`.
   {
     key: "ATLAS_AGENT_AUTH_ENABLED",
     section: "MCP",

--- a/packages/web/src/app/agent/approve/page.test.tsx
+++ b/packages/web/src/app/agent/approve/page.test.tsx
@@ -191,7 +191,7 @@ describe("agent approval page (#4411)", () => {
     expect(screen.getByText("Approve")).toBeDefined();
   });
 
-  test("404 on the pending list → the fail-closed 'not available' state (gate off)", async () => {
+  test("gate 404 on the pending list → the fail-closed 'not available' state (gate off)", async () => {
     pendingResponder = () => jsonResponse(404, { error: "not_found" });
     render(<AgentApprovePage />);
     await waitFor(() =>
@@ -199,6 +199,21 @@ describe("agent approval page (#4411)", () => {
     );
     // No approve control is offered when the surface is gated off.
     expect(screen.queryByText("Approve")).toBeNull();
+    // The guidance names the actor who can actually act: this state is only
+    // reachable via the PLATFORM-tier kill-switch (#4419), which a workspace
+    // admin cannot re-open — only the Atlas operator can.
+    expect(
+      screen.getByText(/not enabled on this Atlas deployment.*Atlas operator/s),
+    ).toBeDefined();
+  });
+
+  test("NON-gate 404 on the pending list → an error state, NOT 'not available' (404 is ambiguous)", async () => {
+    // A per-request 404 (e.g. a future plugin version 404ing a stale agent on
+    // this endpoint) must not be misdiagnosed as "feature disabled".
+    pendingResponder = () => jsonResponse(404, { error: "agent_not_found" });
+    render(<AgentApprovePage />);
+    await waitFor(() => expect(screen.getByText("Couldn't load the request")).toBeDefined());
+    expect(screen.queryByText("Agent approvals are not available")).toBeNull();
   });
 
   test("POST-time gate 404 (surface toggled off mid-flow) → 'not available'", async () => {

--- a/packages/web/src/app/agent/approve/page.tsx
+++ b/packages/web/src/app/agent/approve/page.tsx
@@ -54,7 +54,10 @@ import {
   resolvePendingApproval,
   type PendingApprovalRequest,
 } from "./resolve-pending-approval";
-import { resolveApprovalOutcome } from "./resolve-approval-outcome";
+import {
+  isAgentAuthGateOff,
+  resolveApprovalOutcome,
+} from "./resolve-approval-outcome";
 
 function getApiBase(): string {
   const url = getApiUrl();
@@ -90,7 +93,9 @@ function AgentApproval() {
   // Fetch the pending request once a signed-in user is present. `GET
   // /agent/ciba/pending` returns the user's pending approvals across BOTH
   // methods; `resolvePendingApproval` selects the device request for this
-  // `agent_id`. A 404 means the whole agent-auth surface is gated off.
+  // `agent_id`. A 404 bearing the gate envelope means the whole agent-auth
+  // surface is off; any other 404 is a per-request error (see
+  // resolve-approval-outcome.ts for the discrimination).
   useEffect(() => {
     // No authenticated user yet (session still loading, or signed out) — the
     // render shows the skeleton or the sign-in prompt, so don't fetch.
@@ -109,7 +114,26 @@ function AgentApproval() {
       .then(async (r) => {
         if (controller.signal.aborted) return;
         if (r.status === 404) {
-          setLoad("unavailable");
+          // 404 is ambiguous on this surface (see resolve-approval-outcome.ts):
+          // only the gate's whole-surface envelope means agent auth is off. Any
+          // other 404 is a per-request error and must not be misdiagnosed as
+          // "feature disabled".
+          let body: unknown = null;
+          try {
+            body = await r.json();
+          } catch {
+            // intentionally ignored: a non-JSON 404 body (gateway HTML) carries
+            // no discriminator; it falls to the per-request error branch below.
+            body = null;
+          }
+          if (isAgentAuthGateOff(r.status, body)) {
+            setLoad("unavailable");
+            return;
+          }
+          setError(
+            "Could not load the pending request (HTTP 404). Reopen the link from your agent.",
+          );
+          setLoad("error");
           return;
         }
         if (r.status === 401) {
@@ -152,12 +176,16 @@ function AgentApproval() {
       })
       .catch((err: unknown) => {
         if (err instanceof Error && err.name === "AbortError") return;
+        // Raw error messages (extension/CSP/browser internals) are cryptic UI
+        // text — show fixed actionable copy, keep the cause in the console.
+        console.debug(
+          "agent-approve pending fetch failed",
+          err instanceof Error ? err.message : String(err),
+        );
         setError(
           err instanceof TypeError
             ? "Couldn't reach Atlas. Check your connection and try again."
-            : err instanceof Error
-              ? err.message
-              : "Could not load the pending request.",
+            : "Could not load the pending request. Refresh to try again.",
         );
         setLoad("error");
       });
@@ -196,12 +224,16 @@ function AgentApproval() {
         setError(result.message);
       }
     } catch (err) {
+      // Same discipline as the pending fetch: fixed copy in the UI, raw cause
+      // in the console for diagnosis.
+      console.debug(
+        "agent-approve decision failed",
+        err instanceof Error ? err.message : String(err),
+      );
       setError(
         err instanceof TypeError
           ? "Couldn't reach Atlas. Check your connection and try again."
-          : err instanceof Error
-            ? err.message
-            : "Could not record your decision.",
+          : "Could not record your decision. Refresh the page and try again.",
       );
     } finally {
       setSubmitting(null);
@@ -285,8 +317,11 @@ function AgentApproval() {
         <CardHeader>
           <CardTitle>Agent approvals are not available</CardTitle>
           <CardDescription>
-            Agent authorization is not enabled on this workspace. Ask your
-            workspace admin to enable it, then reopen the link from your agent.
+            {/* Reachable only via the PLATFORM-tier gate 404 (#4419) — a
+                workspace admin cannot enable it; only the Atlas operator can. */}
+            Agent authorization is not enabled on this Atlas deployment. Ask
+            your Atlas operator to enable it, then reopen the link from your
+            agent.
           </CardDescription>
         </CardHeader>
       </Card>

--- a/packages/web/src/app/agent/approve/resolve-approval-outcome.test.ts
+++ b/packages/web/src/app/agent/approve/resolve-approval-outcome.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { resolveApprovalOutcome } from "./resolve-approval-outcome";
+import { isAgentAuthGateOff, resolveApprovalOutcome } from "./resolve-approval-outcome";
 
 describe("resolveApprovalOutcome (#4411)", () => {
   it("200 { status: approved } → resolved/approved", () => {
@@ -61,5 +61,23 @@ describe("resolveApprovalOutcome (#4411)", () => {
   it("2xx with an unexpected status value → error, not a false success", () => {
     const out = resolveApprovalOutcome({ status: 200, body: { status: "weird" } });
     expect(out.kind).toBe("error");
+  });
+});
+
+// Web-side half of the cross-package gate-envelope pin — the API side is the
+// gate-envelope test in packages/api's agent-auth-live-toggle.test.ts. If the
+// gate's `{ error: "not_found" }` envelope ever changes, both go red together.
+describe("isAgentAuthGateOff (the one 404 discrimination)", () => {
+  it("true only for a 404 carrying the gate envelope", () => {
+    expect(isAgentAuthGateOff(404, { error: "not_found" })).toBe(true);
+    expect(isAgentAuthGateOff(404, { error: "not_found", message: "Not found" })).toBe(true);
+  });
+
+  it("false for per-request 404s, non-404 statuses, and undiscriminable bodies", () => {
+    expect(isAgentAuthGateOff(404, { error: "agent_not_found" })).toBe(false);
+    expect(isAgentAuthGateOff(200, { error: "not_found" })).toBe(false);
+    expect(isAgentAuthGateOff(404, null)).toBe(false);
+    expect(isAgentAuthGateOff(404, "not json")).toBe(false);
+    expect(isAgentAuthGateOff(404, {})).toBe(false);
   });
 });

--- a/packages/web/src/app/agent/approve/resolve-approval-outcome.ts
+++ b/packages/web/src/app/agent/approve/resolve-approval-outcome.ts
@@ -16,8 +16,30 @@
  * no longer valid), so it flows to the error branch with the server's message.
  */
 
-/** The exact error code the #4409 request-time gate returns (routes/auth.ts). */
+/**
+ * The exact error code the #4409 request-time gate returns
+ * (`packages/api/src/api/routes/auth.ts` — `{ error: "not_found" }`).
+ *
+ * Cross-package wire contract, duplicated by necessity: the web bundle cannot
+ * import `@atlas/api`, and hoisting the constant into `@useatlas/types` is
+ * blocked until the next published-package window (scaffold-bound source may
+ * only use symbols that exist in the PUBLISHED `@useatlas/*` versions —
+ * `scripts/check-published-symbols.ts`). Both sides pin the literal in tests:
+ * `resolve-approval-outcome.test.ts` here, the gate-envelope assertion in
+ * `packages/api/src/api/__tests__/agent-auth-live-toggle.test.ts` there. If the
+ * gate envelope ever changes, change BOTH and those tests.
+ */
 const GATE_OFF_ERROR = "not_found";
+
+/**
+ * The one statement of the 404 discrimination (see the module header): true
+ * only for the gate's whole-surface "agent auth is off" envelope, never for a
+ * per-request 404 like `agent_not_found`. Shared by the approve/deny resolver
+ * below and the pending-request fetch in `page.tsx`.
+ */
+export function isAgentAuthGateOff(status: number, body: unknown): boolean {
+  return status === 404 && errorCode(body) === GATE_OFF_ERROR;
+}
 
 export type ApprovalOutcome =
   | { kind: "resolved"; decision: "approved" | "denied" }
@@ -73,7 +95,7 @@ export function resolveApprovalOutcome(res: ApprovalHttpResult): ApprovalOutcome
 
   // ONLY the gate's whole-surface 404 means "unavailable". A stale/revoked
   // agent (`agent_not_found`) also 404s but is a per-request error.
-  if (res.status === 404 && errorCode(res.body) === GATE_OFF_ERROR) {
+  if (isAgentAuthGateOff(res.status, res.body)) {
     return { kind: "unavailable" };
   }
 


### PR DESCRIPTION
## Summary

Applies the full four-reviewer panel punch-list from the final wrap-up review of the merged Agent Auth system (#2058 — PRs #4417, #4420, #4423–#4427, #4430). 21 findings addressed across error handling, type containment, test coverage, and comment/doc accuracy — plus **two latent production bugs the new tests surfaced**:

- **15-minute agent workspace keys could never mint in production**: the `@better-auth/api-key` plugin's `minExpiresIn` defaults to 1 *day*, so every real `capability/execute` would have thrown `EXPIRES_IN_IS_TOO_SMALL` at first mint. All prior tests stubbed the minter and stayed green. Fixed in `server.ts` (`keyExpiration.minExpiresIn` admits exactly the 15-min TTL); pinned by a new real-plugin "upstream contract" test.
- **`blockedCapabilities` is not enforced at execute time in `@better-auth/agent-auth` 0.6.2** (only at grant/request/approve). An active grant existing anyway would have let a write/admin capability reach the in-process proxy. Added an Atlas-side execute-time re-check in the wrapped `onExecute` (403 `capability_blocked` before mint/forward), pinned e2e with a seeded blocked grant.

Must-fix findings:
- `membership_lookup_failed` (a DB/infra error) now surfaces as a ref-stamped retriable 500, never a permanent 403 denial; same tri-state treatment for a failed workspace-enablement read at tier 2 (`resolveAgentAuthEnablement`: on/off/indeterminate), with the deny site now logged
- Approval-page "unavailable" copy now points at the Atlas **operator** (the only actor who can enable a platform-off surface), not the workspace admin
- Repointed the phantom "ADR-0016 §Agent Auth" settings reference to the gate module, the #4419 decision on #2058, and the enablement doc

Hardening & type containment: scrubbed (`errorMessage`) proxy failure logs on all three branches; `typeof`-guard on the `createApiKey` double cast; bounded, evicting, factory-based workspace token cache (`createWorkspaceTokenMinter`); compile-checked `AgentAuthClaims` producer keys; audit detail allowlist now constrains value *types* too; `registerInProcessApiFetch` no longer drops `init` for `Request` inputs; structural assert on the OpenAPI-spec cast; loud log when the adapter returns no `onExecute`; pending-fetch 404s on the approval page now use the shared gate-envelope discrimination (`isAgentAuthGateOff`) instead of blanket-mapping to "unavailable"; fixed UI copy instead of raw `err.message`.

New coverage: blocked-cap execute re-check e2e · forged-signature + jti-replay JWT negatives · membership-failure→500 and enablement-indeterminate→500 e2e · token-cache key isolation/refresh/bounding · audit never-rejects contract (emit throws / gate rejects ⇒ fail-closed) · `onEvent` wiring identity pin · `ATLAS_AGENT_AUTH_ENABLED` registry-definition pin · gate tri-state · gate-404 wire-envelope pins on both sides of the web/API contract · WebAuthn step-up enforcement e2e (approve without assertion never completes; passkey plugin now in the harness — without it the library silently disables `proofOfPresence`) · upstream 408 branch · enterprise-flag-unset defaults · real-spec containment tests now fail (not skip) when `openapi.json` is missing in CI.

Comment/doc accuracy: qualified the gate's "never LOOSEN" claim (direct `auth.api.*` calls bypass tier 1 — why the audit bridge re-checks); fixed the settings comment's false "ONLY controls the HTTP surface" and env-var wording; unified the three divergent shape-quarantine enumerations onto the verifier header; corrected "grants are workspace-scoped / proposed per request" doc topic sentences (it's *execution* that is workspace-bound, proposed on the agent record).

Part of the #2058 wrap-up (the epic itself is left open pending a decision to close).

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated (33 new/updated tests across api + web; all agent-auth suites green)
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change)

Full local gate run: `scripts/ci-local.sh` — all 29 gates PASS.

https://claude.ai/code/session_01YRykaFStFHJFBhUGPqnAEb

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRykaFStFHJFBhUGPqnAEb)_