### PR TITLE
feat(knowledge): Front Knowledge Base sync connector — Bearer token, multi-KB + locales

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56690,7 +56690,8 @@
                               "confluence-datacenter",
                               "gitbook",
                               "zendesk",
-                              "salesforce-knowledge"
+                              "salesforce-knowledge",
+                              "front"
                             ]
                           },
                           "description": {

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -685,6 +685,31 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(sf?.endpointUrl).toBeNull();
     expect(sf?.sync).not.toBeNull();
   });
+
+  it("dispatches a Front collection to the connector engine and lists it as source 'front' (#4400)", async () => {
+    COLLECTION = {
+      install_id: "front-support",
+      catalog_id: "catalog:front",
+      status: "published",
+      config: { knowledge_base_id: "kb_1", knowledge_base_name: "Support" },
+    };
+    SYNC_STATES = [
+      { collection_id: "front-support", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/front-support/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const front = body.collections.find((c) => c.slug === "front-support");
+    expect(front?.source).toBe("front");
+    expect(front?.endpointUrl).toBeNull();
+    expect(front?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -60,6 +60,7 @@ import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/co
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
+import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -129,6 +130,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === GITBOOK_CATALOG_ID) return "gitbook";
   if (catalogId === ZENDESK_CATALOG_ID) return "zendesk";
   if (catalogId === SALESFORCE_KNOWLEDGE_CATALOG_ID) return "salesforce-knowledge";
+  if (catalogId === FRONT_CATALOG_ID) return "front";
   return "unknown";
 }
 
@@ -141,7 +143,8 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "confluence-datacenter" ||
     source === "gitbook" ||
     source === "zendesk" ||
-    source === "salesforce-knowledge"
+    source === "salesforce-knowledge" ||
+    source === "front"
   );
 }
 
@@ -162,7 +165,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "front"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -28,6 +28,7 @@ import {
   BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_ZENDESK_CATALOG_ROW,
   BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
+  BUILTIN_FRONT_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -211,6 +212,27 @@ describe("BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW (#4397)", () => {
   });
 });
 
+describe("BUILTIN_FRONT_CATALOG_ROW (#4400)", () => {
+  it("is the `front` form install: a single secret Bearer token, NO base URL / KB field", () => {
+    const row = BUILTIN_FRONT_CATALOG_ROW;
+    expect(row.slug).toBe("front");
+    expect(row.id).toBe("catalog:front");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("api_token");
+    expect(keys).toContain("description");
+    // Front's Core API is a fixed vendor host — no free-form URL field, and no
+    // KB field: knowledge bases are enumerated at install time (one collection
+    // per KB).
+    expect(keys).not.toContain("base_url");
+    expect(keys).not.toContain("knowledge_base_id");
+    // Exactly one secret field: the API token (never echoed).
+    expect(row.configSchema.filter((f) => f.secret === true).map((f) => f.key)).toEqual(["api_token"]);
+    expect(row.configSchema.find((f) => f.key === "api_token")?.required).toBe(true);
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -235,6 +257,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "gitbook",
       "zendesk",
       "salesforce-knowledge",
+      "front",
     ]);
   });
 
@@ -263,6 +286,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "gitbook",
       "zendesk",
       "salesforce-knowledge",
+      "front",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -45,6 +45,7 @@ import {
   SALESFORCE_KNOWLEDGE_CATALOG_ID,
   SALESFORCE_KNOWLEDGE_SLUG,
 } from "@atlas/api/lib/knowledge/salesforce/config";
+import { FRONT_CATALOG_ID, FRONT_SLUG } from "@atlas/api/lib/knowledge/front/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -471,6 +472,48 @@ export const BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW: BuiltinKnowledgeCatalogRo
   ],
 };
 
+/**
+ * The Front Knowledge Base connector catalog row (#4400, PRD #4395). A form
+ * install that enumerates the company's knowledge bases and creates one
+ * review-gated collection per KB; the Scheduler dispatches the registered Front
+ * connector on a cadence (delta-less reconciliation-diff) and every synced
+ * article locale lands `draft`.
+ *
+ * `api_token` (a Bearer token) is `secret: true` but is NOT stored in
+ * `workspace_plugins.config` — the install handler routes it to
+ * `knowledge_sync_credentials` (encrypted, one row per KB collection). Front's
+ * Core API is a fixed vendor host, so there is no free-form base-URL field;
+ * every request still goes through the SSRF egress guard. The id/slug are the
+ * config SSOT (`FRONT_CATALOG_ID` / `FRONT_SLUG`).
+ */
+export const BUILTIN_FRONT_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: FRONT_CATALOG_ID,
+  slug: FRONT_SLUG,
+  name: "Knowledge Base (Front)",
+  description:
+    "Mirror your Front knowledge bases into review-gated knowledge collections (one per knowledge base); Atlas syncs published articles and their locale translations on a schedule and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "api_token",
+      type: "string",
+      secret: true,
+      label: "API token",
+      required: true,
+      description:
+        "A Front API token with the knowledge_bases:read scope (Front → Settings → Developers → API tokens). Knowledge bases are discovered automatically — one collection per KB. Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -481,6 +524,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_GITBOOK_CATALOG_ROW,
   BUILTIN_ZENDESK_CATALOG_ROW,
   BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
+  BUILTIN_FRONT_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/front-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/front-form-handler.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for `FrontFormInstallHandler` (#4400) — the Front Knowledge Base
+ * connector install. Focus: field validation (API token), loud KB-enumeration
+ * verification at install time, the PER-KB FAN-OUT (one collection per knowledge
+ * base; base slug for a single KB, suffixed slugs for multi-KB), credential
+ * routing (token → `knowledge_sync_credentials`, one row per KB collection,
+ * NEVER into `workspace_plugins.config`), and the credential rollback on a
+ * failed row write. Verification uses the REAL egress guard against an injected
+ * fixture fetch; no test touches Front.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:front" }];
+let INSERT_RETURNS_ID = true;
+let INSERT_FAIL_ON_SLUG: string | null = null;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    if (INSERT_FAIL_ON_SLUG !== null && params[3] === INSERT_FAIL_ON_SLUG) {
+      throw new Error("simulated row-write failure");
+    }
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { FrontFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/front-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = { api_token: "front-token" };
+
+interface FixtureKB {
+  id?: string;
+  name?: string;
+}
+
+const ONE_KB: FixtureKB[] = [{ id: "kb_1", name: "Support" }];
+const TWO_KBS: FixtureKB[] = [...ONE_KB, { id: "kb_2", name: "Internal" }];
+
+/** A fixture knowledge-bases-endpoint fetch (or a fixed failure status). */
+function kbFetch(opts: { bases?: FixtureKB[]; status?: number } = {}): typeof fetch {
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url);
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (url.pathname === "/knowledge_bases") {
+      return new Response(
+        JSON.stringify({ _results: opts.bases ?? ONE_KB, _pagination: { next: null } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+  return impl as unknown as typeof fetch;
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  let n = 0;
+  return new FrontFormInstallHandler({
+    idGenerator: () => `fixed-id-${++n}`,
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:front" }];
+  INSERT_RETURNS_ID = true;
+  INSERT_FAIL_ON_SLUG = null;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+async function formErrorOf(promise: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.formErrors[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("requires the API token", async () => {
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, { api_token: "" }), "api_token");
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string description", async () => {
+    const msg = await fieldErrorOf(
+      handler(kbFetch()).validateConfig(WORKSPACE, { ...VALID, description: 42 }),
+      "description",
+    );
+    expect(msg).toMatch(/string/i);
+  });
+});
+
+describe("KB enumeration (install-time verification)", () => {
+  it("blames the api_token field on a 401", async () => {
+    const msg = await fieldErrorOf(
+      handler(kbFetch({ status: 401 })).validateConfig(WORKSPACE, VALID),
+      "api_token",
+    );
+    expect(msg).toMatch(/rejected the credentials/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 429 as a form-level error (the token may be fine)", async () => {
+    const msg = await formErrorOf(handler(kbFetch({ status: 429 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/rate-limited/i);
+  });
+
+  it("surfaces a vendor 5xx as a form-level error, never blaming the token", async () => {
+    const msg = await formErrorOf(handler(kbFetch({ status: 503 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/vendor-side error/i);
+  });
+
+  it("rejects an account with no knowledge bases", async () => {
+    const msg = await formErrorOf(handler(kbFetch({ bases: [] })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/no knowledge bases/i);
+  });
+});
+
+describe("per-KB fan-out", () => {
+  it("single KB: one collection under the base slug, token in credentials not config", async () => {
+    const rec = await handler(kbFetch()).validateConfig(WORKSPACE, VALID);
+    expect(rec.installRecord).toMatchObject({ workspaceId: WORKSPACE, catalogId: "front" });
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].params[3]).toBe("front");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toMatchObject({ knowledge_base_id: "kb_1", knowledge_base_name: "Support" });
+    // The token NEVER lands in the install config…
+    expect(config).not.toHaveProperty("api_token");
+    // …it lands in knowledge_sync_credentials, keyed by the collection slug.
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(saveSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "front", "front-token"]);
+  });
+
+  it("respects a custom collection slug via __install_id__", async () => {
+    await handler(kbFetch()).validateConfig(WORKSPACE, { ...VALID, __install_id__: "support-kb" });
+    expect(insertCalls[0].params[3]).toBe("support-kb");
+  });
+
+  it("multi-KB: one collection per KB under suffixed slugs, one credential each", async () => {
+    const rec = await handler(kbFetch({ bases: TWO_KBS })).validateConfig(WORKSPACE, VALID);
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["front-kb-1", "front-kb-2"]);
+    const configs = insertCalls.map((c) => JSON.parse(c.params[4] as string));
+    expect(configs.map((c) => c.knowledge_base_id)).toEqual(["kb_1", "kb_2"]);
+    expect(saveSyncCredential.mock.calls.map((c) => c[1])).toEqual(["front-kb-1", "front-kb-2"]);
+    // The returned record is the first KB's row.
+    expect(rec.installRecord.id).toBe("fixed-id-1");
+  });
+
+  it("rejects a fan-out slug that would exceed the collection-slug bound BEFORE any write", async () => {
+    const longBase = "z".repeat(124); // valid alone; overflows once "-kb-1" is appended
+    const msg = await fieldErrorOf(
+      handler(kbFetch({ bases: TWO_KBS })).validateConfig(WORKSPACE, {
+        ...VALID,
+        __install_id__: longBase,
+      }),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/exceeds 128 characters/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a fan-out slug taken by another knowledge catalog BEFORE any write", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const msg = await fieldErrorOf(
+      handler(kbFetch({ bases: TWO_KBS })).validateConfig(WORKSPACE, VALID),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/already used/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the failed KB's credential and leaves earlier KBs installed", async () => {
+    INSERT_FAIL_ON_SLUG = "front-kb-2";
+    await expect(
+      handler(kbFetch({ bases: TWO_KBS })).validateConfig(WORKSPACE, VALID),
+    ).rejects.toThrow(/simulated row-write failure/);
+    // First KB fully installed…
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["front-kb-1"]);
+    // …the failed KB's orphaned credential rolled back (and only that one).
+    expect(deleteSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "front-kb-2"]);
+  });
+});
+
+describe("catalog preconditions", () => {
+  it("fails loudly when the catalog row is missing (seed has not run)", async () => {
+    CATALOG_ROWS = [];
+    await expect(handler(kbFetch()).validateConfig(WORKSPACE, VALID)).rejects.toThrow(
+      /catalog row "front" not found/i,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -47,6 +47,7 @@ import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/con
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
+import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -150,7 +151,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, and Salesforce Knowledge sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, Salesforce Knowledge, and Front sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
@@ -158,12 +159,14 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
     expect(getKnowledgeSyncConnector(GITBOOK_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(ZENDESK_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(SALESFORCE_KNOWLEDGE_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(FRONT_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "gitbook", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "zendesk", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "salesforce-knowledge", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "front", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/front-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/front-form-handler.ts
@@ -1,0 +1,381 @@
+/**
+ * `FrontFormInstallHandler` — the {@link FormBasedInstallHandler} for the
+ * built-in `front` Knowledge Base catalog row (#4400, PRD #4395).
+ *
+ * Installing `front` creates one synced collection PER KNOWLEDGE BASE (the
+ * PRD's "each KB maps to a collection"): the handler enumerates the company's
+ * knowledge bases with the supplied Bearer token and upserts one
+ * `pillar='knowledge'` `workspace_plugins` row per KB, each config pinned to
+ * that KB's id. A single knowledge base (the common case) gets exactly the
+ * chosen collection slug; multiple KBs fan out to `<slug>-<kb-slug>`. The
+ * Scheduler dispatches the registered Front connector per collection on a
+ * cadence (`lib/knowledge/connector-sync.ts`), and every synced article
+ * translation lands `draft`.
+ *
+ * Beyond the Confluence/Zendesk precedent it inherits (loud credential
+ * verification, token routed to `knowledge_sync_credentials` — never
+ * `workspace_plugins.config`), two Front-specific choices:
+ *
+ *   1. **Fixed host, single Bearer token.** Front's Core API is a fixed vendor
+ *      host, so there is no customer-supplied URL to SSRF-gate — every request
+ *      still routes through `guardedFetch` at fetch time, and the host is
+ *      re-asserted here as defence in depth.
+ *   2. **Fan-out is validated fully before any write.** Every per-KB slug is
+ *      availability-checked first; writes then run per KB (credential → row). A
+ *      mid-fan-out failure leaves earlier KBs fully installed and working; the
+ *      thrown error says retrying is safe (all writes are idempotent upserts
+ *      converging on the same slugs).
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  assertBaseUrlAllowed,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import {
+  listFrontKnowledgeBases,
+  FrontAuthError,
+  type FrontKnowledgeBase,
+  type FrontClientDeps,
+} from "@atlas/api/lib/knowledge/front/client";
+import {
+  FRONT_SLUG,
+  FRONT_CATALOG_ID,
+  FRONT_API_BASE,
+  type FrontCollectionConfig,
+} from "@atlas/api/lib/knowledge/front/config";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  COLLECTION_SLUG_MAX,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { FRONT_SLUG, FRONT_CATALOG_ID };
+
+/** Defensive upper bound — guard against a pathological token paste. */
+const API_TOKEN_MAX = 8192;
+
+export interface FrontFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the KB-enumeration fetch (no real Front call). */
+  readonly clientDeps?: FrontClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to
+ * `ZENDESK_INSTALL_UPSERT_SQL`: `status='published'` because the COLLECTION
+ * container is live immediately — the review gate is on the DOCUMENTS, which
+ * always sync in as `draft`. Exported so the real-Postgres test executes this
+ * exact string against the live schema.
+ */
+export const FRONT_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class FrontFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: FrontClientDeps;
+  private readonly log = createLogger("integrations.install.front");
+
+  constructor(options: FrontFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const baseSlug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], FRONT_SLUG);
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const apiToken = validateApiToken(rawForm.api_token);
+    const description = validateDescription(rawForm.description);
+
+    // SSRF gate on the fixed Front host (defence in depth — `guardedFetch`
+    // re-validates on every request).
+    assertHostAllowed();
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [FRONT_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "front catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${FRONT_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    // ── Enumerate KBs = verify the connection loudly BEFORE persisting ───────
+    const bases = await this.enumerateKnowledgeBases(apiToken);
+    if (bases.length === 0) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [
+          "This Front account has no knowledge bases — create one in Front, then re-install.",
+        ],
+      });
+    }
+
+    // ── Compute + validate every per-KB slug BEFORE any write ────────────────
+    const planned = bases.map((kb) => ({
+      kb,
+      slug: bases.length === 1 ? baseSlug : `${baseSlug}-${slugifyKnowledgeBaseId(kb.id)}`,
+    }));
+    for (const { slug } of planned) {
+      if (slug.length > COLLECTION_SLUG_MAX) {
+        throw new FormInstallValidationError({
+          fieldErrors: {
+            [KNOWLEDGE_INSTALL_ID_FIELD]: [
+              `Collection id "${slug}" (the per-KB fan-out of "${baseSlug}") exceeds ${COLLECTION_SLUG_MAX} characters — choose a shorter collection id.`,
+            ],
+          },
+          formErrors: [],
+        });
+      }
+      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+    }
+
+    // ── Per-KB writes: credential first, then the collection row ─────────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "api_token");
+    let firstRecord: InstallRecord | null = null;
+    for (const { kb, slug } of planned) {
+      const record = await this.installKnowledgeBaseCollection({
+        workspaceId,
+        catalogId,
+        slug,
+        kb,
+        config: {
+          knowledge_base_id: kb.id,
+          knowledge_base_name: kb.name,
+          ...(description !== null ? { description } : {}),
+        },
+        apiToken,
+      });
+      firstRecord ??= record;
+    }
+
+    this.log.info(
+      {
+        workspaceId,
+        host: hostForLog(FRONT_API_BASE),
+        collections: planned.map((p) => p.slug),
+        knowledgeBases: planned.length,
+      },
+      "Front collection install completed",
+    );
+    // `firstRecord` is set on the first loop iteration (planned is non-empty).
+    if (firstRecord === null) {
+      throw new Error("Front install produced no collection record — invariant violation");
+    }
+    return { installRecord: firstRecord, credentialWritten: true };
+  }
+
+  /** Write one KB's credential + collection row, Zendesk rollback posture. */
+  private async installKnowledgeBaseCollection(input: {
+    workspaceId: WorkspaceId;
+    catalogId: string;
+    slug: string;
+    kb: FrontKnowledgeBase;
+    config: FrontCollectionConfig;
+    apiToken: string;
+  }): Promise<InstallRecord> {
+    const { workspaceId, catalogId, slug, kb, config, apiToken } = input;
+    try {
+      await saveSyncCredential(workspaceId, slug, apiToken);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed KB collections stay installed)",
+      );
+      throw retryableInstallError(slug, err);
+    }
+
+    const candidateId = this.newId();
+    try {
+      const rows = await internalQuery<{ id: string }>(FRONT_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        slug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug: slug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      return { id: returned, workspaceId, catalogId: FRONT_SLUG };
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a
+      // failed install. Best-effort — a re-install overwrites it either way; a
+      // cleanup failure is logged, never masks the original error.
+      this.log.error(
+        {
+          workspaceId,
+          collectionSlug: slug,
+          knowledgeBaseId: kb.id,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to persist front collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, slug);
+      } catch (cleanupErr) {
+        this.log.error(
+          {
+            workspaceId,
+            collectionSlug: slug,
+            err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw retryableInstallError(slug, err);
+    }
+  }
+
+  /**
+   * Enumerate knowledge bases with the supplied token; map every failure to a
+   * 400. Classification is POSITIVE, by `instanceof` on the client's typed
+   * errors — never by message text — so only a failure the client KNOWS is
+   * credential-shaped blames the api_token field; a Front outage or transport
+   * error stays form-level. All messages host-redacted by the client.
+   */
+  private async enumerateKnowledgeBases(apiToken: string): Promise<FrontKnowledgeBase[]> {
+    try {
+      return await listFrontKnowledgeBases({ apiToken }, this.clientDeps);
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        throw new FormInstallValidationError({
+          fieldErrors: {},
+          formErrors: [err.message],
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof FrontAuthError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { api_token: [message] },
+          formErrors: [],
+        });
+      }
+      // Everything else — 404 (FrontNotFoundError), 429 (ConnectorRateLimitError),
+      // vendor 5xx, transport/DNS/non-JSON — is form-level (re-entering a fine
+      // token would be the wrong guidance).
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [message],
+      });
+    }
+  }
+}
+
+/**
+ * Slugify a Front knowledge base id into a collection-slug-safe segment
+ * (`[a-z0-9-]`). Front ids like `kb_abc123` map to `kb-abc123`; the
+ * slug-availability check catches any genuine collision before a write.
+ */
+function slugifyKnowledgeBaseId(id: string): string {
+  const slug = id
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? "kb" : slug;
+}
+
+/** SSRF-gate the fixed Front host, mapping a block to a form-level 400. */
+function assertHostAllowed(): void {
+  try {
+    assertBaseUrlAllowed(FRONT_API_BASE);
+  } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [err.message],
+      });
+    }
+    throw err;
+  }
+}
+
+function validateApiToken(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "api_token",
+      "An API token is required. Create one in Front → Settings → Developers → API tokens with the knowledge_bases:read scope.",
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > API_TOKEN_MAX) {
+    throw fieldError("api_token", `The API token must be ${API_TOKEN_MAX} characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}
+
+/**
+ * Wrap a mid-fan-out persistence failure with the retry guidance the admin
+ * needs: all writes are idempotent upserts converging on the same slugs, so
+ * re-running the install is always safe. The original failure rides as cause.
+ */
+function retryableInstallError(slug: string, err: unknown): Error {
+  return new Error(
+    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed KB collections are simply updated in place.`,
+    { cause: err },
+  );
+}

--- a/packages/api/src/lib/integrations/install/front-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/front-form-handler.ts
@@ -253,6 +253,15 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
       // Roll back the just-written credential so a secret can't outlive a
       // failed install. Best-effort — a re-install overwrites it either way; a
       // cleanup failure is logged, never masks the original error.
+      //
+      // Narrow re-install caveat (shared with the Zendesk/Confluence handlers):
+      // when the row upsert is an ON-CONFLICT UPDATE of a PRE-EXISTING
+      // collection, `saveSyncCredential` has already overwritten that live
+      // collection's credential, so this rollback deletes a credential the
+      // still-existing row depends on — leaving it credential-less until the
+      // admin retries (the row upsert failing after the credential write is a
+      // rare same-transaction-window DB error). Self-healing on retry, and kept
+      // identical across the connector tier rather than diverging here.
       this.log.error(
         {
           workspaceId,

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -55,6 +55,8 @@ import {
   SALESFORCE_KNOWLEDGE_SLUG,
 } from "./salesforce-knowledge-form-handler";
 import { registerSalesforceKnowledgeConnector } from "@atlas/api/lib/knowledge/salesforce/connector";
+import { FrontFormInstallHandler, FRONT_SLUG } from "./front-form-handler";
+import { registerFrontKnowledgeConnector } from "@atlas/api/lib/knowledge/front/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -319,6 +321,18 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(SALESFORCE_KNOWLEDGE_SLUG, new SalesforceKnowledgeFormInstallHandler());
   registerSalesforceKnowledgeConnector();
   log.info("Registered SalesforceKnowledgeFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Front) — the built-in `front` connector install (#4400,
+  // PRD #4395). Knowledge-pillar, multi-instance: ONE install fans out to one
+  // collection per KNOWLEDGE BASE. Config = per-KB binding; the Bearer API token
+  // lands in `knowledge_sync_credentials` (encrypted, one row per KB collection),
+  // never in `workspace_plugins.config`. Front's Core API is a fixed vendor host
+  // → SSRF gated at install and fetch. Registering the FORM handler + the
+  // CONNECTOR together (as with the other knowledge vendors) keeps a half-wired
+  // deploy from having an installable card whose scheduled sync has no registered
+  // vendor client. No env gate.
+  registerFormHandler(FRONT_SLUG, new FrontFormInstallHandler());
+  registerFrontKnowledgeConnector();
+  log.info("Registered FrontFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -40,6 +40,7 @@ import { CONFLUENCE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/insta
 import { CONFLUENCE_DC_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-datacenter-form-handler";
 import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/gitbook-form-handler";
 import { ZENDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/zendesk-form-handler";
+import { FRONT_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/front-form-handler";
 import { SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/salesforce-knowledge-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
@@ -616,6 +617,31 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // Credential-less by design: the config carries scope only — the OAuth
     // install (catalog:salesforce) owns the token; nothing secret lands here.
     expect(row.rows[0]?.config).toEqual({ article_object: "Knowledge__kav", channel: "pkb" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a Front per-KB connector collection against the live schema (#4400)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:front', 'Knowledge Base (Front)', 'front', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(FRONT_INSTALL_UPSERT_SQL, [
+      "row-front",
+      ws,
+      "catalog:front",
+      "front-support",
+      JSON.stringify({ knowledge_base_id: "kb_1", knowledge_base_name: "Support" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-front");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'front-support'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The token is NEVER persisted in the install config.
+    expect(row.rows[0]?.config).not.toHaveProperty("api_token");
+    expect(row.rows[0]?.config).toMatchObject({ knowledge_base_id: "kb_1", knowledge_base_name: "Support" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/front/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/front/__tests__/client.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for the Front vendor client (#4400) — driven entirely through an
+ * injected fixture `fetchImpl`; NO test touches Front. Covers the delta-less
+ * full crawl (per-locale article lists + cursor pagination), the incremental
+ * since-filter over `last_edited`, published/draft/archived filtering, the
+ * high-water mark, the html_content fallback fetch, malformed-item coverage
+ * flagging, 429 → ConnectorRateLimitError, auth/not-found failures, same-origin
+ * pagination pinning, the ingest cap, and the KB enumeration used at install
+ * time.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createFrontVendorClient,
+  listFrontKnowledgeBases,
+  normalizeFrontTimestamp,
+  parseRetryAfter,
+  FrontAuthError,
+  FrontNotFoundError,
+} from "@atlas/api/lib/knowledge/front/client";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+
+const BASE = "https://api2.frontapp.com";
+const KB = "kb_1";
+
+interface FixtureArticle {
+  id?: string | number;
+  name?: string;
+  status?: string;
+  html_content?: string | null;
+  last_edited?: string | number;
+  locale?: string;
+  url?: string;
+}
+
+function art(overrides: FixtureArticle = {}): FixtureArticle {
+  return {
+    id: "art_1",
+    name: "Getting Started",
+    status: "published",
+    html_content: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    last_edited: "2026-07-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+interface FixtureState {
+  calls: string[];
+  authHeaders: Array<string | null>;
+}
+
+/**
+ * A fixture Front API. `kb.locales` drives the per-locale walk; `articlesByLocale`
+ * is keyed by the `?locale=` value (`""` for a default-locale walk).
+ */
+function makeFetch(opts: {
+  kb?: { id?: string; name?: string; locales?: string[] } | null;
+  articlesByLocale?: Record<string, FixtureArticle[]>;
+  splitLocale?: string;
+  offOriginNext?: boolean;
+  articleById?: Record<string, FixtureArticle>;
+  knowledgeBases?: Array<{ id?: string; name?: string }>;
+  failFirst?: { status: number; headers?: Record<string, string> };
+  stuck?: boolean;
+}): { impl: typeof globalThis.fetch; state: FixtureState } {
+  const state: FixtureState = { calls: [], authHeaders: [] };
+  let failed = false;
+  const kb = opts.kb === undefined ? { id: KB, name: "Support", locales: ["en", "fr"] } : opts.kb;
+  const impl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    state.calls.push(raw);
+    state.authHeaders.push(new Headers(init?.headers).get("authorization"));
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    const path = url.pathname;
+    const locale = url.searchParams.get("locale") ?? "";
+
+    if (path === "/knowledge_bases") {
+      return jsonResponse({
+        _results: opts.knowledgeBases ?? [{ id: KB, name: "Support" }],
+        _pagination: { next: null },
+      });
+    }
+    const singleMatch = path.match(/^\/knowledge_bases\/[^/]+\/articles\/([^/]+)$/);
+    if (singleMatch) {
+      const article = opts.articleById?.[singleMatch[1]] ?? {};
+      return jsonResponse(article);
+    }
+    if (path === `/knowledge_bases/${KB}/articles`) {
+      if (opts.stuck) {
+        return jsonResponse({
+          _results: [],
+          _pagination: { next: `${BASE}/knowledge_bases/${KB}/articles?page=stuck` },
+        });
+      }
+      const all = opts.articlesByLocale?.[locale] ?? [];
+      if (opts.splitLocale === locale) {
+        const isSecond = url.searchParams.get("page") === "2";
+        const next = opts.offOriginNext
+          ? "https://evil.example.com/knowledge_bases/kb_1/articles?page=2"
+          : `${BASE}/knowledge_bases/${KB}/articles?locale=${locale}&page=2`;
+        return jsonResponse({
+          _results: isSecond ? all.slice(1) : all.slice(0, 1),
+          _pagination: { next: isSecond ? null : next },
+        });
+      }
+      return jsonResponse({ _results: all, _pagination: { next: null } });
+    }
+    if (path === `/knowledge_bases/${KB}`) {
+      if (kb === null) return new Response("", { status: 404 });
+      return jsonResponse(kb);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, state };
+}
+
+function client(opts: Parameters<typeof makeFetch>[0] = {}, maxDocs?: number) {
+  const { impl, state } = makeFetch(opts);
+  const c = createFrontVendorClient(
+    { knowledgeBaseId: KB, apiToken: "tok", collectionSlug: "front-support" },
+    { fetchImpl: impl, ...(maxDocs !== undefined ? { maxDocs } : {}) },
+  );
+  return { c, state };
+}
+
+describe("fetchAll (reconciliation)", () => {
+  it("emits one document per published locale variant with the max last_edited as the mark", async () => {
+    const { c } = client({
+      articlesByLocale: {
+        en: [art({ last_edited: "2026-07-01T10:00:00Z" })],
+        fr: [art({ name: "Pour commencer", locale: "fr", last_edited: "2026-07-05T08:00:00Z" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "front-support/en/getting-started-art_1.md",
+      "front-support/fr/pour-commencer-art_1.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(false);
+    expect(changes.cursor).toBeNull();
+  });
+
+  it("follows cursor pagination across pages within a locale", async () => {
+    const { c, state } = client({
+      kb: { id: KB, locales: ["en"] },
+      splitLocale: "en",
+      articlesByLocale: {
+        en: [art({ id: "art_1" }), art({ id: "art_2", name: "Billing" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(2);
+    expect(state.calls.filter((u) => u.includes("/articles?"))).toHaveLength(2);
+  });
+
+  it("refuses an off-origin pagination link rather than forward credentials", async () => {
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      splitLocale: "en",
+      offOriginNext: true,
+      articlesByLocale: { en: [art({ id: "art_1" }), art({ id: "art_2" })] },
+    });
+    await expect(c.fetchAll()).rejects.toThrow(/pointing off|refusing to follow/i);
+  });
+
+  it("fails loud on a stuck cursor that keeps returning empty pages (page bound)", async () => {
+    const { c } = client({ kb: { id: KB, locales: ["en"] }, stuck: true });
+    await expect(c.fetchAll()).rejects.toThrow(/did not terminate/i);
+  });
+
+  it("skips draft and archived articles (unpublish/archive = absent = archived)", async () => {
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: {
+        en: [
+          art({ id: "art_1", status: "draft", last_edited: "2026-07-06T00:00:00Z" }),
+          art({ id: "art_2", status: "archived", last_edited: "2026-07-04T00:00:00Z" }),
+          art({ id: "art_3", status: "published", last_edited: "2026-07-02T00:00:00Z" }),
+        ],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual(["front-support/en/getting-started-art_3.md"]);
+    // The draft/archived articles still advance the mark — their change was observed.
+    expect(changes.highWaterMark).toBe("2026-07-06T00:00:00.000Z");
+  });
+
+  it("falls back to a per-article fetch when the list omits html_content", async () => {
+    const { c, state } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: { en: [art({ id: "art_7", html_content: null })] },
+      articleById: { art_7: art({ id: "art_7", html_content: "<p>Fetched body text here.</p>" }) },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(state.calls.some((u) => u.includes("/articles/art_7"))).toBe(true);
+  });
+
+  it("counts a published article with no resolvable body and flags coverage incomplete", async () => {
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: { en: [art({ id: "art_9", html_content: null }), art({ id: "art_1" })] },
+      articleById: { art_9: { id: "art_9" } }, // fallback also has no html_content
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("counts a malformed article (no id/last_edited) and flags coverage incomplete", async () => {
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: {
+        en: [{ name: "no id", status: "published", html_content: "<p>text</p>" }, art({ id: "art_1" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("serves a KB with no declared locales as a single default-locale walk", async () => {
+    const { c, state } = client({
+      kb: { id: KB, locales: [] },
+      articlesByLocale: { "": [art({ id: "art_1" })] },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "front-support/default/getting-started-art_1.md",
+    ]);
+    // No ?locale= param on the default walk.
+    expect(state.calls.some((u) => /\/articles\?locale=/.test(u))).toBe(false);
+  });
+
+  it("rejects a published set over the ingest cap before fetching bodies", async () => {
+    const { c } = client(
+      {
+        kb: { id: KB, locales: ["en"] },
+        articlesByLocale: {
+          en: [art({ id: "art_1" }), art({ id: "art_2" }), art({ id: "art_3" })],
+        },
+      },
+      2,
+    );
+    await expect(c.fetchAll()).rejects.toThrow(/over the 2-document limit/i);
+  });
+});
+
+describe("fetchChanges (incremental)", () => {
+  it("emits only articles edited at-or-after since, with the observed max as the mark", async () => {
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: {
+        en: [
+          art({ id: "art_1", last_edited: "2026-07-01T00:00:00Z" }), // before since
+          art({ id: "art_2", name: "New", last_edited: "2026-07-08T00:00:00Z" }), // after since
+        ],
+      },
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-05T00:00:00.000Z", cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual(["front-support/en/new-art_2.md"]);
+    // The mark is the max observed edit across the whole crawl (not just emitted).
+    expect(changes.highWaterMark).toBe("2026-07-08T00:00:00.000Z");
+  });
+
+  it("serves a null since as a full crawl (defensive)", async () => {
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: { en: [art({ id: "art_1" }), art({ id: "art_2", name: "Two" })] },
+    });
+    const changes = await c.fetchChanges({ since: null, cursor: null });
+    expect(changes.documents).toHaveLength(2);
+  });
+});
+
+describe("authentication", () => {
+  it("sends Front Bearer auth", async () => {
+    const { c, state } = client({ kb: { id: KB, locales: ["en"] }, articlesByLocale: { en: [art()] } });
+    await c.fetchAll();
+    expect(state.authHeaders.length).toBeGreaterThan(0);
+    for (const header of state.authHeaders) expect(header).toBe("Bearer tok");
+  });
+});
+
+describe("vendor failure mapping", () => {
+  it("throws ConnectorRateLimitError with the parsed Retry-After on a 429", async () => {
+    const { c } = client({ failFirst: { status: 429, headers: { "retry-after": "37" } } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+    expect((err as ConnectorRateLimitError).retryAfterSeconds).toBe(37);
+  });
+
+  it("maps a 401 to an actionable, host-redacted credentials error", async () => {
+    const { c } = client({ failFirst: { status: 401 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(FrontAuthError);
+    expect((err as Error).message).toMatch(/rejected the credentials \(401\)/i);
+  });
+
+  it("maps a missing KB to a not-found error", async () => {
+    const { c } = client({ kb: null });
+    await expect(c.fetchAll()).rejects.toBeInstanceOf(FrontNotFoundError);
+  });
+
+  it("never leaks the token in an error message", async () => {
+    const { c } = client({ failFirst: { status: 500 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain("tok");
+  });
+});
+
+describe("listFrontKnowledgeBases (install-time enumeration + credential check)", () => {
+  it("maps knowledge bases and skips malformed entries", async () => {
+    const { impl } = makeFetch({
+      knowledgeBases: [
+        { id: "kb_1", name: "Support" },
+        { id: "kb_2", name: "Internal" },
+        { name: "no id" }, // malformed — skipped
+      ],
+    });
+    const bases = await listFrontKnowledgeBases({ apiToken: "tok" }, { fetchImpl: impl });
+    expect(bases.map((b) => b.id)).toEqual(["kb_1", "kb_2"]);
+    expect(bases[0]).toMatchObject({ id: "kb_1", name: "Support" });
+  });
+
+  it("propagates an auth failure loudly", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 401 } });
+    await expect(
+      listFrontKnowledgeBases({ apiToken: "bad" }, { fetchImpl: impl }),
+    ).rejects.toBeInstanceOf(FrontAuthError);
+  });
+});
+
+describe("normalizeFrontTimestamp", () => {
+  it("normalizes Unix epoch seconds and ISO strings, rejecting garbage", () => {
+    expect(normalizeFrontTimestamp(1783296000)).toBe("2026-07-06T00:00:00.000Z");
+    expect(normalizeFrontTimestamp("2026-07-01T10:00:00Z")).toBe("2026-07-01T10:00:00.000Z");
+    expect(normalizeFrontTimestamp("not-a-date")).toBeNull();
+    expect(normalizeFrontTimestamp(null)).toBeNull();
+    expect(normalizeFrontTimestamp(undefined)).toBeNull();
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds and rejects HTTP-dates/garbage", () => {
+    expect(parseRetryAfter("42")).toBe(42);
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/knowledge/front/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/front/__tests__/client.test.ts
@@ -275,6 +275,17 @@ describe("fetchChanges (incremental)", () => {
     expect(changes.highWaterMark).toBe("2026-07-08T00:00:00.000Z");
   });
 
+  it("re-emits an article edited exactly at the high-water mark (>= is inclusive)", async () => {
+    const since = "2026-07-05T00:00:00.000Z";
+    const { c } = client({
+      kb: { id: KB, locales: ["en"] },
+      articlesByLocale: { en: [art({ id: "art_5", name: "Edge", last_edited: since })] },
+    });
+    const changes = await c.fetchChanges({ since, cursor: null });
+    // A regression to `>` would silently drop an article touched at the mark.
+    expect(changes.documents.map((d) => d.path)).toEqual(["front-support/en/edge-art_5.md"]);
+  });
+
   it("serves a null since as a full crawl (defensive)", async () => {
     const { c } = client({
       kb: { id: KB, locales: ["en"] },

--- a/packages/api/src/lib/knowledge/front/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/front/__tests__/connector.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the Front KnowledgeSyncConnector (#4400) — the createClient factory
+ * contract: parse the stored per-KB config, read the encrypted token loudly,
+ * and build a vendor client. The credential store is mocked (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let tokenResult: string | null | (() => never) = "secret-token";
+
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof tokenResult === "function") return tokenResult();
+    return tokenResult;
+  },
+}));
+
+const { createFrontConnector } = await import("@atlas/api/lib/knowledge/front/connector");
+const { FRONT_CATALOG_ID, FRONT_VENDOR } = await import("@atlas/api/lib/knowledge/front/config");
+
+const VALID_CONFIG = {
+  knowledge_base_id: "kb_1",
+  knowledge_base_name: "Support Center",
+};
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "front-support", config };
+}
+
+afterEach(() => {
+  tokenResult = "secret-token";
+});
+
+describe("createFrontConnector", () => {
+  it("advertises the front catalog id and vendor slug", () => {
+    const connector = createFrontConnector();
+    expect(connector.catalogId).toBe(FRONT_CATALOG_ID);
+    expect(connector.vendor).toBe(FRONT_VENDOR);
+  });
+
+  it("builds a vendor client from valid per-KB config + a stored token", async () => {
+    const connector = createFrontConnector();
+    const client = await connector.createClient(ctx(VALID_CONFIG));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error when the stored config is missing the KB", async () => {
+    const connector = createFrontConnector();
+    await expect(connector.createClient(ctx({ knowledge_base_name: "x" }))).rejects.toThrow(
+      /no Front knowledge base configured/i,
+    );
+  });
+
+  it("throws when the collection has no stored API token", async () => {
+    tokenResult = null;
+    const connector = createFrontConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/no stored API token/i);
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    tokenResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createFrontConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/front/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/front/__tests__/documents.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the Front article-locale → ConnectorDocument assembly (#4400): the
+ * per-locale archive path (`<locale>/<title-slug>-<id>.md`, prefixed), the
+ * `atlas:` provenance block (connector + knowledge base + article id + locale +
+ * last_edited), the shared-converter integration (counted image degradations),
+ * and the contentless skip. Pure — no I/O.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleFrontDocuments,
+  slugifyTitle,
+  type FrontArticleLocale,
+} from "@atlas/api/lib/knowledge/front/documents";
+
+const OPTS = { collectionSlug: "front-support", knowledgeBaseId: "kb_1" };
+
+function article(overrides: Partial<FrontArticleLocale> = {}): FrontArticleLocale {
+  return {
+    articleId: "art_123",
+    knowledgeBaseId: "kb_1",
+    locale: "en",
+    title: "Getting Started",
+    bodyHtml: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    lastEdited: "2026-07-01T10:00:00.000Z",
+    url: "https://help.acme.test/en/articles/art_123",
+    ...overrides,
+  };
+}
+
+describe("slugifyTitle", () => {
+  it("lowercases and dashes non-alphanumerics (NFKD)", () => {
+    expect(slugifyTitle("Setup & Testing Guide!", "x")).toBe("setup-testing-guide");
+  });
+  it("falls back when the title has no usable characters", () => {
+    expect(slugifyTitle("你好", "article")).toBe("article");
+  });
+});
+
+describe("assembleFrontDocuments", () => {
+  it("emits one document per locale at <prefix>/<locale>/<slug>-<id>.md", () => {
+    const result = assembleFrontDocuments(
+      [article(), article({ locale: "fr", title: "Pour commencer", articleId: "art_123" })],
+      OPTS,
+    );
+    expect(result.documents.map((d) => d.path)).toEqual([
+      "front-support/en/getting-started-art_123.md",
+      "front-support/fr/pour-commencer-art_123.md",
+    ]);
+  });
+
+  it("stamps frontmatter provenance and the atlas: extension block", () => {
+    const { documents } = assembleFrontDocuments([article()], OPTS);
+    const content = documents[0].content;
+    expect(content).toContain('title: "Getting Started"');
+    expect(content).toContain('resource: "https://help.acme.test/en/articles/art_123"');
+    expect(content).toContain('timestamp: "2026-07-01T10:00:00.000Z"');
+    expect(content).toContain("atlas:");
+    expect(content).toContain('connector: "front"');
+    expect(content).toContain('knowledge_base: "kb_1"');
+    expect(content).toContain('article_id: "art_123"');
+    expect(content).toContain('locale: "en"');
+    expect(content).toContain('last_edited: "2026-07-01T10:00:00.000Z"');
+    // No provenance tags — `tags` is a mirrored change-comparison column, so
+    // stamping one would re-draft every already-ingested document.
+    expect(content).not.toContain("tags:");
+  });
+
+  it("aggregates image degradations across articles", () => {
+    const { degradations } = assembleFrontDocuments(
+      [
+        article({ bodyHtml: '<p>Some intro text here.</p><img src="a.png"><img src="b.png">' }),
+        article({ locale: "fr", bodyHtml: '<p>Un peu de texte ici dedans.</p><img src="c.png">' }),
+      ],
+      OPTS,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 3 }]);
+  });
+
+  it("skips (and counts) a contentless article instead of emitting an empty doc", () => {
+    const result = assembleFrontDocuments(
+      [article({ bodyHtml: "<div><script>x()</script></div>" }), article({ locale: "fr" })],
+      OPTS,
+    );
+    expect(result.skippedContentless).toBe(1);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].path).toContain("/fr/");
+  });
+
+  it("uses the fallback segment for an unslugifiable title (id keeps it unique)", () => {
+    const { documents } = assembleFrontDocuments([article({ title: "你好", articleId: "art_9" })], OPTS);
+    expect(documents[0].path).toBe("front-support/en/article-art_9.md");
+  });
+});

--- a/packages/api/src/lib/knowledge/front/client.ts
+++ b/packages/api/src/lib/knowledge/front/client.ts
@@ -1,0 +1,589 @@
+/**
+ * The Front Knowledge Base vendor client (#4400, PRD #4395) — a
+ * {@link ConnectorVendorClient} over Front's authenticated Core API
+ * (`api2.frontapp.com`, scope `knowledge_bases:read`), driven by the shared
+ * connector engine (`connector-sync.ts`). It owns ONLY enumerate + fetch +
+ * convert; scheduling, high-water marks, reconciliation cadence, 429 backoff,
+ * and caps are the engine's (ADR-0030).
+ *
+ * Front exposes NO server-side change feed (`updated_since`), so both engine
+ * cadences are served from one full enumeration — the PRD's delta-less
+ * reconciliation-diff posture:
+ *   - `fetchAll()` (reconciliation) — walk every KB locale's article list via
+ *     cursor pagination (`_pagination.next`), emit one document per PUBLISHED
+ *     locale variant. The engine archives previously-ingested paths absent from
+ *     this set, so a draft/archived/deleted article is treated as absent, never
+ *     an error (the AC's "article state drives published filter + archive
+ *     detection").
+ *   - `fetchChanges({ since })` (incremental) — the SAME full crawl, but only
+ *     articles whose `last_edited` is at-or-after `since` are emitted (Front has
+ *     no delta, but each article carries `last_edited`, so the high-water mark
+ *     still narrows the ingest churn). Deletions are not detectable here — the
+ *     reconciliation crawl owns subtractive archiving.
+ *
+ * One client mirrors ONE knowledge base (the install handler fans one install
+ * out to one collection per KB). A KB's declared `locales` drive the per-locale
+ * walk; each `(article, locale)` pair is a distinct document.
+ *
+ * Security + hygiene: the host is a fixed Front constant, but every request
+ * still goes through `guardedFetch` (SSRF egress guard; auth stripped on
+ * cross-origin redirect), and a vendor-supplied `_pagination.next` is pinned to
+ * the same origin before being fetched with the `Authorization` header. A 429
+ * is the ONLY signal that becomes the engine's backoff (thrown as
+ * {@link ConnectorRateLimitError}); every other failure is an actionable error
+ * with the host redacted via `hostForLog` — the token lives in the
+ * `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import { getIngestMaxDocs } from "../ingest-limits";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import { FRONT_API_BASE } from "./config";
+import { assembleFrontDocuments, type FrontArticleLocale } from "./documents";
+
+const log = createLogger("knowledge.front.client");
+
+/**
+ * Front rejected the credentials (401/403). A distinct class — not a
+ * `cause`-presence side channel — so the install handler can blame the
+ * `api_token` field with `instanceof` (the `ConnectorRateLimitError`
+ * precedent; plain subclass, this is not Effect code).
+ */
+export class FrontAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FrontAuthError";
+  }
+}
+
+/** Front returned 404 — the knowledge base id is wrong or invisible to the token. */
+export class FrontNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FrontNotFoundError";
+  }
+}
+
+/** Resolved, non-secret connection inputs plus the token. One KB per client. */
+export interface FrontClientConfig {
+  /** The Front knowledge base id this collection mirrors. */
+  readonly knowledgeBaseId: string;
+  readonly apiToken: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface FrontClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** Test-only override of the ingest doc cap (defaults to the settings value). */
+  readonly maxDocs?: number;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * Hard anti-runaway bound on pages walked in one paginated enumeration — the
+ * article list AND the knowledge-base listing share it, so every walk fails
+ * loud on a stuck `_pagination.next` cursor rather than looping forever.
+ */
+const MAX_FEED_PAGES = 1_000;
+/**
+ * Hard anti-runaway bound on enumerated articles across all locales — NOT the
+ * ingest cap (the engine owns that, and surfaces the real over-limit numbers).
+ * A KB larger than this is pathological; we fail loud rather than loop unbounded
+ * on a broken `next` link.
+ */
+const MAX_ARTICLES = 100_000;
+/**
+ * Anti-runaway bound on the locales walked for one KB. Front supports ~40
+ * locales; a KB reporting far more is an anomalous vendor response.
+ */
+const MAX_LOCALES = 200;
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (only the fields we read; untrusted vendor JSON —
+// every field optional, narrowed at the use sites)
+// ---------------------------------------------------------------------------
+
+interface FrontPagination {
+  readonly next?: string | null;
+}
+interface RawKnowledgeBase {
+  readonly id?: string;
+  readonly name?: string;
+  readonly locales?: readonly unknown[];
+}
+interface KnowledgeBaseListResponse {
+  readonly _results?: readonly RawKnowledgeBase[];
+  readonly _pagination?: FrontPagination;
+}
+interface RawArticle {
+  readonly id?: number | string;
+  readonly name?: string;
+  /** `draft` | `published` | `archived`. */
+  readonly status?: string;
+  readonly html_content?: string | null;
+  /** Front timestamp: Unix epoch seconds (float) or an ISO-8601 string. */
+  readonly last_edited?: number | string;
+  readonly locale?: string;
+  readonly url?: string;
+}
+interface ArticleListResponse {
+  readonly _results?: readonly RawArticle[];
+  readonly _pagination?: FrontPagination;
+}
+
+/** One enumerated article-locale, normalized (timestamp canonical, id stringified). */
+interface NormalizedArticle {
+  readonly id: string;
+  /** Lowercased article status; `""` when the vendor omitted it (= not published). */
+  readonly status: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor value. */
+  readonly lastEdited: string;
+  /** The list entry's `html_content`, or null when the list omitted the body. */
+  readonly htmlContent: string | null;
+  readonly title: string;
+  /** Resolved locale label for the path/provenance (lowercased). */
+  readonly locale: string;
+  /** The `?locale=` param this row was walked with (null = default-locale walk). */
+  readonly localeParam: string | null;
+  readonly url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Front vendor client for ONE knowledge base. `createClient` (the
+ * connector factory) has already decrypted the token and validated config, so
+ * this constructor does no I/O.
+ */
+export function createFrontVendorClient(
+  config: FrontClientConfig,
+  deps: FrontClientDeps = {},
+): ConnectorVendorClient {
+  const api = new FrontApi(config, deps);
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      return api.fetch({ since: params.since });
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetch({ since: null });
+    },
+  };
+}
+
+/** One Front knowledge base, normalized for the install handler's fan-out. */
+export interface FrontKnowledgeBase {
+  /** The knowledge base id. */
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface FrontAccountParams {
+  readonly apiToken: string;
+}
+
+/**
+ * Enumerate the company's knowledge bases — ALSO the install-time credential
+ * check (the first authenticated request doubles as it; loud on every failure).
+ * A bad token surfaces as a 401, both actionable and host-redacted; the install
+ * handler maps it to a field-level 400 so "invalid credentials fail the install
+ * loudly."
+ */
+export async function listFrontKnowledgeBases(
+  params: FrontAccountParams,
+  deps: FrontClientDeps = {},
+): Promise<FrontKnowledgeBase[]> {
+  const http = new FrontHttp(params.apiToken, deps);
+  const bases: FrontKnowledgeBase[] = [];
+  let skippedMalformed = 0;
+  let url: string | null = `${FRONT_API_BASE}/knowledge_bases`;
+  let pages = 0;
+  while (url !== null) {
+    if (++pages > MAX_FEED_PAGES) {
+      throw new Error(
+        `Front knowledge-base listing on ${hostForLog(FRONT_API_BASE)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+      );
+    }
+    const body: KnowledgeBaseListResponse =
+      await http.getJson<KnowledgeBaseListResponse>(url);
+    for (const raw of body._results ?? []) {
+      const id = typeof raw.id === "string" ? raw.id.trim() : "";
+      if (id === "") {
+        skippedMalformed++;
+        continue;
+      }
+      bases.push({
+        id,
+        name: typeof raw.name === "string" && raw.name.trim() !== "" ? raw.name.trim() : id,
+      });
+    }
+    url = nextPageUrl(body._pagination?.next);
+  }
+  if (skippedMalformed > 0) {
+    log.warn(
+      { host: hostForLog(FRONT_API_BASE), skippedMalformed },
+      "Skipped Front knowledge bases missing an id — not installable (unexpected vendor response)",
+    );
+  }
+  return bases;
+}
+
+/**
+ * Resolve a vendor-supplied pagination link and pin it to Front's origin.
+ * `_pagination.next` is fetched with the `Authorization` header — an off-origin
+ * link (broken or malicious vendor payload) must fail loudly rather than
+ * forward credentials. Null / empty ends the walk.
+ */
+function nextPageUrl(rawNext: string | null | undefined): string | null {
+  if (typeof rawNext !== "string" || rawNext === "") return null;
+  let resolved: URL;
+  try {
+    resolved = new URL(rawNext, FRONT_API_BASE);
+  } catch (err) {
+    // Translate-and-rethrow: the raw link must not reach the message (untrusted
+    // vendor payload), but the parse failure rides along as cause.
+    throw new Error(
+      `Front returned an unparseable pagination link from ${hostForLog(FRONT_API_BASE)} — unexpected vendor response.`,
+      { cause: err },
+    );
+  }
+  if (resolved.origin !== new URL(FRONT_API_BASE).origin) {
+    throw new Error(
+      `Front returned a pagination link pointing off ${hostForLog(FRONT_API_BASE)} — refusing to follow it with credentials.`,
+    );
+  }
+  return resolved.toString();
+}
+
+class FrontApi {
+  private readonly http: FrontHttp;
+  private readonly maxDocs: number;
+
+  constructor(
+    private readonly config: FrontClientConfig,
+    deps: FrontClientDeps,
+  ) {
+    this.http = new FrontHttp(config.apiToken, deps);
+    this.maxDocs = deps.maxDocs ?? getIngestMaxDocs();
+  }
+
+  /**
+   * Enumerate every locale variant of the KB's articles + assemble. When
+   * `since` is null this is a reconciliation crawl (every published locale
+   * variant emitted); otherwise an incremental cycle (only variants edited
+   * at-or-after `since`).
+   */
+  async fetch(opts: { since: string | null }): Promise<ConnectorChanges> {
+    const reconciliation = opts.since === null;
+    const locales = await this.resolveLocales();
+
+    const collected: NormalizedArticle[] = [];
+    let skippedMalformed = 0;
+    for (const locale of locales) {
+      const result = await this.listArticlesForLocale(locale);
+      collected.push(...result.articles);
+      skippedMalformed += result.skippedMalformed;
+      if (collected.length > MAX_ARTICLES) {
+        throw new Error(
+          `Front knowledge base "${this.config.knowledgeBaseId}" exceeds ${MAX_ARTICLES} articles — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+        );
+      }
+    }
+
+    // Every article — published or not — advances the mark: its change is what
+    // this fetch observed. ISO instants compare chronologically as strings.
+    let highWaterMark: string | null = null;
+    for (const a of collected) {
+      if (highWaterMark === null || a.lastEdited > highWaterMark) highWaterMark = a.lastEdited;
+    }
+
+    // Only PUBLISHED variants are candidate documents; on incremental, narrow to
+    // those edited at-or-after `since`. Draft/archived variants are simply absent
+    // — the reconciliation crawl's subtractive diff archives their stale paths.
+    const candidates = collected.filter(
+      (a) =>
+        a.status === "published" &&
+        (reconciliation || opts.since === null || a.lastEdited >= opts.since),
+    );
+
+    // Reject an over-cap FULL published set on reconciliation BEFORE fetching
+    // any fallback bodies — the engine's ingest cap is the backstop, but checking
+    // here puts real numbers in the error (the AC's "caps validated over the full
+    // set").
+    if (reconciliation && candidates.length > this.maxDocs) {
+      throw new Error(
+        `This Front knowledge base has ${candidates.length} published article locales, over the ${this.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the KB's scope, or raise the cap.`,
+      );
+    }
+
+    let sideloadFallbacks = 0;
+    const emitted: FrontArticleLocale[] = [];
+    for (const a of candidates) {
+      // The article list SHOULD carry `html_content`; when it doesn't, fetch the
+      // single localized article (the canonical body source). Counted + logged:
+      // the fallback flips the request profile to N+1, and an operator debugging
+      // sudden 429s needs the breadcrumb.
+      let bodyHtml = a.htmlContent;
+      if (bodyHtml === null) {
+        sideloadFallbacks++;
+        bodyHtml = await this.fetchArticleHtml(a.id, a.localeParam);
+      }
+      if (bodyHtml === null) {
+        // A published article we can't get a body for is a KNOWN hole: skip +
+        // count so it flags coverage incomplete (the engine holds subtractive
+        // archiving), never a silently-emitted empty document that a later
+        // reconciliation would then archive.
+        skippedMalformed++;
+        continue;
+      }
+      emitted.push({
+        articleId: a.id,
+        knowledgeBaseId: this.config.knowledgeBaseId,
+        locale: a.locale,
+        title: a.title,
+        bodyHtml,
+        lastEdited: a.lastEdited,
+        url: a.url,
+      });
+    }
+
+    const assembled = assembleFrontDocuments(emitted, {
+      collectionSlug: this.config.collectionSlug,
+      knowledgeBaseId: this.config.knowledgeBaseId,
+    });
+    const mode = reconciliation ? "reconciliation" : "incremental";
+    if (assembled.degradations.length > 0 || assembled.skippedContentless > 0) {
+      log.info(
+        {
+          host: hostForLog(FRONT_API_BASE),
+          knowledgeBaseId: this.config.knowledgeBaseId,
+          mode,
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+        },
+        "Front conversion completed with degradations/skips",
+      );
+    }
+    if (skippedMalformed > 0) {
+      log.warn(
+        { host: hostForLog(FRONT_API_BASE), mode, skippedMalformed },
+        "Skipped Front articles missing id/last_edited/body — not ingested (coverage flagged incomplete)",
+      );
+    }
+    if (sideloadFallbacks > 0) {
+      log.warn(
+        { host: hostForLog(FRONT_API_BASE), mode, sideloadFallbacks },
+        "Front article list returned no html_content — fell back to per-article fetches (N+1 request profile)",
+      );
+    }
+
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+
+  /**
+   * Resolve the KB's locales (the walk set) AND verify the KB is live. A KB
+   * declaring no locales falls back to a single default-locale walk (a `null`
+   * entry = no `?locale=` param). Doubles as the reconciliation-time liveness
+   * check: a missing KB is a loud not-found.
+   */
+  private async resolveLocales(): Promise<Array<string | null>> {
+    const kb = await this.http.getJson<RawKnowledgeBase>(
+      `${FRONT_API_BASE}/knowledge_bases/${encodeURIComponent(this.config.knowledgeBaseId)}`,
+    );
+    if (typeof kb.id !== "string" || kb.id === "") {
+      throw new FrontNotFoundError(
+        `Front knowledge base "${this.config.knowledgeBaseId}" was not found or is not visible to this token — check the KB id and the token's permissions.`,
+      );
+    }
+    const locales = (kb.locales ?? [])
+      .filter((l): l is string => typeof l === "string" && l.trim() !== "")
+      .map((l) => l.trim());
+    if (locales.length > MAX_LOCALES) {
+      throw new Error(
+        `Front knowledge base "${this.config.knowledgeBaseId}" reports ${locales.length} locales, over the ${MAX_LOCALES} safety bound — unexpected vendor response.`,
+      );
+    }
+    return locales.length > 0 ? locales : [null];
+  }
+
+  /** Cursor-paginate one locale's article list. `walkLocale` null = default. */
+  private async listArticlesForLocale(
+    walkLocale: string | null,
+  ): Promise<{ articles: NormalizedArticle[]; skippedMalformed: number }> {
+    const articles: NormalizedArticle[] = [];
+    let skippedMalformed = 0;
+    const localeQuery = walkLocale !== null ? `?locale=${encodeURIComponent(walkLocale)}` : "";
+    let url: string | null =
+      `${FRONT_API_BASE}/knowledge_bases/${encodeURIComponent(this.config.knowledgeBaseId)}/articles${localeQuery}`;
+    let pages = 0;
+    while (url !== null) {
+      if (++pages > MAX_FEED_PAGES) {
+        throw new Error(
+          `Front article listing on ${hostForLog(FRONT_API_BASE)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+        );
+      }
+      const body: ArticleListResponse = await this.http.getJson<ArticleListResponse>(url);
+      for (const raw of body._results ?? []) {
+        const normalized = this.normalizeArticle(raw, walkLocale);
+        if (normalized !== null) articles.push(normalized);
+        else skippedMalformed++;
+      }
+      url = nextPageUrl(body._pagination?.next);
+    }
+    return { articles, skippedMalformed };
+  }
+
+  /** One published article's body when the list omitted it; null = still absent. */
+  private async fetchArticleHtml(
+    articleId: string,
+    localeParam: string | null,
+  ): Promise<string | null> {
+    const localeQuery = localeParam !== null ? `?locale=${encodeURIComponent(localeParam)}` : "";
+    const url = `${FRONT_API_BASE}/knowledge_bases/${encodeURIComponent(this.config.knowledgeBaseId)}/articles/${encodeURIComponent(articleId)}${localeQuery}`;
+    const body = await this.http.getJson<RawArticle>(url);
+    return typeof body.html_content === "string" ? body.html_content : null;
+  }
+
+  /** Normalize one raw article; null = malformed (skip + count). */
+  private normalizeArticle(raw: RawArticle, walkLocale: string | null): NormalizedArticle | null {
+    const id = idOf(raw.id);
+    const lastEdited = normalizeFrontTimestamp(raw.last_edited);
+    if (id === "" || lastEdited === null) return null;
+    const rawLocale =
+      typeof raw.locale === "string" && raw.locale.trim() !== "" ? raw.locale.trim() : walkLocale;
+    return {
+      id,
+      status: typeof raw.status === "string" ? raw.status.trim().toLowerCase() : "",
+      lastEdited,
+      htmlContent: typeof raw.html_content === "string" ? raw.html_content : null,
+      title: typeof raw.name === "string" ? raw.name : "",
+      locale: (rawLocale ?? "default").toLowerCase(),
+      localeParam: walkLocale,
+      url: this.articleUrl(raw, id, walkLocale),
+    };
+  }
+
+  /** Prefer the article's own URL; fall back to a canonical API resource path. */
+  private articleUrl(raw: RawArticle, id: string, walkLocale: string | null): string {
+    if (typeof raw.url === "string" && /^https?:\/\//i.test(raw.url)) return raw.url;
+    const localeQuery = walkLocale !== null ? `?locale=${encodeURIComponent(walkLocale)}` : "";
+    return `${FRONT_API_BASE}/knowledge_bases/${encodeURIComponent(this.config.knowledgeBaseId)}/articles/${encodeURIComponent(id)}${localeQuery}`;
+  }
+}
+
+/** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */
+function idOf(raw: number | string | undefined): string {
+  return typeof raw === "number" || typeof raw === "string" ? String(raw) : "";
+}
+
+/**
+ * Normalize a Front timestamp to a canonical ISO instant. Front core timestamps
+ * are Unix epoch SECONDS (float); a string is parsed as ISO-8601. Anything else
+ * (or an unparseable value) is null.
+ */
+export function normalizeFrontTimestamp(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value * 1000).toISOString();
+  }
+  return toIsoInstant(value);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP (shared by the per-KB client and the account-level KB listing)
+// ---------------------------------------------------------------------------
+
+class FrontHttp {
+  private readonly authHeader: string;
+
+  constructor(
+    apiToken: string,
+    private readonly deps: FrontClientDeps,
+  ) {
+    this.authHeader = `Bearer ${apiToken}`;
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  async getJson<T>(url: string): Promise<T> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `Front request to ${hostForLog(FRONT_API_BASE)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `Front rate-limited the request to ${hostForLog(FRONT_API_BASE)} (Front applies per-endpoint rate limits; honor Retry-After).`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new FrontAuthError(
+        `Front rejected the credentials (${response.status}) for ${hostForLog(FRONT_API_BASE)} — re-enter the API token (Front → Settings → Developers → API tokens) and confirm it has the knowledge_bases:read scope.`,
+      );
+    }
+    if (response.status === 404) {
+      throw new FrontNotFoundError(
+        `Front returned 404 from ${hostForLog(FRONT_API_BASE)} — the knowledge base id may be wrong or the token can't see it.`,
+      );
+    }
+    if (response.status >= 500) {
+      throw new Error(
+        `Front returned HTTP ${response.status} from ${hostForLog(FRONT_API_BASE)} — a vendor-side error; the next scheduled sync (or retrying the install) will usually succeed.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Front returned HTTP ${response.status} from ${hostForLog(FRONT_API_BASE)} — an unexpected Front API response; if it persists, re-install the collection or check Front's API status.`,
+      );
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new Error(
+        `Front returned a non-JSON response from ${hostForLog(FRONT_API_BASE)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/** Parse a `Retry-After` header (delta-seconds only; HTTP-date → null). */
+export function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}

--- a/packages/api/src/lib/knowledge/front/client.ts
+++ b/packages/api/src/lib/knowledge/front/client.ts
@@ -221,7 +221,7 @@ export async function listFrontKnowledgeBases(
     }
     const body: KnowledgeBaseListResponse =
       await http.getJson<KnowledgeBaseListResponse>(url);
-    for (const raw of body._results ?? []) {
+    for (const raw of asArray(body._results)) {
       const id = typeof raw.id === "string" ? raw.id.trim() : "";
       if (id === "") {
         skippedMalformed++;
@@ -315,10 +315,11 @@ class FrontApi {
     // Only PUBLISHED variants are candidate documents; on incremental, narrow to
     // those edited at-or-after `since`. Draft/archived variants are simply absent
     // — the reconciliation crawl's subtractive diff archives their stale paths.
+    // `reconciliation === (opts.since === null)`, so the reconciliation path
+    // keeps every published variant; incremental keeps those edited at-or-after
+    // the mark (>= is inclusive so an article edited exactly at `since` re-emits).
     const candidates = collected.filter(
-      (a) =>
-        a.status === "published" &&
-        (reconciliation || opts.since === null || a.lastEdited >= opts.since),
+      (a) => a.status === "published" && (opts.since === null || a.lastEdited >= opts.since),
     );
 
     // Reject an over-cap FULL published set on reconciliation BEFORE fetching
@@ -415,7 +416,7 @@ class FrontApi {
         `Front knowledge base "${this.config.knowledgeBaseId}" was not found or is not visible to this token — check the KB id and the token's permissions.`,
       );
     }
-    const locales = (kb.locales ?? [])
+    const locales = asArray(kb.locales)
       .filter((l): l is string => typeof l === "string" && l.trim() !== "")
       .map((l) => l.trim());
     if (locales.length > MAX_LOCALES) {
@@ -443,7 +444,7 @@ class FrontApi {
         );
       }
       const body: ArticleListResponse = await this.http.getJson<ArticleListResponse>(url);
-      for (const raw of body._results ?? []) {
+      for (const raw of asArray(body._results)) {
         const normalized = this.normalizeArticle(raw, walkLocale);
         if (normalized !== null) articles.push(normalized);
         else skippedMalformed++;
@@ -475,6 +476,11 @@ class FrontApi {
       id,
       status: typeof raw.status === "string" ? raw.status.trim().toLowerCase() : "",
       lastEdited,
+      // Null-vs-empty contract: a PRESENT string (incl. `""`) is the genuine
+      // body — an empty one assembles to a contentless skip. Only an ABSENT /
+      // non-string field is `null`, which triggers the per-article fallback
+      // fetch (never a silent empty-body emit that a reconciliation could then
+      // wrongly archive — mirrors gitbook/client.ts).
       htmlContent: typeof raw.html_content === "string" ? raw.html_content : null,
       title: typeof raw.name === "string" ? raw.name : "",
       locale: (rawLocale ?? "default").toLowerCase(),
@@ -489,6 +495,16 @@ class FrontApi {
     const localeQuery = walkLocale !== null ? `?locale=${encodeURIComponent(walkLocale)}` : "";
     return `${FRONT_API_BASE}/knowledge_bases/${encodeURIComponent(this.config.knowledgeBaseId)}/articles/${encodeURIComponent(id)}${localeQuery}`;
   }
+}
+
+/**
+ * Coerce an untrusted vendor field to a readonly array — a non-array `_results`
+ * / `locales` (an object, a string) would otherwise throw a bare TypeError at
+ * the `for…of`; treating it as empty keeps the walk's own bounds + coverage
+ * flagging in charge of anomalous responses.
+ */
+function asArray<T>(value: readonly T[] | undefined): readonly T[] {
+  return Array.isArray(value) ? value : [];
 }
 
 /** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */

--- a/packages/api/src/lib/knowledge/front/config.ts
+++ b/packages/api/src/lib/knowledge/front/config.ts
@@ -31,7 +31,7 @@ export const FRONT_API_BASE = "https://api2.frontapp.com";
 
 /** The non-secret config persisted on each per-KB `workspace_plugins` row. */
 export interface FrontCollectionConfig {
-  /** The Front knowledge base this collection mirrors (one KB per install). */
+  /** The Front knowledge base this collection mirrors (one KB per collection). */
   readonly knowledge_base_id: string;
   /** Human KB name, for the admin surface. */
   readonly knowledge_base_name: string;

--- a/packages/api/src/lib/knowledge/front/config.ts
+++ b/packages/api/src/lib/knowledge/front/config.ts
@@ -1,0 +1,62 @@
+/**
+ * Front Knowledge Base connector identity + stored-config contract (#4400,
+ * PRD #4395).
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config),
+ * the connector (reads it back in `createClient`), and the admin-knowledge
+ * surface (recognizes the catalog id) share ONE definition — a field rename
+ * can't drift the three apart silently. The Bearer token is NOT part of this
+ * config; it lives encrypted in `knowledge_sync_credentials` and is read via
+ * `readSyncCredential`.
+ *
+ * Front is a MULTI-KB vendor: one install enumerates the company's knowledge
+ * bases (`GET /knowledge_bases`) and creates one collection per KB (the PRD's
+ * "each KB maps to a collection"). Each collection's config is therefore
+ * KB-scoped: it pins the knowledge-base id its client crawls. Front's API is a
+ * fixed vendor host (`api2.frontapp.com`), so — unlike Confluence — there is no
+ * customer-supplied base URL to persist; every request still goes through the
+ * SSRF egress guard at fetch time (defence in depth; the AC's "host through the
+ * egress guard").
+ */
+
+/** The built-in Front Knowledge Base catalog slug + row id. */
+export const FRONT_SLUG = "front";
+export const FRONT_CATALOG_ID = "catalog:front";
+/** Vendor slug stamped into `atlas_source` as `connector:front`. */
+export const FRONT_VENDOR = "front";
+
+/** The Front Core API base — a fixed vendor host, never customer-supplied. */
+export const FRONT_API_BASE = "https://api2.frontapp.com";
+
+/** The non-secret config persisted on each per-KB `workspace_plugins` row. */
+export interface FrontCollectionConfig {
+  /** The Front knowledge base this collection mirrors (one KB per install). */
+  readonly knowledge_base_id: string;
+  /** Human KB name, for the admin surface. */
+  readonly knowledge_base_name: string;
+  readonly description?: string;
+}
+
+export type ParsedFrontConfig =
+  | { readonly ok: true; readonly knowledgeBaseId: string }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * field means someone edited the row out of band; re-installing repairs it.
+ */
+export function parseFrontConfig(
+  config: Record<string, unknown> | null,
+): ParsedFrontConfig {
+  const knowledgeBaseId =
+    typeof config?.knowledge_base_id === "string" ? config.knowledge_base_id.trim() : "";
+  if (knowledgeBaseId === "") {
+    return {
+      ok: false,
+      error: "Collection has no Front knowledge base configured — re-install it.",
+    };
+  }
+  return { ok: true, knowledgeBaseId };
+}

--- a/packages/api/src/lib/knowledge/front/connector.ts
+++ b/packages/api/src/lib/knowledge/front/connector.ts
@@ -1,0 +1,80 @@
+/**
+ * The Front Knowledge Base {@link KnowledgeSyncConnector} (#4400, PRD #4395) —
+ * the catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * factory contract from ADR-0030: bind the stored per-KB config + the decrypted
+ * token into a vendor client. Scheduling, backoff, reconciliation, caps, and
+ * ingest are the shared engine's.
+ *
+ * One Front install fans out to one collection PER KNOWLEDGE BASE (the install
+ * handler's job); each collection row carries its KB id, so this factory builds
+ * a client scoped to exactly one knowledge base.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { createFrontVendorClient, type FrontClientDeps } from "./client";
+import { FRONT_CATALOG_ID, FRONT_VENDOR, parseFrontConfig } from "./config";
+
+const log = createLogger("knowledge.front.connector");
+
+export interface FrontConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: FrontClientDeps;
+}
+
+/** Build the Front connector. `deps` is test-only vendor-client injection. */
+export function createFrontConnector(
+  deps: FrontConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: FRONT_CATALOG_ID,
+    vendor: FRONT_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseFrontConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiToken = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiToken === null) {
+        throw new Error(
+          "This Front collection has no stored API token — re-install it to re-enter the token.",
+        );
+      }
+
+      return createFrontVendorClient(
+        {
+          knowledgeBaseId: parsed.knowledgeBaseId,
+          apiToken,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the Front connector idempotently — called from the boot seam that
+ * also registers install handlers (`registerBuiltinInstallHandlers`), and from
+ * tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog id, so
+ * gate on the registry first.
+ */
+export function registerFrontKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(FRONT_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createFrontConnector());
+  log.info({ catalogId: FRONT_CATALOG_ID }, "Registered Front knowledge sync connector");
+}

--- a/packages/api/src/lib/knowledge/front/documents.ts
+++ b/packages/api/src/lib/knowledge/front/documents.ts
@@ -52,7 +52,7 @@ export interface FrontArticleLocale {
   readonly bodyHtml: string;
   /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
   readonly lastEdited: string;
-  /** Canonical article URL. */
+  /** The article's own URL, or a canonical API resource path when it omits one. */
   readonly url: string;
 }
 

--- a/packages/api/src/lib/knowledge/front/documents.ts
+++ b/packages/api/src/lib/knowledge/front/documents.ts
@@ -1,0 +1,138 @@
+/**
+ * Front article-locale → OKF `ConnectorDocument` assembly (#4400, PRD #4395).
+ *
+ * Pure, deterministic glue between the SHARED support HTML→markdown converter
+ * (`../support/html-to-markdown.ts` — this vendor deliberately owns no
+ * HTML→md logic of its own) and the connector ingest seam. Each PUBLISHED
+ * locale variant of an article is a distinct document (the PRD's "per-locale
+ * translations are distinct documents"); draft/archived articles are never
+ * emitted, so an unpublish/archive reads as "path absent" and the
+ * reconciliation crawl archives it.
+ *
+ * Paths are `<locale>/<title-slug>-<article-id>.md` — locale + article id make
+ * them collision-free by construction (two locale variants never share both),
+ * and the id suffix means a basename can never be a reserved OKF name — the
+ * `deriveArchivePath` fold still runs as defence in depth. A title rename reads
+ * as "old path archived + new path drafted", the documented rename-churn
+ * posture (same as Zendesk/Confluence).
+ *
+ * Provenance that survives ingest: `resource` = the article's canonical URL,
+ * `timestamp` = its `last_edited`, plus an `atlas:` extension block carrying
+ * connector + knowledge base id + article id + locale + last_edited (the AC's
+ * provenance fields). No provenance `tags`: `tags` is a mirrored column in the
+ * lenient parser's change comparison, so stamping one would re-draft every
+ * already-ingested document; the extension block stays outside the comparison
+ * (the Zendesk/GitBook posture).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import {
+  convertSupportHtmlToMarkdown,
+  type HtmlDegradation,
+} from "../support/html-to-markdown";
+import { FRONT_VENDOR } from "./config";
+
+/** One PUBLISHED locale variant of an article, ready to convert. */
+export interface FrontArticleLocale {
+  /** Stable Front article id (shared across its locale variants). */
+  readonly articleId: string;
+  /** The knowledge base this article belongs to. */
+  readonly knowledgeBaseId: string;
+  /** Article locale, e.g. `en` or `fr` (normalized lowercase). */
+  readonly locale: string;
+  readonly title: string;
+  /** The article's HTML body (`html_content`). */
+  readonly bodyHtml: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly lastEdited: string;
+  /** Canonical article URL. */
+  readonly url: string;
+}
+
+export interface FrontAssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Media degradations aggregated across every assembled article. */
+  readonly degradations: readonly HtmlDegradation[];
+  /** Articles skipped because they carried no ingestable prose. */
+  readonly skippedContentless: number;
+}
+
+/** Slugify a title into a single path segment; `fallback` guarantees non-empty. */
+export function slugifyTitle(title: string, fallback: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched article locales.
+ * `knowledgeBaseId` lands in the `atlas:` provenance block (the AC's "provenance
+ * carries KB + article id + locale + last_edited").
+ */
+export function assembleFrontDocuments(
+  articles: readonly FrontArticleLocale[],
+  options: { readonly collectionSlug: string; readonly knowledgeBaseId: string },
+): FrontAssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  let skippedContentless = 0;
+
+  for (const a of articles) {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(a.bodyHtml, {
+      pageUrl: a.url,
+    });
+    for (const d of degradations) {
+      degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+    }
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    const segments = [
+      slugifyTitle(a.locale, "locale"),
+      `${slugifyTitle(a.title, "article")}-${a.articleId}`,
+    ];
+    const derived = deriveArchivePath(`${segments.join("/")}.md`);
+    const path = [...prefixSegments, derived.path].join("/");
+
+    const title = a.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        resource: a.url,
+        timestamp: a.lastEdited,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: FRONT_VENDOR,
+          knowledge_base: options.knowledgeBaseId,
+          article_id: a.articleId,
+          locale: a.locale,
+          last_edited: a.lastEdited,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless };
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -38,14 +38,17 @@ export interface KnowledgeDocumentCounts {
  *     SOQL pull of published Salesforce Knowledge article versions over the
  *     workspace's EXISTING Salesforce OAuth install — no credential of its
  *     own; one document per published article-version language).
+ *   - `front` — the #4400 Knowledge Sync Connector (a scheduled pull of Front
+ *     knowledge bases via a Bearer token; one collection per KB, one document
+ *     per published article locale; delta-less reconciliation-diff).
  *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
  * `authScheme`; connector collections (`notion`, `confluence`,
- * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`) carry
- * neither (their credential is a token — or, for `salesforce-knowledge`, the
- * reused OAuth install — not an endpoint).
+ * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`,
+ * `front`) carry neither (their credential is a token — or, for
+ * `salesforce-knowledge`, the reused OAuth install — not an endpoint).
  */
 export type KnowledgeCollectionSource =
   | "upload"
@@ -55,7 +58,8 @@ export type KnowledgeCollectionSource =
   | "confluence-datacenter"
   | "gitbook"
   | "zendesk"
-  | "salesforce-knowledge";
+  | "salesforce-knowledge"
+  | "front";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "front"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
Slice of PRD #4395 on the ADR-0030 Knowledge Sync Connector spine. Adds the `front` connector: a Bearer-token install over Front's authenticated Core API (`api2.frontapp.com`, scope `knowledge_bases:read`), one collection per knowledge base, per-locale article variants as distinct documents.

Closes #4400

## What it does
- **Bearer-token install, multi-KB fan-out** — `listFrontKnowledgeBases` enumerates the company's KBs at install (doubling as the loud credential check); one `pillar='knowledge'` collection per KB (base slug for a single KB, `<slug>-<kb>` suffixed for multi-KB). The token lands encrypted in `knowledge_sync_credentials` (one row per KB collection), never in `workspace_plugins.config`, with a per-KB credential rollback on a failed row write.
- **Delta-less reconciliation-diff** — Front exposes no `updated_since`, so both engine cadences run one full crawl over cursor pagination (`_pagination.next`, pinned same-origin): `fetchAll()` emits every published locale variant (engine archives absent paths); `fetchChanges({since})` narrows to `last_edited >= since` (inclusive). `last_edited` drives the high-water mark; article `status` (draft/published/archived) drives the published filter + subtractive archive detection.
- **Multi-KB + multi-locale** — each KB's declared `locales` drive a per-locale article walk; each `(article, locale)` is a distinct document at `<locale>/<title-slug>-<articleId>.md`. Provenance (`atlas:` block) carries connector + knowledge base + article id + locale + last_edited.
- **Shared converter** — consumes the merged `knowledge/support/html-to-markdown.ts` (#4396); no per-vendor HTML→md fork.
- **Security/hygiene** — fixed Front host through the SSRF egress guard at install + every fetch; 429/`Retry-After` → `ConnectorRateLimitError` (engine backoff); loud decrypt failures; draft-only ingest (structural via `connector:front` source); ingest cap validated over the full published set; anti-runaway page/article/locale bounds; token never in a URL or message.

## Files
- **new** `packages/api/src/lib/knowledge/front/{config,client,connector,documents}.ts`
- **new** `packages/api/src/lib/integrations/install/front-form-handler.ts`
- wiring: `register.ts` pairing, `seed-builtin-knowledge-catalog.ts` row, `admin-knowledge.ts` source branch, `@useatlas/types` wire union + web schema mirror, OpenAPI regen

## Tests
Vendor client fully test-doubled (no live Front API): reconciliation, cursor pagination, off-origin-link refusal, stuck-cursor bound, draft/archived filtering, html_content fallback fetch, malformed-item coverage flagging, incremental since-filter (+ inclusive boundary), Bearer auth, 429/401/404 mapping, token-never-leaked, KB enumeration, timestamp normalization. Plus form-handler (fan-out, credential routing, rollback, publish-guard preconditions), connector factory (loud decrypt), documents assembly, catalog-seed row, register pairing, admin-knowledge dispatch/list, and a real-Postgres install lifecycle test.

## Review
Internal review panel: round 1 → 2 must-fixes (a self-contradictory comment; documenting the re-install credential-rollback window) + polish (Array.isArray guards on untrusted arrays, disjunct simplification, null-vs-empty contract doc, an inclusive-boundary regression test) → round 2 CLEAN. Local `scripts/ci-local.sh`: 29/30 gates pass; the `test` gate flaked on two unrelated files (`discord.test.ts`, `python-rest-egress.test.ts`) that pass on isolated re-run and import nothing this PR touches.

https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN)_