### PR TITLE
feat(semantic-improve): shared org-scope clause + one-workspace-owner invariant (#4510)

### DIFF
--- a/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
+++ b/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
@@ -1,21 +1,28 @@
 /**
- * Unit tests for the SaaS scoping of the three semantic-amendment queries
- * (#4487): `getPendingAmendmentCount`, `getPendingAmendments`, and
- * `reviewSemanticAmendment`.
+ * SaaS scoping + one-workspace-owner invariant for semantic amendments
+ * (#4487, #4510).
  *
- * Security invariant: NULL-org ("global scope") amendment rows are the
+ * Reader scoping (#4487): NULL-org ("global scope") amendment rows are the
  * intended shared scope on self-hosted, but on SaaS they must NEVER surface
- * in — or be reviewable from — any tenant workspace. These tests assert the
- * SQL shape flips with deploy mode:
+ * in — or be reviewable from — any tenant workspace. The SQL shape flips with
+ * deploy mode:
  *   - self-hosted (or unloaded config): `(org_id = $1 OR org_id IS NULL)`
  *   - saas:                              `org_id = $1` only, and the org-less
  *                                        path is refused before any query.
+ *
+ * #4510 consolidates that conditional into ONE shared helper,
+ * `amendmentOrgScope`, that every reader (count, list, review) MUST use — pinned
+ * here by a reader-enumeration test — and ratchets the insert seam so no code
+ * path can mint a NULL-owner row anew on SaaS (the one-workspace-owner
+ * invariant; legacy NULL-owner rows stay readable on self-hosted).
  *
  * Deploy mode is resolved through `isSaasModeForGuard()` (fail-closed), which
  * reads the cached config — we drive it here via `_setConfigForTest`.
  */
 
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 // `hasInternalDB()` reads DATABASE_URL at call time; set it before the module
 // under test is imported so the query paths (not the no-DB short-circuits) run.
@@ -25,6 +32,8 @@ import {
   getPendingAmendmentCount,
   getPendingAmendments,
   reviewSemanticAmendment,
+  insertSemanticAmendment,
+  amendmentOrgScope,
   _resetPool,
   _resetCircuitBreaker,
 } from "../internal";
@@ -42,7 +51,9 @@ function makeStubPool() {
   return {
     query: async (sql: string, params?: unknown[]) => {
       captured.push({ sql, params: params ?? [] });
-      // reviewSemanticAmendment reads rows[0]; return an empty result set.
+      // insertSemanticAmendment's INSERT reads back the new row's id; the reader
+      // SELECT/UPDATEs and the insert-time conflict SELECT read an empty set.
+      if (sql.includes("INSERT INTO learned_patterns")) return { rows: [{ id: "new-row-id" }] };
       return { rows: [] };
     },
     async end() {},
@@ -178,5 +189,195 @@ describe("semantic amendment queries — SaaS scoping (#4487)", () => {
 
     expect(reviewed).toBeNull();
     expect(captured).toHaveLength(0);
+  });
+});
+
+describe("amendmentOrgScope helper — direct (#4510)", () => {
+  it("self-hosted + workspace keeps the legacy NULL-owner arm", () => {
+    setDeployMode("self-hosted");
+    expect(amendmentOrgScope("org-a", "$1")).toEqual({
+      withhold: false,
+      clause: "(org_id = $1 OR org_id IS NULL)",
+    });
+  });
+
+  it("SaaS + workspace drops the NULL-owner arm", () => {
+    setDeployMode("saas");
+    expect(amendmentOrgScope("org-a", "$1")).toEqual({ withhold: false, clause: "org_id = $1" });
+  });
+
+  it("self-hosted + org-less is the global-admin NULL-owner view", () => {
+    setDeployMode("self-hosted");
+    expect(amendmentOrgScope(null, "$1")).toEqual({ withhold: false, clause: "org_id IS NULL" });
+  });
+
+  it("SaaS + org-less withholds (there is no global tenant)", () => {
+    setDeployMode("saas");
+    expect(amendmentOrgScope(null, "$1")).toEqual({ withhold: true });
+  });
+
+  it("threads an arbitrary placeholder position into the clause", () => {
+    setDeployMode("self-hosted");
+    expect(amendmentOrgScope("org-a", "$4")).toEqual({
+      withhold: false,
+      clause: "(org_id = $4 OR org_id IS NULL)",
+    });
+  });
+
+  it("treats an empty-string org as org-less (falsy), same as null", () => {
+    // Documents the truthiness boundary: on SaaS an empty owner withholds; on
+    // self-hosted it falls into the global-admin NULL-owner view (never a
+    // silently-scoped-to-"" workspace).
+    setDeployMode("saas");
+    expect(amendmentOrgScope("", "$1")).toEqual({ withhold: true });
+    setDeployMode("self-hosted");
+    expect(amendmentOrgScope("", "$1")).toEqual({ withhold: false, clause: "org_id IS NULL" });
+  });
+});
+
+describe("one-workspace-owner invariant — insert seam (#4510)", () => {
+  const insertBase = {
+    orgId: null as string | null,
+    description: "[add_dimension] orders: adds region",
+    sourceEntity: "orders",
+    confidence: 0.5,
+    connectionGroupId: null as string | null,
+    amendmentPayload: {
+      amendmentType: "add_dimension",
+      amendment: { name: "region", type: "string" },
+    } as Record<string, unknown>,
+  };
+
+  function insertedRow() {
+    return captured.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+  }
+
+  it("refuses a NULL-owner amendment on SaaS, without touching the DB", async () => {
+    setDeployMode("saas");
+    await expect(insertSemanticAmendment({ ...insertBase, orgId: null })).rejects.toThrow(
+      /requires a workspace owner on SaaS/,
+    );
+    expect(captured).toHaveLength(0);
+  });
+
+  it("refuses an undefined owner on SaaS too (falsy, same guard)", async () => {
+    setDeployMode("saas");
+    await expect(insertSemanticAmendment({ ...insertBase, orgId: undefined })).rejects.toThrow(
+      /requires a workspace owner on SaaS/,
+    );
+    expect(captured).toHaveLength(0);
+  });
+
+  it("stamps the workspace owner on SaaS when an org is supplied", async () => {
+    setDeployMode("saas");
+    const res = await insertSemanticAmendment({ ...insertBase, orgId: "org-a" });
+    expect(res.outcome).toBe("inserted");
+    const insert = insertedRow();
+    expect(insert).toBeDefined();
+    // org_id is the first bound parameter of the INSERT.
+    expect(insert!.params[0]).toBe("org-a");
+  });
+
+  it("tolerates a NULL owner on self-hosted (legacy global scope, still writable)", async () => {
+    setDeployMode("self-hosted");
+    const res = await insertSemanticAmendment({ ...insertBase, orgId: null });
+    expect(res.outcome).toBe("inserted");
+    const insert = insertedRow();
+    expect(insert).toBeDefined();
+    expect(insert!.params[0]).toBeNull();
+  });
+});
+
+describe("shared org-scope helper — reader/inserter enumeration (#4510)", () => {
+  const source = readFileSync(join(import.meta.dir, "..", "internal.ts"), "utf8");
+
+  // The canonical amendment readers. Adding a new tenant-scoped amendment reader
+  // means adding it here AND routing its org filter through amendmentOrgScope —
+  // the discovery test below fails if either is skipped.
+  const AMENDMENT_READERS = [
+    "getPendingAmendmentCount",
+    "getPendingAmendments",
+    "reviewSemanticAmendment",
+  ];
+
+  const stripComments = (s: string) =>
+    s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+
+  /**
+   * Every top-level function, each body sliced to the next top-level `function`
+   * declaration. Good enough for marker attribution in this flat DB-helper
+   * module (no nested named function declarations), and robust to reformatting —
+   * we never brace-balance (template `${…}` braces would defeat that).
+   */
+  function topLevelFunctions(): Array<{ name: string; body: string }> {
+    const marks = [
+      ...source.matchAll(/^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z0-9_]+)/gm),
+    ].map((m) => ({ name: m[1], start: m.index ?? 0 }));
+    return marks.map((mk, i) => ({
+      name: mk.name,
+      body: source.slice(mk.start, i + 1 < marks.length ? marks[i + 1].start : source.length),
+    }));
+  }
+
+  function bodyOf(name: string): string {
+    const fn = topLevelFunctions().find((f) => f.name === name);
+    if (!fn) throw new Error(`function ${name} not found in internal.ts`);
+    return fn.body;
+  }
+
+  it("every amendment reader derives its org filter from amendmentOrgScope", () => {
+    for (const name of AMENDMENT_READERS) {
+      expect(bodyOf(name)).toContain("amendmentOrgScope(");
+    }
+  });
+
+  it("no amendment reader inlines a raw org_id scope clause (bypassing the helper)", () => {
+    for (const name of AMENDMENT_READERS) {
+      // Strip comments — a doc comment may *mention* the clause it delegates to
+      // `amendmentOrgScope`; only inlined SQL counts as a bypass.
+      const code = stripComments(bodyOf(name));
+      expect(code).not.toContain("org_id IS NULL");
+      expect(code).not.toMatch(/org_id\s*=\s*\$\d/);
+    }
+  });
+
+  it("pins the reader set — discovery tolerant of predicate order/whitespace/alias", () => {
+    // A reader SELECT/UPDATEs pending amendments: an equality `type =
+    // 'semantic_amendment'` predicate AND a `status = 'pending'` *filter* (in a
+    // WHERE/AND position — not a `SET status = 'pending'` write). Matched
+    // independently and comment-stripped, tolerant of a table alias (`lp.`),
+    // extra whitespace, reordered predicates, or a line break, so a paraphrased
+    // new reader is still discovered and must be added to AMENDMENT_READERS +
+    // route through the helper. Intentionally excludes: findConflictingAmendment
+    // (`status IN (...)`, scoped NULL-safe by `IS NOT DISTINCT FROM` — an
+    // identity dedup, not a tenant read), revertAmendmentToPending (which SETs
+    // status='pending' but filters `status = 'approved'`), and the learned-
+    // pattern decay query (`type != 'semantic_amendment'`).
+    const discovered = topLevelFunctions()
+      .filter((f) => {
+        const code = stripComments(f.body);
+        return (
+          /(?:\w+\.)?type\s*=\s*'semantic_amendment'/.test(code) &&
+          /(?:WHERE|AND)\s+(?:\w+\.)?status\s*=\s*'pending'/.test(code)
+        );
+      })
+      .map((f) => f.name);
+    expect(discovered.sort()).toEqual([...AMENDMENT_READERS].sort());
+  });
+
+  it("pins the single insert seam — only insertSemanticAmendment writes amendment rows", () => {
+    // AC #3's one-workspace-owner guard lives at the single insert choke point.
+    // Pin that it stays single: the only function that INSERTs a
+    // `'semantic_amendment'`-typed learned_patterns row is insertSemanticAmendment.
+    // A new raw inserter added here would evade the guard and could mint a
+    // NULL-owner row anew on SaaS.
+    const inserters = topLevelFunctions()
+      .filter(
+        (f) =>
+          /INSERT INTO learned_patterns/.test(f.body) &&
+          /'semantic_amendment'/.test(stripComments(f.body)),
+      )
+      .map((f) => f.name);
+    expect(inserters).toEqual(["insertSemanticAmendment"]);
   });
 });

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1678,6 +1678,24 @@ export async function insertSemanticAmendment(amendment: {
    */
   connectionGroupId: string | null;
 }): Promise<InsertSemanticAmendmentResult> {
+  // One-workspace-owner invariant (#4510): on SaaS an Amendment MUST be owned by
+  // exactly one workspace. A NULL-owner ("global scope") row is a cross-tenant
+  // leak vector — it would surface in, or be reviewable from, another workspace
+  // (mirror of the reader guard in `amendmentOrgScope` / #4487). Refuse it at
+  // this single insert choke point — the one path every caller (chat tool,
+  // scheduler, CLI) shares — so no code path can mint a NULL-owner row anew on
+  // SaaS, and a future SaaS-capable scheduler (#4516; today force-disabled on
+  // SaaS) would be org-safe by construction. On self-hosted the single workspace
+  // IS the whole deployment, so a NULL owner is that one
+  // workspace's legacy global scope — tolerated (the CLI and scheduler
+  // single-org paths still write it). Fail LOUD, never a silent global insert.
+  if (!amendment.orgId && requireIsSaasModeForGuard()()) {
+    throw new Error(
+      "insertSemanticAmendment: a semantic amendment requires a workspace owner on SaaS " +
+        "(org_id must be non-null). Refusing to queue a NULL-owner / global-scope amendment.",
+    );
+  }
+
   // #3392 — thread the amendment's org through so a per-workspace
   // auto-approve override (admin settings page) governs its own proposals.
   // null orgId (self-hosted / global scope) resolves at the platform tier.
@@ -1791,26 +1809,63 @@ export async function revertAmendmentToPending(id: string): Promise<boolean> {
 }
 
 /**
+ * Result of {@link amendmentOrgScope}: either the reader withholds (returns its
+ * empty value without querying) or it has a ready-to-splice `org_id` predicate.
+ */
+export type AmendmentOrgScope = { withhold: true } | { withhold: false; clause: string };
+
+/**
+ * Shared org-scope filter for the semantic-amendment readers — the ONE home for
+ * the SaaS-vs-self-hosted `org_id` conditional (#4487, #4510). Every amendment
+ * reader (count, list, review) MUST derive its predicate from here rather than
+ * inlining the ternary; `semantic-amendment-saas-scoping.test.ts` pins the
+ * reader set and fails if a new reader bypasses this helper.
+ *
+ *   - SaaS + workspace        → `org_id = <ph>` — a NULL-owner ("global scope")
+ *                               row never surfaces in a tenant workspace (the
+ *                               #4487 leak fix).
+ *   - self-hosted + workspace → `(org_id = <ph> OR org_id IS NULL)` — legacy
+ *                               NULL-owner rows stay readable as the single
+ *                               workspace's global scope (never produced anew —
+ *                               see the invariant in `insertSemanticAmendment`).
+ *   - org-less, self-hosted   → `org_id IS NULL` (the global-admin view).
+ *   - org-less, SaaS          → `{ withhold: true }`: there is no global tenant,
+ *                               so the caller returns its empty value without
+ *                               touching the DB.
+ *
+ * @param orgId       the workspace owner, or null for the org-less path.
+ * @param placeholder the positional parameter that binds `orgId` (e.g. "$1").
+ */
+export function amendmentOrgScope(
+  orgId: string | null,
+  // A positional bind marker, not free text — the raw splice below is only safe
+  // because the type forbids anything but `$<n>` (both call sites pass literals).
+  placeholder: `$${number}`,
+): AmendmentOrgScope {
+  const saas = requireIsSaasModeForGuard()();
+  if (!orgId) {
+    return saas ? { withhold: true } : { withhold: false, clause: "org_id IS NULL" };
+  }
+  return {
+    withhold: false,
+    clause: saas ? `org_id = ${placeholder}` : `(org_id = ${placeholder} OR org_id IS NULL)`,
+  };
+}
+
+/**
  * Count pending semantic amendment proposals for an org.
  * Returns 0 when no internal DB is available.
  */
 export async function getPendingAmendmentCount(orgId: string | null): Promise<number> {
   if (!hasInternalDB()) return 0;
 
-  const saas = requireIsSaasModeForGuard()();
-  // SaaS: NULL-org ("global scope") rows must never surface in any workspace
-  // (#4487). Refuse the org-less path outright, and below drop the
-  // `OR org_id IS NULL` arm so a workspace only ever counts its own rows.
-  if (saas && !orgId) return 0;
+  const scope = amendmentOrgScope(orgId, "$1");
+  if (scope.withhold) return 0;
 
   const rows = await internalQuery<{ count: string }>(
-    orgId
-      ? `SELECT COUNT(*)::text AS count FROM learned_patterns
-         WHERE type = 'semantic_amendment' AND status = 'pending'
-         AND ${saas ? "org_id = $1" : "(org_id = $1 OR org_id IS NULL)"}`
-      : `SELECT COUNT(*)::text AS count FROM learned_patterns
-         WHERE type = 'semantic_amendment' AND status = 'pending'
-         AND org_id IS NULL`,
+    `SELECT COUNT(*)::text AS count FROM learned_patterns
+       WHERE type = 'semantic_amendment' AND status = 'pending'
+       AND ${scope.clause}`,
     orgId ? [orgId] : [],
   );
 
@@ -1840,23 +1895,15 @@ export type PendingAmendmentRow = Record<string, unknown> & {
 export async function getPendingAmendments(orgId: string | null): Promise<PendingAmendmentRow[]> {
   if (!hasInternalDB()) return [];
 
-  const saas = requireIsSaasModeForGuard()();
-  // SaaS: withhold NULL-org rows from every workspace (#4487) — refuse the
-  // org-less path and drop the `OR org_id IS NULL` arm below.
-  if (saas && !orgId) return [];
+  const scope = amendmentOrgScope(orgId, "$1");
+  if (scope.withhold) return [];
 
   return internalQuery<PendingAmendmentRow>(
-    orgId
-      ? `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
-         FROM learned_patterns
-         WHERE type = 'semantic_amendment' AND status = 'pending'
-         AND ${saas ? "org_id = $1" : "(org_id = $1 OR org_id IS NULL)"}
-         ORDER BY created_at DESC`
-      : `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
-         FROM learned_patterns
-         WHERE type = 'semantic_amendment' AND status = 'pending'
-         AND org_id IS NULL
-         ORDER BY created_at DESC`,
+    `SELECT id, source_entity, connection_group_id, description, confidence, amendment_payload, created_at::text
+       FROM learned_patterns
+       WHERE type = 'semantic_amendment' AND status = 'pending'
+       AND ${scope.clause}
+       ORDER BY created_at DESC`,
     orgId ? [orgId] : [],
   );
 }
@@ -1883,24 +1930,19 @@ export async function reviewSemanticAmendment(
     throw new Error("Internal database is not configured. Amendment review requires DATABASE_URL.");
   }
 
-  const saas = requireIsSaasModeForGuard()();
-  // SaaS: a NULL-org row is unreviewable from any workspace (#4487). Refuse
-  // the org-less path (returns null → 404 at the route) and drop the
-  // `OR org_id IS NULL` arm so no tenant admin can approve/reject a global row.
-  if (saas && !orgId) return null;
+  // SaaS: a NULL-org row is unreviewable from any workspace (#4487) — the
+  // org-less path withholds (returns null → 404 at the route) and the
+  // `OR org_id IS NULL` arm is dropped so no tenant admin can approve/reject a
+  // global row. All of that lives in `amendmentOrgScope`.
+  const scope = amendmentOrgScope(orgId, "$4");
+  if (scope.withhold) return null;
 
   const rows = await internalQuery<ReviewedAmendmentRow>(
-    orgId
-      ? `UPDATE learned_patterns
-         SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
-         WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
-         AND ${saas ? "org_id = $4" : "(org_id = $4 OR org_id IS NULL)"}
-         RETURNING id, source_entity, amendment_payload`
-      : `UPDATE learned_patterns
-         SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
-         WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
-         AND org_id IS NULL
-         RETURNING id, source_entity, amendment_payload`,
+    `UPDATE learned_patterns
+       SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
+       WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
+       AND ${scope.clause}
+       RETURNING id, source_entity, amendment_payload`,
     orgId ? [decision, reviewedBy, id, orgId] : [decision, reviewedBy, id],
   );
 


### PR DESCRIPTION
## Summary

Part of the v0.0.48 Semantic-Improve Elevation milestone (PRD #4502). Two mechanical moves that make the SaaS-first scheduler (#4516) org-safe by construction:

- **One shared org-scope clause helper.** Extracts the hand-repeated SaaS-vs-self-hosted `org_id` conditional from the three amendment readers (`getPendingAmendmentCount`, `getPendingAmendments`, `reviewSemanticAmendment`) into `amendmentOrgScope(orgId, placeholder)` — a discriminated union (`{ withhold } | { clause }`) that makes "withhold ⇒ no query" unrepresentable. SaaS drops the NULL-owner arm (#4487 leak fix); self-hosted keeps it as legacy tolerance; org-less withholds on SaaS. The `placeholder` param is a `` `$${number}` `` template-literal type so the raw SQL splice can't take free text.
- **One-workspace-owner invariant at the insert seam.** `insertSemanticAmendment` — the single choke point every path (chat tool, scheduler, CLI) shares — now refuses a NULL owner on SaaS (fails loud, before any DB touch), so no code path can mint a NULL-owner amendment anew on SaaS. Self-hosted's single workspace is the degenerate case: a NULL owner is that one deployment's legacy global scope, tolerated on reads and still writable by the single-org CLI/scheduler paths.

Behavior is identical for existing readers — the #4487 SaaS-scoping tests stay green.

## Test plan

- [x] Existing #4487 SaaS-scoping reader tests unchanged and green (behavior identical)
- [x] Direct `amendmentOrgScope` contract tests (SaaS/self-hosted × workspace/org-less/empty-string)
- [x] Reader-enumeration test — pins the 3 readers to the helper, discovery tolerant of predicate order/whitespace/alias, and pins the single insert seam (fails if a new reader/inserter bypasses)
- [x] One-workspace-owner insert tests — SaaS refuses NULL/undefined owner without touching the DB; SaaS stamps the owner; self-hosted tolerates NULL
- [x] `bun run type` (tsgo), `oxlint`, full `@atlas/api` isolated suite, and the 27 drift/security gates — all green locally
- [ ] GitHub CI (authoritative required checks)

Closes #4510