### PR TITLE
feat(semantic-improve): single decide seam — claim-then-apply (#4506)

### DIFF
--- a/packages/api/src/api/__tests__/admin-semantic-improve-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-semantic-improve-audit.test.ts
@@ -32,9 +32,23 @@ import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
 const mockGetPendingAmendments: Mock<(orgId: string) => Promise<unknown[]>> =
   mock(async () => []);
+// The decide seam (#4506) claims via reviewSemanticAmendment, which now returns
+// the claimed row (with payload + group) or null when the row is not pending.
+type ClaimedRow = {
+  id: string;
+  source_entity: string;
+  connection_group_id: string | null;
+  amendment_payload: Record<string, unknown> | null;
+} | null;
+const claimedRow = (id: string): ClaimedRow => ({
+  id,
+  source_entity: "events",
+  connection_group_id: null,
+  amendment_payload: { amendmentType: "update_description", amendment: { field: "table", description: "text" } },
+});
 const mockReviewSemanticAmendment: Mock<
-  (id: string, orgId: string, decision: string, reviewer: string) => Promise<boolean>
-> = mock(async () => true);
+  (id: string, orgId: string, decision: string, reviewer: string) => Promise<ClaimedRow>
+> = mock(async (id: string) => claimedRow(id));
 
 const mocks = createApiTestMocks({
   authUser: {
@@ -172,7 +186,7 @@ beforeEach(() => {
   mockGetPendingAmendments.mockReset();
   mockGetPendingAmendments.mockImplementation(async () => []);
   mockReviewSemanticAmendment.mockReset();
-  mockReviewSemanticAmendment.mockImplementation(async () => true);
+  mockReviewSemanticAmendment.mockImplementation(async (id: string) => claimedRow(id));
 });
 
 // ---------------------------------------------------------------------------
@@ -277,7 +291,7 @@ describe("POST /api/v1/admin/semantic-improve/amendments/:id/review — audit em
   });
 
   it("does not emit when the amendment is missing (404)", async () => {
-    mockReviewSemanticAmendment.mockImplementation(async () => false);
+    mockReviewSemanticAmendment.mockImplementation(async () => null);
 
     const res = await app.fetch(
       adminRequest(

--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -27,13 +27,23 @@ interface MockAmendmentRow {
 }
 let mockPendingAmendments: MockAmendmentRow[] = [];
 let reviewedCalls: Array<{ id: string; orgId: string | null; decision: string }> = [];
+let revertedIds: string[] = [];
 let applyPayloadCalls: Array<Record<string, unknown>> = [];
-// When true, the mocked YAML apply rejects — models the approve branch's
-// "apply YAML first, only flip the DB status on success" invariant.
+// When true, the mocked YAML apply rejects — models the decide seam's
+// claim-then-apply compensation: the claim is reverted to pending on failure.
 let applyShouldThrow = false;
-// Shared sequence log: proves the route applies YAML *before* flipping the row.
+// Ids already claimed (conditional UPDATE moved them out of `pending`). A
+// second claim for the same id returns null — the atomic-claim race loser.
+let claimedIds: Set<string> = new Set();
+// Shared sequence log: proves the route CLAIMS the row *before* applying YAML
+// (claim-then-apply, the #4506 ordering).
 let callOrder: string[] = [];
 
+// reviewSemanticAmendment is the atomic claim/reject primitive the decide seam
+// builds on: it transitions a still-`pending` row and returns it, or null when
+// the row is no longer pending (not found, or already claimed by a racing
+// caller). Modeled here as claim-once so "concurrent approves → one winner" is
+// observable at the route seam.
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
   internalQuery: async () => [],
@@ -47,20 +57,32 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
     orgId: string | null,
     decision: "approved" | "rejected",
   ) => {
-    callOrder.push("review");
-    reviewedCalls.push({ id, orgId, decision });
+    callOrder.push("claim");
     const row = mockPendingAmendments.find((r) => r.id === id);
-    return row
-      ? { id: row.id, source_entity: row.source_entity, amendment_payload: row.amendment_payload }
-      : null;
+    if (!row || claimedIds.has(id)) return null;
+    claimedIds.add(id);
+    reviewedCalls.push({ id, orgId, decision });
+    return {
+      id: row.id,
+      source_entity: row.source_entity,
+      connection_group_id: row.connection_group_id,
+      amendment_payload: row.amendment_payload,
+    };
+  },
+  revertAmendmentToPending: async (id: string) => {
+    revertedIds.push(id);
+    // The compensating revert re-opens the row for a retry.
+    claimedIds.delete(id);
+    return true;
   },
 }));
 
-// The approve branch dynamically imports the YAML-apply helper. Mock it so the
+// The decide seam dynamically imports the YAML-apply helper. Mock it so the
 // happy-path test never touches disk / the semantic layer — we only assert it
-// was invoked with the target row before the DB status flip. `applyAmendment`
-// is included to keep the module mock total (mock-all-exports discipline) even
-// though this route only reaches the two helpers below.
+// was invoked with the claimed row after the claim. `applyAmendment` /
+// `applyAmendmentToEntity` are included to keep the module mock total
+// (mock-all-exports discipline) even though the seam only reaches the helper
+// below.
 void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
   applyAmendmentFromPayload: async (args: Record<string, unknown>) => {
     callOrder.push("apply");
@@ -166,8 +188,10 @@ describe("admin-semantic-improve", () => {
     mockHasInternalDB = true;
     mockPendingAmendments = [];
     reviewedCalls = [];
+    revertedIds = [];
     applyPayloadCalls = [];
     applyShouldThrow = false;
+    claimedIds = new Set();
     callOrder = [];
   });
 
@@ -207,8 +231,8 @@ describe("admin-semantic-improve", () => {
       created_at: "2026-07-10T00:00:00Z",
     });
 
-    it("approves a proposal: applies the YAML then flips the same row to approved (one identity)", async () => {
-      // Group-scoped row: the route must thread the STORED row's
+    it("approves a proposal: CLAIMS the row then applies the YAML (claim-then-apply, one identity)", async () => {
+      // Group-scoped row: the seam must thread the CLAIMED row's
       // `connection_group_id` into the apply (#4498) — an interactive
       // proposeAmendment row persists the group its baseline was resolved
       // from, and dropping it here would send the apply through the
@@ -225,8 +249,8 @@ describe("admin-semantic-improve", () => {
       const body = (await res.json()) as { ok: boolean; id: string; decision: string };
       expect(body).toEqual({ ok: true, id: "amd-1", decision: "approved" });
 
-      // YAML applied from the row's payload before the status flip — scoped to
-      // the row's own Connection group, never NULL for a group-scoped row.
+      // YAML applied from the CLAIMED row's payload — scoped to the row's own
+      // Connection group, never NULL for a group-scoped row.
       expect(applyPayloadCalls).toHaveLength(1);
       expect(applyPayloadCalls[0]).toMatchObject({
         sourceEntity: "orders",
@@ -234,19 +258,99 @@ describe("admin-semantic-improve", () => {
         connectionGroupId: "eu_prod",
       });
 
-      // The same learned_patterns row is flipped to approved — no stale
-      // pending row left behind.
+      // The same learned_patterns row is claimed → approved — no stale pending
+      // row left behind, and never reverted (apply succeeded).
       expect(reviewedCalls).toEqual([{ id: "amd-1", orgId: "org-test", decision: "approved" }]);
+      expect(revertedIds).toHaveLength(0);
 
-      // Ordering invariant: YAML apply happens strictly before the DB flip.
-      expect(callOrder).toEqual(["apply", "review"]);
+      // Ordering invariant: the conditional claim happens strictly BEFORE the
+      // YAML apply (#4506 — claim-then-apply, not apply-then-flip).
+      expect(callOrder).toEqual(["claim", "apply"]);
     });
 
-    it("approve → YAML apply fails: 500 and the row is NOT flipped to approved", async () => {
-      // The approve branch must apply YAML first and only flip the DB status on
-      // success — otherwise a row could be stamped `approved` with no YAML
-      // written. Pin that: when the apply throws, the route must surface a 500
-      // (via runHandler) and never call reviewSemanticAmendment.
+    it("concurrent approves: exactly one applies; the loser gets a truthful already-reviewed 404 and no YAML mutation", async () => {
+      // Two approves of the same amendment. The claim is atomic (claim-once), so
+      // the first request wins the pending→approved transition + applies; the
+      // second finds the row no longer pending and mutates nothing.
+      mockPendingAmendments = [row("amd-race")];
+
+      const first = await adminSemanticImprove.request("/amendments/amd-race/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+      const second = await adminSemanticImprove.request("/amendments/amd-race/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(404);
+      const loser = (await second.json()) as { error: string };
+      expect(loser.error).toBe("not_found");
+
+      // Exactly one apply, one claim, zero reverts — the loser touched no YAML.
+      expect(applyPayloadCalls).toHaveLength(1);
+      expect(reviewedCalls).toHaveLength(1);
+      expect(revertedIds).toHaveLength(0);
+    });
+
+    it("approve wins, then a racing reject of the same id cannot un-apply or stamp it rejected", async () => {
+      // Criterion 2: approve racing reject. The approve claims + applies; the
+      // subsequent reject finds the row no longer pending → already-reviewed 404,
+      // and must not touch the applied YAML or flip the row to rejected.
+      mockPendingAmendments = [row("amd-ar")];
+
+      const approve = await adminSemanticImprove.request("/amendments/amd-ar/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+      const reject = await adminSemanticImprove.request("/amendments/amd-ar/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "rejected" }),
+      });
+
+      expect(approve.status).toBe(200);
+      expect(((await approve.json()) as { decision: string }).decision).toBe("approved");
+      expect(reject.status).toBe(404);
+      // Exactly one transition + one apply; the reject never applied or reverted.
+      expect(applyPayloadCalls).toHaveLength(1);
+      expect(reviewedCalls).toEqual([{ id: "amd-ar", orgId: "org-test", decision: "approved" }]);
+      expect(revertedIds).toHaveLength(0);
+    });
+
+    it("reject wins, then a racing approve of the same id applies nothing", async () => {
+      // The reverse ordering: reject wins the claim; the later approve finds the
+      // row non-pending → 404, and never touches YAML.
+      mockPendingAmendments = [row("amd-ra")];
+
+      const reject = await adminSemanticImprove.request("/amendments/amd-ra/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "rejected" }),
+      });
+      const approve = await adminSemanticImprove.request("/amendments/amd-ra/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: "approved" }),
+      });
+
+      expect(reject.status).toBe(200);
+      expect(((await reject.json()) as { decision: string }).decision).toBe("rejected");
+      expect(approve.status).toBe(404);
+      expect(applyPayloadCalls).toHaveLength(0);
+    });
+
+    it("approve → apply fails: 500 apply_failed and the claim is reverted to pending (never left approved-but-unapplied)", async () => {
+      // Claim-then-apply: the claim stamps `approved`, the apply throws, and the
+      // seam compensates by reverting the row to pending. Pin that the route
+      // surfaces a truthful `apply_failed` 500 AND the row was reverted — the
+      // invariant "approved means applied" holds because an unapplied row can
+      // never stay approved. A snapshot failure surfaces on this exact path
+      // (the apply throws when it can't take a rollback snapshot).
       mockPendingAmendments = [row("amd-3")];
       applyShouldThrow = true;
 
@@ -256,18 +360,19 @@ describe("admin-semantic-improve", () => {
         body: JSON.stringify({ decision: "approved" }),
       });
 
-      // The throw maps to a 500 with a requestId envelope.
       expect(res.status).toBe(500);
-      const body = (await res.json()) as { requestId?: string };
+      const body = (await res.json()) as { error: string; message: string; requestId?: string };
+      expect(body.error).toBe("apply_failed");
+      expect(body.message).toContain("returned to the pending queue");
       expect(body.requestId).toBeDefined();
-      // The load-bearing invariant: the row stays pending — the flip never ran.
-      expect(reviewedCalls).toHaveLength(0);
-      expect(callOrder).toEqual(["apply"]);
+      // The claim ran, the apply ran, then the compensating revert ran.
+      expect(callOrder).toEqual(["claim", "apply"]);
+      expect(revertedIds).toEqual(["amd-3"]);
     });
 
-    it("returns 404 when rejecting an absent row (reject skips the payload peek)", async () => {
-      // The reject branch bypasses getPendingAmendments and 404s off a null
-      // return from reviewSemanticAmendment — a different path than approve's.
+    it("returns 404 when rejecting an absent row", async () => {
+      // Reject is a single atomic transition; an absent/non-pending row returns
+      // null from the claim primitive → already_reviewed → 404, no YAML.
       mockPendingAmendments = [];
 
       const res = await adminSemanticImprove.request("/amendments/does-not-exist/review", {
@@ -312,7 +417,7 @@ describe("admin-semantic-improve", () => {
       expect(res.status).toBe(404);
       const body = (await res.json()) as { error: string };
       expect(body.error).toBe("not_found");
-      // Missing target short-circuits before any YAML apply.
+      // A lost claim short-circuits before any YAML apply.
       expect(applyPayloadCalls).toHaveLength(0);
     });
   });

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -447,42 +447,43 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
     const { id } = c.req.valid("param");
     const { decision } = c.req.valid("json");
 
-    const { reviewSemanticAmendment } = await import("@atlas/api/lib/db/internal");
+    // The single decide seam (#4506) owns the pending → approved | rejected
+    // transition for every caller. Approve is claim-then-apply: it stamps
+    // `approved` only after a successful apply + version snapshot, and reverts
+    // to pending on failure — so "approved means applied" holds here by
+    // construction, not by this route's discipline. A cross-group
+    // AmbiguousEntityError propagates out and runHandler maps it to 409 with the
+    // group list (the group-picker contract).
+    const { decideAmendment } = await import("@atlas/api/lib/semantic/expert/decide");
+    const result = await decideAmendment({ id, orgId, decision, reviewedBy: "admin", requestId });
 
-    // For approvals, apply YAML first — only update DB status on success
-    if (decision === "approved") {
-      // Peek at the row to get payload before changing status
-      const { getPendingAmendments } = await import("@atlas/api/lib/db/internal");
-      const pending = await getPendingAmendments(orgId);
-      const target = pending.find((r) => r.id === id);
-      if (!target) {
-        return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
-      }
-
-      const payload = target.amendment_payload;
-      if (payload) {
-        const { applyAmendmentFromPayload } = await import("@atlas/api/lib/semantic/expert/apply");
-        // This throws on failure — runHandler maps it to 500 (or 409 for an
-        // AmbiguousEntityError). The shared helper owns the envelope→
-        // AnalysisResult mapping, including extracting the INNER `amendment`
-        // object (the YAML mutation reads `payload.amendment`, not the whole
-        // envelope) and recovering the Connection group (#3284).
-        await applyAmendmentFromPayload({
-          orgId,
-          sourceEntity: target.source_entity,
-          connectionGroupId: target.connection_group_id ?? null,
-          rawPayload: payload,
-          requestId,
-          label: target.id,
-        });
-      }
+    if (result.outcome === "already_reviewed") {
+      // The row was not pending — never existed, or a racing approve/reject
+      // already moved it. Truthful for both, and (crucially) the loser of a
+      // concurrent approve mutated no YAML.
+      return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
     }
 
-    // YAML applied (or rejection) — now update DB status
-    const reviewed = await reviewSemanticAmendment(id, orgId, decision, "admin");
-
-    if (!reviewed) {
-      return c.json({ error: "not_found", message: "Amendment not found or already reviewed.", requestId }, 404);
+    if (result.outcome === "apply_failed") {
+      // The claim was stamped `approved`, the apply failed, and the row was
+      // returned to the pending queue (revertedToPending) so an admin can retry
+      // and see the same failure. Surfacing the apply reason (rather than a bare
+      // generic 500) is deliberate: this route is admin-gated (admin:semantic),
+      // the reason is apply-domain (entity-not-found, missing amendment object,
+      // snapshot failure) with no secrets, and the PRD requires the amendment
+      // return to pending "with a visible reason". `requestId` still correlates
+      // the full context in logs.
+      const requeued = result.revertedToPending
+        ? " It has been returned to the pending queue for review."
+        : " The amendment could not be returned to pending automatically — check its status.";
+      return c.json(
+        {
+          error: "apply_failed",
+          message: `Amendment approved but could not be applied: ${result.reason}.${requeued}`,
+          requestId,
+        },
+        500,
+      );
     }
 
     // Action type reflects the intent, not the route path — an approved
@@ -490,17 +491,17 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
     // fires `improve_reject`.
     logAdminAction({
       actionType:
-        decision === "approved"
+        result.outcome === "approved"
           ? ADMIN_ACTIONS.semantic.improveApply
           : ADMIN_ACTIONS.semantic.improveReject,
       targetType: "semantic",
       targetId: id,
       ipAddress: clientIpFor(c),
-      metadata: { id, decision },
+      metadata: { id, decision: result.outcome },
     });
 
-    log.info({ requestId, orgId, id, decision }, "Amendment reviewed");
-    return c.json({ ok: true, id, decision }, 200);
+    log.info({ requestId, orgId, id, decision: result.outcome }, "Amendment reviewed");
+    return c.json({ ok: true, id, decision: result.outcome }, 200);
   }),
 );
 

--- a/packages/api/src/lib/db/__tests__/semantic-amendment-rejection-guard.test.ts
+++ b/packages/api/src/lib/db/__tests__/semantic-amendment-rejection-guard.test.ts
@@ -88,12 +88,30 @@ describe("insertSemanticAmendment — clean path (#4507)", () => {
   it("queues a new row keyed on the canonical identity when no conflict exists", async () => {
     const result = await insertSemanticAmendment(baseAmendment);
 
-    expect(result).toEqual({ outcome: "inserted", id: "new-row-id", status: "pending" });
+    // The row is always inserted `pending` now (#4506); auto-approve is a
+    // decision the caller routes through the decide seam, not a stamp. This
+    // amendment's confidence (0.9) is below the default threshold, so it is not
+    // even eligible.
+    expect(result).toEqual({ outcome: "inserted", id: "new-row-id", autoApproveEligible: false });
 
     // The identity is the storage key — no timestamp uniquifier.
     const ins = insertSql();
     expect(ins).toBeDefined();
     expect(ins!.params[1]).toBe("default:orders:add_dimension:region");
+  });
+
+  it("always inserts the row as pending — the decide seam is the only writer of approved (#4506)", async () => {
+    await insertSemanticAmendment(baseAmendment);
+
+    const ins = insertSql();
+    expect(ins).toBeDefined();
+    // `status` is the literal 'pending' in VALUES, never a parameter — insert
+    // can never stamp 'approved', so `decideAmendment` stays the SOLE writer of
+    // approved and "approved means applied" holds by construction. The seven
+    // params are (org, identity, description, entity, confidence, payload,
+    // group) — no `status` param slot.
+    expect(ins!.sql).toContain("'pending', 'expert-agent'");
+    expect(ins!.params).toHaveLength(7);
   });
 
   it("scopes the conflict lookup to the amendment's own org (IS NOT DISTINCT FROM)", async () => {

--- a/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
+++ b/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
@@ -25,6 +25,7 @@ import {
   getPendingAmendmentCount,
   getPendingAmendments,
   reviewSemanticAmendment,
+  revertAmendmentToPending,
   _resetPool,
   _resetCircuitBreaker,
 } from "../internal";
@@ -178,5 +179,38 @@ describe("semantic amendment queries — SaaS scoping (#4487)", () => {
 
     expect(reviewed).toBeNull();
     expect(captured).toHaveLength(0);
+  });
+});
+
+describe("decide-seam DB primitives — claim + compensating revert SQL shape (#4506)", () => {
+  it("reviewSemanticAmendment is a conditional claim: only pending rows, RETURNING the group", async () => {
+    setDeployMode("self-hosted");
+    await reviewSemanticAmendment("amd-1", "org-a", "approved", "admin");
+
+    expect(captured).toHaveLength(1);
+    const { sql } = captured[0]!;
+    // The claim only ever transitions a still-`pending` row — this is what makes
+    // exactly one concurrent approve/reject win and "approved" un-double-stampable.
+    expect(sql).toContain("status = 'pending'");
+    // RETURNING carries connection_group_id so the decide seam applies to the
+    // correct group scope without a second read.
+    expect(sql).toContain("RETURNING id, source_entity, connection_group_id, amendment_payload");
+  });
+
+  it("revertAmendmentToPending clears the claim stamp and only matches a claimed (approved) row", async () => {
+    setDeployMode("self-hosted");
+    await revertAmendmentToPending("amd-1");
+
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    // Compensation returns the row to pending AND clears the phantom reviewer so
+    // the requeued row reads as genuinely unreviewed.
+    expect(sql).toContain("status = 'pending'");
+    expect(sql).toContain("reviewed_by = NULL");
+    expect(sql).toContain("reviewed_at = NULL");
+    // It only unwinds a row THIS seam claimed (status='approved') — never a
+    // legitimately-rejected or still-pending row.
+    expect(sql).toContain("status = 'approved'");
+    expect(params).toEqual(["amd-1"]);
   });
 });

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1572,9 +1572,19 @@ export function getAutoApproveTypes(orgId?: string): Set<string> {
 }
 
 /**
- * Outcome of an amendment insert (#4507). A discriminated union so callers
- * handle all three terminal states explicitly:
- *   - `inserted`       — a new row was queued (or auto-approved at insert).
+ * Outcome of an amendment insert (#4507, #4506). A discriminated union so
+ * callers handle all three terminal states explicitly:
+ *   - `inserted`       — a new row was queued as `pending`. `autoApproveEligible`
+ *                        reports whether the row cleared the confidence
+ *                        threshold AND its type is in the auto-approve set — a
+ *                        decision the caller acts on by routing the row through
+ *                        the single decide seam (`decideAmendment`), never a
+ *                        status the insert stamps. Insert is pending-only so the
+ *                        decide seam is the sole writer of `approved` for the
+ *                        improve-loop callers and "approved means applied" holds
+ *                        by construction (#4506). (The legacy `admin-learned-
+ *                        patterns` route still apply-first-then-flips these rows
+ *                        directly; #4594 folds it in.)
  *   - `already_pending`— an identical change is already pending review; the
  *                        insert converged on that row instead of duplicating.
  *   - `rejected`       — the identity was previously rejected by an admin;
@@ -1582,7 +1592,7 @@ export function getAutoApproveTypes(orgId?: string): Set<string> {
  *                        refused. `id` is the existing rejected row.
  */
 export type InsertSemanticAmendmentResult =
-  | { outcome: "inserted"; id: string; status: "approved" | "pending" }
+  | { outcome: "inserted"; id: string; autoApproveEligible: boolean }
   | { outcome: "already_pending"; id: string }
   | { outcome: "rejected"; id: string };
 
@@ -1642,9 +1652,16 @@ async function findConflictingAmendment(
 }
 
 /**
- * Insert a semantic amendment proposal. Status is "approved" only when confidence
- * meets the threshold AND the amendment type is in the eligible set; otherwise "pending".
- * Unlike insertLearnedPattern (fire-and-forget), this awaits the result.
+ * Insert a semantic amendment proposal. The row is ALWAYS inserted `pending`
+ * (#4506): auto-approval is a decision the caller routes through the single
+ * decide seam (`decideAmendment`), never a status the insert stamps — so for
+ * the improve-loop callers the seam is the sole writer of `approved` and
+ * "approved means applied" holds by construction (the legacy `admin-learned-
+ * patterns` route still writes `approved` directly; #4594). The returned
+ * `autoApproveEligible` reports whether the row cleared the confidence threshold
+ * AND its type is in the auto-approve set; `true` tells the caller to hand the
+ * row to `decideAmendment` immediately. Unlike insertLearnedPattern
+ * (fire-and-forget), this awaits the result.
  *
  * Insert-enforced rejection memory + pending dedup (#4507): before queuing, the
  * amendment's canonical group-scoped identity is checked against the org's
@@ -1727,7 +1744,10 @@ export async function insertSemanticAmendment(amendment: {
 
   const meetsThreshold = amendment.confidence >= threshold;
   const typeEligible = amendmentType !== undefined && allowedTypes.has(amendmentType);
-  const status = meetsThreshold && typeEligible ? "approved" : "pending";
+  // Auto-approve eligibility is REPORTED, never stamped: the row lands `pending`
+  // and an eligible caller hands it to `decideAmendment`, the single writer of
+  // `approved` (#4506).
+  const autoApproveEligible = meetsThreshold && typeEligible;
 
   if (meetsThreshold && !typeEligible) {
     log.debug(
@@ -1741,7 +1761,7 @@ export async function insertSemanticAmendment(amendment: {
        (org_id, pattern_sql, description, source_entity, confidence,
         repetition_count, status, proposed_by, type, amendment_payload,
         connection_group_id)
-     VALUES ($1, $2, $3, $4, $5, 1, $6, 'expert-agent', 'semantic_amendment', $7, $8)
+     VALUES ($1, $2, $3, $4, $5, 1, 'pending', 'expert-agent', 'semantic_amendment', $6, $7)
      RETURNING id`,
     [
       amendment.orgId ?? null,
@@ -1749,7 +1769,6 @@ export async function insertSemanticAmendment(amendment: {
       amendment.description,
       amendment.sourceEntity,
       amendment.confidence,
-      status,
       JSON.stringify(amendment.amendmentPayload),
       amendment.connectionGroupId,
     ],
@@ -1761,27 +1780,29 @@ export async function insertSemanticAmendment(amendment: {
     );
   }
 
-  return { outcome: "inserted", id: rows[0].id, status };
+  return { outcome: "inserted", id: rows[0].id, autoApproveEligible };
 }
 
 /**
- * Revert an auto-approved semantic amendment back to `pending` after its apply
- * failed (#4486). `insertSemanticAmendment` stamps eligible rows `approved` at
- * insert time and both auto-approve paths (the scheduler and the interactive
- * `proposeAmendment` tool) apply immediately afterward. If that apply throws,
- * the row must NOT be left `approved` — `approved` is terminal for the pending
- * queue, so it would leave the invariant "status='approved' ⇒ applied" violated
- * and the proposal invisible to admins. Reverting to `pending` re-enters it into
- * the review queue so an admin can retry (and see the same failure). Returns
- * true when a row was reverted; false when no matching `approved` row exists
- * (already reviewed / not found) or no internal DB is configured.
+ * Compensating revert: return a CLAIMED (status='approved') semantic amendment
+ * to `pending` after its apply failed (#4486, #4506). The single decide seam
+ * (`decideAmendment`) claims a row `approved`, then applies; if the apply throws
+ * (bad payload, snapshot failure, …) the row must NOT be left `approved` —
+ * `approved` is terminal for the pending queue and means "applied", so an
+ * unapplied `approved` row both violates the invariant and hides the proposal
+ * from admins. Reverting re-enters it into the review queue so an admin can
+ * retry (and see the same failure). The claim's `reviewed_by` / `reviewed_at`
+ * stamp is cleared too, so the compensated row reads as genuinely unreviewed
+ * rather than a pending row with a phantom reviewer. Returns true when a row was
+ * reverted; false when no matching `approved` row exists (already reviewed / not
+ * found) or no internal DB is configured.
  */
 export async function revertAmendmentToPending(id: string): Promise<boolean> {
   if (!hasInternalDB()) return false;
 
   const rows = await internalQuery<{ id: string }>(
     `UPDATE learned_patterns
-       SET status = 'pending', updated_at = now()
+       SET status = 'pending', reviewed_by = NULL, reviewed_at = NULL, updated_at = now()
      WHERE id = $1 AND type = 'semantic_amendment' AND status = 'approved'
      RETURNING id`,
     [id],
@@ -1865,12 +1886,31 @@ export async function getPendingAmendments(orgId: string | null): Promise<Pendin
 export type ReviewedAmendmentRow = Record<string, unknown> & {
   id: string;
   source_entity: string;
+  /**
+   * Connection group the amendment targets (ADR-0012, #3284). NULL = the
+   * default (flat `entities/`) group. The decide seam threads this into
+   * `applyAmendmentFromPayload` so a claimed amendment applies to the correct
+   * group's row (#4506).
+   */
+  connection_group_id: string | null;
   amendment_payload: Record<string, unknown> | null;
 };
 
 /**
- * Update a pending semantic amendment's status to approved or rejected.
- * Returns the updated row (with payload) on success, or null if not found / already reviewed.
+ * Atomically transition a pending semantic amendment to `approved` or
+ * `rejected`, returning the row (with payload + group) on success or null when
+ * the row is not pending (not found, or already reviewed / claimed by a racing
+ * caller). The conditional `WHERE … status = 'pending'` makes this the claim
+ * primitive the single decide seam (`decideAmendment`, lib/semantic/expert/
+ * decide.ts) builds on: exactly one concurrent caller wins the transition, so
+ * "approved" cannot be double-stamped and an approve cannot overwrite a reject
+ * (or vice versa) (#4506).
+ *
+ * Callers MUST route through `decideAmendment`, not call this directly — an
+ * `approved` transition here is a CLAIM the seam finalizes only after a
+ * successful apply + version snapshot (reverting to pending on failure), so
+ * "approved means applied" holds by construction.
+ *
  * @throws {Error} If the internal database is not configured or the query fails.
  */
 export async function reviewSemanticAmendment(
@@ -1895,12 +1935,12 @@ export async function reviewSemanticAmendment(
          SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
          WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
          AND ${saas ? "org_id = $4" : "(org_id = $4 OR org_id IS NULL)"}
-         RETURNING id, source_entity, amendment_payload`
+         RETURNING id, source_entity, connection_group_id, amendment_payload`
       : `UPDATE learned_patterns
          SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now()
          WHERE id = $3 AND type = 'semantic_amendment' AND status = 'pending'
          AND org_id IS NULL
-         RETURNING id, source_entity, amendment_payload`,
+         RETURNING id, source_entity, connection_group_id, amendment_payload`,
     orgId ? [decision, reviewedBy, id, orgId] : [decision, reviewedBy, id],
   );
 

--- a/packages/api/src/lib/semantic/expert/__tests__/apply-from-payload.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/apply-from-payload.test.ts
@@ -175,4 +175,55 @@ describe("applyAmendmentFromPayload (#3613)", () => {
     ).rejects.toThrow(/Corrupt amendment_payload JSON/);
     expect(upsertEntityForGroup).not.toHaveBeenCalled();
   });
+
+  // ── Rollback-ability is part of the apply (#4506) ──────────────────
+  // A version-snapshot failure must FAIL the apply (throw), so the decide seam
+  // compensates and returns the amendment to pending — never leave an
+  // applied-but-unrollbackable change. These pin the apply.ts coupling directly
+  // (the seam/route tests mock the apply, so only these would catch a
+  // regression that reintroduced the old warn-and-swallow snapshot handling).
+
+  it("fails the apply when the version snapshot cannot be created", async () => {
+    createVersion.mockRejectedValueOnce(new Error("snapshot write failed"));
+
+    await expect(
+      applyAmendmentFromPayload({
+        orgId: "org-1",
+        sourceEntity: "orders",
+        connectionGroupId: null,
+        rawPayload: ENVELOPE,
+        requestId: "req-snap",
+        label: "pat-snap",
+      }),
+    ).rejects.toThrow(/snapshot write failed/);
+
+    // The YAML was upserted (this is a POST-apply snapshot failure), so the
+    // throw is what returns the amendment to pending — not a silent warn.
+    expect(upsertEntityForGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails the apply when the entity cannot be re-read to snapshot a rollback point", async () => {
+    // Baseline read resolves the row; the post-upsert re-read returns null.
+    getEntity.mockResolvedValueOnce({
+      id: "orders-row",
+      connection_group_id: null,
+      yaml_content: "table: orders\ndescription: Orders\n",
+    });
+    getEntity.mockResolvedValueOnce(null);
+
+    await expect(
+      applyAmendmentFromPayload({
+        orgId: "org-1",
+        sourceEntity: "orders",
+        connectionGroupId: null,
+        rawPayload: ENVELOPE,
+        requestId: "req-reread",
+        label: "pat-reread",
+      }),
+    ).rejects.toThrow(/could not be re-read to snapshot a rollback point/);
+
+    expect(upsertEntityForGroup).toHaveBeenCalledTimes(1);
+    // No rollback point was ever taken.
+    expect(createVersion).not.toHaveBeenCalled();
+  });
 });

--- a/packages/api/src/lib/semantic/expert/__tests__/decide.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/decide.test.ts
@@ -1,0 +1,276 @@
+/**
+ * The single decide seam (#4506) — `decideAmendment`.
+ *
+ * Pins the claim-then-apply ordering and the compensation contract that make
+ * "approved means applied" hold by construction, at the seam every caller
+ * shares (review route, interactive auto-approve, scheduler):
+ *   - approve claims (conditional UPDATE) BEFORE applying; the loser of a
+ *     concurrent claim gets `already_reviewed` and never touches YAML;
+ *   - an apply failure (incl. a version-snapshot failure surfaced by the apply)
+ *     reverts the claim to pending and returns `apply_failed` with a reason;
+ *   - a null/corrupt payload is an apply error, never a silent stamp;
+ *   - a cross-group `AmbiguousEntityError` is reverted-then-rethrown (409).
+ *
+ * Mocks the DB claim primitive + the apply seam so the ordering and
+ * compensation are observable without a real DB or YAML write.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { AmbiguousEntityError } from "@atlas/api/lib/effect/errors";
+
+// ---------------------------------------------------------------------------
+// Mocks (before importing the seam)
+// ---------------------------------------------------------------------------
+
+interface ClaimedRow {
+  id: string;
+  source_entity: string;
+  connection_group_id: string | null;
+  amendment_payload: Record<string, unknown> | null;
+}
+
+// Shared sequence log — proves the claim runs strictly before the apply.
+let callOrder: string[] = [];
+
+// reviewSemanticAmendment is the atomic claim/reject primitive. Default: the
+// transition succeeds and returns the row. Tests override to model a lost race
+// (null = the row was already moved out of `pending`).
+const mockReview: Mock<
+  (id: string, orgId: string | null, decision: "approved" | "rejected", by: string) => Promise<ClaimedRow | null>
+> = mock((id: string) => {
+  callOrder.push("claim");
+  return Promise.resolve({
+    id,
+    source_entity: "orders",
+    connection_group_id: "eu_prod",
+    amendment_payload: { amendment: { name: "total_revenue" }, amendmentType: "add_measure" },
+  });
+});
+
+const mockRevert: Mock<(id: string) => Promise<boolean>> = mock(() => Promise.resolve(true));
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  reviewSemanticAmendment: mockReview,
+  revertAmendmentToPending: mockRevert,
+}));
+
+// The apply seam. Default: succeeds. Tests override to throw (apply / snapshot
+// failure, ambiguous entity, null-payload rejection).
+const mockApply: Mock<(args: Record<string, unknown>) => Promise<void>> = mock(() => {
+  callOrder.push("apply");
+  return Promise.resolve();
+});
+
+void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
+  applyAmendmentFromPayload: mockApply,
+  applyAmendmentToEntity: mock(async () => {}),
+  applyAmendment: mock((e: Record<string, unknown>) => e),
+  resolveAmendmentBaseline: mock(async () => ({ row: {}, targetGroupId: null, parsed: {} })),
+}));
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { decideAmendment } = await import("../decide");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const base = { orgId: "org-1", reviewedBy: "admin", requestId: "req-1" } as const;
+
+describe("decideAmendment — claim-then-apply seam (#4506)", () => {
+  beforeEach(() => {
+    callOrder = [];
+    mockReview.mockClear();
+    mockReview.mockImplementation((id: string) => {
+      callOrder.push("claim");
+      return Promise.resolve({
+        id,
+        source_entity: "orders",
+        connection_group_id: "eu_prod",
+        amendment_payload: { amendment: { name: "total_revenue" }, amendmentType: "add_measure" },
+      });
+    });
+    mockRevert.mockClear();
+    mockRevert.mockResolvedValue(true);
+    mockApply.mockClear();
+    mockApply.mockImplementation(() => {
+      callOrder.push("apply");
+      return Promise.resolve();
+    });
+  });
+
+  describe("approve", () => {
+    it("claims BEFORE applying, then returns approved", async () => {
+      const result = await decideAmendment({ id: "amd-1", decision: "approved", ...base });
+
+      expect(result).toEqual({ outcome: "approved", id: "amd-1" });
+      // Ordering invariant: the conditional claim runs strictly before the apply.
+      expect(callOrder).toEqual(["claim", "apply"]);
+      // The claim is a pending→approved transition (the only writer of approved).
+      expect(mockReview).toHaveBeenCalledTimes(1);
+      expect(mockReview.mock.calls[0]).toEqual(["amd-1", "org-1", "approved", "admin"]);
+      // Apply threads the CLAIMED row's entity + group + payload.
+      expect(mockApply).toHaveBeenCalledTimes(1);
+      expect(mockApply.mock.calls[0][0]).toMatchObject({
+        orgId: "org-1",
+        sourceEntity: "orders",
+        connectionGroupId: "eu_prod",
+        label: "amd-1",
+      });
+      // A successful apply is never compensated.
+      expect(mockRevert).not.toHaveBeenCalled();
+    });
+
+    it("the loser of a concurrent claim gets already_reviewed and NEVER applies YAML", async () => {
+      // Model the race loser: the conditional UPDATE matched no pending row.
+      mockReview.mockImplementation(() => {
+        callOrder.push("claim");
+        return Promise.resolve(null);
+      });
+
+      const result = await decideAmendment({ id: "amd-1", decision: "approved", ...base });
+
+      expect(result).toEqual({ outcome: "already_reviewed" });
+      // No apply, no revert — the loser mutates nothing.
+      expect(mockApply).not.toHaveBeenCalled();
+      expect(mockRevert).not.toHaveBeenCalled();
+      expect(callOrder).toEqual(["claim"]);
+    });
+
+    it("apply failure reverts the claim to pending and returns apply_failed with the reason", async () => {
+      mockApply.mockImplementation(() => {
+        callOrder.push("apply");
+        return Promise.reject(new Error("yaml apply failed"));
+      });
+
+      const result = await decideAmendment({ id: "amd-1", decision: "approved", ...base });
+
+      expect(result).toEqual({
+        outcome: "apply_failed",
+        id: "amd-1",
+        reason: "yaml apply failed",
+        revertedToPending: true,
+      });
+      // Compensation ran with the claimed id — never left approved-but-unapplied.
+      expect(mockRevert).toHaveBeenCalledTimes(1);
+      expect(mockRevert.mock.calls[0][0]).toBe("amd-1");
+    });
+
+    it("a version-snapshot failure (surfaced by the apply) reverts to pending", async () => {
+      // The apply throws when it cannot take a rollback snapshot — the seam
+      // treats it like any apply failure and compensates.
+      mockApply.mockImplementation(() =>
+        Promise.reject(new Error("could not snapshot a rollback point — failing the apply")),
+      );
+
+      const result = await decideAmendment({ id: "amd-9", decision: "approved", ...base });
+
+      expect(result.outcome).toBe("apply_failed");
+      if (result.outcome === "apply_failed") {
+        expect(result.reason).toContain("snapshot");
+        expect(result.revertedToPending).toBe(true);
+      }
+      expect(mockRevert).toHaveBeenCalledTimes(1);
+    });
+
+    it("a null/corrupt payload is an apply error that reverts — never a silent stamp", async () => {
+      // The claim returns a row with a null payload; the apply seam rejects it.
+      mockReview.mockImplementation((id: string) => {
+        callOrder.push("claim");
+        return Promise.resolve({
+          id,
+          source_entity: "orders",
+          connection_group_id: null,
+          amendment_payload: null,
+        });
+      });
+      mockApply.mockImplementation((args: Record<string, unknown>) => {
+        if (!args.rawPayload) return Promise.reject(new Error("has no amendment_payload"));
+        return Promise.resolve();
+      });
+
+      const result = await decideAmendment({ id: "amd-2", decision: "approved", ...base });
+
+      expect(result.outcome).toBe("apply_failed");
+      expect(mockRevert).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces revertedToPending=false when BOTH the apply and the revert fail", async () => {
+      mockApply.mockImplementation(() => Promise.reject(new Error("apply exploded")));
+      mockRevert.mockImplementation(() => Promise.reject(new Error("revert exploded")));
+
+      const result = await decideAmendment({ id: "amd-3", decision: "approved", ...base });
+
+      expect(result).toEqual({
+        outcome: "apply_failed",
+        id: "amd-3",
+        reason: "apply exploded",
+        revertedToPending: false,
+      });
+    });
+
+    it("a cross-group AmbiguousEntityError is reverted then rethrown (→ 409 group picker)", async () => {
+      const ambiguous = new AmbiguousEntityError({
+        message: "orders exists in 2 groups",
+        entityName: "orders",
+        entityType: "entity",
+        groups: ["us_prod", "eu_prod"],
+      });
+      mockApply.mockImplementation(() => Promise.reject(ambiguous));
+
+      await expect(decideAmendment({ id: "amd-4", decision: "approved", ...base })).rejects.toBe(
+        ambiguous,
+      );
+      // The claim is still reverted before the rethrow, so the row stays reviewable.
+      expect(mockRevert).toHaveBeenCalledTimes(1);
+      expect(mockRevert.mock.calls[0][0]).toBe("amd-4");
+    });
+
+    it("ambiguous WITH a failed revert returns apply_failed, not a 409 the admin can't resolve", async () => {
+      // Worst case: cross-group ambiguity AND the compensating revert fails, so
+      // the row is stuck `approved`. A 409 group-picker would send the admin
+      // into a retry that 404s against the pending-only claim — surface the
+      // stuck row via apply_failed instead of rethrowing the ambiguity.
+      const ambiguous = new AmbiguousEntityError({
+        message: "orders exists in 2 groups",
+        entityName: "orders",
+        entityType: "entity",
+        groups: ["us_prod", "eu_prod"],
+      });
+      mockApply.mockImplementation(() => Promise.reject(ambiguous));
+      mockRevert.mockImplementation(() => Promise.reject(new Error("revert exploded")));
+
+      const result = await decideAmendment({ id: "amd-7", decision: "approved", ...base });
+
+      expect(result).toEqual({
+        outcome: "apply_failed",
+        id: "amd-7",
+        reason: "orders exists in 2 groups",
+        revertedToPending: false,
+      });
+    });
+  });
+
+  describe("reject", () => {
+    it("rejects atomically without applying YAML", async () => {
+      const result = await decideAmendment({ id: "amd-5", decision: "rejected", ...base });
+
+      expect(result).toEqual({ outcome: "rejected", id: "amd-5" });
+      expect(mockReview.mock.calls[0]).toEqual(["amd-5", "org-1", "rejected", "admin"]);
+      expect(mockApply).not.toHaveBeenCalled();
+      expect(mockRevert).not.toHaveBeenCalled();
+    });
+
+    it("returns already_reviewed when the reject loses the race", async () => {
+      mockReview.mockResolvedValue(null);
+
+      const result = await decideAmendment({ id: "amd-6", decision: "rejected", ...base });
+
+      expect(result).toEqual({ outcome: "already_reviewed" });
+      expect(mockApply).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -1,13 +1,16 @@
 /**
- * runExpertSchedulerTick auto-approve invariant (#4486).
+ * runExpertSchedulerTick auto-approve invariant (#4486, #4506).
  *
- * The scheduler stamps eligible proposals `approved` at insert and applies them
- * immediately. This pins the two behaviors the invariant "status='approved' ⇒
- * applied" depends on, so a future edit that drops the apply or the revert ships
- * red instead of green:
- *   - approved + apply succeeds  → autoApproved, row NOT reverted
- *   - approved + apply fails      → row reverted to pending with the insert's id,
- *                                    counted as an error (never left approved)
+ * The scheduler inserts every proposal `pending`, then hands each
+ * auto-approve-eligible row to the single decide seam (`decideAmendment`). It no
+ * longer applies or reverts directly — the seam owns claim-then-apply with
+ * compensation. This pins the tick's mapping of insert + decide outcomes to the
+ * result counters so a future edit that drops the seam call (or mis-maps an
+ * outcome) ships red:
+ *   - eligible + decide approved   → autoApproved
+ *   - eligible + decide apply_failed → errors (the seam already reverted)
+ *   - not eligible                 → queued, decide never called
+ *   - rejected / already_pending    → suppressed at insert, decide never called
  *
  * A separate file from scheduler.test.ts (which only tests the config getters)
  * so the tick's module mocks don't leak into those tests.
@@ -47,21 +50,25 @@ void mock.module("../analyzer", () => ({
   analyzeSemanticLayer: () => proposals,
 }));
 
-const mockApplyAmendmentToEntity: Mock<() => Promise<void>> = mock(() => Promise.resolve());
-void mock.module("../apply", () => ({
-  applyAmendmentToEntity: mockApplyAmendmentToEntity,
+// The single decide seam (#4506): the tick calls it for every eligible row.
+type DecideResult =
+  | { outcome: "approved"; id: string }
+  | { outcome: "rejected"; id: string }
+  | { outcome: "already_reviewed" }
+  | { outcome: "apply_failed"; id: string; reason: string; revertedToPending: boolean };
+const mockDecideAmendment: Mock<(args: Record<string, unknown>) => Promise<DecideResult>> = mock(() =>
+  Promise.resolve({ outcome: "approved", id: "sch-1" }),
+);
+void mock.module("../decide", () => ({
+  decideAmendment: mockDecideAmendment,
 }));
 
-const mockInsertSemanticAmendment: Mock<() => Promise<{ outcome: string; id?: string; status?: string }>> = mock(() =>
-  Promise.resolve({ outcome: "inserted", id: "sch-1", status: "approved" }),
-);
-const mockRevertAmendmentToPending: Mock<(id: string) => Promise<boolean>> = mock(() =>
-  Promise.resolve(true),
-);
+const mockInsertSemanticAmendment: Mock<
+  () => Promise<{ outcome: string; id?: string; autoApproveEligible?: boolean }>
+> = mock(() => Promise.resolve({ outcome: "inserted", id: "sch-1", autoApproveEligible: true }));
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   insertSemanticAmendment: mockInsertSemanticAmendment,
-  revertAmendmentToPending: mockRevertAmendmentToPending,
 }));
 
 void mock.module("@atlas/api/lib/logger", () => ({
@@ -70,75 +77,91 @@ void mock.module("@atlas/api/lib/logger", () => ({
 
 void mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
-  // scheduler.ts now reads this to force-disable on SaaS (#4487); the tick
-  // tests exercise the self-hosted path, so keep it false (not SaaS).
+  // scheduler.ts reads this to force-disable on SaaS (#4487); the tick tests
+  // exercise the self-hosted path, so keep it false (not SaaS).
   isSaasModeForGuard: () => false,
 }));
 
 const { runExpertSchedulerTick } = await import("../scheduler");
 
-describe("runExpertSchedulerTick auto-approve → apply invariant (#4486)", () => {
+describe("runExpertSchedulerTick auto-approve → decide seam (#4486, #4506)", () => {
   beforeEach(() => {
     proposals = [proposal];
-    mockApplyAmendmentToEntity.mockClear();
-    mockApplyAmendmentToEntity.mockResolvedValue(undefined);
+    mockDecideAmendment.mockClear();
+    mockDecideAmendment.mockResolvedValue({ outcome: "approved", id: "sch-1" });
     mockInsertSemanticAmendment.mockClear();
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-1", status: "approved" });
-    mockRevertAmendmentToPending.mockClear();
-    mockRevertAmendmentToPending.mockResolvedValue(true);
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-1", autoApproveEligible: true });
   });
 
-  it("applies an auto-approved proposal and does not revert it", async () => {
+  it("routes an eligible proposal through the decide seam and counts it auto-approved", async () => {
     const result = await runExpertSchedulerTick();
 
-    expect(mockApplyAmendmentToEntity).toHaveBeenCalledTimes(1);
-    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
+    // The seam is asked to APPROVE the freshly-inserted row under the auto
+    // origin — self-hosted global scope.
+    expect(mockDecideAmendment.mock.calls[0][0]).toMatchObject({
+      id: "sch-1",
+      orgId: null,
+      decision: "approved",
+      reviewedBy: "auto-approve",
+    });
     expect(result.autoApproved).toBe(1);
     expect(result.errors).toBe(0);
   });
 
-  it("reverts the row to pending (with the insert id) when apply fails", async () => {
-    mockApplyAmendmentToEntity.mockRejectedValue(new Error("entity not found"));
+  it("counts an errored (apply_failed) decide as an error — the seam owns the revert", async () => {
+    mockDecideAmendment.mockResolvedValue({
+      outcome: "apply_failed",
+      id: "sch-1",
+      reason: "entity not found",
+      revertedToPending: true,
+    });
 
     const result = await runExpertSchedulerTick();
 
-    // The row must not linger `approved`-but-unapplied: revert is called with
-    // the exact id the insert returned.
-    expect(mockRevertAmendmentToPending).toHaveBeenCalledTimes(1);
-    expect(mockRevertAmendmentToPending.mock.calls[0][0]).toBe("sch-1");
+    expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
     expect(result.autoApproved).toBe(0);
     expect(result.errors).toBe(1);
   });
 
-  it("does not apply or revert when the proposal lands pending", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-2", status: "pending" });
+  it("counts an already_reviewed decide as queued (a racing decision moved the fresh row)", async () => {
+    mockDecideAmendment.mockResolvedValue({ outcome: "already_reviewed" });
 
     const result = await runExpertSchedulerTick();
 
-    expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
-    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
+    expect(result.autoApproved).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(result.queued).toBe(1);
+  });
+
+  it("does not call the seam when the proposal is not auto-approve-eligible", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-2", autoApproveEligible: false });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(mockDecideAmendment).not.toHaveBeenCalled();
     expect(result.queued).toBe(1);
     expect(result.errors).toBe(0);
   });
 
-  it("counts a rejected identity as suppressed — no apply, no queue (#4507)", async () => {
+  it("counts a rejected identity as suppressed — no decide, no queue (#4507)", async () => {
     mockInsertSemanticAmendment.mockResolvedValue({ outcome: "rejected", id: "rej-1" });
 
     const result = await runExpertSchedulerTick();
 
-    expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
-    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(mockDecideAmendment).not.toHaveBeenCalled();
     expect(result.rejected).toBe(1);
     expect(result.queued).toBe(0);
     expect(result.errors).toBe(0);
   });
 
-  it("counts an already-pending identity as deduped — no apply, no queue (#4507)", async () => {
+  it("counts an already-pending identity as deduped — no decide, no queue (#4507)", async () => {
     mockInsertSemanticAmendment.mockResolvedValue({ outcome: "already_pending", id: "pend-1" });
 
     const result = await runExpertSchedulerTick();
 
-    expect(mockApplyAmendmentToEntity).not.toHaveBeenCalled();
+    expect(mockDecideAmendment).not.toHaveBeenCalled();
     expect(result.deduped).toBe(1);
     expect(result.queued).toBe(0);
     expect(result.errors).toBe(0);

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -142,7 +142,6 @@ export async function applyAmendmentToEntity(
     upsertEntityForGroup,
     createVersion,
     generateChangeSummary,
-    AmbiguousEntityError,
   } = await import("@atlas/api/lib/semantic/entities");
 
   // Apply amendment (same logic as CLI's apply-amendment)
@@ -154,27 +153,27 @@ export async function applyAmendmentToEntity(
   // Upsert entity into its own group scope.
   await upsertEntityForGroup(effectiveOrgId, "entity", result.entityName, newYaml, targetGroupId);
 
-  // Create version snapshot. Tagged errors (AmbiguousEntityError) must
-  // re-throw so the route layer maps them to 409 with `groups`; a generic
-  // warn-log would bury the structural ambiguity that the expert agent
-  // needs the operator to resolve.
-  try {
-    const refreshed = await getEntity(effectiveOrgId, "entity", result.entityName, targetGroupId);
-    if (refreshed) {
-      const changeSummary = await generateChangeSummary(entity.yaml_content, newYaml);
-      const versionSummary = `Expert agent: ${result.rationale}${changeSummary ? ` (${changeSummary})` : ""}`;
-      await createVersion(
-        refreshed.id, effectiveOrgId, "entity", result.entityName, newYaml, versionSummary,
-        "expert-agent", "Semantic Expert Agent",
-      );
-    }
-  } catch (versionErr) {
-    if (versionErr instanceof AmbiguousEntityError) throw versionErr;
-    log.warn(
-      { err: versionErr instanceof Error ? versionErr.message : String(versionErr), requestId, orgId, entity: result.entityName },
-      "Amendment applied but version snapshot failed",
+  // Create the version snapshot. Rollback-ability is PART of the apply
+  // (CONTEXT.md § Semantic improvement — "a snapshot that cannot be taken fails
+  // the apply"): a snapshot failure throws so the caller compensates and returns
+  // the amendment to pending, rather than leaving an applied-but-unrollbackable
+  // change stamped `approved` (#4506). Only the disk-mirror sync below stays
+  // warn-only. (Cross-group `AmbiguousEntityError`s originate earlier, in the
+  // unscoped fallback of `resolveAmendmentBaseline` — not this re-read, which is
+  // always group-scoped, `targetGroupId` never `undefined` — and propagate
+  // unchanged so the route maps them to 409 with `groups`.)
+  const refreshed = await getEntity(effectiveOrgId, "entity", result.entityName, targetGroupId);
+  if (!refreshed) {
+    throw new Error(
+      `Amendment applied to "${result.entityName}" but the entity could not be re-read to snapshot a rollback point — failing the apply so it returns to pending.`,
     );
   }
+  const changeSummary = await generateChangeSummary(entity.yaml_content, newYaml);
+  const versionSummary = `Expert agent: ${result.rationale}${changeSummary ? ` (${changeSummary})` : ""}`;
+  await createVersion(
+    refreshed.id, effectiveOrgId, "entity", result.entityName, newYaml, versionSummary,
+    "expert-agent", "Semantic Expert Agent",
+  );
 
   // Invalidate caches
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");

--- a/packages/api/src/lib/semantic/expert/decide.ts
+++ b/packages/api/src/lib/semantic/expert/decide.ts
@@ -1,0 +1,157 @@
+/**
+ * The single decide seam for semantic Amendments (#4506).
+ *
+ * `decideAmendment` owns the `pending → approved | rejected` transition for the
+ * improve-loop callers — the admin review route, the interactive auto-approve
+ * path (`proposeAmendment` tool), and the autonomous scheduler. Routing all
+ * three through one function is what makes CONTEXT.md's "approved means applied"
+ * hold by construction rather than by caller discipline: none of them can
+ * reintroduce a ghost approval, because the only way THEY write `approved` is
+ * this seam, and this seam writes it only after a successful apply. (The legacy
+ * `admin-learned-patterns` route is a second approve path over these rows — it
+ * still apply-first-then-flips; folding it into this seam is #4594.)
+ *
+ * Ordering is claim-then-apply with compensation:
+ *   1. CLAIM — an atomic conditional UPDATE (`reviewSemanticAmendment`) that
+ *      only succeeds on a still-`pending` row. Exactly one concurrent caller
+ *      wins; the loser gets `already_reviewed` and never touches YAML.
+ *   2. APPLY — `applyAmendmentFromPayload` (which fails if a rollback version
+ *      snapshot can't be taken, or the payload is null/corrupt).
+ *   3. COMPENSATE — on any apply failure, revert the claim to `pending` with a
+ *      visible reason, so a stamped-`approved` row can never survive unapplied.
+ *
+ * A cross-group `AmbiguousEntityError` whose revert SUCCEEDED is rethrown so the
+ * route maps it to 409 with the group list (the group-picker retry re-claims a
+ * now-pending row; failure-case UI in PRD #4502). If the revert also failed the
+ * row is stuck `approved`, so a 409 group-picker would send the admin into a
+ * retry that 404s — that case returns `apply_failed` (surfacing the stuck row)
+ * instead. Every other apply failure returns a structured `apply_failed`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("semantic-amendment-decide");
+
+/**
+ * Structural check for a cross-group `AmbiguousEntityError` by its tagged
+ * `_tag` — the same way `runHandler` classifies tagged errors at the HTTP
+ * boundary. Checked structurally (not `instanceof`) so this seam does not
+ * statically import the heavy `errors.ts` graph (which transitively pulls
+ * content-mode → the semantic-entities adapter); a static import there breaks
+ * every test that partial-mocks `lib/semantic/entities`.
+ */
+function isAmbiguousEntityError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "_tag" in err &&
+    (err as { _tag?: unknown })._tag === "AmbiguousEntityError"
+  );
+}
+
+/**
+ * The outcome of a single decide. `apply_failed` carries the failure reason and
+ * whether the compensating revert succeeded — a `false` there means the row may
+ * genuinely still read `approved`-but-unapplied (both the apply AND the revert
+ * failed), which the caller surfaces rather than swallows. An
+ * `AmbiguousEntityError` is thrown, never returned (see module docstring).
+ */
+export type DecideAmendmentResult =
+  | { outcome: "approved"; id: string }
+  | { outcome: "rejected"; id: string }
+  | { outcome: "already_reviewed" }
+  | { outcome: "apply_failed"; id: string; reason: string; revertedToPending: boolean };
+
+export interface DecideAmendmentParams {
+  /** The Amendment (`learned_patterns`) row id to decide. */
+  readonly id: string;
+  /** Org scope; null = self-hosted global scope. */
+  readonly orgId: string | null;
+  /** The admin (or auto-approve pipeline) decision. */
+  readonly decision: "approved" | "rejected";
+  /** Recorded as `reviewed_by` (e.g. "admin", "auto-approve"). */
+  readonly reviewedBy: string;
+  /** Correlation id for logs and the apply's version summary. */
+  readonly requestId: string;
+}
+
+/**
+ * Decide a single Amendment. See the module docstring for the claim-then-apply
+ * ordering and the compensation contract.
+ *
+ * @throws {AmbiguousEntityError} when the apply resolves a name shared across
+ *   Connection groups — after reverting the claim to pending — so the route
+ *   maps it to a 409 group-picker. All other apply failures are returned as
+ *   `apply_failed` (the row is reverted to pending).
+ */
+export async function decideAmendment(
+  params: DecideAmendmentParams,
+): Promise<DecideAmendmentResult> {
+  const { id, orgId, decision, reviewedBy, requestId } = params;
+
+  const { reviewSemanticAmendment, revertAmendmentToPending } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+
+  // Reject is a single atomic transition — no apply, no compensation.
+  if (decision === "rejected") {
+    const rejected = await reviewSemanticAmendment(id, orgId, "rejected", reviewedBy);
+    return rejected ? { outcome: "rejected", id: rejected.id } : { outcome: "already_reviewed" };
+  }
+
+  // Approve — step 1: CLAIM. The conditional UPDATE only matches a pending row,
+  // so a concurrent approve/reject that already moved this row loses the race
+  // here and no YAML is ever touched by the loser.
+  const claimed = await reviewSemanticAmendment(id, orgId, "approved", reviewedBy);
+  if (!claimed) return { outcome: "already_reviewed" };
+
+  // Step 2: APPLY. On ANY failure, step 3 (COMPENSATE) reverts the claim so the
+  // row never lingers `approved`-but-unapplied.
+  try {
+    const { applyAmendmentFromPayload } = await import(
+      "@atlas/api/lib/semantic/expert/apply"
+    );
+    await applyAmendmentFromPayload({
+      orgId,
+      sourceEntity: claimed.source_entity,
+      connectionGroupId: claimed.connection_group_id ?? null,
+      rawPayload: claimed.amendment_payload,
+      requestId,
+      label: claimed.id,
+    });
+    log.info({ requestId, orgId, id: claimed.id }, "Amendment claimed and applied");
+    return { outcome: "approved", id: claimed.id };
+  } catch (err) {
+    // Compensate: return the row to pending so it re-enters the review queue.
+    const revertedToPending = await revertAmendmentToPending(claimed.id).catch(
+      (revertErr: unknown) => {
+        log.error(
+          {
+            err: revertErr instanceof Error ? revertErr.message : String(revertErr),
+            requestId,
+            orgId,
+            id: claimed.id,
+          },
+          "Failed to revert claimed amendment to pending after apply failure — row may remain approved-but-unapplied",
+        );
+        return false;
+      },
+    );
+
+    const reason = err instanceof Error ? err.message : String(err);
+
+    // A cross-group ambiguity is a "please disambiguate", not a hard failure —
+    // BUT only when the compensating revert actually returned the row to pending.
+    // Rethrow then (→ 409 group-picker; the retry re-claims a pending row). If
+    // the revert ALSO failed the row is stuck `approved`, so a 409 would send the
+    // admin into a retry that 404s against the pending-only claim — surface the
+    // stuck row via `apply_failed` instead of a group-picker they can't resolve.
+    if (isAmbiguousEntityError(err) && revertedToPending) throw err;
+
+    log.warn(
+      { err: reason, requestId, orgId, id: claimed.id, revertedToPending },
+      "Amendment apply failed after claim — reverted to pending",
+    );
+    return { outcome: "apply_failed", id: claimed.id, reason, revertedToPending };
+  }
+}

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -121,17 +121,21 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
       return result;
     }
 
-    // 4. Insert proposals — insertSemanticAmendment resolves status (approved/pending) based on threshold
-    const { insertSemanticAmendment, revertAmendmentToPending } =
-      await import("@atlas/api/lib/db/internal");
+    // 4. Insert proposals as pending, then hand every auto-approve-eligible row
+    //    to the single decide seam (#4506) — the scheduler no longer applies or
+    //    reverts directly. The seam claims-then-applies with compensation, so an
+    //    autonomous approval that fails to apply is returned to pending exactly
+    //    like an admin's, and `approved` never means anything but "applied".
+    const { insertSemanticAmendment } = await import("@atlas/api/lib/db/internal");
+    const { decideAmendment } = await import("./decide");
 
     // 5. Process each proposal
     for (const proposal of proposals) {
       try {
-        // Persist the finding's Connection group so the admin approve path can
-        // rebuild the correct scope (#3284). NULL = the default (flat) group:
-        // the layout-aware loader labels the default group `"default"`, which
-        // maps to a NULL `connection_group_id` like everywhere else.
+        // Persist the finding's Connection group so the approve path can rebuild
+        // the correct scope (#3284). NULL = the default (flat) group: the
+        // layout-aware loader labels the default group `"default"`, which maps
+        // to a NULL `connection_group_id` like everywhere else.
         const connectionGroupId =
           proposal.group && proposal.group !== "default" ? proposal.group : null;
         const insertResult = await insertSemanticAmendment({
@@ -160,53 +164,52 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
           continue;
         }
 
-        const { id, status } = insertResult;
+        // Row is `pending`. If it cleared the auto-approve gate, decide it now
+        // through the seam; otherwise it waits for an admin.
+        if (!insertResult.autoApproveEligible) {
+          result.queued++;
+          continue;
+        }
 
-        if (status === "approved") {
-          // Auto-apply
-          try {
-            const { applyAmendmentToEntity } = await import("./apply");
-            await applyAmendmentToEntity(null, proposal, `scheduled-${Date.now()}`);
-            result.autoApproved++;
-            log.info(
-              { entity: proposal.entityName, type: proposal.amendmentType, confidence: proposal.confidence },
-              "Auto-approved and applied semantic amendment",
-            );
-          } catch (applyErr) {
-            // Revert the row so it never lingers as `approved`-but-unapplied —
-            // the invariant "status='approved' ⇒ applied" must hold on this
-            // path too (#4486). Reverting re-queues it for admin review.
-            const reverted = await revertAmendmentToPending(id).catch(
-              (revertErr: unknown) => {
-                log.warn(
-                  {
-                    err: revertErr instanceof Error ? revertErr : new Error(String(revertErr)),
-                    entity: proposal.entityName,
-                    id,
-                  },
-                  "Failed to revert auto-approved amendment to pending after apply failure — row may remain approved-but-unapplied",
-                );
-                return false;
-              },
-            );
-            log.warn(
-              {
-                err: applyErr instanceof Error ? applyErr : new Error(String(applyErr)),
-                entity: proposal.entityName,
-                id,
-                reverted,
-              },
-              "Failed to apply auto-approved amendment — reverted to pending for admin review",
-            );
-            result.errors++;
-          }
+        const decided = await decideAmendment({
+          id: insertResult.id,
+          orgId: null,
+          decision: "approved",
+          reviewedBy: "auto-approve",
+          requestId: `scheduled-${Date.now()}`,
+        });
+
+        if (decided.outcome === "approved") {
+          result.autoApproved++;
+          log.info(
+            { entity: proposal.entityName, type: proposal.amendmentType, confidence: proposal.confidence },
+            "Auto-approved and applied semantic amendment",
+          );
+        } else if (decided.outcome === "apply_failed") {
+          // The seam already reverted the row to pending for admin review.
+          log.warn(
+            {
+              err: decided.reason,
+              entity: proposal.entityName,
+              id: insertResult.id,
+              revertedToPending: decided.revertedToPending,
+            },
+            "Auto-approve apply failed — seam reverted to pending for admin review",
+          );
+          result.errors++;
         } else {
+          // already_reviewed: a racing decision moved the freshly-inserted row.
+          // It's out of pending but not applied-by-us — count it as queued so
+          // the tick summary stays truthful.
           result.queued++;
         }
       } catch (err) {
+        // Covers both the insert and the decide-seam call (a rethrown
+        // AmbiguousEntityError whose revert succeeded lands here) — name both
+        // stages so an operator isn't pointed only at "insert".
         log.warn(
           { err: err instanceof Error ? err : new Error(String(err)), entity: proposal.entityName },
-          "Failed to insert semantic amendment",
+          "Failed to process semantic amendment (insert or decide)",
         );
         result.errors++;
       }

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-group-scope.test.ts
@@ -78,19 +78,38 @@ void mock.module("@atlas/api/lib/semantic/sync", () => ({ syncEntityToDisk }));
 
 // Arg shape mirrors the REAL (now required, #4498) `connectionGroupId` field —
 // `string | null`, not optional — so a caller regressing to omit it is visible
-// here as `undefined` in the persisted-args assertions.
+// here as `undefined` in the persisted-args assertions. The row is inserted
+// `pending`; `autoApproveEligible` drives whether the tool routes it to the
+// decide seam (#4506).
 const insertSemanticAmendment = mock(
   (_args: {
     sourceEntity: string;
     amendmentPayload: AmendmentPayload;
     connectionGroupId: string | null;
-  }) => Promise.resolve({ id: "prop-1", status: "approved" }),
+  }) => Promise.resolve({ outcome: "inserted", id: "prop-1", autoApproveEligible: true }),
 );
 const revertAmendmentToPending = mock(() => Promise.resolve(true));
+
+// The decide seam's claim primitive (#4506). It runs for real end-to-end here
+// (the tool's auto-approve goes tool → decideAmendment → applyAmendmentFromPayload),
+// so the claim must return the row the insert just persisted — same envelope +
+// group — for the real apply to write it back to the correct scope.
+const reviewSemanticAmendment = mock(
+  async (id: string, _org: string | null, _decision: "approved" | "rejected", _by: string) => {
+    const lastInsert = insertSemanticAmendment.mock.calls.at(-1)?.[0];
+    return {
+      id,
+      source_entity: lastInsert?.sourceEntity ?? "orders",
+      connection_group_id: lastInsert?.connectionGroupId ?? null,
+      amendment_payload: (lastInsert?.amendmentPayload ?? null) as Record<string, unknown> | null,
+    };
+  },
+);
 
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   insertSemanticAmendment,
+  reviewSemanticAmendment,
   revertAmendmentToPending,
 }));
 
@@ -143,7 +162,8 @@ describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () =
     createVersion.mockClear();
     syncEntityToDisk.mockClear();
     insertSemanticAmendment.mockClear();
-    insertSemanticAmendment.mockResolvedValue({ id: "prop-1", status: "approved" });
+    insertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-1", autoApproveEligible: true });
+    reviewSemanticAmendment.mockClear();
     revertAmendmentToPending.mockClear();
   });
 
@@ -215,7 +235,7 @@ describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () =
   it("human-review approve of the persisted row resolves the same group-scoped row, no unscoped fallback (#4498)", async () => {
     // Queue the proposal instead of auto-approving, so the ONLY apply in this
     // test is the simulated human review below.
-    insertSemanticAmendment.mockResolvedValue({ id: "prop-1", status: "pending" });
+    insertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-1", autoApproveEligible: false });
     const result = await run();
     expect(result.error).toBeUndefined();
     expect(result.status).toBe("queued");
@@ -264,7 +284,7 @@ describe("proposeAmendment baseline resolution is org/group-aware (#4488)", () =
     // the unscoped fallback — and the persisted group must be the ROW's own
     // scope (NULL), not the request's label.
     activeGroup = null;
-    insertSemanticAmendment.mockResolvedValue({ id: "prop-2", status: "pending" });
+    insertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-2", autoApproveEligible: false });
     const result = await run();
     expect(result.error).toBeUndefined();
     const persisted = insertSemanticAmendment.mock.calls[0][0];

--- a/packages/api/src/lib/tools/__tests__/propose-amendment-no-db.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment-no-db.test.ts
@@ -29,7 +29,7 @@ void mock.module("fs", () => ({
 // never called (stubbed only to satisfy mock-all-exports for the module graph).
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => false,
-  insertSemanticAmendment: mock(() => Promise.resolve({ id: "unused", status: "queued" })),
+  insertSemanticAmendment: mock(() => Promise.resolve({ outcome: "inserted", id: "unused", autoApproveEligible: false })),
   revertAmendmentToPending: mock(() => Promise.resolve(true)),
 }));
 

--- a/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
@@ -22,11 +22,11 @@ const companiesEntity: Record<string, unknown> = {
   dimensions: [{ name: "id", type: "number" }],
 };
 
-// insertSemanticAmendment now returns a discriminated union (#4507):
-// { outcome: "inserted" | "already_pending" | "rejected", ... }.
+// insertSemanticAmendment returns a discriminated union (#4507, #4506):
+// { outcome: "inserted"; id; autoApproveEligible } | { outcome: "already_pending" | "rejected"; id }.
 const mockInsertSemanticAmendment: Mock<
-  (args: Record<string, unknown>) => Promise<{ outcome: string; id?: string; status?: string }>
-> = mock(() => Promise.resolve({ outcome: "inserted", id: "prop-1", status: "pending" }));
+  (args: Record<string, unknown>) => Promise<{ outcome: string; id?: string; autoApproveEligible?: boolean }>
+> = mock(() => Promise.resolve({ outcome: "inserted", id: "prop-1", autoApproveEligible: false }));
 
 const mockRevertAmendmentToPending: Mock<(id: string) => Promise<boolean>> = mock(() =>
   Promise.resolve(true),
@@ -77,6 +77,21 @@ void mock.module("@atlas/api/lib/semantic/expert/apply", () => ({
   applyAmendmentFromPayload: mockApplyAmendmentFromPayload,
   resolveAmendmentBaseline: mockResolveAmendmentBaseline,
   applyAmendment: stubApplyAmendment,
+}));
+
+// The single decide seam (#4506): auto-approve routes through it, never a direct
+// apply. The seam owns claim-then-apply + compensation, so this tool only sees
+// the outcome. Default resolves `approved`; failure-path tests override.
+type DecideResult =
+  | { outcome: "approved"; id: string }
+  | { outcome: "rejected"; id: string }
+  | { outcome: "already_reviewed" }
+  | { outcome: "apply_failed"; id: string; reason: string; revertedToPending: boolean };
+const mockDecideAmendment: Mock<(args: Record<string, unknown>) => Promise<DecideResult>> = mock(
+  (args: Record<string, unknown>) => Promise.resolve({ outcome: "approved", id: String(args.id) }),
+);
+void mock.module("@atlas/api/lib/semantic/expert/decide", () => ({
+  decideAmendment: mockDecideAmendment,
 }));
 
 void mock.module("@atlas/api/lib/logger", () => ({
@@ -150,7 +165,7 @@ describe("proposeAmendment test query routing (#4485)", () => {
     mockRunUserQueryPipeline.mockClear();
     mockRunUserQueryPipeline.mockResolvedValue(okOutcome);
     mockInsertSemanticAmendment.mockClear();
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-1", status: "pending" });
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-1", autoApproveEligible: false });
   });
 
   it("routes the test query through runUserQueryPipeline with an explicit connectionId", async () => {
@@ -218,45 +233,41 @@ describe("proposeAmendment test query routing (#4485)", () => {
   });
 });
 
-describe("proposeAmendment auto-approve applies in the same flow (#4486)", () => {
+describe("proposeAmendment auto-approve routes through the decide seam (#4486, #4506)", () => {
   beforeEach(() => {
     mockRunUserQueryPipeline.mockClear();
     mockRunUserQueryPipeline.mockResolvedValue(okOutcome);
     mockInsertSemanticAmendment.mockClear();
     mockApplyAmendmentFromPayload.mockClear();
     mockApplyAmendmentFromPayload.mockResolvedValue(undefined);
-    mockRevertAmendmentToPending.mockClear();
-    mockRevertAmendmentToPending.mockResolvedValue(true);
+    mockDecideAmendment.mockClear();
+    mockDecideAmendment.mockImplementation((args: Record<string, unknown>) =>
+      Promise.resolve({ outcome: "approved", id: String(args.id) }),
+    );
   });
 
-  it("does NOT apply when the insert lands pending (auto-approve disabled)", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-pending", status: "pending" });
+  it("does NOT decide when the insert is not auto-approve-eligible", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-pending", autoApproveEligible: false });
     const result = await run();
-    expect(mockApplyAmendmentFromPayload).not.toHaveBeenCalled();
-    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    expect(mockDecideAmendment).not.toHaveBeenCalled();
     expect(result.status).toBe("queued");
   });
 
-  it("applies the amendment in the same flow when the insert auto-approves", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", status: "approved" });
+  it("routes an eligible insert through the decide seam and reports auto_approved", async () => {
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", autoApproveEligible: true });
     const result = await run();
 
-    // The invariant: an `approved` insert triggers exactly one apply.
-    expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
-    const applyArgs = mockApplyAmendmentFromPayload.mock.calls[0][0] as {
-      sourceEntity: string;
-      connectionGroupId: string | null;
-      label: string;
-      rawPayload: { amendment: Record<string, unknown> };
-    };
-    expect(applyArgs.sourceEntity).toBe("companies");
-    expect(applyArgs.connectionGroupId).toBeNull();
-    expect(applyArgs.label).toBe("prop-approved");
-    // The inner amendment object is carried through so the YAML mutation applies.
-    expect(applyArgs.rawPayload.amendment).toMatchObject({ name: "region" });
-
-    // Apply succeeded → the row legitimately stays approved; no revert.
-    expect(mockRevertAmendmentToPending).not.toHaveBeenCalled();
+    // The invariant: an eligible insert triggers exactly one decide, asking the
+    // seam to APPROVE the freshly-inserted row under the auto origin. The seam
+    // (not this tool) owns claim-then-apply + the group/payload threading.
+    expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
+    expect(mockDecideAmendment.mock.calls[0][0]).toMatchObject({
+      id: "prop-approved",
+      decision: "approved",
+      reviewedBy: "auto-approve",
+    });
+    // The tool never applies YAML directly anymore.
+    expect(mockApplyAmendmentFromPayload).not.toHaveBeenCalled();
     expect(result.status).toBe("auto_approved");
     // Pin the wire contract the web relies on (#4499): an auto_approved result
     // still carries the row id — `extractProposals` drops results without a
@@ -264,50 +275,52 @@ describe("proposeAmendment auto-approve applies in the same flow (#4486)", () =>
     expect(result.proposalId).toBe("prop-approved");
   });
 
-  it("reverts the row to pending and reports queued when the auto-approve apply fails", async () => {
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", status: "approved" });
-    mockApplyAmendmentFromPayload.mockRejectedValue(new Error("entity not found for org"));
+  it("reports queued (never throws) when the decide seam returns apply_failed", async () => {
+    // The seam claimed the row, failed to apply, and already reverted it to
+    // pending — the tool just tells the model the truth (queued), never an
+    // `auto_approved` lie or a thrown error that hides the row.
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", autoApproveEligible: true });
+    mockDecideAmendment.mockResolvedValue({
+      outcome: "apply_failed",
+      id: "prop-approved",
+      reason: "entity not found for org",
+      revertedToPending: true,
+    });
 
     const result = await run();
 
-    // Apply was attempted, then the row was reverted so it never lingers as
-    // approved-but-unapplied (invariant restored + surfaced, not swallowed).
-    expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
-    expect(mockRevertAmendmentToPending).toHaveBeenCalledTimes(1);
-    expect(mockRevertAmendmentToPending.mock.calls[0][0]).toBe("prop-approved");
-    // The model is told the truth: the proposal is queued, not auto-applied.
-    expect(result.status).toBe("queued");
-    // The apply failure never surfaces as a tool-level error that hides the row.
-    expect(result.error).toBeUndefined();
-  });
-
-  it("still reports queued (never throws) when both the apply AND the revert fail", async () => {
-    // Worst case: apply fails and the revert-to-pending also fails, so the row
-    // genuinely stays `approved`-but-unapplied. This must still be surfaced via
-    // logs and reported honestly to the model (queued), never swallowed into a
-    // tool-level error or an `auto_approved` lie.
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-approved", status: "approved" });
-    mockApplyAmendmentFromPayload.mockRejectedValue(new Error("apply exploded"));
-    mockRevertAmendmentToPending.mockRejectedValue(new Error("revert exploded"));
-
-    const result = await run();
-
-    expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
-    expect(mockRevertAmendmentToPending).toHaveBeenCalledTimes(1);
-    // The double failure never surfaces as a thrown error or auto_approved.
+    expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("queued");
     expect(result.error).toBeUndefined();
   });
 
-  it("invariant: the tool never returns auto_approved without having applied", async () => {
-    // Sweep both insert outcomes; assert apply-count tracks approved+success.
-    for (const status of ["pending", "approved"] as const) {
-      mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: `prop-${status}`, status });
-      mockApplyAmendmentFromPayload.mockClear();
+  it("reports queued (never a tool error) when the decide seam THROWS a cross-group ambiguity", async () => {
+    // decideAmendment throws only for an AmbiguousEntityError whose revert
+    // succeeded — the row is back in the pending queue. The tool must report
+    // queued (the proposal exists, awaiting review), not surface a whole-tool
+    // error that hides the created row.
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-amb", autoApproveEligible: true });
+    mockDecideAmendment.mockRejectedValue(new Error("orders exists in 2 groups"));
+
+    const result = await run();
+
+    expect(result.status).toBe("queued");
+    expect(result.error).toBeUndefined();
+    expect(result.proposalId).toBe("prop-amb");
+  });
+
+  it("invariant: the tool never returns auto_approved without a successful decide", async () => {
+    // Sweep eligibility; auto_approved requires an `approved` decide outcome.
+    for (const eligible of [false, true] as const) {
+      mockInsertSemanticAmendment.mockResolvedValue({
+        outcome: "inserted",
+        id: `prop-${eligible}`,
+        autoApproveEligible: eligible,
+      });
+      mockDecideAmendment.mockClear();
       const result = await run();
       if (result.status === "auto_approved") {
-        // The only way to report auto_approved is a successful apply call.
-        expect(mockApplyAmendmentFromPayload).toHaveBeenCalledTimes(1);
+        expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
       } else {
         expect(result.status).toBe("queued");
       }

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -249,66 +249,58 @@ The amendment object should match the YAML structure for that type (e.g., { name
 
         proposalId = result.id;
 
-        if (result.status === "approved") {
-          // Auto-approve resolved this to `approved` at insert time. `approved`
-          // is terminal for the pending queue, so — exactly like the scheduler
-          // path (semantic/expert/scheduler.ts) — we MUST apply it now, or the
-          // row claims applied while the semantic layer is unchanged and the
-          // diff shown to the user is fiction (#4486). On apply failure, revert
-          // the row to `pending` so the invariant "status='approved' ⇒ applied"
-          // holds and an admin still sees the proposal in the review queue.
+        if (result.autoApproveEligible) {
+          // The row was inserted `pending`; auto-approve now routes through the
+          // single decide seam (#4506) — exactly the path an admin's approve
+          // takes. The seam claims-then-applies with compensation, so an
+          // auto-approve that fails to apply is returned to pending for admin
+          // review, never left approved-but-unapplied (the invariant
+          // "approved means applied" holds by construction). The seam reads the
+          // row's stored `connection_group_id` (set to `applyGroupId` at insert,
+          // #4488), so approval writes the scope the diff was computed against.
+          //
+          // Dynamic import (matching the scheduler + admin approve path): keeps
+          // the seam out of this tool's static graph, so the many partial
+          // `mock.module("…/db/internal")` test stubs that don't exercise the
+          // auto-approve branch don't have to add the export just to link.
+          const { decideAmendment } = await import(
+            "@atlas/api/lib/semantic/expert/decide"
+          );
           try {
-            // Dynamic imports (matching the scheduler + admin approve path):
-            // keeps the apply/revert seam out of this tool's static graph, so
-            // the many partial `mock.module("…/db/internal")` test stubs that
-            // don't exercise the auto-approve branch don't have to add the
-            // export just to link.
-            const { applyAmendmentFromPayload } = await import(
-              "@atlas/api/lib/semantic/expert/apply"
-            );
-            await applyAmendmentFromPayload({
+            const decided = await decideAmendment({
+              id: proposalId,
               orgId,
-              sourceEntity: entityName,
-              // Thread the SAME group the baseline was resolved from (the
-              // resolved row's own `connection_group_id`) so approval writes
-              // the scope the diff was computed against — never the flat/NULL
-              // default for an org/group-scoped entity (#4488).
-              connectionGroupId: applyGroupId,
-              // `rawPayload` is typed `unknown`, so the AmendmentPayload passes
-              // through directly (matches the admin approve call sites).
-              rawPayload: payload,
+              decision: "approved",
+              reviewedBy: "auto-approve",
               requestId: getRequestContext()?.requestId ?? `propose-${Date.now()}`,
-              label: proposalId,
             });
-            status = "auto_approved";
-          } catch (applyErr) {
-            // Surface the failure: revert the row so it never lingers as
-            // `approved`-but-unapplied, and log — never swallow.
-            const { revertAmendmentToPending } = await import(
-              "@atlas/api/lib/db/internal"
-            );
-            const reverted = await revertAmendmentToPending(proposalId).catch(
-              (revertErr: unknown) => {
-                log.error(
-                  {
-                    err: revertErr instanceof Error ? revertErr.message : String(revertErr),
-                    proposalId,
-                    entityName,
-                  },
-                  "Failed to revert auto-approved amendment to pending after apply failure — row may remain approved-but-unapplied",
-                );
-                return false;
-              },
-            );
+            status = decided.outcome === "approved" ? "auto_approved" : "queued";
+            if (decided.outcome === "apply_failed") {
+              // The seam already reverted the row to pending — surface, never swallow.
+              log.warn(
+                {
+                  err: decided.reason,
+                  entityName,
+                  amendmentType,
+                  proposalId,
+                  revertedToPending: decided.revertedToPending,
+                },
+                "Auto-approve apply failed — seam reverted to pending for admin review",
+              );
+            }
+          } catch (decideErr) {
+            // decideAmendment only THROWS for a cross-group AmbiguousEntityError
+            // whose revert succeeded — the row is back in the pending queue. The
+            // proposal exists and awaits review, so report it `queued` (parity
+            // with `apply_failed`), never a whole-tool error that hides the row.
             log.warn(
               {
-                err: applyErr instanceof Error ? applyErr.message : String(applyErr),
+                err: decideErr instanceof Error ? decideErr.message : String(decideErr),
                 entityName,
                 amendmentType,
                 proposalId,
-                reverted,
               },
-              "Auto-approved amendment failed to apply — reverted to pending for admin review",
+              "Auto-approve hit cross-group ambiguity — left pending for admin review",
             );
             status = "queued";
           }


### PR DESCRIPTION
## Summary

Keystone slice of the v0.0.48 Semantic-Improve Elevation milestone (PRD #4502; vocabulary in CONTEXT.md § Semantic improvement; containment per ADR-0032).

One **decide seam** — `packages/api/src/lib/semantic/expert/decide.ts` (`decideAmendment`) — owns the `pending → approved | rejected` transition for every improve-loop caller: the review route (`admin-semantic-improve.ts`), the interactive auto-approve path (`proposeAmendment` tool), and the autonomous scheduler. Ordering is **claim-then-apply with compensation**:

1. **CLAIM** — an atomic conditional `UPDATE … WHERE status='pending'` (`reviewSemanticAmendment`). Exactly one concurrent caller wins; the loser touches no YAML.
2. **APPLY** — `applyAmendmentFromPayload` (now fails if a rollback version snapshot can't be taken, or the payload is null/corrupt).
3. **COMPENSATE** — on any apply failure, revert the claim to `pending` with a visible reason, so a stamped-`approved` row can never survive unapplied.

This makes CONTEXT.md's **"approved means applied"** hold by construction, not by caller discipline. Supporting changes:

- `insertSemanticAmendment` is now **pending-only** and returns `autoApproveEligible` (never stamps `approved`), so the seam is the sole `approved` writer for the improve loop. Auto-approve = insert-pending → `decideAmendment(approved)`.
- `applyAmendmentToEntity`: a **version-snapshot failure now throws** (rollback-ability is part of the apply, CONTEXT.md §255); the disk-mirror sync stays warn-only.
- `revertAmendmentToPending` clears `reviewed_by`/`reviewed_at` so a compensated row reads as genuinely unreviewed.
- `reviewSemanticAmendment` RETURNs `connection_group_id` so the claim applies to the correct group scope with no second read.

## Response-shape contract (for the blocked slices #4511 / #4513)

`decideAmendment(params) → Promise<DecideAmendmentResult>`:

```ts
type DecideAmendmentResult =
  | { outcome: "approved"; id: string }
  | { outcome: "rejected"; id: string }
  | { outcome: "already_reviewed" }                                    // lost the claim race — no YAML touched
  | { outcome: "apply_failed"; id: string; reason: string; revertedToPending: boolean };
// A cross-group AmbiguousEntityError whose revert SUCCEEDED is thrown (not returned) so the
// route maps it to 409 with the group list; if the revert also failed it is returned as
// apply_failed (surfacing the stuck row) rather than a 409 the admin can't resolve.
```

Route `POST /amendments/{id}/review` maps outcomes to HTTP:

| outcome | HTTP | body |
|---|---|---|
| `approved` / `rejected` | 200 | `{ ok: true, id, decision }` |
| `already_reviewed` | 404 | `{ error: "not_found", message, requestId }` |
| `apply_failed` | 500 | `{ error: "apply_failed", message: "…could not be applied: <reason>. Returned to the pending queue…", requestId }` |
| (thrown) `AmbiguousEntityError` | 409 | `{ error: "entity_ambiguous", message, requestId, groups, entityName, entityType }` (unchanged runHandler mapping) |

## Acceptance criteria

- [x] Concurrent approves of the same Amendment: exactly one applies; the loser gets a truthful already-reviewed 404 and no YAML mutation.
- [x] Approve racing reject cannot stamp an applied change as rejected (and vice-versa).
- [x] No improve-loop path produces an approved row without a successful apply + version snapshot; the seam is the sole writer of `approved` (insert is pending-only, pinned at the SQL level).
- [x] Null/corrupt payload → error response, row returned to pending.
- [x] Snapshot failure → apply fails, row back to pending with a visible reason.
- [x] Review route, auto-approve, and scheduler all route through the seam.

## Test plan

- [x] `decide.test.ts` — seam: claim-then-apply ordering, concurrent-loser `already_reviewed`, apply-failure compensation, null-payload, ambiguous rethrow-after-revert, ambiguous+revert-fail → `apply_failed`.
- [x] `admin-semantic-improve.test.ts` — route seam: claim-then-apply, concurrent-approve → one winner, approve-racing-reject (both orderings), `apply_failed` 500 + reverted-to-pending.
- [x] `apply-from-payload.test.ts` — snapshot-fails-apply directly (createVersion rejects; re-read null).
- [x] `scheduler-tick.test.ts` / `propose-amendment*.test.ts` — auto-approve routes through the seam; outcomes mapped to counters / tool status.
- [x] `semantic-amendment-rejection-guard.test.ts` (insert pending-only) + `semantic-amendment-saas-scoping.test.ts` (claim/revert SQL shape).
- [x] `/ci` — all 30 gates green (the sole `test` failure was a confirmed local-env false-fail: `@atlas/mcp` smoke against an un-migrated `DATABASE_URL`; green with it unset; `packages/mcp` untouched by this branch).

## Follow-up

- #4594 — the legacy `admin-learned-patterns` route is a second approve path over these rows (apply-first-then-flip); folding it into the seam is filed separately (out of this issue's file list; its snapshot gap is already closed by the `apply.ts` change here).

## Reviewers

Internal review panel (silent-failure, type-design, test-coverage, comment-accuracy) run pre-PR; all must-fix findings resolved (ambiguous+revert-fail correctness gap, scoped "only writer" docstrings, snapshot-fails-apply coupling tests, approve-racing-reject tests).

Closes #4506