### PR TITLE
feat(semantic-improve): expert is a mode — first-class persona, workspace step cap, origin stamping (#4508)

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -89,12 +89,20 @@ void mock.module("@atlas/api/lib/auth/middleware", () => ({
   getClientIP: () => null,
 }));
 
+// #4508 — the chat handler re-enters withRequestContext to stamp the agent
+// origin; capture the ctx it stamps so the origin/user-binding assertions can
+// read it. The route's call is the innermost, so it wins `lastRequestContext`.
+let lastRequestContext: Record<string, unknown> | undefined;
+
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
   return {
     createLogger: () => logger,
-    withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+    withRequestContext: (ctx: Record<string, unknown>, fn: () => unknown) => {
+      lastRequestContext = ctx;
+      return fn();
+    },
     getRequestContext: () => ({ requestId: "test-req-id" }),
   };
 });
@@ -137,11 +145,21 @@ void mock.module("@atlas/api/lib/billing/enforcement", () => ({
   checkPlanLimits: async () => ({ allowed: true }),
 }));
 
-// Mock the agent and expert registry (not needed for session/proposal tests)
+// Mock the agent and expert registry. The chat-endpoint tests (#4508) capture
+// the runAgent options to assert the persona seam and that the retired
+// hardcoded `maxSteps: 15` is gone — the route now defers to runAgent's default
+// (`stepCountIs(getAgentMaxSteps())`), whose workspace-knob + bounds resolution
+// is pinned by agent-max-steps.test.ts and whose loop-capping is pinned by
+// agent-integration.test.ts.
+let runAgentArgs: Record<string, unknown> | undefined;
+
 void mock.module("@atlas/api/lib/agent", () => ({
-  runAgent: async () => ({
-    toUIMessageStream: () => new ReadableStream(),
-  }),
+  runAgent: async (args: Record<string, unknown>) => {
+    runAgentArgs = args;
+    return {
+      toUIMessageStream: () => new ReadableStream(),
+    };
+  },
 }));
 
 void mock.module("@atlas/api/lib/tools/expert-registry", () => ({
@@ -156,6 +174,7 @@ void mock.module("@atlas/api/lib/tools/expert-registry", () => ({
 // ---------------------------------------------------------------------------
 
 import { adminSemanticImprove } from "../admin-semantic-improve";
+import { EXPERT_PERSONA_PROMPT } from "@atlas/api/lib/semantic/expert/persona";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -169,6 +188,57 @@ describe("admin-semantic-improve", () => {
     applyPayloadCalls = [];
     applyShouldThrow = false;
     callOrder = [];
+    runAgentArgs = undefined;
+    lastRequestContext = undefined;
+  });
+
+  describe("POST /chat — expert is a mode (#4508)", () => {
+    async function postChat(): Promise<Response> {
+      return adminSemanticImprove.request("/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [
+            { id: "m1", role: "user", parts: [{ type: "text", text: "Improve the orders entity." }] },
+          ],
+        }),
+      });
+    }
+
+    it("runs the expert agent with the persona in the role position, never as a warning", async () => {
+      const res = await postChat();
+      expect(res.status).toBe(200);
+
+      // The expert persona is passed as the first-class ROLE section (the
+      // `persona` seam), NOT smuggled into `warnings` — the model gets one
+      // identity. This is the route-seam half of the "expert is a mode" fix;
+      // the prompt-assembly half is agent-expert-persona-prompt.test.ts.
+      expect(runAgentArgs?.persona).toBe(EXPERT_PERSONA_PROMPT);
+      expect(runAgentArgs?.warnings).toBeUndefined();
+    });
+
+    it("passes no hardcoded step cap — defers to runAgent's workspace-knob default", async () => {
+      const res = await postChat();
+      expect(res.status).toBe(200);
+
+      // The retired `maxSteps: 15` is gone: the route passes no override, so
+      // runAgent's `stepCountIs(getAgentMaxSteps())` default governs the loop,
+      // resolving the workspace agent-max-steps knob (with bounds) from the
+      // active org on the request-context frame the route stamps. The knob
+      // resolution itself is pinned by agent-max-steps.test.ts.
+      expect(runAgentArgs?.maxSteps).toBeUndefined();
+    });
+
+    it("stamps agentOrigin 'chat' and binds the requester so origin-scoped approval rules apply", async () => {
+      const res = await postChat();
+      expect(res.status).toBe(200);
+
+      // Without this frame agentOrigin is undefined and origin-scoped approval
+      // rules (#2072) silently no-op for the expert agent's executeSQL. The
+      // requester (approval binding) is bound from authResult.
+      expect(lastRequestContext?.agentOrigin).toBe("chat");
+      expect(lastRequestContext?.user).toBeDefined();
+    });
   });
 
   // The four in-memory session/proposal routes (GET /sessions,

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -18,13 +18,14 @@ import {
   createUIMessageStreamResponse,
   type UIMessage,
 } from "ai";
-import { createLogger } from "@atlas/api/lib/logger";
+import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import type { Context as HonoContext } from "hono";
 import { runAgent } from "@atlas/api/lib/agent";
 import { checkAgentBillingGate } from "@atlas/api/lib/billing/agent-gate";
 import { buildExpertRegistry } from "@atlas/api/lib/tools/expert-registry";
+import { EXPERT_PERSONA_PROMPT } from "@atlas/api/lib/semantic/expert/persona";
 import { ErrorSchema, AuthErrorSchema, createParamSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
@@ -151,88 +152,93 @@ adminSemanticImprove.openapi(chatStreamRoute, async (c) =>
     // Build the expert tool registry
     const expertRegistry = buildExpertRegistry();
 
-    // Build a system prefix for the expert agent
-    const expertSystemPrefix = `You are the Atlas Semantic Expert Agent. You analyze and improve the semantic layer by examining data distributions, identifying gaps, and proposing validated amendments.
+    // #4508 — stamp the agent origin so origin-scoped approval rules (#2072)
+    // fire for the expert agent's `executeSQL`. The interactive improve chat is
+    // a web surface, so it stamps `'chat'` like /chat · /query · /demo; without
+    // this frame `agentOrigin` is undefined and origin-scoped rules silently
+    // no-op for the expert agent. `runAgent` reads the user (approval requester)
+    // + origin from this context — the F-54/F-55 + #2072 agent-surface-registry
+    // guards pin the binding. We bind the user from `authResult` (the source of
+    // truth the adminAuth middleware set), matching /chat, rather than depending
+    // on the upstream ALS frame surviving the Effect bridge; the trust-device id
+    // (which `logAdminAction` reads) is preserved from the same context.
+    const authResult = c.get("authResult");
+    return withRequestContext(
+      {
+        requestId,
+        user: authResult.user,
+        atlasMode: c.get("atlasMode"),
+        trustDeviceIdentifier: c.get("trustDeviceIdentifier"),
+        agentOrigin: "chat",
+      },
+      async () => {
+        try {
+          // #4508 — no `maxSteps` override. The old hardcoded `maxSteps: 15`
+          // is retired: `runAgent`'s default is `stepCountIs(getAgentMaxSteps())`,
+          // which resolves the workspace agent-max-steps knob (workspace DB >
+          // platform DB > env > default, clamped to its bounds) from the active
+          // organization on the request-context frame stamped just above — so
+          // the improve chat honors the same operator knob as every other agent
+          // surface, hot-reloaded per turn, with no separate resolution path.
+          const agentResult = await runAgent({
+            messages,
+            tools: expertRegistry,
+            // #4508 — "expert is a mode": the expert persona REPLACES the analyst
+            // role section (not appended under `## Warnings`), so the model gets
+            // one identity. See lib/semantic/expert/persona.ts.
+            persona: EXPERT_PERSONA_PROMPT,
+          });
 
-## Your Goal
-Analyze the semantic layer and propose improvements. For each finding:
-1. Explain what you found and why it matters
-2. Use your tools to gather evidence (profile tables, check distributions, search audit log)
-3. Propose a specific amendment with a clear rationale and test query
-4. Wait for the user to approve or reject before moving on
+          // Audit the draft surface: an expert-agent chat turn that can propose
+          // amendments via `proposeAmendment`. The tool may persist a pending
+          // `learned_patterns` amendment row mid-stream, so the audit row is the
+          // single anchor for "admin ran the improve chat at time T" even if the
+          // stream errors later. The requestId is the correlation handle — there
+          // is no server-side session resource (#4503).
+          logAdminAction({
+            actionType: ADMIN_ACTIONS.semantic.improveDraft,
+            targetType: "semantic",
+            targetId: requestId,
+            ipAddress: clientIpFor(c),
+            metadata: { requestId, messageCount: messages.length },
+          });
 
-## Available Tools
-- profileTable: Examine table structure, cardinality, null rates, sample values
-- checkDataDistribution: Analyze a column's value distribution
-- searchAuditLog: Find query patterns from actual usage
-- proposeAmendment: Propose a structured YAML change with rationale and confidence
-- validateProposal: Dry-run validate a proposed amendment
-- explore: Read semantic YAML files
-- executeSQL: Run test queries to validate proposals
+          const stream = createUIMessageStream({
+            execute: ({ writer }) => {
+              writer.merge(agentResult.toUIMessageStream());
+            },
+            onError: (error) => {
+              log.error(
+                { err: error instanceof Error ? error : new Error(String(error)), requestId },
+                "Semantic improve stream error",
+              );
+              return `An error occurred while analyzing the semantic layer (ref: ${requestId.slice(0, 8)}). Try again.`;
+            },
+          });
 
-## Guidelines
-- Start with the highest-impact improvements first
-- Always gather evidence before proposing changes
-- Set confidence based on evidence strength
-- Include test queries to validate amendments
-- If the user asks about a specific table or area, focus there`;
-
-    try {
-      const agentResult = await runAgent({
-        messages,
-        tools: expertRegistry,
-        maxSteps: 15,
-        warnings: [expertSystemPrefix],
-      });
-
-      // Audit the draft surface: an expert-agent chat turn that can propose
-      // amendments via `proposeAmendment`. The tool may persist a pending
-      // `learned_patterns` amendment row mid-stream, so the audit row is the
-      // single anchor for "admin ran the improve chat at time T" even if the
-      // stream errors later. The requestId is the correlation handle — there
-      // is no server-side session resource (#4503).
-      logAdminAction({
-        actionType: ADMIN_ACTIONS.semantic.improveDraft,
-        targetType: "semantic",
-        targetId: requestId,
-        ipAddress: clientIpFor(c),
-        metadata: { requestId, messageCount: messages.length },
-      });
-
-      const stream = createUIMessageStream({
-        execute: ({ writer }) => {
-          writer.merge(agentResult.toUIMessageStream());
-        },
-        onError: (error) => {
+          return createUIMessageStreamResponse({
+            stream,
+            headers: {
+              "X-Accel-Buffering": "no",
+              "Cache-Control": "no-cache, no-transform",
+            },
+          });
+        } catch (err) {
           log.error(
-            { err: error instanceof Error ? error : new Error(String(error)), requestId },
-            "Semantic improve stream error",
+            { err: err instanceof Error ? err.message : String(err), requestId },
+            "Failed to start semantic improve agent",
           );
-          return `An error occurred while analyzing the semantic layer (ref: ${requestId.slice(0, 8)}). Try again.`;
-        },
-      });
-
-      return createUIMessageStreamResponse({
-        stream,
-        headers: {
-          "X-Accel-Buffering": "no",
-          "Cache-Control": "no-cache, no-transform",
-        },
-      });
-    } catch (err) {
-      log.error(
-        { err: err instanceof Error ? err.message : String(err), requestId },
-        "Failed to start semantic improve agent",
-      );
-      return c.json(
-        {
-          error: "agent_error",
-          message: `Failed to start the semantic expert agent: ${err instanceof Error ? err.message : String(err)}`,
-          requestId,
-        },
-        500,
-      );
-    }
+          return c.json(
+            {
+              error: "agent_error",
+              message: `Failed to start the semantic expert agent: ${err instanceof Error ? err.message : String(err)}`,
+              requestId,
+            },
+            500,
+          );
+        }
+      },
+    );
   }),
 );
 

--- a/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
@@ -1,0 +1,180 @@
+/**
+ * #4508 — mock-LLM prompt-shape test for the expert persona ("expert is a
+ * mode", PRD #4502).
+ *
+ * The persona unit test (semantic/expert/__tests__/persona.test.ts) pins the
+ * role-section string; this file pins the SEAM ABOVE it: a `runAgent` turn with
+ * a `persona` builds a system prompt whose ROLE section is the expert persona
+ * (in the role position, ahead of the tool guidance) and NOT the analyst
+ * prefix — and, crucially, the persona is never smuggled under `## Warnings`.
+ * A turn with no persona still gets the analyst prefix, so every other surface
+ * is unchanged. Asserted against the prompt the mock LLM actually receives,
+ * mirroring agent-answer-style-prompt-shape.test.ts.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import { EXPERT_PERSONA_PROMPT } from "@atlas/api/lib/semantic/expert/persona";
+
+// ---------------------------------------------------------------------------
+// Module mocks — deterministic single-connection workspace, no internal DB.
+// runAgent runs with NO request context here, so every org-scoped loader
+// (REST datasources, routing context, learned patterns) short-circuits.
+// ---------------------------------------------------------------------------
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      describe: () => [{ id: "default", dbType: "postgres" as const }],
+    },
+  }),
+);
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+void mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => [],
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  buildRetrievalQuery: () => "",
+  getRetrievalTurns: () => 3,
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
+// ---------------------------------------------------------------------------
+// Spying mock model — captures the system prompt each turn renders.
+// ---------------------------------------------------------------------------
+
+let lastSystemPrompt: string | undefined;
+
+function extractSystemPrompt(opts: unknown): string | undefined {
+  const prompt = (opts as { prompt?: ReadonlyArray<{ role: string; content: unknown }> })?.prompt;
+  const systemMsg = Array.isArray(prompt) ? prompt.find((p) => p.role === "system") : undefined;
+  if (!systemMsg) return undefined;
+  const content = systemMsg.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((c) => (c as { text?: string })?.text ?? "").join("");
+  }
+  return "";
+}
+
+function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
+  const parts: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "Profiled orders; proposing a measure." },
+    {
+      type: "finish",
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 20, text: 20, reasoning: undefined },
+      },
+      finishReason: { unified: "stop", raw: "end_turn" },
+    },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async (opts: unknown) => {
+      const content = extractSystemPrompt(opts);
+      if (content) lastSystemPrompt = content;
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+
+function userMessages(text: string): UIMessage[] {
+  return [
+    {
+      id: "msg-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text }],
+    },
+  ];
+}
+
+async function runTurn(persona?: string): Promise<string> {
+  lastSystemPrompt = undefined;
+  const result = await runAgent({
+    messages: userMessages("Improve the orders entity."),
+    aiModel: {
+      model: makeSpyingModel(),
+      providerType: "openai",
+      modelId: "mock-expert-persona-model",
+    },
+    ...(persona ? { persona } : {}),
+  });
+  await result.text; // drain the stream so doStream ran
+  expect(lastSystemPrompt).toBeDefined();
+  return lastSystemPrompt ?? "";
+}
+
+/** The system prompt's `## Warnings` section, or "" when there is none. */
+function warningsSection(prompt: string): string {
+  const idx = prompt.indexOf("## Warnings");
+  return idx === -1 ? "" : prompt.slice(idx);
+}
+
+describe("runAgent — expert persona threading (#4508)", () => {
+  it("a turn with a persona renders it as the ROLE section (ahead of the tool guidance)", async () => {
+    const prompt = await runTurn(EXPERT_PERSONA_PROMPT);
+
+    // The expert identity is the role section: at the very start of the prompt,
+    // before the tool-guidance steps (`### 2. Explore …`).
+    expect(prompt.startsWith("You are the Atlas Semantic Expert Agent.")).toBe(true);
+    const personaIdx = prompt.indexOf("You are the Atlas Semantic Expert Agent.");
+    const exploreIdx = prompt.indexOf("### 2. Explore");
+    expect(personaIdx).toBeGreaterThanOrEqual(0);
+    expect(exploreIdx).toBeGreaterThan(personaIdx);
+
+    // The analyst role section is REPLACED, not co-present — one identity.
+    expect(prompt).not.toContain("You are Atlas, an expert data analyst");
+  });
+
+  it("the persona is the role, never a `## Warnings` bullet", async () => {
+    const prompt = await runTurn(EXPERT_PERSONA_PROMPT);
+
+    // The pre-#4508 bug was the persona smuggled in under `## Warnings` after
+    // the analyst role. Assert nothing expert-shaped lives in that section — if
+    // a `## Warnings` section exists at all here, it carries no persona text.
+    const warnings = warningsSection(prompt);
+    expect(warnings).not.toContain("You are the Atlas Semantic Expert Agent.");
+    expect(warnings).not.toContain("Your work product is a well-evidenced");
+  });
+
+  it("a turn with no persona keeps the analyst role section (every other surface unchanged)", async () => {
+    const prompt = await runTurn();
+    expect(prompt).toContain("You are Atlas, an expert data analyst");
+    expect(prompt).not.toContain("You are the Atlas Semantic Expert Agent.");
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-surface-registry.test.ts
+++ b/packages/api/src/lib/__tests__/agent-surface-registry.test.ts
@@ -77,11 +77,13 @@ const KNOWN_AGENT_CALLERS: AgentCallerSpec[] = [
   },
   {
     file: "packages/api/src/api/routes/admin-semantic-improve.ts",
-    // Admin route — gated by requireAuth middleware that binds the user
-    // via withRequestContext upstream. The route itself uses runAgent
-    // inside that frame, so any of the upstream withRequestContext calls
-    // satisfies the binding requirement.
-    bindingProof: /\b(runAgent|executeAgentQuery)\b/,
+    // #4508: the improve chat re-enters `withRequestContext` around its
+    // `runAgent` call, binding the user (approval requester) from `authResult`
+    // and stamping the origin. The pre-#4508 proof here was the vacuous
+    // `/\b(runAgent|executeAgentQuery)\b/` — satisfied by the import alone, so
+    // it could never fail. This proof matches /chat's and genuinely fails if the
+    // binding frame is dropped.
+    bindingProof: /withRequestContext\(\s*\{[^}]*\buser\b/,
   },
 ];
 
@@ -115,6 +117,11 @@ const KNOWN_ORIGIN_STAMPERS: OriginStamperSpec[] = [
   { file: "packages/api/src/api/routes/demo.ts", originProof: /agentOrigin:\s*"chat"/ },
   // Scheduler executor stamps 'scheduler' on every scheduled run.
   { file: "packages/api/src/lib/scheduler/executor.ts", originProof: /agentOrigin:\s*"scheduler"/ },
+  // #4508 — the interactive semantic-improve chat runs the expert agent on a
+  // web surface, so it stamps 'chat' (like /chat · /query · /demo). Before
+  // #4508 the route stamped nothing and was absent here, so origin-scoped
+  // approval rules (#2072) silently no-op'd for the expert agent's executeSQL.
+  { file: "packages/api/src/api/routes/admin-semantic-improve.ts", originProof: /agentOrigin:\s*"chat"/ },
   // MCP — #3602 centralized the per-tool dispatch frame into one shared
   // wrapper, so the 'mcp' origin stamp for explore / executeSQL / the semantic
   // tools / the datasource lifecycle tools now lives ONCE here (they all route

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -522,9 +522,16 @@ function buildSystemPrompt(
   routingContext?: ScopeRoutingContext,
   boundDashboardContext?: BoundDashboardAgentContext,
   orgKnowledgeToc?: string,
+  persona?: string,
 ): string {
   const suffix = boundDashboardContext ? BOUND_AGENT_PROMPT_GUIDANCE : SYSTEM_PROMPT_SUFFIX;
-  let base = SYSTEM_PROMPT_PREFIX + "\n\n" + registry.describe() + "\n\n" + suffix;
+  // #4508 — "expert is a mode": a persona REPLACES the standard analyst role
+  // section (`SYSTEM_PROMPT_PREFIX`), so the model receives one identity. The
+  // improve route passes the expert persona here instead of smuggling it in as
+  // a `## Warnings` bullet after the analyst prefix. Persona-independent
+  // sections (tool guidance, suffix rules, semantic index) are unchanged.
+  const prefix = persona ?? SYSTEM_PROMPT_PREFIX;
+  let base = prefix + "\n\n" + registry.describe() + "\n\n" + suffix;
   if (boundDashboardContext) {
     base += "\n\n" + boundDashboardContext.cardSummary;
   }
@@ -638,6 +645,16 @@ export interface BuildSystemParamOptions {
   readonly registry?: ToolRegistry;
   /** Startup/context warnings surfaced to the agent under a `## Warnings` section. */
   readonly warnings?: readonly string[];
+  /**
+   * #4508 — the agent's ROLE section, replacing `SYSTEM_PROMPT_PREFIX` ("You
+   * are Atlas, an expert data analyst"). "Expert is a mode": the improve route
+   * passes the expert persona (lib/semantic/expert/persona.ts) so the model
+   * carries one identity — the sibling seam to {@link answerStyle}, which swaps
+   * the editorial voice while this swaps the role. Omitted ⇒ the analyst
+   * prefix, unchanged for every other surface. Do NOT route a persona through
+   * {@link warnings} — a persona is the role, not a footnote appended after it.
+   */
+  readonly persona?: string;
   /** Org-scoped (DB-backed) semantic index section; preferred over the file-based index when present. */
   readonly orgSemanticIndex?: string;
   /**
@@ -722,6 +739,7 @@ export function buildSystemParam(
   const {
     registry = defaultRegistry,
     warnings,
+    persona,
     orgSemanticIndex,
     orgKnowledgeToc,
     learnedPatternsSection,
@@ -733,7 +751,7 @@ export function buildSystemParam(
     memoryBlock,
     sourceCatalog,
   } = options;
-  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext, orgKnowledgeToc);
+  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext, orgKnowledgeToc, persona);
 
   if (sourceCatalog) {
     content += "\n\n" + sourceCatalog;
@@ -1007,6 +1025,7 @@ export async function runAgent({
   tools: toolRegistry = defaultRegistry,
   conversationId,
   warnings,
+  persona,
   contextWarnings,
   maxSteps: maxStepsOverride,
   /** Optional pre-resolved AI model. When provided, skips provider resolution. */
@@ -1022,6 +1041,13 @@ export async function runAgent({
   tools?: ToolRegistry;
   conversationId?: string;
   warnings?: string[];
+  /**
+   * #4508 — the agent's ROLE section, replacing `SYSTEM_PROMPT_PREFIX`
+   * ("expert is a mode"). The improve route passes the expert persona
+   * (lib/semantic/expert/persona.ts); every other surface omits it and keeps
+   * the analyst prefix. Threaded verbatim to {@link buildSystemParam}.
+   */
+  persona?: string;
   /**
    * Out-parameter (#1988 B5). When supplied, the agent's preflight loaders
    * push a structured {@link ChatContextWarning} entry per failure so the
@@ -1654,6 +1680,7 @@ export async function runAgent({
   const systemParam = buildSystemParam(providerType, {
     registry: activeRegistry,
     warnings,
+    persona,
     orgSemanticIndex,
     orgKnowledgeToc,
     learnedPatternsSection,

--- a/packages/api/src/lib/semantic/expert/__tests__/persona.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/persona.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #4508 — expert persona role section (PRD #4502; "expert is a mode").
+ *
+ * Pins the persona's shape as a first-class ROLE section, not a warnings
+ * footnote: it opens with the expert identity, structurally mirrors the analyst
+ * `SYSTEM_PROMPT_PREFIX` (a `## Your Workflow` heading whose `### 1.` step flows
+ * into the tool-guidance steps), and carries none of the analyst identity. The
+ * seam that threads it into a built prompt is pinned separately at the agent
+ * seam (agent-expert-persona-prompt.test.ts) and the route seam
+ * (admin-semantic-improve.test.ts).
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { EXPERT_PERSONA_PROMPT } from "../persona";
+
+describe("EXPERT_PERSONA_PROMPT (#4508)", () => {
+  it("opens with the semantic expert identity", () => {
+    // The role line is the first thing the model reads — the persona IS the
+    // identity, not an addendum to a different one.
+    expect(EXPERT_PERSONA_PROMPT.startsWith("You are the Atlas Semantic Expert Agent.")).toBe(true);
+  });
+
+  it("carries none of the analyst role section's identity", () => {
+    // If this ever contains the analyst identity, the two would coexist and the
+    // "one identity" invariant would be broken — the exact bug #4508 closes.
+    expect(EXPERT_PERSONA_PROMPT).not.toContain("You are Atlas, an expert data analyst");
+  });
+
+  it("mirrors the prefix shape so the numbered tool workflow stays coherent", () => {
+    // `registry.describe()` appends the tool-guidance steps starting at
+    // "### 2. Explore …", so the persona must end its own workflow at "### 1."
+    // for the numbering to read as one sequence across the seam.
+    expect(EXPERT_PERSONA_PROMPT).toContain("## Your Workflow");
+    expect(EXPERT_PERSONA_PROMPT).toContain("### 1.");
+    expect(EXPERT_PERSONA_PROMPT).not.toContain("### 2.");
+  });
+
+  it("frames the work product as a reviewable Amendment, evidence-first", () => {
+    // The persona vocabulary must match CONTEXT.md § Semantic improvement — the
+    // agent proposes Amendments backed by evidence, it does not answer data
+    // questions.
+    expect(EXPERT_PERSONA_PROMPT).toContain("Amendment");
+    expect(EXPERT_PERSONA_PROMPT.toLowerCase()).toContain("evidence");
+  });
+});

--- a/packages/api/src/lib/semantic/expert/persona.ts
+++ b/packages/api/src/lib/semantic/expert/persona.ts
@@ -1,0 +1,44 @@
+/**
+ * Expert persona — the first-class ROLE section for Improvement conversations
+ * (#4508, PRD #4502; CONTEXT.md § Semantic improvement).
+ *
+ * "Expert is a mode": the semantic expert agent is the same agent loop wearing
+ * a different persona, exactly as an answer style is the same agent wearing a
+ * different editorial voice (lib/answer-styles.ts). Where the analyst role
+ * section (`SYSTEM_PROMPT_PREFIX` in lib/agent.ts) opens "You are Atlas, an
+ * expert data analyst," the expert persona *replaces* that role section — it
+ * rides `buildSystemParam`'s `persona` seam, the sibling of the answer-style
+ * addendum seam — so the model receives ONE identity, the semantic expert, not
+ * two conflicting ones. Every persona-independent section (tool guidance, the
+ * `## Rules` suffix, the semantic index) is unchanged.
+ *
+ * Contrast the pre-#4508 shape, where this text was smuggled in as a
+ * `## Warnings` bullet AFTER the analyst role section: the model was told it was
+ * a data analyst and, in a warnings footnote, also a semantic expert.
+ *
+ * The prompt structurally mirrors `SYSTEM_PROMPT_PREFIX` — a role line, then a
+ * `## Your Workflow` heading whose `### 1.` step flows into the tool-guidance
+ * steps (`### 2. Explore …`) that `registry.describe()` appends next — so the
+ * numbered workflow stays coherent across the persona / tool-guidance seam.
+ */
+
+/**
+ * The expert agent's role section. Replaces `SYSTEM_PROMPT_PREFIX` when the
+ * improve route calls `runAgent({ persona: EXPERT_PERSONA_PROMPT })`.
+ */
+export const EXPERT_PERSONA_PROMPT = `You are the Atlas Semantic Expert Agent. You analyze and improve the semantic layer — the entity YAML, glossary, measures, and joins the analyst agent reads to answer questions — by examining real data distributions, mining how the data is actually queried, and proposing validated changes an admin reviews.
+
+You are not answering an end-user's data question. Your work product is a well-evidenced **Amendment**: a specific, reviewable change to the semantic layer, backed by data and a test query, that an admin approves or rejects.
+
+Principles:
+- Start with the highest-impact improvements first.
+- Always gather evidence before proposing — profile the table, check a column's distribution, and search the audit log for how the data is used. Never propose from a guess.
+- Set each Amendment's confidence from the strength of its evidence, and include a test query that validates it whenever you can.
+- Propose one Amendment at a time and let the admin approve or reject it before you move on.
+
+## Your Workflow
+
+Follow these steps for every improvement:
+
+### 1. Understand the Goal
+Identify what to improve — the table, column, or coverage gap the admin cares about, or the highest-impact finding when they haven't named one. Then gather the evidence that a change is warranted before proposing it.`;


### PR DESCRIPTION
Closes #4508 · Milestone v0.0.48 (Semantic-Improve Elevation, PRD #4502).

## What & why

The expert (improve-chat) agent's identity, step cap, and approval-governance now match every other agent surface, closing three gaps from the elevation audit.

### 1. Expert is a first-class PERSONA, not a `## Warnings` footnote
Before, the expert prompt was appended as a warnings bullet *after* the analyst role section — the model was told it was a data analyst **and**, in a footnote, a semantic expert (two conflicting identities). Now:
- New `packages/api/src/lib/semantic/expert/persona.ts` (`EXPERT_PERSONA_PROMPT`), modeled after the answer-styles registry.
- `agent.ts` gains a `persona` seam (`buildSystemParam` / `buildSystemPrompt` / `runAgent`): when set it **replaces** `SYSTEM_PROMPT_PREFIX` (the analyst role section), so the model receives **one** identity. Persona-independent sections (tool guidance, `## Rules`, semantic index) are unchanged.
- The improve route passes `persona` instead of `warnings`.

### 2. Step cap follows the workspace agent-max-steps knob
The hardcoded `maxSteps: 15` is retired. The route now passes no override, so `runAgent`'s default `stepCountIs(getAgentMaxSteps())` resolves the workspace `ATLAS_AGENT_MAX_STEPS` knob (workspace DB > platform DB > env > default, clamped to bounds) from the active org on the request-context frame the route now stamps — same operator knob as every other surface, hot-reloaded per turn, no separate resolution path.

### 3. Origin stamping — closes the vacuous-guard finding
The route wraps `runAgent` in `withRequestContext`, binding the user (approval requester) from `authResult` and stamping `agentOrigin: "chat"` (web surface, like `/chat` · `/query` · `/demo`). Without it, `agentOrigin` was undefined and origin-scoped approval rules (#2072) silently no-op'd for the expert agent's `executeSQL`. `agent-surface-registry.test.ts` is strengthened so it can **genuinely fail** for this route: the `bindingProof` goes from the vacuous `/runAgent|executeAgentQuery/` (satisfied by the import alone) to `/chat`'s real `withRequestContext`-binds-`user` proof, and the route joins `KNOWN_ORIGIN_STAMPERS` with `agentOrigin: "chat"`.

## Acceptance criteria
- [x] Prompt assembly verified at the mock-LLM agent seam: expert persona in the role position, nothing expert-shaped under Warnings
- [x] Step cap honors the workspace knob (and its bounds), no hardcoded override
- [x] Agent origin stamped on improve-chat runs; the surface-registry test can genuinely fail for this route
- [x] Origin-scoped approval rules demonstrably match improve-chat traffic (`agentOrigin: "chat"`)

## Tests
- `semantic/expert/__tests__/persona.test.ts` — persona shape (identity, mirrors prefix, no analyst identity).
- `__tests__/agent-expert-persona-prompt.test.ts` — mock-LLM agent seam: persona in role position ahead of tool guidance, nothing expert-shaped under `## Warnings`, non-persona turn keeps the analyst prefix.
- `admin-semantic-improve.test.ts` — route seam: persona-not-warnings, no hardcoded step cap, `agentOrigin: "chat"` + user bound.
- `agent-surface-registry.test.ts` — strengthened binding + origin proofs.

## Design note
Chose to *remove* the route's `maxSteps` override rather than import `getAgentMaxSteps` into the route: the new import would break 31 partial `@atlas/api/lib/agent` mocks (the known "new export breaks every partial mock" tax). Deferring to `runAgent`'s knob-honoring default is cleaner and honors the same knob.

## CI note
Local `/ci`: all 29 non-test gates pass (type, lint, lint-type-aware, openapi-drift, published-symbols, schema-drift, …). The only `test`-gate failure is a pre-existing, environmental `@atlas/mcp` `smoke.test.ts` (needs a migrated internal DB for the billing-gate workspace check) — it fails identically on the clean base with my changes stashed, in a package this PR does not touch. Full `@atlas/api` affected suite is 79/79 green. Relying on GitHub CI (which provides the DB) as the authoritative gate.