### PR TITLE
feat(semantic-improve): SaaS-first autonomous improvement — per-workspace opt-in scheduler (#4516)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -345,8 +345,9 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                           # Default 72.
 
 # === Semantic Expert ===
-# ATLAS_EXPERT_SCHEDULER_ENABLED=false    # Enable periodic semantic layer analysis
+# ATLAS_EXPERT_SCHEDULER_ENABLED=false    # Platform master switch: run the autonomous-improvement fiber
 # ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS=24  # Hours between scheduled runs
+# ATLAS_AUTONOMOUS_IMPROVE_ENABLED=false  # Per-workspace opt-in: let Atlas propose amendments on its own cadence (off by default)
 # ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD=     # Auto-approve threshold (e.g. 0.9). Empty = disabled
 # ATLAS_EXPERT_AUTO_APPROVE_TYPES=update_description,add_dimension  # Amendment types eligible for auto-approval
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1690,8 +1690,10 @@ export async function insertSemanticAmendment(amendment: {
   // (mirror of the reader guard in `amendmentOrgScope` / #4487). Refuse it at
   // this single insert choke point — the one path every caller (chat tool,
   // scheduler, CLI) shares — so no code path can mint a NULL-owner row anew on
-  // SaaS, and a future SaaS-capable scheduler (#4516; today force-disabled on
-  // SaaS) would be org-safe by construction. On self-hosted the single workspace
+  // SaaS. The SaaS-capable autonomous scheduler (#4516) is org-safe by
+  // construction because of this guard: it stamps a real orgId per workspace,
+  // and this invariant fails loud if a stamping regression ever passes NULL.
+  // On self-hosted the single workspace
   // IS the whole deployment, so a NULL owner is that one
   // workspace's legacy global scope — tolerated (the CLI and scheduler
   // single-org paths still write it). Fail LOUD, never a silent global insert.

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1816,7 +1816,12 @@ export function makeSchedulerLive(
         onTickFailure: { level: "warn", message: "Onboarding email tick failed" },
       });
 
-      // ── Periodic fiber: semantic expert scheduler (#1269) ──────────
+      // ── Periodic fiber: autonomous-improvement scheduler (#1269, #4516) ──
+      // SaaS-first: the gate is the PLATFORM master switch (does the fiber run
+      // on this deployment at all). The per-workspace opt-in + billing gate +
+      // org-stamping live INSIDE the tick (runExpertSchedulerTick), so the
+      // deploy-mode force-disable boot-guard (#4487) is retired — the fiber
+      // runs on SaaS, gated per-workspace.
       yield* registerPeriodicFiber({
         name: "expert_scheduler",
         // Settings-registry-backed (platform DB override > env > default);

--- a/packages/api/src/lib/semantic/expert/__tests__/load-audit-patterns.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-audit-patterns.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `loadAuditPatterns` — the audit-pattern context loader (#1269) with the
+ * #4516 org-scope param.
+ *
+ * `audit_log` is a shared, multi-tenant table. The SaaS per-workspace scheduler
+ * passes an `orgId` so the scan is scoped to one tenant; without it, one
+ * workspace's query patterns would surface in another workspace's proposals — a
+ * cross-tenant leak. Self-hosted / CLI omit it (global NULL-org scan). This file
+ * pins that the tenant filter is present exactly when an orgId is passed and
+ * absent otherwise, so a regression that drops or hard-codes the filter ships red.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+let capturedSql = "";
+let capturedParams: unknown[] = [];
+
+// context-loader dynamically imports internal ONLY inside loadAuditPatterns, and
+// uses just these two exports — a partial mock is complete for this file.
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  internalQuery: async (sql: string, params: unknown[]) => {
+    capturedSql = sql;
+    capturedParams = params;
+    return [
+      { sql: "SELECT 1", count: "5", last_seen: "2026-01-01", tables_accessed: ["orders"] },
+    ];
+  },
+}));
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { loadAuditPatterns } = await import("../context-loader");
+
+describe("loadAuditPatterns org-scope (#4516)", () => {
+  it("scopes the scan to one workspace when an orgId is passed", async () => {
+    await loadAuditPatterns("org-42");
+
+    expect(capturedSql).toContain("org_id = $1");
+    expect(capturedParams).toEqual(["org-42"]);
+  });
+
+  it("does not filter by org when no orgId is passed (self-hosted / CLI)", async () => {
+    await loadAuditPatterns();
+
+    expect(capturedSql).not.toContain("org_id = $1");
+    expect(capturedParams).toEqual([]);
+  });
+
+  it("still parses the pattern rows regardless of scoping", async () => {
+    const patterns = await loadAuditPatterns("org-42");
+
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]).toMatchObject({ sql: "SELECT 1", count: 5, tables: ["orders"] });
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/load-rejected-keys.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-rejected-keys.test.ts
@@ -16,13 +16,15 @@
 import { describe, it, expect, mock } from "bun:test";
 
 let capturedSql = "";
+let capturedParams: unknown[] = [];
 
 // context-loader dynamically imports internal ONLY inside loadRejectedKeys, and
 // uses just these two exports — a partial mock is complete for this file.
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
-  internalQuery: async (sql: string) => {
+  internalQuery: async (sql: string, params: unknown[]) => {
     capturedSql = sql;
+    capturedParams = params;
     return [
       {
         source_entity: "orders",
@@ -58,5 +60,22 @@ describe("loadRejectedKeys (#4507)", () => {
     expect(keys.has("eu:orders:add_dimension:region")).toBe(true);
     expect(keys.has("default:orders:add_measure:total_amount")).toBe(true);
     expect(keys.size).toBe(2);
+  });
+
+  // #4516 — the SaaS per-workspace scheduler passes an orgId so the pre-filter
+  // is scoped to one tenant; without it the union of every tenant's rejections
+  // would over-suppress. Self-hosted / CLI omit it (global NULL-org scan).
+  it("scopes the scan to one workspace when an orgId is passed", async () => {
+    await loadRejectedKeys("org-42");
+
+    expect(capturedSql).toContain("org_id = $1");
+    expect(capturedParams).toEqual(["org-42"]);
+  });
+
+  it("does not filter by org when no orgId is passed (self-hosted / CLI)", async () => {
+    await loadRejectedKeys();
+
+    expect(capturedSql).not.toContain("org_id = $1");
+    expect(capturedParams).toEqual([]);
   });
 });

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -42,10 +42,19 @@ const proposal: AnalysisResult = {
 let saasMode = false;
 // SaaS opt-in enumeration: org ids returned by the settings-table scan.
 let optedInOrgs: string[] = [];
-// Per-org billing gate: default allow; a test can block a specific workspace.
-type GateResult = { allowed: true } | { allowed: false; errorCode: string };
+// When true, the settings-table enumeration query rejects (models a DB blip).
+let enumerationThrows = false;
+// Captured enumeration query + params (assert the opt-in filter + the key).
+let enumerationSql = "";
+let enumerationParams: unknown[] = [];
+// Per-org billing gate: default allow; a test can block/error a workspace, or
+// throw from the gate entirely (models a gate-lookup that itself fails).
+// `httpStatus` drives the block(policy)/error(fail-closed 503) split in the tick.
+type GateResult = { allowed: true } | { allowed: false; errorCode: string; httpStatus: 403 | 404 | 429 | 503 };
 let gateFor: (orgId: string | undefined) => GateResult = () => ({ allowed: true });
 const gateCalls: Array<string | undefined> = [];
+// Captured request-context frames — assert origin/actor stamping (#4508, AC3).
+const capturedContexts: Array<{ requestId?: string; agentOrigin?: string; actor?: { kind?: string } }> = [];
 // Loader org-scope capture — which orgId each context loader was called with.
 const loaderOrgIds: {
   entitiesForOrg: string[];
@@ -103,13 +112,24 @@ void mock.module("../decide", () => ({
 const mockInsertSemanticAmendment: Mock<
   (params: { orgId: string | null }) => Promise<{ outcome: string; id?: string; autoApprove?: boolean }>
 > = mock(() => Promise.resolve({ outcome: "inserted", id: "sch-1", autoApprove: true }));
+// internal DB: partial mock — the tick uses only hasInternalDB (loader/decide
+// gate), insertSemanticAmendment (choke point), and internalQuery (the SaaS
+// opt-in enumeration). Complete for this file; every other DB access is mocked
+// away by the context-loader / decide mocks above.
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   insertSemanticAmendment: mockInsertSemanticAmendment,
-  internalQuery: async () => optedInOrgs.map((org_id) => ({ org_id })),
+  internalQuery: async (sql: string, params: unknown[]) => {
+    enumerationSql = sql;
+    enumerationParams = params;
+    if (enumerationThrows) throw new Error("settings enumeration failed");
+    return optedInOrgs.map((org_id) => ({ org_id }));
+  },
 }));
 
-// Billing gate — records every orgId it was asked about and answers via gateFor.
+// Billing gate — partial mock (the tick calls only checkAgentBillingGate).
+// Records every orgId it was asked about and answers via gateFor (which may
+// itself throw, to model a gate-lookup that fails rather than returns a block).
 void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   checkAgentBillingGate: async (orgId: string | undefined) => {
     gateCalls.push(orgId);
@@ -117,24 +137,34 @@ void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
   },
 }));
 
+// logger — partial mock (createLogger + withRequestContext are all the tick
+// touches). withRequestContext is a passthrough that ALSO records the frame so
+// origin/actor stamping can be asserted.
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
-  // Passthrough so the origin frame doesn't swallow the tick body.
-  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  withRequestContext: (ctx: { requestId?: string; agentOrigin?: string; actor?: { kind?: string } }, fn: () => unknown) => {
+    capturedContexts.push(ctx);
+    return fn();
+  },
 }));
 
+// settings — partial mock (getSetting + isSaasModeForGuard are all the tick reads).
 void mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
   isSaasModeForGuard: () => saasMode,
 }));
 
-const { runExpertSchedulerTick } = await import("../scheduler");
+const { runExpertSchedulerTick, AUTONOMOUS_IMPROVE_ENABLED_KEY } = await import("../scheduler");
 
 function resetMocks(): void {
   saasMode = false;
   optedInOrgs = [];
+  enumerationThrows = false;
+  enumerationSql = "";
+  enumerationParams = [];
   gateFor = () => ({ allowed: true });
   gateCalls.length = 0;
+  capturedContexts.length = 0;
   loaderOrgIds.entitiesForOrg = [];
   loaderOrgIds.entitiesFromDisk = 0;
   loaderOrgIds.audit = [];
@@ -243,6 +273,14 @@ describe("runExpertSchedulerTick — self-hosted degenerate case (#4516)", () =>
     await runExpertSchedulerTick();
     expect(gateCalls).toEqual([undefined]);
   });
+
+  it("stamps agentOrigin 'scheduler' with a self-scoped requestId", async () => {
+    await runExpertSchedulerTick();
+
+    expect(capturedContexts).toHaveLength(1);
+    expect(capturedContexts[0].agentOrigin).toBe("scheduler");
+    expect(capturedContexts[0].requestId).toMatch(/^scheduled-self-/);
+  });
 });
 
 describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () => {
@@ -282,15 +320,19 @@ describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () =
     expect(result.autoApproved).toBe(2);
   });
 
-  it("a blocked workspace no-ops at the gate — zero inserts, counted as gate-blocked", async () => {
+  it("a POLICY-blocked workspace no-ops at the gate — zero inserts, counted as gate-blocked", async () => {
     optedInOrgs = ["org-blocked", "org-ok"];
+    // 429 = over budget: a real policy block, not an infra failure.
     gateFor = (orgId) =>
-      orgId === "org-blocked" ? { allowed: false, errorCode: "plan_limit_exceeded" } : { allowed: true };
+      orgId === "org-blocked"
+        ? { allowed: false, errorCode: "plan_limit_exceeded", httpStatus: 429 }
+        : { allowed: true };
 
     const result = await runExpertSchedulerTick();
 
     expect(result.workspacesConsidered).toBe(2);
     expect(result.workspacesGateBlocked).toBe(1);
+    expect(result.workspacesGateErrored).toBe(0);
     // The blocked workspace never loaded context or inserted anything.
     expect(loaderOrgIds.entitiesForOrg).toEqual(["org-ok"]);
     const insertOrgs = mockInsertSemanticAmendment.mock.calls.map((c) => c[0].orgId);
@@ -298,20 +340,89 @@ describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () =
     expect(result.autoApproved).toBe(1);
   });
 
-  it("one workspace's failure never aborts the sweep", async () => {
-    optedInOrgs = ["org-a", "org-b"];
-    // org-a's insert throws; org-b must still be processed.
-    mockInsertSemanticAmendment.mockImplementation(async (params: { orgId: string | null }) => {
-      if (params.orgId === "org-a") throw new Error("insert failed");
-      return { outcome: "inserted", id: "sch-b", autoApprove: true };
-    });
+  it("a fail-closed gate (503) is counted as errored, NOT blocked — infra ≠ policy", async () => {
+    optedInOrgs = ["org-brownout", "org-ok"];
+    // 503 = the workspace-status / plan lookup could not complete (fail-closed).
+    gateFor = (orgId) =>
+      orgId === "org-brownout"
+        ? { allowed: false, errorCode: "workspace_check_failed", httpStatus: 503 }
+        : { allowed: true };
 
     const result = await runExpertSchedulerTick();
 
     expect(result.workspacesConsidered).toBe(2);
-    expect(result.errors).toBeGreaterThanOrEqual(1);
-    // org-b still auto-approved despite org-a failing.
+    expect(result.workspacesGateErrored).toBe(1);
+    expect(result.workspacesGateBlocked).toBe(0);
+    // Still skips the workspace (fail-closed) — no spend.
+    expect(loaderOrgIds.entitiesForOrg).toEqual(["org-ok"]);
+    expect(result.autoApproved).toBe(1);
+  });
+
+  it("one workspace throwing never aborts the sweep (outer per-workspace catch)", async () => {
+    optedInOrgs = ["org-a", "org-b"];
+    // org-a's gate lookup THROWS (not a returned block) — this escapes
+    // runWorkspaceImproveTick and must be contained by the sweep-level catch so
+    // org-b is still processed.
+    gateFor = (orgId) => {
+      if (orgId === "org-a") throw new Error("gate lookup crashed");
+      return { allowed: true };
+    };
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(2);
+    expect(result.errors).toBe(1);
+    // org-a never loaded context; org-b still auto-approved.
+    expect(loaderOrgIds.entitiesForOrg).toEqual(["org-b"]);
     expect(result.autoApproved).toBe(1);
     expect(mockDecideAmendment.mock.calls.map((c) => c[0].orgId)).toEqual(["org-b"]);
+  });
+
+  it("stamps agentOrigin + actor 'scheduler' and an org-scoped requestId per workspace", async () => {
+    optedInOrgs = ["org-a"];
+
+    await runExpertSchedulerTick();
+
+    expect(capturedContexts).toHaveLength(1);
+    const ctx = capturedContexts[0];
+    expect(ctx.agentOrigin).toBe("scheduler");
+    expect(ctx.actor?.kind).toBe("scheduler");
+    expect(ctx.requestId).toMatch(/^scheduled-org-a-/);
+  });
+
+  it("enumerates opted-in workspaces with the autonomy key and opt-in filter (AC2)", async () => {
+    optedInOrgs = ["org-a"];
+
+    await runExpertSchedulerTick();
+
+    // The scan filters on the shared knob key + explicit-true + non-null org.
+    expect(enumerationParams).toEqual([AUTONOMOUS_IMPROVE_ENABLED_KEY]);
+    expect(enumerationSql).toContain("s.key = $1");
+    expect(enumerationSql).toContain("s.value IN ('true', '1')");
+    expect(enumerationSql).toContain("s.org_id IS NOT NULL");
+    // JOIN drops stale overrides for deleted workspaces.
+    expect(enumerationSql).toContain("JOIN organization");
+  });
+
+  it("an enumeration failure is logged + counted, never a NULL-org fallthrough", async () => {
+    enumerationThrows = true;
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.errors).toBe(1);
+    expect(result.workspacesConsidered).toBe(0);
+    // Critically, a failed enumeration must NOT degrade to the self-hosted
+    // [{ orgId: null }] path and produce a global-scope tick on SaaS.
+    expect(mockInsertSemanticAmendment).not.toHaveBeenCalled();
+    expect(gateCalls).toEqual([]);
+  });
+});
+
+describe("runExpertSchedulerTick — key/registry drift guard (#4516)", () => {
+  it("the enumeration key matches the exported constant (registry must mirror it)", () => {
+    // If settings.ts renames the registry key/envVar without updating the
+    // constant, the SaaS enumeration silently matches zero workspaces. This
+    // pins the constant's value so that drift is at least visible here.
+    expect(AUTONOMOUS_IMPROVE_ENABLED_KEY).toBe("ATLAS_AUTONOMOUS_IMPROVE_ENABLED");
   });
 });

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -1,15 +1,21 @@
 /**
- * runExpertSchedulerTick auto-approve invariant (#4486, #4506).
+ * runExpertSchedulerTick — auto-approve invariant (#4486, #4506) + SaaS-first
+ * per-workspace iteration (#4516).
  *
- * Every proposal is inserted `pending`; eligible ones route through the decide
- * seam (`decideAmendment`), which owns claim → apply → stamp. This pins the
- * behaviors the invariant "status='approved' ⇒ applied" depends on, so a
- * future edit that bypasses the seam or mishandles its outcomes ships red:
+ * Auto-approve invariant: every proposal is inserted `pending`; eligible ones
+ * route through the decide seam (`decideAmendment`), which owns claim → apply →
+ * stamp. This pins "status='approved' ⇒ applied":
  *   - eligible + seam approves     → autoApproved
- *   - eligible + seam throws       → counted as an error (the seam has already
- *                                     compensated the row back to pending)
- *   - eligible + already decided   → counted as queued, never a second apply
+ *   - eligible + seam throws       → an error (seam already compensated to pending)
+ *   - eligible + already decided   → queued, never a second apply
  *   - not eligible                 → queued, the seam never invoked
+ *   - rejected identity            → suppressed, no seam, no queue (#4507)
+ *   - already-pending identity     → deduped, no seam, no queue (#4507)
+ *
+ * SaaS-first iteration (#4516): the tick enumerates opted-in workspaces on SaaS,
+ * runs each degenerate self-hosted case identically, gates each workspace on its
+ * billing status (a blocked workspace no-ops), and org-stamps every insert +
+ * decide.
  *
  * A separate file from scheduler.test.ts (which only tests the config getters)
  * so the tick's module mocks don't leak into those tests.
@@ -31,13 +37,45 @@ const proposal: AnalysisResult = {
   score: 0.85,
 };
 
-// One entity so the tick clears the `entities.length === 0` early return; the
-// analyzer is mocked to return our proposal regardless of inputs.
+// ── Mutable mock state (flipped per-test) ─────────────────────────────────
+// Deploy mode: self-hosted (degenerate single-workspace) vs SaaS (enumerate).
+let saasMode = false;
+// SaaS opt-in enumeration: org ids returned by the settings-table scan.
+let optedInOrgs: string[] = [];
+// Per-org billing gate: default allow; a test can block a specific workspace.
+type GateResult = { allowed: true } | { allowed: false; errorCode: string };
+let gateFor: (orgId: string | undefined) => GateResult = () => ({ allowed: true });
+const gateCalls: Array<string | undefined> = [];
+// Loader org-scope capture — which orgId each context loader was called with.
+const loaderOrgIds: {
+  entitiesForOrg: string[];
+  entitiesFromDisk: number;
+  audit: Array<string | undefined>;
+  rejected: Array<string | undefined>;
+} = { entitiesForOrg: [], entitiesFromDisk: 0, audit: [], rejected: [] };
+
+// Context loaders. `loadEntitiesForOrg` is only reached on the SaaS (orgId)
+// path; `loadEntitiesFromDisk` on the self-hosted degenerate path. The analyzer
+// is mocked to return our proposal regardless, so any non-empty entity list
+// clears the `entities.length === 0` early return.
 void mock.module("../context-loader", () => ({
-  loadEntitiesFromDisk: async () => [{ name: "companies" }],
+  loadEntitiesFromDisk: async () => {
+    loaderOrgIds.entitiesFromDisk++;
+    return [{ name: "companies" }];
+  },
+  loadEntitiesForOrg: async (orgId: string) => {
+    loaderOrgIds.entitiesForOrg.push(orgId);
+    return { entities: [{ name: "companies" }], totalRows: 1, parseFailures: 0 };
+  },
   loadGlossaryFromDisk: async () => [],
-  loadAuditPatterns: async () => [],
-  loadRejectedKeys: async () => new Set<string>(),
+  loadAuditPatterns: async (orgId?: string) => {
+    loaderOrgIds.audit.push(orgId);
+    return [];
+  },
+  loadRejectedKeys: async (orgId?: string) => {
+    loaderOrgIds.rejected.push(orgId);
+    return new Set<string>();
+  },
 }));
 
 void mock.module("../profile-cache", () => ({
@@ -63,34 +101,53 @@ void mock.module("../decide", () => ({
 // insertSemanticAmendment returns a discriminated union (#4507); the
 // `inserted` arm reports auto-approve ELIGIBILITY (#4506).
 const mockInsertSemanticAmendment: Mock<
-  () => Promise<{ outcome: string; id?: string; autoApprove?: boolean }>
+  (params: { orgId: string | null }) => Promise<{ outcome: string; id?: string; autoApprove?: boolean }>
 > = mock(() => Promise.resolve({ outcome: "inserted", id: "sch-1", autoApprove: true }));
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   insertSemanticAmendment: mockInsertSemanticAmendment,
+  internalQuery: async () => optedInOrgs.map((org_id) => ({ org_id })),
+}));
+
+// Billing gate — records every orgId it was asked about and answers via gateFor.
+void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: async (orgId: string | undefined) => {
+    gateCalls.push(orgId);
+    return gateFor(orgId);
+  },
 }));
 
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  // Passthrough so the origin frame doesn't swallow the tick body.
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }));
 
 void mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
-  // scheduler.ts now reads this to force-disable on SaaS (#4487); the tick
-  // tests exercise the self-hosted path, so keep it false (not SaaS).
-  isSaasModeForGuard: () => false,
+  isSaasModeForGuard: () => saasMode,
 }));
 
 const { runExpertSchedulerTick } = await import("../scheduler");
 
+function resetMocks(): void {
+  saasMode = false;
+  optedInOrgs = [];
+  gateFor = () => ({ allowed: true });
+  gateCalls.length = 0;
+  loaderOrgIds.entitiesForOrg = [];
+  loaderOrgIds.entitiesFromDisk = 0;
+  loaderOrgIds.audit = [];
+  loaderOrgIds.rejected = [];
+  proposals = [proposal];
+  mockDecideAmendment.mockClear();
+  mockDecideAmendment.mockImplementation(async (params) => ({ kind: "approved", id: params.id }));
+  mockInsertSemanticAmendment.mockClear();
+  mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-1", autoApprove: true });
+}
+
 describe("runExpertSchedulerTick auto-approve → decide seam invariant (#4486, #4506)", () => {
-  beforeEach(() => {
-    proposals = [proposal];
-    mockDecideAmendment.mockClear();
-    mockDecideAmendment.mockImplementation(async (params) => ({ kind: "approved", id: params.id }));
-    mockInsertSemanticAmendment.mockClear();
-    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-1", autoApprove: true });
-  });
+  beforeEach(resetMocks);
 
   it("routes an eligible proposal through the decide seam with the insert's id", async () => {
     const result = await runExpertSchedulerTick();
@@ -159,5 +216,102 @@ describe("runExpertSchedulerTick auto-approve → decide seam invariant (#4486, 
     expect(result.deduped).toBe(1);
     expect(result.queued).toBe(0);
     expect(result.errors).toBe(0);
+  });
+});
+
+describe("runExpertSchedulerTick — self-hosted degenerate case (#4516)", () => {
+  beforeEach(resetMocks);
+
+  it("runs once for the NULL-org workspace and stamps NULL on inserts + decides", async () => {
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(1);
+    expect(result.workspacesGateBlocked).toBe(0);
+    // Degenerate path reads the bundled disk layer (never the per-org loader).
+    expect(loaderOrgIds.entitiesFromDisk).toBe(1);
+    expect(loaderOrgIds.entitiesForOrg).toEqual([]);
+    // Global (unscoped) audit + rejected loaders — self-hosted single workspace.
+    expect(loaderOrgIds.audit).toEqual([undefined]);
+    expect(loaderOrgIds.rejected).toEqual([undefined]);
+    // Insert + decide are NULL-org stamped.
+    expect(mockInsertSemanticAmendment.mock.calls[0][0]).toMatchObject({ orgId: null });
+    expect(mockDecideAmendment.mock.calls[0][0]).toMatchObject({ orgId: null });
+    expect(result.autoApproved).toBe(1);
+  });
+
+  it("passes the billing gate for the no-org workspace (self-hosted passthrough)", async () => {
+    await runExpertSchedulerTick();
+    expect(gateCalls).toEqual([undefined]);
+  });
+});
+
+describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () => {
+  beforeEach(() => {
+    resetMocks();
+    saasMode = true;
+  });
+
+  it("no opted-in workspaces → no work, no inserts", async () => {
+    optedInOrgs = [];
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(0);
+    expect(mockInsertSemanticAmendment).not.toHaveBeenCalled();
+    expect(mockDecideAmendment).not.toHaveBeenCalled();
+    expect(gateCalls).toEqual([]);
+  });
+
+  it("iterates each opted-in workspace and org-stamps every insert + decide", async () => {
+    optedInOrgs = ["org-a", "org-b"];
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(2);
+    // Per-org entity loader used (never the bundled disk loader) on SaaS.
+    expect(loaderOrgIds.entitiesForOrg).toEqual(["org-a", "org-b"]);
+    expect(loaderOrgIds.entitiesFromDisk).toBe(0);
+    // Audit + rejected loaders org-scoped so no cross-tenant contamination.
+    expect(loaderOrgIds.audit).toEqual(["org-a", "org-b"]);
+    expect(loaderOrgIds.rejected).toEqual(["org-a", "org-b"]);
+    // Every insert + decide carries the workspace owner.
+    const insertOrgs = mockInsertSemanticAmendment.mock.calls.map((c) => c[0].orgId);
+    const decideOrgs = mockDecideAmendment.mock.calls.map((c) => c[0].orgId);
+    expect(insertOrgs).toEqual(["org-a", "org-b"]);
+    expect(decideOrgs).toEqual(["org-a", "org-b"]);
+    expect(result.autoApproved).toBe(2);
+  });
+
+  it("a blocked workspace no-ops at the gate — zero inserts, counted as gate-blocked", async () => {
+    optedInOrgs = ["org-blocked", "org-ok"];
+    gateFor = (orgId) =>
+      orgId === "org-blocked" ? { allowed: false, errorCode: "plan_limit_exceeded" } : { allowed: true };
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(2);
+    expect(result.workspacesGateBlocked).toBe(1);
+    // The blocked workspace never loaded context or inserted anything.
+    expect(loaderOrgIds.entitiesForOrg).toEqual(["org-ok"]);
+    const insertOrgs = mockInsertSemanticAmendment.mock.calls.map((c) => c[0].orgId);
+    expect(insertOrgs).toEqual(["org-ok"]);
+    expect(result.autoApproved).toBe(1);
+  });
+
+  it("one workspace's failure never aborts the sweep", async () => {
+    optedInOrgs = ["org-a", "org-b"];
+    // org-a's insert throws; org-b must still be processed.
+    mockInsertSemanticAmendment.mockImplementation(async (params: { orgId: string | null }) => {
+      if (params.orgId === "org-a") throw new Error("insert failed");
+      return { outcome: "inserted", id: "sch-b", autoApprove: true };
+    });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(2);
+    expect(result.errors).toBeGreaterThanOrEqual(1);
+    // org-b still auto-approved despite org-a failing.
+    expect(result.autoApproved).toBe(1);
+    expect(mockDecideAmendment.mock.calls.map((c) => c[0].orgId)).toEqual(["org-b"]);
   });
 });

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -55,6 +55,10 @@ let gateFor: (orgId: string | undefined) => GateResult = () => ({ allowed: true 
 const gateCalls: Array<string | undefined> = [];
 // Captured request-context frames — assert origin/actor stamping (#4508, AC3).
 const capturedContexts: Array<{ requestId?: string; agentOrigin?: string; actor?: { kind?: string } }> = [];
+// When set, `loadEntitiesForOrg` rejects for this orgId (models a mid-frame,
+// inside-the-request-context-frame failure that must still be contained by the
+// sweep-level catch, a different path than a pre-frame gate throw).
+let entitiesForOrgThrowsFor: string | null = null;
 // Loader org-scope capture — which orgId each context loader was called with.
 const loaderOrgIds: {
   entitiesForOrg: string[];
@@ -63,10 +67,12 @@ const loaderOrgIds: {
   rejected: Array<string | undefined>;
 } = { entitiesForOrg: [], entitiesFromDisk: 0, audit: [], rejected: [] };
 
-// Context loaders. `loadEntitiesForOrg` is only reached on the SaaS (orgId)
-// path; `loadEntitiesFromDisk` on the self-hosted degenerate path. The analyzer
-// is mocked to return our proposal regardless, so any non-empty entity list
-// clears the `entities.length === 0` early return.
+// Context loaders — partial mock (the tick calls only these five; the sixth
+// export `loadEntitiesFromDB` is never reached by the scheduler). Complete for
+// this file. `loadEntitiesForOrg` is only reached on the SaaS (orgId) path;
+// `loadEntitiesFromDisk` on the self-hosted degenerate path. The analyzer is
+// mocked to return our proposal regardless, so any non-empty entity list clears
+// the `entities.length === 0` early return.
 void mock.module("../context-loader", () => ({
   loadEntitiesFromDisk: async () => {
     loaderOrgIds.entitiesFromDisk++;
@@ -74,6 +80,7 @@ void mock.module("../context-loader", () => ({
   },
   loadEntitiesForOrg: async (orgId: string) => {
     loaderOrgIds.entitiesForOrg.push(orgId);
+    if (orgId === entitiesForOrgThrowsFor) throw new Error("entity load failed");
     return { entities: [{ name: "companies" }], totalRows: 1, parseFailures: 0 };
   },
   loadGlossaryFromDisk: async () => [],
@@ -159,6 +166,7 @@ const { runExpertSchedulerTick, AUTONOMOUS_IMPROVE_ENABLED_KEY } = await import(
 function resetMocks(): void {
   saasMode = false;
   optedInOrgs = [];
+  entitiesForOrgThrowsFor = null;
   enumerationThrows = false;
   enumerationSql = "";
   enumerationParams = [];
@@ -204,6 +212,20 @@ describe("runExpertSchedulerTick auto-approve → decide seam invariant (#4486, 
     expect(mockDecideAmendment).toHaveBeenCalledTimes(1);
     expect(result.autoApproved).toBe(0);
     expect(result.errors).toBe(1);
+  });
+
+  it("counts an error (never queued/approved) when the insert itself throws", async () => {
+    mockInsertSemanticAmendment.mockImplementation(async () => {
+      throw new Error("db write failed");
+    });
+
+    const result = await runExpertSchedulerTick();
+
+    // The per-proposal catch counts it and the seam is never reached.
+    expect(mockDecideAmendment).not.toHaveBeenCalled();
+    expect(result.errors).toBe(1);
+    expect(result.queued).toBe(0);
+    expect(result.autoApproved).toBe(0);
   });
 
   it("counts queued (never autoApproved) when a concurrent decision beat the tick", async () => {
@@ -378,6 +400,22 @@ describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () =
     expect(mockDecideAmendment.mock.calls.map((c) => c[0].orgId)).toEqual(["org-b"]);
   });
 
+  it("a mid-frame loader throw is contained by the sweep too (inside the origin frame)", async () => {
+    optedInOrgs = ["org-a", "org-b"];
+    // org-a passes the gate, enters the request-context frame, then its entity
+    // load throws — a different escape path than the pre-frame gate throw above.
+    entitiesForOrgThrowsFor = "org-a";
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(2);
+    expect(result.errors).toBe(1);
+    // Both workspaces entered the frame + loader; only org-b completed.
+    expect(loaderOrgIds.entitiesForOrg).toEqual(["org-a", "org-b"]);
+    expect(result.autoApproved).toBe(1);
+    expect(mockDecideAmendment.mock.calls.map((c) => c[0].orgId)).toEqual(["org-b"]);
+  });
+
   it("stamps agentOrigin + actor 'scheduler' and an org-scoped requestId per workspace", async () => {
     optedInOrgs = ["org-a"];
 
@@ -418,11 +456,3 @@ describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () =
   });
 });
 
-describe("runExpertSchedulerTick — key/registry drift guard (#4516)", () => {
-  it("the enumeration key matches the exported constant (registry must mirror it)", () => {
-    // If settings.ts renames the registry key/envVar without updating the
-    // constant, the SaaS enumeration silently matches zero workspaces. This
-    // pins the constant's value so that drift is at least visible here.
-    expect(AUTONOMOUS_IMPROVE_ENABLED_KEY).toBe("ATLAS_AUTONOMOUS_IMPROVE_ENABLED");
-  });
-});

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
@@ -75,11 +75,13 @@ describe("isExpertSchedulerEnabled", () => {
   });
 });
 
-// #4487 — the scheduler inserts NULL-org ("global scope") amendment rows,
-// which are only sound on self-hosted. In `saas` deploy mode the scheduler is
-// force-disabled regardless of the setting, so it can never produce global
-// rows that would leak into every workspace's pending list.
-describe("isExpertSchedulerEnabled — SaaS boot-guard (#4487)", () => {
+// #4516 — the #4487 SaaS boot-guard is RETIRED. The scheduler no longer inserts
+// NULL-org ("global scope") rows: every insert is org-stamped and the tick is
+// gated per-workspace (billing gate + `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`). So
+// `isExpertSchedulerEnabled` is now the DEPLOYMENT master switch only — the
+// fiber runs on SaaS too, deploy mode is not consulted here. This block pins the
+// retirement: if a future change re-adds a `saas → false` branch, it ships red.
+describe("isExpertSchedulerEnabled — SaaS boot-guard retired (#4516)", () => {
   // Fully-typed `ResolvedConfig` so a `deployMode` typo can't compile silently.
   function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
     return {
@@ -102,9 +104,9 @@ describe("isExpertSchedulerEnabled — SaaS boot-guard (#4487)", () => {
     _resetConfig();
   });
 
-  it("returns false in saas deploy mode even when the setting is enabled", () => {
+  it("returns true in saas deploy mode when the setting is enabled (boot-guard gone)", () => {
     _setConfigForTest(configWithDeployMode("saas"));
-    expect(isExpertSchedulerEnabled()).toBe(false);
+    expect(isExpertSchedulerEnabled()).toBe(true);
   });
 
   it("returns true in self-hosted deploy mode when the setting is enabled", () => {
@@ -112,9 +114,10 @@ describe("isExpertSchedulerEnabled — SaaS boot-guard (#4487)", () => {
     expect(isExpertSchedulerEnabled()).toBe(true);
   });
 
-  it("returns true when config is unloaded (self-hosted default) and the setting is enabled", () => {
-    _resetConfig();
-    expect(isExpertSchedulerEnabled()).toBe(true);
+  it("returns false in saas deploy mode when the setting is disabled", () => {
+    delete process.env.ATLAS_EXPERT_SCHEDULER_ENABLED;
+    _setConfigForTest(configWithDeployMode("saas"));
+    expect(isExpertSchedulerEnabled()).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
@@ -3,8 +3,9 @@ import {
   isExpertSchedulerEnabled,
   getExpertSchedulerIntervalMs,
   DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS,
+  AUTONOMOUS_IMPROVE_ENABLED_KEY,
 } from "../scheduler";
-import { loadSettings, _resetSettingsCache } from "@atlas/api/lib/settings";
+import { loadSettings, _resetSettingsCache, getSettingDefinition } from "@atlas/api/lib/settings";
 import type { ResolvedConfig } from "@atlas/api/lib/config";
 import { _setConfigForTest, _resetConfig } from "@atlas/api/lib/config";
 
@@ -122,6 +123,21 @@ describe("isExpertSchedulerEnabled — SaaS boot-guard retired (#4516)", () => {
     delete process.env.ATLAS_EXPERT_SCHEDULER_ENABLED;
     _setConfigForTest(configWithDeployMode("saas"));
     expect(isExpertSchedulerEnabled()).toBe(false);
+  });
+});
+
+// #4516 — the SaaS enumeration filters `WHERE s.key = $1` bound to
+// AUTONOMOUS_IMPROVE_ENABLED_KEY. If settings.ts renames the registry key/envVar
+// without updating the constant, enumeration silently matches ZERO workspaces
+// (autonomy never runs for any tenant) with no other failure. This crosses the
+// constant against the REAL registry (scheduler.test uses the unmocked settings
+// module) so that drift ships red — the tautology `KEY === "literal"` cannot.
+describe("ATLAS_AUTONOMOUS_IMPROVE_ENABLED registry ↔ constant (#4516)", () => {
+  it("the registry has a workspace-scoped entry keyed by the exported constant", () => {
+    const def = getSettingDefinition(AUTONOMOUS_IMPROVE_ENABLED_KEY);
+    expect(def).toBeDefined();
+    expect(def?.scope).toBe("workspace");
+    expect(def?.envVar).toBe(AUTONOMOUS_IMPROVE_ENABLED_KEY);
   });
 });
 

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler.test.ts
@@ -40,7 +40,9 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   setWorkspaceRegion: mock(async () => {}),
 }));
 
-// Mock logger
+// Mock logger. scheduler.ts imports `withRequestContext` at module top (used by
+// the tick), so the mock must provide it even though this file only exercises
+// the config getters — otherwise a future tick test here hits `undefined`.
 void mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({
     info: () => {},
@@ -48,6 +50,7 @@ void mock.module("@atlas/api/lib/logger", () => ({
     error: () => {},
     debug: () => {},
   }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }));
 
 describe("isExpertSchedulerEnabled", () => {
@@ -75,9 +78,10 @@ describe("isExpertSchedulerEnabled", () => {
   });
 });
 
-// #4516 — the #4487 SaaS boot-guard is RETIRED. The scheduler no longer inserts
-// NULL-org ("global scope") rows: every insert is org-stamped and the tick is
-// gated per-workspace (billing gate + `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`). So
+// #4516 — the #4487 SaaS boot-guard is RETIRED. On SaaS every insert is now
+// org-stamped and the tick is gated per-workspace (billing gate +
+// `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`); self-hosted still inserts its single
+// NULL-org row, which is sound because there is only one tenant. So
 // `isExpertSchedulerEnabled` is now the DEPLOYMENT master switch only — the
 // fiber runs on SaaS too, deploy mode is not consulted here. This block pins the
 // retirement: if a future change re-adds a `saas → false` branch, it ships red.

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -436,8 +436,15 @@ function normalizeGlossaryTerm(raw: unknown, fallbackTerm?: string): GlossaryTer
 /**
  * Load audit patterns from the internal DB.
  * Returns empty array when no internal DB is available.
+ *
+ * `orgId` scopes the scan to one workspace's audit rows (#4516). The SaaS
+ * per-workspace scheduler MUST pass it: `audit_log` is a shared table across
+ * every tenant, so an unscoped scan would surface one workspace's query
+ * patterns into another workspace's proposals — a cross-tenant leak. Omit it
+ * on self-hosted / CLI (single implicit workspace, NULL-org rows), where the
+ * unscoped global scan is the intended behavior.
  */
-export async function loadAuditPatterns(): Promise<AuditPattern[]> {
+export async function loadAuditPatterns(orgId?: string): Promise<AuditPattern[]> {
   try {
     const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
     if (!hasInternalDB()) return [];
@@ -450,12 +457,12 @@ export async function loadAuditPatterns(): Promise<AuditPattern[]> {
     }>(
       `SELECT sql, COUNT(*) AS count, MAX(timestamp) AS last_seen, tables_accessed
        FROM audit_log
-       WHERE success = true AND deleted_at IS NULL
+       WHERE success = true AND deleted_at IS NULL${orgId ? " AND org_id = $1" : ""}
        GROUP BY sql, tables_accessed
        HAVING COUNT(*) >= 2
        ORDER BY COUNT(*) DESC
        LIMIT 200`,
-      [],
+      orgId ? [orgId] : [],
     );
 
     return rows.map((row) => {
@@ -496,8 +503,16 @@ export async function loadAuditPatterns(): Promise<AuditPattern[]> {
  * separately). Keys are built via the shared `amendmentIdentityFromRow`, so
  * the staleness key here, the insert-time guard, and the analyzer's
  * `stalenessFactor` all agree on what "the same change" is.
+ *
+ * `orgId` scopes the pre-filter to one workspace's rejections (#4516). The
+ * SaaS per-workspace scheduler MUST pass it: without it the union of every
+ * tenant's rejected identities would over-suppress — workspace B would never
+ * be re-proposed a change workspace A rejected. (The durable insert-time guard
+ * `findConflictingAmendment` is already org-scoped, so this pre-filter is the
+ * only place a global scan could leak across tenants.) Omit it on
+ * self-hosted / CLI (single implicit workspace, NULL-org rows).
  */
-export async function loadRejectedKeys(): Promise<Set<string>> {
+export async function loadRejectedKeys(orgId?: string): Promise<Set<string>> {
   const keys = new Set<string>();
 
   try {
@@ -510,8 +525,8 @@ export async function loadRejectedKeys(): Promise<Set<string>> {
       amendment_payload: string | Record<string, unknown> | null;
     }>(
       `SELECT source_entity, connection_group_id, amendment_payload FROM learned_patterns
-       WHERE type = 'semantic_amendment' AND status = 'rejected'`,
-      [],
+       WHERE type = 'semantic_amendment' AND status = 'rejected'${orgId ? " AND org_id = $1" : ""}`,
+      orgId ? [orgId] : [],
     );
 
     for (const row of rows) {

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -20,7 +20,9 @@ const log = createLogger("semantic-expert-scheduler");
 export const DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Per-workspace autonomous-improvement opt-in (#4516). Workspace-scoped,
- * off by default — enabling it is a workspace-admin settings action. */
+ * off by default — enabling it is a workspace-admin settings action. Must match
+ * the `key`/`envVar` of the registry entry in lib/settings.ts (a guard test in
+ * scheduler-tick.test.ts pins that they don't drift). */
 export const AUTONOMOUS_IMPROVE_ENABLED_KEY = "ATLAS_AUTONOMOUS_IMPROVE_ENABLED";
 
 /** Counters produced by a single workspace's tick. */
@@ -40,9 +42,25 @@ interface WorkspaceTickCounters {
 export interface ExpertTickResult extends WorkspaceTickCounters {
   /** Workspaces the tick iterated (1 on the self-hosted degenerate path). */
   workspacesConsidered: number;
-  /** Workspaces whose billing gate blocked — their tick no-op'd, zero spend. */
+  /** Workspaces a billing POLICY block skipped — over-budget / suspended /
+   * trial-expired. Their tick no-op'd, zero spend: this is the working system. */
   workspacesGateBlocked: number;
+  /** Workspaces the billing gate could not evaluate (fail-closed 503 — e.g. an
+   * internal-DB brownout). Kept SEPARATE from `workspacesGateBlocked` so a
+   * gate-lookup outage doesn't masquerade as "everyone is over budget" in the
+   * tick summary. Skipped like a block, but the cause is infra, not policy. */
+  workspacesGateErrored: number;
 }
+
+/** Outcome of one workspace's tick. `counters` is present iff the tick actually
+ * ran (gate passed) — a skipped workspace structurally carries no counters, so
+ * the aggregator can't fold a blocked/errored workspace's absent work into the
+ * totals. `gate-blocked` (policy) and `gate-errored` (fail-closed infra) are
+ * kept distinct so the summary never conflates the two (#4516). */
+type WorkspaceTickOutcome =
+  | { status: "ran"; counters: WorkspaceTickCounters }
+  | { status: "gate-blocked" }
+  | { status: "gate-errored" };
 
 function emptyCounters(): WorkspaceTickCounters {
   return { proposalsGenerated: 0, autoApproved: 0, queued: 0, rejected: 0, deduped: 0, errors: 0 };
@@ -69,9 +87,11 @@ function addCounters(into: WorkspaceTickCounters, from: WorkspaceTickCounters): 
  *
  * Deploy-mode agnostic: the pre-#4516 SaaS force-disable boot-guard (#4487) is
  * RETIRED. It existed because the scheduler inserted NULL-org ("global scope")
- * rows that leak across tenants on SaaS; now every insert is org-stamped and
- * gated per-workspace (see {@link runExpertSchedulerTick}), so the fiber is
- * safe to run on SaaS and the deployment master switch is the only gate here.
+ * rows that leak across tenants on SaaS; now on SaaS every insert is org-stamped
+ * and the tick is gated per-workspace (see {@link runExpertSchedulerTick}) —
+ * self-hosted still inserts its single-tenant NULL-org row, which is sound
+ * because there is only one tenant — so the fiber is safe to run on SaaS and the
+ * deployment master switch is the only gate here.
  */
 export function isExpertSchedulerEnabled(): boolean {
   const v = getSetting("ATLAS_EXPERT_SCHEDULER_ENABLED");
@@ -123,6 +143,12 @@ async function resolveImproveWorkspaces(): Promise<Array<{ orgId: string | null 
  * `organization` so a stale override for a deleted workspace is dropped; the
  * per-workspace billing gate is the authoritative filter for suspended /
  * over-budget workspaces, so this query intentionally does not re-check status.
+ *
+ * "opted in" means "has an explicit workspace-scoped DB override set to true" —
+ * this deliberately does NOT route through getSetting()'s env/default tier: an
+ * env var or platform default cannot opt a *specific* tenant into autonomy. So a
+ * platform-level `ATLAS_AUTONOMOUS_IMPROVE_ENABLED=true` enrolls nobody by
+ * design; enrollment is always a per-workspace admin action.
  */
 async function listAutonomousImproveOrgIds(): Promise<string[]> {
   const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
@@ -151,6 +177,7 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     ...emptyCounters(),
     workspacesConsidered: 0,
     workspacesGateBlocked: 0,
+    workspacesGateErrored: 0,
   };
 
   let workspaces: Array<{ orgId: string | null }>;
@@ -172,8 +199,12 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     totals.workspacesConsidered++;
     try {
       const outcome = await runWorkspaceImproveTick(orgId);
-      if (outcome.gateBlocked) {
+      if (outcome.status === "gate-blocked") {
         totals.workspacesGateBlocked++;
+        continue;
+      }
+      if (outcome.status === "gate-errored") {
+        totals.workspacesGateErrored++;
         continue;
       }
       addCounters(totals, outcome.counters);
@@ -190,6 +221,7 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
     {
       workspacesConsidered: totals.workspacesConsidered,
       workspacesGateBlocked: totals.workspacesGateBlocked,
+      workspacesGateErrored: totals.workspacesGateErrored,
       total: totals.proposalsGenerated,
       autoApproved: totals.autoApproved,
       queued: totals.queued,
@@ -220,19 +252,29 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
  * 5. Routes eligible proposals through the decide seam (#4506) — claim →
  *    apply + version snapshot → stamp `approved`
  */
-async function runWorkspaceImproveTick(
-  orgId: string | null,
-): Promise<{ gateBlocked: true } | { gateBlocked: false; counters: WorkspaceTickCounters }> {
+async function runWorkspaceImproveTick(orgId: string | null): Promise<WorkspaceTickOutcome> {
   // Billing gate first — a blocked workspace's tick no-ops before any context
   // load or LLM/apply work (#4516 AC3). On self-hosted (orgId null) the gate
   // is a passthrough (checkAgentBillingGate treats no-org as always-allowed).
   const gate = await checkAgentBillingGate(orgId ?? undefined);
   if (!gate.allowed) {
+    // Distinguish a fail-closed infra failure (503 — the workspace-status /
+    // plan-limit lookup could not complete, e.g. an internal-DB brownout) from
+    // a real policy block. Both skip the workspace (fail-closed is the safe
+    // direction), but conflating them would make a gate-lookup outage read as
+    // "every workspace is over budget" in the tick summary (#4516).
+    if (gate.httpStatus === 503) {
+      log.warn(
+        { orgId, errorCode: gate.errorCode, httpStatus: gate.httpStatus },
+        "Autonomous improvement skipped — billing gate unavailable (fail-closed); workspace not run",
+      );
+      return { status: "gate-errored" };
+    }
     log.info(
       { orgId, errorCode: gate.errorCode },
-      "Autonomous improvement skipped for workspace — billing gate blocked",
+      "Autonomous improvement skipped for workspace — billing gate blocked (over-budget / suspended)",
     );
-    return { gateBlocked: true };
+    return { status: "gate-blocked" };
   }
 
   const counters = emptyCounters();
@@ -248,8 +290,12 @@ async function runWorkspaceImproveTick(
       //    the workspace's own DB rows + per-org disk mirror; on self-hosted read
       //    the bundled disk layer. Audit patterns + rejected keys are org-scoped
       //    so one tenant's query history / rejections never bleed into another's
-      //    proposals (#4516). Glossary stays the bundled disk union — shared
-      //    default files, not tenant data, so no cross-tenant concern.
+      //    proposals (#4516). Glossary is loaded from the shared/default disk
+      //    layer for both paths — the scheduler does NOT yet read the per-org DB
+      //    glossary (`semantic_entities` type=glossary). Reading shared disk files
+      //    carries no tenant data, so there's no cross-tenant leak; the tradeoff
+      //    is that a workspace's own DB glossary terms aren't consulted here yet
+      //    (group-scoped glossary is #4518's surface, not this slice).
       const {
         loadEntitiesForOrg,
         loadEntitiesFromDisk,
@@ -267,10 +313,14 @@ async function runWorkspaceImproveTick(
 
       if (entities.length === 0) {
         log.debug({ orgId }, "No semantic entities found — skipping workspace tick");
-        return { gateBlocked: false, counters };
+        return { status: "ran", counters };
       }
 
-      // 2. Load cached profiles (from last `atlas init` / `atlas improve` run)
+      // 2. Load cached profiles (from last `atlas init` / `atlas improve` run).
+      //    This is the bundled/global disk cache of column statistics, not
+      //    tenant data — keyed by table, matched to entities by name — so it
+      //    stays unscoped: on SaaS it is normally empty and the analyzer degrades
+      //    gracefully (per-workspace profiling is #4509's surface, not this slice).
       const { loadCachedProfiles } = await import("./profile-cache");
       const profiles = loadCachedProfiles();
 
@@ -288,7 +338,7 @@ async function runWorkspaceImproveTick(
 
       if (proposals.length === 0) {
         log.info({ orgId }, "Autonomous-improvement tick: no proposals generated");
-        return { gateBlocked: false, counters };
+        return { status: "ran", counters };
       }
 
       // 4. Insert proposals — every row lands `pending`; insertSemanticAmendment
@@ -387,7 +437,7 @@ async function runWorkspaceImproveTick(
         }
       }
 
-      return { gateBlocked: false, counters };
+      return { status: "ran", counters };
     },
   );
 }

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -1,20 +1,30 @@
 /**
  * Scheduled semantic expert — periodic analysis engine tick.
  *
- * Runs the semantic layer analyzer, auto-approves high-confidence proposals,
- * and queues the rest for human review.
+ * SaaS-first (#4516): one platform fiber, forked once at boot, iterates the
+ * workspaces that opted into autonomous improvement. Self-hosted's single
+ * implicit workspace is the degenerate case of the same per-workspace tick —
+ * not a different model. Each workspace's tick passes that workspace's billing
+ * gate (a blocked workspace no-ops, spending nothing), loads that workspace's
+ * own semantic context, and inserts org-stamped proposals; eligible ones route
+ * through the decide seam for auto-apply.
  */
 
-import { createLogger } from "@atlas/api/lib/logger";
+import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { getSetting, isSaasModeForGuard } from "@atlas/api/lib/settings";
+import { checkAgentBillingGate } from "@atlas/api/lib/billing/agent-gate";
 
 const log = createLogger("semantic-expert-scheduler");
 
 /** Default interval: 24 hours. */
 export const DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-/** Result summary from a single tick. */
-export interface ExpertTickResult {
+/** Per-workspace autonomous-improvement opt-in (#4516). Workspace-scoped,
+ * off by default — enabling it is a workspace-admin settings action. */
+export const AUTONOMOUS_IMPROVE_ENABLED_KEY = "ATLAS_AUTONOMOUS_IMPROVE_ENABLED";
+
+/** Counters produced by a single workspace's tick. */
+interface WorkspaceTickCounters {
   proposalsGenerated: number;
   autoApproved: number;
   queued: number;
@@ -25,28 +35,45 @@ export interface ExpertTickResult {
   errors: number;
 }
 
+/** Result summary from a single tick — the sum across every workspace the
+ * tick considered, plus the iteration/gate counters (#4516). */
+export interface ExpertTickResult extends WorkspaceTickCounters {
+  /** Workspaces the tick iterated (1 on the self-hosted degenerate path). */
+  workspacesConsidered: number;
+  /** Workspaces whose billing gate blocked — their tick no-op'd, zero spend. */
+  workspacesGateBlocked: number;
+}
+
+function emptyCounters(): WorkspaceTickCounters {
+  return { proposalsGenerated: 0, autoApproved: 0, queued: 0, rejected: 0, deduped: 0, errors: 0 };
+}
+
+function addCounters(into: WorkspaceTickCounters, from: WorkspaceTickCounters): void {
+  into.proposalsGenerated += from.proposalsGenerated;
+  into.autoApproved += from.autoApproved;
+  into.queued += from.queued;
+  into.rejected += from.rejected;
+  into.deduped += from.deduped;
+  into.errors += from.errors;
+}
+
 /**
- * Check whether the expert scheduler is enabled.
+ * Check whether the autonomous-improvement fiber is enabled on this deployment.
  *
- * Platform-scoped (#3392): the scheduler is a single process-global fiber
- * forked once at boot by `makeSchedulerLive` (lib/effect/layers.ts) — there
- * is no per-workspace tick, so this key takes no workspace override.
- * Resolved via getSetting() so a platform-level DB override (admin
- * settings page) wins over the env var (platform DB override > env >
- * default). Consumed once at boot — changes require a restart
- * (`requiresRestart` in the registry); the scheduler layer sequences
- * after `loadSettings()` so the DB override is visible here.
+ * This is the PLATFORM MASTER SWITCH (#4516) — whether the single
+ * process-global fiber runs at all — not the per-workspace opt-in. Resolved via
+ * getSetting() so a platform-level DB override (admin settings page) wins over
+ * the env var (platform DB override > env > default). Consumed once at boot by
+ * the fiber gate (`makeSchedulerLive`, lib/effect/layers.ts) — changes require a
+ * restart (`requiresRestart` in the registry).
  *
- * SaaS boot-guard (#4487): the scheduler's proposals are inserted with
- * `orgId: null` ("global scope for self-hosted"). A NULL-org row is only
- * sound on self-hosted; on SaaS it is the leak vector — no workspace should
- * ever produce global amendment rows. So the scheduler is force-disabled in
- * `saas` deploy mode regardless of the setting. Fail-CLOSED
- * (`isSaasModeForGuard` treats `errored` as SaaS) is the safe direction:
- * if we cannot confirm we're self-hosted, do not produce global rows.
+ * Deploy-mode agnostic: the pre-#4516 SaaS force-disable boot-guard (#4487) is
+ * RETIRED. It existed because the scheduler inserted NULL-org ("global scope")
+ * rows that leak across tenants on SaaS; now every insert is org-stamped and
+ * gated per-workspace (see {@link runExpertSchedulerTick}), so the fiber is
+ * safe to run on SaaS and the deployment master switch is the only gate here.
  */
 export function isExpertSchedulerEnabled(): boolean {
-  if (isSaasModeForGuard()) return false;
   const v = getSetting("ATLAS_EXPERT_SCHEDULER_ENABLED");
   return v === "true" || v === "1";
 }
@@ -67,174 +94,300 @@ export function getExpertSchedulerIntervalMs(): number {
 }
 
 /**
- * Run a single tick of the expert scheduler.
+ * Resolve the set of workspaces this tick should improve.
  *
- * 1. Loads semantic layer entities, glossary, audit patterns, and rejected keys
- * 2. Loads cached profiles from last `atlas init` or `atlas improve` run
- * 3. Runs analysis engine with cached profiles
+ * SaaS-first (#4516): on SaaS, iterate the workspaces that opted into
+ * autonomous improvement (the workspace-scoped `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`
+ * knob, off by default). On self-hosted the whole deployment is one implicit
+ * workspace — the degenerate case — so it runs once with the global (NULL-org)
+ * scope, equivalent to the pre-#4516 behavior; the platform master switch the
+ * fiber already checked is its sole enable.
+ *
+ * NOTE: this deploy-mode branch SELECTS an iteration strategy (enumerate
+ * per-workspace vs. one degenerate workspace); it is NOT the retired #4487
+ * boot-guard, which force-DISABLED the scheduler on SaaS. Per-workspace billing
+ * gating + the one-workspace-owner insert invariant (#4510) are what make
+ * running on SaaS org-safe by construction.
+ */
+async function resolveImproveWorkspaces(): Promise<Array<{ orgId: string | null }>> {
+  if (!isSaasModeForGuard()) {
+    return [{ orgId: null }];
+  }
+  const orgIds = await listAutonomousImproveOrgIds();
+  return orgIds.map((orgId) => ({ orgId }));
+}
+
+/**
+ * Enumerate the workspaces that opted into autonomous improvement. Reads the
+ * settings table directly (one row per workspace override) joined to
+ * `organization` so a stale override for a deleted workspace is dropped; the
+ * per-workspace billing gate is the authoritative filter for suspended /
+ * over-budget workspaces, so this query intentionally does not re-check status.
+ */
+async function listAutonomousImproveOrgIds(): Promise<string[]> {
+  const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
+  if (!hasInternalDB()) return [];
+
+  const rows = await internalQuery<{ org_id: string }>(
+    `SELECT DISTINCT s.org_id AS org_id
+       FROM settings s
+       JOIN organization o ON o.id = s.org_id
+      WHERE s.key = $1 AND s.value IN ('true', '1') AND s.org_id IS NOT NULL`,
+    [AUTONOMOUS_IMPROVE_ENABLED_KEY],
+  );
+  return rows.map((r) => r.org_id);
+}
+
+/**
+ * Run a single tick of the autonomous-improvement scheduler.
+ *
+ * Iterates the resolved workspace set (see {@link resolveImproveWorkspaces})
+ * and runs each workspace's tick independently — a per-workspace failure is
+ * logged and never aborts the sweep. Returns the aggregate counters plus the
+ * iteration/gate observability fields.
+ */
+export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
+  const totals: ExpertTickResult = {
+    ...emptyCounters(),
+    workspacesConsidered: 0,
+    workspacesGateBlocked: 0,
+  };
+
+  let workspaces: Array<{ orgId: string | null }>;
+  try {
+    workspaces = await resolveImproveWorkspaces();
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Failed to resolve autonomous-improvement workspaces",
+    );
+    totals.errors++;
+    return totals;
+  }
+
+  // Sequential, not Promise.all: a background sweep over a normally-small set —
+  // serializing keeps the per-workspace DB + apply work from bursting the
+  // internal pool alongside live traffic (matches reportPeriodOverages).
+  for (const { orgId } of workspaces) {
+    totals.workspacesConsidered++;
+    try {
+      const outcome = await runWorkspaceImproveTick(orgId);
+      if (outcome.gateBlocked) {
+        totals.workspacesGateBlocked++;
+        continue;
+      }
+      addCounters(totals, outcome.counters);
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err : new Error(String(err)), orgId },
+        "Autonomous-improvement tick failed for workspace — will retry next tick",
+      );
+      totals.errors++;
+    }
+  }
+
+  log.info(
+    {
+      workspacesConsidered: totals.workspacesConsidered,
+      workspacesGateBlocked: totals.workspacesGateBlocked,
+      total: totals.proposalsGenerated,
+      autoApproved: totals.autoApproved,
+      queued: totals.queued,
+      rejected: totals.rejected,
+      deduped: totals.deduped,
+      errors: totals.errors,
+    },
+    "Autonomous-improvement scheduler tick complete",
+  );
+
+  return totals;
+}
+
+/**
+ * Run one workspace's improvement tick.
+ *
+ * `orgId` is the workspace owner — a real id on SaaS, `null` on the self-hosted
+ * degenerate path. The billing gate is checked FIRST: a suspended / over-budget
+ * workspace no-ops here and spends nothing (#4516 AC3). The analysis + insert +
+ * decide work runs under an `agentOrigin: 'scheduler'` request-context frame so
+ * origin-scoped approval rules (#2072 / ADR-0015) fire and any metered spend
+ * attributes to origin `scheduler` for this workspace.
+ *
+ * 1. Loads this workspace's entities, glossary, audit patterns, and rejected keys
+ * 2. Loads cached profiles from the last `atlas init` / `atlas improve` run
+ * 3. Runs the analysis engine
  * 4. Inserts each proposal `pending`; the insert reports auto-approve eligibility
  * 5. Routes eligible proposals through the decide seam (#4506) — claim →
  *    apply + version snapshot → stamp `approved`
  */
-export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
-  const result: ExpertTickResult = {
-    proposalsGenerated: 0,
-    autoApproved: 0,
-    queued: 0,
-    rejected: 0,
-    deduped: 0,
-    errors: 0,
-  };
-
-  try {
-    // 1. Load semantic layer from disk
-    const { loadEntitiesFromDisk, loadGlossaryFromDisk, loadAuditPatterns, loadRejectedKeys } =
-      await import("./context-loader");
-
-    const entities = await loadEntitiesFromDisk();
-    const glossary = await loadGlossaryFromDisk();
-    const auditPatterns = await loadAuditPatterns();
-    const rejectedKeys = await loadRejectedKeys();
-
-    if (entities.length === 0) {
-      log.debug("No semantic entities found — skipping expert tick");
-      return result;
-    }
-
-    // 2. Load cached profiles (from last `atlas init` or `atlas improve` run)
-    const { loadCachedProfiles } = await import("./profile-cache");
-    const profiles = loadCachedProfiles();
-
-    // 3. Run analysis
-    const { analyzeSemanticLayer } = await import("./analyzer");
-    const proposals = analyzeSemanticLayer({
-      profiles,
-      entities,
-      glossary,
-      auditPatterns,
-      rejectedKeys,
-    });
-
-    result.proposalsGenerated = proposals.length;
-
-    if (proposals.length === 0) {
-      log.info("Expert scheduler tick: no proposals generated");
-      return result;
-    }
-
-    // 4. Insert proposals — every row lands `pending`; insertSemanticAmendment
-    //    reports auto-approve ELIGIBILITY and the decide seam (#4506) is the
-    //    only path to `approved`.
-    const { insertSemanticAmendment } = await import("@atlas/api/lib/db/internal");
-
-    // 5. Process each proposal
-    for (const proposal of proposals) {
-      try {
-        // Persist the finding's Connection group so the admin approve path can
-        // rebuild the correct scope (#3284). NULL = the default (flat) group:
-        // the layout-aware loader labels the default group `"default"`, which
-        // maps to a NULL `connection_group_id` like everywhere else.
-        const connectionGroupId =
-          proposal.group && proposal.group !== "default" ? proposal.group : null;
-        const insertResult = await insertSemanticAmendment({
-          orgId: null, // global scope for self-hosted
-          description: proposal.rationale,
-          sourceEntity: proposal.entityName,
-          connectionGroupId,
-          confidence: proposal.confidence,
-          amendmentPayload: {
-            category: proposal.category,
-            amendmentType: proposal.amendmentType,
-            amendment: proposal.amendment,
-            testQuery: proposal.testQuery,
-          },
-        });
-
-        // Permanent rejection memory + pending dedup (#4507): a rejected
-        // identity is refused at insert; an identical pending proposal
-        // converges on the existing row. Neither queues a new row.
-        if (insertResult.outcome === "rejected") {
-          result.rejected++;
-          continue;
-        }
-        if (insertResult.outcome === "already_pending") {
-          result.deduped++;
-          continue;
-        }
-
-        const { id, autoApprove } = insertResult;
-
-        if (autoApprove) {
-          // Route the auto-approve through the decide seam: claim-then-apply,
-          // `approved` stamped only after a successful apply + version
-          // snapshot. On apply failure the seam has already compensated the
-          // row back to `pending` with a visible reason — the invariant
-          // "status='approved' ⇒ applied" holds by construction (#4486, #4506).
-          try {
-            const { decideAmendment } = await import("./decide");
-            const outcome = await decideAmendment({
-              id,
-              orgId: null,
-              decision: "approved",
-              reviewedBy: "expert-scheduler",
-              requestId: `scheduled-${Date.now()}`,
-            });
-            if (outcome.kind === "approved") {
-              result.autoApproved++;
-              log.info(
-                { entity: proposal.entityName, type: proposal.amendmentType, confidence: proposal.confidence },
-                "Auto-approved and applied semantic amendment",
-              );
-            } else {
-              // A concurrent decision beat the scheduler to its own insert
-              // (admin reviewing the queue mid-tick) — nothing to do here.
-              result.queued++;
-              log.info(
-                { entity: proposal.entityName, id, outcome: outcome.kind },
-                "Auto-approve skipped — amendment was already decided concurrently",
-              );
-            }
-          } catch (applyErr) {
-            log.warn(
-              {
-                err: applyErr instanceof Error ? applyErr : new Error(String(applyErr)),
-                entity: proposal.entityName,
-                id,
-              },
-              "Failed to apply auto-approved amendment — the decide seam returned it to pending for admin review",
-            );
-            result.errors++;
-          }
-        } else {
-          result.queued++;
-        }
-      } catch (err) {
-        log.warn(
-          { err: err instanceof Error ? err : new Error(String(err)), entity: proposal.entityName },
-          "Failed to insert semantic amendment",
-        );
-        result.errors++;
-      }
-    }
-
+async function runWorkspaceImproveTick(
+  orgId: string | null,
+): Promise<{ gateBlocked: true } | { gateBlocked: false; counters: WorkspaceTickCounters }> {
+  // Billing gate first — a blocked workspace's tick no-ops before any context
+  // load or LLM/apply work (#4516 AC3). On self-hosted (orgId null) the gate
+  // is a passthrough (checkAgentBillingGate treats no-org as always-allowed).
+  const gate = await checkAgentBillingGate(orgId ?? undefined);
+  if (!gate.allowed) {
     log.info(
-      {
-        total: result.proposalsGenerated,
-        autoApproved: result.autoApproved,
-        queued: result.queued,
-        rejected: result.rejected,
-        deduped: result.deduped,
-        errors: result.errors,
-      },
-      "Expert scheduler tick complete",
+      { orgId, errorCode: gate.errorCode },
+      "Autonomous improvement skipped for workspace — billing gate blocked",
     );
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
-      "Expert scheduler tick failed",
-    );
-    result.errors++;
+    return { gateBlocked: true };
   }
 
-  return result;
+  const counters = emptyCounters();
+  const requestId = `scheduled-${orgId ?? "self"}-${Date.now()}`;
+
+  // Stamp origin `scheduler` (#4508 / ADR-0015) so the decide seam's auto-apply
+  // validation (executeSQL) matches origin-scoped approval rules and any metered
+  // spend attributes to this workspace under origin `scheduler`.
+  return withRequestContext(
+    { requestId, agentOrigin: "scheduler", actor: { kind: "scheduler" } },
+    async () => {
+      // 1. Load this workspace's semantic context. On SaaS (orgId present) read
+      //    the workspace's own DB rows + per-org disk mirror; on self-hosted read
+      //    the bundled disk layer. Audit patterns + rejected keys are org-scoped
+      //    so one tenant's query history / rejections never bleed into another's
+      //    proposals (#4516). Glossary stays the bundled disk union — shared
+      //    default files, not tenant data, so no cross-tenant concern.
+      const {
+        loadEntitiesForOrg,
+        loadEntitiesFromDisk,
+        loadGlossaryFromDisk,
+        loadAuditPatterns,
+        loadRejectedKeys,
+      } = await import("./context-loader");
+
+      const entities = orgId
+        ? (await loadEntitiesForOrg(orgId, "published")).entities
+        : await loadEntitiesFromDisk();
+      const glossary = await loadGlossaryFromDisk();
+      const auditPatterns = await loadAuditPatterns(orgId ?? undefined);
+      const rejectedKeys = await loadRejectedKeys(orgId ?? undefined);
+
+      if (entities.length === 0) {
+        log.debug({ orgId }, "No semantic entities found — skipping workspace tick");
+        return { gateBlocked: false, counters };
+      }
+
+      // 2. Load cached profiles (from last `atlas init` / `atlas improve` run)
+      const { loadCachedProfiles } = await import("./profile-cache");
+      const profiles = loadCachedProfiles();
+
+      // 3. Run analysis
+      const { analyzeSemanticLayer } = await import("./analyzer");
+      const proposals = analyzeSemanticLayer({
+        profiles,
+        entities,
+        glossary,
+        auditPatterns,
+        rejectedKeys,
+      });
+
+      counters.proposalsGenerated = proposals.length;
+
+      if (proposals.length === 0) {
+        log.info({ orgId }, "Autonomous-improvement tick: no proposals generated");
+        return { gateBlocked: false, counters };
+      }
+
+      // 4. Insert proposals — every row lands `pending`; insertSemanticAmendment
+      //    reports auto-approve ELIGIBILITY and the decide seam (#4506) is the
+      //    only path to `approved`. Every insert is org-stamped (#4510) — the
+      //    one-workspace-owner invariant refuses a NULL-org insert on SaaS by
+      //    construction, so a stamping regression fails loudly rather than
+      //    leaking a global row.
+      const { insertSemanticAmendment } = await import("@atlas/api/lib/db/internal");
+
+      for (const proposal of proposals) {
+        try {
+          // Persist the finding's Connection group so the admin approve path can
+          // rebuild the correct scope (#3284). NULL = the default (flat) group.
+          const connectionGroupId =
+            proposal.group && proposal.group !== "default" ? proposal.group : null;
+          const insertResult = await insertSemanticAmendment({
+            orgId,
+            description: proposal.rationale,
+            sourceEntity: proposal.entityName,
+            connectionGroupId,
+            confidence: proposal.confidence,
+            amendmentPayload: {
+              category: proposal.category,
+              amendmentType: proposal.amendmentType,
+              amendment: proposal.amendment,
+              testQuery: proposal.testQuery,
+            },
+          });
+
+          // Permanent rejection memory + pending dedup (#4507): a rejected
+          // identity is refused at insert; an identical pending proposal
+          // converges on the existing row. Neither queues a new row.
+          if (insertResult.outcome === "rejected") {
+            counters.rejected++;
+            continue;
+          }
+          if (insertResult.outcome === "already_pending") {
+            counters.deduped++;
+            continue;
+          }
+
+          const { id, autoApprove } = insertResult;
+
+          if (autoApprove) {
+            // Route the auto-approve through the decide seam: claim-then-apply,
+            // `approved` stamped only after a successful apply + version
+            // snapshot. On apply failure the seam has already compensated the
+            // row back to `pending` with a visible reason — the invariant
+            // "status='approved' ⇒ applied" holds by construction (#4486, #4506).
+            try {
+              const { decideAmendment } = await import("./decide");
+              const decision = await decideAmendment({
+                id,
+                orgId,
+                decision: "approved",
+                reviewedBy: "expert-scheduler",
+                requestId,
+              });
+              if (decision.kind === "approved") {
+                counters.autoApproved++;
+                log.info(
+                  { orgId, entity: proposal.entityName, type: proposal.amendmentType, confidence: proposal.confidence },
+                  "Auto-approved and applied semantic amendment",
+                );
+              } else {
+                // A concurrent decision beat the scheduler to its own insert
+                // (admin reviewing the queue mid-tick) — nothing to do here.
+                counters.queued++;
+                log.info(
+                  { orgId, entity: proposal.entityName, id, outcome: decision.kind },
+                  "Auto-approve skipped — amendment was already decided concurrently",
+                );
+              }
+            } catch (applyErr) {
+              log.warn(
+                {
+                  err: applyErr instanceof Error ? applyErr : new Error(String(applyErr)),
+                  orgId,
+                  entity: proposal.entityName,
+                  id,
+                },
+                "Failed to apply auto-approved amendment — the decide seam returned it to pending for admin review",
+              );
+              counters.errors++;
+            }
+          } else {
+            counters.queued++;
+          }
+        } catch (err) {
+          log.warn(
+            { err: err instanceof Error ? err : new Error(String(err)), orgId, entity: proposal.entityName },
+            "Failed to insert semantic amendment",
+          );
+          counters.errors++;
+        }
+      }
+
+      return { gateBlocked: false, counters };
+    },
+  );
 }

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -21,8 +21,9 @@ export const DEFAULT_EXPERT_SCHEDULER_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Per-workspace autonomous-improvement opt-in (#4516). Workspace-scoped,
  * off by default — enabling it is a workspace-admin settings action. Must match
- * the `key`/`envVar` of the registry entry in lib/settings.ts (a guard test in
- * scheduler-tick.test.ts pins that they don't drift). */
+ * the `key`/`envVar` of the registry entry in lib/settings.ts; a guard test in
+ * scheduler.test.ts cross-checks this constant against the real registry
+ * (`getSettingDefinition`) so a rename can't silently zero out enumeration. */
 export const AUTONOMOUS_IMPROVE_ENABLED_KEY = "ATLAS_AUTONOMOUS_IMPROVE_ENABLED";
 
 /** Counters produced by a single workspace's tick. */
@@ -317,10 +318,11 @@ async function runWorkspaceImproveTick(orgId: string | null): Promise<WorkspaceT
       }
 
       // 2. Load cached profiles (from last `atlas init` / `atlas improve` run).
-      //    This is the bundled/global disk cache of column statistics, not
-      //    tenant data — keyed by table, matched to entities by name — so it
-      //    stays unscoped: on SaaS it is normally empty and the analyzer degrades
-      //    gracefully (per-workspace profiling is #4509's surface, not this slice).
+      //    This is a single GLOBAL disk cache written only by the CLI — normally
+      //    empty on SaaS, so there is no per-tenant profile to read and the
+      //    analyzer degrades gracefully. It stays unscoped for that reason (not
+      //    because profiles aren't tenant data — sampled column values are);
+      //    per-workspace profiling is #4509's surface, not this slice.
       const { loadCachedProfiles } = await import("./profile-cache");
       const profiles = loadCachedProfiles();
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -623,8 +623,9 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     // #4516 — per-workspace autonomous-improvement opt-in. Off by default and
     // WORKSPACE-scoped so enabling it is a workspace-admin settings action
     // (visible + writable to SaaS workspace admins via the default of the
-    // saasVisible/saasWritable axis). Read per-tick (no `requiresRestart`):
-    // the SaaS scheduler enumerates workspaces where this resolves true. It is
+    // saasVisible/saasWritable axis). Read per-tick (no `requiresRestart`): the
+    // SaaS scheduler enumerates workspaces that have an explicit workspace-scoped
+    // DB override set to true (not env/platform-default resolution). It is
     // orthogonal to auto-approve below — autonomy governs whether the scheduler
     // runs for a workspace; auto-approve governs whether eligible proposals
     // self-apply vs. queue, and is never implied by autonomy.

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -580,17 +580,21 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
 
   // Semantic Expert
   //
-  // Scope split (#3392, #4516): the scheduler PAIR below is PLATFORM-scoped.
-  // `ATLAS_EXPERT_SCHEDULER_ENABLED` is the platform MASTER SWITCH — does the
-  // single process-global autonomous-improvement fiber run on this deployment
-  // at all (forked once at boot by `makeSchedulerLive` in lib/effect/layers.ts,
-  // hence `requiresRestart`)? The per-workspace opt-in decision moved OUT of
-  // this key in #4516: on SaaS the tick iterates workspaces that set the
-  // WORKSPACE-scoped `ATLAS_AUTONOMOUS_IMPROVE_ENABLED` below; on self-hosted the
-  // whole deployment is one implicit workspace gated by this master switch (the
-  // degenerate case, equivalent to the pre-#4516 behavior). The auto-approve
-  // pair is WORKSPACE-scoped: read per proposal in `insertSemanticAmendment`
-  // (lib/db/internal.ts), which has the amendment's orgId in scope.
+  // Scope split (#3392, #4516): the two `ATLAS_EXPERT_SCHEDULER_*` keys are
+  // PLATFORM-scoped; the `ATLAS_AUTONOMOUS_IMPROVE_ENABLED` key after them is
+  // WORKSPACE-scoped, as is the auto-approve pair.
+  //  - `ATLAS_EXPERT_SCHEDULER_ENABLED` is the platform MASTER SWITCH — does the
+  //    single process-global autonomous-improvement fiber run on this deployment
+  //    at all (forked once at boot by `makeSchedulerLive` in lib/effect/layers.ts,
+  //    hence `requiresRestart`)? `_INTERVAL_HOURS` is its cadence.
+  //  - The per-workspace opt-in moved OUT of the master switch in #4516: on SaaS
+  //    the tick iterates workspaces that set the WORKSPACE-scoped
+  //    `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`; on self-hosted the whole deployment is
+  //    one implicit workspace gated by the master switch (the degenerate case,
+  //    equivalent to the pre-#4516 behavior).
+  //  - The auto-approve pair is WORKSPACE-scoped: read per proposal in
+  //    `insertSemanticAmendment` (lib/db/internal.ts), which has the amendment's
+  //    orgId in scope.
   {
     key: "ATLAS_EXPERT_SCHEDULER_ENABLED",
     section: "Intelligence",
@@ -599,6 +603,18 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: "boolean",
     default: "false",
     envVar: "ATLAS_EXPERT_SCHEDULER_ENABLED",
+    requiresRestart: true,
+    scope: "platform",
+    saasVisible: false,
+  },
+  {
+    key: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
+    section: "Intelligence",
+    label: "Expert Schedule Interval",
+    description: "Hours between scheduled expert analysis runs",
+    type: "number",
+    default: "24",
+    envVar: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
     requiresRestart: true,
     scope: "platform",
     saasVisible: false,
@@ -621,18 +637,6 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     default: "false",
     envVar: "ATLAS_AUTONOMOUS_IMPROVE_ENABLED",
     scope: "workspace",
-  },
-  {
-    key: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
-    section: "Intelligence",
-    label: "Expert Schedule Interval",
-    description: "Hours between scheduled expert analysis runs",
-    type: "number",
-    default: "24",
-    envVar: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",
-    requiresRestart: true,
-    scope: "platform",
-    saasVisible: false,
   },
   {
     key: "ATLAS_EXPERT_AUTO_APPROVE_THRESHOLD",

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -580,25 +580,47 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
 
   // Semantic Expert
   //
-  // Scope split (#3392): the scheduler pair is PLATFORM-scoped — the expert
-  // scheduler is a single process-global fiber forked once at boot
-  // (`makeSchedulerLive` in lib/effect/layers.ts); there is no per-workspace
-  // tick, so a workspace override would have nothing to apply to. Both are
-  // consumed once at boot, hence `requiresRestart`. The auto-approve pair
-  // below stays WORKSPACE-scoped: it is read per proposal in
-  // `insertSemanticAmendment` (lib/db/internal.ts), which has the
-  // amendment's orgId in scope.
+  // Scope split (#3392, #4516): the scheduler PAIR below is PLATFORM-scoped.
+  // `ATLAS_EXPERT_SCHEDULER_ENABLED` is the platform MASTER SWITCH — does the
+  // single process-global autonomous-improvement fiber run on this deployment
+  // at all (forked once at boot by `makeSchedulerLive` in lib/effect/layers.ts,
+  // hence `requiresRestart`)? The per-workspace opt-in decision moved OUT of
+  // this key in #4516: on SaaS the tick iterates workspaces that set the
+  // WORKSPACE-scoped `ATLAS_AUTONOMOUS_IMPROVE_ENABLED` below; on self-hosted the
+  // whole deployment is one implicit workspace gated by this master switch (the
+  // degenerate case, equivalent to the pre-#4516 behavior). The auto-approve
+  // pair is WORKSPACE-scoped: read per proposal in `insertSemanticAmendment`
+  // (lib/db/internal.ts), which has the amendment's orgId in scope.
   {
     key: "ATLAS_EXPERT_SCHEDULER_ENABLED",
     section: "Intelligence",
     label: "Expert Scheduler",
-    description: "Enable periodic semantic layer analysis (runs the improvement engine automatically)",
+    description: "Enable the autonomous-improvement fiber platform-wide (per-workspace opt-in is separate on SaaS)",
     type: "boolean",
     default: "false",
     envVar: "ATLAS_EXPERT_SCHEDULER_ENABLED",
     requiresRestart: true,
     scope: "platform",
     saasVisible: false,
+  },
+  {
+    // #4516 — per-workspace autonomous-improvement opt-in. Off by default and
+    // WORKSPACE-scoped so enabling it is a workspace-admin settings action
+    // (visible + writable to SaaS workspace admins via the default of the
+    // saasVisible/saasWritable axis). Read per-tick (no `requiresRestart`):
+    // the SaaS scheduler enumerates workspaces where this resolves true. It is
+    // orthogonal to auto-approve below — autonomy governs whether the scheduler
+    // runs for a workspace; auto-approve governs whether eligible proposals
+    // self-apply vs. queue, and is never implied by autonomy.
+    key: "ATLAS_AUTONOMOUS_IMPROVE_ENABLED",
+    section: "Intelligence",
+    label: "Autonomous Improvement",
+    description:
+      "Let Atlas propose semantic-layer amendments for this workspace on its own cadence (spends this workspace's budget; off by default)",
+    type: "boolean",
+    default: "false",
+    envVar: "ATLAS_AUTONOMOUS_IMPROVE_ENABLED",
+    scope: "workspace",
   },
   {
     key: "ATLAS_EXPERT_SCHEDULER_INTERVAL_HOURS",

--- a/scripts/check-settings-readers.sh
+++ b/scripts/check-settings-readers.sh
@@ -89,6 +89,16 @@ ALLOWLIST=(
   "STRIPE_STARTER_OVERAGE_PRICE_ID"
   "STRIPE_PRO_OVERAGE_PRICE_ID"
   "STRIPE_BUSINESS_OVERAGE_PRICE_ID"
+  # ATLAS_AUTONOMOUS_IMPROVE_ENABLED (#4516) IS read at runtime — but by a bulk
+  # ENUMERATION, not a per-org getSetting the grep below can detect. The SaaS
+  # autonomous-improvement scheduler (listAutonomousImproveOrgIds in
+  # lib/semantic/expert/scheduler.ts) selects every workspace that opted in with
+  # `SELECT DISTINCT org_id FROM settings WHERE key = AUTONOMOUS_IMPROVE_ENABLED_KEY
+  # AND value IN ('true','1')`. getSetting(key, orgId) resolves ONE org's value and
+  # cannot enumerate the opted-in set, so the enumeration is the only possible
+  # reader. It is NOT runtime-inert (drift class 1) — allowlisted because the
+  # reader is a table-scan enumeration, not a literal-keyed getSetting call.
+  "ATLAS_AUTONOMOUS_IMPROVE_ENABLED"
 )
 
 if [ ! -f "$SETTINGS_FILE" ]; then


### PR DESCRIPTION
Closes #4516. Milestone v0.0.48 — Semantic-Improve Elevation (PRD #4502).

## What & why

The autonomous-improvement scheduler becomes **SaaS-first**: one platform fiber iterates the workspaces that opted into autonomous improvement, with self-hosted's single workspace as the degenerate case of the *same* per-workspace tick — not a different model. This retires the #4487 SaaS boot-guard (which force-disabled the scheduler on SaaS because it minted NULL-org "global scope" rows) and replaces it with per-workspace gating that is org-safe by construction.

## Changes

- **New workspace-scoped knob** `ATLAS_AUTONOMOUS_IMPROVE_ENABLED` (off by default, `settings.ts`). Enabling it is a workspace-admin settings action; orthogonal to the auto-approve pair (autonomy = does the scheduler run for a workspace; auto-approve = do eligible proposals self-apply).
- **Retired the #4487 boot-guard** in `isExpertSchedulerEnabled()` — it's now the platform *master switch* only (does the fiber run on this deployment). Deploy mode is no longer consulted there.
- **Per-workspace tick** (`runWorkspaceImproveTick`): resolves the workspace set (SaaS → enumerate opted-in workspaces from the settings table; self-hosted → one degenerate `{orgId: null}`, equivalent to pre-#4516). Each workspace:
  - passes `checkAgentBillingGate` **first** — a blocked workspace no-ops before any context load or apply work, spending nothing;
  - runs under an `agentOrigin: "scheduler"` / `actor.kind: "scheduler"` request-context frame so origin-scoped approval rules fire and any metered spend attributes correctly;
  - loads its **own** semantic context (org-scoped entities, audit patterns, rejected keys);
  - inserts **org-stamped** proposals — the one-workspace-owner invariant (#4510) makes SaaS org-safety hold by construction (a stamping regression fails loud).
- **Org-scoped `loadAuditPatterns` / `loadRejectedKeys`** (`context-loader.ts`) — both are shared multi-tenant tables; an unscoped scan would leak one tenant's query history / rejections into another's proposals. Backward-compatible optional `orgId` (self-hosted/CLI keep the global scan).
- **Gate-error vs policy-block split**: a fail-closed 503 (e.g. internal-DB brownout) is counted/logged as `workspacesGateErrored`, kept distinct from real over-budget/suspended `workspacesGateBlocked` so a gate-lookup outage can't read as "everyone is over budget."

## Acceptance criteria

- [x] Autonomy disabled → no scheduler work; enabling is a workspace-admin settings action
- [x] Inserts always org-stamped; rejection memory + eligibility apply identically (insert-time guard is org-scoped; pre-filter now org-scoped too)
- [x] LLM spend passes the workspace billing gate under origin `scheduler`; suspended/over-budget spend nothing (gate no-op)
- [x] Boot-guard removed; runs on SaaS gated per-workspace; self-hosted single-workspace equivalent to today when enabled
- [x] Scheduler-seam tests: iteration, opt-in, gate no-op, org stamping (+ gate-error split, sweep isolation, enumeration-failure, origin frame, registry-drift guard)

## Testing

- New `load-audit-patterns.test.ts`; expanded `scheduler-tick.test.ts` (19 tests) and `scheduler.test.ts` (16, incl. a real registry↔constant drift guard via `getSettingDefinition`).
- Internal `/review-panel` ran **2 rounds → CLEAN** (silent-failure, type-design, test-coverage, comment reviewers). No correctness bugs; addressed the gate-error/budget conflation, a tautological drift guard (now a real registry cross-check), `internal.ts` comment rot, and coverage gaps.
- `/ci`: **all 29 non-test gates green** (incl. `settings-readers` after allowlisting the enumeration-read key). The full local test suite's only failure is the pre-existing WSL2 load-flake `ai-saas.test.ts` (AtlasAiModel TTL-cache timing — unrelated to this diff; passes in isolation). Relying on CI's isolated `api-tests` shards as the authoritative test signal.

## Out of scope (separate milestone slices)

Proactive notification of autonomously-queued Amendments (#4520), per-org glossary reads (#4518), per-workspace profiling (#4509).
