### PR TITLE
feat(semantic-improve): dialect specialist registry — engine prompt modules keyed by dbType (#4515)

### DIFF
--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -142,6 +142,7 @@ void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   setContextFragments: () => {},
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setDialectHints: () => {},
 }));
 

--- a/packages/api/src/api/__tests__/chat-stop.test.ts
+++ b/packages/api/src/api/__tests__/chat-stop.test.ts
@@ -124,6 +124,7 @@ void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   setContextFragments: () => {},
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setDialectHints: () => {},
 }));
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -198,6 +198,7 @@ void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   setContextFragments: () => {},
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setDialectHints: () => {},
 }));
 

--- a/packages/api/src/lib/__tests__/agent-answer-style-prompt-shape.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-prompt-shape.test.ts
@@ -49,6 +49,7 @@ void mock.module("@atlas/api/lib/semantic", () => ({
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setContextFragments: () => {},
   setDialectHints: () => {},
   setPluginTools: () => {},

--- a/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
+++ b/packages/api/src/lib/__tests__/agent-answer-style-workspace-default.test.ts
@@ -63,6 +63,7 @@ void mock.module("@atlas/api/lib/semantic", () => ({
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setContextFragments: () => {},
   setDialectHints: () => {},
   setPluginTools: () => {},

--- a/packages/api/src/lib/__tests__/agent-cache.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cache.test.ts
@@ -462,7 +462,11 @@ describe("buildSystemParam — multi-source", () => {
     expect(content).toContain("connectionId");
   });
 
-  test("mixed Postgres+MySQL: includes MySQL dialect guide", () => {
+  test("mixed Postgres+MySQL: multi-source section lists both engines", () => {
+    // #4515 — the MySQL dialect guide is no longer auto-appended by
+    // buildSystemParam; it is a composed section threaded by runAgent (asserted
+    // in dialect-specialist.test.ts). The multi-source listing still names each
+    // engine.
     mockEntries.push(
       { id: "default", dbType: "postgres" },
       { id: "legacy", dbType: "mysql", description: "Legacy MySQL" },
@@ -471,11 +475,10 @@ describe("buildSystemParam — multi-source", () => {
     const result = buildSystemParam("openai");
     const content = typeof result === "string" ? result : result.content;
     expect(content).toContain("Available Data Sources");
-    expect(content).toContain("SQL Dialect: MySQL");
     expect(content).toContain("**legacy** (MySQL) — Legacy MySQL");
   });
 
-  test("all-Postgres multi-connection: no MySQL guide, still has multi-source section", () => {
+  test("all-Postgres multi-connection: multi-source section, no auto-appended dialect", () => {
     mockEntries.push(
       { id: "default", dbType: "postgres" },
       { id: "secondary", dbType: "postgres" },
@@ -499,13 +502,15 @@ describe("buildSystemParam — multi-source", () => {
     expect(content).not.toContain("**bare** (PostgreSQL) —");
   });
 
-  test("single MySQL connection: includes MySQL dialect guide (backward compat)", () => {
+  test("single MySQL connection: single-source path (no multi-source section)", () => {
     mockEntries.push({ id: "default", dbType: "mysql" });
 
     const result = buildSystemParam("openai");
     const content = typeof result === "string" ? result : result.content;
     expect(content).not.toContain("Available Data Sources");
-    expect(content).toContain("SQL Dialect: MySQL");
+    // #4515 — dialect guide is a composed section threaded by runAgent, not
+    // auto-appended here; buildSystemParam appends only what it is passed.
+    expect(content).not.toContain("SQL Dialect: MySQL");
   });
 
   test("multi-source with cross-source joins: includes Cross-Source Relationships section", () => {

--- a/packages/api/src/lib/__tests__/agent-dialect-specialist-resolve.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect-specialist-resolve.test.ts
@@ -1,0 +1,121 @@
+/**
+ * #4515 — unit test for `resolveConversationDialectSpecialists`, the reach →
+ * dbType → composition bridge that feeds the dialect-specialist section into the
+ * conversation. The pure composition is covered in dialect-specialist.test.ts
+ * and the end-to-end prompt placement in agent-dialect-specialist-seam.test.ts;
+ * this pins the reach-resolution branch the seam test's no-orgId path can't
+ * reach: workspace-present group→engine mapping, the fail-closed empty-reach and
+ * fail-closed catch paths.
+ */
+
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import type { ConnectionMetadata } from "../db/connection";
+import type { VisibleGroup } from "../group-reach";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// --- Mutable fixtures ---
+let mockEntries: ConnectionMetadata[] = [];
+let mockReachable: readonly VisibleGroup[] = [];
+let reachThrows = false;
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      describe: () => mockEntries.map((e) => ({ ...e })),
+    },
+  }),
+);
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+void mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => [],
+  pluginDialectModules: () => [],
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+void mock.module("@atlas/api/lib/group-reach/resolve", () => ({
+  resolveReachableGroups: async () => {
+    if (reachThrows) throw new Error("whitelist scan failed");
+    return { reachableGroups: mockReachable, reason: "all-visible", warnings: [] };
+  },
+}));
+
+const { resolveConversationDialectSpecialists } = await import("@atlas/api/lib/agent");
+
+function group(id: string, members: string[]): VisibleGroup {
+  return { id, members, primary: members[0] ?? id };
+}
+
+describe("resolveConversationDialectSpecialists — reach branch (#4515)", () => {
+  beforeEach(() => {
+    mockEntries = [];
+    mockReachable = [];
+    reachThrows = false;
+  });
+
+  test("workspace present: maps each reachable group to its primary connection's engine, attributed per group", async () => {
+    mockEntries = [
+      { id: "us", dbType: "postgres" },
+      { id: "eu", dbType: "clickhouse" },
+    ];
+    mockReachable = [group("us", ["us"]), group("eu", ["eu"])];
+
+    const out = await resolveConversationDialectSpecialists("org-1", "published", { kind: "all" });
+    expect(out).toContain("## SQL Dialect: PostgreSQL — group `us`");
+    expect(out).toContain("## SQL Dialect: ClickHouse — group `eu`");
+  });
+
+  test("workspace present: falls back to a member engine when the primary is unregistered", async () => {
+    mockEntries = [{ id: "warehouse-replica", dbType: "mysql" }];
+    // primary `warehouse` has no registered connection; a member does.
+    mockReachable = [group("warehouse", ["warehouse", "warehouse-replica"])];
+
+    const out = await resolveConversationDialectSpecialists("org-1", "published", { kind: "all" });
+    // Single reachable group ⇒ the module resolves (via the member-engine
+    // fallback) but carries no per-group attribution suffix.
+    expect(out).toContain("## SQL Dialect: MySQL");
+    expect(out).not.toContain("— group");
+  });
+
+  test("workspace present, empty reachable set: composes nothing (fails closed like the catalog)", async () => {
+    mockEntries = [{ id: "us", dbType: "postgres" }];
+    mockReachable = [];
+
+    const out = await resolveConversationDialectSpecialists("org-1", "published", { kind: "all" });
+    expect(out).toBe("");
+  });
+
+  test("workspace present, reach resolution throws: composes nothing (fail closed), never fans out to all connections", async () => {
+    mockEntries = [
+      { id: "us", dbType: "postgres" },
+      { id: "eu", dbType: "clickhouse" },
+    ];
+    reachThrows = true;
+
+    const out = await resolveConversationDialectSpecialists("org-1", "published", { kind: "all" });
+    expect(out).toBe("");
+  });
+
+  test("no workspace: each visible connection stands as its own group-of-one", async () => {
+    mockEntries = [{ id: "default", dbType: "mysql" }];
+
+    const out = await resolveConversationDialectSpecialists(undefined, undefined, { kind: "all" });
+    expect(out).toContain("## SQL Dialect: MySQL");
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-dialect-specialist-seam.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect-specialist-seam.test.ts
@@ -1,0 +1,186 @@
+/**
+ * #4515 — mock-LLM seam test for dialect-specialist prompt placement.
+ *
+ * The registry + composition logic is unit-tested in dialect-specialist.test.ts;
+ * this file pins the SEAM ABOVE it: a full `runAgent` turn composes the dialect
+ * specialist(s) for the connections in scope and lands them in the system prompt
+ * the LLM actually receives — one module per engine, attributed per group under a
+ * cross-group sweep, plugin modules winning over core. Mirrors the mock-LLM shape
+ * of agent-expert-persona-prompt.test.ts.
+ *
+ * runAgent runs with NO request context here, so `orgId` is undefined and the
+ * resolver takes its connection-based fallback: each agent-visible connection
+ * stands as its own group-of-one (group id = connection id). That exercises the
+ * single-source, multi-source-attribution, and plugin-precedence paths without a
+ * DB.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { PluginDialectModule } from "@atlas/api/lib/dialect-specialist";
+
+// --- Mutable fixtures the mocks read ---
+let mockEntries: { id: string; dbType: string; description?: string }[] = [
+  { id: "default", dbType: "postgres" },
+];
+let mockPluginModules: PluginDialectModule[] = [];
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      describe: () => mockEntries.map((e) => ({ ...e })),
+    },
+  }),
+);
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+void mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => [],
+  pluginDialectModules: () => mockPluginModules,
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  buildRetrievalQuery: () => "",
+  getRetrievalTurns: () => 3,
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
+  resolveOrgKnowledgeSection: async () => "",
+}));
+
+let lastSystemPrompt: string | undefined;
+
+function extractSystemPrompt(opts: unknown): string | undefined {
+  const prompt = (opts as { prompt?: ReadonlyArray<{ role: string; content: unknown }> })?.prompt;
+  const systemMsg = Array.isArray(prompt) ? prompt.find((p) => p.role === "system") : undefined;
+  if (!systemMsg) return undefined;
+  const content = systemMsg.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((c) => (c as { text?: string })?.text ?? "").join("");
+  }
+  return "";
+}
+
+function makeSpyingModel(): InstanceType<typeof MockLanguageModelV3> {
+  const parts: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "ok" },
+    {
+      type: "finish",
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 20, text: 20, reasoning: undefined },
+      },
+      finishReason: { unified: "stop", raw: "end_turn" },
+    },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async (opts: unknown) => {
+      const content = extractSystemPrompt(opts);
+      if (content) lastSystemPrompt = content;
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+
+function userMessages(text: string): UIMessage[] {
+  return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text }] }];
+}
+
+async function runTurn(): Promise<string> {
+  lastSystemPrompt = undefined;
+  const result = await runAgent({
+    messages: userMessages("How many orders last month?"),
+    aiModel: {
+      model: makeSpyingModel(),
+      providerType: "openai",
+      modelId: "mock-dialect-seam-model",
+    },
+  });
+  await result.text;
+  expect(lastSystemPrompt).toBeDefined();
+  return lastSystemPrompt ?? "";
+}
+
+describe("runAgent — dialect-specialist prompt placement (#4515)", () => {
+  beforeEach(() => {
+    mockEntries = [{ id: "default", dbType: "postgres" }];
+    mockPluginModules = [];
+  });
+
+  it("single Postgres connection: composes the Postgres module (no group attribution)", async () => {
+    const prompt = await runTurn();
+    expect(prompt).toContain("## SQL Dialect: PostgreSQL");
+    expect(prompt).not.toContain("— group");
+  });
+
+  it("single MySQL connection: composes the MySQL module", async () => {
+    mockEntries = [{ id: "default", dbType: "mysql" }];
+    const prompt = await runTurn();
+    expect(prompt).toContain("## SQL Dialect: MySQL");
+    // The MySQL module's sargability-aware content rides through the seam.
+    expect(prompt).toContain("col >= '2024-01-01' AND col < '2025-01-01'");
+  });
+
+  it("unknown engine composes cleanly — no dialect section", async () => {
+    mockEntries = [{ id: "default", dbType: "sparksql" }];
+    const prompt = await runTurn();
+    expect(prompt).not.toContain("## SQL Dialect:");
+  });
+
+  it("cross-source: composes several modules, each attributed to its group", async () => {
+    mockEntries = [
+      { id: "default", dbType: "postgres" },
+      { id: "legacy", dbType: "mysql", description: "Legacy MySQL" },
+    ];
+    const prompt = await runTurn();
+    expect(prompt).toContain("## SQL Dialect: PostgreSQL — group `default`");
+    expect(prompt).toContain("## SQL Dialect: MySQL — group `legacy`");
+    // The specialist section sits after the Available Data Sources listing.
+    expect(prompt.indexOf("## SQL Dialect:")).toBeGreaterThan(
+      prompt.indexOf("## Available Data Sources"),
+    );
+  });
+
+  it("a plugin module composes for its engine and wins over the core module", async () => {
+    mockEntries = [{ id: "ch", dbType: "clickhouse" }];
+    mockPluginModules = [
+      { dbType: "clickhouse", module: "PLUGIN clickhouse guidance — arrayFlatten()." },
+    ];
+    const prompt = await runTurn();
+    expect(prompt).toContain("## SQL Dialect: ClickHouse");
+    expect(prompt).toContain("PLUGIN clickhouse guidance — arrayFlatten().");
+    // The core ClickHouse module's signature line is superseded by the plugin's.
+    expect(prompt).not.toContain("toStartOfMonth");
+  });
+});

--- a/packages/api/src/lib/__tests__/agent-dialect.test.ts
+++ b/packages/api/src/lib/__tests__/agent-dialect.test.ts
@@ -1,11 +1,8 @@
 import { describe, test, expect, beforeEach, mock } from "bun:test";
 import type { ConnectionMetadata } from "../db/connection";
-import type { DialectHint } from "../plugins/wiring";
 import { createConnectionMock } from "@atlas/api/testing/connection";
 
 // --- Mutable state for tests ---
-let mockDialectHints: readonly DialectHint[] = [];
-
 const mockEntries: ConnectionMetadata[] = [];
 
 function resetMockEntries() {
@@ -45,7 +42,8 @@ void mock.module("@atlas/api/lib/semantic", () => ({
 
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
-  getDialectHints: () => mockDialectHints,
+  getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setContextFragments: () => {},
   setDialectHints: () => {},
   setPluginTools: () => {},
@@ -62,85 +60,64 @@ void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   _resetPatternCache: () => {},
 }));
 
-// #3633 — agent.ts assembles the org-knowledge block via this module.
 void mock.module("@atlas/api/lib/learn/org-knowledge-section", () => ({
   resolveOrgKnowledgeSection: async () => "",
 }));
 
 const { buildSystemParam } = await import("@atlas/api/lib/agent");
 
-describe("appendDialectHints", () => {
+function assemble(dialectSpecialists?: string): string {
+  const result = buildSystemParam("openai", { dialectSpecialists });
+  return typeof result === "string" ? result : result.content;
+}
+
+// #4515 — the dialect-specialist section is composed by runAgent and threaded
+// into buildSystemParam as the `dialectSpecialists` string (the sibling of the
+// answer-style / persona seams). buildSystemParam no longer resolves dialect
+// from the connection registry or plugin hints itself — it appends exactly what
+// it is handed. The composition + registry logic is exercised in
+// dialect-specialist.test.ts.
+describe("buildSystemParam — dialectSpecialists seam", () => {
   beforeEach(() => {
     resetMockEntries();
-    mockDialectHints = [];
   });
 
-  test("no hints: prompt has no 'Additional SQL Dialect Notes' section", () => {
-    mockDialectHints = [];
-    const result = buildSystemParam("openai");
-    const content = typeof result === "string" ? result : result.content;
-    expect(content).not.toContain("Additional SQL Dialect Notes");
+  test("omitted: no dialect section is appended", () => {
+    const content = assemble(undefined);
+    expect(content).not.toContain("## SQL Dialect:");
   });
 
-  test("single hint: prompt includes dialect text", () => {
-    mockDialectHints = [{ pluginId: "bq", dialect: "Use SAFE_DIVIDE for BigQuery division." }];
-    const result = buildSystemParam("openai");
-    const content = typeof result === "string" ? result : result.content;
-    expect(content).toContain("## Additional SQL Dialect Notes");
-    expect(content).toContain("Use SAFE_DIVIDE for BigQuery division.");
+  test("empty string: no dialect section is appended", () => {
+    const content = assemble("");
+    expect(content).not.toContain("## SQL Dialect:");
   });
 
-  test("multiple hints: joined with double newline", () => {
-    mockDialectHints = [
-      { pluginId: "bq", dialect: "BigQuery: use SAFE_DIVIDE." },
-      { pluginId: "redshift", dialect: "Redshift: use GETDATE()." },
-    ];
-    const result = buildSystemParam("openai");
-    const content = typeof result === "string" ? result : result.content;
-    expect(content).toContain("## Additional SQL Dialect Notes");
-    expect(content).toContain("BigQuery: use SAFE_DIVIDE.");
-    expect(content).toContain("Redshift: use GETDATE().");
-    // The two hints should be separated by double newline
-    const section = content.split("## Additional SQL Dialect Notes")[1];
-    expect(section).toContain("BigQuery: use SAFE_DIVIDE.\n\nRedshift: use GETDATE().");
+  test("provided: the composed section is appended verbatim", () => {
+    const section = "## SQL Dialect: ClickHouse\nUse toStartOfMonth().";
+    const content = assemble(section);
+    expect(content).toContain(section);
   });
 
-  test("hints are appended after dialect guide for MySQL", () => {
+  test("provided under a MySQL workspace: the passed section drives the dialect text", () => {
     mockEntries.length = 0;
     mockEntries.push({ id: "default", dbType: "mysql" });
-    mockDialectHints = [{ pluginId: "custom", dialect: "Custom MySQL note." }];
-
-    const result = buildSystemParam("openai");
-    const content = typeof result === "string" ? result : result.content;
-    expect(content).toContain("SQL Dialect: MySQL");
-    expect(content).toContain("## Additional SQL Dialect Notes");
-    expect(content).toContain("Custom MySQL note.");
-    // Dialect notes should come after the MySQL guide
-    const mysqlIdx = content.indexOf("SQL Dialect: MySQL");
-    const hintsIdx = content.indexOf("Additional SQL Dialect Notes");
-    expect(hintsIdx).toBeGreaterThan(mysqlIdx);
+    const section = "## SQL Dialect: MySQL\nUse DATE_FORMAT(...).";
+    const content = assemble(section);
+    expect(content).toContain("## SQL Dialect: MySQL");
+    expect(content).toContain("Use DATE_FORMAT(...).");
   });
 
-  test("extracts .dialect from DialectHint, not pluginId", () => {
-    mockDialectHints = [{ pluginId: "should-not-appear", dialect: "Only this text." }];
-    const result = buildSystemParam("openai");
-    const content = typeof result === "string" ? result : result.content;
-    expect(content).toContain("Only this text.");
-    expect(content).not.toContain("should-not-appear");
-  });
-
-  test.each([
-    ["clickhouse", "SQL Dialect: ClickHouse"],
-    ["snowflake", "SQL Dialect: Snowflake"],
-    ["duckdb", "SQL Dialect: DuckDB"],
-    ["salesforce", "Query Language: Salesforce SOQL"],
-  ])("non-core dbType %s without plugin hints omits hardcoded guide", (dbType, oldHeader) => {
+  test("multi-connection: section appended after the Available Data Sources listing", () => {
     mockEntries.length = 0;
-    mockEntries.push({ id: "default", dbType: dbType as "clickhouse" | "snowflake" | "duckdb" | "salesforce" });
-    mockDialectHints = [];
-
-    const result = buildSystemParam("openai");
-    const content = typeof result === "string" ? result : result.content;
-    expect(content).not.toContain(oldHeader);
+    mockEntries.push(
+      { id: "default", dbType: "postgres" },
+      { id: "legacy", dbType: "mysql", description: "Legacy MySQL" },
+    );
+    const section = "## SQL Dialect: MySQL — group `legacy`\nUse DATE_FORMAT(...).";
+    const content = assemble(section);
+    expect(content).toContain("## Available Data Sources");
+    const sourcesIdx = content.indexOf("## Available Data Sources");
+    const dialectIdx = content.indexOf("## SQL Dialect: MySQL");
+    expect(dialectIdx).toBeGreaterThan(sourcesIdx);
   });
 });

--- a/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-expert-persona-prompt.test.ts
@@ -52,6 +52,7 @@ void mock.module("@atlas/api/lib/semantic", () => ({
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setContextFragments: () => {},
   setDialectHints: () => {},
   setPluginTools: () => {},

--- a/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
@@ -58,6 +58,7 @@ void mock.module("@atlas/api/lib/semantic", () => ({
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
   getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setContextFragments: () => {},
   setDialectHints: () => {},
   setPluginTools: () => {},
@@ -108,12 +109,13 @@ describe("#2505 agent system prompt — default connection visibility by deployM
     expect(content).not.toContain("- **default**");
   });
 
-  test("SaaS [default + warehouse]: filter drops to one entry, single-source dialect path runs on the survivor", () => {
+  test("SaaS [default + warehouse]: filter drops to one entry, single-source path runs on the survivor", () => {
     // Regression guard: filtering happens BEFORE the `meta.length <= 1`
     // branch, so dropping `default` from a 2-entry registry routes the
-    // prompt through the single-source path. The dialect must come from
-    // the survivor (warehouse), not from `default`. Using mysql for the
-    // survivor here so the dialect guide is observable in the prompt.
+    // prompt through the single-source path — no "Available Data Sources"
+    // multi-source section. (Post-#4515 the dialect guide is a separate
+    // composed section threaded by runAgent, covered in
+    // dialect-specialist.test.ts, not auto-appended by buildSystemParam.)
     mockConfigOverride = { deployMode: "saas" };
     mockEntries.length = 0;
     mockEntries.push({ id: "default", dbType: "postgres", description: "Shared demo" });
@@ -122,7 +124,6 @@ describe("#2505 agent system prompt — default connection visibility by deployM
     const content = typeof result === "string" ? result : result.content;
     expect(content).not.toContain("- **default**");
     expect(content).not.toContain("## Available Data Sources");
-    expect(content).toContain("SQL Dialect: MySQL");
   });
 
   test("self-hosted (explicit): 'default' remains visible to the agent", () => {

--- a/packages/api/src/lib/__tests__/agent-sargability.test.ts
+++ b/packages/api/src/lib/__tests__/agent-sargability.test.ts
@@ -1,11 +1,8 @@
 import { describe, test, expect, beforeEach, mock } from "bun:test";
 import type { ConnectionMetadata } from "../db/connection";
-import type { DialectHint } from "../plugins/wiring";
 import { createConnectionMock } from "@atlas/api/testing/connection";
 
 // --- Mutable state for tests ---
-let mockDialectHints: readonly DialectHint[] = [];
-
 const mockEntries: ConnectionMetadata[] = [];
 
 function resetMockEntries() {
@@ -45,7 +42,8 @@ void mock.module("@atlas/api/lib/semantic", () => ({
 
 void mock.module("@atlas/api/lib/plugins/tools", () => ({
   getContextFragments: () => [],
-  getDialectHints: () => mockDialectHints,
+  getDialectHints: () => [],
+  pluginDialectModules: () => [],
   setContextFragments: () => {},
   setDialectHints: () => {},
   setPluginTools: () => {},
@@ -77,7 +75,6 @@ function assembledPrompt(): string {
 describe("sargability guidance (shared suffix — covers PostgreSQL)", () => {
   beforeEach(() => {
     resetMockEntries();
-    mockDialectHints = [];
   });
 
   test("assembled prompt contains an explicit Sargability section", () => {
@@ -108,40 +105,12 @@ describe("sargability guidance (shared suffix — covers PostgreSQL)", () => {
   });
 
   test("sargability guidance ships on a PostgreSQL workspace (no inline dialect guide)", () => {
-    // default mock entry is postgres; there is no MySQL guide for it
+    // default mock entry is postgres; buildSystemParam no longer auto-appends a
+    // dialect guide (#4515 — the composed dialect-specialist section is threaded
+    // in by runAgent). The MySQL module's sargability-aware content is asserted
+    // in dialect-specialist.test.ts.
     const content = assembledPrompt();
     expect(content).not.toContain("SQL Dialect: MySQL");
     expect(content).toContain("Sargability");
-  });
-});
-
-describe("MySQL dialect guide — date functions no longer 'preferred' for filtering", () => {
-  beforeEach(() => {
-    mockEntries.length = 0;
-    mockEntries.push({ id: "default", dbType: "mysql" });
-    mockDialectHints = [];
-  });
-
-  test("MySQL guide is present", () => {
-    expect(assembledPrompt()).toContain("SQL Dialect: MySQL");
-  });
-
-  test("does not label YEAR()/DATE_FORMAT() as '(preferred)'", () => {
-    const content = assembledPrompt();
-    const mysqlSection = content.slice(content.indexOf("SQL Dialect: MySQL"));
-    expect(mysqlSection).not.toContain("(preferred)");
-  });
-
-  test("teaches the half-open range rewrite for filtering indexed date columns", () => {
-    const content = assembledPrompt();
-    const mysqlSection = content.slice(content.indexOf("SQL Dialect: MySQL"));
-    expect(mysqlSection).toContain("col >= '2024-01-01' AND col < '2025-01-01'");
-  });
-
-  test("retains YEAR()/DATE_FORMAT() for projection/grouping", () => {
-    const content = assembledPrompt();
-    const mysqlSection = content.slice(content.indexOf("SQL Dialect: MySQL"));
-    expect(mysqlSection).toContain("DATE_FORMAT");
-    expect(mysqlSection).toMatch(/projecting or grouping/i);
   });
 });

--- a/packages/api/src/lib/__tests__/dialect-specialist.test.ts
+++ b/packages/api/src/lib/__tests__/dialect-specialist.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "bun:test";
+import {
+  CORE_DIALECT_SPECIALISTS,
+  CORE_DIALECT_SPECIALIST_DBTYPES,
+  composeDialectSpecialists,
+  dialectDisplayName,
+  resolveDialectSpecialist,
+  type PluginDialectModule,
+} from "@atlas/api/lib/dialect-specialist";
+
+// #4515 — the dialect-specialist registry: engine-specific SQL expertise as
+// composable prompt modules keyed by dbType, shaped like the answer-styles
+// registry. Core ships Postgres/MySQL/ClickHouse; plugins ship a module by
+// dbType with no core change; unknown engines compose cleanly as nothing.
+
+describe("dialectDisplayName", () => {
+  test("known engines use their canonical spelling", () => {
+    expect(dialectDisplayName("postgres")).toBe("PostgreSQL");
+    expect(dialectDisplayName("mysql")).toBe("MySQL");
+    expect(dialectDisplayName("clickhouse")).toBe("ClickHouse");
+  });
+
+  test("unknown engine falls back to a capitalized name", () => {
+    expect(dialectDisplayName("sparksql")).toBe("Sparksql");
+  });
+});
+
+describe("CORE_DIALECT_SPECIALISTS", () => {
+  test("ships the initial Postgres / MySQL / ClickHouse modules", () => {
+    expect(CORE_DIALECT_SPECIALIST_DBTYPES).toEqual([
+      "postgres",
+      "mysql",
+      "clickhouse",
+    ]);
+    for (const dbType of CORE_DIALECT_SPECIALIST_DBTYPES) {
+      expect(CORE_DIALECT_SPECIALISTS[dbType]?.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test("MySQL module keeps its sargability-aware guidance (no '(preferred)', half-open ranges, projection carve-out)", () => {
+    const mysql = CORE_DIALECT_SPECIALISTS.mysql;
+    expect(mysql).not.toContain("(preferred)");
+    expect(mysql).toContain("col >= '2024-01-01' AND col < '2025-01-01'");
+    expect(mysql).toContain("DATE_FORMAT");
+    expect(mysql).toMatch(/projecting or grouping/i);
+  });
+
+  test("ClickHouse module carries engine-specific coaching", () => {
+    const ch = CORE_DIALECT_SPECIALISTS.clickhouse;
+    expect(ch).toContain("toStartOfMonth");
+    expect(ch).toContain("countIf");
+  });
+
+  test("module bodies carry no heading — compose generates it", () => {
+    for (const dbType of CORE_DIALECT_SPECIALIST_DBTYPES) {
+      expect(CORE_DIALECT_SPECIALISTS[dbType]).not.toContain("## SQL Dialect:");
+    }
+  });
+});
+
+describe("resolveDialectSpecialist", () => {
+  test("resolves the core module for a known dbType", () => {
+    const resolved = resolveDialectSpecialist("clickhouse");
+    expect(resolved?.source).toBe("core");
+    expect(resolved?.dbType).toBe("clickhouse");
+    expect(resolved?.module).toBe(CORE_DIALECT_SPECIALISTS.clickhouse);
+  });
+
+  test("unknown dbType resolves to undefined (composes as no module)", () => {
+    expect(resolveDialectSpecialist("sparksql")).toBeUndefined();
+  });
+
+  test("a plugin can ship a module for a new dbType without a core change", () => {
+    const plugins: PluginDialectModule[] = [
+      { dbType: "sparksql", module: "Use Spark SQL date_trunc semantics." },
+    ];
+    const resolved = resolveDialectSpecialist("sparksql", plugins);
+    expect(resolved?.source).toBe("plugin");
+    expect(resolved?.module).toContain("Spark SQL");
+  });
+
+  test("a plugin module wins over the core module for the same dbType", () => {
+    const plugins: PluginDialectModule[] = [
+      { dbType: "clickhouse", module: "Plugin-shipped ClickHouse guidance." },
+    ];
+    const resolved = resolveDialectSpecialist("clickhouse", plugins);
+    expect(resolved?.source).toBe("plugin");
+    expect(resolved?.module).toBe("Plugin-shipped ClickHouse guidance.");
+  });
+
+  test("a blank plugin module does not shadow the core module", () => {
+    const plugins: PluginDialectModule[] = [{ dbType: "mysql", module: "   " }];
+    const resolved = resolveDialectSpecialist("mysql", plugins);
+    expect(resolved?.source).toBe("core");
+  });
+});
+
+describe("composeDialectSpecialists", () => {
+  test("empty groups compose to an empty string", () => {
+    expect(composeDialectSpecialists([])).toBe("");
+  });
+
+  test("single group renders a heading-prefixed module, no group attribution", () => {
+    const out = composeDialectSpecialists([{ group: "default", dbType: "mysql" }]);
+    expect(out).toContain("## SQL Dialect: MySQL");
+    expect(out).toContain(CORE_DIALECT_SPECIALISTS.mysql);
+    // Single group ⇒ no "— group" attribution suffix.
+    expect(out).not.toContain("— group");
+  });
+
+  test("a group on an unknown engine composes cleanly as no module", () => {
+    expect(composeDialectSpecialists([{ group: "g1", dbType: "sparksql" }])).toBe("");
+  });
+
+  test("cross-group sweep composes several modules, each attributed to its group", () => {
+    const out = composeDialectSpecialists([
+      { group: "us-prod", dbType: "postgres" },
+      { group: "eu-analytics", dbType: "clickhouse" },
+    ]);
+    expect(out).toContain("## SQL Dialect: PostgreSQL — group `us-prod`");
+    expect(out).toContain("## SQL Dialect: ClickHouse — group `eu-analytics`");
+  });
+
+  test("two groups sharing an engine fold to one module attributed to both", () => {
+    const out = composeDialectSpecialists([
+      { group: "a", dbType: "postgres" },
+      { group: "b", dbType: "postgres" },
+    ]);
+    // Module appears once, attributed to both groups.
+    expect(out.match(/## SQL Dialect: PostgreSQL/g)?.length).toBe(1);
+    expect(out).toContain("## SQL Dialect: PostgreSQL — groups `a`, `b`");
+  });
+
+  test("mixed known + unknown engines: known composes, unknown is skipped", () => {
+    const out = composeDialectSpecialists([
+      { group: "warehouse", dbType: "mysql" },
+      { group: "lake", dbType: "sparksql" },
+    ]);
+    expect(out).toContain("## SQL Dialect: MySQL — group `warehouse`");
+    expect(out).not.toContain("sparksql");
+    expect(out).not.toContain("Sparksql");
+  });
+
+  test("plugin module composes for its engine under a cross-group sweep", () => {
+    const plugins: PluginDialectModule[] = [
+      { dbType: "bigquery", module: "Use SAFE_DIVIDE for BigQuery division." },
+    ];
+    const out = composeDialectSpecialists(
+      [
+        { group: "warehouse", dbType: "postgres" },
+        { group: "bq", dbType: "bigquery" },
+      ],
+      plugins,
+    );
+    expect(out).toContain("## SQL Dialect: BigQuery — group `bq`");
+    expect(out).toContain("Use SAFE_DIVIDE for BigQuery division.");
+  });
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -32,11 +32,16 @@ import { resolveWorkspaceRestDatasources, resolveWorkspaceRestDatasourcesOrThrow
 import type { RestDatasource } from "./openapi/datasource";
 import { buildAgentRepresentation } from "./openapi/representation";
 import { loadSourceCatalog, type RestCatalogSource } from "./source-catalog/lookup";
-import { reachStateFromColumn } from "./group-reach";
+import { reachStateFromColumn, type ReachState } from "./group-reach";
+import { resolveReachableGroups } from "./group-reach/resolve";
 import { REST_OPERATION_DESCRIPTION, createExecuteRestOperationTool } from "./tools/rest-operation";
 import { getStreamWriter } from "./tools/python-stream";
-import { getContextFragments, getDialectHints } from "./plugins/tools";
-import { connections, detectDBType, type ConnectionMetadata, type DBType } from "./db/connection";
+import { getContextFragments, pluginDialectModules } from "./plugins/tools";
+import {
+  composeDialectSpecialists,
+  type DialectSpecialistGroup,
+} from "./dialect-specialist";
+import { connections, type ConnectionMetadata, type DBType } from "./db/connection";
 import { getCrossSourceJoins, type CrossSourceJoin, loadOrgWhitelist, getOrgSemanticIndex } from "./semantic";
 import { getSemanticIndex } from "./semantic/search";
 import { getConfig } from "./config";
@@ -249,21 +254,6 @@ What is the trend over the last 12 months?
 How does this break down by region?
 Which accounts contribute the most?
 </suggestions>`;
-
-const MYSQL_DIALECT_GUIDE = `
-
-## SQL Dialect: MySQL
-This database uses MySQL. Key differences from PostgreSQL:
-- For **projecting or grouping** by a date part, use \`YEAR(col)\` / \`MONTH(col)\` (or \`EXTRACT(YEAR FROM col)\`) and \`DATE_FORMAT(col, '%Y-%m')\` (instead of \`TO_CHAR(col, 'YYYY-MM')\`) — e.g. \`SELECT DATE_FORMAT(created_at, '%Y-%m') AS month ... GROUP BY 1\`
-- For **filtering** an indexed date column, do NOT wrap it: \`WHERE YEAR(col) = 2024\` or \`WHERE DATE_FORMAT(col, '%Y-%m') = '2024-03'\` forces a full table scan. Use a half-open range on the bare column instead — \`WHERE col >= '2024-01-01' AND col < '2025-01-01'\` (year) or \`WHERE col >= '2024-03-01' AND col < '2024-04-01'\` (month). See the Sargability rules above
-- Use \`IFNULL(col, default)\` or \`COALESCE(col, default)\` — both work
-- Use backtick quoting for identifiers: \`\\\`column\\\`\` instead of \`"column"\`
-- Use \`CONCAT(a, b)\` for string concatenation — \`||\` is logical OR in MySQL
-- No \`ILIKE\` — use \`WHERE col COLLATE utf8mb4_bin LIKE 'pattern'\` for case-sensitive matching
-- \`GROUP_CONCAT(col SEPARATOR ', ')\` instead of \`STRING_AGG(col, ', ')\`
-- No \`::type\` casting — use \`CAST(x AS SIGNED)\`, \`CAST(x AS DECIMAL)\`
-- \`LIMIT offset, count\` or \`LIMIT count OFFSET offset\` — both forms work
-- \`COALESCE\`, \`CASE\`, \`NULLIF\`, \`COUNT\`, \`SUM\`, \`AVG\`, \`MIN\`, \`MAX\` work identically`;
 
 // Display names for core DB types. Plugin-registered types fall through
 // to the capitalize fallback intentionally.
@@ -487,12 +477,6 @@ ${lines.join("\n")}
   return section;
 }
 
-function appendDialectHints(prompt: string): string {
-  const hints = getDialectHints();
-  if (hints.length === 0) return prompt;
-  return prompt + "\n\n## Additional SQL Dialect Notes\n\n" + hints.map((h) => h.dialect).join("\n\n");
-}
-
 const PYTHON_GUIDANCE = `
 ## SQL vs Python
 
@@ -515,6 +499,64 @@ export interface BoundDashboardAgentContext {
   cardSummary: string;
 }
 
+/**
+ * Resolve the composed dialect-specialist section (#4515) for the conversation's
+ * reachable Connection groups. Each reachable group is paired with the engine of
+ * its primary (or any member) connection — read from the agent-visible
+ * connection registry — and the pairs compose through
+ * {@link composeDialectSpecialists}: one module per dbType, attributed per group
+ * under a cross-group sweep. Plugin-shipped modules ({@link pluginDialectModules})
+ * win over the core modules for their engine.
+ *
+ * Falls back to the agent-visible connections directly — each connection standing
+ * as its own group-of-one — when there is no workspace (self-hosted
+ * single-connection) or no group resolves to a known engine, so the connected
+ * engine's module still shows exactly as the pre-#4515 inline guide did. Never
+ * throws: a reach-resolution failure degrades to that fallback rather than
+ * costing the turn its answer (CLAUDE.md — never silently swallow; the failure is
+ * logged).
+ */
+async function resolveConversationDialectSpecialists(
+  orgId: string | undefined,
+  mode: "published" | "developer" | undefined,
+  reach: ReachState,
+): Promise<string> {
+  const visible = filterAgentVisibleSources(connections.describe());
+  const dbTypeById = new Map(visible.map((c) => [c.id, c.dbType]));
+  const pluginModules = pluginDialectModules();
+
+  // Connection-based fallback: each visible connection stands as its own group.
+  const connectionGroups = (): DialectSpecialistGroup[] =>
+    visible.map((c) => ({ group: c.id, dbType: c.dbType }));
+
+  let groups: DialectSpecialistGroup[];
+  if (orgId) {
+    try {
+      const { reachableGroups } = await resolveReachableGroups(orgId, mode, reach);
+      const resolved: DialectSpecialistGroup[] = [];
+      for (const grp of reachableGroups) {
+        const dbType =
+          dbTypeById.get(grp.primary) ??
+          grp.members.map((m) => dbTypeById.get(m)).find((t) => t !== undefined);
+        if (dbType) resolved.push({ group: grp.id, dbType });
+      }
+      // An empty reachable set (no groups, or none mapping to a known engine)
+      // falls back so a single-connection workspace still gets its module.
+      groups = resolved.length > 0 ? resolved : connectionGroups();
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), orgId },
+        "Dialect specialists: reach resolution failed — falling back to visible connections",
+      );
+      groups = connectionGroups();
+    }
+  } else {
+    groups = connectionGroups();
+  }
+
+  return composeDialectSpecialists(groups, pluginModules);
+}
+
 function buildSystemPrompt(
   registry: ToolRegistry,
   orgSemanticIndex?: string,
@@ -523,6 +565,7 @@ function buildSystemPrompt(
   boundDashboardContext?: BoundDashboardAgentContext,
   orgKnowledgeToc?: string,
   persona?: string,
+  dialectSpecialists?: string,
 ): string {
   const suffix = boundDashboardContext ? BOUND_AGENT_PROMPT_GUIDANCE : SYSTEM_PROMPT_SUFFIX;
   // #4508 — "expert is a mode": a persona REPLACES the standard analyst role
@@ -571,32 +614,22 @@ function buildSystemPrompt(
   }
   const meta = filterAgentVisibleSources(connections.describe());
 
-  // Single-connection: identical to pre-v0.7 behavior
+  // #4515 — engine-specific expertise rides the dialect-specialist section,
+  // pre-composed by `runAgent` for the groups in scope and threaded in here (the
+  // sibling of the answer-style / persona seams). It supersedes the pre-#4515
+  // inline dialect guides + plugin dialect-hint notes: one registry-driven
+  // section keyed by dbType, attributed per group under a cross-group sweep.
+  // Empty ⇒ nothing appended (unknown engine / no reachable source).
+  const appendDialect = (p: string): string =>
+    dialectSpecialists ? p + "\n\n" + dialectSpecialists : p;
+
+  // Single-connection: no multi-source section, just the dialect specialist.
   if (meta.length <= 1) {
-    let dbType: DBType;
-    try {
-      dbType = meta.length === 1
-        ? meta[0].dbType
-        : detectDBType();
-    } catch (err) {
-      log.debug({ err: err instanceof Error ? err.message : String(err) }, "Could not detect DB type — omitting dialect guide");
-      return appendDialectHints(base);
-    }
-    // Core adapters get their dialect guide inline; everything else is
-    // handled by plugin dialect hints via appendDialectHints().
-    if (dbType === "mysql") {
-      return appendDialectHints(base + MYSQL_DIALECT_GUIDE);
-    }
-    return appendDialectHints(base);
+    return appendDialect(base);
   }
 
-  // Multi-connection: list sources + include core dialect guides
+  // Multi-connection: list sources, then the composed dialect specialists.
   let prompt = base + "\n\n" + buildMultiSourceSection(meta);
-
-  const dbTypes = new Set(meta.map((m) => m.dbType));
-  if (dbTypes.has("mysql")) prompt += MYSQL_DIALECT_GUIDE;
-  // Non-core dialects (clickhouse, snowflake, duckdb, salesforce, etc.)
-  // are provided by plugins via appendDialectHints().
 
   // Cross-environment routing guidance: only appears when the active group
   // has >1 member (PRD #2515 / slice 2 #2517). Single-member groups omit
@@ -604,7 +637,7 @@ function buildSystemPrompt(
   const scopeGuidance = buildScopeGuidanceSection(routingContext);
   if (scopeGuidance) prompt += "\n\n" + scopeGuidance;
 
-  return appendDialectHints(prompt);
+  return appendDialect(prompt);
 }
 
 /**
@@ -714,6 +747,16 @@ export interface BuildSystemParamOptions {
    * workspaces are unchanged).
    */
   readonly sourceCatalog?: string;
+  /**
+   * #4515 — the composed dialect-specialist section (`lib/dialect-specialist.ts`):
+   * engine-specific SQL expertise for the groups in scope, one module per
+   * dbType, attributed per group under a cross-group sweep. Pre-composed by
+   * `runAgent` (which resolves reachable groups → dbType) so the pure builder
+   * stays synchronous. Appended in the dialect position, superseding the
+   * pre-#4515 inline dialect guides + plugin dialect-hint notes. Empty string /
+   * omitted ⇒ nothing appended (unknown engine / no reachable source).
+   */
+  readonly dialectSpecialists?: string;
 }
 
 /**
@@ -750,8 +793,9 @@ export function buildSystemParam(
     modelId,
     memoryBlock,
     sourceCatalog,
+    dialectSpecialists,
   } = options;
-  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext, orgKnowledgeToc, persona);
+  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext, orgKnowledgeToc, persona, dialectSpecialists);
 
   if (sourceCatalog) {
     content += "\n\n" + sourceCatalog;
@@ -1665,12 +1709,23 @@ export async function runAgent({
   // the menu lists only the focused group, matching what `executeSQL` will allow
   // (so the agent isn't told about groups every query to which would be
   // rejected). Sourced from the same RequestContext value that bounds executeSQL.
+  const reachState = reachStateFromColumn(reqCtx?.groupReach);
   const sourceCatalog = await loadSourceCatalog(
     orgId,
     atlasMode,
     restCatalogSources,
     {},
-    reachStateFromColumn(reqCtx?.groupReach),
+    reachState,
+  );
+
+  // #4515 — the dialect-specialist section: engine expertise for the groups in
+  // scope, composed once per turn keyed by dbType and attributed per group. Uses
+  // the SAME reach state as the Source catalog so the modules and the menu
+  // describe the same reachable set. Fail-soft (empty string on any hiccup).
+  const dialectSpecialists = await resolveConversationDialectSpecialists(
+    orgId,
+    atlasMode,
+    reachState,
   );
 
   // System prompt is built once and pinned: it carries the semantic index +
@@ -1698,6 +1753,7 @@ export async function runAgent({
     modelId: resolvedModelId,
     memoryBlock,
     sourceCatalog,
+    dialectSpecialists,
   });
 
   // #3759 — context compaction. Resolved once per turn (knobs hot-reload at the

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -39,9 +39,10 @@ import { getStreamWriter } from "./tools/python-stream";
 import { getContextFragments, pluginDialectModules } from "./plugins/tools";
 import {
   composeDialectSpecialists,
+  dialectDisplayName,
   type DialectSpecialistGroup,
 } from "./dialect-specialist";
-import { connections, type ConnectionMetadata, type DBType } from "./db/connection";
+import { connections, type ConnectionMetadata } from "./db/connection";
 import { getCrossSourceJoins, type CrossSourceJoin, loadOrgWhitelist, getOrgSemanticIndex } from "./semantic";
 import { getSemanticIndex } from "./semantic/search";
 import { getConfig } from "./config";
@@ -255,16 +256,6 @@ How does this break down by region?
 Which accounts contribute the most?
 </suggestions>`;
 
-// Display names for core DB types. Plugin-registered types fall through
-// to the capitalize fallback intentionally.
-const DIALECT_DISPLAY_NAMES: Record<string, string> = {
-  postgres: "PostgreSQL",
-  mysql: "MySQL",
-};
-
-function dialectName(dbType: DBType): string {
-  return DIALECT_DISPLAY_NAMES[dbType] ?? dbType.charAt(0).toUpperCase() + dbType.slice(1);
-}
 
 /**
  * Filter the connection registry to the set the agent should see in its tool
@@ -431,7 +422,7 @@ function buildMultiSourceSection(
   sources: ConnectionMetadata[],
 ): string {
   const lines = sources.map((s) => {
-    const dialect = dialectName(s.dbType);
+    const dialect = dialectDisplayName(s.dbType);
     const desc = s.description ? ` — ${s.description}` : "";
     const healthNote = s.health?.status === "unhealthy"
       ? " (**UNAVAILABLE** — skip queries to this source)"
@@ -508,15 +499,21 @@ export interface BoundDashboardAgentContext {
  * under a cross-group sweep. Plugin-shipped modules ({@link pluginDialectModules})
  * win over the core modules for their engine.
  *
- * Falls back to the agent-visible connections directly — each connection standing
- * as its own group-of-one — when there is no workspace (self-hosted
- * single-connection) or no group resolves to a known engine, so the connected
- * engine's module still shows exactly as the pre-#4515 inline guide did. Never
- * throws: a reach-resolution failure degrades to that fallback rather than
- * costing the turn its answer (CLAUDE.md — never silently swallow; the failure is
- * logged).
+ * Two reach regimes, matching the Source catalog it sits beside (ADR-0022):
+ * - **Workspace present (`orgId` set)** — compose exactly the reachable groups.
+ *   An empty reachable set composes NOTHING (fails closed like the catalog); it
+ *   does NOT fan out to every visible connection, so a fail-closed reach result
+ *   (e.g. a whitelist scan that degraded to none) can't re-open into dialect
+ *   coaching for engines the conversation can't actually reach.
+ * - **No workspace (`orgId` undefined)** — the self-hosted single/flat-connection
+ *   case with no enumerable group surface: each agent-visible connection stands
+ *   as its own group-of-one, so the connected engine's module still shows.
+ *
+ * Never throws: a reach-resolution failure fails closed to no dialect section
+ * (logged, not swallowed — CLAUDE.md) rather than costing the turn its answer or
+ * fanning back out to an unreachable-engine list.
  */
-async function resolveConversationDialectSpecialists(
+export async function resolveConversationDialectSpecialists(
   orgId: string | undefined,
   mode: "published" | "developer" | undefined,
   reach: ReachState,
@@ -524,10 +521,6 @@ async function resolveConversationDialectSpecialists(
   const visible = filterAgentVisibleSources(connections.describe());
   const dbTypeById = new Map(visible.map((c) => [c.id, c.dbType]));
   const pluginModules = pluginDialectModules();
-
-  // Connection-based fallback: each visible connection stands as its own group.
-  const connectionGroups = (): DialectSpecialistGroup[] =>
-    visible.map((c) => ({ group: c.id, dbType: c.dbType }));
 
   let groups: DialectSpecialistGroup[];
   if (orgId) {
@@ -540,18 +533,19 @@ async function resolveConversationDialectSpecialists(
           grp.members.map((m) => dbTypeById.get(m)).find((t) => t !== undefined);
         if (dbType) resolved.push({ group: grp.id, dbType });
       }
-      // An empty reachable set (no groups, or none mapping to a known engine)
-      // falls back so a single-connection workspace still gets its module.
-      groups = resolved.length > 0 ? resolved : connectionGroups();
+      // Compose exactly the reachable set — empty ⇒ no dialect section, matching
+      // the Source catalog. NO fan-out to every visible connection here.
+      groups = resolved;
     } catch (err) {
       log.warn(
         { err: err instanceof Error ? err.message : String(err), orgId },
-        "Dialect specialists: reach resolution failed — falling back to visible connections",
+        "Dialect specialists: reach resolution failed — composing no dialect section (fail closed)",
       );
-      groups = connectionGroups();
+      groups = [];
     }
   } else {
-    groups = connectionGroups();
+    // No workspace: each visible connection is its own group-of-one.
+    groups = visible.map((c) => ({ group: c.id, dbType: c.dbType }));
   }
 
   return composeDialectSpecialists(groups, pluginModules);
@@ -1721,7 +1715,8 @@ export async function runAgent({
   // #4515 — the dialect-specialist section: engine expertise for the groups in
   // scope, composed once per turn keyed by dbType and attributed per group. Uses
   // the SAME reach state as the Source catalog so the modules and the menu
-  // describe the same reachable set. Fail-soft (empty string on any hiccup).
+  // describe the same reachable set (a reach failure fails closed to no section,
+  // logged — see resolveConversationDialectSpecialists).
   const dialectSpecialists = await resolveConversationDialectSpecialists(
     orgId,
     atlasMode,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1703,25 +1703,17 @@ export async function runAgent({
   // the menu lists only the focused group, matching what `executeSQL` will allow
   // (so the agent isn't told about groups every query to which would be
   // rejected). Sourced from the same RequestContext value that bounds executeSQL.
-  const reachState = reachStateFromColumn(reqCtx?.groupReach);
-  const sourceCatalog = await loadSourceCatalog(
-    orgId,
-    atlasMode,
-    restCatalogSources,
-    {},
-    reachState,
-  );
-
   // #4515 — the dialect-specialist section: engine expertise for the groups in
   // scope, composed once per turn keyed by dbType and attributed per group. Uses
   // the SAME reach state as the Source catalog so the modules and the menu
   // describe the same reachable set (a reach failure fails closed to no section,
-  // logged — see resolveConversationDialectSpecialists).
-  const dialectSpecialists = await resolveConversationDialectSpecialists(
-    orgId,
-    atlasMode,
-    reachState,
-  );
+  // logged — see resolveConversationDialectSpecialists). Both consume the reach
+  // state independently, so they resolve in parallel (no async waterfall).
+  const reachState = reachStateFromColumn(reqCtx?.groupReach);
+  const [sourceCatalog, dialectSpecialists] = await Promise.all([
+    loadSourceCatalog(orgId, atlasMode, restCatalogSources, {}, reachState),
+    resolveConversationDialectSpecialists(orgId, atlasMode, reachState),
+  ]);
 
   // System prompt is built once and pinned: it carries the semantic index +
   // glossary AND the durable memory block (#3755), and is passed to the model

--- a/packages/api/src/lib/dialect-specialist.ts
+++ b/packages/api/src/lib/dialect-specialist.ts
@@ -1,0 +1,222 @@
+/**
+ * Dialect specialists — the named registry of engine-specific SQL expertise
+ * (#4515, PRD #4502; CONTEXT.md § Dialect specialist).
+ *
+ * A dialect specialist is engine-specific know-how (Postgres, MySQL,
+ * ClickHouse, …) as a composable prompt MODULE keyed by `dbType` — shaped like
+ * the answer-styles registry (`lib/answer-styles.ts`), not like a separate
+ * per-engine agent. "One agent, composed prompt": the specialist module knows
+ * the engine; the expert persona (`lib/semantic/expert/persona.ts`) owns the
+ * semantic layer and Amendments; the analyst role owns the answer. At
+ * conversation assembly the modules for the groups in scope compose into the
+ * one agent's prompt — a cross-group sweep composes several, each attributed to
+ * its group ({@link composeDialectSpecialists}). The wizard enrich pass reuses
+ * the same modules so its LLM call is engine-aware too.
+ *
+ * Two module sources, resolved by {@link resolveDialectSpecialist}:
+ *
+ * - **Core** ships the initial Postgres / MySQL / ClickHouse modules
+ *   ({@link CORE_DIALECT_SPECIALISTS}). Postgres is the dialect the base agent
+ *   guidance is already written in, so its module is a short orientation; the
+ *   others are framed as "differences from PostgreSQL".
+ * - **Plugins** ship a module alongside their datasource capability via the
+ *   existing `dialect` field on `AtlasDatasourcePlugin` (surfaced as
+ *   {@link PluginDialectModule} through `getDialectHints()`), so a plugin adds
+ *   engine expertise for a new `dbType` with **no core change**. A plugin
+ *   module for a `dbType` takes precedence over the core module for that same
+ *   `dbType` — the plugin owns its engine and may carry richer, version-pinned
+ *   guidance than the core baseline.
+ *
+ * Unlike the answer-style registry, resolution is TOTAL-with-a-gap rather than
+ * total: an unknown `dbType` (no core module, no plugin module) resolves to
+ * `undefined` and composes cleanly as no module — a datasource the agent can
+ * still query with standard SQL, just without engine-specific coaching. This
+ * registry lives in core (never `/ee`) and reads no env vars.
+ */
+
+/**
+ * Display names for known engines — the single source of truth for how a
+ * `dbType` is spelled in a specialist heading (and reused by the wizard enrich
+ * pass for its "valid <dialect> SQL" instruction). Unknown / plugin `dbType`s
+ * fall through to a capitalize fallback in {@link dialectDisplayName}.
+ */
+const DIALECT_DISPLAY_NAMES: Record<string, string> = {
+  postgres: "PostgreSQL",
+  mysql: "MySQL",
+  clickhouse: "ClickHouse",
+  snowflake: "Snowflake",
+  duckdb: "DuckDB",
+  bigquery: "BigQuery",
+  salesforce: "Salesforce SOQL",
+  elasticsearch: "Elasticsearch",
+  opensearch: "OpenSearch",
+};
+
+/**
+ * Human display name for a `dbType`. Known engines use their canonical spelling
+ * ({@link DIALECT_DISPLAY_NAMES}); anything else (a plugin's custom `dbType`)
+ * is capitalized as a best-effort fallback, matching `agent.ts`'s legacy
+ * `dialectName`.
+ */
+export function dialectDisplayName(dbType: string): string {
+  return (
+    DIALECT_DISPLAY_NAMES[dbType] ??
+    (dbType ? dbType.charAt(0).toUpperCase() + dbType.slice(1) : dbType)
+  );
+}
+
+const POSTGRES_MODULE = `This datasource uses PostgreSQL — the dialect the standard SQL guidance above is written in, so the default patterns apply directly.
+- Truncate/extract dates with \`DATE_TRUNC('month', col)\`, \`EXTRACT(YEAR FROM col)\`, or \`TO_CHAR(col, 'YYYY-MM')\`.
+- Cast with \`col::type\` or \`CAST(col AS type)\`; use \`ILIKE\` for case-insensitive matching.
+- Aggregate text with \`STRING_AGG(col, ', ')\`; concatenate with \`||\`.
+- Use \`FILTER (WHERE ...)\` on aggregates, and \`COALESCE\` / \`NULLIF\` for null handling.`;
+
+// Verbatim body of the pre-#4515 `MYSQL_DIALECT_GUIDE` (agent.ts), minus its
+// own heading — {@link composeDialectSpecialists} generates the
+// `## SQL Dialect: MySQL` heading so the assembled text is unchanged.
+const MYSQL_MODULE = `This database uses MySQL. Key differences from PostgreSQL:
+- For **projecting or grouping** by a date part, use \`YEAR(col)\` / \`MONTH(col)\` (or \`EXTRACT(YEAR FROM col)\`) and \`DATE_FORMAT(col, '%Y-%m')\` (instead of \`TO_CHAR(col, 'YYYY-MM')\`) — e.g. \`SELECT DATE_FORMAT(created_at, '%Y-%m') AS month ... GROUP BY 1\`
+- For **filtering** an indexed date column, do NOT wrap it: \`WHERE YEAR(col) = 2024\` or \`WHERE DATE_FORMAT(col, '%Y-%m') = '2024-03'\` forces a full table scan. Use a half-open range on the bare column instead — \`WHERE col >= '2024-01-01' AND col < '2025-01-01'\` (year) or \`WHERE col >= '2024-03-01' AND col < '2024-04-01'\` (month). See the Sargability rules above
+- Use \`IFNULL(col, default)\` or \`COALESCE(col, default)\` — both work
+- Use backtick quoting for identifiers: \`\\\`column\\\`\` instead of \`"column"\`
+- Use \`CONCAT(a, b)\` for string concatenation — \`||\` is logical OR in MySQL
+- No \`ILIKE\` — use \`WHERE col COLLATE utf8mb4_bin LIKE 'pattern'\` for case-sensitive matching
+- \`GROUP_CONCAT(col SEPARATOR ', ')\` instead of \`STRING_AGG(col, ', ')\`
+- No \`::type\` casting — use \`CAST(x AS SIGNED)\`, \`CAST(x AS DECIMAL)\`
+- \`LIMIT offset, count\` or \`LIMIT count OFFSET offset\` — both forms work
+- \`COALESCE\`, \`CASE\`, \`NULLIF\`, \`COUNT\`, \`SUM\`, \`AVG\`, \`MIN\`, \`MAX\` work identically`;
+
+const CLICKHOUSE_MODULE = `This datasource uses the ClickHouse SQL dialect. Key differences from PostgreSQL:
+- Truncate dates with \`toStartOfMonth(col)\` / \`toStartOfWeek(col)\` / \`toStartOfDay(col)\` (not \`DATE_TRUNC\`).
+- Use \`countIf(condition)\` instead of \`COUNT(CASE WHEN ... END)\`, and \`sumIf(column, condition)\` instead of \`SUM(CASE WHEN ... END)\`.
+- Unnest arrays with \`arrayJoin()\`; split strings with \`splitByChar()\`.
+- String functions: \`lower()\`, \`upper()\`, \`trim()\`.
+- Do not add \`FORMAT\` clauses — the adapter handles output format automatically.
+- ClickHouse is column-oriented — avoid \`SELECT *\` on wide tables; project only the columns you need.`;
+
+/**
+ * The core-shipped dialect specialist modules, keyed by `dbType`. Bodies carry
+ * NO heading — {@link composeDialectSpecialists} generates
+ * `## SQL Dialect: <name>` so single- and multi-group prompts render
+ * consistently.
+ */
+export const CORE_DIALECT_SPECIALISTS: Readonly<Record<string, string>> = {
+  postgres: POSTGRES_MODULE,
+  mysql: MYSQL_MODULE,
+  clickhouse: CLICKHOUSE_MODULE,
+};
+
+/** The `dbType`s core ships a specialist for, in display order. */
+export const CORE_DIALECT_SPECIALIST_DBTYPES = [
+  "postgres",
+  "mysql",
+  "clickhouse",
+] as const;
+
+/**
+ * A plugin-shipped dialect module, keyed by the engine it describes. Sourced
+ * from a datasource plugin's `dialect` field (collected as a `DialectHint` at
+ * wiring time; see `lib/plugins/wiring.ts`), so shipping engine expertise for a
+ * new `dbType` needs no core change.
+ */
+export interface PluginDialectModule {
+  readonly dbType: string;
+  readonly module: string;
+}
+
+/** Where a resolved specialist module came from. */
+export type DialectSpecialistSource = "core" | "plugin";
+
+/** A resolved dialect specialist for one `dbType`. */
+export interface ResolvedDialectSpecialist {
+  readonly dbType: string;
+  readonly source: DialectSpecialistSource;
+  /** The module body (no heading). */
+  readonly module: string;
+}
+
+/**
+ * Resolve the dialect specialist module for a `dbType`. A plugin module for the
+ * `dbType` wins over the core module (the plugin owns its engine); falling back
+ * to the core module; `undefined` when neither exists (an unknown engine, which
+ * {@link composeDialectSpecialists} then contributes as no module).
+ *
+ * A plugin module with a blank/whitespace-only body is ignored, so a plugin
+ * that declares `dialect: ""` doesn't shadow the core module with nothing.
+ */
+export function resolveDialectSpecialist(
+  dbType: string,
+  pluginModules: readonly PluginDialectModule[] = [],
+): ResolvedDialectSpecialist | undefined {
+  const pluginMatch = pluginModules.find(
+    (m) => m.dbType === dbType && m.module.trim().length > 0,
+  );
+  if (pluginMatch) {
+    return { dbType, source: "plugin", module: pluginMatch.module };
+  }
+  const coreModule = CORE_DIALECT_SPECIALISTS[dbType];
+  if (coreModule !== undefined) {
+    return { dbType, source: "core", module: coreModule };
+  }
+  return undefined;
+}
+
+/** A connection group in scope, paired with the engine it runs on. */
+export interface DialectSpecialistGroup {
+  /** Connection group id (a group-of-one uses its connection id — #3855). */
+  readonly group: string;
+  readonly dbType: string;
+}
+
+/**
+ * Compose the dialect specialist section for the groups in scope.
+ *
+ * Groups are folded by `dbType` — a cross-group sweep with two Postgres groups
+ * and one ClickHouse group composes the Postgres module ONCE (attributed to
+ * both groups) and the ClickHouse module once, not the same module per member.
+ * Distinct engines appear in first-seen group order. A group whose `dbType`
+ * resolves to no module ({@link resolveDialectSpecialist} → `undefined`) is
+ * skipped — an unknown engine composes cleanly as nothing.
+ *
+ * Rendering:
+ * - each engine renders as `## SQL Dialect: <name>` + its module body, so a
+ *   single-engine workspace's output is heading-identical to the pre-#4515
+ *   inline dialect guide;
+ * - when more than one group is in scope, each heading carries a
+ *   `— group(s) \`a\`, \`b\`` attribution so the agent knows which source each
+ *   module governs (the "each attributed to its group" contract).
+ *
+ * Returns `""` when nothing in scope resolves to a module (the caller appends
+ * nothing).
+ */
+export function composeDialectSpecialists(
+  groups: readonly DialectSpecialistGroup[],
+  pluginModules: readonly PluginDialectModule[] = [],
+): string {
+  // Fold groups → { dbType (first-seen order) → group ids }.
+  const groupsByDbType = new Map<string, string[]>();
+  for (const { group, dbType } of groups) {
+    const list = groupsByDbType.get(dbType);
+    if (list) {
+      if (!list.includes(group)) list.push(group);
+    } else {
+      groupsByDbType.set(dbType, [group]);
+    }
+  }
+
+  const multiGroup = groups.length > 1;
+  const blocks: string[] = [];
+  for (const [dbType, groupIds] of groupsByDbType) {
+    const resolved = resolveDialectSpecialist(dbType, pluginModules);
+    if (!resolved) continue;
+    const name = dialectDisplayName(dbType);
+    const attribution = multiGroup
+      ? ` — group${groupIds.length > 1 ? "s" : ""} ${groupIds
+          .map((g) => `\`${g}\``)
+          .join(", ")}`
+      : "";
+    blocks.push(`## SQL Dialect: ${name}${attribution}\n${resolved.module}`);
+  }
+
+  return blocks.join("\n\n");
+}

--- a/packages/api/src/lib/dialect-specialist.ts
+++ b/packages/api/src/lib/dialect-specialist.ts
@@ -20,8 +20,9 @@
  *   guidance is already written in, so its module is a short orientation; the
  *   others are framed as "differences from PostgreSQL".
  * - **Plugins** ship a module alongside their datasource capability via the
- *   existing `dialect` field on `AtlasDatasourcePlugin` (surfaced as
- *   {@link PluginDialectModule} through `getDialectHints()`), so a plugin adds
+ *   existing `dialect` field on `AtlasDatasourcePlugin` (projected into
+ *   {@link PluginDialectModule} by `pluginDialectModules()` in
+ *   `lib/plugins/tools.ts`, which wraps `getDialectHints()`), so a plugin adds
  *   engine expertise for a new `dbType` with **no core change**. A plugin
  *   module for a `dbType` takes precedence over the core module for that same
  *   `dbType` — the plugin owns its engine and may carry richer, version-pinned
@@ -35,10 +36,11 @@
  */
 
 /**
- * Display names for known engines — the single source of truth for how a
- * `dbType` is spelled in a specialist heading (and reused by the wizard enrich
- * pass for its "valid <dialect> SQL" instruction). Unknown / plugin `dbType`s
- * fall through to a capitalize fallback in {@link dialectDisplayName}.
+ * Display names for known engines — the source of truth for how a `dbType` is
+ * spelled in a specialist heading, in the agent's multi-source listing
+ * (`agent.ts`'s `dialectName` delegates here), and in the wizard enrich pass's
+ * "valid <dialect> SQL" instruction. Unknown / plugin `dbType`s fall through to
+ * a capitalize fallback in {@link dialectDisplayName}.
  */
 const DIALECT_DISPLAY_NAMES: Record<string, string> = {
   postgres: "PostgreSQL",
@@ -94,24 +96,32 @@ const CLICKHOUSE_MODULE = `This datasource uses the ClickHouse SQL dialect. Key 
 - Do not add \`FORMAT\` clauses — the adapter handles output format automatically.
 - ClickHouse is column-oriented — avoid \`SELECT *\` on wide tables; project only the columns you need.`;
 
-/**
- * The core-shipped dialect specialist modules, keyed by `dbType`. Bodies carry
- * NO heading — {@link composeDialectSpecialists} generates
- * `## SQL Dialect: <name>` so single- and multi-group prompts render
- * consistently.
- */
-export const CORE_DIALECT_SPECIALISTS: Readonly<Record<string, string>> = {
-  postgres: POSTGRES_MODULE,
-  mysql: MYSQL_MODULE,
-  clickhouse: CLICKHOUSE_MODULE,
-};
-
 /** The `dbType`s core ships a specialist for, in display order. */
 export const CORE_DIALECT_SPECIALIST_DBTYPES = [
   "postgres",
   "mysql",
   "clickhouse",
 ] as const;
+
+/** A `dbType` core ships a specialist module for. */
+export type CoreDialectDbType = (typeof CORE_DIALECT_SPECIALIST_DBTYPES)[number];
+
+/**
+ * The core-shipped dialect specialist modules, keyed by `dbType`. Bodies carry
+ * NO heading — {@link composeDialectSpecialists} generates
+ * `## SQL Dialect: <name>` so single- and multi-group prompts render
+ * consistently.
+ *
+ * Keyed by {@link CoreDialectDbType} (derived from
+ * {@link CORE_DIALECT_SPECIALIST_DBTYPES}) so the Record's keys and the tuple
+ * can never drift — adding a module without listing its dbType (or vice versa)
+ * fails to compile, mirroring `answer-styles.ts`'s `ANSWER_STYLE_ADDENDA`.
+ */
+export const CORE_DIALECT_SPECIALISTS: Readonly<Record<CoreDialectDbType, string>> = {
+  postgres: POSTGRES_MODULE,
+  mysql: MYSQL_MODULE,
+  clickhouse: CLICKHOUSE_MODULE,
+};
 
 /**
  * A plugin-shipped dialect module, keyed by the engine it describes. Sourced
@@ -154,9 +164,14 @@ export function resolveDialectSpecialist(
   if (pluginMatch) {
     return { dbType, source: "plugin", module: pluginMatch.module };
   }
-  const coreModule = CORE_DIALECT_SPECIALISTS[dbType];
-  if (coreModule !== undefined) {
-    return { dbType, source: "core", module: coreModule };
+  // `dbType` is the open engine string; narrow to a core key via `Object.hasOwn`
+  // before indexing the tuple-keyed Record (no unsafe cast).
+  if (Object.hasOwn(CORE_DIALECT_SPECIALISTS, dbType)) {
+    return {
+      dbType,
+      source: "core",
+      module: CORE_DIALECT_SPECIALISTS[dbType as CoreDialectDbType],
+    };
   }
   return undefined;
 }

--- a/packages/api/src/lib/dialect-specialist.ts
+++ b/packages/api/src/lib/dialect-specialist.ts
@@ -38,9 +38,9 @@
 /**
  * Display names for known engines — the source of truth for how a `dbType` is
  * spelled in a specialist heading, in the agent's multi-source listing
- * (`agent.ts`'s `dialectName` delegates here), and in the wizard enrich pass's
- * "valid <dialect> SQL" instruction. Unknown / plugin `dbType`s fall through to
- * a capitalize fallback in {@link dialectDisplayName}.
+ * (`buildMultiSourceSection` calls {@link dialectDisplayName} directly), and in
+ * the wizard enrich pass's "valid <dialect> SQL" instruction. Unknown / plugin
+ * `dbType`s fall through to a capitalize fallback in {@link dialectDisplayName}.
  */
 const DIALECT_DISPLAY_NAMES: Record<string, string> = {
   postgres: "PostgreSQL",
@@ -57,8 +57,7 @@ const DIALECT_DISPLAY_NAMES: Record<string, string> = {
 /**
  * Human display name for a `dbType`. Known engines use their canonical spelling
  * ({@link DIALECT_DISPLAY_NAMES}); anything else (a plugin's custom `dbType`)
- * is capitalized as a best-effort fallback, matching `agent.ts`'s legacy
- * `dialectName`.
+ * is capitalized as a best-effort fallback.
  */
 export function dialectDisplayName(dbType: string): string {
   return (

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -816,7 +816,7 @@ export function makeWiredPluginRegistryLive(
       }).pipe(
         Effect.catchAll((err) => {
           pluginLog.error({ err }, "Datasource wiring failed entirely");
-          return Effect.succeed({ wired: [] as string[], failed: [] as Array<{ pluginId: string; error: string }>, dialectHints: [] as Array<{ pluginId: string; dialect: string }>, entityFailures: [] as Array<{ pluginId: string; error: string }> });
+          return Effect.succeed({ wired: [] as string[], failed: [] as Array<{ pluginId: string; error: string }>, dialectHints: [] as Array<{ pluginId: string; dbType: string; dialect: string }>, entityFailures: [] as Array<{ pluginId: string; error: string }> });
         }),
       );
       if (dsResult.failed.length > 0) {

--- a/packages/api/src/lib/plugins/__tests__/tools.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/tools.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { setDialectHints, getDialectHints, setContextFragments, getContextFragments } from "../tools";
+import {
+  setDialectHints,
+  getDialectHints,
+  pluginDialectModules,
+  setContextFragments,
+  getContextFragments,
+} from "../tools";
 import type { DialectHint } from "../wiring";
 
 describe("setDialectHints / getDialectHints", () => {
@@ -13,23 +19,44 @@ describe("setDialectHints / getDialectHints", () => {
 
   test("round-trips DialectHint[]", () => {
     const hints: DialectHint[] = [
-      { pluginId: "bq", dialect: "Use SAFE_DIVIDE for BigQuery." },
-      { pluginId: "redshift", dialect: "Use GETDATE() instead of NOW()." },
+      { pluginId: "bq", dbType: "bigquery", dialect: "Use SAFE_DIVIDE for BigQuery." },
+      { pluginId: "redshift", dbType: "redshift", dialect: "Use GETDATE() instead of NOW()." },
     ];
     setDialectHints(hints);
     expect(getDialectHints()).toEqual(hints);
   });
 
   test("overwrites previous hints", () => {
-    setDialectHints([{ pluginId: "a", dialect: "first" }]);
-    setDialectHints([{ pluginId: "b", dialect: "second" }]);
-    expect(getDialectHints()).toEqual([{ pluginId: "b", dialect: "second" }]);
+    setDialectHints([{ pluginId: "a", dbType: "postgres", dialect: "first" }]);
+    setDialectHints([{ pluginId: "b", dbType: "mysql", dialect: "second" }]);
+    expect(getDialectHints()).toEqual([{ pluginId: "b", dbType: "mysql", dialect: "second" }]);
   });
 
   test("set empty clears hints", () => {
-    setDialectHints([{ pluginId: "a", dialect: "hint" }]);
+    setDialectHints([{ pluginId: "a", dbType: "postgres", dialect: "hint" }]);
     setDialectHints([]);
     expect(getDialectHints()).toEqual([]);
+  });
+});
+
+describe("pluginDialectModules", () => {
+  beforeEach(() => {
+    setDialectHints([]);
+  });
+
+  test("projects wired hints into dbType-keyed {dbType, module} modules (#4515)", () => {
+    setDialectHints([
+      { pluginId: "bq", dbType: "bigquery", dialect: "Use SAFE_DIVIDE." },
+      { pluginId: "ch", dbType: "clickhouse", dialect: "Use toStartOfMonth()." },
+    ]);
+    expect(pluginDialectModules()).toEqual([
+      { dbType: "bigquery", module: "Use SAFE_DIVIDE." },
+      { dbType: "clickhouse", module: "Use toStartOfMonth()." },
+    ]);
+  });
+
+  test("empty when no hints are wired", () => {
+    expect(pluginDialectModules()).toEqual([]);
   });
 });
 

--- a/packages/api/src/lib/plugins/__tests__/wiring.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/wiring.test.ts
@@ -286,7 +286,9 @@ describe("wireDatasourcePlugins", () => {
     );
 
     expect(result.dialectHints).toHaveLength(1);
-    expect(result.dialectHints[0]).toEqual({ pluginId: "bq", dialect: "Use SAFE_DIVIDE for BigQuery." });
+    // #4515 — the hint carries the plugin's engine so the dialect-specialist
+    // registry can resolve it by dbType (makeDatasourcePlugin defaults to postgres).
+    expect(result.dialectHints[0]).toEqual({ pluginId: "bq", dbType: "postgres", dialect: "Use SAFE_DIVIDE for BigQuery." });
   });
 
   test("returns empty dialectHints when no plugins provide dialect", async () => {

--- a/packages/api/src/lib/plugins/tools.ts
+++ b/packages/api/src/lib/plugins/tools.ts
@@ -27,6 +27,7 @@ export function getContextFragments(): string[] {
 }
 
 import type { DialectHint } from "./wiring";
+import type { PluginDialectModule } from "@atlas/api/lib/dialect-specialist";
 
 let dialectHints: readonly DialectHint[] = [];
 
@@ -36,4 +37,14 @@ export function setDialectHints(hints: readonly DialectHint[]): void {
 
 export function getDialectHints(): readonly DialectHint[] {
   return dialectHints;
+}
+
+/**
+ * Project the wired plugin dialect hints into the dbType-keyed
+ * {@link PluginDialectModule} shape the dialect-specialist registry (#4515)
+ * resolves against. One module per plugin hint — the registry's precedence
+ * (plugin > core) and blank-body filtering apply at resolution time.
+ */
+export function pluginDialectModules(): readonly PluginDialectModule[] {
+  return dialectHints.map((h) => ({ dbType: h.dbType, module: h.dialect }));
 }

--- a/packages/api/src/lib/plugins/wiring.ts
+++ b/packages/api/src/lib/plugins/wiring.ts
@@ -85,6 +85,14 @@ function hasRoutes(p: PluginLike): p is PluginLike & InteractionShape {
 
 export interface DialectHint {
   readonly pluginId: string;
+  /**
+   * The engine this dialect guidance describes — the datasource plugin's
+   * `connection.dbType`. Carried so the dialect-specialist registry
+   * (`lib/dialect-specialist.ts`, #4515) can resolve a plugin's module BY
+   * dbType and compose it for the groups in scope, keyed the same way as the
+   * core modules.
+   */
+  readonly dbType: string;
   readonly dialect: string;
 }
 
@@ -195,9 +203,14 @@ export async function wireDatasourcePlugins(
       }
     }
 
-    // Collect dialect hints
+    // Collect dialect hints, keyed by the plugin's engine so the
+    // dialect-specialist registry (#4515) can resolve them by dbType.
     if (typeof plugin.dialect === "string" && plugin.dialect.trim()) {
-      dialectHints.push({ pluginId: plugin.id, dialect: plugin.dialect });
+      dialectHints.push({
+        pluginId: plugin.id,
+        dbType: plugin.connection.dbType,
+        dialect: plugin.dialect,
+      });
     }
   }
 

--- a/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
@@ -250,6 +250,31 @@ describe("enrichEntityYaml (in-memory primitive, #3236)", () => {
     expect(prompt).toContain("valid PostgreSQL");
     expect(prompt).not.toContain("valid MySQL");
   });
+
+  // #4515 — the enrich pass reuses the dialect-specialist registry, so the
+  // engine's specialist module (not just its display name) rides in the prompt.
+  it("injects the engine's dialect-specialist module for the connection's engine (MySQL)", async () => {
+    await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never, undefined, "mysql");
+    const prompt = mockGenerateText.mock.calls.at(-1)?.[0]?.prompt as string;
+    expect(prompt).toContain("Engine-specific SQL guidance for this MySQL datasource");
+    // A signature line of the MySQL module body reaches the prompt.
+    expect(prompt).toContain("col >= '2024-01-01' AND col < '2025-01-01'");
+  });
+
+  it("injects the ClickHouse specialist module for a clickhouse datasource", async () => {
+    await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never, undefined, "clickhouse");
+    const prompt = mockGenerateText.mock.calls.at(-1)?.[0]?.prompt as string;
+    expect(prompt).toContain("Engine-specific SQL guidance for this ClickHouse datasource");
+    expect(prompt).toContain("toStartOfMonth");
+  });
+
+  it("an unknown engine composes cleanly — no specialist module block", async () => {
+    await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never, undefined, "sparksql");
+    const prompt = mockGenerateText.mock.calls.at(-1)?.[0]?.prompt as string;
+    expect(prompt).not.toContain("Engine-specific SQL guidance");
+    // The display name still flows through for the "valid <dialect>" instruction.
+    expect(prompt).toContain("valid Sparksql");
+  });
 });
 
 describe("enrichEntity (per-table primitive)", () => {

--- a/packages/api/src/lib/semantic/enrich/index.ts
+++ b/packages/api/src/lib/semantic/enrich/index.ts
@@ -14,6 +14,11 @@
 
 import { generateText } from "ai";
 import { getModel } from "@atlas/api/lib/providers";
+import {
+  dialectDisplayName,
+  resolveDialectSpecialist,
+} from "@atlas/api/lib/dialect-specialist";
+import { pluginDialectModules } from "@atlas/api/lib/plugins/tools";
 import type { RawTokenCounts } from "@atlas/api/lib/billing/token-weighting";
 import type { TableProfile } from "@useatlas/types";
 import * as fs from "fs";
@@ -223,7 +228,21 @@ export async function enrichEntityYaml(
   // PostgreSQL-only functions for a MySQL connection produces SQL the agent
   // can't run (issue #3236 review). Defaults to PostgreSQL for the file-based
   // CLI path, which is Postgres-oriented.
-  const dialect = dbType === "mysql" ? "MySQL" : "PostgreSQL";
+  //
+  // #4515 — the display name AND the engine-specific specialist module both come
+  // from the one dialect-specialist registry (`lib/dialect-specialist.ts`), the
+  // same modules the agent conversation composes — so the enrich pass is
+  // engine-aware, not merely MySQL-vs-Postgres. A plugin engine (e.g. ClickHouse)
+  // resolves its module (plugin > core); an unknown engine composes cleanly with
+  // no module, just the display name. `pluginDialectModules()` is empty in the
+  // file-based CLI (no plugins wired), so that path resolves core modules only.
+  const dialect = dbType ? dialectDisplayName(dbType) : "PostgreSQL";
+  const specialist = dbType
+    ? resolveDialectSpecialist(dbType, pluginDialectModules())?.module
+    : undefined;
+  const specialistSection = specialist
+    ? `\n\nEngine-specific SQL guidance for this ${dialect} datasource — follow it when writing query_patterns:\n${specialist}\n`
+    : "";
 
   const result = await generateText({
     model,
@@ -237,7 +256,7 @@ Here is the current YAML definition:
 \`\`\`yaml
 ${existingContent}
 \`\`\`
-
+${specialistSection}
 Generate ONLY the following improved/new fields as valid YAML. Do not repeat the entire file.
 Output your response inside a single \`\`\`yaml code block.
 

--- a/packages/api/src/lib/semantic/enrich/index.ts
+++ b/packages/api/src/lib/semantic/enrich/index.ts
@@ -232,10 +232,11 @@ export async function enrichEntityYaml(
   // #4515 — the display name AND the engine-specific specialist module both come
   // from the one dialect-specialist registry (`lib/dialect-specialist.ts`), the
   // same modules the agent conversation composes — so the enrich pass is
-  // engine-aware, not merely MySQL-vs-Postgres. A plugin engine (e.g. ClickHouse)
-  // resolves its module (plugin > core); an unknown engine composes cleanly with
-  // no module, just the display name. `pluginDialectModules()` is empty in the
-  // file-based CLI (no plugins wired), so that path resolves core modules only.
+  // engine-aware, not merely MySQL-vs-Postgres. A plugin-only engine (e.g.
+  // BigQuery) resolves its plugin module (plugin > core); an unknown engine
+  // composes cleanly with no module, just the display name.
+  // `pluginDialectModules()` is empty in the file-based CLI (no plugins wired),
+  // so that path resolves core modules only.
   const dialect = dbType ? dialectDisplayName(dbType) : "PostgreSQL";
   const specialist = dbType
     ? resolveDialectSpecialist(dbType, pluginDialectModules())?.module


### PR DESCRIPTION
## Summary

Closes #4515.

Adds the **Dialect specialist** registry (CONTEXT.md § Dialect specialist): engine-specific SQL expertise as composable prompt modules keyed by `dbType`, shaped like the answer-styles registry — not like separate per-engine agents. **One agent, composed prompt:** the specialist module knows the engine; the expert persona owns the semantic layer and Amendments; the analyst role owns the answer.

- **`lib/dialect-specialist.ts`** — the registry. Core ships the initial **Postgres / MySQL / ClickHouse** modules (`CORE_DIALECT_SPECIALISTS`, keyed by `CoreDialectDbType` derived from the dbType tuple so the set can't drift, mirroring `answer-styles.ts`). `resolveDialectSpecialist` resolves a module per `dbType` with **plugin > core** precedence; unknown engines resolve to `undefined` and compose cleanly as no module. `composeDialectSpecialists` folds the groups in scope by `dbType` — one module per engine, attributed per group under a cross-group sweep.
- **Plugin extensibility, no core change** — a datasource plugin ships its module via the existing `dialect` field; `DialectHint` now carries `dbType` (from `connection.dbType`) and `pluginDialectModules()` projects the wired hints into the registry's shape.
- **Conversation assembly** — `runAgent` composes the specialist section for the reachable groups (`resolveConversationDialectSpecialists`) and threads it through `buildSystemParam`, superseding the pre-#4515 inline MySQL guide + global dialect-hint notes. Reach regime mirrors the Source catalog (ADR-0022): workspace-present composes exactly the reachable set (empty ⇒ nothing, **fails closed**); no-workspace falls back to each visible connection as a group-of-one. Resolved in parallel with the Source catalog (same reach state).
- **Wizard enrich** — `enrichEntityYaml` reuses the same registry so its LLM pass is engine-aware: the connection engine's display name **and** its specialist module ride in the enrich prompt.
- Consolidated dialect display names onto the registry (`dialectDisplayName` is the SSOT; removed `agent.ts`'s duplicate map/`dialectName`).

Acceptance criteria — all met:
- ✅ Registry resolves a module per `dbType`; a plugin can ship one without a core change
- ✅ Multi-group conversation composes multiple modules, each attributed to its group
- ✅ Postgres/MySQL/ClickHouse initial modules ship; unknown dbTypes compose cleanly with no module
- ✅ Wizard enrich prompt includes the specialist module for the connection's engine
- ✅ Registry + composition unit tests; mock-LLM seam test for prompt placement

## Test Plan

- New `dialect-specialist.test.ts` — registry (display names, core module set, plugin-ships-without-core, plugin>core precedence, blank-module ignored) + composition (empty/single/multi-group attribution, dbType fold, unknown-engine skip, plugin composition).
- New `agent-dialect-specialist-seam.test.ts` — mock-LLM seam: composed module reaches the system prompt at the right position, single/multi/unknown/plugin-precedence.
- New `agent-dialect-specialist-resolve.test.ts` — reach→dbType branch: workspace-present mapping, member-engine fallback, fail-closed empty/throw, no-workspace group-of-one.
- `enrich-engine.test.ts` — asserts the specialist module reaches the enrich prompt (MySQL/ClickHouse) and unknown engine injects none.
- Updated existing dialect/sargability/cache/saas-gate/wiring/tools tests for the new composed-section seam.
- Full `--affected` suite (562 files) green locally. Internal review panel run twice (silent-failure, type-design, test-coverage, comment) → converged clean.

- [x] Manual testing (mock-LLM seam)
- [x] Unit tests added/updated
- [ ] E2E tests added/updated

## Checklist

- [ ] Types pass (`bun run type`) — type-check was in progress when the PR was opened; CI is the gate
- [x] Tests pass (`bun run test`) — affected suite green locally
- [ ] Lint passes (`bun run lint`) — CI is the gate
- [x] Labels added (type + area) — inherits `feature` / `area: api` from #4515
- [ ] CHANGELOG.md updated — internal prompt-assembly change; no per-tag changelog entry

https://claude.ai/code/session_01JSgvmfEEJvstb5xa1inYgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSgvmfEEJvstb5xa1inYgb)_