### PR TITLE
semantic-improve: one Pending queue — remove the source swap, add conversation markers

### DIFF
--- a/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, it, expect } from "bun:test";
 import type { UIMessage } from "@ai-sdk/react";
-import { extractProposals } from "../proposals";
+import { extractProposals, buildProposalQueue, type Proposal } from "../proposals";
 
 // Build an assistant message carrying a single proposeAmendment tool part.
 // `output === undefined` models an in-flight call (no result yet).
@@ -150,5 +150,178 @@ describe("extractProposals", () => {
       assistantWithTool(baseInput, { proposalId: "amd-2", testResult: { success: true } }),
     ]);
     expect(bad[0]?.testResult).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProposalQueue — the one Pending queue (#4504)
+//
+// A live conversation must never hide pre-existing pending Amendments; the
+// approvable list is exactly the DB queue, the conversation only marks and
+// decorates. These tests pin the queue merge + markers at the pure seam.
+// ---------------------------------------------------------------------------
+
+function mkProposal(dbId: string, overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    index: 0,
+    entityName: "orders",
+    category: "",
+    amendmentType: "add_measure",
+    amendment: {},
+    rationale: "",
+    confidence: 0.8,
+    decision: null,
+    dbId,
+    ...overrides,
+  };
+}
+
+describe("buildProposalQueue", () => {
+  it("returns two empty lists for empty inputs (initial render)", () => {
+    const q = buildProposalQueue({ pending: [], conversation: [], decisions: new Map() });
+    expect(q).toEqual({ pending: [], recentlyDecided: [] });
+  });
+
+  it("renders the pending queue as-is when there is no conversation", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("a"), mkProposal("b")],
+      conversation: [],
+      decisions: new Map(),
+    });
+
+    expect(q.pending.map((p) => p.dbId)).toEqual(["a", "b"]);
+    expect(q.pending.every((p) => !p.fromConversation)).toBe(true);
+    expect(q.recentlyDecided).toEqual([]);
+  });
+
+  it("keeps pre-existing pending Amendments visible alongside conversation-created ones, marking and sorting the conversation row to the top", () => {
+    // "b" was proposed this conversation and has landed in /pending (post-refetch).
+    const q = buildProposalQueue({
+      pending: [mkProposal("a"), mkProposal("b")],
+      conversation: [mkProposal("b")],
+      decisions: new Map(),
+    });
+
+    // Conversation row sorts to the top; the pre-existing one stays visible.
+    expect(q.pending.map((p) => p.dbId)).toEqual(["b", "a"]);
+    expect(q.pending.find((p) => p.dbId === "b")?.fromConversation).toBe(true);
+    expect(q.pending.find((p) => p.dbId === "a")?.fromConversation).toBe(false);
+  });
+
+  it("sorts marked rows to the top in /pending order (not conversation order) and keeps each group's relative order", () => {
+    // a and c were created this conversation; the conversation array is in a
+    // different order than /pending to prove marked rows follow the DB queue's
+    // order, not the extraction order (the stable-sort contract #4504 relies on).
+    const q = buildProposalQueue({
+      pending: [mkProposal("a"), mkProposal("b"), mkProposal("c"), mkProposal("d")],
+      conversation: [mkProposal("c"), mkProposal("a")],
+      decisions: new Map(),
+    });
+
+    expect(q.pending.map((p) => p.dbId)).toEqual(["a", "c", "b", "d"]);
+    expect(q.pending.map((p) => p.fromConversation)).toEqual([true, true, false, false]);
+  });
+
+  it("treats the marker as presentation state, not a data source — a proposal not yet in /pending is not approvable until the refetch lands it", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("a")],
+      conversation: [mkProposal("b")], // just proposed; refetch pending
+      decisions: new Map(),
+    });
+
+    expect(q.pending.map((p) => p.dbId)).toEqual(["a"]);
+    expect(q.recentlyDecided).toEqual([]);
+  });
+
+  it("dedups by dbId — a conversation proposal already in /pending is marked once, not duplicated", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("b")],
+      conversation: [mkProposal("b")],
+      decisions: new Map(),
+    });
+
+    expect(q.pending).toHaveLength(1);
+    expect(q.pending[0]?.fromConversation).toBe(true);
+  });
+
+  it("keeps the pending badge and the panel in agreement — every approvable row is undecided", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("a"), mkProposal("b"), mkProposal("c")],
+      conversation: [mkProposal("b")],
+      decisions: new Map([["a", "accepted"]]),
+    });
+
+    // The rendered approvable list is exactly the undecided pending rows
+    // (the decided "a" dropped out), conversation-marked "b" sorted to the top.
+    expect(q.pending.every((p) => p.decision === null)).toBe(true);
+    expect(q.pending.map((p) => p.dbId)).toEqual(["b", "c"]);
+  });
+
+  it("moves a decided row out of the approvable queue into the recently-decided strip", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("a"), mkProposal("b")],
+      conversation: [],
+      decisions: new Map([["a", "accepted"]]), // admin just approved a
+    });
+
+    expect(q.pending.map((p) => p.dbId)).toEqual(["b"]);
+    expect(q.recentlyDecided.map((p) => ({ id: p.dbId, decision: p.decision }))).toEqual([
+      { id: "a", decision: "accepted" },
+    ]);
+  });
+
+  it("surfaces an auto-applied conversation proposal only in the recently-decided strip, never as approvable", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("a")], // pre-existing pending, untouched
+      conversation: [mkProposal("x", { decision: "applied" })], // auto-approved in-flow, never in /pending
+      decisions: new Map(),
+    });
+
+    expect(q.pending.map((p) => p.dbId)).toEqual(["a"]);
+    expect(
+      q.recentlyDecided.map((p) => ({ id: p.dbId, decision: p.decision, marked: p.fromConversation })),
+    ).toEqual([{ id: "x", decision: "applied", marked: true }]);
+  });
+
+  it("moves a locally-decided conversation row still in /pending to the strip, marked", () => {
+    const q = buildProposalQueue({
+      pending: [mkProposal("b")],
+      conversation: [mkProposal("b")],
+      decisions: new Map([["b", "rejected"]]),
+    });
+
+    expect(q.pending).toEqual([]);
+    expect(
+      q.recentlyDecided.map((p) => ({ id: p.dbId, decision: p.decision, marked: p.fromConversation })),
+    ).toEqual([{ id: "b", decision: "rejected", marked: true }]);
+  });
+
+  it("keeps a decided conversation row in the strip after the refetch drops it from /pending", () => {
+    // Steady state after approving a conversation-created row: the refetch has
+    // removed it from /pending, but it's still in the message stream and the
+    // session `decisions` map — it must linger in the strip, marked, never
+    // approvable (the literal AC4 "lingering display" case).
+    const q = buildProposalQueue({
+      pending: [],
+      conversation: [mkProposal("b")],
+      decisions: new Map([["b", "accepted"]]),
+    });
+
+    expect(q.pending).toEqual([]);
+    expect(
+      q.recentlyDecided.map((p) => ({ id: p.dbId, decision: p.decision, marked: p.fromConversation })),
+    ).toEqual([{ id: "b", decision: "accepted", marked: true }]);
+  });
+
+  it("ignores a stale decision whose row is in neither input — no phantom card", () => {
+    // After a refetch drops a decided pre-existing row, its id lingers in the
+    // session `decisions` map. It must not resurrect a card from nothing.
+    const q = buildProposalQueue({
+      pending: [],
+      conversation: [],
+      decisions: new Map([["ghost", "accepted"]]),
+    });
+
+    expect(q).toEqual({ pending: [], recentlyDecided: [] });
   });
 });

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, isToolUIPart, getToolName } from "ai";
-import { extractProposals, type Proposal, type TestResult } from "./proposals";
+import { extractProposals, buildProposalQueue, type Proposal, type QueueRow, type TestResult } from "./proposals";
 import { useAtlasConfig } from "@/ui/context";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -90,7 +90,7 @@ function ProposalCard({
   approving,
   rejecting,
 }: {
-  proposal: Proposal;
+  proposal: QueueRow;
   onApprove: () => void;
   onReject: () => void;
   approving: boolean;
@@ -114,6 +114,15 @@ function ProposalCard({
             <Badge variant="outline" className="text-[10px]">
               {proposal.amendmentType.replace(/_/g, " ")}
             </Badge>
+            {/* Presentation marker — this row was created in the live
+                conversation (#4504): a mark on the one-queue model, not a
+                parallel list. Also renders on the recently-decided strip. */}
+            {proposal.fromConversation && (
+              <Badge variant="secondary" className="gap-1 text-[10px]">
+                <Sparkles className="size-2.5" />
+                this conversation
+              </Badge>
+            )}
           </CardTitle>
           <div className="flex items-center gap-2">
             <span className={`text-xs font-medium ${confidenceColor}`}>
@@ -272,14 +281,28 @@ export default function SemanticImprovePage() {
     dbId: a.id,
   }));
 
-  // Extract proposals from current chat session messages
-  const chatProposals = extractProposals(messages).map((p) => ({
-    ...p,
-    decision: (p.dbId ? proposalDecisions.get(p.dbId) : undefined) ?? p.decision,
-  }));
+  // The live conversation's proposals — supply markers on the one Pending
+  // queue plus the already-decided rows in the strip below, never a second
+  // source of approvable rows (#4504).
+  const chatProposals = extractProposals(messages);
 
-  // Show chat proposals when a session is active, otherwise show DB pending
-  const proposals = chatProposals.length > 0 ? chatProposals : pendingAmendments;
+  // The one Pending queue: pre-existing pending Amendments and this
+  // conversation's rows together, conversation rows marked and sorted to the
+  // top. Decided/auto-applied rows drop to the presentation-only strip below.
+  const { pending: proposals, recentlyDecided } = buildProposalQueue({
+    pending: pendingAmendments,
+    conversation: chatProposals,
+    decisions: proposalDecisions,
+  });
+
+  // A new proposeAmendment result must surface in the queue: refetch /pending
+  // when the set of conversation-created rows changes. `refetchPending`
+  // (TanStack Query) is referentially stable, so this fires only on new rows,
+  // not every render.
+  const conversationIdsKey = chatProposals.map((p) => p.dbId ?? "").join(",");
+  useEffect(() => {
+    if (conversationIdsKey) void refetchPending();
+  }, [conversationIdsKey, refetchPending]);
 
   function handleSend() {
     if (!inputValue.trim() || isLoading) return;
@@ -475,7 +498,9 @@ export default function SemanticImprovePage() {
                   Proposals
                   {proposals.length > 0 && (
                     <span className="ml-2 text-muted-foreground font-normal">
-                      ({proposals.filter((p) => p.decision === null).length} pending)
+                      {/* Every row here is approvable, so this badge can never
+                          disagree with the rendered queue (#4504). */}
+                      ({proposals.length} pending)
                     </span>
                   )}
                 </h2>
@@ -484,14 +509,14 @@ export default function SemanticImprovePage() {
                 <div className="space-y-3">
                   <MutationErrorSurface error={pendingError} feature="Semantic Layer" onRetry={refetchPending} />
                   <MutationErrorSurface error={mutationError} feature="Semantic Layer" />
-                  {proposals.length === 0 && !pendingLoading && (
+                  {proposals.length === 0 && recentlyDecided.length === 0 && !pendingLoading && (
                     <div className="py-12 text-center text-xs text-muted-foreground">
                       {messages.length === 0
                         ? "No pending improvements. Run an analysis to identify opportunities."
                         : "Proposals will appear here as the agent identifies improvements."}
                     </div>
                   )}
-                  {pendingLoading && proposals.length === 0 && (
+                  {pendingLoading && proposals.length === 0 && recentlyDecided.length === 0 && (
                     <div className="flex items-center justify-center py-12 text-xs text-muted-foreground">
                       <Loader2 className="size-3 animate-spin mr-2" />
                       Loading pending amendments...
@@ -511,6 +536,27 @@ export default function SemanticImprovePage() {
                       />
                     );
                   })}
+
+                  {/* Recently decided — presentation-only. These rows are
+                      auto-applied or reviewed this session; they're not in the
+                      pending queue and are clearly not approvable (#4504). */}
+                  {recentlyDecided.length > 0 && (
+                    <div className="space-y-3 pt-2">
+                      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                        Recently decided
+                      </p>
+                      {recentlyDecided.map((proposal) => (
+                        <ProposalCard
+                          key={proposal.dbId ?? `decided-${proposal.index}`}
+                          proposal={proposal}
+                          onApprove={() => {}}
+                          onReject={() => {}}
+                          approving={false}
+                          rejecting={false}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </div>
               </ScrollArea>
             </div>

--- a/packages/web/src/app/admin/semantic/improve/proposals.ts
+++ b/packages/web/src/app/admin/semantic/improve/proposals.ts
@@ -113,3 +113,111 @@ export function extractProposals(messages: UIMessage[]): Proposal[] {
   }
   return proposals;
 }
+
+// ---------------------------------------------------------------------------
+// buildProposalQueue — the one Pending queue (#4504)
+//
+// The proposals panel renders a single data source: the org's Pending queue
+// (per CONTEXT.md). A live conversation must never hide pre-existing pending
+// Amendments — including ones the scheduler queued. So the approvable list is
+// exactly `/pending`; the conversation only supplies *markers* (which rows it
+// created, so they badge + sort to the top) and *decided rows* that never
+// entered the queue (an auto-approved amendment is already live). The marker is
+// presentation state, not a second data source — a proposal streamed this turn
+// becomes approvable only once the refetch lands it in `/pending`.
+// ---------------------------------------------------------------------------
+
+export interface QueueRow extends Proposal {
+  /**
+   * True when this row's `dbId` was created by a `proposeAmendment` in the live
+   * conversation. A presentation marker (badge + sort-to-top) only — the row's
+   * approvability comes solely from the pending queue.
+   */
+  fromConversation: boolean;
+}
+
+/**
+ * A queue row that is approvable. Approvable rows are undecided by construction,
+ * so `ProposalQueue.pending.length` is the pending badge and the two can never
+ * disagree (#4504) — the type, not just a runtime branch, holds that guarantee.
+ */
+export interface ApprovableRow extends QueueRow {
+  decision: null;
+}
+
+export interface ProposalQueue {
+  /**
+   * The approvable Pending queue, conversation-created rows sorted to the top.
+   * Its length is the pending badge; every row is `decision: null`.
+   */
+  pending: ApprovableRow[];
+  /**
+   * Presentation-only strip of rows decided this session (approve/reject) or
+   * auto-applied in-flow. Never approvable; shown so the admin sees what just
+   * happened.
+   */
+  recentlyDecided: QueueRow[];
+}
+
+/**
+ * Merge the DB Pending queue with the live conversation into the panel's two
+ * lists. `pending` is the sole source of approvable rows; `conversation` (from
+ * {@link extractProposals}) contributes markers and auto-applied rows; and
+ * `decisions` reflects approve/reject clicks this session so a decided row
+ * leaves the approvable list immediately, before the refetch drops it.
+ */
+export function buildProposalQueue(args: {
+  pending: Proposal[];
+  conversation: Proposal[];
+  decisions: Map<string, "accepted" | "rejected">;
+}): ProposalQueue {
+  const { pending, conversation, decisions } = args;
+
+  const conversationIds = new Set(
+    conversation.map((p) => p.dbId).filter((id): id is string => Boolean(id)),
+  );
+
+  // One entry per dbId. The pending queue is the sole source of approvable
+  // rows; the conversation only adds rows not yet in it — an auto-applied one
+  // surfaces in the decided strip, a just-streamed undecided one waits for the
+  // refetch.
+  interface Entry {
+    id: string;
+    row: Proposal;
+    inPending: boolean;
+    fromConversation: boolean;
+  }
+  const byId = new Map<string, Entry>();
+  for (const row of pending) {
+    if (!row.dbId) continue;
+    byId.set(row.dbId, { id: row.dbId, row, inPending: true, fromConversation: conversationIds.has(row.dbId) });
+  }
+  for (const row of conversation) {
+    if (!row.dbId || byId.has(row.dbId)) continue;
+    byId.set(row.dbId, { id: row.dbId, row, inPending: false, fromConversation: true });
+  }
+
+  const pendingQueue: ApprovableRow[] = [];
+  const recentlyDecided: QueueRow[] = [];
+  for (const { id, row, inPending, fromConversation } of byId.values()) {
+    // A session approve/reject wins over the row's own decision so the click
+    // reflects before the refetch; otherwise a chat-streamed row carries its
+    // `applied` (auto-approved) status.
+    const decision = decisions.get(id) ?? row.decision;
+    if (decision === null) {
+      // Only rows actually in the pending queue are approvable — a proposal
+      // streamed this turn but not yet refetched into `/pending` waits. The
+      // narrowed `decision: null` makes each pushed row an `ApprovableRow`.
+      if (inPending) pendingQueue.push({ ...row, decision, fromConversation });
+    } else {
+      recentlyDecided.push({ ...row, decision, fromConversation });
+    }
+  }
+
+  return {
+    pending: pendingQueue.toSorted(
+      (a, b) => Number(b.fromConversation) - Number(a.fromConversation),
+    ),
+    recentlyDecided,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #4504 (PRD #4502 — Semantic-Improve Elevation).

The proposals panel swapped data sources — chat proposals **or** the DB pending queue (`chatProposals.length > 0 ? chatProposals : pendingAmendments`). So a live conversation **hid** pre-existing pending Amendments (including ones the scheduler queued), and the sidebar badge — which counts all of `/pending` — disagreed with the panel it rendered.

Now the panel renders **one data source: the org Pending queue** (per CONTEXT.md § "one Pending queue"):

- **New pure seam** `buildProposalQueue({ pending, conversation, decisions })` in `proposals.ts`. `/pending` is the sole source of approvable rows; the live conversation only supplies **markers** (which `dbId`s it created → badge + sort-to-top) and **auto-applied rows** for a presentation-only "recently decided" strip — never a second source of approvable rows.
- A `proposeAmendment` result **triggers a `/pending` refetch** (a `useEffect` keyed on the conversation's `dbId`s; `refetchPending` is TanStack-Query-stable, so no loop), and the created row surfaces in the queue, marked.
- **Decided/auto-applied rows leave the approvable queue** and show in the recently-decided strip — clearly not approvable.
- The in-panel badge is now `proposals.length`, and `ApprovableRow extends QueueRow { decision: null }` makes **"approvable ⟹ undecided" a compile-time guarantee** — the badge and the rendered list can no longer disagree.

## Acceptance criteria

- [x] Mid-conversation, pre-existing pending Amendments remain visible alongside conversation-created ones
- [x] Conversation-created rows are visually marked ("this conversation" badge); the marker is presentation state, not a second data source
- [x] The pending badge and the panel never disagree (`ApprovableRow` enforces it in the type)
- [x] Decided rows leave the pending list; the lingering strip is clearly decided, not approvable
- [x] Unit tests at the web pure-module seam (queue merge + markers)

## Test plan

- [x] 12 unit tests for `buildProposalQueue` at the pure seam — merge, markers, dedup-by-`dbId`, refetch gap, auto-applied routing, ordering stability, decided-lingers-after-refetch, stale-decision no-phantom (`proposals.test.ts`, 21/21 with the existing `extractProposals` tests)
- [x] `@atlas/web` full suite green (274/274); web type-check clean
- [x] Internal review panel clean (silent-failure, type-design, test-coverage, comment-accuracy) across 2 rounds
- [x] Local CI: 29/30 gates green; the one red is a pre-existing WSL2 timing flake in `@atlas/api` `ai-saas.test.ts` (untouched by this diff, green on remote CI)

Web-only change; no API/schema/migration/wire-contract changes.