### PR TITLE
feat(agents): /elevate — extract the feature elevation cycle as a command

### DIFF
--- a/.claude/commands/elevate.md
+++ b/.claude/commands/elevate.md
@@ -1,0 +1,85 @@
+# Elevate
+
+Run the audit phase of a **feature elevation cycle**: a shipped surface works, but it's beneath its potential. Audit it in parallel dimensions, collate a ranked findings doc into `.claude/research/`, and hand off to a `/grill-with-docs` session. This command produces a **briefing, not a plan** — the grill, PRD, and issue slicing happen downstream with the user in the loop.
+
+**Argument:** a product surface — `dashboards`, `chat`, `notebook`, `onboarding`, `semantic-layer`, … Not a single page (that's `/revamp` granularity) and not a one-issue-sized finding (that's `/investigate`).
+
+**Lineage (the worked examples this extracts):**
+- The chat turn-presentation cycle — full chat-page audit → CONTEXT.md § *Chat turn presentation* glossary → PRD #4292 → milestone `v0.0.43 — The Analyst Voice`.
+- The dashboard elevation — `.claude/research/dashboard-audit-2026-07-04.md` ("prep for a `/grill-with-docs` session") → CONTEXT.md § *Dashboard editing* vocabulary.
+
+**Where it sits:** Phase 1 ("Notice") of `docs/agents/workflow.md`, feeding `/grill-with-docs` → `/to-prd` → `/to-issues` → milestone. `/elevate` never writes the PRD itself.
+
+---
+
+## Step 0 — Borrow the audit-family mechanics
+
+Read `docs/agents/audits.md` and apply these conventions (borrowed — `/elevate` is **not** a member of the `-audit` family and not part of the pre-tag battery; its job is elevation, not verification):
+
+- **Step-0 self-verify** — check every repo path this command file references before trusting it; fix drift in the same session.
+- **Discover, don't enumerate** — every list below (dimensions, surfaces, file paths) is illustrative; the discovery command or the codebase is authoritative.
+- **State snapshots decay** — verify issue numbers and "currently X" claims against present reality before repeating them in the findings doc.
+- **Cite, don't re-file** — a finding an open issue already tracks gets the issue link inline, never a duplicate.
+
+## Step 1 — Derive the audit dimensions
+
+Pick **3–5 dimensions**, derived from the surface's actual architecture. Two are always seeded:
+
+1. **End-user UX of the surface** — what a trial admin or business user experiences.
+2. **The agent/AI path through it** — if the surface has one (agent-built dashboards, chat turns, semantic generation). Elevation-grade problems concentrate at this seam.
+
+Derive the rest from what the surface *is*: data model & persistence, draft/publish or other lifecycle, sharing/permissions, editorial voice, integration seams. The dashboard run's four — frontend viewer/editor UX, backend/data model, agent-driven building, sharing/screenshots/drafts — are a worked example, **not** a template; "sharing/drafts" existed because dashboards have that lifecycle. A `/elevate onboarding` slices differently.
+
+Before spawning, sweep open issues for the surface (`gh issue list -R AtlasDevHQ/atlas --state open --search "<surface>"`) so agents can cite instead of rediscover.
+
+## Step 2 — Run the parallel audits
+
+One sub-agent per dimension, in parallel. Evidence discipline for every agent:
+
+- **Baseline is code-reading with `file:line` anchors.** Every finding names the file and line range it stands on. No anchor, no finding.
+- **The UX dimension drives the live product when feasible** — dev server + Playwright, screenshots saved into the research folder (`.claude/research/<surface>-audit-<date>/`). If the environment can't run the app, the doc says so explicitly rather than silently degrading to code-only.
+- Findings state **what breaks for whom** (trial admin, business user, operator), not just what the code does.
+- Agents return structured findings: severity, title, anchors, the failure scenario, and (where obvious) a fix direction.
+
+## Step 3 — Collate, dedup, rank, verify
+
+Merge all dimensions into one document:
+
+- **Dedup across dimensions** — seam findings surface in multiple audits; merge them, keeping all anchors.
+- **Severity ladder** from `audits.md`: CRITICAL > HIGH > MEDIUM > LOW.
+- **Spot-verify the anchor findings by hand** — the CRITICALs and top HIGHs get re-read at the cited lines (or reproduced) before the doc claims them; mark these `verified`. An elevation grill built on an unverified anchor finding wastes the user's session.
+
+## Step 4 — File the fix-invariant bugs only
+
+Most findings stay in the doc. File a GitHub issue immediately **only** when BOTH hold:
+
+1. The behavior is **broken or unsafe today** — not merely beneath its potential.
+2. The correct fix is **identical no matter what the elevation decides** — no design decision pending on it.
+
+Worked boundary (from the dashboard audit): a cookieless SSR fetch 403-ing every org-share viewer, or a validation error silently downgrading an org share to public — **file** (the fix is the fix, grill or no grill). Agent-built dashboards rendering an empty canvas — **doc only**: plainly broken, but the fix is entangled with the draft-model design the grill exists to settle; filing it standalone would pre-decide the design.
+
+File per `/investigate` conventions (type + area labels, milestone, Atlas body format), and list the filed issues in the findings doc with their links so the grill still sees the complete picture. Fix nothing — `/elevate` mutates no product code.
+
+## Step 5 — Write the findings doc
+
+`.claude/research/<surface>-audit-<YYYY-MM-DD>.md`, structured as:
+
+1. **Header** — what this is: "Prep for a `/grill-with-docs` session on elevating <surface>", which dimensions ran, whether the UX dimension had a live product, which anchor findings were hand-verified.
+2. **Verdict** — the "strong engine, unfinished cockpit" move: first what is genuinely good and should be **preserved wholesale** (named, with anchors — this constrains the grill as much as the problems do), then a one-paragraph statement of where the problems live (typically: at the seams).
+3. **Ranked findings** — CRITICAL → LOW, each with anchors, failure scenario, `verified` markers, issue links for anything filed in Step 4 or already tracked.
+4. **Grill agenda** — the design questions the findings force, phrased as questions ("what does the canvas render for a user holding a draft?"), not solutions. This is the doc's real output: the grill walks this list.
+5. **Handoff** — `Next: run /grill-with-docs with this doc.` If — and only if — the findings turned out purely presentational and page-scoped, hand off to `/revamp <page>` instead and say the grill is unnecessary.
+
+## Step 6 — Report
+
+Summarize to the user: verdict in one line, finding counts by severity, issues filed (with links), the grill agenda, and the handoff. Do **not** start the grill, write a PRD, or create a milestone — those are the user's moves, made through `/grill-with-docs` → `/to-prd` → `/to-issues` per `docs/agents/workflow.md`.
+
+---
+
+## What NOT to do
+
+- Don't fix findings (beyond Step 4's filing) — this is a read-only briefing pass.
+- Don't pre-slice findings into issues; `/to-issues` will cut different slices than the audit found.
+- Don't pin new domain vocabulary in `CONTEXT.md` from here — vocabulary gets pinned *in the grill*, where the user is present.
+- Don't run `/elevate` on a surface with an active elevation PRD in flight — read the PRD and `/investigate` gaps against it instead.
+- Don't inflate the doc: a finding without an anchor, or a severity without a failure scenario, gets cut in Step 3.

--- a/.claude/commands/investigate.md
+++ b/.claude/commands/investigate.md
@@ -4,6 +4,7 @@ Investigate something you've noticed — a bug, tech debt, rough edge, or idea �
 
 **Pick the right tool first:**
 - **One-issue-sized finding** (bug, tech debt, small feature, < half a day of work) — stay here, use `/investigate`
+- **A whole shipped surface beneath its potential** (problems at the seams, would take a grill + PRD to fix right) — stop and use `/elevate` instead; it audits the surface in parallel dimensions and produces the findings doc that feeds the grill
 - **Milestone-sized direction or architectural change** — stop and use `/to-prd` instead; it synthesises the conversation into a PRD issue that `/to-issues` can then break into vertical slices
 - **You have a plan but want it stress-tested first** — `/grill-me` (plain interview) or `/grill-with-docs` (interview + update CONTEXT.md / ADRs inline) before filing
 - See `docs/agents/workflow.md` for the full decision tree

--- a/.claude/commands/revamp.md
+++ b/.claude/commands/revamp.md
@@ -2,7 +2,7 @@
 
 Revamp a cluttered admin or SaaS page using the `.impeccable.md` toolkit — the same workflow that turned `/admin/integrations` from a wall of ten open forms into a clean progressive-disclosure surface.
 
-**Use this when:** a page feels like wall-of-cards, wall-of-forms, or is otherwise visually monotonous / overwhelming in its empty state.
+**Use this when:** a page feels like wall-of-cards, wall-of-forms, or is otherwise visually monotonous / overwhelming in its empty state. If the itch is more than presentational — the surface's behavior, data model, or agent path is beneath its potential — use `/elevate` instead; a revamp is a presentational pass only.
 
 **Argument:** path or URL of the page to revamp (e.g. `/admin/integrations`, `packages/web/src/app/admin/billing/page.tsx`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ See `.env.example` for the full list. Key vars: `ATLAS_PROVIDER`, `ATLAS_MODEL`,
 
 ## Agent skills
 
-- **Workflow** — how Atlas commands (`/next`, `/tidy`, `/investigate`, `/kickoff`, `/closeout`, `/ci`, `/pr`) compose with the Matt Pocock skills (`/diagnose`, `/tdd`, `/to-prd`, `/to-issues`, `/triage`, `/grill-with-docs`, `/improve-codebase-architecture`, `/zoom-out`, `/prototype`, `/handoff`). See `docs/agents/workflow.md`
+- **Workflow** — how Atlas commands (`/next`, `/tidy`, `/investigate`, `/elevate`, `/kickoff`, `/closeout`, `/ci`, `/pr`) compose with the Matt Pocock skills (`/diagnose`, `/tdd`, `/to-prd`, `/to-issues`, `/triage`, `/grill-with-docs`, `/improve-codebase-architecture`, `/zoom-out`, `/prototype`, `/handoff`). See `docs/agents/workflow.md`
 - **Issue tracker** — GitHub issues at `AtlasDevHQ/atlas` via `gh` (always `-R AtlasDevHQ/atlas`). Atlas body format (`## Key files / ## Acceptance criteria / ## Dependencies`); labels on two axes (kind+area AND triage state). See `docs/agents/issue-tracker.md`
 - **Triage labels** — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix` (created lazily). Orthogonal to kind/area. See `docs/agents/triage-labels.md`
 - **Audit commands** — `/docs-audit`, `/www-audit`, `/prod-audit`, `/contracts-audit` share conventions in `docs/agents/audits.md`: Step-0 self-check (each command verifies its own references before trusting its checks), discover-don't-enumerate, guard-first (run existing CI gates, audit only the residue), the promote-to-CI ratchet for repeat findings, and the pre-tag battery (which audits to run before `/release`)

--- a/docs/agents/audits.md
+++ b/docs/agents/audits.md
@@ -2,6 +2,8 @@
 
 Conventions shared by the `-audit` family — `/docs-audit` (docs vs code), `/www-audit` (marketing/legal vs reality), `/prod-audit` (runtime readiness vs prod requirements), `/contracts-audit` (code vs stability commitments — semver evidence for `/release`). Each command reads this file before spawning its agents.
 
+**A borrower, not a member:** `/elevate` (feature elevation audits, Phase 1 of `workflow.md`) reads this file and applies Step 0, discover-don't-enumerate, snapshot-decay, and cite-don't-refile — but it is **not** in the `-audit` family or the pre-tag battery. Its job is elevation (find what's beneath potential), not verification (check claims against reality), and its report discipline differs: findings stay in a `.claude/research/` doc for a grill session; issues are filed only when the fix is invariant under the grill's outcome.
+
 **The pre-tag battery:** at the end of a code cycle, before `/release`: `/docs-audit` (with Part K) + `/contracts-audit` always; `/www-audit` when the window touched pricing/legal/marketing surfaces; `/prod-audit` (with Part F, the security seam sweep) when it touched infra, boot, or security seams. `/contracts-audit`'s output — the semver recommendation and any policy violations — feeds the tag decision directly.
 
 **Why this file exists:** a 2026-07 sweep found all three commands had drifted from the codebase — dead file paths, shipped features still described as open issues, checks that silently matched nothing (a grep against a file that no longer contained the pattern), and a security check whose success criterion was inverted for SaaS. Audit commands are snapshots of reality, and reality moves. These conventions are the mechanics that make drift self-announcing instead of silent.

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -1,6 +1,6 @@
 # Agent workflow: Atlas commands × Engineering skills
 
-How `/next`, `/tidy`, `/investigate`, `/kickoff`, `/closeout`, `/ci`, `/pr` (Atlas project rituals) compose with the Matt Pocock engineering skills (`/diagnose`, `/tdd`, `/to-prd`, `/to-issues`, `/triage`, `/grill-with-docs`, `/grill-me`, `/improve-codebase-architecture`, `/zoom-out`, `/prototype`, `/handoff`).
+How `/next`, `/tidy`, `/investigate`, `/elevate`, `/kickoff`, `/closeout`, `/ci`, `/pr` (Atlas project rituals) compose with the Matt Pocock engineering skills (`/diagnose`, `/tdd`, `/to-prd`, `/to-issues`, `/triage`, `/grill-with-docs`, `/grill-me`, `/improve-codebase-architecture`, `/zoom-out`, `/prototype`, `/handoff`).
 
 The Atlas commands own **project rituals** — ROADMAP, milestones, CI/PR gates, deploy. The engineering skills own **craft loops** inside each phase. They don't duplicate — they layer.
 
@@ -15,11 +15,12 @@ The Atlas commands own **project rituals** — ROADMAP, milestones, CI/PR gates,
 | Situation | Use |
 | --- | --- |
 | Spotted a bug, rough edge, or tech debt | `/investigate` (Atlas) — light: research → file issue → park-or-fix |
+| A shipped surface works but is beneath its potential | `/elevate` (Atlas) — parallel multi-dimension audit → ranked findings doc in `.claude/research/` → hand off to `/grill-with-docs` |
 | Have a half-formed idea worth designing | `/to-prd` — synthesise the current conversation into a PRD issue |
 | Have a plan but want it stress-tested first | `/grill-me` — interview until every branch of the decision tree is resolved |
 | Plan touches domain terminology or contradicts a past decision | `/grill-with-docs` — grill + update `CONTEXT.md` and `docs/adr/` inline |
 
-**Decision rule:** if the finding fits in one issue (< half a day of work), use `/investigate`. If it would span a milestone or change architecture, use `/to-prd` (optionally after `/grill-with-docs`).
+**Decision rule:** three tiers by size of the itch. One-issue-sized (< half a day of work) → `/investigate`. Surface-sized — a whole feature beneath its potential, problems likely at the seams → `/elevate`, whose findings doc feeds `/grill-with-docs` → `/to-prd` → `/to-issues` (the chat answer-styles cycle #4292 and the 2026-07-04 dashboard elevation are the worked examples). Already know what to build → `/to-prd` directly (optionally after `/grill-with-docs`). Purely presentational, page-scoped itch → `/revamp` skips the cycle entirely.
 
 ### Phase 2 — Plan
 


### PR DESCRIPTION
## Summary

Extracts the feature improvement/elevation cycle — the pattern behind the chat answer-styles cycle (PRD #4292 → milestone `v0.0.43 — The Analyst Voice`) and the 2026-07-04 dashboard elevation audit — into a reusable command: `/elevate <surface>`.

The command owns the **audit phase only**: parallel multi-dimension audit of a shipped surface (3–5 dimensions derived per surface, always seeded with end-user UX + the agent/AI path) → collated, deduped, severity-ranked findings with file:line anchors, top findings hand-verified → a verdict-first briefing in `.claude/research/<surface>-audit-<date>.md` ending with a grill agenda and handoff to `/grill-with-docs` → `/to-prd` → `/to-issues`. Issues are filed during the audit only when a finding is broken today **and** its fix is invariant under the grill's outcome; everything else stays in the doc. Purely-presentational findings route to `/revamp`.

Integration changes in the same commit:
- `docs/agents/workflow.md` — Phase 1 row for `/elevate` + three-tier decision rule (`/investigate` one-issue-sized → `/elevate` surface-sized → `/to-prd` when the design is already known)
- `docs/agents/audits.md` — "borrower, not a member" note: `/elevate` applies Step 0, discover-don't-enumerate, snapshot-decay, and cite-don't-refile, but is not in the `-audit` family or pre-tag battery
- `.claude/commands/investigate.md` / `.claude/commands/revamp.md` — upward pointers to `/elevate`
- `CLAUDE.md` + `workflow.md` header — command enumerations updated

## Test Plan

Docs/command-file-only change — no runtime surface.

- [x] Manual testing — ran `audits.md` Step-0 self-check against `elevate.md` (all referenced repo paths resolve); verified the command appears in the session's skill list
- [ ] Unit tests added/updated — n/a
- [ ] E2E tests added/updated — n/a

## Checklist

- [ ] Types pass (`bun run type`) — n/a, no TS touched (CI runs it regardless)
- [ ] Tests pass (`bun run test`) — n/a, no code touched (CI runs it regardless)
- [ ] Lint passes (`bun run lint`) — n/a, markdown only
- [ ] Deps consistent — no dependency changes
- [ ] Labels added (type + area)
- [ ] CHANGELOG.md updated — not user-facing (agent workflow docs)

https://claude.ai/code/session_01LX4ZytTnkSt3tZi5djBrQb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX4ZytTnkSt3tZi5djBrQb)_