### PR TITLE
fix(learn): harden getApprovedPatterns — query_pattern-only + SaaS NULL-org guard

### DIFF
--- a/packages/api/src/lib/db/__tests__/approved-patterns-injection-scoping-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/approved-patterns-injection-scoping-pg.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Real-Postgres behavioral regression for `getApprovedPatterns` injection
+ * scoping (#4534) — the two isolation gaps proven against real rows, which the
+ * stub-pool SQL-shape test (`approved-patterns-injection-scoping.test.ts`)
+ * pins structurally:
+ *
+ *   - an approved `semantic_amendment` row is never returned as a query pattern
+ *     (the `type = 'query_pattern'` filter, behaviorally);
+ *   - on SaaS, a NULL-org approved `query_pattern` is not returned for a tenant
+ *     `orgId` (the #4487 cross-tenant guard, behaviorally);
+ *   - on self-hosted, that same NULL-org row IS returned for a tenant — the
+ *     legacy global scope is preserved, so the guard didn't over-tighten.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches
+ * `pattern-latency-pg` / `migrate-pg`). CI's api-tests workflow provides the
+ * Postgres service.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  getApprovedPatterns,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import { _setConfigForTest, _resetConfig, type ResolvedConfig } from "@atlas/api/lib/config";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TIMEOUT_MS = 30_000;
+
+// `getApprovedPatterns` short-circuits to `[]` when `hasInternalDB()` is false,
+// which reads `process.env.DATABASE_URL`. When this suite runs (TEST_DATABASE_URL
+// set) point DATABASE_URL at the same DB so the query path — not the no-DB
+// guard — executes. `??=` respects an already-set value.
+if (TEST_DB_URL) process.env.DATABASE_URL ??= TEST_DB_URL;
+
+/** Fully-typed `ResolvedConfig` so a `deployMode` typo can't compile silently. */
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
+describeIfPg("getApprovedPatterns injection scoping (real Postgres, #4534)", () => {
+  let pool: Pool;
+  const schemaName = `approved_patterns_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    // Pin search_path at connection STARTUP (libpq `options`), not via a
+    // fire-and-forget `SET` on the pool's `connect` event: this test inserts on
+    // one pooled connection and reads back on another, and an unawaited `SET`
+    // can lose the race so a fresh connection reads the wrong schema (empty →
+    // false-negative `[]`). Startup `options` applies to EVERY connection before
+    // its first query, deterministically. `CREATE SCHEMA` below is explicit, so
+    // pointing at a not-yet-created schema is fine.
+    pool = new Pool({ connectionString: TEST_DB_URL, options: `-c search_path=${schemaName}` });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Point the production internal-DB helpers at this pool so the exact
+    // getApprovedPatterns SQL under test runs against this schema.
+    _resetPool(pool as unknown as InternalPool);
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    _resetPool(null);
+    _resetConfig();
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    _resetConfig();
+    await pool.query("DELETE FROM learned_patterns");
+  });
+
+  async function insertRow(row: {
+    orgId: string | null;
+    type: string;
+    status: string;
+    patternSql: string;
+    description: string;
+    sourceEntity: string;
+    confidence?: number;
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO learned_patterns
+         (org_id, type, status, pattern_sql, description, source_entity, confidence)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        row.orgId,
+        row.type,
+        row.status,
+        row.patternSql,
+        row.description,
+        row.sourceEntity,
+        row.confidence ?? 0.9,
+      ],
+    );
+  }
+
+  it(
+    "excludes an approved semantic_amendment row from a tenant's approved patterns",
+    async () => {
+      _setConfigForTest(configWithDeployMode("self-hosted"));
+      await insertRow({
+        orgId: "org-a",
+        type: "query_pattern",
+        status: "approved",
+        patternSql: "SELECT SUM(revenue) FROM orders",
+        description: "Revenue total",
+        sourceEntity: "orders",
+      });
+      // An approved amendment: its `pattern_sql` is the identity-key sentinel
+      // `<group>:<entity>:<amendmentType>[:<target>]` (see `amendmentIdentityKey`),
+      // not a runnable query; the description carries real keywords.
+      const amendmentSentinel = "default:orders:add_dimension:region";
+      await insertRow({
+        orgId: "org-a",
+        type: "semantic_amendment",
+        status: "approved",
+        patternSql: amendmentSentinel,
+        description: "adds region dimension to orders revenue",
+        sourceEntity: "orders",
+      });
+
+      const rows = await getApprovedPatterns("org-a");
+      expect(rows.map((r) => r.pattern_sql)).toEqual(["SELECT SUM(revenue) FROM orders"]);
+      expect(rows.some((r) => r.pattern_sql === amendmentSentinel)).toBe(false);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "on SaaS, a NULL-org approved query_pattern is NOT returned for a tenant",
+    async () => {
+      _setConfigForTest(configWithDeployMode("saas"));
+      await insertRow({
+        orgId: null,
+        type: "query_pattern",
+        status: "approved",
+        patternSql: "SELECT * FROM other_tenant_shape",
+        description: "global revenue leak",
+        sourceEntity: "other_tenant_shape",
+      });
+      await insertRow({
+        orgId: "org-a",
+        type: "query_pattern",
+        status: "approved",
+        patternSql: "SELECT * FROM tenant_a_orders",
+        description: "tenant a orders",
+        sourceEntity: "tenant_a_orders",
+      });
+
+      const rows = await getApprovedPatterns("org-a");
+      expect(rows.map((r) => r.pattern_sql)).toEqual(["SELECT * FROM tenant_a_orders"]);
+      expect(rows.some((r) => r.org_id === null)).toBe(false);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "on self-hosted, the NULL-org approved query_pattern IS returned (legacy global scope)",
+    async () => {
+      _setConfigForTest(configWithDeployMode("self-hosted"));
+      await insertRow({
+        orgId: null,
+        type: "query_pattern",
+        status: "approved",
+        patternSql: "SELECT * FROM shared_shape",
+        description: "shared revenue",
+        sourceEntity: "shared_shape",
+      });
+      await insertRow({
+        orgId: "org-a",
+        type: "query_pattern",
+        status: "approved",
+        patternSql: "SELECT * FROM tenant_a_orders",
+        description: "tenant a orders",
+        sourceEntity: "tenant_a_orders",
+      });
+
+      const rows = await getApprovedPatterns("org-a");
+      expect(rows.map((r) => r.pattern_sql).sort()).toEqual([
+        "SELECT * FROM shared_shape",
+        "SELECT * FROM tenant_a_orders",
+      ]);
+    },
+    PG_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/db/__tests__/approved-patterns-injection-scoping.test.ts
+++ b/packages/api/src/lib/db/__tests__/approved-patterns-injection-scoping.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Injection-read scoping for approved learned patterns (#4534).
+ *
+ * `getApprovedPatterns` is the read path that feeds approved patterns into every
+ * agent turn's system prompt (pattern cache → org-knowledge-section). It had two
+ * isolation gaps its sibling amendment-read path (`amendmentOrgScope`, #4487) did
+ * not — both fixed here and pinned by the SQL shape (the injection tests mock
+ * `getApprovedPatterns` wholesale, so only a query-layer test can catch these):
+ *
+ *   1. type filter — the query MUST restrict to `type = 'query_pattern'` so a
+ *      `semantic_amendment` row (sentinel `pattern_sql`, same table, reaches
+ *      `status = 'approved'` on approval) can never be injected as a "previously
+ *      successful query pattern". Mirrors `getPromoteDecayCandidates`.
+ *   2. SaaS NULL-org guard (#4487) — on SaaS the `OR org_id IS NULL` arm is
+ *      dropped so a NULL-org ("global scope") approved pattern can never surface
+ *      in a tenant's agent context (cross-tenant leak). On self-hosted the arm
+ *      stays: the single workspace's legacy global scope remains readable.
+ *
+ * Deploy mode resolves through `isSaasModeForGuard()` (fail-closed) off the
+ * cached config — driven here via `_setConfigForTest`, exactly like
+ * `semantic-amendment-saas-scoping.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+
+// `hasInternalDB()` reads DATABASE_URL at call time; set it before the module
+// under test is imported so the query path (not the no-DB short-circuit) runs.
+process.env.DATABASE_URL ??= "postgresql://test:test@localhost:5432/atlas_test";
+
+import { getApprovedPatterns, _resetPool, _resetCircuitBreaker } from "../internal";
+import type { ResolvedConfig } from "../../config";
+import { _setConfigForTest, _resetConfig } from "../../config";
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+}
+
+let captured: Captured[] = [];
+
+function makeStubPool() {
+  return {
+    query: async (sql: string, params?: unknown[]) => {
+      captured.push({ sql, params: params ?? [] });
+      return { rows: [] };
+    },
+    async end() {},
+    async connect() {
+      return { query: async () => ({ rows: [] }), release() {} };
+    },
+    on() {},
+  };
+}
+
+/** Fully-typed `ResolvedConfig` so a `deployMode` typo can't compile silently. */
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
+/** Drive `isSaasModeForGuard()` by seeding the cached deploy mode. */
+function setDeployMode(mode: "saas" | "self-hosted") {
+  _setConfigForTest(configWithDeployMode(mode));
+}
+
+beforeEach(() => {
+  captured = [];
+  _resetCircuitBreaker();
+  _resetPool(makeStubPool() as unknown as Parameters<typeof _resetPool>[0], null);
+});
+
+afterEach(() => {
+  _resetConfig();
+});
+
+afterAll(() => {
+  _resetPool(null, null);
+  _resetConfig();
+  _resetCircuitBreaker();
+  mock.restore();
+});
+
+describe("getApprovedPatterns — type filter (#4534)", () => {
+  it("restricts to query_pattern rows, so an amendment row can never be injected", async () => {
+    setDeployMode("self-hosted");
+    await getApprovedPatterns("org-a");
+
+    expect(captured).toHaveLength(1);
+    const { sql } = captured[0]!;
+    expect(sql).toContain("type = 'query_pattern'");
+    // Belt-and-braces: the query must not read amendment rows at all.
+    expect(sql).not.toContain("semantic_amendment");
+  });
+
+  it("keeps the type filter on the org-less (global) path too", async () => {
+    setDeployMode("self-hosted");
+    await getApprovedPatterns(null);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("type = 'query_pattern'");
+  });
+
+  it("keeps the type filter when a connection group is scoped", async () => {
+    setDeployMode("self-hosted");
+    await getApprovedPatterns("org-a", "us-prod");
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("type = 'query_pattern'");
+  });
+});
+
+describe("getApprovedPatterns — SaaS NULL-org guard (#4487, #4534)", () => {
+  it("drops the OR org_id IS NULL arm for a tenant on SaaS", async () => {
+    setDeployMode("saas");
+    await getApprovedPatterns("org-a");
+
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    expect(sql).toContain("org_id = $1");
+    // The `org_id IS NULL` arm is the leak vector — it must be gone on SaaS.
+    // (The group clause `connection_group_id IS NULL` is unaffected: this
+    // substring is specifically the org arm.)
+    expect(sql).not.toContain("org_id IS NULL");
+    expect(params).toEqual(["org-a"]);
+  });
+
+  it("keeps the OR org_id IS NULL arm for a tenant on self-hosted (legacy global scope)", async () => {
+    setDeployMode("self-hosted");
+    await getApprovedPatterns("org-a");
+
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    expect(sql).toContain("(org_id = $1 OR org_id IS NULL)");
+    expect(params).toEqual(["org-a"]);
+  });
+
+  it("withholds entirely for an org-less read on SaaS (no global tenant), touching no DB", async () => {
+    setDeployMode("saas");
+    const rows = await getApprovedPatterns(null);
+
+    expect(rows).toEqual([]);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("still targets org_id IS NULL for an org-less read on self-hosted (global admin view)", async () => {
+    setDeployMode("self-hosted");
+    await getApprovedPatterns(null);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("org_id IS NULL");
+  });
+
+  it("threads the group placeholder after the org placeholder on SaaS (bind order pinned)", async () => {
+    setDeployMode("saas");
+    await getApprovedPatterns("org-a", "us-prod");
+
+    expect(captured).toHaveLength(1);
+    const { sql, params } = captured[0]!;
+    // Org arm binds $1, the group arm binds $2 — a transposed bind order would
+    // silently scope by the wrong value.
+    expect(sql).toContain("org_id = $1");
+    expect(sql).not.toContain("org_id IS NULL");
+    expect(sql).toContain("(connection_group_id = $2 OR connection_group_id IS NULL)");
+    expect(params).toEqual(["org-a", "us-prod"]);
+  });
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2337,16 +2337,24 @@ export interface QuerySuggestionRow {
 }
 
 /**
- * Fetch approved learned patterns, scoped to an org (or global when orgId is
- * null) AND a connection group (#3611).
+ * Fetch approved learned patterns for agent-context injection, scoped to an org
+ * AND a connection group (#3611). Restricted to `type = 'query_pattern'` rows
+ * (#4534) — `semantic_amendment` rows share this table and can reach
+ * `status = 'approved'`, but their sentinel `pattern_sql` is not an executable
+ * query and must never be injected as one.
  *
- * Group scoping mirrors the org rule: a pattern is in scope when its
+ * Org scoping is deploy-mode aware (#4487, #4534): on SaaS the `OR org_id IS
+ * NULL` arm is dropped for a workspace — and an org-less read withholds entirely
+ * (no global tenant) — so a NULL-org ("global scope") pattern can never surface
+ * cross-tenant in an agent's system prompt; on self-hosted the arm stays,
+ * keeping the single deployment's legacy global scope readable.
+ *
+ * Group scoping mirrors the self-hosted org rule: a pattern is in scope when its
  * `connection_group_id` matches the active group OR is NULL (the default flat
- * `entities/` scope, shared across groups the same way `org_id IS NULL` is
- * shared across orgs). When `connectionGroupId` is null/omitted the active
- * scope IS the default group, so only `connection_group_id IS NULL` rows match
- * — this keeps `us-prod` patterns out of a `eu-prod` agent session and
- * vice-versa. Ordered by confidence DESC, capped at 100 rows.
+ * `entities/` scope). When `connectionGroupId` is null/omitted the active scope
+ * IS the default group, so only `connection_group_id IS NULL` rows match — this
+ * keeps `us-prod` patterns out of a `eu-prod` agent session and vice-versa.
+ * Ordered by confidence DESC, capped at 100 rows.
  */
 export async function getApprovedPatterns(
   orgId: string | null,
@@ -2356,10 +2364,28 @@ export async function getApprovedPatterns(
 
   const params: unknown[] = [];
 
+  // Org scope, deploy-mode aware (#4487, #4534). On SaaS a NULL-org ("global
+  // scope") approved pattern must NEVER surface in a tenant's agent context:
+  //   - workspace → `org_id = $N` only (the `OR org_id IS NULL` leak arm is
+  //                 dropped, so a NULL-org row can't be injected cross-tenant);
+  //   - org-less  → withhold entirely — there is no global tenant on SaaS, so
+  //                 fail closed rather than return NULL-org rows to a no-tenant
+  //                 read.
+  // Both mirror `amendmentOrgScope`'s SaaS behavior. On self-hosted the single
+  // workspace IS the whole deployment, so a NULL-org row is that deployment's
+  // legacy global scope and stays readable in both cases. Inlined rather than
+  // routed through `amendmentOrgScope` — that helper is the amendment readers'
+  // and is pinned to that set by the #4510 reader-enumeration guard, and it emits
+  // no group clause; this is a `query_pattern` reader with its own group scope.
+  const saas = requireIsSaasModeForGuard()();
   let orgClause: string;
   if (orgId) {
     params.push(orgId);
-    orgClause = `(org_id = $${params.length} OR org_id IS NULL)`;
+    orgClause = saas
+      ? `org_id = $${params.length}`
+      : `(org_id = $${params.length} OR org_id IS NULL)`;
+  } else if (saas) {
+    return [];
   } else {
     orgClause = `org_id IS NULL`;
   }
@@ -2372,10 +2398,16 @@ export async function getApprovedPatterns(
     groupClause = `connection_group_id IS NULL`;
   }
 
+  // `type = 'query_pattern'` is load-bearing (#4534): `semantic_amendment` rows
+  // live in this same table and reach `status = 'approved'` on approval, but
+  // their `pattern_sql` is a non-executable identity-key sentinel (see
+  // `amendmentIdentityKey`), never a runnable query — injecting one as a query
+  // pattern is garbage in the prompt. Mirrors the filter
+  // `getPromoteDecayCandidates` already applies.
   return internalQuery<ApprovedPatternRow>(
     `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence, avg_duration_ms
      FROM learned_patterns
-     WHERE status = 'approved' AND ${orgClause} AND ${groupClause}
+     WHERE status = 'approved' AND type = 'query_pattern' AND ${orgClause} AND ${groupClause}
      ORDER BY confidence DESC
      LIMIT 100`,
     params,


### PR DESCRIPTION
## Summary

`getApprovedPatterns` is the read path that injects approved learned patterns into every agent turn's system prompt (pattern cache → org-knowledge-section). It had two isolation gaps its sibling amendment read path (`amendmentOrgScope`, #4487) does not:

- **No `type = 'query_pattern'` filter (LIVE).** An approved `semantic_amendment` row — same table, sentinel identity-key `pattern_sql`, reaches `status = 'approved'` on approval — was returned and rendered into the prompt verbatim as a "previously successful query pattern": non-executable noise that wastes tokens and can mislead the model. Now filtered, mirroring `getPromoteDecayCandidates`.
- **No SaaS fail-closed NULL-org guard (LATENT).** The `OR org_id IS NULL` arm surfaced a NULL-org ("global scope") approved pattern in **every** SaaS tenant's agent context — a latent cross-tenant leak, armed the moment the auto-promote scheduler (`ATLAS_LEARN_PROMOTE_DECAY_ENABLED`) runs in a SaaS region. Org scoping is now deploy-mode aware: on SaaS the arm is dropped for a workspace and an org-less read withholds entirely (no global tenant); on self-hosted the arm stays (legacy global scope for the single deployment).

The SaaS guard reuses the fail-CLOSED `requireIsSaasModeForGuard()` probe (returns `true` on config error), so uncertainty resolves toward withholding NULL-org rows.

## Test plan
- [x] Fast stub-pool SQL-shape test (`approved-patterns-injection-scoping.test.ts`) — pins the `type = 'query_pattern'` filter, the SaaS drop-arm / self-hosted keep-arm, org-less-SaaS withhold (no DB touch), and org/group bind order. Verified RED before the fix, GREEN after.
- [x] Real-Postgres behavioral test (`approved-patterns-injection-scoping-pg.test.ts`, `TEST_DATABASE_URL`-gated) — an approved `semantic_amendment` row is excluded; a NULL-org approved `query_pattern` is withheld on SaaS but returned on self-hosted. Passes 3/3 against local Postgres; skips cleanly without a DB.
- [x] `@atlas/api` full suite green (899/899); internal review panel CLEAN (2 rounds).

Closes #4534