### PR TITLE
fix(wizard): gate semantic enrich on billing + meter token usage

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -16412,7 +16412,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — admin role required",
+            "description": "Forbidden — admin role required, or blocked by billing enforcement (#3437/#4489 — workspace suspended/deleted, trial expired, or subscription ended)",
             "content": {
               "application/json": {
                 "schema": {
@@ -16448,7 +16448,7 @@
             }
           },
           "429": {
-            "description": "Rate limit exceeded",
+            "description": "Rate limit exceeded, or blocked by billing enforcement (#3437/#4489 — plan token budget exceeded, or abuse throttle carrying Retry-After)",
             "content": {
               "application/json": {
                 "schema": {
@@ -16484,7 +16484,7 @@
             }
           },
           "503": {
-            "description": "Enrichment unavailable — no LLM provider configured",
+            "description": "Enrichment unavailable — no LLM provider configured, or billing enforcement could not verify billing/workspace status (fail-closed, retryable)",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/wizard-enrich-billing.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-billing.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Billing-enforcement suite for the wizard `/enrich` route (#4489).
+ *
+ * `POST /api/v1/wizard/enrich` runs `generateText` (real platform-token LLM
+ * spend, metered against the workspace budget via `logUsageEvent`), so it must
+ * consult the shared billing gate (`checkAgentBillingGate`, #3419/#3420) BEFORE
+ * the model runs — exactly like the semantic-improve chat route (#3437). Pre-fix
+ * the wizard had no billing references at all: a suspended / trial-expired /
+ * over-budget workspace admin could burn platform tokens through the per-table
+ * enrich loop, unmetered.
+ *
+ * Mirrors `admin-semantic-improve-billing.test.ts`: a mutable gate verdict drives
+ * each block arm (403 / 429 / 429+Retry-After / 503) and asserts the mock LLM
+ * NEVER fired and nothing was metered; the allowed arm asserts the LLM ran once
+ * and a `token` usage event was recorded against the workspace budget.
+ *
+ * Harness is adapted from `wizard-enrich-mock-llm.test.ts` — the route is driven
+ * end-to-end (auth → resolver → model → enrich engine) with the enrich model
+ * resolved through the AtlasAiModel test layer, so the gate wiring is exercised
+ * against the real route rather than a stub.
+ */
+
+import { describe, expect, it, beforeEach, mock, type Mock } from "bun:test";
+import { Effect } from "effect";
+import { MockLanguageModelV3 } from "ai/test";
+import type { LanguageModel } from "ai";
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+// --- Mock LLM resolved through the AtlasAiModel test layer -------------------
+
+const ENRICH_RESPONSE =
+  "```yaml\ndescription: |\n  Enriched by the mock LLM.\nuse_cases:\n  - Analyze volume over time\n```";
+
+const mockModel = new MockLanguageModelV3({
+  doGenerate: async (_options: LanguageModelV3CallOptions) => ({
+    content: [{ type: "text" as const, text: ENRICH_RESPONSE }],
+    finishReason: { unified: "stop" as const, raw: "end_turn" },
+    usage: {
+      inputTokens: { total: 50, noCache: 50, cacheRead: 0, cacheWrite: 0 },
+      outputTokens: { total: 30, text: 30, reasoning: 0 },
+    },
+    warnings: [],
+  }),
+});
+
+const { createAiModelTestLayer, AtlasAiModel } = await import("@atlas/api/lib/effect/ai");
+const aiTestLayer = createAiModelTestLayer({ model: mockModel as unknown as LanguageModel });
+const layerModel = await Effect.runPromise(
+  Effect.gen(function* () {
+    const ai = yield* AtlasAiModel;
+    return ai.model;
+  }).pipe(Effect.provide(aiTestLayer)),
+);
+
+// --- Billing gate mock (#4489) — mutable verdict per test -------------------
+
+type GateVerdict =
+  | { allowed: true; warning?: unknown }
+  | {
+      allowed: false;
+      errorCode: string;
+      errorMessage: string;
+      httpStatus: 403 | 404 | 429 | 503;
+      retryable: boolean;
+      retryAfterSeconds?: number;
+      usage?: { currentUsage: number; limit: number; metric: string };
+    };
+let billingGateVerdict: GateVerdict = { allowed: true };
+const mockCheckAgentBillingGate = mock(async (_orgId?: string) => billingGateVerdict);
+
+void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError: class BillingBlockedError extends Error {
+    override readonly name = "BillingBlockedError";
+  },
+}));
+
+// Metering spy — assert the token event on the allowed arm, and its ABSENCE on
+// every block arm (the enrich never ran, so nothing is metered).
+const mockLogUsageEvent = mock((_event: unknown) => {});
+void mock.module("@atlas/api/lib/metering", () => ({
+  logUsageEvent: mockLogUsageEvent,
+  emitLoginEvent: async () => {},
+  aggregateUsageSummary: async () => {},
+  getCurrentPeriodUsage: async () => ({}),
+  getUsageHistory: async () => [],
+  getUsageBreakdown: async () => [],
+}));
+
+// --- Route collaborators ----------------------------------------------------
+
+const mockConnectionHas: Mock<(id: string) => boolean> = mock(
+  (id: string) => id === "analytics" || id === "default",
+);
+const mockConnectionDescribe: Mock<() => Array<{ id: string; dbType: string; status: string }>> = mock(
+  () => [{ id: "analytics", dbType: "postgres", status: "healthy" }],
+);
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      has: mockConnectionHas,
+      describe: mockConnectionDescribe,
+    },
+    detectDBType: () => "postgres",
+  }),
+);
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
+  internalQuery: async () => [],
+  internalExecute: () => {},
+  isInternalCircuitOpen: () => false,
+  encryptSecret: (url: string) => `encrypted:${url}`,
+  decryptSecret: (url: string) => url,
+  migrateInternalDB: async () => {},
+  loadSavedConnections: async () => 0,
+  isPlaintextUrl: () => true,
+  getEncryptionKey: () => null,
+  _resetPool: () => {},
+  _resetCircuitBreaker: () => {},
+  _resetEncryptionKeyCache: () => {},
+  closeInternalDB: async () => {},
+  setWorkspaceRegion: mock(async () => {}),
+  insertSemanticAmendment: mock(async () => "mock-amendment-id"),
+  getPendingAmendmentCount: mock(async () => 0),
+}));
+
+// Mutable so one test can drop `activeOrganizationId` (the self-hosted /
+// no-workspace path where the gate is a no-op and metering records null).
+let authUser: Record<string, unknown> = {
+  id: "user-1",
+  mode: "managed",
+  label: "admin@test.com",
+  role: "admin",
+  activeOrganizationId: "org-alpha",
+};
+const mockAuthenticate = mock(() =>
+  Promise.resolve({ authenticated: true, mode: "managed", user: authUser }),
+);
+
+void mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: mockAuthenticate,
+  checkRateLimit: () => ({ allowed: true }),
+  getClientIP: () => null,
+}));
+
+void mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => "managed",
+  resetAuthModeCache: () => {},
+}));
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getWhitelistedTables: () => new Set(),
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  _resetWhitelists: () => {},
+}));
+
+void mock.module("@atlas/api/lib/semantic/entities", () => ({
+  upsertProfileStatus: mock(() => Promise.resolve()),
+  listIncompleteProfileLayers: mock(() => Promise.resolve([])),
+  DEMO_CONNECTION_ID: "__demo__",
+  SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+  bulkUpsertEntities: async () => 0,
+  resolveGroupIdForConnection: async () => null,
+  upsertEntity: async () => {},
+  upsertDraftEntity: async () => {},
+  upsertTombstone: async () => {},
+  deleteDraftEntity: async () => false,
+  listEntityRows: async () => [],
+  listEntities: async () => [],
+  listEntitiesWithOverlay: async () => [],
+  getEntity: async () => null,
+  deleteEntity: async () => false,
+  countEntities: async () => 0,
+  createVersion: async () => "",
+  listVersions: async () => [],
+  getVersion: async () => null,
+  generateChangeSummary: async () => "",
+  applyTombstones: async () => 0,
+  promoteDraftEntities: async () => 0,
+  archiveSingleConnection: async () => ({ ok: true as const, archived: 0 }),
+  restoreSingleConnection: async () => ({ ok: true as const, restored: 0 }),
+}));
+
+void mock.module("@atlas/api/lib/semantic/sync", () => ({
+  syncEntityToDisk: async () => {},
+  syncEntityDeleteFromDisk: async () => {},
+  syncAllEntitiesToDisk: async () => 0,
+  getSemanticRoot: () => "/tmp/test-semantic",
+  reconcileAllOrgs: async () => {},
+}));
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
+
+void mock.module("@atlas/api/lib/plugins/hooks", () => ({ dispatchHook: async () => {} }));
+
+void mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: () => undefined,
+  getSettingAuto: () => undefined,
+  getSettingLive: async () => undefined,
+  setSetting: async () => {},
+  deleteSetting: async () => {},
+  getAllSettingOverrides: async () => [],
+  loadSettings: async () => 0,
+  getSettingsForAdmin: () => [],
+  getSettingsRegistry: () => [],
+  getSettingDefinition: () => undefined,
+  _resetSettingsCache: () => {},
+}));
+
+void mock.module("@atlas/api/lib/security", () => ({
+  getSecurityHeaders: () => ({}),
+  applySecurityHeaders: () => {},
+}));
+
+import * as _providersActual from "@atlas/api/lib/providers";
+void mock.module("@atlas/api/lib/providers", () => ({
+  ..._providersActual,
+  getModel: () => layerModel,
+  getModelFromWorkspaceConfig: () => layerModel,
+  getMissingModelConfig: () => ({ provider: "anthropic", missing: [] as string[] }),
+}));
+
+import * as _enterpriseLayerActual from "@atlas/api/lib/effect/enterprise-layer";
+void mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  ..._enterpriseLayerActual,
+  runEnterprise: async () => null,
+}));
+
+// Profiler seam — mechanical (no LLM). The wizard's /enrich re-profiles the one
+// table before invoking the LLM enrich engine.
+const mockProfile = mock(async () => ({
+  profiles: [
+    {
+      table_name: "orders",
+      object_type: "table" as const,
+      row_count: 100,
+      columns: [
+        {
+          name: "id",
+          type: "integer",
+          nullable: false,
+          unique_count: 100,
+          null_count: 0,
+          sample_values: [],
+          is_primary_key: true,
+          is_foreign_key: false,
+          fk_target_table: null,
+          fk_target_column: null,
+          is_enum_like: false,
+          profiler_notes: [],
+        },
+      ],
+      primary_key_columns: ["id"],
+      foreign_keys: [],
+      inferred_foreign_keys: [],
+      profiler_notes: [],
+      table_flags: { possibly_abandoned: false, possibly_denormalized: false },
+    },
+  ],
+  errors: [],
+}));
+
+void mock.module("@atlas/api/lib/datasources/profiling-connection", () => ({
+  resolveProfilingConnection: async () => ({
+    kind: "ok" as const,
+    dbType: "postgres",
+    querySchema: "public",
+    connection: {
+      dbType: "postgres",
+      connectionGroupId: null,
+      query: async () => ({ columns: [], rows: [] as Record<string, unknown>[] }),
+      listObjects: async () => [{ name: "orders", type: "table" }],
+      profile: mockProfile,
+      close: async () => {},
+    },
+  }),
+}));
+
+// --- Import after mocks -----------------------------------------------------
+
+const { wizard } = await import("../routes/wizard");
+const { OpenAPIHono } = await import("@hono/zod-openapi");
+import { validationHook } from "../routes/validation-hook";
+
+const app = new OpenAPIHono({ defaultHook: validationHook });
+app.route("/api/v1/wizard", wizard);
+
+function enrichRequest() {
+  return app.request("http://localhost/api/v1/wizard/enrich", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ connectionId: "analytics", tableName: "orders", yaml: "table: orders\n" }),
+  });
+}
+
+async function json(res: Response): Promise<Record<string, unknown>> {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  billingGateVerdict = { allowed: true };
+  authUser = {
+    id: "user-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  };
+  mockCheckAgentBillingGate.mockClear();
+  mockLogUsageEvent.mockClear();
+  mockProfile.mockClear();
+  mockModel.doGenerateCalls.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/wizard/enrich — billing gate (#4489)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/wizard/enrich — billing gate (#4489)", () => {
+  it("blocks a trial-expired workspace with 403 before the model runs", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "trial_expired",
+      errorMessage: "Your free trial has expired. Upgrade to a paid plan to continue using Atlas.",
+      httpStatus: 403,
+      retryable: false,
+    };
+
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(403);
+    const body = await json(res);
+    expect(body.error).toBe("trial_expired");
+    expect(body.message).toContain("trial has expired");
+    expect(body.retryable).toBe(false);
+    expect(typeof body.requestId).toBe("string");
+    expect((body.requestId as string).length).toBeGreaterThan(0);
+    // Gate consulted with the caller's workspace; the model + metering never ran.
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledWith("org-alpha");
+    expect(mockModel.doGenerateCalls.length).toBe(0);
+    expect(mockProfile).not.toHaveBeenCalled();
+    expect(mockLogUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("blocks a token-hard-cap workspace with 429 + usage before the model runs", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "plan_limit_exceeded",
+      errorMessage: "You have used your full included usage credit.",
+      httpStatus: 429,
+      retryable: false,
+      usage: { currentUsage: 23, limit: 20, metric: "usd" },
+    };
+
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(429);
+    // A hard-cap block is NOT a transient throttle — no Retry-After, unlike the
+    // abuse-throttle arm below (that distinction drives the client's retry UX).
+    expect(res.headers.get("Retry-After")).toBeNull();
+    const body = await json(res);
+    expect(body.error).toBe("plan_limit_exceeded");
+    expect(body.usage).toEqual({ currentUsage: 23, limit: 20, metric: "usd" });
+    expect(mockModel.doGenerateCalls.length).toBe(0);
+    expect(mockLogUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 when the gate itself THROWS (contract violation) — no spend, no bypass", async () => {
+    // Distinct from the returned-block 503 above: here the gate REJECTS. The
+    // route's Effect.tryPromise+either must catch it and surface the same shaped,
+    // retry-guided 503 — never a generic 500, and never a silent bypass that
+    // would let the LLM spend. A regression awaiting the gate directly would
+    // bubble a 500 or skip the gate, and this is the only arm that catches it.
+    mockCheckAgentBillingGate.mockImplementationOnce(async () => {
+      throw new Error("billing lookup exploded");
+    });
+
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(503);
+    const body = await json(res);
+    expect(body.error).toBe("billing_check_failed");
+    expect(body.retryable).toBe(true);
+    expect(typeof body.requestId).toBe("string");
+    expect(mockModel.doGenerateCalls.length).toBe(0);
+    expect(mockProfile).not.toHaveBeenCalled();
+    expect(mockLogUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("maps an abuse-throttle block to 429 with a Retry-After header", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "workspace_throttled",
+      errorMessage: "Workspace is temporarily throttled due to high usage. Please retry shortly.",
+      httpStatus: 429,
+      retryable: true,
+      retryAfterSeconds: 5,
+    };
+
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    const body = await json(res);
+    expect(body.error).toBe("workspace_throttled");
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfterSeconds).toBe(5);
+    expect(mockModel.doGenerateCalls.length).toBe(0);
+    expect(mockLogUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with 503 when the billing check itself fails — try again, not upgrade", async () => {
+    billingGateVerdict = {
+      allowed: false,
+      errorCode: "billing_check_failed",
+      errorMessage: "Unable to verify billing status. Please try again.",
+      httpStatus: 503,
+      retryable: true,
+    };
+
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(503);
+    const body = await json(res);
+    expect(body.error).toBe("billing_check_failed");
+    expect(body.retryable).toBe(true);
+    expect(mockModel.doGenerateCalls.length).toBe(0);
+    expect(mockLogUsageEvent).not.toHaveBeenCalled();
+  });
+
+  it("runs the enrich and meters token usage when the gate allows (allowed arm)", async () => {
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.enriched).toBe(true);
+    // Gate ran once against the workspace, then the model ran.
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledTimes(1);
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledWith("org-alpha");
+    expect(mockModel.doGenerateCalls.length).toBe(1);
+    // Token usage (mock LLM: 50 in + 30 out) metered against the workspace budget
+    // as a `token` event — the budget denominator checkPlanLimits enforces.
+    expect(mockLogUsageEvent).toHaveBeenCalledTimes(1);
+    const event = mockLogUsageEvent.mock.calls[0][0] as {
+      eventType: string;
+      quantity: number;
+      workspaceId: string | null;
+      userId: string | null;
+      weightedQuantity?: number | null;
+      metadata?: Record<string, unknown>;
+    };
+    expect(event.eventType).toBe("token");
+    expect(event.quantity).toBe(80);
+    expect(event.workspaceId).toBe("org-alpha");
+    expect(event.userId).toBe("user-1");
+    expect(typeof event.weightedQuantity).toBe("number");
+    // Metadata is load-bearing for billing attribution — assert the source tag,
+    // table, and the input/output split (not just the total).
+    expect(event.metadata).toMatchObject({
+      source: "wizard_enrich",
+      tableName: "orders",
+      input: 50,
+      output: 30,
+    });
+    expect(typeof (event.metadata as Record<string, unknown>).model).toBe("string");
+  });
+
+  it("no workspace (self-hosted / no orgId) — gate no-ops, run 200s, metering records a null workspace", async () => {
+    // Drop the active org: the gate is invoked with `undefined` (a no-op pass on
+    // self-hosted), the enrich still runs, and the token event is recorded with
+    // workspaceId null rather than crashing on an unguarded orgId deref.
+    authUser = { id: "user-1", mode: "managed", label: "admin@test.com", role: "admin" };
+
+    const res = await enrichRequest();
+
+    expect(res.status).toBe(200);
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledWith(undefined);
+    expect(mockModel.doGenerateCalls.length).toBe(1);
+    expect(mockLogUsageEvent).toHaveBeenCalledTimes(1);
+    const event = mockLogUsageEvent.mock.calls[0][0] as { workspaceId: string | null; quantity: number };
+    expect(event.workspaceId).toBeNull();
+    expect(event.quantity).toBe(80);
+  });
+});

--- a/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
@@ -118,6 +118,29 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getPendingAmendmentCount: mock(async () => 0),
 }));
 
+// #4489 — the /enrich route now gates on billing before spend and meters token
+// usage after. This suite drives the REAL enrich engine through the mock LLM, so
+// stub the gate to allow and metering to a no-op spy (the internal-DB mock above
+// intentionally omits `isInternalCircuitOpen`, which real `logUsageEvent` reads).
+// Billing-block arms are covered by wizard-enrich-billing.test.ts.
+const mockCheckAgentBillingGate = mock(async (_orgId?: string) => ({ allowed: true as const }));
+void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError: class BillingBlockedError extends Error {
+    override readonly name = "BillingBlockedError";
+  },
+}));
+
+const mockLogUsageEvent = mock((_event: unknown) => {});
+void mock.module("@atlas/api/lib/metering", () => ({
+  logUsageEvent: mockLogUsageEvent,
+  emitLoginEvent: async () => {},
+  aggregateUsageSummary: async () => {},
+  getCurrentPeriodUsage: async () => ({}),
+  getUsageHistory: async () => [],
+  getUsageBreakdown: async () => [],
+}));
+
 const mockAuthenticate = mock(() =>
   Promise.resolve({
     authenticated: true,
@@ -315,6 +338,8 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
     mockProfile.mockClear();
     mockListObjects.mockClear();
     mockModel.doGenerateCalls.length = 0;
+    mockCheckAgentBillingGate.mockClear();
+    mockLogUsageEvent.mockClear();
   });
 
   it("phase 1 — mechanical generate emits entity YAML and makes NO LLM call", async () => {
@@ -350,6 +375,18 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
     // once — the two-phase flow's LLM step genuinely ran through the AI test layer.
     expect(mockProfile).toHaveBeenCalledTimes(1);
     expect(mockModel.doGenerateCalls.length).toBe(1);
+    // #4489 — the gate ran before spend, and the real engine's surfaced token
+    // usage (mock LLM: 50 in + 30 out) was metered as a `token` usage event.
+    expect(mockCheckAgentBillingGate).toHaveBeenCalledTimes(1);
+    expect(mockLogUsageEvent).toHaveBeenCalledTimes(1);
+    const event = mockLogUsageEvent.mock.calls[0][0] as {
+      eventType: string;
+      quantity: number;
+      workspaceId: string | null;
+    };
+    expect(event.eventType).toBe("token");
+    expect(event.quantity).toBe(80);
+    expect(event.workspaceId).toBe("org-1");
   });
 
   it("the AtlasAiModel test layer is the model source (sanity: layer resolves our mock)", async () => {

--- a/packages/api/src/api/__tests__/wizard.test.ts
+++ b/packages/api/src/api/__tests__/wizard.test.ts
@@ -446,14 +446,40 @@ const mockEnrichEntityYaml: Mock<
     model: unknown,
     usage?: unknown,
     dbType?: string,
-  ) => Promise<{ yaml: string; enriched: boolean }>
-> = mock(async (content: string) => ({ yaml: `${content}description: Enriched by AI.\n`, enriched: true }));
+  ) => Promise<{ yaml: string; enriched: boolean; usage: { inputTokens: number; outputTokens: number } }>
+> = mock(async (content: string) => ({
+  yaml: `${content}description: Enriched by AI.\n`,
+  enriched: true,
+  usage: { inputTokens: 40, outputTokens: 30 },
+}));
 void mock.module("@atlas/api/lib/semantic/enrich", () => ({
   enrichEntityYaml: mockEnrichEntityYaml,
   enrichEntity: async () => {},
   enrichGlossary: async () => {},
   enrichMetric: async () => {},
   enrichSemanticLayer: async () => {},
+}));
+
+// #4489 — the /enrich route now consults the shared billing gate before spend
+// and meters token usage afterwards. Stub both seams so this suite (route
+// dispatch, not billing) stays green: the gate always allows, and metering is a
+// no-op spy. The dedicated wizard-enrich-billing.test.ts drives the block arms.
+const mockCheckAgentBillingGate = mock(async (_orgId?: string) => ({ allowed: true as const }));
+void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mockCheckAgentBillingGate,
+  BillingBlockedError: class BillingBlockedError extends Error {
+    override readonly name = "BillingBlockedError";
+  },
+}));
+
+const mockLogUsageEvent = mock((_event: unknown) => {});
+void mock.module("@atlas/api/lib/metering", () => ({
+  logUsageEvent: mockLogUsageEvent,
+  emitLoginEvent: async () => {},
+  aggregateUsageSummary: async () => {},
+  getCurrentPeriodUsage: async () => ({}),
+  getUsageHistory: async () => [],
+  getUsageBreakdown: async () => [],
 }));
 
 // One profiler home (#3657, ADR-0017 §Amendment(#3667)). The wizard routes now
@@ -617,8 +643,15 @@ beforeEach(() => {
   mockGetMissingModelConfig.mockImplementation(() => ({ provider: "anthropic", missing: [] }));
   mockEnrichEntityYaml.mockReset();
   mockEnrichEntityYaml.mockImplementation(
-    async (content: string) => ({ yaml: `${content}description: Enriched by AI.\n`, enriched: true }),
+    async (content: string) => ({
+      yaml: `${content}description: Enriched by AI.\n`,
+      enriched: true,
+      usage: { inputTokens: 40, outputTokens: 30 },
+    }),
   );
+  mockCheckAgentBillingGate.mockClear();
+  mockCheckAgentBillingGate.mockImplementation(async () => ({ allowed: true as const }));
+  mockLogUsageEvent.mockClear();
   mockRunEnterprise.mockReset();
   mockRunEnterprise.mockImplementation(async () => null); // no workspace BYOT by default
 
@@ -921,6 +954,7 @@ describe("POST /api/v1/wizard/enrich", () => {
     mockEnrichEntityYaml.mockImplementationOnce(async (content: string) => ({
       yaml: content,
       enriched: false,
+      usage: { inputTokens: 40, outputTokens: 0 },
     }));
     const res = await postJson("/api/v1/wizard/enrich", {
       connectionId: "default",
@@ -931,6 +965,29 @@ describe("POST /api/v1/wizard/enrich", () => {
     const data = await json(res);
     expect(data.enriched).toBe(false);
     expect(data.yaml).toBe("table: users\n");
+    // #4489 — the LLM still spent tokens on an unparseable response, so the
+    // enrich must STILL be metered (the enriched flag doesn't gate the spend).
+    expect(mockLogUsageEvent).toHaveBeenCalledTimes(1);
+    const event = mockLogUsageEvent.mock.calls[0][0] as { eventType: string; quantity: number };
+    expect(event.eventType).toBe("token");
+    expect(event.quantity).toBe(40);
+  });
+
+  it("meters nothing when the enrich call reports zero token usage (#4489)", async () => {
+    // A zero-usage response (provider omitted counts, coalesced to 0) must not
+    // emit a zero-quantity noise event — the `totalTokens > 0` guard holds.
+    mockEnrichEntityYaml.mockImplementationOnce(async (content: string) => ({
+      yaml: `${content}description: Enriched by AI.\n`,
+      enriched: true,
+      usage: { inputTokens: 0, outputTokens: 0 },
+    }));
+    const res = await postJson("/api/v1/wizard/enrich", {
+      connectionId: "default",
+      tableName: "users",
+      yaml: "table: users\n",
+    });
+    expect(res.status).toBe(200);
+    expect(mockLogUsageEvent).not.toHaveBeenCalled();
   });
 
   it("returns 503 and never enriches when no LLM provider is configured", async () => {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -65,6 +65,12 @@ import { SAFE_TABLE_NAME, safeSemanticRowName } from "@atlas/api/lib/semantic/sh
 // variant lets the wizard enrich a YAML string per table without touching disk.
 import { enrichEntityYaml } from "@atlas/api/lib/semantic/enrich";
 import { refreshGroupAutoDescription } from "@atlas/api/lib/source-catalog/lookup";
+// #3437 / #4489 — the wizard's Phase-2 enrich spends platform LLM tokens, so it
+// consults the same shared billing gate as every other agent surface before the
+// spend and meters the result against the workspace token budget afterwards.
+import { checkAgentBillingGate } from "@atlas/api/lib/billing/agent-gate";
+import { logUsageEvent } from "@atlas/api/lib/metering";
+import { toOutputEquivalentTokens } from "@atlas/api/lib/billing/token-weighting";
 import {
   getModel,
   getMissingModelConfig,
@@ -405,7 +411,9 @@ const enrichRoute = createRoute({
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     403: {
-      description: "Forbidden — admin role required",
+      description:
+        "Forbidden — admin role required, or blocked by billing enforcement " +
+        "(#3437/#4489 — workspace suspended/deleted, trial expired, or subscription ended)",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     404: {
@@ -413,11 +421,15 @@ const enrichRoute = createRoute({
       content: { "application/json": { schema: ErrorSchema } },
     },
     429: {
-      description: "Rate limit exceeded",
+      description:
+        "Rate limit exceeded, or blocked by billing enforcement " +
+        "(#3437/#4489 — plan token budget exceeded, or abuse throttle carrying Retry-After)",
       content: { "application/json": { schema: AuthErrorSchema } },
     },
     503: {
-      description: "Enrichment unavailable — no LLM provider configured",
+      description:
+        "Enrichment unavailable — no LLM provider configured, or billing enforcement " +
+        "could not verify billing/workspace status (fail-closed, retryable)",
       content: { "application/json": { schema: ErrorSchema } },
     },
     500: {
@@ -853,11 +865,66 @@ wizard.openapi(enrichRoute, async (c) => {
 
     const { connectionId, tableName, yaml: baselineYaml } = c.req.valid("json");
 
+    const orgId = user?.activeOrganizationId;
+
+    // #3437 / #4489 — billing enforcement BEFORE any LLM spend, mirroring the
+    // semantic-improve chat route (admin-semantic-improve.ts). The per-table
+    // enrich runs `generateText` on platform tokens metered against the
+    // workspace budget (below), so the run must pass the shared gate
+    // (workspace status → abuse → plan limits, #3419/#3420) first. Admin
+    // maintenance is intentionally NOT exempt: an admin of a suspended /
+    // trial-expired / over-budget workspace resolves billing before enriching.
+    // Runs ahead of model + connection resolution so a blocked workspace never
+    // reaches the provider. `checkAgentBillingGate` fails closed by RETURNING a
+    // block on a lookup error (a 503 `workspace_check_failed` or `billing_check_failed`,
+    // depending on which sub-check's lookup failed) rather than throwing, and is a
+    // no-op when there is no workspace (self-hosted / no orgId).
+    // An UNEXPECTED throw (contract violation) is caught here and surfaced as
+    // the same shaped, retry-guided 503 — never a generic 500, never a bypass.
+    const gateResult = yield* Effect.tryPromise({
+      try: () => checkAgentBillingGate(orgId),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(Effect.either);
+    if (gateResult._tag === "Left") {
+      log.error(
+        { err: gateResult.left, requestId, orgId },
+        "Wizard enrich: billing gate threw unexpectedly — failing closed",
+      );
+      return c.json({
+        error: "billing_check_failed",
+        message: "Unable to verify billing status. Please try again.",
+        retryable: true,
+        requestId,
+      }, 503);
+    }
+    const gateCheck = gateResult.right;
+    if (!gateCheck.allowed) {
+      log.warn(
+        { requestId, orgId, errorCode: gateCheck.errorCode },
+        "Wizard enrich blocked by billing enforcement",
+      );
+      const blockBody = {
+        error: gateCheck.errorCode,
+        message: gateCheck.errorMessage,
+        retryable: gateCheck.retryable,
+        requestId,
+        ...(gateCheck.retryAfterSeconds !== undefined && { retryAfterSeconds: gateCheck.retryAfterSeconds }),
+        ...(gateCheck.usage && { usage: gateCheck.usage }),
+      };
+      if (gateCheck.retryAfterSeconds !== undefined) {
+        return c.json(blockBody, {
+          status: gateCheck.httpStatus,
+          headers: { "Retry-After": String(gateCheck.retryAfterSeconds) },
+        });
+      }
+      return c.json(blockBody, gateCheck.httpStatus);
+    }
+
     // Resolve the enrichment model up front (workspace BYOT → platform env), so
     // the UI surfaces ONE actionable 503 banner when nothing is configured
     // instead of every per-table enrich hitting the same provider-auth error.
     const modelResolution = yield* Effect.tryPromise({
-      try: () => resolveEnrichModel(user?.activeOrganizationId),
+      try: () => resolveEnrichModel(orgId),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(Effect.either);
     if (modelResolution._tag === "Left") {
@@ -880,7 +947,7 @@ wizard.openapi(enrichRoute, async (c) => {
     const model = modelChoice.model;
 
     const ctxResult = yield* Effect.tryPromise({
-      try: () => resolveProfilingConnection(connectionId, user?.activeOrganizationId),
+      try: () => resolveProfilingConnection(connectionId, orgId),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
     }).pipe(Effect.either);
 
@@ -964,6 +1031,36 @@ wizard.openapi(enrichRoute, async (c) => {
         message: `Table "${tableName}" was not found while profiling for enrichment.`,
         requestId,
       }, 404);
+    }
+
+    // #4489 — meter the enrichment's token spend against the workspace budget.
+    // The `generateText` call ran on platform tokens, so its usage must count
+    // toward the same per-period token budget the gate above enforces
+    // (usage_events → getCurrentPeriodUsage → checkPlanLimits). Fire-and-forget
+    // and a no-op when there is no internal DB (self-hosted, CLI); a run with an
+    // internal DB but no workspace still records a null-workspace row. Only the
+    // budget-relevant `token` event is emitted — an admin maintenance enrich is
+    // not an end-user "query", so it is intentionally left out of query_count.
+    // Weighted the same way as an agent turn (`toOutputEquivalentTokens`) so the
+    // output-equivalent budget denominator stays consistent across surfaces.
+    const usage = data.enriched.usage;
+    const totalTokens = usage.inputTokens + usage.outputTokens;
+    if (totalTokens > 0) {
+      const modelId = typeof model === "string" ? model : model.modelId;
+      logUsageEvent({
+        workspaceId: orgId ?? null,
+        userId: user?.id ?? null,
+        eventType: "token",
+        quantity: totalTokens,
+        weightedQuantity: toOutputEquivalentTokens(usage, modelId),
+        metadata: {
+          source: "wizard_enrich",
+          tableName,
+          model: modelId,
+          input: usage.inputTokens,
+          output: usage.outputTokens,
+        },
+      });
     }
 
     log.info(

--- a/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
@@ -30,7 +30,12 @@ const ENTITY_RESPONSE = "```yaml\ndescription: |\n  Enriched: orders placed by a
 const GLOSSARY_RESPONSE = "```yaml\nterms:\n  refund:\n    status: defined\n    definition: An order whose payment was returned.\n```";
 const METRIC_RESPONSE = "```yaml\nmetrics:\n  - id: avg_order_value\n    label: Average order value\n    description: Mean amount per order.\n    type: derived\n    sql: |\n      SELECT AVG(amount) FROM orders\n```";
 
-const mockGenerateText = mock(async ({ prompt }: GenArgs) => {
+// Usage typed loosely so per-test overrides can return either the legacy
+// promptTokens/completionTokens shape or the AI-SDK v6 inputTokens/outputTokens
+// shape without a type clash (the enrich engine reads `inputTokens`/`outputTokens`
+// and coalesces anything absent to 0).
+type GenResult = { text: string; usage: Record<string, number> };
+const mockGenerateText = mock(async ({ prompt }: GenArgs): Promise<GenResult> => {
   let text = "no usable yaml here";
   if (prompt.includes("enriching a semantic layer YAML file")) text = ENTITY_RESPONSE;
   else if (prompt.includes("building a business glossary")) text = GLOSSARY_RESPONSE;
@@ -197,6 +202,39 @@ describe("enrichEntityYaml (in-memory primitive, #3236)", () => {
     const usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
     await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never, usage);
     expect(usage.totalTokens).toBe(33); // from the mocked generateText usage
+  });
+
+  it("surfaces this call's raw AI-SDK token usage on the result (#4489, workspace metering)", async () => {
+    // The wizard route meters `result.usage` against the workspace budget, so it
+    // must carry the AI-SDK inputTokens/outputTokens shape verbatim.
+    mockGenerateText.mockImplementationOnce(async () => ({
+      text: ENTITY_RESPONSE,
+      usage: { inputTokens: 123, outputTokens: 45, totalTokens: 168 },
+    }));
+    const result = await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never);
+    expect(result.enriched).toBe(true);
+    expect(result.usage).toEqual({ inputTokens: 123, outputTokens: 45 });
+  });
+
+  it("surfaces usage on the unparseable-response path too — tokens were spent (#4489)", async () => {
+    // An unusable (but successful) response still spent tokens; the result must
+    // carry them so the caller meters the spend even when nothing was merged.
+    mockGenerateText.mockImplementationOnce(async () => ({
+      text: "Sorry, I cannot help with that.",
+      usage: { inputTokens: 70, outputTokens: 0, totalTokens: 70 },
+    }));
+    const result = await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never);
+    expect(result.enriched).toBe(false);
+    expect(result.yaml).toBe(ENTITY_YAML);
+    expect(result.usage).toEqual({ inputTokens: 70, outputTokens: 0 });
+  });
+
+  it("coalesces provider-omitted token counts to 0 rather than surfacing undefined (#4489)", async () => {
+    // The default mock returns the pre-v6 promptTokens/completionTokens shape (no
+    // inputTokens/outputTokens) — the `?? 0` coalesce must yield 0, never NaN or
+    // undefined, so metering records a concrete quantity.
+    const result = await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never);
+    expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
   });
 
   it("asks for the datasource dialect (MySQL) so query_patterns aren't PostgreSQL-only", async () => {

--- a/packages/api/src/lib/semantic/enrich/index.ts
+++ b/packages/api/src/lib/semantic/enrich/index.ts
@@ -14,6 +14,7 @@
 
 import { generateText } from "ai";
 import { getModel } from "@atlas/api/lib/providers";
+import type { RawTokenCounts } from "@atlas/api/lib/billing/token-weighting";
 import type { TableProfile } from "@useatlas/types";
 import * as fs from "fs";
 import * as path from "path";
@@ -179,6 +180,17 @@ export interface EnrichEntityYamlResult {
   yaml: string;
   /** True when LLM fields were merged in; false when the input was returned as-is. */
   enriched: boolean;
+  /**
+   * Raw token spend of THIS enrichment call (#4489), surfaced so an API caller
+   * (the wizard `/enrich` route) can meter it against the workspace budget via
+   * `logUsageEvent` — the same {@link RawTokenCounts} shape `toOutputEquivalentTokens`
+   * consumes, so it feeds the budget weighting without a re-pack. Present on BOTH
+   * the merged and the unparseable-response paths — tokens are spent whenever the
+   * LLM call itself succeeds, regardless of whether the output was mergeable.
+   * Distinct from the optional {@link TokenUsage} accumulator param, which is the
+   * CLI cross-table summary sink (still in active use on the file-based path).
+   */
+  usage: RawTokenCounts;
 }
 
 /**
@@ -263,12 +275,21 @@ Important:
 
   if (usage) addUsage(usage, result.usage);
 
+  // Raw per-call token spend for workspace-budget metering (#4489). The AI SDK
+  // usage shape is inputTokens/outputTokens (undefined when a provider omits
+  // counts → coalesce to 0). Captured before the parse branches so it rides
+  // BOTH return paths — the tokens were charged either way.
+  const callUsage = {
+    inputTokens: result.usage.inputTokens ?? 0,
+    outputTokens: result.usage.outputTokens ?? 0,
+  };
+
   const yamlText = extractYamlBlock(result.text);
   const enriched = safeParse(yamlText);
 
   if (!enriched) {
     // Successful call, unusable response — keep the mechanical baseline.
-    return { yaml: existingContent, enriched: false };
+    return { yaml: existingContent, enriched: false, usage: callUsage };
   }
 
   // `loadYaml` preserves v4's undefined-on-empty (v5 throws on a blank file);
@@ -276,7 +297,7 @@ Important:
   const existingYaml = (loadYaml(existingContent) ?? {}) as Record<string, unknown>;
   const merged = deepMerge(existingYaml, enriched);
   const output = yaml.dump(merged, { lineWidth: 120, noRefs: true });
-  return { yaml: output, enriched: true };
+  return { yaml: output, enriched: true, usage: callUsage };
 }
 
 export async function enrichEntity(


### PR DESCRIPTION
## Summary

The wizard `/enrich` route spent platform LLM tokens with **no** `checkAgentBillingGate` and **no** usage metering — unlike the semantic-improve chat route, which was gated per #3437. A suspended / trial-expired / over-budget workspace admin could burn platform tokens freely through the wizard's per-table enrich loop, unmetered against the plan budget.

This closes that asymmetry, mirroring `admin-semantic-improve.ts`:

- **Gate before spend** — `/enrich` now runs `checkAgentBillingGate(orgId)` before any LLM call, returning the same structured 403/429/503 envelope (with `Retry-After` on the abuse-throttle arm). The gate is wrapped in `Effect.tryPromise(...).pipe(Effect.either)` so an *unexpected* gate throw fails closed as a shaped 503 `billing_check_failed` (never a generic 500, never a spend bypass). It runs ahead of model + connection resolution, so a blocked workspace never reaches the provider.
- **Meter the spend** — `enrichEntityYaml` now surfaces this call's raw token usage (`RawTokenCounts`) on **both** the merged and unparseable-response paths (tokens are charged either way). The route meters it against the workspace budget via `logUsageEvent` (a model-weighted `token` event) — the exact `usage_events → getCurrentPeriodUsage → checkPlanLimits` denominator the gate enforces. Only the budget-relevant `token` event is emitted; an admin maintenance enrich is intentionally not counted in `query_count`.
- Regenerated `apps/docs/openapi.json` for the `/enrich` 403/429/503 description changes.

The CLI file-based enrich path (`atlas init --enrich`) is unchanged — it runs with no workspace, so the gate is a no-op and metering records nothing.

## Test plan

- [x] New `wizard-enrich-billing.test.ts` mirroring `admin-semantic-improve-billing.test.ts`: 403 trial-expired, 429 plan-limit + usage, 429 throttle + `Retry-After`, 503 fail-closed (returned block **and** gate-throw), and the allowed arm asserting the LLM ran once + a `token` event metered (quantity, workspace, user, weighted, metadata).
- [x] `no-orgId` self-hosted no-op path; `enriched:false`-still-meters; `totalTokens === 0` guard.
- [x] `enrich-engine.test.ts` — asserts the surfaced `usage` on both return paths + the provider-omitted coalesce-to-0.
- [x] Internal review panel: clean across error-handling, type-safety, test-coverage, and comment axes (3 rounds).
- [x] `/ci`: all gates green (type, lint, lint-type-aware, full isolated test suite, openapi-drift, …).

Closes #4489

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY)_