### PR TITLE
fix(semantic): scope NULL-org amendments to self-hosted; boot-guard scheduler off on SaaS (#4487)

### DIFF
--- a/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
+++ b/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the SaaS scoping of the three semantic-amendment queries
+ * (#4487): `getPendingAmendmentCount`, `getPendingAmendments`, and
+ * `reviewSemanticAmendment`.
+ *
+ * Security invariant: NULL-org ("global scope") amendment rows are the
+ * intended shared scope on self-hosted, but on SaaS they must NEVER surface
+ * in — or be reviewable from — any tenant workspace. These tests assert the
+ * SQL shape flips with deploy mode:
+ *   - self-hosted (or unloaded config): `(org_id = $1 OR org_id IS NULL)`
+ *   - saas:                              `org_id = $1` only, and the org-less
+ *                                        path is refused before any query.
+ *
+ * Deploy mode is resolved through `isSaasModeForGuard()` (fail-closed), which
+ * reads the cached config — we drive it here via `_setConfigForTest`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+
+// `hasInternalDB()` reads DATABASE_URL at call time; set it before the module
+// under test is imported so the query paths (not the no-DB short-circuits) run.
+process.env.DATABASE_URL ??= "postgresql://test:test@localhost:5432/atlas_test";
+
+import {
+  getPendingAmendmentCount,
+  getPendingAmendments,
+  reviewSemanticAmendment,
+  _resetPool,
+  _resetCircuitBreaker,
+} from "../internal";
+import type { ResolvedConfig } from "../../config";
+import { _setConfigForTest, _resetConfig } from "../../config";
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+}
+
+let captured: Captured[] = [];
+
+function makeStubPool() {
+  return {
+    query: async (sql: string, params?: unknown[]) => {
+      captured.push({ sql, params: params ?? [] });
+      // reviewSemanticAmendment reads rows[0]; return an empty result set.
+      return { rows: [] };
+    },
+    async end() {},
+    async connect() {
+      return { query: async () => ({ rows: [] }), release() {} };
+    },
+    on() {},
+  };
+}
+
+/** Fully-typed `ResolvedConfig` so a `deployMode` typo can't compile silently. */
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
+/** Drive `isSaasModeForGuard()` by seeding the cached deploy mode. */
+function setDeployMode(mode: "saas" | "self-hosted") {
+  _setConfigForTest(configWithDeployMode(mode));
+}
+
+beforeEach(() => {
+  captured = [];
+  _resetCircuitBreaker();
+  _resetPool(makeStubPool() as unknown as Parameters<typeof _resetPool>[0], null);
+});
+
+afterEach(() => {
+  _resetConfig();
+});
+
+afterAll(() => {
+  _resetPool(null, null);
+  _resetConfig();
+  _resetCircuitBreaker();
+  mock.restore();
+});
+
+describe("semantic amendment queries — self-hosted scoping (unchanged)", () => {
+  it("getPendingAmendmentCount includes the OR org_id IS NULL arm for an org", async () => {
+    setDeployMode("self-hosted");
+    await getPendingAmendmentCount("org-a");
+
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    expect(sql).toContain("(org_id = $1 OR org_id IS NULL)");
+    expect(params).toEqual(["org-a"]);
+  });
+
+  it("getPendingAmendments includes the OR org_id IS NULL arm for an org", async () => {
+    setDeployMode("self-hosted");
+    await getPendingAmendments("org-a");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("(org_id = $1 OR org_id IS NULL)");
+  });
+
+  it("reviewSemanticAmendment includes the OR org_id IS NULL arm for an org", async () => {
+    setDeployMode("self-hosted");
+    await reviewSemanticAmendment("amd-1", "org-a", "approved", "admin");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("(org_id = $4 OR org_id IS NULL)");
+  });
+
+  it("null-org (global admin) path still targets org_id IS NULL rows", async () => {
+    setDeployMode("self-hosted");
+    await getPendingAmendments(null);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("org_id IS NULL");
+  });
+});
+
+describe("semantic amendment queries — SaaS scoping (#4487)", () => {
+  it("getPendingAmendmentCount drops the OR org_id IS NULL arm for a workspace", async () => {
+    setDeployMode("saas");
+    await getPendingAmendmentCount("org-a");
+
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    expect(sql).toContain("org_id = $1");
+    expect(sql).not.toContain("org_id IS NULL");
+    expect(params).toEqual(["org-a"]);
+  });
+
+  it("getPendingAmendments drops the OR org_id IS NULL arm for a workspace", async () => {
+    setDeployMode("saas");
+    await getPendingAmendments("org-a");
+
+    expect(captured).toHaveLength(1);
+    const { sql } = captured[0]!;
+    expect(sql).toContain("org_id = $1");
+    expect(sql).not.toContain("org_id IS NULL");
+  });
+
+  it("reviewSemanticAmendment drops the OR org_id IS NULL arm for a workspace", async () => {
+    setDeployMode("saas");
+    await reviewSemanticAmendment("amd-1", "org-a", "approved", "admin");
+
+    expect(captured).toHaveLength(1);
+    const { sql } = captured[0]!;
+    expect(sql).toContain("org_id = $4");
+    expect(sql).not.toContain("org_id IS NULL");
+  });
+
+  it("refuses the org-less path without touching the DB (count → 0)", async () => {
+    setDeployMode("saas");
+    const count = await getPendingAmendmentCount(null);
+
+    expect(count).toBe(0);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("refuses the org-less path without touching the DB (list → [])", async () => {
+    setDeployMode("saas");
+    const rows = await getPendingAmendments(null);
+
+    expect(rows).toEqual([]);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("refuses the org-less path without touching the DB (review → null)", async () => {
+    setDeployMode("saas");
+    const reviewed = await reviewSemanticAmendment("amd-1", null, "approved", "admin");
+
+    expect(reviewed).toBeNull();
+    expect(captured).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1495,6 +1495,27 @@ function requireGetSetting(): (key: string, orgId?: string) => string | undefine
 }
 
 /**
+ * Lazily resolve `isSaasModeForGuard` from the settings module — same
+ * circular-import avoidance as `requireGetSetting` (settings.ts statically
+ * imports db/internal.ts).
+ *
+ * `isSaasModeForGuard()` is the guard-oriented, fail-CLOSED SaaS probe:
+ * `saas` → true, `errored` → true (assume SaaS), `self-hosted`/`unloaded`
+ * → false. The amendment read/review functions below (#4487) use it to
+ * drop the `OR org_id IS NULL` arm on SaaS so a NULL-org ("global scope")
+ * row can never surface in — or be reviewed by — any tenant workspace.
+ * Fail-closed is the secure direction here: if config resolution is
+ * uncertain, we withhold the global rows rather than leak them.
+ */
+function requireIsSaasModeForGuard(): () => boolean {
+  // oxlint-disable-next-line @typescript-eslint/no-require-imports -- lazy import avoids circular dependency (settings.ts imports db/internal.ts)
+  const { isSaasModeForGuard } = require("@atlas/api/lib/settings") as {
+    isSaasModeForGuard: () => boolean;
+  };
+  return isSaasModeForGuard;
+}
+
+/**
  * Parse the auto-approve threshold. Returns a value > 1 (disabled) if not
  * set or invalid. Single source of truth for the threshold logic.
  *
@@ -1654,11 +1675,17 @@ export async function revertAmendmentToPending(id: string): Promise<boolean> {
 export async function getPendingAmendmentCount(orgId: string | null): Promise<number> {
   if (!hasInternalDB()) return 0;
 
+  const saas = requireIsSaasModeForGuard()();
+  // SaaS: NULL-org ("global scope") rows must never surface in any workspace
+  // (#4487). Refuse the org-less path outright, and below drop the
+  // `OR org_id IS NULL` arm so a workspace only ever counts its own rows.
+  if (saas && !orgId) return 0;
+
   const rows = await internalQuery<{ count: string }>(
     orgId
       ? `SELECT COUNT(*)::text AS count FROM learned_patterns
          WHERE type = 'semantic_amendment' AND status = 'pending'
-         AND (org_id = $1 OR org_id IS NULL)`
+         AND ${saas ? "org_id = $1" : "(org_id = $1 OR org_id IS NULL)"}`
       : `SELECT COUNT(*)::text AS count FROM learned_patterns
          WHERE type = 'semantic_amendment' AND status = 'pending'
          AND org_id IS NULL`,
@@ -1691,12 +1718,17 @@ export type PendingAmendmentRow = Record<string, unknown> & {
 export async function getPendingAmendments(orgId: string | null): Promise<PendingAmendmentRow[]> {
   if (!hasInternalDB()) return [];
 
+  const saas = requireIsSaasModeForGuard()();
+  // SaaS: withhold NULL-org rows from every workspace (#4487) — refuse the
+  // org-less path and drop the `OR org_id IS NULL` arm below.
+  if (saas && !orgId) return [];
+
   return internalQuery<PendingAmendmentRow>(
     orgId
       ? `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
          FROM learned_patterns
          WHERE type = 'semantic_amendment' AND status = 'pending'
-         AND (org_id = $1 OR org_id IS NULL)
+         AND ${saas ? "org_id = $1" : "(org_id = $1 OR org_id IS NULL)"}
          ORDER BY created_at DESC`
       : `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
          FROM learned_patterns
@@ -1729,12 +1761,18 @@ export async function reviewSemanticAmendment(
     throw new Error("Internal database is not configured. Amendment review requires DATABASE_URL.");
   }
 
+  const saas = requireIsSaasModeForGuard()();
+  // SaaS: a NULL-org row is unreviewable from any workspace (#4487). Refuse
+  // the org-less path (returns null → 404 at the route) and drop the
+  // `OR org_id IS NULL` arm so no tenant admin can approve/reject a global row.
+  if (saas && !orgId) return null;
+
   const rows = await internalQuery<ReviewedAmendmentRow>(
     orgId
       ? `UPDATE learned_patterns
          SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
          WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
-         AND (org_id = $4 OR org_id IS NULL)
+         AND ${saas ? "org_id = $4" : "(org_id = $4 OR org_id IS NULL)"}
          RETURNING id, source_entity, amendment_payload`
       : `UPDATE learned_patterns
          SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -70,6 +70,9 @@ void mock.module("@atlas/api/lib/logger", () => ({
 
 void mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
+  // scheduler.ts now reads this to force-disable on SaaS (#4487); the tick
+  // tests exercise the self-hosted path, so keep it false (not SaaS).
+  isSaasModeForGuard: () => false,
 }));
 
 const { runExpertSchedulerTick } = await import("../scheduler");

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
@@ -5,6 +5,8 @@ import {
   DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS,
 } from "../scheduler";
 import { loadSettings, _resetSettingsCache } from "@atlas/api/lib/settings";
+import type { ResolvedConfig } from "@atlas/api/lib/config";
+import { _setConfigForTest, _resetConfig } from "@atlas/api/lib/config";
 
 // Mock internal DB. `dbAvailable` / `settingsRows` are mutable so the
 // #3392 tests below can seed the settings cache via loadSettings() (the
@@ -67,6 +69,49 @@ describe("isExpertSchedulerEnabled", () => {
   it("returns false for other values", () => {
     process.env.ATLAS_EXPERT_SCHEDULER_ENABLED = "yes";
     expect(isExpertSchedulerEnabled()).toBe(false);
+  });
+});
+
+// #4487 — the scheduler inserts NULL-org ("global scope") amendment rows,
+// which are only sound on self-hosted. In `saas` deploy mode the scheduler is
+// force-disabled regardless of the setting, so it can never produce global
+// rows that would leak into every workspace's pending list.
+describe("isExpertSchedulerEnabled — SaaS boot-guard (#4487)", () => {
+  // Fully-typed `ResolvedConfig` so a `deployMode` typo can't compile silently.
+  function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+    return {
+      datasources: {},
+      tools: ["explore", "executeSQL"],
+      auth: "managed",
+      semanticLayer: "./semantic",
+      maxTotalConnections: 100,
+      source: "file",
+      deployMode,
+    };
+  }
+
+  beforeEach(() => {
+    process.env.ATLAS_EXPERT_SCHEDULER_ENABLED = "true";
+  });
+
+  afterEach(() => {
+    delete process.env.ATLAS_EXPERT_SCHEDULER_ENABLED;
+    _resetConfig();
+  });
+
+  it("returns false in saas deploy mode even when the setting is enabled", () => {
+    _setConfigForTest(configWithDeployMode("saas"));
+    expect(isExpertSchedulerEnabled()).toBe(false);
+  });
+
+  it("returns true in self-hosted deploy mode when the setting is enabled", () => {
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+    expect(isExpertSchedulerEnabled()).toBe(true);
+  });
+
+  it("returns true when config is unloaded (self-hosted default) and the setting is enabled", () => {
+    _resetConfig();
+    expect(isExpertSchedulerEnabled()).toBe(true);
   });
 });
 

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { getSetting } from "@atlas/api/lib/settings";
+import { getSetting, isSaasModeForGuard } from "@atlas/api/lib/settings";
 
 const log = createLogger("semantic-expert-scheduler");
 
@@ -32,8 +32,17 @@ export interface ExpertTickResult {
  * default). Consumed once at boot — changes require a restart
  * (`requiresRestart` in the registry); the scheduler layer sequences
  * after `loadSettings()` so the DB override is visible here.
+ *
+ * SaaS boot-guard (#4487): the scheduler's proposals are inserted with
+ * `orgId: null` ("global scope for self-hosted"). A NULL-org row is only
+ * sound on self-hosted; on SaaS it is the leak vector — no workspace should
+ * ever produce global amendment rows. So the scheduler is force-disabled in
+ * `saas` deploy mode regardless of the setting. Fail-CLOSED
+ * (`isSaasModeForGuard` treats `errored` as SaaS) is the safe direction:
+ * if we cannot confirm we're self-hosted, do not produce global rows.
  */
 export function isExpertSchedulerEnabled(): boolean {
+  if (isSaasModeForGuard()) return false;
   const v = getSetting("ATLAS_EXPERT_SCHEDULER_ENABLED");
   return v === "true" || v === "1";
 }


### PR DESCRIPTION
## Summary

Closes #4487.

The three semantic-amendment queries (`getPendingAmendmentCount`, `getPendingAmendments`, `reviewSemanticAmendment`) matched `(org_id = $1 OR org_id IS NULL)`, and the expert scheduler inserted NULL-org "global scope" rows unconditionally. On SaaS this **fails open**: a NULL-org row surfaces in — and is reviewable from — *every* workspace's pending list and sidebar badge (leaking entity names, rationales, and `testResult.sampleRows`), the first reviewer consumes it for all tenants, and an approval applies YAML under the reviewing org's scope. Latent today (the scheduler setting defaults off) but nothing structural prevents it.

This change makes the scoping fail **closed** on SaaS while leaving self-hosted behavior untouched:

- **`db/internal.ts`** — lazily resolve the guard-oriented `isSaasModeForGuard()` probe (mirroring the existing `requireGetSetting` circular-import avoidance). On SaaS, refuse the org-less path before any query (`count → 0`, `list → []`, `review → null → 404`) and drop the `OR org_id IS NULL` arm so a workspace only ever sees its own rows. Bound params are unchanged; the interpolated fragment is a hardcoded literal chosen by a boolean, not user input.
- **`semantic/expert/scheduler.ts`** — force-disable the expert scheduler in `saas` deploy mode regardless of the setting, so no NULL-org rows are ever produced.
- Fail-closed direction: `errored` config resolution is treated as SaaS (withhold the global rows rather than leak them).

Acceptance criteria — all met: (1) on `saas`, NULL-org rows are neither counted, listed, nor reviewable from any workspace; (2) the scheduler does not run on `saas`; (3) self-hosted behavior unchanged; (4) tests pin the SaaS-mode scoping.

## Test Plan

- [ ] Manual testing
- [x] Unit tests added/updated

New `db/__tests__/semantic-amendment-saas-scoping.test.ts` pins the SQL-arm flip and the org-less refusal-*before-DB* (`captured.toHaveLength(0)`) for all three functions across deploy modes; `scheduler.test.ts` gains a SaaS boot-guard block (saas → disabled, self-hosted → enabled, unloaded → self-hosted default). Both new test files use a fully-typed `configWithDeployMode` factory rather than an `as unknown as ResolvedConfig` cast. Affected suites: 25 pass / 0 fail.

## Checklist

- [x] Types pass (via affected tests + type-clean per review)
- [x] Tests pass (affected suites green; full suite via CI)
- [x] Lint passes (`oxlint-disable` justified on the lazy require, mirroring the sibling helper)
- [ ] Deps consistent — no dependency changes
- [x] Labels added (type + area) — inherits `bug`, `area: api`, `security` from the issue
- [ ] CHANGELOG.md updated — internal security hardening of a latent path; not surfaced to end users

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDrVdoyYpDPPXksrpHFbQY)_