### PR TITLE
feat(semantic-improve): profile tiers — baseline-on-create + tracked LLM profile (#4509)

### DIFF
--- a/packages/api/src/api/__tests__/wizard-enrich-billing.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-billing.test.ts
@@ -109,10 +109,17 @@ void mock.module("@atlas/api/lib/db/connection", () =>
   }),
 );
 
+// Captures every internalQuery SQL so a block-arm test can assert the LLM-profile
+// run (#4509) is NEVER recorded when the gate blocks before spend.
+const enrichInternalQuerySqls: string[] = [];
+
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => true,
   getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
-  internalQuery: async () => [],
+  internalQuery: async (sql: string) => {
+    enrichInternalQuerySqls.push(sql);
+    return [];
+  },
   internalExecute: () => {},
   isInternalCircuitOpen: () => false,
   encryptSecret: (url: string) => `encrypted:${url}`,
@@ -325,6 +332,7 @@ beforeEach(() => {
   mockLogUsageEvent.mockClear();
   mockProfile.mockClear();
   mockModel.doGenerateCalls.length = 0;
+  enrichInternalQuerySqls.length = 0;
 });
 
 // ---------------------------------------------------------------------------
@@ -355,6 +363,9 @@ describe("POST /api/v1/wizard/enrich — billing gate (#4489)", () => {
     expect(mockModel.doGenerateCalls.length).toBe(0);
     expect(mockProfile).not.toHaveBeenCalled();
     expect(mockLogUsageEvent).not.toHaveBeenCalled();
+    // #4509 — a blocked enrich spends nothing, so it records NO LLM-profile run
+    // (a "enriched N days ago" stamp for a run that never happened would be a lie).
+    expect(enrichInternalQuerySqls.some((sql) => sql.includes("connection_profile_state"))).toBe(false);
   });
 
   it("blocks a token-hard-cap workspace with 429 + usage before the model runs", async () => {

--- a/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
@@ -387,6 +387,21 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
     expect(event.eventType).toBe("token");
     expect(event.quantity).toBe(80);
     expect(event.workspaceId).toBe("org-1");
+
+    // #4509 — the enrich route records the LLM-profile run per connection:
+    // WHEN (now()) + OVER WHAT scope, keyed on the connection install id. This
+    // is what feeds the briefing's "enriched N days ago" marker.
+    const llmRecord = mockInternalQuery.mock.calls.find(
+      ([sql]) =>
+        typeof sql === "string" &&
+        sql.includes("INSERT INTO connection_profile_state") &&
+        sql.includes("llm_profiled_at = now()"),
+    );
+    expect(llmRecord).toBeDefined();
+    const llmParams = llmRecord?.[1] as unknown[];
+    expect(llmParams[0]).toBe("org-1"); // org scope
+    expect(llmParams[1]).toBe("analytics"); // install_id = the connection
+    expect(JSON.parse(llmParams[3] as string)).toEqual({ tables: ["orders"] });
   });
 
   it("the AtlasAiModel test layer is the model source (sanity: layer resolves our mock)", async () => {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -64,6 +64,7 @@ import { SAFE_TABLE_NAME, safeSemanticRowName } from "@atlas/api/lib/semantic/sh
 // Phase-2 enrichment is the same shared engine (issue #3236, § D); the in-memory
 // variant lets the wizard enrich a YAML string per table without touching disk.
 import { enrichEntityYaml } from "@atlas/api/lib/semantic/enrich";
+import { recordLlmProfileRun } from "@atlas/api/lib/semantic/connection-profile";
 import { refreshGroupAutoDescription } from "@atlas/api/lib/source-catalog/lookup";
 // #3437 / #4489 — the wizard's Phase-2 enrich spends platform LLM tokens, so it
 // consults the same shared billing gate as every other agent surface before the
@@ -1066,6 +1067,27 @@ wizard.openapi(enrichRoute, async (c) => {
     log.info(
       { requestId, connectionId, tableName, enriched: data.enriched.enriched },
       "Wizard enrich complete",
+    );
+
+    // Track the LLM-profile (enrichment) run per connection (#4509): WHEN it last
+    // ran and OVER WHAT scope. Enrichment is never automatic and stays billing-
+    // gated (the agent gate above) — this only RECORDS the run that just
+    // completed, feeding the briefing's "enriched N days ago" marker. Fire-and-
+    // forget + a no-op with no internal DB (self-hosted CLI enrichment writes YAML
+    // to disk, not this store); recording must never fail the enrich response.
+    //
+    // `connectionId` here is the SAME `workspace_plugins.install_id` the baseline
+    // on-create hook keys on (both resolve through `resolveLiveConnection(orgId,
+    // installId)`), so the two tiers converge on ONE (org, install_id) row.
+    void recordLlmProfileRun({
+      orgId: orgId ?? null,
+      installId: connectionId,
+      scope: { tables: [tableName] },
+    }).catch((err) =>
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), requestId, connectionId, tableName },
+        "Failed to record LLM-profile run",
+      ),
     );
 
     return c.json(

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -484,6 +484,7 @@ describe("migrateAuthTables", () => {
             // pending. Atlas-internal column, no FK to a Better Auth table, so
             // it runs in every auth mode.
             { name: "0170_learned_patterns_last_apply_error.sql" },
+            { name: "0171_connection_profile_state.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/datasources/__tests__/connection-baseline.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/connection-baseline.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Baseline-profile orchestration (#4509) — the connection-creation hook seam.
+ *
+ * Pins, at the highest seam that stays DB-free:
+ *   • the on-create hook's decision for BOTH dbType classes — a profilable type
+ *     schedules a baseline; a REST/OpenAPI (unsupported) type does not;
+ *   • `runBaselineProfile` — resolve → profile → store, with a failure recorded
+ *     as a VISIBLE baseline_error (never silent) and the connection always closed;
+ *   • `ensureConnectionBaseline` — lazy backfill runs only when no baseline
+ *     exists (one connection on demand, never a bulk sweep).
+ *
+ * `db/internal` is mocked (the `internalQuery`-spy pattern) so the store's SQL is
+ * captured without a live DB; the connection + capability resolvers are injected
+ * so no live connection or plugin registry is needed.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { ProfileCapability, ResolveLiveConnectionResult } from "../mcp-lifecycle";
+
+let mockHasDB = true;
+const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
+let selectRows: Record<string, unknown>[][] = [];
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasDB,
+  internalQuery: async (sql: string, params: unknown[]) => {
+    dbCalls.push({ sql, params });
+    if (/^\s*SELECT/i.test(sql)) return selectRows.shift() ?? [];
+    return [];
+  },
+  internalExecute: () => {},
+  getInternalDB: () => ({}),
+}));
+
+const {
+  planConnectionBaseline,
+  runBaselineProfile,
+  ensureConnectionBaseline,
+  profileConnectionOnCreate,
+} = await import("../connection-baseline");
+
+const native: ProfileCapability = { kind: "native", dbType: "postgres" };
+const plugin: ProfileCapability = { kind: "plugin", dbType: "elasticsearch" };
+const unsupported: ProfileCapability = {
+  kind: "unsupported",
+  dbType: "openapi-generic",
+  message: "REST/OpenAPI cannot be profiled.",
+};
+
+function fakeConnection(overrides: Partial<{ profiles: unknown[]; errors: unknown[]; throwOnProfile: Error }> = {}) {
+  const closed = { count: 0 };
+  const conn = {
+    dbType: "postgres" as const,
+    connectionGroupId: "g_resolved" as string | null,
+    query: async () => ({ columns: [], rows: [] }),
+    listObjects: async () => [],
+    profile: async () => {
+      if (overrides.throwOnProfile) throw overrides.throwOnProfile;
+      return { profiles: overrides.profiles ?? [], errors: overrides.errors ?? [] };
+    },
+    close: async () => {
+      closed.count += 1;
+    },
+  };
+  return { conn, closed };
+}
+
+function okResolver(conn: ReturnType<typeof fakeConnection>["conn"]) {
+  return async (): Promise<ResolveLiveConnectionResult> =>
+    ({ kind: "ok", connection: conn, defaultSchema: undefined }) as unknown as ResolveLiveConnectionResult;
+}
+
+beforeEach(() => {
+  mockHasDB = true;
+  dbCalls.length = 0;
+  selectRows = [];
+});
+
+describe("planConnectionBaseline — both dbType classes", () => {
+  it("marks a native (postgres/mysql) type profilable", async () => {
+    const plan = await planConnectionBaseline("postgres", { resolveCapability: async () => native });
+    expect(plan).toEqual({ profilable: true, capabilityKind: "native" });
+  });
+
+  it("marks a plugin datasource (elasticsearch) profilable", async () => {
+    const plan = await planConnectionBaseline("elasticsearch", { resolveCapability: async () => plugin });
+    expect(plan.profilable).toBe(true);
+  });
+
+  it("marks a REST/OpenAPI (unsupported) type NOT profilable", async () => {
+    const plan = await planConnectionBaseline("openapi-generic", { resolveCapability: async () => unsupported });
+    expect(plan).toEqual({ profilable: false, capabilityKind: "unsupported" });
+  });
+});
+
+describe("profileConnectionOnCreate — the on-create hook seam", () => {
+  it("schedules a background baseline for a profilable connection", async () => {
+    const runBaseline = mock(async () => {});
+    const decision = await profileConnectionOnCreate(
+      { orgId: "org_1", installId: "cn_pg", connectionGroupId: "g", dbType: "postgres" },
+      { resolveCapability: async () => native, runBaseline },
+    );
+    expect(decision).toEqual({ action: "scheduled" });
+    expect(runBaseline).toHaveBeenCalledTimes(1);
+    expect(runBaseline).toHaveBeenCalledWith({
+      orgId: "org_1",
+      installId: "cn_pg",
+      connectionGroupId: "g",
+      dbType: "postgres",
+    });
+  });
+
+  it("does NOT profile a REST/OpenAPI datasource", async () => {
+    const runBaseline = mock(async () => {});
+    const decision = await profileConnectionOnCreate(
+      { orgId: "org_1", installId: "cn_rest", dbType: "openapi-generic" },
+      { resolveCapability: async () => unsupported, runBaseline },
+    );
+    expect(decision).toEqual({ action: "skipped", reason: "not-profilable" });
+    expect(runBaseline).not.toHaveBeenCalled();
+  });
+
+  it("skips (no throw) when there is no internal DB", async () => {
+    mockHasDB = false;
+    const runBaseline = mock(async () => {});
+    const decision = await profileConnectionOnCreate(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      { resolveCapability: async () => native, runBaseline },
+    );
+    expect(decision).toEqual({ action: "skipped", reason: "no-internal-db" });
+    expect(runBaseline).not.toHaveBeenCalled();
+  });
+
+  it("never throws — a capability-lookup error degrades to a skip", async () => {
+    const decision = await profileConnectionOnCreate(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      {
+        resolveCapability: async () => {
+          throw new Error("registry down");
+        },
+      },
+    );
+    expect(decision).toEqual({ action: "skipped", reason: "error" });
+  });
+});
+
+describe("runBaselineProfile", () => {
+  it("stores the profiler payload and closes the connection", async () => {
+    const { conn, closed } = fakeConnection({ profiles: [{ table_name: "orders" }] });
+    await runBaselineProfile(
+      { orgId: "org_1", installId: "cn", connectionGroupId: "g", dbType: "postgres" },
+      { resolveConnection: okResolver(conn) },
+    );
+    const insert = dbCalls.find((c) => c.sql.includes("INSERT INTO connection_profile_state"));
+    expect(insert).toBeDefined();
+    expect(insert?.sql).toContain("baseline_profiled_at = now()");
+    expect(insert?.params[1]).toBe("cn");
+    expect(closed.count).toBe(1);
+  });
+
+  it("records a VISIBLE baseline_error when profiling throws, still closing the connection", async () => {
+    const { conn, closed } = fakeConnection({ throwOnProfile: new Error("permission denied") });
+    await runBaselineProfile(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      { resolveConnection: okResolver(conn) },
+    );
+    const errWrite = dbCalls.find((c) => c.sql.includes("baseline_error = EXCLUDED.baseline_error"));
+    expect(errWrite).toBeDefined();
+    expect(errWrite?.params[4]).toBe("permission denied");
+    expect(closed.count).toBe(1);
+  });
+
+  it("records a baseline_error when the connection cannot be resolved", async () => {
+    await runBaselineProfile(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      { resolveConnection: async () => ({ kind: "not_found" }) },
+    );
+    const errWrite = dbCalls.find((c) => c.sql.includes("baseline_error = EXCLUDED.baseline_error"));
+    expect(errWrite).toBeDefined();
+    expect(String(errWrite?.params[4])).toContain("could not resolve a live connection");
+  });
+
+  it("SCRUBS a DSN out of a driver error before storing it (never leaks a credential)", async () => {
+    // The stored baseline_error is agent-readable via the briefing/coverage — a
+    // raw pg error can echo the connection string. This guards the scrub so a
+    // refactor dropping errorMessage() fails here rather than leaking silently.
+    const { conn } = fakeConnection({
+      throwOnProfile: new Error("connect to postgres://admin:s3cr3t@db.internal:5432/prod failed"),
+    });
+    await runBaselineProfile(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      { resolveConnection: okResolver(conn) },
+    );
+    const errWrite = dbCalls.find((c) => c.sql.includes("baseline_error = EXCLUDED.baseline_error"));
+    const stored = String(errWrite?.params[4]);
+    expect(stored).not.toContain("s3cr3t");
+    expect(stored).toContain("postgres://***@db.internal");
+  });
+
+  it("does NOT throw when the resolver itself throws — records the (scrubbed) failure instead", async () => {
+    // The default resolveLiveConnection throws on some OAuth/reconnect paths;
+    // runBaselineProfile must stay total so ensureConnectionBaseline (awaited off
+    // a briefing render) can't reject.
+    let threw = false;
+    await runBaselineProfile(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      {
+        resolveConnection: async () => {
+          throw new Error("token expired");
+        },
+      },
+    ).catch(() => {
+      threw = true;
+    });
+    expect(threw).toBe(false);
+    const errWrite = dbCalls.find((c) => c.sql.includes("baseline_error = EXCLUDED.baseline_error"));
+    expect(errWrite).toBeDefined();
+    expect(String(errWrite?.params[4])).toContain("token expired");
+  });
+
+  it("is a no-op with no internal DB", async () => {
+    mockHasDB = false;
+    const { conn } = fakeConnection();
+    let resolved = false;
+    await runBaselineProfile(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      {
+        resolveConnection: async () => {
+          resolved = true;
+          return okResolver(conn)();
+        },
+      },
+    );
+    expect(resolved).toBe(false);
+    expect(dbCalls).toHaveLength(0);
+  });
+});
+
+describe("ensureConnectionBaseline — lazy backfill", () => {
+  it("does NOT re-profile a connection that already has a baseline", async () => {
+    // First (and only) getConnectionProfileState read returns a baselined row.
+    selectRows = [
+      [
+        {
+          install_id: "cn",
+          org_id: "org_1",
+          connection_group_id: "g",
+          db_type: "postgres",
+          baseline_table_count: 2,
+          baseline_profiled_at: "2026-07-01T00:00:00.000Z",
+          baseline_error: null,
+          llm_profiled_at: null,
+          llm_profile_scope: null,
+        },
+      ],
+    ];
+    let resolved = false;
+    const state = await ensureConnectionBaseline(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      {
+        resolveConnection: async () => {
+          resolved = true;
+          return { kind: "not_found" };
+        },
+      },
+    );
+    expect(resolved).toBe(false); // no live-connection work
+    expect(dbCalls.every((c) => !c.sql.includes("INSERT INTO"))).toBe(true);
+    expect(state?.baseline?.tableCount).toBe(2);
+  });
+
+  it("profiles on first need when no baseline exists, then returns the fresh state", async () => {
+    const { conn } = fakeConnection({ profiles: [{ table_name: "orders" }] });
+    // 1st read: no baseline → run; 2nd read (post-run): the populated row.
+    selectRows = [
+      [],
+      [
+        {
+          install_id: "cn",
+          org_id: "org_1",
+          connection_group_id: "g",
+          db_type: "postgres",
+          baseline_table_count: 1,
+          baseline_profiled_at: "2026-07-11T00:00:00.000Z",
+          baseline_error: null,
+          llm_profiled_at: null,
+          llm_profile_scope: null,
+        },
+      ],
+    ];
+    const state = await ensureConnectionBaseline(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      { resolveConnection: okResolver(conn) },
+    );
+    expect(dbCalls.some((c) => c.sql.includes("INSERT INTO connection_profile_state"))).toBe(true);
+    expect(state?.baseline?.tableCount).toBe(1);
+  });
+
+  it("re-attempts when the last baseline only FAILED (error row, no success facts)", async () => {
+    // An error-only row (baseline_error set, no baseline_profiled_at) is NOT a
+    // successful baseline, so a fixed connection recovers on the next need.
+    const { conn } = fakeConnection({ profiles: [{ table_name: "orders" }] });
+    let resolved = false;
+    selectRows = [
+      [
+        {
+          install_id: "cn",
+          org_id: "org_1",
+          connection_group_id: "g",
+          db_type: "postgres",
+          baseline_table_count: null,
+          baseline_profiled_at: null,
+          baseline_error: "permission denied",
+          llm_profiled_at: null,
+          llm_profile_scope: null,
+        },
+      ],
+      [], // post-run read (irrelevant to this assertion)
+    ];
+    await ensureConnectionBaseline(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      {
+        resolveConnection: async () => {
+          resolved = true;
+          return okResolver(conn)();
+        },
+      },
+    );
+    expect(resolved).toBe(true); // retried
+    expect(dbCalls.some((c) => c.sql.includes("INSERT INTO connection_profile_state"))).toBe(true);
+  });
+});

--- a/packages/api/src/lib/datasources/connection-baseline.ts
+++ b/packages/api/src/lib/datasources/connection-baseline.ts
@@ -1,0 +1,265 @@
+/**
+ * Baseline-profile orchestration (#4509) — the seam that turns a connection into
+ * a tracked baseline profile:
+ *
+ *   • {@link profileConnectionOnCreate} — the on-create hook. Called from the
+ *     native datasource-install seam (`WorkspaceInstaller.installDatasource`)
+ *     when a connection is created. Capability-gated: a *profilable* connection
+ *     (native pg/mysql or a plugin that builds a connection) kicks off a
+ *     background baseline; a REST/OpenAPI or OAuth-managed type is skipped. Never
+ *     blocks or fails the install. Connections that persist through the plugin
+ *     form-install spine instead (which bypasses `installDatasource`) are covered
+ *     by the lazy backfill below.
+ *
+ *   • {@link ensureConnectionBaseline} — the lazy backfill. A pre-existing
+ *     unprofiled connection is baseline-profiled the first time something needs
+ *     it (a briefing, the coverage view), NOT via a bulk sweep. A no-op when a
+ *     baseline already exists.
+ *
+ *   • {@link runBaselineProfile} — resolve the live connection → run the
+ *     deterministic profiler → store the payload; a failure is recorded as a
+ *     VISIBLE `baseline_error`, never silent.
+ *
+ * The store (DB seam) is `lib/semantic/connection-profile.ts`. Dependencies are
+ * injectable so the hook + run seams are unit-testable without a live DB or a
+ * real connection.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import type {
+  ProfileCapability,
+  ResolveLiveConnectionResult,
+} from "@atlas/api/lib/datasources/mcp-lifecycle";
+import {
+  getConnectionProfileState,
+  recordBaselineError,
+  upsertBaselineProfile,
+  type ConnectionProfileState,
+} from "@atlas/api/lib/semantic/connection-profile";
+
+const log = createLogger("datasources:connection-baseline");
+
+// Lazy-import the mcp-lifecycle resolvers so this module's static graph stays
+// light (db/internal + the store) — the heavy `mcp-lifecycle` graph is pulled
+// only when a default dependency is actually invoked, mirroring how
+// `profiling-connection.ts` keeps that graph out of its consumers' load path.
+// Tests inject `deps` and never touch these.
+async function defaultResolveCapability(dbType: string): Promise<ProfileCapability> {
+  const { resolveProfileCapabilityByDbType } = await import("@atlas/api/lib/datasources/mcp-lifecycle");
+  return resolveProfileCapabilityByDbType(dbType);
+}
+async function defaultResolveConnection(
+  orgId: string,
+  installId: string,
+): Promise<ResolveLiveConnectionResult> {
+  const { resolveLiveConnection } = await import("@atlas/api/lib/datasources/mcp-lifecycle");
+  return resolveLiveConnection(orgId, installId);
+}
+
+/** Identity + type of the connection to baseline-profile. */
+export interface BaselineProfileTarget {
+  readonly orgId: string;
+  readonly installId: string;
+  readonly connectionGroupId?: string | null;
+  readonly dbType: string;
+}
+
+/** Whether a dbType is baseline-profilable, from the unified profiler capability. */
+export interface BaselinePlan {
+  readonly profilable: boolean;
+  readonly capabilityKind: ProfileCapability["kind"];
+}
+
+/**
+ * Decide whether a dbType gets a baseline profile — the connection-creation hook
+ * seam's policy, keyed on the SAME `resolveProfileCapabilityByDbType` predicate
+ * provisioning + live-connection resolution use, so "profilable at create" can
+ * never drift from "profilable at query/profile time". REST/OpenAPI and OAuth-
+ * managed types resolve to `unsupported` → not profilable.
+ */
+export async function planConnectionBaseline(
+  dbType: string,
+  deps: {
+    resolveCapability?: (dbType: string) => Promise<ProfileCapability>;
+  } = {},
+): Promise<BaselinePlan> {
+  const resolveCapability = deps.resolveCapability ?? defaultResolveCapability;
+  const capability = await resolveCapability(dbType);
+  return { profilable: capability.kind !== "unsupported", capabilityKind: capability.kind };
+}
+
+/**
+ * Resolve the connection's live introspection surface and run the deterministic
+ * baseline profiler (schema/types/counts/samples), storing the payload. A
+ * resolution or profiling failure is recorded as a VISIBLE `baseline_error`
+ * (DSN-scrubbed via {@link errorMessage} — the raw driver message can echo the
+ * connection string). This function NEVER throws: an unexpected resolver throw
+ * or a DB-write failure is logged (and best-effort recorded), never propagated —
+ * `ensureConnectionBaseline` awaits it inline off a briefing/coverage render,
+ * which must not fail on an infra hiccup. The lazy backfill retries on next need.
+ */
+export async function runBaselineProfile(
+  target: BaselineProfileTarget,
+  deps: {
+    resolveConnection?: (orgId: string, installId: string) => Promise<ResolveLiveConnectionResult>;
+  } = {},
+): Promise<void> {
+  if (!hasInternalDB()) return; // nowhere to store the baseline
+  const resolveConnection = deps.resolveConnection ?? defaultResolveConnection;
+
+  try {
+    const resolved = await resolveConnection(target.orgId, target.installId);
+    if (resolved.kind !== "ok") {
+      // The non-ok variants are exhaustive: `not_found` (no message) plus
+      // `unsupported` / `reconnect_required` (both carry an actionable message).
+      const reason = resolved.kind === "not_found" ? "the connection was not found" : resolved.message;
+      await recordBaselineError({
+        orgId: target.orgId,
+        installId: target.installId,
+        connectionGroupId: target.connectionGroupId,
+        dbType: target.dbType,
+        error: `Baseline profile could not resolve a live connection: ${reason}.`,
+      });
+      return;
+    }
+
+    const conn = resolved.connection;
+    try {
+      const result = await conn.profile({ logger: log });
+      await upsertBaselineProfile({
+        orgId: target.orgId,
+        installId: target.installId,
+        // Prefer the resolved connection's own group scope when the caller didn't
+        // thread one (it is authoritative for the built connection).
+        connectionGroupId: target.connectionGroupId ?? conn.connectionGroupId,
+        dbType: target.dbType,
+        profiles: result.profiles,
+      });
+      if (result.errors.length > 0) {
+        log.info(
+          { installId: target.installId, failed: result.errors.length, profiled: result.profiles.length },
+          "Baseline profile completed with per-table failures below the abort threshold",
+        );
+      }
+    } catch (err) {
+      // Profiling threw — scrub before storing: a pg/mysql driver error message
+      // can echo the DSN, one column away from an agent-visible briefing.
+      await recordBaselineError({
+        orgId: target.orgId,
+        installId: target.installId,
+        connectionGroupId: target.connectionGroupId,
+        dbType: target.dbType,
+        error: errorMessage(err),
+      });
+    } finally {
+      // Log (don't swallow) a close failure so a pool leak is visible without
+      // failing the baseline (CLAUDE.md: no empty catch).
+      await conn.close().catch((closeErr) =>
+        log.warn(
+          { err: errorMessage(closeErr), installId: target.installId },
+          "Baseline profile: connection close failed",
+        ),
+      );
+    }
+  } catch (err) {
+    // A thrown resolver (the default `resolveLiveConnection` throws on some
+    // OAuth/reconnect paths) or a DB write that itself failed. Log it and make a
+    // best-effort visible record — but never let a second failure escape.
+    const message = errorMessage(err);
+    log.warn({ err: message, installId: target.installId }, "Baseline profile failed unexpectedly");
+    try {
+      await recordBaselineError({
+        orgId: target.orgId,
+        installId: target.installId,
+        connectionGroupId: target.connectionGroupId,
+        dbType: target.dbType,
+        error: message,
+      });
+    } catch (recordErr) {
+      log.warn(
+        { err: errorMessage(recordErr), installId: target.installId },
+        "Baseline profile: could not record the failure reason",
+      );
+    }
+  }
+}
+
+/**
+ * Lazily backfill a connection's baseline profile — the "on first need" path for
+ * a pre-existing unprofiled connection (a briefing, the coverage view). Memoizes
+ * SUCCESS: returns the current state without re-profiling once a successful
+ * baseline exists. A connection whose last attempt only FAILED (error row, no
+ * success facts) is re-attempted, so a fixed-permission connection recovers on
+ * the next need — callers should therefore invoke this on genuine need (a page
+ * load), not on every conversational turn. This is one connection on demand, NOT
+ * a bulk sweep. Returns `null` when there's no internal DB. Never throws
+ * ({@link runBaselineProfile} is total).
+ */
+export async function ensureConnectionBaseline(
+  target: BaselineProfileTarget,
+  deps: {
+    resolveConnection?: (orgId: string, installId: string) => Promise<ResolveLiveConnectionResult>;
+  } = {},
+): Promise<ConnectionProfileState | null> {
+  // Total by contract: the two state reads (not just the profile run) are
+  // wrapped so a transient internal-DB read failure degrades to `null` rather
+  // than rejecting a briefing/coverage render (CLAUDE.md: never a 500 from a
+  // read hiccup on a degradable surface).
+  try {
+    const existing = await getConnectionProfileState(target.orgId, target.installId);
+    if (existing?.baseline) return existing; // successful baseline already — no re-run
+    await runBaselineProfile(target, deps);
+    return await getConnectionProfileState(target.orgId, target.installId);
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), installId: target.installId },
+      "ensureConnectionBaseline: profile-state read failed — returning null",
+    );
+    return null;
+  }
+}
+
+/** Outcome of the on-create hook — observable so the creation seam + tests can assert. */
+export type OnCreateBaselineDecision =
+  | { readonly action: "scheduled" }
+  | { readonly action: "skipped"; readonly reason: "not-profilable" | "no-internal-db" | "error" };
+
+/**
+ * On-create hook: baseline-profile a newly-created profilable connection without
+ * operator action. Capability-gated (REST/OpenAPI + OAuth-managed types are
+ * skipped) and FIRE-AND-FORGET — the baseline runs in the background so it never
+ * blocks or fails the install; its own success/failure is recorded durably and
+ * the lazy backfill retries on first need. Never throws.
+ */
+export async function profileConnectionOnCreate(
+  target: BaselineProfileTarget,
+  deps: {
+    resolveCapability?: (dbType: string) => Promise<ProfileCapability>;
+    runBaseline?: (target: BaselineProfileTarget) => Promise<void>;
+  } = {},
+): Promise<OnCreateBaselineDecision> {
+  try {
+    if (!hasInternalDB()) return { action: "skipped", reason: "no-internal-db" };
+    const plan = await planConnectionBaseline(target.dbType, deps);
+    if (!plan.profilable) return { action: "skipped", reason: "not-profilable" };
+
+    const runBaseline = deps.runBaseline ?? runBaselineProfile;
+    void runBaseline(target).catch((err) =>
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), installId: target.installId },
+        "Baseline profile on create failed to run in background",
+      ),
+    );
+    return { action: "scheduled" };
+  } catch (err) {
+    // The hook must never break a connection install. A capability-lookup or
+    // scheduling error is logged, not thrown; the lazy backfill covers it later.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), installId: target.installId, dbType: target.dbType },
+      "Baseline profile on create hook errored — deferring to lazy backfill",
+    );
+    return { action: "skipped", reason: "error" };
+  }
+}

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -216,7 +216,9 @@ describe("runMigrations", () => {
     //   notebook-surface retirement, ADR-0035, #4587) = 170.
     //   Plus 0170 (learned_patterns.last_apply_error — the visible reason when
     //   the decide seam compensates a failed approve back to pending, #4506) = 171.
-    expect(count).toBe(171);
+    //   Plus 0171 (connection_profile_state — per-connection baseline + LLM
+    //   profile-tier tracking for the semantic-improve briefing, #4509) = 172.
+    expect(count).toBe(172);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -416,6 +418,7 @@ describe("runMigrations", () => {
         "0168_knowledge_sync_state_high_water.sql",
         "0169_convert_notebook_conversations.sql",
         "0170_learned_patterns_last_apply_error.sql",
+        "0171_connection_profile_state.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0171_connection_profile_state.sql
+++ b/packages/api/src/lib/db/migrations/0171_connection_profile_state.sql
@@ -1,0 +1,90 @@
+-- 0171 — per-connection profile-tier state (baseline + LLM), #4509.
+--
+-- Two tracked tiers of "knowing a connection" (CONTEXT.md § Semantic
+-- improvement, "Baseline profile / LLM profile"):
+--
+--   • Baseline profile — cheap, deterministic (schema/types/counts/samples via
+--     the unified profiler capability). Runs automatically when a *profilable*
+--     connection is created (REST/OpenAPI excluded by the capability gate);
+--     pre-existing connections backfill lazily on first need. The payload is the
+--     `TableProfile[]` the profiler produced, stored so briefings + the coverage
+--     view read the physical schema from tracked data WITHOUT re-querying the
+--     customer database just to start a chat.
+--
+--   • LLM profile — the enrichment pass. NEVER automatic, billing-gated, and
+--     tracked per connection: when it last ran and over what scope.
+--
+-- One row per (org, connection install_id). `org_id` is nullable: on SaaS every
+-- write supplies the workspace, but a self-hosted deployment with no active org
+-- writes a NULL owner (the LLM-tier enrich path threads `orgId ?? null`), so a
+-- NULL owner is a VALID live row here, not a legacy artifact — a future cleanup
+-- must not treat NULL-owner rows as historical. Uniqueness keys on the COALESCE
+-- sentinel so the NULL-owner rows stay a single bucket (mirrors migration 0138's
+-- convention), and the `ON CONFLICT` targets in `connection-profile.ts` match it.
+--
+-- NOT content-mode-managed: this is operator/agent-facing DIAGNOSTIC metadata
+-- ABOUT a connection (profile freshness + payload), not member-visible content
+-- with a draft/published lifecycle, so it stays out of `CONTENT_MODE_TABLES`.
+--
+-- Additive-only: a brand-new table, no constraint changes to existing tables,
+-- so it ships safely in a single release (the two-phase-drop discipline only
+-- governs DROP COLUMN / DROP TABLE). The Drizzle mirror in `db/schema.ts`
+-- (`connectionProfileState`) lands in the SAME PR so `check-schema-drift` stays
+-- green and the next `drizzle-kit generate` doesn't emit a DROP for this table.
+--
+-- Not Better-Auth-managed, so this file does NOT join MANAGED_AUTH_MIGRATIONS
+-- (db/internal.ts).
+--
+-- Idempotent: `CREATE TABLE IF NOT EXISTS` + `CREATE ... INDEX IF NOT EXISTS`
+-- are no-ops on re-run.
+
+CREATE TABLE IF NOT EXISTS connection_profile_state (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- NULL = self-hosted single-workspace owner with no active org (a valid live
+  -- state written by the LLM-tier enrich path when there's no orgId). SaaS always
+  -- supplies a workspace.
+  org_id TEXT,
+  -- The datasource connection's `workspace_plugins.install_id` — the per-
+  -- connection identity the creation seam + the lazy backfill both key on.
+  install_id TEXT NOT NULL,
+  -- Connection-group scope (NULL = flat default group), so group-keyed consumers
+  -- (briefing, coverage view) can find a connection's profile by its group.
+  connection_group_id TEXT,
+  -- Resolved dbType at profile time — readable metadata, NULL until first baseline.
+  db_type TEXT,
+  -- ── Baseline tier (deterministic profiler facts) ────────────────────
+  -- The `TableProfile[]` payload; NULL until the first baseline succeeds.
+  baseline_profiles JSONB,
+  -- Denormalised `profiles.length` for cheap "N tables profiled" reads.
+  baseline_table_count INTEGER,
+  -- Freshness marker ("profiled N days ago"); NULL = never baseline-profiled.
+  baseline_profiled_at TIMESTAMPTZ,
+  -- Last auto/backfill failure reason (DSN-scrubbed at the profiler boundary),
+  -- so a failed baseline is VISIBLE, never silent. Cleared on a clean re-profile.
+  baseline_error TEXT,
+  -- ── LLM tier (enrichment run tracking) ──────────────────────────────
+  -- Last enrichment run; NULL = never LLM-profiled.
+  llm_profiled_at TIMESTAMPTZ,
+  -- What the last run covered, e.g. { "tables": ["orders"] }.
+  llm_profile_scope JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Natural key: one state row per (org, install_id). The COALESCE sentinel keeps
+-- the NULL-owner (legacy self-hosted) row a single bucket, mirroring migration
+-- 0138. Drizzle can't represent an expression index, so this is managed here in
+-- raw SQL and mirrored by a NON-unique placeholder index (same name) in
+-- `db/schema.ts` so `drizzle-kit generate` doesn't emit a spurious DROP/CREATE
+-- INDEX. The `ON CONFLICT` targets in `connection-profile.ts` match this
+-- expression exactly.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_connection_profile_state_org_install
+  ON connection_profile_state (COALESCE(org_id, '__self_hosted__'), install_id);
+
+-- Group-scoped consumers (briefing, coverage view) list a group's connection
+-- profiles; a plain index keeps that scan tight.
+CREATE INDEX IF NOT EXISTS idx_connection_profile_state_org_group
+  ON connection_profile_state (org_id, connection_group_id);
+
+COMMENT ON TABLE connection_profile_state IS
+  'Per-connection profile-tier state (#4509): one row per (org, connection install_id) tracking the baseline profile (deterministic schema/types/counts/samples payload + freshness) and the LLM-profile (enrichment) run (timestamp + scope). Feeds the briefing staleness marker and the coverage view. Diagnostic metadata — NOT content-mode-managed.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -582,6 +582,51 @@ export const semanticProfileStatus = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// Connection profile-tier state (baseline + LLM profile, #4509)
+// ---------------------------------------------------------------------------
+
+export const connectionProfileState = pgTable(
+  "connection_profile_state",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // NULL = self-hosted no-active-org owner (a valid live row via the LLM-tier
+    // enrich path); SaaS always supplies a workspace.
+    orgId: text("org_id"),
+    // The datasource connection's `workspace_plugins.install_id`.
+    installId: text("install_id").notNull(),
+    // Connection-group scope (NULL = flat default group).
+    connectionGroupId: text("connection_group_id"),
+    // Resolved dbType at profile time; NULL until first baseline.
+    dbType: text("db_type"),
+    // Baseline tier — the `TableProfile[]` payload; NULL until first baseline.
+    baselineProfiles: jsonb("baseline_profiles"),
+    baselineTableCount: integer("baseline_table_count"),
+    baselineProfiledAt: timestamp("baseline_profiled_at", { withTimezone: true }),
+    baselineError: text("baseline_error"),
+    // LLM tier — enrichment run tracking (never automatic, billing-gated).
+    llmProfiledAt: timestamp("llm_profiled_at", { withTimezone: true }),
+    llmProfileScope: jsonb("llm_profile_scope"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // IMPORTANT: placeholder stub. The REAL natural-key index is UNIQUE on
+    // (COALESCE(org_id, '__self_hosted__'), install_id) and is managed by raw
+    // SQL in migration 0171. Drizzle can't represent the COALESCE expression
+    // index, so this non-unique approximation carries the SAME NAME
+    // (`uq_connection_profile_state_org_install`) so the next `drizzle-kit
+    // generate` sees a name match and does NOT emit a spurious DROP/CREATE INDEX
+    // — mirrors the `semantic_profile_status` 0138 pattern. Never use Drizzle's
+    // query builder for ON CONFLICT on this table: the real target is the
+    // expression index and only exists in raw SQL — `connection-profile.ts` keys
+    // on it, NOT this stub.
+    index("uq_connection_profile_state_org_install").on(t.orgId, t.installId),
+    // Real group-scoped read index from 0171 — briefing + coverage list a group.
+    index("idx_connection_profile_state_org_group").on(t.orgId, t.connectionGroupId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Semantic entity versions (version history for rollback + diff)
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -242,6 +242,31 @@ void mock.module("@atlas/api/lib/db/datasource-registry-bridge", () => ({
   unregisterDatasourceInstall: mockBridgeUnregister,
 }));
 
+// Baseline-profile on-create hook (#4509) — installDatasource fires it
+// fire-and-forget after registering the pool. Mocking it lets the installer
+// tests assert the wiring (target passed through) WITHOUT loading the real
+// mcp-lifecycle graph or doing background live-connection work in an otherwise
+// fully-mocked suite. (The capability gate / REST-exclusion is unit-tested in
+// datasources/__tests__/connection-baseline.test.ts.)
+const baselineOnCreateCalls: Array<{
+  orgId: string;
+  installId: string;
+  connectionGroupId: string | null;
+  dbType: string;
+}> = [];
+const mockProfileConnectionOnCreate = mock(
+  async (target: { orgId: string; installId: string; connectionGroupId: string | null; dbType: string }) => {
+    baselineOnCreateCalls.push(target);
+    return { action: "scheduled" as const };
+  },
+);
+void mock.module("@atlas/api/lib/datasources/connection-baseline", () => ({
+  profileConnectionOnCreate: mockProfileConnectionOnCreate,
+  planConnectionBaseline: mock(async () => ({ profilable: true, capabilityKind: "native" as const })),
+  runBaselineProfile: mock(async () => {}),
+  ensureConnectionBaseline: mock(async () => null),
+}));
+
 // ---------------------------------------------------------------------------
 // Lazy import of the facade after mocks are in place
 // ---------------------------------------------------------------------------
@@ -267,6 +292,7 @@ function resetState() {
   twentyDeleteCalls.length = 0;
   bridgeRegisterCalls.length = 0;
   bridgeUnregisterCalls.length = 0;
+  baselineOnCreateCalls.length = 0;
   onUninstallHookCalls.length = 0;
   teardownSequence.length = 0;
   dispatchHandlers.clear();
@@ -1513,6 +1539,13 @@ describe("WorkspaceInstaller.installDatasource", () => {
       c.sql.includes("INSERT INTO workspace_plugins"),
     );
     expect(insertCall).toBeDefined();
+    // #4509 — after persisting + registering, the baseline-profile on-create
+    // hook fired with the resolved target (org, install id, group, dbType). The
+    // capability gate (REST/OpenAPI skip) is the hook's own concern, unit-tested
+    // in datasources/__tests__/connection-baseline.test.ts.
+    expect(baselineOnCreateCalls).toEqual([
+      { orgId: WSID, installId: "prod", connectionGroupId: "prod-cluster", dbType: "postgres" },
+    ]);
   });
 
   it("writes status='draft' when atlasMode is 'draft'", async () => {

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -136,6 +136,19 @@ function lazyGetInstallHandler(): (row: CatalogRowForDispatch) => PlatformInstal
   return mod.getInstallHandler;
 }
 
+// Lazy-`require` the baseline-profile hook, mirroring `lazyDatasourceBridge` /
+// `lazyInternalQuery` above: it keeps this installer's static import graph free
+// of the `connection-baseline → connection-profile → db/internal` chain and
+// keeps partial `mock.module` route tests loading cleanly. (`connection-baseline`
+// itself already keeps the heavy `mcp-lifecycle` graph lazy, so this is graph
+// hygiene + test-loader consistency — NOT a boot-cycle break.) Resolved once per
+// datasource install.
+type ConnectionBaselineModule = typeof import("@atlas/api/lib/datasources/connection-baseline");
+function lazyConnectionBaseline(): ConnectionBaselineModule {
+  // oxlint-disable-next-line @typescript-eslint/no-require-imports
+  return require("@atlas/api/lib/datasources/connection-baseline") as ConnectionBaselineModule;
+}
+
 const log = createLogger("workspace-installer");
 
 // ---------------------------------------------------------------------------
@@ -1549,6 +1562,43 @@ function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
         { workspaceId, catalogSlug, installId: input.installId, dbType: dryRun.dbType, status },
         "WorkspaceInstaller.installDatasource completed",
       );
+
+      // Baseline-profile a newly-created profilable connection (#4509) — no
+      // operator action. The hook is capability-gated (REST/OpenAPI + OAuth-
+      // managed types are skipped) and fire-and-forget: it re-resolves the live
+      // connection and runs the deterministic baseline in the background, records
+      // its own outcome durably, and never blocks or fails this install. The
+      // plugin form-install spine (`DatasourceFormInstallHandler` via
+      // `/install-form`, which INSERTs `workspace_plugins` directly rather than
+      // through this facade) is covered by the lazy backfill on first
+      // briefing/coverage need.
+      yield* Effect.sync(() => {
+        // Guard the SYNCHRONOUS lazy-`require` too: a module-load failure inside
+        // `Effect.sync` would surface as a defect that fails an install already
+        // persisted + registered above. `profileConnectionOnCreate` itself never
+        // throws/rejects (it returns a decision), so the `.catch` is
+        // belt-and-suspenders.
+        try {
+          void lazyConnectionBaseline()
+            .profileConnectionOnCreate({
+              orgId: workspaceId,
+              installId: input.installId,
+              connectionGroupId: input.groupId ?? null,
+              dbType: dryRun.dbType,
+            })
+            .catch((err) =>
+              log.warn(
+                { err: err instanceof Error ? err.message : String(err), installId: input.installId },
+                "Baseline profile on-create hook rejected unexpectedly",
+              ),
+            );
+        } catch (err) {
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err), installId: input.installId },
+            "Baseline profile on-create hook failed to schedule — deferring to lazy backfill",
+          );
+        }
+      });
 
       return shapeDatasourceRow({
         rowId,

--- a/packages/api/src/lib/semantic/__tests__/connection-profile-pg.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/connection-profile-pg.test.ts
@@ -1,0 +1,190 @@
+/**
+ * LIVE-Postgres round-trip for the connection profile-tier store (#4509).
+ *
+ * The unit suite (`connection-profile.test.ts`) string-matches the SQL, which
+ * proves intent but CANNOT prove the `ON CONFLICT (COALESCE(org_id,
+ * '__self_hosted__'), install_id)` target actually matches migration 0171's
+ * expression unique index — a drift there throws "no unique or exclusion
+ * constraint matching the ON CONFLICT specification" only at runtime, with every
+ * unit test green. This file executes the real upserts against Postgres to pin:
+ *   • both tiers converge on ONE (org, install_id) row;
+ *   • the baseline and LLM upserts are DISJOINT — neither clobbers the other's
+ *     columns;
+ *   • a re-profile FAILURE keeps the last good baseline facts + surfaces the error;
+ *   • a first-ever failure is visible (error row, no success facts);
+ *   • the NULL-owner (legacy self-hosted) row resolves through the COALESCE
+ *     sentinel — one bucket, not one row per NULL.
+ *
+ * Skips cleanly when `TEST_DATABASE_URL` is unset (CI sets it; opt in locally
+ * with `bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas`).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import type { TableProfile } from "@useatlas/types";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import {
+  upsertBaselineProfile,
+  recordBaselineError,
+  recordLlmProfileRun,
+  getConnectionProfileState,
+  getBaselineProfiles,
+  listConnectionProfileStates,
+} from "@atlas/api/lib/semantic/connection-profile";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+if (!TEST_DB_URL) {
+  console.warn(
+    "connection-profile-pg: TEST_DATABASE_URL unset — skipping live profile-tier round-trip (set it to opt in).",
+  );
+}
+
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+function fakeProfile(name: string): TableProfile {
+  return {
+    table_name: name,
+    object_type: "table",
+    row_count: 10,
+    columns: [],
+    primary_key_columns: [],
+    foreign_keys: [],
+    inferred_foreign_keys: [],
+    profiler_notes: [],
+    table_flags: {},
+  } as unknown as TableProfile;
+}
+
+describeIfPg("connection profile-tier store — live Postgres round-trip (#4509)", () => {
+  let pool: Pool;
+  const schemaName = `conn_prof_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  let prevDatabaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    prevDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = TEST_DB_URL;
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `connection-profile-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool as unknown as InternalPool);
+  }, PG_TEST_TIMEOUT_MS * 2);
+
+  afterAll(async () => {
+    _resetPool(null);
+    if (prevDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDatabaseUrl;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`).catch((err) => {
+      console.error(
+        `connection-profile-pg: schema cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+    await pool.end();
+  });
+
+  it("both tiers converge on ONE row; the baseline and LLM upserts are disjoint", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    const installId = "cn_prod";
+
+    await upsertBaselineProfile({
+      orgId,
+      installId,
+      connectionGroupId: "g_prod",
+      dbType: "postgres",
+      profiles: [fakeProfile("orders"), fakeProfile("customers")],
+    });
+    // A second upsert on the SAME (org, install) MUST hit ON CONFLICT (proves the
+    // expression index matches) rather than inserting a duplicate or throwing.
+    await recordLlmProfileRun({ orgId, installId, scope: { tables: ["orders"] } });
+
+    const rows = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM connection_profile_state WHERE org_id = $1 AND install_id = $2`,
+      [orgId, installId],
+    );
+    expect(rows.rows[0].n).toBe("1"); // one row, both tiers
+
+    const state = await getConnectionProfileState(orgId, installId);
+    expect(state?.baseline?.tableCount).toBe(2);
+    expect(state?.baseline?.profiledAt).toBeTruthy();
+    expect(state?.baselineError).toBeNull();
+    expect(state?.llm?.scope).toEqual({ tables: ["orders"] });
+    expect(state?.connectionGroupId).toBe("g_prod");
+
+    // The stored payload is readable for the coverage view.
+    const profiles = await getBaselineProfiles(orgId, installId);
+    expect(profiles?.map((p) => p.table_name)).toEqual(["orders", "customers"]);
+  });
+
+  it("a re-profile failure keeps the last good baseline facts and surfaces the error", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    const installId = "cn";
+    await upsertBaselineProfile({
+      orgId,
+      installId,
+      dbType: "postgres",
+      profiles: [fakeProfile("orders")],
+    });
+    await recordBaselineError({ orgId, installId, dbType: "postgres", error: "permission denied later" });
+
+    const state = await getConnectionProfileState(orgId, installId);
+    expect(state?.baseline?.tableCount).toBe(1); // last good facts survive
+    expect(state?.baselineError).toBe("permission denied later"); // latest failure visible
+    expect((await getBaselineProfiles(orgId, installId))?.length).toBe(1);
+  });
+
+  it("a first-ever failure is visible (error row, no success facts)", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    const installId = "cn_never";
+    await recordBaselineError({ orgId, installId, dbType: "postgres", error: "connect ECONNREFUSED" });
+
+    const state = await getConnectionProfileState(orgId, installId);
+    expect(state?.baseline).toBeNull();
+    expect(state?.baselineError).toBe("connect ECONNREFUSED");
+  });
+
+  it("the NULL-owner (legacy self-hosted) row resolves through the COALESCE sentinel", async () => {
+    const installId = `cn_self_hosted_${Math.floor(Math.random() * 1e9)}`;
+    await upsertBaselineProfile({
+      orgId: null,
+      installId,
+      dbType: "postgres",
+      profiles: [fakeProfile("t")],
+    });
+    // A second NULL-owner write on the same install MUST converge (one bucket),
+    // not insert a second row — the sentinel keeps NULLs from being distinct.
+    await recordLlmProfileRun({ orgId: null, installId, scope: { tables: ["t"] } });
+
+    const rows = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM connection_profile_state WHERE org_id IS NULL AND install_id = $1`,
+      [installId],
+    );
+    expect(rows.rows[0].n).toBe("1");
+
+    const state = await getConnectionProfileState(null, installId);
+    expect(state?.baseline?.tableCount).toBe(1);
+    expect(state?.llm?.scope).toEqual({ tables: ["t"] });
+  });
+
+  it("listConnectionProfileStates scopes to the workspace", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    await upsertBaselineProfile({ orgId, installId: "a", dbType: "postgres", profiles: [] });
+    await upsertBaselineProfile({ orgId, installId: "b", dbType: "postgres", profiles: [fakeProfile("x")] });
+
+    const states = await listConnectionProfileStates(orgId);
+    expect(states.map((s) => s.installId).sort()).toEqual(["a", "b"]);
+    expect(states.every((s) => s.orgId === orgId)).toBe(true);
+  });
+});

--- a/packages/api/src/lib/semantic/__tests__/connection-profile.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/connection-profile.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Connection profile-tier store (#4509).
+ *
+ * Pins the SQL contract of the baseline + LLM-profile upserts and the row→shape
+ * reads (so both tiers converge on ONE (org, install_id) row and freshness is
+ * readable), plus the pure `describeProfileFreshness` helper that feeds the
+ * briefing's "profiled N days ago" marker. Mocks `db/internal` so no live DB is
+ * needed — the repo's `internalQuery`-spy pattern (see `profile-status.test.ts`).
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { TableProfile } from "@useatlas/types";
+
+let mockHasDB = true;
+const dbCalls: Array<{ sql: string; params: unknown[] }> = [];
+let nextRows: Record<string, unknown>[] = [];
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasDB,
+  internalQuery: async (sql: string, params: unknown[]) => {
+    dbCalls.push({ sql, params });
+    return nextRows;
+  },
+  internalExecute: () => {},
+  getInternalDB: () => ({}),
+}));
+
+const {
+  upsertBaselineProfile,
+  recordBaselineError,
+  recordLlmProfileRun,
+  getConnectionProfileState,
+  getBaselineProfiles,
+  listConnectionProfileStates,
+  describeProfileFreshness,
+} = await import("../connection-profile");
+
+function fakeProfile(name: string): TableProfile {
+  return {
+    table_name: name,
+    object_type: "table",
+    row_count: 1,
+    columns: [],
+    primary_key_columns: [],
+    foreign_keys: [],
+    inferred_foreign_keys: [],
+    profiler_notes: [],
+    table_flags: {},
+  } as unknown as TableProfile;
+}
+
+beforeEach(() => {
+  mockHasDB = true;
+  dbCalls.length = 0;
+  nextRows = [];
+});
+
+describe("upsertBaselineProfile", () => {
+  it("writes the baseline tier keyed on the COALESCE sentinel, stamping now() and clearing the error", async () => {
+    await upsertBaselineProfile({
+      orgId: "org_1",
+      installId: "cn_prod",
+      connectionGroupId: "g_prod",
+      dbType: "postgres",
+      profiles: [fakeProfile("orders"), fakeProfile("customers")],
+    });
+
+    expect(dbCalls).toHaveLength(1);
+    const { sql, params } = dbCalls[0];
+    expect(sql).toContain("INSERT INTO connection_profile_state");
+    // Natural key = the same expression the raw-SQL unique index in 0171 uses.
+    expect(sql).toContain("ON CONFLICT (COALESCE(org_id, '__self_hosted__'), install_id)");
+    expect(sql).toContain("baseline_profiled_at = now()");
+    expect(sql).toContain("baseline_error = NULL");
+    // Touches ONLY the baseline tier on conflict (leaves the LLM tier alone).
+    expect(sql).not.toContain("llm_profiled_at");
+    expect(params[0]).toBe("org_1");
+    expect(params[1]).toBe("cn_prod");
+    expect(params[2]).toBe("g_prod");
+    expect(params[3]).toBe("postgres");
+    expect(JSON.parse(params[4] as string)).toHaveLength(2);
+    expect(params[5]).toBe(2); // denormalised table count
+  });
+
+  it("normalizes an empty-string group to null", async () => {
+    await upsertBaselineProfile({
+      orgId: "org_1",
+      installId: "cn",
+      connectionGroupId: "",
+      dbType: "mysql",
+      profiles: [],
+    });
+    expect(dbCalls[0].params[2]).toBeNull();
+  });
+
+  it("throws when no internal DB is configured", async () => {
+    mockHasDB = false;
+    await expect(
+      upsertBaselineProfile({ orgId: "o", installId: "c", dbType: "postgres", profiles: [] }),
+    ).rejects.toThrow(/Internal DB required/);
+  });
+});
+
+describe("recordBaselineError", () => {
+  it("records the visible failure reason without touching baseline_profiled_at or the payload", async () => {
+    await recordBaselineError({
+      orgId: "org_1",
+      installId: "cn",
+      dbType: "postgres",
+      error: "permission denied for schema public",
+    });
+    const { sql, params } = dbCalls[0];
+    expect(sql).toContain("baseline_error = EXCLUDED.baseline_error");
+    expect(sql).not.toContain("baseline_profiled_at");
+    expect(sql).not.toContain("baseline_profiles");
+    expect(params[4]).toBe("permission denied for schema public");
+  });
+});
+
+describe("recordLlmProfileRun", () => {
+  it("stamps llm_profiled_at now() + scope, touching ONLY the LLM tier", async () => {
+    await recordLlmProfileRun({
+      orgId: "org_1",
+      installId: "cn",
+      connectionGroupId: "g",
+      scope: { tables: ["orders"] },
+    });
+    const { sql, params } = dbCalls[0];
+    expect(sql).toContain("INSERT INTO connection_profile_state");
+    expect(sql).toContain("llm_profiled_at = now()");
+    expect(sql).toContain("ON CONFLICT (COALESCE(org_id, '__self_hosted__'), install_id)");
+    // The LLM run must PRESERVE (not clobber) a baseline-established group when
+    // the caller threads none — the COALESCE keeps a null EXCLUDED from nulling it.
+    expect(sql).toContain("COALESCE(EXCLUDED.connection_group_id, connection_profile_state.connection_group_id)");
+    // The LLM tier upsert must not clobber the baseline tier.
+    expect(sql).not.toContain("baseline_profiled_at");
+    expect(JSON.parse(params[3] as string)).toEqual({ tables: ["orders"] });
+  });
+
+  it("is a no-op (no DB call) when no internal DB is configured", async () => {
+    mockHasDB = false;
+    await recordLlmProfileRun({ orgId: "o", installId: "c", scope: { tables: [] } });
+    expect(dbCalls).toHaveLength(0);
+  });
+});
+
+describe("getConnectionProfileState", () => {
+  it("maps a row with both tiers, ISO-normalising the timestamps", async () => {
+    nextRows = [
+      {
+        install_id: "cn",
+        org_id: "org_1",
+        connection_group_id: "g",
+        db_type: "postgres",
+        baseline_table_count: 3,
+        baseline_profiled_at: new Date("2026-07-01T00:00:00.000Z"),
+        baseline_error: null,
+        llm_profiled_at: new Date("2026-07-05T00:00:00.000Z"),
+        llm_profile_scope: { tables: ["orders", "customers"] },
+      },
+    ];
+    const state = await getConnectionProfileState("org_1", "cn");
+    expect(state).toEqual({
+      installId: "cn",
+      orgId: "org_1",
+      connectionGroupId: "g",
+      dbType: "postgres",
+      baseline: { profiledAt: "2026-07-01T00:00:00.000Z", tableCount: 3 },
+      baselineError: null,
+      llm: { profiledAt: "2026-07-05T00:00:00.000Z", scope: { tables: ["orders", "customers"] } },
+    });
+    // Sentinel-keyed read so a legacy NULL-owner row resolves.
+    expect(dbCalls[0].sql).toContain("COALESCE(org_id, '__self_hosted__')");
+  });
+
+  it("returns null baseline/llm tiers for a never-profiled row", async () => {
+    nextRows = [
+      {
+        install_id: "cn",
+        org_id: null,
+        connection_group_id: null,
+        db_type: null,
+        baseline_table_count: null,
+        baseline_profiled_at: null,
+        baseline_error: null,
+        llm_profiled_at: null,
+        llm_profile_scope: null,
+      },
+    ];
+    const state = await getConnectionProfileState(null, "cn");
+    expect(state?.baseline).toBeNull();
+    expect(state?.baselineError).toBeNull();
+    expect(state?.llm).toBeNull();
+  });
+
+  it("surfaces a first-ever baseline failure (error set, no successful profile) — not 'never profiled'", async () => {
+    // recordBaselineError writes baseline_error WITHOUT stamping
+    // baseline_profiled_at, so the failure must be visible at the top level even
+    // though `baseline` (success facts) is null.
+    nextRows = [
+      {
+        install_id: "cn",
+        org_id: "org_1",
+        connection_group_id: "g",
+        db_type: "postgres",
+        baseline_table_count: null,
+        baseline_profiled_at: null,
+        baseline_error: "permission denied for schema public",
+        llm_profiled_at: null,
+        llm_profile_scope: null,
+      },
+    ];
+    const state = await getConnectionProfileState("org_1", "cn");
+    expect(state?.baseline).toBeNull();
+    expect(state?.baselineError).toBe("permission denied for schema public");
+  });
+
+  it("returns null when no row exists", async () => {
+    nextRows = [];
+    expect(await getConnectionProfileState("org_1", "missing")).toBeNull();
+  });
+
+  it("tolerates a malformed llm scope (returns scope=null, keeps freshness)", async () => {
+    nextRows = [
+      {
+        install_id: "cn",
+        org_id: "org_1",
+        connection_group_id: null,
+        db_type: "postgres",
+        baseline_table_count: 0,
+        baseline_profiled_at: null,
+        baseline_error: null,
+        llm_profiled_at: "2026-07-05T00:00:00.000Z",
+        llm_profile_scope: "junk",
+      },
+    ];
+    const state = await getConnectionProfileState("org_1", "cn");
+    expect(state?.llm).toEqual({ profiledAt: "2026-07-05T00:00:00.000Z", scope: null });
+  });
+
+  it("returns null when no internal DB is configured", async () => {
+    mockHasDB = false;
+    expect(await getConnectionProfileState("org_1", "cn")).toBeNull();
+    expect(dbCalls).toHaveLength(0);
+  });
+});
+
+describe("getBaselineProfiles", () => {
+  it("returns the stored TableProfile[] payload — the coverage view's data source", async () => {
+    nextRows = [{ baseline_profiles: [fakeProfile("orders")] }];
+    const profiles = await getBaselineProfiles("org_1", "cn");
+    expect(profiles).toHaveLength(1);
+    expect(profiles?.[0].table_name).toBe("orders");
+  });
+
+  it("returns null for an unprofiled / malformed payload", async () => {
+    nextRows = [{ baseline_profiles: null }];
+    expect(await getBaselineProfiles("org_1", "cn")).toBeNull();
+  });
+});
+
+describe("listConnectionProfileStates", () => {
+  it("scopes to the workspace and maps every row", async () => {
+    nextRows = [
+      {
+        install_id: "a",
+        org_id: "org_1",
+        connection_group_id: null,
+        db_type: "postgres",
+        baseline_table_count: 1,
+        baseline_profiled_at: "2026-07-01T00:00:00.000Z",
+        baseline_error: null,
+        llm_profiled_at: null,
+        llm_profile_scope: null,
+      },
+    ];
+    const states = await listConnectionProfileStates("org_1");
+    expect(states).toHaveLength(1);
+    expect(dbCalls[0].sql).toContain("COALESCE(org_id, '__self_hosted__')");
+    expect(dbCalls[0].params[0]).toBe("org_1");
+  });
+
+  it("returns [] with no internal DB", async () => {
+    mockHasDB = false;
+    expect(await listConnectionProfileStates("org_1")).toEqual([]);
+  });
+});
+
+describe("describeProfileFreshness", () => {
+  const now = new Date("2026-07-11T12:00:00.000Z");
+
+  it("labels a profile from today", () => {
+    expect(describeProfileFreshness("2026-07-11T01:00:00.000Z", now)).toEqual({
+      days: 0,
+      label: "profiled today",
+    });
+  });
+
+  it("labels one day ago in the singular", () => {
+    expect(describeProfileFreshness("2026-07-10T01:00:00.000Z", now)).toEqual({
+      days: 1,
+      label: "profiled 1 day ago",
+    });
+  });
+
+  it("labels N days ago", () => {
+    expect(describeProfileFreshness("2026-07-01T12:00:00.000Z", now)).toEqual({
+      days: 10,
+      label: "profiled 10 days ago",
+    });
+  });
+
+  it("clamps a future timestamp to today (never negative)", () => {
+    expect(describeProfileFreshness("2026-07-20T00:00:00.000Z", now)?.days).toBe(0);
+  });
+
+  it("returns null for an absent or malformed timestamp", () => {
+    expect(describeProfileFreshness(null, now)).toBeNull();
+    expect(describeProfileFreshness("not-a-date", now)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/semantic/connection-profile.ts
+++ b/packages/api/src/lib/semantic/connection-profile.ts
@@ -1,0 +1,323 @@
+/**
+ * Per-connection profile-tier state (#4509) — the durable store behind
+ * CONTEXT.md § Semantic improvement's two tiers of "knowing a connection":
+ *
+ *   • Baseline profile — cheap, deterministic (schema/types/counts/samples).
+ *     Runs automatically when a profilable connection is created (REST excluded)
+ *     and lazily backfills on first need. The `TableProfile[]` payload is stored
+ *     so the briefing's staleness marker and the coverage view read tracked data
+ *     WITHOUT re-querying the customer database just to start a chat.
+ *
+ *   • LLM profile — the enrichment pass. Never automatic, billing-gated, tracked
+ *     per connection: when it last ran and over what scope.
+ *
+ * This module is the DB seam only (store + typed reads + a pure freshness
+ * helper); the orchestration that RUNS a baseline (resolve live connection →
+ * profile → upsert) lives in `lib/datasources/connection-baseline.ts` so this
+ * layer stays free of the connection-resolution machinery and is trivially
+ * mockable via the `db/internal` `internalQuery`-spy pattern.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import type { TableProfile } from "@useatlas/types";
+
+/**
+ * What an LLM-profile (enrichment) run covered — the "over what" the issue
+ * tracks alongside "when". `tables` is the set the last run enriched; shaped as
+ * a list so a future batch enrich can record several at once.
+ */
+export interface LlmProfileScope {
+  readonly tables: readonly string[];
+}
+
+/** Baseline tier success facts — present only when a baseline has succeeded. */
+export interface BaselineProfileState {
+  /** ISO-8601 timestamp of the last successful baseline profile. */
+  readonly profiledAt: string;
+  /** Number of tables/objects in the stored payload. */
+  readonly tableCount: number;
+}
+
+/** LLM tier as surfaced to consumers. */
+export interface LlmProfileState {
+  /** ISO-8601 timestamp of the last enrichment run. */
+  readonly profiledAt: string;
+  /** What the last run covered, or `null` when unrecorded. */
+  readonly scope: LlmProfileScope | null;
+}
+
+/** Both tiers for one connection, with freshness readable per tier. */
+export interface ConnectionProfileState {
+  readonly installId: string;
+  readonly orgId: string | null;
+  readonly connectionGroupId: string | null;
+  readonly dbType: string | null;
+  /** Success facts of the last successful baseline; `null` until one succeeds. */
+  readonly baseline: BaselineProfileState | null;
+  /**
+   * The latest baseline FAILURE reason (DSN-scrubbed), surfaced INDEPENDENTLY of
+   * whether a prior success exists — so a first-ever baseline failure is VISIBLE
+   * (never indistinguishable from "never profiled"), and a re-profile failure
+   * after a success surfaces the reason alongside the last good `baseline` facts.
+   * `null` when the last baseline attempt succeeded or none has run.
+   */
+  readonly baselineError: string | null;
+  /** `null` until the first enrichment run is recorded. */
+  readonly llm: LlmProfileState | null;
+}
+
+/**
+ * The COALESCE sentinel that keeps a NULL-owner (legacy self-hosted) row a
+ * single bucket — MUST match the raw-SQL expression unique index in migration
+ * 0171 (`uq_connection_profile_state_org_install`).
+ */
+const SELF_HOSTED_SENTINEL = "__self_hosted__";
+const ON_CONFLICT = `(COALESCE(org_id, '${SELF_HOSTED_SENTINEL}'), install_id)`;
+
+/** Normalise undefined / "" → null so a "no scope" caller can't split buckets. */
+function normGroup(connectionGroupId: string | null | undefined): string | null {
+  return connectionGroupId == null || connectionGroupId === "" ? null : connectionGroupId;
+}
+
+/**
+ * Store a fresh baseline profile for one connection. Upserts ONLY the baseline
+ * columns (leaves the LLM tier untouched), stamps `baseline_profiled_at = now()`
+ * and CLEARS any prior `baseline_error`.
+ */
+export async function upsertBaselineProfile(input: {
+  orgId: string | null;
+  installId: string;
+  connectionGroupId?: string | null;
+  dbType: string;
+  profiles: readonly TableProfile[];
+}): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for connection profile state");
+  }
+  await internalQuery(
+    `INSERT INTO connection_profile_state
+       (org_id, install_id, connection_group_id, db_type,
+        baseline_profiles, baseline_table_count, baseline_profiled_at, baseline_error)
+     VALUES ($1, $2, $3, $4, $5::jsonb, $6, now(), NULL)
+     ON CONFLICT ${ON_CONFLICT}
+     DO UPDATE SET connection_group_id = EXCLUDED.connection_group_id,
+                   db_type = EXCLUDED.db_type,
+                   baseline_profiles = EXCLUDED.baseline_profiles,
+                   baseline_table_count = EXCLUDED.baseline_table_count,
+                   baseline_profiled_at = now(),
+                   baseline_error = NULL,
+                   updated_at = now()`,
+    [
+      input.orgId,
+      input.installId,
+      normGroup(input.connectionGroupId),
+      input.dbType,
+      JSON.stringify(input.profiles),
+      input.profiles.length,
+    ],
+  );
+}
+
+/**
+ * Record a baseline-profile FAILURE for one connection — the visible reason the
+ * auto/backfill profile couldn't complete. Leaves any prior successful baseline
+ * (payload + `baseline_profiled_at`) intact: a re-profile that fails keeps the
+ * last good facts and surfaces the new error.
+ */
+export async function recordBaselineError(input: {
+  orgId: string | null;
+  installId: string;
+  connectionGroupId?: string | null;
+  dbType: string;
+  error: string;
+}): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error("Internal DB required for connection profile state");
+  }
+  await internalQuery(
+    `INSERT INTO connection_profile_state
+       (org_id, install_id, connection_group_id, db_type, baseline_error)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT ${ON_CONFLICT}
+     DO UPDATE SET connection_group_id = EXCLUDED.connection_group_id,
+                   db_type = EXCLUDED.db_type,
+                   baseline_error = EXCLUDED.baseline_error,
+                   updated_at = now()`,
+    [input.orgId, input.installId, normGroup(input.connectionGroupId), input.dbType, input.error],
+  );
+}
+
+/**
+ * Record an LLM-profile (enrichment) run for one connection: stamps
+ * `llm_profiled_at = now()` and the run's scope. Upserts ONLY the LLM columns
+ * (leaves the baseline tier untouched). Fire-and-forget at the enrichment seam,
+ * so it swallows nothing but a missing internal DB (a no-op there).
+ */
+export async function recordLlmProfileRun(input: {
+  orgId: string | null;
+  installId: string;
+  connectionGroupId?: string | null;
+  scope: LlmProfileScope;
+}): Promise<void> {
+  if (!hasInternalDB()) return;
+  await internalQuery(
+    `INSERT INTO connection_profile_state
+       (org_id, install_id, connection_group_id, llm_profiled_at, llm_profile_scope)
+     VALUES ($1, $2, $3, now(), $4::jsonb)
+     ON CONFLICT ${ON_CONFLICT}
+     -- Preserve a baseline-recorded group when the enrichment caller doesn't
+     -- thread one (the wizard doesn't), so recording a run never NULLs the group
+     -- a prior baseline established — unlike the baseline upserts, which own it.
+     DO UPDATE SET connection_group_id = COALESCE(EXCLUDED.connection_group_id, connection_profile_state.connection_group_id),
+                   llm_profiled_at = now(),
+                   llm_profile_scope = EXCLUDED.llm_profile_scope,
+                   updated_at = now()`,
+    [input.orgId, input.installId, normGroup(input.connectionGroupId), JSON.stringify(input.scope)],
+  );
+}
+
+interface ProfileStateRow extends Record<string, unknown> {
+  install_id: string;
+  org_id: string | null;
+  connection_group_id: string | null;
+  db_type: string | null;
+  baseline_table_count: number | null;
+  baseline_profiled_at: Date | string | null;
+  baseline_error: string | null;
+  llm_profiled_at: Date | string | null;
+  llm_profile_scope: unknown;
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function parseScope(raw: unknown): LlmProfileScope | null {
+  // pg returns jsonb already parsed. Tolerate a malformed payload rather than
+  // throwing a read — a bad scope shouldn't hide a connection's freshness.
+  if (raw == null || typeof raw !== "object") return null;
+  const tables = (raw as { tables?: unknown }).tables;
+  if (!Array.isArray(tables)) return null;
+  return { tables: tables.filter((t): t is string => typeof t === "string") };
+}
+
+function mapRow(row: ProfileStateRow): ConnectionProfileState {
+  const baselineProfiledAt = toIso(row.baseline_profiled_at);
+  const llmProfiledAt = toIso(row.llm_profiled_at);
+  return {
+    installId: row.install_id,
+    orgId: row.org_id,
+    connectionGroupId: row.connection_group_id,
+    dbType: row.db_type,
+    baseline: baselineProfiledAt
+      ? {
+          profiledAt: baselineProfiledAt,
+          tableCount: typeof row.baseline_table_count === "number" ? row.baseline_table_count : 0,
+        }
+      : null,
+    // Surfaced at the top level, NOT nested under `baseline`, so a first-ever
+    // failure (baseline_error set, baseline_profiled_at still NULL) is visible.
+    baselineError: row.baseline_error,
+    llm: llmProfiledAt ? { profiledAt: llmProfiledAt, scope: parseScope(row.llm_profile_scope) } : null,
+  };
+}
+
+const STATE_COLUMNS = `install_id, org_id, connection_group_id, db_type,
+       baseline_table_count, baseline_profiled_at, baseline_error,
+       llm_profiled_at, llm_profile_scope`;
+
+/**
+ * Read one connection's profile-tier state (both tiers + freshness). Returns
+ * `null` when there's no row (never profiled) or no internal DB. Keyed on the
+ * same COALESCE sentinel as the write path so a legacy NULL-owner row resolves.
+ */
+export async function getConnectionProfileState(
+  orgId: string | null,
+  installId: string,
+): Promise<ConnectionProfileState | null> {
+  if (!hasInternalDB()) return null;
+  const rows = await internalQuery<ProfileStateRow>(
+    `SELECT ${STATE_COLUMNS}
+       FROM connection_profile_state
+      WHERE COALESCE(org_id, '${SELF_HOSTED_SENTINEL}') = COALESCE($1, '${SELF_HOSTED_SENTINEL}')
+        AND install_id = $2
+      LIMIT 1`,
+    [orgId, installId],
+  );
+  const row = rows[0];
+  return row ? mapRow(row) : null;
+}
+
+/**
+ * Read the stored baseline `TableProfile[]` payload for one connection — the
+ * coverage view's data source (the physical schema matched against the semantic
+ * store). Returns `null` when unprofiled / no internal DB, and tolerates a
+ * NON-ARRAY payload by returning `null` (the caller triggers a re-profile). The
+ * cast trusts element shape: the payload is origin-written by
+ * {@link upsertBaselineProfile} from real `TableProfile[]`, never user input.
+ *
+ * This module is a deliberately logger-free DB seam, so a persistently-corrupt
+ * payload degrades silently to "unprofiled" — an acceptable trade for diagnostic
+ * metadata; the re-profile a reader triggers is the recovery path.
+ */
+export async function getBaselineProfiles(
+  orgId: string | null,
+  installId: string,
+): Promise<TableProfile[] | null> {
+  if (!hasInternalDB()) return null;
+  const rows = await internalQuery<{ baseline_profiles: unknown }>(
+    `SELECT baseline_profiles
+       FROM connection_profile_state
+      WHERE COALESCE(org_id, '${SELF_HOSTED_SENTINEL}') = COALESCE($1, '${SELF_HOSTED_SENTINEL}')
+        AND install_id = $2
+      LIMIT 1`,
+    [orgId, installId],
+  );
+  const payload = rows[0]?.baseline_profiles;
+  if (!Array.isArray(payload)) return null;
+  return payload as TableProfile[];
+}
+
+/**
+ * List every tracked connection profile state for a workspace — the briefing /
+ * coverage-overview read. Empty when no internal DB.
+ */
+export async function listConnectionProfileStates(orgId: string | null): Promise<ConnectionProfileState[]> {
+  if (!hasInternalDB()) return [];
+  const rows = await internalQuery<ProfileStateRow>(
+    `SELECT ${STATE_COLUMNS}
+       FROM connection_profile_state
+      WHERE COALESCE(org_id, '${SELF_HOSTED_SENTINEL}') = COALESCE($1, '${SELF_HOSTED_SENTINEL}')
+      ORDER BY connection_group_id NULLS FIRST, install_id`,
+    [orgId],
+  );
+  return rows.map(mapRow);
+}
+
+/** Human-readable freshness for a tracked timestamp. */
+export interface ProfileFreshness {
+  /** Whole days since the profile ran (0 = today; negative clamps to 0). */
+  readonly days: number;
+  /** "profiled today" / "profiled 1 day ago" / "profiled N days ago". */
+  readonly label: string;
+}
+
+/**
+ * Pure freshness helper — feeds the briefing's "profiled N days ago" staleness
+ * marker. `now` is injected so it's deterministic under test. Returns `null` for
+ * an absent/malformed timestamp (never profiled).
+ */
+export function describeProfileFreshness(
+  profiledAtIso: string | null,
+  now: Date,
+): ProfileFreshness | null {
+  if (!profiledAtIso) return null;
+  const then = new Date(profiledAtIso);
+  if (Number.isNaN(then.getTime())) return null;
+  const days = Math.max(0, Math.floor((now.getTime() - then.getTime()) / 86_400_000));
+  const label =
+    days === 0 ? "profiled today" : days === 1 ? "profiled 1 day ago" : `profiled ${days} days ago`;
+  return { days, label };
+}


### PR DESCRIPTION
Closes #4509 · Parent PRD #4502 · Milestone v0.0.48

## What

Two tracked tiers of "knowing a connection" (CONTEXT.md § Semantic improvement):

- **Baseline profile** — cheap, deterministic (schema/types/counts/samples via the unified profiler capability). Runs **automatically when a profilable connection is created** (REST/OpenAPI + OAuth-managed types excluded by the capability gate); pre-existing connections **backfill lazily on first need**, never a bulk sweep.
- **LLM profile** (enrichment) — never automatic, stays **billing-gated**, tracked per connection (when it last ran + over what scope).

Connection profile state exposes both tiers with freshness ("profiled N days ago"), consumable by the briefing's staleness marker (#4514) and the coverage view (#4521) — served from tracked data, never re-querying the customer DB to start a chat.

## How

- **Store** `lib/semantic/connection-profile.ts` + migration `0171` (`connection_profile_state`, one row per `(org, install_id)` via a COALESCE sentinel) + Drizzle mirror. Baseline `TableProfile[]` payload + `baseline_profiled_at`, a **top-level `baselineError`** (DSN-scrubbed, visible even on a first-ever failure), and `llm_profiled_at` + `llm_profile_scope`.
- **Orchestration** `lib/datasources/connection-baseline.ts`: `planConnectionBaseline` (capability decision, keyed on the same `resolveProfileCapabilityByDbType` provisioning uses), `runBaselineProfile` (resolve live connection → `conn.profile()` → upsert; **total — records a visible error, never throws**), `ensureConnectionBaseline` (lazy backfill, success-memoized), `profileConnectionOnCreate` (fire-and-forget hook).
- **Wiring**: the hook fires at `WorkspaceInstaller.installDatasource` (covers MCP `create_datasource` for all profilable types + admin native create); the plugin form-install spine is covered by the lazy backfill. `recordLlmProfileRun` fires at the billing-gated wizard/enrich route.

## Acceptance criteria

- [x] Creating a profilable connection produces a baseline profile without operator action; creating a REST datasource does not
- [x] A pre-existing unprofiled connection backfills on first need, not via a bulk sweep
- [x] LLM-profile runs are recorded per connection (timestamp, scope); no implicit enrichment anywhere
- [x] Profile freshness readable per connection (feeds "profiled N days ago")
- [x] Tests at the connection-creation hook seam for both dbType classes

## Tests

- Store SQL contract + pure freshness helper (unit) **and a live-Postgres round-trip** (`connection-profile-pg.test.ts`) proving the `ON CONFLICT` expression matches the 0171 index, disjoint baseline/LLM upserts, re-profile-keeps-facts, first-failure visibility, and the NULL-owner sentinel bucket.
- Hook seam for both dbType classes; `runBaselineProfile` incl. **DSN-scrub** + **resolver-throw totality**; lazy backfill (success-memoize + failure-retry).
- Enrich route records the LLM run (install_id + scope); installer fires the hook with the resolved target; a **billing-blocked enrich records nothing**.
- Migration bookkeeping: both `db/` and `auth/` migrate tests updated (count 171→172 + 0171 in both applied-lists).

## Review

Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy), 2 rounds: round 1 CHANGES REQUESTED → round 2 CLEAN. Addressed a HIGH secret-scrub leak (`baseline_error` now routed through `errorMessage()`), non-throwing orchestration, the first-ever-failure-visible invariant, and comment accuracy (NULL-owner semantics, lazy-require rationale).

Local `/ci`: all 29 non-test gates pass; full API suite 876/877 on a clean Postgres (the one failure is the unrelated pre-existing `ai-saas.test.ts` flake). `migrate-pg` replays 0171 end-to-end against real Postgres.
