### PR TITLE
fix(semantic-improve): route chat proposal reviews through the DB-backed path (#4484)

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -14,6 +14,26 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 
 let mockHasInternalDB = true;
 
+// Mutable fixtures for the DB-backed amendment review path
+// (POST /amendments/:id/review) — the route the improve UI actually calls.
+interface MockAmendmentRow {
+  id: string;
+  source_entity: string;
+  connection_group_id: string | null;
+  description: string | null;
+  confidence: number;
+  amendment_payload: Record<string, unknown> | null;
+  created_at: string;
+}
+let mockPendingAmendments: MockAmendmentRow[] = [];
+let reviewedCalls: Array<{ id: string; orgId: string | null; decision: string }> = [];
+let applyPayloadCalls: Array<Record<string, unknown>> = [];
+// When true, the mocked YAML apply rejects — models the approve branch's
+// "apply YAML first, only flip the DB status on success" invariant.
+let applyShouldThrow = false;
+// Shared sequence log: proves the route applies YAML *before* flipping the row.
+let callOrder: string[] = [];
+
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: async () => [],
@@ -21,6 +41,34 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   setWorkspaceRegion: async () => {},
   insertSemanticAmendment: async () => "mock-amendment-id",
   getPendingAmendmentCount: async () => 0,
+  getPendingAmendments: async () => mockPendingAmendments,
+  reviewSemanticAmendment: async (
+    id: string,
+    orgId: string | null,
+    decision: "approved" | "rejected",
+  ) => {
+    callOrder.push("review");
+    reviewedCalls.push({ id, orgId, decision });
+    const row = mockPendingAmendments.find((r) => r.id === id);
+    return row
+      ? { id: row.id, source_entity: row.source_entity, amendment_payload: row.amendment_payload }
+      : null;
+  },
+}));
+
+// The approve branch dynamically imports the YAML-apply helper. Mock it so the
+// happy-path test never touches disk / the semantic layer — we only assert it
+// was invoked with the target row before the DB status flip. `applyAmendment`
+// is included to keep the module mock total (mock-all-exports discipline) even
+// though this route only reaches the two helpers below.
+void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
+  applyAmendmentFromPayload: async (args: Record<string, unknown>) => {
+    callOrder.push("apply");
+    if (applyShouldThrow) throw new Error("yaml apply failed");
+    applyPayloadCalls.push(args);
+  },
+  applyAmendmentToEntity: async () => {},
+  applyAmendment: () => ({}),
 }));
 
 void mock.module("@atlas/api/lib/auth/middleware", () => ({
@@ -51,8 +99,29 @@ void mock.module("@atlas/api/lib/logger", () => {
   };
 });
 
+// Mirror the real runHandler's error-to-HTTP behavior closely enough to
+// exercise throw paths: an uncaught throw becomes a 500 with a requestId
+// envelope (the real bridge classifies further, but 500 is the fallback). This
+// is transparent to the success/validation tests, which never throw.
 void mock.module("@atlas/api/lib/effect/hono", () => ({
-  runHandler: async (_c: unknown, _label: string, fn: () => unknown) => fn(),
+  runHandler: async (
+    c: { json: (body: unknown, status?: number) => Response },
+    _label: string,
+    fn: () => unknown,
+  ) => {
+    try {
+      return await fn();
+    } catch (err) {
+      return c.json(
+        {
+          error: "internal_error",
+          message: err instanceof Error ? err.message : String(err),
+          requestId: "test-req-id",
+        },
+        500,
+      );
+    }
+  },
   runEffect: async (_c: unknown, effect: unknown) => effect,
 }));
 
@@ -95,6 +164,11 @@ import { adminSemanticImprove } from "../admin-semantic-improve";
 describe("admin-semantic-improve", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
+    mockPendingAmendments = [];
+    reviewedCalls = [];
+    applyPayloadCalls = [];
+    applyShouldThrow = false;
+    callOrder = [];
   });
 
   describe("GET /sessions", () => {
@@ -160,6 +234,126 @@ describe("admin-semantic-improve", () => {
 
       const body = (await res.json()) as { error: string };
       expect(body.error).toBe("invalid_id");
+    });
+  });
+
+  describe("POST /amendments/:id/review — DB-backed review (the path the improve UI calls)", () => {
+    // #4484: chat-streamed proposals carry the `learned_patterns` row id and
+    // route through this endpoint (not the dead in-memory `/proposals/:index`
+    // path). These pin the propose→approve / propose→reject happy paths that
+    // no test covered before — only the 404/400 branches were exercised.
+    const row = (id: string): MockAmendmentRow => ({
+      id,
+      source_entity: "orders",
+      connection_group_id: null,
+      description: "[add_measure] orders: total revenue",
+      confidence: 0.9,
+      amendment_payload: {
+        entityName: "orders",
+        amendmentType: "add_measure",
+        amendment: { name: "total_revenue", type: "number" },
+        rationale: "Frequently aggregated in the audit log.",
+      },
+      created_at: "2026-07-10T00:00:00Z",
+    });
+
+    it("approves a proposal: applies the YAML then flips the same row to approved (one identity)", async () => {
+      mockPendingAmendments = [row("amd-1")];
+
+      const res = await adminSemanticImprove.request("/amendments/amd-1/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; id: string; decision: string };
+      expect(body).toEqual({ ok: true, id: "amd-1", decision: "approved" });
+
+      // YAML applied from the row's payload before the status flip.
+      expect(applyPayloadCalls).toHaveLength(1);
+      expect(applyPayloadCalls[0]).toMatchObject({ sourceEntity: "orders", label: "amd-1" });
+
+      // The same learned_patterns row is flipped to approved — no stale
+      // pending row left behind.
+      expect(reviewedCalls).toEqual([{ id: "amd-1", orgId: "org-test", decision: "approved" }]);
+
+      // Ordering invariant: YAML apply happens strictly before the DB flip.
+      expect(callOrder).toEqual(["apply", "review"]);
+    });
+
+    it("approve → YAML apply fails: 500 and the row is NOT flipped to approved", async () => {
+      // The approve branch must apply YAML first and only flip the DB status on
+      // success — otherwise a row could be stamped `approved` with no YAML
+      // written. Pin that: when the apply throws, the route must surface a 500
+      // (via runHandler) and never call reviewSemanticAmendment.
+      mockPendingAmendments = [row("amd-3")];
+      applyShouldThrow = true;
+
+      const res = await adminSemanticImprove.request("/amendments/amd-3/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+
+      // The throw maps to a 500 with a requestId envelope.
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { requestId?: string };
+      expect(body.requestId).toBeDefined();
+      // The load-bearing invariant: the row stays pending — the flip never ran.
+      expect(reviewedCalls).toHaveLength(0);
+      expect(callOrder).toEqual(["apply"]);
+    });
+
+    it("returns 404 when rejecting an absent row (reject skips the payload peek)", async () => {
+      // The reject branch bypasses getPendingAmendments and 404s off a null
+      // return from reviewSemanticAmendment — a different path than approve's.
+      mockPendingAmendments = [];
+
+      const res = await adminSemanticImprove.request("/amendments/does-not-exist/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "rejected" }),
+      });
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("not_found");
+      expect(applyPayloadCalls).toHaveLength(0);
+    });
+
+    it("rejects a proposal: marks the row rejected without applying YAML", async () => {
+      mockPendingAmendments = [row("amd-2")];
+
+      const res = await adminSemanticImprove.request("/amendments/amd-2/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "rejected" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; id: string; decision: string };
+      expect(body).toEqual({ ok: true, id: "amd-2", decision: "rejected" });
+
+      // Rejection never touches the semantic layer.
+      expect(applyPayloadCalls).toHaveLength(0);
+      expect(reviewedCalls).toEqual([{ id: "amd-2", orgId: "org-test", decision: "rejected" }]);
+    });
+
+    it("returns 404 when the amendment row is absent (already reviewed or wrong org)", async () => {
+      mockPendingAmendments = [];
+
+      const res = await adminSemanticImprove.request("/amendments/does-not-exist/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("not_found");
+      // Missing target short-circuits before any YAML apply.
+      expect(applyPayloadCalls).toHaveLength(0);
     });
   });
 

--- a/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for extractProposals — the tool-result → approvable-card logic of the
+ * semantic-improve page (#4484).
+ *
+ * The load-bearing invariant (acceptance criterion #4): a proposal is only
+ * surfaced as an approvable card when its `proposeAmendment` tool result
+ * carries a `proposalId` (⇒ a `learned_patterns` row exists). Results that
+ * came back as `{ error }` (no row) and in-flight calls (no result yet) are
+ * dropped so the UI never renders a card that would 404 on Approve/Reject.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { UIMessage } from "@ai-sdk/react";
+import { extractProposals } from "../proposals";
+
+// Build an assistant message carrying a single proposeAmendment tool part.
+// `output === undefined` models an in-flight call (no result yet).
+function assistantWithTool(
+  input: Record<string, unknown>,
+  output?: Record<string, unknown>,
+): UIMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-proposeAmendment",
+        toolCallId: "call-1",
+        state: output ? "output-available" : "input-available",
+        input,
+        ...(output ? { output } : {}),
+      },
+    ],
+  } as unknown as UIMessage;
+}
+
+const baseInput = {
+  entityName: "orders",
+  category: "measures",
+  amendmentType: "add_measure",
+  amendment: { name: "total_revenue" },
+  rationale: "Frequently aggregated.",
+  confidence: 0.9,
+  impact: 0.8,
+  score: 0.85,
+};
+
+describe("extractProposals", () => {
+  it("surfaces a proposal with dbId when the tool result carries a proposalId", () => {
+    const proposals = extractProposals([
+      assistantWithTool(baseInput, { proposalId: "amd-1", diff: "--- a\n+++ b" }),
+    ]);
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      index: 0,
+      entityName: "orders",
+      amendmentType: "add_measure",
+      dbId: "amd-1",
+      diff: "--- a\n+++ b",
+      decision: null,
+    });
+  });
+
+  it("drops a result that came back as { error } (no proposalId ⇒ no DB row ⇒ unapprovable)", () => {
+    const proposals = extractProposals([
+      assistantWithTool(baseInput, { error: "Entity file not found: orders" }),
+    ]);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it("drops an in-flight call that has no result yet", () => {
+    const proposals = extractProposals([assistantWithTool(baseInput)]);
+
+    expect(proposals).toEqual([]);
+  });
+
+  it("keeps only the persisted proposals and re-indexes them densely", () => {
+    const proposals = extractProposals([
+      assistantWithTool({ ...baseInput, entityName: "ok1" }, { proposalId: "amd-1" }),
+      assistantWithTool({ ...baseInput, entityName: "failed" }, { error: "boom" }),
+      assistantWithTool({ ...baseInput, entityName: "inflight" }),
+      assistantWithTool({ ...baseInput, entityName: "ok2" }, { proposalId: "amd-2" }),
+    ]);
+
+    expect(proposals.map((p) => ({ index: p.index, entityName: p.entityName, dbId: p.dbId }))).toEqual([
+      { index: 0, entityName: "ok1", dbId: "amd-1" },
+      { index: 1, entityName: "ok2", dbId: "amd-2" },
+    ]);
+  });
+
+  it("ignores non-assistant messages and non-proposeAmendment tool parts", () => {
+    const userMsg = {
+      id: "u1",
+      role: "user",
+      parts: [{ type: "text", text: "improve orders" }],
+    } as unknown as UIMessage;
+    const otherTool = {
+      id: "a2",
+      role: "assistant",
+      parts: [
+        { type: "tool-profileTable", toolCallId: "c", state: "output-available", input: { entityName: "orders" }, output: { proposalId: "not-a-proposal" } },
+      ],
+    } as unknown as UIMessage;
+
+    expect(extractProposals([userMsg, otherTool])).toEqual([]);
+  });
+
+  it("preserves a valid testResult and drops a malformed one", () => {
+    const good = extractProposals([
+      assistantWithTool(baseInput, {
+        proposalId: "amd-1",
+        testResult: { success: true, rowCount: 3, sampleRows: [] },
+      }),
+    ]);
+    expect(good[0]?.testResult).toEqual({ success: true, rowCount: 3, sampleRows: [] });
+
+    const bad = extractProposals([
+      assistantWithTool(baseInput, { proposalId: "amd-2", testResult: { success: true } }),
+    ]);
+    expect(bad[0]?.testResult).toBeUndefined();
+  });
+});

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useMemo } from "react";
-import { useChat, type UIMessage } from "@ai-sdk/react";
+import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, isToolUIPart, getToolName } from "ai";
-import { getToolArgs, getToolResult } from "@/ui/lib/helpers";
+import { extractProposals, type Proposal, type TestResult } from "./proposals";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -32,31 +32,6 @@ import Link from "next/link";
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface TestResult {
-  success: boolean;
-  rowCount: number;
-  sampleRows: Record<string, unknown>[];
-  error?: string;
-}
-
-interface Proposal {
-  index: number;
-  entityName: string;
-  category: string;
-  amendmentType: string;
-  amendment: Record<string, unknown>;
-  rationale: string;
-  diff?: string;
-  testQuery?: string;
-  testResult?: TestResult;
-  confidence: number;
-  impact?: number;
-  score?: number;
-  decision: "accepted" | "rejected" | "skipped" | null;
-  /** DB row id for pending amendments loaded from previous sessions. */
-  dbId?: string;
-}
 
 interface PendingAmendment {
   id: string;
@@ -237,63 +212,18 @@ function formatAmendment(type: string, amendment: Record<string, unknown>): stri
 }
 
 // ---------------------------------------------------------------------------
-// Extract proposals from assistant messages
-// ---------------------------------------------------------------------------
-
-/** Try to parse proposals from tool call results in the messages. */
-function extractProposals(messages: UIMessage[]): Proposal[] {
-  const proposals: Proposal[] = [];
-  let idx = 0;
-
-  for (const msg of messages) {
-    if (msg.role !== "assistant") continue;
-    for (const part of msg.parts) {
-      if (isToolUIPart(part)) {
-        let name: string;
-        try { name = getToolName(part as Parameters<typeof getToolName>[0]); } catch { /* intentionally ignored: skip unrecognizable tool parts */ continue; }
-        if (name !== "proposeAmendment") continue;
-        const args = getToolArgs(part);
-        if (args.entityName) {
-          // Extract diff and testResult from tool result if available
-          const result = getToolResult(part) as Record<string, unknown> | null;
-          const diff = typeof result?.diff === "string" ? result.diff : undefined;
-          const rawTR = result?.testResult;
-          const testResult: Proposal["testResult"] | undefined =
-            rawTR && typeof rawTR === "object" && !Array.isArray(rawTR) &&
-            "success" in rawTR && typeof (rawTR as Record<string, unknown>).rowCount === "number"
-              ? (rawTR as Proposal["testResult"])
-              : undefined;
-          proposals.push({
-            index: idx++,
-            entityName: String((args.entityName as string) ?? "unknown"),
-            category: String((args.category as string) ?? ""),
-            amendmentType: String((args.amendmentType as string) ?? ""),
-            amendment: (args.amendment as Record<string, unknown>) ?? {},
-            rationale: String((args.rationale as string) ?? ""),
-            diff,
-            testQuery: args.testQuery ? String(args.testQuery as string) : undefined,
-            testResult,
-            confidence: Number(args.confidence ?? 0.5),
-            impact: Number(args.impact ?? 0.5),
-            score: Number(args.score ?? 0.5),
-            decision: null,
-          });
-        }
-      }
-    }
-  }
-  return proposals;
-}
-
-// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export default function SemanticImprovePage() {
   const { apiUrl, isCrossOrigin } = useAtlasConfig();
   const [inputValue, setInputValue] = useState("");
+  // Keyed by the proposal's DB row id (`dbId`) so a decision made on a
+  // chat-streamed card survives re-renders and pending-list refetches — the
+  // card is re-derived from the message stream each render, so an index-keyed
+  // decision would drift as proposals stream in.
   const [proposalDecisions, setProposalDecisions] = useState<
-    Map<number, "accepted" | "rejected">
+    Map<string, "accepted" | "rejected">
   >(new Map());
 
   // Transport for the semantic expert agent endpoint
@@ -349,7 +279,7 @@ export default function SemanticImprovePage() {
   // Extract proposals from current chat session messages
   const chatProposals = extractProposals(messages).map((p) => ({
     ...p,
-    decision: proposalDecisions.get(p.index) ?? p.decision,
+    decision: (p.dbId ? proposalDecisions.get(p.dbId) : undefined) ?? p.decision,
   }));
 
   // Show chat proposals when a session is active, otherwise show DB pending
@@ -382,25 +312,25 @@ export default function SemanticImprovePage() {
   }
 
   async function handleReview(proposal: Proposal, decision: "approved" | "rejected") {
+    // Every rendered proposal — chat-streamed or loaded from the pending list —
+    // carries the `learned_patterns` row id, so all reviews go through the one
+    // working DB-backed path. The in-memory `/proposals/{index}` route is never
+    // populated in the web flow and always 404s.
+    const dbId = proposal.dbId;
+    if (!dbId) return;
     const label = decision === "approved" ? "approve" : "reject";
-    if (proposal.dbId) {
-      const result = await mutate({
-        path: `/api/v1/admin/semantic-improve/amendments/${proposal.dbId}/review`,
-        itemId: `${label}-${proposal.dbId}`,
-        body: { decision },
-      });
-      // fire-and-forget: refresh pending amendments list after review
-      if (result.ok) void refetchPending();
-    } else {
-      const chatDecision = decision === "approved" ? "accepted" as const : "rejected" as const;
-      const chatPath = decision === "approved" ? "approve" : "reject";
-      const result = await mutate({
-        path: `/api/v1/admin/semantic-improve/proposals/${proposal.index}/${chatPath}`,
-        itemId: `${label}-${proposal.index}`,
-      });
-      if (result.ok) {
-        setProposalDecisions((prev) => new Map(prev).set(proposal.index, chatDecision));
-      }
+    const result = await mutate({
+      path: `/api/v1/admin/semantic-improve/amendments/${dbId}/review`,
+      itemId: `${label}-${dbId}`,
+      body: { decision },
+    });
+    if (result.ok) {
+      // Mark the card decided (chat cards persist across renders) and refresh
+      // the pending list so a reviewed row drops out of it.
+      setProposalDecisions((prev) =>
+        new Map(prev).set(dbId, decision === "approved" ? "accepted" : "rejected"),
+      );
+      void refetchPending();
     }
   }
 

--- a/packages/web/src/app/admin/semantic/improve/proposals.ts
+++ b/packages/web/src/app/admin/semantic/improve/proposals.ts
@@ -1,0 +1,103 @@
+import { type UIMessage } from "@ai-sdk/react";
+import { isToolUIPart, getToolName } from "ai";
+import { getToolArgs, getToolResult } from "@/ui/lib/helpers";
+
+// ---------------------------------------------------------------------------
+// Proposal types + tool-result extraction for the semantic-improve page.
+//
+// Split out of page.tsx so `extractProposals` — the pure logic behind
+// acceptance criterion #4 of #4484 (a `proposeAmendment` result that failed to
+// persist must never render as an approvable card) — is unit-testable without a
+// React harness.
+// ---------------------------------------------------------------------------
+
+export interface TestResult {
+  success: boolean;
+  rowCount: number;
+  sampleRows: Record<string, unknown>[];
+  error?: string;
+}
+
+export interface Proposal {
+  index: number;
+  entityName: string;
+  category: string;
+  amendmentType: string;
+  amendment: Record<string, unknown>;
+  rationale: string;
+  diff?: string;
+  testQuery?: string;
+  testResult?: TestResult;
+  confidence: number;
+  impact?: number;
+  score?: number;
+  decision: "accepted" | "rejected" | "skipped" | null;
+  /**
+   * The proposal's `learned_patterns` row id — the key every review routes on.
+   * Set for every rendered proposal: chat-streamed cards derive it from the
+   * `proposeAmendment` tool result (see `extractProposals`), and pending-list
+   * cards derive it from the DB row. A proposal without a `dbId` is
+   * unreviewable and is never rendered.
+   */
+  dbId?: string;
+}
+
+/**
+ * Parse approvable proposals from `proposeAmendment` tool results in the chat
+ * message stream.
+ *
+ * Only results that carry a `proposalId` are surfaced. On the internal-DB path
+ * (the admin web flow always has one) `proposeAmendment` persists each proposal
+ * as a `learned_patterns` row and returns its id as `proposalId`; we carry it as
+ * `dbId` so Approve/Reject route through the working `/amendments/{id}/review`
+ * path (keyed on that exact row) rather than the dead in-memory
+ * `/proposals/{index}` path. A result carrying `{ error }` (the tool failed —
+ * bad/missing entity file, or a persist error — so no row exists) has no
+ * `proposalId`, and an in-flight call has no result yet; both lack a `dbId` and
+ * are skipped so no unapprovable card is rendered.
+ */
+export function extractProposals(messages: UIMessage[]): Proposal[] {
+  const proposals: Proposal[] = [];
+  let idx = 0;
+
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    for (const part of msg.parts) {
+      if (isToolUIPart(part)) {
+        let name: string;
+        try { name = getToolName(part as Parameters<typeof getToolName>[0]); } catch { /* intentionally ignored: skip unrecognizable tool parts */ continue; }
+        if (name !== "proposeAmendment") continue;
+        const args = getToolArgs(part);
+        if (args.entityName) {
+          const result = getToolResult(part) as Record<string, unknown> | null;
+          const dbId = typeof result?.proposalId === "string" ? result.proposalId : undefined;
+          if (!dbId) continue;
+          const diff = typeof result?.diff === "string" ? result.diff : undefined;
+          const rawTR = result?.testResult;
+          const testResult: Proposal["testResult"] | undefined =
+            rawTR && typeof rawTR === "object" && !Array.isArray(rawTR) &&
+            "success" in rawTR && typeof (rawTR as Record<string, unknown>).rowCount === "number"
+              ? (rawTR as Proposal["testResult"])
+              : undefined;
+          proposals.push({
+            index: idx++,
+            entityName: String((args.entityName as string) ?? "unknown"),
+            category: String((args.category as string) ?? ""),
+            amendmentType: String((args.amendmentType as string) ?? ""),
+            amendment: (args.amendment as Record<string, unknown>) ?? {},
+            rationale: String((args.rationale as string) ?? ""),
+            diff,
+            testQuery: args.testQuery ? String(args.testQuery as string) : undefined,
+            testResult,
+            confidence: Number(args.confidence ?? 0.5),
+            impact: Number(args.impact ?? 0.5),
+            score: Number(args.score ?? 0.5),
+            decision: null,
+            dbId,
+          });
+        }
+      }
+    }
+  }
+  return proposals;
+}


### PR DESCRIPTION
## What & why

The flagship `/admin/semantic/improve` flow was structurally dead end-to-end: an admin clicks "Run Analysis", the expert agent streams `proposeAmendment` proposal cards, and every Approve/Reject click returned **404 "Proposal not found. Start an improvement session first."** — while the admin was visibly inside a session.

Two halves never met: the route's in-memory `SessionState.proposals` is never populated in the web path (only the CLI populates it), so `/proposals/{index}/approve` always 404s. Meanwhile `proposeAmendment` already persists each proposal as a `learned_patterns` row and returns its `proposalId` — but the UI dropped it and routed to the dead path instead of the working `/amendments/{id}/review`.

## The fix (minimal invariant, per the issue's scope guard)

- `extractProposals` carries `proposalId` from the tool result as `dbId`, and **only surfaces proposals that have one** — so `{ error }` results (no persisted row) and in-flight calls are never rendered as approvable cards.
- `handleReview` routes **every** review through `/amendments/{id}/review`, keyed on the exact `learned_patterns` row the tool persisted → one identity, no stale pending row. `proposalDecisions` rekeyed index → `dbId` so a chat card's decision survives re-renders/refetch.
- Extracted `extractProposals` + the `Proposal`/`TestResult` types into a pure `proposals.ts` module so the gate is unit-testable without a React harness.

Deliberately **not** in scope (left to the elevation grill, per the issue): deleting vs populating the in-memory session machinery, the `/sessions` endpoints, and unifying the two proposal sources.

## Acceptance criteria
- [x] Approving a chat-streamed proposal applies the amendment and updates the same `learned_patterns` row (one identity — no stale pending row)
- [x] Rejecting marks the DB row rejected
- [x] Happy-path test covers propose → approve through the route the UI actually calls (`/amendments/{id}/review`)
- [x] Tool-result proposals that returned `{ error }` (no DB row) are not rendered as approvable cards

## Tests
- **API** (`admin-semantic-improve.test.ts`): approve happy path (applies YAML then flips the same row, ordering asserted), approve → apply-fails (row stays pending — apply-before-flip invariant), reject happy path, reject-404. Added the missing `applyAmendment` export to the `apply.ts` mock (mock-all-exports discipline).
- **Web** (`proposals.test.ts`): `extractProposals` — `proposalId` → `dbId` card, `{ error }` dropped, in-flight dropped, dense re-indexing, non-`proposeAmendment` ignored, `testResult` valid vs malformed.

Internal review panel (silent-failure, type-design, pr-test, comment): CLEAN over two rounds. Local `/ci`: all 29 gates green.

Closes #4484

https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY)_