### PR TITLE
fix(web): render auto-approved chat proposals as applied, not approvable (#4499)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
@@ -256,6 +256,10 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
     // Apply succeeded → the row legitimately stays approved; no revert.
     expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
     expect(result.status).toBe("auto_approved");
+    // Pin the wire contract the web relies on (#4499): an auto_approved result
+    // still carries the row id — `extractProposals` drops results without a
+    // `proposalId`, so losing it would silently hide the applied card.
+    expect(result.proposalId).toBe("prop-approved");
   });
 
   it("reverts the row to pending and reports queued when the auto-approve apply fails", async () => {

--- a/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
@@ -107,6 +107,36 @@ describe("extractProposals", () => {
     expect(extractProposals([userMsg, otherTool])).toEqual([]);
   });
 
+  // #4499 — a card must not offer a decision the server cannot accept. An
+  // `auto_approved` result was already applied in-flow (its `learned_patterns`
+  // row is `approved`), so `/amendments/{id}/review` — which claims
+  // `WHERE status='pending'` — would 404 on it.
+  it("renders an auto_approved result as already applied (no review actions)", () => {
+    const proposals = extractProposals([
+      assistantWithTool(baseInput, { proposalId: "amd-1", status: "auto_approved" }),
+    ]);
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({ dbId: "amd-1", decision: "applied" });
+  });
+
+  it("renders a queued result as approvable (decision null)", () => {
+    const proposals = extractProposals([
+      assistantWithTool(baseInput, { proposalId: "amd-1", status: "queued" }),
+    ]);
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({ dbId: "amd-1", decision: null });
+  });
+
+  it("renders a result with no status field as approvable (decision null)", () => {
+    const proposals = extractProposals([
+      assistantWithTool(baseInput, { proposalId: "amd-1" }),
+    ]);
+
+    expect(proposals[0]?.decision).toBeNull();
+  });
+
   it("preserves a valid testResult and drops a malformed one", () => {
     const good = extractProposals([
       assistantWithTool(baseInput, {

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -121,10 +121,15 @@ function ProposalCard({
             </span>
             {decided && (
               <Badge
-                variant={proposal.decision === "accepted" ? "default" : "secondary"}
+                variant={
+                  proposal.decision === "accepted" || proposal.decision === "applied"
+                    ? "default"
+                    : "secondary"
+                }
                 className="text-[10px]"
               >
-                {proposal.decision}
+                {/* "applied" = auto-approved in-flow, already live (#4499) */}
+                {proposal.decision === "applied" ? "auto-approved" : proposal.decision}
               </Badge>
             )}
           </div>

--- a/packages/web/src/app/admin/semantic/improve/proposals.ts
+++ b/packages/web/src/app/admin/semantic/improve/proposals.ts
@@ -31,7 +31,13 @@ export interface Proposal {
   confidence: number;
   impact?: number;
   score?: number;
-  decision: "accepted" | "rejected" | "skipped" | null;
+  /**
+   * `null` = awaiting review (Approve/Reject shown). `accepted`/`rejected` =
+   * decided by the admin in this session. `applied` = the tool auto-approved
+   * and applied the amendment in-flow (#4499) — already live, nothing to
+   * review. `skipped` is reserved (legacy in-memory flow).
+   */
+  decision: "accepted" | "rejected" | "skipped" | "applied" | null;
   /**
    * The proposal's `learned_patterns` row id — the key every review routes on.
    * Set for every rendered proposal: chat-streamed cards derive it from the
@@ -55,6 +61,12 @@ export interface Proposal {
  * bad/missing entity file, or a persist error — so no row exists) has no
  * `proposalId`, and an in-flight call has no result yet; both lack a `dbId` and
  * are skipped so no unapprovable card is rendered.
+ *
+ * A result with `status: "auto_approved"` was already applied in-flow — its
+ * `learned_patterns` row is `approved`, so `/amendments/{id}/review` (which
+ * claims `WHERE status='pending'`) would 404 on it. It surfaces as
+ * `decision: "applied"` — a decided card with no review actions (#4499).
+ * `status: "queued"` (or a legacy result with no status) stays approvable.
  */
 export function extractProposals(messages: UIMessage[]): Proposal[] {
   const proposals: Proposal[] = [];
@@ -92,7 +104,7 @@ export function extractProposals(messages: UIMessage[]): Proposal[] {
             confidence: Number(args.confidence ?? 0.5),
             impact: Number(args.impact ?? 0.5),
             score: Number(args.score ?? 0.5),
-            decision: null,
+            decision: result?.status === "auto_approved" ? "applied" : null,
             dbId,
           });
         }


### PR DESCRIPTION
Closes #4499

## What

Since #4486, a `proposeAmendment` result with `status: "auto_approved"` has already been applied in-flow and its `learned_patterns` row is `approved`. But `extractProposals` never read `result.status` and set `decision: null` unconditionally, so the auto-approved proposal rendered as an approvable card whose Approve/Reject POST to `/amendments/{id}/review` — a claim on `WHERE status='pending'` — always 404s ("not found or already reviewed") on an amendment that is in fact live.

Invariant (same spirit as #4484's "no `dbId` ⇒ no card"): **a card must not offer a decision the server cannot accept.**

## How

- `packages/web/src/app/admin/semantic/improve/proposals.ts` — `Proposal.decision` union gains `"applied"`; `extractProposals` maps `result.status === "auto_approved"` → `decision: "applied"`. `"queued"` (auto-approve apply failed, row reverted to pending) and legacy results with no status stay `null` (approvable).
- `packages/web/src/app/admin/semantic/improve/page.tsx` — `"applied"` renders as a decided card: default-variant badge labeled "auto-approved", no Approve/Reject (the existing `decided` gate hides them). Pending count (`decision === null`) excludes applied cards for free.
- `packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts` — pins all three: `auto_approved` → applied/no actions, `queued` → approvable, absent status → approvable.
- `packages/api/src/lib/tools/__tests__/propose-amendment.test.ts` — panel advisory: pins that an `auto_approved` result still carries `proposalId` (the web drops results without one, so losing it would silently hide the applied card).

Out of scope per the issue: fabricated `0.5` impact/score defaults, markdown/tool-state/billing-error presentation parity (elevation-grill territory, audit M6/Q10).

## Review panel (pre-PR, 1 round — CLEAN)

- silent-failure-hunter: clean; 1 LOW advisory (unknown future status falls back to approvable — fail-closed server-side, surfaced via `MutationErrorSurface`)
- type-design-analyzer: no CRITICAL/HIGH; MEDIUM advisory on the hand-duplicated `"auto_approved"` literal (no wire-type SSOT — follow-up candidate for `@useatlas/types`), LOWs on the dead `"skipped"` member + non-exhaustive badge map
- pr-test-analyzer: clean; MEDIUM advisory addressed (API-side `proposalId` pin)
- comment-analyzer: clean; all load-bearing comment claims verified against `internal.ts:1774` and `propose-amendment.ts:221-286`

## CI

`scripts/ci-local.sh`: all 29 gates PASS (type, lint, lint-type-aware, drift gates, full test suite).

https://claude.ai/code/session_019Nguc1bp5AtvWDcdXPboDF

---
_Generated by [Claude Code](https://claude.ai/code/session_019Nguc1bp5AtvWDcdXPboDF)_