### PR TITLE
feat(knowledge): Freshdesk Solutions sync connector — API key/Basic, category tree-walk, reconciliation-diff

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -56693,7 +56693,8 @@
                               "salesforce-knowledge",
                               "intercom",
                               "front",
-                              "helpscout"
+                              "helpscout",
+                              "freshdesk"
                             ]
                           },
                           "description": {

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -760,6 +760,31 @@ describe("POST /{collectionSlug}/sync — connector collections (#4378)", () => 
     expect(hs?.endpointUrl).toBeNull();
     expect(hs?.sync).not.toBeNull();
   });
+
+  it("dispatches a Freshdesk collection to the connector engine and lists it as source 'freshdesk' (#4401)", async () => {
+    COLLECTION = {
+      install_id: "freshdesk-support",
+      catalog_id: "catalog:freshdesk",
+      status: "published",
+      config: { subdomain: "acme", category_id: "80000001", category_name: "Support" },
+    };
+    SYNC_STATES = [
+      { collection_id: "freshdesk-support", last_sync_at: "2026-07-02T02:00:00.000Z", status: "success", error: null },
+    ];
+    const syncRes = await adminKnowledge.request("/freshdesk-support/sync", { method: "POST" });
+    expect(syncRes.status).toBe(200);
+    expect(syncConnectorCollection).toHaveBeenCalledTimes(1);
+    expect(syncCollection).not.toHaveBeenCalled();
+
+    const listRes = await adminKnowledge.request("/", { method: "GET" });
+    const body = (await listRes.json()) as {
+      collections: Array<{ slug: string; source: string; endpointUrl: string | null; sync: unknown }>;
+    };
+    const freshdesk = body.collections.find((c) => c.slug === "freshdesk-support");
+    expect(freshdesk?.source).toBe("freshdesk");
+    expect(freshdesk?.endpointUrl).toBeNull();
+    expect(freshdesk?.sync).not.toBeNull();
+  });
 });
 
 describe("knowledge mirror invalidation (#4208)", () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -63,6 +63,7 @@ import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesf
 import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
 import { HELPSCOUT_CATALOG_ID } from "@atlas/api/lib/knowledge/helpscout/config";
+import { FRESHDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/freshdesk/config";
 import { syncCollection } from "@atlas/api/lib/knowledge/sync";
 import { getKnowledgeSyncConnector } from "@atlas/api/lib/knowledge/connectors";
 import { syncConnectorCollection } from "@atlas/api/lib/knowledge/connector-sync";
@@ -135,6 +136,7 @@ function sourceOf(catalogId: string): KnowledgeSource {
   if (catalogId === INTERCOM_CATALOG_ID) return "intercom";
   if (catalogId === FRONT_CATALOG_ID) return "front";
   if (catalogId === HELPSCOUT_CATALOG_ID) return "helpscout";
+  if (catalogId === FRESHDESK_CATALOG_ID) return "freshdesk";
   return "unknown";
 }
 
@@ -150,7 +152,8 @@ function isSyncedSource(source: KnowledgeSource): boolean {
     source === "salesforce-knowledge" ||
     source === "intercom" ||
     source === "front" ||
-    source === "helpscout"
+    source === "helpscout" ||
+    source === "freshdesk"
   );
 }
 
@@ -171,7 +174,7 @@ const CollectionListResponseSchema = z.object({
   collections: z.array(
     z.object({
       slug: z.string(),
-      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout"]),
+      source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout", "freshdesk"]),
       description: z.string().nullable(),
       installedAt: z.string().nullable(),
       endpointUrl: z.string().nullable(),

--- a/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-knowledge-catalog.test.ts
@@ -31,6 +31,7 @@ import {
   BUILTIN_INTERCOM_CATALOG_ROW,
   BUILTIN_FRONT_CATALOG_ROW,
   BUILTIN_HELPSCOUT_CATALOG_ROW,
+  BUILTIN_FRESHDESK_CATALOG_ROW,
   BUILTIN_KNOWLEDGE_CATALOG_ROWS,
   type BuiltinKnowledgeCatalogSeedDb,
 } from "@atlas/api/lib/db/seed-builtin-knowledge-catalog";
@@ -277,6 +278,29 @@ describe("BUILTIN_HELPSCOUT_CATALOG_ROW (#4398)", () => {
   });
 });
 
+describe("BUILTIN_FRESHDESK_CATALOG_ROW (#4401)", () => {
+  it("is the `freshdesk` form install: a subdomain + a single secret API key, NO base URL", () => {
+    const row = BUILTIN_FRESHDESK_CATALOG_ROW;
+    expect(row.slug).toBe("freshdesk");
+    expect(row.id).toBe("catalog:freshdesk");
+    expect(row.installModel).toBe("form");
+    expect(row.autoInstall).toBe(false);
+    const keys = row.configSchema.map((f) => f.key);
+    expect(keys).toContain("subdomain");
+    expect(keys).toContain("api_key");
+    expect(keys).toContain("description");
+    // Hosts are composed from the subdomain label (`*.freshdesk.com`) — no
+    // free-form URL field, and no category field: categories are enumerated at
+    // install time (one collection per category).
+    expect(keys).not.toContain("base_url");
+    expect(keys).not.toContain("category_id");
+    // Exactly one secret field: the API key (never echoed).
+    expect(row.configSchema.filter((f) => f.secret === true).map((f) => f.key)).toEqual(["api_key"]);
+    expect(row.configSchema.find((f) => f.key === "api_key")?.required).toBe(true);
+    expect(row.configSchema.find((f) => f.key === "subdomain")?.required).toBe(true);
+  });
+});
+
 describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
   it("issues one INSERT per built-in row with type 'context' and pillar 'knowledge'", async () => {
     const { db, captured } = captureDb();
@@ -304,6 +328,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "intercom",
       "front",
       "helpscout",
+      "freshdesk",
     ]);
   });
 
@@ -335,6 +360,7 @@ describe("seedBuiltinKnowledgeCatalog (idempotent boot seed)", () => {
       "intercom",
       "front",
       "helpscout",
+      "freshdesk",
     ]);
     // Empty RETURNING = rows already existed (ON CONFLICT DO NOTHING path).
     const reboot = await seedBuiltinKnowledgeCatalog(captureDb(false).db);

--- a/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-knowledge-catalog.ts
@@ -48,6 +48,7 @@ import {
 } from "@atlas/api/lib/knowledge/salesforce/config";
 import { FRONT_CATALOG_ID, FRONT_SLUG } from "@atlas/api/lib/knowledge/front/config";
 import { HELPSCOUT_CATALOG_ID, HELPSCOUT_SLUG } from "@atlas/api/lib/knowledge/helpscout/config";
+import { FRESHDESK_CATALOG_ID, FRESHDESK_SLUG } from "@atlas/api/lib/knowledge/freshdesk/config";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import { assertOperatorCatalogWrite } from "@atlas/api/lib/plugins/catalog-provenance";
 
@@ -606,6 +607,57 @@ export const BUILTIN_HELPSCOUT_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
   ],
 };
 
+/**
+ * The Freshdesk Solutions connector Knowledge Base catalog row (#4401,
+ * PRD #4395). A form install that enumerates the account's Solutions categories
+ * and creates one review-gated collection per category; the Scheduler
+ * dispatches the registered Freshdesk connector on a cadence (delta-less
+ * reconciliation-diff over a category folder→article tree-walk) and every
+ * synced article translation lands `draft`.
+ *
+ * `api_key` is `secret: true` but is NOT stored in `workspace_plugins.config`
+ * — the install handler routes it to `knowledge_sync_credentials` (encrypted,
+ * one row per category collection). Hosts are composed from the validated
+ * subdomain label (`*.freshdesk.com`), so there is no free-form base-URL field;
+ * every request still goes through the SSRF egress guard. The id/slug are the
+ * config SSOT (`FRESHDESK_CATALOG_ID` / `FRESHDESK_SLUG`).
+ */
+export const BUILTIN_FRESHDESK_CATALOG_ROW: BuiltinKnowledgeCatalogRow = {
+  id: FRESHDESK_CATALOG_ID,
+  slug: FRESHDESK_SLUG,
+  name: "Knowledge Base (Freshdesk Solutions)",
+  description:
+    "Mirror your Freshdesk Solutions help center into review-gated knowledge collections (one per category); Atlas syncs published articles and their language translations on a schedule and queues changes for review.",
+  installModel: "form",
+  autoInstall: false,
+  saasEligible: true,
+  configSchema: [
+    {
+      key: "subdomain",
+      type: "string",
+      label: "Freshdesk subdomain",
+      required: true,
+      description:
+        'The "acme" in acme.freshdesk.com (you can paste the full URL). Solutions categories are discovered automatically — one collection per category.',
+    },
+    {
+      key: "api_key",
+      type: "string",
+      secret: true,
+      label: "API key",
+      required: true,
+      description:
+        "Your Freshdesk API key (Profile settings → Your API Key). Stored encrypted; never returned.",
+    },
+    {
+      key: "description",
+      type: "string",
+      label: "Description",
+      description: "Optional. A human description of this knowledge collection.",
+    },
+  ],
+};
+
 /** Every built-in Knowledge Base catalog row, in seed order. */
 export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatalogRow> = [
   BUILTIN_KNOWLEDGE_CATALOG_ROW,
@@ -619,6 +671,7 @@ export const BUILTIN_KNOWLEDGE_CATALOG_ROWS: ReadonlyArray<BuiltinKnowledgeCatal
   BUILTIN_INTERCOM_CATALOG_ROW,
   BUILTIN_FRONT_CATALOG_ROW,
   BUILTIN_HELPSCOUT_CATALOG_ROW,
+  BUILTIN_FRESHDESK_CATALOG_ROW,
 ];
 
 /**

--- a/packages/api/src/lib/integrations/install/__tests__/freshdesk-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/freshdesk-form-handler.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for `FreshdeskFormInstallHandler` (#4401) — the Freshdesk
+ * Solutions connector install. Focus: field validation (subdomain, API key),
+ * loud category-enumeration verification at install time, the PER-CATEGORY
+ * FAN-OUT (one collection per category; base slug for a single category,
+ * suffixed slugs for multi-category), credential routing (key →
+ * `knowledge_sync_credentials`, one row per category collection, NEVER into
+ * `workspace_plugins.config`), and the credential rollback on a failed row
+ * write. Verification uses the REAL egress guard against an injected fixture
+ * fetch; no test touches Freshdesk.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
+import type { WorkspaceId } from "@useatlas/types";
+
+let CATALOG_ROWS: { id: string }[] = [{ id: "catalog:freshdesk" }];
+let INSERT_RETURNS_ID = true;
+let INSERT_FAIL_ON_SLUG: string | null = null;
+let CROSS_CATALOG_ROWS: { catalog_id: string }[] = [];
+const insertCalls: { sql: string; params: unknown[] }[] = [];
+
+const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<unknown[]> => {
+  if (sql.includes("FROM plugin_catalog")) return CATALOG_ROWS;
+  if (sql.includes("catalog_id <> $3")) return CROSS_CATALOG_ROWS;
+  if (sql.includes("INSERT INTO workspace_plugins")) {
+    if (INSERT_FAIL_ON_SLUG !== null && params[3] === INSERT_FAIL_ON_SLUG) {
+      throw new Error("simulated row-write failure");
+    }
+    insertCalls.push({ sql, params });
+    return INSERT_RETURNS_ID ? [{ id: params[0] }] : [];
+  }
+  throw new Error(`unexpected SQL: ${sql.slice(0, 50)}`);
+});
+
+void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const saveSyncCredential = mock(async (_w: string, _c: string, _s: string) => {});
+const deleteSyncCredential = mock(async (_w: string, _c: string) => {});
+const readSyncCredential = mock(async () => null);
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential,
+  deleteSyncCredential,
+  readSyncCredential,
+}));
+
+const { FreshdeskFormInstallHandler } = await import(
+  "@atlas/api/lib/integrations/install/freshdesk-form-handler"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/persist-form-install"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const VALID = { subdomain: "acme", api_key: "fd-key" };
+
+interface FixtureCategory {
+  id?: string | number;
+  name?: string;
+}
+
+const ONE_CAT: FixtureCategory[] = [{ id: 1, name: "Support" }];
+const TWO_CATS: FixtureCategory[] = [...ONE_CAT, { id: 2, name: "Internal" }];
+
+/** A fixture categories-endpoint fetch (or a fixed failure status / SSRF redirect). */
+function catFetch(
+  opts: { categories?: FixtureCategory[]; status?: number; redirectToBlocked?: boolean } = {},
+): typeof fetch {
+  const impl = async (input: string | URL | Request): Promise<Response> => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url);
+    if (opts.status && opts.status !== 200) return new Response("", { status: opts.status });
+    if (url.pathname === "/api/v2/solutions/categories") {
+      if (opts.redirectToBlocked) {
+        // Redirect the guarded fetch at a link-local metadata IP; guardedFetch
+        // re-validates the hop and raises EgressBlockedError before it leaves.
+        return new Response("", { status: 302, headers: { location: "http://169.254.169.254/latest" } });
+      }
+      return new Response(JSON.stringify(opts.categories ?? ONE_CAT), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`fixture: unexpected URL ${url}`);
+  };
+  return impl as unknown as typeof fetch;
+}
+
+function handler(fetchImpl?: typeof fetch) {
+  let n = 0;
+  return new FreshdeskFormInstallHandler({
+    idGenerator: () => `fixed-id-${++n}`,
+    clientDeps: fetchImpl ? { fetchImpl } : {},
+  });
+}
+
+beforeEach(() => {
+  CATALOG_ROWS = [{ id: "catalog:freshdesk" }];
+  INSERT_RETURNS_ID = true;
+  INSERT_FAIL_ON_SLUG = null;
+  CROSS_CATALOG_ROWS = [];
+  insertCalls.length = 0;
+  internalQuery.mockClear();
+  saveSyncCredential.mockClear();
+  deleteSyncCredential.mockClear();
+});
+afterEach(() => internalQuery.mockClear());
+
+async function fieldErrorOf(promise: Promise<unknown>, field: string): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.fieldErrors[field]?.[0];
+    throw err;
+  }
+  return undefined;
+}
+
+async function formErrorOf(promise: Promise<unknown>): Promise<string | undefined> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof FormInstallValidationError) return err.formErrors[0];
+    throw err;
+  }
+  return undefined;
+}
+
+describe("field validation", () => {
+  it("requires the subdomain", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { api_key: "fd-key" }),
+      "subdomain",
+    );
+    expect(msg).toMatch(/required/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("requires the API key", async () => {
+    const msg = await fieldErrorOf(
+      handler().validateConfig(WORKSPACE, { subdomain: "acme", api_key: "" }),
+      "api_key",
+    );
+    expect(msg).toMatch(/required/i);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("reduces a pasted full URL to the subdomain label", async () => {
+    await handler(catFetch()).validateConfig(WORKSPACE, {
+      subdomain: "https://acme.freshdesk.com/a/solutions",
+      api_key: "fd-key",
+    });
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config.subdomain).toBe("acme");
+  });
+
+  it("rejects a non-string description", async () => {
+    const msg = await fieldErrorOf(
+      handler(catFetch()).validateConfig(WORKSPACE, { ...VALID, description: 42 }),
+      "description",
+    );
+    expect(msg).toMatch(/string/i);
+  });
+});
+
+describe("category enumeration (install-time verification)", () => {
+  it("blames the api_key field on a 401", async () => {
+    const msg = await fieldErrorOf(
+      handler(catFetch({ status: 401 })).validateConfig(WORKSPACE, VALID),
+      "api_key",
+    );
+    expect(msg).toMatch(/rejected the credentials/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("blames the subdomain field on a 404", async () => {
+    const msg = await fieldErrorOf(
+      handler(catFetch({ status: 404 })).validateConfig(WORKSPACE, VALID),
+      "subdomain",
+    );
+    expect(msg).toMatch(/check the subdomain/i);
+  });
+
+  it("surfaces a 429 as a form-level error (the key may be fine)", async () => {
+    const msg = await formErrorOf(handler(catFetch({ status: 429 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/rate-limited/i);
+  });
+
+  it("surfaces a vendor 5xx as a form-level error, never blaming the key", async () => {
+    const msg = await formErrorOf(handler(catFetch({ status: 503 })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/vendor-side error/i);
+  });
+
+  it("rejects an account with no Solutions categories", async () => {
+    const msg = await formErrorOf(handler(catFetch({ categories: [] })).validateConfig(WORKSPACE, VALID));
+    expect(msg).toMatch(/no Solutions categories/i);
+  });
+
+  it("maps an SSRF egress block to the subdomain field and writes nothing", async () => {
+    const msg = await fieldErrorOf(
+      handler(catFetch({ redirectToBlocked: true })).validateConfig(WORKSPACE, VALID),
+      "subdomain",
+    );
+    expect(msg).toMatch(/refusing to fetch host|private|link-local/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+});
+
+describe("per-category fan-out", () => {
+  it("single category: one collection under the base slug, key in credentials not config", async () => {
+    const rec = await handler(catFetch()).validateConfig(WORKSPACE, VALID);
+    expect(rec.installRecord).toMatchObject({ workspaceId: WORKSPACE, catalogId: "freshdesk" });
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].params[3]).toBe("freshdesk");
+    const config = JSON.parse(insertCalls[0].params[4] as string);
+    expect(config).toMatchObject({ subdomain: "acme", category_id: "1", category_name: "Support" });
+    // The key NEVER lands in the install config…
+    expect(config).not.toHaveProperty("api_key");
+    // …it lands in knowledge_sync_credentials, keyed by the collection slug.
+    expect(saveSyncCredential).toHaveBeenCalledTimes(1);
+    expect(saveSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "freshdesk", "fd-key"]);
+  });
+
+  it("respects a custom collection slug via __install_id__", async () => {
+    await handler(catFetch()).validateConfig(WORKSPACE, { ...VALID, __install_id__: "support-kb" });
+    expect(insertCalls[0].params[3]).toBe("support-kb");
+  });
+
+  it("multi-category: one collection per category under suffixed slugs, one credential each", async () => {
+    const rec = await handler(catFetch({ categories: TWO_CATS })).validateConfig(WORKSPACE, VALID);
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["freshdesk-1", "freshdesk-2"]);
+    const configs = insertCalls.map((c) => JSON.parse(c.params[4] as string));
+    expect(configs.map((c) => c.category_id)).toEqual(["1", "2"]);
+    expect(saveSyncCredential.mock.calls.map((c) => c[1])).toEqual(["freshdesk-1", "freshdesk-2"]);
+    // The returned record is the first category's row.
+    expect(rec.installRecord.id).toBe("fixed-id-1");
+  });
+
+  it("rejects a fan-out slug that would exceed the collection-slug bound BEFORE any write", async () => {
+    const longBase = "z".repeat(127); // valid alone; overflows once "-1" is appended
+    const msg = await fieldErrorOf(
+      handler(catFetch({ categories: TWO_CATS })).validateConfig(WORKSPACE, {
+        ...VALID,
+        __install_id__: longBase,
+      }),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/exceeds 128 characters/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rejects a fan-out slug taken by another knowledge catalog BEFORE any write", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const msg = await fieldErrorOf(
+      handler(catFetch({ categories: TWO_CATS })).validateConfig(WORKSPACE, VALID),
+      "__install_id__",
+    );
+    expect(msg).toMatch(/already used/i);
+    expect(insertCalls).toHaveLength(0);
+    expect(saveSyncCredential).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the failed category's credential and leaves earlier categories installed", async () => {
+    INSERT_FAIL_ON_SLUG = "freshdesk-2";
+    await expect(
+      handler(catFetch({ categories: TWO_CATS })).validateConfig(WORKSPACE, VALID),
+    ).rejects.toThrow(/simulated row-write failure/);
+    // First category fully installed…
+    expect(insertCalls.map((c) => c.params[3])).toEqual(["freshdesk-1"]);
+    // …the failed category's orphaned credential rolled back (and only that one).
+    expect(deleteSyncCredential).toHaveBeenCalledTimes(1);
+    expect(deleteSyncCredential.mock.calls[0]).toEqual([WORKSPACE, "freshdesk-2"]);
+  });
+});
+
+describe("catalog preconditions", () => {
+  it("fails loudly when the catalog row is missing (seed has not run)", async () => {
+    CATALOG_ROWS = [];
+    await expect(handler(catFetch()).validateConfig(WORKSPACE, VALID)).rejects.toThrow(
+      /catalog row "freshdesk" not found/i,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -50,6 +50,7 @@ import { SALESFORCE_KNOWLEDGE_CATALOG_ID } from "@atlas/api/lib/knowledge/salesf
 import { INTERCOM_CATALOG_ID } from "@atlas/api/lib/knowledge/intercom/config";
 import { FRONT_CATALOG_ID } from "@atlas/api/lib/knowledge/front/config";
 import { HELPSCOUT_CATALOG_ID } from "@atlas/api/lib/knowledge/helpscout/config";
+import { FRESHDESK_CATALOG_ID } from "@atlas/api/lib/knowledge/freshdesk/config";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -153,7 +154,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
   // walk dispatches on the connector registry, not the form handler). Pin that
   // one call to registerBuiltinInstallHandlers() registers every vendor's
   // connector alongside its form handler. No env gate on any.
-  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, Salesforce Knowledge, Intercom, Front, and Help Scout sync connectors alongside their form handlers", () => {
+  it("registers the Confluence, Confluence DC, Notion, GitBook, Zendesk, Salesforce Knowledge, Intercom, Front, Help Scout, and Freshdesk sync connectors alongside their form handlers", () => {
     registerBuiltinInstallHandlers();
     expect(getKnowledgeSyncConnector(CONFLUENCE_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(CONFLUENCE_DC_CATALOG_ID)).toBeDefined();
@@ -164,6 +165,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
     expect(getKnowledgeSyncConnector(INTERCOM_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(FRONT_CATALOG_ID)).toBeDefined();
     expect(getKnowledgeSyncConnector(HELPSCOUT_CATALOG_ID)).toBeDefined();
+    expect(getKnowledgeSyncConnector(FRESHDESK_CATALOG_ID)).toBeDefined();
     expect(getInstallHandler({ slug: "confluence", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "confluence-datacenter", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "notion-knowledge", install_model: "form" }).kind).toBe("form");
@@ -173,6 +175,7 @@ describe("registerBuiltinInstallHandlers — knowledge sync connector pairing (#
     expect(getInstallHandler({ slug: "intercom", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "front", install_model: "form" }).kind).toBe("form");
     expect(getInstallHandler({ slug: "helpscout", install_model: "form" }).kind).toBe("form");
+    expect(getInstallHandler({ slug: "freshdesk", install_model: "form" }).kind).toBe("form");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/freshdesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/freshdesk-form-handler.ts
@@ -1,0 +1,437 @@
+/**
+ * `FreshdeskFormInstallHandler` — the {@link FormBasedInstallHandler} for the
+ * built-in `freshdesk` Knowledge Base catalog row (#4401, PRD #4395).
+ *
+ * Installing `freshdesk` creates one synced collection PER SOLUTIONS CATEGORY
+ * (the PRD's "each product/portal maps to a collection" — a Freshdesk category
+ * is the top-level Solutions grouping, portal-scoped in multi-product
+ * accounts): the handler enumerates the account's categories with the supplied
+ * API key and upserts one `pillar='knowledge'` `workspace_plugins` row per
+ * category, each config pinned to that category's id + the account subdomain. A
+ * single category (the common case) gets exactly the chosen collection slug;
+ * multiple categories fan out to `<slug>-<category-slug>`. The Scheduler
+ * dispatches the registered Freshdesk connector per collection on a cadence
+ * (`lib/knowledge/connector-sync.ts`), and every synced article translation
+ * lands `draft`.
+ *
+ * Beyond the Zendesk/Front precedent it inherits (loud credential verification,
+ * key routed to `knowledge_sync_credentials` — never `workspace_plugins.config`),
+ * two Freshdesk-specific choices:
+ *
+ *   1. **Hosts are composed, never pasted.** The admin supplies a SUBDOMAIN
+ *      (a bare label; a pasted `acme.freshdesk.com` / full URL is reduced to
+ *      its label), so every host is `https://<label>.freshdesk.com` by
+ *      construction — then still egress-guard-checked at install and fetch.
+ *   2. **Fan-out is validated fully before any write.** Every per-category slug
+ *      is availability-checked first; writes then run per category
+ *      (credential → row). A mid-fan-out failure leaves earlier categories
+ *      fully installed and working; the thrown error says retrying is safe (all
+ *      writes are idempotent upserts converging on the same slugs).
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  assertBaseUrlAllowed,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import {
+  saveSyncCredential,
+  deleteSyncCredential,
+} from "@atlas/api/lib/knowledge/sync-credentials";
+import {
+  listFreshdeskCategories,
+  FreshdeskAuthError,
+  FreshdeskNotFoundError,
+  type FreshdeskCategory,
+  type FreshdeskClientDeps,
+} from "@atlas/api/lib/knowledge/freshdesk/client";
+import {
+  FRESHDESK_SLUG,
+  FRESHDESK_CATALOG_ID,
+  FRESHDESK_SUBDOMAIN_PATTERN,
+  freshdeskHostFor,
+  type FreshdeskCollectionConfig,
+} from "@atlas/api/lib/knowledge/freshdesk/config";
+import {
+  assertSaasEncryptionKeyset,
+  FormInstallValidationError,
+} from "./persist-form-install";
+import {
+  assertCollectionSlugAvailable,
+  resolveCollectionSlug,
+  COLLECTION_SLUG_MAX,
+  KNOWLEDGE_INSTALL_ID_FIELD,
+} from "./okf-upload-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+// Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
+export { FRESHDESK_SLUG, FRESHDESK_CATALOG_ID };
+
+/** Defensive upper bounds — guard against pathological pastes. */
+const SUBDOMAIN_INPUT_MAX = 2048; // a pasted URL is allowed; the label is extracted
+const SUBDOMAIN_LABEL_MAX = 63; // DNS label bound
+const API_KEY_MAX = 4096;
+
+export interface FreshdeskFormInstallHandlerOptions {
+  /** Test-only injection of the row-id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only injection of the category-enumeration fetch (no real Freshdesk call). */
+  readonly clientDeps?: FreshdeskClientDeps;
+}
+
+/**
+ * The multi-instance synced-collection upsert. Identical shape to
+ * `ZENDESK_INSTALL_UPSERT_SQL`: `status='published'` because the COLLECTION
+ * container is live immediately — the review gate is on the DOCUMENTS, which
+ * always sync in as `draft`. Exported so the real-Postgres test executes this
+ * exact string against the live schema.
+ */
+export const FRESHDESK_INSTALL_UPSERT_SQL = `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'knowledge', $5::jsonb, true, 'published', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               status = 'published',
+               updated_at = NOW()
+         RETURNING id`;
+
+export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+  private readonly clientDeps: FreshdeskClientDeps;
+  private readonly log = createLogger("integrations.install.freshdesk");
+
+  constructor(options: FreshdeskFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.clientDeps = options.clientDeps ?? {};
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    if (formData === null || typeof formData !== "object" || Array.isArray(formData)) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: ["Request body must be a JSON object of config fields."],
+      });
+    }
+    const rawForm = formData as Record<string, unknown>;
+
+    const baseSlug = resolveCollectionSlug(rawForm[KNOWLEDGE_INSTALL_ID_FIELD], FRESHDESK_SLUG);
+
+    // ── Validate fields ────────────────────────────────────────────────────
+    const subdomain = validateSubdomain(rawForm.subdomain);
+    const apiKey = validateApiKey(rawForm.api_key);
+    const description = validateDescription(rawForm.description);
+
+    // SSRF gate on the composed account host (defence in depth — `*.freshdesk.com`
+    // by construction; `guardedFetch` re-validates on every request).
+    assertAccountHostAllowed(subdomain);
+
+    // Confirm the catalog row exists + is enabled.
+    const catalogRows = await internalQuery<{ id: string }>(
+      `SELECT id FROM plugin_catalog WHERE slug = $1 AND enabled = true LIMIT 1`,
+      [FRESHDESK_SLUG],
+    );
+    if (catalogRows.length === 0) {
+      this.log.error(
+        { workspaceId },
+        "freshdesk catalog row missing or disabled — cannot install (built-in knowledge catalog seed has not run)",
+      );
+      throw new Error(
+        `Catalog row "${FRESHDESK_SLUG}" not found or disabled — the built-in Knowledge Base catalog seed has not run.`,
+      );
+    }
+    const catalogId = catalogRows[0].id;
+
+    // ── Enumerate categories = verify the connection loudly BEFORE persisting ─
+    const categories = await this.enumerateCategories({ subdomain, apiKey });
+    if (categories.length === 0) {
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [
+          `The Freshdesk account "${subdomain}" has no Solutions categories — create a category in Freshdesk, then re-install.`,
+        ],
+      });
+    }
+
+    // ── Compute + validate every per-category slug BEFORE any write ──────────
+    const planned = categories.map((category) => ({
+      category,
+      slug: categories.length === 1 ? baseSlug : `${baseSlug}-${slugifyCategoryId(category.id)}`,
+    }));
+    for (const { slug } of planned) {
+      if (slug.length > COLLECTION_SLUG_MAX) {
+        throw new FormInstallValidationError({
+          fieldErrors: {
+            [KNOWLEDGE_INSTALL_ID_FIELD]: [
+              `Collection id "${slug}" (the per-category fan-out of "${baseSlug}") exceeds ${COLLECTION_SLUG_MAX} characters — choose a shorter collection id.`,
+            ],
+          },
+          formErrors: [],
+        });
+      }
+      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+    }
+
+    // ── Per-category writes: credential first, then the collection row ────────
+    assertSaasEncryptionKeyset(this.log, workspaceId, "api_key");
+    let firstRecord: InstallRecord | null = null;
+    for (const { category, slug } of planned) {
+      const record = await this.installCategoryCollection({
+        workspaceId,
+        catalogId,
+        slug,
+        category,
+        config: {
+          subdomain,
+          category_id: category.id,
+          category_name: category.name,
+          ...(description !== null ? { description } : {}),
+        },
+        apiKey,
+      });
+      firstRecord ??= record;
+    }
+
+    this.log.info(
+      {
+        workspaceId,
+        accountHost: hostForLog(freshdeskHostFor(subdomain)),
+        collections: planned.map((p) => p.slug),
+        categories: planned.length,
+      },
+      "Freshdesk collection install completed",
+    );
+    // `firstRecord` is set on the first loop iteration (planned is non-empty).
+    if (firstRecord === null) {
+      throw new Error("Freshdesk install produced no collection record — invariant violation");
+    }
+    return { installRecord: firstRecord, credentialWritten: true };
+  }
+
+  /** Write one category's credential + collection row, Zendesk rollback posture. */
+  private async installCategoryCollection(input: {
+    workspaceId: WorkspaceId;
+    catalogId: string;
+    slug: string;
+    category: FreshdeskCategory;
+    config: FreshdeskCollectionConfig;
+    apiKey: string;
+  }): Promise<InstallRecord> {
+    const { workspaceId, catalogId, slug, category, config, apiKey } = input;
+    try {
+      await saveSyncCredential(workspaceId, slug, apiKey);
+    } catch (err) {
+      this.log.error(
+        { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed category collections stay installed)",
+      );
+      throw retryableInstallError(slug, err);
+    }
+
+    const candidateId = this.newId();
+    try {
+      const rows = await internalQuery<{ id: string }>(FRESHDESK_INSTALL_UPSERT_SQL, [
+        candidateId,
+        workspaceId,
+        catalogId,
+        slug,
+        JSON.stringify(config),
+      ]);
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        this.log.error(
+          { workspaceId, candidateId, collectionSlug: slug },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      return { id: returned, workspaceId, catalogId: FRESHDESK_SLUG };
+    } catch (err) {
+      // Roll back the just-written credential so a secret can't outlive a
+      // failed install. Best-effort — a re-install overwrites it either way; a
+      // cleanup failure is logged, never masks the original error.
+      //
+      // Narrow re-install caveat (shared with the Zendesk/Front handlers): when
+      // the row upsert is an ON-CONFLICT UPDATE of a PRE-EXISTING collection,
+      // `saveSyncCredential` has already overwritten that live collection's
+      // credential, so this rollback deletes a credential the still-existing row
+      // depends on — leaving it credential-less until the admin retries (a rare
+      // same-window DB error). Self-healing on retry, and kept identical across
+      // the connector tier rather than diverging here.
+      this.log.error(
+        {
+          workspaceId,
+          collectionSlug: slug,
+          categoryId: category.id,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to persist freshdesk collection install — rolling back the orphaned credential (retrying the install is safe)",
+      );
+      try {
+        await deleteSyncCredential(workspaceId, slug);
+      } catch (cleanupErr) {
+        this.log.error(
+          {
+            workspaceId,
+            collectionSlug: slug,
+            err: cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr),
+          },
+          "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
+        );
+      }
+      throw retryableInstallError(slug, err);
+    }
+  }
+
+  /**
+   * Enumerate categories with the supplied key; map every failure to a 400.
+   * Classification is POSITIVE, by `instanceof` on the client's typed errors —
+   * never by message text — so only a failure the client KNOWS is
+   * credential-shaped blames the api_key field; a Freshdesk outage or transport
+   * error stays form-level. All messages host-redacted by the client.
+   */
+  private async enumerateCategories(input: {
+    subdomain: string;
+    apiKey: string;
+  }): Promise<FreshdeskCategory[]> {
+    try {
+      return await listFreshdeskCategories(input, this.clientDeps);
+    } catch (err) {
+      if (err instanceof EgressBlockedError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { subdomain: [err.message] },
+          formErrors: [],
+        });
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof FreshdeskAuthError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { api_key: [message] },
+          formErrors: [],
+        });
+      }
+      if (err instanceof FreshdeskNotFoundError) {
+        throw new FormInstallValidationError({
+          fieldErrors: { subdomain: [message] },
+          formErrors: [],
+        });
+      }
+      // Everything else — 429 (ConnectorRateLimitError), vendor 5xx,
+      // transport/DNS/non-JSON — is form-level (re-entering a fine key would be
+      // the wrong guidance).
+      throw new FormInstallValidationError({
+        fieldErrors: {},
+        formErrors: [message],
+      });
+    }
+  }
+}
+
+/**
+ * Slugify a Freshdesk category id into a collection-slug-safe segment
+ * (`[a-z0-9-]`). Freshdesk ids are numeric (`80000123` → `80000123`); the
+ * slug-availability check catches any genuine collision before a write.
+ */
+function slugifyCategoryId(id: string): string {
+  const slug = id
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? "category" : slug;
+}
+
+/**
+ * Validate the account subdomain: required, reduced to a bare label (a pasted
+ * `acme.freshdesk.com` or full URL is accepted and reduced), bounded, matching
+ * the DNS-label pattern the host is composed from.
+ */
+function validateSubdomain(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "subdomain",
+      'The Freshdesk subdomain is required — the "acme" in acme.freshdesk.com (you can paste the full URL).',
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > SUBDOMAIN_INPUT_MAX) {
+    throw fieldError("subdomain", `The subdomain must be ${SUBDOMAIN_INPUT_MAX} characters or fewer.`);
+  }
+  let label = trimmed.toLowerCase();
+  // Accept a pasted URL or host and reduce it to the leading label.
+  label = label.replace(/^https?:\/\//, "");
+  const freshdeskHost = /^([a-z0-9-]+)\.freshdesk\.com(?:[/:?#].*)?$/.exec(label);
+  if (freshdeskHost) label = freshdeskHost[1];
+  else label = label.split(/[/:?#]/, 1)[0];
+  if (label.length > SUBDOMAIN_LABEL_MAX || !FRESHDESK_SUBDOMAIN_PATTERN.test(label)) {
+    throw fieldError(
+      "subdomain",
+      'Enter the bare Freshdesk subdomain — the "acme" in acme.freshdesk.com (letters, digits, and dashes).',
+    );
+  }
+  return label;
+}
+
+function validateApiKey(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw fieldError(
+      "api_key",
+      "An API key is required. Find it in Freshdesk → Profile settings → Your API Key.",
+    );
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length > API_KEY_MAX) {
+    throw fieldError("api_key", `The API key must be ${API_KEY_MAX} characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function validateDescription(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw fieldError("description", "Description must be a string.");
+  }
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/** SSRF-gate the composed account host, mapping a block to a field-level 400. */
+function assertAccountHostAllowed(subdomain: string): void {
+  try {
+    assertBaseUrlAllowed(freshdeskHostFor(subdomain));
+  } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      throw new FormInstallValidationError({
+        fieldErrors: { subdomain: [err.message] },
+        formErrors: [],
+      });
+    }
+    throw err;
+  }
+}
+
+function fieldError(field: string, message: string): FormInstallValidationError {
+  return new FormInstallValidationError({ fieldErrors: { [field]: [message] }, formErrors: [] });
+}
+
+/**
+ * Wrap a mid-fan-out persistence failure with the retry guidance the admin
+ * needs: all writes are idempotent upserts converging on the same slugs, so
+ * re-running the install is always safe. The original failure rides as cause.
+ */
+function retryableInstallError(slug: string, err: unknown): Error {
+  return new Error(
+    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed category collections are simply updated in place.`,
+    { cause: err },
+  );
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -61,6 +61,8 @@ import { FrontFormInstallHandler, FRONT_SLUG } from "./front-form-handler";
 import { registerFrontKnowledgeConnector } from "@atlas/api/lib/knowledge/front/connector";
 import { HelpScoutFormInstallHandler, HELPSCOUT_SLUG } from "./helpscout-form-handler";
 import { registerHelpScoutKnowledgeConnector } from "@atlas/api/lib/knowledge/helpscout/connector";
+import { FreshdeskFormInstallHandler, FRESHDESK_SLUG } from "./freshdesk-form-handler";
+import { registerFreshdeskKnowledgeConnector } from "@atlas/api/lib/knowledge/freshdesk/connector";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
@@ -367,6 +369,19 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(HELPSCOUT_SLUG, new HelpScoutFormInstallHandler());
   registerHelpScoutKnowledgeConnector();
   log.info("Registered HelpScoutFormInstallHandler + knowledge sync connector");
+  // Knowledge Base (Freshdesk Solutions) — the built-in `freshdesk` connector
+  // install (#4401, PRD #4395). Knowledge-pillar, multi-instance: ONE install
+  // fans out to one collection per SOLUTIONS CATEGORY. Config = account
+  // subdomain + per-category binding; the API key lands in
+  // `knowledge_sync_credentials` (encrypted, one row per category collection),
+  // never in `workspace_plugins.config`. Hosts are composed `*.freshdesk.com`
+  // labels → SSRF gated at install and fetch. Registering the FORM handler +
+  // the CONNECTOR together (as with the other knowledge vendors) keeps a
+  // half-wired deploy from having an installable card whose scheduled sync has
+  // no registered vendor client. No env gate.
+  registerFormHandler(FRESHDESK_SLUG, new FreshdeskFormInstallHandler());
+  registerFreshdeskKnowledgeConnector();
+  log.info("Registered FreshdeskFormInstallHandler + knowledge sync connector");
   // Generic OpenAPI REST datasource (#2926). Datasource-pillar, multi-instance
   // (a workspace installs Twenty, Stripe, an internal service side by side).
   // No env gate — the customer admin supplies the spec URL + credential at

--- a/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/knowledge-lifecycle-pg.test.ts
@@ -42,6 +42,7 @@ import { GITBOOK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/
 import { ZENDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/zendesk-form-handler";
 import { INTERCOM_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/intercom-form-handler";
 import { FRONT_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/front-form-handler";
+import { FRESHDESK_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/freshdesk-form-handler";
 import { SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/salesforce-knowledge-form-handler";
 import { HELPSCOUT_INSTALL_UPSERT_SQL } from "@atlas/api/lib/integrations/install/helpscout-form-handler";
 import { SYNC_CYCLE_INSTALLS_SQL, SYNC_STATE_UPSERT_SQL } from "@atlas/api/lib/knowledge/sync";
@@ -695,6 +696,35 @@ describeIfPg("knowledge ingest lifecycle against the live schema", () => {
     // The Docs API key is NEVER persisted in the install config.
     expect(row.rows[0]?.config).not.toHaveProperty("api_key");
     expect(row.rows[0]?.config).toMatchObject({ site_id: "site-1", subdomain: "acme" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs a Freshdesk per-category connector collection against the live schema (#4401)", async () => {
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+       VALUES ('catalog:freshdesk', 'Knowledge Base (Freshdesk Solutions)', 'freshdesk', 'context', 'knowledge', 'form')
+       ON CONFLICT (id) DO NOTHING`,
+    );
+    const installed = await pool.query<{ id: string }>(FRESHDESK_INSTALL_UPSERT_SQL, [
+      "row-freshdesk",
+      ws,
+      "catalog:freshdesk",
+      "freshdesk-support",
+      JSON.stringify({ subdomain: "acme", category_id: "80000001", category_name: "Support" }),
+    ]);
+    expect(installed.rows[0]?.id).toBe("row-freshdesk");
+    const row = await pool.query<{ pillar: string; status: string; config: Record<string, unknown> }>(
+      `SELECT pillar, status, config FROM workspace_plugins
+        WHERE workspace_id = $1 AND install_id = 'freshdesk-support'`,
+      [ws],
+    );
+    expect(row.rows[0]).toMatchObject({ pillar: "knowledge", status: "published" });
+    // The API key is NEVER persisted in the install config.
+    expect(row.rows[0]?.config).not.toHaveProperty("api_key");
+    expect(row.rows[0]?.config).toMatchObject({
+      subdomain: "acme",
+      category_id: "80000001",
+      category_name: "Support",
+    });
   }, PG_TEST_TIMEOUT_MS);
 
   it("the cycle's install listing returns ONLY enabled, non-archived bundle-sync installs (#4211)", async () => {

--- a/packages/api/src/lib/knowledge/freshdesk/__tests__/client.test.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/__tests__/client.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Tests for the Freshdesk vendor client (#4401) — driven entirely through an
+ * injected fixture `fetchImpl`; NO test touches Freshdesk. Covers the delta-less
+ * category tree-walk (categories→folders→subfolders→articles), the incremental
+ * since-filter over `updated_at`, the status=2 published filter, the high-water
+ * mark, per-language `{language_code}` translation fetches (distinct documents),
+ * the `articles_count` completeness check, malformed-item coverage flagging,
+ * 429 → ConnectorRateLimitError, auth/not-found failures, the ingest cap, and
+ * the category enumeration used at install time.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createFreshdeskVendorClient,
+  listFreshdeskCategories,
+  parseRetryAfter,
+  FreshdeskAuthError,
+  FreshdeskNotFoundError,
+} from "@atlas/api/lib/knowledge/freshdesk/client";
+import { ConnectorRateLimitError } from "@atlas/api/lib/knowledge/connectors";
+
+const SUB = "acme";
+const CAT = "80000001";
+
+interface FixtureArticle {
+  id?: string | number;
+  title?: string;
+  description?: string | null;
+  status?: number;
+  updated_at?: string;
+  language?: string;
+  url?: string;
+}
+
+function art(overrides: FixtureArticle = {}): FixtureArticle {
+  return {
+    id: "9001",
+    title: "Getting Started",
+    description: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    status: 2,
+    updated_at: "2026-07-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+interface FixtureState {
+  calls: string[];
+  authHeaders: Array<string | null>;
+}
+
+interface FixtureFolder {
+  id: string;
+  sub_folders_count?: number;
+  articles_count?: number;
+}
+
+/**
+ * A fixture Freshdesk Solutions API. One category with folders → (optional
+ * subfolders) → articles; translations keyed by `${articleId}/${lang}`.
+ */
+function makeFetch(opts: {
+  category?: { id?: string; name?: string } | null;
+  settings?: { primary_language?: string; supported_languages?: string[] } | null;
+  settingsStatus?: number;
+  folders?: FixtureFolder[];
+  subfolders?: Record<string, FixtureFolder[]>;
+  articlesByFolder?: Record<string, FixtureArticle[]>;
+  translations?: Record<string, FixtureArticle>;
+  splitFolder?: string;
+  failFirst?: { status: number; headers?: Record<string, string> };
+}): { impl: typeof globalThis.fetch; state: FixtureState } {
+  const state: FixtureState = { calls: [], authHeaders: [] };
+  let failed = false;
+  const category = opts.category === undefined ? { id: CAT, name: "Support" } : opts.category;
+  const impl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    state.calls.push(raw);
+    state.authHeaders.push(new Headers(init?.headers).get("authorization"));
+    if (opts.failFirst && !failed) {
+      failed = true;
+      return new Response("", { status: opts.failFirst.status, headers: opts.failFirst.headers });
+    }
+    const url = new URL(raw);
+    const path = url.pathname;
+    const page = url.searchParams.get("page") ?? "1";
+
+    if (path === "/api/v2/settings/helpdesk") {
+      if (opts.settingsStatus && opts.settingsStatus !== 200) {
+        return new Response("", { status: opts.settingsStatus });
+      }
+      return jsonResponse(opts.settings ?? { primary_language: "en", supported_languages: [] });
+    }
+    if (path === `/api/v2/solutions/categories/${CAT}`) {
+      if (category === null) return new Response("", { status: 404 });
+      return jsonResponse(category);
+    }
+    if (path === "/api/v2/solutions/categories") {
+      return jsonResponse([{ id: CAT, name: "Support" }]);
+    }
+    const folderMatch = path.match(/^\/api\/v2\/solutions\/categories\/[^/]+\/folders$/);
+    if (folderMatch) {
+      return jsonResponse(opts.folders ?? [{ id: "700", articles_count: 0 }]);
+    }
+    const subMatch = path.match(/^\/api\/v2\/solutions\/folders\/([^/]+)\/subfolders$/);
+    if (subMatch) {
+      return jsonResponse(opts.subfolders?.[subMatch[1]] ?? []);
+    }
+    const artListMatch = path.match(/^\/api\/v2\/solutions\/folders\/([^/]+)\/articles$/);
+    if (artListMatch) {
+      const folderId = artListMatch[1];
+      const all = opts.articlesByFolder?.[folderId] ?? [];
+      if (opts.splitFolder === folderId) {
+        // Emulate two pages: page 1 returns 100 (a full page) so the walk asks
+        // for page 2; page 2 returns the remainder.
+        if (page === "1") return jsonResponse(padPage(all.slice(0, 1)));
+        return jsonResponse(all.slice(1));
+      }
+      return jsonResponse(all);
+    }
+    const translationMatch = path.match(/^\/api\/v2\/solutions\/articles\/([^/]+)\/([^/]+)$/);
+    if (translationMatch) {
+      const key = `${translationMatch[1]}/${translationMatch[2]}`;
+      const t = opts.translations?.[key];
+      if (t === undefined) return new Response("", { status: 404 });
+      return jsonResponse(t);
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  return { impl, state };
+}
+
+/** Pad a page to exactly PER_PAGE (100) rows so the pager fetches the next page. */
+function padPage(head: FixtureArticle[]): FixtureArticle[] {
+  const filler: FixtureArticle[] = [];
+  for (let i = 0; i < 100 - head.length; i++) {
+    filler.push(art({ id: `pad-${i}`, status: 1 })); // drafts — never emitted
+  }
+  return [...head, ...filler];
+}
+
+function client(opts: Parameters<typeof makeFetch>[0] = {}, maxDocs?: number) {
+  const { impl, state } = makeFetch(opts);
+  const c = createFreshdeskVendorClient(
+    { subdomain: SUB, categoryId: CAT, categoryName: "Support", apiKey: "fd-secret", collectionSlug: "freshdesk-support" },
+    { fetchImpl: impl, ...(maxDocs !== undefined ? { maxDocs } : {}) },
+  );
+  return { c, state };
+}
+
+describe("fetchAll (reconciliation)", () => {
+  it("walks the category tree and emits one document per published article", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      articlesByFolder: {
+        "700": [
+          art({ id: "9001", updated_at: "2026-07-01T10:00:00Z" }),
+          art({ id: "9002", title: "Billing", updated_at: "2026-07-05T08:00:00Z" }),
+        ],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "freshdesk-support/en/getting-started-9001.md",
+      "freshdesk-support/en/billing-9002.md",
+    ]);
+    expect(changes.highWaterMark).toBe("2026-07-05T08:00:00.000Z");
+    expect(changes.coverageIncomplete).toBe(false);
+    expect(changes.cursor).toBeNull();
+  });
+
+  it("skips draft (status !== 2) articles but still advances the mark", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      articlesByFolder: {
+        "700": [
+          art({ id: "9001", status: 1, updated_at: "2026-07-06T00:00:00Z" }), // draft
+          art({ id: "9002", title: "Live", status: 2, updated_at: "2026-07-02T00:00:00Z" }),
+        ],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual(["freshdesk-support/en/live-9002.md"]);
+    // The draft still advances the mark — its change was observed.
+    expect(changes.highWaterMark).toBe("2026-07-06T00:00:00.000Z");
+  });
+
+  it("descends into subfolders (sub_folders_count > 0)", async () => {
+    const { c } = client({
+      folders: [{ id: "700", sub_folders_count: 1, articles_count: 1 }],
+      subfolders: { "700": [{ id: "701", articles_count: 1 }] },
+      articlesByFolder: {
+        "700": [art({ id: "9001" })],
+        "701": [art({ id: "9002", title: "Nested" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path).sort()).toEqual([
+      "freshdesk-support/en/getting-started-9001.md",
+      "freshdesk-support/en/nested-9002.md",
+    ]);
+  });
+
+  it("flags coverageIncomplete when a folder lists fewer than its articles_count", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 5 }], // claims 5…
+      articlesByFolder: { "700": [art({ id: "9001" })] }, // …lists 1
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("counts a published article with no body and flags coverage incomplete", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      articlesByFolder: {
+        "700": [art({ id: "9001", description: null }), art({ id: "9002", title: "Ok" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("counts a malformed article (no id/updated_at) and flags coverage incomplete", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      articlesByFolder: {
+        "700": [{ title: "no id", status: 2, description: "<p>text</p>" }, art({ id: "9002" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+
+  it("follows page pagination within a folder", async () => {
+    const { c, state } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      splitFolder: "700",
+      articlesByFolder: {
+        "700": [art({ id: "9001" }), art({ id: "9002", title: "Two" })],
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "freshdesk-support/en/getting-started-9001.md",
+      "freshdesk-support/en/two-9002.md",
+    ]);
+    expect(state.calls.filter((u) => /\/folders\/700\/articles/.test(u))).toHaveLength(2);
+  });
+
+  it("rejects a published set over the ingest cap", async () => {
+    const { c } = client(
+      {
+        folders: [{ id: "700", articles_count: 3 }],
+        articlesByFolder: {
+          "700": [art({ id: "9001" }), art({ id: "9002" }), art({ id: "9003" })],
+        },
+      },
+      2,
+    );
+    await expect(c.fetchAll()).rejects.toThrow(/over the 2-document limit/i);
+  });
+});
+
+describe("multi-language translations", () => {
+  it("emits a distinct document per published translation via the {language_code} segment", async () => {
+    const { c, state } = client({
+      settings: { primary_language: "en", supported_languages: ["fr"] },
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9001", language: "en" })] },
+      translations: {
+        "9001/fr": art({ id: "9001", title: "Pour commencer", language: "fr", status: 2, updated_at: "2026-07-03T00:00:00Z" }),
+      },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "freshdesk-support/en/getting-started-9001.md",
+      "freshdesk-support/fr/pour-commencer-9001.md",
+    ]);
+    // The translation was fetched via the language path segment.
+    expect(state.calls.some((u) => /\/solutions\/articles\/9001\/fr$/.test(u))).toBe(true);
+  });
+
+  it("skips a missing translation (404) without failing the sync", async () => {
+    const { c } = client({
+      settings: { primary_language: "en", supported_languages: ["fr", "de"] },
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9001" })] },
+      translations: {}, // no translations exist → 404 each
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(changes.coverageIncomplete).toBe(false);
+  });
+
+  it("makes no translation requests for a single-language account", async () => {
+    const { c, state } = client({
+      settings: { primary_language: "en", supported_languages: [] },
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9001" })] },
+    });
+    await c.fetchAll();
+    expect(state.calls.some((u) => /\/solutions\/articles\//.test(u))).toBe(false);
+  });
+
+  it("falls back to primary-only when /settings/helpdesk is forbidden (403)", async () => {
+    const { c, state } = client({
+      settingsStatus: 403,
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9001" })] },
+    });
+    const changes = await c.fetchAll();
+    expect(changes.documents).toHaveLength(1);
+    expect(state.calls.some((u) => /\/solutions\/articles\//.test(u))).toBe(false);
+  });
+
+  it("throws (never swallows) a real 401 on /settings/helpdesk — only 403/404 are tolerated", async () => {
+    const { c } = client({
+      settingsStatus: 401,
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9001" })] },
+    });
+    await expect(c.fetchAll()).rejects.toBeInstanceOf(FreshdeskAuthError);
+  });
+
+  it("counts a present translation with an unparseable updated_at (not conflated with 404-absent)", async () => {
+    const { c } = client({
+      settings: { primary_language: "en", supported_languages: ["fr"] },
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9001" })] },
+      // Present translation body but no orderable timestamp → malformed, not absent.
+      translations: { "9001/fr": { id: "9001", title: "Cassé", status: 2, description: "<p>x</p>" } },
+    });
+    const changes = await c.fetchAll();
+    // Only the primary is emitted; the malformed translation is counted, not
+    // silently dropped, so coverage is held incomplete.
+    expect(changes.documents.map((d) => d.path)).toEqual([
+      "freshdesk-support/en/getting-started-9001.md",
+    ]);
+    expect(changes.coverageIncomplete).toBe(true);
+  });
+});
+
+describe("fetchChanges (incremental)", () => {
+  it("emits only articles edited at-or-after since, with the observed max as the mark", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      articlesByFolder: {
+        "700": [
+          art({ id: "9001", updated_at: "2026-07-01T00:00:00Z" }), // before since
+          art({ id: "9002", title: "New", updated_at: "2026-07-08T00:00:00Z" }), // after since
+        ],
+      },
+    });
+    const changes = await c.fetchChanges({ since: "2026-07-05T00:00:00.000Z", cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual(["freshdesk-support/en/new-9002.md"]);
+    expect(changes.highWaterMark).toBe("2026-07-08T00:00:00.000Z");
+  });
+
+  it("re-emits an article edited exactly at since (>= is inclusive)", async () => {
+    const since = "2026-07-05T00:00:00.000Z";
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art({ id: "9005", title: "Edge", updated_at: since })] },
+    });
+    const changes = await c.fetchChanges({ since, cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual(["freshdesk-support/en/edge-9005.md"]);
+  });
+
+  it("serves a null since as a full crawl (defensive)", async () => {
+    const { c } = client({
+      folders: [{ id: "700", articles_count: 2 }],
+      articlesByFolder: { "700": [art({ id: "9001" }), art({ id: "9002", title: "Two" })] },
+    });
+    const changes = await c.fetchChanges({ since: null, cursor: null });
+    expect(changes.documents).toHaveLength(2);
+  });
+
+  it("re-emits a fresh translation of a stale primary (translations change independently)", async () => {
+    const since = "2026-07-05T00:00:00.000Z";
+    const { c } = client({
+      settings: { primary_language: "en", supported_languages: ["fr"] },
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: {
+        // Primary edited BEFORE since — must not re-emit.
+        "700": [art({ id: "9001", language: "en", updated_at: "2026-07-01T00:00:00Z" })],
+      },
+      translations: {
+        // Translation edited AFTER since — must re-emit even though its primary is stale.
+        "9001/fr": art({ id: "9001", title: "À jour", language: "fr", status: 2, updated_at: "2026-07-09T00:00:00Z" }),
+      },
+    });
+    const changes = await c.fetchChanges({ since, cursor: null });
+    expect(changes.documents.map((d) => d.path)).toEqual(["freshdesk-support/fr/a-jour-9001.md"]);
+    expect(changes.highWaterMark).toBe("2026-07-09T00:00:00.000Z");
+  });
+});
+
+describe("authentication", () => {
+  it("sends Freshdesk API-key Basic auth (key as username, X as password)", async () => {
+    const { c, state } = client({
+      folders: [{ id: "700", articles_count: 1 }],
+      articlesByFolder: { "700": [art()] },
+    });
+    await c.fetchAll();
+    const expected = `Basic ${Buffer.from("fd-secret:X").toString("base64")}`;
+    expect(state.authHeaders.length).toBeGreaterThan(0);
+    for (const header of state.authHeaders) expect(header).toBe(expected);
+  });
+});
+
+describe("vendor failure mapping", () => {
+  it("throws ConnectorRateLimitError with the parsed Retry-After on a 429", async () => {
+    const { c } = client({ failFirst: { status: 429, headers: { "retry-after": "37" } } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(ConnectorRateLimitError);
+    expect((err as ConnectorRateLimitError).retryAfterSeconds).toBe(37);
+  });
+
+  it("maps a 401 to an actionable, host-redacted credentials error", async () => {
+    const { c } = client({ failFirst: { status: 401 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(FreshdeskAuthError);
+    expect((err as Error).message).toMatch(/rejected the credentials \(401\)/i);
+  });
+
+  it("maps a missing category to a not-found error", async () => {
+    const { c } = client({ category: null });
+    await expect(c.fetchAll()).rejects.toBeInstanceOf(FreshdeskNotFoundError);
+  });
+
+  it("never leaks the API key in an error message", async () => {
+    const { c } = client({ failFirst: { status: 500 } });
+    const err = await c.fetchAll().then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain("fd-secret");
+  });
+});
+
+describe("listFreshdeskCategories (install-time enumeration + credential check)", () => {
+  it("maps categories and skips malformed entries", async () => {
+    const { impl } = makeFetch({});
+    // Override the categories endpoint via a custom fetch.
+    const custom = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const raw = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(raw);
+      if (url.pathname === "/api/v2/solutions/categories") {
+        return jsonResponse([
+          { id: 1, name: "Support" },
+          { id: 2, name: "Internal" },
+          { name: "no id" }, // malformed — skipped
+        ]);
+      }
+      return impl(input as never, init);
+    }) as unknown as typeof globalThis.fetch;
+    const categories = await listFreshdeskCategories({ subdomain: SUB, apiKey: "key" }, { fetchImpl: custom });
+    expect(categories.map((c) => c.id)).toEqual(["1", "2"]);
+    expect(categories[0]).toMatchObject({ id: "1", name: "Support" });
+  });
+
+  it("propagates an auth failure loudly", async () => {
+    const { impl } = makeFetch({ failFirst: { status: 401 } });
+    await expect(
+      listFreshdeskCategories({ subdomain: SUB, apiKey: "bad" }, { fetchImpl: impl }),
+    ).rejects.toBeInstanceOf(FreshdeskAuthError);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds and rejects HTTP-dates/garbage", () => {
+    expect(parseRetryAfter("42")).toBe(42);
+    expect(parseRetryAfter("0")).toBe(0);
+    expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/knowledge/freshdesk/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/__tests__/connector.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the Freshdesk KnowledgeSyncConnector (#4401) — the createClient
+ * factory contract: parse the stored per-category config, read the encrypted
+ * API key loudly, and build a vendor client. The credential store is mocked
+ * (mock-all-exports).
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let keyResult: string | null | (() => never) = "secret-key";
+
+void mock.module("@atlas/api/lib/knowledge/sync-credentials", () => ({
+  SYNC_CREDENTIAL_UPSERT_SQL: "INSERT ...",
+  saveSyncCredential: async () => {},
+  deleteSyncCredential: async () => {},
+  readSyncCredential: async () => {
+    if (typeof keyResult === "function") return keyResult();
+    return keyResult;
+  },
+}));
+
+const { createFreshdeskConnector } = await import("@atlas/api/lib/knowledge/freshdesk/connector");
+const { FRESHDESK_CATALOG_ID, FRESHDESK_VENDOR } = await import(
+  "@atlas/api/lib/knowledge/freshdesk/config"
+);
+
+const VALID_CONFIG = {
+  subdomain: "acme",
+  category_id: "80000001",
+  category_name: "Support",
+};
+
+function ctx(config: Record<string, unknown> | null) {
+  return { workspaceId: "org-1", collectionSlug: "freshdesk-support", config };
+}
+
+afterEach(() => {
+  keyResult = "secret-key";
+});
+
+describe("createFreshdeskConnector", () => {
+  it("advertises the freshdesk catalog id and vendor slug", () => {
+    const connector = createFreshdeskConnector();
+    expect(connector.catalogId).toBe(FRESHDESK_CATALOG_ID);
+    expect(connector.vendor).toBe(FRESHDESK_VENDOR);
+  });
+
+  it("builds a vendor client from valid per-category config + a stored key", async () => {
+    const connector = createFreshdeskConnector();
+    const client = await connector.createClient(ctx(VALID_CONFIG));
+    expect(typeof client.fetchChanges).toBe("function");
+    expect(typeof client.fetchAll).toBe("function");
+  });
+
+  it("throws an actionable error when the config has no subdomain", async () => {
+    const connector = createFreshdeskConnector();
+    await expect(
+      connector.createClient(ctx({ category_id: "1", category_name: "x" })),
+    ).rejects.toThrow(/no valid Freshdesk subdomain/i);
+  });
+
+  it("throws an actionable error when the config has no category", async () => {
+    const connector = createFreshdeskConnector();
+    await expect(
+      connector.createClient(ctx({ subdomain: "acme" })),
+    ).rejects.toThrow(/no Freshdesk Solutions category/i);
+  });
+
+  it("throws when the collection has no stored API key", async () => {
+    keyResult = null;
+    const connector = createFreshdeskConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/no stored API key/i);
+  });
+
+  it("propagates a loud decrypt failure from the credential store", async () => {
+    keyResult = () => {
+      throw new Error("failed to decrypt knowledge_sync_credentials — key rotated without re-encryption");
+    };
+    const connector = createFreshdeskConnector();
+    await expect(connector.createClient(ctx(VALID_CONFIG))).rejects.toThrow(/failed to decrypt/i);
+  });
+});

--- a/packages/api/src/lib/knowledge/freshdesk/__tests__/documents.test.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/__tests__/documents.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the Freshdesk article-locale → ConnectorDocument assembly (#4401):
+ * the per-locale archive path (`<locale>/<title-slug>-<id>.md`, prefixed), the
+ * `atlas:` provenance block (connector + product + category id + article id +
+ * locale + updated_at), the shared-converter integration (counted image
+ * degradations), and the contentless skip. Pure — no I/O.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  assembleFreshdeskDocuments,
+  slugifyTitle,
+  type FreshdeskArticleLocale,
+} from "@atlas/api/lib/knowledge/freshdesk/documents";
+
+const OPTS = { collectionSlug: "freshdesk-support" };
+
+function article(overrides: Partial<FreshdeskArticleLocale> = {}): FreshdeskArticleLocale {
+  return {
+    articleId: "9001",
+    categoryId: "80000001",
+    categoryName: "Support",
+    locale: "en",
+    title: "Getting Started",
+    bodyHtml: "<p>Welcome to the product. Follow the setup guide to begin.</p>",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    url: "https://acme.freshdesk.com/support/solutions/articles/9001",
+    ...overrides,
+  };
+}
+
+describe("slugifyTitle", () => {
+  it("lowercases and dashes non-alphanumerics (NFKD)", () => {
+    expect(slugifyTitle("Setup & Testing Guide!", "x")).toBe("setup-testing-guide");
+  });
+  it("falls back when the title has no usable characters", () => {
+    expect(slugifyTitle("你好", "article")).toBe("article");
+  });
+});
+
+describe("assembleFreshdeskDocuments", () => {
+  it("emits one document per locale at <prefix>/<locale>/<slug>-<id>.md", () => {
+    const result = assembleFreshdeskDocuments(
+      [article(), article({ locale: "fr", title: "Pour commencer" })],
+      OPTS,
+    );
+    expect(result.documents.map((d) => d.path)).toEqual([
+      "freshdesk-support/en/getting-started-9001.md",
+      "freshdesk-support/fr/pour-commencer-9001.md",
+    ]);
+  });
+
+  it("stamps frontmatter provenance and the atlas: extension block", () => {
+    const { documents } = assembleFreshdeskDocuments([article()], OPTS);
+    const content = documents[0].content;
+    expect(content).toContain('title: "Getting Started"');
+    expect(content).toContain('resource: "https://acme.freshdesk.com/support/solutions/articles/9001"');
+    expect(content).toContain('timestamp: "2026-07-01T10:00:00.000Z"');
+    expect(content).toContain("atlas:");
+    expect(content).toContain('connector: "freshdesk"');
+    expect(content).toContain('product: "Support"');
+    expect(content).toContain('category_id: "80000001"');
+    expect(content).toContain('article_id: "9001"');
+    expect(content).toContain('locale: "en"');
+    expect(content).toContain('updated_at: "2026-07-01T10:00:00.000Z"');
+    // No provenance tags — `tags` is a mirrored change-comparison column, so
+    // stamping one would re-draft every already-ingested document.
+    expect(content).not.toContain("tags:");
+  });
+
+  it("falls back to the category id for product when the name is blank", () => {
+    const { documents } = assembleFreshdeskDocuments([article({ categoryName: "" })], OPTS);
+    expect(documents[0].content).toContain('product: "80000001"');
+  });
+
+  it("aggregates image degradations across articles", () => {
+    const { degradations } = assembleFreshdeskDocuments(
+      [
+        article({ bodyHtml: '<p>Some intro text here.</p><img src="a.png"><img src="b.png">' }),
+        article({ locale: "fr", bodyHtml: '<p>Un peu de texte ici dedans.</p><img src="c.png">' }),
+      ],
+      OPTS,
+    );
+    expect(degradations).toEqual([{ name: "#image", count: 3 }]);
+  });
+
+  it("skips (and counts) a contentless article instead of emitting an empty doc", () => {
+    const result = assembleFreshdeskDocuments(
+      [article({ bodyHtml: "<div><script>x()</script></div>" }), article({ locale: "fr" })],
+      OPTS,
+    );
+    expect(result.skippedContentless).toBe(1);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0].path).toContain("/fr/");
+  });
+
+  it("uses the fallback segment for an unslugifiable title (id keeps it unique)", () => {
+    const { documents } = assembleFreshdeskDocuments([article({ title: "你好", articleId: "77" })], OPTS);
+    expect(documents[0].path).toBe("freshdesk-support/en/article-77.md");
+  });
+});

--- a/packages/api/src/lib/knowledge/freshdesk/client.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/client.ts
@@ -1,0 +1,769 @@
+/**
+ * The Freshdesk Solutions vendor client (#4401, PRD #4395) — a
+ * {@link ConnectorVendorClient} over Freshdesk's Solutions REST API
+ * (`{subdomain}.freshdesk.com/api/v2`, API-key Basic auth), driven by the
+ * shared connector engine (`connector-sync.ts`). It owns ONLY enumerate +
+ * fetch + convert; scheduling, high-water marks, reconciliation cadence, 429
+ * backoff, and caps are the engine's (ADR-0030).
+ *
+ * Freshdesk Solutions exposes NO server-side change feed (`updated_since`), so
+ * both engine cadences are served from one full CATEGORY TREE-WALK — the PRD's
+ * delta-less reconciliation-diff posture:
+ *   - `fetchAll()` (reconciliation) — walk the collection's category →
+ *     folders → subfolders → articles (the folder-article list carries each
+ *     article's `description` body inline), emit one document per PUBLISHED
+ *     language variant. The engine archives previously-ingested paths absent
+ *     from this set, so a draft/deleted article is treated as absent, never an
+ *     error (the AC's "deletes via reconcile").
+ *   - `fetchChanges({ since })` (incremental) — the SAME full tree-walk, but
+ *     only variants whose `updated_at` is at-or-after `since` are emitted
+ *     (Freshdesk has no delta, but each article/translation carries
+ *     `updated_at`, so the high-water mark still narrows the ingest churn).
+ *     Deletions are not detectable here — the reconciliation crawl owns
+ *     subtractive archiving.
+ *
+ * One client mirrors ONE Solutions category (the install handler fans one
+ * install out to one collection per category). Multi-language: the account's
+ * `supported_languages` (from `/settings/helpdesk`) drive a per-language
+ * translation fetch (`GET /solutions/articles/{id}/{language_code}`); each
+ * `(article, language)` pair is a distinct document. A single-language account
+ * (the common case) pays nothing — the `others` set is empty and no translation
+ * requests are made.
+ *
+ * Security + hygiene: the host is composed from a validated `*.freshdesk.com`
+ * subdomain label (never a customer-supplied URL), and every request goes
+ * through `guardedFetch` (SSRF egress guard; auth stripped on cross-origin
+ * redirect). A 429 is the ONLY signal that becomes the engine's backoff (thrown
+ * as {@link ConnectorRateLimitError}); every other failure is an actionable
+ * error with the host redacted via `hostForLog` — the API key lives in the
+ * `Authorization` header, never a URL or a message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  guardedFetch,
+  EgressBlockedError,
+  hostForLog,
+} from "@atlas/api/lib/openapi/egress-guard";
+import { getIngestMaxDocs } from "../ingest-limits";
+import {
+  ConnectorRateLimitError,
+  toIsoInstant,
+  type ConnectorChanges,
+  type ConnectorFetchSince,
+  type ConnectorVendorClient,
+} from "../connectors";
+import { freshdeskHostFor } from "./config";
+import { assembleFreshdeskDocuments, type FreshdeskArticleLocale } from "./documents";
+
+const log = createLogger("knowledge.freshdesk.client");
+
+/**
+ * Freshdesk rejected the credentials (401/403). A distinct class — not a
+ * `cause`-presence side channel — so the install handler can blame the
+ * `api_key` field with `instanceof` (the `ConnectorRateLimitError` precedent;
+ * plain subclass, this is not Effect code).
+ */
+export class FreshdeskAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FreshdeskAuthError";
+  }
+}
+
+/** Freshdesk returned 404 — wrong subdomain, or the category is gone. */
+export class FreshdeskNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FreshdeskNotFoundError";
+  }
+}
+
+/** Freshdesk Solutions article/translation status: 1 = draft, 2 = published. */
+const PUBLISHED_STATUS = 2;
+
+/** Resolved, non-secret connection inputs plus the key. One category per client. */
+export interface FreshdeskClientConfig {
+  /** The account's validated subdomain label — the help-center host to fetch. */
+  readonly subdomain: string;
+  /** The Solutions category id this collection mirrors. */
+  readonly categoryId: string;
+  /** Human category name — the provenance `product` label. */
+  readonly categoryName: string;
+  readonly apiKey: string;
+  /** The KB collection slug = `workspace_plugins.install_id` — the path prefix. */
+  readonly collectionSlug: string;
+}
+
+export interface FreshdeskClientDeps {
+  /** Injected fetch for tests; defaults to the guarded global fetch. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** Test-only override of the ingest doc cap (defaults to the settings value). */
+  readonly maxDocs?: number;
+}
+
+/** Per-request timeout (bounds the whole redirect chain). */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Freshdesk list page size (`per_page` max is 100). */
+const PER_PAGE = 100;
+/**
+ * Hard anti-runaway bound on pages walked in one paginated enumeration — the
+ * category listing, folder listing, subfolder listing, AND article listing all
+ * share it, so every walk fails loud on a stuck page cursor rather than looping
+ * forever.
+ */
+const MAX_FEED_PAGES = 1_000;
+/**
+ * Hard anti-runaway bound on enumerated articles across a category tree — NOT
+ * the ingest cap (the engine owns that, and surfaces the real over-limit
+ * numbers). A category larger than this is pathological; we fail loud rather
+ * than loop unbounded on a broken pagination response.
+ */
+const MAX_ARTICLES = 100_000;
+/** Anti-runaway bound on subfolder nesting depth walked under one category. */
+const MAX_FOLDER_DEPTH = 20;
+/**
+ * Anti-runaway bound on the non-primary languages walked per article. Freshdesk
+ * supports a few dozen languages; far more is an anomalous account response.
+ */
+const MAX_LANGUAGES = 60;
+
+// ---------------------------------------------------------------------------
+// Raw API response shapes (only the fields we read; untrusted vendor JSON —
+// every field optional, narrowed at the use sites)
+// ---------------------------------------------------------------------------
+
+interface RawCategory {
+  readonly id?: number | string;
+  readonly name?: string;
+}
+interface RawFolder {
+  readonly id?: number | string;
+  readonly sub_folders_count?: number;
+  readonly articles_count?: number;
+}
+interface RawArticle {
+  readonly id?: number | string;
+  readonly title?: string;
+  /** HTML body. */
+  readonly description?: string | null;
+  /** 1 = draft, 2 = published. */
+  readonly status?: number;
+  readonly updated_at?: string;
+  readonly language?: string;
+  readonly url?: string;
+}
+interface RawHelpdeskSettings {
+  readonly primary_language?: string;
+  readonly supported_languages?: readonly unknown[];
+}
+
+/** One enumerated primary-language article, normalized. */
+interface NormalizedArticle {
+  readonly id: string;
+  /** 1 = draft, 2 = published (`0` when the vendor omitted it = not published). */
+  readonly status: number;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  /** The primary-language `description` body, or null when absent. */
+  readonly bodyHtml: string | null;
+  readonly title: string;
+  /** The article's own `language`, lowercased (`""` when the vendor omitted it). */
+  readonly language: string;
+  readonly url: string;
+}
+
+/** The account's language set — the walk driver. */
+interface AccountLanguages {
+  /** Primary language label, or null when `/settings/helpdesk` was unreadable. */
+  readonly primary: string | null;
+  /** Supported non-primary languages (translation variants to fetch). */
+  readonly others: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Freshdesk vendor client for ONE Solutions category. `createClient`
+ * (the connector factory) has already decrypted the key and validated config,
+ * so this constructor does no I/O.
+ */
+export function createFreshdeskVendorClient(
+  config: FreshdeskClientConfig,
+  deps: FreshdeskClientDeps = {},
+): ConnectorVendorClient {
+  const api = new FreshdeskApi(config, deps);
+  return {
+    async fetchChanges(params: ConnectorFetchSince): Promise<ConnectorChanges> {
+      return api.fetch({ since: params.since });
+    },
+    async fetchAll(): Promise<ConnectorChanges> {
+      return api.fetch({ since: null });
+    },
+  };
+}
+
+/** One Freshdesk Solutions category, normalized for the install handler's fan-out. */
+export interface FreshdeskCategory {
+  /** Stringified numeric category id. */
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface FreshdeskAccountParams {
+  /** The account subdomain (validated label) to enumerate categories from. */
+  readonly subdomain: string;
+  readonly apiKey: string;
+}
+
+/**
+ * Enumerate the account's Solutions categories — ALSO the install-time
+ * credential check (the first authenticated request doubles as it; loud on
+ * every failure). A bad key surfaces as a 401, a wrong subdomain typically as a
+ * 404, both actionable and host-redacted; the install handler maps them to
+ * field-level 400s so "invalid credentials fail the install loudly."
+ */
+export async function listFreshdeskCategories(
+  params: FreshdeskAccountParams,
+  deps: FreshdeskClientDeps = {},
+): Promise<FreshdeskCategory[]> {
+  const base = freshdeskHostFor(params.subdomain);
+  const http = new FreshdeskHttp(base, params.apiKey, deps);
+  const categories: FreshdeskCategory[] = [];
+  let skippedMalformed = 0;
+  await paginate(base, `${base}/api/v2/solutions/categories`, async (url) => {
+    const rows = await http.getJson<RawCategory[]>(url);
+    for (const raw of asArray(rows)) {
+      const id = idOf(raw.id);
+      if (id === "") {
+        skippedMalformed++;
+        continue;
+      }
+      categories.push({
+        id,
+        name: typeof raw.name === "string" && raw.name.trim() !== "" ? raw.name.trim() : id,
+      });
+    }
+    return asArray(rows).length;
+  });
+  if (skippedMalformed > 0) {
+    log.warn(
+      { host: hostForLog(base), skippedMalformed },
+      "Skipped Freshdesk categories missing an id — not installable (unexpected vendor response)",
+    );
+  }
+  return categories;
+}
+
+/**
+ * Page-walk a Freshdesk list endpoint (`?page=N&per_page=100`), stopping when a
+ * page returns fewer than `PER_PAGE` rows. `onPage` fetches + accumulates and
+ * returns the row count it saw. Bounded by `MAX_FEED_PAGES` so a vendor that
+ * keeps returning full pages fails loud rather than looping forever.
+ */
+async function paginate(
+  base: string,
+  endpoint: string,
+  onPage: (url: string) => Promise<number>,
+): Promise<void> {
+  const sep = endpoint.includes("?") ? "&" : "?";
+  for (let page = 1; ; page++) {
+    if (page > MAX_FEED_PAGES) {
+      throw new Error(
+        `Freshdesk listing on ${hostForLog(base)} did not terminate after ${MAX_FEED_PAGES} pages — unexpected vendor pagination.`,
+      );
+    }
+    const url = `${endpoint}${sep}per_page=${PER_PAGE}&page=${page}`;
+    const count = await onPage(url);
+    if (count < PER_PAGE) break;
+  }
+}
+
+class FreshdeskApi {
+  private readonly base: string;
+  private readonly http: FreshdeskHttp;
+  private readonly maxDocs: number;
+
+  constructor(
+    private readonly config: FreshdeskClientConfig,
+    deps: FreshdeskClientDeps,
+  ) {
+    this.base = freshdeskHostFor(config.subdomain);
+    this.http = new FreshdeskHttp(this.base, config.apiKey, deps);
+    this.maxDocs = deps.maxDocs ?? getIngestMaxDocs();
+  }
+
+  /**
+   * Walk the category tree + assemble. When `since` is null this is a
+   * reconciliation crawl (every published language variant emitted); otherwise
+   * an incremental cycle (only variants edited at-or-after `since`).
+   */
+  async fetch(opts: { since: string | null }): Promise<ConnectorChanges> {
+    const reconciliation = opts.since === null;
+    await this.assertCategoryLive();
+    const languages = await this.resolveLanguages();
+
+    // Walk category → folders → subfolders, collecting every folder to list.
+    const folders = await this.collectFolders();
+
+    const primaryArticles: NormalizedArticle[] = [];
+    let skippedMalformed = 0;
+    let coverageIncomplete = false;
+    for (const folder of folders) {
+      const result = await this.listFolderArticles(folder.id);
+      primaryArticles.push(...result.articles);
+      skippedMalformed += result.skippedMalformed;
+      // `articles_count` completeness check: fewer listed than the folder
+      // reports means the walk missed some (a mid-walk vendor hiccup) — hold
+      // subtractive archiving rather than wrongly archive the unseen ones.
+      if (folder.articlesCount !== null && result.total < folder.articlesCount) {
+        coverageIncomplete = true;
+        log.warn(
+          {
+            host: hostForLog(this.base),
+            folderId: folder.id,
+            listed: result.total,
+            reported: folder.articlesCount,
+          },
+          "Freshdesk folder listed fewer articles than its articles_count — holding subtractive archiving this cycle",
+        );
+      }
+      if (primaryArticles.length > MAX_ARTICLES) {
+        throw new Error(
+          `Freshdesk category "${this.config.categoryId}" on ${hostForLog(this.base)} exceeds ${MAX_ARTICLES} articles — narrow the connector's scope. (This is a safety bound, not the ingest cap ATLAS_KNOWLEDGE_INGEST_MAX_DOCS.)`,
+        );
+      }
+    }
+
+    // Build the candidate variant set (primary + translations) and track the
+    // high-water mark over EVERY observed timestamp (published or not, primary
+    // or translation) — a draft's change was still observed by this fetch.
+    let highWaterMark: string | null = null;
+    const bump = (iso: string): void => {
+      if (highWaterMark === null || iso > highWaterMark) highWaterMark = iso;
+    };
+    const emitted: FreshdeskArticleLocale[] = [];
+    let translationFetches = 0;
+
+    for (const a of primaryArticles) {
+      bump(a.updatedAt);
+      // Primary-language variant.
+      const primaryLocale = a.language !== "" ? a.language : (languages.primary ?? "en");
+      if (a.status === PUBLISHED_STATUS && withinSince(a.updatedAt, opts.since)) {
+        if (a.bodyHtml === null) {
+          // A published article with no body is a KNOWN hole: flag coverage and
+          // skip rather than emit an empty document a later reconciliation would
+          // then archive.
+          skippedMalformed++;
+        } else {
+          emitted.push(this.toLocale(a, primaryLocale, a.title, a.bodyHtml, a.updatedAt));
+        }
+      }
+
+      // Per-language translation variants. Freshdesk carries no per-article
+      // translation list, so each `(article, language)` is a direct fetch —
+      // gated on a multi-language account (single-language accounts pay
+      // nothing). A translation can change independently of its primary, so the
+      // delta-less posture fetches them on both cadences.
+      for (const lang of languages.others) {
+        translationFetches++;
+        const t = await this.fetchTranslation(a.id, lang);
+        if (t.kind === "absent") continue; // 404 — no translation in this language, not an error
+        if (t.kind === "malformed") {
+          // A PRESENT translation we can't order (unparseable updated_at) is a
+          // known hole, not an absent one — count it (mirrors the primary path)
+          // so coverage is flagged and the end-of-fetch warn surfaces it, never
+          // a silent drop.
+          skippedMalformed++;
+          continue;
+        }
+        bump(t.updatedAt);
+        if (t.status === PUBLISHED_STATUS && withinSince(t.updatedAt, opts.since)) {
+          if (t.bodyHtml === null) {
+            skippedMalformed++;
+            continue;
+          }
+          emitted.push(this.toLocale(a, lang, t.title, t.bodyHtml, t.updatedAt, lang));
+        }
+      }
+    }
+
+    // Reject an over-cap published set on reconciliation BEFORE assembling — the
+    // engine's ingest cap is the backstop, but checking here puts real numbers
+    // in the error (the AC's "caps validated over the full set").
+    if (reconciliation && emitted.length > this.maxDocs) {
+      throw new Error(
+        `This Freshdesk category has ${emitted.length} published article locales, over the ${this.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the category's scope, or raise the cap.`,
+      );
+    }
+
+    const assembled = assembleFreshdeskDocuments(emitted, {
+      collectionSlug: this.config.collectionSlug,
+    });
+    const mode = reconciliation ? "reconciliation" : "incremental";
+    if (assembled.degradations.length > 0 || assembled.skippedContentless > 0) {
+      log.info(
+        {
+          host: hostForLog(this.base),
+          categoryId: this.config.categoryId,
+          mode,
+          degradations: assembled.degradations,
+          skippedContentless: assembled.skippedContentless,
+        },
+        "Freshdesk conversion completed with degradations/skips",
+      );
+    }
+    if (skippedMalformed > 0) {
+      log.warn(
+        { host: hostForLog(this.base), mode, skippedMalformed },
+        "Skipped Freshdesk articles missing id/updated_at/body — not ingested (coverage flagged incomplete)",
+      );
+    }
+    if (translationFetches > 0) {
+      log.info(
+        { host: hostForLog(this.base), mode, translationFetches },
+        "Freshdesk translation fetches (multi-language account — N+1 request profile per language)",
+      );
+    }
+
+    return {
+      documents: assembled.documents,
+      highWaterMark,
+      cursor: null,
+      coverageIncomplete: coverageIncomplete || skippedMalformed > 0,
+    };
+  }
+
+  /**
+   * Verify the collection's category is live — doubles as the sync-time
+   * liveness check. A missing category is a loud not-found the engine surfaces
+   * on the collection.
+   */
+  private async assertCategoryLive(): Promise<void> {
+    const cat = await this.http.getJson<RawCategory | null>(
+      `${this.base}/api/v2/solutions/categories/${encodeURIComponent(this.config.categoryId)}`,
+    );
+    // A 200 with a null / non-object body (a vendor quirk) must map to the
+    // actionable not-found, never a bare TypeError from `idOf(cat.id)`.
+    if (cat === null || typeof cat !== "object" || idOf(cat.id) === "") {
+      throw new FreshdeskNotFoundError(
+        `Freshdesk Solutions category "${this.config.categoryId}" was not found on ${hostForLog(this.base)} — check the category still exists and the API key can see it.`,
+      );
+    }
+  }
+
+  /**
+   * Resolve the account's language set from `/settings/helpdesk`. Best-effort:
+   * a 403/404 (an agent-scoped key without settings access, or an account
+   * without the endpoint) degrades to primary-only with a logged warning — the
+   * multilingual walk is an enhancement, not a reason to fail the whole sync. A
+   * 401 still throws loudly (real auth failure).
+   */
+  private async resolveLanguages(): Promise<AccountLanguages> {
+    const settings = await this.http.getJsonTolerant<RawHelpdeskSettings>(
+      `${this.base}/api/v2/settings/helpdesk`,
+      [403, 404],
+    );
+    if (settings === null) {
+      log.warn(
+        { host: hostForLog(this.base) },
+        "Freshdesk /settings/helpdesk unreadable (403/404) — syncing primary language only",
+      );
+      return { primary: null, others: [] };
+    }
+    const primary =
+      typeof settings.primary_language === "string" && settings.primary_language.trim() !== ""
+        ? settings.primary_language.trim().toLowerCase()
+        : null;
+    const others = asArray(settings.supported_languages)
+      .filter((l): l is string => typeof l === "string" && l.trim() !== "")
+      .map((l) => l.trim().toLowerCase())
+      .filter((l) => l !== primary);
+    if (others.length > MAX_LANGUAGES) {
+      throw new Error(
+        `Freshdesk account on ${hostForLog(this.base)} reports ${others.length} supported languages, over the ${MAX_LANGUAGES} safety bound — unexpected vendor response.`,
+      );
+    }
+    return { primary, others };
+  }
+
+  /**
+   * Walk the collection's category → folders → subfolders, returning every
+   * (sub)folder to list articles from. `sub_folders_count` on the folder object
+   * gates the subfolder descent, and `MAX_FOLDER_DEPTH` bounds nesting.
+   */
+  private async collectFolders(): Promise<Array<{ id: string; articlesCount: number | null }>> {
+    const collected: Array<{ id: string; articlesCount: number | null }> = [];
+    const topLevel = await this.listFolders(
+      `${this.base}/api/v2/solutions/categories/${encodeURIComponent(this.config.categoryId)}/folders`,
+    );
+    const queue = topLevel.map((f) => ({ folder: f, depth: 0 }));
+    while (queue.length > 0) {
+      const item = queue.shift();
+      if (item === undefined) break;
+      const { folder, depth } = item;
+      collected.push({ id: folder.id, articlesCount: folder.articlesCount });
+      if (folder.subFoldersCount > 0 && depth < MAX_FOLDER_DEPTH) {
+        const subs = await this.listFolders(
+          `${this.base}/api/v2/solutions/folders/${encodeURIComponent(folder.id)}/subfolders`,
+        );
+        for (const sub of subs) queue.push({ folder: sub, depth: depth + 1 });
+      }
+    }
+    return collected;
+  }
+
+  /** List one folder-listing endpoint, paginated + normalized. */
+  private async listFolders(
+    endpoint: string,
+  ): Promise<Array<{ id: string; subFoldersCount: number; articlesCount: number | null }>> {
+    const folders: Array<{ id: string; subFoldersCount: number; articlesCount: number | null }> =
+      [];
+    await paginate(this.base, endpoint, async (url) => {
+      const rows = await this.http.getJson<RawFolder[]>(url);
+      for (const raw of asArray(rows)) {
+        const id = idOf(raw.id);
+        if (id === "") continue;
+        folders.push({
+          id,
+          subFoldersCount: typeof raw.sub_folders_count === "number" ? raw.sub_folders_count : 0,
+          articlesCount: typeof raw.articles_count === "number" ? raw.articles_count : null,
+        });
+      }
+      return asArray(rows).length;
+    });
+    return folders;
+  }
+
+  /** Paginate one folder's primary-language articles. */
+  private async listFolderArticles(
+    folderId: string,
+  ): Promise<{ articles: NormalizedArticle[]; skippedMalformed: number; total: number }> {
+    const articles: NormalizedArticle[] = [];
+    let skippedMalformed = 0;
+    let total = 0;
+    await paginate(
+      this.base,
+      `${this.base}/api/v2/solutions/folders/${encodeURIComponent(folderId)}/articles`,
+      async (url) => {
+        const rows = await this.http.getJson<RawArticle[]>(url);
+        const list = asArray(rows);
+        total += list.length;
+        for (const raw of list) {
+          const normalized = normalizeArticle(raw);
+          if (normalized !== null) articles.push(normalized);
+          else skippedMalformed++;
+        }
+        return list.length;
+      },
+    );
+    return { articles, skippedMalformed, total };
+  }
+
+  /**
+   * Fetch one article's translation in `language` via the `{language_code}`
+   * path segment (the AC's "multi-language via {language_code} path segment").
+   * A 404 means no translation exists in that language — returns null (not an
+   * error). Malformed (no updated_at) also returns null.
+   */
+  private async fetchTranslation(
+    articleId: string,
+    language: string,
+  ): Promise<
+    | { kind: "absent" }
+    | { kind: "malformed" }
+    | { kind: "ok"; status: number; updatedAt: string; bodyHtml: string | null; title: string }
+  > {
+    const raw = await this.http.getJsonTolerant<RawArticle>(
+      `${this.base}/api/v2/solutions/articles/${encodeURIComponent(articleId)}/${encodeURIComponent(language)}`,
+      [404],
+    );
+    if (raw === null) return { kind: "absent" }; // 404 — no translation in this language
+    const updatedAt = toIsoInstant(raw.updated_at);
+    // A PRESENT translation with an unparseable timestamp is distinct from an
+    // absent one — the caller counts it (never conflated with the 404).
+    if (updatedAt === null) return { kind: "malformed" };
+    return {
+      kind: "ok",
+      status: typeof raw.status === "number" ? raw.status : 0,
+      updatedAt,
+      bodyHtml: typeof raw.description === "string" ? raw.description : null,
+      title: typeof raw.title === "string" ? raw.title : "",
+    };
+  }
+
+  /** Build one `FreshdeskArticleLocale` for assembly. */
+  private toLocale(
+    a: NormalizedArticle,
+    locale: string,
+    title: string,
+    bodyHtml: string,
+    updatedAt: string,
+    langSegment?: string,
+  ): FreshdeskArticleLocale {
+    return {
+      articleId: a.id,
+      categoryId: this.config.categoryId,
+      categoryName: this.config.categoryName,
+      locale: locale.toLowerCase(),
+      title,
+      bodyHtml,
+      updatedAt,
+      url: this.articleUrl(a, langSegment),
+    };
+  }
+
+  /** Prefer the article's own URL; fall back to a canonical help-center path. */
+  private articleUrl(a: NormalizedArticle, langSegment?: string): string {
+    if (a.url !== "" && /^https?:\/\//i.test(a.url)) return a.url;
+    const suffix = langSegment !== undefined ? `/${encodeURIComponent(langSegment)}` : "";
+    return `${this.base}/support/solutions/articles/${encodeURIComponent(a.id)}${suffix}`;
+  }
+}
+
+/**
+ * Whether a variant's `updatedAt` qualifies for `since`. Null since = full
+ * crawl (everything). `>=` is inclusive so a variant edited exactly at the mark
+ * re-emits (a regression to `>` would silently drop it). ISO instants compare
+ * chronologically as strings.
+ */
+function withinSince(updatedAt: string, since: string | null): boolean {
+  return since === null || updatedAt >= since;
+}
+
+/**
+ * Coerce an untrusted vendor field to an array — a non-array body (an object, a
+ * string) would otherwise throw a bare TypeError at the `for…of`; treating it as
+ * empty keeps the walk's own bounds + coverage flagging in charge of anomalous
+ * responses.
+ */
+function asArray<T>(value: readonly T[] | undefined | null): readonly T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/** Stringify an untrusted vendor id — scalars only (`null`/objects = malformed). */
+function idOf(raw: unknown): string {
+  return typeof raw === "number" || typeof raw === "string" ? String(raw) : "";
+}
+
+/** Normalize one raw primary-language article; null = malformed (skip + count). */
+function normalizeArticle(raw: RawArticle): NormalizedArticle | null {
+  const id = idOf(raw.id);
+  const updatedAt = toIsoInstant(raw.updated_at);
+  if (id === "" || updatedAt === null) return null;
+  return {
+    id,
+    status: typeof raw.status === "number" ? raw.status : 0,
+    updatedAt,
+    // Null-vs-empty contract: a PRESENT string (incl. `""`) is the genuine body
+    // — an empty one assembles to a contentless skip. Only an ABSENT / non-string
+    // `description` is null, which flags coverage rather than emit an empty doc.
+    bodyHtml: typeof raw.description === "string" ? raw.description : null,
+    title: typeof raw.title === "string" ? raw.title : "",
+    language: typeof raw.language === "string" ? raw.language.trim().toLowerCase() : "",
+    url: typeof raw.url === "string" ? raw.url : "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP (shared by the per-category client and the account-level category listing)
+// ---------------------------------------------------------------------------
+
+class FreshdeskHttp {
+  private readonly authHeader: string;
+
+  constructor(
+    private readonly base: string,
+    apiKey: string,
+    private readonly deps: FreshdeskClientDeps,
+  ) {
+    // Freshdesk API-key auth is HTTP Basic with the key as the username and any
+    // string as the password (`X` by convention). Buffer.from handles any UTF-8.
+    this.authHeader = `Basic ${Buffer.from(`${apiKey}:X`).toString("base64")}`;
+  }
+
+  /** GET + JSON through the SSRF guard, mapping vendor failures to typed errors. */
+  async getJson<T>(url: string): Promise<T> {
+    const result = await this.request<T>(url, []);
+    // `request` only returns null for a tolerated status; with no tolerated
+    // statuses a non-2xx always throws, so this is a real body.
+    return result as T;
+  }
+
+  /**
+   * GET + JSON, returning null for the given tolerated statuses instead of
+   * throwing (used for the best-effort `/settings/helpdesk` read and the
+   * per-language translation fetch where a 404 means "no translation").
+   */
+  async getJsonTolerant<T>(url: string, tolerate: readonly number[]): Promise<T | null> {
+    return this.request<T>(url, tolerate);
+  }
+
+  private async request<T>(url: string, tolerate: readonly number[]): Promise<T | null> {
+    const fetchImpl = this.deps.fetchImpl;
+    let response: Response;
+    try {
+      response = await guardedFetch(
+        url,
+        {
+          method: "GET",
+          headers: { Authorization: this.authHeader, Accept: "application/json" },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        },
+        fetchImpl ? { fetchImpl } : {},
+      );
+    } catch (err) {
+      if (err instanceof EgressBlockedError) throw err; // host-redacted + actionable
+      throw new Error(
+        `Freshdesk request to ${hostForLog(this.base)} failed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+
+    if (tolerate.includes(response.status)) return null;
+
+    if (response.status === 429) {
+      throw new ConnectorRateLimitError(
+        `Freshdesk rate-limited the request to ${hostForLog(this.base)} (Freshdesk applies plan-tiered per-minute rate limits; honor Retry-After).`,
+        parseRetryAfter(response.headers.get("retry-after")),
+      );
+    }
+    if (response.status === 401 || response.status === 403) {
+      throw new FreshdeskAuthError(
+        `Freshdesk rejected the credentials (${response.status}) for ${hostForLog(this.base)} — re-enter the API key (Freshdesk → Profile settings → Your API Key) and confirm it can read Solutions.`,
+      );
+    }
+    if (response.status === 404) {
+      throw new FreshdeskNotFoundError(
+        `Freshdesk returned 404 from ${hostForLog(this.base)} — check the subdomain, and that the Solutions category still exists.`,
+      );
+    }
+    if (response.status >= 500) {
+      throw new Error(
+        `Freshdesk returned HTTP ${response.status} from ${hostForLog(this.base)} — a vendor-side error; the next scheduled sync (or retrying the install) will usually succeed.`,
+      );
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Freshdesk returned HTTP ${response.status} from ${hostForLog(this.base)} — an unexpected Freshdesk API response; if it persists, re-install the collection or check Freshdesk's API status.`,
+      );
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      throw new Error(
+        `Freshdesk returned a non-JSON response from ${hostForLog(this.base)}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+}
+
+/** Parse a `Retry-After` header (delta-seconds only; HTTP-date → null). */
+export function parseRetryAfter(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}

--- a/packages/api/src/lib/knowledge/freshdesk/config.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/config.ts
@@ -1,0 +1,91 @@
+/**
+ * Freshdesk Solutions connector identity + stored-config contract (#4401,
+ * PRD #4395).
+ *
+ * A leaf module: the catalog id / slug / vendor constants and the non-secret
+ * install config shape live here so the install handler (writes the config),
+ * the connector (reads it back in `createClient`), and the admin-knowledge
+ * surface (recognizes the catalog id) share ONE definition — a field rename
+ * can't drift the three apart silently. The API key is NOT part of this config;
+ * it lives encrypted in `knowledge_sync_credentials` and is read via
+ * `readSyncCredential`.
+ *
+ * Freshdesk is a MULTI-CATEGORY vendor: one install enumerates the account's
+ * Solutions categories (`GET /api/v2/solutions/categories`) and creates one
+ * collection per category (the PRD's "each product/portal maps to a
+ * collection" — a Freshdesk category is the top-level Solutions grouping;
+ * Freshdesk itself may portal-scope a category via `visible_in_portals`, but the
+ * connector mirrors every enumerated category regardless of portal visibility).
+ * Each collection's config is therefore CATEGORY-scoped: it pins the category
+ * id whose folder→subfolder→article tree its client walks, alongside the
+ * account subdomain the install enumerated from. Hosts are always composed from
+ * a validated subdomain label — never a customer-supplied URL — so the egress
+ * surface stays `*.freshdesk.com` by construction, and every fetch still goes
+ * through the SSRF egress guard.
+ */
+
+/** The built-in Freshdesk Solutions Knowledge Base catalog slug + row id. */
+export const FRESHDESK_SLUG = "freshdesk";
+export const FRESHDESK_CATALOG_ID = "catalog:freshdesk";
+/** Vendor slug stamped into `atlas_source` as `connector:freshdesk`. */
+export const FRESHDESK_VENDOR = "freshdesk";
+
+/**
+ * A Freshdesk subdomain label (`acme` in `acme.freshdesk.com`). Composing
+ * hosts from this validated label (rather than accepting a URL) keeps the
+ * egress surface to `*.freshdesk.com` by construction.
+ */
+export const FRESHDESK_SUBDOMAIN_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/** The API base for a Freshdesk subdomain. `subdomain` MUST be pre-validated. */
+export function freshdeskHostFor(subdomain: string): string {
+  return `https://${subdomain}.freshdesk.com`;
+}
+
+/** The non-secret config persisted on each per-category `workspace_plugins` row. */
+export interface FreshdeskCollectionConfig {
+  /** The account subdomain the install enumerated categories from. */
+  readonly subdomain: string;
+  /** The Solutions category this collection mirrors (stringified numeric id). */
+  readonly category_id: string;
+  /** Human category name, for the admin surface + provenance `product`. */
+  readonly category_name: string;
+  readonly description?: string;
+}
+
+export type ParsedFreshdeskConfig =
+  | {
+      readonly ok: true;
+      readonly subdomain: string;
+      readonly categoryId: string;
+      readonly categoryName: string;
+    }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Parse a stored install config back into the connector's inputs. Actionable,
+ * admin-facing errors (they land in `knowledge_sync_state.error`) — a missing
+ * field means someone edited the row out of band; re-installing repairs it.
+ */
+export function parseFreshdeskConfig(
+  config: Record<string, unknown> | null,
+): ParsedFreshdeskConfig {
+  const subdomain =
+    typeof config?.subdomain === "string" ? config.subdomain.trim().toLowerCase() : "";
+  const categoryId = typeof config?.category_id === "string" ? config.category_id.trim() : "";
+  const categoryName =
+    typeof config?.category_name === "string" ? config.category_name.trim() : "";
+  if (subdomain === "" || !FRESHDESK_SUBDOMAIN_PATTERN.test(subdomain)) {
+    return {
+      ok: false,
+      error: "Collection has no valid Freshdesk subdomain configured — re-install it.",
+    };
+  }
+  if (categoryId === "") {
+    return {
+      ok: false,
+      error: "Collection has no Freshdesk Solutions category configured — re-install it.",
+    };
+  }
+  return { ok: true, subdomain, categoryId, categoryName };
+}

--- a/packages/api/src/lib/knowledge/freshdesk/connector.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/connector.ts
@@ -1,0 +1,85 @@
+/**
+ * The Freshdesk Solutions {@link KnowledgeSyncConnector} (#4401, PRD #4395) —
+ * the catalog-id-keyed adapter the sync cycle dispatches on. It owns only the
+ * factory contract from ADR-0030: bind the stored per-category config + the
+ * decrypted API key into a vendor client. Scheduling, backoff, reconciliation,
+ * caps, and ingest are the shared engine's.
+ *
+ * One Freshdesk install fans out to one collection PER SOLUTIONS CATEGORY (the
+ * install handler's job); each collection row carries its category id, so this
+ * factory builds a client scoped to exactly one category's folder→article tree.
+ *
+ * `createClient` is where a bad/missing/undecryptable credential becomes an
+ * actionable error surfaced on `/admin/knowledge`: `readSyncCredential` THROWS
+ * on a decrypt failure (a rotated key, corrupt ciphertext) — loud, never a
+ * silent unauthenticated fetch — and a missing row is a clear "re-install"
+ * message.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readSyncCredential } from "../sync-credentials";
+import {
+  getKnowledgeSyncConnector,
+  registerKnowledgeSyncConnector,
+  type ConnectorInstallContext,
+  type ConnectorVendorClient,
+  type KnowledgeSyncConnector,
+} from "../connectors";
+import { createFreshdeskVendorClient, type FreshdeskClientDeps } from "./client";
+import { FRESHDESK_CATALOG_ID, FRESHDESK_VENDOR, parseFreshdeskConfig } from "./config";
+
+const log = createLogger("knowledge.freshdesk.connector");
+
+export interface FreshdeskConnectorDeps {
+  /** Injected fetch for tests — threaded into the vendor client. */
+  readonly clientDeps?: FreshdeskClientDeps;
+}
+
+/** Build the Freshdesk connector. `deps` is test-only vendor-client injection. */
+export function createFreshdeskConnector(
+  deps: FreshdeskConnectorDeps = {},
+): KnowledgeSyncConnector {
+  return {
+    catalogId: FRESHDESK_CATALOG_ID,
+    vendor: FRESHDESK_VENDOR,
+    async createClient(ctx: ConnectorInstallContext): Promise<ConnectorVendorClient> {
+      const parsed = parseFreshdeskConfig(ctx.config);
+      if (!parsed.ok) throw new Error(parsed.error);
+
+      // Decrypt failure THROWS here (loud) — the engine turns it into the
+      // collection's error outcome, never a silent unauthenticated fetch.
+      const apiKey = await readSyncCredential(ctx.workspaceId, ctx.collectionSlug);
+      if (apiKey === null) {
+        throw new Error(
+          "This Freshdesk collection has no stored API key — re-install it to re-enter the key.",
+        );
+      }
+
+      return createFreshdeskVendorClient(
+        {
+          subdomain: parsed.subdomain,
+          categoryId: parsed.categoryId,
+          categoryName: parsed.categoryName,
+          apiKey,
+          collectionSlug: ctx.collectionSlug,
+        },
+        deps.clientDeps ?? {},
+      );
+    },
+  };
+}
+
+/**
+ * Register the Freshdesk connector idempotently — called from the boot seam
+ * that also registers install handlers (`registerBuiltinInstallHandlers`), and
+ * from tests. `registerKnowledgeSyncConnector` throws on a duplicate catalog
+ * id, so gate on the registry first.
+ */
+export function registerFreshdeskKnowledgeConnector(): void {
+  if (getKnowledgeSyncConnector(FRESHDESK_CATALOG_ID) !== undefined) return;
+  registerKnowledgeSyncConnector(createFreshdeskConnector());
+  log.info(
+    { catalogId: FRESHDESK_CATALOG_ID },
+    "Registered Freshdesk knowledge sync connector",
+  );
+}

--- a/packages/api/src/lib/knowledge/freshdesk/documents.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/documents.ts
@@ -1,0 +1,142 @@
+/**
+ * Freshdesk article-locale → OKF `ConnectorDocument` assembly (#4401,
+ * PRD #4395).
+ *
+ * Pure, deterministic glue between the SHARED support HTML→markdown converter
+ * (`../support/html-to-markdown.ts` — this vendor deliberately owns no
+ * HTML→md logic of its own) and the connector ingest seam. Each PUBLISHED
+ * language variant of an article is a distinct document (the PRD's "per-language
+ * translations are distinct documents"); draft articles (`status !== 2`) are
+ * never emitted, so an unpublish/delete reads as "path absent" and the
+ * reconciliation crawl archives it.
+ *
+ * Paths are `<locale>/<title-slug>-<article-id>.md` — locale + article id make
+ * them collision-free by construction (two language variants never share both),
+ * and the id suffix means a basename can never be a reserved OKF name — the
+ * `deriveArchivePath` fold still runs as defence in depth. A title rename reads
+ * as "old path archived + new path drafted", the documented rename-churn
+ * posture (same as Zendesk/Front).
+ *
+ * Provenance that survives ingest: `resource` = the article's canonical
+ * help-center URL, `timestamp` = its `updated_at`, plus an `atlas:` extension
+ * block carrying connector + product (category) + category id + article id +
+ * locale + updated_at (the AC's provenance fields). No provenance `tags`:
+ * `tags` is a mirrored column in the lenient parser's change comparison, so
+ * stamping one would re-draft every already-ingested document; the extension
+ * block stays outside the comparison (the Zendesk/Front posture).
+ */
+
+import {
+  deriveArchivePath,
+  normalizePrefix,
+  renderOkfDocument,
+  isContentlessBody,
+  ATLAS_EXTENSION_KEY,
+} from "@atlas/okf-bundle";
+import type { ConnectorDocument } from "../connectors";
+import {
+  convertSupportHtmlToMarkdown,
+  type HtmlDegradation,
+} from "../support/html-to-markdown";
+import { FRESHDESK_VENDOR } from "./config";
+
+/** One PUBLISHED language variant of an article, ready to convert. */
+export interface FreshdeskArticleLocale {
+  /** Stable Freshdesk article id (shared across its language variants). */
+  readonly articleId: string;
+  /** The Solutions category this article belongs to (its numeric id). */
+  readonly categoryId: string;
+  /** Human category name — the provenance `product` label. */
+  readonly categoryName: string;
+  /** Article language, e.g. `en` or `fr` (normalized lowercase). */
+  readonly locale: string;
+  readonly title: string;
+  /** The article's HTML body (`description`). */
+  readonly bodyHtml: string;
+  /** Canonical ISO instant (`toIsoInstant`) — never the raw vendor string. */
+  readonly updatedAt: string;
+  /** The article's own URL, or a canonical help-center path when it omits one. */
+  readonly url: string;
+}
+
+export interface FreshdeskAssembleResult {
+  readonly documents: readonly ConnectorDocument[];
+  /** Media degradations aggregated across every assembled article. */
+  readonly degradations: readonly HtmlDegradation[];
+  /** Articles skipped because they carried no ingestable prose. */
+  readonly skippedContentless: number;
+}
+
+/** Slugify a title into a single path segment; `fallback` guarantees non-empty. */
+export function slugifyTitle(title: string, fallback: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug === "" ? fallback : slug;
+}
+
+/**
+ * Assemble collected OKF documents from a set of fetched article locales.
+ * `categoryName`/`categoryId` land in the `atlas:` provenance block (the AC's
+ * "provenance carries product + article id + locale + updated_at").
+ */
+export function assembleFreshdeskDocuments(
+  articles: readonly FreshdeskArticleLocale[],
+  options: { readonly collectionSlug: string },
+): FreshdeskAssembleResult {
+  const prefixSegments = normalizePrefix(options.collectionSlug);
+  const documents: ConnectorDocument[] = [];
+  const degradationTotals = new Map<string, number>();
+  let skippedContentless = 0;
+
+  for (const a of articles) {
+    const { markdown, degradations } = convertSupportHtmlToMarkdown(a.bodyHtml, {
+      pageUrl: a.url,
+    });
+    for (const d of degradations) {
+      degradationTotals.set(d.name, (degradationTotals.get(d.name) ?? 0) + d.count);
+    }
+    if (isContentlessBody(markdown)) {
+      skippedContentless++;
+      continue;
+    }
+
+    const segments = [
+      slugifyTitle(a.locale, "locale"),
+      `${slugifyTitle(a.title, "article")}-${a.articleId}`,
+    ];
+    const derived = deriveArchivePath(`${segments.join("/")}.md`);
+    const path = [...prefixSegments, derived.path].join("/");
+
+    const title = a.title.trim();
+    const content = renderOkfDocument(
+      {
+        ...(title !== "" ? { title } : {}),
+        resource: a.url,
+        timestamp: a.updatedAt,
+      },
+      [],
+      markdown,
+      {
+        key: ATLAS_EXTENSION_KEY,
+        fields: {
+          connector: FRESHDESK_VENDOR,
+          product: a.categoryName !== "" ? a.categoryName : a.categoryId,
+          category_id: a.categoryId,
+          article_id: a.articleId,
+          locale: a.locale,
+          updated_at: a.updatedAt,
+        },
+      },
+    );
+    documents.push({ path, content });
+  }
+
+  const degradations = [...degradationTotals.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
+
+  return { documents, degradations, skippedContentless };
+}

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -55,7 +55,7 @@ export interface KnowledgeDocumentCounts {
  * "Sync now". Only `bundle-sync` additionally exposes an `endpointUrl` /
  * `authScheme`; connector collections (`notion`, `confluence`,
  * `confluence-datacenter`, `gitbook`, `zendesk`, `salesforce-knowledge`,
- * `intercom`, `front`, `helpscout`) carry neither (their credential is a token — or, for
+ * `intercom`, `front`, `helpscout`, `freshdesk`) carry neither (their credential is a token — or, for
  * `salesforce-knowledge`, the reused OAuth install — not an endpoint).
  */
 export type KnowledgeCollectionSource =
@@ -69,7 +69,8 @@ export type KnowledgeCollectionSource =
   | "salesforce-knowledge"
   | "intercom"
   | "front"
-  | "helpscout";
+  | "helpscout"
+  | "freshdesk";
 
 /**
  * Bundle-endpoint auth schemes for `bundle-sync` collections — the one wire

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -665,7 +665,7 @@ const KnowledgeCollectionSyncStatusSchema = z.object({
 
 export const KnowledgeCollectionSchema = z.object({
   slug: z.string(),
-  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout"]),
+  source: z.enum(["upload", "bundle-sync", "notion", "confluence", "confluence-datacenter", "gitbook", "zendesk", "salesforce-knowledge", "intercom", "front", "helpscout", "freshdesk"]),
   description: z.string().nullable(),
   installedAt: z.string().nullable(),
   endpointUrl: z.string().nullable(),


### PR DESCRIPTION
## Summary

Slice of PRD #4395 on the ADR-0030 Knowledge Sync Connector spine. Adds a **Freshdesk Solutions** knowledge connector: API-key Basic install over `{subdomain}.freshdesk.com/api/v2`; one review-gated collection **per Solutions category**; per-language article translations as distinct documents; **delta-less reconciliation-diff** over a **category → folder → subfolder → article tree-walk** with an `updated_at` high-water mark and `status` (1=draft, 2=published) driving the published filter + archive-via-reconcile detection. Consumes the shared support HTML→markdown converter (#4396) — no per-vendor converter fork.

Closes #4401

### What it does (acceptance criteria)
- **API-key/Basic install; collection per category; secret encrypted, decrypt failures loud; host through egress guard.** API key routed to `knowledge_sync_credentials` (encrypted), never `workspace_plugins.config`; `readSyncCredential` throws loudly on decrypt failure. Hosts are composed from a validated `*.freshdesk.com` subdomain label (paste-a-URL reduced to the label) and pass through the SSRF egress guard at install and every fetch.
- **Tree-walk enumeration** (categories→folders→subfolders→articles, `sub_folders_count`-gated descent); **reconciliation-diff on `updated_at`**; `status=2` filters to published; deletes handled by the engine's subtractive reconcile; `articles_count` per folder drives a completeness check that holds archiving on a short walk.
- **Multi-language** via the `{language_code}` path segment (`/solutions/articles/{id}/{lang}`) as distinct documents; supported languages discovered from `/settings/helpdesk` (best-effort, single-language accounts pay nothing); provenance carries `product` (category) + `category_id` + `article_id` + `locale` + `updated_at`.
- **Plan-tiered rate limit + 429/`Retry-After`** honored (mapped to `ConnectorRateLimitError` → engine backoff); draft-only ingest (every synced article lands `draft`); publish-guard covered by the engine's non-upload-source rejection; pairing test (form handler + connector registered together); vendor client fully test-doubled.

Follows the merged Zendesk (#4396, subdomain host) and Front (#4400, delta-less multi-collection) siblings; same `KnowledgeSyncConnector` seam, config/connector/client/documents shape, install-handler pairing in `registerBuiltinInstallHandlers`, catalog seed row, `admin-knowledge.ts` source branch, `@useatlas/types` wire union + web schema mirror + OpenAPI regen.

## Test Plan

- [x] Unit tests added — vendor client (tree-walk, incremental since-filter, published filter, multi-language translations incl. independent-update + malformed-present, 429/auth/not-found mapping, ingest cap, category enumeration), connector factory (config parse, loud decrypt), documents assembly (paths, provenance, degradations), form handler (field validation, per-category fan-out, credential routing + rollback, SSRF-block → subdomain field), plus register/seed/admin-knowledge/lifecycle-pg additions.
- [x] All vendor client + install driven through an injected `fetchImpl` — **no live Freshdesk API**.

## Checklist

- [x] Types pass (`bun run type`)
- [x] Tests pass (freshdesk suite; full `bun run test` via local `/ci`)
- [x] Lint passes (`bun run lint`)
- [x] Internal review panel run (silent-failure / type-design / test-coverage / comment) — findings addressed
- [x] Labels: feature, area: api, area: docs (inherited from #4401)

https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aoubg2HaL1ihqnfXmzamjN)_