### PR TITLE
docs: second dashboard elevation grill — draft cache + canvas modes vocabulary, ADR-0034, grill outcomes

### DIFF
--- a/.claude/research/dashboards-audit-2026-07-10.md
+++ b/.claude/research/dashboards-audit-2026-07-10.md
@@ -379,4 +379,57 @@ walks this list):
 
 ---
 
-**Next: run `/grill-with-docs` with this doc.**
+## Grill outcomes (2026-07-10)
+
+The grill ran same-day and resolved the full agenda. Decisions (vocabulary
+pinned in `CONTEXT.md` § *Dashboard editing*; the two structural ones recorded
+in [ADR-0034](../../docs/adr/0034-dashboard-draft-cache-single-edit-mechanism.md)):
+
+1. **Draft data (Q1)** — both: the draft render/refresh path becomes reachable
+   for draft-only cards (the `getCard` 404 gate yields to draft resolution),
+   AND draft cards carry their own persisted cached data — the **draft cache**
+   (new glossary term). Draft executions never touch published cached data or
+   the Query Cache.
+2. **Exec timing (Q2)** — tool-side seed + lazy fallback: `createDashboard` /
+   bound `addCard` execute each staged card inside the tool call (concurrent,
+   wall-clock-budgeted, fail-soft per card), report per-card outcomes to the
+   agent, and anything unseeded falls back to a canvas-mount draft render.
+   Resolves M2 alongside C1.
+3. **View mode (Q3)** — View is strictly read-only for the definition:
+   Remove/Rename/Duplicate/drag move to Edit; View keeps refresh, fullscreen,
+   CSV, parameters. A browsing gesture must never fork a draft. (Verified
+   during the grill: View-mode mutations were already draft-routed —
+   `routes/dashboards.ts:2082-2093` — so M4's worst case was UX confusion, not
+   data loss.) New glossary term: **View / Edit (canvas modes)**.
+4. **Edit model (Q4)** — collapse into the draft; retire the stage tracker
+   (`dashboard_stage_changes`, two-phase drop). Destructive bound ops land in
+   the draft with inline undo. (Verified during the grill: publish merges the
+   draft only — pending stages were silently stranded, resolving this doc's
+   open question.) Reverses #2365; rationale in ADR-0034.
+5. **Card parity (Q5)** — parity via one shared card union: define the card
+   input union (chart | text, + layout) once in `@useatlas/schemas`; both
+   `createDashboard` and bound `addCard`/`updateCard` consume it.
+6. **Outward face (Q6)** — both link and embed: mirror the conversation embed
+   (`/shared/dashboard/:token/embed`, same any-origin frame-ancestors posture,
+   same token/DTO/revocation) + an Embed tab in the share dialog.
+7. **As-of promise (Q7)** — single as-of contract: all temporal framing on the
+   shared view (parameter chips, captions) derives from the shown data's
+   capture instant; "Captured {creation date}" retires. (#4538 is the
+   fix-invariant piece.)
+8. **Tool scoping (Q8)** — `createDashboard` gates by default to surfaces that
+   own a dashboards route; embed/SDK hosts opt in by supplying a dashboard-URL
+   resolver for the handoff link.
+9. **Creation origin (new, raised in-grill)** — the dashboards surface is a
+   first-class creation origin: "New dashboard" (switcher, empty state) lands
+   on the canvas with the **bound editor open**, and the empty-canvas copy
+   invites building there instead of bouncing to main chat
+   (`new-dashboard-dialog.tsx:104` routes without `?openChat=true`;
+   `page.tsx:1285-1287` points back to main chat). Main-chat `createDashboard`
+   stays as the second origin.
+
+H1's direction was already decided by the pinned Canvas contract
+(`CONTEXT.md`: the canvas "renders the caller's draft when they have one") —
+it's a conform-to-contract fix, not a design question.
+
+**Next: run `/to-prd` from this doc + grill outcomes; `/to-issues` folds in
+the four filed fix-invariant issues as sub-issues of the PRD.**

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -312,7 +312,11 @@ How a dashboard is edited and made visible to a team. **Target-state vocabulary*
 
 - **Draft**:
   The caller's private, per-user working copy of a dashboard. **Every** edit — direct manipulation (drag, rename, delete) and agent/chat edits alike — lands in the draft; it is invisible to teammates until **published**. One draft per (user, dashboard).
-  _Avoid_: conflating with the content-mode `draft` status enum (a dashboard row is not content-mode gated); "staged change" (that is the **stage tracker**'s pending-destructive-op concept, a step *inside* draft editing).
+  _Avoid_: conflating with the content-mode `draft` status enum (a dashboard row is not content-mode gated); "staged change" (the retired **stage tracker**'s pending-destructive-op concept — decided 2026-07-10: destructive bound-editor ops land directly in the draft like every other edit, with inline undo; there is no second pending-changes store, and publish can no longer strand an unaccepted change).
+
+- **Draft cache**:
+  A draft card's own cached data, private to the **draft** it lives in — pinned during the second dashboard elevation grill (2026-07-10). Executing a card while holding a draft (refresh, parameter change, retry, first load of a never-published card) reads and writes the draft cache, never the **published** card's cached data and never the **Query Cache**. Every tile affordance — refresh, staleness, age, retry — works identically whether the card's data comes from the draft cache or the published cached data; a draft-only card is fully operable before **first publish**.
+  _Avoid_: "the cache" unqualified on the dashboard surface (three distinct stores: draft cache, published cached data, Query Cache); treating a draft-only card as un-runnable until publish (the 404-until-published behavior is the defect this term retires).
 
 - **Published**:
   The shared, org-visible state of a dashboard — the card set + metadata that teammates and shared links see. The merge target of **publish**.
@@ -327,8 +331,12 @@ How a dashboard is edited and made visible to a team. **Target-state vocabulary*
   _Avoid_: "save" (editing continuously auto-persists to the draft; publish is the *promotion*, not the save).
 
 - **Bound editor**:
-  The dashboard-scoped chat drawer through which the agent builds and edits a dashboard. Its edits land in the caller's **draft**; the **canvas** — cards materializing and updating live — is the turn's **answer-bearing artifact**, so the drawer shows conversation + a collapsed **receipt** (per *Chat turn presentation*), not inline card previews.
+  The dashboard-scoped chat drawer through which the agent builds and edits a dashboard. Its edits land in the caller's **draft**; the **canvas** — cards materializing and updating live — is the turn's **answer-bearing artifact**, so the drawer shows conversation + a collapsed **receipt** (per *Chat turn presentation*), not inline card previews. It is also the dashboards surface's own **creation instrument** (pinned 2026-07-10): creating a dashboard from the surface opens the bound editor on the empty canvas — the surface is a first-class creation origin, not a viewer that bounces new users back to main chat.
   _Avoid_: "bound chat" for the surface (say bound editor); rendering the build as full-weight inline tool cards (that is the divergent pre-convergence renderer being retired).
+
+- **View / Edit (canvas modes)**:
+  The two interaction modes of the **canvas**, pinned 2026-07-10: **View** is strictly read-only for the dashboard's *definition* — it offers only non-mutating affordances (refresh, fullscreen, CSV export, parameter/filter changes) and can never fork or touch a **draft**; **Edit** is where every definition mutation (remove, rename, duplicate, drag, SQL/config change) lives, all landing in the caller's draft. A browsing gesture must never create a draft.
+  _Avoid_: exposing mutating tile controls in View (the pre-2026-07-10 defect); "read-only" to mean no-refresh (refreshing data is a View affordance — read-only gates the *definition*, not the data's freshness).
 
 - **Tile**:
   The rendered presentation of a single **card** on the **canvas**, and the **unit of trust**: a tile carries its own status — loading, fresh, **stale**, errored, empty, not-filtered — surfaced *on the tile*, rather than deferring failures to a page-level banner.
@@ -340,13 +348,15 @@ How a dashboard is edited and made visible to a team. **Target-state vocabulary*
 
 - **Shared view**:
   The read-only, **data-only snapshot presentation** of a **published** dashboard reached through a share token. Exposes title/description + per-card title/kind/chart-config/annotations/cached data/layout — and *nothing else*. Never the raw SQL, connection/owner/org identifiers, refresh cron, or parameter definitions. Uniform across **public** (no-auth) and **org** (authenticated-teammate) share modes.
-  _Avoid_: treating the shared view as a live or inspectable dashboard (query inspection happens in-app, where auth gates it); "public dashboard" (the *dashboard* isn't public — a *token* grants snapshot access).
+  Reached as a standalone page or as an **embed** (an iframe-framable presentation of the same shared view — decided 2026-07-10, mirroring the conversation embed): same token, same snapshot, same revocation/expiry; the embed is a frame around the shared view, never a second sharing surface.
+  _Avoid_: treating the shared view as a live or inspectable dashboard (query inspection happens in-app, where auth gates it); "public dashboard" (the *dashboard* isn't public — a *token* grants snapshot access); modeling the embed as a new access mode (the token is the access control, framed or not).
 
 ### Anti-confusions
 
 - The **draft** is a per-user *working copy*, not a content-mode visibility tier. Two editors have two independent drafts of the same published dashboard; publish merges, never overwrites (except last-writer-wins on title/description).
 - **Publish** is not **refresh**. Publish promotes *definitions* (SQL, layout, config); refresh re-executes a card's SQL to update its *cached data*. A publish that changes SQL must trigger a refresh or the **shared view** shows new definitions over stale data.
 - The **shared view** is data-only by construction, not by redaction-after-the-fact — the public projection is built from a minimal DTO, so a field can't leak by being forgotten. Raw SQL never reaches the wire on this surface.
+- The **shared view** has a single **as-of** instant (decided 2026-07-10): every piece of temporal framing a share viewer sees — parameter chips, "data as of" captions — derives from the shown data's capture instant, never from view time or dashboard creation time. When a refresh updates the rows, all framing moves with them; the page can never contradict itself about what window the numbers cover.
 
 ## MCP & agent governance
 

--- a/docs/adr/0029-dashboards-draft-first-editing.md
+++ b/docs/adr/0029-dashboards-draft-first-editing.md
@@ -1,5 +1,9 @@
 # Dashboards use a draft-first, publish-gated editing model
 
+> Amended by [ADR-0034](./0034-dashboard-draft-cache-single-edit-mechanism.md)
+> (2026-07-10): draft cards carry their own cached data (the *draft cache*),
+> and the stage tracker retires — the draft is the only edit mechanism.
+
 Every edit to a dashboard — direct manipulation (drag, rename, delete) *and*
 agent/chat edits alike — lands in the caller's private per-user **draft**; the
 **canvas** renders that draft while editing; **publish** is the single gated

--- a/docs/adr/0034-dashboard-draft-cache-single-edit-mechanism.md
+++ b/docs/adr/0034-dashboard-draft-cache-single-edit-mechanism.md
@@ -1,0 +1,65 @@
+# Draft cards carry their own cached data; the draft is the only edit mechanism
+
+Status: accepted (2026-07-10, second dashboard elevation grill — amends
+[ADR-0029](./0029-dashboards-draft-first-editing.md))
+
+The first elevation cycle (ADR-0029) made every dashboard edit land in a
+private per-user **draft**, but left two gaps the second audit
+(`.claude/research/dashboards-audit-2026-07-10.md`) surfaced: a draft-only
+(never-published) card had **no data home** — render/refresh 404'd on the
+published-table lookup, so an agent-built board was a grid of "Never run"
+tiles that only publishing could populate — and destructive bound-editor ops
+lived in a **second store** (`dashboard_stage_changes` accept/discard ghosts,
+#2365) that publish silently ignored. We decided both gaps close the same
+way: **the draft is the one home for private work — its data and its edits.**
+
+## Decision 1 — the draft cache
+
+A draft card carries its **own cached data** (the *draft cache*, see
+`CONTEXT.md` § Dashboard editing). Executing a card while holding a draft —
+refresh, parameter change, retry, first load — reads and writes the draft
+cache, never the published card's cached data and never the shared Query
+Cache. The draft execution path is reachable for draft-only cards (the
+published-card 404 gate yields to the draft resolution when the caller views
+their draft). Seeding: `createDashboard` / bound `addCard` execute each staged
+card **inside the tool call** (concurrent, wall-clock-budgeted, fail-soft per
+card) and report per-card outcomes to the agent, so it can self-correct
+instead of announcing a board with empty or broken cards; anything left
+unseeded falls back to a canvas-mount draft render.
+
+Rejected: **ephemeral-only draft execution** (every canvas mount re-runs every
+draft card's SQL — a 12-card board costs 12 queries per reload and tile
+age/staleness is meaningless); **cache-only without a reachable exec path**
+(fixes the empty canvas but refresh/params/retry stay dead until publish);
+**agent-step execution** (1+ step per card against the 25-step default budget
+risks exhaustion mid-build, and a prompt instruction enforces nothing).
+
+## Decision 2 — retire the stage tracker
+
+Destructive bound-editor ops (`removeCard`, `updateCardSql`) apply **directly
+to the caller's draft** like every other edit, with a lightweight inline undo,
+and `dashboard_stage_changes` retires (two-phase drop per migration
+discipline). This deliberately reverses #2365, which added the accept/discard
+gate **before** drafts were universally publish-gated. Now that every edit is
+private, reversible, and diffed at publish, the per-op accept gate duplicated
+the draft's own review mechanism at the cost of a second mental model — and a
+real trap: publish merges the draft only, so a staged-but-unaccepted change
+was silently stranded.
+
+Rejected: **keeping both stores with a legible seam** (publish warns on
+pending stages) — it preserves a permanent two-model tax to defend a safety
+property the draft already provides; **staging everything** (every agent op
+becomes a proposal) — it fights the live-materializing canvas the bound editor
+is built on.
+
+## Consequences
+
+- The draft snapshot card gains data fields; per-user drafts grow by their
+  cached rows (the abandoned-draft sweep already bounds retention).
+- Draft results never touch the published cached data or the Query Cache —
+  the privacy invariant ADR-0029 stated is now held by construction, since
+  draft executions have their own home.
+- Tile trust semantics (age, stale, errored, empty, never-run) apply
+  uniformly to draft and published data.
+- `dashboard_stage_changes` drops via the two-phase discipline; the bound
+  editor's accept/discard UI and ghost overlays retire with it.


### PR DESCRIPTION
## Summary

Documentation output of the 2026-07-10 second dashboard elevation grill (the `/elevate` → `/grill-with-docs` pass behind PRD #4553):

- **`CONTEXT.md` § Dashboard editing** — pins the grill's vocabulary: **Draft cache** (a draft card's own cached data, private to the draft), **View / Edit (canvas modes)** (View strictly read-only for the definition; a browsing gesture never forks a draft), the bound editor as the surface's **creation instrument**, the embed as a frame around the **Shared view** (never a second sharing surface), and the single **as-of** instant for shared-view temporal framing. The stage-tracker "staged change" concept is marked retired.
- **`docs/adr/0034-dashboard-draft-cache-single-edit-mechanism.md`** (new, amends ADR-0029) — records the two structural decisions: draft cards carry their own cached data (seeded tool-side at build, lazy render fallback), and the stage tracker retires (destructive bound ops land in the draft with inline undo; reverses #2365; `dashboard_stage_changes` drops two-phase). ADR-0029 gains an amendment pointer.
- **`.claude/research/dashboards-audit-2026-07-10.md`** — gains a *Grill outcomes* section recording all nine decisions and resolving two of the audit's open questions from code (publish ignores pending stages; View-mode tile mutations were already draft-routed), handing off to `/to-prd`.

Docs-only; no product code changes. The 14 implementation slices (#4554–#4567) and PRD #4553 reference these documents.

## Test Plan

- [x] Docs-only change — no runtime surface; CI gates (type/lint/tests) validate nothing regressed

## Checklist

- [ ] Types pass (`bun run type`)
- [ ] Tests pass (`bun run test`)
- [ ] Lint passes (`bun run lint`)
- [x] Labels added (type + area)

https://claude.ai/code/session_01J7WCmo3DtLVnto6fBx53UB

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WCmo3DtLVnto6fBx53UB)_