### PR TITLE
feat(semantic-improve): permanent, insert-enforced rejection memory with identity dedup

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -262,7 +262,11 @@ export function buildInternalDbMockDefaults(deps: {
     }),
     getAutoApproveThreshold: mock(() => 2),
     getAutoApproveTypes: mock(() => new Set(["update_description", "add_dimension"])),
-    insertSemanticAmendment: mock(async () => ({ id: "mock-amendment-id", status: "pending" as const })),
+    insertSemanticAmendment: mock(async () => ({
+      outcome: "inserted" as const,
+      id: "mock-amendment-id",
+      status: "pending" as const,
+    })),
     getPendingAmendmentCount: mock(async () => 0),
     getPendingAmendments: mock(async () => []),
     reviewSemanticAmendment: mock(async () => null),

--- a/packages/api/src/lib/db/__tests__/semantic-amendment-rejection-guard.test.ts
+++ b/packages/api/src/lib/db/__tests__/semantic-amendment-rejection-guard.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Insert-enforced rejection memory + pending dedup for semantic amendments
+ * (#4507).
+ *
+ * `insertSemanticAmendment` is the single choke point every path (chat tool,
+ * scheduler, CLI) shares. Before queuing, it checks the amendment's canonical
+ * group-scoped identity against the org's existing rejected/pending rows:
+ *   - a rejected identity → refused permanently (`outcome: "rejected"`), NO INSERT;
+ *   - an identical pending identity → converges (`outcome: "already_pending"`), NO INSERT;
+ *   - no conflict → a new row is queued, keyed on the identity (`pattern_sql`).
+ *
+ * These assert the SQL the guard runs and that the INSERT only fires on the
+ * clean path — using a captured-SQL stub pool (same harness as
+ * semantic-amendment-saas-scoping.test.ts).
+ */
+
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
+
+// `hasInternalDB()`/`getInternalDB()` read DATABASE_URL at call time; set it
+// before importing the module under test so the query path runs.
+process.env.DATABASE_URL ??= "postgresql://test:test@localhost:5432/atlas_test";
+
+import { insertSemanticAmendment, _resetPool, _resetCircuitBreaker } from "../internal";
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+}
+
+let captured: Captured[] = [];
+
+/** Rows the conflict SELECT returns for the current test. */
+let conflictRows: Array<{
+  id: string;
+  status: string;
+  connection_group_id: string | null;
+  amendment_payload: Record<string, unknown> | string | null;
+}> = [];
+
+function makeStubPool() {
+  return {
+    query: async (sql: string, params?: unknown[]) => {
+      captured.push({ sql, params: params ?? [] });
+      if (sql.includes("INSERT INTO learned_patterns")) {
+        return { rows: [{ id: "new-row-id" }] };
+      }
+      // The conflict SELECT (status IN ('rejected','pending')).
+      return { rows: conflictRows };
+    },
+    async end() {},
+    async connect() {
+      return { query: async () => ({ rows: [] }), release() {} };
+    },
+    on() {},
+  };
+}
+
+const baseAmendment = {
+  orgId: "org-a",
+  description: "[add_dimension] orders: adds region",
+  sourceEntity: "orders",
+  confidence: 0.9,
+  connectionGroupId: null as string | null,
+  amendmentPayload: {
+    amendmentType: "add_dimension",
+    amendment: { name: "region", type: "string" },
+  } as Record<string, unknown>,
+};
+
+function insertSql(): Captured | undefined {
+  return captured.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+}
+
+beforeEach(() => {
+  captured = [];
+  conflictRows = [];
+  _resetCircuitBreaker();
+  _resetPool(makeStubPool() as unknown as Parameters<typeof _resetPool>[0], null);
+});
+
+afterAll(() => {
+  _resetPool(null, null);
+  _resetCircuitBreaker();
+  mock.restore();
+});
+
+describe("insertSemanticAmendment — clean path (#4507)", () => {
+  it("queues a new row keyed on the canonical identity when no conflict exists", async () => {
+    const result = await insertSemanticAmendment(baseAmendment);
+
+    expect(result).toEqual({ outcome: "inserted", id: "new-row-id", status: "pending" });
+
+    // The identity is the storage key — no timestamp uniquifier.
+    const ins = insertSql();
+    expect(ins).toBeDefined();
+    expect(ins!.params[1]).toBe("default:orders:add_dimension:region");
+  });
+
+  it("scopes the conflict lookup to the amendment's own org (IS NOT DISTINCT FROM)", async () => {
+    await insertSemanticAmendment(baseAmendment);
+
+    const lookup = captured.find((c) => c.sql.includes("status IN ('rejected', 'pending')"));
+    expect(lookup).toBeDefined();
+    expect(lookup!.sql).toContain("org_id IS NOT DISTINCT FROM $2");
+    expect(lookup!.params).toEqual(["orders", "org-a"]);
+  });
+});
+
+describe("insertSemanticAmendment — permanent rejection memory (#4507)", () => {
+  it("refuses the insert when the identity was previously rejected", async () => {
+    conflictRows = [
+      {
+        id: "rejected-1",
+        status: "rejected",
+        connection_group_id: null,
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+    ];
+
+    const result = await insertSemanticAmendment(baseAmendment);
+
+    expect(result).toEqual({ outcome: "rejected", id: "rejected-1" });
+    expect(insertSql()).toBeUndefined(); // NO INSERT ran
+  });
+
+  it("does NOT suppress a different amendment on the same entity (identity is per-target)", async () => {
+    // A rejected add_dimension:region must not block add_dimension:status.
+    conflictRows = [
+      {
+        id: "rejected-1",
+        status: "rejected",
+        connection_group_id: null,
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+    ];
+
+    const result = await insertSemanticAmendment({
+      ...baseAmendment,
+      amendmentPayload: { amendmentType: "add_dimension", amendment: { name: "status" } },
+    });
+
+    expect(result.outcome).toBe("inserted");
+    expect(insertSql()).toBeDefined();
+  });
+
+  it("does NOT suppress the same identity in a different Connection group", async () => {
+    // Rejected in the default group; a proposal in group `eu` must still queue.
+    conflictRows = [
+      {
+        id: "rejected-1",
+        status: "rejected",
+        connection_group_id: null,
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+    ];
+
+    const result = await insertSemanticAmendment({ ...baseAmendment, connectionGroupId: "eu" });
+
+    expect(result.outcome).toBe("inserted");
+  });
+});
+
+describe("insertSemanticAmendment — pending dedup (#4507)", () => {
+  it("converges on the existing pending row instead of queuing a duplicate", async () => {
+    conflictRows = [
+      {
+        id: "pending-1",
+        status: "pending",
+        connection_group_id: null,
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+    ];
+
+    const result = await insertSemanticAmendment(baseAmendment);
+
+    expect(result).toEqual({ outcome: "already_pending", id: "pending-1" });
+    expect(insertSql()).toBeUndefined(); // NO duplicate INSERT
+  });
+
+  it("prefers rejected over pending when both share the identity", async () => {
+    conflictRows = [
+      {
+        id: "pending-1",
+        status: "pending",
+        connection_group_id: null,
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+      {
+        id: "rejected-1",
+        status: "rejected",
+        connection_group_id: null,
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+    ];
+
+    const result = await insertSemanticAmendment(baseAmendment);
+
+    expect(result).toEqual({ outcome: "rejected", id: "rejected-1" });
+  });
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -25,6 +25,11 @@ import { normalizeError } from "@atlas/api/lib/effect/errors";
 import { resolveStatusClause } from "@atlas/api/lib/content-mode/port";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import { foldRollingMean } from "@atlas/api/lib/learn/rolling-mean";
+import {
+  amendmentIdentityFromRow,
+  amendmentIdentityKey,
+  type AmendmentIdentityRow,
+} from "@atlas/api/lib/semantic/amendment-identity";
 
 const log = createLogger("internal-db");
 
@@ -1567,9 +1572,77 @@ export function getAutoApproveTypes(orgId?: string): Set<string> {
 }
 
 /**
+ * Outcome of an amendment insert (#4507). A discriminated union so callers
+ * handle all three terminal states explicitly:
+ *   - `inserted`       — a new row was queued (or auto-approved at insert).
+ *   - `already_pending`— an identical change is already pending review; the
+ *                        insert converged on that row instead of duplicating.
+ *   - `rejected`       — the identity was previously rejected by an admin;
+ *                        rejection memory is permanent, so the insert is
+ *                        refused. `id` is the existing rejected row.
+ */
+export type InsertSemanticAmendmentResult =
+  | { outcome: "inserted"; id: string; status: "approved" | "pending" }
+  | { outcome: "already_pending"; id: string }
+  | { outcome: "rejected"; id: string };
+
+/**
+ * Find an existing rejected-or-pending amendment sharing `identityKey` within
+ * the same org (#4507). Rejected wins over pending: a rejected identity must
+ * never be re-queued even if a stale pending duplicate also exists. Scoped to
+ * the amendment's own org (`IS NOT DISTINCT FROM` matches the NULL/self-hosted
+ * scope), so one workspace's review decision never governs another's. Matching
+ * is by reconstructed identity (`amendmentIdentityFromRow`), not by
+ * `pattern_sql` equality, so rows written before the identity storage key
+ * (older `amendment:<entity>:<ts>` keys) are still caught.
+ */
+async function findConflictingAmendment(
+  orgId: string | null,
+  sourceEntity: string,
+  identityKey: string,
+): Promise<{ outcome: "rejected" | "already_pending"; id: string } | null> {
+  const rows = await internalQuery<{
+    id: string;
+    status: string;
+    connection_group_id: string | null;
+    amendment_payload: string | Record<string, unknown> | null;
+  }>(
+    `SELECT id, status, connection_group_id, amendment_payload
+       FROM learned_patterns
+      WHERE type = 'semantic_amendment'
+        AND status IN ('rejected', 'pending')
+        AND source_entity = $1
+        AND org_id IS NOT DISTINCT FROM $2`,
+    [sourceEntity, orgId],
+  );
+
+  let pendingId: string | null = null;
+  for (const row of rows) {
+    const key = amendmentIdentityFromRow({
+      sourceEntity,
+      connectionGroupId: row.connection_group_id,
+      amendmentPayload: row.amendment_payload,
+    });
+    if (key !== identityKey) continue;
+    if (row.status === "rejected") return { outcome: "rejected", id: row.id };
+    if (row.status === "pending" && pendingId === null) pendingId = row.id;
+  }
+  return pendingId ? { outcome: "already_pending", id: pendingId } : null;
+}
+
+/**
  * Insert a semantic amendment proposal. Status is "approved" only when confidence
  * meets the threshold AND the amendment type is in the eligible set; otherwise "pending".
  * Unlike insertLearnedPattern (fire-and-forget), this awaits the result.
+ *
+ * Insert-enforced rejection memory + pending dedup (#4507): before queuing, the
+ * amendment's canonical group-scoped identity is checked against the org's
+ * existing rejected/pending rows. A rejected identity refuses the insert
+ * (permanent — no time window); an identical pending identity converges on the
+ * existing row. The identity is also the row's storage key (`pattern_sql`),
+ * replacing the timestamp-uniquified key that made every re-proposal a
+ * duplicate. This is the single choke point every path (chat tool, scheduler,
+ * CLI) shares, so the guard holds on all three by construction.
  */
 export async function insertSemanticAmendment(amendment: {
   orgId: string | null | undefined;
@@ -1593,7 +1666,7 @@ export async function insertSemanticAmendment(amendment: {
    * unscoped fallback (which remains only for stale group labels).
    */
   connectionGroupId: string | null;
-}): Promise<{ id: string; status: "approved" | "pending" }> {
+}): Promise<InsertSemanticAmendmentResult> {
   // #3392 — thread the amendment's org through so a per-workspace
   // auto-approve override (admin settings page) governs its own proposals.
   // null orgId (self-hosted / global scope) resolves at the platform tier.
@@ -1608,6 +1681,37 @@ export async function insertSemanticAmendment(amendment: {
       { entity: amendment.sourceEntity, payloadKeys: Object.keys(amendment.amendmentPayload) },
       "amendmentPayload.amendmentType is missing or not a string — amendment will not be eligible for auto-approval",
     );
+  }
+
+  // Canonical group-scoped identity (#4507): (group, entity, type, target).
+  // Drives the rejection guard + pending dedup below and becomes the row's
+  // storage key. A malformed payload (no amendmentType) yields no identity —
+  // fall back to a stable per-entity key so the NOT NULL storage slot is
+  // filled without reintroducing timestamp uniquification.
+  const identityRow: AmendmentIdentityRow = {
+    sourceEntity: amendment.sourceEntity,
+    connectionGroupId: amendment.connectionGroupId,
+    amendmentPayload: amendment.amendmentPayload,
+  };
+  const identityKey =
+    amendmentIdentityFromRow(identityRow) ??
+    amendmentIdentityKey(amendment.connectionGroupId, amendment.sourceEntity, "unknown");
+
+  // Insert-enforced rejection memory + pending dedup. A rejected identity is
+  // refused permanently; an identical pending identity converges on its row.
+  const conflict = await findConflictingAmendment(
+    amendment.orgId ?? null,
+    amendment.sourceEntity,
+    identityKey,
+  );
+  if (conflict) {
+    log.debug(
+      { entity: amendment.sourceEntity, amendmentType, outcome: conflict.outcome, existingId: conflict.id },
+      conflict.outcome === "rejected"
+        ? "Amendment refused — identity previously rejected (permanent rejection memory)"
+        : "Amendment converged on existing pending row — no duplicate queued",
+    );
+    return conflict;
   }
 
   const meetsThreshold = amendment.confidence >= threshold;
@@ -1630,7 +1734,7 @@ export async function insertSemanticAmendment(amendment: {
      RETURNING id`,
     [
       amendment.orgId ?? null,
-      `amendment:${amendment.sourceEntity}:${Date.now()}`,
+      identityKey,
       amendment.description,
       amendment.sourceEntity,
       amendment.confidence,
@@ -1646,7 +1750,7 @@ export async function insertSemanticAmendment(amendment: {
     );
   }
 
-  return { id: rows[0].id, status };
+  return { outcome: "inserted", id: rows[0].id, status };
 }
 
 /**

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1623,6 +1623,17 @@ async function findConflictingAmendment(
       connectionGroupId: row.connection_group_id,
       amendmentPayload: row.amendment_payload,
     });
+    if (key === null) {
+      // A stored rejected/pending row whose payload can't be reconstructed to
+      // an identity stops being enforced — surface it so an operator can spot
+      // a rejection that has silently gone dark (should never happen: the
+      // writer always stamps `amendmentType`).
+      log.warn(
+        { existingId: row.id, status: row.status, sourceEntity },
+        "learned_patterns amendment row has an unreconstructable identity — not enforced by the rejection/dedup guard",
+      );
+      continue;
+    }
     if (key !== identityKey) continue;
     if (row.status === "rejected") return { outcome: "rejected", id: row.id };
     if (row.status === "pending" && pendingId === null) pendingId = row.id;

--- a/packages/api/src/lib/semantic/__tests__/amendment-identity.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/amendment-identity.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Canonical amendment identity key (#4507).
+ *
+ * These pin the "one key, everywhere" contract: the analyzer's staleness key,
+ * `loadRejectedKeys`, and the insert-time guard must all agree on what "the
+ * same change" is. In particular:
+ *   - group scoping (NULL → "default") — a decision in one group must not
+ *     govern another's same-named amendment;
+ *   - per-type target extraction — distinct amendments of the same type on the
+ *     same entity must NOT collapse into one identity (which would turn the
+ *     permanent rejection guard into an over-broad block).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  amendmentIdentityKey,
+  amendmentIdentityFromRow,
+  amendmentTargetName,
+} from "../amendment-identity";
+
+describe("amendmentIdentityKey", () => {
+  it("is group-scoped — NULL and undefined groups map to 'default'", () => {
+    expect(amendmentIdentityKey(null, "orders", "add_dimension", "region")).toBe(
+      "default:orders:add_dimension:region",
+    );
+    expect(amendmentIdentityKey(undefined, "orders", "add_dimension", "region")).toBe(
+      "default:orders:add_dimension:region",
+    );
+  });
+
+  it("keeps distinct groups distinct", () => {
+    expect(amendmentIdentityKey("eu", "orders", "add_dimension", "region")).not.toBe(
+      amendmentIdentityKey("us", "orders", "add_dimension", "region"),
+    );
+  });
+
+  it("omits the target segment when absent (coarse identities)", () => {
+    expect(amendmentIdentityKey("default", "orders", "add_query_pattern")).toBe(
+      "default:orders:add_query_pattern",
+    );
+    expect(amendmentIdentityKey("default", "orders", "add_query_pattern", "")).toBe(
+      "default:orders:add_query_pattern",
+    );
+  });
+});
+
+describe("amendmentTargetName", () => {
+  it("reads .name for name-keyed types", () => {
+    expect(amendmentTargetName("add_dimension", { name: "region" })).toBe("region");
+    expect(amendmentTargetName("add_measure", { name: "total_amount" })).toBe("total_amount");
+    expect(amendmentTargetName("update_dimension", { name: "status" })).toBe("status");
+    expect(amendmentTargetName("add_virtual_dimension", { name: "created_month" })).toBe("created_month");
+  });
+
+  it("reads the join name (to_<table>) for add_join", () => {
+    expect(amendmentTargetName("add_join", { name: "to_customers" })).toBe("to_customers");
+  });
+
+  it("distinguishes table vs dimension description edits", () => {
+    expect(amendmentTargetName("update_description", { field: "table", description: "x" })).toBe("table");
+    expect(amendmentTargetName("update_description", { dimension: "region", description: "x" })).toBe("region");
+    // Two update_description edits on the same entity must NOT collapse.
+    expect(amendmentTargetName("update_description", { field: "table" })).not.toBe(
+      amendmentTargetName("update_description", { dimension: "region" }),
+    );
+  });
+
+  it("reads .term for glossary terms", () => {
+    expect(amendmentTargetName("add_glossary_term", { term: "arr", definition: "" })).toBe("arr");
+  });
+
+  it("is coarse (undefined) for add_query_pattern — the stored name carries a per-run index", () => {
+    expect(amendmentTargetName("add_query_pattern", { name: "pattern_orders_3" })).toBeUndefined();
+  });
+
+  it("returns undefined for a non-object amendment", () => {
+    expect(amendmentTargetName("add_dimension", null)).toBeUndefined();
+    expect(amendmentTargetName("add_dimension", "nope")).toBeUndefined();
+    expect(amendmentTargetName("add_dimension", ["a"])).toBeUndefined();
+  });
+});
+
+describe("amendmentIdentityFromRow", () => {
+  it("reconstructs the same key from a stored payload (object) as amendmentIdentityKey builds", () => {
+    const key = amendmentIdentityFromRow({
+      sourceEntity: "orders",
+      connectionGroupId: "eu",
+      amendmentPayload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+    });
+    expect(key).toBe("eu:orders:add_dimension:region");
+    expect(key).toBe(amendmentIdentityKey("eu", "orders", "add_dimension", "region"));
+  });
+
+  it("parses a JSON-string payload", () => {
+    const key = amendmentIdentityFromRow({
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      amendmentPayload: JSON.stringify({ amendmentType: "add_measure", amendment: { name: "total_amount" } }),
+    });
+    expect(key).toBe("default:orders:add_measure:total_amount");
+  });
+
+  it("reconstructs the join identity the analyzer keys staleness on", () => {
+    // Analyzer keys add_join on `to_<table>`; the stored payload carries the
+    // same name — the two must reconstruct to the same identity.
+    const key = amendmentIdentityFromRow({
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      amendmentPayload: { amendmentType: "add_join", amendment: { name: "to_customers", sql: "..." } },
+    });
+    expect(key).toBe("default:orders:add_join:to_customers");
+  });
+
+  it("does not collapse two update_description edits on the same entity", () => {
+    const tableKey = amendmentIdentityFromRow({
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      amendmentPayload: { amendmentType: "update_description", amendment: { field: "table", description: "x" } },
+    });
+    const dimKey = amendmentIdentityFromRow({
+      sourceEntity: "orders",
+      connectionGroupId: null,
+      amendmentPayload: { amendmentType: "update_description", amendment: { dimension: "region", description: "y" } },
+    });
+    expect(tableKey).toBe("default:orders:update_description:table");
+    expect(dimKey).toBe("default:orders:update_description:region");
+    expect(tableKey).not.toBe(dimKey);
+  });
+
+  it("returns null for a malformed payload (missing amendmentType)", () => {
+    expect(
+      amendmentIdentityFromRow({ sourceEntity: "orders", connectionGroupId: null, amendmentPayload: { amendment: { name: "x" } } }),
+    ).toBeNull();
+    expect(
+      amendmentIdentityFromRow({ sourceEntity: "orders", connectionGroupId: null, amendmentPayload: "not-json{" }),
+    ).toBeNull();
+    expect(
+      amendmentIdentityFromRow({ sourceEntity: "orders", connectionGroupId: null, amendmentPayload: null }),
+    ).toBeNull();
+  });
+});

--- a/packages/api/src/lib/semantic/amendment-identity.ts
+++ b/packages/api/src/lib/semantic/amendment-identity.ts
@@ -12,7 +12,8 @@
  *      existing row instead of queuing a duplicate; the key is the row's
  *      storage key (`pattern_sql`).
  *   3. Staleness dampening in the analyzer (`expert/categories.ts`) — a
- *      recently-rejected identity scores lower.
+ *      rejected identity scores lower (rejection memory is permanent — no
+ *      time window, so this is "ever-rejected", not "recently-rejected").
  *
  * Lives in its own leaf module (no imports) so the DB layer
  * (`db/internal.ts`), the analyzer (`expert/categories.ts`,

--- a/packages/api/src/lib/semantic/amendment-identity.ts
+++ b/packages/api/src/lib/semantic/amendment-identity.ts
@@ -1,0 +1,113 @@
+/**
+ * Canonical group-scoped identity for a semantic amendment (#4507).
+ *
+ * The tuple `(group, entity, amendmentType, target)` identifies *what* an
+ * amendment changes, independent of *when* it was proposed. It is the single
+ * key used for three things that must never diverge:
+ *
+ *   1. Permanent rejection memory — a rejected identity is refused on
+ *      re-proposal at insert time (`insertSemanticAmendment`), on every path
+ *      (chat tool, scheduler, CLI).
+ *   2. Pending dedup — a re-proposed *pending* change converges on the
+ *      existing row instead of queuing a duplicate; the key is the row's
+ *      storage key (`pattern_sql`).
+ *   3. Staleness dampening in the analyzer (`expert/categories.ts`) — a
+ *      recently-rejected identity scores lower.
+ *
+ * Lives in its own leaf module (no imports) so the DB layer
+ * (`db/internal.ts`), the analyzer (`expert/categories.ts`,
+ * `expert/context-loader.ts`), and the CLI can all import the same formula
+ * without dragging each other's surface into their test fixtures — the
+ * mechanical guarantee that "group-scoped keys everywhere" cannot drift back
+ * apart. Mirrors the sibling `dedup-key.ts`.
+ */
+
+/** The stored-row inputs needed to reconstruct an amendment's identity. */
+export interface AmendmentIdentityRow {
+  sourceEntity: string;
+  connectionGroupId: string | null;
+  /** `learned_patterns.amendment_payload` — JSON string or already-parsed. */
+  amendmentPayload: string | Record<string, unknown> | null;
+}
+
+/**
+ * The semantic *target* that distinguishes one amendment from another of the
+ * same type on the same entity. Each amendment type stores its target under a
+ * different field, so a single `.name` read would collapse distinct changes
+ * (e.g. a table-description edit and a dimension-description edit) into one
+ * identity — turning the permanent rejection guard into an over-broad block.
+ * This mirrors, per type, the `name` the analyzer keys staleness on
+ * (`expert/categories.ts`), so an identity reconstructed from a stored row
+ * matches the identity the analyzer computed for the same finding.
+ *
+ * `add_query_pattern` is intentionally coarse (no target): the generated
+ * pattern name carries a per-run index and is not a stable identity, so the
+ * analyzer keys all query-pattern proposals for an entity as one — matched
+ * here by returning `undefined`.
+ */
+export function amendmentTargetName(
+  amendmentType: string,
+  amendment: unknown,
+): string | undefined {
+  if (!amendment || typeof amendment !== "object" || Array.isArray(amendment)) {
+    return undefined;
+  }
+  const a = amendment as Record<string, unknown>;
+  switch (amendmentType) {
+    case "add_query_pattern":
+      return undefined;
+    case "update_description":
+      // Table-level edits key on the field ("table"); dimension-level edits
+      // key on the dimension name.
+      if (typeof a.field === "string") return a.field;
+      if (typeof a.dimension === "string") return a.dimension;
+      return undefined;
+    case "add_glossary_term":
+      return typeof a.term === "string" ? a.term : undefined;
+    default:
+      return typeof a.name === "string" ? a.name : undefined;
+  }
+}
+
+/**
+ * Build the canonical identity key. A NULL/absent group maps to `"default"`
+ * (ADR-0012 flat group), matching `entity.group` in the analyzer so one
+ * group's rejection never suppresses another group's same-named amendment.
+ * The target is omitted when absent (e.g. coarse query-pattern identities).
+ */
+export function amendmentIdentityKey(
+  group: string | null | undefined,
+  entity: string,
+  amendmentType: string,
+  target?: string | null,
+): string {
+  const g = group ?? "default";
+  return `${g}:${entity}:${amendmentType}${target ? `:${target}` : ""}`;
+}
+
+/**
+ * Reconstruct the identity key from a stored `learned_patterns` amendment row.
+ * Returns `null` when the payload is malformed or missing an `amendmentType`
+ * (an unreconstructable row is never treated as matching any identity).
+ */
+export function amendmentIdentityFromRow(row: AmendmentIdentityRow): string | null {
+  let payload: unknown = row.amendmentPayload;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch {
+      // intentionally ignored: malformed payload — cannot reconstruct identity
+      return null;
+    }
+  }
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  const amendmentType = p.amendmentType;
+  if (typeof amendmentType !== "string" || amendmentType.length === 0) return null;
+  return amendmentIdentityKey(
+    row.connectionGroupId,
+    row.sourceEntity,
+    amendmentType,
+    amendmentTargetName(amendmentType, p.amendment),
+  );
+}

--- a/packages/api/src/lib/semantic/expert/__tests__/categories.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/categories.test.ts
@@ -268,6 +268,25 @@ describe("findMissingJoins", () => {
     expect(results[0].confidence).toBe(0.95); // constraint = high confidence
   });
 
+  test("a rejected join identity dampens staleness — keyed on the stored `to_<table>` name (#4507)", () => {
+    // The staleness key must match what `amendmentIdentityFromRow`
+    // reconstructs from the persisted `amendment.name` (`to_users`), NOT the
+    // bare `to_table`. A rejection of `default:orders:add_join:to_users` must
+    // mark this proposal stale.
+    const ctx = makeContext({
+      profiles: [makeProfile({
+        table_name: "orders",
+        foreign_keys: [{ from_column: "user_id", to_table: "users", to_column: "id", source: "constraint" }],
+      })],
+      entities: [makeEntity({ name: "orders" }), makeEntity({ name: "users" })],
+      rejectedKeys: new Set(["default:orders:add_join:to_users"]),
+    });
+
+    const results = findMissingJoins(ctx);
+    expect(results.length).toBe(1);
+    expect(results[0].staleness).toBe(0.8);
+  });
+
   test("inferred FKs get lower confidence", () => {
     const ctx = makeContext({
       profiles: [makeProfile({

--- a/packages/api/src/lib/semantic/expert/__tests__/load-rejected-keys.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-rejected-keys.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `loadRejectedKeys` — the single canonical, group-scoped rejected-key loader
+ * consumed by the analyzer staleness path on every surface (scheduler + CLI;
+ * #4507).
+ *
+ * Pins two things the DB-seam guard test can't (it exercises a different
+ * query, `findConflictingAmendment`):
+ *   - Acceptance criterion 3: rejection memory is PERMANENT — the query has NO
+ *     time window. Re-introducing `reviewed_at >= now() - interval '30 days'`
+ *     would silently restore expiry and pass every other gate.
+ *   - Keys are reconstructed group-scoped via the shared
+ *     `amendmentIdentityFromRow`, so the loader agrees with the analyzer's
+ *     `stalenessFactor` and the insert-time guard.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+let capturedSql = "";
+
+// context-loader dynamically imports internal ONLY inside loadRejectedKeys, and
+// uses just these two exports — a partial mock is complete for this file.
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  internalQuery: async (sql: string) => {
+    capturedSql = sql;
+    return [
+      {
+        source_entity: "orders",
+        connection_group_id: "eu",
+        amendment_payload: { amendmentType: "add_dimension", amendment: { name: "region" } },
+      },
+      {
+        source_entity: "orders",
+        connection_group_id: null,
+        amendment_payload: JSON.stringify({ amendmentType: "add_measure", amendment: { name: "total_amount" } }),
+      },
+    ];
+  },
+}));
+
+const { loadRejectedKeys } = await import("../context-loader");
+
+describe("loadRejectedKeys (#4507)", () => {
+  it("queries rejected rows with NO time window — rejection memory is permanent", async () => {
+    await loadRejectedKeys();
+
+    expect(capturedSql).toContain("status = 'rejected'");
+    // Acceptance criterion 3 — no time-based expiry anywhere.
+    expect(capturedSql).not.toContain("interval");
+    expect(capturedSql).not.toContain("reviewed_at");
+  });
+
+  it("reconstructs group-scoped identity keys via the shared canonical builder", async () => {
+    const keys = await loadRejectedKeys();
+
+    // NULL group → "default"; a real group is preserved. Object and
+    // JSON-string payloads both reconstruct.
+    expect(keys.has("eu:orders:add_dimension:region")).toBe(true);
+    expect(keys.has("default:orders:add_measure:total_amount")).toBe(true);
+    expect(keys.size).toBe(2);
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -52,8 +52,8 @@ void mock.module("../apply", () => ({
   applyAmendmentToEntity: mockApplyAmendmentToEntity,
 }));
 
-const mockInsertSemanticAmendment: Mock<() => Promise<{ id: string; status: string }>> = mock(() =>
-  Promise.resolve({ id: "sch-1", status: "approved" }),
+const mockInsertSemanticAmendment: Mock<() => Promise<{ outcome: string; id?: string; status?: string }>> = mock(() =>
+  Promise.resolve({ outcome: "inserted", id: "sch-1", status: "approved" }),
 );
 const mockRevertAmendmentToPending: Mock<(id: string) => Promise<boolean>> = mock(() =>
   Promise.resolve(true),
@@ -83,7 +83,7 @@ describe("runExpertSchedulerTick auto-approve → apply invariant (#4486)", () =
     mockApplyAmendmentToEntity.mockClear();
     mockApplyAmendmentToEntity.mockResolvedValue(undefined);
     mockInsertSemanticAmendment.mockClear();
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "sch-1", status: "approved" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-1", status: "approved" });
     mockRevertAmendmentToPending.mockClear();
     mockRevertAmendmentToPending.mockResolvedValue(true);
   });
@@ -111,13 +111,36 @@ describe("runExpertSchedulerTick auto-approve → apply invariant (#4486)", () =
   });
 
   it("does not apply or revert when the proposal lands pending", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "sch-2", status: "pending" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-2", status: "pending" });
 
     const result = await runExpertSchedulerTick();
 
     expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
     expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
     expect(result.queued).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it("counts a rejected identity as suppressed — no apply, no queue (#4507)", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "rejected", id: "rej-1" });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
+    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(result.rejected).toBe(1);
+    expect(result.queued).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("counts an already-pending identity as deduped — no apply, no queue (#4507)", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "already_pending", id: "pend-1" });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
+    expect(result.deduped).toBe(1);
+    expect(result.queued).toBe(0);
     expect(result.errors).toBe(0);
   });
 });

--- a/packages/api/src/lib/semantic/expert/categories.ts
+++ b/packages/api/src/lib/semantic/expert/categories.ts
@@ -6,21 +6,19 @@
 
 import { mapSQLType } from "@atlas/api/lib/profiler-utils";
 import { suggestMeasureType, describeMeasure } from "@atlas/api/lib/profiler-patterns";
+import { amendmentIdentityKey } from "@atlas/api/lib/semantic/amendment-identity";
 import type { AnalysisContext, AnalysisResult, ParsedEntity } from "./types";
 import { createAnalysisResult, tableFrequencyImpact } from "./scoring";
 
 // ── Helpers ──────────────────────────────────────────────────────
 
-// Rejection/staleness keys are group-scoped (#3284): a review decision in one
-// Connection group must not suppress the same-named amendment in another group.
-// `loadRejectedKeys` builds the matching key from each rejected row's
-// `connection_group_id` (NULL → "default").
-function rejectionKey(group: string, entity: string, type: string, name?: string): string {
-  return `${group}:${entity}:${type}${name ? `:${name}` : ""}`;
-}
-
+// Rejection/staleness keys are the canonical group-scoped amendment identity
+// (#3284, #4507): a review decision in one Connection group must not suppress
+// the same-named amendment in another group. `loadRejectedKeys` and the
+// insert-time guard build the matching key from the same
+// `amendmentIdentityKey` — the single source of truth for "same change".
 function stalenessFactor(group: string, entity: string, type: string, name: string | undefined, rejectedKeys: Set<string>): number {
-  return rejectedKeys.has(rejectionKey(group, entity, type, name)) ? 0.8 : 0;
+  return rejectedKeys.has(amendmentIdentityKey(group, entity, type, name)) ? 0.8 : 0;
 }
 
 /**
@@ -273,7 +271,10 @@ export function findMissingJoins(ctx: AnalysisContext): AnalysisResult[] {
         if (!targetInGroup) continue;
 
         const joinSql = `${profile.table_name}.${fk.from_column} = ${fk.to_table}.${fk.to_column}`;
-        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_join", fk.to_table, ctx.rejectedKeys);
+        // Key on the stored join name (`to_<table>`), not the bare table, so
+        // the staleness identity matches what `amendmentIdentityFromRow`
+        // reconstructs from the persisted `amendment.name` (#4507).
+        const staleness = stalenessFactor(entity.group ?? "default", entity.name, "add_join", `to_${fk.to_table}`, ctx.rejectedKeys);
         const impact = 0.8;
         const confidence = fk.source === "constraint" ? 0.95 : 0.6;
 

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -9,6 +9,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
 import { createLogger } from "@atlas/api/lib/logger";
+import { amendmentIdentityFromRow } from "@atlas/api/lib/semantic/amendment-identity";
 import type { ParsedEntity, GlossaryTerm, AuditPattern } from "./types";
 
 const log = createLogger("semantic-expert-context");
@@ -485,8 +486,16 @@ export async function loadAuditPatterns(): Promise<AuditPattern[]> {
 }
 
 /**
- * Load rejected proposal keys from the internal DB.
- * Returns empty set when no internal DB is available.
+ * Load rejected amendment identity keys from the internal DB — the canonical,
+ * group-scoped loader consumed by the analyzer staleness path on every surface
+ * (the scheduler and the CLI `improve` command; #4507). Returns an empty set
+ * when no internal DB is available.
+ *
+ * Rejection memory is permanent: no time window. A rejected identity is
+ * suppressed until an admin explicitly reconsiders it (Reconsider ships
+ * separately). Keys are built via the shared `amendmentIdentityFromRow`, so
+ * the staleness key here, the insert-time guard, and the analyzer's
+ * `stalenessFactor` all agree on what "the same change" is.
  */
 export async function loadRejectedKeys(): Promise<Set<string>> {
   const keys = new Set<string>();
@@ -501,26 +510,17 @@ export async function loadRejectedKeys(): Promise<Set<string>> {
       amendment_payload: string | Record<string, unknown> | null;
     }>(
       `SELECT source_entity, connection_group_id, amendment_payload FROM learned_patterns
-       WHERE type = 'semantic_amendment' AND status = 'rejected'
-       AND reviewed_at >= now() - interval '30 days'`,
+       WHERE type = 'semantic_amendment' AND status = 'rejected'`,
       [],
     );
 
     for (const row of rows) {
-      try {
-        const payload = typeof row.amendment_payload === "string"
-          ? JSON.parse(row.amendment_payload)
-          : row.amendment_payload;
-        if (payload && payload.amendmentType) {
-          // Group-scoped key (#3284): NULL `connection_group_id` → "default",
-          // matching `entity.group` in `categories.ts` so one group's rejection
-          // doesn't mark another group's same-named amendment stale.
-          const group = row.connection_group_id ?? "default";
-          keys.add(`${group}:${row.source_entity}:${payload.amendmentType}:${payload.amendment?.name ?? ""}`);
-        }
-      } catch {
-        // intentionally ignored: malformed payload
-      }
+      const key = amendmentIdentityFromRow({
+        sourceEntity: row.source_entity,
+        connectionGroupId: row.connection_group_id,
+        amendmentPayload: row.amendment_payload,
+      });
+      if (key) keys.add(key);
     }
   } catch (err) {
     log.warn(

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -18,6 +18,10 @@ export interface ExpertTickResult {
   proposalsGenerated: number;
   autoApproved: number;
   queued: number;
+  /** Refused at insert — the identity was previously rejected (#4507). */
+  rejected: number;
+  /** Converged on an existing pending row — no duplicate queued (#4507). */
+  deduped: number;
   errors: number;
 }
 
@@ -76,6 +80,8 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     proposalsGenerated: 0,
     autoApproved: 0,
     queued: 0,
+    rejected: 0,
+    deduped: 0,
     errors: 0,
   };
 
@@ -128,7 +134,7 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
         // maps to a NULL `connection_group_id` like everywhere else.
         const connectionGroupId =
           proposal.group && proposal.group !== "default" ? proposal.group : null;
-        const { id, status } = await insertSemanticAmendment({
+        const insertResult = await insertSemanticAmendment({
           orgId: null, // global scope for self-hosted
           description: proposal.rationale,
           sourceEntity: proposal.entityName,
@@ -141,6 +147,20 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
             testQuery: proposal.testQuery,
           },
         });
+
+        // Permanent rejection memory + pending dedup (#4507): a rejected
+        // identity is refused at insert; an identical pending proposal
+        // converges on the existing row. Neither queues a new row.
+        if (insertResult.outcome === "rejected") {
+          result.rejected++;
+          continue;
+        }
+        if (insertResult.outcome === "already_pending") {
+          result.deduped++;
+          continue;
+        }
+
+        const { id, status } = insertResult;
 
         if (status === "approved") {
           // Auto-apply
@@ -193,7 +213,14 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     }
 
     log.info(
-      { total: result.proposalsGenerated, autoApproved: result.autoApproved, queued: result.queued, errors: result.errors },
+      {
+        total: result.proposalsGenerated,
+        autoApproved: result.autoApproved,
+        queued: result.queued,
+        rejected: result.rejected,
+        deduped: result.deduped,
+        errors: result.errors,
+      },
       "Expert scheduler tick complete",
     );
   } catch (err) {

--- a/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
@@ -22,9 +22,11 @@ const companiesEntity: Record<string, unknown> = {
   dimensions: [{ name: "id", type: "number" }],
 };
 
+// insertSemanticAmendment now returns a discriminated union (#4507):
+// { outcome: "inserted" | "already_pending" | "rejected", ... }.
 const mockInsertSemanticAmendment: Mock<
-  (args: Record<string, unknown>) => Promise<{ id: string; status: string }>
-> = mock(() => Promise.resolve({ id: "prop-1", status: "queued" }));
+  (args: Record<string, unknown>) => Promise<{ outcome: string; id?: string; status?: string }>
+> = mock(() => Promise.resolve({ outcome: "inserted", id: "prop-1", status: "pending" }));
 
 const mockRevertAmendmentToPending: Mock<(id: string) => Promise<boolean>> = mock(() =>
   Promise.resolve(true),
@@ -148,7 +150,7 @@ describe("proposeAmendment test query routing (#4485)", () => {
     mockRunUserQueryPipeline.mockClear();
     mockRunUserQueryPipeline.mockResolvedValue(okOutcome);
     mockInsertSemanticAmendment.mockClear();
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-1", status: "queued" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-1", status: "pending" });
   });
 
   it("routes the test query through runUserQueryPipeline with an explicit connectionId", async () => {
@@ -228,7 +230,7 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
   });
 
   it("does NOT apply when the insert lands pending (auto-approve disabled)", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-pending", status: "pending" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-pending", status: "pending" });
     const result = await run();
     expect(mockApplyAmendmentFromPayload).not.toHaveBeenCalled();
     expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
@@ -236,7 +238,7 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
   });
 
   it("applies the amendment in the same flow when the insert auto-approves", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-approved", status: "approved" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", status: "approved" });
     const result = await run();
 
     // The invariant: an `approved` insert triggers exactly one apply.
@@ -263,7 +265,7 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
   });
 
   it("reverts the row to pending and reports queued when the auto-approve apply fails", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-approved", status: "approved" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", status: "approved" });
     mockApplyAmendmentFromPayload.mockRejectedValue(new Error("entity not found for org"));
 
     const result = await run();
@@ -284,7 +286,7 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
     // genuinely stays `approved`-but-unapplied. This must still be surfaced via
     // logs and reported honestly to the model (queued), never swallowed into a
     // tool-level error or an `auto_approved` lie.
-    mockInsertSemanticAmendment.mockResolvedValue({ id: "prop-approved", status: "approved" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", status: "approved" });
     mockApplyAmendmentFromPayload.mockRejectedValue(new Error("apply exploded"));
     mockRevertAmendmentToPending.mockRejectedValue(new Error("revert exploded"));
 
@@ -300,7 +302,7 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
   it("invariant: the tool never returns auto_approved without having applied", async () => {
     // Sweep both insert outcomes; assert apply-count tracks approved+success.
     for (const status of ["pending", "approved"] as const) {
-      mockInsertSemanticAmendment.mockResolvedValue({ id: `prop-${status}`, status });
+      mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: `prop-${status}`, status });
       mockApplyAmendmentFromPayload.mockClear();
       const result = await run();
       if (result.status === "auto_approved") {
@@ -310,5 +312,43 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
         expect(result.status).toBe("queued");
       }
     }
+  });
+});
+
+describe("proposeAmendment permanent rejection memory + pending dedup (#4507)", () => {
+  beforeEach(() => {
+    mockRunUserQueryPipeline.mockClear();
+    mockRunUserQueryPipeline.mockResolvedValue(okOutcome);
+    mockInsertSemanticAmendment.mockClear();
+    mockApplyAmendmentFromPayload.mockClear();
+    mockApplyAmendmentFromPayload.mockResolvedValue(undefined);
+  });
+
+  it("reports rejected (with a reason the model can see) and applies nothing when the identity was previously rejected", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "rejected", id: "rej-1" });
+
+    const result = await run();
+
+    expect(result.status).toBe("rejected");
+    // The tool result says WHY (acceptance criterion 1) — the model must learn
+    // not to re-propose it.
+    expect(String((result as { reason?: string }).reason)).toMatch(/previously rejected/i);
+    // A refused insert never applies and never claims a queued proposal id.
+    expect(mockApplyAmendmentFromPayload).not.toHaveBeenCalled();
+    expect(result.proposalId).toBeUndefined();
+    // The diff is still surfaced so the model sees what it tried to change.
+    expect(result.diff).toBeDefined();
+  });
+
+  it("converges on the existing pending row instead of re-applying or duplicating", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "already_pending", id: "pend-1" });
+
+    const result = await run();
+
+    expect(result.status).toBe("already_pending");
+    // Points the model at the existing proposal, not a new one.
+    expect(result.proposalId).toBe("pend-1");
+    // An already-pending identity is not auto-approved/applied.
+    expect(mockApplyAmendmentFromPayload).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -223,6 +223,30 @@ The amendment object should match the YAML structure for that type (e.g., { name
           connectionGroupId: applyGroupId,
         });
 
+        // Permanent rejection memory (#4507): the identity was previously
+        // rejected by an admin. Surface WHY so the model stops re-proposing it
+        // — the row is not re-queued and nothing is applied.
+        if (result.outcome === "rejected") {
+          return {
+            status: "rejected",
+            reason:
+              "This change was previously rejected by an admin and will not be re-queued. Rejection memory is permanent — do not re-propose the same amendment unless the admin reconsiders it.",
+            diff,
+          };
+        }
+
+        // Pending dedup (#4507): an identical change is already awaiting
+        // review. Point the model at the existing proposal instead of queuing
+        // a duplicate; the diff is unchanged, so nothing new is applied.
+        if (result.outcome === "already_pending") {
+          return {
+            proposalId: result.id,
+            status: "already_pending",
+            diff,
+            ...(testResult && { testResult }),
+          };
+        }
+
         proposalId = result.id;
 
         if (result.status === "approved") {

--- a/packages/cli/src/commands/improve.ts
+++ b/packages/cli/src/commands/improve.ts
@@ -221,28 +221,14 @@ export async function handleImprove(args: string[]): Promise<void> {
 
       console.log(`  Analyzed ${pc.bold(String(auditPatterns.length))} audit log patterns`);
 
-      // Fetch rejected proposals
-      const rejectedRows = await internalQuery<{
-        source_entity: string;
-        amendment_payload: string | Record<string, unknown> | null;
-      }>(
-        `SELECT source_entity, amendment_payload FROM learned_patterns
-         WHERE type = 'semantic_amendment' AND status = 'rejected'
-         AND reviewed_at >= now() - interval '30 days'`,
-        [],
-      );
-
-      for (const row of rejectedRows) {
-        try {
-          const payload = typeof row.amendment_payload === "string"
-            ? JSON.parse(row.amendment_payload)
-            : row.amendment_payload;
-          if (payload && payload.amendmentType) {
-            rejectedKeys.add(`${row.source_entity}:${payload.amendmentType}:${payload.amendment?.name ?? ""}`);
-          }
-        } catch {
-          // intentionally ignored: malformed payload
-        }
+      // Rejection memory — converge on the ONE canonical, group-scoped loader
+      // (#4507). This command used to build its own key set that omitted the
+      // Connection-group prefix, so its keys never matched the group-scoped
+      // identities the analyzer and scheduler use (drift bug). `loadRejectedKeys`
+      // is the single loader; rejection is permanent (no time window).
+      const { loadRejectedKeys } = await import("@atlas/api/lib/semantic/expert/context-loader");
+      for (const key of await loadRejectedKeys()) {
+        rejectedKeys.add(key);
       }
 
       await closeInternalDB();
@@ -363,9 +349,11 @@ export async function handleImprove(args: string[]): Promise<void> {
       getInternalDB();
 
       let stored = 0;
+      let suppressed = 0;
+      let deduped = 0;
       for (const r of filtered) {
         try {
-          await insertSemanticAmendment({
+          const res = await insertSemanticAmendment({
             orgId: null, // CLI runs in single-org mode
             description: `[${r.amendmentType}] ${r.entityName}: ${r.rationale}`,
             sourceEntity: r.entityName,
@@ -384,13 +372,24 @@ export async function handleImprove(args: string[]): Promise<void> {
               ...(r.testQuery && { testQuery: r.testQuery }),
             },
           });
-          stored++;
+          // Permanent rejection memory + pending dedup (#4507): a rejected
+          // identity is refused; an identical pending proposal converges on
+          // the existing row. Neither stores a new row.
+          if (res.outcome === "rejected") suppressed++;
+          else if (res.outcome === "already_pending") deduped++;
+          else stored++;
         } catch (err) {
           console.debug(`Failed to store proposal: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
 
-      console.log(pc.dim(`\nStored ${stored} proposal(s) in learned_patterns table for admin review.`));
+      console.log(
+        pc.dim(
+          `\nStored ${stored} proposal(s) in learned_patterns table for admin review.` +
+            (deduped > 0 ? ` ${deduped} already pending.` : "") +
+            (suppressed > 0 ? ` ${suppressed} suppressed (previously rejected).` : ""),
+        ),
+      );
       await closeInternalDB();
     } catch (err) {
       console.debug(`Failed to store proposals: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

Makes semantic-layer amendment **rejection memory permanent and insert-enforced**, with identity-based dedup — the core of the Semantic-Improve Elevation milestone (#4502).

- **Insert-enforced rejection.** `insertSemanticAmendment` (the single choke point all three paths share) now checks the org's rejected identities before queuing and **refuses** a previously-rejected identity with a result the model can see (`{status:"rejected", reason}`), on **every** path — chat tool, scheduler, CLI. Because the guard lives at the one insert seam, all three are enforced by construction.
- **Pending dedup.** The canonical group-scoped identity `(group, entity, amendmentType, target)` **replaces the timestamp-uniquified storage key** (`pattern_sql`). Re-proposing an already-pending change now converges on the existing row (`already_pending`) instead of duplicating it.
- **No expiry.** The 30-day window is removed from `loadRejectedKeys` — a rejection stands until an admin reconsiders (Reconsider ships separately).
- **One loader, group-scoped everywhere.** The scheduler's and CLI's rejected-key sets converge on the single canonical `loadRejectedKeys`, fixing the CLI's un-group-scoped key drift. A new leaf module `semantic/amendment-identity.ts` is the SSOT for the key, with **per-type target extraction** (`update_description`→field/dimension, `add_glossary_term`→term, `add_join`→`to_<table>`, `add_query_pattern`→coarse) so distinct amendments of the same type on one entity never collapse into one over-broad block.

`insertSemanticAmendment` now returns a discriminated union `InsertSemanticAmendmentResult` (`inserted | already_pending | rejected`); all three callers narrow on `outcome`. No migration/schema change — matching is by reconstructed identity (robust to pre-existing `amendment:<entity>:<ts>` rows). The conflict lookup is org-scoped (`IS NOT DISTINCT FROM`) and fails **closed** (a lookup error propagates rather than inserting past a rejection).

## Test plan

- [x] `amendment-identity.test.ts` — key canonicalization: group scoping, per-type target extraction, `update_description` non-collapse, malformed→null, object/JSON payloads
- [x] `semantic-amendment-rejection-guard.test.ts` — DB-seam: suppression (no INSERT), pending dedup (no INSERT), rejected-over-pending precedence, per-target + per-group non-suppression, org-scoped lookup, identity-as-storage-key
- [x] `load-rejected-keys.test.ts` — pins **no time window** (no `interval`/`reviewed_at`) + group-scoped reconstruction
- [x] `propose-amendment.test.ts` — chat tool `rejected` (reason surfaced, nothing applied) + `already_pending` (converges, no apply)
- [x] `scheduler-tick.test.ts` — `rejected`/`already_pending` counted, nothing applied/queued
- [x] `categories.test.ts` — `add_join` staleness keyed on `to_<table>`
- [x] `/ci`: 29/30 gates green; the `test` gate's lone failure was a stale-local-`DATABASE_URL` MCP smoke artifact (passes 5/5 unset; diff touches no MCP/billing/whitelist code) — `test:others` with `DATABASE_URL` unset: all 38 packages pass
- [x] Internal review panel (4 specialists) — CLEAN after 2 rounds

Closes #4507