### PR TITLE
fix(semantic): persist the resolved applyGroupId on interactive proposeAmendment rows (#4498)

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -258,7 +258,12 @@ describe("admin-semantic-improve", () => {
     });
 
     it("approves a proposal: applies the YAML then flips the same row to approved (one identity)", async () => {
-      mockPendingAmendments = [row("amd-1")];
+      // Group-scoped row: the route must thread the STORED row's
+      // `connection_group_id` into the apply (#4498) — an interactive
+      // proposeAmendment row persists the group its baseline was resolved
+      // from, and dropping it here would send the apply through the
+      // default-scope → unscoped-fallback path (409 on ambiguous names).
+      mockPendingAmendments = [{ ...row("amd-1"), connection_group_id: "eu_prod" }];
 
       const res = await adminSemanticImprove.request("/amendments/amd-1/review", {
         method: "POST",
@@ -270,9 +275,14 @@ describe("admin-semantic-improve", () => {
       const body = (await res.json()) as { ok: boolean; id: string; decision: string };
       expect(body).toEqual({ ok: true, id: "amd-1", decision: "approved" });
 
-      // YAML applied from the row's payload before the status flip.
+      // YAML applied from the row's payload before the status flip — scoped to
+      // the row's own Connection group, never NULL for a group-scoped row.
       expect(applyPayloadCalls).toHaveLength(1);
-      expect(applyPayloadCalls[0]).toMatchObject({ sourceEntity: "orders", label: "amd-1" });
+      expect(applyPayloadCalls[0]).toMatchObject({
+        sourceEntity: "orders",
+        label: "amd-1",
+        connectionGroupId: "eu_prod",
+      });
 
       // The same learned_patterns row is flipped to approved — no stale
       // pending row left behind.

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1582,8 +1582,12 @@ export async function insertSemanticAmendment(amendment: {
    * the default (flat `entities/`) group. Persisted so the admin approve path,
    * which rebuilds the proposal from the stored row's `source_entity` alone,
    * can recover the group and apply the amendment against the correct scope
-   * (no 409, no default-scope corruption). The interactive `proposeAmendment`
-   * tool omits it — it reads the flat root, so the default scope is correct.
+   * (no 409, no default-scope corruption). Every DB-backed caller supplies it:
+   * the scheduler passes the finding's group, and the interactive
+   * `proposeAmendment` tool passes the `applyGroupId` its baseline was
+   * resolved from via `resolveAmendmentBaseline` (#4488, #4498) — so
+   * human-reviewed approves resolve the same row the propose-time diff was
+   * computed against, never the unscoped fallback.
    */
   connectionGroupId?: string | null;
 }): Promise<{ id: string; status: "approved" | "pending" }> {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1584,7 +1584,8 @@ export async function insertSemanticAmendment(amendment: {
    * derivable from `source_entity`), can recover the group and apply the
    * amendment against the correct scope (no 409, no default-scope
    * corruption). Required so the invariant is compile-enforced, not
-   * doc-enforced: the scheduler passes the finding's group, and the
+   * doc-enforced: the scheduler and the CLI `improve` command pass the
+   * finding's group (the CLI's flat-root findings map to NULL), and the
    * interactive `proposeAmendment` tool passes the `applyGroupId` its
    * baseline was resolved from via `resolveAmendmentBaseline` (#4488, #4498)
    * — so human-reviewed approves resolve the same scoped row the

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1578,18 +1578,20 @@ export async function insertSemanticAmendment(amendment: {
   confidence: number;
   amendmentPayload: Record<string, unknown>;
   /**
-   * Connection group the amendment targets (ADR-0012, #3284). NULL/omitted =
-   * the default (flat `entities/`) group. Persisted so the admin approve path,
-   * which rebuilds the proposal from the stored row's `source_entity` alone,
-   * can recover the group and apply the amendment against the correct scope
-   * (no 409, no default-scope corruption). Every DB-backed caller supplies it:
-   * the scheduler passes the finding's group, and the interactive
-   * `proposeAmendment` tool passes the `applyGroupId` its baseline was
-   * resolved from via `resolveAmendmentBaseline` (#4488, #4498) — so
-   * human-reviewed approves resolve the same row the propose-time diff was
-   * computed against, never the unscoped fallback.
+   * Connection group the amendment targets (ADR-0012, #3284). NULL = the
+   * default (flat `entities/`) group. Persisted so the admin approve paths,
+   * which rebuild the proposal from the stored row (the group is not
+   * derivable from `source_entity`), can recover the group and apply the
+   * amendment against the correct scope (no 409, no default-scope
+   * corruption). Required so the invariant is compile-enforced, not
+   * doc-enforced: the scheduler passes the finding's group, and the
+   * interactive `proposeAmendment` tool passes the `applyGroupId` its
+   * baseline was resolved from via `resolveAmendmentBaseline` (#4488, #4498)
+   * — so human-reviewed approves resolve the same scoped row the
+   * propose-time diff was computed against, rather than depending on the
+   * unscoped fallback (which remains only for stale group labels).
    */
-  connectionGroupId?: string | null;
+  connectionGroupId: string | null;
 }): Promise<{ id: string; status: "approved" | "pending" }> {
   // #3392 — thread the amendment's org through so a per-workspace
   // auto-approve override (admin settings page) governs its own proposals.
@@ -1633,7 +1635,7 @@ export async function insertSemanticAmendment(amendment: {
       amendment.confidence,
       status,
       JSON.stringify(amendment.amendmentPayload),
-      amendment.connectionGroupId ?? null,
+      amendment.connectionGroupId,
     ],
   );
 

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
@@ -65,8 +65,11 @@ void mock.module("@atlas/api/lib/semantic", () => ({ invalidateOrgWhitelist }));
 void mock.module("@atlas/api/lib/semantic/sync", () => ({ syncEntityToDisk }));
 
 const insertSemanticAmendment = mock(
-  (_args: { sourceEntity: string; amendmentPayload: AmendmentPayload }) =>
-    Promise.resolve({ id: "prop-1", status: "approved" }),
+  (_args: {
+    sourceEntity: string;
+    amendmentPayload: AmendmentPayload;
+    connectionGroupId?: string | null;
+  }) => Promise.resolve({ id: "prop-1", status: "approved" }),
 );
 const revertAmendmentToPending = mock(() => Promise.resolve(true));
 
@@ -181,5 +184,61 @@ describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () =
     expect(persisted.sourceEntity).toBe("orders");
     expect(persisted.amendmentPayload.amendment).toMatchObject({ name: "region" });
     expect(revertAmendmentToPending).not.toHaveBeenCalled();
+  });
+
+  it("persists the resolved applyGroupId as the row's connection_group_id (#4498)", async () => {
+    await run();
+    // The stored row must carry the group the baseline was resolved from —
+    // NOT NULL. A NULL group forces the human-review approve into the
+    // default-scope → unscoped-fallback path, which 409s the moment the
+    // entity name exists in a second group (elevation-audit M5 dead-end).
+    const persisted = insertSemanticAmendment.mock.calls[0][0];
+    expect(persisted.connectionGroupId).toBe("eu_prod");
+  });
+
+  it("human-review approve of the persisted row resolves the same group-scoped row, no unscoped fallback (#4498)", async () => {
+    // Queue the proposal instead of auto-approving, so the ONLY apply in this
+    // test is the simulated human review below.
+    insertSemanticAmendment.mockResolvedValue({ id: "prop-1", status: "pending" });
+    const result = await run();
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe("queued");
+    expect(upsertEntityForGroup).not.toHaveBeenCalled();
+
+    // Replay the review-route approve (admin-semantic-improve.ts, POST
+    // /amendments/:id/review) against the persisted row: it applies with the
+    // row's `connection_group_id ?? null`.
+    const persisted = insertSemanticAmendment.mock.calls[0][0];
+    getEntity.mockClear();
+    const { applyAmendmentFromPayload } = await import("@atlas/api/lib/semantic/expert/apply");
+    await applyAmendmentFromPayload({
+      orgId: "org-1",
+      sourceEntity: persisted.sourceEntity,
+      connectionGroupId: persisted.connectionGroupId ?? null,
+      rawPayload: persisted.amendmentPayload,
+      requestId: "req-review",
+      label: "prop-1",
+    });
+
+    // Every lookup during the review apply is SCOPED to the persisted group —
+    // the unscoped back-compat fallback (4th arg undefined) never runs. The
+    // getEntity mock only resolves `group === "eu_prod"`, so a NULL persisted
+    // group (the pre-fix behavior: default scope → scoped miss → unscoped
+    // fallback → miss) would have thrown "Entity not found" above.
+    expect(getEntity.mock.calls.length).toBeGreaterThan(0);
+    for (const call of getEntity.mock.calls) {
+      expect(call[3]).toBe("eu_prod");
+    }
+
+    // And the write lands in the same row the propose-time diff was computed
+    // against: the eu_prod scope, with the DB baseline plus the new dimension.
+    expect(upsertEntityForGroup).toHaveBeenCalledTimes(1);
+    expect(upsertEntityForGroup.mock.calls[0][4]).toBe("eu_prod");
+    const parsed = loadYaml(upsertEntityForGroup.mock.calls[0][3]) as {
+      description?: string;
+      dimensions?: Array<{ name?: string }>;
+    };
+    expect(parsed.description).toBe("Orders (eu_prod DB-backed)");
+    expect((parsed.dimensions ?? []).map((d) => d.name)).toContain("region");
   });
 });

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
@@ -32,17 +32,29 @@ const ordersYaml = [
   "    type: number",
 ].join("\n");
 
-const ordersRow = {
-  id: "orders-eu",
-  connection_group_id: "eu_prod",
-  yaml_content: ordersYaml,
-};
+// The group the "orders" row lives in for the current scenario: "eu_prod" for
+// the group-scoped tests, null (the default flat group) for the default-scope
+// test. Reset in beforeEach.
+let activeGroup: string | null = "eu_prod";
 
-// getEntity resolves "orders" ONLY in group "eu_prod" (scoped or the refreshed
-// version read). Any other name/scope is a miss.
+const ordersRowFor = (group: string | null) => ({
+  id: group === null ? "orders-default" : `orders-${group}`,
+  connection_group_id: group,
+  yaml_content: ordersYaml,
+});
+
+// Scoped lookups resolve "orders" ONLY at the row's own scope (`activeGroup`).
+// The UNSCOPED lookup (4th arg absent — resolveAmendmentBaseline's back-compat
+// fallback) resolves only in the default-scope scenario, where the
+// propose-time request group ("eu_prod") legitimately misses; in the
+// group-scoped scenario it stays a hard miss, so any fallback reliance fails
+// loudly instead of silently resolving.
 const getEntity = mock(
-  async (_org: string, _type: string, name: string, group?: string | null) =>
-    name === "orders" && group === "eu_prod" ? ordersRow : null,
+  async (_org: string, _type: string, name: string, group?: string | null) => {
+    if (name !== "orders") return null;
+    if (group === undefined) return activeGroup === null ? ordersRowFor(null) : null;
+    return group === activeGroup ? ordersRowFor(activeGroup) : null;
+  },
 );
 const upsertEntityForGroup = mock(
   async (_org: string, _type: string, _name: string, _yaml: string, _group?: string | null): Promise<void> => {},
@@ -64,11 +76,14 @@ void mock.module("@atlas/api/lib/semantic/entities", () => ({
 void mock.module("@atlas/api/lib/semantic", () => ({ invalidateOrgWhitelist }));
 void mock.module("@atlas/api/lib/semantic/sync", () => ({ syncEntityToDisk }));
 
+// Arg shape mirrors the REAL (now required, #4498) `connectionGroupId` field —
+// `string | null`, not optional — so a caller regressing to omit it is visible
+// here as `undefined` in the persisted-args assertions.
 const insertSemanticAmendment = mock(
   (_args: {
     sourceEntity: string;
     amendmentPayload: AmendmentPayload;
-    connectionGroupId?: string | null;
+    connectionGroupId: string | null;
   }) => Promise.resolve({ id: "prop-1", status: "approved" }),
 );
 const revertAmendmentToPending = mock(() => Promise.resolve(true));
@@ -122,6 +137,7 @@ async function run(): Promise<ProposeResult> {
 
 describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () => {
   beforeEach(() => {
+    activeGroup = "eu_prod";
     getEntity.mockClear();
     upsertEntityForGroup.mockClear();
     createVersion.mockClear();
@@ -240,5 +256,39 @@ describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () =
     };
     expect(parsed.description).toBe("Orders (eu_prod DB-backed)");
     expect((parsed.dimensions ?? []).map((d) => d.name)).toContain("region");
+  });
+
+  it("persists NULL for a default-scope entity resolved via the fallback; review applies with the explicit default scope (#4498)", async () => {
+    // The entity lives in the default (flat) group. The request's group
+    // ("eu_prod") misses the scoped lookup, so the baseline resolves through
+    // the unscoped fallback — and the persisted group must be the ROW's own
+    // scope (NULL), not the request's label.
+    activeGroup = null;
+    insertSemanticAmendment.mockResolvedValue({ id: "prop-2", status: "pending" });
+    const result = await run();
+    expect(result.error).toBeUndefined();
+    const persisted = insertSemanticAmendment.mock.calls[0][0];
+    expect(persisted.connectionGroupId).toBeNull();
+
+    // Review replay: a NULL stored group maps to the explicit `"default"`
+    // label, so every apply-time lookup is EXPLICITLY default-scoped (4th arg
+    // null) — never the unscoped ambiguity check (4th arg undefined), which
+    // would 409 if the name also existed in a group.
+    getEntity.mockClear();
+    const { applyAmendmentFromPayload } = await import("@atlas/api/lib/semantic/expert/apply");
+    await applyAmendmentFromPayload({
+      orgId: "org-1",
+      sourceEntity: persisted.sourceEntity,
+      connectionGroupId: persisted.connectionGroupId ?? null,
+      rawPayload: persisted.amendmentPayload,
+      requestId: "req-review-default",
+      label: "prop-2",
+    });
+    expect(getEntity.mock.calls.length).toBeGreaterThan(0);
+    for (const call of getEntity.mock.calls) {
+      expect(call[3]).toBeNull();
+    }
+    expect(upsertEntityForGroup).toHaveBeenCalledTimes(1);
+    expect(upsertEntityForGroup.mock.calls[0][4]).toBeNull();
   });
 });

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -214,6 +214,12 @@ The amendment object should match the YAML structure for that type (e.g., { name
           sourceEntity: entityName,
           confidence,
           amendmentPayload: payload as unknown as Record<string, unknown>,
+          // Persist the group the baseline was resolved from (the row's OWN
+          // `connection_group_id`) so a HUMAN-reviewed approve — which applies
+          // with the stored row's group (admin-semantic-improve.ts) — targets
+          // the same row this diff was computed against, instead of falling
+          // back to unscoped resolution (409 on ambiguous names) (#4498).
+          connectionGroupId: applyGroupId,
         });
 
         proposalId = result.id;

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -216,9 +216,10 @@ The amendment object should match the YAML structure for that type (e.g., { name
           amendmentPayload: payload as unknown as Record<string, unknown>,
           // Persist the group the baseline was resolved from (the row's OWN
           // `connection_group_id`) so a HUMAN-reviewed approve — which applies
-          // with the stored row's group (admin-semantic-improve.ts) — targets
-          // the same row this diff was computed against, instead of falling
-          // back to unscoped resolution (409 on ambiguous names) (#4498).
+          // with the stored row's group via `applyAmendmentFromPayload`, the
+          // seam every admin approve path shares — targets the same row this
+          // diff was computed against, instead of falling back to unscoped
+          // resolution (409 on ambiguous names) (#4498).
           connectionGroupId: applyGroupId,
         });
 

--- a/packages/cli/src/commands/improve.ts
+++ b/packages/cli/src/commands/improve.ts
@@ -369,6 +369,10 @@ export async function handleImprove(args: string[]): Promise<void> {
             orgId: null, // CLI runs in single-org mode
             description: `[${r.amendmentType}] ${r.entityName}: ${r.rationale}`,
             sourceEntity: r.entityName,
+            // The CLI analyzes the flat `entities/` dir, so findings are
+            // normally the default (NULL) group; map any explicit group label
+            // the same way the scheduler does (#3284, #4498).
+            connectionGroupId: r.group && r.group !== "default" ? r.group : null,
             confidence: r.confidence,
             amendmentPayload: {
               entityName: r.entityName,


### PR DESCRIPTION
Closes #4498

## What

Post-#4488, interactive `proposeAmendment` resolves its baseline through `resolveAmendmentBaseline`, whose `applyGroupId` is the resolved row's own `connection_group_id` — documented as authoritative for every write-back. The in-flow auto-approve apply threaded it correctly, but the `insertSemanticAmendment` call dropped it, so the stored row had a NULL group. A **human-reviewed** approve (`POST /amendments/{id}/review`) then applied with the stored row's group → default scope → scoped miss → unscoped fallback, which 409s with `AmbiguousEntityError` the moment the entity name exists in a second group — and with no group picker in the review UI (elevation-audit M5), the amendment was permanently unapprovable.

## Changes

- `lib/tools/propose-amendment.ts` — persist `connectionGroupId: applyGroupId` on the inserted row
- `lib/db/internal.ts` — `insertSemanticAmendment.connectionGroupId` is now **required** (`string | null`), compile-enforcing the "every caller supplies it" invariant (panel type-design finding); stale doc comment ("the interactive tool reads the flat root") corrected
- `cli/src/commands/improve.ts` — third caller surfaced by the required field: threads the finding's group like the scheduler does (flat-root findings → NULL)
- Tests (`propose-amendment-group-scope.test.ts`): persisted row carries the resolved group; a replayed human-review approve resolves the same eu_prod-scoped row with every lookup scoped (no unscoped fallback — the mock makes fallback a hard miss); default-scope row persists NULL and review applies with the explicit default scope
- Route test (`admin-semantic-improve.test.ts`): `/amendments/:id/review` threads the stored row's `connection_group_id` into `applyAmendmentFromPayload`

## Verification

- Internal review panel (4 specialists): CLEAN — all MEDIUM findings addressed in-branch
- `scripts/ci-local.sh`: all 29 gates PASS (incl. full isolated test suite)
- Both new regression tests fail pre-fix (NULL persisted group → unscoped fallback → miss)

https://claude.ai/code/session_019Nguc1bp5AtvWDcdXPboDF

---
_Generated by [Claude Code](https://claude.ai/code/session_019Nguc1bp5AtvWDcdXPboDF)_