### PR TITLE
fix(semantic): resolve proposeAmendment baseline through the org/group-aware DB read (#4488)

### DIFF
--- a/packages/api/src/lib/semantic/expert/__tests__/resolve-amendment-baseline.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/resolve-amendment-baseline.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for `resolveAmendmentBaseline` (#4488) — the single org/group-aware
+ * read both the diff preview and the apply write go through. Covers the branches
+ * the acceptance criteria name: scoped hit, scoped-miss → unscoped fallback,
+ * not-found throw, malformed-YAML throw, and AmbiguousEntityError propagation.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+class AmbiguousEntityError extends Error {
+  readonly groups: (string | null)[];
+  constructor(opts: { message: string; groups: (string | null)[] }) {
+    super(opts.message);
+    this.name = "AmbiguousEntityError";
+    this.groups = opts.groups;
+  }
+}
+
+type Row = { id: string; connection_group_id: string | null; yaml_content: string };
+
+// Explicit param signatures so `.mock.calls[n][i]` is well-typed.
+const getEntity = mock(
+  async (
+    _org: string,
+    _type: string,
+    _name: string,
+    _group?: string | null,
+  ): Promise<Row | null> => null,
+);
+
+void mock.module("@atlas/api/lib/semantic/entities", () => ({
+  getEntity,
+  AmbiguousEntityError,
+}));
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { resolveAmendmentBaseline } = await import(`../apply.ts?t=${Date.now()}`);
+
+describe("resolveAmendmentBaseline (#4488)", () => {
+  beforeEach(() => {
+    getEntity.mockReset();
+  });
+
+  it("scoped hit: reads the group-scoped row and returns its own group + parsed YAML", async () => {
+    getEntity.mockResolvedValue({
+      id: "orders-eu",
+      connection_group_id: "eu_prod",
+      yaml_content: "name: orders\ndescription: Orders\n",
+    });
+
+    const result = await resolveAmendmentBaseline("org-1", "orders", "eu_prod");
+
+    // One scoped read — no unscoped fallback needed.
+    expect(getEntity).toHaveBeenCalledTimes(1);
+    expect(getEntity.mock.calls[0].slice(0, 4)).toEqual(["org-1", "entity", "orders", "eu_prod"]);
+    expect(result.targetGroupId).toBe("eu_prod");
+    expect(result.parsed).toMatchObject({ name: "orders", description: "Orders" });
+  });
+
+  it("scoped miss → unscoped fallback resolves, targetGroupId is the resolved row's OWN group", async () => {
+    // First (scoped) read misses; the unscoped fallback resolves the unique row.
+    getEntity
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "orders-eu",
+        connection_group_id: "eu_prod",
+        yaml_content: "name: orders\n",
+      });
+
+    const result = await resolveAmendmentBaseline("org-1", "orders", "stale_group");
+
+    expect(getEntity).toHaveBeenCalledTimes(2);
+    expect(getEntity.mock.calls[0][3]).toBe("stale_group"); // scoped attempt
+    expect(getEntity.mock.calls[1][3]).toBeUndefined(); // unscoped fallback
+    // Write scope is the row's OWN group, never the stale requested label.
+    expect(result.targetGroupId).toBe("eu_prod");
+  });
+
+  it("throws when the entity is absent (and names self-hosted global scope for a null org)", async () => {
+    getEntity.mockResolvedValue(null);
+    await expect(resolveAmendmentBaseline(null, "ghost", "default")).rejects.toThrow(
+      /Entity "ghost" not found for org self-hosted \(global\)/,
+    );
+  });
+
+  it("throws when the stored YAML is not a mapping (scalar/array)", async () => {
+    getEntity.mockResolvedValue({
+      id: "orders-eu",
+      connection_group_id: "eu_prod",
+      yaml_content: "- just\n- a\n- list\n",
+    });
+    await expect(resolveAmendmentBaseline("org-1", "orders", "eu_prod")).rejects.toThrow(
+      /expected a mapping/,
+    );
+  });
+
+  it("propagates AmbiguousEntityError from an unscoped multi-group lookup (never swallowed)", async () => {
+    // group=undefined → the primary read is unscoped; getEntity 409s on a name
+    // shared across groups. The resolver must let it propagate.
+    getEntity.mockImplementation(async (_o, _t, _n, group?: string | null) => {
+      if (group === undefined) {
+        throw new AmbiguousEntityError({ message: "orders exists in 2 environments", groups: [null, "eu_prod"] });
+      }
+      return null;
+    });
+    await expect(resolveAmendmentBaseline("org-1", "orders", undefined)).rejects.toThrow(
+      "exists in 2 environments",
+    );
+  });
+});

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -32,12 +32,14 @@ function groupToLookupScope(group: string | undefined): string | null | undefine
 
 /**
  * Resolve the current entity ROW + parsed YAML baseline for an amendment,
- * scoped to its Connection group (ADR-0012, #3284). This is the SINGLE read
+ * scoped to its Connection group (ADR-0012, #3284). This is the SINGLE resolver
  * both the diff preview (`proposeAmendment`) and the write
- * (`applyAmendmentToEntity`) go through, so the document an admin reviews is
- * provably the one approval mutates — no more flat-root-vs-DB divergence where
- * the tool diffed a stale/absent file while apply mutated the org's DB row
- * (#4488).
+ * (`applyAmendmentToEntity`) go through — identical org/group scoping on both,
+ * so the document an admin reviews is the one approval mutates (each path does
+ * its own DB read, so a concurrent write between them is not excluded — but the
+ * scope can no longer diverge, which is the flat-root-vs-DB bug this closes:
+ * the tool diffed a stale/absent file while apply mutated the org's DB row,
+ * #4488).
  *
  * Lookup:
  * - scoped lookup via `groupToLookupScope(group)` — an explicit group avoids
@@ -45,15 +47,16 @@ function groupToLookupScope(group: string | undefined): string | null | undefine
  *   group keeps the legacy unscoped behavior for the interactive path;
  * - on a scoped miss (`group !== undefined`), fall back to the back-compat
  *   UNSCOPED lookup, which resolves a unique match (and only throws
- *   `AmbiguousEntityError` → 409 on genuine cross-group ambiguity).
+ *   `AmbiguousEntityError` on genuine cross-group ambiguity).
  *
  * The returned `targetGroupId` is the resolved row's OWN `connection_group_id`
  * — authoritative for every write-back, and the group callers must thread to
  * the apply so it lands in the exact scope the baseline was read from.
  *
- * @throws when the entity is absent for this org (an `AmbiguousEntityError`
- *   from an unscoped multi-group lookup propagates to the route as 409), or its
- *   stored YAML is not a mapping.
+ * @throws when the entity is absent for this org, or its stored YAML is not a
+ *   mapping. An `AmbiguousEntityError` from an unscoped multi-group lookup
+ *   propagates too — the apply/approve route path maps it to 409; the
+ *   `proposeAmendment` tool catches it and returns a generic error result.
  */
 export async function resolveAmendmentBaseline(
   orgId: string | null,
@@ -75,11 +78,19 @@ export async function resolveAmendmentBaseline(
     // The persisted group didn't resolve to a row — e.g. an interactive
     // `proposeAmendment` row (NULL group) whose flat-root entity was imported
     // under a datasource group, or a stale group label. Fall back to the
-    // back-compat UNSCOPED lookup.
+    // back-compat UNSCOPED lookup. Log the fallback so a wrong-scope diagnosis
+    // isn't silent — the write-back below still targets the resolved row's OWN
+    // group, so this only widens the read, never the write.
+    log.debug(
+      { entityName, requestedScope: lookupScope },
+      "scoped amendment baseline lookup missed — falling back to unscoped resolve",
+    );
     row = await getEntity(effectiveOrgId, "entity", entityName);
   }
   if (!row) {
-    throw new Error(`Entity "${entityName}" not found for org ${orgId}`);
+    throw new Error(
+      `Entity "${entityName}" not found for org ${orgId ?? "self-hosted (global)"}`,
+    );
   }
 
   // The row's OWN group is authoritative for every write-back — whether we

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -10,6 +10,7 @@ import { loadYaml } from "../yaml";
 import { ANALYSIS_CATEGORIES, type AnalysisResult, type AnalysisCategory } from "./types";
 import { AMENDMENT_TYPES, type AmendmentType } from "@useatlas/types";
 import { createLogger } from "@atlas/api/lib/logger";
+import type { SemanticEntityRow } from "@atlas/api/lib/semantic/entities";
 
 const log = createLogger("semantic-expert-apply");
 
@@ -30,11 +31,81 @@ function groupToLookupScope(group: string | undefined): string | null | undefine
 }
 
 /**
+ * Resolve the current entity ROW + parsed YAML baseline for an amendment,
+ * scoped to its Connection group (ADR-0012, #3284). This is the SINGLE read
+ * both the diff preview (`proposeAmendment`) and the write
+ * (`applyAmendmentToEntity`) go through, so the document an admin reviews is
+ * provably the one approval mutates — no more flat-root-vs-DB divergence where
+ * the tool diffed a stale/absent file while apply mutated the org's DB row
+ * (#4488).
+ *
+ * Lookup:
+ * - scoped lookup via `groupToLookupScope(group)` — an explicit group avoids
+ *   the unscoped ambiguity 409 for a name shared across groups; an undefined
+ *   group keeps the legacy unscoped behavior for the interactive path;
+ * - on a scoped miss (`group !== undefined`), fall back to the back-compat
+ *   UNSCOPED lookup, which resolves a unique match (and only throws
+ *   `AmbiguousEntityError` → 409 on genuine cross-group ambiguity).
+ *
+ * The returned `targetGroupId` is the resolved row's OWN `connection_group_id`
+ * — authoritative for every write-back, and the group callers must thread to
+ * the apply so it lands in the exact scope the baseline was read from.
+ *
+ * @throws when the entity is absent for this org (an `AmbiguousEntityError`
+ *   from an unscoped multi-group lookup propagates to the route as 409), or its
+ *   stored YAML is not a mapping.
+ */
+export async function resolveAmendmentBaseline(
+  orgId: string | null,
+  entityName: string,
+  group: string | undefined,
+): Promise<{
+  row: SemanticEntityRow;
+  targetGroupId: string | null;
+  parsed: Record<string, unknown>;
+}> {
+  // Self-hosted (null orgId) uses empty string as sentinel for global scope
+  const effectiveOrgId = orgId ?? "";
+
+  const { getEntity } = await import("@atlas/api/lib/semantic/entities");
+
+  const lookupScope = groupToLookupScope(group);
+  let row = await getEntity(effectiveOrgId, "entity", entityName, lookupScope);
+  if (!row && lookupScope !== undefined) {
+    // The persisted group didn't resolve to a row — e.g. an interactive
+    // `proposeAmendment` row (NULL group) whose flat-root entity was imported
+    // under a datasource group, or a stale group label. Fall back to the
+    // back-compat UNSCOPED lookup.
+    row = await getEntity(effectiveOrgId, "entity", entityName);
+  }
+  if (!row) {
+    throw new Error(`Entity "${entityName}" not found for org ${orgId}`);
+  }
+
+  // The row's OWN group is authoritative for every write-back — whether we
+  // resolved it by explicit scope or via the unscoped fallback, this is the
+  // exact row we read, so the amendment can never be written into a different
+  // (e.g. default) scope than the one it was analyzed against (#3284).
+  const targetGroupId = row.connection_group_id ?? null;
+
+  // Parse current YAML.
+  // `loadYaml` returns undefined for a document-less row (v5 would throw),
+  // routing it into the "expected a mapping" guard below.
+  const parsed = loadYaml(row.yaml_content) as Record<string, unknown>;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Failed to parse YAML for entity "${entityName}": expected a mapping`);
+  }
+
+  return { row, targetGroupId, parsed };
+}
+
+/**
  * Apply an amendment from an AnalysisResult to the org's semantic entity.
  *
  * 1. Read current YAML from DB — scoped to the finding's Connection group
- *    (`result.group`) so a group entity resolves without a 409 (#3284)
- * 2. Parse, apply amendment, serialize back
+ *    (`result.group`) so a group entity resolves without a 409 (#3284), via the
+ *    shared {@link resolveAmendmentBaseline} the diff preview also uses (#4488)
+ * 2. Apply amendment, serialize back
  * 3. Upsert entity + create version snapshot — written back to the row's OWN
  *    `connection_group_id`, so the amendment can never land in the wrong scope
  * 4. Invalidate caches and sync to disk (same group)
@@ -47,6 +118,14 @@ export async function applyAmendmentToEntity(
   // Self-hosted (null orgId) uses empty string as sentinel for global scope
   const effectiveOrgId = orgId ?? "";
 
+  // Read the baseline through the shared resolver so the diff preview and this
+  // write agree on the exact row + scope (#4488). Returns the row's OWN group.
+  const { row: entity, targetGroupId, parsed } = await resolveAmendmentBaseline(
+    orgId,
+    result.entityName,
+    result.group,
+  );
+
   const {
     getEntity,
     upsertEntityForGroup,
@@ -54,41 +133,6 @@ export async function applyAmendmentToEntity(
     generateChangeSummary,
     AmbiguousEntityError,
   } = await import("@atlas/api/lib/semantic/entities");
-
-  // Look the entity up in its Connection group (ADR-0012, #3284). An explicit
-  // group avoids the unscoped ambiguity 409 for a name shared across groups;
-  // an undefined group keeps the legacy unscoped behavior for the interactive
-  // path. `getEntity` may still throw AmbiguousEntityError (undefined group,
-  // 2+ groups) — that propagates to the route as a 409 with `groups`.
-  const lookupScope = groupToLookupScope(result.group);
-  let entity = await getEntity(effectiveOrgId, "entity", result.entityName, lookupScope);
-  if (!entity && lookupScope !== undefined) {
-    // The persisted group didn't resolve to a row — e.g. an interactive
-    // `proposeAmendment` row (NULL group) whose flat-root entity was imported
-    // under a datasource group, or a stale group label. Fall back to the
-    // back-compat UNSCOPED lookup, which resolves a unique match (and only
-    // throws AmbiguousEntityError → 409 on genuine cross-group ambiguity). The
-    // write-back below still targets the resolved row's OWN group, so a wrong
-    // scope is never written.
-    entity = await getEntity(effectiveOrgId, "entity", result.entityName);
-  }
-  if (!entity) {
-    throw new Error(`Entity "${result.entityName}" not found for org ${orgId}`);
-  }
-
-  // The row's OWN group is authoritative for every write-back below — whether
-  // we resolved it by explicit scope or via the unscoped fallback, this is the
-  // exact row we read, so the amendment can never be written into a different
-  // (e.g. default) scope than the one it was analyzed against (#3284).
-  const targetGroupId = entity.connection_group_id ?? null;
-
-  // Parse current YAML
-  // `loadYaml` returns undefined for a document-less row (v5 would throw),
-  // routing it into the "expected a mapping" guard below.
-  const parsed = loadYaml(entity.yaml_content) as Record<string, unknown>;
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`Failed to parse YAML for entity "${result.entityName}": expected a mapping`);
-  }
 
   // Apply amendment (same logic as CLI's apply-amendment)
   const updated = applyAmendment(parsed, result);

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression (#4488): proposeAmendment resolves its baseline through the same
+ * org/group-aware DB read the apply path uses — never the flat disk root.
+ *
+ * Before the fix the tool read `getSemanticRoot()/entities/<name>.yml`, so a
+ * group-scoped entity (present only in `semantic_entities`, ADR-0012) either
+ * errored "Entity file not found" or the tool diffed a stale flat-root file
+ * while approval mutated the DB row — the diff didn't describe what apply wrote.
+ *
+ * This test uses the REAL apply module end-to-end (resolveAmendmentBaseline +
+ * applyAmendment + applyAmendmentFromPayload → applyAmendmentToEntity), mocking
+ * only the DB/entities/disk layer, and proves:
+ *   1. the baseline comes from the DB row scoped to the request's Connection
+ *      group ("eu_prod"), NOT the flat root (the flat root is a dead path here);
+ *   2. the previewed diff and the applied write agree — both derive from the
+ *      SAME DB document and produce the same new dimension;
+ *   3. the apply targets the entity's OWN group scope, not the NULL default.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { loadYaml } from "@atlas/api/lib/semantic/yaml";
+import type { AmendmentPayload } from "@useatlas/types";
+
+// The group-scoped entity as it lives in `semantic_entities` — with a
+// distinctive description that could ONLY come from the DB row, so the diff
+// proving the baseline source is unambiguous.
+const ordersYaml = [
+  "name: orders",
+  "description: Orders (eu_prod DB-backed)",
+  "dimensions:",
+  "  - name: id",
+  "    type: number",
+].join("\n");
+
+const ordersRow = {
+  id: "orders-eu",
+  connection_group_id: "eu_prod",
+  yaml_content: ordersYaml,
+};
+
+// getEntity resolves "orders" ONLY in group "eu_prod" (scoped or the refreshed
+// version read). Any other name/scope is a miss.
+const getEntity = mock(
+  async (_org: string, _type: string, name: string, group?: string | null) =>
+    name === "orders" && group === "eu_prod" ? ordersRow : null,
+);
+const upsertEntityForGroup = mock(
+  async (_org: string, _type: string, _name: string, _yaml: string, _group?: string | null): Promise<void> => {},
+);
+const createVersion = mock(async (): Promise<string> => "version-1");
+const generateChangeSummary = mock(async (): Promise<string> => "added region");
+const invalidateOrgWhitelist = mock((_org: string): void => {});
+const syncEntityToDisk = mock(async (): Promise<void> => {});
+
+class AmbiguousEntityError extends Error {}
+
+void mock.module("@atlas/api/lib/semantic/entities", () => ({
+  getEntity,
+  upsertEntityForGroup,
+  createVersion,
+  generateChangeSummary,
+  AmbiguousEntityError,
+}));
+void mock.module("@atlas/api/lib/semantic", () => ({ invalidateOrgWhitelist }));
+void mock.module("@atlas/api/lib/semantic/sync", () => ({ syncEntityToDisk }));
+
+const insertSemanticAmendment = mock(
+  (_args: { sourceEntity: string; amendmentPayload: AmendmentPayload }) =>
+    Promise.resolve({ id: "prop-1", status: "approved" }),
+);
+const revertAmendmentToPending = mock(() => Promise.resolve(true));
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  insertSemanticAmendment,
+  revertAmendmentToPending,
+}));
+
+// Request context: the org + Connection group the turn resolves entities
+// against. `connectionGroupId: "eu_prod"` is what threads the group scope.
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => ({
+    requestId: "req-1",
+    user: { activeOrganizationId: "org-1" },
+    connectionGroupId: "eu_prod",
+  }),
+}));
+
+// A flat root that does NOT contain orders.yml — so if the tool ever fell back
+// to the disk path it would error "Entity file not found", making the DB path
+// the only way this test can succeed.
+void mock.module("@atlas/api/lib/semantic/files", () => ({
+  getSemanticRoot: () => "/nonexistent-flat-root",
+}));
+
+void mock.module("@atlas/api/lib/tools/sql", () => ({
+  runUserQueryPipeline: mock(() => Promise.resolve({ kind: "ok", columns: [], rows: [], rowCount: 0, executionMs: 0, truncated: false })),
+}));
+
+const { proposeAmendment } = await import("@atlas/api/lib/tools/propose-amendment");
+
+type ProposeResult = { proposalId?: string; status?: string; diff?: string; error?: string };
+
+async function run(): Promise<ProposeResult> {
+  return (await proposeAmendment.execute!(
+    {
+      entityName: "orders",
+      amendmentType: "add_dimension",
+      amendment: { name: "region", sql: "region", type: "string", description: "Region" },
+      rationale: "Add a region dimension",
+      confidence: 0.95,
+    },
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- AI SDK execute options are irrelevant here
+    {} as any,
+  )) as ProposeResult;
+}
+
+describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () => {
+  beforeEach(() => {
+    getEntity.mockClear();
+    upsertEntityForGroup.mockClear();
+    createVersion.mockClear();
+    syncEntityToDisk.mockClear();
+    insertSemanticAmendment.mockClear();
+    insertSemanticAmendment.mockResolvedValue({ id: "prop-1", status: "approved" });
+    revertAmendmentToPending.mockClear();
+  });
+
+  it("reads the baseline from the DB row scoped to the request's group, not the flat root", async () => {
+    const result = await run();
+
+    // No flat-root "Entity file not found" — the pre-#4488 failure mode.
+    expect(result.error).toBeUndefined();
+    // The FIRST entity read is scoped to the request's Connection group. Since
+    // the flat root has no orders.yml, resolving a diff at all is only possible
+    // via the DB row — the pre-#4488 flat-root read would have errored here.
+    expect(getEntity.mock.calls[0].slice(0, 4)).toEqual(["org-1", "entity", "orders", "eu_prod"]);
+    // The diff is computed against the DB document: the baseline `id` dimension
+    // (context) plus the added `region` dimension.
+    expect(result.diff).toContain("name: id");
+    expect(result.diff).toContain("name: region");
+  });
+
+  it("the previewed diff and the applied write agree on the same change", async () => {
+    const result = await run();
+    expect(result.status).toBe("auto_approved");
+
+    // Apply wrote back to the entity's OWN group scope ("eu_prod"), never NULL.
+    expect(upsertEntityForGroup).toHaveBeenCalledTimes(1);
+    const writtenGroup = upsertEntityForGroup.mock.calls[0][4];
+    expect(writtenGroup).toBe("eu_prod");
+
+    // The YAML apply persisted parses to the SAME structural change the diff
+    // previewed: the original `id` dimension plus the new `region` dimension,
+    // both derived from the one DB baseline.
+    const writtenYaml = upsertEntityForGroup.mock.calls[0][3];
+    const parsed = loadYaml(writtenYaml) as { description?: string; dimensions?: Array<{ name?: string }> };
+    expect(parsed.description).toBe("Orders (eu_prod DB-backed)");
+    const dimNames = (parsed.dimensions ?? []).map((d) => d.name);
+    expect(dimNames).toContain("id");
+    expect(dimNames).toContain("region");
+  });
+
+  it("threads the resolved group through to the apply payload envelope", async () => {
+    await run();
+    // The persisted amendment carries the entity name; the apply targeted the
+    // resolved group (asserted via upsert above). The proposal is auto-applied,
+    // never left approved-but-unapplied.
+    const persisted = insertSemanticAmendment.mock.calls[0][0];
+    expect(persisted.sourceEntity).toBe("orders");
+    expect(persisted.amendmentPayload.amendment).toMatchObject({ name: "region" });
+    expect(revertAmendmentToPending).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
@@ -152,6 +152,15 @@ describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () =
     const writtenGroup = upsertEntityForGroup.mock.calls[0][4];
     expect(writtenGroup).toBe("eu_prod");
 
+    // Both the preview read AND the apply re-read (+ the refreshed post-upsert
+    // read) resolve the SAME scope — the "single shared resolver" contract. If
+    // the apply path scoped its read differently from the preview, the diff
+    // would no longer describe what apply wrote.
+    expect(getEntity.mock.calls.length).toBeGreaterThan(1);
+    for (const call of getEntity.mock.calls) {
+      expect(call[3]).toBe("eu_prod");
+    }
+
     // The YAML apply persisted parses to the SAME structural change the diff
     // previewed: the original `id` dimension plus the new `region` dimension,
     // both derived from the one DB baseline.

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-no-db.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-no-db.test.ts
@@ -1,0 +1,114 @@
+/**
+ * proposeAmendment without an internal DB (#4488): self-hosted preview reads the
+ * baseline from the flat disk root, and the DB-backed insert + auto-approve
+ * apply seam never runs. Covers the disk-read branch left uncovered when the
+ * DB-path tests swapped the `fs` mock for the `resolveAmendmentBaseline` stub —
+ * the found/parsed preview plus both error returns (missing file, malformed).
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+const entityYaml = [
+  "name: companies",
+  "description: Customer companies",
+  "dimensions:",
+  "  - name: id",
+  "    type: number",
+].join("\n");
+
+// Toggled per test so one file can exercise found / missing / malformed.
+let fileExists = true;
+let fileContents = entityYaml;
+
+void mock.module("fs", () => ({
+  existsSync: () => fileExists,
+  readFileSync: () => fileContents,
+}));
+
+// No internal DB → the insert/apply seam is skipped entirely; the resolver is
+// never called (stubbed only to satisfy mock-all-exports for the module graph).
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => false,
+  insertSemanticAmendment: mock(() => Promise.resolve({ id: "unused", status: "queued" })),
+  revertAmendmentToPending: mock(() => Promise.resolve(true)),
+}));
+
+const stubApplyAmendment = (entity: Record<string, unknown>): Record<string, unknown> => {
+  const clone = structuredClone(entity);
+  const dims = (clone.dimensions ?? []) as Record<string, unknown>[];
+  dims.push({ name: "region", type: "string" });
+  clone.dimensions = dims;
+  return clone;
+};
+
+void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
+  applyAmendment: stubApplyAmendment,
+  resolveAmendmentBaseline: mock(() => Promise.reject(new Error("should not be called without a DB"))),
+  applyAmendmentFromPayload: mock(() => Promise.resolve()),
+}));
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => null,
+}));
+
+void mock.module("@atlas/api/lib/semantic/files", () => ({
+  getSemanticRoot: () => "/semantic",
+}));
+
+void mock.module("@atlas/api/lib/tools/sql", () => ({
+  runUserQueryPipeline: mock(() =>
+    Promise.resolve({ kind: "ok", columns: [], rows: [], rowCount: 0, executionMs: 0, truncated: false }),
+  ),
+}));
+
+const { proposeAmendment } = await import("@atlas/api/lib/tools/propose-amendment");
+
+type ProposeResult = { proposalId?: string; status?: string; diff?: string; error?: string };
+
+async function run(): Promise<ProposeResult> {
+  return (await proposeAmendment.execute!(
+    {
+      entityName: "companies",
+      amendmentType: "add_dimension",
+      amendment: { name: "region", type: "string" },
+      rationale: "Add region",
+      confidence: 0.9,
+    },
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- AI SDK execute options are irrelevant here
+    {} as any,
+  )) as ProposeResult;
+}
+
+describe("proposeAmendment no-internal-DB disk fallback (#4488)", () => {
+  it("previews from the flat-root file and reports queued with a local id", async () => {
+    fileExists = true;
+    fileContents = entityYaml;
+
+    const result = await run();
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe("queued");
+    expect(result.proposalId).toMatch(/^local-/);
+    expect(result.diff).toContain("name: region");
+  });
+
+  it("returns 'Entity file not found' when the flat-root file is absent", async () => {
+    fileExists = false;
+
+    const result = await run();
+
+    expect(result.error).toContain("Entity file not found");
+    expect(result.status).toBeUndefined();
+  });
+
+  it("returns a parse error when the flat-root file is not a YAML mapping", async () => {
+    fileExists = true;
+    fileContents = "- just\n- a\n- list\n";
+
+    const result = await run();
+
+    expect(result.error).toContain("could not be parsed as a YAML mapping");
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
@@ -12,19 +12,15 @@ import type { AmendmentPayload } from "@useatlas/types";
 
 // --- Mocks (registered before importing the module under test) ---
 
-// A real on-disk entity YAML so the tool reaches the test-query stage.
-const entityYaml = [
-  "name: companies",
-  "description: Customer companies",
-  "dimensions:",
-  "  - name: id",
-  "    type: number",
-].join("\n");
-
-void mock.module("fs", () => ({
-  existsSync: () => true,
-  readFileSync: () => entityYaml,
-}));
+// Parsed entity baseline the DB-backed resolver returns (#4488). With an
+// internal DB present the tool resolves the baseline through
+// `resolveAmendmentBaseline`, NOT the flat disk root — so the test stubs that
+// resolver rather than `fs`.
+const companiesEntity: Record<string, unknown> = {
+  name: "companies",
+  description: "Customer companies",
+  dimensions: [{ name: "id", type: "number" }],
+};
 
 const mockInsertSemanticAmendment: Mock<
   (args: Record<string, unknown>) => Promise<{ id: string; status: string }>
@@ -47,8 +43,38 @@ const mockApplyAmendmentFromPayload: Mock<(args: Record<string, unknown>) => Pro
   () => Promise.resolve(),
 );
 
+// The baseline resolver (#4488): the tool reads the current entity through the
+// SAME org/group-aware DB read the apply path uses. Returns the default-scope
+// (NULL group) companies row here.
+const mockResolveAmendmentBaseline: Mock<
+  (
+    orgId: string | null,
+    entityName: string,
+    group: string | undefined,
+  ) => Promise<{ row: Record<string, unknown>; targetGroupId: string | null; parsed: Record<string, unknown> }>
+> = mock(() =>
+  Promise.resolve({
+    row: { id: "companies-row", connection_group_id: null },
+    targetGroupId: null,
+    parsed: structuredClone(companiesEntity),
+  }),
+);
+
+// The authoritative mutation (#4488): the tool applies the amendment through
+// the shared `applyAmendment`, not a divergent local copy. Stubbed to a minimal
+// add_dimension so the tool has a non-trivial "after" to diff/serialize.
+function stubApplyAmendment(entity: Record<string, unknown>): Record<string, unknown> {
+  const clone = structuredClone(entity);
+  const dims = (clone.dimensions ?? []) as Record<string, unknown>[];
+  dims.push({ name: "region", type: "string", description: "Region" });
+  clone.dimensions = dims;
+  return clone;
+}
+
 void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
   applyAmendmentFromPayload: mockApplyAmendmentFromPayload,
+  resolveAmendmentBaseline: mockResolveAmendmentBaseline,
+  applyAmendment: stubApplyAmendment,
 }));
 
 void mock.module("@atlas/api/lib/logger", () => ({

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -297,7 +297,12 @@ The amendment object should match the YAML structure for that type (e.g., { name
       };
     } catch (err) {
       log.warn(
-        { err: err instanceof Error ? err.message : String(err), entityName, amendmentType },
+        {
+          err: err instanceof Error ? err.message : String(err),
+          entityName,
+          amendmentType,
+          requestId: getRequestContext()?.requestId,
+        },
         "proposeAmendment failed",
       );
       return {

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -15,73 +15,11 @@ import { createTwoFilesPatch } from "diff";
 import { hasInternalDB, insertSemanticAmendment } from "@atlas/api/lib/db/internal";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { runUserQueryPipeline } from "@atlas/api/lib/tools/sql";
-import type { AmendmentPayload, AmendmentType } from "@useatlas/types";
+import type { AmendmentPayload } from "@useatlas/types";
+import type { AnalysisResult } from "@atlas/api/lib/semantic/expert/types";
 import { getSemanticRoot } from "@atlas/api/lib/semantic/files";
 
 const log = createLogger("tool:propose-amendment");
-
-/** Apply an amendment to a parsed entity object and return the updated object. */
-function applyAmendment(
-  entity: Record<string, unknown>,
-  amendmentType: AmendmentType,
-  amendment: Record<string, unknown>,
-): Record<string, unknown> {
-  const updated = structuredClone(entity);
-
-  switch (amendmentType) {
-    case "add_dimension": {
-      const dims = (updated.dimensions ?? []) as Record<string, unknown>[];
-      dims.push(amendment);
-      updated.dimensions = dims;
-      break;
-    }
-    case "add_measure": {
-      const measures = (updated.measures ?? []) as Record<string, unknown>[];
-      measures.push(amendment);
-      updated.measures = measures;
-      break;
-    }
-    case "add_join": {
-      const joins = (updated.joins ?? []) as Record<string, unknown>[];
-      joins.push(amendment);
-      updated.joins = joins;
-      break;
-    }
-    case "add_query_pattern": {
-      const patterns = (updated.query_patterns ?? []) as Record<string, unknown>[];
-      patterns.push(amendment);
-      updated.query_patterns = patterns;
-      break;
-    }
-    case "update_description": {
-      if (amendment.field === "table") {
-        updated.description = amendment.description;
-      } else if (amendment.dimension) {
-        const dims = (updated.dimensions ?? []) as Record<string, unknown>[];
-        const target = dims.find((d) => d.name === amendment.dimension);
-        if (target) target.description = amendment.description;
-      }
-      break;
-    }
-    case "update_dimension": {
-      const dims = (updated.dimensions ?? []) as Record<string, unknown>[];
-      const target = dims.find((d) => d.name === amendment.name);
-      if (target) Object.assign(target, amendment);
-      break;
-    }
-    case "add_virtual_dimension": {
-      const dims = (updated.dimensions ?? []) as Record<string, unknown>[];
-      dims.push({ ...amendment, virtual: true });
-      updated.dimensions = dims;
-      break;
-    }
-    case "add_glossary_term":
-      // Glossary amendments don't modify entity files — handled separately
-      break;
-  }
-
-  return updated;
-}
 
 export const proposeAmendment = tool({
   description: `Propose a semantic layer YAML change. Generates a unified diff and writes to the review queue.
@@ -128,35 +66,74 @@ The amendment object should match the YAML structure for that type (e.g., { name
     confidence,
   }) => {
     try {
-      // Load current entity YAML
-      const entityPath = path.join(
-        getSemanticRoot(),
-        "entities",
-        `${entityName}.yml`,
-      );
+      // Content scope for this turn: the org + Connection group the request
+      // resolves entities against (#2345). Threaded into the baseline read so
+      // the diff is computed against the SAME document approval will mutate.
+      const orgId = getRequestContext()?.user?.activeOrganizationId ?? null;
+      const connectionGroupId = getRequestContext()?.connectionGroupId;
 
-      let beforeYaml: string;
+      // Load the current entity baseline.
+      //
+      // When an internal DB is present (SaaS + self-hosted-with-DB), entities
+      // live in `semantic_entities` — org entities and group entities are
+      // ABSENT from the flat disk root (ADR-0012). Read them through the SAME
+      // org/group-aware resolver the apply path uses, so the diff the admin
+      // reviews describes exactly what approval writes (#4488). The resolved
+      // `targetGroupId` is the row's OWN group — threaded into the auto-approve
+      // apply below so the write lands in the scope the diff was computed from.
       let entity: Record<string, unknown>;
+      let applyGroupId: string | null = null;
 
-      if (fs.existsSync(entityPath)) {
-        beforeYaml = fs.readFileSync(entityPath, "utf-8");
+      if (hasInternalDB()) {
+        const { resolveAmendmentBaseline } = await import(
+          "@atlas/api/lib/semantic/expert/apply"
+        );
+        const baseline = await resolveAmendmentBaseline(
+          orgId,
+          entityName,
+          connectionGroupId,
+        );
+        entity = baseline.parsed;
+        applyGroupId = baseline.targetGroupId;
+      } else {
+        // No internal DB (self-hosted preview only): entities live on disk in
+        // the flat root and the apply path never runs (the DB-backed insert +
+        // apply seam below is skipped), so there is no diff-vs-apply scope to
+        // reconcile. Read the flat-root mirror for the preview.
+        const entityPath = path.join(getSemanticRoot(), "entities", `${entityName}.yml`);
+        if (!fs.existsSync(entityPath)) {
+          return {
+            error: `Entity file not found: ${entityPath}. Check that the entity name matches a YAML file in the semantic layer.`,
+          };
+        }
         // `loadYaml` returns undefined for an empty file (v5 would throw),
         // routing it into the tailored "empty or malformed" error below.
-        const raw = loadYaml(beforeYaml);
+        const raw = loadYaml(fs.readFileSync(entityPath, "utf-8"));
         if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
           return {
             error: `Entity file ${entityName}.yml could not be parsed as a YAML mapping. The file may be empty or malformed.`,
           };
         }
         entity = raw as Record<string, unknown>;
-      } else {
-        return {
-          error: `Entity file not found: ${entityPath}. Check that the entity name matches a YAML file in the semantic layer.`,
-        };
       }
 
-      // Apply amendment
-      const updated = applyAmendment(entity, amendmentType, amendment);
+      // Apply the amendment through the SAME authoritative mutation the apply
+      // path uses (upsertByIdentity, throw-on-missing-target) — no divergent
+      // local copy that could preview a clean append where apply replaces, or
+      // "no change" where apply errors (#4488).
+      const { applyAmendment } = await import("@atlas/api/lib/semantic/expert/apply");
+      const updated = applyAmendment(entity, {
+        category: "coverage_gaps",
+        entityName,
+        group: connectionGroupId ?? "default",
+        amendmentType,
+        amendment,
+        rationale,
+        impact: 0,
+        confidence,
+        staleness: 0,
+        score: 0,
+      } satisfies AnalysisResult);
 
       // Normalize both sides through yaml.dump() with identical options so
       // the diff only shows actual content changes, not formatting drift
@@ -231,7 +208,6 @@ The amendment object should match the YAML structure for that type (e.g., { name
       let status: "queued" | "auto_approved";
 
       if (hasInternalDB()) {
-        const orgId = getRequestContext()?.user?.activeOrganizationId ?? null;
         const result = await insertSemanticAmendment({
           orgId,
           description: `[${amendmentType}] ${entityName}: ${rationale}`,
@@ -262,9 +238,11 @@ The amendment object should match the YAML structure for that type (e.g., { name
             await applyAmendmentFromPayload({
               orgId,
               sourceEntity: entityName,
-              // Interactive proposals read the flat semantic root, so the
-              // default (NULL) Connection group is the correct apply scope.
-              connectionGroupId: null,
+              // Thread the SAME group the baseline was resolved from (the
+              // resolved row's own `connection_group_id`) so approval writes
+              // the scope the diff was computed against — never the flat/NULL
+              // default for an org/group-scoped entity (#4488).
+              connectionGroupId: applyGroupId,
               // `rawPayload` is typed `unknown`, so the AmendmentPayload passes
               // through directly (matches the admin approve call sites).
               rawPayload: payload,


### PR DESCRIPTION
## Summary
- `proposeAmendment` loaded its entity baseline from the flat disk root (`getSemanticRoot()/entities/<name>.yml`), so org/group-scoped entities — which live in `semantic_entities` with a mirror under `groups/<group>/` or `.orgs/<org>/` (ADR-0012) — either errored "Entity file not found" or the tool diffed a stale flat-root doc while approval mutated the org's DB row. The reviewed diff was not guaranteed to describe what approval applied.
- Extracted `resolveAmendmentBaseline` in `semantic/expert/apply.ts` (scoped lookup → unscoped fallback → parse), now the **single resolver** both the diff preview and the apply write go through — identical org/group scoping on both, so the scope can no longer diverge.
- `proposeAmendment` reads the baseline via `resolveAmendmentBaseline` when an internal DB is present, threading `orgId` + connection group; the resolved row's **own** group is threaded into the auto-approve apply so the write lands in the scope the diff was computed from.
- Dropped the tool's divergent local `applyAmendment` copy (blind `push` → duplicates, silent-skip on missing update target) in favor of the authoritative `expert/apply.applyAmendment` (`upsertByIdentity`, throw-on-missing-target).
- No-internal-DB self-hosted preview keeps the flat-root disk read (the DB-backed insert + apply seam never runs there, so there is no diff-vs-apply scope to reconcile).

## Acceptance criteria
- [x] `proposeAmendment` resolves the baseline through the same org/group-aware read the apply path uses, threading orgId + connection group
- [x] Diff and apply agree — previewed diff for a group-scoped entity matches what approval writes (covered by `propose-amendment-group-scope.test.ts`, which drives the real apply path)
- [x] "Entity file not found" no longer occurs for entities visible in the workspace's semantic layer

## Test plan
- [x] `resolve-amendment-baseline.test.ts` — resolver branches: scoped hit, scoped-miss → unscoped fallback, not-found throw, malformed-YAML throw, `AmbiguousEntityError` propagation
- [x] `propose-amendment-group-scope.test.ts` — integration: group-scoped baseline read from DB, diff == apply, apply writes the entity's own group scope
- [x] `propose-amendment-no-db.test.ts` — no-internal-DB flat-root fallback: found preview, missing-file error, malformed-YAML error
- [x] Existing `propose-amendment.test.ts` / `apply*.test.ts` updated and green
- [x] Local `/ci` — all 29 gates pass (incl. full isolated test suite)

Internal review panel: silent-failure, type-design, comment-analyzer, pr-test — all CLEAN (2 rounds; round-1 pr-test coverage findings addressed).

Closes #4488

https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY)_