### PR TITLE
fix(api): prod-audit trivial fixes — requestId on teams install 500, stale metrics doc comment

### DIFF
--- a/packages/api/src/api/routes/teams.ts
+++ b/packages/api/src/api/routes/teams.ts
@@ -161,7 +161,11 @@ teams.openapi(installRoute, async (c) => {
       "Failed to save OAuth state for Teams install",
     );
     return c.json(
-      { error: "state_save_failed", message: "Could not initiate OAuth flow. Please try again." },
+      {
+        error: "state_save_failed",
+        message: "Could not initiate OAuth flow. Please try again.",
+        requestId,
+      },
       500,
     );
   }

--- a/packages/api/src/lib/metrics.ts
+++ b/packages/api/src/lib/metrics.ts
@@ -10,10 +10,10 @@
  * with no enclosing HTTP request, so they need a Meter to feed dashboards
  * and alerting hooks.
  *
- * SDK initialization lives in telemetry.ts. Adding a metric here without
- * also wiring a `metricReader` into the NodeSDK means the value is
- * collected but not exported — operators who want abuse counters in their
- * Grafana board need to extend telemetry.ts with an OTLP metrics exporter.
+ * SDK initialization lives in telemetry.ts, which wires a
+ * `PeriodicExportingMetricReader` + OTLP metrics exporter (60s cadence) into
+ * the NodeSDK — metrics defined here are exported to the same collector as
+ * traces whenever OTEL_EXPORTER_OTLP_ENDPOINT is set.
  */
 
 import { metrics, type Counter, type Gauge, type Histogram } from "@opentelemetry/api";


### PR DESCRIPTION
## Summary

The two trivial (&lt; 5 lines) fixes from the 2026-07-10 `/prod-audit` sweep:

- **`packages/api/src/api/routes/teams.ts`** — the `/api/v1/teams/install` OAuth-state-save failure was the only 500 response in the API surface (of 208) missing `requestId`; the id was already in scope from `adminAuthPreamble`, and `ErrorSchema` already declares `requestId` as optional, so no OpenAPI change.
- **`packages/api/src/lib/metrics.ts`** — header comment still claimed metrics are "collected but not exported" until an operator extends telemetry.ts; `telemetry.ts:96-103` has wired a `PeriodicExportingMetricReader` + OTLP exporter (60s cadence) since the abuse-counter work. Comment updated to match.

Larger audit findings were filed separately as #4457–#4465.

## Test Plan

- [x] Unit tests: `bun run scripts/test-isolated.ts --affected` — 34 files, all pass
- [x] Lint passes (`bun run lint`)
- [ ] Manual testing — n/a (response-body field + doc comment)
- [ ] E2E tests added/updated — n/a

## Checklist

- [x] Types pass — `requestId: string` into `ErrorSchema`'s existing optional field; comment-only change in metrics.ts (CI `ci` gate verifies)
- [x] Tests pass (affected suite locally; full suite in CI)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent — n/a, no dependency changes
- [x] Labels added (type + area)
- [ ] CHANGELOG.md — n/a, not user-facing

https://claude.ai/code/session_01H2LvbDH1dFFzCNcatiz57o

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2LvbDH1dFFzCNcatiz57o)_