### PR TITLE
docs: learned-patterns elevation grill — CONTEXT.md vocabulary + grill outcomes

### DIFF
--- a/.claude/research/learned-patterns-audit-2026-07-10.md
+++ b/.claude/research/learned-patterns-audit-2026-07-10.md
@@ -6,6 +6,7 @@
 - **Live product:** NOT available for this run (no Docker/Postgres in the audit environment) — the UX dimension is code-reading only, no screenshots. Every finding stands on `file:line` anchors instead.
 - **Anchor findings hand-verified by the orchestrator** (re-read at the cited lines): the `getApprovedPatterns` type-filter + NULL-org gaps (H1), the amendment sentinel `pattern_sql` + approved-status write, the `getRelevantPatterns` 0.7 confidence gate (H3), the missing `admin:semantic` permission gate (H2a), the NULL-org clause asymmetry vs `reviewSemanticAmendment`, and the absence of `logAdminAction` in the bulk handler (H2c). These carry `verified`.
 - **Issue filed this pass (fix-invariant only):** **#4534** — `getApprovedPatterns` injects non-query-pattern and NULL-org rows into agent context. One issue; everything else carries a design question the grill must settle and stays in this doc.
+- **Filed during the grill (2026-07-10):** **#4569** — fold amendments out of the learned-patterns route (query_pattern-only); settles H2 per grill Q2 decision (option a), lands as an unlisted #4502 slice in milestone v0.0.47, sub-issue of the PRD. Resolves H2a/H2b/H2d/H2e for amendment rows, M7's conflation, and M9; H2f dissolves via #4534's `type` filter. The query_pattern half of H2c (bulk audit rows) remains this elevation's scope.
 
 ## Scope boundary — this is NOT the amendment elevation
 

--- a/.claude/research/learned-patterns-audit-2026-07-10.md
+++ b/.claude/research/learned-patterns-audit-2026-07-10.md
@@ -147,7 +147,24 @@ The design questions the findings force, for the `/grill-with-docs` session. Phr
 
 ---
 
-## Handoff
+## Grill outcomes (2026-07-10)
+
+The grill session walked the full agenda; vocabulary pinned in **CONTEXT.md § Learned query patterns**. Decisions, in agenda order:
+
+1. **Coexistence with #4502 (agenda 2, H2):** amendments **fold out** — the learned-patterns route/page become strictly `type='query_pattern'`; #4502's decide seam is the only amendment door. Filed as **#4569** (milestone v0.0.47, sub-issue of PRD #4502). H2f dissolves via #4534's `type` filter (amendment flips stop affecting the pattern cache). The query_pattern half of H2c (bulk audit rows) remains this elevation's scope.
+2. **Approve semantics (agenda 1, H3):** approval = **injection-eligibility bypass** — human-approved patterns skip the confidence gate; confidence is never written by human decisions (stays the machine evidence meter). The bypass must reach the SQL pre-cut, not just the in-memory filter.
+3. **SaaS lifecycle (agenda 3, M3):** auto-promotion becomes a **workspace-scoped, per-workspace opt-in settings-registry knob, off by default** — same SaaS-first posture as #4502's scheduler; the env-only platform knob retires. M6 discoverability (badge, explainer) is a complement, not an alternative.
+4. **Efficacy (agenda 4, M1):** **attribution substrate only** — record which pattern IDs entered which turn; surface per-pattern injection counts in the cockpit. Crediting adapted SQL to its source and demotion signals are explicitly deferred (PRD Out of Scope) until attribution data exists.
+5. **Identity (agenda 5, M4 + L1):** DB-enforced — partial unique index on (org, group, normalized fingerprint) over `type='query_pattern'`, inserts via `ON CONFLICT` increment (NULL handling via `NULLS NOT DISTINCT`/coalesced expressions — slice detail). Seen-once rows persist but sit below the default review queue and all promotion gates.
+6. **Cockpit trust floor (agenda 6, H4/H5/L10/M6/M7/M8/L8/L9):** sort gets **implemented** (whitelisted API `sort` param), not removed; confidence-range filter exposed; in-sheet/toast mutation errors + "Dismiss" relabel; nav pending badge + one-sentence approval explainer + injection counts; resolved reviewer names; `connectionGroupId` on the wire + group column for multi-group workspaces; `useAdminFetch`-idiom stats; keyboard-openable rows.
+7. **Wire contract (agenda 7, M5):** settled by repo convention, not a fork — `LearnedPattern*` moves to `@useatlas/schemas`, route imports it, page uses the validated `useServerDataTable` variant.
+8. **Retrieval (agenda 8, M2):** remove the arbitrary `LIMIT 100` pre-cut — fetch the full eligible set per (workspace, group) with a high safety cap, ordered human-approved-first → confidence → last-observed; keep in-memory scoring + cache. **FTS deferred**, adopted on evidence.
+
+No ADR: nothing here is hard-to-reverse in the ADR sense; the load-bearing semantics live in CONTEXT.md § Learned query patterns. Residual findings that ride slices without needing decisions: L2 (CHECK constraints ride the identity migration), L3 (SQL-fold pg-fixture test), L4 (candidate-cap ordering), L6 (audit description edits), L7 (conceptual docs guide + stale admin-console section), M10 (org-scope guard parity — joins #4502's shared clause helper/reader enumeration), L5 (document the two-pipeline split as intentional), L11/L12 (informational).
+
+**Next: `/to-prd`** — this section plus the ranked findings are the PRD's inputs; #4534, #4569 attach as sub-issues alongside the slices.
+
+## Handoff (pre-grill, superseded by the section above)
 
 **Next: run `/grill-with-docs` with this doc.** The findings are not purely presentational or page-scoped — the central questions (the payoff model, the #4502 coexistence, the SaaS lifecycle) are design decisions that need the user in the loop and that will update CONTEXT.md § Semantic improvement and possibly a new ADR. Do **not** `/revamp` this — the dead sort and hidden-error UX bugs (H4, H5) are real but they are the smallest part of the story.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -277,6 +277,9 @@ The capture-and-payoff loop through which SQL query shapes observed in live exec
 - **Injection** — the payoff act: eligible, relevant query patterns rendered into an agent turn's prompt. Every injection is **attributed** — which patterns entered which turn is recorded — so a pattern's usage is observable evidence, in the cockpit and for any future feedback design. Crediting adapted queries back to their source pattern, and demoting patterns on bad outcomes, are explicitly deferred until attribution data exists.
   _Avoid_: unattributed injection (an approval whose effect nobody can observe); inferring usefulness from confidence.
 
+- **Pattern identity** — what makes two observations the *same* query pattern: (workspace, connection group, normalized SQL fingerprint), enforced by the database. A repeat observation increments the existing pattern — it can never mint a second row. A seen-once pattern is captured but sits below the default review queue and below every promotion gate until it repeats.
+  _Avoid_: application-side read-then-insert as the only dedup; timestamp uniquifiers; a review queue full of seen-once noise.
+
 ## Chat turn presentation
 
 How one agent turn is presented in the chat transcript. A turn has two faces: the **activity** (everything the agent did on the way) and the **answer** (what the turn exists to deliver). Presentation is answer-first: the answer is the visually dominant element; activity is live while the agent works, then settles into a collapsed receipt. Vocabulary pinned by PRD #4292 (answer-first chat turn presentation); the receipt/promotion mechanics shipped with #4298 (finished turns, notebook convergence #4301) and #4300 (live working phase), so the present-tense descriptions below are shipped behavior — remaining #4292 slices (answer styles, editorial voice) note their own status.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -271,6 +271,9 @@ The capture-and-payoff loop through which SQL query shapes observed in live exec
 - **Confidence** — the machine's evidence meter for a query pattern, derived from observed repetition. It gates **machine** promotion and ranks retrieval; it is never written by human decisions and never encodes trust. Human approval and machine confidence are the two independent roads to injection eligibility.
   _Avoid_: reading confidence as correctness or human endorsement; any human action that mutates it.
 
+- **Auto-promotion** — the machine road to injection eligibility: a **workspace-scoped, per-workspace opt-in, off by default** — the same SaaS-first posture as autonomous improvement, with self-hosted's single workspace as the degenerate case. Capture is always-on everywhere (it is free and deterministic); auto-promotion is the workspace's one trust dial. Decay is its counterpart and never touches human approvals.
+  _Avoid_: a platform-scoped or env-only promotion switch (a tenant-behavior knob belongs in the workspace settings registry); "the loop is self-maintaining" on a workspace that hasn't opted in.
+
 ## Chat turn presentation
 
 How one agent turn is presented in the chat transcript. A turn has two faces: the **activity** (everything the agent did on the way) and the **answer** (what the turn exists to deliver). Presentation is answer-first: the answer is the visually dominant element; activity is live while the agent works, then settles into a collapsed receipt. Vocabulary pinned by PRD #4292 (answer-first chat turn presentation); the receipt/promotion mechanics shipped with #4298 (finished turns, notebook convergence #4301) and #4300 (live working phase), so the present-tense descriptions below are shipped behavior — remaining #4292 slices (answer styles, editorial voice) note their own status.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -258,6 +258,19 @@ The review loop through which AI-proposed changes to the semantic layer become r
 
 - **An Amendment has exactly one workspace owner.** Every path that creates one stamps the workspace it belongs to; a NULL-owner row is legacy self-hosted data — tolerated on read there, never produced anew anywhere.
 
+## Learned query patterns
+
+The capture-and-payoff loop through which SQL query shapes observed in live execution become reusable knowledge for the agent: successful queries are captured as pending patterns, promotion (human or machine) makes them injectable, and relevant approved patterns are injected into future agent prompts. Vocabulary pinned by the learned-patterns elevation grill (2026-07-10, audit `.claude/research/learned-patterns-audit-2026-07-10.md`).
+
+- **Query pattern** — the durable unit of learned query knowledge: a normalized SQL shape captured from a successful live execution, scoped to one workspace and one connection group. Lifecycle `pending → approved | rejected`. The learned-patterns surface shows query patterns **only** — Amendments are a different concept that historically shares the storage table, reviewed exclusively on the improve surface (#4569).
+  _Avoid_: "learned pattern" and "query pattern" as different things (one concept; "learned" describes how it was born); treating an Amendment as a kind of pattern or vice versa.
+
+- **Approval (of a query pattern)** — a human grant of **injection eligibility**: "this pattern is correct — inject it whenever it's relevant." An approved-by-human pattern is always eligible regardless of confidence; relevance still decides which eligible patterns enter a given turn. Approval never rewrites confidence.
+  _Avoid_: stamping a floor confidence on approve (overloads the evidence meter with a trust signal); an approval whose effect the admin cannot observe.
+
+- **Confidence** — the machine's evidence meter for a query pattern, derived from observed repetition. It gates **machine** promotion and ranks retrieval; it is never written by human decisions and never encodes trust. Human approval and machine confidence are the two independent roads to injection eligibility.
+  _Avoid_: reading confidence as correctness or human endorsement; any human action that mutates it.
+
 ## Chat turn presentation
 
 How one agent turn is presented in the chat transcript. A turn has two faces: the **activity** (everything the agent did on the way) and the **answer** (what the turn exists to deliver). Presentation is answer-first: the answer is the visually dominant element; activity is live while the agent works, then settles into a collapsed receipt. Vocabulary pinned by PRD #4292 (answer-first chat turn presentation); the receipt/promotion mechanics shipped with #4298 (finished turns, notebook convergence #4301) and #4300 (live working phase), so the present-tense descriptions below are shipped behavior — remaining #4292 slices (answer styles, editorial voice) note their own status.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -280,6 +280,9 @@ The capture-and-payoff loop through which SQL query shapes observed in live exec
 - **Pattern identity** — what makes two observations the *same* query pattern: (workspace, connection group, normalized SQL fingerprint), enforced by the database. A repeat observation increments the existing pattern — it can never mint a second row. A seen-once pattern is captured but sits below the default review queue and below every promotion gate until it repeats.
   _Avoid_: application-side read-then-insert as the only dedup; timestamp uniquifiers; a review queue full of seen-once noise.
 
+- **Eligible set** — the workspace-and-group's injectable patterns, from which relevance picks per turn: every human-approved pattern unconditionally, plus machine-promoted patterns by confidence. Ordered human-approved first (they never fall off any cap), then confidence, then last-observed as the saturation tiebreak. Full-text retrieval is the recorded scaling exit, adopted on evidence (library size, attribution showing relevant-but-unfetched misses), not preemptively.
+  _Avoid_: any pre-relevance truncation that can drop a human-approved pattern; an unspecified order among confidence ties.
+
 ## Chat turn presentation
 
 How one agent turn is presented in the chat transcript. A turn has two faces: the **activity** (everything the agent did on the way) and the **answer** (what the turn exists to deliver). Presentation is answer-first: the answer is the visually dominant element; activity is live while the agent works, then settles into a collapsed receipt. Vocabulary pinned by PRD #4292 (answer-first chat turn presentation); the receipt/promotion mechanics shipped with #4298 (finished turns, notebook convergence #4301) and #4300 (live working phase), so the present-tense descriptions below are shipped behavior — remaining #4292 slices (answer styles, editorial voice) note their own status.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -274,6 +274,9 @@ The capture-and-payoff loop through which SQL query shapes observed in live exec
 - **Auto-promotion** — the machine road to injection eligibility: a **workspace-scoped, per-workspace opt-in, off by default** — the same SaaS-first posture as autonomous improvement, with self-hosted's single workspace as the degenerate case. Capture is always-on everywhere (it is free and deterministic); auto-promotion is the workspace's one trust dial. Decay is its counterpart and never touches human approvals.
   _Avoid_: a platform-scoped or env-only promotion switch (a tenant-behavior knob belongs in the workspace settings registry); "the loop is self-maintaining" on a workspace that hasn't opted in.
 
+- **Injection** — the payoff act: eligible, relevant query patterns rendered into an agent turn's prompt. Every injection is **attributed** — which patterns entered which turn is recorded — so a pattern's usage is observable evidence, in the cockpit and for any future feedback design. Crediting adapted queries back to their source pattern, and demoting patterns on bad outcomes, are explicitly deferred until attribution data exists.
+  _Avoid_: unattributed injection (an approval whose effect nobody can observe); inferring usefulness from confidence.
+
 ## Chat turn presentation
 
 How one agent turn is presented in the chat transcript. A turn has two faces: the **activity** (everything the agent did on the way) and the **answer** (what the turn exists to deliver). Presentation is answer-first: the answer is the visually dominant element; activity is live while the agent works, then settles into a collapsed receipt. Vocabulary pinned by PRD #4292 (answer-first chat turn presentation); the receipt/promotion mechanics shipped with #4298 (finished turns, notebook convergence #4301) and #4300 (live working phase), so the present-tense descriptions below are shipped behavior — remaining #4292 slices (answer styles, editorial voice) note their own status.


### PR DESCRIPTION
## Summary

Documentation artifacts from the learned-patterns elevation grill session (2026-07-10):

- **CONTEXT.md** gains a new **§ Learned query patterns** glossary section pinning the vocabulary decided in the grill: Query pattern, Approval (injection-eligibility grant), Confidence (machine evidence meter), Auto-promotion (workspace-scoped, off-by-default dial), Injection (attributed), Pattern identity (DB-enforced), and Eligible set (human-approved-first ordering, FTS as the evidence-triggered scaling exit).
- **`.claude/research/learned-patterns-audit-2026-07-10.md`** gains a **Grill outcomes** section recording all eight resolved agenda decisions (the `/to-prd` input), plus a header note for #4569 filed mid-grill.

Downstream artifacts produced from these decisions (not in this diff): PRD #4570 and its 14 slices #4571–#4584; #4569 in milestone v0.0.47.

Docs-only change — no product code touched.

## Test Plan

Not applicable — markdown documentation only (glossary + research notes). No runtime surface.

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`) — no TS touched
- [x] Tests pass (`bun run test`) — no code touched
- [x] Lint passes (`bun run lint`) — no lintable sources touched
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed (n/a)
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change) (n/a)

https://claude.ai/code/session_0149gBxKbjHnx8M2qKQbHLQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0149gBxKbjHnx8M2qKQbHLQJ)_