### PR TITLE
fix(semantic): apply auto-approved interactive amendments in the same flow

### DIFF
--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1622,6 +1622,32 @@ export async function insertSemanticAmendment(amendment: {
 }
 
 /**
+ * Revert an auto-approved semantic amendment back to `pending` after its apply
+ * failed (#4486). `insertSemanticAmendment` stamps eligible rows `approved` at
+ * insert time and both auto-approve paths (the scheduler and the interactive
+ * `proposeAmendment` tool) apply immediately afterward. If that apply throws,
+ * the row must NOT be left `approved` — `approved` is terminal for the pending
+ * queue, so it would leave the invariant "status='approved' ⇒ applied" violated
+ * and the proposal invisible to admins. Reverting to `pending` re-enters it into
+ * the review queue so an admin can retry (and see the same failure). Returns
+ * true when a row was reverted; false when no matching `approved` row exists
+ * (already reviewed / not found) or no internal DB is configured.
+ */
+export async function revertAmendmentToPending(id: string): Promise<boolean> {
+  if (!hasInternalDB()) return false;
+
+  const rows = await internalQuery<{ id: string }>(
+    `UPDATE learned_patterns
+       SET status = 'pending', updated_at = now()
+     WHERE id = $1 AND type = 'semantic_amendment' AND status = 'approved'
+     RETURNING id`,
+    [id],
+  );
+
+  return rows.length > 0;
+}
+
+/**
  * Count pending semantic amendment proposals for an org.
  * Returns 0 when no internal DB is available.
  */

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -1,0 +1,120 @@
+/**
+ * runExpertSchedulerTick auto-approve invariant (#4486).
+ *
+ * The scheduler stamps eligible proposals `approved` at insert and applies them
+ * immediately. This pins the two behaviors the invariant "status='approved' ⇒
+ * applied" depends on, so a future edit that drops the apply or the revert ships
+ * red instead of green:
+ *   - approved + apply succeeds  → autoApproved, row NOT reverted
+ *   - approved + apply fails      → row reverted to pending with the insert's id,
+ *                                    counted as an error (never left approved)
+ *
+ * A separate file from scheduler.test.ts (which only tests the config getters)
+ * so the tick's module mocks don't leak into those tests.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type { AnalysisResult } from "../types";
+
+const proposal: AnalysisResult = {
+  category: "coverage_gaps",
+  entityName: "companies",
+  group: "default",
+  amendmentType: "add_dimension",
+  amendment: { name: "region", type: "string", description: "Region" },
+  rationale: "Adds region dimension",
+  impact: 0.9,
+  confidence: 0.95,
+  staleness: 0,
+  score: 0.85,
+};
+
+// One entity so the tick clears the `entities.length === 0` early return; the
+// analyzer is mocked to return our proposal regardless of inputs.
+void mock.module("../context-loader", () => ({
+  loadEntitiesFromDisk: async () => [{ name: "companies" }],
+  loadGlossaryFromDisk: async () => [],
+  loadAuditPatterns: async () => [],
+  loadRejectedKeys: async () => new Set<string>(),
+}));
+
+void mock.module("../profile-cache", () => ({
+  loadCachedProfiles: () => [],
+}));
+
+let proposals: AnalysisResult[] = [proposal];
+void mock.module("../analyzer", () => ({
+  analyzeSemanticLayer: () => proposals,
+}));
+
+const mockApplyAmendmentToEntity: Mock<() => Promise<void>> = mock(() => Promise.resolve());
+void mock.module("../apply", () => ({
+  applyAmendmentToEntity: mockApplyAmendmentToEntity,
+}));
+
+const mockInsertSemanticAmendment: Mock<() => Promise<{ id: string; status: string }>> = mock(() =>
+  Promise.resolve({ id: "sch-1", status: "approved" }),
+);
+const mockRevertAmendmentToPending: Mock<(id: string) => Promise<boolean>> = mock(() =>
+  Promise.resolve(true),
+);
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  insertSemanticAmendment: mockInsertSemanticAmendment,
+  revertAmendmentToPending: mockRevertAmendmentToPending,
+}));
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+void mock.module("@atlas/api/lib/settings", () => ({
+  getSetting: () => undefined,
+}));
+
+const { runExpertSchedulerTick } = await import("../scheduler");
+
+describe("runExpertSchedulerTick auto-approve → apply invariant (#4486)", () => {
+  beforeEach(() => {
+    proposals = [proposal];
+    mockApplyAmendmentToEntity.mockClear();
+    mockApplyAmendmentToEntity.mockResolvedValue(undefined);
+    mockInsertSemanticAmendment.mockClear();
+    mockInsertSemanticAmendment.mockResolvedValue({ id: "sch-1", status: "approved" });
+    mockRevertAmendmentToPending.mockClear();
+    mockRevertAmendmentToPending.mockResolvedValue(true);
+  });
+
+  it("applies an auto-approved proposal and does not revert it", async () => {
+    const result = await runExpertSchedulerTick();
+
+    expect(mockApplyAmendmentToEntity).toHaveBeenCalledTimes(1);
+    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(result.autoApproved).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it("reverts the row to pending (with the insert id) when apply fails", async () => {
+    mockApplyAmendmentToEntity.mockRejectedValue(new Error("entity not found"));
+
+    const result = await runExpertSchedulerTick();
+
+    // The row must not linger `approved`-but-unapplied: revert is called with
+    // the exact id the insert returned.
+    expect(mockRevertAmendmentToPending).toHaveBeenCalledTimes(1);
+    expect(mockRevertAmendmentToPending.mock.calls[0][0]).toBe("sch-1");
+    expect(result.autoApproved).toBe(0);
+    expect(result.errors).toBe(1);
+  });
+
+  it("does not apply or revert when the proposal lands pending", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ id: "sch-2", status: "pending" });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
+    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(result.queued).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
@@ -26,6 +26,7 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getAutoApproveThreshold: () => 2, // disabled
   getAutoApproveTypes: () => new Set(["update_description", "add_dimension"]),
   insertSemanticAmendment: mock(async () => ({ id: "test-id", status: "pending" as const })),
+  revertAmendmentToPending: mock(async () => true),
   getPendingAmendmentCount: mock(async () => 0),
   getApprovedPatterns: async () => [],
   getEncryptionKey: () => null,

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -107,7 +107,7 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     }
 
     // 4. Insert proposals — insertSemanticAmendment resolves status (approved/pending) based on threshold
-    const { insertSemanticAmendment } =
+    const { insertSemanticAmendment, revertAmendmentToPending } =
       await import("@atlas/api/lib/db/internal");
 
     // 5. Process each proposal
@@ -119,7 +119,7 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
         // maps to a NULL `connection_group_id` like everywhere else.
         const connectionGroupId =
           proposal.group && proposal.group !== "default" ? proposal.group : null;
-        const { status } = await insertSemanticAmendment({
+        const { id, status } = await insertSemanticAmendment({
           orgId: null, // global scope for self-hosted
           description: proposal.rationale,
           sourceEntity: proposal.entityName,
@@ -144,9 +144,30 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
               "Auto-approved and applied semantic amendment",
             );
           } catch (applyErr) {
+            // Revert the row so it never lingers as `approved`-but-unapplied —
+            // the invariant "status='approved' ⇒ applied" must hold on this
+            // path too (#4486). Reverting re-queues it for admin review.
+            const reverted = await revertAmendmentToPending(id).catch(
+              (revertErr: unknown) => {
+                log.warn(
+                  {
+                    err: revertErr instanceof Error ? revertErr : new Error(String(revertErr)),
+                    entity: proposal.entityName,
+                    id,
+                  },
+                  "Failed to revert auto-approved amendment to pending after apply failure — row may remain approved-but-unapplied",
+                );
+                return false;
+              },
+            );
             log.warn(
-              { err: applyErr instanceof Error ? applyErr : new Error(String(applyErr)), entity: proposal.entityName },
-              "Failed to apply auto-approved amendment",
+              {
+                err: applyErr instanceof Error ? applyErr : new Error(String(applyErr)),
+                entity: proposal.entityName,
+                id,
+                reverted,
+              },
+              "Failed to apply auto-approved amendment — reverted to pending for admin review",
             );
             result.errors++;
           }

--- a/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
@@ -30,9 +30,25 @@ const mockInsertSemanticAmendment: Mock<
   (args: Record<string, unknown>) => Promise<{ id: string; status: string }>
 > = mock(() => Promise.resolve({ id: "prop-1", status: "queued" }));
 
+const mockRevertAmendmentToPending: Mock<(id: string) => Promise<boolean>> = mock(() =>
+  Promise.resolve(true),
+);
+
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   insertSemanticAmendment: mockInsertSemanticAmendment,
+  revertAmendmentToPending: mockRevertAmendmentToPending,
+}));
+
+// The auto-approve apply seam (#4486). When insertSemanticAmendment resolves a
+// proposal to `approved` at insert time, the tool must apply it in the same
+// flow (mirroring the scheduler) — never leave it approved-but-unapplied.
+const mockApplyAmendmentFromPayload: Mock<(args: Record<string, unknown>) => Promise<void>> = mock(
+  () => Promise.resolve(),
+);
+
+void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
+  applyAmendmentFromPayload: mockApplyAmendmentFromPayload,
 }));
 
 void mock.module("@atlas/api/lib/logger", () => ({
@@ -171,5 +187,98 @@ describe("proposeAmendment test query routing (#4485)", () => {
     expect(result.testResult?.success).toBe(false);
     expect(result.testResult?.error).toContain("RLS");
     expect(result.testResult?.sampleRows).toEqual([]);
+  });
+});
+
+describe("proposeAmendment auto-approve applies in the same flow (#4486)", () => {
+  beforeEach(() => {
+    mockRunUserQueryPipeline.mockClear();
+    mockRunUserQueryPipeline.mockResolvedValue(okOutcome);
+    mockInsertSemanticAmendment.mockClear();
+    mockApplyAmendmentFromPayload.mockClear();
+    mockApplyAmendmentFromPayload.mockResolvedValue(undefined);
+    mockRevertAmendmentToPending.mockClear();
+    mockRevertAmendmentToPending.mockResolvedValue(true);
+  });
+
+  it("does NOT apply when the insert lands pending (auto-approve disabled)", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-pending", status: "pending" });
+    const result = await run();
+    expect(mockApplyAmendmentFromPayload).not.toHaveBeenCalled();
+    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(result.status).toBe("queued");
+  });
+
+  it("applies the amendment in the same flow when the insert auto-approves", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-approved", status: "approved" });
+    const result = await run();
+
+    // The invariant: an `approved` insert triggers exactly one apply.
+    expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
+    const applyArgs = mockApplyAmendmentFromPayload.mock.calls[0][0] as {
+      sourceEntity: string;
+      connectionGroupId: string | null;
+      label: string;
+      rawPayload: { amendment: Record<string, unknown> };
+    };
+    expect(applyArgs.sourceEntity).toBe("companies");
+    expect(applyArgs.connectionGroupId).toBeNull();
+    expect(applyArgs.label).toBe("prop-approved");
+    // The inner amendment object is carried through so the YAML mutation applies.
+    expect(applyArgs.rawPayload.amendment).toMatchObject({ name: "region" });
+
+    // Apply succeeded → the row legitimately stays approved; no revert.
+    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(result.status).toBe("auto_approved");
+  });
+
+  it("reverts the row to pending and reports queued when the auto-approve apply fails", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-approved", status: "approved" });
+    mockApplyAmendmentFromPayload.mockRejectedValue(new Error("entity not found for org"));
+
+    const result = await run();
+
+    // Apply was attempted, then the row was reverted so it never lingers as
+    // approved-but-unapplied (invariant restored + surfaced, not swallowed).
+    expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
+    expect(mockRevertAmendmentToPending).toHaveBeenCalledTimes(1);
+    expect(mockRevertAmendmentToPending.mock.calls[0][0]).toBe("prop-approved");
+    // The model is told the truth: the proposal is queued, not auto-applied.
+    expect(result.status).toBe("queued");
+    // The apply failure never surfaces as a tool-level error that hides the row.
+    expect(result.error).toBeUndefined();
+  });
+
+  it("still reports queued (never throws) when both the apply AND the revert fail", async () => {
+    // Worst case: apply fails and the revert-to-pending also fails, so the row
+    // genuinely stays `approved`-but-unapplied. This must still be surfaced via
+    // logs and reported honestly to the model (queued), never swallowed into a
+    // tool-level error or an `auto_approved` lie.
+    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-approved", status: "approved" });
+    mockApplyAmendmentFromPayload.mockRejectedValue(new Error("apply exploded"));
+    mockRevertAmendmentToPending.mockRejectedValue(new Error("revert exploded"));
+
+    const result = await run();
+
+    expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
+    expect(mockRevertAmendmentToPending).toHaveBeenCalledTimes(1);
+    // The double failure never surfaces as a thrown error or auto_approved.
+    expect(result.status).toBe("queued");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("invariant: the tool never returns auto_approved without having applied", async () => {
+    // Sweep both insert outcomes; assert apply-count tracks approved+success.
+    for (const status of ["pending", "approved"] as const) {
+      mockInsertSemanticAmendment.mockResolvedValue({ id: `prop-${status}`, status });
+      mockApplyAmendmentFromPayload.mockClear();
+      const result = await run();
+      if (result.status === "auto_approved") {
+        // The only way to report auto_approved is a successful apply call.
+        expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
+      } else {
+        expect(result.status).toBe("queued");
+      }
+    }
   });
 });

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -231,8 +231,9 @@ The amendment object should match the YAML structure for that type (e.g., { name
       let status: "queued" | "auto_approved";
 
       if (hasInternalDB()) {
+        const orgId = getRequestContext()?.user?.activeOrganizationId ?? null;
         const result = await insertSemanticAmendment({
-          orgId: getRequestContext()?.user?.activeOrganizationId ?? null,
+          orgId,
           description: `[${amendmentType}] ${entityName}: ${rationale}`,
           sourceEntity: entityName,
           confidence,
@@ -240,7 +241,71 @@ The amendment object should match the YAML structure for that type (e.g., { name
         });
 
         proposalId = result.id;
-        status = result.status === "approved" ? "auto_approved" : "queued";
+
+        if (result.status === "approved") {
+          // Auto-approve resolved this to `approved` at insert time. `approved`
+          // is terminal for the pending queue, so — exactly like the scheduler
+          // path (semantic/expert/scheduler.ts) — we MUST apply it now, or the
+          // row claims applied while the semantic layer is unchanged and the
+          // diff shown to the user is fiction (#4486). On apply failure, revert
+          // the row to `pending` so the invariant "status='approved' ⇒ applied"
+          // holds and an admin still sees the proposal in the review queue.
+          try {
+            // Dynamic imports (matching the scheduler + admin approve path):
+            // keeps the apply/revert seam out of this tool's static graph, so
+            // the many partial `mock.module("…/db/internal")` test stubs that
+            // don't exercise the auto-approve branch don't have to add the
+            // export just to link.
+            const { applyAmendmentFromPayload } = await import(
+              "@atlas/api/lib/semantic/expert/apply"
+            );
+            await applyAmendmentFromPayload({
+              orgId,
+              sourceEntity: entityName,
+              // Interactive proposals read the flat semantic root, so the
+              // default (NULL) Connection group is the correct apply scope.
+              connectionGroupId: null,
+              // `rawPayload` is typed `unknown`, so the AmendmentPayload passes
+              // through directly (matches the admin approve call sites).
+              rawPayload: payload,
+              requestId: getRequestContext()?.requestId ?? `propose-${Date.now()}`,
+              label: proposalId,
+            });
+            status = "auto_approved";
+          } catch (applyErr) {
+            // Surface the failure: revert the row so it never lingers as
+            // `approved`-but-unapplied, and log — never swallow.
+            const { revertAmendmentToPending } = await import(
+              "@atlas/api/lib/db/internal"
+            );
+            const reverted = await revertAmendmentToPending(proposalId).catch(
+              (revertErr: unknown) => {
+                log.error(
+                  {
+                    err: revertErr instanceof Error ? revertErr.message : String(revertErr),
+                    proposalId,
+                    entityName,
+                  },
+                  "Failed to revert auto-approved amendment to pending after apply failure — row may remain approved-but-unapplied",
+                );
+                return false;
+              },
+            );
+            log.warn(
+              {
+                err: applyErr instanceof Error ? applyErr.message : String(applyErr),
+                entityName,
+                amendmentType,
+                proposalId,
+                reverted,
+              },
+              "Auto-approved amendment failed to apply — reverted to pending for admin review",
+            );
+            status = "queued";
+          }
+        } else {
+          status = "queued";
+        }
       } else {
         proposalId = `local-${Date.now()}`;
         status = "queued";


### PR DESCRIPTION
## Summary

When auto-approve is enabled (`ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD`/`_TYPES`, workspace-overridable), `insertSemanticAmendment` stamps eligible rows `status='approved'` at insert time. The scheduler applied such rows, but the interactive `proposeAmendment` tool path just reported `status:"auto_approved"` back to the model and returned **without ever calling apply**. Since `approved` is terminal for the pending queue, the row left the queue, no admin ever saw it, and no code path applied it — the DB said approved while the semantic layer was unchanged and the diff shown to the user was fiction.

This restores the invariant **`status='approved'` implies the amendment was applied**:

- `proposeAmendment` now applies auto-approved proposals in the same flow, mirroring the scheduler via the shared `applyAmendmentFromPayload` seam (the same one the admin approve path uses).
- On apply failure, **both** auto-approve paths (interactive tool + scheduler) revert the row to `pending` via a new `revertAmendmentToPending` helper — surfaced (log + row status), never swallowed — so the proposal re-enters the admin review queue instead of lingering as `approved`-but-unapplied.

## Changes
- `db/internal.ts` — new `revertAmendmentToPending(id)` (flips an `approved` semantic_amendment row back to `pending`; atomic `UPDATE … WHERE status='approved' RETURNING`).
- `tools/propose-amendment.ts` — apply on auto-approve; revert + honest `queued` status on failure.
- `semantic/expert/scheduler.ts` — capture the insert `id` and revert on apply failure (previously left the row `approved`).

## Test plan
- [x] `propose-amendment.test.ts` — pins the invariant: auto-approve → apply called once; apply-failure → revert-to-pending + `queued`; both-apply-and-revert-fail → still `queued`, never throws; pending → no apply; sweep asserting the tool never returns `auto_approved` without an apply.
- [x] `scheduler-tick.test.ts` (new) — the scheduler mirror: approved+success applies & doesn't revert; approved+apply-fails reverts with the insert id and counts an error; pending neither applies nor reverts.
- [x] Full `bash scripts/ci-local.sh` — all 29 gates green.
- [x] Internal review panel (4 specialist reviewers) — clean, no must-fix.

Closes #4486

https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY)_