### PR TITLE
refactor: learned-pattern wire contract SSOT — schemas package + validated table

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -22819,7 +22819,78 @@
                               "object",
                               "null"
                             ],
-                            "additionalProperties": {}
+                            "properties": {
+                              "entityName": {
+                                "type": "string"
+                              },
+                              "amendmentType": {
+                                "type": "string",
+                                "enum": [
+                                  "add_dimension",
+                                  "add_measure",
+                                  "add_join",
+                                  "add_query_pattern",
+                                  "update_description",
+                                  "update_dimension",
+                                  "add_glossary_term",
+                                  "update_glossary_term",
+                                  "add_virtual_dimension"
+                                ]
+                              },
+                              "amendment": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "rationale": {
+                                "type": "string"
+                              },
+                              "diff": {
+                                "type": "string"
+                              },
+                              "testQuery": {
+                                "type": "string"
+                              },
+                              "testResult": {
+                                "type": "object",
+                                "properties": {
+                                  "success": {
+                                    "type": "boolean"
+                                  },
+                                  "rowCount": {
+                                    "type": "number"
+                                  },
+                                  "sampleRows": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    }
+                                  },
+                                  "error": {
+                                    "type": "string"
+                                  },
+                                  "deferred": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "success",
+                                  "rowCount",
+                                  "sampleRows"
+                                ]
+                              },
+                              "confidence": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "entityName",
+                              "amendmentType",
+                              "amendment",
+                              "rationale",
+                              "diff",
+                              "confidence"
+                            ]
                           },
                           "autoPromoted": {
                             "type": "boolean"
@@ -22854,8 +22925,7 @@
                       }
                     },
                     "total": {
-                      "type": "number",
-                      "description": "Total count"
+                      "type": "number"
                     },
                     "limit": {
                       "type": "number"
@@ -23103,7 +23173,78 @@
                         "object",
                         "null"
                       ],
-                      "additionalProperties": {}
+                      "properties": {
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "amendmentType": {
+                          "type": "string",
+                          "enum": [
+                            "add_dimension",
+                            "add_measure",
+                            "add_join",
+                            "add_query_pattern",
+                            "update_description",
+                            "update_dimension",
+                            "add_glossary_term",
+                            "update_glossary_term",
+                            "add_virtual_dimension"
+                          ]
+                        },
+                        "amendment": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "rationale": {
+                          "type": "string"
+                        },
+                        "diff": {
+                          "type": "string"
+                        },
+                        "testQuery": {
+                          "type": "string"
+                        },
+                        "testResult": {
+                          "type": "object",
+                          "properties": {
+                            "success": {
+                              "type": "boolean"
+                            },
+                            "rowCount": {
+                              "type": "number"
+                            },
+                            "sampleRows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            },
+                            "error": {
+                              "type": "string"
+                            },
+                            "deferred": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "success",
+                            "rowCount",
+                            "sampleRows"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "entityName",
+                        "amendmentType",
+                        "amendment",
+                        "rationale",
+                        "diff",
+                        "confidence"
+                      ]
                     },
                     "autoPromoted": {
                       "type": "boolean"
@@ -23365,7 +23506,78 @@
                         "object",
                         "null"
                       ],
-                      "additionalProperties": {}
+                      "properties": {
+                        "entityName": {
+                          "type": "string"
+                        },
+                        "amendmentType": {
+                          "type": "string",
+                          "enum": [
+                            "add_dimension",
+                            "add_measure",
+                            "add_join",
+                            "add_query_pattern",
+                            "update_description",
+                            "update_dimension",
+                            "add_glossary_term",
+                            "update_glossary_term",
+                            "add_virtual_dimension"
+                          ]
+                        },
+                        "amendment": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "rationale": {
+                          "type": "string"
+                        },
+                        "diff": {
+                          "type": "string"
+                        },
+                        "testQuery": {
+                          "type": "string"
+                        },
+                        "testResult": {
+                          "type": "object",
+                          "properties": {
+                            "success": {
+                              "type": "boolean"
+                            },
+                            "rowCount": {
+                              "type": "number"
+                            },
+                            "sampleRows": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            },
+                            "error": {
+                              "type": "string"
+                            },
+                            "deferred": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "success",
+                            "rowCount",
+                            "sampleRows"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "entityName",
+                        "amendmentType",
+                        "amendment",
+                        "rationale",
+                        "diff",
+                        "confidence"
+                      ]
                     },
                     "autoPromoted": {
                       "type": "boolean"

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -14,8 +14,9 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { LEARNED_PATTERN_STATUSES, type LearnedPattern } from "@useatlas/types";
+import { LearnedPatternSchema, LearnedPatternsListResponseSchema } from "@useatlas/schemas";
 import { invalidatePatternCache } from "@atlas/api/lib/learn/pattern-cache";
-import { ErrorSchema, AuthErrorSchema, parsePagination, createIdParamSchema, createListResponseSchema, DeletedResponseSchema } from "./shared-schemas";
+import { ErrorSchema, AuthErrorSchema, parsePagination, createIdParamSchema, DeletedResponseSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-learned-patterns");
@@ -100,32 +101,14 @@ const QUERY_PATTERN_SCOPE = "type = 'query_pattern'";
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
-
-const LearnedPatternSchema = z.object({
-  id: z.string(),
-  orgId: z.string().nullable(),
-  patternSql: z.string(),
-  description: z.string().nullable(),
-  sourceEntity: z.string().nullable(),
-  sourceQueries: z.array(z.string()).nullable(),
-  confidence: z.number(),
-  repetitionCount: z.number(),
-  status: z.enum(["pending", "approved", "rejected"]),
-  proposedBy: z.enum(["agent", "atlas-learn", "expert-agent"]).nullable(),
-  reviewedBy: z.string().nullable(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  reviewedAt: z.string().nullable(),
-  type: z.enum(["query_pattern", "semantic_amendment"]),
-  amendmentPayload: z.record(z.string(), z.unknown()).nullable(),
-  autoPromoted: z.boolean(),
-  avgDurationMs: z.number().nullable(),
-});
-
-const ListResponseSchema = createListResponseSchema("patterns", LearnedPatternSchema, {
-  limit: z.number(),
-  offset: z.number(),
-});
+//
+// The learned-pattern wire shape (`LearnedPatternSchema`) and its list
+// envelope (`LearnedPatternsListResponseSchema`) live in `@useatlas/schemas`
+// — one source of truth shared with the cockpit page's response parsing, so a
+// field rename can't silently drift between route and web (#4579). The enum
+// tuples come from `@useatlas/types`, and `satisfies z.ZodType<LearnedPattern>`
+// pins the schema to the wire type at compile time. Route-local schemas below
+// are the ones that describe route-only responses (bulk / deleted).
 
 const BulkResponseSchema = z.object({
   updated: z.array(z.string()),
@@ -159,7 +142,7 @@ const listPatternsRoute = createRoute({
   responses: {
     200: {
       description: "Paginated list of learned patterns",
-      content: { "application/json": { schema: ListResponseSchema } },
+      content: { "application/json": { schema: LearnedPatternsListResponseSchema } },
     },
     400: {
       description: "Invalid filter parameters",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -21,6 +21,7 @@
     "./custom-domain": "./src/custom-domain.ts",
     "./dashboard": "./src/dashboard.ts",
     "./integrations": "./src/integrations.ts",
+    "./learned-pattern": "./src/learned-pattern.ts",
     "./mcp-prompts": "./src/mcp-prompts.ts",
     "./mcp-usage": "./src/mcp-usage.ts",
     "./platform": "./src/platform.ts",

--- a/packages/schemas/src/__tests__/learned-pattern.test.ts
+++ b/packages/schemas/src/__tests__/learned-pattern.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LearnedPatternSchema,
+  LearnedPatternsListResponseSchema,
+  AmendmentPayloadSchema,
+} from "../learned-pattern";
+import {
+  LEARNED_PATTERN_STATUSES,
+  LEARNED_PATTERN_SOURCES,
+  LEARNED_PATTERN_TYPES,
+} from "@useatlas/types";
+
+const validPattern = {
+  id: "pat-1",
+  orgId: "org-1",
+  patternSql: "SELECT COUNT(*) FROM orders",
+  description: "Order count",
+  sourceEntity: "orders",
+  sourceQueries: ["audit-1"],
+  confidence: 0.8,
+  repetitionCount: 5,
+  status: "pending" as const,
+  proposedBy: "agent" as const,
+  reviewedBy: null,
+  createdAt: "2026-03-18T00:00:00Z",
+  updatedAt: "2026-03-18T00:00:00Z",
+  reviewedAt: null,
+  type: "query_pattern" as const,
+  amendmentPayload: null,
+  autoPromoted: false,
+  avgDurationMs: null,
+};
+
+const validListResponse = {
+  patterns: [validPattern, { ...validPattern, id: "pat-2" }],
+  total: 2,
+  limit: 50,
+  offset: 0,
+};
+
+describe("happy-path parses", () => {
+  test("LearnedPatternSchema parses a query_pattern row", () => {
+    expect(LearnedPatternSchema.parse(validPattern)).toEqual(validPattern);
+  });
+
+  test("LearnedPatternsListResponseSchema parses the list envelope", () => {
+    expect(LearnedPatternsListResponseSchema.parse(validListResponse)).toEqual(
+      validListResponse,
+    );
+  });
+
+  test("round-trip (parse → serialize → parse) preserves fields", () => {
+    const parsed = LearnedPatternSchema.parse(validPattern);
+    const serialized = JSON.parse(JSON.stringify(parsed));
+    expect(LearnedPatternSchema.parse(serialized)).toEqual(validPattern);
+  });
+
+  test("parses a semantic_amendment row with a structured amendmentPayload", () => {
+    const amendment = {
+      ...validPattern,
+      id: "amd-1",
+      type: "semantic_amendment" as const,
+      amendmentPayload: {
+        entityName: "orders",
+        amendmentType: "add_measure" as const,
+        amendment: { name: "total_revenue", sql: "SUM(amount)" },
+        rationale: "Frequently requested aggregate.",
+        diff: "+ measure: total_revenue",
+        confidence: 0.9,
+      },
+    };
+    expect(LearnedPatternSchema.parse(amendment)).toEqual(amendment);
+  });
+});
+
+describe("enum-tuple coverage", () => {
+  test("every LEARNED_PATTERN_STATUSES value parses", () => {
+    for (const status of LEARNED_PATTERN_STATUSES) {
+      expect(LearnedPatternSchema.parse({ ...validPattern, status }).status).toBe(
+        status,
+      );
+    }
+  });
+
+  test("every LEARNED_PATTERN_SOURCES value parses", () => {
+    for (const proposedBy of LEARNED_PATTERN_SOURCES) {
+      expect(
+        LearnedPatternSchema.parse({ ...validPattern, proposedBy }).proposedBy,
+      ).toBe(proposedBy);
+    }
+  });
+
+  test("every LEARNED_PATTERN_TYPES value parses", () => {
+    for (const type of LEARNED_PATTERN_TYPES) {
+      const row =
+        type === "semantic_amendment"
+          ? { ...validPattern, type, amendmentPayload: null }
+          : { ...validPattern, type };
+      expect(LearnedPatternSchema.parse(row).type).toBe(type);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drift rejection — the whole point of the migration. The cockpit page
+// previously consumed this endpoint through the unvalidated table variant with
+// an `as` cast, so a wire rename surfaced as a silently empty table. Pinning
+// the shape here means drift fails parse and surfaces a `schema_mismatch`
+// banner instead.
+// ---------------------------------------------------------------------------
+
+describe("drift rejection", () => {
+  test("unknown status fails parse", () => {
+    const drifted = { ...validPattern, status: "archived" };
+    expect(LearnedPatternSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("unknown proposedBy source fails parse", () => {
+    const drifted = { ...validPattern, proposedBy: "cron-job" };
+    expect(LearnedPatternSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("renamed pattern field (patternSql → sql) fails parse", () => {
+    const { patternSql: _drop, ...rest } = validPattern;
+    const drifted = { ...rest, sql: "SELECT 1" };
+    expect(LearnedPatternSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("non-numeric confidence fails parse", () => {
+    const drifted = { ...validPattern, confidence: "0.8" };
+    expect(LearnedPatternSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("list envelope with a string total fails parse (the classic silent-empty drift)", () => {
+    const drifted = { ...validListResponse, total: "2" };
+    expect(LearnedPatternsListResponseSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("list envelope with a drifted pattern element fails parse", () => {
+    const drifted = {
+      ...validListResponse,
+      patterns: [{ ...validPattern, status: "archived" }],
+    };
+    expect(LearnedPatternsListResponseSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("amendmentPayload missing a required field fails parse", () => {
+    const drifted = {
+      entityName: "orders",
+      amendmentType: "add_measure",
+      amendment: {},
+      // rationale intentionally omitted
+      diff: "+ measure",
+      confidence: 0.5,
+    };
+    expect(AmendmentPayloadSchema.safeParse(drifted).success).toBe(false);
+  });
+
+  test("amendmentPayload with an unknown amendmentType fails parse", () => {
+    const drifted = {
+      entityName: "orders",
+      amendmentType: "delete_entity",
+      amendment: {},
+      rationale: "x",
+      diff: "y",
+      confidence: 0.5,
+    };
+    expect(AmendmentPayloadSchema.safeParse(drifted).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -15,6 +15,7 @@ export * from "./execute-sql";
 export * from "./metric-run";
 export * from "./mode";
 export * from "./integrations";
+export * from "./learned-pattern";
 export * from "./mcp-prompts";
 export * from "./mcp-usage";
 export * from "./platform";

--- a/packages/schemas/src/learned-pattern.ts
+++ b/packages/schemas/src/learned-pattern.ts
@@ -1,0 +1,92 @@
+/**
+ * Learned-pattern wire-format schemas.
+ *
+ * Single source of truth for the admin learned-patterns surface
+ * (`/api/v1/admin/learned-patterns`) — shared by the route-layer
+ * `@hono/zod-openapi` response contract (the compile-time-typed `c.json`
+ * shape + generated OpenAPI doc) and the web-layer `useServerDataTable` /
+ * `useAdminFetch` runtime response parsing, so a rename on one side can't
+ * silently drift from the other.
+ *
+ * Before #4579 the route hand-rolled this shape inline with hardcoded enum
+ * literals (no tie to the `LEARNED_PATTERN_*` tuples, no `satisfies
+ * z.ZodType`), while the cockpit page consumed the endpoint through the
+ * unvalidated `useServerDataTable` variant with an `as` cast — so a wire
+ * rename surfaced as a silently empty "No learned patterns" table instead of
+ * a `schema_mismatch` banner. Centralizing here closes that gap.
+ *
+ * The enum tuples come from `@useatlas/types` so a new status/source/type
+ * propagates without a second edit. `satisfies z.ZodType<T>` (not `as`) makes
+ * a field rename in `@useatlas/types` a compile error here instead of passing
+ * through to runtime.
+ */
+import { z } from "zod";
+import {
+  LEARNED_PATTERN_STATUSES,
+  LEARNED_PATTERN_SOURCES,
+  LEARNED_PATTERN_TYPES,
+  AMENDMENT_TYPES,
+  type AmendmentPayload,
+  type LearnedPattern,
+} from "@useatlas/types";
+
+/** Result of running an amendment's test query (nested in AmendmentPayload). */
+const AmendmentTestResultSchema = z.object({
+  success: z.boolean(),
+  rowCount: z.number(),
+  sampleRows: z.array(z.record(z.string(), z.unknown())),
+  error: z.string().optional(),
+  deferred: z.boolean().optional(),
+});
+
+/**
+ * Structured payload for `type = 'semantic_amendment'` proposals. The
+ * learned-patterns route is query-pattern-only (#4569), so this is always
+ * `null` on that surface — but the wire type carries it, so the schema models
+ * it faithfully rather than relaxing to an untyped record.
+ */
+export const AmendmentPayloadSchema = z.object({
+  entityName: z.string(),
+  amendmentType: z.enum(AMENDMENT_TYPES),
+  amendment: z.record(z.string(), z.unknown()),
+  rationale: z.string(),
+  diff: z.string(),
+  testQuery: z.string().optional(),
+  testResult: AmendmentTestResultSchema.optional(),
+  confidence: z.number(),
+}) satisfies z.ZodType<AmendmentPayload>;
+
+/** One learned-pattern row as served on the wire. */
+export const LearnedPatternSchema = z.object({
+  id: z.string(),
+  orgId: z.string().nullable(),
+  patternSql: z.string(),
+  description: z.string().nullable(),
+  sourceEntity: z.string().nullable(),
+  sourceQueries: z.array(z.string()).nullable(),
+  confidence: z.number(),
+  repetitionCount: z.number(),
+  status: z.enum(LEARNED_PATTERN_STATUSES),
+  proposedBy: z.enum(LEARNED_PATTERN_SOURCES).nullable(),
+  reviewedBy: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  reviewedAt: z.string().nullable(),
+  type: z.enum(LEARNED_PATTERN_TYPES),
+  amendmentPayload: AmendmentPayloadSchema.nullable(),
+  autoPromoted: z.boolean(),
+  avgDurationMs: z.number().nullable(),
+}) satisfies z.ZodType<LearnedPattern>;
+
+/**
+ * Paginated list envelope for `GET /api/v1/admin/learned-patterns`
+ * (`{ patterns, total, limit, offset }`). The route types its response against
+ * this and the cockpit page runtime-parses the same schema, so the list shape
+ * can't drift between the two.
+ */
+export const LearnedPatternsListResponseSchema = z.object({
+  patterns: z.array(LearnedPatternSchema),
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});

--- a/packages/web/src/app/admin/learned-patterns/page.tsx
+++ b/packages/web/src/app/admin/learned-patterns/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { z } from "zod";
 import { useQueryStates } from "nuqs";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { LearnedPattern, LearnedPatternStatus } from "@/ui/lib/types";
@@ -9,6 +10,7 @@ import { getLearnedPatternColumns, statusBadge, autoApprovedBadge } from "./colu
 import { useAtlasConfig } from "@/ui/context";
 import { ServerDataTable } from "@/ui/components/admin/server-data-table";
 import { useServerDataTable } from "@/ui/hooks/use-server-data-table";
+import { LearnedPatternsListResponseSchema } from "@/ui/lib/admin-schemas";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -295,15 +297,16 @@ export default function LearnedPatternsPage() {
     loading,
     error,
     refetch,
-  } = useServerDataTable<LearnedPattern>({
+  } = useServerDataTable<
+    LearnedPattern,
+    z.infer<typeof LearnedPatternsListResponseSchema>
+  >({
     columns,
     getRowId: (row) => row.id,
     defaultPerPage: LIMIT,
     defaultSorting: [{ id: "createdAt", desc: true }],
-    select: (r) => {
-      const d = r as { patterns?: LearnedPattern[]; total?: number };
-      return { rows: d.patterns ?? [], total: d.total ?? 0 };
-    },
+    schema: LearnedPatternsListResponseSchema,
+    select: (r) => ({ rows: r.patterns, total: r.total }),
     buildPath: ({ offset, perPage }) => {
       const qs = new URLSearchParams({
         limit: String(perPage),

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -566,6 +566,17 @@ export type {
   PlatformSecurityMetrics,
 } from "@useatlas/types";
 
+// ── Learned patterns (/admin/learned-patterns) ────────────────
+// Wire schema lives in `@useatlas/schemas` (single source of truth shared
+// with the API route layer, #4579). Re-exported here for the cockpit page's
+// `useServerDataTable` call site, so a wire rename surfaces as a
+// `schema_mismatch` banner instead of a silently empty table.
+
+export {
+  LearnedPatternSchema,
+  LearnedPatternsListResponseSchema,
+} from "@useatlas/schemas";
+
 // ── Demo tracking (#3931) ────────────────────────────────────────────
 // Web-local mirrors of the inline shapes in
 // `packages/api/src/api/routes/platform-demo.ts`. Kept here (not in


### PR DESCRIPTION
## Summary

Foundational wire-contract refactor for milestone v0.0.50 (Learned-Patterns Elevation). Moves the learned-pattern wire Zod shape into the shared `@useatlas/schemas` package as the single source of truth, and switches the cockpit page from the unvalidated `useServerDataTable` variant (an `as` cast in `select`) to the validated one — so wire drift surfaces as a `schema_mismatch` banner instead of a silently empty "No learned patterns" table.

- **New `packages/schemas/src/learned-pattern.ts`** — `LearnedPatternSchema` (`satisfies z.ZodType<LearnedPattern>`), `AmendmentPayloadSchema`, and `LearnedPatternsListResponseSchema`. Enum tuples (`LEARNED_PATTERN_STATUSES/SOURCES/TYPES`, `AMENDMENT_TYPES`) come from `@useatlas/types`, so union tightening is drift-free by construction. Barrel + subpath export added.
- **Route `admin-learned-patterns.ts`** imports the shared schema instead of a hand-rolled inline shape (whose `amendmentPayload` was an untyped `z.record(...)`); drops the now-unused `createListResponseSchema` import. No hand-rolled duplicate of the pattern shape remains.
- **Web page** uses `useServerDataTable<LearnedPattern, z.infer<typeof LearnedPatternsListResponseSchema>>` with `schema:` passed; re-exported through `admin-schemas.ts` (the documented `@useatlas/schemas` re-export convention).
- **Regenerated `apps/docs/openapi.json`** — `amendmentPayload` now serializes as the structured object shape.

Respects the CLAUDE.md import boundary: `@atlas/web` never imports `@atlas/api`; wire types stay in `@useatlas/types`, Zod validation in `@useatlas/schemas`. `@useatlas/schemas` is private/never published, so no publish-sequencing or dependency-ref bump is needed — `published-symbols` + `unpublished-versions` gates stay green.

This is the base other cockpit slices (#4577 sort/filter, #4578 visibility, #4580 governance) rebase onto, so the schema shape is kept clean and complete.

## Test plan

- [x] New `packages/schemas/src/__tests__/learned-pattern.test.ts` — happy-path parse, exhaustive enum-tuple coverage, and drift rejection (renamed `patternSql`→`sql`, string `total`, unknown enum, drifted `amendmentPayload`) all fail parse. AC#2 ("a deliberately drifted response surfaces as a schema mismatch") is proven compositionally: schema rejects drift + the hook maps a rejected parse to `error.code === "schema_mismatch"` (already covered in `use-server-data-table.test.tsx`).
- [x] Existing route tests (`admin-learned-patterns*.test.ts`, 41) still green — behavior unchanged, import-swap only.
- [x] `bun run type` clean; local `/ci` gates green (openapi-drift passes on committed spec).
- [x] Internal review panel: CLEAN across all four axes.

## Note

The `UseServerDataTableOptions` union permits both the validated and unvalidated variants, so a future edit that drops `schema:` from this call would silently re-open the unvalidated path. That is guarded by review/convention here rather than a heavyweight page-render test (per the test-panel recommendation) — flagging for reviewer awareness.

Closes #4579