### PR TITLE
fix(semantic-improve): knock out 4 impeccable-pass follow-ups (#4611–#4614)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -62030,6 +62030,9 @@
                               },
                               "error": {
                                 "type": "string"
+                              },
+                              "deferred": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -62201,6 +62204,9 @@
                               },
                               "error": {
                                 "type": "string"
+                              },
+                              "deferred": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -64602,6 +64608,15 @@
             },
             "required": false,
             "name": "connection",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "true"
+            },
+            "required": false,
+            "name": "includeDrafts",
             "in": "query"
           }
         ],

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1009,6 +1009,19 @@ describe("GET /api/v1/admin/semantic/entities — DB branch + mode fan-out", () 
     expect(mockListEntitiesAdmin).not.toHaveBeenCalled();
   });
 
+  it("includeDrafts=true forces the developer overlay even in published mode (#4613 — improve launcher)", async () => {
+    setOrgScopedAdmin("org-saas-1");
+    // No developer cookie ⇒ the global mode is published. The Semantic
+    // Improvement launcher opts into the draft layer via includeDrafts so
+    // draft-only entities aren't hidden.
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/semantic/entities?includeDrafts=true"),
+    );
+    expect(res.status).toBe(200);
+    expect(mockListEntitiesWithOverlay).toHaveBeenCalledWith("org-saas-1", "entity");
+    expect(mockListEntitiesAdmin).not.toHaveBeenCalled();
+  });
+
   it("DB-row's status reaches the response (draft shadows disk on name collision)", async () => {
     setOrgScopedAdmin("org-saas-1");
     mockListEntitiesWithOverlay.mockResolvedValue([

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -336,6 +336,9 @@ const TestResultSchema = z.object({
   rowCount: z.number(),
   sampleRows: z.array(z.record(z.string(), z.unknown())),
   error: z.string().optional(),
+  // #4614 — the test query was deferred (not run) because the entity is
+  // draft-only and absent from the query whitelist. Rendered as a neutral note.
+  deferred: z.boolean().optional(),
 });
 
 const PendingAmendmentSchema = z.object({

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -806,6 +806,16 @@ const listEntitiesRoute = createRoute({
         param: { name: "connection", in: "query" },
         example: "default",
       }),
+      // #4613 — force the developer overlay (draft + published) regardless of
+      // the caller's global mode. The Semantic Improvement surface edits the
+      // draft layer, so its entity launcher must show draft-only entities that
+      // published mode hides. Admin-only route, so this grants no data an admin
+      // couldn't already see in developer mode — it just decouples this read
+      // from the global published/developer toggle.
+      includeDrafts: z.string().optional().openapi({
+        param: { name: "includeDrafts", in: "query" },
+        example: "true",
+      }),
     }),
   },
   responses: {
@@ -1671,9 +1681,11 @@ admin.openapi(overviewRoute, async (c) => {
 admin.openapi(listEntitiesRoute, async (c) => {
   const { authResult, requestId } = await adminAuthAndContext(c, "admin:semantic");
   const orgId = authResult.user?.activeOrganizationId;
+  const { connection: connectionId, includeDrafts } = c.req.valid("query");
   const atlasMode = getAtlasMode(c);
-  const mode = atlasMode === "developer" ? "developer" : "published";
-  const { connection: connectionId } = c.req.valid("query");
+  // #4613 — the improve launcher opts into the developer overlay so draft-only
+  // entities (invisible in published mode) still appear.
+  const mode = includeDrafts === "true" || atlasMode === "developer" ? "developer" : "published";
   try {
     const result = await listAdminEntities({ orgId, mode });
 

--- a/packages/api/src/lib/semantic/expert/__tests__/resolve-amendment-baseline.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/resolve-amendment-baseline.test.ts
@@ -16,7 +16,7 @@ class AmbiguousEntityError extends Error {
   }
 }
 
-type Row = { id: string; connection_group_id: string | null; yaml_content: string };
+type Row = { id: string; connection_group_id: string | null; yaml_content: string; status?: string };
 
 // Explicit param signatures so `.mock.calls[n][i]` is well-typed.
 const getEntity = mock(
@@ -25,6 +25,7 @@ const getEntity = mock(
     _type: string,
     _name: string,
     _group?: string | null,
+    _mode?: string,
   ): Promise<Row | null> => null,
 );
 
@@ -213,6 +214,70 @@ describe("resolveAmendmentBaseline (#4488)", () => {
       await expect(resolveAmendmentBaseline("org-1", "orders", "stale_group")).rejects.toThrow(
         "orders in 2 groups",
       );
+    });
+  });
+
+  // ── #4614 — the published-existence probe (opt-in, for the draft-only
+  // test-query deferral). Off by default so the per-render live-diff path pays
+  // no extra query; only proposeAmendment opts in. ──────────────────────────
+  describe("publishedExists probe (#4614)", () => {
+    it("does not probe when the caller doesn't opt in — publishedExists is undefined", async () => {
+      getEntity.mockResolvedValue({
+        id: "orders-eu",
+        connection_group_id: "eu_prod",
+        status: "draft",
+        yaml_content: "name: orders\n",
+      });
+
+      const result = await resolveAmendmentBaseline("org-1", "orders", "eu_prod");
+
+      // One scoped read, no separate published probe.
+      expect(getEntity).toHaveBeenCalledTimes(1);
+      expect(result.publishedExists).toBeUndefined();
+    });
+
+    it("a published resolved row proves publishedExists with no extra query", async () => {
+      getEntity.mockResolvedValue({
+        id: "orders-eu",
+        connection_group_id: "eu_prod",
+        status: "published",
+        yaml_content: "name: orders\n",
+      });
+
+      const result = await resolveAmendmentBaseline("org-1", "orders", "eu_prod", undefined, "developer", true);
+
+      // The resolved row IS published — no separate probe needed.
+      expect(getEntity).toHaveBeenCalledTimes(1);
+      expect(result.publishedExists).toBe(true);
+    });
+
+    it("a draft-only entity (no published sibling) reports publishedExists false", async () => {
+      getEntity.mockImplementation(
+        async (_o: string, _t: string, _n: string, _group?: string | null, mode?: string) =>
+          mode === "published"
+            ? null
+            : { id: "orders-draft", connection_group_id: "eu_prod", status: "draft", yaml_content: "name: orders\n" },
+      );
+
+      const result = await resolveAmendmentBaseline("org-1", "orders", "eu_prod", undefined, "developer", true);
+
+      // Developer read (draft) hit + one published probe that missed ⇒ draft-only.
+      expect(getEntity).toHaveBeenCalledTimes(2);
+      expect(getEntity.mock.calls[1][4]).toBe("published");
+      expect(result.publishedExists).toBe(false);
+    });
+
+    it("a draft over a published sibling reports publishedExists true", async () => {
+      getEntity.mockImplementation(
+        async (_o: string, _t: string, _n: string, _group?: string | null, mode?: string) =>
+          mode === "published"
+            ? { id: "orders-pub", connection_group_id: "eu_prod", status: "published", yaml_content: "name: orders\n" }
+            : { id: "orders-draft", connection_group_id: "eu_prod", status: "draft", yaml_content: "name: orders\n" },
+      );
+
+      const result = await resolveAmendmentBaseline("org-1", "orders", "eu_prod", undefined, "developer", true);
+
+      expect(result.publishedExists).toBe(true);
     });
   });
 });

--- a/packages/api/src/lib/semantic/expert/apply.ts
+++ b/packages/api/src/lib/semantic/expert/apply.ts
@@ -95,10 +95,23 @@ export async function resolveAmendmentBaseline(
   // the amendment's target (that case is the dual-apply's visible skip, not an
   // apply failure). Defaults to "developer" for any other caller.
   mode: "developer" | "published" = "developer",
+  // #4614 — opt into a PUBLISHED-existence probe (default off). Only
+  // `proposeAmendment` needs it; the per-render live-diff and apply/decide paths
+  // don't, so it stays off there — no extra query per pending-list row.
+  probePublished = false,
 ): Promise<{
   row: SemanticEntityRow;
   targetGroupId: string | null;
   parsed: Record<string, unknown>;
+  /**
+   * #4614 — whether a PUBLISHED row for this entity exists (in the resolved
+   * scope), or `undefined` when not probed (`probePublished` off). The query
+   * whitelist is published-only, so a draft-only entity (`publishedExists ===
+   * false`) can't be test-queried until it's published — `proposeAmendment` uses
+   * this to DEFER the test query instead of running it into a "not in the allowed
+   * list" failure. No extra query when the resolved row is already published.
+   */
+  publishedExists?: boolean;
 }> {
   // Self-hosted (null orgId) uses empty string as sentinel for global scope
   const effectiveOrgId = orgId ?? "";
@@ -170,7 +183,19 @@ export async function resolveAmendmentBaseline(
     throw new Error(`Failed to parse YAML for entity "${entityName}": expected a mapping`);
   }
 
-  return { row, targetGroupId, parsed };
+  // #4614 — does a PUBLISHED sibling exist? Only computed when the caller opts
+  // in (`probePublished`). A published resolved row IS the proof (no extra
+  // query); otherwise the resolved row is a draft, so probe the published
+  // overlay directly at the resolved row's OWN group (`targetGroupId`, a concrete
+  // scope — no unscoped fallback, so it can't 409 when published siblings exist
+  // across groups). A null result means never-published (draft-only).
+  const publishedExists = !probePublished
+    ? undefined
+    : row.status === "published"
+      ? true
+      : (await getEntity(effectiveOrgId, "entity", entityName, targetGroupId, "published")) !== null;
+
+  return { row, targetGroupId, parsed, publishedExists };
 }
 
 // ── Glossary amendments (#4518) ──────────────────────────────────────────────

--- a/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
+++ b/packages/api/src/lib/tools/__tests__/propose-amendment.test.ts
@@ -62,10 +62,17 @@ const mockResolveAmendmentBaseline: Mock<
     orgId: string | null,
     entityName: string,
     group: string | undefined,
-  ) => Promise<{ row: Record<string, unknown>; targetGroupId: string | null; parsed: Record<string, unknown> }>
+  ) => Promise<{
+    row: Record<string, unknown>;
+    targetGroupId: string | null;
+    parsed: Record<string, unknown>;
+    // #4614 — the published-existence probe result. Undefined here (the default
+    // mock doesn't opt in); the draft-only deferral suite overrides it per-test.
+    publishedExists?: boolean;
+  }>
 > = mock(() =>
   Promise.resolve({
-    row: { id: "companies-row", connection_group_id: null },
+    row: { id: "companies-row", connection_group_id: null, status: "published" },
     targetGroupId: null,
     parsed: structuredClone(companiesEntity),
   }),
@@ -234,6 +241,61 @@ describe("proposeAmendment test query routing (#4485)", () => {
     expect(result.testResult?.success).toBe(false);
     expect(result.testResult?.error).toContain("RLS");
     expect(result.testResult?.sampleRows).toEqual([]);
+  });
+});
+
+describe("proposeAmendment defers the test query for a draft-only entity (#4614)", () => {
+  beforeEach(() => {
+    mockRunUserQueryPipeline.mockClear();
+    mockRunUserQueryPipeline.mockResolvedValue(okOutcome);
+    mockInsertSemanticAmendment.mockClear();
+    mockInsertSemanticAmendment.mockResolvedValue({ outcome: "inserted", id: "prop-1", autoApprove: false });
+    mockResolveAmendmentBaseline.mockClear();
+  });
+
+  it("defers (never runs) the test query when no published sibling exists", async () => {
+    // A never-published (draft-only) entity is absent from the published-only
+    // query whitelist, so the pipeline would fail closed with "not in the allowed
+    // list". The tool must DEFER instead.
+    mockResolveAmendmentBaseline.mockResolvedValueOnce({
+      row: { id: "companies-row", connection_group_id: null, status: "draft" },
+      targetGroupId: null,
+      parsed: structuredClone(companiesEntity),
+      publishedExists: false,
+    });
+
+    const result = await run("SELECT email FROM companies");
+
+    // The query is never executed — no fail-closed "not in the allowed list".
+    expect(mockRunUserQueryPipeline).not.toHaveBeenCalled();
+    expect(result.testResult?.deferred).toBe(true);
+    expect(result.testResult?.success).toBe(false);
+    expect(result.testResult?.sampleRows).toEqual([]);
+    // No error string — deferral is not a failure.
+    expect(result.testResult?.error).toBeUndefined();
+
+    // The deferred marker is persisted so the review card renders the neutral note.
+    const persisted = mockInsertSemanticAmendment.mock.calls[0][0] as {
+      amendmentPayload: { testResult?: { deferred?: boolean; success: boolean } };
+    };
+    expect(persisted.amendmentPayload.testResult?.deferred).toBe(true);
+    expect(persisted.amendmentPayload.testResult?.success).toBe(false);
+  });
+
+  it("runs the test query normally when a published sibling exists", async () => {
+    mockResolveAmendmentBaseline.mockResolvedValueOnce({
+      row: { id: "companies-row", connection_group_id: null, status: "published" },
+      targetGroupId: null,
+      parsed: structuredClone(companiesEntity),
+      publishedExists: true,
+    });
+
+    const result = await run("SELECT email FROM companies");
+
+    // Published entity ⇒ whitelisted ⇒ the test query runs as before.
+    expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(1);
+    expect(result.testResult?.deferred).toBeUndefined();
+    expect(result.testResult?.success).toBe(true);
   });
 });
 

--- a/packages/api/src/lib/tools/propose-amendment.ts
+++ b/packages/api/src/lib/tools/propose-amendment.ts
@@ -99,6 +99,13 @@ The amendment object should match the YAML structure for that type (e.g., { name
       // in the scope the diff was computed from.
       let entity: Record<string, unknown>;
       let applyGroupId: string | null = null;
+      // #4614 — a never-published (draft-only) entity is absent from the query
+      // whitelist (which is published-only), so any test query against it fails
+      // "not in the allowed list". Track it so the test query below is DEFERRED
+      // with a neutral "runs after publish" note rather than run-and-failed with
+      // a red error. Only the DB-backed entity path can be draft-only; glossary
+      // docs and the no-DB disk preview have no draft/published split.
+      let entityIsDraftOnly = false;
 
       if (hasInternalDB()) {
         if (isGlossary) {
@@ -115,9 +122,19 @@ The amendment object should match the YAML structure for that type (e.g., { name
             orgId,
             entityName,
             connectionGroupId,
+            // No admin disambiguation here, developer overlay (the default), and
+            // opt into the published-existence probe (#4614).
+            undefined,
+            "developer",
+            /* probePublished */ true,
           );
           entity = baseline.parsed;
           applyGroupId = baseline.targetGroupId;
+          // #4614 — draft-only when the resolver found no PUBLISHED sibling (the
+          // whitelisted one). `publishedExists === false` (never `undefined`)
+          // guards the deferral, so if the probe were ever off it defaults to
+          // running the test query as before.
+          entityIsDraftOnly = baseline.publishedExists === false;
         }
       } else if (isGlossary) {
         // No internal DB (self-hosted preview only): the group-scoped store/apply
@@ -244,7 +261,14 @@ The amendment object should match the YAML structure for that type (e.g., { name
       // unmasked-data-at-rest vector (#4485). The persisted `sampleRows` below
       // are therefore the pipeline's masked, capped output.
       let testResult: AmendmentPayload["testResult"];
-      if (testQuery) {
+      if (testQuery && entityIsDraftOnly) {
+        // #4614 — the entity isn't published yet, so it's not in the query
+        // whitelist. Running the test would fail closed with "not in the allowed
+        // list", which reads as a broken error on a fresh all-draft workspace.
+        // Defer it instead: `success: false` but `deferred: true`, so the review
+        // card shows a neutral "runs after publish" note, not a red failure.
+        testResult = { success: false, rowCount: 0, sampleRows: [], deferred: true };
+      } else if (testQuery) {
         const outcome = await runUserQueryPipeline({
           sql: testQuery,
           // Evidence runs where the change lives (#4513): the amendment's own

--- a/packages/types/src/learned-pattern.ts
+++ b/packages/types/src/learned-pattern.ts
@@ -48,6 +48,14 @@ export interface AmendmentPayload {
     sampleRows: Record<string, unknown>[];
     /** Present when `success` is false — describes why the test query failed. */
     error?: string;
+    /**
+     * #4614 — the test query was NOT run: the amendment targets a draft-only
+     * entity, which is absent from the query whitelist (published-only), so the
+     * query would fail "not in the allowed list". It's deferred until the entity
+     * is published. `success` is `false` but this is not a failure — the card
+     * renders a neutral "deferred until publish" note, not a red error.
+     */
+    deferred?: boolean;
   };
   /** Agent's confidence this amendment is correct (0.0–1.0). */
   confidence: number;

--- a/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/proposals.test.ts
@@ -153,6 +153,23 @@ describe("extractProposals", () => {
     ]);
     expect(bad[0]?.testResult).toBeUndefined();
   });
+
+  it("carries a deferred testResult through (draft-only entity, #4614)", () => {
+    // A draft-only entity's test query is deferred, not run: success:false but
+    // deferred:true, so the card renders a neutral note, not a red failure.
+    const deferred = extractProposals([
+      assistantWithTool(baseInput, {
+        proposalId: "amd-1",
+        testResult: { success: false, rowCount: 0, sampleRows: [], deferred: true },
+      }),
+    ]);
+    expect(deferred[0]?.testResult).toEqual({
+      success: false,
+      rowCount: 0,
+      sampleRows: [],
+      deferred: true,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/app/admin/semantic/improve/page.tsx
+++ b/packages/web/src/app/admin/semantic/improve/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, type ReactNode } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, isToolUIPart, getToolName } from "ai";
 import { extractProposals, buildProposalQueue, buildReviewBody, classifyReviewResult, toolPartStatus, type Proposal, type QueueRow, type TestResult } from "./proposals";
@@ -24,6 +24,12 @@ import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surfa
 // the shared billing/permission ErrorBanner (CTA + Retry-After countdown).
 import { Markdown } from "@/ui/components/chat/markdown";
 import { ErrorBanner } from "@/ui/components/chat/error-banner";
+// #4612 — the expert agent ends turns with a `<suggestions>` block (the same
+// contract as the main chat). Strip it from the rendered prose and surface it as
+// clickable follow-up chips, mirroring the main chat surface — otherwise the raw
+// `<suggestions>…</suggestions>` tags leak into the transcript as literal text.
+import { FollowUpChips } from "@/ui/components/chat/follow-up-chips";
+import { parseSuggestions } from "@/ui/lib/helpers";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -197,11 +203,20 @@ function ProposalCard({
             <span className="font-medium">Test query:</span>{" "}
             <code className="rounded bg-muted px-1 py-0.5">{proposal.testQuery}</code>
             {proposal.testResult && (
-              <p className={proposal.testResult.success ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}>
-                {proposal.testResult.success
-                  ? `Passed — ${proposal.testResult.rowCount} row${proposal.testResult.rowCount === 1 ? "" : "s"}`
-                  : `Failed${proposal.testResult.error ? ` — ${proposal.testResult.error}` : ""}`}
-              </p>
+              // #4614 — a deferred test query is NOT a failure: the entity isn't
+              // published yet (so it's absent from the query whitelist). Render a
+              // neutral note instead of a red "Failed — not in the allowed list".
+              proposal.testResult.deferred ? (
+                <p className="text-muted-foreground">
+                  Deferred — this entity isn&rsquo;t published yet; the test query runs after publish.
+                </p>
+              ) : (
+                <p className={proposal.testResult.success ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}>
+                  {proposal.testResult.success
+                    ? `Passed — ${proposal.testResult.rowCount} row${proposal.testResult.rowCount === 1 ? "" : "s"}`
+                    : `Failed${proposal.testResult.error ? ` — ${proposal.testResult.error}` : ""}`}
+                </p>
+              )
             )}
           </div>
         )}
@@ -407,6 +422,51 @@ export function ActiveAnchorChip({ anchor, onClear }: { anchor: ActiveAnchor; on
 }
 
 // ---------------------------------------------------------------------------
+// Adaptive split (#4611)
+//
+// Below the mobile breakpoint the two panes stack into a single column using
+// PLAIN flex divs — NOT react-resizable-panels with a dynamic `orientation`.
+// The library pins its layout at mount and doesn't re-measure when `orientation`
+// flips live (the SSR-`false` → mobile-`true` breakpoint transition), which left
+// the vertical stack stale/offscreen and rendered the review pane blank below
+// ~768px. A plain flex-col with two `flex-1` panes can't render blank. Desktop
+// keeps the resizable horizontal split (always horizontal — no live flip).
+// ---------------------------------------------------------------------------
+
+/** Group wrapper: resizable horizontal split on desktop, plain stacked column on mobile. */
+function AdaptiveSplit({ mobile, children }: { mobile: boolean; children: ReactNode }) {
+  return mobile ? (
+    <div className="flex h-full min-h-0 flex-col">{children}</div>
+  ) : (
+    <ResizablePanelGroup orientation="horizontal">{children}</ResizablePanelGroup>
+  );
+}
+
+/** Pane wrapper: a resizable panel on desktop, a plain `flex-1` div on mobile. */
+function AdaptivePane({
+  mobile,
+  defaultSize,
+  minSize,
+  mobileClassName,
+  children,
+}: {
+  mobile: boolean;
+  defaultSize: number;
+  minSize: number;
+  /** Extra classes applied only to the mobile div (e.g. a separating border). */
+  mobileClassName?: string;
+  children: ReactNode;
+}) {
+  return mobile ? (
+    <div className={`min-h-0 flex-1 overflow-hidden ${mobileClassName ?? ""}`}>{children}</div>
+  ) : (
+    <ResizablePanel defaultSize={defaultSize} minSize={minSize}>
+      {children}
+    </ResizablePanel>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -517,7 +577,11 @@ export default function SemanticImprovePage() {
   });
   const launcherGroups = groupsData ?? [];
 
-  const { data: entitiesData } = useAdminFetch<LauncherEntity[]>("/api/v1/admin/semantic/entities", {
+  // #4613 — `includeDrafts=true` forces the developer overlay so draft-only
+  // entities appear in the launcher. The improve surface edits the draft layer;
+  // without this the launcher shows only PUBLISHED entities and a draft-heavy
+  // (e.g. freshly-profiled) workspace looks empty until an amendment publishes one.
+  const { data: entitiesData } = useAdminFetch<LauncherEntity[]>("/api/v1/admin/semantic/entities?includeDrafts=true", {
     transform: (json) => {
       const raw = (json as { entities?: unknown }).entities;
       if (!Array.isArray(raw)) {
@@ -602,6 +666,16 @@ export default function SemanticImprovePage() {
         setInputValue(saved);
       },
     );
+  }
+
+  // #4612 — send a follow-up suggestion chip's text directly. Mirrors handleSend
+  // minus the composer round-trip (the text comes from the parsed `<suggestions>`
+  // block, not the input box).
+  function sendText(text: string) {
+    if (!text.trim() || isLoading) return;
+    sendMessage({ role: "user", parts: [{ type: "text" as const, text }] }).catch((err: unknown) => {
+      console.error("Failed to send suggestion:", err instanceof Error ? err.message : String(err));
+    });
   }
 
   // #4517 — retry the failed turn by replaying the last user message (mirrors the
@@ -805,11 +879,11 @@ export default function SemanticImprovePage() {
         />
       </div>
 
-      {/* Split view */}
+      {/* Split view — #4611: desktop resizable split, mobile stacked column. */}
       <div className="min-h-0 flex-1 overflow-hidden">
-        <ResizablePanelGroup orientation={isMobile ? "vertical" : "horizontal"}>
+        <AdaptiveSplit mobile={isMobile}>
           {/* Chat panel */}
-          <ResizablePanel defaultSize={55} minSize={35}>
+          <AdaptivePane mobile={isMobile} defaultSize={55} minSize={35}>
             <div className="flex h-full min-h-0 flex-col">
               {/* #4519 — the active anchor, visible in the conversation UI.
                   Free typing still works anchored; Clear drops the scope
@@ -847,8 +921,12 @@ export default function SemanticImprovePage() {
                           if (part.type === "text") {
                             // Agent prose renders markdown like the main chat
                             // surface (#4517); the user's own text stays plain.
+                            // #4612 — strip the trailing `<suggestions>` block
+                            // from the agent prose (it renders as chips below);
+                            // an unclosed block mid-stream is left in place until
+                            // it closes, matching the main chat.
                             return msg.role === "assistant" ? (
-                              <Markdown key={i} content={part.text} />
+                              <Markdown key={i} content={parseSuggestions(part.text).text} />
                             ) : (
                               <p key={i} className="whitespace-pre-wrap">{part.text}</p>
                             );
@@ -898,6 +976,22 @@ export default function SemanticImprovePage() {
                     </div>
                   ))}
 
+                  {/* #4612 — follow-up chips parsed from the last assistant
+                      turn's `<suggestions>` block. Rendered only when idle (a
+                      mid-stream partial block carries no closed suggestions yet);
+                      FollowUpChips renders nothing when the list is empty. */}
+                  {!isLoading && (() => {
+                    const lastAssistant = messages.filter((m) => m.role === "assistant").at(-1);
+                    if (!lastAssistant) return null;
+                    const lastText = lastAssistant.parts
+                      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+                      .map((p) => p.text)
+                      .join("\n");
+                    return (
+                      <FollowUpChips suggestions={parseSuggestions(lastText).suggestions} onSelect={sendText} />
+                    );
+                  })()}
+
                   {isLoading && messages.length > 0 && (
                     <div className="flex items-center gap-2 text-xs text-muted-foreground">
                       <Loader2 className="size-3 animate-spin" />
@@ -944,12 +1038,14 @@ export default function SemanticImprovePage() {
                 </div>
               </div>
             </div>
-          </ResizablePanel>
+          </AdaptivePane>
 
-          <ResizableHandle withHandle />
+          {/* Desktop-only drag handle; on mobile a top border separates the
+              stacked panes (#4611). */}
+          {!isMobile && <ResizableHandle withHandle />}
 
           {/* Proposals panel */}
-          <ResizablePanel defaultSize={45} minSize={25}>
+          <AdaptivePane mobile={isMobile} defaultSize={45} minSize={25} mobileClassName="border-t">
             <Tabs
               value={view}
               onValueChange={(v) => setView(v as "pending" | "rejected")}
@@ -1078,8 +1174,8 @@ export default function SemanticImprovePage() {
                 <CoverageView onColumnAnchor={launchColumn} disabled={isLoading} />
               </TabsContent>
             </Tabs>
-          </ResizablePanel>
-        </ResizablePanelGroup>
+          </AdaptivePane>
+        </AdaptiveSplit>
       </div>
     </div>
   );

--- a/packages/web/src/app/admin/semantic/improve/proposals.ts
+++ b/packages/web/src/app/admin/semantic/improve/proposals.ts
@@ -18,6 +18,13 @@ export interface TestResult {
   rowCount: number;
   sampleRows: Record<string, unknown>[];
   error?: string;
+  /**
+   * #4614 — the test query was deferred, not run: the entity is draft-only (not
+   * yet published), so it's absent from the query whitelist. `success` is false
+   * but this is not a failure — the card renders a neutral "deferred until
+   * publish" note rather than a red error.
+   */
+  deferred?: boolean;
 }
 
 /**


### PR DESCRIPTION
Knocks out four backlog follow-ups filed during the #4522 impeccable pass. `#4615` (wire a CI browser lane) is **deferred to its own PR** — it's a net-new CI job (Postgres + dev server + seed + a required-vs-advisory decision), too big to bundle.

## #4612 — `<suggestions>` block leaked as raw XML
The expert agent ends turns with a `<suggestions>` block (same contract as the main chat), but the improve chat rendered it as literal text. Now mirrors the main chat: strips the block from the rendered prose (`parseSuggestions`) and surfaces it as clickable `FollowUpChips`.

## #4614 — draft-only test query read as a hard error
A test query on a draft-only entity failed `Table "X" is not in the allowed list` (the query whitelist is published-only), which reads as broken on a fresh all-draft workspace.
- `resolveAmendmentBaseline` gains an **opt-in** `publishedExists` probe (`proposeAmendment` only — the per-render live-diff / apply paths don't pay the extra query). Probes published directly at the resolved row's own group (no unscoped fallback → can't 409).
- When the entity is draft-only, the test query is **deferred** (`deferred: true`, never executed) and the card renders a neutral *"runs after publish"* note instead of a red failure.

## #4613 — entity launcher hidden on a draft-heavy workspace
**The issue's stated root cause is wrong.** It blames a lazy mode-root, but the route reads the **DB** (mode-derived), not the mode-root. The real cause: the launcher fetches **published** mode, so draft-only entities are invisible.

Confirmed live against a draft-heavy workspace (read-only, `listAdminEntities` in both modes):
| mode | entities |
|---|---|
| published (launcher today) | **1** (`orders`) |
| developer (the fix) | **13** |

12 draft-only entities (`categories, customers, products, …`) were hidden. "Appears after agent activity" = an auto-approved amendment publishes an entity.

Fix: the improve launcher opts into the developer overlay via a new **admin-only** `includeDrafts=true` query param on `/admin/semantic/entities`. Admin-only route, so it grants no data an admin couldn't already see in developer mode — it just decouples this read from the global published/developer toggle.

## #4611 — two-panel split blank below ~768px
`react-resizable-panels` pins its layout at mount and doesn't re-measure when `orientation` flips live (the SSR-`false` → mobile-`true` breakpoint transition), leaving the vertical stack stale/offscreen. Replaced the dynamic-orientation group with small adaptive wrappers: desktop keeps the resizable horizontal split; mobile stacks into plain `flex-1` divs that **can't render blank**.

## Verification
- **Live**: reproduced #4613's mechanism against a real draft-heavy workspace (published=1 vs developer=13). Full browser click-through was blocked by a local placeholder `BETTER_AUTH_SECRET` on a DB shared with a parallel session (rotating JWKS would disrupt it), so #4611/#4612/#4614 rely on unit coverage.
- **Tests**: propose-amendment deferral (draft-only vs published) · `resolveAmendmentBaseline` `publishedExists` probe · admin `/semantic/entities` `includeDrafts` forces developer overlay · `extractProposals` carries `deferred` through.
- **Gates (local)**: type, oxlint, schema-drift, openapi-drift, published-symbols, template-drift, unpublished-versions all green; 164 affected api test files pass. OpenAPI spec regenerated for the new field + query param. Full `-pg` suite deferred to CI (no local `TEST_DATABASE_URL`; shared DB).

Closes #4611, #4612, #4613, #4614.