### PR TITLE
fix(api,scheduler): converge scheduler gates on config per-region (#4623)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -856,6 +856,12 @@ export function createApiTestMocks(
     listScheduledTaskRuns: mock(async () => []),
     getRecentRuns: mock(async () => []),
     scheduledTaskBelongsToUser: mock(async () => false),
+    // The scheduled-tasks route now mounts unconditionally (#4623), so the
+    // full set of exports it imports must be present even when a suite never
+    // exercises the route (missing export → "not found" at module load).
+    listTaskRuns: mock(async () => []),
+    listAllRuns: mock(async () => ({ runs: [], total: 0 })),
+    validateCronExpression: mock(() => ({ valid: true })),
   }));
 
   void mock.module("@atlas/api/lib/scheduler", () => ({

--- a/packages/api/src/api/__tests__/scheduled-tasks-audit.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks-audit.test.ts
@@ -104,6 +104,17 @@ void mock.module("@atlas/api/lib/audit", async () => {
 // afterAll; the `??=` here is the module-load contract, not teardown.
 process.env.ATLAS_SCHEDULER_ENABLED ??= "true";
 
+// The scheduled-tasks router is now mounted unconditionally and gated per-request
+// on `getConfig()?.scheduler` (#4623). Override createApiTestMocks' default
+// `getConfig: () => null` with a resolved scheduler backend (later mock.module
+// wins) so the gate passes — otherwise every request 404s before its handler.
+void mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => ({
+    scheduler: { backend: "bun", maxConcurrentTasks: 5, taskTimeout: 60_000, tickIntervalSeconds: 60 },
+  }),
+  defineConfig: (c: unknown) => c,
+}));
+
 const { app } = await import("../index");
 
 afterAll(() => {

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -245,6 +245,32 @@ describe("scheduled-tasks routes", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Per-request scheduler gate (#4623)
+  // -------------------------------------------------------------------------
+
+  describe("scheduler gate", () => {
+    it("404s CRUD when no scheduler backend is configured", async () => {
+      // getConfig() unresolved / no `scheduler` (e.g. self-hosted without a
+      // scheduler backend) → the router's per-request gate rejects before the handler.
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simulate getConfig() === null
+      mockGetConfig.mockReturnValue(null as any);
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks"),
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("404s /tick when no scheduler backend is configured", async () => {
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simulate getConfig() === null
+      mockGetConfig.mockReturnValue(null as any);
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks/tick", { method: "POST" }),
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // GET /api/v1/scheduled-tasks
   // -------------------------------------------------------------------------
 

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -305,23 +305,24 @@ if (process.env.ATLAS_ACTIONS_ENABLED === "true") {
   log.debug("Action framework disabled (ATLAS_ACTIONS_ENABLED not set)");
 }
 
-// Scheduled tasks routes — lazy import, only loaded if ATLAS_SCHEDULER_ENABLED is set.
+// Scheduled tasks routes — mounted UNCONDITIONALLY, gated per-request inside the
+// router on the resolved `config.scheduler` (#4623).
 //
-// CO-GATING INVARIANT (#3687): this is the ONLY customer-facing path that INSERTs
-// into `scheduled_tasks` (via createScheduledTask), and it is gated on the exact
-// same `ATLAS_SCHEDULER_ENABLED === "true"` flag that drives the scheduler fiber
-// (config.scheduler.backend → makeSchedulerLive in lib/effect/layers.ts) and the
-// `/health` scheduler reporter. The single global (US) scheduler design is
-// therefore safe: a region without the scheduler fiber (EU/APAC) does not mount
-// this route either, so customers there get a 404 on creation rather than a task
-// that is written but never fires. Keep these three sites flag-coherent.
-if (process.env.ATLAS_SCHEDULER_ENABLED === "true") {
-  const { scheduledTasks } = await import("./routes/scheduled-tasks");
-  app.route("/api/v1/scheduled-tasks", scheduledTasks);
-  log.info("Scheduled tasks enabled");
-} else {
-  log.debug("Scheduled tasks disabled (ATLAS_SCHEDULER_ENABLED not set)");
-}
+// CO-GATING INVARIANT: this is the ONLY customer-facing path that INSERTs into
+// `scheduled_tasks`, and it must agree with the scheduler fiber
+// (`config.scheduler.backend` → makeSchedulerLive in lib/effect/layers.ts) and
+// the `/health` reporter. The earlier construction-time `ATLAS_SCHEDULER_ENABLED`
+// gate did NOT: on the file-config deploy the config sets `backend: "bun"` for
+// every region, so the engine ran in EU/APAC while this env-gated mount and
+// `/health` reported "disabled". All three now read the SAME source
+// (`config.scheduler`). Mounting must be unconditional because `getConfig()` is
+// null at module-construction time (the initConfig race — server.ts resolves
+// config AFTER the static `import { app }`); the router's per-request gate 404s
+// when no scheduler backend is configured, preserving the "never write a task
+// that silently never fires" guarantee without depending on the env var.
+const { scheduledTasks } = await import("./routes/scheduled-tasks");
+app.route("/api/v1/scheduled-tasks", scheduledTasks);
+log.info("Scheduled tasks route mounted (per-request scheduler gate)");
 
 // User session self-service routes — requires managed auth + internal DB.
 try {

--- a/packages/api/src/api/routes/health.ts
+++ b/packages/api/src/api/routes/health.ts
@@ -421,7 +421,13 @@ health.openapi(healthRoute, async (c) => {
 
     // Build components section for the health dashboard
     const now = new Date().toISOString();
-    const schedulerEnabled = process.env.ATLAS_SCHEDULER_ENABLED === "true";
+    // Scheduler status derives from the RESOLVED CONFIG — the same source the
+    // engine fiber starts from (`makeSchedulerLive` → `config.scheduler.backend`)
+    // — so `/health` reflects what actually runs. Reading `ATLAS_SCHEDULER_ENABLED`
+    // here diverged from the engine on the file-config deploy, mislabeling a live
+    // fiber as "disabled" in EU/APAC (#4623). `scheduler` is present in the
+    // resolved config iff the scheduler is configured (backend bun/webhook/vercel).
+    const schedulerEnabled = getConfig()?.scheduler != null;
 
     // #1987 — aggregate plugin healthcheck results into a `plugins` component.
     // Plugin failures NEVER escalate to 503 — that path is reserved for the
@@ -545,16 +551,15 @@ health.openapi(healthRoute, async (c) => {
         lastCheckedAt: now,
         ...(hasKeyError && { message: "MISSING_API_KEY" }),
       },
-      // Config-level status only — does not probe the scheduler engine at runtime.
-      //
-      // `disabled` is EXPECTED and SAFE on EU/APAC regions (#3687): the scheduler
-      // is a single global (US) fiber by design. Crucially, the customer-facing
-      // task-creation route `POST /api/v1/scheduled-tasks` is mounted behind the
-      // SAME `ATLAS_SCHEDULER_ENABLED === "true"` flag that starts the fiber
-      // (api/index.ts) — so a region reporting `scheduler: "disabled"` also
-      // returns 404 for task creation. Creation and execution are co-gated, so an
-      // EU/APAC customer can never create a scheduled task that silently never
-      // fires.
+      // Config-level status only — does not probe the scheduler engine at runtime,
+      // but derives from the SAME `config.scheduler` the engine starts from, so
+      // `healthy` here means the fiber is running in this region. The scheduler
+      // runs per-region against each region's own internal DB (#4623), so all
+      // regions with a configured backend report `healthy`; `disabled` means no
+      // scheduler backend is configured (e.g. self-hosted without one). The
+      // customer-facing task-creation route is co-gated on the same config, so a
+      // region that reports `disabled` also 404s task creation — no task is ever
+      // written that would silently never fire.
       scheduler: {
         status: schedulerEnabled ? "healthy" as const : "disabled" as const,
         lastCheckedAt: now,

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -1,7 +1,9 @@
 /**
  * Scheduled tasks REST routes — CRUD + trigger + run history.
  *
- * Gated behind ATLAS_SCHEDULER_ENABLED=true (conditional mount in index.ts).
+ * Mounted unconditionally in index.ts and gated per-request on the resolved
+ * `config.scheduler` (#4623) — the same source the engine fiber and `/health`
+ * read, so all three agree per region. No scheduler backend configured → 404.
  * CRUD routes use `adminAuth` + `requireOrgContext` middleware (admin/owner
  * role required, org-scoped). The `/tick` endpoint uses its own cron-secret
  * auth and is registered on the outer app so it bypasses user-auth middleware.
@@ -17,6 +19,7 @@ import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { getConfig } from "@atlas/api/lib/config";
 import { verifyGroupBelongsToOrg } from "@atlas/api/lib/conversations";
 import {
   createScheduledTask,
@@ -263,6 +266,27 @@ const listTaskRunsRoute = createRoute({ method: "get", path: "/{id}/runs", tags:
 
 // Outer app: tick route (cron-secret auth, no user-auth middleware)
 const scheduledTasks = new OpenAPIHono<AuthEnv>({ defaultHook: validationHook });
+
+// Per-request scheduler gate (#4623). The router mounts UNCONDITIONALLY in
+// index.ts — `getConfig()` is null at module-construction time (the initConfig
+// race), so a construction-time env gate diverged from the engine which starts
+// per `config.scheduler`. Gate here on the RESOLVED config instead, the same
+// source the engine fiber and `/health` read. No scheduler backend configured
+// → 404, so a task is never created that would silently never fire. On the
+// 3-region deploy every region has `scheduler.backend`, so this passes
+// everywhere; only a self-hosted deploy without a scheduler backend 404s.
+scheduledTasks.use("*", async (c, next) => {
+  if (getConfig()?.scheduler == null) {
+    return c.json(
+      {
+        error: "not_found",
+        message: "Scheduled tasks are not enabled on this deployment.",
+      },
+      404,
+    );
+  }
+  return next();
+});
 
 // Inner app: admin-authenticated, org-scoped routes (adminAuth + requireOrgContext)
 const authed = createAdminRouter();

--- a/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
@@ -657,7 +657,7 @@ describe("scheduled-tasks module", () => {
     it("returns true when lock acquired", async () => {
       enableInternalDB();
       // First call: SELECT task (getScheduledTask to read cron expression)
-      // Second call: UPDATE with atomic lock (next_run_at IS NOT NULL)
+      // Second call: UPDATE with atomic time-based claim (next_run_at <= now())
       setResults(
         { rows: [makeTaskRow()] },
         { rows: [{ id: "task-123" }] },
@@ -670,7 +670,9 @@ describe("scheduled-tasks module", () => {
       // Second query is the atomic UPDATE
       expect(queryCalls[1].sql).toContain("UPDATE scheduled_tasks");
       expect(queryCalls[1].sql).toContain("last_run_at = now()");
-      expect(queryCalls[1].sql).toContain("next_run_at IS NOT NULL");
+      // Correct time-based claim guard (#4623) — an `IS NOT NULL` guard would
+      // not prevent a concurrent claimer from also matching.
+      expect(queryCalls[1].sql).toContain("next_run_at <= now()");
     });
 
     it("re-checks plugin ownership atomically in the lock UPDATE (#3180 TOCTOU guard)", async () => {

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1751,15 +1751,17 @@ export function makeSchedulerLive(
 
       // Start main scheduler.
       //
-      // SINGLE GLOBAL (US) SCHEDULER (#3687): `config.scheduler.backend` is `bun`
-      // only when `ATLAS_SCHEDULER_ENABLED === "true"` (config.ts), which in SaaS
-      // is set on the US region only. EU/APAC report `scheduler: "disabled"` at
-      // `/health` by design. This is SAFE because the customer-facing task-creation
-      // route (`POST /api/v1/scheduled-tasks` in api/index.ts) is gated on the SAME
-      // flag — so a region without this fiber also rejects task creation with a 404
-      // rather than persisting a task that would never fire. The fiber reads/writes
-      // `scheduled_tasks` in the shared internal DB, so the US fiber executes every
-      // workspace's tasks regardless of the workspace's region.
+      // PER-REGION SCHEDULER (#4623, supersedes the #3687 "single global US"
+      // framing). The engine starts wherever `config.scheduler.backend === "bun"`.
+      // On the 3-region deploy the shared file config (deploy/api/atlas.config.ts)
+      // sets that for EVERY region, and each region runs its OWN internal DB
+      // (us/eu/apac-int-postgres, via each service's own DATABASE_URL) — so each
+      // region's fiber processes its own tenants' `scheduled_tasks` in-region.
+      // There is NO shared internal DB and no cross-region execution (the earlier
+      // "US fiber executes every workspace's tasks" note assumed a shared DB that
+      // does not exist here). `config.scheduler` is the single source of truth,
+      // shared with the `/health` reporter and the task-creation route gate, so
+      // all three agree per region.
       if (backend === "bun") {
         yield* Effect.tryPromise({
           try: async () => {

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -608,9 +608,13 @@ export async function getTasksDueForExecution(): Promise<ScheduledTask[]> {
 /**
  * Atomically lock a task for execution.
  *
- * Uses a single UPDATE with AND next_run_at IS NOT NULL as a lightweight
- * lock: the first process to UPDATE sets next_run_at to the future, preventing
- * concurrent UPDATEs from matching. Also updates last_run_at.
+ * Uses a single UPDATE with `AND next_run_at <= now()` as the claim guard: the
+ * first process to UPDATE advances next_run_at to the future, so a concurrent
+ * claimer re-evaluating under READ COMMITTED sees `next_run_at > now()` and no
+ * longer matches (0 rows → false). This is a genuine time-based claim — an
+ * earlier `IS NOT NULL` guard did NOT prevent the race, since next_run_at stays
+ * non-null after the first claim (#4623). Now single-writer per region, but the
+ * guard must be correct for any multi-writer future. Also updates last_run_at.
  *
  * Returns true if lock acquired, false if task is already locked, disabled,
  * or not found.
@@ -628,8 +632,11 @@ export async function lockTaskForExecution(taskId: string): Promise<boolean> {
 
     const nextRun = computeNextRun(taskResult.data.cronExpression);
 
-    // Atomic UPDATE: only succeeds if enabled AND next_run_at IS NOT NULL
-    // (prevents double-execution — second process sees next_run_at already set to future).
+    // Atomic UPDATE: only succeeds if enabled AND next_run_at <= now(), i.e.
+    // the task is still due and unclaimed. The first claimer advances
+    // next_run_at to the future, so a concurrent claimer re-checking
+    // `next_run_at <= now()` no longer matches — a correct time-based claim that
+    // prevents double-execution (an `IS NOT NULL` guard would not; #4623).
     //
     // Orphan guard (#3180 / #3196 review): re-check plugin ownership HERE, not
     // just at getTasksDueForExecution time. The tick selects due tasks, then
@@ -644,7 +651,7 @@ export async function lockTaskForExecution(taskId: string): Promise<boolean> {
          last_run_at = now(),
          next_run_at = $1,
          updated_at = now()
-       WHERE id = $2 AND enabled = true AND next_run_at IS NOT NULL
+       WHERE id = $2 AND enabled = true AND next_run_at <= now()
          AND (
            plugin_id IS NULL
            OR EXISTS (


### PR DESCRIPTION
## Summary

The scheduled-tasks **engine** starts in every region (the shared prod file config `deploy/api/atlas.config.ts` hardcodes `scheduler.backend: "bun"`), while **`/health`** and the **task-creation route** gated on `ATLAS_SCHEDULER_ENABLED` (set only in US). So EU/APAC actually run the fiber but report `scheduler:"disabled"` and 404 task creation — three sites reading two different sources of truth. Ground-truthed on prod: EU + APAC boot logs both emit `Scheduler starting` while `/health` says `disabled` and `ATLAS_SCHEDULER_ENABLED=false`.

This converges all three on `config.scheduler` (the source the engine already uses), for **per-region parity** — which the deploy topology (separate `us/eu/apac-int-postgres`, each region on its own `DATABASE_URL`) already implements:

- **`/health`** (`health.ts`): `schedulerEnabled = getConfig()?.scheduler != null` (was the env var) — status now reflects the fiber that actually runs.
- **Route** (`index.ts` + `scheduled-tasks.ts`): mount **unconditionally** + a **per-request** config gate. `getConfig()` is `null` at module-construction time (the `initConfig` race — `server.ts` resolves config after the static `import { app }`), so a construction-time gate can't read it; a request-time gate can. Off (no scheduler backend) → 404, preserving "never write a task that silently never fires."
- **Claim guard** (`scheduled-tasks.ts` `lockTaskForExecution`): `next_run_at <= now()` (was `IS NOT NULL`, which does **not** prevent a concurrent claimer from also matching once the first advances `next_run_at` to the future). Dormant today (1 replica/region), but now a correct time-based claim.
- **Comments** (`layers.ts`): corrected the stale "single global US scheduler / shared internal DB" rationale — there is no shared internal DB; each region runs its own tenants' tasks in-region.

**Deploy effect:** on next deploy EU/APAC flip to `scheduler:"healthy"` with task creation enabled, **no Railway change** — `ATLAS_SCHEDULER_ENABLED` is now vestigial for the file-config deploy (still honored on the self-hosted env-config path via `configFromEnv`).

Follow-up to #3687, whose "only US runs the scheduler fiber / shared internal DB" premise was never true for the 3-region deploy.

## Test plan
- [x] `bun run type` — clean
- [x] `bun run lint` / `lint-type-aware` — clean
- [x] Affected isolated suite — 149/149 (unconditional mount now loads the route in every `../index` test → completed the shared `createApiTestMocks` scheduled-tasks mock, fixing 14 admin-test regressions centrally)
- [x] Added gate tests (404 when no scheduler backend configured) + updated the lock-guard assertion to `next_run_at <= now()`
- [x] `scripts/ci-local.sh` — 29/30 gates pass; the lone `test`-gate failure is `packages/mcp/.../smoke.test.ts` with `relation "settings" does not exist`, the documented local env-flake (unmigrated SaaS-local DB, #1472) — unrelated to this `packages/api`-only change; the real `api-tests` shards run against a migrated Postgres

Closes #4623