### PR TITLE
docs-audit: 2026-07-10 residue — query schema, CLI help, agent-auth audit docs, .env.example policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,15 @@
 #   https://docs.useatlas.dev/reference/environment-variables
 # All commented (#) vars below are optional — uncomment only the ones you need.
 #
+# Inclusion policy: this file enumerates every knob the API reads from env —
+# including registry-backed settings (packages/api/src/lib/settings.ts) that
+# are also editable at runtime in Admin → Settings. For registry-backed knobs,
+# env is the seed/fallback: a value saved in the Admin console overrides env
+# (precedence: workspace setting > platform setting > env > built-in default),
+# so prefer the Admin console on a running deploy. The one exception is where
+# a section explicitly points at Admin → Settings instead of enumerating
+# (e.g. the Stripe per-tier Price IDs) — those are deliberately not listed.
+#
 # ─────────────────────────────────────────────────────────────────────────────
 # Running Atlas as a hosted SaaS region? You do NOT need most of this file.
 # A hosted region needs only the ~21-var SaaS boot floor — the single source of
@@ -245,6 +254,10 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                           # eval/canonical-questions/questions.yml resolved from the repo root.
 #                                           # Setting it to an empty string is rejected (refuses rather than
 #                                           # silently masking an env-template error).
+# ATLAS_MCP_EXPOSE_CANONICAL_PROMPTS=auto   # Surface the NovaMart canonical eval questions as MCP prompts/list
+#                                           # entries: auto (only when the workspace has a published __demo__
+#                                           # connection or ATLAS_DEMO_INDUSTRY is set) | always | never.
+#                                           # Default auto. Registry-backed; workspace-scoped.
 
 # === OAuth Provider (MCP / DCR) ===
 # Atlas issues OAuth 2.1 tokens via @better-auth/oauth-provider so MCP clients
@@ -256,8 +269,19 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS=2592000   # Refresh-token lifetime. Default: 2592000 (30d). Same parse rules as access TTL
 # ATLAS_OAUTH_STATE_TTL_SECONDS=600        # TTL for OAuth state tokens during integration install flows. Default: 600 (10m), clamped [60, 3600]
 
+# === Agent Auth (experimental) ===
+# ATLAS_AGENT_AUTH_ENABLED=false           # Expose the experimental Agent Auth Protocol surface (agent/host/capability
+#                                          # endpoints + /.well-known/agent-configuration). Off by default — everything
+#                                          # 404s when off. Pinned to an upstream 0.x spec; keep off in production.
+#                                          # Registry-backed; hot-reloadable. See docs/agent-auth.
+
 # === Agent ===
 # ATLAS_AGENT_MAX_STEPS=25     # Default: 25, range 1–100. Max tool-call steps per agent run
+# ATLAS_DEFAULT_ANSWER_STYLE=               # Workspace default answer style (house voice) for surfaces that
+#                                           # don't pick one: plain-english | analyst | executive | conversational.
+#                                           # A per-conversation pick always wins; chat platforms choose their own
+#                                           # voice per turn. Unset = track the built-in default (analyst).
+#                                           # Registry-backed (Admin → Settings → Agent); hot-reloadable.
 # ATLAS_BYOT_CATALOG_TTL_MS=21600000        # Default 6h. Server-side TTL for the per-workspace BYOT
 #                                           # provider catalog (Anthropic /v1/models — #2271). Discovery
 #                                           # hits upstream when the workspace's cache entry has
@@ -280,6 +304,28 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_COMPACTION_PINNED_RECENT_STEPS=6    # Most-recent steps pinned verbatim (1–100). Default 6.
 # ATLAS_COMPACTION_CONTEXT_WINDOW_TOKENS=200000 # Coarse window (tokens) for the trigger. Default 200000
 #                                           # (accurate per-model resolution is a follow-up, #3760).
+# ATLAS_COMPACTION_SUMMARY_MODEL=           # Optional model id for the compaction summarization call —
+#                                           # typically a cheaper/faster tier (e.g. Haiku/mini). Resolved on the
+#                                           # same provider/credentials as the turn model. Empty = summarize on
+#                                           # the active turn model.
+
+# Durable agent sessions (ADR-0020). Per-step checkpoints of each agent turn in
+# the internal DB — the foundation for crash-resume and approval-park. Requires
+# an internal DATABASE_URL; default OFF, and degrades cleanly without one.
+# Registry-backed (Admin → Settings); workspace-scoped.
+# ATLAS_DURABILITY_ENABLED=false            # Master on/off. Default false.
+# ATLAS_DURABILITY_RETENTION_DAYS=30        # Days terminal run checkpoints are kept before the retention
+#                                           # sweep deletes them. Non-terminal runs are never swept. Default 30.
+# ATLAS_DURABILITY_RESUME_LEASE_SECONDS=300 # How long a crash-resume holds the single-resumer lease on an
+#                                           # interrupted turn; concurrent resumes are rejected while live.
+#                                           # Default 300.
+# ATLAS_DURABILITY_MAX_PARK_MINUTES=1440    # How long a turn may stay parked awaiting a human approval before
+#                                           # the sweep fails it. Default 1440 (24h), matching the
+#                                           # approval-request expiry default.
+# ATLAS_MEMORY_MAX_SLOTS=64                 # Max named working-memory slots per session; a write adding a slot
+#                                           # past the cap is rejected (never truncated). Default 64.
+# ATLAS_MEMORY_MAX_VALUE_BYTES=16384        # Max serialized size (bytes) of one working-memory slot value;
+#                                           # larger writes are rejected before persistence. Default 16384 (16 KiB).
 # ATLAS_DASHBOARD_DRAFT_RETENTION_DAYS=30   # Default: 30. Days an un-touched per-user dashboard draft
 #                                           # (dashboard_user_drafts) may sit before the scheduler deletes
 #                                           # it — bounds the table's growth from forked-then-abandoned
@@ -292,6 +338,11 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_DASHBOARD_EXPORT_TIMEOUT_MS=60000   # Default: 60000 (60s). Overall wall-clock budget for a headless dashboard
 #                                           # PDF/PNG export (lib/dashboard-screenshot.ts). Clamped to [5000, 180000];
 #                                           # a lower value degrades to a documented PARTIAL capture, not a 504.
+# ATLAS_DASHBOARD_RENDER_CONCURRENCY=3      # Max simultaneous dashboard screenshot/export renders on the shared
+#                                           # headless Chromium; excess requests queue. Default 3, clamped 1–16.
+# ATLAS_DASHBOARD_ABANDON_CLEANUP_HOURS=72  # Hours a never-published, empty dashboard shell (no cards, no drafts)
+#                                           # may sit before the scheduler soft-deletes it. 0 disables cleanup.
+#                                           # Default 72.
 
 # === Semantic Expert ===
 # ATLAS_EXPERT_SCHEDULER_ENABLED=false    # Enable periodic semantic layer analysis
@@ -329,6 +380,27 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_LEARN_RETRIEVAL_TURNS=3          # Default: 3 — trailing user turns assembled into the learned-pattern retrieval query
 # ATLAS_LEARN_PROMOTE_DECAY_ENABLED=false        # Default: false — enable the nightly job (#3636) that auto-promotes high-confidence, fast, frequently-seen learned patterns and demotes stale auto-promoted ones (human approvals are never demoted). Platform-scoped; requires restart. Also runtime-controllable in Admin → Settings
 # ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS=24    # Default: 24 — hours between auto-promote/decay runs. Platform-scoped; requires restart
+# ATLAS_LEARN_PROMOTE_MIN_REPETITIONS=5          # Default: 5 — min times a pending pattern must have been seen before the nightly job auto-promotes it
+# ATLAS_LEARN_LATENCY_BUDGET_MS=5000             # Default: 5000 — patterns averaging at or under this execution time rank normally in retrieval; slower ones are down-weighted (never excluded). Also the auto-promotion latency ceiling
+# ATLAS_LEARN_DECAY_UNSEEN_DAYS=30               # Default: 30 — an auto-promoted pattern unseen this long is demoted back to pending. Human-approved patterns are never auto-demoted
+
+# === Knowledge Base ===
+# Per-workspace OKF knowledge collections served to the agent (ADR-0028).
+# Registry-backed (Admin → Settings → Knowledge); platform-scoped, hot-reloadable.
+# ATLAS_KNOWLEDGE_TOC_MAX_BYTES=12000              # Max size of the KB table-of-contents injected into the agent's
+#                                                  # system prompt (≈3k tokens); collections beyond the cap are omitted
+#                                                  # from the prompt but stay browsable via explore. Default 12000.
+# ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES=25000000 # Max raw upload size of a knowledge bundle (25 MB); also the
+#                                                  # decoded-total cap that aborts a decompression bomb mid-inflate.
+# ATLAS_KNOWLEDGE_INGEST_MAX_DOCS=1000             # Max documents a single knowledge bundle may ingest. Default 1000.
+# ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES=1000000     # Max decoded size of any single document in a bundle (1 MB);
+#                                                  # oversized documents are rejected per-file.
+# ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS=24           # How often bundle-sync collections pull their endpoint (nightly).
+# ATLAS_KNOWLEDGE_SYNC_RECONCILE_INTERVAL_HOURS=168 # How often connector-synced collections run a full reconciliation
+#                                                  # crawl (archives vendor-deleted pages, re-validates ingest caps).
+#                                                  # Default 168 (weekly); incremental change syncs run more often.
+# ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS=60    # Per-sync time budget for downloading a collection's bundle
+#                                                  # endpoint, including redirects and body streaming. Default 60.
 
 # === Starter Prompts ===
 # ATLAS_STARTER_PROMPT_COLD_WINDOW_DAYS=90     # Default: 90 — window (days) on prompt_collections.created_at for the adaptive starter-prompt resolver and the auto-promote eligibility window
@@ -343,6 +415,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_DEMO_RATE_LIMIT_RPM=10           # Max requests per minute per demo user (default: 10)
 # ATLAS_DEMO_MAX_STEPS=10                # Max agent steps per demo request (default: 10)
 # ATLAS_DEMO_INDUSTRY=                   # Industry for the seeded __demo__ connection (e.g. cybersecurity, ecommerce). Set at signup via onboarding — drives prompt-library filtering + publish archival cascade
+# ATLAS_DEMO_MODEL=                      # Model the public /demo path runs on — a gateway model id (e.g. anthropic/claude-haiku-4.5) or a direct model id matching the configured provider. Empty = Haiku on the gateway (SaaS) or the platform default model
 
 # === Encryption ===
 # ATLAS_ENCRYPTION_KEYS=v1:PRIMARY-KEY[,v2:NEW-KEY]  # F-47: comma-separated versioned keyset. First entry is the active write key; later entries are legacy read-only keys kept for the rotation soak. Use during rotation — see docs/platform-ops/encryption-key-rotation.
@@ -356,6 +429,10 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # SENDGRID_API_KEY=                               # SendGrid API key (used when ATLAS_EMAIL_PROVIDER=sendgrid)
 # POSTMARK_SERVER_TOKEN=                          # Postmark server token (used when ATLAS_EMAIL_PROVIDER=postmark)
 # ATLAS_EMAIL_ALLOWED_DOMAINS=                    # Comma-separated allowed recipient domains for email actions (unset = all allowed)
+# ATLAS_EMAIL_ALLOWED_RECIPIENT_DOMAINS=          # Distinct from the ACTION knob above: comma-separated domains the agent's
+#                                                 # sendEmail INTEGRATION tool may deliver to, in addition to workspace member
+#                                                 # addresses (e.g. example.com,partner.example). Empty = workspace members only.
+#                                                 # Registry-backed (Admin → Settings); workspace-scoped.
 # ATLAS_EMAIL_FROM=Atlas <noreply@useatlas.dev>   # From address for scheduled task and action emails
 # ATLAS_SMTP_URL=                                 # Webhook URL for email delivery (POST JSON with from/to/subject/html) — alternative to Resend
 # ATLAS_ONBOARDING_EMAILS_ENABLED=false           # Enable automated onboarding drip campaign for new signups. Default: from ATLAS_DEPLOY_ENV profile (prod: true, staging/dev: false).
@@ -726,11 +803,24 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # === Stripe Billing (SaaS only) ===
 # Enables Stripe billing when STRIPE_SECRET_KEY is set. Self-hosted deployments
 # skip this entirely — the self-hosted experience is the free tier.
-# Only the two genuine secrets live in env. The six per-tier Price IDs are
-# now platform settings (Admin → Settings → Billing) — editable at runtime
-# without a redeploy (#3703). Setting them via env still works as a fallback.
+# Only the two genuine secrets live in env. The nine per-tier Price IDs
+# (STRIPE_{STARTER,PRO,BUSINESS}_PRICE_ID + _ANNUAL_ + _OVERAGE_ variants) are
+# platform settings (Admin → Settings → Billing) — editable at runtime without
+# a redeploy (#3703) and deliberately not enumerated here. Setting them via
+# env still works as a fallback.
 # STRIPE_SECRET_KEY=sk_test_...                    # Stripe secret key (test or live)
 # STRIPE_WEBHOOK_SECRET=whsec_...                  # Stripe webhook signing secret
+# ATLAS_SPEND_POLICY=continue                      # What happens once a workspace spends its included usage credit:
+#                                                  # continue (default — serve at provider cost, bounded by the abuse
+#                                                  # ceiling) | cutoff (hard-block overage with a 429).
+#                                                  # Registry-backed; workspace-scoped.
+# ATLAS_ABUSE_CEILING=500                          # Hard cutoff for metered at-cost overage under the continue spend
+#                                                  # policy, as a percent of the included usage credit (500 = 5×).
+#                                                  # Registry-backed; workspace-scoped.
+# ATLAS_BILLING_RECONCILE_INTERVAL_HOURS=6         # Hours between plan-tier reconciliation sweeps (heals plan_tier
+#                                                  # drift from Stripe subscriptions, prunes the webhook event ledger).
+# ATLAS_UNCLAIMED_GRACE_REAP_INTERVAL_HOURS=1      # Hours between unclaimed-grace reaper sweeps (demotes lapsed
+#                                                  # unclaimed trial workspaces to the locked tier).
 
 # === Data Residency ===
 # ATLAS_API_REGION=                   # Region identity of this API instance (e.g. "us-west", "eu-west", "ap-southeast"). Used for misrouting detection. Falls back to residency.defaultRegion from atlas.config.ts if unset.

--- a/apps/docs/content/docs/agent-auth/index.mdx
+++ b/apps/docs/content/docs/agent-auth/index.mdx
@@ -160,6 +160,46 @@ This is deliberately narrow: a long-lived grant for _"read the daily-orders summ
 very different risk than a standing `webauthn` bypass, and Agent Auth only offers the
 former.
 
+## Audit trail
+
+Every significant mutation in the agent lifecycle — register → enroll → request →
+approve/deny → execute → revoke — writes a row to the workspace's admin action log, the
+same log every other admin surface writes to. The rows carry `agent.*` action types:
+
+| Action | Written when |
+|---|---|
+| `agent.register` | An agent identity is registered |
+| `agent.revoke` | An agent identity is revoked |
+| `agent.host.enroll` | An agent is enrolled to a host |
+| `agent.host.revoke` | A host enrollment is revoked (metadata records how many agents it covered) |
+| `agent.capability.request` | A capability grant is requested (metadata records the requested capabilities and whether approval is pending or was auto-approved) |
+| `agent.capability.approve` | A capability grant is approved |
+| `agent.capability.deny` | A capability grant is denied — a normal decision outcome, so the row's status is still `success` |
+| `agent.capability.revoke` | A capability grant is revoked (metadata records the revoked grant ids) |
+| `agent.capability.execute` | A granted capability is executed — see the sampling note below |
+
+The row's target id is the agent id (the host id for the two `agent.host.*` actions). A few
+things to know when reading these rows:
+
+- **Identity lives in the row's metadata, not its columns.** These events fire from the
+  auth layer, outside a normal Atlas request, so the log's `actor` / workspace columns read
+  `unknown`. The trustworthy identifiers travel in the row metadata instead: `actorId` (the
+  owning or approving user), `actorType`, `agentId`, `hostId`, and `orgId` when the event
+  carries one; execute rows add `userId`.
+- **Execution is summarized, never per-call.** Successful executes are high-volume, so one
+  `agent.capability.execute` row is written per 25 successful executions of the same
+  agent + capability pair, with `metadata.representedExecuteCount` recording how many calls
+  the row stands for and `metadata.sampled: true` marking it a summary. Execute **failures**
+  bypass the sampler — every failure writes a row with status `failure` and a scrubbed,
+  truncated error message.
+- **Capability arguments and output are never recorded.** They can carry customer SQL and
+  query results, so only the capability name and the outcome are auditable.
+- **Off means silent.** When `ATLAS_AGENT_AUTH_ENABLED` is off (the default — this surface
+  is experimental), no `agent.*` row is ever written, matching the rest of the surface
+  returning `404`. And because Agent Auth is pinned to an upstream `0.x` spec, lifecycle
+  events outside the catalog above (agent updates, key rotations, …) are deliberately not
+  audited yet.
+
 ## See also
 
 - [MCP Server](/guides/mcp) — the OAuth 2.1 + DCR + PKCE surface Agent Auth layers on top of

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -2387,6 +2387,44 @@
                         "totalTokens"
                       ]
                     },
+                    "conversationId": {
+                      "type": "string",
+                      "description": "Conversation the question and answer were persisted to. Present when the deployment has an internal database and persistence succeeded — either the (verified) conversationId from the request, or a newly created conversation. Absent when there is no internal database or persistence failed."
+                    },
+                    "runId": {
+                      "type": "string",
+                      "description": "Identifier of the underlying agent run. Present whenever the agent loop ran; useful for correlating with durable-session records and server logs."
+                    },
+                    "pendingApproval": {
+                      "type": "object",
+                      "properties": {
+                        "requestId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "ruleName": {
+                          "type": "string"
+                        },
+                        "matchedRules": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "requestId",
+                        "ruleName",
+                        "matchedRules",
+                        "message"
+                      ],
+                      "description": "Set when one or more SQL queries matched an approval rule and were enqueued for admin approval instead of executed. The run is NOT a complete answer in this case — the queued query runs only after approval. requestId is null when no approval-queue row could be created."
+                    },
                     "pendingActions": {
                       "type": "array",
                       "items": {

--- a/packages/api/src/api/routes/query.ts
+++ b/packages/api/src/api/routes/query.ts
@@ -65,6 +65,29 @@ export const QueryResponseSchema = z.object({
   usage: z.object({
     totalTokens: z.number().int(),
   }),
+  conversationId: z
+    .string()
+    .optional()
+    .describe(
+      "Conversation the question and answer were persisted to. Present when the deployment has an internal database and persistence succeeded — either the (verified) conversationId from the request, or a newly created conversation. Absent when there is no internal database or persistence failed.",
+    ),
+  runId: z
+    .string()
+    .optional()
+    .describe(
+      "Identifier of the underlying agent run. Present whenever the agent loop ran; useful for correlating with durable-session records and server logs.",
+    ),
+  pendingApproval: z
+    .object({
+      requestId: z.string().nullable(),
+      ruleName: z.string(),
+      matchedRules: z.array(z.string()),
+      message: z.string(),
+    })
+    .optional()
+    .describe(
+      "Set when one or more SQL queries matched an approval rule and were enqueued for admin approval instead of executed. The run is NOT a complete answer in this case — the queued query runs only after approval. requestId is null when no approval-queue row could be created.",
+    ),
   pendingActions: z
     .array(
       z.object({

--- a/packages/cli/lib/help.ts
+++ b/packages/cli/lib/help.ts
@@ -213,6 +213,10 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
         flag: "--connection <id>",
         description: "Query a specific datasource",
       },
+      {
+        flag: "--api-key <key>",
+        description: "Use a workspace API key instead of your `atlas login` session (also: ATLAS_API_KEY)",
+      },
     ],
     examples: [
       'atlas query "How many users signed up last month?"',
@@ -240,6 +244,10 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       {
         flag: "--csv",
         description: "CSV output (headers + rows, pipe-friendly)",
+      },
+      {
+        flag: "--api-key <key>",
+        description: "Use a workspace API key instead of your `atlas login` session (also: ATLAS_API_KEY)",
       },
     ],
     examples: [
@@ -480,6 +488,7 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
       { flag: "--schema <s>", description: "(create) Schema to scope to (e.g. a Postgres schema)" },
       { flag: "--group <id>", description: "(create) Attach to an existing environment/group" },
       { flag: "--new-group <name>", description: "(create) Create a new inline environment/group" },
+      { flag: "--api-key <key>", description: "Use a workspace API key instead of your `atlas login` session (also: ATLAS_API_KEY)" },
     ],
     examples: [
       "atlas datasource list",
@@ -514,6 +523,7 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
     flags: [
       { flag: "--connection <id>", description: "Run against a specific datasource in the metric's group" },
       { flag: "--json", description: "Machine-readable JSON output" },
+      { flag: "--api-key <key>", description: "Use a workspace API key instead of your `atlas login` session (also: ATLAS_API_KEY)" },
     ],
     examples: [
       "atlas metric run total_gmv",
@@ -619,11 +629,37 @@ export const SUBCOMMAND_HELP: Record<string, SubcommandHelp> = {
         description:
           "Run the full agent loop (slower, nondeterministic) instead of calling typed semantic-layer reads directly",
       },
+      {
+        flag: "--mcp-llm",
+        description:
+          "Dispatch each question through the real MCP route via an LLM (mutually exclusive with --llm)",
+      },
+      {
+        flag: "--baseline <path>",
+        description:
+          "Override the per-question latency baseline file for --mcp-llm runs (default: eval/canonical-questions/mcp-llm-baseline.json)",
+      },
+      {
+        flag: "--write-baseline",
+        description:
+          "Write the run's per-question latencies back to the baseline file (only with --mcp-llm)",
+      },
+      {
+        flag: "--tool-selection",
+        description:
+          "Run the held-out tool-selection grader instead of the question set (requires --mcp-llm)",
+      },
+      {
+        flag: "--tool-selection-fixture <path>",
+        description:
+          "Override the tool-selection fixture path (default: eval/canonical-questions/tool-selection.json)",
+      },
       { flag: "--json", description: "JSON summary output" },
     ],
     examples: [
       "atlas canonical-eval",
       "atlas canonical-eval --llm",
+      "atlas canonical-eval --mcp-llm --write-baseline",
     ],
   },
   smoke: {

--- a/packages/cli/src/__tests__/help-drift.test.ts
+++ b/packages/cli/src/__tests__/help-drift.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Ratchet against `--help` drift (#4472): `SUBCOMMAND_HELP` in lib/help.ts is
+ * static text, and bin/atlas.ts intercepts `--help` before handlers run — so
+ * when a handler grows a flag, the stale help text is what users see. Caught
+ * once by the 2026-07-10 docs audit (`--api-key` missing on four commands,
+ * five canonical-eval flags absent); this test makes the drift class fail CI.
+ *
+ * Flags are extracted from each handler's source with the same quoted-literal
+ * patterns the handlers actually parse with (`=== "--x"`, `getFlag(args,
+ * "--x")`, `args.includes("--x")`, value-flag Set literals). A flag literal a
+ * handler parses must be mentioned in its SUBCOMMAND_HELP entry.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { SUBCOMMAND_HELP } from "../../lib/help";
+
+const CLI_ROOT = path.resolve(import.meta.dir, "..", "..");
+
+/** Commands whose handler source is scanned against their help entry. */
+const COMMAND_SOURCES: Record<string, string> = {
+  query: "src/commands/query.ts",
+  sql: "src/commands/sql.ts",
+  metric: "src/commands/metric.ts",
+  datasource: "src/commands/datasource.ts",
+  "canonical-eval": "bin/canonical-eval-run.ts",
+};
+
+/**
+ * `--help`/`-h` are intercepted globally in bin/atlas.ts before any handler
+ * runs, so handlers checking for them defensively don't need a help entry.
+ */
+const GLOBAL_FLAGS = new Set(["--help"]);
+
+/**
+ * Extract the `--flag` literals a source file parses. Matches the concrete
+ * parsing constructs used across the CLI (strict equality against an arg,
+ * getFlag lookups, args.includes membership, and Set/array literals of
+ * value-taking flags) rather than every `--x` substring, so prose in error
+ * messages that references other commands' flags can't create false demands.
+ */
+function extractParsedFlags(source: string): Set<string> {
+  const patterns = [
+    /===\s*"(--[a-z][a-z-]*)"/g,
+    /getFlag\(\s*args,\s*"(--[a-z][a-z-]*)"/g,
+    /args\.includes\(\s*"(--[a-z][a-z-]*)"/g,
+    /"(--[a-z][a-z-]*)"\s*[,\]]/g,
+  ];
+  const flags = new Set<string>();
+  for (const re of patterns) {
+    for (const m of source.matchAll(re)) {
+      const flag = m[1];
+      if (flag && !GLOBAL_FLAGS.has(flag)) flags.add(flag);
+    }
+  }
+  return flags;
+}
+
+/** Every flag string mentioned anywhere in a help entry (flags list + usage). */
+function helpMentions(command: string): string {
+  const entry = SUBCOMMAND_HELP[command];
+  if (!entry) return "";
+  return [
+    entry.usage,
+    ...(entry.flags ?? []).map((f) => f.flag),
+    ...(entry.subcommands ?? []).map((s) => s.name),
+  ].join("\n");
+}
+
+describe("SUBCOMMAND_HELP tracks the flags handlers actually parse", () => {
+  for (const [command, relPath] of Object.entries(COMMAND_SOURCES)) {
+    test(`${command}: every parsed flag is mentioned in its help entry`, () => {
+      const source = fs.readFileSync(path.join(CLI_ROOT, relPath), "utf8");
+      const parsed = extractParsedFlags(source);
+      // The extractor going blind (refactor away from the matched parsing
+      // constructs) must fail loudly, not pass vacuously.
+      expect(parsed.size).toBeGreaterThan(0);
+      const mentions = helpMentions(command);
+      expect(mentions).not.toBe("");
+      const missing = [...parsed].filter((f) => !mentions.includes(f));
+      expect(
+        missing,
+        `${relPath} parses flags absent from SUBCOMMAND_HELP["${command}"] — update lib/help.ts`,
+      ).toEqual([]);
+    });
+  }
+
+  test("query/sql/metric/datasource all document --api-key", () => {
+    for (const command of ["query", "sql", "metric", "datasource"]) {
+      expect(
+        (SUBCOMMAND_HELP[command]?.flags ?? []).some((f) =>
+          f.flag.startsWith("--api-key"),
+        ),
+        `SUBCOMMAND_HELP["${command}"] must list --api-key`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -155,6 +155,24 @@ export interface QueryResponse {
   steps: number;
   usage: { totalTokens: number };
   conversationId?: string;
+  /**
+   * Identifier of the underlying agent run. Present whenever the agent loop
+   * ran; useful for correlating with durable-session records and server logs.
+   */
+  runId?: string;
+  /**
+   * Set when one or more SQL queries matched an approval rule and were
+   * enqueued for admin approval instead of executed. The run is NOT a
+   * complete answer in this case — the queued query runs only after
+   * approval. `requestId` is null when no approval-queue row could be
+   * created.
+   */
+  pendingApproval?: {
+    requestId: string | null;
+    ruleName: string;
+    matchedRules: string[];
+    message: string;
+  };
   pendingActions?: Array<{
     id: string;
     type: string;


### PR DESCRIPTION
## Summary

Works four `ready-for-agent` issues from the 2026-07-10 `/docs-audit`, one commit each:

- **#4471** — `POST /api/v1/query` returned `conversationId` (plus, found by the requested sweep, `runId` and `pendingApproval`) through a spread that bypassed excess-property checking; `QueryResponseSchema` now declares all three as optional with descriptions, the SDK's `QueryResponse` mirrors them, and `openapi.json` is regenerated (api-reference MDX unchanged — pages reference operations by id).
- **#4472** — CLI `--help` synced with real flags: `--api-key` on query/sql/metric/datasource, the five missing `canonical-eval` flags. New `help-drift.test.ts` ratchet extracts the flag literals each handler parses and fails when one is missing from `SUBCOMMAND_HELP`, so this drift class now breaks CI.
- **#4470** — new "Audit trail" section in the agent-auth guide documenting the `agent.*` admin-action catalog: per-action triggers, identity-in-metadata, the 1-per-25 execute sampling (failures always emit), never-record-arguments, and fail-closed silence when `ATLAS_AGENT_AUTH_ENABLED` is off. Note: the catalog defines **nine** actions, not the issue's eleven — docs follow the code.
- **#4473** — `.env.example` now states its inclusion policy in the header (registry-backed knobs included as env seeds/fallbacks; precedence workspace > platform > env > default) and completes every split family: durable sessions (ADR-0020), a new Knowledge Base section, learn/dashboard/billing knobs, Agent Auth, `ATLAS_EMAIL_ALLOWED_RECIPIENT_DOMAINS` (disambiguated from the env-only action knob). The nine Stripe price IDs remain the one pointer-policy family (Stripe section corrected from "six").

Closes #4470
Closes #4471
Closes #4472
Closes #4473

## Test Plan

- [x] `/ci` — all 29 local gates green (type, lint, lint-type-aware, openapi-drift, gate-fixtures, full isolated test suite, …)
- [x] Unit tests added/updated — new `packages/cli/src/__tests__/help-drift.test.ts` ratchet (6 tests); full CLI suite 48/48 files, SDK suite 213 tests, affected API tests 34/34 files
- [ ] E2E tests added/updated — n/a (docs/reference + schema-declaration changes, no behavior change)

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (`bun run test`)
- [x] Lint passes (`bun run lint`)
- [ ] Deps consistent (`bun run deps:lint`) — dependencies unchanged (syncpack gate green)
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated — skipped: audit-residue docs/reference fixes; the per-tag docs changelog is handled by `/release`

https://claude.ai/code/session_018bPYz5GEM2UfXiL5fgxFz5

---
_Generated by [Claude Code](https://claude.ai/code/session_018bPYz5GEM2UfXiL5fgxFz5)_