### PR TITLE
feat(knowledge): Intercom Articles sync connector (#4399)

### DIFF
--- a/apps/docs/content/docs/guides/connect-intercom.mdx
+++ b/apps/docs/content/docs/guides/connect-intercom.mdx
@@ -9,7 +9,7 @@ import { Steps, Step } from "fumadocs-ui/components/steps";
 An **Intercom** connector mirrors your Intercom help center's articles into a [Knowledge Base](/guides/knowledge-base) collection. Atlas pulls your articles on a schedule, converts each one's HTML body to plain markdown, and queues every article as a **draft** for review — the same review gate as every other knowledge source. Connectors never publish on their own.
 
 <Callout title="Prerequisites">
-The Knowledge Base requires the internal database and managed auth (see the [Knowledge Base guide](/guides/knowledge-base)). The API host is fixed (`api.intercom.io`), so there is no base-URL field. Images and other media are **not** mirrored (text-first); they are replaced with links back to the source article.
+The Knowledge Base requires the internal database and managed auth (see the [Knowledge Base guide](/guides/knowledge-base)). The API host is fixed to Intercom's default US region (`api.intercom.io`); EU/AU data-residency workspaces are not yet supported. Images and other media are **not** mirrored (text-first); they are replaced with links back to the source article.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/guides/connect-intercom.mdx
+++ b/apps/docs/content/docs/guides/connect-intercom.mdx
@@ -1,0 +1,81 @@
+---
+title: Connect Intercom
+description: Mirror your Intercom help center's published articles into a review-gated Knowledge Base collection — access-token install, all locales, and the sync + review model.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+
+An **Intercom** connector mirrors your Intercom help center's articles into a [Knowledge Base](/guides/knowledge-base) collection. Atlas pulls your articles on a schedule, converts each one's HTML body to plain markdown, and queues every article as a **draft** for review — the same review gate as every other knowledge source. Connectors never publish on their own.
+
+<Callout title="Prerequisites">
+The Knowledge Base requires the internal database and managed auth (see the [Knowledge Base guide](/guides/knowledge-base)). The API host is fixed (`api.intercom.io`), so there is no base-URL field. Images and other media are **not** mirrored (text-first); they are replaced with links back to the source article.
+</Callout>
+
+---
+
+## Create an access token
+
+Atlas authenticates to Intercom with your app's access token (Bearer auth).
+
+<Steps>
+<Step>
+In Intercom, go to **Settings → Developers** and open (or create) an app in the Developer Hub.
+</Step>
+<Step>
+Under **Authentication**, copy the **Access Token**. It inherits your app's permissions, so make sure the app can **read Articles**.
+</Step>
+</Steps>
+
+<Callout type="warn" title="One workspace per collection">
+Intercom has no multi-brand concept, so one install mirrors your whole workspace's articles into a single collection. All locales of an article come along — each becomes its own independently-reviewable document.
+</Callout>
+
+---
+
+## Install
+
+Navigate to **Admin → Integrations**, choose **Knowledge Base (Intercom)**, and provide:
+
+- **Access token** — stored encrypted at rest; never shown again.
+- **Description** *(optional)* — a human note about what this collection covers.
+
+Atlas verifies the connection at install time by resolving your app identity with the token. A bad token points you at the token field — the install fails **loudly** rather than creating a collection that silently never syncs. On success the collection is created and its first sync is scheduled.
+
+---
+
+## How sync works
+
+Intercom exposes **no server-side "changed since" feed**, so Atlas uses a **reconciliation-diff** posture: every cycle walks the full article list (cursor-paginated with `starting_after`) and diffs each article's `updated_at` against the collection's high-water mark. Intercom's generous rate budget (~1,000 requests/minute) makes the full walk affordable. Two cadences are decided per collection:
+
+- **Incremental** (the common, cheap cycle) — the same full walk, but only articles changed since the high-water mark (minus a small overlap window that absorbs clock skew) contribute documents.
+- **Reconciliation** (the correctness anchor, weekly by default, and always on the first sync) — every published article locale is emitted. This is the only cycle that **archives** articles or locales that were deleted or unpublished, and the only one that validates the ingest caps over the full set.
+
+Each collection card shows the last sync's status and time, with a **Sync now** button for an on-demand pull. Intercom `429`s are honored with bounded backoff automatically. If a crawl comes back knowingly incomplete (Intercom returned malformed article entries), Atlas upserts what it got but defers all archiving until a clean crawl — deletions are never inferred from a partial view.
+
+### Locales, paths, and what a rename does
+
+Each **published locale** of an article (`translated_content`) is a distinct document at `<locale>/<title-slug>-<article-id>.md`. A `draft` locale — or a `draft` article — is **never** ingested; when a previously-published locale becomes draft or is deleted, the reconciliation crawl archives its document. Because a document's path follows the article's title, **retitling an article archives the old path and re-drafts the new one** for re-review. That churn is expected and safe — nothing is ever hard-deleted. Each document's provenance (`atlas:` — connector, article id, locale, last-modified time) travels with it so any answer traces back to its Intercom article.
+
+---
+
+## Review and publish
+
+Every synced article lands as a **draft**. Review it in **Admin → Knowledge Base**, and publish when it's ready — only then does the agent read it. An article whose content changes in Intercom and had already been published is **demoted back to draft** on the next sync, so an edit re-enters review rather than silently going live.
+
+---
+
+## Caps and limits
+
+A very large help center can overflow the Knowledge Base ingest caps. When that happens, reconciliation fails with the **actual translation count** and names the knob to raise:
+
+- `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` — maximum documents per collection (default 1000).
+- `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` — maximum size of a single document. An oversized document is rejected individually (visible in the sync report) rather than failing the cycle.
+
+Raise the cap in the settings registry if your help center is genuinely large. The reconciliation cadence itself is the `ATLAS_KNOWLEDGE_SYNC_RECONCILE_INTERVAL_HOURS` knob (weekly default); the incremental cadence is `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` (nightly default).
+
+---
+
+## Uninstall
+
+Uninstalling an Intercom collection **archives** its documents (never hard-deletes) and removes the stored token and sync bookkeeping. Re-installing re-syncs the workspace, which brings the archived articles back as drafts for re-review.

--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -43,6 +43,7 @@ Connector-backed sources install from **Admin → Integrations** rather than thi
 - **[Connect GitBook](/guides/connect-gitbook)** — mirrors one GitBook Cloud space per collection (space id + API token).
 - **[Connect Zendesk Guide](/guides/connect-zendesk)** — mirrors your help center's published articles, one collection per brand (subdomain + email + API token).
 - **[Connect Salesforce Knowledge](/guides/connect-salesforce-knowledge)** — mirrors your org's published Knowledge articles, reusing the workspace's existing Salesforce connection (no new credentials).
+- **[Connect Intercom](/guides/connect-intercom)** — mirrors your Intercom help center's published articles (all locales), one collection per workspace (access token).
 
 ---
 

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -26,6 +26,7 @@
     "connect-gitbook",
     "connect-zendesk",
     "connect-salesforce-knowledge",
+    "connect-intercom",
     "developer-mode",
     "demo-mode",
     "guided-tour",

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56690,7 +56690,8 @@
                               "confluence-datacenter",
                               "gitbook",
                               "zendesk",
-                              "salesforce-knowledge"
+                              "salesforce-knowledge",
+                              "intercom"
                             ]
                           },
                           "description": {

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -685,6 +685,31 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(sf?.endpointUrl).toBeNull();
     expect(sf?.sync).not.toBeNull();
   });
+
+  it("dispatches an Intercom collection to the connector engine and lists it as source 'intercom' (#4399)", async () => {
+    COLLECTION = {
+      install_id: "intercom-kb",
+      catalog_id: "catalog:intercom",
+      status: "published",
+      config: { description: "Support docs" },
+    };
+    SYNC_STATES = [
+      { collection_id: "intercom-kb", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/intercom-kb/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const ic = body.collections.find((c) => c.slug === "intercom-kb");
+    expect(ic?.source).toBe("intercom");
+    expect(ic?.endpointUrl).toBeNull();
+    expect(ic?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -60,6 +60,7 @@ import { CONFLUENCE_DC_CATALOG_ID } from "@atlas/api/lib/knowledge/confluence/co
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
+import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -129,6 +130,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === GITBOOK_CATALOG_ID) return "gitbook";
   if (catalogId === ZENDESK_CATALOG_ID) return "zendesk";
   if (catalogId === SALESFORCE_KNOWLEDGE_CATALOG_ID) return "salesforce-knowledge";
+  if (catalogId === INTERCOM_CATALOG_ID) return "intercom";
   return "unknown";
 }
 
@@ -141,7 +143,8 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "confluence-datacenter" ||
     source === "gitbook" ||
     source === "zendesk" ||
-    source === "salesforce-knowledge"
+    source === "salesforce-knowledge" ||
+    source === "intercom"
   );
 }
 
@@ -162,7 +165,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -28,6 +28,7 @@ import {
   BUILTIN_CONFLUENCE_DC_CATALOG_ROW,
   BUILTIN_ZENDESK_CATALOG_ROW,
   BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
+  BUILTIN_INTERCOM_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -211,6 +212,25 @@ describe("BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW (#4397)", () => {
   });
 });
 
+describe("BUILTIN_INTERCOM_CATALOG_ROW (#4399)", () => {
+  it("is the `intercom` form install: a required secret access_token + optional description, NO base URL", () => {
+    const row = BUILTIN_INTERCOM_CATALOG_ROW;
+    expect(row.slug).toBe("intercom");
+    expect(row.id).toBe("catalog:intercom");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("access_token");
+    expect(keys).toContain("description");
+    // The access token is the only secret; the API host is a fixed vendor
+    // constant, so there is no free-form base-URL field.
+    expect(row.configSchema.find((f) => f.key === "access_token")?.secret).toBe(true);
+    expect(row.configSchema.find((f) => f.key === "access_token")?.required).toBe(true);
+    expect(keys).not.toContain("base_url");
+    expect(keys).not.toContain("subdomain");
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -235,6 +255,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "gitbook",
       "zendesk",
       "salesforce-knowledge",
+      "intercom",
     ]);
   });
 
@@ -263,6 +284,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "gitbook",
       "zendesk",
       "salesforce-knowledge",
+      "intercom",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -41,6 +41,7 @@ import {
 } from "@atlas/api/lib/knowledge/notion/connector";
 import { GITBOOK_CATALOG_ID, GITBOOK_SLUG } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID, ZENDESK_SLUG } from "@atlas/api/lib/knowledge/zendesk/config";
+import { INTERCOM_CATALOG_ID, INTERCOM_SLUG } from "@atlas/api/lib/knowledge/intercom/config";
 import {
   SALESFORCE_KNOWLEDGE_CATALOG_ID,
   SALESFORCE_KNOWLEDGE_SLUG,
@@ -471,6 +472,52 @@ export const BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW: BuiltinKnowledgeCatalogRo
   ],
 };
 
+/**
+ * The Intercom connector Knowledge Base catalog row (#4399, PRD #4395). A form
+ * install that mirrors the workspace's Intercom Articles into a review-gated
+ * collection; the Scheduler dispatches the registered Intercom connector on a
+ * cadence and every synced article translation lands `draft`.
+ *
+ * Intercom has no server-side change feed and no multi-brand concept, so this is
+ * the tier's simplest install: a single `access_token` plus an optional
+ * description — one workspace maps to one collection, and the connector
+ * reconciliation-diffs `updated_at` against the high-water mark each cycle.
+ *
+ * `access_token` is `secret: true` but is NOT stored in
+ * `workspace_plugins.config` — the install handler routes it to
+ * `knowledge_sync_credentials` (encrypted). The Intercom API host is a fixed
+ * vendor constant, so there is no base-URL field; every request still goes
+ * through the SSRF egress guard at fetch time. The id/slug are the config SSOT
+ * (`INTERCOM_CATALOG_ID` / `INTERCOM_SLUG`).
+ */
+export const BUILTIN_INTERCOM_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: INTERCOM_CATALOG_ID,
+  slug: INTERCOM_SLUG,
+  name: "Knowledge Base (Intercom)",
+  description:
+    "Mirror your Intercom help center's published articles (all locales) into a review-gated knowledge collection; Atlas syncs on a schedule and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "access_token",
+      type: "string",
+      secret: true,
+      label: "Access token",
+      required: true,
+      description:
+        "An Intercom access token (Settings → Developers → your app → Authentication). Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -481,6 +528,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_GITBOOK_CATALOG_ROW,
   BUILTIN_ZENDESK_CATALOG_ROW,
   BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
+  BUILTIN_INTERCOM_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/intercom-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/intercom-form-handler.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for `IntercomFormInstallHandler` (#4399) — the Intercom connector
+ * install. Focus: field validation (access token), loud credential verification
+ * at install time (`GET /me`), credential routing (token →
+ * `knowledge_sync_credentials`, NEVER into `workspace_plugins.config`), the
+ * multi-instance `pillar='knowledge'` upsert shape, and rollback on a failed
+ * install row. Verification uses the REAL egress guard against an injected
+ * fixture fetch; no test touches Intercom.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:intercom" }];
+let INSERT_RETURNS_ID = true;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { IntercomFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/intercom-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = { access_token: "intercom-token" };
+
+/** A fixture verify-fetch: /me returns an identity (or a status). */
+function verifyFetch(opts: { status?: number; hollow?: boolean } = {}): typeof fetch {
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url);
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (url.pathname === "/me") {
+      return new Response(JSON.stringify(opts.hollow ? {} : { type: "admin", id: "admin-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+  return impl as unknown as typeof fetch;
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  return new IntercomFormInstallHandler({
+    idGenerator: () => "fixed-id",
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:intercom" }];
+  INSERT_RETURNS_ID = true;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("requires the access token", async () => {
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, { access_token: "" }), "access_token");
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token with embedded whitespace", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { access_token: "abc def" }),
+      "access_token",
+    );
+    expect(msg).toMatch(/spaces/i);
+  });
+});
+
+describe("credential verification", () => {
+  it("blames the access_token field on a 401", async () => {
+    const msg = await fieldErrorOf(
+      handler(verifyFetch({ status: 401 })).validateConfig(WORKSPACE, VALID),
+      "access_token",
+    );
+    expect(msg).toMatch(/rejected the credentials/i);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("routes a rate-limit (429) verification failure to a form-level error, not a field", async () => {
+    try {
+      await handler(verifyFetch({ status: 429 })).validateConfig(WORKSPACE, VALID);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormInstallValidationError);
+      const e = err as InstanceType<typeof FormInstallValidationError>;
+      expect(e.formErrors.length).toBeGreaterThan(0);
+      expect(Object.keys(e.fieldErrors)).toHaveLength(0);
+    }
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("routes a hollow /me (no identity) to a form-level error", async () => {
+    try {
+      await handler(verifyFetch({ hollow: true })).validateConfig(WORKSPACE, VALID);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormInstallValidationError);
+      const e = err as InstanceType<typeof FormInstallValidationError>;
+      expect(e.formErrors.length).toBeGreaterThan(0);
+    }
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+});
+
+describe("successful install", () => {
+  it("verifies, writes the credential, then upserts the knowledge collection (token never in config)", async () => {
+    const rec = await handler(verifyFetch()).validateConfig(WORKSPACE, {
+      ...VALID,
+      description: "Support docs",
+    });
+    expect(rec.installRecord.id).toBe("fixed-id");
+    expect(rec.credentialWritten).toBe(true);
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].sql).toContain("pillar");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toEqual({ description: "Support docs" });
+    expect(JSON.stringify(config)).not.toContain("intercom-token");
+  });
+
+  it("rolls back the credential when the install-row upsert fails", async () => {
+    INSERT_RETURNS_ID = false;
+    await expect(handler(verifyFetch()).validateConfig(WORKSPACE, VALID)).rejects.toThrow();
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -47,6 +47,7 @@ import { NOTION_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/notion/con
 import { GITBOOK_CATALOG_ID } from "@atlas/api/lib/knowledge/gitbook/config";
 import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
+import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -150,7 +151,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, and Salesforce Knowledge sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, Salesforce Knowledge, and Intercom sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
@@ -158,12 +159,14 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
     expect(getKnowledgeSyncConnector(GITBOOK_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(ZENDESK_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(SALESFORCE_KNOWLEDGE_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(INTERCOM_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "gitbook", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "zendesk", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "salesforce-knowledge", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "intercom", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/intercom-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/intercom-form-handler.ts
@@ -1,0 +1,273 @@
+/**
+ * `IntercomFormInstallHandler` — the {@link FormBasedInstallHandler} for the
+ * built-in `intercom` Knowledge Base catalog row (#4399, PRD #4395).
+ *
+ * Installing `intercom` creates a **synced collection** mirroring the
+ * workspace's Intercom Articles: a `pillar='knowledge'` `workspace_plugins` row
+ * (multi-instance, `install_id` = collection slug) whose config carries only an
+ * optional description. Intercom has no multi-brand concept — ONE workspace maps
+ * to ONE collection — so, unlike Zendesk, there is no fan-out. The Scheduler
+ * dispatches the registered Intercom connector on a cadence
+ * (`lib/knowledge/connector-sync.ts`), and every synced article translation
+ * lands `draft` behind the review gate.
+ *
+ * Intercom's API host is a FIXED vendor constant (`api.intercom.io`), not a
+ * customer-supplied URL, so there is no install-time SSRF gate (the connector
+ * still routes every request through the egress guard at fetch time). Beyond
+ * that it mirrors the GitBook/Notion handlers:
+ *   1. **Loud credential verification.** Before persisting anything, it resolves
+ *      the authenticated admin with the supplied token (`verifyIntercomAccess`)
+ *      — a bad token fails the install with actionable guidance instead of
+ *      silently creating a collection that never syncs.
+ *   2. **The access token is a Knowledge Base credential.** It routes to the
+ *      dedicated `knowledge_sync_credentials` table (encrypted), NEVER to
+ *      `workspace_plugins.config`. Write order mirrors GitBook/Notion: verify →
+ *      SaaS keyset gate → credential row → install row (rollback on failure).
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import { EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import {
+  verifyIntercomAccess,
+  IntercomAuthError,
+  type IntercomClientDeps,
+} from "@atlas/api/lib/knowledge/intercom/client";
+import {
+  INTERCOM_SLUG,
+  INTERCOM_CATALOG_ID,
+  type IntercomCollectionConfig,
+} from "@atlas/api/lib/knowledge/intercom/config";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { INTERCOM_SLUG, INTERCOM_CATALOG_ID };
+
+/** Defensive upper bounds — guard against pathological pastes. */
+const ACCESS_TOKEN_MAX = 4096;
+
+export interface IntercomFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the verification fetch (no real Intercom call). */
+  readonly clientDeps?: IntercomClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to the
+ * okf-upload / GitBook / Zendesk knowledge upserts: `status='published'` because
+ * the COLLECTION container is live immediately — the review gate is on the
+ * DOCUMENTS, which always sync in as `draft`. Exported so the real-Postgres test
+ * executes this exact string against the live schema.
+ */
+export const INTERCOM_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class IntercomFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: IntercomClientDeps;
+  private readonly log = createLogger("integrations.install.intercom");
+
+  constructor(options: IntercomFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const collectionSlug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], INTERCOM_SLUG);
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const accessToken = validateAccessToken(rawForm.access_token);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [INTERCOM_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "intercom catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${INTERCOM_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+
+    // ── Verify the connection loudly BEFORE persisting anything ─────────────
+    await this.verifyConnection({ accessToken, collectionSlug });
+
+    // ── Credential first (mirrors the GitBook/Notion write order) ───────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "access_token");
+    try {
+      await saveSyncCredential(workspaceId, collectionSlug, accessToken);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install",
+      );
+      throw err;
+    }
+
+    // ── Upsert the collection container (never carries the token) ────────────
+    const config: IntercomCollectionConfig = {
+      ...(description !== null ? { description } : {}),
+    };
+
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(INTERCOM_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        collectionSlug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a failed
+      // install (its install row never landed, so uninstall would never reach
+      // it). Best-effort — a re-install overwrites it either way; a cleanup
+      // failure is logged, never masks the original error. Same block as the
+      // GitBook/Notion handlers — keep them in step.
+      this.log.error(
+        { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist intercom collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, collectionSlug);
+      } catch (cleanupErr) {
+        this.log.error(
+          { workspaceId, collectionSlug, err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr) },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw err;
+    }
+
+    this.log.info(
+      { workspaceId, collectionSlug, rowId: persistedId },
+      "Intercom collection install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: INTERCOM_SLUG },
+      credentialWritten: true,
+    };
+  }
+
+  /**
+   * Resolve the admin with the supplied token; map every failure to a 400.
+   * Classification is POSITIVE, by `instanceof` on the client's typed errors —
+   * never by message text or `cause`-presence sniffing — so only a failure the
+   * client KNOWS is credential-shaped blames the access_token field; an Intercom
+   * outage or transport error stays form-level. All messages host-redacted.
+   */
+  private async verifyConnection(input: {
+    accessToken: string;
+    collectionSlug: string;
+  }): Promise<void> {
+    try {
+      await verifyIntercomAccess(
+        { apiToken: input.accessToken, collectionSlug: input.collectionSlug },
+        this.clientDeps,
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        // Defence-in-depth: the fixed Intercom host should never be blocked, but
+        // if a deploy's egress policy blocks it, surface it as a form-level error.
+        throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [err.message] });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof IntercomAuthError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { access_token: [message] },
+          formErrors: [],
+        });
+      }
+      // Everything else — a 429 (ConnectorRateLimitError), vendor 5xx,
+      // transport/DNS/non-JSON, or a hollow /me — is form-level: blaming a field
+      // would send the admin re-entering a value that may be fine.
+      throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [message] });
+    }
+  }
+}
+
+function validateAccessToken(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "access_token",
+      "An access token is required. Create one in Intercom → Settings → Developers → your app → Authentication (or use your app's Access Token).",
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > ACCESS_TOKEN_MAX) {
+    throw fieldError("access_token", `The access token must be ${ACCESS_TOKEN_MAX} characters or fewer.`);
+  }
+  if (/\s/.test(trimmed)) {
+    throw fieldError("access_token", "Token must not contain spaces — paste it exactly as Intercom shows it.");
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -55,6 +55,8 @@ import {
   SALESFORCE_KNOWLEDGE_SLUG,
 } from "./salesforce-knowledge-form-handler";
 import { registerSalesforceKnowledgeConnector } from "@atlas/api/lib/knowledge/salesforce/connector";
+import { IntercomFormInstallHandler, INTERCOM_SLUG } from "./intercom-form-handler";
+import { registerIntercomKnowledgeConnector } from "@atlas/api/lib/knowledge/intercom/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -319,6 +321,21 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(SALESFORCE_KNOWLEDGE_SLUG, new SalesforceKnowledgeFormInstallHandler());
   registerSalesforceKnowledgeConnector();
   log.info("Registered SalesforceKnowledgeFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Intercom) — the built-in `intercom` connector install
+  // (#4399, PRD #4395). Knowledge-pillar, multi-instance: ONE workspace maps to
+  // ONE collection (Intercom has no multi-brand concept). Config = an optional
+  // description; the access token lands in `knowledge_sync_credentials`
+  // (encrypted), never in `workspace_plugins.config`. Intercom exposes no
+  // server-side change feed, so the connector reconciliation-diffs `updated_at`
+  // against the high-water mark; the API host is a fixed vendor constant, so
+  // there is no base URL — every request still routes through the SSRF egress
+  // guard at fetch time. Registering the FORM handler + the CONNECTOR together
+  // (as with the other knowledge vendors) keeps a half-wired deploy from having
+  // an installable card whose scheduled sync has no registered vendor client.
+  // No env gate.
+  registerFormHandler(INTERCOM_SLUG, new IntercomFormInstallHandler());
+  registerIntercomKnowledgeConnector();
+  log.info("Registered IntercomFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -40,6 +40,7 @@ import { CONFLUENCE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/insta
 import { CONFLUENCE_DC_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/confluence-datacenter-form-handler";
 import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/gitbook-form-handler";
 import { ZENDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/zendesk-form-handler";
+import { INTERCOM_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/intercom-form-handler";
 import { SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/salesforce-knowledge-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
@@ -616,6 +617,32 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // Credential-less by design: the config carries scope only — the OAuth
     // install (catalog:salesforce) owns the token; nothing secret lands here.
     expect(row.rows[0]?.config).toEqual({ article_object: "Knowledge__kav", channel: "pkb" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs an Intercom connector collection against the live schema (#4399)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:intercom', 'Knowledge Base (Intercom)', 'intercom', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(INTERCOM_INSTALL_UPSERT_SQL, [
+      "row-intercom",
+      ws,
+      "catalog:intercom",
+      "intercom-docs",
+      JSON.stringify({ description: "Support docs" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-intercom");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'intercom-docs'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The access token is NEVER persisted in the install config — one workspace,
+    // one collection, so the config carries only the optional description.
+    expect(row.rows[0]?.config).not.toHaveProperty("access_token");
+    expect(row.rows[0]?.config).toEqual({ description: "Support docs" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/intercom/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/intercom/__tests__/client.test.ts
@@ -279,6 +279,37 @@ describe("fetchChanges (incremental reconciliation-diff)", () => {
     const changes = await c.fetchChanges({ since: "2026-07-05T00:00:00.000Z", cursor: null });
     expect(changes.documents).toHaveLength(2);
   });
+
+  it("picks up a translation-only edit: a locale newer than its article bumps the mark AND passes the since filter", async () => {
+    // The delta-less posture's whole point — an edit to a single translation
+    // bumps only the locale's updated_at, NOT the article's. Filtering on the
+    // article timestamp alone would silently drop it.
+    const { c } = client({
+      articles: [
+        {
+          id: 5,
+          state: "published",
+          updated_at: T_JUL1, // article stamp is OLD
+          default_locale: "en",
+          translated_content: {
+            type: "translated_content",
+            en: content({ updated_at: T_JUL1 }),
+            fr: content({ title: "Nouveau", updated_at: T_JUL5 }), // one locale edited later
+          },
+        },
+      ],
+    });
+    // The mark reflects the newest locale, not the stale article stamp.
+    const full = await c.fetchAll();
+    expect(full.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    // A since strictly between the two timestamps still selects the article
+    // (its effective updatedAt is the fr locale's), and emits BOTH locales.
+    const inc = await c.fetchChanges({ since: "2026-07-03T00:00:00.000Z", cursor: null });
+    expect(inc.documents.map((d) => d.path).toSorted()).toEqual([
+      "intercom-docs/en/getting-started-5.md",
+      "intercom-docs/fr/nouveau-5.md",
+    ]);
+  });
 });
 
 describe("authentication", () => {
@@ -309,6 +340,16 @@ describe("vendor failure mapping", () => {
     );
     expect(err).toBeInstanceOf(IntercomAuthError);
     expect((err as Error).message).toMatch(/rejected the credentials \(401\)/i);
+  });
+
+  it("maps a 403 (token valid but missing Articles scope) to the same typed auth error", async () => {
+    const { c } = client({ failFirst: { status: 403 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(IntercomAuthError);
+    expect((err as Error).message).toMatch(/rejected the credentials \(403\)/i);
   });
 
   it("never leaks the token in an error message", async () => {

--- a/packages/api/src/lib/knowledge/intercom/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/intercom/__tests__/client.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for the Intercom vendor client (#4399) — driven entirely through an
+ * injected fixture `fetchImpl`; NO test touches Intercom. Covers the
+ * reconciliation-diff posture (full `starting_after` walk for both cadences),
+ * the incremental `updated_at`-vs-high-water-mark client diff, multi-locale
+ * (each published `translated_content` entry a distinct document), the
+ * publish-guard (draft article/locale filtered out), epoch-seconds
+ * normalization, the doc cap over the full set, cursor pagination, 429 →
+ * ConnectorRateLimitError, auth failure, and install-time verification.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createIntercomVendorClient,
+  verifyIntercomAccess,
+  epochSecondsToIso,
+  parseRetryAfter,
+  IntercomAuthError,
+} from "@atlas/api/lib/knowledge/intercom/client";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+
+/** 2026-07-01T10:00:00Z / 2026-07-05T08:00:00Z in epoch seconds. */
+const T_JUL1 = 1782900000;
+const T_JUL5 = 1783238400;
+
+interface FixtureContent {
+  title?: string;
+  body?: string;
+  state?: string;
+  updated_at?: number;
+  url?: string;
+}
+interface FixtureArticle {
+  id?: number | string;
+  title?: string;
+  body?: string;
+  state?: string;
+  updated_at?: number;
+  url?: string;
+  default_locale?: string;
+  translated_content?: Record<string, unknown> | null;
+}
+
+function content(overrides: FixtureContent = {}): FixtureContent {
+  return {
+    title: "Getting Started",
+    body: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    state: "published",
+    updated_at: T_JUL1,
+    url: `https://help.acme.com/en/articles/1-getting-started`,
+    ...overrides,
+  };
+}
+
+const ARTICLES: FixtureArticle[] = [
+  {
+    id: 1,
+    state: "published",
+    updated_at: T_JUL1,
+    default_locale: "en",
+    translated_content: { type: "translated_content", en: content() },
+  },
+  {
+    id: 2,
+    state: "published",
+    updated_at: T_JUL5,
+    default_locale: "en",
+    translated_content: {
+      type: "translated_content",
+      en: content({ title: "Billing FAQ", updated_at: T_JUL5, url: "https://help.acme.com/en/articles/2-billing-faq" }),
+      fr: content({ title: "Facturation FAQ", updated_at: T_JUL5, url: "https://help.acme.com/fr/articles/2" }),
+    },
+  },
+];
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+interface FixtureState {
+  calls: string[];
+  authHeaders: Array<string | null>;
+}
+
+/**
+ * A fixture Intercom API. `articles` serves the `/articles` cursor list
+ * (optionally split into two pages via `starting_after`); `/me` serves the
+ * verification probe.
+ */
+function makeFetch(opts: {
+  articles?: FixtureArticle[];
+  splitList?: boolean;
+  failFirst?: { status: number; headers?: Record<string, string> };
+  me?: unknown;
+}): { impl: typeof globalThis.fetch; state: FixtureState } {
+  const state: FixtureState = { calls: [], authHeaders: [] };
+  const articles = opts.articles ?? ARTICLES;
+  let failed = false;
+  const impl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    state.calls.push(raw);
+    state.authHeaders.push(new Headers(init?.headers).get("authorization"));
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    if (url.pathname === "/me") {
+      return jsonResponse(opts.me ?? { type: "admin", id: "admin-1" });
+    }
+    if (url.pathname === "/articles") {
+      if (opts.splitList) {
+        const isSecondPage = url.searchParams.get("starting_after") === "cursor-2";
+        return jsonResponse({
+          type: "list",
+          data: isSecondPage ? articles.slice(1) : articles.slice(0, 1),
+          pages: { type: "pages", next: isSecondPage ? null : { starting_after: "cursor-2" } },
+        });
+      }
+      return jsonResponse({ type: "list", data: articles, pages: { type: "pages", next: null } });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, state };
+}
+
+function client(opts: Parameters<typeof makeFetch>[0] = {}, maxDocs?: number) {
+  const { impl, state } = makeFetch(opts);
+  const c = createIntercomVendorClient(
+    { apiToken: "tok", collectionSlug: "intercom-docs" },
+    { fetchImpl: impl, ...(maxDocs !== undefined ? { maxDocs } : {}) },
+  );
+  return { c, state };
+}
+
+describe("epochSecondsToIso", () => {
+  it("converts unix seconds (number or numeric string) to a canonical ISO instant", () => {
+    expect(epochSecondsToIso(T_JUL1)).toBe("2026-07-01T10:00:00.000Z");
+    expect(epochSecondsToIso(String(T_JUL1))).toBe("2026-07-01T10:00:00.000Z");
+  });
+  it("returns null for a non-numeric / absent value (never a bogus instant)", () => {
+    expect(epochSecondsToIso(undefined)).toBeNull();
+    expect(epochSecondsToIso("not-a-number")).toBeNull();
+    expect(epochSecondsToIso(null)).toBeNull();
+  });
+});
+
+describe("fetchAll (reconciliation)", () => {
+  it("emits one document per published locale with the max updated_at as the mark", async () => {
+    const { c } = client();
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "intercom-docs/en/getting-started-1.md",
+      "intercom-docs/en/billing-faq-2.md",
+      "intercom-docs/fr/facturation-faq-2.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(false);
+    expect(changes.cursor).toBeNull();
+  });
+
+  it("stamps the atlas provenance block (connector + article id + locale) on each document", async () => {
+    const { c } = client();
+    const changes = await c.fetchAll();
+    expect(changes.documents.every((d) => d.content.includes('connector: "intercom"'))).toBe(true);
+    const fr = changes.documents.find((d) => d.path.includes("/fr/"));
+    expect(fr?.content).toContain('locale: "fr"');
+    expect(fr?.content).toContain('article_id: "2"');
+  });
+
+  it("follows starting_after cursor pagination across pages", async () => {
+    const { c, state } = client({ splitList: true });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(3);
+    expect(state.calls.filter((u) => u.includes("/articles"))).toHaveLength(2);
+    expect(state.calls.some((u) => u.includes("starting_after=cursor-2"))).toBe(true);
+  });
+
+  it("skips draft articles and draft locales (unpublish = absent = archived), still advancing the mark", async () => {
+    const { c } = client({
+      articles: [
+        // A fully-draft article — no published locale, but its timestamp is newest.
+        {
+          id: 1,
+          state: "draft",
+          updated_at: 1783324800, // 2026-07-06T08:00:00Z
+          translated_content: { type: "translated_content", en: content({ state: "draft", updated_at: 1783324800 }) },
+        },
+        // A published article with one published + one draft locale.
+        {
+          id: 2,
+          state: "published",
+          updated_at: T_JUL1,
+          translated_content: {
+            type: "translated_content",
+            en: content({ updated_at: T_JUL1 }),
+            de: content({ state: "draft", updated_at: T_JUL1 }),
+          },
+        },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual(["intercom-docs/en/getting-started-2.md"]);
+    // The draft article still advances the mark — its change was observed.
+    expect(changes.highWaterMark).toBe("2026-07-06T08:00:00.000Z");
+  });
+
+  it("synthesizes one locale from the top-level fields when translated_content is absent", async () => {
+    const { c } = client({
+      articles: [
+        { id: 7, state: "published", updated_at: T_JUL1, default_locale: "en", body: "<p>Only the top-level body exists here.</p>", title: "Top Level", url: "https://help.acme.com/en/articles/7" },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual(["intercom-docs/en/top-level-7.md"]);
+  });
+
+  it("counts a malformed article (no id) and flags coverage incomplete", async () => {
+    const { c } = client({
+      articles: [
+        { title: "no id", state: "published", updated_at: T_JUL1 }, // malformed article
+        { id: 2, state: "published", updated_at: T_JUL1, translated_content: { type: "translated_content", en: content({ updated_at: T_JUL1 }) } },
+      ],
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("throws an actionable, real-numbered error when the full set exceeds the doc cap", async () => {
+    const { c } = client({}, 1);
+    await expect(c.fetchAll()).rejects.toThrow(/has 3 published article translations, over the 1-document limit/);
+  });
+
+  it("fails loud on a stuck cursor that never terminates (page bound)", async () => {
+    const impl = (async (): Promise<Response> =>
+      jsonResponse({ type: "list", data: [], pages: { next: { starting_after: "stuck" } } })) as unknown as typeof globalThis.fetch;
+    const c = createIntercomVendorClient(
+      { apiToken: "tok", collectionSlug: "intercom-docs" },
+      { fetchImpl: impl },
+    );
+    await expect(c.fetchAll()).rejects.toThrow(/did not terminate/i);
+  });
+});
+
+describe("fetchChanges (incremental reconciliation-diff)", () => {
+  it("emits only articles changed at-or-after `since`, keeping the mark across ALL articles", async () => {
+    const { c } = client();
+    const changes = await c.fetchChanges({ since: "2026-07-05T00:00:00.000Z", cursor: null });
+    // Article 1 (Jul 1) is filtered out; article 2 (Jul 5, two locales) stays.
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "intercom-docs/en/billing-faq-2.md",
+      "intercom-docs/fr/facturation-faq-2.md",
+    ]);
+    // High-water mark still reflects the newest across ALL enumerated articles.
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+  });
+
+  it("includes an article whose effective updatedAt exactly equals `since` (>= boundary)", async () => {
+    const { c } = client();
+    const changes = await c.fetchChanges({ since: "2026-07-05T08:00:00.000Z", cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "intercom-docs/en/billing-faq-2.md",
+      "intercom-docs/fr/facturation-faq-2.md",
+    ]);
+  });
+
+  it("serves a null since as a full crawl (defensive)", async () => {
+    const { c } = client();
+    const changes = await c.fetchChanges({ since: null, cursor: null });
+    expect(changes.documents).toHaveLength(3);
+  });
+
+  it("does not apply the doc cap on an incremental cycle (cap is a full-set check)", async () => {
+    const { c } = client({}, 1);
+    const changes = await c.fetchChanges({ since: "2026-07-05T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(2);
+  });
+});
+
+describe("authentication", () => {
+  it("sends Bearer token auth on every request", async () => {
+    const { c, state } = client();
+    await c.fetchAll();
+    expect(state.authHeaders.length).toBeGreaterThan(0);
+    for (const header of state.authHeaders) expect(header).toBe("Bearer tok");
+  });
+});
+
+describe("vendor failure mapping", () => {
+  it("throws ConnectorRateLimitError with the parsed Retry-After on a 429", async () => {
+    const { c } = client({ failFirst: { status: 429, headers: { "retry-after": "37" } } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+    expect((err as ConnectorRateLimitError).retryAfterSeconds).toBe(37);
+  });
+
+  it("maps a 401 to a typed, host-redacted IntercomAuthError", async () => {
+    const { c } = client({ failFirst: { status: 401 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(IntercomAuthError);
+    expect((err as Error).message).toMatch(/rejected the credentials \(401\)/i);
+  });
+
+  it("never leaks the token in an error message", async () => {
+    const { c } = client({ failFirst: { status: 500 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain("tok");
+  });
+
+  it("wraps a non-JSON body in a host-redacted error carrying the cause (never the token)", async () => {
+    const impl = (async (): Promise<Response> =>
+      new Response("<html>oops</html>", { status: 200, headers: { "content-type": "text/html" } })) as unknown as typeof globalThis.fetch;
+    const c = createIntercomVendorClient({ apiToken: "tok", collectionSlug: "c" }, { fetchImpl: impl });
+    try {
+      await c.fetchAll();
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toMatch(/non-JSON response/i);
+      expect(message).toContain("api.intercom.io");
+      expect(message).not.toContain("tok");
+      expect((err as { cause?: unknown }).cause).toBeDefined();
+    }
+  });
+});
+
+describe("verifyIntercomAccess", () => {
+  it("resolves when /me returns an identity", async () => {
+    const { impl } = makeFetch({});
+    await expect(
+      verifyIntercomAccess({ apiToken: "tok", collectionSlug: "c" }, { fetchImpl: impl }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws a typed auth error when /me is 401", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 401 } });
+    await expect(
+      verifyIntercomAccess({ apiToken: "bad", collectionSlug: "c" }, { fetchImpl: impl }),
+    ).rejects.toBeInstanceOf(IntercomAuthError);
+  });
+
+  it("throws when /me returns a hollow body with no identity", async () => {
+    const { impl } = makeFetch({ me: {} });
+    await expect(
+      verifyIntercomAccess({ apiToken: "tok", collectionSlug: "c" }, { fetchImpl: impl }),
+    ).rejects.toThrow(/did not return a recognizable identity/i);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds and rejects HTTP-dates/garbage", () => {
+    expect(parseRetryAfter("42")).toBe(42);
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/knowledge/intercom/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/intercom/__tests__/connector.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for the Intercom KnowledgeSyncConnector (#4399) — the createClient
+ * factory contract: read the encrypted token loudly and build a vendor client.
+ * The credential store is mocked (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let tokenResult: string | null | (() => never) = "secret-token";
+
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof tokenResult === "function") return tokenResult();
+    return tokenResult;
+  },
+}));
+
+const { createIntercomConnector } = await import("@atlas/api/lib/knowledge/intercom/connector");
+const { INTERCOM_CATALOG_ID, INTERCOM_VENDOR } = await import("@atlas/api/lib/knowledge/intercom/config");
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "intercom-docs", config };
+}
+
+afterEach(() => {
+  tokenResult = "secret-token";
+});
+
+describe("createIntercomConnector", () => {
+  it("advertises the intercom catalog id and vendor slug", () => {
+    const connector = createIntercomConnector();
+    expect(connector.catalogId).toBe(INTERCOM_CATALOG_ID);
+    expect(connector.vendor).toBe(INTERCOM_VENDOR);
+  });
+
+  it("builds a vendor client from a stored token", async () => {
+    const connector = createIntercomConnector();
+    const client = await connector.createClient(ctx({ description: "Support docs" }));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws when the collection has no stored access token", async () => {
+    tokenResult = null;
+    const connector = createIntercomConnector();
+    await expect(connector.createClient(ctx({}))).rejects.toThrow(/no stored access token/i);
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    tokenResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createIntercomConnector();
+    await expect(connector.createClient(ctx(null))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/intercom/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/intercom/__tests__/documents.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the Intercom document assembly (#4399) — the pure glue between the
+ * SHARED support HTML→markdown converter and the connector ingest seam. Covers
+ * the per-locale path shape (`<locale>/<title-slug>-<id>.md`), the `atlas:`
+ * provenance block, contentless skips, relative-link rewriting, and degradation
+ * aggregation.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleIntercomDocuments,
+  slugifyTitle,
+  type IntercomArticleContent,
+} from "@atlas/api/lib/knowledge/intercom/documents";
+
+function con(overrides: Partial<IntercomArticleContent> = {}): IntercomArticleContent {
+  return {
+    articleId: "42",
+    locale: "en",
+    title: "Getting Started",
+    bodyHtml: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    url: "https://help.acme.com/en/articles/42-getting-started",
+    ...overrides,
+  };
+}
+
+describe("assembleIntercomDocuments", () => {
+  it("builds a locale/title-slug-id path and stamps provenance", () => {
+    const { documents } = assembleIntercomDocuments([con()], { collectionSlug: "intercom-docs" });
+    expect(documents).toHaveLength(1);
+    expect(documents[0].path).toBe("intercom-docs/en/getting-started-42.md");
+    const content = documents[0].content;
+    expect(content).toContain('connector: "intercom"');
+    expect(content).toContain('article_id: "42"');
+    expect(content).toContain('locale: "en"');
+    expect(content).toContain('updated_at: "2026-07-01T10:00:00.000Z"');
+    expect(content).toContain('resource: "https://help.acme.com/en/articles/42-getting-started"');
+  });
+
+  it("gives each locale of the same article a distinct, collision-free path", () => {
+    const { documents } = assembleIntercomDocuments(
+      [con({ locale: "en" }), con({ locale: "fr", title: "Facturation" })],
+      { collectionSlug: "kb" },
+    );
+    expect(documents.map((d) => d.path).toSorted()).toEqual([
+      "kb/en/getting-started-42.md",
+      "kb/fr/facturation-42.md",
+    ]);
+  });
+
+  it("skips a locale whose body converts to nothing (contentless)", () => {
+    const { documents, skippedContentless } = assembleIntercomDocuments(
+      [con({ bodyHtml: "<p>   </p>" })],
+      { collectionSlug: "kb" },
+    );
+    expect(documents).toHaveLength(0);
+    expect(skippedContentless).toBe(1);
+  });
+
+  it("absolutizes a relative in-body link against the locale's own URL", () => {
+    const { documents } = assembleIntercomDocuments(
+      [con({ bodyHtml: '<p>See <a href="/en/articles/99-more">more here in the docs</a> now.</p>' })],
+      { collectionSlug: "kb" },
+    );
+    expect(documents[0].content).toContain("https://help.acme.com/en/articles/99-more");
+  });
+
+  it("aggregates media degradations across locales", () => {
+    const { degradations } = assembleIntercomDocuments(
+      [con({ bodyHtml: '<p>Body prose here for length.</p><img src="https://x/a.png">' })],
+      { collectionSlug: "kb" },
+    );
+    expect(degradations.some((d) => d.name === "#image" && d.count >= 1)).toBe(true);
+  });
+});
+
+describe("slugifyTitle", () => {
+  it("slugifies and falls back to the given token when empty", () => {
+    expect(slugifyTitle("Hello World!", "x")).toBe("hello-world");
+    expect(slugifyTitle("   ", "fallback")).toBe("fallback");
+  });
+});

--- a/packages/api/src/lib/knowledge/intercom/client.ts
+++ b/packages/api/src/lib/knowledge/intercom/client.ts
@@ -1,0 +1,509 @@
+/**
+ * The Intercom vendor client (#4399, PRD #4395) — a {@link ConnectorVendorClient}
+ * over the Intercom Articles REST API, driven by the shared connector engine
+ * (`connector-sync.ts`). It owns ONLY enumerate + fetch + convert; scheduling,
+ * high-water marks, reconciliation cadence, 429 backoff, and caps are the
+ * engine's (ADR-0030).
+ *
+ * RECONCILIATION-DIFF POSTURE (the PRD's delta-less design): Intercom exposes
+ * NO server-side `updated_since` change feed, so BOTH cadences the engine
+ * decides are served from the same full cursor-paginated walk of
+ * `GET /articles`:
+ *   - `fetchAll()` (reconciliation) — walk every article, emit one document per
+ *     published locale. The engine archives paths absent from this set, so a
+ *     deleted or unpublished (`state: "draft"`) article/locale is treated as
+ *     absent, never an error.
+ *   - `fetchChanges({ since })` (incremental) — the SAME full walk, but only the
+ *     articles whose newest `updated_at` is at-or-after `since` contribute
+ *     documents (a client-side diff against the high-water mark). Intercom's
+ *     generous 1,000+ rpm budget makes the full-page-and-diff affordable; the
+ *     engine's overlap window re-emits the boundary and the upsert-by-path diff
+ *     no-ops unchanged docs.
+ *
+ * Multi-locale: each `translated_content` entry is a distinct document with its
+ * own `state`. A `state: "draft"` locale is UNPUBLISHED — never emitted; an
+ * article/locale that BECOMES draft simply stops appearing in the emitted set,
+ * and the reconciliation crawl's subtractive diff archives its documents (the
+ * AC's "deletes via reconcile").
+ *
+ * Security + hygiene: the host is a fixed Intercom constant, yet every request
+ * still goes through `guardedFetch` (SSRF egress guard; auth stripped on
+ * cross-origin redirect). A 429 is the ONLY signal that becomes the engine's
+ * backoff (thrown as {@link ConnectorRateLimitError}); every other failure is an
+ * actionable error with the host redacted via `hostForLog` — the token lives in
+ * the `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import { getIngestMaxDocs } from "../ingest-limits";
+import {
+  ConnectorRateLimitError,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import { INTERCOM_API_BASE } from "./config";
+import { assembleIntercomDocuments, type IntercomArticleContent } from "./documents";
+
+const log = createLogger("knowledge.intercom.client");
+
+/**
+ * Intercom rejected the credentials (401/403). A distinct class — not a
+ * `cause`-presence side channel — so the install handler can blame the
+ * `access_token` field with `instanceof` (the `ConnectorRateLimitError`
+ * precedent; plain subclass, this is not Effect code).
+ */
+export class IntercomAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IntercomAuthError";
+  }
+}
+
+/** Resolved, non-secret connection inputs plus the token. */
+export interface IntercomClientConfig {
+  readonly apiToken: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface IntercomClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** Test-only override of the ingest doc cap (defaults to the settings value). */
+  readonly maxDocs?: number;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Article-list page size (`starting_after` cursor pagination). */
+const PAGE_SIZE = 150;
+/**
+ * Hard anti-runaway bound on enumerated articles — NOT the ingest cap (the
+ * engine owns that, and surfaces the real over-limit numbers). A help center
+ * larger than this is pathological; we fail loud rather than loop unbounded on a
+ * broken `next` cursor.
+ */
+const MAX_ARTICLES = 100_000;
+/**
+ * Anti-runaway bound on pages walked in one paginated enumeration — a stuck
+ * `starting_after` cursor fails loud rather than looping forever.
+ */
+const MAX_FEED_PAGES = 2_000;
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (only the fields we read; untrusted vendor JSON —
+// every field optional, narrowed at the use sites)
+// ---------------------------------------------------------------------------
+
+interface RawArticleContent {
+  readonly title?: string;
+  readonly body?: string | null;
+  readonly state?: string;
+  readonly updated_at?: number;
+  readonly url?: string;
+}
+interface RawArticle {
+  readonly id?: number | string;
+  readonly title?: string;
+  readonly body?: string | null;
+  readonly state?: string;
+  readonly updated_at?: number;
+  readonly url?: string;
+  readonly default_locale?: string;
+  /** Locale → article_content, plus a `type` discriminator we skip. */
+  readonly translated_content?: Record<string, unknown> | null;
+}
+interface RawPagesNext {
+  readonly starting_after?: string;
+}
+interface RawPages {
+  readonly next?: RawPagesNext | string | null;
+}
+interface ArticleListResponse {
+  readonly data?: readonly RawArticle[];
+  readonly pages?: RawPages | null;
+}
+interface RawMe {
+  readonly type?: string;
+  readonly id?: string;
+}
+
+/** One locale of an article, normalized (timestamp canonical, published flag resolved). */
+interface NormalizedContent {
+  readonly locale: string;
+  readonly title: string;
+  readonly bodyHtml: string;
+  /** Canonical ISO instant — never the raw vendor epoch. */
+  readonly updatedAt: string;
+  readonly url: string;
+  readonly published: boolean;
+}
+
+/** One enumerated article, normalized to its per-locale contents. */
+interface NormalizedArticle {
+  readonly id: string;
+  /** Newest instant across the article + all its locales — drives the mark + since filter. */
+  readonly effectiveUpdatedAt: string;
+  readonly contents: readonly NormalizedContent[];
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an Intercom vendor client. `createClient` (the connector factory) has
+ * already decrypted the token, so this constructor does no I/O.
+ */
+export function createIntercomVendorClient(
+  config: IntercomClientConfig,
+  deps: IntercomClientDeps = {},
+): ConnectorVendorClient {
+  const api = new IntercomApi(config, deps);
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      return api.fetch({ since: params.since });
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetch({ since: null });
+    },
+  };
+}
+
+/**
+ * Verify the connection at INSTALL time — resolve the authenticated admin with
+ * the supplied token (`GET /me`). Cheap (one request) and loud: a bad token
+ * surfaces as a 401. The install handler maps it to a field-level 400 so
+ * "invalid credentials fail the install loudly."
+ */
+export async function verifyIntercomAccess(
+  config: IntercomClientConfig,
+  deps: IntercomClientDeps = {},
+): Promise<void> {
+  await new IntercomApi(config, deps).verifyAccess();
+}
+
+class IntercomApi {
+  private readonly authHeader: string;
+  private readonly maxDocs: number;
+
+  constructor(
+    private readonly config: IntercomClientConfig,
+    private readonly deps: IntercomClientDeps,
+  ) {
+    this.authHeader = `Bearer ${config.apiToken}`;
+    this.maxDocs = deps.maxDocs ?? getIngestMaxDocs();
+  }
+
+  /** Install-time reachability + credential check (`GET /me`). */
+  async verifyAccess(): Promise<void> {
+    const me = await this.getJson<RawMe>(`${INTERCOM_API_BASE}/me`);
+    // Intercom's /me always carries a `type` (and an `id`); neither present is
+    // an anomalous response — surface it rather than accept a hollow 200.
+    if (typeof me.type !== "string" && typeof me.id !== "string") {
+      throw new Error(
+        `Intercom did not return a recognizable identity from ${hostForLog(INTERCOM_API_BASE)} — check that the access token is valid.`,
+      );
+    }
+  }
+
+  /**
+   * Walk the full article list + assemble. When `since` is null this is a
+   * reconciliation crawl (every published locale emitted); otherwise an
+   * incremental cycle (only articles changed at-or-after `since` contribute —
+   * the client-side diff of the delta-less posture).
+   */
+  async fetch(opts: { since: string | null }): Promise<ConnectorChanges> {
+    const reconciliation = opts.since === null;
+    const { articles, skippedMalformed } = await this.enumerateArticles();
+
+    let highWaterMark: string | null = null;
+    for (const a of articles) {
+      if (highWaterMark === null || a.effectiveUpdatedAt > highWaterMark) {
+        highWaterMark = a.effectiveUpdatedAt;
+      }
+    }
+
+    // `effectiveUpdatedAt` is a normalized ISO instant, and the engine's `since`
+    // is a toISOString — string comparisons are chronological.
+    const selected = reconciliation
+      ? articles
+      : articles.filter((a) => opts.since === null || a.effectiveUpdatedAt >= opts.since);
+
+    const contents: IntercomArticleContent[] = [];
+    for (const a of selected) {
+      for (const c of a.contents) {
+        if (!c.published) continue; // draft locale — never emitted
+        contents.push({
+          articleId: a.id,
+          locale: c.locale,
+          title: c.title,
+          bodyHtml: c.bodyHtml,
+          updatedAt: c.updatedAt,
+          url: c.url,
+        });
+      }
+    }
+
+    // Reject an over-cap FULL set BEFORE converting bodies (the engine's ingest
+    // cap is the backstop, but checking here puts real numbers in the error —
+    // the AC's "caps validated over the full set").
+    if (reconciliation && contents.length > this.maxDocs) {
+      throw new Error(
+        `This Intercom workspace has ${contents.length} published article translations, over the ${this.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the connector's scope, or raise the cap.`,
+      );
+    }
+
+    const assembled = assembleIntercomDocuments(contents, {
+      collectionSlug: this.config.collectionSlug,
+    });
+    if (assembled.degradations.length > 0 || assembled.skippedContentless > 0) {
+      log.info(
+        {
+          host: hostForLog(INTERCOM_API_BASE),
+          mode: reconciliation ? "reconciliation" : "incremental",
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+        },
+        "Intercom conversion completed with degradations/skips",
+      );
+    }
+    if (skippedMalformed > 0) {
+      // A skipped article/locale is a KNOWN hole in the set: its document would
+      // otherwise be archived by a reconciliation off this partial crawl. The
+      // flag makes the engine upsert-only and hold the reconcile clock.
+      log.warn(
+        { host: hostForLog(INTERCOM_API_BASE), skippedMalformed },
+        "Skipped Intercom articles/translations missing id/locale/timestamp — not ingested (unexpected for published content)",
+      );
+    }
+
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+
+  /** Cursor-paginate the full article list, normalizing each into its locales. */
+  private async enumerateArticles(): Promise<{
+    articles: NormalizedArticle[];
+    skippedMalformed: number;
+  }> {
+    const articles: NormalizedArticle[] = [];
+    let skippedMalformed = 0;
+    let url: string | null = `${INTERCOM_API_BASE}/articles?per_page=${PAGE_SIZE}`;
+    let pages = 0;
+    while (url !== null) {
+      if (++pages > MAX_FEED_PAGES) {
+        throw new Error(
+          `Intercom article listing on ${hostForLog(INTERCOM_API_BASE)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+        );
+      }
+      const body: ArticleListResponse = await this.getJson<ArticleListResponse>(url);
+      for (const raw of body.data ?? []) {
+        const { article, skipped } = normalizeArticle(raw);
+        skippedMalformed += skipped;
+        if (article !== null) articles.push(article);
+      }
+      if (articles.length > MAX_ARTICLES) {
+        throw new Error(
+          `Intercom workspace on ${hostForLog(INTERCOM_API_BASE)} exceeds ${MAX_ARTICLES} articles — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+        );
+      }
+      url = nextPageUrl(body.pages);
+    }
+    return { articles, skippedMalformed };
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  private async getJson<T>(url: string): Promise<T> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `Intercom request to ${hostForLog(INTERCOM_API_BASE)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `Intercom rate-limited the request to ${hostForLog(INTERCOM_API_BASE)} (the Articles API allows ~1,000 requests/minute).`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new IntercomAuthError(
+        `Intercom rejected the credentials (${response.status}) for ${hostForLog(INTERCOM_API_BASE)} — re-enter the access token (Intercom → Settings → Developers → your app → Authentication) and confirm it can read Articles.`,
+      );
+    }
+    if (response.status >= 500) {
+      throw new Error(
+        `Intercom returned HTTP ${response.status} from ${hostForLog(INTERCOM_API_BASE)} — a vendor-side error; the next scheduled sync (or retrying the install) will usually succeed.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Intercom returned HTTP ${response.status} from ${hostForLog(INTERCOM_API_BASE)} — an unexpected Intercom API response; if it persists, re-install the collection or check Intercom's API status.`,
+      );
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new Error(
+        `Intercom returned a non-JSON response from ${hostForLog(INTERCOM_API_BASE)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/**
+ * Resolve the next-page cursor into a same-origin URL, or null when the walk is
+ * done. `pages.next` is either a `{ starting_after }` object (cursor pagination,
+ * the documented shape) or null; a missing / empty cursor stops the walk.
+ */
+function nextPageUrl(pages: RawPages | null | undefined): string | null {
+  const next = pages?.next;
+  if (next === null || next === undefined) return null;
+  const cursor =
+    typeof next === "object" && typeof next.starting_after === "string" ? next.starting_after.trim() : "";
+  if (cursor === "") return null;
+  return `${INTERCOM_API_BASE}/articles?per_page=${PAGE_SIZE}&starting_after=${encodeURIComponent(cursor)}`;
+}
+
+/** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */
+function idOf(raw: number | string | undefined): string {
+  return typeof raw === "number" || typeof raw === "string" ? String(raw) : "";
+}
+
+/**
+ * Normalize a Unix epoch-seconds timestamp (Intercom's clock) to a canonical
+ * ISO-8601 instant, or null when it doesn't parse. Intercom returns integer
+ * seconds; `toIsoInstant` (which `Date.parse`es a string) can't read those, so
+ * connector timestamps route through here.
+ */
+export function epochSecondsToIso(value: unknown): string | null {
+  const seconds =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))
+        ? Number(value)
+        : null;
+  if (seconds === null || !Number.isFinite(seconds)) return null;
+  const ms = seconds * 1000;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/**
+ * Normalize one raw article into its per-locale contents. Returns
+ * `{ article: null, skipped }` when the article itself is malformed (no
+ * id/updated_at); `skipped` also counts individual locales dropped for a
+ * missing locale key.
+ */
+function normalizeArticle(raw: RawArticle): { article: NormalizedArticle | null; skipped: number } {
+  const id = idOf(raw.id);
+  const articleUpdatedAt = epochSecondsToIso(raw.updated_at);
+  if (id === "" || articleUpdatedAt === null) return { article: null, skipped: 1 };
+
+  const rawLocales = collectLocaleContents(raw);
+  const contents: NormalizedContent[] = [];
+  let skipped = 0;
+  let effectiveUpdatedAt = articleUpdatedAt;
+
+  for (const { locale, content } of rawLocales) {
+    const trimmedLocale = locale.trim().toLowerCase();
+    if (trimmedLocale === "") {
+      skipped++;
+      continue;
+    }
+    // A locale content's own updated_at wins; fall back to the article's so a
+    // locale without its own timestamp still orders (never a null instant).
+    const updatedAt = epochSecondsToIso(content.updated_at) ?? articleUpdatedAt;
+    if (updatedAt > effectiveUpdatedAt) effectiveUpdatedAt = updatedAt;
+    // Per-locale state is authoritative; fall back to the article-level state
+    // (the default locale mirrors it) so a locale without its own state still
+    // resolves published/draft rather than defaulting silently.
+    const state = typeof content.state === "string" ? content.state : raw.state;
+    contents.push({
+      locale: trimmedLocale,
+      title: typeof content.title === "string" ? content.title : "",
+      bodyHtml: typeof content.body === "string" ? content.body : "",
+      updatedAt,
+      url: contentUrl(content.url, raw.url, id),
+      published: state === "published",
+    });
+  }
+
+  return { article: { id, effectiveUpdatedAt, contents }, skipped };
+}
+
+/**
+ * Collect the per-locale contents of an article. Prefers `translated_content`
+ * (the canonical multi-locale source — each key is a locale, minus the `type`
+ * discriminator); when it carries no usable locale, synthesizes one content from
+ * the top-level article fields under its `default_locale` (so a single-locale
+ * article with no translation block still ingests).
+ */
+function collectLocaleContents(
+  raw: RawArticle,
+): Array<{ locale: string; content: RawArticleContent }> {
+  const out: Array<{ locale: string; content: RawArticleContent }> = [];
+  const translated = raw.translated_content;
+  if (translated !== null && typeof translated === "object") {
+    for (const [key, value] of Object.entries(translated)) {
+      if (key === "type") continue; // the object's discriminator, not a locale
+      if (value !== null && typeof value === "object") {
+        out.push({ locale: key, content: value as RawArticleContent });
+      }
+    }
+  }
+  if (out.length === 0) {
+    const locale = typeof raw.default_locale === "string" && raw.default_locale.trim() !== "" ? raw.default_locale : "en";
+    out.push({
+      locale,
+      content: {
+        title: raw.title,
+        body: raw.body,
+        state: raw.state,
+        updated_at: raw.updated_at,
+        url: raw.url,
+      },
+    });
+  }
+  return out;
+}
+
+/** The canonical help-center URL for one locale, with fallbacks. */
+function contentUrl(contentUrlRaw: unknown, articleUrl: unknown, id: string): string {
+  if (typeof contentUrlRaw === "string" && contentUrlRaw !== "") return contentUrlRaw;
+  if (typeof articleUrl === "string" && articleUrl !== "") return articleUrl;
+  return `${INTERCOM_API_BASE}/articles/${id}`;
+}
+
+/** Parse a `Retry-After` header (delta-seconds only; HTTP-date → null). */
+export function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}

--- a/packages/api/src/lib/knowledge/intercom/client.ts
+++ b/packages/api/src/lib/knowledge/intercom/client.ts
@@ -391,7 +391,7 @@ function nextPageUrl(pages: RawPages | null | undefined): string | null {
   return `${INTERCOM_API_BASE}/articles?per_page=${PAGE_SIZE}&starting_after=${encodeURIComponent(cursor)}`;
 }
 
-/** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */
+/** Stringify an untrusted vendor id — string/number only (anything else = malformed → ""). */
 function idOf(raw: number | string | undefined): string {
   return typeof raw === "number" || typeof raw === "string" ? String(raw) : "";
 }

--- a/packages/api/src/lib/knowledge/intercom/config.ts
+++ b/packages/api/src/lib/knowledge/intercom/config.ts
@@ -1,0 +1,36 @@
+/**
+ * Intercom connector identity + stored-config contract (#4399, PRD #4395).
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config), the
+ * connector (reads it back in `createClient`), and the admin-knowledge surface
+ * (recognizes the catalog id) share ONE definition — a field rename can't drift
+ * the three apart silently. The access token is NOT part of this config; it
+ * lives encrypted in `knowledge_sync_credentials` and is read via
+ * `readSyncCredential`.
+ *
+ * Intercom's REST API is a fixed vendor host (`api.intercom.io`) and has no
+ * multi-brand concept — ONE workspace maps to ONE collection — so, unlike
+ * Zendesk (per-brand host) or Confluence (customer base URL), there is no scope
+ * field to persist: the only config is an optional human description. Every
+ * request still goes through the SSRF egress guard at fetch time (defence in
+ * depth; the AC's "host through the egress guard").
+ */
+
+/** The built-in Intercom Knowledge Base catalog slug + row id. */
+export const INTERCOM_SLUG = "intercom";
+export const INTERCOM_CATALOG_ID = "catalog:intercom";
+/** Vendor slug stamped into `atlas_source` as `connector:intercom`. */
+export const INTERCOM_VENDOR = "intercom";
+
+/** The Intercom REST base — a fixed vendor host, never customer-supplied. */
+export const INTERCOM_API_BASE = "https://api.intercom.io";
+
+/**
+ * The non-secret config persisted on the `workspace_plugins` row. Intercom has
+ * no per-collection scope (one workspace = one collection), so the only field
+ * is the optional description.
+ */
+export interface IntercomCollectionConfig {
+  readonly description?: string;
+}

--- a/packages/api/src/lib/knowledge/intercom/config.ts
+++ b/packages/api/src/lib/knowledge/intercom/config.ts
@@ -23,7 +23,15 @@ export const INTERCOM_CATALOG_ID = "catalog:intercom";
 /** Vendor slug stamped into `atlas_source` as `connector:intercom`. */
 export const INTERCOM_VENDOR = "intercom";
 
-/** The Intercom REST base — a fixed vendor host, never customer-supplied. */
+/**
+ * The Intercom REST base — a fixed vendor host, never customer-supplied.
+ *
+ * NOTE: Intercom serves EU/AU data-residency workspaces from regional hosts
+ * (`api.eu.intercom.io`, `api.au.intercom.io`). This slice targets the default
+ * US host only; a token for an EU/AU workspace will 401/403 against it. Regional
+ * host selection is deliberately out of scope here (a future config field), not
+ * an oversight.
+ */
 export const INTERCOM_API_BASE = "https://api.intercom.io";
 
 /**

--- a/packages/api/src/lib/knowledge/intercom/connector.ts
+++ b/packages/api/src/lib/knowledge/intercom/connector.ts
@@ -1,0 +1,73 @@
+/**
+ * The Intercom {@link KnowledgeSyncConnector} (#4399, PRD #4395) — the
+ * catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * factory contract from ADR-0030: bind the stored config + the decrypted token
+ * into a vendor client. Scheduling, backoff, reconciliation, caps, and ingest
+ * are the shared engine's.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message. Intercom has no per-collection scope (one workspace = one
+ * collection), so there is nothing to parse from `config`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { createIntercomVendorClient, type IntercomClientDeps } from "./client";
+import { INTERCOM_CATALOG_ID, INTERCOM_VENDOR } from "./config";
+
+const log = createLogger("knowledge.intercom.connector");
+
+export interface IntercomConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: IntercomClientDeps;
+}
+
+/** Build the Intercom connector. `deps` is test-only vendor-client injection. */
+export function createIntercomConnector(
+  deps: IntercomConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: INTERCOM_CATALOG_ID,
+    vendor: INTERCOM_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiToken = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiToken === null) {
+        throw new Error(
+          "This Intercom collection has no stored access token — re-install it to re-enter the token.",
+        );
+      }
+
+      return createIntercomVendorClient(
+        {
+          apiToken,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the Intercom connector idempotently — called from the boot seam that
+ * also registers install handlers (`registerBuiltinInstallHandlers`), and from
+ * tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog id, so
+ * gate on the registry first.
+ */
+export function registerIntercomKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(INTERCOM_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createIntercomConnector());
+  log.info({ catalogId: INTERCOM_CATALOG_ID }, "Registered Intercom knowledge sync connector");
+}

--- a/packages/api/src/lib/knowledge/intercom/documents.ts
+++ b/packages/api/src/lib/knowledge/intercom/documents.ts
@@ -1,0 +1,154 @@
+/**
+ * Intercom article translation → OKF `ConnectorDocument` assembly (#4399,
+ * PRD #4395).
+ *
+ * Pure, deterministic glue between the SHARED support HTML→markdown converter
+ * (`../support/html-to-markdown.ts` — this vendor deliberately owns no HTML→md
+ * logic of its own; it CONSUMES the Zendesk-anchor converter) and the connector
+ * ingest seam. Each PUBLISHED locale of an article (a `translated_content`
+ * entry with `state: "published"`) is a distinct document (the PRD's
+ * "per-locale translations are distinct documents"); draft locales are never
+ * emitted, so an unpublish reads as "path absent" and the reconciliation crawl
+ * archives it.
+ *
+ * Paths are `<locale>/<title-slug>-<article-id>.md` — locale + article id make
+ * them collision-free by construction (two locales never share both), and the
+ * id suffix means a basename can never be a reserved OKF name — the
+ * `deriveArchivePath` fold still runs as defence in depth. A title rename reads
+ * as "old path archived + new path drafted", the documented rename-churn
+ * posture (same as Zendesk/GitBook).
+ *
+ * Provenance that survives ingest: `resource` = the locale's canonical
+ * help-center URL, `timestamp` = its modification time, plus an `atlas:`
+ * extension block carrying connector + article id + locale + updated_at (the
+ * AC's provenance fields). No provenance `tags`: `tags` is a mirrored column in
+ * the lenient parser's change comparison, so stamping one would re-draft every
+ * already-ingested document; the extension block stays outside the comparison
+ * (the Zendesk/GitBook posture).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import {
+  convertSupportHtmlToMarkdown,
+  type HtmlDegradation,
+} from "../support/html-to-markdown";
+import { INTERCOM_VENDOR } from "./config";
+
+/** One PUBLISHED locale of an article, ready to convert. */
+export interface IntercomArticleContent {
+  /** Stringified article id (stable across renames/locales). */
+  readonly articleId: string;
+  /** Locale code, e.g. `en` / `fr` (Intercom locales are lowercase). */
+  readonly locale: string;
+  readonly title: string;
+  /** The locale's HTML body. */
+  readonly bodyHtml: string;
+  /** Canonical ISO instant (`epochSecondsToIso`) — never the raw vendor value. */
+  readonly updatedAt: string;
+  /** Canonical help-center URL of this locale. */
+  readonly url: string;
+}
+
+export interface IntercomAssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Media degradations aggregated across every assembled locale. */
+  readonly degradations: readonly HtmlDegradation[];
+  /** Locales skipped because they carried no ingestable prose. */
+  readonly skippedContentless: number;
+}
+
+/** Slugify a title into a single path segment; `fallback` guarantees non-empty. */
+export function slugifyTitle(title: string, fallback: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched locales. Relative
+ * hrefs in a body absolutize against that locale's own canonical URL (the
+ * converter's cross-link hook), so a mirrored article's in-body links stay live.
+ */
+export function assembleIntercomDocuments(
+  contents: readonly IntercomArticleContent[],
+  options: { readonly collectionSlug: string },
+): IntercomAssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  let skippedContentless = 0;
+
+  for (const c of contents) {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(c.bodyHtml, {
+      pageUrl: c.url,
+      rewriteLink: (href) => rewriteRelativeLink(href, c.url),
+    });
+    for (const d of degradations) {
+      degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+    }
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    const segments = [
+      slugifyTitle(c.locale, "locale"),
+      `${slugifyTitle(c.title, "article")}-${c.articleId}`,
+    ];
+    const derived = deriveArchivePath(`${segments.join("/")}.md`);
+    const path = [...prefixSegments, derived.path].join("/");
+
+    const title = c.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        resource: c.url,
+        timestamp: c.updatedAt,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: INTERCOM_VENDOR,
+          article_id: c.articleId,
+          locale: c.locale,
+          updated_at: c.updatedAt,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless };
+}
+
+/**
+ * The converter's cross-link hook: absolutize a relative help-center href
+ * against the locale's own canonical URL so an in-body `/…` link stays live.
+ * Absolute and unparseable hrefs pass through untouched.
+ */
+function rewriteRelativeLink(href: string, pageUrl: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return href; // already absolute (any scheme)
+  try {
+    return new URL(href, pageUrl).toString();
+  } catch {
+    // intentionally ignored: an unparseable href renders as-is — the label text
+    // is preserved either way, and a broken vendor link is the vendor's.
+    return href;
+  }
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -38,14 +38,19 @@ export interface KnowledgeDocumentCounts {
  *     SOQL pull of published Salesforce Knowledge article versions over the
  *     workspace's EXISTING Salesforce OAuth install — no credential of its
  *     own; one document per published article-version language).
+ *   - `intercom` — the #4399 Knowledge Sync Connector (a scheduled full-walk
+ *     pull of the workspace's Intercom Articles via an access token; one
+ *     collection per workspace, one document per published article locale.
+ *     Intercom has no server-side change feed, so the connector
+ *     reconciliation-diffs `updated_at` against the high-water mark).
  *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
  * `authScheme`; connector collections (`notion`, `confluence`,
- * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`) carry
- * neither (their credential is a token — or, for `salesforce-knowledge`, the
- * reused OAuth install — not an endpoint).
+ * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`,
+ * `intercom`) carry neither (their credential is a token — or, for
+ * `salesforce-knowledge`, the reused OAuth install — not an endpoint).
  */
 export type KnowledgeCollectionSource =
   | "upload"
@@ -55,7 +60,8 @@ export type KnowledgeCollectionSource =
   | "confluence-datacenter"
   | "gitbook"
   | "zendesk"
-  | "salesforce-knowledge";
+  | "salesforce-knowledge"
+  | "intercom";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
## Summary

Adds the **Intercom** Knowledge Sync Connector (ADR-0030 seam, a slice of PRD #4395 — KB Support Center Connectors), the fourth support-tier connector after Zendesk (#4396) / Salesforce Knowledge (#4397) / GitBook (#4393).

- **Access-token install.** Single `access_token` (Bearer) + optional description; one collection per workspace (Intercom has no multi-brand concept). Verified loudly at install via `GET /me`; the token is encrypted into `knowledge_sync_credentials` (never `workspace_plugins.config`), with loud decrypt failures.
- **Reconciliation-diff sync.** Intercom exposes no server-side `updated_since` feed, so both cadences are served from one full cursor-paginated (`starting_after`) walk of `GET /articles`: `fetchAll()` emits every published locale; `fetchChanges({ since })` client-diffs each article's effective `updated_at` against the high-water mark. Deletions/unpublishes are archived via the reconciliation crawl.
- **Multi-locale.** Each published `translated_content` entry is a distinct document at `<locale>/<title-slug>-<article-id>.md`; `state` filters to `published` (draft article/locale never ingested); provenance carries connector + article id + locale + updated_at.
- **CONSUMES the shared `support/html-to-markdown.ts` converter** from the Zendesk anchor (#4396) — no per-vendor fork.
- **Draft-only ingest** (engine stamps `connector:intercom`); every fetch routes through the SSRF egress guard even though the host is a fixed constant; 429/`Retry-After` honored via the engine's bounded backoff; vendor client fully test-doubled (no live API).

Wiring: `install/intercom-form-handler.ts` + `register.ts` pairing, `seed-builtin-knowledge-catalog.ts` row, `admin-knowledge.ts` source branch, `KnowledgeCollectionSource` wire type + web schema enum, and a `connect-intercom.mdx` guide (+ knowledge-base list + meta.json).

> Note: this slice targets Intercom's default US host (`api.intercom.io`); EU/AU regional hosts are documented as out of scope (a future config field), not an oversight.

## Test plan

- [x] `intercom/__tests__/{client,connector,documents}.test.ts` — reconciliation, incremental diff, translation-only edit (locale newer than article), multi-locale, publish-guard (draft filtered), epoch-seconds normalization, doc cap over full set, cursor pagination, 429 → `ConnectorRateLimitError`, 401/403 → typed auth error, loud decrypt failure. Vendor client driven entirely through an injected `fetchImpl`.
- [x] `intercom-form-handler.test.ts` — field validation, verify-then-persist ordering, credential routing (token never in config), rollback on install-row failure.
- [x] Pairing test (`register.test.ts`), seed-catalog row test, admin-knowledge source-dispatch test, and a real-Postgres upsert case in `knowledge-lifecycle-pg.test.ts`.
- [x] Internal review-panel (4 specialists) clean; `/ci` green (openapi spec regenerated for the new `source` enum). The one local `test`-gate flake was 3 Teams/Discord API-mount tests unrelated to this diff — verified passing in isolation.

Closes #4399

https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN)_