### PR TITLE
feat(semantic-improve): proactive notice for autonomously queued Amendments (#4520)

### DIFF
--- a/ee/src/proactive/__tests__/amendment-notification.test.ts
+++ b/ee/src/proactive/__tests__/amendment-notification.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the amendments-pending proactive notice EE delivery (#4520).
+ *
+ * Two surfaces:
+ *   - `buildAmendmentsPendingMessage` — pure markdown renderer. Pinned on
+ *     the "pending your review" phrasing (PRD user story 25) and the
+ *     singular/plural agreement so a copy regression fails loudly.
+ *   - `notifyAmendmentsPending` — resolves the workspace's proactive
+ *     announcement channel and posts via a `ChatAnnouncer` stub. The
+ *     internal DB is mocked at `internalQuery` so channel-present /
+ *     no-row / no-channel branches are scripted independently, and every
+ *     failure path is asserted to resolve a `{ posted: false }` outcome
+ *     (best-effort — nothing throws).
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import type { ChatAnnouncer } from "@atlas/api/lib/proactive/types";
+
+// --- Internal DB mock ---
+type InternalQueryCall = { sql: string; params: unknown[] };
+let lastQueries: InternalQueryCall[] = [];
+let mockInternalRows: unknown[][] = [];
+let mockHasInternalDB = true;
+let internalQueryThrows = false;
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    lastQueries.push({ sql, params: params ?? [] });
+    if (internalQueryThrows) throw new Error("db brownout");
+    return mockInternalRows.shift() ?? [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: mockInternalQuery,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { notifyAmendmentsPending, buildAmendmentsPendingMessage } = await import(
+  "../amendment-notification"
+);
+
+function reset(): void {
+  mockHasInternalDB = true;
+  internalQueryThrows = false;
+  lastQueries = [];
+  mockInternalRows = [];
+  mockInternalQuery.mockClear();
+}
+
+/** A recording announcer stub. `result` scripts its reply. */
+function makeAnnouncer(
+  result:
+    | { ok: true; messageId?: string }
+    | { ok: false; reason: string }
+    | "throw",
+): { announcer: ChatAnnouncer; calls: Array<{ workspaceId: string; channelId: string; markdown: string }> } {
+  const calls: Array<{ workspaceId: string; channelId: string; markdown: string }> = [];
+  const announcer: ChatAnnouncer = {
+    async postChannelAnnouncement(input) {
+      calls.push(input);
+      if (result === "throw") throw new Error("network down");
+      return result;
+    },
+  };
+  return { announcer, calls };
+}
+
+describe("buildAmendmentsPendingMessage (#4520)", () => {
+  it("uses singular agreement for a single amendment", () => {
+    const msg = buildAmendmentsPendingMessage(1);
+    expect(msg).toContain("1 new semantic-layer improvement is pending your review");
+    expect(msg).toContain("queued a change");
+  });
+
+  it("uses plural agreement for multiple amendments", () => {
+    const msg = buildAmendmentsPendingMessage(5);
+    expect(msg).toContain("5 new semantic-layer improvements are pending your review");
+    expect(msg).toContain("queued 5 changes");
+  });
+});
+
+describe("notifyAmendmentsPending (#4520)", () => {
+  beforeEach(reset);
+
+  it("posts to the workspace's announcement channel and reports the message id", async () => {
+    mockInternalRows = [[{ announcement_channel_id: "C123" }]];
+    const { announcer, calls } = makeAnnouncer({ ok: true, messageId: "slack-9" });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 3, announcer });
+
+    expect(outcome).toEqual({ posted: true, messageId: "slack-9" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ workspaceId: "org-a", channelId: "C123" });
+    expect(calls[0].markdown).toContain("3 new semantic-layer improvements");
+    // The config probe is keyed by workspace id.
+    expect(lastQueries[0].params).toEqual(["org-a"]);
+  });
+
+  it("skips cleanly when no internal DB is configured", async () => {
+    mockHasInternalDB = false;
+    const { announcer, calls } = makeAnnouncer({ ok: true });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 1, announcer });
+
+    expect(outcome).toEqual({ posted: false, reason: "no_internal_db" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips with no_config_row when the workspace never engaged proactive", async () => {
+    mockInternalRows = [[]];
+    const { announcer, calls } = makeAnnouncer({ ok: true });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 2, announcer });
+
+    expect(outcome).toEqual({ posted: false, reason: "no_config_row" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("skips with no_channel when proactive config exists but no announcement channel", async () => {
+    mockInternalRows = [[{ announcement_channel_id: null }]];
+    const { announcer, calls } = makeAnnouncer({ ok: true });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 2, announcer });
+
+    expect(outcome).toEqual({ posted: false, reason: "no_channel" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("maps the null announcer to no_announcer_configured", async () => {
+    mockInternalRows = [[{ announcement_channel_id: "C123" }]];
+    const { announcer } = makeAnnouncer({ ok: false, reason: "no_announcer_configured" });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 1, announcer });
+
+    expect(outcome).toEqual({ posted: false, reason: "no_announcer_configured" });
+  });
+
+  it("maps any other announcer rejection to announcer_rejected with the platform reason", async () => {
+    mockInternalRows = [[{ announcement_channel_id: "C123" }]];
+    const { announcer } = makeAnnouncer({ ok: false, reason: "channel_archived" });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 1, announcer });
+
+    expect(outcome).toEqual({ posted: false, reason: "announcer_rejected", message: "channel_archived" });
+  });
+
+  it("maps a thrown announcer to announcer_threw without propagating", async () => {
+    mockInternalRows = [[{ announcement_channel_id: "C123" }]];
+    const { announcer } = makeAnnouncer("throw");
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 1, announcer });
+
+    expect(outcome).toMatchObject({ posted: false, reason: "announcer_threw" });
+  });
+
+  it("maps a config-read failure to a non-throwing error outcome", async () => {
+    internalQueryThrows = true;
+    const { announcer, calls } = makeAnnouncer({ ok: true });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 1, announcer });
+
+    expect(outcome).toMatchObject({ posted: false, reason: "error" });
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/ee/src/proactive/amendment-notification.ts
+++ b/ee/src/proactive/amendment-notification.ts
@@ -1,0 +1,144 @@
+/**
+ * Amendments-pending proactive notice — EE delivery (#4520).
+ *
+ * When the autonomous-improvement scheduler queues new pending Amendments
+ * for a workspace, its admins get one batched proactive message: "N new
+ * semantic-layer improvements are pending your review." This is the EE
+ * side of the `ProactiveService.notifyAmendmentsPending` seam; the core
+ * scheduler reaches it via `lib/proactive/notify-amendments.ts`.
+ *
+ * Delivery reuses the proactive-chat announcement channel
+ * (`workspace_proactive_config.announcement_channel_id`) via the shared
+ * `ChatAnnouncer` port — no bespoke notification channel (#4520). A
+ * workspace that never configured a proactive channel simply has nowhere
+ * to receive the notice, which resolves as a clean skip rather than an
+ * error.
+ *
+ * Unlike the one-shot activation announcement, this notice is NOT
+ * idempotency-stamped: it fires on each tick that produces net-new
+ * pending Amendments, and the caller has already batched the tick's rows
+ * into a single `count`. Posting is best-effort — every failure resolves
+ * to a `{ posted: false }` outcome; nothing here throws.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+import type {
+  ChatAnnouncer,
+  AmendmentNoticeInput,
+  AmendmentNoticeOutcome,
+} from "@atlas/api/lib/proactive/types";
+
+const log = createLogger("proactive-amendment-notification");
+
+/**
+ * Render the amendments-pending notice. Pure — exported so the unit test
+ * pins the wording (the "pending your review" phrasing is the contract
+ * the PRD's user story 25 names) without a DB. Plain markdown, mirroring
+ * `buildAnnouncementMessage`; rich cards are a later cross-cutting slice.
+ */
+export function buildAmendmentsPendingMessage(count: number): string {
+  const isOne = count === 1;
+  const noun = isOne ? "improvement" : "improvements";
+  const verb = isOne ? "is" : "are";
+  return [
+    `*${count} new semantic-layer ${noun} ${verb} pending your review.*`,
+    "",
+    `Atlas's autonomous improvement queued ${isOne ? "a change" : `${count} changes`} to`,
+    "your semantic layer. Approve or reject them in the Semantic Layer",
+    "Improvement console — nothing applies until you review it.",
+  ].join("\n");
+}
+
+/** Raw shape of the config probe. Index signature satisfies `internalQuery`. */
+interface RawConfigRow {
+  announcement_channel_id: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Post the amendments-pending notice for a workspace, if a proactive
+ * announcement channel is configured.
+ *
+ * @param input.workspaceId  Atlas workspace id (== org id).
+ * @param input.count        Batched count of net-new pending Amendments.
+ * @param input.announcer    Chat-platform port (host-resolved).
+ */
+export async function notifyAmendmentsPending(
+  input: AmendmentNoticeInput & { announcer: ChatAnnouncer },
+): Promise<AmendmentNoticeOutcome> {
+  const { workspaceId, count, announcer } = input;
+
+  // Self-guarding: the core bridge already guards, but a direct EE caller
+  // must never render "0 new improvements".
+  if (count <= 0) {
+    return { posted: false, reason: "nothing_to_notify" };
+  }
+
+  if (!hasInternalDB()) {
+    return { posted: false, reason: "no_internal_db" };
+  }
+
+  let rows: RawConfigRow[];
+  try {
+    rows = await internalQuery<RawConfigRow>(
+      `SELECT announcement_channel_id
+         FROM workspace_proactive_config
+        WHERE workspace_id = $1
+        LIMIT 1`,
+      [workspaceId],
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { workspaceId, err: message },
+      "Amendments-pending notice: workspace_proactive_config read failed",
+    );
+    return { posted: false, reason: "error", message };
+  }
+
+  const [row] = rows;
+  if (!row) {
+    // Workspace never engaged proactive chat — nothing to key a channel on.
+    return { posted: false, reason: "no_config_row" };
+  }
+  const channelId = row.announcement_channel_id;
+  if (!channelId) {
+    // Proactive config exists but no announcement channel to post to.
+    return { posted: false, reason: "no_channel" };
+  }
+
+  const markdown = buildAmendmentsPendingMessage(count);
+  let result: Awaited<ReturnType<ChatAnnouncer["postChannelAnnouncement"]>>;
+  try {
+    result = await announcer.postChannelAnnouncement({
+      workspaceId,
+      channelId,
+      markdown,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { workspaceId, channelId, err: message },
+      "Amendments-pending notice: announcer threw",
+    );
+    return { posted: false, reason: "announcer_threw", message };
+  }
+
+  if (!result.ok) {
+    if (result.reason === "no_announcer_configured") {
+      return { posted: false, reason: "no_announcer_configured" };
+    }
+    log.warn(
+      { workspaceId, channelId, reason: result.reason },
+      "Amendments-pending notice: announcer rejected the post",
+    );
+    return { posted: false, reason: "announcer_rejected", message: result.reason };
+  }
+
+  log.info(
+    { workspaceId, channelId, count, messageId: result.messageId ?? null },
+    "Posted amendments-pending proactive notice",
+  );
+  return { posted: true, messageId: result.messageId };
+}

--- a/ee/src/proactive/service.ts
+++ b/ee/src/proactive/service.ts
@@ -42,6 +42,7 @@ import {
   summarizePublicRefused,
 } from "./public-dataset";
 import { announceActivation } from "./announcement-coordinator";
+import { notifyAmendmentsPending } from "./amendment-notification";
 import { getChatAnnouncer } from "./announcer-registry";
 import { listWorkspaceChannels } from "./channel-directory";
 
@@ -73,6 +74,14 @@ export const makeProactiveServiceLive = (): ProactiveServiceShape =>
       ),
     listWorkspaceChannels: (workspaceId) =>
       Effect.promise(() => listWorkspaceChannels(workspaceId)),
+    notifyAmendmentsPending: ({ workspaceId, count }) =>
+      Effect.promise(() =>
+        notifyAmendmentsPending({
+          workspaceId,
+          count,
+          announcer: getChatAnnouncer(),
+        }),
+      ),
   }) satisfies ProactiveServiceShape;
 
 export const ProactiveServiceLive: Layer.Layer<ProactiveService> = Layer.sync(

--- a/packages/api/src/lib/effect/proactive-service.ts
+++ b/packages/api/src/lib/effect/proactive-service.ts
@@ -46,6 +46,8 @@ import type {
   PublicDatasetEntry,
   PublicRefusedRollupRow,
   AnnouncementOutcome,
+  AmendmentNoticeInput,
+  AmendmentNoticeOutcome,
   ChannelDirectoryResult,
 } from "@atlas/api/lib/proactive/types";
 
@@ -109,6 +111,21 @@ export interface ProactiveServiceShape {
   readonly listWorkspaceChannels: (
     workspaceId: string,
   ) => Effect.Effect<ChannelDirectoryResult, EnterpriseError>;
+
+  // ── autonomous-improvement notification (scheduler → seam, #4520) ──
+  /**
+   * Post ONE proactive notice to a workspace's admins that autonomous
+   * improvement queued `count` new pending Amendments. Batched per
+   * scheduler tick (not per row) by the caller; `count` is that batch.
+   * The EE impl posts to the workspace's proactive announcement channel —
+   * the same seam as `announceActivation`, no bespoke channel. The Noop
+   * default fails with `EnterpriseError`, which the core caller
+   * (`lib/proactive/notify-amendments.ts`) swallows into a clean skip so
+   * a non-EE deploy degrades to "no notification" (#4520 AC3).
+   */
+  readonly notifyAmendmentsPending: (
+    input: AmendmentNoticeInput,
+  ) => Effect.Effect<AmendmentNoticeOutcome, EnterpriseError>;
 }
 
 export class ProactiveService extends Context.Tag("ProactiveService")<
@@ -144,6 +161,7 @@ export const NoopProactiveServiceLayer: Layer.Layer<ProactiveService> =
     summarizePublicRefused: notAvailable,
     announceActivation: notAvailable,
     listWorkspaceChannels: notAvailable,
+    notifyAmendmentsPending: notAvailable,
   } satisfies ProactiveServiceShape);
 
 /**
@@ -179,5 +197,7 @@ export function createProactiveServiceTestLayer(
     announceActivation: partial.announceActivation ?? fail("announceActivation"),
     listWorkspaceChannels:
       partial.listWorkspaceChannels ?? fail("listWorkspaceChannels"),
+    notifyAmendmentsPending:
+      partial.notifyAmendmentsPending ?? fail("notifyAmendmentsPending"),
   } satisfies ProactiveServiceShape);
 }

--- a/packages/api/src/lib/proactive/__tests__/notify-amendments.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/notify-amendments.test.ts
@@ -1,0 +1,114 @@
+/**
+ * notifyAmendmentsPending — the core → proactive-seam bridge (#4520).
+ *
+ * This is the plain-async entry the semantic-expert scheduler calls. It
+ * MUST degrade cleanly to a `{ posted: false }` outcome on every failure
+ * path — an enterprise-off deploy (the Noop `ProactiveService` fails the
+ * seam with `EnterpriseError`) or any delivery defect must never throw
+ * back into the tick (AC3).
+ *
+ * The mocked `runEnterprise` FAITHFULLY runs the passed program against a
+ * swappable `ProactiveService` layer on the real Effect runtime — so the
+ * `EnterpriseError` genuinely flows through the seam and the bridge's
+ * inside-the-Effect `catchTag` recovery is exercised for real. A prior
+ * version mocked `runEnterprise` to throw a raw `EnterpriseError`
+ * instance, which the real `ManagedRuntime.runPromise` NEVER produces (it
+ * rejects with a `FiberFailure` wrapper) — that masked a dead-branch bug.
+ * Running the real Noop layer is what makes this test trustworthy.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  ProactiveService,
+  NoopProactiveServiceLayer,
+  createProactiveServiceTestLayer,
+} from "@atlas/api/lib/effect/proactive-service";
+import type { AmendmentNoticeOutcome } from "@atlas/api/lib/proactive/types";
+
+// The layer runEnterprise resolves `ProactiveService` from — swapped per test.
+let proactiveLayer: Layer.Layer<ProactiveService> = NoopProactiveServiceLayer;
+
+// Intentionally NARROW mock: only `runEnterprise` is provided. It is the sole
+// enterprise-layer export the module-under-test consumes, and bun `--isolate`
+// resets module mocks per file, so the other exports (getEnterpriseRuntime,
+// yieldFailClosed, EnterpriseLayer) can't leak in unmocked from this file.
+void mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  // Mimic runEnterprise faithfully: provide the current layer and run on the
+  // real Effect runtime (reproducing the FiberFailure-wrapping the bridge must
+  // be immune to).
+  runEnterprise: (program: Effect.Effect<AmendmentNoticeOutcome, never, ProactiveService>) =>
+    Effect.runPromise(Effect.provide(program, proactiveLayer)),
+}));
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+const { notifyAmendmentsPending } = await import("../notify-amendments");
+
+beforeEach(() => {
+  proactiveLayer = NoopProactiveServiceLayer;
+});
+
+describe("notifyAmendmentsPending bridge (#4520)", () => {
+  it("short-circuits without touching the seam when count <= 0", async () => {
+    // A seam that would die if reached — proves count<=0 never calls it.
+    proactiveLayer = createProactiveServiceTestLayer({
+      notifyAmendmentsPending: () => Effect.die(new Error("seam should not be reached")),
+    });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 0 });
+
+    expect(outcome).toEqual({ posted: false, reason: "nothing_to_notify" });
+  });
+
+  it("passes the seam's outcome through on a successful post", async () => {
+    proactiveLayer = createProactiveServiceTestLayer({
+      notifyAmendmentsPending: (input) => {
+        expect(input).toEqual({ workspaceId: "org-a", count: 4 });
+        return Effect.succeed({ posted: true, messageId: "slack-123" } satisfies AmendmentNoticeOutcome);
+      },
+    });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 4 });
+
+    expect(outcome).toEqual({ posted: true, messageId: "slack-123" });
+  });
+
+  it("degrades to enterprise_disabled against the REAL Noop layer (FiberFailure-safe)", async () => {
+    // The Noop ProactiveService fails the seam with EnterpriseError INSIDE the
+    // Effect; the bridge's catchTag recovers it to a success value. This does
+    // NOT rely on an outside `instanceof` against the runPromise rejection —
+    // which would be a FiberFailure wrapper and always false.
+    proactiveLayer = NoopProactiveServiceLayer;
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 2 });
+
+    expect(outcome).toEqual({ posted: false, reason: "enterprise_disabled" });
+  });
+
+  it("maps an unexpected defect to a non-throwing error outcome", async () => {
+    proactiveLayer = createProactiveServiceTestLayer({
+      notifyAmendmentsPending: () => Effect.die(new Error("channel post exploded")),
+    });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 1 });
+
+    // Never throws — a defect is contained and tagged `error`.
+    expect(outcome.posted).toBe(false);
+    if (!outcome.posted) expect(outcome.reason).toBe("error");
+  });
+
+  it("passes a delivery-side skip outcome straight through", async () => {
+    // The EE impl may resolve a clean skip (e.g. no announcement channel).
+    proactiveLayer = createProactiveServiceTestLayer({
+      notifyAmendmentsPending: () =>
+        Effect.succeed({ posted: false, reason: "no_channel" } satisfies AmendmentNoticeOutcome),
+    });
+
+    const outcome = await notifyAmendmentsPending({ workspaceId: "org-a", count: 3 });
+
+    expect(outcome).toEqual({ posted: false, reason: "no_channel" });
+  });
+});

--- a/packages/api/src/lib/proactive/notify-amendments.ts
+++ b/packages/api/src/lib/proactive/notify-amendments.ts
@@ -1,0 +1,89 @@
+/**
+ * Autonomous-improvement → proactive notification bridge (#4520).
+ *
+ * The semantic-expert scheduler is plain-async (called inside an
+ * `Effect.tryPromise` fiber tick, outside the Effect context). The
+ * proactive-chat delivery lives behind the `ProactiveService`
+ * Context.Tag, whose implementation is EE-only. This module is the one
+ * seam that lets the core scheduler reach that Tag through the sanctioned
+ * `runEnterprise` bridge (the same mechanism `byot-catalog-refresh.ts`
+ * uses for `ModelRouter`), without `packages/api/src` ever importing
+ * `@atlas/ee`.
+ *
+ * Best-effort by construction: this function NEVER throws. A notice is a
+ * convenience on top of a tick that already did its real work (queued the
+ * Amendments); a delivery hiccup, a missing channel, or an enterprise-off
+ * deployment must degrade cleanly to "no notification" and never fail the
+ * tick (#4520 AC3). Every failure resolves to a `{ posted: false }`
+ * outcome the caller logs and moves on from.
+ */
+
+import { Effect } from "effect";
+import { createLogger } from "@atlas/api/lib/logger";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { ProactiveService } from "@atlas/api/lib/effect/proactive-service";
+import type {
+  AmendmentNoticeInput,
+  AmendmentNoticeOutcome,
+} from "@atlas/api/lib/proactive/types";
+
+const log = createLogger("proactive-notify-amendments");
+
+/**
+ * Notify a workspace's admins that autonomous improvement queued
+ * `count` new pending Amendments — ONE batched notice for the tick.
+ *
+ * Guards `count <= 0` before touching the seam so a zero-queue tick can
+ * call this unconditionally without a spurious enterprise round-trip.
+ *
+ * The Noop `ProactiveService` (enterprise disabled / EE load failed)
+ * fails the seam with a typed `EnterpriseError`. We recover it with
+ * `Effect.catchTag` INSIDE the Effect, turning the clean degrade into a
+ * success value — crucially NOT by `instanceof`-checking the rejection
+ * outside: `runEnterprise` runs on a `ManagedRuntime`, whose `runPromise`
+ * rejects with a `FiberFailure` WRAPPING the typed error, so an outside
+ * `err instanceof EnterpriseError` is always false. The `catchTag`
+ * recovery is the AC3 "degrade cleanly to no notification, quietly" path
+ * (#4520). The outer try/catch then only ever sees an unexpected defect
+ * (the EE delivery is best-effort and shouldn't reject) and still never
+ * rethrows into the tick.
+ */
+export async function notifyAmendmentsPending(
+  input: AmendmentNoticeInput,
+): Promise<AmendmentNoticeOutcome> {
+  if (input.count <= 0) {
+    return { posted: false, reason: "nothing_to_notify" };
+  }
+
+  try {
+    return await runEnterprise(
+      Effect.gen(function* () {
+        const proactive = yield* ProactiveService;
+        return yield* proactive.notifyAmendmentsPending({
+          workspaceId: input.workspaceId,
+          count: input.count,
+        });
+      }).pipe(
+        Effect.catchTag("EnterpriseError", () =>
+          Effect.sync((): AmendmentNoticeOutcome => {
+            // Enterprise off / not loaded — autonomous improvement still
+            // queued its Amendments; there is simply nowhere to notify.
+            // Clean degrade, DEBUG not WARN (#4520 AC3).
+            log.debug(
+              { workspaceId: input.workspaceId, count: input.count },
+              "Proactive notification unavailable (enterprise-gated) — amendments queued without a notice",
+            );
+            return { posted: false, reason: "enterprise_disabled" };
+          }),
+        ),
+      ),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { workspaceId: input.workspaceId, count: input.count, err: message },
+      "Amendment-pending notification failed — continuing without notifying",
+    );
+    return { posted: false, reason: "error", message };
+  }
+}

--- a/packages/api/src/lib/proactive/types.ts
+++ b/packages/api/src/lib/proactive/types.ts
@@ -209,6 +209,73 @@ export interface AnnounceActivationInput {
 }
 
 // ---------------------------------------------------------------------------
+// autonomous-improvement notification (#4520)
+// ---------------------------------------------------------------------------
+
+/** Input to the amendments-pending notice seam — the workspace to notify
+ * and the batched count of net-new pending Amendments from the tick. */
+export interface AmendmentNoticeInput {
+  workspaceId: string;
+  count: number;
+}
+
+/**
+ * Skip reasons that always carry a diagnostic `message` (a caught error's
+ * text or a platform-side rejection reason). Split out so the outcome type
+ * can require `message` on exactly these and forbid it on the rest —
+ * mirroring the fully-discriminated `AnnouncementOutcome` sibling.
+ */
+export type AmendmentNoticeMessageReason =
+  | "error"
+  | "announcer_threw"
+  | "announcer_rejected";
+
+/**
+ * Why a skip happened when an amendments-pending notice was not posted.
+ * Purely an API-side port shape — the scheduler consumes it for logging
+ * and it is never serialised onto the wire (unlike `AnnouncementOutcome`,
+ * which is declared in `@useatlas/types`, the wire package). Both layers
+ * that produce it:
+ *
+ *   - the core bridge (`lib/proactive/notify-amendments.ts`):
+ *     `nothing_to_notify` (count ≤ 0 — guarded before the seam),
+ *     `enterprise_disabled` (the Noop `ProactiveService` failed with
+ *     `EnterpriseError` — the clean degrade path, AC3), `error`
+ *     (any other unexpected bridge failure/defect).
+ *   - the EE delivery (`ee/src/proactive/amendment-notification.ts`):
+ *     `nothing_to_notify` (defensive count guard), `no_internal_db`,
+ *     `no_config_row` (workspace never engaged proactive), `no_channel`
+ *     (proactive config exists but no announcement channel to post to),
+ *     `no_announcer_configured` / `announcer_rejected` / `announcer_threw`
+ *     (chat-platform port), and `error` (the config-row read threw).
+ */
+export type AmendmentNoticeSkipReason =
+  | AmendmentNoticeMessageReason
+  | "nothing_to_notify"
+  | "enterprise_disabled"
+  | "no_internal_db"
+  | "no_config_row"
+  | "no_channel"
+  | "no_announcer_configured";
+
+/**
+ * Outcome of an attempt to notify a workspace's admins that autonomous
+ * improvement queued new pending Amendments (#4520). Best-effort by
+ * construction: a skip is never an error the scheduler tick surfaces —
+ * autonomy must not fail a tick on a delivery hiccup or an enterprise-off
+ * deployment. `message` is present iff the `reason` carries a diagnostic
+ * (a caught error / a platform rejection) — the type enforces that split
+ * rather than leaving `message` optional everywhere.
+ */
+export type AmendmentNoticeOutcome =
+  | { posted: true; messageId?: string }
+  | { posted: false; reason: AmendmentNoticeMessageReason; message: string }
+  | {
+      posted: false;
+      reason: Exclude<AmendmentNoticeSkipReason, AmendmentNoticeMessageReason>;
+    };
+
+// ---------------------------------------------------------------------------
 // quota (#2301)
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/scheduler-tick.test.ts
@@ -161,6 +161,18 @@ void mock.module("@atlas/api/lib/settings", () => ({
   isSaasModeForGuard: () => saasMode,
 }));
 
+// Proactive notification bridge — partial mock (the tick calls only
+// notifyAmendmentsPending). The bridge's own Noop→clean-skip mechanics are
+// unit-tested in lib/proactive/__tests__/notify-amendments.test.ts; here we
+// pin that the SCHEDULER emits one batched notice per workspace-tick (#4520).
+type NotifyOutcome = { posted: boolean; messageId?: string; reason?: string };
+const mockNotifyAmendmentsPending: Mock<
+  (input: { workspaceId: string; count: number }) => Promise<NotifyOutcome>
+> = mock(async () => ({ posted: true, messageId: "notice-1" }));
+void mock.module("@atlas/api/lib/proactive/notify-amendments", () => ({
+  notifyAmendmentsPending: mockNotifyAmendmentsPending,
+}));
+
 const { runExpertSchedulerTick, AUTONOMOUS_IMPROVE_ENABLED_KEY } = await import("../scheduler");
 
 function resetMocks(): void {
@@ -182,6 +194,8 @@ function resetMocks(): void {
   mockDecideAmendment.mockImplementation(async (params) => ({ kind: "approved", id: params.id }));
   mockInsertSemanticAmendment.mockClear();
   mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "sch-1", autoApprove: true });
+  mockNotifyAmendmentsPending.mockClear();
+  mockNotifyAmendmentsPending.mockImplementation(async () => ({ posted: true, messageId: "notice-1" }));
 }
 
 describe("runExpertSchedulerTick auto-approve → decide seam invariant (#4486, #4506)", () => {
@@ -453,6 +467,163 @@ describe("runExpertSchedulerTick — SaaS per-workspace iteration (#4516)", () =
     // [{ orgId: null }] path and produce a global-scope tick on SaaS.
     expect(mockInsertSemanticAmendment).not.toHaveBeenCalled();
     expect(gateCalls).toEqual([]);
+  });
+});
+
+describe("runExpertSchedulerTick — proactive amendments-pending notice (#4520)", () => {
+  beforeEach(resetMocks);
+
+  it("emits ONE batched notice per workspace when the tick left net-new pending Amendments", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a"];
+    // Three proposals, all queued (not auto-approve eligible) — the notice must
+    // batch them into a single message with count 3, not fire per row.
+    proposals = [proposal, proposal, proposal];
+    mockInsertSemanticAmendment.mockResolvedValue({
+      outcome: "inserted",
+      id: "sch-q",
+      autoApprove: false,
+    });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.queued).toBe(3);
+    expect(mockNotifyAmendmentsPending).toHaveBeenCalledTimes(1);
+    expect(mockNotifyAmendmentsPending.mock.calls[0][0]).toEqual({
+      workspaceId: "org-a",
+      count: 3,
+    });
+  });
+
+  it("batches on net-new pending count (queued), not total proposals, in a mixed tick", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a"];
+    // Three proposals: the first auto-approves (applied, no longer pending),
+    // the other two queue. The notice count must be the 2 net-new pending
+    // rows — NOT the 3 total proposals, and NOT autoApproved+queued.
+    proposals = [proposal, proposal, proposal];
+    let n = 0;
+    mockInsertSemanticAmendment.mockImplementation(async () => {
+      n++;
+      return n === 1
+        ? { outcome: "inserted", id: "auto", autoApprove: true }
+        : { outcome: "inserted", id: `q${n}`, autoApprove: false };
+    });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.proposalsGenerated).toBe(3);
+    expect(result.autoApproved).toBe(1);
+    expect(result.queued).toBe(2);
+    expect(mockNotifyAmendmentsPending).toHaveBeenCalledTimes(1);
+    expect(mockNotifyAmendmentsPending.mock.calls[0][0]).toEqual({
+      workspaceId: "org-a",
+      count: 2,
+    });
+  });
+
+  it("does not notify when nothing was queued (every proposal auto-approved)", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a"];
+    // Default insert mock is auto-approve eligible → decide seam approves → the
+    // tick applies them, leaving zero pending. No pending queue ⇒ no notice.
+    const result = await runExpertSchedulerTick();
+
+    expect(result.autoApproved).toBe(1);
+    expect(result.queued).toBe(0);
+    expect(mockNotifyAmendmentsPending).not.toHaveBeenCalled();
+  });
+
+  it("does not notify a rejected/deduped-only tick (no net-new pending rows)", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a"];
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "already_pending", id: "pend" });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.deduped).toBe(1);
+    expect(result.queued).toBe(0);
+    expect(mockNotifyAmendmentsPending).not.toHaveBeenCalled();
+  });
+
+  it("notifies each opted-in workspace independently with its own batched count", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a", "org-b"];
+    mockInsertSemanticAmendment.mockResolvedValue({
+      outcome: "inserted",
+      id: "sch-q",
+      autoApprove: false,
+    });
+
+    await runExpertSchedulerTick();
+
+    expect(mockNotifyAmendmentsPending).toHaveBeenCalledTimes(2);
+    const targets = mockNotifyAmendmentsPending.mock.calls.map((c) => c[0]);
+    expect(targets).toEqual([
+      { workspaceId: "org-a", count: 1 },
+      { workspaceId: "org-b", count: 1 },
+    ]);
+  });
+
+  it("does not notify the self-hosted degenerate workspace (null org, no workspace identity)", async () => {
+    // Self-hosted: orgId is null, proposals queue, but there is no workspace id
+    // to key the proactive channel on — the notice is skipped by construction.
+    mockInsertSemanticAmendment.mockResolvedValue({
+      outcome: "inserted",
+      id: "sch-q",
+      autoApprove: false,
+    });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.queued).toBe(1);
+    expect(mockNotifyAmendmentsPending).not.toHaveBeenCalled();
+  });
+
+  it("a not-posted notice (enterprise disabled / degraded) never fails the tick", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a"];
+    mockInsertSemanticAmendment.mockResolvedValue({
+      outcome: "inserted",
+      id: "sch-q",
+      autoApprove: false,
+    });
+    // The bridge is best-effort: on a non-EE deploy it resolves a clean skip.
+    mockNotifyAmendmentsPending.mockImplementation(async () => ({
+      posted: false,
+      reason: "enterprise_disabled",
+    }));
+
+    const result = await runExpertSchedulerTick();
+
+    // The tick completed normally — the queued Amendment is the real work; the
+    // absent notice is not an error (#4520 AC3).
+    expect(mockNotifyAmendmentsPending).toHaveBeenCalledTimes(1);
+    expect(result.queued).toBe(1);
+    expect(result.errors).toBe(0);
+  });
+
+  it("a THROWING notice never taints the tick's reporting (defensive containment)", async () => {
+    saasMode = true;
+    optedInOrgs = ["org-a"];
+    mockInsertSemanticAmendment.mockResolvedValue({
+      outcome: "inserted",
+      id: "sch-q",
+      autoApprove: false,
+    });
+    // Contract violation: the bridge should never throw, but if it (or the
+    // dynamic import) ever did, the scheduler's own try/catch must contain it
+    // so the already-committed queued row is not dropped from the aggregate by
+    // the sweep-level catch (which would also mis-count errors) (#4520 AC3).
+    mockNotifyAmendmentsPending.mockImplementation(async () => {
+      throw new Error("bridge contract violated");
+    });
+
+    const result = await runExpertSchedulerTick();
+
+    expect(result.workspacesConsidered).toBe(1);
+    expect(result.queued).toBe(1);
+    expect(result.errors).toBe(0);
   });
 });
 

--- a/packages/api/src/lib/semantic/expert/scheduler.ts
+++ b/packages/api/src/lib/semantic/expert/scheduler.ts
@@ -252,6 +252,9 @@ export async function runExpertSchedulerTick(): Promise<ExpertTickResult> {
  * 4. Inserts each proposal `pending`; the insert reports auto-approve eligibility
  * 5. Routes eligible proposals through the decide seam (#4506) — claim →
  *    apply + version snapshot → stamp `approved`
+ * 6. Emits ONE batched proactive notice (#4520) when the tick left net-new
+ *    pending Amendments (`queued > 0`) for a real workspace — best-effort,
+ *    over the proactive seam, degrading cleanly to no notice when disabled
  */
 async function runWorkspaceImproveTick(orgId: string | null): Promise<WorkspaceTickOutcome> {
   // Billing gate first — a blocked workspace's tick no-ops before any context
@@ -436,6 +439,60 @@ async function runWorkspaceImproveTick(orgId: string | null): Promise<WorkspaceT
             "Failed to insert semantic amendment",
           );
           counters.errors++;
+        }
+      }
+
+      // 6. One batched proactive notice per tick (#4520). Only the scheduler
+      //    notifies — interactive proposals (admin console / CLI) don't, because
+      //    the admin is already there. `counters.queued` is the net-new pending
+      //    rows the admin must review (auto-approved rows are already applied;
+      //    deduped/rejected produced no new work; plus a rare concurrent-decision
+      //    fallback), so it is exactly the notice's count. The self-hosted
+      //    degenerate workspace (orgId null) has no
+      //    workspace identity to key the proactive channel on, so it is skipped;
+      //    autonomy notifications are a SaaS-first, per-workspace convenience.
+      //
+      //    The whole block is wrapped: the notice is a best-effort convenience
+      //    on top of work already durably committed (the queued Amendments),
+      //    so NOTHING in the notification path — not the dynamic import, not a
+      //    contract violation in the bridge — may taint this tick's reporting.
+      //    Containing it here keeps the already-counted queued/autoApproved rows
+      //    from being dropped by the sweep-level catch (#4520 AC3). The bridge
+      //    itself already degrades a non-EE deploy to a `{ posted: false }`
+      //    skip; this is defence in depth against an unexpected throw.
+      if (orgId && counters.queued > 0) {
+        try {
+          const { notifyAmendmentsPending } = await import(
+            "@atlas/api/lib/proactive/notify-amendments"
+          );
+          const notice = await notifyAmendmentsPending({
+            workspaceId: orgId,
+            count: counters.queued,
+          });
+          if (notice.posted) {
+            log.info(
+              { orgId, count: counters.queued, messageId: notice.messageId ?? null },
+              "Notified workspace admins of pending semantic-layer amendments",
+            );
+          } else {
+            log.debug(
+              { orgId, count: counters.queued, reason: notice.reason },
+              "Amendments-pending notice not posted",
+            );
+          }
+        } catch (notifyErr) {
+          // Should-never-fire: the bridge is designed never to throw, and the
+          // dynamic import is a local module. WARN (not DEBUG) so a genuine
+          // contract regression / module-load break surfaces to operators —
+          // this path is invisible on the healthy tick, so it costs no noise.
+          log.warn(
+            {
+              orgId,
+              count: counters.queued,
+              err: notifyErr instanceof Error ? notifyErr.message : String(notifyErr),
+            },
+            "Amendments-pending notice step threw — tick reporting unaffected",
+          );
         }
       }
 


### PR DESCRIPTION
## Summary

When the autonomous-improvement scheduler queues net-new pending Amendments for a workspace, its admins now get **one batched proactive notice per tick** ("N new semantic-layer improvements are pending your review") over the existing proactive-chat seam — no bespoke notification channel. Closes the failure mode where a workspace with autonomy on and nobody watching the queue silently accumulates work.

- **Seam, not a channel:** `ProactiveService` gains `notifyAmendmentsPending` (Noop layer fails `EnterpriseError`). The EE delivery posts to the workspace's proactive announcement channel via the shared `ChatAnnouncer` port — same seam as the activation announcement.
- **Batched per tick, not per row:** the scheduler emits once per workspace-tick when `counters.queued > 0`; the count is the net-new pending rows. Interactive proposals never notify (the admin is already in the console). The self-hosted null-org degenerate tick is skipped.
- **Degrades cleanly (AC3):** the core bridge (`lib/proactive/notify-amendments.ts`) reaches the seam via `runEnterprise` and recovers `EnterpriseError` **inside** the Effect with `catchTag` — `ManagedRuntime.runPromise` wraps a typed failure in a `FiberFailure`, so an outside `instanceof` would be dead code. A non-EE deploy quietly no-ops.
- **Best-effort containment:** the scheduler wraps the whole notice step (incl. the dynamic import) in its own try/catch, so a notification-path throw can never taint the tick's already-committed counters.

## Test plan

- [x] Scheduler-seam tests: emission, batching (mixed tick pins `count == queued`, not total), no-queue/rejected-deduped no-notify, per-workspace independence, self-hosted skip, throwing-notice containment, not-posted-never-fails.
- [x] Core bridge tests run against the **real** Noop layer via a faithful `runEnterprise` (FiberFailure-safe `enterprise_disabled`, defect→`error`, count-guard, passthrough).
- [x] EE delivery tests: message wording (singular/plural), channel resolution, full skip/error taxonomy — all non-throwing.
- [x] Internal review panel (4 specialists) CLEAN after 2 rounds; `tsgo`, `oxlint`, `ee-imports`, and all 29 non-test `ci-local` gates green.
- [x] Affected tests pass in isolation; the sole local `-pg` failure (`@atlas/mcp` smoke, `relation "organization" does not exist`) is an environmental DB-state artifact unrelated to this diff — GitHub CI's sharded api-tests arbitrate.

Closes #4520