### PR TITLE
fix(learned-patterns): working sort + confidence-range filter in the cockpit

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -22699,6 +22699,26 @@
           {
             "schema": {
               "type": "string",
+              "description": "Sort field: confidence, repetition, latency, created (default created). Non-whitelisted values are rejected with 400."
+            },
+            "required": false,
+            "description": "Sort field: confidence, repetition, latency, created (default created). Non-whitelisted values are rejected with 400.",
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Sort direction: asc or desc (default desc)"
+            },
+            "required": false,
+            "description": "Sort direction: asc or desc (default desc)",
+            "name": "dir",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
               "description": "Maximum results (default 50, max 200)"
             },
             "required": false,

--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -266,21 +266,24 @@ describe("admin learned-patterns routes", () => {
 
     // ─── Sort (whitelisted) ─────────────────────────────────────────
 
-    it("defaults to ORDER BY created_at DESC when no sort param", async () => {
+    it("defaults to newest-first with a deterministic tiebreaker when no sort param", async () => {
       mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
       await req("GET", "/");
       const calls = mocks.mockInternalQuery.mock.calls;
-      // The SELECT (last call) carries the ORDER BY; the COUNT does not.
+      // The SELECT (last call) carries the ORDER BY; the COUNT does not. Assert
+      // the FULL clause — the `NULLS LAST` and `id DESC` tiebreaker are
+      // load-bearing (deterministic pagination), so a loose substring wouldn't
+      // catch their removal.
       const selectSql = calls[calls.length - 1][0] as string;
-      expect(selectSql).toContain("ORDER BY created_at DESC");
+      expect(selectSql).toContain("ORDER BY created_at DESC NULLS LAST, id DESC");
     });
 
-    it("sorts by a whitelisted field + direction", async () => {
+    it("sorts by a whitelisted field + direction, keeping the tiebreaker", async () => {
       mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
       await req("GET", "/?sort=confidence&dir=asc");
       const calls = mocks.mockInternalQuery.mock.calls;
       const selectSql = calls[calls.length - 1][0] as string;
-      expect(selectSql).toContain("ORDER BY confidence ASC");
+      expect(selectSql).toContain("ORDER BY confidence ASC NULLS LAST, id DESC");
     });
 
     it("maps each whitelisted sort key to its real column", async () => {
@@ -295,7 +298,7 @@ describe("admin learned-patterns routes", () => {
         await req("GET", `/?sort=${key}&dir=desc`);
         const calls = mocks.mockInternalQuery.mock.calls;
         const selectSql = calls[calls.length - 1][0] as string;
-        expect(selectSql).toContain(`ORDER BY ${column} DESC`);
+        expect(selectSql).toContain(`ORDER BY ${column} DESC NULLS LAST, id DESC`);
       }
     });
 

--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -244,6 +244,15 @@ describe("admin learned-patterns routes", () => {
       expect(params).toContain(0.9);
     });
 
+    it("rejects an inverted confidence range (min > max) with 400", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      const res = await req("GET", "/?min_confidence=0.9&max_confidence=0.5");
+      expect(res.status).toBe(400);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.error).toBe("bad_request");
+    });
+
     it("applies combined filters", async () => {
       mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
       await req("GET", "/?status=pending&source_entity=orders&min_confidence=0.5");

--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -263,6 +263,76 @@ describe("admin learned-patterns routes", () => {
       expect(params).toContain("orders");
       expect(params).toContain(0.5);
     });
+
+    // ─── Sort (whitelisted) ─────────────────────────────────────────
+
+    it("defaults to ORDER BY created_at DESC when no sort param", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      await req("GET", "/");
+      const calls = mocks.mockInternalQuery.mock.calls;
+      // The SELECT (last call) carries the ORDER BY; the COUNT does not.
+      const selectSql = calls[calls.length - 1][0] as string;
+      expect(selectSql).toContain("ORDER BY created_at DESC");
+    });
+
+    it("sorts by a whitelisted field + direction", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      await req("GET", "/?sort=confidence&dir=asc");
+      const calls = mocks.mockInternalQuery.mock.calls;
+      const selectSql = calls[calls.length - 1][0] as string;
+      expect(selectSql).toContain("ORDER BY confidence ASC");
+    });
+
+    it("maps each whitelisted sort key to its real column", async () => {
+      const cases: Array<[string, string]> = [
+        ["repetition", "repetition_count"],
+        ["latency", "avg_duration_ms"],
+        ["created", "created_at"],
+      ];
+      for (const [key, column] of cases) {
+        mocks.mockInternalQuery.mockReset();
+        mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+        await req("GET", `/?sort=${key}&dir=desc`);
+        const calls = mocks.mockInternalQuery.mock.calls;
+        const selectSql = calls[calls.length - 1][0] as string;
+        expect(selectSql).toContain(`ORDER BY ${column} DESC`);
+      }
+    });
+
+    it("rejects a non-whitelisted sort field with 400 (never interpolated)", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      const res = await req("GET", "/?sort=pattern_sql");
+      expect(res.status).toBe(400);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.error).toBe("bad_request");
+      // The raw value must not appear in any executed SQL.
+      for (const call of mocks.mockInternalQuery.mock.calls) {
+        expect(call[0] as string).not.toContain("pattern_sql DESC");
+        expect(call[0] as string).not.toContain("pattern_sql ASC");
+      }
+    });
+
+    it("rejects a SQL-injection sort payload with 400", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      const res = await req("GET", `/?sort=${encodeURIComponent("created; DROP TABLE learned_patterns")}`);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a prototype key as sort (Map.get is pollution-safe)", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      const res = await req("GET", "/?sort=constructor");
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a non-whitelisted sort direction with 400", async () => {
+      mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+      const res = await req("GET", "/?sort=confidence&dir=sideways");
+      expect(res.status).toBe(400);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.error).toBe("bad_request");
+    });
   });
 
   // ─── GET /:id ─────────────────────────────────────────────────────

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -97,10 +97,11 @@ const VALID_STATUSES = new Set<string>(LEARNED_PATTERN_STATUSES);
 
 // Whitelisted sort key (from the shared `LEARNED_PATTERN_SORT_KEYS` wire
 // vocabulary) → real DB column. The ORDER BY column name is only ever taken
-// from THIS map (via `.get()`, which is prototype-pollution-safe and returns
-// `undefined` for anything unknown), never from the raw `sort=` value — so a
-// non-whitelisted sort key is rejected with 400 and can never be interpolated
-// into SQL. `avg_duration_ms` is nullable, so the query sorts NULLS LAST in
+// from this whitelist — via `SORT_COLUMNS.get()`, which is
+// prototype-pollution-safe and returns `undefined` for anything unknown — never
+// from the raw `sort=` value, so a non-whitelisted sort key is rejected with
+// 400 and can never be interpolated into SQL. `avg_duration_ms` is nullable, so
+// the query sorts NULLS LAST in
 // both directions (rows without a latency measurement sink to the bottom rather
 // than jumping to the top), with a stable `id DESC` tiebreaker so pagination is
 // deterministic when the primary sort ties. The `satisfies Record<...>` makes a

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -14,7 +14,12 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
 import { LEARNED_PATTERN_STATUSES, type LearnedPattern } from "@useatlas/types";
-import { LearnedPatternSchema, LearnedPatternsListResponseSchema } from "@useatlas/schemas";
+import {
+  LearnedPatternSchema,
+  LearnedPatternsListResponseSchema,
+  LEARNED_PATTERN_SORT_DIRECTIONS,
+  type LearnedPatternSortKey,
+} from "@useatlas/schemas";
 import { invalidatePatternCache } from "@atlas/api/lib/learn/pattern-cache";
 import { ErrorSchema, AuthErrorSchema, parsePagination, createIdParamSchema, DeletedResponseSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
@@ -90,26 +95,27 @@ function orgFilter(
 
 const VALID_STATUSES = new Set<string>(LEARNED_PATTERN_STATUSES);
 
-// Whitelisted sort fields → real DB columns. The ORDER BY column name is only
-// ever taken from THIS map (via `.get()`, which is prototype-pollution-safe and
-// returns `undefined` for anything unknown), never from the raw `sort=` value —
-// so a non-whitelisted sort key is rejected with 400 and can never be
-// interpolated into SQL. `avg_duration_ms` is nullable, so the query sorts
-// NULLS LAST in both directions (rows without a latency measurement sink to the
-// bottom rather than jumping to the top), with a stable `id DESC` tiebreaker so
-// pagination is deterministic when the primary sort ties. Keep the key set in
-// lockstep with the cockpit's `SORT_PARAM_BY_COLUMN` map
-// (packages/web/src/app/admin/learned-patterns/list-query.ts).
-const SORT_COLUMNS = new Map<string, string>([
-  ["confidence", "confidence"],
-  ["repetition", "repetition_count"],
-  ["latency", "avg_duration_ms"],
-  ["created", "created_at"],
-]);
-const SORT_DIRECTIONS = new Map<string, "ASC" | "DESC">([
-  ["asc", "ASC"],
-  ["desc", "DESC"],
-]);
+// Whitelisted sort key (from the shared `LEARNED_PATTERN_SORT_KEYS` wire
+// vocabulary) → real DB column. The ORDER BY column name is only ever taken
+// from THIS map (via `.get()`, which is prototype-pollution-safe and returns
+// `undefined` for anything unknown), never from the raw `sort=` value — so a
+// non-whitelisted sort key is rejected with 400 and can never be interpolated
+// into SQL. `avg_duration_ms` is nullable, so the query sorts NULLS LAST in
+// both directions (rows without a latency measurement sink to the bottom rather
+// than jumping to the top), with a stable `id DESC` tiebreaker so pagination is
+// deterministic when the primary sort ties. The `satisfies Record<...>` makes a
+// missing/typo'd key a compile error; the cockpit binds the *other* side (its
+// map's values are typed `LearnedPatternSortKey`), so the two can't drift.
+const SORT_COLUMN_BY_KEY = {
+  confidence: "confidence",
+  repetition: "repetition_count",
+  latency: "avg_duration_ms",
+  created: "created_at",
+} as const satisfies Record<LearnedPatternSortKey, string>;
+const SORT_COLUMNS = new Map<string, string>(Object.entries(SORT_COLUMN_BY_KEY));
+const SORT_DIRECTIONS = new Map<string, "ASC" | "DESC">(
+  LEARNED_PATTERN_SORT_DIRECTIONS.map((d) => [d, d.toUpperCase() as "ASC" | "DESC"]),
+);
 
 // This route governs `type = 'query_pattern'` rows ONLY (#4569). Every handler
 // scopes its reads and writes to this predicate, so `semantic_amendment` rows
@@ -420,8 +426,9 @@ adminLearnedPatterns.openapi(listPatternsRoute, async (c) => {
 
     // Sort is whitelisted: the ORDER BY column/direction comes only from the
     // SORT_COLUMNS/SORT_DIRECTIONS maps, never from the raw value — an unknown
-    // `sort`/`dir` is a 400, never interpolated. Absent params default to the
-    // prior behavior (newest first).
+    // `sort`/`dir` is a 400, never interpolated. Absent params default to
+    // newest-first (now with a deterministic `id` tiebreaker, so pagination is
+    // stable even without an explicit sort).
     let orderColumn = "created_at";
     if (sort !== null) {
       const mapped = SORT_COLUMNS.get(sort);

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -90,6 +90,27 @@ function orgFilter(
 
 const VALID_STATUSES = new Set<string>(LEARNED_PATTERN_STATUSES);
 
+// Whitelisted sort fields → real DB columns. The ORDER BY column name is only
+// ever taken from THIS map (via `.get()`, which is prototype-pollution-safe and
+// returns `undefined` for anything unknown), never from the raw `sort=` value —
+// so a non-whitelisted sort key is rejected with 400 and can never be
+// interpolated into SQL. `avg_duration_ms` is nullable, so the query sorts
+// NULLS LAST in both directions (rows without a latency measurement sink to the
+// bottom rather than jumping to the top), with a stable `id DESC` tiebreaker so
+// pagination is deterministic when the primary sort ties. Keep the key set in
+// lockstep with the cockpit's `SORT_PARAM_BY_COLUMN` map
+// (packages/web/src/app/admin/learned-patterns/list-query.ts).
+const SORT_COLUMNS = new Map<string, string>([
+  ["confidence", "confidence"],
+  ["repetition", "repetition_count"],
+  ["latency", "avg_duration_ms"],
+  ["created", "created_at"],
+]);
+const SORT_DIRECTIONS = new Map<string, "ASC" | "DESC">([
+  ["asc", "ASC"],
+  ["desc", "DESC"],
+]);
+
 // This route governs `type = 'query_pattern'` rows ONLY (#4569). Every handler
 // scopes its reads and writes to this predicate, so `semantic_amendment` rows
 // are invisible and untouchable here — their sole decide door is the improve
@@ -135,6 +156,8 @@ const listPatternsRoute = createRoute({
       source_entity: z.string().optional().openapi({ description: "Filter by source entity name" }),
       min_confidence: z.string().optional().openapi({ description: "Minimum confidence (0–1)" }),
       max_confidence: z.string().optional().openapi({ description: "Maximum confidence (0–1)" }),
+      sort: z.string().optional().openapi({ description: "Sort field: confidence, repetition, latency, created (default created). Non-whitelisted values are rejected with 400." }),
+      dir: z.string().optional().openapi({ description: "Sort direction: asc or desc (default desc)" }),
       limit: z.string().optional().openapi({ description: "Maximum results (default 50, max 200)" }),
       offset: z.string().optional().openapi({ description: "Pagination offset (default 0)" }),
     }),
@@ -386,12 +409,32 @@ adminLearnedPatterns.openapi(listPatternsRoute, async (c) => {
     const sourceEntity = url.searchParams.get("source_entity");
     const minConfidence = url.searchParams.get("min_confidence");
     const maxConfidence = url.searchParams.get("max_confidence");
+    const sort = url.searchParams.get("sort");
+    const dir = url.searchParams.get("dir");
     const { limit, offset } = parsePagination(c);
 
     if (status && !VALID_STATUSES.has(status)) return c.json({ error: "bad_request", message: `Invalid status filter. Must be one of: pending, approved, rejected.` }, 400);
     if (minConfidence !== null) { const val = parseFloat(minConfidence); if (!Number.isFinite(val) || val < 0 || val > 1) return c.json({ error: "bad_request", message: "min_confidence must be a number between 0 and 1." }, 400); }
     if (maxConfidence !== null) { const val = parseFloat(maxConfidence); if (!Number.isFinite(val) || val < 0 || val > 1) return c.json({ error: "bad_request", message: "max_confidence must be a number between 0 and 1." }, 400); }
     if (minConfidence !== null && maxConfidence !== null) { if (parseFloat(minConfidence) > parseFloat(maxConfidence)) return c.json({ error: "bad_request", message: "min_confidence must be less than or equal to max_confidence." }, 400); }
+
+    // Sort is whitelisted: the ORDER BY column/direction comes only from the
+    // SORT_COLUMNS/SORT_DIRECTIONS maps, never from the raw value — an unknown
+    // `sort`/`dir` is a 400, never interpolated. Absent params default to the
+    // prior behavior (newest first).
+    let orderColumn = "created_at";
+    if (sort !== null) {
+      const mapped = SORT_COLUMNS.get(sort);
+      if (mapped === undefined) return c.json({ error: "bad_request", message: `Invalid sort field. Must be one of: ${[...SORT_COLUMNS.keys()].join(", ")}.` }, 400);
+      orderColumn = mapped;
+    }
+    let orderDir: "ASC" | "DESC" = "DESC";
+    if (dir !== null) {
+      const mapped = SORT_DIRECTIONS.get(dir);
+      if (mapped === undefined) return c.json({ error: "bad_request", message: "Invalid sort direction. Must be one of: asc, desc." }, 400);
+      orderDir = mapped;
+    }
+    const orderByClause = `ORDER BY ${orderColumn} ${orderDir} NULLS LAST, id DESC`;
 
     const whereParts: string[] = [];
     const params: unknown[] = [];
@@ -415,7 +458,7 @@ adminLearnedPatterns.openapi(listPatternsRoute, async (c) => {
     const limitIdx = nextIdx;
     selectParams.push(offset);
     const offsetIdx = limitIdx + 1;
-    const rows = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns ${whereClause} ORDER BY created_at DESC LIMIT $${limitIdx} OFFSET $${offsetIdx}`, selectParams);
+    const rows = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns ${whereClause} ${orderByClause} LIMIT $${limitIdx} OFFSET $${offsetIdx}`, selectParams);
 
     return c.json({ patterns: rows.map(toLearnedPattern), total, limit, offset }, 200);
   }), { label: "list learned patterns" });

--- a/packages/schemas/src/__tests__/learned-pattern.test.ts
+++ b/packages/schemas/src/__tests__/learned-pattern.test.ts
@@ -3,6 +3,8 @@ import {
   LearnedPatternSchema,
   LearnedPatternsListResponseSchema,
   AmendmentPayloadSchema,
+  LEARNED_PATTERN_SORT_KEYS,
+  LEARNED_PATTERN_SORT_DIRECTIONS,
 } from "../learned-pattern";
 import {
   LEARNED_PATTERN_STATUSES,
@@ -166,5 +168,18 @@ describe("drift rejection", () => {
       confidence: 0.5,
     };
     expect(AmendmentPayloadSchema.safeParse(drifted).success).toBe(false);
+  });
+});
+
+describe("learned-pattern sort vocabulary", () => {
+  test("exposes the whitelisted sort keys as the shared wire contract", () => {
+    // The route's SORT_COLUMN_BY_KEY (satisfies Record<LearnedPatternSortKey,…>)
+    // and the cockpit's SORT_PARAM_BY_COLUMN values both derive from this tuple;
+    // pinning it here makes an accidental reorder/rename a visible change.
+    expect(LEARNED_PATTERN_SORT_KEYS).toEqual(["confidence", "repetition", "latency", "created"]);
+  });
+
+  test("exposes the two sort directions", () => {
+    expect(LEARNED_PATTERN_SORT_DIRECTIONS).toEqual(["asc", "desc"]);
   });
 });

--- a/packages/schemas/src/learned-pattern.ts
+++ b/packages/schemas/src/learned-pattern.ts
@@ -79,6 +79,22 @@ export const LearnedPatternSchema = z.object({
 }) satisfies z.ZodType<LearnedPattern>;
 
 /**
+ * Whitelisted sort fields for `GET /api/v1/admin/learned-patterns` — the wire
+ * vocabulary shared by the route (which maps each key to a real DB column and
+ * rejects anything else with a 400) and the cockpit (which maps its sortable
+ * TanStack column ids onto these keys). Kept here, next to the other wire
+ * contracts (#4579), so the two sides can't drift: the route's column map is
+ * `satisfies Record<LearnedPatternSortKey, string>` (exhaustive) and the web
+ * map's values are typed `LearnedPatternSortKey` (a typo is a compile error).
+ */
+export const LEARNED_PATTERN_SORT_KEYS = ["confidence", "repetition", "latency", "created"] as const;
+export type LearnedPatternSortKey = (typeof LEARNED_PATTERN_SORT_KEYS)[number];
+
+/** Sort directions accepted by the same endpoint (`?dir=`). */
+export const LEARNED_PATTERN_SORT_DIRECTIONS = ["asc", "desc"] as const;
+export type LearnedPatternSortDirection = (typeof LEARNED_PATTERN_SORT_DIRECTIONS)[number];
+
+/**
  * Paginated list envelope for `GET /api/v1/admin/learned-patterns`
  * (`{ patterns, total, limit, offset }`). The route types its response against
  * this and the cockpit page runtime-parses the same schema, so the list shape

--- a/packages/web/src/app/admin/learned-patterns/__tests__/columns.test.ts
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/columns.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { getLearnedPatternColumns } from "../columns";
+import { SORT_PARAM_BY_COLUMN } from "../list-query";
+
+describe("getLearnedPatternColumns", () => {
+  test("returns the documented column ids in order", () => {
+    // Column ids are the wire contract for the DataTable toolbar (sort list,
+    // visibility menu) and the `?sort=` state parser. A silent rename here
+    // breaks the sort → API mapping in `list-query.ts`.
+    const ids = getLearnedPatternColumns().map((c) => c.id);
+    expect(ids).toEqual([
+      "select",
+      "status",
+      "patternSql",
+      "description",
+      "sourceEntity",
+      "confidence",
+      "avgDurationMs",
+      "repetitionCount",
+      "proposedBy",
+      "createdAt",
+    ]);
+  });
+
+  test("exactly the sortable columns map to a whitelisted API sort key", () => {
+    // A column renders a sort affordance iff `enableSorting !== false`
+    // (`DataTableColumnHeader` gates the chevron on `column.getCanSort()`).
+    // That set must match the API sort whitelist 1:1 — a sortable column with
+    // no wire mapping would flip an arrow that the server ignores (the bug this
+    // fixes); a mapping with no sortable column would be dead config.
+    const sortableIds = getLearnedPatternColumns()
+      .filter((c) => c.enableSorting !== false)
+      .map((c) => c.id as string)
+      .toSorted();
+
+    const mappedIds = [...SORT_PARAM_BY_COLUMN.keys()].toSorted();
+
+    expect(sortableIds).toEqual(mappedIds);
+    expect(sortableIds).toEqual(
+      ["avgDurationMs", "confidence", "createdAt", "repetitionCount"].toSorted(),
+    );
+  });
+});

--- a/packages/web/src/app/admin/learned-patterns/__tests__/confidence-filter.test.tsx
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/confidence-filter.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import { render, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
+import { ConfidenceFilter } from "../confidence-filter";
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Open the popover by clicking the trigger; return its content root. */
+async function openPopover(container: HTMLElement): Promise<HTMLElement> {
+  const trigger = container.querySelector("button");
+  if (!trigger) throw new Error("trigger button not found");
+  fireEvent.click(trigger);
+  await waitFor(() => {
+    if (!document.querySelector("#confidence-min")) throw new Error("popover not open");
+  });
+  return document.body;
+}
+
+describe("ConfidenceFilter", () => {
+  test("shows a neutral label when no bounds are set", () => {
+    const { container } = render(
+      <ConfidenceFilter min="" max="" onApply={() => {}} />,
+    );
+    expect(container.querySelector("button")?.textContent).toContain("Confidence");
+    expect(container.querySelector("button")?.textContent).not.toContain("%");
+  });
+
+  test("shows the applied range as a percentage in the trigger label", () => {
+    const { container } = render(
+      <ConfidenceFilter min="0.5" max="0.9" onApply={() => {}} />,
+    );
+    expect(container.querySelector("button")?.textContent).toContain("Confidence 50–90%");
+  });
+
+  test("apply converts percentage inputs to the API decimal bounds", async () => {
+    const onApply = mock((_bounds: { min: string; max: string }) => {});
+    const { container } = render(
+      <ConfidenceFilter min="" max="" onApply={onApply} />,
+    );
+    const body = await openPopover(container);
+    fireEvent.change(within(body).getByLabelText("Min %"), { target: { value: "50" } });
+    fireEvent.change(within(body).getByLabelText("Max %"), { target: { value: "90" } });
+    fireEvent.click(within(body).getByText("Apply"));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply.mock.calls[0][0]).toEqual({ min: "0.5", max: "0.9" });
+  });
+
+  test("clear emits empty bounds", async () => {
+    const onApply = mock((_bounds: { min: string; max: string }) => {});
+    const { container } = render(
+      <ConfidenceFilter min="0.5" max="0.9" onApply={onApply} />,
+    );
+    const body = await openPopover(container);
+    fireEvent.click(within(body).getByText("Clear"));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply.mock.calls[0][0]).toEqual({ min: "", max: "" });
+  });
+
+  test("seeds the draft inputs from the applied bounds on open", async () => {
+    const { container } = render(
+      <ConfidenceFilter min="0.25" max="0.75" onApply={() => {}} />,
+    );
+    const body = await openPopover(container);
+    expect((within(body).getByLabelText("Min %") as HTMLInputElement).value).toBe("25");
+    expect((within(body).getByLabelText("Max %") as HTMLInputElement).value).toBe("75");
+  });
+});

--- a/packages/web/src/app/admin/learned-patterns/__tests__/confidence-filter.test.tsx
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/confidence-filter.test.tsx
@@ -33,6 +33,14 @@ describe("ConfidenceFilter", () => {
     expect(container.querySelector("button")?.textContent).toContain("Confidence 50–90%");
   });
 
+  test("labels a one-sided range with the open bound's placeholder", () => {
+    const minOnly = render(<ConfidenceFilter min="0.5" max="" onApply={() => {}} />);
+    expect(minOnly.container.querySelector("button")?.textContent).toContain("Confidence 50–100%");
+    cleanup();
+    const maxOnly = render(<ConfidenceFilter min="" max="0.9" onApply={() => {}} />);
+    expect(maxOnly.container.querySelector("button")?.textContent).toContain("Confidence 0–90%");
+  });
+
   test("apply converts percentage inputs to the API decimal bounds", async () => {
     const onApply = mock((_bounds: { min: string; max: string }) => {});
     const { container } = render(
@@ -41,6 +49,20 @@ describe("ConfidenceFilter", () => {
     const body = await openPopover(container);
     fireEvent.change(within(body).getByLabelText("Min %"), { target: { value: "50" } });
     fireEvent.change(within(body).getByLabelText("Max %"), { target: { value: "90" } });
+    fireEvent.click(within(body).getByText("Apply"));
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply.mock.calls[0][0]).toEqual({ min: "0.5", max: "0.9" });
+  });
+
+  test("apply swaps an inverted range so it is never sent min > max", async () => {
+    const onApply = mock((_bounds: { min: string; max: string }) => {});
+    const { container } = render(
+      <ConfidenceFilter min="" max="" onApply={onApply} />,
+    );
+    const body = await openPopover(container);
+    fireEvent.change(within(body).getByLabelText("Min %"), { target: { value: "90" } });
+    fireEvent.change(within(body).getByLabelText("Max %"), { target: { value: "50" } });
     fireEvent.click(within(body).getByText("Apply"));
 
     expect(onApply).toHaveBeenCalledTimes(1);

--- a/packages/web/src/app/admin/learned-patterns/__tests__/list-query.test.ts
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/list-query.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { LEARNED_PATTERN_SORT_KEYS } from "@/ui/lib/admin-schemas";
 import {
   buildLearnedPatternsPath,
   confidenceToPct,
@@ -104,6 +105,21 @@ describe("SORT_PARAM_BY_COLUMN", () => {
       ["avgDurationMs", "latency"],
       ["createdAt", "created"],
     ]);
+  });
+
+  test("every emitted sort value is in the shared API whitelist (no cross-package drift)", () => {
+    // The route accepts exactly `LEARNED_PATTERN_SORT_KEYS`; the cockpit must
+    // never emit a value outside it, or a legitimate sort click 400s. Binding
+    // the web map's values to the shared vocabulary here (plus the values being
+    // typed `LearnedPatternSortKey`) closes the drift the two lockstep comments
+    // otherwise guard by convention alone.
+    const emitted = new Set<string>(SORT_PARAM_BY_COLUMN.values());
+    const whitelist = new Set<string>(LEARNED_PATTERN_SORT_KEYS);
+    for (const value of emitted) {
+      expect(whitelist.has(value)).toBe(true);
+    }
+    // And the cockpit exercises the whole whitelist — no dead API sort key.
+    expect(emitted).toEqual(whitelist);
   });
 });
 

--- a/packages/web/src/app/admin/learned-patterns/__tests__/list-query.test.ts
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/list-query.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildLearnedPatternsPath,
+  confidenceToPct,
+  pctToConfidence,
+  SORT_PARAM_BY_COLUMN,
+  type LearnedPatternsFilters,
+} from "../list-query";
+
+const NO_FILTERS: LearnedPatternsFilters = {
+  status: "",
+  source_entity: "",
+  min_confidence: "",
+  max_confidence: "",
+};
+
+function query(path: string): URLSearchParams {
+  return new URL(path, "http://x").searchParams;
+}
+
+describe("buildLearnedPatternsPath", () => {
+  test("always includes limit + offset from the binding", () => {
+    const qs = query(
+      buildLearnedPatternsPath({ offset: 50, perPage: 25 }, NO_FILTERS),
+    );
+    expect(qs.get("limit")).toBe("25");
+    expect(qs.get("offset")).toBe("50");
+  });
+
+  test("omits empty filters and sort when nothing is set", () => {
+    const path = buildLearnedPatternsPath({ offset: 0, perPage: 50 }, NO_FILTERS);
+    const qs = query(path);
+    for (const key of ["status", "source_entity", "min_confidence", "max_confidence", "sort", "dir"]) {
+      expect(qs.has(key)).toBe(false);
+    }
+  });
+
+  test("threads page-owned filters", () => {
+    const qs = query(
+      buildLearnedPatternsPath(
+        { offset: 0, perPage: 50 },
+        { status: "pending", source_entity: "orders", min_confidence: "0.5", max_confidence: "0.9" },
+      ),
+    );
+    expect(qs.get("status")).toBe("pending");
+    expect(qs.get("source_entity")).toBe("orders");
+    expect(qs.get("min_confidence")).toBe("0.5");
+    expect(qs.get("max_confidence")).toBe("0.9");
+  });
+
+  test("maps a sortable column id to the whitelisted sort param + direction", () => {
+    const qs = query(
+      buildLearnedPatternsPath(
+        { offset: 0, perPage: 50, sortId: "confidence", sortDesc: true },
+        NO_FILTERS,
+      ),
+    );
+    expect(qs.get("sort")).toBe("confidence");
+    expect(qs.get("dir")).toBe("desc");
+  });
+
+  test("asc direction when sortDesc is false", () => {
+    const qs = query(
+      buildLearnedPatternsPath(
+        { offset: 0, perPage: 50, sortId: "avgDurationMs", sortDesc: false },
+        NO_FILTERS,
+      ),
+    );
+    expect(qs.get("sort")).toBe("latency");
+    expect(qs.get("dir")).toBe("asc");
+  });
+
+  test("every sortable column id maps to its wire key", () => {
+    const expected: Record<string, string> = {
+      confidence: "confidence",
+      repetitionCount: "repetition",
+      avgDurationMs: "latency",
+      createdAt: "created",
+    };
+    for (const [columnId, wireKey] of Object.entries(expected)) {
+      const qs = query(
+        buildLearnedPatternsPath({ offset: 0, perPage: 50, sortId: columnId }, NO_FILTERS),
+      );
+      expect(qs.get("sort")).toBe(wireKey);
+    }
+  });
+
+  test("a non-sortable / unknown column id emits no sort param", () => {
+    for (const bogus of ["patternSql", "status", "constructor", "select"]) {
+      const qs = query(
+        buildLearnedPatternsPath({ offset: 0, perPage: 50, sortId: bogus }, NO_FILTERS),
+      );
+      expect(qs.has("sort")).toBe(false);
+      expect(qs.has("dir")).toBe(false);
+    }
+  });
+});
+
+describe("SORT_PARAM_BY_COLUMN", () => {
+  test("covers exactly the four sortable columns, in wire vocabulary", () => {
+    expect([...SORT_PARAM_BY_COLUMN.entries()]).toEqual([
+      ["confidence", "confidence"],
+      ["repetitionCount", "repetition"],
+      ["avgDurationMs", "latency"],
+      ["createdAt", "created"],
+    ]);
+  });
+});
+
+describe("confidence ⇄ percentage conversion", () => {
+  test("pctToConfidence divides by 100", () => {
+    expect(pctToConfidence("50")).toBe("0.5");
+    expect(pctToConfidence("100")).toBe("1");
+    expect(pctToConfidence("0")).toBe("0");
+  });
+
+  test("pctToConfidence clamps out-of-range input", () => {
+    expect(pctToConfidence("150")).toBe("1");
+    expect(pctToConfidence("-10")).toBe("0");
+  });
+
+  test("pctToConfidence returns '' for empty / non-numeric", () => {
+    expect(pctToConfidence("")).toBe("");
+    expect(pctToConfidence("  ")).toBe("");
+    expect(pctToConfidence("abc")).toBe("");
+  });
+
+  test("confidenceToPct multiplies by 100 and rounds", () => {
+    expect(confidenceToPct("0.5")).toBe("50");
+    expect(confidenceToPct("0.335")).toBe("34");
+    expect(confidenceToPct("1")).toBe("100");
+  });
+
+  test("confidenceToPct returns '' for empty / non-numeric", () => {
+    expect(confidenceToPct("")).toBe("");
+    expect(confidenceToPct("nope")).toBe("");
+  });
+
+  test("round-trips a whole percentage", () => {
+    expect(confidenceToPct(pctToConfidence("75"))).toBe("75");
+  });
+});

--- a/packages/web/src/app/admin/learned-patterns/confidence-filter.tsx
+++ b/packages/web/src/app/admin/learned-patterns/confidence-filter.tsx
@@ -51,7 +51,16 @@ export function ConfidenceFilter({ min, max, onApply }: ConfidenceFilterProps) {
   }
 
   function apply() {
-    onApply({ min: pctToConfidence(minPct), max: pctToConfidence(maxPct) });
+    let min = pctToConfidence(minPct);
+    let max = pctToConfidence(maxPct);
+    // Forgive an inverted range: if both bounds are set and min > max, swap
+    // them. The user who typed 90/50 meant the 50–90 band, so ordering it
+    // avoids a doomed `min_confidence > max_confidence` 400 and the nonsensical
+    // "90–50%" trigger label.
+    if (min !== "" && max !== "" && Number(min) > Number(max)) {
+      [min, max] = [max, min];
+    }
+    onApply({ min, max });
     setOpen(false);
   }
 

--- a/packages/web/src/app/admin/learned-patterns/confidence-filter.tsx
+++ b/packages/web/src/app/admin/learned-patterns/confidence-filter.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { SlidersHorizontal, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { confidenceToPct, pctToConfidence } from "./list-query";
+
+interface ConfidenceFilterProps {
+  /** Current lower bound as the API decimal string (0–1), or "" for unset. */
+  min: string;
+  /** Current upper bound as the API decimal string (0–1), or "" for unset. */
+  max: string;
+  /** Apply new bounds as API decimal strings ("" clears that side). */
+  onApply: (bounds: { min: string; max: string }) => void;
+}
+
+/**
+ * Confidence min/max range filter for the learned-patterns cockpit.
+ *
+ * Presents the bounds as percentages (0–100) for readability but stores/applies
+ * them as the API's decimal `min_confidence`/`max_confidence` (0–1), so the
+ * URL is directly shareable and maps 1:1 onto the route's validated params.
+ * Edits are staged in local draft state and committed on Apply — a keystroke
+ * doesn't refetch the list on every character.
+ */
+export function ConfidenceFilter({ min, max, onApply }: ConfidenceFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [minPct, setMinPct] = useState(() => confidenceToPct(min));
+  const [maxPct, setMaxPct] = useState(() => confidenceToPct(max));
+
+  const active = min !== "" || max !== "";
+  const label = active
+    ? `Confidence ${confidenceToPct(min) || "0"}–${confidenceToPct(max) || "100"}%`
+    : "Confidence";
+
+  // Reseed the draft inputs from the applied bounds each time the popover opens,
+  // so a cancelled edit never lingers into the next open.
+  function handleOpenChange(next: boolean) {
+    if (next) {
+      setMinPct(confidenceToPct(min));
+      setMaxPct(confidenceToPct(max));
+    }
+    setOpen(next);
+  }
+
+  function apply() {
+    onApply({ min: pctToConfidence(minPct), max: pctToConfidence(maxPct) });
+    setOpen(false);
+  }
+
+  function clear() {
+    setMinPct("");
+    setMaxPct("");
+    onApply({ min: "", max: "" });
+    setOpen(false);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant={active ? "secondary" : "ghost"}>
+          <SlidersHorizontal className="mr-1.5 size-3.5" />
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 space-y-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Confidence range</p>
+          <p className="text-xs text-muted-foreground">
+            Filter patterns by confidence (0–100%).
+          </p>
+        </div>
+        <div className="flex items-end gap-2">
+          <div className="space-y-1">
+            <Label htmlFor="confidence-min" className="text-xs">
+              Min %
+            </Label>
+            <Input
+              id="confidence-min"
+              type="number"
+              min={0}
+              max={100}
+              inputMode="numeric"
+              placeholder="0"
+              value={minPct}
+              onChange={(e) => setMinPct(e.target.value)}
+            />
+          </div>
+          <span className="pb-2 text-muted-foreground">–</span>
+          <div className="space-y-1">
+            <Label htmlFor="confidence-max" className="text-xs">
+              Max %
+            </Label>
+            <Input
+              id="confidence-max"
+              type="number"
+              min={0}
+              max={100}
+              inputMode="numeric"
+              placeholder="100"
+              value={maxPct}
+              onChange={(e) => setMaxPct(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex items-center justify-between">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={clear}
+            disabled={!active && minPct === "" && maxPct === ""}
+          >
+            <X className="mr-1.5 size-3.5" />
+            Clear
+          </Button>
+          <Button size="sm" onClick={apply}>
+            Apply
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/web/src/app/admin/learned-patterns/list-query.ts
+++ b/packages/web/src/app/admin/learned-patterns/list-query.ts
@@ -16,7 +16,7 @@
  * vocabulary in `@useatlas/schemas`), so a value that drifts from the route's
  * `SORT_COLUMN_BY_KEY` whitelist is a compile error rather than a runtime 400.
  */
-import type { LearnedPatternSortKey } from "@/ui/lib/admin-schemas";
+import type { LearnedPatternSortKey, LearnedPatternSortDirection } from "@/ui/lib/admin-schemas";
 
 /**
  * Maps a sortable TanStack column id (from `columns.tsx`) to the API's
@@ -72,8 +72,9 @@ export function buildLearnedPatternsPath(
 
   const sortKey = binding.sortId ? SORT_PARAM_BY_COLUMN.get(binding.sortId) : undefined;
   if (sortKey) {
+    const dir: LearnedPatternSortDirection = binding.sortDesc ? "desc" : "asc";
     qs.set("sort", sortKey);
-    qs.set("dir", binding.sortDesc ? "desc" : "asc");
+    qs.set("dir", dir);
   }
 
   return `/api/v1/admin/learned-patterns?${qs}`;

--- a/packages/web/src/app/admin/learned-patterns/list-query.ts
+++ b/packages/web/src/app/admin/learned-patterns/list-query.ts
@@ -1,0 +1,97 @@
+/**
+ * Request-path builder for the learned-patterns cockpit list fetch.
+ *
+ * Extracted from `page.tsx` so the sort/filter → query-string threading is unit
+ * testable in isolation (the page component is a large client tree). The
+ * cockpit's `useServerDataTable` call delegates its `buildPath` here.
+ *
+ * Sorting: `useServerDataTable` already reads the table's `?sort=` state and
+ * hands us the first sort column's TanStack id (`sortId`) + direction
+ * (`sortDesc`). `SORT_PARAM_BY_COLUMN` maps that id to the API's WHITELISTED
+ * `sort` value — only the four sortable columns appear, so a non-sortable
+ * column id (or anything else) yields no `sort` param and the route defaults to
+ * newest-first. The route rejects any non-whitelisted `sort` with a 400, so the
+ * whitelist is enforced server-side; this map just keeps the client from ever
+ * sending one. Keep the values in lockstep with the route's `SORT_COLUMNS` map
+ * (packages/api/src/api/routes/admin-learned-patterns.ts).
+ */
+
+/**
+ * Maps a sortable TanStack column id (from `columns.tsx`) to the API's
+ * whitelisted `sort` value. A `Map` (not a plain object) so an unexpected key
+ * like `"constructor"` resolves to `undefined` rather than walking the
+ * prototype chain.
+ */
+export const SORT_PARAM_BY_COLUMN = new Map<string, string>([
+  ["confidence", "confidence"],
+  ["repetitionCount", "repetition"],
+  ["avgDurationMs", "latency"],
+  ["createdAt", "created"],
+]);
+
+/** Page-owned filter state threaded into the list request. */
+export interface LearnedPatternsFilters {
+  status: string;
+  source_entity: string;
+  min_confidence: string;
+  max_confidence: string;
+}
+
+/** The pagination + sort binding `useServerDataTable` passes to `buildPath`. */
+export interface LearnedPatternsBinding {
+  offset: number;
+  perPage: number;
+  sortId?: string;
+  sortDesc?: boolean;
+}
+
+/**
+ * Build the `/api/v1/admin/learned-patterns` request path from the table
+ * binding + page filters. Only non-empty filters are appended; sort is emitted
+ * only for a whitelisted sortable column.
+ */
+export function buildLearnedPatternsPath(
+  binding: LearnedPatternsBinding,
+  filters: LearnedPatternsFilters,
+): string {
+  const qs = new URLSearchParams({
+    limit: String(binding.perPage),
+    offset: String(binding.offset),
+  });
+  if (filters.status) qs.set("status", filters.status);
+  if (filters.source_entity) qs.set("source_entity", filters.source_entity);
+  if (filters.min_confidence) qs.set("min_confidence", filters.min_confidence);
+  if (filters.max_confidence) qs.set("max_confidence", filters.max_confidence);
+
+  const sortKey = binding.sortId ? SORT_PARAM_BY_COLUMN.get(binding.sortId) : undefined;
+  if (sortKey) {
+    qs.set("sort", sortKey);
+    qs.set("dir", binding.sortDesc ? "desc" : "asc");
+  }
+
+  return `/api/v1/admin/learned-patterns?${qs}`;
+}
+
+// ── Confidence display ⇄ wire conversion ──────────────────────────────
+// The URL/API carry confidence as a decimal in [0,1]; the cockpit shows it as a
+// percentage. These pure converters bridge the two and clamp out-of-range or
+// non-numeric input to a safe value (or "" for unset), so the API only ever
+// receives a well-formed `min_confidence`/`max_confidence`.
+
+/** Percentage input (0–100) → the API's decimal confidence string (0–1). "" stays "". */
+export function pctToConfidence(pct: string): string {
+  const trimmed = pct.trim();
+  if (trimmed === "") return "";
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return "";
+  const clamped = Math.min(100, Math.max(0, n));
+  return String(clamped / 100);
+}
+
+/** API decimal confidence string (0–1) → percentage string for display. "" stays "". */
+export function confidenceToPct(dec: string): string {
+  if (dec === "") return "";
+  const n = Number(dec);
+  if (!Number.isFinite(n)) return "";
+  return String(Math.round(n * 100));
+}

--- a/packages/web/src/app/admin/learned-patterns/list-query.ts
+++ b/packages/web/src/app/admin/learned-patterns/list-query.ts
@@ -12,37 +12,44 @@
  * column id (or anything else) yields no `sort` param and the route defaults to
  * newest-first. The route rejects any non-whitelisted `sort` with a 400, so the
  * whitelist is enforced server-side; this map just keeps the client from ever
- * sending one. Keep the values in lockstep with the route's `SORT_COLUMNS` map
- * (packages/api/src/api/routes/admin-learned-patterns.ts).
+ * sending one. Its values are typed `LearnedPatternSortKey` (the shared wire
+ * vocabulary in `@useatlas/schemas`), so a value that drifts from the route's
+ * `SORT_COLUMN_BY_KEY` whitelist is a compile error rather than a runtime 400.
  */
+import type { LearnedPatternSortKey } from "@/ui/lib/admin-schemas";
 
 /**
  * Maps a sortable TanStack column id (from `columns.tsx`) to the API's
  * whitelisted `sort` value. A `Map` (not a plain object) so an unexpected key
  * like `"constructor"` resolves to `undefined` rather than walking the
- * prototype chain.
+ * prototype chain. Values are the shared `LearnedPatternSortKey` union.
  */
-export const SORT_PARAM_BY_COLUMN = new Map<string, string>([
+export const SORT_PARAM_BY_COLUMN = new Map<string, LearnedPatternSortKey>([
   ["confidence", "confidence"],
   ["repetitionCount", "repetition"],
   ["avgDurationMs", "latency"],
   ["createdAt", "created"],
 ]);
 
-/** Page-owned filter state threaded into the list request. */
+/** Page-owned filter state threaded into the list request (a read-only input). */
 export interface LearnedPatternsFilters {
-  status: string;
-  source_entity: string;
-  min_confidence: string;
-  max_confidence: string;
+  readonly status: string;
+  readonly source_entity: string;
+  readonly min_confidence: string;
+  readonly max_confidence: string;
 }
 
-/** The pagination + sort binding `useServerDataTable` passes to `buildPath`. */
+/**
+ * The pagination + sort binding `useServerDataTable` passes to `buildPath`. An
+ * intentional decoupled subset of the hook's `ServerDataTableBinding` — keeping
+ * only the four fields this builder reads leaves `list-query.ts` free of the
+ * hook's generic `TData` so it stays trivially unit-testable.
+ */
 export interface LearnedPatternsBinding {
-  offset: number;
-  perPage: number;
-  sortId?: string;
-  sortDesc?: boolean;
+  readonly offset: number;
+  readonly perPage: number;
+  readonly sortId?: string;
+  readonly sortDesc?: boolean;
 }
 
 /**

--- a/packages/web/src/app/admin/learned-patterns/page.tsx
+++ b/packages/web/src/app/admin/learned-patterns/page.tsx
@@ -6,6 +6,8 @@ import { useQueryStates } from "nuqs";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { LearnedPattern, LearnedPatternStatus } from "@/ui/lib/types";
 import { learnedPatternsSearchParams } from "./search-params";
+import { buildLearnedPatternsPath } from "./list-query";
+import { ConfidenceFilter } from "./confidence-filter";
 import { getLearnedPatternColumns, statusBadge, autoApprovedBadge } from "./columns";
 import { useAtlasConfig } from "@/ui/context";
 import { ServerDataTable } from "@/ui/components/admin/server-data-table";
@@ -307,19 +309,24 @@ export default function LearnedPatternsPage() {
     defaultSorting: [{ id: "createdAt", desc: true }],
     schema: LearnedPatternsListResponseSchema,
     select: (r) => ({ rows: r.patterns, total: r.total }),
-    buildPath: ({ offset, perPage }) => {
-      const qs = new URLSearchParams({
-        limit: String(perPage),
-        offset: String(offset),
-      });
-      if (params.status) qs.set("status", params.status);
-      if (params.source_entity) qs.set("source_entity", params.source_entity);
-      return `/api/v1/admin/learned-patterns?${qs}`;
-    },
+    buildPath: ({ offset, perPage, sortId, sortDesc }) =>
+      buildLearnedPatternsPath(
+        { offset, perPage, sortId, sortDesc },
+        {
+          status: params.status,
+          source_entity: params.source_entity,
+          min_confidence: params.min_confidence,
+          max_confidence: params.max_confidence,
+        },
+      ),
   });
 
   const selectedCount = table.getSelectedRowModel().rows.length;
-  const hasFilters = !!params.status || !!params.source_entity;
+  const hasFilters =
+    !!params.status ||
+    !!params.source_entity ||
+    !!params.min_confidence ||
+    !!params.max_confidence;
 
   return (
     <TooltipProvider>
@@ -389,6 +396,15 @@ export default function LearnedPatternsPage() {
                   </SelectContent>
                 </Select>
               )}
+              <ConfidenceFilter
+                min={params.min_confidence}
+                max={params.max_confidence}
+                onApply={({ min, max }) => {
+                  table.setPageIndex(0);
+                  // fire-and-forget: nuqs URL update
+                  void setParams({ min_confidence: min, max_confidence: max, page: 1 });
+                }}
+              />
               {hasFilters && (
                 <Button
                   variant="ghost"
@@ -396,7 +412,7 @@ export default function LearnedPatternsPage() {
                   onClick={() => {
                     table.setPageIndex(0);
                     // fire-and-forget: nuqs URL update
-                    void setParams({ status: "", source_entity: "", page: 1 });
+                    void setParams({ status: "", source_entity: "", min_confidence: "", max_confidence: "", page: 1 });
                   }}
                 >
                   <X className="mr-1.5 size-3.5" />
@@ -448,7 +464,7 @@ export default function LearnedPatternsPage() {
                 description: "Patterns will appear here when the agent or atlas learn CLI proposes new query patterns.",
               }}
               hasFilters={hasFilters}
-              onClearFilters={() => setParams({ status: "", source_entity: "", page: 1 })}
+              onClearFilters={() => setParams({ status: "", source_entity: "", min_confidence: "", max_confidence: "", page: 1 })}
               onRowClick={(row, e) => {
                 if ((e.target as HTMLElement).closest('[role="checkbox"], button')) return;
                 setDetailPattern(row.original);

--- a/packages/web/src/app/admin/learned-patterns/search-params.ts
+++ b/packages/web/src/app/admin/learned-patterns/search-params.ts
@@ -3,5 +3,10 @@ import { parseAsString, parseAsInteger } from "nuqs";
 export const learnedPatternsSearchParams = {
   status: parseAsString.withDefault(""),
   source_entity: parseAsString.withDefault(""),
+  // Confidence bounds are the exact API params (`min_confidence`/`max_confidence`,
+  // decimals in [0,1]) so the URL is directly shareable and maps 1:1 onto the
+  // route's validated filter. Empty string = unset.
+  min_confidence: parseAsString.withDefault(""),
+  max_confidence: parseAsString.withDefault(""),
   page: parseAsInteger.withDefault(1),
 };

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -575,7 +575,9 @@ export type {
 export {
   LearnedPatternSchema,
   LearnedPatternsListResponseSchema,
+  LEARNED_PATTERN_SORT_KEYS,
 } from "@useatlas/schemas";
+export type { LearnedPatternSortKey } from "@useatlas/schemas";
 
 // ── Demo tracking (#3931) ────────────────────────────────────────────
 // Web-local mirrors of the inline shapes in

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -577,7 +577,7 @@ export {
   LearnedPatternsListResponseSchema,
   LEARNED_PATTERN_SORT_KEYS,
 } from "@useatlas/schemas";
-export type { LearnedPatternSortKey } from "@useatlas/schemas";
+export type { LearnedPatternSortKey, LearnedPatternSortDirection } from "@useatlas/schemas";
 
 // ── Demo tracking (#3931) ────────────────────────────────────────────
 // Web-local mirrors of the inline shapes in


### PR DESCRIPTION
## Summary

The learned-patterns cockpit's column sort headers flipped arrows and updated the URL while the API hard-coded `ORDER BY created_at DESC` — sorting was a no-op. This makes it real, end to end:

- **Real server-side sort.** The table's sort state is threaded to a **whitelisted** API `sort`/`dir` param (`confidence`, `repetition`, `latency`, `created`). The route maps each key to a real DB column via a prototype-safe `Map`; a non-whitelisted `sort`/`dir` is rejected with a **400 and never interpolated** into SQL. `ORDER BY` carries `NULLS LAST` (nullable `avg_duration_ms` sinks to the bottom) + a deterministic `id DESC` tiebreaker for stable pagination.
- **Confidence min/max filter UI.** A Popover with percentage inputs, wired to the route's existing `min_confidence`/`max_confidence` params, kept on nuqs and shareable via URL. An inverted range is forgiven (swapped) client-side so the cockpit never sends a doomed `min>max`.
- **Sort affordances only where they work.** Only the four sortable columns render sort controls; a seam test binds the sortable-column set 1:1 to the API whitelist.
- **Shared wire vocabulary.** `LEARNED_PATTERN_SORT_KEYS`/`_DIRECTIONS` live in `@useatlas/schemas` (the #4579 wire-contract home). The route's column map is `satisfies Record<LearnedPatternSortKey, string>` (exhaustive) and the cockpit map's values are typed `LearnedPatternSortKey`, so a rename on either side is a compile error — not a runtime 400.

Built on the just-merged #4579 SSOT refactor. Touches only the route + cockpit page/table (no overlap with the in-flight `db/internal.ts` work in #4534 / #4572).

## Test plan
- [x] `@atlas/api` route tests: whitelisted sort → correct `ORDER BY` (full clause incl. `NULLS LAST, id DESC`); non-whitelisted sort/dir/injection/prototype key → 400; inverted confidence range → 400 (35 tests)
- [x] Web seam tests: `buildLearnedPatternsPath` threading, `SORT_PARAM_BY_COLUMN` ↔ shared whitelist binding, sortable-set ↔ whitelist lockstep, `ConfidenceFilter` apply/clear/reseed/swap + %↔decimal conversions (24 tests)
- [x] `@useatlas/schemas` tuple tests
- [x] Local `type`, `lint`, `lint-type-aware`, `openapi-drift` + all drift gates green; full suite green except the known env-dependent `@atlas/mcp` smoke false-fail (needs a migrated DB — passes in remote CI)

Closes #4577