### PR TITLE
chore(web): type-check test files (tsconfig.test-check.json) + fix the 183-error backlog + guard fixture suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Adversarial fixtures for the admin-plugin-removal gate (#3159)
         run: bash scripts/__tests__/check-no-admin-plugin.test.sh
 
+      - name: Adversarial fixtures for the web vacuous-type-program guard (#4447/#4450)
+        run: bash scripts/__tests__/check-type-program-not-vacuous.test.sh
+
       - name: Check no legacy `connections` / `connection_groups` SQL outside migrations (#2744)
         run: bash scripts/check-no-legacy-connections-sql.sh
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "type": "tsgo --noEmit && bash scripts/check-type-program-not-vacuous.sh",
+    "type": "tsgo --noEmit && tsgo -p tsconfig.test-check.json --noEmit && bash scripts/check-type-program-not-vacuous.sh",
     "test": "bun scripts/test-isolated.ts"
   },
   "exports": {

--- a/packages/web/scripts/check-type-program-not-vacuous.sh
+++ b/packages/web/scripts/check-type-program-not-vacuous.sh
@@ -13,8 +13,10 @@ set -euo pipefail
 # Parameterized for the adversarial fixture suite at root
 # scripts/__tests__/check-type-program-not-vacuous.test.sh, which points the
 # guard at a scaffolded synthetic tree instead of mutating the real tsconfigs:
-#   TYPE_PROGRAM_GUARD_ROOT — project dir to check (default: packages/web)
-#   TYPE_PROGRAM_GUARD_MIN  — minimum src-file floor (default: 450)
+#   TYPE_PROGRAM_GUARD_ROOT     — project dir to check (default: packages/web)
+#   TYPE_PROGRAM_GUARD_MIN      — minimum src-file floor (default: 450)
+#   TYPE_PROGRAM_GUARD_TEST_MIN — minimum test-file floor for the test-check
+#                                 program (default: 200)
 
 cd "${TYPE_PROGRAM_GUARD_ROOT:-$(dirname "$0")/..}"
 
@@ -29,8 +31,10 @@ else
   }
 fi
 
-# Must mirror the `type` script's `tsgo --noEmit` invocation in package.json
-# (same implicit tsconfig.json) — if that ever grows `-p`/flags, change both.
+# Must mirror the FIRST `tsgo --noEmit` invocation of the `type` script in
+# package.json (the main-program check, implicit tsconfig.json; the script's
+# second invocation is the test-check program, floored separately below) —
+# if that first invocation ever grows `-p`/flags, change both.
 files=$("$TSGO" --noEmit --listFilesOnly) || {
   echo "check-type-program-not-vacuous: FAIL — '$TSGO --noEmit --listFilesOnly' exited non-zero." >&2
   exit 1
@@ -57,9 +61,17 @@ esac
 # trips on partial vacuation (a reference claiming a whole subtree like
 # src/ui/** would drop hundreds of files), not just the total wipe-out.
 min="${TYPE_PROGRAM_GUARD_MIN:-450}"
+# A non-numeric floor would make `-lt` error out and the if-branch silently
+# skip — a guard that cannot run must fail, not pass.
+case "$min" in
+  '' | *[!0-9]*)
+    echo "check-type-program-not-vacuous: FAIL — non-numeric TYPE_PROGRAM_GUARD_MIN '$min'; guard could not run." >&2
+    exit 1
+    ;;
+esac
 
 if [ "$count" -lt "$min" ]; then
-  echo "check-type-program-not-vacuous: FAIL — only $count packages/web/src files in the type program (expected >= $min)." >&2
+  echo "check-type-program-not-vacuous: FAIL — only $count files under $(pwd -P)/src in the type program (expected >= $min)." >&2
   echo "A tsconfig 'references'/include/exclude change likely re-vacuated the program (see #4447)," >&2
   echo "or tsgo's --listFilesOnly output format changed — inspect the raw file list." >&2
   exit 1
@@ -73,4 +85,39 @@ fi
   exit 1
 }
 
-echo "check-type-program-not-vacuous: OK ($count src files in the type program)"
+# #4450: floor the TEST-CHECK program the same way. Its file set is
+# glob-driven (tsconfig.test.json's include, reused by tsconfig.test-check.json),
+# so include/exclude rot — tests adopting a new suffix, an added exclude, a
+# test root outside src/ — would shrink what `tsgo -p tsconfig.test-check.json`
+# checks while the web `type` gate stays green: the exact #4447 failure mode,
+# one config over. ~284 test files today; 200 allows churn but trips on rot.
+test_files=$("$TSGO" -p tsconfig.test-check.json --listFilesOnly) || {
+  echo "check-type-program-not-vacuous: FAIL — 'tsgo -p tsconfig.test-check.json --listFilesOnly' exited non-zero (the test type-check gate cannot run; see #4450)." >&2
+  exit 1
+}
+test_count=$(printf '%s\n' "$test_files" | grep -cE '\.test\.(ts|tsx)$|/__tests__/') || {
+  status=$?
+  if [ "$status" -gt 1 ]; then
+    echo "check-type-program-not-vacuous: FAIL — grep exited $status while counting test files; guard could not run." >&2
+    exit 1
+  fi
+}
+case "$test_count" in
+  '' | *[!0-9]*)
+    echo "check-type-program-not-vacuous: FAIL — non-numeric test-file count '$test_count'; guard could not run." >&2
+    exit 1
+    ;;
+esac
+test_min="${TYPE_PROGRAM_GUARD_TEST_MIN:-200}"
+case "$test_min" in
+  '' | *[!0-9]*)
+    echo "check-type-program-not-vacuous: FAIL — non-numeric TYPE_PROGRAM_GUARD_TEST_MIN '$test_min'; guard could not run." >&2
+    exit 1
+    ;;
+esac
+if [ "$test_count" -lt "$test_min" ]; then
+  echo "check-type-program-not-vacuous: FAIL — only $test_count test files in the test-check program (expected >= $test_min); tsconfig.test.json's include has rotted (see #4450)." >&2
+  exit 1
+fi
+
+echo "check-type-program-not-vacuous: OK ($count src files, $test_count test files in the type programs)"

--- a/packages/web/scripts/check-type-program-not-vacuous.sh
+++ b/packages/web/scripts/check-type-program-not-vacuous.sh
@@ -9,8 +9,14 @@ set -euo pipefail
 # contains a healthy number of this package's source files.
 # --listFilesOnly skips the check phase, so this costs a small fraction of
 # the full check.
+#
+# Parameterized for the adversarial fixture suite at root
+# scripts/__tests__/check-type-program-not-vacuous.test.sh, which points the
+# guard at a scaffolded synthetic tree instead of mutating the real tsconfigs:
+#   TYPE_PROGRAM_GUARD_ROOT — project dir to check (default: packages/web)
+#   TYPE_PROGRAM_GUARD_MIN  — minimum src-file floor (default: 450)
 
-cd "$(dirname "$0")/.."
+cd "${TYPE_PROGRAM_GUARD_ROOT:-$(dirname "$0")/..}"
 
 if [ -x "node_modules/.bin/tsgo" ]; then
   TSGO="node_modules/.bin/tsgo"
@@ -30,8 +36,10 @@ files=$("$TSGO" --noEmit --listFilesOnly) || {
   exit 1
 }
 
+# tsgo prints absolute paths; count this project's src files. -F because the
+# resolved path is a literal, not a pattern.
 # grep -c prints 0 before exiting 1 on no-match; only exit 1 is expected.
-count=$(printf '%s\n' "$files" | grep -c "packages/web/src/") || {
+count=$(printf '%s\n' "$files" | grep -cF "$(pwd -P)/src/") || {
   status=$?
   if [ "$status" -gt 1 ]; then
     echo "check-type-program-not-vacuous: FAIL — grep exited $status while counting src files; guard could not run." >&2
@@ -48,7 +56,7 @@ esac
 # The program is ~580 src files today. 450 allows real code shrinkage but
 # trips on partial vacuation (a reference claiming a whole subtree like
 # src/ui/** would drop hundreds of files), not just the total wipe-out.
-min=450
+min="${TYPE_PROGRAM_GUARD_MIN:-450}"
 
 if [ "$count" -lt "$min" ]; then
   echo "check-type-program-not-vacuous: FAIL — only $count packages/web/src files in the type program (expected >= $min)." >&2

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/cross-filter.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/cross-filter.test.ts
@@ -46,6 +46,7 @@ function chartCard(id: string, sql: string): DashboardCard {
     cachedAt: null,
     connectionGroupId: null,
     layout: null,
+    annotations: [],
     createdAt: "2026-04-25T12:00:00Z",
     updatedAt: "2026-04-25T12:00:00Z",
   };

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/dashboard-card-render.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/dashboard-card-render.test.ts
@@ -39,6 +39,7 @@ const baseCard: DashboardCard = {
   cachedAt: "2026-06-04T00:00:00Z",
   connectionGroupId: null,
   layout: { x: 0, y: 0, w: 12, h: 8 },
+  annotations: [],
   createdAt: "2026-06-04T00:00:00Z",
   updatedAt: "2026-06-04T00:00:00Z",
 };

--- a/packages/web/src/app/admin/actions/__tests__/deny-dialog-behavior.test.tsx
+++ b/packages/web/src/app/admin/actions/__tests__/deny-dialog-behavior.test.tsx
@@ -99,7 +99,7 @@ describe("ReasonDialog — reason reset timing", () => {
 
 describe("ReasonDialog — Cmd+Enter keyboard", () => {
   test("Cmd+Enter while not loading triggers onConfirm with trimmed reason", async () => {
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open
@@ -124,7 +124,7 @@ describe("ReasonDialog — Cmd+Enter keyboard", () => {
   });
 
   test("Ctrl+Enter (non-macOS) also triggers onConfirm", async () => {
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open
@@ -149,7 +149,7 @@ describe("ReasonDialog — Cmd+Enter keyboard", () => {
     // Guards against a double-fire if the operator hits Cmd+Enter twice —
     // the second invocation would trigger a duplicate deny without this
     // check. Audit-sensitive.
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open
@@ -176,7 +176,7 @@ describe("ReasonDialog — Cmd+Enter keyboard", () => {
   });
 
   test("plain Enter (no modifier) does NOT trigger onConfirm — preserves newline insertion", async () => {
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open
@@ -198,7 +198,7 @@ describe("ReasonDialog — Cmd+Enter keyboard", () => {
 
 describe("ReasonDialog — trim behavior", () => {
   test("confirm click passes trimmed reason to onConfirm", async () => {
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open
@@ -227,7 +227,7 @@ describe("ReasonDialog — trim behavior", () => {
     // trimmed — including the empty string. A substitution like
     // `reason || "no reason given"` would corrupt the audit trail by
     // making "no reason given" indistinguishable from a real typed one.
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open
@@ -250,7 +250,7 @@ describe("ReasonDialog — trim behavior", () => {
   });
 
   test("required=true blocks confirm when reason is whitespace-only", async () => {
-    const onConfirm = mock(async () => {});
+    const onConfirm = mock(async (_reason: string) => {});
     render(
       <ReasonDialog
         open

--- a/packages/web/src/app/admin/actions/__tests__/rollback-warning.test.ts
+++ b/packages/web/src/app/admin/actions/__tests__/rollback-warning.test.ts
@@ -53,20 +53,20 @@ describe("coerceRollbackWarning", () => {
 
 describe("logUnsurfacedRollbackWarning", () => {
   test("does not log null / undefined (no warning to drift)", () => {
-    const logger = mock(() => {});
+    const logger = mock((_message: string, _value: unknown) => {});
     logUnsurfacedRollbackWarning(null, logger);
     logUnsurfacedRollbackWarning(undefined, logger);
     expect(logger).not.toHaveBeenCalled();
   });
 
   test("does not log well-formed non-empty strings (surfaced verbatim)", () => {
-    const logger = mock(() => {});
+    const logger = mock((_message: string, _value: unknown) => {});
     logUnsurfacedRollbackWarning("rollback may not have reversed", logger);
     expect(logger).not.toHaveBeenCalled();
   });
 
   test("logs non-string shapes with the raw value (schema-drift signal)", () => {
-    const logger = mock(() => {});
+    const logger = mock((_message: string, _value: unknown) => {});
     logUnsurfacedRollbackWarning({ code: "partial", message: "x" }, logger);
     expect(logger).toHaveBeenCalledTimes(1);
     const [msg, value] = logger.mock.calls[0] ?? [];
@@ -75,7 +75,7 @@ describe("logUnsurfacedRollbackWarning", () => {
   });
 
   test("logs blank strings separately from non-string shapes", () => {
-    const logger = mock(() => {});
+    const logger = mock((_message: string, _value: unknown) => {});
     logUnsurfacedRollbackWarning("   ", logger);
     logUnsurfacedRollbackWarning("", logger);
     expect(logger).toHaveBeenCalledTimes(2);
@@ -83,7 +83,7 @@ describe("logUnsurfacedRollbackWarning", () => {
   });
 
   test("logs arrays as non-string shape (not blank string)", () => {
-    const logger = mock(() => {});
+    const logger = mock((_message: string, _value: unknown) => {});
     logUnsurfacedRollbackWarning(["a", "b"], logger);
     expect(logger).toHaveBeenCalledTimes(1);
     expect(logger.mock.calls[0]?.[0]).toBe("handleRollback: non-string warning shape");

--- a/packages/web/src/app/admin/audit/__tests__/retention-clamp-behavior.test.tsx
+++ b/packages/web/src/app/admin/audit/__tests__/retention-clamp-behavior.test.tsx
@@ -14,7 +14,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -31,8 +31,8 @@ function wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/app/admin/branding/__tests__/config-form.test.tsx
+++ b/packages/web/src/app/admin/branding/__tests__/config-form.test.tsx
@@ -20,7 +20,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -37,8 +37,8 @@ function Wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/app/admin/connections/__tests__/connection-form-fields.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/connection-form-fields.test.tsx
@@ -107,10 +107,10 @@ describe("TestConnectionButton (#3846)", () => {
 
   test("clicking reads the latest url + schema at click time, not a stale snapshot", async () => {
     const onTest = mock((_url: string, _schema: string) => {});
-    let captured: UseFormReturn<ConnectionFormValues> | null = null;
+    const captured: { current: UseFormReturn<ConnectionFormValues> | null } = { current: null };
 
     const { getByText, getByTestId } = render(
-      <Harness onForm={(f) => (captured = f)}>
+      <Harness onForm={(f) => (captured.current = f)}>
         {(form) => (
           <TestConnectionButton form={form} saving={false} onTest={onTest} />
         )}
@@ -124,9 +124,9 @@ describe("TestConnectionButton (#3846)", () => {
     // Mutate schema AFTER mount: the button reads it via `getValues` at click
     // time, so a regression that snapshots schema into a prop/closure at mount
     // would surface the old (empty) value here.
-    const form = captured;
+    const form = captured.current;
     if (!form) throw new Error("form not captured");
-    void act(() => form.setValue("schema", "analytics"));
+    act(() => form.setValue("schema", "analytics"));
 
     const button = getByText("Test").closest("button");
     if (!button) throw new Error("Test button not found");
@@ -159,19 +159,19 @@ describe("TestConnectionButton (#3846)", () => {
 
 describe("NewEnvNameField (#3846)", () => {
   test("hidden until envSelection becomes the create-sentinel, then mounts", async () => {
-    let captured: UseFormReturn<ConnectionFormValues> | null = null;
+    const captured: { current: UseFormReturn<ConnectionFormValues> | null } = { current: null };
 
     const { queryByTestId } = render(
-      <Harness onForm={(f) => (captured = f)}>
+      <Harness onForm={(f) => (captured.current = f)}>
         {(form) => <NewEnvNameField form={form} />}
       </Harness>,
     );
 
     expect(queryByTestId("env-new-name-input")).toBeNull();
 
-    const form = captured;
+    const form = captured.current;
     if (!form) throw new Error("form not captured");
-    void act(() => form.setValue("envSelection", ENV_SENTINEL_CREATE));
+    act(() => form.setValue("envSelection", ENV_SENTINEL_CREATE));
 
     await waitFor(() => {
       expect(queryByTestId("env-new-name-input")).not.toBeNull();
@@ -181,19 +181,19 @@ describe("NewEnvNameField (#3846)", () => {
 
 describe("PostgresSchemaField (#3846)", () => {
   test("shown for postgres and hidden once dbType changes away", async () => {
-    let captured: UseFormReturn<ConnectionFormValues> | null = null;
+    const captured: { current: UseFormReturn<ConnectionFormValues> | null } = { current: null };
 
     const { queryByText } = render(
-      <Harness defaults={{ dbType: "postgres" }} onForm={(f) => (captured = f)}>
+      <Harness defaults={{ dbType: "postgres" }} onForm={(f) => (captured.current = f)}>
         {(form) => <PostgresSchemaField form={form} />}
       </Harness>,
     );
 
     expect(queryByText("Schema")).not.toBeNull();
 
-    const form = captured;
+    const form = captured.current;
     if (!form) throw new Error("form not captured");
-    void act(() => form.setValue("dbType", "mysql"));
+    act(() => form.setValue("dbType", "mysql"));
 
     await waitFor(() => {
       expect(queryByText("Schema")).toBeNull();

--- a/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
@@ -52,7 +52,7 @@ const SALESFORCE_ROW_DEFAULTS = {
   accessible: true,
   upgradeRequired: null as string | null,
   pillar: "datasource" as const,
-  implementationStatus: "available" as const,
+  implementationStatus: "available" as "available" | "coming_soon",
   installConfig: null as Record<string, unknown> | null,
 };
 
@@ -66,9 +66,10 @@ const testConfig = {
   apiUrl: "http://localhost:3001",
   isCrossOrigin: false,
   authClient: {
-    getToken: async () => null,
-    getOrgId: () => null,
-    onAuthChange: () => () => undefined,
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: async () => {},
+    useSession: () => ({ data: null, isPending: false }),
   },
 };
 

--- a/packages/web/src/app/admin/custom-domain/__tests__/plan-gate.test.tsx
+++ b/packages/web/src/app/admin/custom-domain/__tests__/plan-gate.test.tsx
@@ -19,7 +19,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -36,8 +36,8 @@ function Wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/app/admin/email-provider/__tests__/dirty-gate.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/dirty-gate.test.tsx
@@ -20,7 +20,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -37,8 +37,8 @@ function Wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
+++ b/packages/web/src/app/admin/email-provider/__tests__/mutation-error-chain.test.tsx
@@ -23,7 +23,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -40,8 +40,8 @@ function Wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/app/admin/integrations/__tests__/byot-install-modal.test.tsx
+++ b/packages/web/src/app/admin/integrations/__tests__/byot-install-modal.test.tsx
@@ -38,9 +38,10 @@ const testConfig = {
   apiUrl: "http://localhost:3001",
   isCrossOrigin: false,
   authClient: {
-    getToken: async () => null,
-    getOrgId: () => null,
-    onAuthChange: () => () => undefined,
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: async () => {},
+    useSession: () => ({ data: null, isPending: false }),
   },
 };
 

--- a/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
+++ b/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
@@ -44,9 +44,10 @@ const testConfig = {
   apiUrl: "http://localhost:3001",
   isCrossOrigin: false,
   authClient: {
-    getToken: async () => null,
-    getOrgId: () => null,
-    onAuthChange: () => () => undefined,
+    signIn: { email: async () => ({}) },
+    signUp: { email: async () => ({}) },
+    signOut: async () => {},
+    useSession: () => ({ data: null, isPending: false }),
   },
 };
 
@@ -805,7 +806,6 @@ describe("CatalogSection — pillar split + status error surface (#2746)", () =>
           status: 0,
           message,
           requestId: undefined,
-          rawBody: null,
         }}
         onChange={noopChange}
       />,

--- a/packages/web/src/app/admin/knowledge/__tests__/upload-bundle-dialog.test.tsx
+++ b/packages/web/src/app/admin/knowledge/__tests__/upload-bundle-dialog.test.tsx
@@ -20,8 +20,9 @@ const realFetch = globalThis.fetch;
 beforeEach(() => {
   responseStatus = 200;
   responseBody = {};
-  globalThis.fetch = (async () =>
-    new Response(JSON.stringify(responseBody), { status: responseStatus })) as typeof globalThis.fetch;
+  globalThis.fetch = mock(
+    async () => new Response(JSON.stringify(responseBody), { status: responseStatus }),
+  ) as unknown as typeof globalThis.fetch;
 });
 afterEach(() => {
   globalThis.fetch = realFetch;

--- a/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
+++ b/packages/web/src/app/admin/sandbox/__tests__/saas-backend-selection.test.tsx
@@ -25,7 +25,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 function wrapper({ children }: { children: ReactNode }) {
@@ -40,8 +40,8 @@ function wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/app/admin/semantic/__tests__/generate-empty-state.test.tsx
+++ b/packages/web/src/app/admin/semantic/__tests__/generate-empty-state.test.tsx
@@ -27,7 +27,7 @@ void mock.module("@/ui/context", () => ({
   useAtlasConfig: () => ({
     apiUrl: "http://localhost",
     isCrossOrigin: false,
-    authClient: { useSession: () => ({ data: null }) },
+    authClient: { useSession: () => ({ data: null, isPending: false }) },
   }),
 }));
 

--- a/packages/web/src/app/admin/semantic/__tests__/import-empty-state.test.tsx
+++ b/packages/web/src/app/admin/semantic/__tests__/import-empty-state.test.tsx
@@ -41,7 +41,7 @@ void mock.module("@/ui/context", () => ({
   useAtlasConfig: () => ({
     apiUrl: "http://localhost",
     isCrossOrigin: false,
-    authClient: { useSession: () => ({ data: null }) },
+    authClient: { useSession: () => ({ data: null, isPending: false }) },
   }),
 }));
 

--- a/packages/web/src/app/admin/semantic/__tests__/normalize-connection-groups.test.ts
+++ b/packages/web/src/app/admin/semantic/__tests__/normalize-connection-groups.test.ts
@@ -49,7 +49,8 @@ describe("connectionGroupsFrom", () => {
     // A member with an empty dbType is dropped entirely; a later member with a
     // real dbType still sets the group's datasource label.
     const groups = connectionGroupsFrom([
-      conn({ id: "a", groupId: "g_x", dbType: "" }),
+      // deliberately invalid: server rows can carry an empty dbType at runtime
+      conn({ id: "a", groupId: "g_x", dbType: "" as unknown as ConnectionInfo["dbType"] }),
       conn({ id: "b", groupId: "g_x", dbType: "postgres" }),
     ]);
     expect(groups).toHaveLength(1);
@@ -74,14 +75,18 @@ describe("connectionGroupsFrom", () => {
   });
 
   test("drops connections with no dbType", () => {
-    const groups = connectionGroupsFrom([conn({ id: "a", groupId: "g_x", dbType: "" })]);
+    // deliberately invalid: server rows can carry an empty dbType at runtime
+    const groups = connectionGroupsFrom([
+      conn({ id: "a", groupId: "g_x", dbType: "" as unknown as ConnectionInfo["dbType"] }),
+    ]);
     // The only member had no dbType → the group has no members → not emitted.
     expect(groups).toEqual([]);
   });
 
   test("dbTypeLabel is omitted for an unknown datasource type", () => {
     const groups = connectionGroupsFrom([
-      conn({ id: "a", groupId: "g_x", dbType: "exotic-engine" }),
+      // deliberately invalid: exercises the unknown-datasource fallback
+      conn({ id: "a", groupId: "g_x", dbType: "exotic-engine" as unknown as ConnectionInfo["dbType"] }),
     ]);
     // labelForDbType returns the raw value for unknown types (not undefined),
     // so the header still shows *something* rather than dropping it silently.

--- a/packages/web/src/app/admin/settings/__tests__/workspace-identity-card.test.tsx
+++ b/packages/web/src/app/admin/settings/__tests__/workspace-identity-card.test.tsx
@@ -50,7 +50,7 @@ describe("WorkspaceIdentityCard", () => {
   });
 
   test("copies the orgId to the clipboard and flips the icon to the copied state", async () => {
-    const writeText = mock(async () => undefined);
+    const writeText = mock(async (_text: string) => undefined);
     Object.defineProperty(globalThis.navigator, "clipboard", {
       configurable: true,
       value: { writeText },

--- a/packages/web/src/app/login/region-gate.test.tsx
+++ b/packages/web/src/app/login/region-gate.test.tsx
@@ -25,7 +25,9 @@ Object.defineProperty(window, "location", {
   configurable: true,
 });
 
-const fetchMock = mock(async (): Promise<Response> => new Response("{}"));
+const fetchMock = mock(
+  async (_input?: RequestInfo | URL, _init?: RequestInit): Promise<Response> => new Response("{}"),
+);
 const originalFetch = globalThis.fetch;
 globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
 
@@ -66,7 +68,7 @@ describe("LoginRegionGate", () => {
     expect(applyRegionSignalMock).toHaveBeenCalledWith("eu", "https://api-eu.useatlas.dev");
     expect(reloadMock).toHaveBeenCalledTimes(1);
 
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("/api/login/resolve-region");
     expect(JSON.parse(init.body as string)).toEqual({ email: "alice@corp.com" });
   });

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -19,10 +19,12 @@ void mock.module("@/lib/auth/client", () => ({ authClient: {} }));
 import * as realTwoFactorClient from "@/lib/auth/two-factor-client";
 
 const verifyTotpMock = mock(
-  async (_opts: { code: string; trustDevice?: boolean }) => ({
-    data: { token: "session-token" },
-    error: null,
-  }),
+  async (
+    _opts: { code: string; trustDevice?: boolean },
+  ): Promise<
+    | { data: { token: string }; error: null }
+    | { data: null; error: { code: string; message: string; status: number } }
+  > => ({ data: { token: "session-token" }, error: null }),
 );
 const verifyBackupCodeMock = mock(
   async (_opts: { code: string; trustDevice?: boolean }) => ({

--- a/packages/web/src/app/settings/profile/__tests__/password-section.test.tsx
+++ b/packages/web/src/app/settings/profile/__tests__/password-section.test.tsx
@@ -52,8 +52,8 @@ function wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/lib/auth/__tests__/sign-out.test.ts
+++ b/packages/web/src/lib/auth/__tests__/sign-out.test.ts
@@ -43,7 +43,7 @@ describe("signOutForgettingRegion", () => {
 
     // Forgotten before the request ran — not after, so the hint can't survive a
     // signOut that hangs or the page navigating away mid-flight.
-    expect(presentDuringSignOut).toBe(false);
+    expect<boolean | null>(presentDuringSignOut).toBe(false);
     expect(hasRegionCookie()).toBe(false);
   });
 

--- a/packages/web/src/lib/cross-origin-api.test.ts
+++ b/packages/web/src/lib/cross-origin-api.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { isCrossOriginApi } from "./cross-origin-api";
 
 const env = (v: string | undefined) =>
-  ({ NEXT_PUBLIC_ATLAS_API_URL: v }) as NodeJS.ProcessEnv;
+  ({ NEXT_PUBLIC_ATLAS_API_URL: v, NODE_ENV: "test" }) as NodeJS.ProcessEnv;
 
 describe("isCrossOriginApi", () => {
   it("is true when NEXT_PUBLIC_ATLAS_API_URL is a non-empty origin (SaaS app↔api split)", () => {

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -27,6 +27,7 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       routingMode: "pin",
       restExcludedDatasourceIds: ["billing-api"],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
     const s = useChatRoutingPreferenceStore.getState();
     expect(s.workspaceId).toBe("org-1");
@@ -46,6 +47,7 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       routingMode: "all",
       restExcludedDatasourceIds: ["billing-api"],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
     const raw = localStorage.getItem(STORAGE_KEY);
     expect(raw).not.toBeNull();
@@ -57,6 +59,7 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       routingMode: "all",
       restExcludedDatasourceIds: ["billing-api"],
       restFocusDatasourceId: "stripe",
+      groupReach: null,
     });
     // Setters must never be serialized.
     expect(persisted.state.setPreference).toBeUndefined();
@@ -71,6 +74,9 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       groupId: "prod",
       connectionId: "warehouse",
       routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: null,
     });
     expect(useChatRoutingPreferenceStore.getState().workspaceId).toBe("org-A");
   });
@@ -82,6 +88,9 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       groupId: "prod",
       connectionId: "us-prod",
       routingMode: "auto",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: null,
     });
     store.clear();
     const s = useChatRoutingPreferenceStore.getState();
@@ -160,6 +169,9 @@ describe("useChatRoutingPreferenceStore hydration gate (#3064)", () => {
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: null,
     });
     const raw = localStorage.getItem(STORAGE_KEY);
     expect(raw).not.toBeNull();

--- a/packages/web/src/ui/__tests__/add-to-dashboard-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/add-to-dashboard-dialog.test.tsx
@@ -79,7 +79,7 @@ function Wrapper({ children }: { children: ReactNode }) {
   return React.createElement(QueryClientProvider, { client }, children);
 }
 
-const noChartResult = { chartable: false as const, recommendations: [] };
+const noChartResult = { chartable: false as const, columns: [], recommendations: [] };
 
 const baseProps = {
   open: true,

--- a/packages/web/src/ui/__tests__/admin-layout.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-layout.test.tsx
@@ -72,7 +72,7 @@ function makeAuthClient(overrides: Partial<AtlasAuthClient> = {}): AtlasAuthClie
     signIn: { email: async () => ({}) },
     signUp: { email: async () => ({}) },
     signOut: mockSignOut,
-    useSession: () => mockSession,
+    useSession: () => ({ isPending: false, ...mockSession }),
     ...overrides,
   };
 }

--- a/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-mutation-error-passthrough.test.tsx
@@ -22,7 +22,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -39,8 +39,8 @@ function Wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/ui/__tests__/change-password-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/change-password-dialog.test.tsx
@@ -7,7 +7,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 function renderDialog(open: boolean, onComplete?: () => void) {

--- a/packages/web/src/ui/__tests__/conversation-url-open.test.tsx
+++ b/packages/web/src/ui/__tests__/conversation-url-open.test.tsx
@@ -113,11 +113,7 @@ function wrapper(
   onUrlUpdate?: (e: UrlUpdateEvent) => void,
 ) {
   return ({ children }: { children: ReactNode }) =>
-    createElement(
-      NuqsTestingAdapter,
-      { searchParams, onUrlUpdate, hasMemory: true },
-      children,
-    );
+    createElement(NuqsTestingAdapter, { searchParams, onUrlUpdate, hasMemory: true, children });
 }
 
 afterEach(() => cleanup());

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1521,7 +1521,7 @@ describe("ChatEnvPicker three-state routing mode (#2518)", () => {
   });
 
   test("selecting Auto produces a triple with routingMode='auto' keeping the current member", () => {
-    let captured: { groupId: string; connectionId: string; routingMode: string } | null = null;
+    let captured: ChatEnvSelection | null = null;
     const { container } = render(
       <ChatEnvPicker
         groups={multiMemberGroup}
@@ -1544,7 +1544,7 @@ describe("ChatEnvPicker three-state routing mode (#2518)", () => {
   });
 
   test("selecting All produces a triple with routingMode='all' keeping the current member", () => {
-    let captured: { groupId: string; connectionId: string; routingMode: string } | null = null;
+    let captured: ChatEnvSelection | null = null;
     const { container } = render(
       <ChatEnvPicker
         groups={multiMemberGroup}
@@ -1568,7 +1568,7 @@ describe("ChatEnvPicker three-state routing mode (#2518)", () => {
     // The user picks a member from the per-group section while in Auto.
     // The natural interpretation is "pin to that member" — you can't
     // 'select a member' in fanout.
-    let captured: { groupId: string; connectionId: string; routingMode: string } | null = null;
+    let captured: ChatEnvSelection | null = null;
     const { container } = render(
       <ChatEnvPicker
         groups={multiMemberGroup}
@@ -1722,6 +1722,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1738,6 +1741,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1763,6 +1769,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1785,13 +1794,16 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     // `selectedConnectionId !== null` guard no longer locks the default in.
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null },
+        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null },
         provenance: "default",
         preference: {
           workspaceId: "org-1",
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1813,13 +1825,16 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     // restore rather than no-op (routingMode is part of the selection).
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "eu-prod", routingMode: null },
+        current: { groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null },
         provenance: "default",
         preference: {
           workspaceId: "org-1",
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "auto",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1840,7 +1855,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     // been seeded and no preference matches, leave it — don't seed again.
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null },
+        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null },
         provenance: "default",
       }),
     );
@@ -1852,13 +1867,16 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     // authoritative — the resolver must never auto-replace it.
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null },
+        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null },
         provenance: "explicit",
         preference: {
           workspaceId: "org-1",
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1870,13 +1888,16 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     const decision = resolveEnvSelection(
       input({
         // Full match including routing mode — nothing to restore.
-        current: { groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
+        current: { groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null, groupReach: null },
         provenance: "default",
         preference: {
           workspaceId: "org-1",
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1903,6 +1924,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           groupId: "g_prod",
           connectionId: "gone-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-1",
       }),
@@ -1925,6 +1949,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: "org-A",
       }),
@@ -1947,6 +1974,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
           groupId: "g_prod",
           connectionId: "eu-prod",
           routingMode: "auto",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+          groupReach: null,
         },
         activeWorkspaceId: null,
       }),
@@ -2884,7 +2914,7 @@ describe("ChatEnvPicker — Group reach axis (#3895)", () => {
     container
       .querySelector<HTMLElement>('[data-testid="chat-env-picker-reach-all"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(captured).toEqual({
+    expect<ChatEnvSelection | null>(captured).toEqual({
       groupReach: null,
       groupId: null,
       connectionId: null,
@@ -2908,7 +2938,7 @@ describe("ChatEnvPicker — Group reach axis (#3895)", () => {
     container
       .querySelector<HTMLElement>('[data-testid="chat-env-picker-reach-focus-g_prod"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(captured).toEqual({
+    expect<ChatEnvSelection | null>(captured).toEqual({
       groupReach: "g_prod",
       groupId: "g_prod",
       connectionId: "us-prod",

--- a/packages/web/src/ui/__tests__/fetch-error.test.ts
+++ b/packages/web/src/ui/__tests__/fetch-error.test.ts
@@ -317,14 +317,17 @@ describe("extractFetchError empty-message clobber guard", () => {
 });
 
 describe("buildFetchError empty-message invariant", () => {
+  // Next's types declare NODE_ENV readonly; the invariant under test branches
+  // on it, so write through a widened view of process.env.
+  const mutableEnv = process.env as Record<string, string | undefined>;
   const originalEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
-    process.env.NODE_ENV = "test";
+    mutableEnv.NODE_ENV = "test";
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = originalEnv;
+    mutableEnv.NODE_ENV = originalEnv;
   });
 
   test("returns a FetchError with trimmed message on happy path", () => {
@@ -351,33 +354,33 @@ describe("buildFetchError empty-message invariant", () => {
   });
 
   test("throws in development when message is empty", () => {
-    process.env.NODE_ENV = "development";
+    mutableEnv.NODE_ENV = "development";
     expect(() => buildFetchError({ message: "", status: 500 })).toThrow(
       /refused to construct FetchError with empty message/,
     );
   });
 
   test("throws in development when message is whitespace-only", () => {
-    process.env.NODE_ENV = "development";
+    mutableEnv.NODE_ENV = "development";
     expect(() => buildFetchError({ message: "   ", status: 500 })).toThrow(
       /refused to construct FetchError with empty message/,
     );
   });
 
   test("throws in development when message is undefined", () => {
-    process.env.NODE_ENV = "development";
+    mutableEnv.NODE_ENV = "development";
     expect(() => buildFetchError({ status: 500 })).toThrow(
       /refused to construct FetchError with empty message/,
     );
   });
 
   test("throws in non-production (e.g. test env too)", () => {
-    process.env.NODE_ENV = "test";
+    mutableEnv.NODE_ENV = "test";
     expect(() => buildFetchError({ message: "" })).toThrow();
   });
 
   test("substitutes a generic message in production", () => {
-    process.env.NODE_ENV = "production";
+    mutableEnv.NODE_ENV = "production";
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     try {
       const err = buildFetchError({ message: "", status: 502 });
@@ -392,7 +395,7 @@ describe("buildFetchError empty-message invariant", () => {
   });
 
   test("production substitute uses 'unknown' when status is undefined", () => {
-    process.env.NODE_ENV = "production";
+    mutableEnv.NODE_ENV = "production";
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     try {
       const err = buildFetchError({ message: undefined });
@@ -404,7 +407,7 @@ describe("buildFetchError empty-message invariant", () => {
   });
 
   test("production substitute still preserves code and requestId", () => {
-    process.env.NODE_ENV = "production";
+    mutableEnv.NODE_ENV = "production";
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     try {
       const err = buildFetchError({

--- a/packages/web/src/ui/__tests__/mfa-enrollment-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/mfa-enrollment-dialog.test.tsx
@@ -20,7 +20,7 @@ function makeAuthClient(overrides: Partial<AtlasAuthClient> = {}): AtlasAuthClie
     signIn: { email: async () => ({}) },
     signUp: { email: async () => ({}) },
     signOut: mockSignOut,
-    useSession: () => ({ data: null }),
+    useSession: () => ({ data: null, isPending: false }),
     ...overrides,
   };
 }

--- a/packages/web/src/ui/__tests__/notebook-empty-state.test.tsx
+++ b/packages/web/src/ui/__tests__/notebook-empty-state.test.tsx
@@ -30,7 +30,7 @@ describe("NotebookEmptyState", () => {
           total: 1,
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as typeof fetch;
+      )) as unknown as typeof fetch;
 
     try {
       const { findByText } = render(
@@ -59,7 +59,7 @@ describe("NotebookEmptyState", () => {
         JSON.stringify({ error: "Forbidden", requestId: "req-xyz" }),
         { status: 403, headers: { "Content-Type": "application/json" } },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     try {
       const { findByTestId, getByRole } = render(

--- a/packages/web/src/ui/__tests__/passkey-tile.test.tsx
+++ b/packages/web/src/ui/__tests__/passkey-tile.test.tsx
@@ -5,8 +5,18 @@
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
 import { render, fireEvent, waitFor, cleanup, act, screen } from "@testing-library/react";
 
-const addPasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
-const updatePasskeyMock = mock(async (_opts?: unknown) => ({ data: null, error: null }));
+/** Result shape the tile consumes from better-auth's passkey client — wide
+ * enough for the success/error variants the tests stage per call. */
+type PasskeyCallResult = {
+  data: { id?: string; createdAt?: Date } | null;
+  error: { code?: string; message?: string; status?: number } | null;
+};
+const addPasskeyMock = mock(
+  async (_opts?: unknown): Promise<PasskeyCallResult> => ({ data: null, error: null }),
+);
+const updatePasskeyMock = mock(
+  async (_opts?: unknown): Promise<PasskeyCallResult> => ({ data: null, error: null }),
+);
 const listUserPasskeysMock = mock(async () => ({ data: [], error: null }));
 const deletePasskeyMock = mock(async (_opts?: unknown) => ({ data: { status: true }, error: null }));
 
@@ -25,7 +35,7 @@ void mock.module("@/lib/auth/passkey-client", () => ({
 const signInEmailMock = mock(
   async (_opts: { email: string; password: string }) =>
     ({ data: null, error: null }) as {
-      data: { twoFactorRedirect?: boolean } | null;
+      data: { twoFactorRedirect?: boolean; user?: Record<string, unknown> } | null;
       error: { message?: string; code?: string } | null;
     },
 );

--- a/packages/web/src/ui/__tests__/prompt-columns.test.tsx
+++ b/packages/web/src/ui/__tests__/prompt-columns.test.tsx
@@ -1,7 +1,13 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { render, cleanup } from "@testing-library/react";
-import { flexRender, type Row, type Table, type Cell } from "@tanstack/react-table";
-import type { PromptCollection } from "@useatlas/types/prompt";
+import {
+  flexRender,
+  type CellContext,
+  type Row,
+  type Table,
+  type Cell,
+} from "@tanstack/react-table";
+import type { PromptCollection } from "@/ui/lib/types";
 import { getPromptCollectionColumns } from "../../app/admin/prompts/columns";
 
 function baseCollection(partial: Partial<PromptCollection> = {}): PromptCollection {
@@ -35,7 +41,9 @@ function renderNameCell(row: PromptCollection) {
     column: nameCol,
     getValue: () => row.name,
     renderValue: () => row.name,
-  };
+    // The cell renderer only reads row/getValue; a real Column instance is
+    // not constructible in a unit test, so narrow through unknown.
+  } as unknown as CellContext<PromptCollection, unknown>;
   return render(<>{flexRender(nameCol.cell, ctx)}</>);
 }
 

--- a/packages/web/src/ui/__tests__/prompt-columns.test.tsx
+++ b/packages/web/src/ui/__tests__/prompt-columns.test.tsx
@@ -41,8 +41,9 @@ function renderNameCell(row: PromptCollection) {
     column: nameCol,
     getValue: () => row.name,
     renderValue: () => row.name,
-    // The cell renderer only reads row/getValue; a real Column instance is
-    // not constructible in a unit test, so narrow through unknown.
+    // The cell renderer only reads row/getValue; a real Column instance
+    // isn't cheaply constructible without standing up a full Table, so
+    // narrow through unknown.
   } as unknown as CellContext<PromptCollection, unknown>;
   return render(<>{flexRender(nameCol.cell, ctx)}</>);
 }

--- a/packages/web/src/ui/__tests__/prompt-prefill.test.tsx
+++ b/packages/web/src/ui/__tests__/prompt-prefill.test.tsx
@@ -37,7 +37,7 @@ function PromptHarness(props: { onPrefill: (text: string) => void }) {
 
 function wrapper(searchParams: Record<string, string>) {
   return ({ children }: { children: ReactNode }) =>
-    createElement(NuqsTestingAdapter, { searchParams, hasMemory: true }, children);
+    createElement(NuqsTestingAdapter, { searchParams, hasMemory: true, children });
 }
 
 afterEach(() => cleanup());

--- a/packages/web/src/ui/__tests__/rest-write-confirm-card.test.tsx
+++ b/packages/web/src/ui/__tests__/rest-write-confirm-card.test.tsx
@@ -18,7 +18,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -88,7 +88,7 @@ describe("RestWriteConfirmCard — retrySafe gating on confirm outcome", () => {
     global.fetch = (async () =>
       new Response(JSON.stringify({ error: "writes_disabled", message: "Writes are disabled." }), {
         status: 403,
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
     renderCard();
     clickConfirm();
     await waitFor(() => expect(screen.getByText(/Writes are disabled\./)).toBeTruthy());
@@ -102,7 +102,7 @@ describe("RestWriteConfirmCard — retrySafe gating on confirm outcome", () => {
     global.fetch = (async () =>
       new Response(JSON.stringify({ error: "internal_error", message: "Failed to execute the write." }), {
         status: 500,
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
     renderCard();
     clickConfirm();
     await waitFor(() => expect(screen.getByText(/may have completed/)).toBeTruthy());
@@ -114,7 +114,7 @@ describe("RestWriteConfirmCard — retrySafe gating on confirm outcome", () => {
   test("a network fault (fetch threw) withholds Try again — the outcome is ambiguous", async () => {
     global.fetch = (async () => {
       throw new TypeError("Failed to fetch");
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     renderCard();
     clickConfirm();
     await waitFor(() => expect(screen.getByText(/Network error/)).toBeTruthy());
@@ -124,7 +124,7 @@ describe("RestWriteConfirmCard — retrySafe gating on confirm outcome", () => {
 
   test("a 2xx whose body can't be read reports the write ran and withholds Try again", async () => {
     global.fetch = (async () =>
-      new Response("<<not json>>", { status: 200, headers: { "Content-Type": "application/json" } })) as typeof fetch;
+      new Response("<<not json>>", { status: 200, headers: { "Content-Type": "application/json" } })) as unknown as typeof fetch;
     renderCard();
     clickConfirm();
     await waitFor(() => expect(screen.getByText(/The write completed/)).toBeTruthy());

--- a/packages/web/src/ui/__tests__/sso-provider-management.test.tsx
+++ b/packages/web/src/ui/__tests__/sso-provider-management.test.tsx
@@ -12,7 +12,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -23,8 +23,7 @@ function wrapper({ children }: { children: ReactNode }) {
     { client: testQueryClient },
     createElement(
       AtlasProvider,
-      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
-      children,
+      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient }, children },
     ),
   );
 }

--- a/packages/web/src/ui/__tests__/tool-part.test.tsx
+++ b/packages/web/src/ui/__tests__/tool-part.test.tsx
@@ -30,7 +30,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/web/src/ui/__tests__/trusted-devices-list.test.tsx
+++ b/packages/web/src/ui/__tests__/trusted-devices-list.test.tsx
@@ -11,7 +11,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -28,8 +28,8 @@ function Wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -82,7 +82,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -93,8 +93,7 @@ function wrapper({ children }: { children: ReactNode }) {
     { client: testQueryClient },
     createElement(
       AtlasProvider,
-      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
-      children,
+      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient }, children },
     ),
   );
 }
@@ -768,7 +767,7 @@ describe("useAdminFetch", () => {
       expect(second.current.loading).toBe(false);
     });
 
-    expect(second.current.data).toEqual({ connections: [{ id: "a" }] });
+    expect(second.current.data as unknown).toEqual({ connections: [{ id: "a" }] });
     expect(Array.isArray(second.current.data)).toBe(false);
   });
 
@@ -817,11 +816,10 @@ function gatedWrapper({ children }: { children: ReactNode }) {
   return createElement(
     QueryClientProvider,
     { client: testQueryClient },
-    createElement(
-      AtlasProvider,
-      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
-      createElement(MfaGateProvider, null, children),
-    ),
+    createElement(AtlasProvider, {
+      config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient },
+      children: createElement(MfaGateProvider, null, children),
+    }),
   );
 }
 

--- a/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-mutation.test.ts
@@ -14,7 +14,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -25,8 +25,7 @@ function wrapper({ children }: { children: ReactNode }) {
     { client: testQueryClient },
     createElement(
       AtlasProvider,
-      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
-      children,
+      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient }, children },
     ),
   );
 }

--- a/packages/web/src/ui/__tests__/use-config-form.test.ts
+++ b/packages/web/src/ui/__tests__/use-config-form.test.ts
@@ -14,7 +14,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -25,8 +25,7 @@ function wrapper({ children }: { children: ReactNode }) {
     { client: testQueryClient },
     createElement(
       AtlasProvider,
-      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient } },
-      children,
+      { config: { apiUrl: "http://localhost:3001", isCrossOrigin: false as const, authClient: stubAuthClient }, children },
     ),
   );
 }

--- a/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
+++ b/packages/web/src/ui/__tests__/use-context-warnings.test.tsx
@@ -266,8 +266,8 @@ describe("useContextWarnings (integration)", () => {
     render(<Probe />);
     await act(async () => { await Promise.resolve(); });
 
-    expect(returnedForWarning).toBe(true);
-    expect(returnedForOther).toBe(false);
+    expect<boolean | null>(returnedForWarning).toBe(true);
+    expect<boolean | null>(returnedForOther).toBe(false);
   });
 
   test("turn-N warnings attach to turn N's assistant, NOT turn N-1's", async () => {

--- a/packages/web/src/ui/__tests__/use-datasource-summary.test.tsx
+++ b/packages/web/src/ui/__tests__/use-datasource-summary.test.tsx
@@ -28,7 +28,7 @@ describe("useDatasourceSummary", () => {
       new Response(
         JSON.stringify({ entities: [{ name: "users" }, { name: "orders" }] }),
         { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as typeof fetch;
+      )) as unknown as typeof fetch;
 
     const { result } = renderHook(
       () =>
@@ -53,7 +53,7 @@ describe("useDatasourceSummary", () => {
       new Response(JSON.stringify({ requestId: "req_abc" }), {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
 
     try {
       const { result } = renderHook(
@@ -87,7 +87,7 @@ describe("useDatasourceSummary", () => {
       new Response(JSON.stringify({ entities: null }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
 
     const { result } = renderHook(
       () =>

--- a/packages/web/src/ui/__tests__/use-dev-mode-no-drafts.test.tsx
+++ b/packages/web/src/ui/__tests__/use-dev-mode-no-drafts.test.tsx
@@ -34,6 +34,8 @@ function counts(partial: Partial<ModeDraftCounts> = {}): ModeDraftCounts {
     entityEdits: 0,
     entityDeletes: 0,
     prompts: 0,
+    starterPrompts: 0,
+    knowledgeDocuments: 0,
     ...partial,
   };
 }

--- a/packages/web/src/ui/__tests__/use-password-status.test.ts
+++ b/packages/web/src/ui/__tests__/use-password-status.test.ts
@@ -9,7 +9,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -26,8 +26,8 @@ function wrapper({ children }: { children: ReactNode }) {
           isCrossOrigin: false as const,
           authClient: stubAuthClient,
         },
+        children,
       },
-      children,
     ),
   );
 }

--- a/packages/web/src/ui/__tests__/use-queue-row.test.tsx
+++ b/packages/web/src/ui/__tests__/use-queue-row.test.tsx
@@ -19,8 +19,8 @@ const INITIAL: Row[] = [
 function ok<T>(data: T): MutateResult<T> {
   return { ok: true, data };
 }
-function fail(error: string): MutateResult<never> {
-  return { ok: false, error };
+function fail(message: string): MutateResult<never> {
+  return { ok: false, error: { message } };
 }
 
 /**

--- a/packages/web/src/ui/__tests__/use-server-data-table.test.tsx
+++ b/packages/web/src/ui/__tests__/use-server-data-table.test.tsx
@@ -38,7 +38,7 @@ const stubAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 let testQueryClient: QueryClient;
@@ -46,25 +46,21 @@ let testQueryClient: QueryClient;
 /** Compose nuqs (URL state) → react-query → AtlasProvider around the hook. */
 function makeWrapper(searchParams: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(
-      NuqsTestingAdapter,
-      { searchParams },
-      createElement(
+    return createElement(NuqsTestingAdapter, {
+      searchParams,
+      children: createElement(
         QueryClientProvider,
         { client: testQueryClient },
-        createElement(
-          AtlasProvider,
-          {
-            config: {
-              apiUrl: "http://localhost:3001",
-              isCrossOrigin: false as const,
-              authClient: stubAuthClient,
-            },
+        createElement(AtlasProvider, {
+          config: {
+            apiUrl: "http://localhost:3001",
+            isCrossOrigin: false as const,
+            authClient: stubAuthClient,
           },
           children,
-        ),
+        }),
       ),
-    );
+    });
   };
 }
 

--- a/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
+++ b/packages/web/src/ui/components/chat/__tests__/turn-partitioner.test.ts
@@ -16,6 +16,8 @@ import {
   activityAwaitsUser,
   partitionTurn,
   summarizeActivity,
+  type TextTurnPart,
+  type ToolTurnPart,
   type TurnPart,
 } from "../turn-partitioner";
 
@@ -23,7 +25,7 @@ import {
 /*  Part fixtures                                                      */
 /* ------------------------------------------------------------------ */
 
-function text(t: string, state?: "streaming" | "done"): TurnPart {
+function text(t: string, state?: "streaming" | "done"): TextTurnPart {
   return { type: "text", text: t, state };
 }
 
@@ -41,7 +43,7 @@ function sql(opts: {
   success?: boolean;
   state?: "input-streaming" | "input-available" | "output-available";
   sql?: string;
-}): TurnPart {
+}): ToolTurnPart {
   const state = opts.state ?? "output-available";
   return {
     type: "tool-executeSQL",
@@ -56,27 +58,27 @@ function sql(opts: {
               : { success: true, columns: ["n"], rows: [{ n: 1 }] },
         }
       : {}),
-  } as TurnPart;
+  } as ToolTurnPart;
 }
 
-function explore(command = "ls semantic/entities"): TurnPart {
+function explore(command = "ls semantic/entities"): ToolTurnPart {
   return {
     type: "tool-explore",
     toolCallId: `call-${nextCallId++}`,
     state: "output-available",
     input: { command },
     output: "entities.yml",
-  } as TurnPart;
+  } as ToolTurnPart;
 }
 
-function python(): TurnPart {
+function python(): ToolTurnPart {
   return {
     type: "tool-executePython",
     toolCallId: `call-${nextCallId++}`,
     state: "output-available",
     input: { code: "print(1)" },
     output: { success: true, stdout: "1" },
-  } as TurnPart;
+  } as ToolTurnPart;
 }
 
 /* ------------------------------------------------------------------ */
@@ -190,7 +192,7 @@ describe("partitionTurn", () => {
 
     const result = partitionTurn(parts);
 
-    const surfaced = [
+    const surfaced: TurnPart[] = [
       ...result.activity.map((p) => p.part),
       ...result.answer.map((p) => p.part),
       ...(result.answerBearingArtifact ? [result.answerBearingArtifact.part] : []),
@@ -243,14 +245,14 @@ describe("partitionTurn", () => {
 /* ------------------------------------------------------------------ */
 
 /** A generic tool part with an arbitrary output envelope. */
-function toolWithOutput(output: unknown): TurnPart {
+function toolWithOutput(output: unknown): ToolTurnPart {
   return {
     type: "tool-someAction",
     toolCallId: `call-${nextCallId++}`,
     state: "output-available",
     input: {},
     output,
-  } as TurnPart;
+  } as ToolTurnPart;
 }
 
 describe("activityAwaitsUser", () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
@@ -13,7 +13,7 @@ export const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 export function dashboardsWrapper({ children }: { children: ReactNode }) {

--- a/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
@@ -5,6 +5,7 @@ import { COLS, DEFAULT_TEXT_TILE_H, DEFAULT_TILE_H } from "../grid-constants";
 
 const DEFAULT_CARD: Omit<DashboardCard, "id" | "position" | "layout"> = {
   dashboardId: "d1",
+  annotations: [],
   title: "Untitled",
   kind: "chart",
   sql: "SELECT 1",

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-diff.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-diff.test.ts
@@ -38,6 +38,7 @@ function dashboard(cards: DashboardCard[], overrides?: Partial<DashboardWithCard
     nextRefreshAt: null,
     createdAt: "2026-05-17T00:00:00Z",
     updatedAt: "2026-05-17T00:00:00Z",
+    parameters: [],
     cards,
     ...overrides,
   };

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -30,6 +30,7 @@ const noop = () => {};
 const card: DashboardCard = {
   id: "card-1",
   dashboardId: "dash-1",
+  annotations: [],
   position: 0,
   title: "Pipeline by stage",
   kind: "chart",
@@ -54,7 +55,7 @@ const baseProps = {
   onDuplicate: noop,
   onDelete: noop,
   onUpdateTitle: noop,
-} as const;
+};
 
 describe("DashboardGrid", () => {
   afterEach(cleanup);

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-switcher.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-switcher.test.tsx
@@ -103,7 +103,7 @@ describe("DashboardSwitcher", () => {
       new Response(JSON.stringify({ error: "boom" }), {
         status: 500,
         headers: { "Content-Type": "application/json" },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
 
     render(<DashboardSwitcher currentId="d-1" />, { wrapper: dashboardsWrapper });
     openSwitcher();

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile-cross-filter.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile-cross-filter.test.tsx
@@ -31,6 +31,7 @@ const noop = () => {};
 const tableCard: DashboardCard = {
   id: "card-table",
   dashboardId: "dash-1",
+  annotations: [],
   position: 0,
   title: "Pipeline by stage",
   kind: "chart",

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile-status.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile-status.test.tsx
@@ -121,7 +121,7 @@ describe("DashboardTile — per-tile status (#4321)", () => {
     // …but labeled stale with an amber-or-worse caption.
     const caption = screen.getByTestId("tile-age-caption");
     expect(caption.textContent).toContain("Stale");
-    expect(["amber", "red"]).toContain(caption.getAttribute("data-caption-tone"));
+    expect<Array<string | null>>(["amber", "red"]).toContain(caption.getAttribute("data-caption-tone"));
     // …and a one-click retry that re-renders THIS card.
     fireEvent.click(screen.getByTestId("tile-retry"));
     expect(onRetry).toHaveBeenCalledTimes(1);

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -210,6 +210,7 @@ describe("DashboardTile", () => {
 
 const textCard: DashboardCard = {
   id: "card-text",
+  annotations: [],
   dashboardId: "dash-1",
   position: 0,
   title: "Top of funnel",
@@ -260,6 +261,7 @@ describe("DashboardTile — text cards", () => {
 
 const kpiCard: DashboardCard = {
   id: "card-kpi",
+  annotations: [],
   dashboardId: "dash-1",
   position: 0,
   title: "Revenue",

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar-touch.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar-touch.test.tsx
@@ -42,7 +42,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 const noop = () => {};

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar.test.tsx
@@ -28,7 +28,7 @@ const stubAuthClient: AtlasAuthClient = {
   signIn: { email: async () => ({}) },
   signUp: { email: async () => ({}) },
   signOut: async () => {},
-  useSession: () => ({ data: null }),
+  useSession: () => ({ data: null, isPending: false }),
 };
 
 const unexpected = (label: string) => () => {
@@ -99,7 +99,7 @@ describe("DashboardTopBar", () => {
     const editBtn = screen.getByRole("button", { name: /Edit/ });
     expect(editBtn.getAttribute("aria-pressed")).toBe("false");
     fireEvent.click(editBtn);
-    expect(captured).toBe(true);
+    expect<boolean | null>(captured).toBe(true);
   });
 
   test("Suggest button disabled when no cards", () => {
@@ -137,7 +137,7 @@ describe("DashboardTopBar", () => {
     fireEvent.change(input, { target: { value: "  New title  " } });
     fireEvent.keyDown(input, { key: "Enter" });
 
-    expect(saved).toBe("New title");
+    expect<string | null>(saved).toBe("New title");
   });
 
   test("Escape cancels the title edit without firing onTitleChange", () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/kpi-card.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/kpi-card.test.tsx
@@ -392,6 +392,7 @@ describe("kpiComparisonSignature", () => {
 
 const kpiCard: DashboardCard = {
   id: "kpi-1",
+  annotations: [],
   dashboardId: "dash-1",
   position: 0,
   title: "Revenue",

--- a/packages/web/src/ui/hooks/__tests__/use-coarse-pointer.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-coarse-pointer.test.tsx
@@ -24,7 +24,7 @@ function stubMatchMedia(matches: boolean) {
     addListener: (cb: Listener) => listeners.add(cb),
     removeListener: (cb: Listener) => listeners.delete(cb),
     dispatchEvent: () => true,
-  })) as typeof window.matchMedia;
+  })) as unknown as typeof window.matchMedia;
   return {
     listenerCount: () => listeners.size,
     restore: () => {
@@ -45,7 +45,7 @@ describe("useCoarsePointer (#4323)", () => {
     const mm = stubMatchMedia(true);
     let value: boolean | null = null;
     render(<Probe onValue={(v) => { value = v; }} />);
-    expect(value).toBe(true);
+    expect<boolean | null>(value).toBe(true);
     mm.restore();
   });
 
@@ -53,7 +53,7 @@ describe("useCoarsePointer (#4323)", () => {
     const mm = stubMatchMedia(false);
     let value: boolean | null = null;
     render(<Probe onValue={(v) => { value = v; }} />);
-    expect(value).toBe(false);
+    expect<boolean | null>(value).toBe(false);
     mm.restore();
   });
 

--- a/packages/web/src/ui/hooks/__tests__/use-deploy-mode.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-deploy-mode.test.tsx
@@ -45,7 +45,7 @@ describe("useDeployMode { enabled } forwarding", () => {
     staged({});
     lastOpts = undefined;
     renderHook(() => useDeployMode());
-    expect(lastOpts).toEqual({ enabled: undefined });
+    expect<{ enabled?: boolean } | undefined>(lastOpts).toEqual({ enabled: undefined });
   });
 
   test("explicit enabled: false threads through to skip the fetch", () => {
@@ -54,14 +54,14 @@ describe("useDeployMode { enabled } forwarding", () => {
     staged({});
     lastOpts = undefined;
     renderHook(() => useDeployMode({ enabled: false }));
-    expect(lastOpts).toEqual({ enabled: false });
+    expect<{ enabled?: boolean } | undefined>(lastOpts).toEqual({ enabled: false });
   });
 
   test("explicit enabled: true also threads through", () => {
     staged({});
     lastOpts = undefined;
     renderHook(() => useDeployMode({ enabled: true }));
-    expect(lastOpts).toEqual({ enabled: true });
+    expect<{ enabled?: boolean } | undefined>(lastOpts).toEqual({ enabled: true });
   });
 
   test("falls back to the hostname guess when the fetch is disabled", () => {

--- a/packages/web/src/ui/hooks/__tests__/use-resume-handler.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-resume-handler.test.tsx
@@ -11,15 +11,17 @@ import { useResumeHandler } from "@/ui/hooks/use-resume-handler";
 import { ATLAS_RESUME_MARKER } from "@/ui/hooks/use-atlas-transport";
 
 function makeOpts(over: Partial<Parameters<typeof useResumeHandler>[0]> = {}) {
-  return {
-    regenerate: mock(() => Promise.resolve()),
+  const base = {
+    regenerate: mock((_opts?: { body?: Record<string, unknown> }) => Promise.resolve()),
     clearRunStatus: mock(() => {}),
     refetchRunStatus: mock(() => {}),
     isLoading: false,
     resetPendingWarnings: mock(() => {}),
-    onError: mock(() => {}),
-    ...over,
+    onError: mock((_message: string, _detail?: string) => {}),
   };
+  // `over` may swap in same-shaped mocks; keep the Mock-typed fields so
+  // `.mock.calls` stays typed at the assertion sites.
+  return { ...base, ...over } as typeof base;
 }
 
 describe("useResumeHandler (#3749)", () => {

--- a/packages/web/tsconfig.test-check.json
+++ b/packages/web/tsconfig.test-check.json
@@ -6,8 +6,11 @@
   // This config drops `composite` so the compiler may pull app src into the
   // program unlisted, giving `tsgo -p tsconfig.test-check.json` a real
   // type-check over every web test file. It is NOT in tsconfig.json's
-  // `references` on purpose — referencing it would let it claim files out of
-  // the main program (#4447). The include list stays stated once, in
+  // `references` on purpose — a non-composite/noEmit reference is a hard
+  // error (TS6306/TS6310), and a reference here is redundant anyway; only
+  // tsconfig.test.json plays the routing-artifact role. If you both
+  // referenced a config like this AND broadened its include, you'd re-create
+  // the #4447 vacuation. The include list stays stated once, in
   // tsconfig.test.json.
   "extends": "./tsconfig.test.json",
   "compilerOptions": {

--- a/packages/web/tsconfig.test-check.json
+++ b/packages/web/tsconfig.test-check.json
@@ -1,0 +1,17 @@
+{
+  // Check-only companion to tsconfig.test.json (#4450): the routing artifact
+  // it extends is composite (load-bearing for the tsgolint project-reference
+  // redirect) and therefore can't compile standalone — composite demands a
+  // complete file list, while the include is deliberately test-only (#4447).
+  // This config drops `composite` so the compiler may pull app src into the
+  // program unlisted, giving `tsgo -p tsconfig.test-check.json` a real
+  // type-check over every web test file. It is NOT in tsconfig.json's
+  // `references` on purpose — referencing it would let it claim files out of
+  // the main program (#4447). The include list stays stated once, in
+  // tsconfig.test.json.
+  "extends": "./tsconfig.test.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true
+  }
+}

--- a/packages/web/tsconfig.test.json
+++ b/packages/web/tsconfig.test.json
@@ -7,7 +7,10 @@
   // app code into the program unlisted), so never build this with `tsc -b`.
   // Keep `include` narrowed to test files only — a broader include claims
   // app src files and redirects them OUT of the main program, silently
-  // emptying the web `type` gate (#4447).
+  // emptying the web `type` gate (#4447). The non-composite sibling
+  // tsconfig.test-check.json extends this file to actually TYPE-CHECK the
+  // test program (#4450) — this include is the single statement of the
+  // test-file set for both.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": true,

--- a/scripts/__tests__/check-type-program-not-vacuous.test.sh
+++ b/scripts/__tests__/check-type-program-not-vacuous.test.sh
@@ -9,12 +9,20 @@
 #   2. FLOOR — a healthy-but-shrunken program below the minimum trips.
 #   3. ROUTING ARTIFACT — tsconfig.test.json failing to load as a program
 #      (the tsgolint file->program routing seam, #4443) trips.
-#   4. TSGO LOOKUP — no resolvable tsgo binary fails loudly, never green.
+#   4. TEST-CHECK FLOOR — the test-check program (#4450's gate) shrinking
+#      below its own test-file floor trips.
+#   5. TSGO LOOKUP — no resolvable tsgo binary fails loudly, never green.
+#
+# Every expected-fail case also greps the guard's stderr for that branch's
+# specific FAIL message, so a case can't drift into tripping a DIFFERENT
+# branch (or a harness error like a bad interpreter lookup) while staying
+# green — bare non-zero exit is not attributable.
 #
 # Fixtures point the guard at a scaffolded temp tree via
-# TYPE_PROGRAM_GUARD_ROOT (+ TYPE_PROGRAM_GUARD_MIN for a fixture-sized
-# floor), so they never touch the real packages/web tsconfigs; the suite ends
-# with one real-repo sanity case that runs the guard un-overridden.
+# TYPE_PROGRAM_GUARD_ROOT (+ TYPE_PROGRAM_GUARD_MIN / _TEST_MIN for
+# fixture-sized floors), so they never touch the real packages/web tsconfigs;
+# the suite ends with one real-repo sanity case that runs the guard
+# un-overridden.
 
 set -euo pipefail
 
@@ -25,6 +33,12 @@ if [ ! -f "$SCRIPT" ]; then
   echo "::error::script under test not found at $SCRIPT" >&2
   exit 2
 fi
+
+# Resolve bash NOW: the tsgo-lookup case empties PATH, and a `PATH=... bash`
+# prefix assignment applies to the lookup of `bash` itself — invoking via an
+# absolute interpreter is what keeps that case exercising the GUARD's lookup
+# branch instead of failing before the guard ever runs.
+BASH_BIN="$(command -v bash)"
 
 # The synthetic trees have no node_modules; let the guard's `command -v tsgo`
 # fallback find the repo's tsgo.
@@ -38,8 +52,8 @@ PASS=0
 FAIL=0
 
 # Scaffold a temp tree shaped like the real seam: a main program of $1 src
-# files that excludes tests, referencing a composite test-only project.
-# Returns the tree path.
+# files that excludes tests, referencing a composite test-only project, plus
+# the non-composite test-check sibling (#4450). Returns the tree path.
 scaffold() {
   local n="$1" tmp i
   tmp="$(mktemp -d)"
@@ -64,13 +78,21 @@ EOF
   "exclude": []
 }
 EOF
+  cat > "$tmp/tsconfig.test-check.json" <<'EOF'
+{
+  "extends": "./tsconfig.test.json",
+  "compilerOptions": { "composite": false, "noEmit": true }
+}
+EOF
   printf '%s' "$tmp"
 }
 
-# run_case EXPECTED NAME MIN TREE — run the guard against TREE with the given
-# floor, assert pass/fail, clean up.
+# run_case EXPECTED NAME MIN TEST_MIN MSG TREE — run the guard against TREE
+# with the given floors, assert pass/fail, and for fail-cases assert stderr
+# carries MSG (the branch-specific FAIL text). Cleans up TREE.
 run_case() {
-  local expected="$1" name="$2" min="$3" tree="$4" status=0
+  local expected="$1" name="$2" min="$3" test_min="$4" msg="$5" tree="$6"
+  local status=0 stderr_file
   # Refuse to run against an unbuilt fixture: an empty ROOT would make the
   # guard fall back to the real packages/web (`:-` treats "" as unset), which
   # would silently turn a fail-case into a result about the live tree.
@@ -79,23 +101,28 @@ run_case() {
     FAIL=$((FAIL + 1))
     return
   fi
-  (PATH="$TSGO_PATH:$PATH" TYPE_PROGRAM_GUARD_ROOT="$tree" TYPE_PROGRAM_GUARD_MIN="$min" \
-    bash "$SCRIPT" >/dev/null 2>&1) || status=$?
-  if { [ "$expected" = pass ] && [ "$status" -eq 0 ]; } ||
-     { [ "$expected" = fail ] && [ "$status" -ne 0 ]; }; then
-    echo "  ok   $name (expected $expected)"
+  stderr_file="$(mktemp)"
+  (PATH="$TSGO_PATH:$PATH" TYPE_PROGRAM_GUARD_ROOT="$tree" \
+    TYPE_PROGRAM_GUARD_MIN="$min" TYPE_PROGRAM_GUARD_TEST_MIN="$test_min" \
+    "$BASH_BIN" "$SCRIPT" >/dev/null 2>"$stderr_file") || status=$?
+  if [ "$expected" = pass ] && [ "$status" -eq 0 ]; then
+    echo "  ok   $name (expected pass)"
+    PASS=$((PASS + 1))
+  elif [ "$expected" = fail ] && [ "$status" -ne 0 ] && grep -qF "$msg" "$stderr_file"; then
+    echo "  ok   $name (expected fail: '$msg')"
     PASS=$((PASS + 1))
   else
-    echo "  FAIL $name — expected $expected, got status=$status" >&2
+    echo "  FAIL $name — expected $expected('$msg'), got status=$status, stderr:" >&2
+    sed 's/^/    /' "$stderr_file" >&2
     FAIL=$((FAIL + 1))
   fi
-  rm -rf "$tree"
+  rm -rf "$tree" "$stderr_file"
 }
 
 # --- healthy tree ------------------------------------------------------------
 
-# 5 src files, floor 3: the main program is populated and the test project loads.
-run_case pass "healthy tree passes" 3 "$(scaffold 5)"
+# 5 src files / 1 test file, floors 3/1: both programs populated, artifact loads.
+run_case pass "healthy tree passes" 3 1 "" "$(scaffold 5)"
 
 # --- vacuation (#4447) --------------------------------------------------------
 
@@ -111,18 +138,20 @@ cat > "$tree/tsconfig.test.json" <<'EOF'
   "exclude": []
 }
 EOF
-run_case fail "broadened test include vacuates the main program (#4447)" 3 "$tree"
+run_case fail "broadened test include vacuates the main program (#4447)" 3 1 \
+  "re-vacuated the program" "$tree"
 
 # --- floor -------------------------------------------------------------------
 
 # A structurally healthy program below the floor still trips (partial
 # vacuation looks exactly like this: hundreds of files silently gone).
-run_case fail "src count below the floor trips" 6 "$(scaffold 5)"
+run_case fail "src count below the floor trips" 6 1 \
+  "in the type program (expected >= 6)" "$(scaffold 5)"
 
 # --- routing artifact (#4443) --------------------------------------------------
 
 # Main program healthy, but tsconfig.test.json no longer loads as a program:
-# the guard's second assertion (tsgolint file->program routing) must trip.
+# the guard's routing assertion (tsgolint file->program routing) must trip.
 tree="$(scaffold 5)"
 cat > "$tree/tsconfig.json" <<'EOF'
 {
@@ -132,29 +161,62 @@ cat > "$tree/tsconfig.json" <<'EOF'
 }
 EOF
 printf '{ this is not json\n' > "$tree/tsconfig.test.json"
-run_case fail "unloadable tsconfig.test.json trips the routing assertion" 3 "$tree"
+run_case fail "unloadable tsconfig.test.json trips the routing assertion" 3 1 \
+  "no longer loads as a program" "$tree"
+
+# --- test-check floor (#4450) ---------------------------------------------------
+
+# The test-check program shrinking below its test-file floor trips — include
+# rot must not quietly degrade the gate back to the pre-#4450 state. The
+# scaffold has 1 test file; a floor of 2 simulates the shrink.
+run_case fail "test-check program below the test-file floor trips (#4450)" 3 2 \
+  "test files in the test-check program (expected >= 2)" "$(scaffold 5)"
 
 # --- tsgo lookup ---------------------------------------------------------------
 
-# No tsgo anywhere (tree has no node_modules, PATH has none): the guard must
-# fail loudly instead of skipping the check.
+# No tsgo anywhere (tree has no node_modules, PATH has none): the guard's
+# lookup branch must fail loudly instead of skipping the check. Invoked via
+# $BASH_BIN so the emptied PATH hits the GUARD's `command -v tsgo`, not the
+# suite's own interpreter lookup; the message grep pins it to that branch.
 tree="$(scaffold 5)"
 empty_path="$(mktemp -d)"
+stderr_file="$(mktemp)"
 status=0
 (PATH="$empty_path" TYPE_PROGRAM_GUARD_ROOT="$tree" TYPE_PROGRAM_GUARD_MIN=3 \
-  bash "$SCRIPT" >/dev/null 2>&1) || status=$?
-if [ "$status" -ne 0 ]; then
-  echo "  ok   missing tsgo fails loudly (expected fail)"
+  TYPE_PROGRAM_GUARD_TEST_MIN=1 \
+  "$BASH_BIN" "$SCRIPT" >/dev/null 2>"$stderr_file") || status=$?
+if [ "$status" -ne 0 ] && grep -qF "tsgo not found" "$stderr_file"; then
+  echo "  ok   missing tsgo fails loudly (expected fail: 'tsgo not found')"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL missing tsgo did not fail — status=$status" >&2
+  echo "  FAIL missing tsgo — status=$status, stderr:" >&2
+  sed 's/^/    /' "$stderr_file" >&2
   FAIL=$((FAIL + 1))
 fi
-rm -rf "$tree" "$empty_path"
+rm -rf "$tree" "$empty_path" "$stderr_file"
+
+# --- non-numeric floor override --------------------------------------------------
+
+# A typo'd floor must fail the guard, not skip the comparison and exit green.
+tree="$(scaffold 5)"
+stderr_file="$(mktemp)"
+status=0
+(PATH="$TSGO_PATH:$PATH" TYPE_PROGRAM_GUARD_ROOT="$tree" \
+  TYPE_PROGRAM_GUARD_MIN="45O" TYPE_PROGRAM_GUARD_TEST_MIN=1 \
+  "$BASH_BIN" "$SCRIPT" >/dev/null 2>"$stderr_file") || status=$?
+if [ "$status" -ne 0 ] && grep -qF "non-numeric TYPE_PROGRAM_GUARD_MIN" "$stderr_file"; then
+  echo "  ok   non-numeric floor override fails loudly (expected fail)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL non-numeric floor override — status=$status, stderr:" >&2
+  sed 's/^/    /' "$stderr_file" >&2
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$tree" "$stderr_file"
 
 # --- real tree sanity ----------------------------------------------------------
 
-# The actual repo must pass with no overrides (default ROOT + 450 floor).
+# The actual repo must pass with no overrides (default ROOT + 450/200 floors).
 real_status=0
 (bash "$SCRIPT" >/dev/null 2>&1) || real_status=$?
 if [ "$real_status" -eq 0 ]; then

--- a/scripts/__tests__/check-type-program-not-vacuous.test.sh
+++ b/scripts/__tests__/check-type-program-not-vacuous.test.sh
@@ -56,7 +56,8 @@ FAIL=0
 # the non-composite test-check sibling (#4450). Returns the tree path.
 scaffold() {
   local n="$1" tmp i
-  tmp="$(mktemp -d)"
+  # Guard the substitution: an empty $tmp would scatter fixture files at /src.
+  tmp="$(mktemp -d)" || return 1
   mkdir -p "$tmp/src"
   for ((i = 1; i <= n; i++)); do
     printf 'export const v%d = %d;\n' "$i" "$i" > "$tmp/src/f$i.ts"
@@ -214,18 +215,42 @@ else
 fi
 rm -rf "$tree" "$stderr_file"
 
+# --- non-numeric test-check floor override ---------------------------------------
+
+# Same discipline for the second floor: a typo'd TEST_MIN must fail loudly.
+tree="$(scaffold 5)"
+stderr_file="$(mktemp)"
+status=0
+(PATH="$TSGO_PATH:$PATH" TYPE_PROGRAM_GUARD_ROOT="$tree" \
+  TYPE_PROGRAM_GUARD_MIN=3 TYPE_PROGRAM_GUARD_TEST_MIN="2O" \
+  "$BASH_BIN" "$SCRIPT" >/dev/null 2>"$stderr_file") || status=$?
+if [ "$status" -ne 0 ] && grep -qF "non-numeric TYPE_PROGRAM_GUARD_TEST_MIN" "$stderr_file"; then
+  echo "  ok   non-numeric test-check floor override fails loudly (expected fail)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL non-numeric test-check floor override — status=$status, stderr:" >&2
+  sed 's/^/    /' "$stderr_file" >&2
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$tree" "$stderr_file"
+
 # --- real tree sanity ----------------------------------------------------------
 
 # The actual repo must pass with no overrides (default ROOT + 450/200 floors).
+# Capture stderr so a CI failure here is attributable to a branch, not a bare
+# status code.
+stderr_file="$(mktemp)"
 real_status=0
-(bash "$SCRIPT" >/dev/null 2>&1) || real_status=$?
+("$BASH_BIN" "$SCRIPT" >/dev/null 2>"$stderr_file") || real_status=$?
 if [ "$real_status" -eq 0 ]; then
   echo "  ok   real repo passes the guard (expected pass)"
   PASS=$((PASS + 1))
 else
-  echo "  FAIL real repo does not pass the guard — status=$real_status" >&2
+  echo "  FAIL real repo does not pass the guard — status=$real_status, stderr:" >&2
+  sed 's/^/    /' "$stderr_file" >&2
   FAIL=$((FAIL + 1))
 fi
+rm -rf "$stderr_file"
 
 echo ""
 echo "check-type-program-not-vacuous.test.sh: $PASS passed, $FAIL failed"

--- a/scripts/__tests__/check-type-program-not-vacuous.test.sh
+++ b/scripts/__tests__/check-type-program-not-vacuous.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Adversarial fixture suite for
+# packages/web/scripts/check-type-program-not-vacuous.sh (#4447, #4450).
+#
+# Locks in the guard's FAIL branches against silent regression:
+#   1. VACUATION — a tsconfig.test.json include broadened to claim app src
+#      redirects those files OUT of the main program (#4447's failure mode);
+#      the src-file count drops below the floor and the guard must trip.
+#   2. FLOOR — a healthy-but-shrunken program below the minimum trips.
+#   3. ROUTING ARTIFACT — tsconfig.test.json failing to load as a program
+#      (the tsgolint file->program routing seam, #4443) trips.
+#   4. TSGO LOOKUP — no resolvable tsgo binary fails loudly, never green.
+#
+# Fixtures point the guard at a scaffolded temp tree via
+# TYPE_PROGRAM_GUARD_ROOT (+ TYPE_PROGRAM_GUARD_MIN for a fixture-sized
+# floor), so they never touch the real packages/web tsconfigs; the suite ends
+# with one real-repo sanity case that runs the guard un-overridden.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/packages/web/scripts/check-type-program-not-vacuous.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+
+# The synthetic trees have no node_modules; let the guard's `command -v tsgo`
+# fallback find the repo's tsgo.
+TSGO_PATH="$REPO_ROOT/node_modules/.bin"
+if [ ! -x "$TSGO_PATH/tsgo" ]; then
+  echo "::error::tsgo not found at $TSGO_PATH — run bun install first" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# Scaffold a temp tree shaped like the real seam: a main program of $1 src
+# files that excludes tests, referencing a composite test-only project.
+# Returns the tree path.
+scaffold() {
+  local n="$1" tmp i
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/src"
+  for ((i = 1; i <= n; i++)); do
+    printf 'export const v%d = %d;\n' "$i" "$i" > "$tmp/src/f$i.ts"
+  done
+  printf 'export const t = 1;\n' > "$tmp/src/f1.test.ts"
+  cat > "$tmp/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": { "noEmit": true, "skipLibCheck": true, "types": [] },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.test.json" }]
+}
+EOF
+  cat > "$tmp/tsconfig.test.json" <<'EOF'
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "composite": true, "noEmit": false, "outDir": "dist/t" },
+  "include": ["src/**/*.test.ts"],
+  "exclude": []
+}
+EOF
+  printf '%s' "$tmp"
+}
+
+# run_case EXPECTED NAME MIN TREE — run the guard against TREE with the given
+# floor, assert pass/fail, clean up.
+run_case() {
+  local expected="$1" name="$2" min="$3" tree="$4" status=0
+  # Refuse to run against an unbuilt fixture: an empty ROOT would make the
+  # guard fall back to the real packages/web (`:-` treats "" as unset), which
+  # would silently turn a fail-case into a result about the live tree.
+  if [ -z "$tree" ] || [ ! -d "$tree" ]; then
+    echo "  FAIL $name — scaffold produced no usable tree (got '$tree')" >&2
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  (PATH="$TSGO_PATH:$PATH" TYPE_PROGRAM_GUARD_ROOT="$tree" TYPE_PROGRAM_GUARD_MIN="$min" \
+    bash "$SCRIPT" >/dev/null 2>&1) || status=$?
+  if { [ "$expected" = pass ] && [ "$status" -eq 0 ]; } ||
+     { [ "$expected" = fail ] && [ "$status" -ne 0 ]; }; then
+    echo "  ok   $name (expected $expected)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $name — expected $expected, got status=$status" >&2
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tree"
+}
+
+# --- healthy tree ------------------------------------------------------------
+
+# 5 src files, floor 3: the main program is populated and the test project loads.
+run_case pass "healthy tree passes" 3 "$(scaffold 5)"
+
+# --- vacuation (#4447) --------------------------------------------------------
+
+# Broaden the referenced test project's include to claim app src: project-
+# reference semantics redirect every claimed file OUT of the main program,
+# so the count drops to 0 and the guard must trip.
+tree="$(scaffold 5)"
+cat > "$tree/tsconfig.test.json" <<'EOF'
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "composite": true, "noEmit": false, "outDir": "dist/t" },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}
+EOF
+run_case fail "broadened test include vacuates the main program (#4447)" 3 "$tree"
+
+# --- floor -------------------------------------------------------------------
+
+# A structurally healthy program below the floor still trips (partial
+# vacuation looks exactly like this: hundreds of files silently gone).
+run_case fail "src count below the floor trips" 6 "$(scaffold 5)"
+
+# --- routing artifact (#4443) --------------------------------------------------
+
+# Main program healthy, but tsconfig.test.json no longer loads as a program:
+# the guard's second assertion (tsgolint file->program routing) must trip.
+tree="$(scaffold 5)"
+cat > "$tree/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": { "noEmit": true, "skipLibCheck": true, "types": [] },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}
+EOF
+printf '{ this is not json\n' > "$tree/tsconfig.test.json"
+run_case fail "unloadable tsconfig.test.json trips the routing assertion" 3 "$tree"
+
+# --- tsgo lookup ---------------------------------------------------------------
+
+# No tsgo anywhere (tree has no node_modules, PATH has none): the guard must
+# fail loudly instead of skipping the check.
+tree="$(scaffold 5)"
+empty_path="$(mktemp -d)"
+status=0
+(PATH="$empty_path" TYPE_PROGRAM_GUARD_ROOT="$tree" TYPE_PROGRAM_GUARD_MIN=3 \
+  bash "$SCRIPT" >/dev/null 2>&1) || status=$?
+if [ "$status" -ne 0 ]; then
+  echo "  ok   missing tsgo fails loudly (expected fail)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL missing tsgo did not fail — status=$status" >&2
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$tree" "$empty_path"
+
+# --- real tree sanity ----------------------------------------------------------
+
+# The actual repo must pass with no overrides (default ROOT + 450 floor).
+real_status=0
+(bash "$SCRIPT" >/dev/null 2>&1) || real_status=$?
+if [ "$real_status" -eq 0 ]; then
+  echo "  ok   real repo passes the guard (expected pass)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL real repo does not pass the guard — status=$real_status" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "check-type-program-not-vacuous.test.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #4450.

`packages/web`'s 283 test files were type-checked by nothing: the main tsconfig excludes them, `bun test` strips types, and the composite `tsconfig.test.json` is a tsgolint routing artifact that cannot compile standalone (410× TS6307). This PR closes the gap along the lines the issue laid out:

- **`tsconfig.test-check.json`** — non-composite, check-only sibling that extends `tsconfig.test.json` (the include stays stated once) and is deliberately **not** referenced from `tsconfig.json`, so it can't claim files out of the main program (#4447). The web `type` script now chains `tsgo -p tsconfig.test-check.json --noEmit`, making a type error in any web test file fail the CI-blocking `type` job — verified by injecting a deliberate error (gate exits 1).
- **183-error backlog fixed** (66 test files, type-level only): stale fixture shapes (`DashboardCard.annotations`, `ChatRoutingPreference` reach fields, `ModeDraftCounts`, `AtlasAuthClient.useSession().isPending`), `createElement` children-in-props, untyped bun `mock()` spies, closure-narrowed `expect()`s widened via explicit generics, deliberately-invalid inputs kept via commented `as unknown as` casts, and fossil auth-client stubs rewritten to the real `AtlasAuthClient` surface. All 283 web test files still pass.
- **#4447 guard hardened + adversarial fixture suite** (the issue's optional item): the guard is parameterized (`TYPE_PROGRAM_GUARD_ROOT`/`_MIN`/`_TEST_MIN`), now also floors the test-check program (~284 test files today, floor 200) so include rot can't silently shrink the new gate, and validates floor overrides. `scripts/__tests__/check-type-program-not-vacuous.test.sh` (registered in the CI drift job; `ci-local` picks it up via glob) locks in every FAIL branch against scaffolded synthetic trees with branch-specific message assertions — 9 cases, sabotage-tested (a guard whose lookup branch is replaced with `exit 0` fails the suite).

Internal review panel: round 1 found the missing-tsgo fixture case was itself vacuous (a `PATH=… bash` prefix broke the interpreter lookup) plus the unfloored test-check program; both fixed and sabotage-verified in round 2.

## Test Plan

- Deliberate type error injected into a web test file → `bun run type` exits 1 (the acceptance criterion, verified end-to-end)
- `tsgo -p tsconfig.test-check.json --noEmit` → 0 errors (was 183)
- Full web test suite: 283/283 files pass (runtime behavior unchanged)
- `check-type-program-not-vacuous.sh` green on the real repo (577 src / 284 test files); fixture suite 9/9
- `bun run lint:type-aware` green (tsgolint routing preserved)
- `scripts/ci-local.sh`: all 29 gates green

- [ ] Manual testing
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change)

https://claude.ai/code/session_012AvML39nntoSe1BBECUC6t

---
_Generated by [Claude Code](https://claude.ai/code/session_012AvML39nntoSe1BBECUC6t)_