### PR TITLE
docs: notebook elevation grill — retire the notebook surface (ADR-0035)

### DIFF
--- a/.claude/research/notebook-audit-2026-07-10.md
+++ b/.claude/research/notebook-audit-2026-07-10.md
@@ -194,3 +194,9 @@ The findings force these design questions. Phrased as questions — the grill wa
 ## Handoff
 
 **Next: run `/grill-with-docs` with this doc.** The findings are not purely presentational and not page-scoped — they turn on load-bearing design decisions (the cell/document model, the share projection, the fork data model, save semantics), so the grill is warranted. Do not slice these into issues yet; `/to-issues` will cut different slices than the audit found, and the grill will settle the model first.
+
+---
+
+## Grill outcome (2026-07-10)
+
+The grill resolved the question *above* the agenda: **the notebook surface is retired** ([ADR-0035](../../docs/adr/0035-retire-the-notebook-surface.md)). Post ADR-0029/0034, dashboards own the agent-built shareable-artifact job; branching exploration is dropped with no successor; the memo/report deliverable is deferred to a future frozen-dashboard extension (vocabulary pinned in CONTEXT.md § Notebooks, retired). The seven agenda questions are therefore moot — the findings above stand as **evidence for the retirement**, not as a fix backlog. #4535 was closed as superseded by the retirement.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -300,7 +300,7 @@ How a dashboard is edited and made visible to a team. **Target-state vocabulary*
 
 - **Dashboard**:
   A persistent, shareable grid of **cards** with an optional top-level **parameter bar**. The unit that is created, shared, and published.
-  _Avoid_: "board" (informal only), "report" (a separate shared-conversation concept).
+  _Avoid_: "board" (informal only), "report" (a distinct point-in-time deliverable with no current home — see § Notebooks, retired).
 
 - **Card**:
   The unit on the grid. A **chart card** carries a SQL query + visualization; a **text card** carries markdown (section headers, explainers) and no data.
@@ -357,6 +357,18 @@ How a dashboard is edited and made visible to a team. **Target-state vocabulary*
 - **Publish** is not **refresh**. Publish promotes *definitions* (SQL, layout, config); refresh re-executes a card's SQL to update its *cached data*. A publish that changes SQL must trigger a refresh or the **shared view** shows new definitions over stale data.
 - The **shared view** is data-only by construction, not by redaction-after-the-fact — the public projection is built from a minimal DTO, so a field can't leak by being forgotten. Raw SQL never reaches the wire on this surface.
 - The **shared view** has a single **as-of** instant (decided 2026-07-10): every piece of temporal framing a share viewer sees — parameter chips, "data as of" captions — derives from the shown data's capture instant, never from view time or dashboard creation time. When a refresh updates the rows, all framing moves with them; the page can never contradict itself about what window the numbers cover.
+
+## Notebooks (retired)
+
+The notebook surface was retired on 2026-07-10 ([ADR-0035](./docs/adr/0035-retire-the-notebook-surface.md)), killed in the pre-customer window after its elevation audit. These terms are pinned so the words don't dangle.
+
+- **Notebook**:
+  Retired surface — a cell-based analysis document painted over a chat transcript. Nothing new is built on it: exploration lives in chat; persistent, shareable, agent-built artifacts are **dashboards**.
+  _Avoid_: proposing notebook features; branching/forking a conversation died with the surface, deliberately — it has no successor.
+
+- **Report**:
+  The point-in-time narrated analysis deliverable — linear prose interleaved with evidence, all written about one as-of instant (the *memo*, where a dashboard is the *monitor*). Has **no home in Atlas today**: deferred to a future dashboard extension whose price of admission is a frozen (never-refreshed, as-of-pinned) presentation, because prose cites numbers and refresh moves them out from under it.
+  _Avoid_: "report" for a dashboard, a shared view, or a shared chat transcript (the retired "Share as Report" misnomer — it shipped a raw transcript).
 
 ## MCP & agent governance
 

--- a/docs/adr/0035-retire-the-notebook-surface.md
+++ b/docs/adr/0035-retire-the-notebook-surface.md
@@ -1,0 +1,24 @@
+# Retire the notebook surface
+
+Status: accepted (2026-07-10, notebook elevation grill — audit: `.claude/research/notebook-audit-2026-07-10.md`)
+
+The notebook shipped as a cell-based curation layer painted over a chat transcript. Its elevation audit found that the curation was largely a display-only illusion — every CRITICAL (rerun truncation, fork-metadata erasure, share-ships-the-raw-transcript, deletes-that-don't-delete) was a variant of one root: the notebook projection and the persisted/shared truth had silently diverged. Fixing that class required committing to a real document/projection model. Meanwhile the two dashboard elevation cycles ([ADR-0029](./0029-dashboards-draft-first-editing.md), [ADR-0034](./0034-dashboard-draft-cache-single-edit-mechanism.md)) gave dashboards the notebook's headline job — agent-built, curated, shareable artifacts — on a sounder model (per-user draft, publish gate, data-only snapshot shared view, bound editor as a creation instrument).
+
+**We decided to kill the surface** rather than fix it, in the pre-customer clean-break window (CONTEXT.md § Deployment posture) — the cheapest moment we will ever have to delete a shipped surface.
+
+## Considered options
+
+- **Commit narrowly** — keep the notebook as the report-authoring surface and make the projection persisted and universally honored (every reader — loader, share, export — renders through it). Coherent, but it funds a third transcript surface whose remaining unique jobs didn't justify it (below).
+- **Fold into chat** — a light "curate & share" pass on chat instead of a surface. Rejected: it smuggles the same projection-vs-truth problem into chat and still kills forking.
+- **Kill** — chosen.
+
+## What the kill explicitly costs (accepted in the grill)
+
+1. **Branching exploration dies with no successor.** Fork/"what if" was the one job neither chat nor dashboards cover — and the audit showed it was already a data-loss trap (fork metadata erased by ordinary edits; dangling branch pointers; multi-level trees fragmenting). We are deleting a broken promise, not a working feature. If ever missed, it would be rebuilt on chat, not by resurrecting notebooks.
+2. **The memo deliverable has no home for now.** The point-in-time narrated analysis (linear prose interleaved with evidence — the *memo*, vs the dashboard's *monitor*) is deferred to a future dashboard extension. Its price of admission is a **frozen** presentation (as-of-pinned, refresh disabled): a dashboard's defining behavior is that data moves, a memo's is that it doesn't, and no tile-staleness badge rescues prose that cites a number a refresh just changed — prose isn't a tile. The dashboard shared view's data-only snapshot + single as-of instant already point in this direction.
+
+## Consequences
+
+- The removal deletes the notebook routes/components, the fork/branch endpoints and `branches` JSONB pointers, the chat→notebook conversion, the "Share as Report" path, and (two-phase, per migration discipline) the `notebook_state` column and `"notebook"` `Surface` value. The `partitionTurn` → `AssistantTurn`/`AgentTurn` render convergence (#4301) is chat's renderer and survives; the add-to-dashboard bridge survives wherever chat uses it.
+- The audit's findings stand as evidence for this decision, not as a fix backlog; the one filed issue (#4535, notebook↔dashboard association stripped on save) is closed as superseded.
+- The glossary's reserved "report — a separate shared-conversation concept" is retired and re-pinned as the deferred memo deliverable (CONTEXT.md § Notebooks, retired).

--- a/docs/adr/0035-retire-the-notebook-surface.md
+++ b/docs/adr/0035-retire-the-notebook-surface.md
@@ -19,6 +19,7 @@ The notebook shipped as a cell-based curation layer painted over a chat transcri
 
 ## Consequences
 
+- Existing notebook conversations (two internal workspaces only) are **converted to chat** (`surface: "web"`), preserving their message history — a deploy never silently destroys user-visible history, even in the clean-break window. Fork children become ordinary standalone chats (their " (fork)" titles are cosmetic); the branch pointers die with `notebook_state`.
 - The removal deletes the notebook routes/components, the fork/branch endpoints and `branches` JSONB pointers, the chat→notebook conversion, the "Share as Report" path, and (two-phase, per migration discipline) the `notebook_state` column and `"notebook"` `Surface` value. The `partitionTurn` → `AssistantTurn`/`AgentTurn` render convergence (#4301) is chat's renderer and survives; the add-to-dashboard bridge survives wherever chat uses it.
 - The audit's findings stand as evidence for this decision, not as a fix backlog; the one filed issue (#4535, notebook↔dashboard association stripped on save) is closed as superseded.
 - The glossary's reserved "report — a separate shared-conversation concept" is retired and re-pinned as the deferred memo deliverable (CONTEXT.md § Notebooks, retired).


### PR DESCRIPTION
## Summary

Grill outcome for the 2026-07-10 notebook elevation audit (`.claude/research/notebook-audit-2026-07-10.md`): **retire the notebook surface** rather than fix its projection model.

- **ADR-0035** (`docs/adr/0035-retire-the-notebook-surface.md`) — records the kill-vs-fold-vs-commit trade-off, the two explicitly accepted costs (branching dies with no successor; the memo/report deliverable is deferred to a future frozen-dashboard extension), the removal consequences, and the disposition of existing notebook conversations (convert to chat, preserving message history).
- **CONTEXT.md** — new *§ Notebooks (retired)* section pinning **Notebook** (retired) and **Report** (point-in-time memo vs the dashboard's monitor; no home today); repoints the dashboard entry's dangling `_Avoid: "report"` line.
- **Audit doc** — appends a *Grill outcome* section so its handoff line doesn't dangle; findings re-framed as evidence for retirement, not a fix backlog.

#4535 was closed as superseded by this decision (comment on the issue). The removal itself is follow-up work executed against ADR-0035 — this PR is docs only.

## Test Plan

Docs-only change — no runtime surface.

- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [x] Types pass (`bun run type`) — docs only
- [x] Tests pass (`bun run test`) — docs only
- [x] Lint passes (`bun run lint`) — docs only
- [ ] Deps consistent (`bun run deps:lint`) — if dependencies changed
- [x] Labels added (type + area)
- [ ] CHANGELOG.md updated (if user-facing change) — not user-facing

https://claude.ai/code/session_01YYDtTm3t6KFWUsSvUpnKmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYDtTm3t6KFWUsSvUpnKmR)_