### PR TITLE
feat(learned-patterns): DB-enforced pattern identity via ON CONFLICT upsert (#4572)

### DIFF
--- a/packages/api/src/lib/__tests__/pattern-proposer.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-proposer.test.ts
@@ -103,6 +103,29 @@ describe("pattern-proposer", () => {
     expect(insertCall!.sql).toContain("'pending'");
   });
 
+  test("novel insert upserts on the DB identity — ON CONFLICT increments, never multiplies (#4572)", async () => {
+    setResults({ rows: [] });
+
+    await _analyzeAndPropose(defaultInput);
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insertCall).toBeDefined();
+    // The insert is the guarantee against a concurrent-proposer race: on
+    // conflict with the partial unique identity it folds into the increment.
+    expect(insertCall!.sql).toContain(
+      "ON CONFLICT (org_id, connection_group_id, md5(pattern_sql)) WHERE type = 'query_pattern'",
+    );
+    expect(insertCall!.sql).toContain("DO UPDATE SET");
+    expect(insertCall!.sql).toContain("repetition_count = learned_patterns.repetition_count + 1");
+    // The reject guard rides the ON CONFLICT path too (#3636): a race against a
+    // rejected row must leave it frozen, not resurrect it.
+    expect(insertCall!.sql).toContain("WHERE learned_patterns.status <> 'rejected'");
+    // No new bind params — the fold reads EXCLUDED, so the VALUES params are
+    // unchanged (org, sql, description, entity, sourceQueries, proposedBy,
+    // connectionGroupId, avgDuration).
+    expect(insertCall!.params?.length).toBe(8);
+  });
+
   // ── Duplicate detection ────────────────────────────────────────────
 
   test("increments count when pattern already exists in DB", async () => {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -485,6 +485,11 @@ describe("migrateAuthTables", () => {
             // it runs in every auth mode.
             { name: "0170_learned_patterns_last_apply_error.sql" },
             { name: "0171_connection_profile_state.sql" },
+            // 0172 (#4572) — learned_patterns identity: partial unique index +
+            // status/type CHECK constraints. Not a MANAGED_AUTH_MIGRATION and
+            // runs in every auth mode — must be in the already-applied set so
+            // this "all applied" test still sees zero new migrations.
+            { name: "0172_learned_patterns_identity.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -218,7 +218,9 @@ describe("runMigrations", () => {
     //   the decide seam compensates a failed approve back to pending, #4506) = 171.
     //   Plus 0171 (connection_profile_state — per-connection baseline + LLM
     //   profile-tier tracking for the semantic-improve briefing, #4509) = 172.
-    expect(count).toBe(172);
+    //   Plus 0172 (learned_patterns identity — partial unique index +
+    //   status/type CHECK constraints, #4572) = 173.
+    expect(count).toBe(173);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -419,6 +421,7 @@ describe("runMigrations", () => {
         "0169_convert_notebook_conversations.sql",
         "0170_learned_patterns_last_apply_error.sql",
         "0171_connection_profile_state.sql",
+        "0172_learned_patterns_identity.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
@@ -40,6 +40,7 @@ interface PatternRow {
   repetition_count: number;
   confidence: number;
   avg_duration_ms: number | null;
+  last_seen_at: Date | null;
   status: string;
   source_queries: string[] | null;
 }
@@ -77,7 +78,7 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
   async function rows(patternSql: string): Promise<PatternRow[]> {
     const res = await pool.query<PatternRow>(
       `SELECT id, org_id, connection_group_id, repetition_count, confidence,
-              avg_duration_ms, status, source_queries
+              avg_duration_ms, last_seen_at, status, source_queries
          FROM learned_patterns WHERE pattern_sql = $1 ORDER BY id`,
       [patternSql],
     );
@@ -182,11 +183,16 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
       seed(sql, { durationMs: 100, fp: "d1" });
       const [before] = await pollRows(sql, (r) => r.length === 1 && r[0].avg_duration_ms === 100);
       // Second observation via ON CONFLICT, but with no measurement → the fold's
-      // `WHEN EXCLUDED.avg_duration_ms IS NULL THEN <keep old>` branch fires.
+      // `WHEN EXCLUDED.avg_duration_ms IS NULL THEN <keep old>` branch fires for
+      // BOTH avg_duration_ms and last_seen_at.
       seed(sql, { fp: "d2" }); // no durationMs
       const [after] = await pollRows(sql, (r) => r.length === 1 && r[0].repetition_count === 2);
       expect(after.avg_duration_ms).toBe(100); // unchanged
       expect(before.avg_duration_ms).toBe(100);
+      // last_seen_at also held to the seed's timestamp (its keep-old arm), not
+      // bumped to now() — a flip of that arm would go uncaught otherwise.
+      expect(after.last_seen_at).not.toBeNull();
+      expect(after.last_seen_at!.getTime()).toBe(before.last_seen_at!.getTime());
     },
     PG_TIMEOUT_MS,
   );
@@ -358,11 +364,15 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
       // The reject-race upsert is fire-and-forget, and its correct outcome
       // ("row unchanged") is indistinguishable from "not run yet" — so a
       // `() => true` poll could green even if the guard were deleted. Establish
-      // a happens-before barrier: fire a CONTROL upsert for a fresh identity
-      // through the same write path and drive it to rep 2. Once the control's
-      // second observation has landed, the write queue has demonstrably drained
-      // past the reject-race upsert dispatched before it, so a still-frozen
-      // rejected row is a real assertion, not a timing artifact.
+      // a timing barrier: fire a CONTROL upsert for a fresh identity through the
+      // same write path and drive it to rep 2. The pool has >1 connection so
+      // this isn't strict FIFO serialization, but the reject-race upsert is
+      // dispatched first and is a single fast op, while the control spans two
+      // writes plus polling — by the time the control reaches rep 2 the earlier
+      // upsert has, with overwhelming probability, already run, making a
+      // still-frozen rejected row a real assertion rather than a timing artifact.
+      // (Strict serialization would need a max:1 pool, but the AC#1 concurrency
+      // test above shares this pool and needs the extra connections.)
       const controlSql = "select a from reject_race_control where b = ?";
       seed(controlSql, { org: ORG, group: null, fp: "c1" });
       await pollRows(controlSql, (r) => r.length === 1);
@@ -431,7 +441,13 @@ describeIfPg("migration 0172 pre-dedup fold (real Postgres, #4572)", () => {
            (NULL, NULL, 'dup sql', 2, 0.3, 'pending', 'query_pattern'),
            (NULL, NULL, 'dup sql', 3, 0.2, 'pending', 'query_pattern'),
            ('o1', 'g1', 'single sql', 7, 0.5, 'pending', 'query_pattern'),
-           (NULL, NULL, 'dup sql', 1, 0.1, 'pending', 'semantic_amendment')`,
+           (NULL, NULL, 'dup sql', 1, 0.1, 'pending', 'semantic_amendment'),
+           -- A duplicate group where one member is admin-rejected: the fold must
+           -- keep the rejected row as survivor (sticky reject, #3636, on the
+           -- deploy path) even though a pending duplicate has a higher rep — a
+           -- pending survivor here would silently resurrect a rejected pattern.
+           ('o2', 'g2', 'rej dup', 5, 0.4, 'pending', 'query_pattern'),
+           ('o2', 'g2', 'rej dup', 2, 0.9, 'rejected', 'query_pattern')`,
       );
 
       // Apply the real migration file (dedup fold + unique index + CHECKs).
@@ -458,6 +474,19 @@ describeIfPg("migration 0172 pre-dedup fold (real Postgres, #4572)", () => {
           WHERE pattern_sql = 'dup sql' AND type = 'semantic_amendment'`,
       );
       expect(amend.rows[0].c).toBe("1");
+
+      // Sticky reject on the deploy path (#3636): the rejected member survives
+      // the fold even though a pending duplicate had a higher rep. Survivor is
+      // rejected, absorbs both counts (5+2), and takes the group-max confidence
+      // (0.9). A pending survivor here would silently un-reject the pattern.
+      const rej = await pool.query<{ status: string; repetition_count: number; confidence: number }>(
+        `SELECT status, repetition_count, confidence FROM learned_patterns
+          WHERE pattern_sql = 'rej dup'`,
+      );
+      expect(rej.rows).toHaveLength(1);
+      expect(rej.rows[0].status).toBe("rejected");
+      expect(rej.rows[0].repetition_count).toBe(7);
+      expect(rej.rows[0].confidence).toBeCloseTo(0.9, 5);
 
       // The unique index is now live: a raw duplicate insert (no ON CONFLICT)
       // of the same identity is rejected with 23505.

--- a/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Real-Postgres tests for DB-enforced learned-pattern identity (#4572, v0.0.50).
+ *
+ * Migration 0172 adds a PARTIAL UNIQUE INDEX over query_pattern rows on
+ * (org_id, connection_group_id, md5(pattern_sql)) with NULLS NOT DISTINCT, and
+ * turns `insertLearnedPattern` into an `ON CONFLICT DO UPDATE` upsert. The
+ * guarantee — a concurrent duplicate observation collapses into the repetition
+ * increment it should have been, never a second row — is a property of the
+ * index + ON CONFLICT under real concurrency, so none of it is exercisable
+ * through a mocked query layer. These run the production `insertLearnedPattern`
+ * / `incrementPatternCount` against a real Postgres and assert convergence.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches `pattern-latency-pg`
+ * / `migrate-pg`). CI's api-tests workflow provides the Postgres service.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  insertLearnedPattern,
+  incrementPatternCount,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TIMEOUT_MS = 30_000;
+const ORG = "org-identity-test";
+
+interface PatternRow {
+  id: string;
+  org_id: string | null;
+  connection_group_id: string | null;
+  repetition_count: number;
+  confidence: number;
+  avg_duration_ms: number | null;
+  status: string;
+  source_queries: string[] | null;
+}
+
+describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () => {
+  let pool: Pool;
+  const schemaName = `identity_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`pattern-identity-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Point the production internal-DB helpers at this pool so the exact
+    // upsert/increment SQL under test runs against this schema.
+    _resetPool(pool as unknown as InternalPool);
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    _resetPool(null);
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM learned_patterns");
+  });
+
+  async function rows(patternSql: string): Promise<PatternRow[]> {
+    const res = await pool.query<PatternRow>(
+      `SELECT id, org_id, connection_group_id, repetition_count, confidence,
+              avg_duration_ms, status, source_queries
+         FROM learned_patterns WHERE pattern_sql = $1 ORDER BY id`,
+      [patternSql],
+    );
+    return res.rows;
+  }
+
+  /**
+   * insertLearnedPattern / incrementPatternCount are fire-and-forget (they
+   * return void — no awaitable handle), so poll until the observable end state
+   * lands rather than sleeping a fixed interval (which flakes on a loaded
+   * runner). Fails loudly with the last-seen rows if the deadline passes.
+   */
+  async function pollRows(
+    patternSql: string,
+    predicate: (r: PatternRow[]) => boolean,
+    timeoutMs = 5000,
+  ): Promise<PatternRow[]> {
+    const deadline = Date.now() + timeoutMs;
+    let last: PatternRow[] = [];
+    while (Date.now() < deadline) {
+      last = await rows(patternSql);
+      if (predicate(last)) return last;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    // Surface what we last saw so the caller's assertion prints a clear diff.
+    return last;
+  }
+
+  const seed = (patternSql: string, opts: { org?: string | null; group?: string | null; durationMs?: number; fp?: string } = {}) =>
+    insertLearnedPattern({
+      orgId: opts.org === undefined ? ORG : opts.org,
+      connectionGroupId: opts.group ?? null,
+      patternSql,
+      description: "identity test",
+      sourceEntity: "t",
+      sourceQueries: [opts.fp ?? "fp1"],
+      proposedBy: "agent",
+      durationMs: opts.durationMs,
+    });
+
+  // ── AC #1: concurrent proposals yield one row, incremented ──────────
+
+  it(
+    "concurrent proposals of the same SQL collapse to one row with incremented repetition",
+    async () => {
+      const sql = "select a from concurrent where b = ?";
+      const N = 8;
+      // Fire N fire-and-forget upserts in the same tick — they race on the pool.
+      // Exactly one INSERT wins; the other N-1 take ON CONFLICT DO UPDATE. The
+      // partial unique index is what serializes that, so the terminal state is
+      // deterministic: one row, repetition_count = N.
+      for (let i = 0; i < N; i++) seed(sql, { fp: `fp-${i}` });
+
+      const settled = await pollRows(sql, (r) => r.length === 1 && r[0].repetition_count === N);
+      expect(settled).toHaveLength(1);
+      expect(settled[0].repetition_count).toBe(N);
+      // Confidence climbs 0.1 per observation, capped at 1.0.
+      expect(settled[0].confidence).toBeCloseTo(Math.min(1.0, 0.1 * N), 5);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── AC #2: ON CONFLICT increment == fast-path increment ─────────────
+
+  it(
+    "a repeat observation via ON CONFLICT updates confidence/repetition/latency identically to incrementPatternCount",
+    async () => {
+      // Row A: driven purely through the ON CONFLICT path (two inserts).
+      const sqlA = "select a from conflict_path where b = ?";
+      seed(sqlA, { durationMs: 100, fp: "a1" });
+      await pollRows(sqlA, (r) => r.length === 1);
+      seed(sqlA, { durationMs: 200, fp: "a2" });
+      const aRows = await pollRows(sqlA, (r) => r.length === 1 && r[0].repetition_count === 2);
+
+      // Row B: seeded once, then bumped through the fast path (incrementPatternCount).
+      const sqlB = "select a from increment_path where b = ?";
+      seed(sqlB, { durationMs: 100, fp: "b1" });
+      const [bSeed] = await pollRows(sqlB, (r) => r.length === 1);
+      incrementPatternCount(bSeed.id, "b2", 200);
+      const bRows = await pollRows(sqlB, (r) => r.length === 1 && r[0].repetition_count === 2);
+
+      // The two paths must land on identical row math.
+      expect(aRows).toHaveLength(1);
+      expect(bRows).toHaveLength(1);
+      const a = aRows[0];
+      const b = bRows[0];
+      expect(a.repetition_count).toBe(b.repetition_count); // 2
+      expect(a.confidence).toBeCloseTo(b.confidence, 6); // 0.2
+      expect(a.avg_duration_ms).toBe(b.avg_duration_ms); // (100+200)/2 = 150
+      expect(a.avg_duration_ms).toBe(150);
+      // Both accumulated two source fingerprints.
+      expect(a.source_queries).toHaveLength(2);
+      expect(b.source_queries).toHaveLength(2);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── AC #3: CHECK constraints reject invalid status/type ─────────────
+
+  it(
+    "chk_learned_patterns_status rejects an unknown status with 23514 and admits the transient 'applying'",
+    async () => {
+      // Unknown status → check_violation.
+      await expect(
+        pool.query(
+          `INSERT INTO learned_patterns (org_id, pattern_sql, status) VALUES ($1, 'select 1', 'bogus')`,
+          [ORG],
+        ),
+      ).rejects.toMatchObject({ code: "23514" });
+
+      // 'applying' is a DB value (amendment claim state, #4506) even though it is
+      // not a wire status — the CHECK must admit it or the claim UPDATE breaks.
+      await pool.query(
+        `INSERT INTO learned_patterns (org_id, pattern_sql, type, status)
+         VALUES ($1, 'select 2', 'semantic_amendment', 'applying')`,
+        [ORG],
+      );
+      const { rows: r } = await pool.query<{ status: string }>(
+        `SELECT status FROM learned_patterns WHERE pattern_sql = 'select 2'`,
+      );
+      expect(r[0]?.status).toBe("applying");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "chk_learned_patterns_type rejects an unknown type with 23514",
+    async () => {
+      await expect(
+        pool.query(
+          `INSERT INTO learned_patterns (org_id, pattern_sql, type) VALUES ($1, 'select 3', 'bogus_type')`,
+          [ORG],
+        ),
+      ).rejects.toMatchObject({ code: "23514" });
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── AC #4: legacy NULL-scope rows cannot multiply ───────────────────
+
+  it(
+    "NULL-scope rows (org_id NULL, connection_group_id NULL) collide rather than multiply",
+    async () => {
+      const sql = "select a from null_scope where b = ?";
+      seed(sql, { org: null, group: null, fp: "n1" });
+      seed(sql, { org: null, group: null, fp: "n2" });
+
+      const settled = await pollRows(sql, (r) => r.length === 1 && r[0].repetition_count === 2);
+      expect(settled).toHaveLength(1);
+      expect(settled[0].org_id).toBeNull();
+      expect(settled[0].connection_group_id).toBeNull();
+      expect(settled[0].repetition_count).toBe(2);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "NULL-group rows under a real org still collide (NULLS NOT DISTINCT on the group column)",
+    async () => {
+      const sql = "select a from org_null_group where b = ?";
+      seed(sql, { org: "o-nn", group: null, fp: "g1" });
+      seed(sql, { org: "o-nn", group: null, fp: "g2" });
+
+      const settled = await pollRows(sql, (r) => r.length === 1 && r[0].repetition_count === 2);
+      expect(settled).toHaveLength(1);
+      expect(settled[0].org_id).toBe("o-nn");
+      expect(settled[0].connection_group_id).toBeNull();
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Scope + type non-collision (the flip side of identity) ──────────
+
+  it(
+    "the same SQL under different connection groups stays two distinct rows",
+    async () => {
+      const sql = "select a from cross_group where b = ?";
+      seed(sql, { org: "o-x", group: "us-prod", fp: "u1" });
+      seed(sql, { org: "o-x", group: "eu-prod", fp: "e1" });
+      seed(sql, { org: "o-x", group: null, fp: "d1" });
+
+      const settled = await pollRows(sql, (r) => r.length === 3);
+      expect(settled).toHaveLength(3);
+      const groups = settled.map((r) => r.connection_group_id);
+      expect(groups).toContain("us-prod");
+      expect(groups).toContain("eu-prod");
+      expect(groups).toContain(null);
+      // No row was ever bumped — each is a distinct identity.
+      expect(settled.every((r) => r.repetition_count === 1)).toBe(true);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "semantic_amendment rows are unconstrained by the partial index (many per scope)",
+    async () => {
+      // The partial index is WHERE type = 'query_pattern', so amendment rows —
+      // a review queue — may share (org, group, sql) freely.
+      for (let i = 0; i < 3; i++) {
+        await pool.query(
+          `INSERT INTO learned_patterns (org_id, connection_group_id, pattern_sql, type, status)
+           VALUES ($1, NULL, 'amend body', 'semantic_amendment', 'pending')`,
+          [ORG],
+        );
+      }
+      const settled = await rows("amend body");
+      expect(settled).toHaveLength(3);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Reject guard rides the ON CONFLICT race (#3636) ─────────────────
+
+  it(
+    "a proposal race against an admin-rejected row leaves it frozen, never resurrected",
+    async () => {
+      const sql = "select a from rejected_race where b = ?";
+      // Land a rejected row directly (simulating a prior admin reject).
+      await pool.query(
+        `INSERT INTO learned_patterns (org_id, connection_group_id, pattern_sql, status, repetition_count, confidence)
+         VALUES ($1, NULL, $2, 'rejected', 5, 0.9)`,
+        [ORG, sql],
+      );
+
+      // A fresh proposal for the same identity would upsert — but the reject
+      // guard on DO UPDATE must no-op it (conflict handled, zero rows updated).
+      seed(sql, { org: ORG, group: null, durationMs: 999, fp: "resurrect" });
+
+      // Give the fire-and-forget a beat, then assert the row never moved.
+      const settled = await pollRows(sql, () => true, 1500);
+      expect(settled).toHaveLength(1);
+      expect(settled[0].status).toBe("rejected");
+      expect(settled[0].repetition_count).toBe(5); // not bumped to 6
+      expect(settled[0].confidence).toBeCloseTo(0.9, 6); // not eroded
+      expect(settled[0].avg_duration_ms).toBeNull(); // 999 never folded in
+    },
+    PG_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
@@ -15,6 +15,8 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import {
@@ -173,6 +175,37 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
     PG_TIMEOUT_MS,
   );
 
+  it(
+    "ON CONFLICT latency fold: a later observation with no duration leaves avg/last_seen untouched (EXCLUDED-NULL branch)",
+    async () => {
+      const sql = "select a from conflict_no_dur where b = ?";
+      seed(sql, { durationMs: 100, fp: "d1" });
+      const [before] = await pollRows(sql, (r) => r.length === 1 && r[0].avg_duration_ms === 100);
+      // Second observation via ON CONFLICT, but with no measurement → the fold's
+      // `WHEN EXCLUDED.avg_duration_ms IS NULL THEN <keep old>` branch fires.
+      seed(sql, { fp: "d2" }); // no durationMs
+      const [after] = await pollRows(sql, (r) => r.length === 1 && r[0].repetition_count === 2);
+      expect(after.avg_duration_ms).toBe(100); // unchanged
+      expect(before.avg_duration_ms).toBe(100);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "ON CONFLICT latency fold: a first measurement arriving on the conflict seeds the previously-NULL average (avg-NULL branch)",
+    async () => {
+      const sql = "select a from conflict_late_seed where b = ?";
+      seed(sql, { fp: "l1" }); // seeded NULL latency
+      await pollRows(sql, (r) => r.length === 1 && r[0].avg_duration_ms === null);
+      // Second observation carries the first real duration → the fold's
+      // `WHEN learned_patterns.avg_duration_ms IS NULL THEN EXCLUDED` branch fires.
+      seed(sql, { durationMs: 200, fp: "l2" });
+      const [after] = await pollRows(sql, (r) => r.length === 1 && r[0].repetition_count === 2);
+      expect(after.avg_duration_ms).toBe(200); // seeded directly, not averaged against NULL
+    },
+    PG_TIMEOUT_MS,
+  );
+
   // ── AC #3: CHECK constraints reject invalid status/type ─────────────
 
   it(
@@ -270,6 +303,24 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
   );
 
   it(
+    "the same SQL + same group under two different orgs stays two distinct rows (org_id is part of the identity)",
+    async () => {
+      // Guards the org_id column of the composite: under NULLS NOT DISTINCT, a
+      // dropped or reordered org_id term would let two tenants' identical SQL
+      // collide — a cross-tenant merge. Two orgs, identical sql+group → two rows.
+      const sql = "select a from cross_org where b = ?";
+      seed(sql, { org: "o-1", group: "g", fp: "t1" });
+      seed(sql, { org: "o-2", group: "g", fp: "t2" });
+
+      const settled = await pollRows(sql, (r) => r.length === 2);
+      expect(settled).toHaveLength(2);
+      expect(settled.map((r) => r.org_id).sort()).toEqual(["o-1", "o-2"]);
+      expect(settled.every((r) => r.repetition_count === 1)).toBe(true);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
     "semantic_amendment rows are unconstrained by the partial index (many per scope)",
     async () => {
       // The partial index is WHERE type = 'query_pattern', so amendment rows —
@@ -304,13 +355,125 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
       // guard on DO UPDATE must no-op it (conflict handled, zero rows updated).
       seed(sql, { org: ORG, group: null, durationMs: 999, fp: "resurrect" });
 
-      // Give the fire-and-forget a beat, then assert the row never moved.
-      const settled = await pollRows(sql, () => true, 1500);
+      // The reject-race upsert is fire-and-forget, and its correct outcome
+      // ("row unchanged") is indistinguishable from "not run yet" — so a
+      // `() => true` poll could green even if the guard were deleted. Establish
+      // a happens-before barrier: fire a CONTROL upsert for a fresh identity
+      // through the same write path and drive it to rep 2. Once the control's
+      // second observation has landed, the write queue has demonstrably drained
+      // past the reject-race upsert dispatched before it, so a still-frozen
+      // rejected row is a real assertion, not a timing artifact.
+      const controlSql = "select a from reject_race_control where b = ?";
+      seed(controlSql, { org: ORG, group: null, fp: "c1" });
+      await pollRows(controlSql, (r) => r.length === 1);
+      seed(controlSql, { org: ORG, group: null, fp: "c2" });
+      await pollRows(controlSql, (r) => r.length === 1 && r[0].repetition_count === 2);
+
+      const settled = await rows(sql);
       expect(settled).toHaveLength(1);
       expect(settled[0].status).toBe("rejected");
       expect(settled[0].repetition_count).toBe(5); // not bumped to 6
       expect(settled[0].confidence).toBeCloseTo(0.9, 6); // not eroded
       expect(settled[0].avg_duration_ms).toBeNull(); // 999 never folded in
+    },
+    PG_TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Migration 0172 pre-dedup fold. The index this migration adds would abort the
+// deploy if prod already held concurrent-race duplicate rows (the artifact the
+// index exists to prevent). 0172 folds those into one survivor first. This can
+// only be exercised on a table that still HAS duplicates — i.e. before the
+// index exists — so this block runs every migration EXCEPT 0172 into its own
+// schema, seeds duplicates, then applies the real 0172 SQL file (not a copy, so
+// no drift) and asserts the fold + the now-live index/CHECK.
+// ---------------------------------------------------------------------------
+describeIfPg("migration 0172 pre-dedup fold (real Postgres, #4572)", () => {
+  let pool: Pool;
+  const schemaName = `identity_dedup_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const migration0172 = readFileSync(
+    join(import.meta.dir, "../migrations/0172_learned_patterns_identity.sql"),
+    "utf8",
+  );
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`pattern-identity-pg dedup: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    // Every migration EXCEPT 0172 — so learned_patterns exists WITHOUT the
+    // unique index, and duplicates can be seeded to exercise the fold.
+    await runMigrations(pool, {
+      skip: [...MANAGED_AUTH_MIGRATIONS, "0172_learned_patterns_identity.sql"],
+    });
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it(
+    "folds pre-existing duplicate query_pattern rows into one survivor, then the index + CHECK go live",
+    async () => {
+      // Three NULL-scope duplicates (rep 1/2/3, confidence .1/.3/.2) — exactly
+      // the concurrent-race artifact — plus a singleton that must survive intact
+      // and an amendment sharing the identity that must be left unconstrained.
+      await pool.query(
+        `INSERT INTO learned_patterns (org_id, connection_group_id, pattern_sql, repetition_count, confidence, status, type) VALUES
+           (NULL, NULL, 'dup sql', 1, 0.1, 'pending', 'query_pattern'),
+           (NULL, NULL, 'dup sql', 2, 0.3, 'pending', 'query_pattern'),
+           (NULL, NULL, 'dup sql', 3, 0.2, 'pending', 'query_pattern'),
+           ('o1', 'g1', 'single sql', 7, 0.5, 'pending', 'query_pattern'),
+           (NULL, NULL, 'dup sql', 1, 0.1, 'pending', 'semantic_amendment')`,
+      );
+
+      // Apply the real migration file (dedup fold + unique index + CHECKs).
+      await pool.query(migration0172);
+
+      // The three query_pattern duplicates collapsed to one, repetition summed
+      // (1+2+3) and confidence set to the group max (0.3).
+      const dup = await pool.query<{ repetition_count: number; confidence: number }>(
+        `SELECT repetition_count, confidence FROM learned_patterns
+          WHERE pattern_sql = 'dup sql' AND type = 'query_pattern'`,
+      );
+      expect(dup.rows).toHaveLength(1);
+      expect(dup.rows[0].repetition_count).toBe(6);
+      expect(dup.rows[0].confidence).toBeCloseTo(0.3, 5);
+
+      // The singleton is untouched; the amendment sharing the identity survives
+      // (the partial index is query_pattern-only).
+      const single = await pool.query<{ c: string }>(
+        `SELECT count(*)::text AS c FROM learned_patterns WHERE pattern_sql = 'single sql'`,
+      );
+      expect(single.rows[0].c).toBe("1");
+      const amend = await pool.query<{ c: string }>(
+        `SELECT count(*)::text AS c FROM learned_patterns
+          WHERE pattern_sql = 'dup sql' AND type = 'semantic_amendment'`,
+      );
+      expect(amend.rows[0].c).toBe("1");
+
+      // The unique index is now live: a raw duplicate insert (no ON CONFLICT)
+      // of the same identity is rejected with 23505.
+      await expect(
+        pool.query(
+          `INSERT INTO learned_patterns (org_id, connection_group_id, pattern_sql, type)
+           VALUES (NULL, NULL, 'dup sql', 'query_pattern')`,
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+
+      // And the CHECK is live: an out-of-set status is rejected with 23514.
+      await expect(
+        pool.query(
+          `INSERT INTO learned_patterns (pattern_sql, status) VALUES ('chk probe', 'bogus')`,
+        ),
+      ).rejects.toMatchObject({ code: "23514" });
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/pattern-identity-pg.test.ts
@@ -320,7 +320,9 @@ describeIfPg("DB-enforced learned-pattern identity (real Postgres, #4572)", () =
 
       const settled = await pollRows(sql, (r) => r.length === 2);
       expect(settled).toHaveLength(2);
-      expect(settled.map((r) => r.org_id).sort()).toEqual(["o-1", "o-2"]);
+      const orgs = settled.map((r) => r.org_id);
+      expect(orgs).toContain("o-1");
+      expect(orgs).toContain("o-2");
       expect(settled.every((r) => r.repetition_count === 1)).toBe(true);
     },
     PG_TIMEOUT_MS,

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -1430,7 +1430,18 @@ export async function findPatternBySQL(
 }
 
 /**
- * Insert a new learned pattern. Fire-and-forget — errors are logged, never thrown.
+ * Insert a novel learned pattern, upserting on the DB-enforced identity.
+ *
+ * Fire-and-forget — errors are logged, never thrown. The proposer calls this
+ * only on the novel path (findPatternBySQL missed), but two concurrent
+ * proposers can both miss the read and both reach here. The partial unique
+ * index `uq_learned_patterns_identity` (org_id, connection_group_id,
+ * md5(pattern_sql)) WHERE type = 'query_pattern', NULLS NOT DISTINCT (migration
+ * 0172, #4572) makes that race safe: exactly one INSERT wins and the loser's
+ * `ON CONFLICT DO UPDATE` folds into the same increment `incrementPatternCount`
+ * would have applied — so a concurrent duplicate becomes the repetition it
+ * should have been, never a second row. The application read-then-insert dedup
+ * is now a fast path; this ON CONFLICT is the guarantee.
  */
 export function insertLearnedPattern(pattern: {
   orgId: string | null | undefined;
@@ -1468,9 +1479,37 @@ export function insertLearnedPattern(pattern: {
   const avgDuration = foldRollingMean(null, 0, seedDuration);
   // `avgDuration` is null iff `seedDuration` is null, so the `$8 IS NULL` guard
   // below still stamps `last_seen_at` exactly when there is a real measurement.
+  // On a lost insert race, DO UPDATE must produce the SAME row mutation
+  // `incrementPatternCount` applies on the fast path: +1 repetition, +0.1
+  // confidence (capped), the rolling-mean latency fold, source-fingerprint
+  // append (capped at 100), and `updated_at`. `EXCLUDED.avg_duration_ms` is the
+  // would-be-inserted seed = `foldRollingMean(null, 0, sample)` = the raw sample
+  // (or NULL), so it feeds the fold as the observation exactly as the UPDATE
+  // path's `$LAT` does — keep this CASE in lockstep with `incrementPatternCount`
+  // and `foldRollingMean` (#3723). The `WHERE ... status <> 'rejected'` mirrors
+  // the fast path's reject guard (#3636): a race against an admin-rejected row
+  // leaves it frozen (conflict handled, zero rows updated) rather than
+  // resurrecting it.
   internalExecute(
     `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, source_queries, confidence, repetition_count, status, proposed_by, connection_group_id, avg_duration_ms, last_seen_at)
-     VALUES ($1, $2, $3, $4, $5, 0.1, 1, 'pending', $6, $7, $8, CASE WHEN $8::double precision IS NULL THEN NULL ELSE now() END)`,
+     VALUES ($1, $2, $3, $4, $5, 0.1, 1, 'pending', $6, $7, $8, CASE WHEN $8::double precision IS NULL THEN NULL ELSE now() END)
+     ON CONFLICT (org_id, connection_group_id, md5(pattern_sql)) WHERE type = 'query_pattern'
+     DO UPDATE SET
+       repetition_count = learned_patterns.repetition_count + 1,
+       confidence = LEAST(1.0, learned_patterns.confidence + 0.1),
+       avg_duration_ms = CASE
+         WHEN EXCLUDED.avg_duration_ms IS NULL THEN learned_patterns.avg_duration_ms
+         WHEN learned_patterns.avg_duration_ms IS NULL THEN EXCLUDED.avg_duration_ms
+         ELSE (learned_patterns.avg_duration_ms * learned_patterns.repetition_count + EXCLUDED.avg_duration_ms) / (learned_patterns.repetition_count + 1)
+       END,
+       last_seen_at = CASE WHEN EXCLUDED.avg_duration_ms IS NULL THEN learned_patterns.last_seen_at ELSE now() END,
+       source_queries = CASE
+         WHEN learned_patterns.source_queries IS NULL THEN EXCLUDED.source_queries
+         WHEN jsonb_array_length(learned_patterns.source_queries) >= 100 THEN learned_patterns.source_queries
+         ELSE learned_patterns.source_queries || EXCLUDED.source_queries
+       END,
+       updated_at = now()
+     WHERE learned_patterns.status <> 'rejected'`,
     [
       pattern.orgId ?? null,
       pattern.patternSql,

--- a/packages/api/src/lib/db/migrations/0172_learned_patterns_identity.sql
+++ b/packages/api/src/lib/db/migrations/0172_learned_patterns_identity.sql
@@ -1,0 +1,60 @@
+-- Migration 0172: DB-enforced learned-pattern identity (#4572, v0.0.50).
+--
+-- Pattern identity — (org_id, connection_group_id, normalized SQL) per
+-- CONTEXT.md § Learned query patterns — becomes DB-enforced for query_pattern
+-- rows via a PARTIAL UNIQUE INDEX. The fire-and-forget proposer inserts via
+-- ON CONFLICT (see insertLearnedPattern in db/internal.ts), so a concurrent
+-- duplicate observation that slips past the application-side read-then-insert
+-- dedup (findPatternBySQL) becomes exactly the repetition increment it should
+-- have been. The read is now a fast path; this index is the guarantee.
+--
+-- PARTIAL on `type = 'query_pattern'`: only query patterns have this identity.
+-- `semantic_amendment` rows are a review queue — many proposals may target the
+-- same entity/scope — so they must stay unconstrained by this index.
+--
+-- Indexed on md5(pattern_sql), NOT pattern_sql directly: a normalized query has
+-- no length cap (normalizeSQL), and a btree index tuple over the raw text would
+-- exceed Postgres's ~2704-byte btree maximum for a large analytical query,
+-- silently dropping the fire-and-forget INSERT. Hashing keeps the key
+-- fixed-width — the same reason peer query_suggestions indexes normalized_hash
+-- and user_favorite_prompts indexes md5(text). Collision risk is ~2^-128; the
+-- application fast path (findPatternBySQL) still matches on exact pattern_sql.
+--
+-- NULLS NOT DISTINCT (PG15+; we run PG16 everywhere): the legacy/default scope
+-- carries org_id = NULL (global) and/or connection_group_id = NULL (the flat
+-- entities/ group). Without NULLS NOT DISTINCT, Postgres treats each NULL as
+-- distinct, so two NULL-scope rows with identical SQL would MULTIPLY rather than
+-- collide. NULLS NOT DISTINCT makes those NULLs equal, so the index dedups them
+-- — matching findPatternBySQL's `IS NULL` scope match. Peer query_suggestions
+-- (0000_baseline) already relies on the same construct.
+--
+-- status / type CHECK constraints ride the same migration — peer status tables
+-- (query_suggestions, dashboard_stage_changes, workspace_proactive_config)
+-- already carry equivalents. `applying` is included in the status set even
+-- though it is NOT a wire status (LEARNED_PATTERN_STATUSES omits it): it is the
+-- transient claim state the amendment decide seam writes
+-- (pending → applying → approved|pending, #4506). Omitting it would make the
+-- claim UPDATE violate the CHECK.
+--
+-- Additive / single-release safe: index + CHECKs only — no column drop/rename,
+-- no two-phase concern. Idempotent (IF NOT EXISTS / DROP-IF-EXISTS-then-ADD).
+-- Mirrored in db/schema.ts (chk_learned_patterns_status /
+-- chk_learned_patterns_type + a comment for the raw-SQL partial unique index)
+-- in the same commit.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_learned_patterns_identity
+  ON learned_patterns (org_id, connection_group_id, md5(pattern_sql))
+  NULLS NOT DISTINCT
+  WHERE type = 'query_pattern';
+
+ALTER TABLE learned_patterns
+  DROP CONSTRAINT IF EXISTS chk_learned_patterns_status;
+ALTER TABLE learned_patterns
+  ADD CONSTRAINT chk_learned_patterns_status
+  CHECK (status IN ('pending', 'applying', 'approved', 'rejected'));
+
+ALTER TABLE learned_patterns
+  DROP CONSTRAINT IF EXISTS chk_learned_patterns_type;
+ALTER TABLE learned_patterns
+  ADD CONSTRAINT chk_learned_patterns_type
+  CHECK (type IN ('query_pattern', 'semantic_amendment'));

--- a/packages/api/src/lib/db/migrations/0172_learned_patterns_identity.sql
+++ b/packages/api/src/lib/db/migrations/0172_learned_patterns_identity.sql
@@ -14,10 +14,12 @@
 --
 -- Indexed on md5(pattern_sql), NOT pattern_sql directly: a normalized query has
 -- no length cap (normalizeSQL), and a btree index tuple over the raw text would
--- exceed Postgres's ~2704-byte btree maximum for a large analytical query,
--- silently dropping the fire-and-forget INSERT. Hashing keeps the key
--- fixed-width — the same reason peer query_suggestions indexes normalized_hash
--- and user_favorite_prompts indexes md5(text). Collision risk is ~2^-128; the
+-- exceed Postgres's ~2704-byte btree maximum for a large analytical query —
+-- Postgres raises `index row size ... exceeds btree ... maximum`, which errors
+-- the fire-and-forget INSERT (the wrapper logs it, then the pattern is dropped:
+-- logged, but invisible to the user). Hashing keeps the key fixed-width — the
+-- same reason peer query_suggestions indexes normalized_hash and
+-- user_favorite_prompts indexes md5(text). Collision risk is ~2^-128; the
 -- application fast path (findPatternBySQL) still matches on exact pattern_sql.
 --
 -- NULLS NOT DISTINCT (PG15+; we run PG16 everywhere): the legacy/default scope
@@ -36,11 +38,57 @@
 -- (pending → applying → approved|pending, #4506). Omitting it would make the
 -- claim UPDATE violate the CHECK.
 --
--- Additive / single-release safe: index + CHECKs only — no column drop/rename,
--- no two-phase concern. Idempotent (IF NOT EXISTS / DROP-IF-EXISTS-then-ADD).
--- Mirrored in db/schema.ts (chk_learned_patterns_status /
+-- Additive / single-release safe: a one-time fold of pre-existing duplicate
+-- rows, then index + CHECKs — no column drop/rename, no two-phase concern. The
+-- index/CHECK DDL is idempotent (IF NOT EXISTS / DROP-IF-EXISTS-then-ADD); the
+-- dedup fold is a no-op on a table with no duplicates, so a manual re-run is
+-- safe. Mirrored in db/schema.ts (chk_learned_patterns_status /
 -- chk_learned_patterns_type + a comment for the raw-SQL partial unique index)
 -- in the same commit.
+
+-- Pre-dedup: fold any pre-existing duplicate query_pattern rows into one
+-- survivor per identity BEFORE creating the unique index, so CREATE UNIQUE
+-- INDEX cannot abort the deploy on the very concurrent-race artifact this
+-- migration exists to prevent (historical rows predating the ON CONFLICT
+-- guarantee). The window PARTITION treats NULL org/group as equal (SQL groups
+-- NULLs together in PARTITION BY), matching the index's NULLS NOT DISTINCT.
+-- Survivor = a rejected row if the group has one (preserve the sticky admin
+-- reject, #3636), else the most-repeated / most-recent. The survivor absorbs
+-- the folded rows' repetition_count (w_all is unordered, so its SUM is the
+-- full-partition total, not a running sum) and takes the group-max confidence;
+-- its source_queries / latency already represent the same normalized SQL. On a
+-- clean table with no duplicates both statements match zero rows.
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER w_ord AS rn,
+         sum(repetition_count) OVER w_all AS group_total,
+         max(confidence) OVER w_all AS group_conf,
+         count(*) OVER w_all AS group_size
+    FROM learned_patterns
+   WHERE type = 'query_pattern'
+  WINDOW
+    w_ord AS (PARTITION BY org_id, connection_group_id, md5(pattern_sql)
+              ORDER BY (status = 'rejected') DESC, repetition_count DESC, updated_at DESC, id DESC),
+    w_all AS (PARTITION BY org_id, connection_group_id, md5(pattern_sql))
+)
+UPDATE learned_patterns lp
+   SET repetition_count = r.group_total,
+       confidence = r.group_conf,
+       updated_at = now()
+  FROM ranked r
+ WHERE lp.id = r.id AND r.rn = 1 AND r.group_size > 1;
+
+WITH ranked AS (
+  SELECT id,
+         row_number() OVER (
+           PARTITION BY org_id, connection_group_id, md5(pattern_sql)
+           ORDER BY (status = 'rejected') DESC, repetition_count DESC, updated_at DESC, id DESC
+         ) AS rn
+    FROM learned_patterns
+   WHERE type = 'query_pattern'
+)
+DELETE FROM learned_patterns
+ WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_learned_patterns_identity
   ON learned_patterns (org_id, connection_group_id, md5(pattern_sql))

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -708,10 +708,11 @@ export const learnedPatterns = pgTable(
     // Handled via raw SQL in the migration because no single Drizzle builder
     // combines all three properties: `unique().nullsNotDistinct()` accepts only
     // plain columns and is non-partial (no md5() expression, no WHERE), while
-    // `uniqueIndex()` supports the md5() expression column + partial `.where()`
-    // (cf. `uq_user_favorite_prompts` below) but has no `nullsNotDistinct()`
-    // method. The proposer upserts against it via ON CONFLICT so a concurrent
-    // duplicate observation increments rather than multiplies.
+    // `uniqueIndex()` supports an md5() expression column (cf. the `md5(...)` in
+    // `uq_user_favorite_prompts` below) plus a partial `.where()`, but has no
+    // `nullsNotDistinct()` method. The proposer upserts against it via ON
+    // CONFLICT so a concurrent duplicate observation increments rather than
+    // multiplies.
     check(
       "chk_learned_patterns_status",
       // `applying` is the transient amendment-claim state (#4506) — a DB value

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -705,11 +705,13 @@ export const learnedPatterns = pgTable(
     // DB-enforced pattern identity (#4572, migration 0172): a PARTIAL UNIQUE
     // INDEX `uq_learned_patterns_identity` over query_pattern rows on
     // (org_id, connection_group_id, md5(pattern_sql)) with NULLS NOT DISTINCT.
-    // Handled via raw SQL in the migration because Drizzle can express neither
-    // NULLS NOT DISTINCT nor an md5(pattern_sql) expression column on a partial
-    // unique index (same as query_suggestions' NULLS NOT DISTINCT constraint).
-    // The proposer upserts against it via ON CONFLICT so a concurrent duplicate
-    // observation increments rather than multiplies.
+    // Handled via raw SQL in the migration because no single Drizzle builder
+    // combines all three properties: `unique().nullsNotDistinct()` accepts only
+    // plain columns and is non-partial (no md5() expression, no WHERE), while
+    // `uniqueIndex()` supports the md5() expression column + partial `.where()`
+    // (cf. `uq_user_favorite_prompts` below) but has no `nullsNotDistinct()`
+    // method. The proposer upserts against it via ON CONFLICT so a concurrent
+    // duplicate observation increments rather than multiplies.
     check(
       "chk_learned_patterns_status",
       // `applying` is the transient amendment-claim state (#4506) — a DB value

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -702,6 +702,21 @@ export const learnedPatterns = pgTable(
     index("idx_learned_patterns_org_status").on(t.orgId, t.status),
     index("idx_learned_patterns_org_entity").on(t.orgId, t.sourceEntity),
     index("idx_learned_patterns_type").on(t.type),
+    // DB-enforced pattern identity (#4572, migration 0172): a PARTIAL UNIQUE
+    // INDEX `uq_learned_patterns_identity` over query_pattern rows on
+    // (org_id, connection_group_id, md5(pattern_sql)) with NULLS NOT DISTINCT.
+    // Handled via raw SQL in the migration because Drizzle can express neither
+    // NULLS NOT DISTINCT nor an md5(pattern_sql) expression column on a partial
+    // unique index (same as query_suggestions' NULLS NOT DISTINCT constraint).
+    // The proposer upserts against it via ON CONFLICT so a concurrent duplicate
+    // observation increments rather than multiplies.
+    check(
+      "chk_learned_patterns_status",
+      // `applying` is the transient amendment-claim state (#4506) — a DB value
+      // the wire enum LEARNED_PATTERN_STATUSES deliberately omits. Keep it here.
+      sql`status IN ('pending', 'applying', 'approved', 'rejected')`,
+    ),
+    check("chk_learned_patterns_type", sql`type IN ('query_pattern', 'semantic_amendment')`),
   ],
 );
 

--- a/packages/types/src/learned-pattern.ts
+++ b/packages/types/src/learned-pattern.ts
@@ -1,6 +1,16 @@
 /** Learned query pattern types — wire format for the learned_patterns table. */
 
-/** All valid learned pattern statuses. */
+/**
+ * All valid learned pattern statuses **on the wire**.
+ *
+ * Deliberately a subset of the DB `chk_learned_patterns_status` CHECK (migration
+ * 0172), which also admits `applying` — the transient amendment-claim state the
+ * decide seam writes (pending → applying → approved|pending, #4506) and filters
+ * out before anything reaches the wire. Do NOT add `applying` here to "sync"
+ * with the CHECK, and do NOT drop it from the CHECK to "sync" with this: the
+ * claim UPDATE depends on the DB value existing, the review queue depends on the
+ * wire enum never surfacing it.
+ */
 export const LEARNED_PATTERN_STATUSES = ["pending", "approved", "rejected"] as const;
 /** Status lifecycle for learned query patterns. */
 export type LearnedPatternStatus = (typeof LEARNED_PATTERN_STATUSES)[number];


### PR DESCRIPTION
## Summary

DB-enforces learned-pattern identity so concurrent duplicate observations can no longer multiply into separate rows.

- **Migration 0172** adds a partial unique index over `query_pattern` rows on `(org_id, connection_group_id, md5(pattern_sql))` with `NULLS NOT DISTINCT`, plus `status`/`type` CHECK constraints.
- **`insertLearnedPattern` becomes an `ON CONFLICT DO UPDATE` upsert**: a concurrent duplicate that slips past the application read-then-insert dedup (`findPatternBySQL`) now folds into the exact repetition increment `incrementPatternCount` would apply — the read is a fast path, the index is the guarantee.
- **`md5(pattern_sql)`, not raw text**: `normalizeSQL` has no length cap; a raw-text btree tuple would exceed Postgres's ~2704-byte max for a large analytical query and drop the fire-and-forget insert. Hashing keeps the key fixed-width (as peer `query_suggestions`/`user_favorite_prompts` do).
- **`NULLS NOT DISTINCT`** so legacy NULL scopes (global org / flat entities group) collide rather than multiply, matching `findPatternBySQL`'s `IS NULL` match. **Partial on `type = 'query_pattern'`** so `semantic_amendment` rows (a review queue) stay unconstrained.
- **Pre-dedup fold** runs before `CREATE UNIQUE INDEX` so a deploy can't abort on historical race-duplicate rows (folds duplicates into one survivor — sticky-reject survivor preserved, repetition summed).
- **CHECK sets**: `status IN ('pending','applying','approved','rejected')` (`applying` is the transient decide-seam claim state the wire enum omits, #4506) and `type IN ('query_pattern','semantic_amendment')`.
- Drizzle `schema.ts` mirror (two `check()` + a documented comment for the raw-SQL partial index), and both `migrate.test.ts` migration-count assertions bumped.

## Test plan

- [x] Real-Postgres seam tests (`pattern-identity-pg.test.ts`): concurrent collapse (8 upserts → 1 row rep 8), ON-CONFLICT == fast-path increment equivalence, both latency-fold NULL branches, CHECK rejection (incl. `applying` admit), NULL-scope non-multiplication, cross-group/cross-org distinctness, reject-guard-under-race, and the pre-dedup fold (applies the real migration file against seeded duplicates incl. sticky-reject survivor).
- [x] `migrate-pg` green (migration 0172 runs + idempotent); schema-drift + all other CI gates green locally.
- [x] Every affected test verified green in isolation (the full-suite local `test` gate hits the known WSL2 cross-process `-pg` Postgres contention; CI's sharded `api-tests` run these against dedicated Postgres).

Closes #4572