### PR TITLE
feat: Help Scout Docs sync connector (Docs API key, multi-site, updatedAt watermark)

### DIFF
--- a/apps/docs/content/docs/guides/connect-helpscout.mdx
+++ b/apps/docs/content/docs/guides/connect-helpscout.mdx
@@ -1,0 +1,98 @@
+---
+title: Connect Help Scout Docs
+description: Mirror your Help Scout Docs help center into review-gated Knowledge Base collections — a single Docs API key, one collection per site, and an updatedAt watermark.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+
+A **Help Scout Docs** connector mirrors your help center's published articles into [Knowledge Base](/guides/knowledge-base) collections. Atlas pulls articles on a schedule, converts each article's HTML to markdown, and queues every document as a **draft** for review — the same review gate as every other knowledge source. Connectors never publish on their own. This is the simplest connector to install in the support tier: a single Docs API key, no OAuth, no host to configure.
+
+<Callout title="Prerequisites">
+The Knowledge Base requires the internal database and managed auth (see the [Knowledge Base guide](/guides/knowledge-base)). Your account needs at least one **Docs site**. Atlas only ever talks to the fixed Help Scout Docs host (`docsapi.helpscout.net`) — distinct from the Mailbox API. Images and embedded media are **not** mirrored (text-first); they are replaced with links back to the source article.
+</Callout>
+
+---
+
+## Create a Docs API key
+
+Atlas authenticates with a single Help Scout **Docs API key** over HTTP Basic auth (the key is the username; the password is a dummy value).
+
+<Steps>
+<Step>
+In Help Scout, go to **Your Profile → Authentication → API Keys** and generate a key. Give it a recognizable label like `atlas-knowledge`.
+</Step>
+<Step>
+Copy the key immediately, and confirm your account includes **Docs** — the key must have Docs access.
+</Step>
+</Steps>
+
+---
+
+## Install
+
+Navigate to **Admin → Integrations**, choose **Knowledge Base (Help Scout Docs)**, and provide:
+
+- **Docs API key** — stored encrypted at rest; never shown again.
+
+At install time Atlas verifies the key and enumerates your account's **Docs sites**. A bad key, or an account with no Docs site, fails the install **loudly** with an actionable message. On success, collections are created and the first sync is scheduled.
+
+### One collection per site
+
+Help Scout Docs is multi-site, and Atlas mirrors that: the install discovers every **Docs site** and creates one collection per site, so each site's articles are independently searchable with their own review queue.
+
+- An account with one site gets one collection under the plain slug (default `helpscout`).
+- With several sites, each collection is suffixed with the site's subdomain (or its id when it has none): `helpscout-acme`, `helpscout-support`.
+
+<Callout type="warn" title="Adding a site later">
+Sites added after install are not discovered automatically — **re-install the connector** to fan out to new sites (the install is idempotent; existing collections are unaffected). One edge to know: if an account goes from one site to several, the re-install creates site-suffixed collections and the original plain-slug collection stays behind — uninstall it by hand.
+</Callout>
+
+---
+
+## How sync works
+
+Atlas runs two kinds of cycle, decided per collection:
+
+- **Incremental** (the common, cheap cycle) — the Docs article list is fetched **newest-first** (`sort=updatedAt`), so Atlas walks each collection only until it reaches an article at or before the collection's high-water mark, then stops. The list is bodyless, so Atlas fetches the full body of **only the changed articles** — never a full re-download. The Docs API allows roughly 200–400 requests/minute (scaling with site count); Atlas honors `429` / `Retry-After` signals with bounded backoff. Deletions are invisible here.
+- **Reconciliation** (the correctness anchor, weekly by default, and always on the first sync) — enumerates every published article across the site's collections. This is the only cycle that **archives** articles that were deleted or unpublished in Help Scout, and the only one that validates the ingest caps over the full set.
+
+Each collection card shows the last sync's status and time, with a **Sync now** button for an on-demand pull. If a crawl comes back knowingly incomplete (an article vanished between listing and body fetch), Atlas upserts what it got but defers all archiving until a clean crawl — deletions are never inferred from a partial view.
+
+### What syncs — published articles
+
+Only **published** content syncs: the article list is filtered to `status=published`, so an unpublished (`notpublished`) or deleted article is never pulled and is archived on the next reconciliation. Each published article is its own document, filed under its source collection (`helpscout/onboarding/getting-started-<id>.md`).
+
+### Paths, and what a rename does
+
+A document's path is built from its **source collection, title, and article id** (`helpscout/billing/reset-your-password-<id>.md`). Two consequences:
+
+- **Renaming an article's title archives the old path and re-drafts the new one** for re-review — expected churn; nothing is ever hard-deleted.
+- **Moving an article to a different Docs collection changes its path** (old path archived, new one drafted) — the same churn posture.
+
+### HTML, images, and honest conversion
+
+Article HTML converts structurally — headings, lists, tables, code blocks, quotes. Images, videos, iframes, and other embeds **degrade to visible placeholders that link back to the source article** and are counted — never silently dropped (text-first). Relative links inside an article are rewritten to absolute URLs against the article's public URL, so cross-references in mirrored documents stay live.
+
+---
+
+## Review and publish
+
+Every synced article lands as a **draft**. Review it in **Admin → Knowledge Base**, and publish when it's ready — only then does the agent read it. An article whose content changes in Help Scout and had already been published is **demoted back to draft** on the next sync, so an edit re-enters review rather than silently going live. Provenance (`atlas:` — vendor, site, article id, last-modified time) travels with every document so any answer traces back to its help-center article.
+
+---
+
+## Caps and limits
+
+A very large help center can overflow the Knowledge Base ingest caps. When that happens, reconciliation fails with the **actual document count** and names the knob to raise:
+
+- `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` — maximum documents per collection (default 1000).
+- `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` — maximum size of a single document. An oversized document is rejected individually (visible in the sync report) rather than failing the cycle, and its previously-synced version is never archived out from under it.
+
+Raise the cap in the settings registry, or keep sites in separate collections (the default) so each stays under it. The reconciliation cadence is the `ATLAS_KNOWLEDGE_SYNC_RECONCILE_INTERVAL_HOURS` knob (weekly default); the incremental cadence is `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` (nightly default).
+
+---
+
+## Uninstall
+
+Uninstalling a Help Scout collection **archives** its documents (never hard-deletes) and removes the stored key and sync bookkeeping for that site. Re-installing re-syncs it, which brings the archived articles back as drafts for re-review.

--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -44,6 +44,7 @@ Connector-backed sources install from **Admin → Integrations** rather than thi
 - **[Connect Zendesk Guide](/guides/connect-zendesk)** — mirrors your help center's published articles, one collection per brand (subdomain + email + API token).
 - **[Connect Salesforce Knowledge](/guides/connect-salesforce-knowledge)** — mirrors your org's published Knowledge articles, reusing the workspace's existing Salesforce connection (no new credentials).
 - **[Connect Intercom](/guides/connect-intercom)** — mirrors your Intercom help center's published articles (all locales), one collection per workspace (access token).
+- **[Connect Help Scout Docs](/guides/connect-helpscout)** — mirrors your help center's published articles, one collection per site (a single Docs API key).
 
 ---
 

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -27,6 +27,7 @@
     "connect-zendesk",
     "connect-salesforce-knowledge",
     "connect-intercom",
+    "connect-helpscout",
     "developer-mode",
     "demo-mode",
     "guided-tour",

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56692,7 +56692,8 @@
                               "zendesk",
                               "salesforce-knowledge",
                               "intercom",
-                              "front"
+                              "front",
+                              "helpscout"
                             ]
                           },
                           "description": {

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -735,6 +735,31 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(front?.endpointUrl).toBeNull();
     expect(front?.sync).not.toBeNull();
   });
+
+  it("dispatches a Help Scout collection to the connector engine and lists it as source 'helpscout' (#4398)", async () => {
+    COLLECTION = {
+      install_id: "hs-docs",
+      catalog_id: "catalog:helpscout",
+      status: "published",
+      config: { site_id: "site-1", site_name: "Acme Docs", subdomain: "acme" },
+    };
+    SYNC_STATES = [
+      { collection_id: "hs-docs", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/hs-docs/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const hs = body.collections.find((c) => c.slug === "hs-docs");
+    expect(hs?.source).toBe("helpscout");
+    expect(hs?.endpointUrl).toBeNull();
+    expect(hs?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -62,6 +62,7 @@ import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
 import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
+import { HELPSCOUT_CATALOG_ID } from "@atlas/api/lib/knowledge/helpscout/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -133,6 +134,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === SALESFORCE_KNOWLEDGE_CATALOG_ID) return "salesforce-knowledge";
   if (catalogId === INTERCOM_CATALOG_ID) return "intercom";
   if (catalogId === FRONT_CATALOG_ID) return "front";
+  if (catalogId === HELPSCOUT_CATALOG_ID) return "helpscout";
   return "unknown";
 }
 
@@ -147,7 +149,8 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "zendesk" ||
     source === "salesforce-knowledge" ||
     source === "intercom" ||
-    source === "front"
+    source === "front" ||
+    source === "helpscout"
   );
 }
 
@@ -168,7 +171,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -30,6 +30,7 @@ import {
   BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_INTERCOM_CATALOG_ROW,
   BUILTIN_FRONT_CATALOG_ROW,
+  BUILTIN_HELPSCOUT_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -253,6 +254,29 @@ describe("BUILTIN_FRONT_CATALOG_ROW (#4400)", () => {
   });
 });
 
+describe("BUILTIN_HELPSCOUT_CATALOG_ROW (#4398)", () => {
+  it("is the `helpscout` form install: a single secret Docs API key, NO host/subdomain", () => {
+    const row = BUILTIN_HELPSCOUT_CATALOG_ROW;
+    expect(row.slug).toBe("helpscout");
+    expect(row.id).toBe("catalog:helpscout");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("api_key");
+    expect(keys).toContain("description");
+    // Fixed vendor host + auto-discovered sites — no free-form URL, no subdomain
+    // field, no email (a single Docs API key is the whole credential).
+    expect(keys).not.toContain("base_url");
+    expect(keys).not.toContain("subdomain");
+    expect(keys).not.toContain("email");
+    // Exactly one secret field: the Docs API key (never echoed).
+    expect(row.configSchema.filter((f) => f.secret === true).map((f) => f.key)).toEqual([
+      "api_key",
+    ]);
+    expect(row.configSchema.find((f) => f.key === "api_key")?.required).toBe(true);
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -279,6 +303,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "salesforce-knowledge",
       "intercom",
       "front",
+      "helpscout",
     ]);
   });
 
@@ -309,6 +334,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "salesforce-knowledge",
       "intercom",
       "front",
+      "helpscout",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -47,6 +47,7 @@ import {
   SALESFORCE_KNOWLEDGE_SLUG,
 } from "@atlas/api/lib/knowledge/salesforce/config";
 import { FRONT_CATALOG_ID, FRONT_SLUG } from "@atlas/api/lib/knowledge/front/config";
+import { HELPSCOUT_CATALOG_ID, HELPSCOUT_SLUG } from "@atlas/api/lib/knowledge/helpscout/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -561,6 +562,50 @@ export const BUILTIN_FRONT_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The Help Scout Docs connector Knowledge Base catalog row (#4398, PRD #4395 —
+ * the simplest install in the support tier). A form install that enumerates the
+ * account's Docs SITES and creates one review-gated collection per site; the
+ * Scheduler dispatches the registered Help Scout connector on a cadence
+ * (`sort=updatedAt` incremental + full reconciliation) and every synced article
+ * lands `draft`.
+ *
+ * `api_key` is `secret: true` but is NOT stored in `workspace_plugins.config` —
+ * the install handler routes it to `knowledge_sync_credentials` (encrypted, one
+ * row per site collection). The Docs API host is a fixed vendor constant
+ * (`docsapi.helpscout.net`), so there is no free-form base-URL field and no
+ * subdomain field (sites are discovered automatically); every request still
+ * goes through the SSRF egress guard. The id/slug are the config SSOT
+ * (`HELPSCOUT_CATALOG_ID` / `HELPSCOUT_SLUG`).
+ */
+export const BUILTIN_HELPSCOUT_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: HELPSCOUT_CATALOG_ID,
+  slug: HELPSCOUT_SLUG,
+  name: "Knowledge Base (Help Scout Docs)",
+  description:
+    "Mirror your Help Scout Docs help center into review-gated knowledge collections (one per site); Atlas syncs published articles on a schedule (incremental + reconciliation) and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "api_key",
+      type: "string",
+      secret: true,
+      label: "Docs API key",
+      required: true,
+      description:
+        "A Help Scout Docs API key (Help Scout → Your Profile → Authentication → API Keys). Sites are discovered automatically — one collection per Docs site. Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -573,6 +618,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_SALESFORCE_KNOWLEDGE_CATALOG_ROW,
   BUILTIN_INTERCOM_CATALOG_ROW,
   BUILTIN_FRONT_CATALOG_ROW,
+  BUILTIN_HELPSCOUT_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/helpscout-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/helpscout-form-handler.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for `HelpScoutFormInstallHandler` (#4398) — the Help Scout Docs
+ * connector install. Focus: field validation (the single Docs API key), loud
+ * site-enumeration verification at install time, the PER-SITE FAN-OUT (one
+ * collection per Docs site; base slug for a single site, suffixed slugs for
+ * multi-site), credential routing (key → `knowledge_sync_credentials`, one row
+ * per site collection, NEVER into `workspace_plugins.config`), and the
+ * credential rollback on a failed row write. Verification uses the REAL egress
+ * guard against an injected fixture fetch; no test touches Help Scout.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:helpscout" }];
+let INSERT_RETURNS_ID = true;
+let INSERT_FAIL_ON_SLUG: string | null = null;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    if (INSERT_FAIL_ON_SLUG !== null && params[3] === INSERT_FAIL_ON_SLUG) {
+      throw new Error("simulated row-write failure");
+    }
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { HelpScoutFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/helpscout-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = { api_key: "hs-docs-key" };
+
+interface FixtureSite {
+  id?: string | number;
+  title?: string;
+  subDomain?: string;
+}
+
+const ONE_SITE: FixtureSite[] = [{ id: "site-1", title: "Acme", subDomain: "acme" }];
+const TWO_SITES: FixtureSite[] = [...ONE_SITE, { id: "site-2", title: "Beta", subDomain: "beta" }];
+
+/** A fixture sites-endpoint fetch (or a fixed failure status). */
+function sitesFetch(opts: { sites?: FixtureSite[]; status?: number } = {}): typeof fetch {
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url);
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (url.pathname.endsWith("/v1/sites")) {
+      return new Response(
+        JSON.stringify({ sites: { page: 1, pages: 1, items: opts.sites ?? ONE_SITE } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+  return impl as unknown as typeof fetch;
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  let n = 0;
+  return new HelpScoutFormInstallHandler({
+    idGenerator: () => `fixed-id-${++n}`,
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:helpscout" }];
+  INSERT_RETURNS_ID = true;
+  INSERT_FAIL_ON_SLUG = null;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+async function formErrorOf(promise: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.formErrors[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("requires the API key", async () => {
+    const msg = await fieldErrorOf(handler().validateConfig(WORKSPACE, { api_key: "" }), "api_key");
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a key with whitespace", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { api_key: "has space" }),
+      "api_key",
+    );
+    expect(msg).toMatch(/spaces/i);
+  });
+});
+
+describe("site enumeration (install-time verification)", () => {
+  it("blames the api_key field on a 401", async () => {
+    const msg = await fieldErrorOf(
+      handler(sitesFetch({ status: 401 })).validateConfig(WORKSPACE, VALID),
+      "api_key",
+    );
+    expect(msg).toMatch(/rejected the credentials/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 429 as a form-level error (the key may be fine)", async () => {
+    const msg = await formErrorOf(handler(sitesFetch({ status: 429 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/rate-limited/i);
+  });
+
+  it("surfaces a vendor 5xx as a form-level error, never blaming the key", async () => {
+    const msg = await formErrorOf(handler(sitesFetch({ status: 503 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/vendor-side error/i);
+  });
+
+  it("rejects an account with no Docs sites", async () => {
+    const msg = await formErrorOf(handler(sitesFetch({ sites: [] })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/no Docs sites/i);
+  });
+});
+
+describe("per-site fan-out", () => {
+  it("single site: one collection under the base slug, key → credentials only", async () => {
+    const rec = await handler(sitesFetch()).validateConfig(WORKSPACE, VALID);
+    expect(rec.installRecord).toMatchObject({ workspaceId: WORKSPACE, catalogId: "helpscout" });
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].params[3]).toBe("helpscout");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toMatchObject({ site_id: "site-1", site_name: "Acme", subdomain: "acme" });
+    // The key NEVER lands in the install config…
+    expect(config).not.toHaveProperty("api_key");
+    // …it lands in knowledge_sync_credentials, keyed by the collection slug.
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(saveSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "helpscout", "hs-docs-key"]);
+  });
+
+  it("respects a custom collection slug via __install_id__", async () => {
+    await handler(sitesFetch()).validateConfig(WORKSPACE, { ...VALID, __install_id__: "support-kb" });
+    expect(insertCalls[0].params[3]).toBe("support-kb");
+  });
+
+  it("multi-site: one collection per site under suffixed slugs, one credential each", async () => {
+    const rec = await handler(sitesFetch({ sites: TWO_SITES })).validateConfig(WORKSPACE, VALID);
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["helpscout-acme", "helpscout-beta"]);
+    const configs = insertCalls.map((c) => JSON.parse(c.params[4] as string));
+    expect(configs.map((c) => c.site_id)).toEqual(["site-1", "site-2"]);
+    expect(saveSyncCredential.mock.calls.map((c) => c[1])).toEqual(["helpscout-acme", "helpscout-beta"]);
+    // The returned record is the first site's row.
+    expect(rec.installRecord.id).toBe("fixed-id-1");
+  });
+
+  it("falls back to the site id suffix when a site has no subdomain", async () => {
+    await handler(
+      sitesFetch({ sites: [ONE_SITE[0], { id: "site-2", title: "Beta", subDomain: "" }] }),
+    ).validateConfig(WORKSPACE, VALID);
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["helpscout-acme", "helpscout-site-2"]);
+  });
+
+  it("rejects a fan-out slug that would exceed the collection-slug bound BEFORE any write", async () => {
+    const longBase = "z".repeat(125); // valid alone (≤128); overflows once "-acme" is appended
+    const msg = await fieldErrorOf(
+      handler(sitesFetch({ sites: TWO_SITES })).validateConfig(WORKSPACE, {
+        ...VALID,
+        __install_id__: longBase,
+      }),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/exceeds 128 characters/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a fan-out slug taken by another knowledge catalog BEFORE any write", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const msg = await fieldErrorOf(
+      handler(sitesFetch({ sites: TWO_SITES })).validateConfig(WORKSPACE, VALID),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/already used/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the failed site's credential and leaves earlier sites installed", async () => {
+    INSERT_FAIL_ON_SLUG = "helpscout-beta";
+    await expect(
+      handler(sitesFetch({ sites: TWO_SITES })).validateConfig(WORKSPACE, VALID),
+    ).rejects.toThrow(/simulated row-write failure/);
+    // First site fully installed…
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["helpscout-acme"]);
+    // …the failed site's orphaned credential rolled back (and only that one).
+    expect(deleteSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "helpscout-beta"]);
+  });
+});
+
+describe("catalog preconditions", () => {
+  it("fails loudly when the catalog row is missing (seed has not run)", async () => {
+    CATALOG_ROWS = [];
+    await expect(handler(sitesFetch()).validateConfig(WORKSPACE, VALID)).rejects.toThrow(
+      /catalog row "helpscout" not found/i,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -49,6 +49,7 @@ import { ZENDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/zendesk/config";
 import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesforce/config";
 import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
+import { HELPSCOUT_CATALOG_ID } from "@atlas/api/lib/knowledge/helpscout/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -152,7 +153,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, Salesforce Knowledge, Intercom, and Front sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, Salesforce Knowledge, Intercom, Front, and Help Scout sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
@@ -162,6 +163,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
     expect(getKnowledgeSyncConnector(SALESFORCE_KNOWLEDGE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(INTERCOM_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(FRONT_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(HELPSCOUT_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
@@ -170,6 +172,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
     expect(getInstallHandler({ slug: "salesforce-knowledge", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "intercom", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "front", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "helpscout", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/helpscout-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/helpscout-form-handler.ts
@@ -1,0 +1,362 @@
+/**
+ * `HelpScoutFormInstallHandler` — the {@link FormBasedInstallHandler} for the
+ * built-in `helpscout` Knowledge Base catalog row (#4398, PRD #4395). The
+ * simplest install in the support tier: a single Docs API key over HTTP Basic
+ * auth, no OAuth, no customer-supplied host.
+ *
+ * Installing `helpscout` creates one synced collection PER Docs SITE (the PRD's
+ * "one collection per Site"): the handler enumerates the account's sites with
+ * the supplied key and upserts one `pillar='knowledge'` `workspace_plugins` row
+ * per site, each config pinned to that site's id. A single site (the common
+ * case) gets exactly the chosen collection slug; multiple sites fan out to
+ * `<slug>-<site>`. The Scheduler dispatches the registered Help Scout connector
+ * per collection on a cadence (`lib/knowledge/connector-sync.ts`), and every
+ * synced article lands `draft`.
+ *
+ * Beyond the GitBook precedent it inherits (fixed vendor host — no install-time
+ * SSRF gate, the connector still routes every fetch through the egress guard;
+ * loud credential verification; key routed to `knowledge_sync_credentials`,
+ * never `workspace_plugins.config`), it follows Zendesk's multi-instance
+ * discipline: every per-site slug is availability-checked BEFORE any write;
+ * writes then run per site (credential → row). A mid-fan-out failure leaves
+ * earlier sites fully installed and working; the thrown error says retrying is
+ * safe (all writes are idempotent upserts converging on the same slugs). The
+ * one transition caveat: a single-site install that later becomes multi-site
+ * re-fans-out under suffixed slugs — the old base-slug collection stays behind
+ * and should be uninstalled by the admin.
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import { EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import {
+  listHelpScoutSites,
+  HelpScoutAuthError,
+  type HelpScoutSite,
+  type HelpScoutClientDeps,
+} from "@atlas/api/lib/knowledge/helpscout/client";
+import {
+  HELPSCOUT_SLUG,
+  HELPSCOUT_CATALOG_ID,
+  type HelpScoutCollectionConfig,
+} from "@atlas/api/lib/knowledge/helpscout/config";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  COLLECTION_SLUG_MAX,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { HELPSCOUT_SLUG, HELPSCOUT_CATALOG_ID };
+
+/** Defensive upper bounds — guard against pathological pastes. */
+const API_KEY_MAX = 4096;
+/** A slug-safe suffix label (the per-site fan-out suffix). */
+const SLUG_LABEL_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export interface HelpScoutFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the site-enumeration fetch (no real Help Scout call). */
+  readonly clientDeps?: HelpScoutClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to the Zendesk /
+ * GitBook knowledge upserts: `status='published'` because the COLLECTION
+ * container is live immediately — the review gate is on the DOCUMENTS, which
+ * always sync in as `draft`. Exported so the real-Postgres test executes this
+ * exact string against the live schema.
+ */
+export const HELPSCOUT_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: HelpScoutClientDeps;
+  private readonly log = createLogger("integrations.install.helpscout");
+
+  constructor(options: HelpScoutFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const baseSlug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], HELPSCOUT_SLUG);
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const apiKey = validateApiKey(rawForm.api_key);
+    const description = validateDescription(rawForm.description);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [HELPSCOUT_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "helpscout catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${HELPSCOUT_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    // ── Enumerate sites = verify the connection loudly BEFORE persisting ─────
+    const sites = await this.enumerateSites(apiKey);
+    if (sites.length === 0) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [
+          "This Help Scout account has no Docs sites — create a Docs site in Help Scout, then re-install.",
+        ],
+      });
+    }
+
+    // ── Compute + validate every per-site slug BEFORE any write ──────────────
+    const planned = sites.map((site) => ({
+      site,
+      slug: sites.length === 1 ? baseSlug : `${baseSlug}-${siteSlugSuffix(site)}`,
+    }));
+    for (const { slug } of planned) {
+      if (slug.length > COLLECTION_SLUG_MAX) {
+        throw new FormInstallValidationError({
+          fieldErrors: {
+            [KNOWLEDGE_INSTALL_ID_FIELD]: [
+              `Collection id "${slug}" (the per-site fan-out of "${baseSlug}") exceeds ${COLLECTION_SLUG_MAX} characters — choose a shorter collection id.`,
+            ],
+          },
+          formErrors: [],
+        });
+      }
+      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+    }
+
+    // ── Per-site writes: credential first, then the collection row ───────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "api_key");
+    let firstRecord: InstallRecord | null = null;
+    for (const { site, slug } of planned) {
+      const record = await this.installSiteCollection({
+        workspaceId,
+        catalogId,
+        slug,
+        site,
+        config: {
+          site_id: site.id,
+          site_name: site.name,
+          ...(site.subdomain !== null ? { subdomain: site.subdomain } : {}),
+          ...(description !== null ? { description } : {}),
+        },
+        apiKey,
+      });
+      firstRecord ??= record;
+    }
+
+    this.log.info(
+      {
+        workspaceId,
+        collections: planned.map((p) => p.slug),
+        sites: planned.length,
+      },
+      "Help Scout collection install completed",
+    );
+    // `firstRecord` is set on the first loop iteration (planned is non-empty).
+    if (firstRecord === null) {
+      throw new Error("Help Scout install produced no collection record — invariant violation");
+    }
+    return { installRecord: firstRecord, credentialWritten: true };
+  }
+
+  /** Write one site's credential + collection row, GitBook/Zendesk rollback posture. */
+  private async installSiteCollection(input: {
+    workspaceId: WorkspaceId;
+    catalogId: string;
+    slug: string;
+    site: HelpScoutSite;
+    config: HelpScoutCollectionConfig;
+    apiKey: string;
+  }): Promise<InstallRecord> {
+    const { workspaceId, catalogId, slug, site, config, apiKey } = input;
+    try {
+      await saveSyncCredential(workspaceId, slug, apiKey);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed site collections stay installed)",
+      );
+      throw retryableInstallError(slug, err);
+    }
+
+    const candidateId = this.newId();
+    try {
+      const rows = await internalQuery<{ id: string }>(HELPSCOUT_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        slug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug: slug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      return { id: returned, workspaceId, catalogId: HELPSCOUT_SLUG };
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a failed
+      // install (this site's install row never landed, so uninstall would never
+      // reach it). Best-effort — a re-install overwrites it either way; a
+      // cleanup failure is logged, never masks the original error.
+      this.log.error(
+        {
+          workspaceId,
+          collectionSlug: slug,
+          siteId: site.id,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to persist helpscout collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, slug);
+      } catch (cleanupErr) {
+        this.log.error(
+          {
+            workspaceId,
+            collectionSlug: slug,
+            err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw retryableInstallError(slug, err);
+    }
+  }
+
+  /**
+   * Enumerate Docs sites with the supplied key; map every failure to a 400.
+   * Classification is POSITIVE, by `instanceof` on the client's typed errors —
+   * never by message text or `cause`-presence sniffing — so only a failure the
+   * client KNOWS is credential-shaped blames the api_key field; a Help Scout
+   * outage or transport error stays form-level (re-entering a fine key would be
+   * the wrong guidance). All messages host-redacted by the client.
+   */
+  private async enumerateSites(apiKey: string): Promise<HelpScoutSite[]> {
+    try {
+      return await listHelpScoutSites({ apiKey }, this.clientDeps);
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        // Defence-in-depth: the fixed Help Scout host should never be blocked,
+        // but if a deploy's egress policy blocks it, surface it as form-level.
+        throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [err.message] });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof HelpScoutAuthError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { api_key: [message] },
+          formErrors: [],
+        });
+      }
+      // Everything else — 429 (ConnectorRateLimitError), a 404 (unexpected on
+      // /v1/sites), vendor 5xx, transport/DNS/non-JSON — is form-level: the key
+      // may be fine, so blaming the field would send the admin re-entering a
+      // good value. All host-redacted by the client.
+      throw new FormInstallValidationError({ fieldErrors: {}, formErrors: [message] });
+    }
+  }
+}
+
+/**
+ * Derive a slug-safe fan-out suffix for a site: prefer its `*.helpscoutdocs.com`
+ * subdomain label (clean + stable), else its immutable id — both sanitized to
+ * `[a-z0-9-]`. The id is the deterministic fallback so two sites never collide.
+ */
+function siteSlugSuffix(site: HelpScoutSite): string {
+  const preferred =
+    site.subdomain !== null && SLUG_LABEL_PATTERN.test(site.subdomain) ? site.subdomain : site.id;
+  const sanitized = preferred
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized === "" ? "site" : sanitized;
+}
+
+function validateApiKey(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "api_key",
+      "A Help Scout Docs API key is required. Create one in Help Scout → Your Profile → Authentication → API Keys.",
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > API_KEY_MAX) {
+    throw fieldError("api_key", `The API key must be ${API_KEY_MAX} characters or fewer.`);
+  }
+  if (/\s/.test(trimmed)) {
+    throw fieldError("api_key", "Key must not contain spaces — paste it exactly as Help Scout shows it.");
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}
+
+/**
+ * Wrap a mid-fan-out persistence failure with the retry guidance the admin
+ * needs: all writes are idempotent upserts converging on the same slugs, so
+ * re-running the install is always safe. The original failure rides as cause.
+ */
+function retryableInstallError(slug: string, err: unknown): Error {
+  return new Error(
+    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed site collections are simply updated in place.`,
+    { cause: err },
+  );
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -59,6 +59,8 @@ import { IntercomFormInstallHandler, INTERCOM_SLUG } from "./intercom-form-handl
 import { registerIntercomKnowledgeConnector } from "@atlas/api/lib/knowledge/intercom/connector";
 import { FrontFormInstallHandler, FRONT_SLUG } from "./front-form-handler";
 import { registerFrontKnowledgeConnector } from "@atlas/api/lib/knowledge/front/connector";
+import { HelpScoutFormInstallHandler, HELPSCOUT_SLUG } from "./helpscout-form-handler";
+import { registerHelpScoutKnowledgeConnector } from "@atlas/api/lib/knowledge/helpscout/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -350,6 +352,21 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(FRONT_SLUG, new FrontFormInstallHandler());
   registerFrontKnowledgeConnector();
   log.info("Registered FrontFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Help Scout Docs) — the built-in `helpscout` connector
+  // install (#4398, PRD #4395). Knowledge-pillar, multi-instance: ONE install
+  // fans out to one collection per Docs SITE. Config = site id + name (+ optional
+  // subdomain/description); the Docs API key lands in
+  // `knowledge_sync_credentials` (encrypted, one row per site
+  // collection), never in `workspace_plugins.config`. The Docs API host is a
+  // fixed vendor constant (`docsapi.helpscout.net`), so there is no
+  // customer-supplied base URL — every request still routes through the SSRF
+  // egress guard at fetch time. Registering the FORM handler + the CONNECTOR
+  // together (as with the other knowledge vendors) keeps a half-wired deploy
+  // from having an installable card whose scheduled sync has no registered
+  // vendor client. No env gate.
+  registerFormHandler(HELPSCOUT_SLUG, new HelpScoutFormInstallHandler());
+  registerHelpScoutKnowledgeConnector();
+  log.info("Registered HelpScoutFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -43,6 +43,7 @@ import { ZENDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/
 import { INTERCOM_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/intercom-form-handler";
 import { FRONT_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/front-form-handler";
 import { SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/salesforce-knowledge-form-handler";
+import { HELPSCOUT_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/helpscout-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
 import {
   CONNECTOR_SYNC_STATE_SELECT_SQL,
@@ -669,6 +670,31 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // The token is NEVER persisted in the install config.
     expect(row.rows[0]?.config).not.toHaveProperty("api_token");
     expect(row.rows[0]?.config).toMatchObject({ knowledge_base_id: "kb_1", knowledge_base_name: "Support" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a Help Scout per-site connector collection against the live schema (#4398)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:helpscout', 'Knowledge Base (Help Scout Docs)', 'helpscout', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(HELPSCOUT_INSTALL_UPSERT_SQL, [
+      "row-helpscout",
+      ws,
+      "catalog:helpscout",
+      "helpscout-acme",
+      JSON.stringify({ site_id: "site-1", site_name: "Acme Docs", subdomain: "acme" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-helpscout");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'helpscout-acme'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The Docs API key is NEVER persisted in the install config.
+    expect(row.rows[0]?.config).not.toHaveProperty("api_key");
+    expect(row.rows[0]?.config).toMatchObject({ site_id: "site-1", subdomain: "acme" });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/helpscout/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/helpscout/__tests__/client.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for the Help Scout Docs vendor client (#4398) — driven entirely through
+ * an injected fixture `fetchImpl`; NO test touches Help Scout. Covers
+ * reconciliation (collections → paginated bodyless article list → per-article
+ * body fetch), incremental (`sort=updatedAt` watermark with per-collection
+ * early-stop; ONE body fetch per changed article), the high-water mark, a
+ * deleted-mid-sweep article flagging coverage incomplete, 429 →
+ * ConnectorRateLimitError, auth failure, key redaction, Basic auth, and the
+ * site enumeration used at install time.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createHelpScoutVendorClient,
+  listHelpScoutSites,
+  parseRetryAfter,
+} from "@atlas/api/lib/knowledge/helpscout/client";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+import { HelpScoutAuthError } from "@atlas/api/lib/knowledge/helpscout/client";
+
+interface RefLite {
+  id?: string;
+  updatedAt?: string;
+  status?: string;
+}
+interface BodyLite {
+  name?: string;
+  text?: string | null;
+  status?: string;
+  updatedAt?: string;
+  publicUrl?: string;
+}
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+interface FixtureState {
+  calls: string[];
+  authHeaders: Array<string | null>;
+}
+
+interface FixtureOpts {
+  sites?: Array<{ id?: string | number; title?: string; subDomain?: string }>;
+  collections?: Array<{ id?: string | number; slug?: string; name?: string }>;
+  /** collectionId → article refs (newest-first, as `sort=updatedAt desc` returns). */
+  articlesByCollection?: Record<string, RefLite[]>;
+  /** collectionId → explicit pages of refs (overrides articlesByCollection). */
+  pagesByCollection?: Record<string, RefLite[][]>;
+  /** articleId → full body; a missing id 404s the body fetch. */
+  bodies?: Record<string, BodyLite>;
+  splitArticles?: boolean;
+  failFirst?: { status: number; headers?: Record<string, string> };
+}
+
+const DEFAULT_COLLECTIONS = [{ id: "col-1", slug: "onboarding" }];
+const DEFAULT_REFS: Record<string, RefLite[]> = {
+  "col-1": [
+    { id: "a1", updatedAt: "2026-07-05T08:00:00Z" },
+    { id: "a2", updatedAt: "2026-07-01T10:00:00Z" },
+  ],
+};
+const DEFAULT_BODIES: Record<string, BodyLite> = {
+  a1: {
+    name: "Getting Started",
+    text: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    status: "published",
+    updatedAt: "2026-07-05T08:00:00Z",
+    publicUrl: "https://acme.helpscoutdocs.com/article/a1",
+  },
+  a2: {
+    name: "Billing FAQ",
+    text: "<p>Answers to common billing questions and how to update a card.</p>",
+    status: "published",
+    updatedAt: "2026-07-01T10:00:00Z",
+    publicUrl: "https://acme.helpscoutdocs.com/article/a2",
+  },
+};
+
+function makeFetch(opts: FixtureOpts = {}): { impl: typeof globalThis.fetch; state: FixtureState } {
+  const state: FixtureState = { calls: [], authHeaders: [] };
+  const sites = opts.sites ?? [{ id: "site-1", title: "Acme Docs", subDomain: "acme" }];
+  const collections = opts.collections ?? DEFAULT_COLLECTIONS;
+  const refs = opts.articlesByCollection ?? DEFAULT_REFS;
+  const bodies = opts.bodies ?? DEFAULT_BODIES;
+  let failed = false;
+
+  const impl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    state.calls.push(raw);
+    state.authHeaders.push(new Headers(init?.headers).get("authorization"));
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    const path = url.pathname;
+
+    const single = path.match(/\/v1\/articles\/([^/]+)$/);
+    if (single) {
+      const body = bodies[decodeURIComponent(single[1])];
+      if (body === undefined) return new Response("not found", { status: 404 });
+      return jsonResponse({ article: { id: single[1], ...body } });
+    }
+    const listArticles = path.match(/\/v1\/collections\/([^/]+)\/articles$/);
+    if (listArticles) {
+      const collectionId = decodeURIComponent(listArticles[1]);
+      const page = Number(url.searchParams.get("page") ?? "1");
+      const explicitPages = opts.pagesByCollection?.[collectionId];
+      if (explicitPages !== undefined) {
+        return jsonResponse({
+          articles: { page, pages: explicitPages.length, items: explicitPages[page - 1] ?? [] },
+        });
+      }
+      const all = refs[collectionId] ?? [];
+      if (opts.splitArticles) {
+        const items = page === 1 ? all.slice(0, 1) : all.slice(1);
+        return jsonResponse({ articles: { page, pages: 2, items } });
+      }
+      return jsonResponse({ articles: { page: 1, pages: 1, items: all } });
+    }
+    if (path.endsWith("/v1/collections")) {
+      return jsonResponse({ collections: { page: 1, pages: 1, items: collections } });
+    }
+    if (path.endsWith("/v1/sites")) {
+      return jsonResponse({ sites: { page: 1, pages: 1, items: sites } });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, state };
+}
+
+function client(opts: FixtureOpts = {}) {
+  const { impl, state } = makeFetch(opts);
+  const c = createHelpScoutVendorClient(
+    { siteId: "site-1", apiKey: "sk-secret-xyz", collectionSlug: "helpscout-acme" },
+    { fetchImpl: impl },
+  );
+  return { c, state };
+}
+
+describe("fetchAll (reconciliation)", () => {
+  it("emits one document per published article with the max updatedAt as the mark", async () => {
+    const { c } = client();
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "helpscout-acme/onboarding/getting-started-a1.md",
+      "helpscout-acme/onboarding/billing-faq-a2.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(false);
+    expect(changes.cursor).toBeNull();
+  });
+
+  it("fetches exactly one body per article (bodyless list)", async () => {
+    const { c, state } = client();
+    await c.fetchAll();
+    const bodyCalls = state.calls.filter((u) => /\/v1\/articles\/[^/]+$/.test(new URL(u).pathname));
+    expect(bodyCalls).toHaveLength(2);
+  });
+
+  it("follows page pagination within a collection's article list", async () => {
+    const { c, state } = client({ splitArticles: true });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(2);
+    const listCalls = state.calls.filter((u) => /\/articles$/.test(new URL(u).pathname));
+    expect(listCalls).toHaveLength(2);
+  });
+
+  it("filters the list to published and sorts by updatedAt desc", async () => {
+    const { c, state } = client();
+    await c.fetchAll();
+    const listCall = state.calls.find((u) => /\/articles$/.test(new URL(u).pathname))!;
+    const q = new URL(listCall).searchParams;
+    expect(q.get("status")).toBe("published");
+    expect(q.get("sort")).toBe("updatedAt");
+    expect(q.get("order")).toBe("desc");
+    expect(q.get("pageSize")).toBe("100");
+  });
+
+  it("skips an article that unpublished between list and body fetch (never emitted)", async () => {
+    const { c } = client({
+      bodies: { ...DEFAULT_BODIES, a2: { ...DEFAULT_BODIES.a2, status: "notpublished" } },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "helpscout-acme/onboarding/getting-started-a1.md",
+    ]);
+    // Not a coverage hole — a clean 200 that we deliberately dropped.
+    expect(changes.coverageIncomplete).toBe(false);
+  });
+
+  it("flags coverage incomplete when a listed article 404s on body fetch (deleted mid-sweep)", async () => {
+    const bodies = { ...DEFAULT_BODIES };
+    delete (bodies as Record<string, BodyLite>).a2;
+    const { c } = client({ bodies });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+});
+
+describe("fetchChanges (incremental)", () => {
+  it("takes only articles newer than `since` and stops the collection at the mark", async () => {
+    const { c, state } = client();
+    // since is between a2 (07-01) and a1 (07-05): only a1 changed.
+    const changes = await c.fetchChanges({ since: "2026-07-03T00:00:00.000Z", cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "helpscout-acme/onboarding/getting-started-a1.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    // ONE body fetch — only the changed article, never a full sweep.
+    const bodyCalls = state.calls.filter((u) => /\/v1\/articles\/[^/]+$/.test(new URL(u).pathname));
+    expect(bodyCalls).toHaveLength(1);
+    expect(bodyCalls[0]).toContain("/v1/articles/a1");
+  });
+
+  it("stops at the mark WITHIN page 1 and never requests page 2 (early-stop)", async () => {
+    // page 1 = [n1 (07-05, changed), n2 (07-02, at/older than the mark)];
+    // page 2 = [n3 (07-01)]. `since` = 07-03 → the walk must break on n2 and
+    // never fetch page 2 (the load-bearing incremental efficiency guarantee).
+    const bodies = {
+      n1: { ...DEFAULT_BODIES.a1, updatedAt: "2026-07-05T08:00:00Z" },
+    };
+    const { c, state } = client({
+      pagesByCollection: {
+        "col-1": [
+          [
+            { id: "n1", updatedAt: "2026-07-05T08:00:00Z" },
+            { id: "n2", updatedAt: "2026-07-02T00:00:00Z" },
+          ],
+          [{ id: "n3", updatedAt: "2026-07-01T00:00:00Z" }],
+        ],
+      },
+      bodies,
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-03T00:00:00.000Z", cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "helpscout-acme/onboarding/getting-started-n1.md",
+    ]);
+    // Exactly ONE article-list page request — page 2 was never asked for.
+    const listCalls = state.calls.filter((u) => /\/articles$/.test(new URL(u).pathname));
+    expect(listCalls).toHaveLength(1);
+    // …and exactly one body fetch (only the changed article).
+    const bodyCalls = state.calls.filter((u) => /\/v1\/articles\/[^/]+$/.test(new URL(u).pathname));
+    expect(bodyCalls).toHaveLength(1);
+  });
+
+  it("flags coverage incomplete when a listed ref is missing its id/timestamp", async () => {
+    const { c } = client({
+      articlesByCollection: {
+        "col-1": [
+          { id: "a1", updatedAt: "2026-07-05T08:00:00Z" },
+          { id: "malformed" }, // no updatedAt → skipped + counted
+        ],
+      },
+    });
+    // since below both → the well-formed ref is a change; the malformed one is
+    // skipped (never a silent drop) and flags coverage so the engine holds
+    // subtractive archiving (governs "deletes via reconcile").
+    const changes = await c.fetchChanges({ since: "2026-07-01T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("emits nothing when no article is newer than the mark", async () => {
+    const { c, state } = client();
+    const changes = await c.fetchChanges({ since: "2026-07-06T00:00:00.000Z", cursor: null });
+    expect(changes.documents).toHaveLength(0);
+    // No body fetch at all — every ref was at/older than the mark.
+    const bodyCalls = state.calls.filter((u) => /\/v1\/articles\/[^/]+$/.test(new URL(u).pathname));
+    expect(bodyCalls).toHaveLength(0);
+  });
+
+  it("throws on an unparseable since instant (defensive)", async () => {
+    const { c } = client();
+    await expect(c.fetchChanges({ since: "not-a-date", cursor: null })).rejects.toThrow(
+      /unparseable since/i,
+    );
+  });
+
+  it("serves a null since as a full crawl (defensive)", async () => {
+    const { c } = client();
+    const changes = await c.fetchChanges({ since: null, cursor: null });
+    expect(changes.documents).toHaveLength(2);
+  });
+});
+
+describe("authentication", () => {
+  it("sends Help Scout Basic auth: base64('{apiKey}:X')", async () => {
+    const { c, state } = client();
+    await c.fetchAll();
+    const expected = `Basic ${Buffer.from("sk-secret-xyz:X").toString("base64")}`;
+    expect(state.authHeaders.length).toBeGreaterThan(0);
+    for (const header of state.authHeaders) expect(header).toBe(expected);
+  });
+});
+
+describe("vendor failure mapping", () => {
+  it("throws ConnectorRateLimitError with the parsed Retry-After on a 429", async () => {
+    const { c } = client({ failFirst: { status: 429, headers: { "retry-after": "37" } } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+    expect((err as ConnectorRateLimitError).retryAfterSeconds).toBe(37);
+  });
+
+  it("maps a 401 to an actionable, host-redacted credentials error", async () => {
+    const { c } = client({ failFirst: { status: 401 } });
+    await expect(c.fetchAll()).rejects.toThrow(/rejected the credentials \(401\)/i);
+  });
+
+  it("never leaks the API key in an error message", async () => {
+    const { c } = client({ failFirst: { status: 500 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain("sk-secret-xyz");
+  });
+});
+
+describe("listHelpScoutSites (install-time enumeration + credential check)", () => {
+  it("maps sites, normalizes the subdomain, and skips entries missing an id", async () => {
+    const { impl } = makeFetch({
+      sites: [
+        { id: "s1", title: "Acme", subDomain: "Acme" },
+        { id: 2, title: "Beta", subDomain: "" },
+        { title: "NoId" }, // malformed — skipped
+      ],
+    });
+    const sites = await listHelpScoutSites({ apiKey: "key" }, { fetchImpl: impl });
+    expect(sites.map((s) => s.id)).toEqual(["s1", "2"]);
+    expect(sites.map((s) => s.subdomain)).toEqual(["acme", null]);
+    expect(sites[0]).toMatchObject({ name: "Acme" });
+  });
+
+  it("propagates an auth failure loudly", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 401 } });
+    const err = await listHelpScoutSites({ apiKey: "bad" }, { fetchImpl: impl }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(HelpScoutAuthError);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds and rejects HTTP-dates/garbage", () => {
+    expect(parseRetryAfter("42")).toBe(42);
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/knowledge/helpscout/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/helpscout/__tests__/connector.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the Help Scout KnowledgeSyncConnector (#4398) — the createClient
+ * factory contract: parse the stored per-site config, read the encrypted Docs
+ * API key loudly, and build a vendor client. Also pins the draft-only
+ * (publish-guard) guarantee: the connector's vendor slug stamps a
+ * `connector:helpscout` IngestSource, which the shared ingest seam refuses to
+ * publish (ADR-0028 §4). The credential store is mocked (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let keyResult: string | null | (() => never) = "docs-api-key";
+
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof keyResult === "function") return keyResult();
+    return keyResult;
+  },
+}));
+
+const { createHelpScoutConnector } = await import("@atlas/api/lib/knowledge/helpscout/connector");
+const { HELPSCOUT_CATALOG_ID, HELPSCOUT_VENDOR } = await import(
+  "@atlas/api/lib/knowledge/helpscout/config"
+);
+
+const VALID_CONFIG = { site_id: "site-1", site_name: "Acme Docs", subdomain: "acme" };
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "helpscout-acme", config };
+}
+
+afterEach(() => {
+  keyResult = "docs-api-key";
+});
+
+describe("createHelpScoutConnector", () => {
+  it("advertises the helpscout catalog id and vendor slug", () => {
+    const connector = createHelpScoutConnector();
+    expect(connector.catalogId).toBe(HELPSCOUT_CATALOG_ID);
+    expect(connector.vendor).toBe(HELPSCOUT_VENDOR);
+  });
+
+  it("is draft-only: its IngestSource is a non-upload connector source (publish-guard)", () => {
+    const connector = createHelpScoutConnector();
+    const source = `connector:${connector.vendor}`;
+    // `ingestBundle` throws for any source !== "upload" (ADR-0028 §4), so a
+    // `connector:helpscout` document can never be published — draft only.
+    expect(source).toBe("connector:helpscout");
+    expect(source).not.toBe("upload");
+  });
+
+  it("builds a vendor client from valid per-site config + a stored key", async () => {
+    const connector = createHelpScoutConnector();
+    const client = await connector.createClient(ctx(VALID_CONFIG));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error when the stored config is missing the site", async () => {
+    const connector = createHelpScoutConnector();
+    await expect(connector.createClient(ctx({ site_name: "Acme" }))).rejects.toThrow(
+      /no Help Scout site configured/i,
+    );
+  });
+
+  it("throws when the collection has no stored API key", async () => {
+    keyResult = null;
+    const connector = createHelpScoutConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/no stored Docs API key/i);
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    keyResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createHelpScoutConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/helpscout/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/helpscout/__tests__/documents.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the Help Scout article → ConnectorDocument assembly (#4398): the
+ * archive path (`<collection-slug>/<title-slug>-<id>.md`, prefixed), the
+ * `atlas:` provenance block (connector + site + article id + updated_at), the
+ * shared-converter integration (cross-link rewriting against the article's
+ * public URL, counted image degradations), and the contentless skip. Pure — no
+ * I/O.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleHelpScoutDocuments,
+  slugifyTitle,
+  type HelpScoutArticle,
+} from "@atlas/api/lib/knowledge/helpscout/documents";
+
+const OPTS = { collectionSlug: "helpscout-acme", siteId: "site-1" };
+
+function article(overrides: Partial<HelpScoutArticle> = {}): HelpScoutArticle {
+  return {
+    articleId: "abc123",
+    title: "Getting Started",
+    bodyHtml: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    url: "https://acme.helpscoutdocs.com/article/1-getting-started",
+    collectionSlug: "onboarding",
+    ...overrides,
+  };
+}
+
+describe("slugifyTitle", () => {
+  it("lowercases and dashes non-alphanumerics (NFKD)", () => {
+    expect(slugifyTitle("Setup & Testing Guide!", "x")).toBe("setup-testing-guide");
+  });
+  it("falls back when the title has no usable characters", () => {
+    expect(slugifyTitle("你好", "article")).toBe("article");
+  });
+});
+
+describe("assembleHelpScoutDocuments", () => {
+  it("emits one document per article at <prefix>/<collection>/<slug>-<id>.md", () => {
+    const result = assembleHelpScoutDocuments(
+      [article(), article({ articleId: "def456", title: "Billing FAQ", collectionSlug: "billing" })],
+      OPTS,
+    );
+    expect(result.documents.map((d) => d.path)).toEqual([
+      "helpscout-acme/onboarding/getting-started-abc123.md",
+      "helpscout-acme/billing/billing-faq-def456.md",
+    ]);
+  });
+
+  it("stamps frontmatter provenance and the atlas: extension block (site + article id + updated_at)", () => {
+    const { documents } = assembleHelpScoutDocuments([article()], OPTS);
+    const content = documents[0].content;
+    expect(content).toContain('title: "Getting Started"');
+    expect(content).toContain(
+      'resource: "https://acme.helpscoutdocs.com/article/1-getting-started"',
+    );
+    expect(content).toContain('timestamp: "2026-07-01T10:00:00.000Z"');
+    expect(content).toContain("atlas:");
+    expect(content).toContain('connector: "helpscout"');
+    expect(content).toContain('site: "site-1"');
+    expect(content).toContain('article_id: "abc123"');
+    expect(content).toContain('updated_at: "2026-07-01T10:00:00.000Z"');
+    // No provenance tags — `tags` is a mirrored change-comparison column, so
+    // stamping one would re-draft every already-ingested document.
+    expect(content).not.toContain("tags:");
+  });
+
+  it("rewrites relative article links against the article's public URL", () => {
+    const { documents } = assembleHelpScoutDocuments(
+      [article({ bodyHtml: '<p>See <a href="/article/456-faq">the FAQ</a> for details.</p>' })],
+      OPTS,
+    );
+    expect(documents[0].content).toContain(
+      "[the FAQ](https://acme.helpscoutdocs.com/article/456-faq)",
+    );
+  });
+
+  it("leaves relative links untouched when the article has no public URL", () => {
+    const { documents } = assembleHelpScoutDocuments(
+      [article({ url: "", bodyHtml: '<p>See <a href="/article/456">the FAQ</a> here.</p>' })],
+      OPTS,
+    );
+    expect(documents[0].content).toContain("[the FAQ](/article/456)");
+    // …and with no resource URL, the frontmatter omits it rather than empty.
+    expect(documents[0].content).not.toContain('resource: ""');
+  });
+
+  it("leaves absolute links untouched", () => {
+    const { documents } = assembleHelpScoutDocuments(
+      [article({ bodyHtml: '<p>Visit <a href="https://example.com/page">our site</a> now.</p>' })],
+      OPTS,
+    );
+    expect(documents[0].content).toContain("[our site](https://example.com/page)");
+  });
+
+  it("aggregates image degradations across articles", () => {
+    const { degradations } = assembleHelpScoutDocuments(
+      [
+        article({ bodyHtml: '<p>Some intro text here.</p><img src="a.png"><img src="b.png">' }),
+        article({ articleId: "z9", bodyHtml: '<p>Etwas Text hier drin.</p><img src="c.png">' }),
+      ],
+      OPTS,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 3 }]);
+  });
+
+  it("skips (and counts) a contentless article instead of emitting an empty doc", () => {
+    const result = assembleHelpScoutDocuments(
+      [article({ bodyHtml: "<div><script>x()</script></div>" }), article({ articleId: "keep" })],
+      OPTS,
+    );
+    expect(result.skippedContentless).toBe(1);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].path).toContain("-keep.md");
+  });
+
+  it("uses the fallback segment for an unslugifiable title (id keeps it unique)", () => {
+    const { documents } = assembleHelpScoutDocuments(
+      [article({ title: "你好", articleId: "9", collectionSlug: "misc" })],
+      OPTS,
+    );
+    expect(documents[0].path).toBe("helpscout-acme/misc/article-9.md");
+  });
+});

--- a/packages/api/src/lib/knowledge/helpscout/client.ts
+++ b/packages/api/src/lib/knowledge/helpscout/client.ts
@@ -1,0 +1,580 @@
+/**
+ * The Help Scout Docs vendor client (#4398, PRD #4395) — a
+ * {@link ConnectorVendorClient} over the Help Scout **Docs** API
+ * (`docsapi.helpscout.net`, distinct from the Mailbox API), driven by the
+ * shared connector engine (`connector-sync.ts`). It owns ONLY enumerate +
+ * fetch + convert; scheduling, high-water marks, reconciliation cadence, 429
+ * backoff, and caps are the engine's (ADR-0030).
+ *
+ * The Docs API lists articles BODYLESS — `GET …/articles` returns article REFS
+ * (id, updatedAt, no HTML). So each cadence enumerates refs, then fetches the
+ * body of exactly the articles it needs via `GET /v1/articles/{id}`:
+ *
+ *   - `fetchChanges({ since })` (incremental) — for each collection in the
+ *     site, page the article list `sort=updatedAt&order=desc` and take refs
+ *     newer than `since`, STOPPING each collection's walk at the first ref at
+ *     or before the mark (the list is newest-first, so the rest are older).
+ *     Then fetch ONE body per changed ref — the AC's "one Get Article per
+ *     changed article only (not per full sweep)".
+ *   - `fetchAll()` (reconciliation) — page every collection's full published
+ *     article list and fetch each body. The engine archives paths absent from
+ *     this set, so an unpublished/deleted article (never returned under
+ *     `status=published`) is treated as absent, never an error.
+ *
+ * Published semantics: the list is filtered to `status=published`, so a
+ * `notpublished` (unpublished) or deleted article simply stops appearing; the
+ * reconciliation crawl's subtractive diff archives its document (the AC's
+ * "deletes via reconcile").
+ *
+ * Security + hygiene: the host is a fixed vendor constant and every request
+ * goes through `guardedFetch` (SSRF egress guard; auth stripped on cross-origin
+ * redirect). A 429 is the ONLY signal that becomes the engine's backoff; every
+ * other failure is an actionable error with the host redacted via `hostForLog`
+ * — the key lives in the `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import { HELPSCOUT_DOCS_API_BASE } from "./config";
+import { assembleHelpScoutDocuments, type HelpScoutArticle } from "./documents";
+
+const log = createLogger("knowledge.helpscout.client");
+
+/**
+ * Help Scout rejected the credentials (401/403). A distinct class — not a
+ * `cause`-presence side channel — so the install handler can blame the
+ * `api_key` field with `instanceof` (the `ConnectorRateLimitError` precedent;
+ * plain subclass, this is not Effect code).
+ */
+export class HelpScoutAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HelpScoutAuthError";
+  }
+}
+
+/** Help Scout returned 404 — the site/collection/article is gone or unreachable. */
+export class HelpScoutNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HelpScoutNotFoundError";
+  }
+}
+
+/** Resolved connection inputs plus the key. One Docs Site per client. */
+export interface HelpScoutClientConfig {
+  /** The Docs Site id this client enumerates (the API filter). */
+  readonly siteId: string;
+  /** The Docs API key (Basic-auth username). */
+  readonly apiKey: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface HelpScoutClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Article-list page size — the Docs API caps `pageSize` at 100 (the AC bound). */
+const PAGE_SIZE = 100;
+/**
+ * Hard anti-runaway bound on enumerated articles per site — NOT the ingest cap
+ * (the engine owns that, and surfaces the real over-limit numbers). A Docs site
+ * larger than this is pathological; we fail loud rather than loop unbounded on a
+ * broken pagination cursor.
+ */
+const MAX_ARTICLES = 100_000;
+/**
+ * Anti-runaway bound on pages walked in one paginated enumeration — the
+ * collection listing AND each collection's article listing share it, so every
+ * walk fails loud on a stuck `pages` count rather than looping forever.
+ */
+const MAX_FEED_PAGES = 1_000;
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (only the fields we read; untrusted vendor JSON —
+// every field optional, narrowed at the use sites). The Docs API wraps list
+// responses in a named paged envelope: `{ "<key>": { page, pages, items } }`.
+// ---------------------------------------------------------------------------
+
+interface RawPage<T> {
+  readonly page?: number;
+  readonly pages?: number;
+  readonly items?: readonly T[];
+}
+interface RawSite {
+  readonly id?: string | number;
+  readonly title?: string;
+  readonly subDomain?: string;
+  readonly status?: string;
+}
+interface SitesResponse {
+  readonly sites?: RawPage<RawSite>;
+}
+interface RawCollection {
+  readonly id?: string | number;
+  readonly name?: string;
+  readonly slug?: string;
+}
+interface CollectionsResponse {
+  readonly collections?: RawPage<RawCollection>;
+}
+/** A bodyless article ref from a list endpoint — no `text`. */
+interface RawArticleRef {
+  readonly id?: string | number;
+  readonly updatedAt?: string;
+  readonly status?: string;
+}
+interface ArticlesResponse {
+  readonly articles?: RawPage<RawArticleRef>;
+}
+/** A full article from `GET /v1/articles/{id}` — carries the `text` HTML body. */
+interface RawArticle {
+  readonly id?: string | number;
+  readonly name?: string;
+  readonly text?: string | null;
+  readonly status?: string;
+  readonly updatedAt?: string;
+  readonly publicUrl?: string;
+}
+interface ArticleResponse {
+  readonly article?: RawArticle;
+}
+
+/** One enumerated article ref, normalized (timestamp canonical, id stringified). */
+interface NormalizedRef {
+  readonly id: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  /** The source Docs collection slug (or id fallback) — a path segment. */
+  readonly collectionSlug: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Help Scout Docs vendor client for ONE Docs Site. `createClient` (the
+ * connector factory) has already decrypted the key and validated config, so
+ * this constructor does no I/O.
+ */
+export function createHelpScoutVendorClient(
+  config: HelpScoutClientConfig,
+  deps: HelpScoutClientDeps = {},
+): ConnectorVendorClient {
+  const api = new HelpScoutApi(config, deps);
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      // The engine only runs incremental with a persisted mark, but a null
+      // `since` is served defensively as a full crawl (the contract's advice).
+      if (params.since === null) return api.fetchAll();
+      return api.fetchChanges(params.since);
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetchAll();
+    },
+  };
+}
+
+/** One enumerated Docs Site, normalized for the install handler's fan-out. */
+export interface HelpScoutSite {
+  /** Stringified site id. */
+  readonly id: string;
+  /** Human site title (falls back to the id when the vendor omits it). */
+  readonly name: string;
+  /** The site's `*.helpscoutdocs.com` subdomain label, or null. */
+  readonly subdomain: string | null;
+}
+
+export interface HelpScoutAccountParams {
+  readonly apiKey: string;
+}
+
+/**
+ * Enumerate the account's Docs Sites — ALSO the install-time credential check
+ * (the first authenticated request doubles as it; loud on every failure). A bad
+ * key surfaces as a 401, both actionable and host-redacted; the install handler
+ * maps it to a field-level 400 so "invalid credentials fail the install
+ * loudly." One collection is created per site returned here.
+ */
+export async function listHelpScoutSites(
+  params: HelpScoutAccountParams,
+  deps: HelpScoutClientDeps = {},
+): Promise<HelpScoutSite[]> {
+  const http = new HelpScoutHttp(params.apiKey, deps);
+  const sites: HelpScoutSite[] = [];
+  let skippedMalformed = 0;
+  for (let page = 1; page <= MAX_FEED_PAGES; page++) {
+    const body = await http.getJson<SitesResponse>(
+      `${HELPSCOUT_DOCS_API_BASE}/v1/sites?page=${page}`,
+    );
+    const envelope = body.sites;
+    for (const raw of envelope?.items ?? []) {
+      const id = idOf(raw.id);
+      if (id === "") {
+        skippedMalformed++;
+        continue;
+      }
+      const title = typeof raw.title === "string" && raw.title.trim() !== "" ? raw.title.trim() : id;
+      const sub = typeof raw.subDomain === "string" ? raw.subDomain.trim().toLowerCase() : "";
+      sites.push({ id, name: title, subdomain: sub === "" ? null : sub });
+    }
+    if (!hasNextPage(envelope, page)) break;
+    if (page === MAX_FEED_PAGES) {
+      throw new Error(
+        `Help Scout site listing on ${hostForLog(HELPSCOUT_DOCS_API_BASE)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+      );
+    }
+  }
+  if (skippedMalformed > 0) {
+    log.warn(
+      { host: hostForLog(HELPSCOUT_DOCS_API_BASE), skippedMalformed },
+      "Skipped Help Scout sites missing an id — not installable (unexpected vendor response)",
+    );
+  }
+  return sites;
+}
+
+class HelpScoutApi {
+  private readonly http: HelpScoutHttp;
+
+  constructor(
+    private readonly config: HelpScoutClientConfig,
+    deps: HelpScoutClientDeps,
+  ) {
+    this.http = new HelpScoutHttp(config.apiKey, deps);
+  }
+
+  /**
+   * Reconciliation: enumerate EVERY published article in the site (all
+   * collections, all pages), fetch each body. One document per published
+   * article.
+   */
+  async fetchAll(): Promise<ConnectorChanges> {
+    const { refs, skippedMalformed, highWaterMark } = await this.collectRefs(null);
+    return this.assemble(refs, skippedMalformed, highWaterMark, "reconciliation");
+  }
+
+  /**
+   * Incremental: for each collection, walk the `updatedAt desc` article list
+   * and take refs newer than `since`, stopping each collection's walk at the
+   * first ref at or before the mark. Then fetch one body per changed ref.
+   */
+  async fetchChanges(since: string): Promise<ConnectorChanges> {
+    if (toIsoInstant(since) === null) {
+      // The engine derives `since` from its own persisted ISO mark, so this is
+      // defensive — fail loud rather than silently refetch everything.
+      throw new Error(`Help Scout incremental fetch got an unparseable since instant ("${since}").`);
+    }
+    const { refs, skippedMalformed, highWaterMark } = await this.collectRefs(since);
+    return this.assemble(refs, skippedMalformed, highWaterMark, "incremental");
+  }
+
+  /**
+   * Enumerate article refs across the site's collections. `since === null`
+   * collects every published article (reconciliation); a non-null `since`
+   * collects only refs strictly newer than the mark, early-stopping each
+   * collection's newest-first walk at the first older ref (incremental).
+   */
+  private async collectRefs(
+    since: string | null,
+  ): Promise<{ refs: NormalizedRef[]; skippedMalformed: number; highWaterMark: string | null }> {
+    const collections = await this.listCollections();
+    const refs: NormalizedRef[] = [];
+    let skippedMalformed = 0;
+    let highWaterMark: string | null = null;
+
+    for (const collection of collections) {
+      let stop = false;
+      for (let page = 1; page <= MAX_FEED_PAGES && !stop; page++) {
+        const url =
+          `${HELPSCOUT_DOCS_API_BASE}/v1/collections/${encodeURIComponent(collection.id)}/articles` +
+          `?status=published&sort=updatedAt&order=desc&pageSize=${PAGE_SIZE}&page=${page}`;
+        const body = await this.http.getJson<ArticlesResponse>(url);
+        const envelope = body.articles;
+        for (const raw of envelope?.items ?? []) {
+          const id = idOf(raw.id);
+          const updatedAt = toIsoInstant(raw.updatedAt);
+          if (id === "" || updatedAt === null) {
+            skippedMalformed++;
+            continue;
+          }
+          // Every ref read advances the mark — the newest change this fetch
+          // observed. ISO instants compare chronologically as strings.
+          if (highWaterMark === null || updatedAt > highWaterMark) highWaterMark = updatedAt;
+          if (since !== null && updatedAt <= since) {
+            // Newest-first: this ref and every later one are at/older than the
+            // mark — nothing more changed in this collection.
+            stop = true;
+            break;
+          }
+          refs.push({ id, updatedAt, collectionSlug: collection.slug });
+          if (refs.length > MAX_ARTICLES) {
+            throw new Error(
+              `Help Scout site on ${hostForLog(HELPSCOUT_DOCS_API_BASE)} exceeds ${MAX_ARTICLES} articles — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+            );
+          }
+        }
+        if (!hasNextPage(envelope, page)) break;
+        if (page === MAX_FEED_PAGES) {
+          throw new Error(
+            `Help Scout article listing on ${hostForLog(HELPSCOUT_DOCS_API_BASE)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+          );
+        }
+      }
+    }
+    return { refs, skippedMalformed, highWaterMark };
+  }
+
+  /** Enumerate the site's collections (paginated). */
+  private async listCollections(): Promise<Array<{ id: string; slug: string }>> {
+    const collections: Array<{ id: string; slug: string }> = [];
+    let skippedMalformed = 0;
+    for (let page = 1; page <= MAX_FEED_PAGES; page++) {
+      const url = `${HELPSCOUT_DOCS_API_BASE}/v1/collections?siteId=${encodeURIComponent(this.config.siteId)}&page=${page}`;
+      const body = await this.http.getJson<CollectionsResponse>(url);
+      const envelope = body.collections;
+      for (const raw of envelope?.items ?? []) {
+        const id = idOf(raw.id);
+        if (id === "") {
+          skippedMalformed++;
+          continue;
+        }
+        const slug =
+          typeof raw.slug === "string" && raw.slug.trim() !== ""
+            ? raw.slug.trim()
+            : typeof raw.name === "string" && raw.name.trim() !== ""
+              ? raw.name.trim()
+              : id;
+        collections.push({ id, slug });
+      }
+      if (!hasNextPage(envelope, page)) break;
+      if (page === MAX_FEED_PAGES) {
+        throw new Error(
+          `Help Scout collection listing on ${hostForLog(HELPSCOUT_DOCS_API_BASE)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+        );
+      }
+    }
+    if (skippedMalformed > 0) {
+      log.warn(
+        { host: hostForLog(HELPSCOUT_DOCS_API_BASE), skippedMalformed },
+        "Skipped Help Scout collections missing an id — cannot enumerate their articles (unexpected vendor response)",
+      );
+    }
+    return collections;
+  }
+
+  /**
+   * Fetch each ref's body (`GET /v1/articles/{id}`) and convert. A 404 on a
+   * just-listed article (deleted mid-sweep) is skipped and flags coverage
+   * incomplete — the engine then holds subtractive archiving rather than
+   * archiving off a partial view. Auth/429/5xx propagate (429 → engine backoff;
+   * auth → fail loud).
+   */
+  private async assemble(
+    refs: readonly NormalizedRef[],
+    skippedMalformedRefs: number,
+    highWaterMark: string | null,
+    mode: "incremental" | "reconciliation",
+  ): Promise<ConnectorChanges> {
+    let skippedMalformed = skippedMalformedRefs;
+    const articles: HelpScoutArticle[] = [];
+
+    for (const ref of refs) {
+      let raw: RawArticle | undefined;
+      try {
+        const body = await this.http.getJson<ArticleResponse>(
+          `${HELPSCOUT_DOCS_API_BASE}/v1/articles/${encodeURIComponent(ref.id)}`,
+        );
+        raw = body.article;
+      } catch (err) {
+        if (err instanceof HelpScoutNotFoundError) {
+          // Deleted between list and fetch — a KNOWN hole; flag coverage so the
+          // engine doesn't archive off this partial view. Never a silent drop.
+          skippedMalformed++;
+          log.warn(
+            { host: hostForLog(HELPSCOUT_DOCS_API_BASE), mode, articleId: ref.id },
+            "Help Scout article vanished between listing and fetch — skipping (coverage held)",
+          );
+          continue;
+        }
+        throw err; // 429 (backoff), auth, 5xx — surfaced loudly
+      }
+      if (raw === undefined) {
+        skippedMalformed++;
+        continue;
+      }
+      // A published-list race: the article was unpublished between list and
+      // fetch. Treat as absent (reconciliation archives it), never emitted. Not
+      // a coverage hole (a clean 200 we deliberately dropped), but logged so the
+      // drop is observable — in incremental mode there is no subtractive
+      // archiving, so the already-ingested doc stays live until reconciliation.
+      if (typeof raw.status === "string" && raw.status.trim().toLowerCase() !== "published") {
+        log.debug(
+          { host: hostForLog(HELPSCOUT_DOCS_API_BASE), mode, articleId: ref.id },
+          "Help Scout article unpublished between listing and body fetch — skipping (archived on next reconciliation)",
+        );
+        continue;
+      }
+
+      articles.push({
+        articleId: ref.id,
+        title: typeof raw.name === "string" ? raw.name : "",
+        bodyHtml: typeof raw.text === "string" ? raw.text : "",
+        updatedAt: toIsoInstant(raw.updatedAt) ?? ref.updatedAt,
+        url: typeof raw.publicUrl === "string" ? raw.publicUrl : "",
+        collectionSlug: ref.collectionSlug,
+      });
+    }
+
+    const assembled = assembleHelpScoutDocuments(articles, {
+      collectionSlug: this.config.collectionSlug,
+      siteId: this.config.siteId,
+    });
+    if (assembled.degradations.length > 0 || assembled.skippedContentless > 0) {
+      log.info(
+        {
+          host: hostForLog(HELPSCOUT_DOCS_API_BASE),
+          mode,
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+        },
+        "Help Scout conversion completed with degradations/skips",
+      );
+    }
+    if (skippedMalformed > 0) {
+      log.warn(
+        { host: hostForLog(HELPSCOUT_DOCS_API_BASE), mode, skippedMalformed },
+        "Skipped Help Scout articles missing id/timestamp or vanished mid-sweep — not ingested (coverage held)",
+      );
+    }
+
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: skippedMalformed > 0,
+    };
+  }
+}
+
+/** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */
+function idOf(raw: string | number | undefined): string {
+  return typeof raw === "number" || typeof raw === "string" ? String(raw).trim() : "";
+}
+
+/** True when a paged envelope reports more pages after `page`. */
+function hasNextPage(envelope: RawPage<unknown> | undefined, page: number): boolean {
+  const pages = typeof envelope?.pages === "number" ? envelope.pages : 1;
+  const items = envelope?.items ?? [];
+  // Stop on an empty page too — a `pages` count that never shrinks would loop.
+  return items.length > 0 && page < pages;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+class HelpScoutHttp {
+  private readonly authHeader: string;
+
+  constructor(
+    apiKey: string,
+    private readonly deps: HelpScoutClientDeps,
+  ) {
+    // Help Scout Docs API auth is HTTP Basic with the API KEY as the username
+    // and a dummy password (their documented "X"). Buffer.from handles any
+    // UTF-8 in the key (unlike btoa).
+    this.authHeader = `Basic ${Buffer.from(`${apiKey}:X`).toString("base64")}`;
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  async getJson<T>(url: string): Promise<T> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `Help Scout request to ${hostForLog(HELPSCOUT_DOCS_API_BASE)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `Help Scout rate-limited the request to ${hostForLog(HELPSCOUT_DOCS_API_BASE)} (the Docs API allows roughly 200–400 requests/minute, scaling with site count).`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new HelpScoutAuthError(
+        `Help Scout rejected the credentials (${response.status}) for ${hostForLog(HELPSCOUT_DOCS_API_BASE)} — re-enter the Docs API key (Help Scout → Your Profile → Authentication → API Keys) and confirm Docs access is enabled.`,
+      );
+    }
+    if (response.status === 404) {
+      throw new HelpScoutNotFoundError(
+        `Help Scout returned 404 from ${hostForLog(HELPSCOUT_DOCS_API_BASE)} — the site, collection, or article was not found.`,
+      );
+    }
+    if (response.status >= 500) {
+      throw new Error(
+        `Help Scout returned HTTP ${response.status} from ${hostForLog(HELPSCOUT_DOCS_API_BASE)} — a vendor-side error; the next scheduled sync (or retrying the install) will usually succeed.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Help Scout returned HTTP ${response.status} from ${hostForLog(HELPSCOUT_DOCS_API_BASE)} — an unexpected Docs API response; if it persists, re-install the collection or check Help Scout's API status.`,
+      );
+    }
+    let json: unknown;
+    try {
+      json = await response.json();
+    } catch (err) {
+      throw new Error(
+        `Help Scout returned a non-JSON response from ${hostForLog(HELPSCOUT_DOCS_API_BASE)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+    // A top-level `null`/array/primitive is valid JSON but not a Docs envelope;
+    // reject it with an actionable message rather than let a caller's `body.x`
+    // deref throw an opaque TypeError.
+    if (json === null || typeof json !== "object") {
+      throw new Error(
+        `Help Scout returned an unexpected JSON envelope from ${hostForLog(HELPSCOUT_DOCS_API_BASE)} (not an object) — an unexpected Docs API response.`,
+      );
+    }
+    return json as T;
+  }
+}
+
+/** Parse a `Retry-After` header (delta-seconds only; HTTP-date → null). */
+export function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}

--- a/packages/api/src/lib/knowledge/helpscout/config.ts
+++ b/packages/api/src/lib/knowledge/helpscout/config.ts
@@ -1,0 +1,74 @@
+/**
+ * Help Scout Docs connector identity + stored-config contract (#4398, PRD
+ * #4395). The simplest install in the support tier: a single Docs API key over
+ * HTTP Basic auth, no OAuth, no customer-supplied host.
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config),
+ * the connector (reads it back in `createClient`), and the admin-knowledge
+ * surface (recognizes the catalog id) share ONE definition — a field rename
+ * can't drift the three apart silently. The Docs API key is NOT part of this
+ * config; it lives encrypted in `knowledge_sync_credentials` and is read via
+ * `readSyncCredential`.
+ *
+ * Help Scout is a MULTI-SITE vendor: one install enumerates the account's Docs
+ * Sites (Help Scout's multi-brand unit) and creates one collection per Site
+ * (the PRD's "one collection per Site"). Each collection's config is therefore
+ * SITE-scoped: it pins the numeric/opaque `site_id` the client filters
+ * enumeration by. Unlike Zendesk, the Docs API host is a FIXED vendor constant
+ * (`docsapi.helpscout.net`) — the Site is a query-param filter, never a host —
+ * so there is no customer-supplied URL to validate; every request still routes
+ * through the SSRF egress guard at fetch time (the AC's "host through the
+ * egress guard").
+ */
+
+/** The built-in Help Scout Docs Knowledge Base catalog slug + row id. */
+export const HELPSCOUT_SLUG = "helpscout";
+export const HELPSCOUT_CATALOG_ID = "catalog:helpscout";
+/** Vendor slug stamped into `atlas_source` as `connector:helpscout`. */
+export const HELPSCOUT_VENDOR = "helpscout";
+
+/**
+ * The Help Scout Docs REST base — a fixed vendor host, never customer-supplied
+ * (distinct from the Mailbox API's `api.helpscout.net`). The Site is a
+ * query-param filter on top of this host, not a per-site subdomain.
+ */
+export const HELPSCOUT_DOCS_API_BASE = "https://docsapi.helpscout.net";
+
+/**
+ * The non-secret config persisted on each per-site `workspace_plugins` row.
+ * The Docs API key is NOT here — it lands encrypted in
+ * `knowledge_sync_credentials`, one row per site collection.
+ */
+export interface HelpScoutCollectionConfig {
+  /** The Docs Site id this collection mirrors (the enumeration filter). */
+  readonly site_id: string;
+  /** Human site title, for the admin surface + provenance. */
+  readonly site_name: string;
+  /** The site's `*.helpscoutdocs.com` subdomain, when it has one (admin/provenance). */
+  readonly subdomain?: string;
+  readonly description?: string;
+}
+
+export type ParsedHelpScoutConfig =
+  | { readonly ok: true; readonly siteId: string; readonly siteName: string; readonly subdomain: string | null }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * `site_id` means someone edited the row out of band; re-installing repairs it.
+ */
+export function parseHelpScoutConfig(
+  config: Record<string, unknown> | null,
+): ParsedHelpScoutConfig {
+  const siteId = typeof config?.site_id === "string" ? config.site_id.trim() : "";
+  if (siteId === "") {
+    return { ok: false, error: "Collection has no Help Scout site configured — re-install it." };
+  }
+  const siteName = typeof config?.site_name === "string" ? config.site_name.trim() : "";
+  const subdomain = typeof config?.subdomain === "string" && config.subdomain.trim() !== ""
+    ? config.subdomain.trim()
+    : null;
+  return { ok: true, siteId, siteName, subdomain };
+}

--- a/packages/api/src/lib/knowledge/helpscout/connector.ts
+++ b/packages/api/src/lib/knowledge/helpscout/connector.ts
@@ -1,0 +1,80 @@
+/**
+ * The Help Scout Docs {@link KnowledgeSyncConnector} (#4398, PRD #4395) — the
+ * catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * factory contract from ADR-0030: bind the stored per-site config + the
+ * decrypted Docs API key into a vendor client. Scheduling, backoff,
+ * reconciliation, caps, and ingest are the shared engine's.
+ *
+ * One Help Scout install fans out to one collection PER SITE (the install
+ * handler's job); each collection row carries its site id, so this factory
+ * builds a client scoped to exactly one Docs Site.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { createHelpScoutVendorClient, type HelpScoutClientDeps } from "./client";
+import { HELPSCOUT_CATALOG_ID, HELPSCOUT_VENDOR, parseHelpScoutConfig } from "./config";
+
+const log = createLogger("knowledge.helpscout.connector");
+
+export interface HelpScoutConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: HelpScoutClientDeps;
+}
+
+/** Build the Help Scout connector. `deps` is test-only vendor-client injection. */
+export function createHelpScoutConnector(
+  deps: HelpScoutConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: HELPSCOUT_CATALOG_ID,
+    vendor: HELPSCOUT_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseHelpScoutConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiKey = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiKey === null) {
+        throw new Error(
+          "This Help Scout collection has no stored Docs API key — re-install it to re-enter the key.",
+        );
+      }
+
+      return createHelpScoutVendorClient(
+        {
+          siteId: parsed.siteId,
+          apiKey,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the Help Scout connector idempotently — called from the boot seam
+ * that also registers install handlers (`registerBuiltinInstallHandlers`), and
+ * from tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog
+ * id, so gate on the registry first.
+ */
+export function registerHelpScoutKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(HELPSCOUT_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createHelpScoutConnector());
+  log.info({ catalogId: HELPSCOUT_CATALOG_ID }, "Registered Help Scout knowledge sync connector");
+}

--- a/packages/api/src/lib/knowledge/helpscout/documents.ts
+++ b/packages/api/src/lib/knowledge/helpscout/documents.ts
@@ -1,0 +1,154 @@
+/**
+ * Help Scout article → OKF `ConnectorDocument` assembly (#4398, PRD #4395).
+ *
+ * Pure, deterministic glue between the SHARED support HTML→markdown converter
+ * (`../support/html-to-markdown.ts` — this vendor deliberately owns no HTML→md
+ * logic of its own, per the PRD) and the connector ingest seam. Each PUBLISHED
+ * article is a distinct document; unpublished/deleted articles never reach here
+ * (the client filters `status=published`), so an unpublish reads as "path
+ * absent" and the reconciliation crawl archives it.
+ *
+ * Paths are `<source-collection-slug>/<title-slug>-<article-id>.md` under the
+ * KB collection's slug prefix (`normalizePrefix(options.collectionSlug)`) — the
+ * article id makes them collision-free by construction (two articles never
+ * share it) and means a basename can never be a reserved OKF name; the
+ * `deriveArchivePath` fold still runs as defence in depth. A title rename reads
+ * as "old path archived + new path drafted", the documented rename-churn
+ * posture (same as Zendesk/GitBook/Confluence).
+ *
+ * Provenance that survives ingest: `resource` = the article's canonical public
+ * URL, `timestamp` = its modification time, plus an `atlas:` extension block
+ * carrying connector + site + article id + updated_at (the AC's provenance
+ * fields). No provenance `tags`: `tags` is a mirrored column in the lenient
+ * parser's change comparison, so stamping one would re-draft every
+ * already-ingested document; the extension block stays outside the comparison
+ * (the Zendesk/GitBook posture).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import {
+  convertSupportHtmlToMarkdown,
+  type HtmlDegradation,
+} from "../support/html-to-markdown";
+import { HELPSCOUT_VENDOR } from "./config";
+
+/** One PUBLISHED article, body fetched, ready to convert. */
+export interface HelpScoutArticle {
+  /** Stringified article id (stable across renames/moves). */
+  readonly articleId: string;
+  readonly title: string;
+  /** The article's HTML body (`text`). */
+  readonly bodyHtml: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  /** Canonical public URL of this article (may be empty for a private site). */
+  readonly url: string;
+  /** The source Docs collection slug — the leading path segment. */
+  readonly collectionSlug: string;
+}
+
+export interface HelpScoutAssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Media degradations aggregated across every assembled article. */
+  readonly degradations: readonly HtmlDegradation[];
+  /** Articles skipped because they carried no ingestable prose. */
+  readonly skippedContentless: number;
+}
+
+/** Slugify a title into a single path segment; `fallback` guarantees non-empty. */
+export function slugifyTitle(title: string, fallback: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched articles. `siteId`
+ * lands in the `atlas:` provenance block (the AC's "site"); the article's own
+ * public URL resolves the converter's cross-link hook (relative hrefs
+ * absolutize against it).
+ */
+export function assembleHelpScoutDocuments(
+  articles: readonly HelpScoutArticle[],
+  options: { readonly collectionSlug: string; readonly siteId: string },
+): HelpScoutAssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  let skippedContentless = 0;
+
+  for (const a of articles) {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(a.bodyHtml, {
+      pageUrl: a.url,
+      rewriteLink: (href) => rewriteArticleLink(href, a.url),
+    });
+    for (const d of degradations) {
+      degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+    }
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    const segments = [
+      slugifyTitle(a.collectionSlug, "collection"),
+      `${slugifyTitle(a.title, "article")}-${a.articleId}`,
+    ];
+    const derived = deriveArchivePath(`${segments.join("/")}.md`);
+    const path = [...prefixSegments, derived.path].join("/");
+
+    const title = a.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        ...(a.url !== "" ? { resource: a.url } : {}),
+        timestamp: a.updatedAt,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: HELPSCOUT_VENDOR,
+          site: options.siteId,
+          article_id: a.articleId,
+          updated_at: a.updatedAt,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless };
+}
+
+/**
+ * The converter's cross-link hook: absolutize relative article hrefs against
+ * the article's own public URL so a mirrored link stays live. Absolute and
+ * unparseable hrefs (and the no-public-URL case) pass through untouched.
+ */
+function rewriteArticleLink(href: string, articleUrl: string): string {
+  if (articleUrl === "") return href;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return href; // already absolute (any scheme)
+  try {
+    return new URL(href, articleUrl).toString();
+  } catch {
+    // intentionally ignored: an unparseable href renders as-is — the label text
+    // is preserved either way, and a broken vendor link is the vendor's.
+    return href;
+  }
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -46,13 +46,16 @@ export interface KnowledgeDocumentCounts {
  *   - `front` — the #4400 Knowledge Sync Connector (a scheduled pull of Front
  *     knowledge bases via a Bearer token; one collection per KB, one document
  *     per published article locale; delta-less reconciliation-diff).
+ *   - `helpscout` — the #4398 Knowledge Sync Connector (a scheduled pull of the
+ *     Help Scout Docs API via a single Docs API key; one collection per Docs
+ *     site, one document per published article).
  *
  * Every value except `upload` is a "synced" collection: its content is owned by
  * an external source, it has last-sync bookkeeping, and it can be re-pulled with
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
  * `authScheme`; connector collections (`notion`, `confluence`,
  * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`,
- * `intercom`, `front`) carry neither (their credential is a token — or, for
+ * `intercom`, `front`, `helpscout`) carry neither (their credential is a token — or, for
  * `salesforce-knowledge`, the reused OAuth install — not an endpoint).
  */
 export type KnowledgeCollectionSource =
@@ -65,7 +68,8 @@ export type KnowledgeCollectionSource =
   | "zendesk"
   | "salesforce-knowledge"
   | "intercom"
-  | "front";
+  | "front"
+  | "helpscout";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
Slice of PRD #4395 (KB Support Center Connectors). Adds a `KnowledgeSyncConnector` over the Help Scout **Docs** API (`docsapi.helpscout.net`) — the simplest install in the support tier: a single Docs API key over HTTP Basic auth, no OAuth.

## Shape

Help Scout combines the two sibling patterns already in the tier:
- **Fixed vendor host** (like GitBook #4393) — `docsapi.helpscout.net` is a constant, so there is no customer-supplied URL and no subdomain field. Every fetch still routes through the SSRF egress guard.
- **Per-Site multi-instance fan-out** (like Zendesk brands #4396) — one install enumerates the account's Docs **Sites** and creates one review-gated collection per site (base slug for a single site, `<slug>-<site>` suffixed slugs for several).

Enumerate Sites → Collections → **bodyless** article refs → fetch one `GET /v1/articles/{id}` **per changed article only**. Consumes the shared support HTML→markdown converter (`lib/knowledge/support/html-to-markdown.ts`, the #4396 anchor) — no per-vendor fork.

## Acceptance criteria (#4398)

- [x] Docs API key / Basic install (`{apiKey}:X`); one collection per Site; secret encrypted in `knowledge_sync_credentials`, decrypt failures loud; host through the egress guard.
- [x] Incremental via `sort=updatedAt&order=desc` watermark — per-collection early-stop at the last-sync mark (one body fetch per changed article, never a full sweep). Reconciliation via full page walk (`pageSize=100`, `status=published`); deletes via reconcile.
- [x] Rate limit (~200–400/min, scales with site count) honored via `429` → `ConnectorRateLimitError` → engine backoff.
- [x] Draft-only ingest (structural: `connector:helpscout` is a non-upload `IngestSource`, publish-guarded by `ingestBundle`); provenance (`atlas:` — connector + site + article id + updated_at); pairing test; vendor client test-doubled (no live API in tests).

## Files

- **new** `lib/knowledge/helpscout/`: `config.ts`, `client.ts`, `connector.ts`, `documents.ts` (+ tests).
- **new** `install/helpscout-form-handler.ts` (+ test); `register.ts` form-handler + connector pairing; `seed-builtin-knowledge-catalog.ts` catalog row; `admin-knowledge.ts` source branch.
- `helpscout` wire source in `@useatlas/types` + web `admin-schemas.ts` + regenerated `apps/docs/openapi.json`.
- Parity blocks in `register.test.ts`, `seed-*.test.ts`, `admin-knowledge.test.ts`, `knowledge-lifecycle-pg.test.ts`; `connect-helpscout.mdx` guide.

## Verification

Internal review panel (4 specialist reviewers): CLEAN, no must-fix — applied the high-value suggestions (non-object JSON-envelope guard, unpublished-race observability log, two extra client tests). Local `/ci`: every gate covering this diff passes (type, lint, lint-type-aware, openapi-drift, schema-drift, and all new/updated tests). Two wrapper failures (`schema-drift` for the unrelated `stripe_purged_subscriptions`, and 6 SCIM/IP-allowlist/discord/teams test files — none touched by this diff) were confirmed flakes: all pass on isolated re-run.

Closes #4398

https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN)_