### PR TITLE
feat(learn): eligible-set — approval bypasses the confidence gate (#4571)

### DIFF
--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -333,6 +333,26 @@ describe("admin learned-patterns routes", () => {
       expect(sql).toContain("reviewed_at");
     });
 
+    it("approving a pattern never writes confidence — approval is an eligibility grant, not a confidence write (#4571)", async () => {
+      let callCount = 0;
+      mocks.mockInternalQuery.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([mockRow()]);
+        return Promise.resolve([mockRow({ status: "approved", reviewed_by: "admin-1" })]);
+      });
+
+      const res = await req("PATCH", "/pat-1", { status: "approved" });
+      expect(res.status).toBe(200);
+      const calls = mocks.mockInternalQuery.mock.calls;
+      const updateSql = calls[1][0] as string;
+      // The approve UPDATE must touch status/reviewer/auto_promoted only — never
+      // confidence. Confidence is the machine's evidence meter and no human
+      // action may mutate it (CONTEXT.md § Learned query patterns).
+      expect(updateSql).toContain("SET ");
+      expect(updateSql).toContain("auto_promoted = false");
+      expect(updateSql).not.toContain("confidence");
+    });
+
     it("returns 400 for invalid status", async () => {
       mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([mockRow()]));
       const res = await req("PATCH", "/pat-1", { status: "invalid" });

--- a/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns.test.ts
@@ -345,9 +345,9 @@ describe("admin learned-patterns routes", () => {
       expect(res.status).toBe(200);
       const calls = mocks.mockInternalQuery.mock.calls;
       const updateSql = calls[1][0] as string;
-      // The approve UPDATE must touch status/reviewer/auto_promoted only — never
-      // confidence. Confidence is the machine's evidence meter and no human
-      // action may mutate it (CONTEXT.md § Learned query patterns).
+      // The approve UPDATE touches status/reviewer/auto_promoted (plus
+      // timestamps) — never confidence. Confidence is the machine's evidence
+      // meter and no human action may mutate it (CONTEXT.md § Learned query patterns).
       expect(updateSql).toContain("SET ");
       expect(updateSql).toContain("auto_promoted = false");
       expect(updateSql).not.toContain("confidence");
@@ -407,6 +407,25 @@ describe("admin learned-patterns routes", () => {
       const body = (await res.json()) as any;
       expect(body.updated).toBeArray();
       expect(body.notFound).toBeArray();
+    });
+
+    it("bulk approve never writes confidence — the second human-action path is also confidence-safe (#4571)", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT")) return Promise.resolve([{ id: "pat-1" }]);
+        return Promise.resolve([mockRow({ status: "approved" })]);
+      });
+
+      const res = await req("POST", "/bulk", { ids: ["pat-1"], status: "approved" });
+      expect(res.status).toBe(200);
+      // The bulk UPDATE is a second human-action write path — assert it, like the
+      // single PATCH, touches auto_promoted but never confidence (AC: "No code
+      // path lets a human action mutate confidence").
+      const updateSql = mocks.mockInternalQuery.mock.calls
+        .map((c) => c[0] as string)
+        .find((sql) => sql.includes("UPDATE learned_patterns"));
+      expect(updateSql).toBeDefined();
+      expect(updateSql).toContain("auto_promoted = false");
+      expect(updateSql).not.toContain("confidence");
     });
 
     it("returns partial results for mixed ids", async () => {

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -530,7 +530,26 @@ describe("importBundle — learned-pattern amendment identity (#4569)", () => {
     expect(p[11]).toBe(3);
   });
 
-  it("defaults a pre-#4569 bundle (no amendment fields) to a query pattern", async () => {
+  it("carries the human-approval flag (#4571) so the eligibility bypass survives import", async () => {
+    const { client, calls } = captureClient();
+    await importBundle(client, bundleWithPatterns([
+      {
+        patternSql: "SELECT COUNT(*) FROM orders",
+        description: "Order count",
+        sourceEntity: "orders",
+        confidence: 0.1, // below threshold — only survives injection via the bypass
+        status: "approved",
+        autoPromoted: false,
+      },
+    ]), "org-test");
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO learned_patterns"));
+    expect(insert).toBeDefined();
+    // auto_promoted is the last INSERT column (param $13 → index 12).
+    expect(insert!.params[12]).toBe(false);
+  });
+
+  it("defaults a pre-#4569 bundle (no amendment fields) to a query pattern, failing closed on auto_promoted (#4571)", async () => {
     const { client, calls } = captureClient();
     await importBundle(client, bundleWithPatterns([
       {
@@ -551,5 +570,8 @@ describe("importBundle — learned-pattern amendment identity (#4569)", () => {
     expect(p[9]).toBeNull(); // reviewed_by
     expect(p[10]).toBeNull(); // reviewed_at
     expect(p[11]).toBe(1); // repetition_count default
+    // A pre-#4571 bundle omits auto_promoted → fail closed to machine/gated
+    // (true), so an old bundle can never grant an unearned confidence bypass.
+    expect(p[12]).toBe(true);
   });
 });

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -269,8 +269,8 @@ export async function importBundle(
     // already-decided row (its applied YAML travels in this same bundle's
     // `semantic_entities`), the same way a DB restore would.
     await client.query(
-      `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, confidence, status, type, amendment_payload, connection_group_id, reviewed_by, reviewed_at, repetition_count)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      `INSERT INTO learned_patterns (org_id, pattern_sql, description, source_entity, confidence, status, type, amendment_payload, connection_group_id, reviewed_by, reviewed_at, repetition_count, auto_promoted)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
       [
         orgId,
         pattern.patternSql,
@@ -284,6 +284,13 @@ export async function importBundle(
         pattern.reviewedBy ?? null,
         pattern.reviewedAt ?? null,
         pattern.repetitionCount ?? 1,
+        // Human vs machine approval road (#4571): carried so the injection
+        // eligibility bypass survives migration. A human-approved pattern
+        // (`false`) stays injectable regardless of confidence; a machine one
+        // (`true`) stays confidence-gated. Fail closed on absence — a pre-#4571
+        // bundle can't prove provenance, so default to machine/gated (`true`)
+        // rather than granting an unearned bypass.
+        pattern.autoPromoted ?? true,
       ],
     );
     result.learnedPatterns.imported++;

--- a/packages/api/src/lib/__tests__/pattern-injection.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-injection.test.ts
@@ -9,6 +9,11 @@ let mockApprovedPatterns: Array<{
   description: string | null;
   source_entity: string | null;
   confidence: number;
+  // #4571 — the eligible-set decision fields. Optional so existing fixtures that
+  // omit them read as machine-promoted (the gated road), which is the safe
+  // default; the bypass tests set `auto_promoted: false` explicitly.
+  auto_promoted?: boolean;
+  last_seen_at?: string | null;
 }> = [];
 
 let mockConfigLearn: { confidenceThreshold: number; retrievalTurns?: number } | undefined = {
@@ -446,6 +451,113 @@ describe("getRelevantPatterns", () => {
     expect(results.length).toBe(2);
     // Pattern 2 has more keyword overlap (revenue, region, companies)
     expect(results[0].patternSql).toContain("region");
+  });
+});
+
+// #4571 — the payoff seam: approval is an eligibility bypass, so a human-approved
+// pattern injects on the next turn regardless of confidence, while the confidence
+// gate still holds for machine-promoted rows. Exercised through the same cache →
+// getRelevantPatterns read path the agent uses.
+describe("approval is an eligibility bypass, not a confidence write (#4571)", () => {
+  beforeEach(() => {
+    _resetPatternCache();
+    mockApprovedPatterns = [];
+    mockConfigLearn = { confidenceThreshold: 0.7 };
+    mockGetApprovedPatternsError = null;
+  });
+
+  test("a human-approved low-confidence pattern is injectable on the next turn", async () => {
+    // Confidence 0.1 is far below the 0.7 threshold, but a human approved it
+    // (auto_promoted = false) → it must still surface.
+    mockApprovedPatterns = [
+      {
+        id: "1",
+        org_id: null,
+        pattern_sql: "SELECT SUM(revenue) FROM companies",
+        description: "Total revenue",
+        source_entity: "companies",
+        confidence: 0.1,
+        auto_promoted: false,
+      },
+    ];
+
+    const results = await getRelevantPatterns(null, "What is the total revenue?");
+    expect(results.length).toBe(1);
+    expect(results[0].patternSql).toContain("revenue");
+  });
+
+  test("a machine-promoted low-confidence pattern still gates on confidence", async () => {
+    // Same confidence 0.1, but this one reached approved via the nightly job
+    // (auto_promoted = true) → the gate still excludes it.
+    mockApprovedPatterns = [
+      {
+        id: "1",
+        org_id: null,
+        pattern_sql: "SELECT SUM(revenue) FROM companies",
+        description: "Total revenue",
+        source_entity: "companies",
+        confidence: 0.1,
+        auto_promoted: true,
+      },
+    ];
+
+    const results = await getRelevantPatterns(null, "What is the total revenue?");
+    expect(results.length).toBe(0);
+  });
+
+  test("approving flips eligibility across a cache invalidation (status flip → injectable)", async () => {
+    // Starts machine-promoted + below threshold → not injectable.
+    mockApprovedPatterns = [
+      {
+        id: "1",
+        org_id: "org-1",
+        pattern_sql: "SELECT SUM(revenue) FROM companies",
+        description: "Total revenue",
+        source_entity: "companies",
+        confidence: 0.2,
+        auto_promoted: true,
+      },
+    ];
+    const before = await getRelevantPatterns("org-1", "What is the total revenue?");
+    expect(before.length).toBe(0);
+
+    // A human approves it: auto_promoted → false (confidence UNCHANGED), and the
+    // approve path invalidates the org cache.
+    mockApprovedPatterns = [{ ...mockApprovedPatterns[0], auto_promoted: false }];
+    invalidatePatternCache("org-1");
+
+    const after = await getRelevantPatterns("org-1", "What is the total revenue?");
+    expect(after.length).toBe(1);
+    expect(after[0].patternSql).toContain("revenue");
+  });
+
+  test("a human-approved pattern survives a library larger than the old 100-row cap", async () => {
+    // 120 higher-confidence machine rows would have pushed a low-confidence human
+    // pattern past the old confidence-DESC 100-row pre-cut. The eligible set keeps
+    // it (all rows keyword-match, so relevance doesn't hide the regression).
+    const machineRows = Array.from({ length: 120 }, (_, i) => ({
+      id: `m${i}`,
+      org_id: null,
+      pattern_sql: "SELECT revenue FROM companies",
+      description: "revenue report",
+      source_entity: "companies",
+      confidence: 0.9,
+      auto_promoted: true,
+    }));
+    const humanLow = {
+      id: "human-low",
+      org_id: null,
+      pattern_sql: "SELECT SUM(revenue) FROM companies GROUP BY region",
+      description: "revenue by region",
+      source_entity: "companies",
+      confidence: 0.01,
+      auto_promoted: false,
+    };
+    mockApprovedPatterns = [...machineRows, humanLow];
+
+    // Ask for enough patterns that the human one can't be crowded out by relevance.
+    const results = await getRelevantPatterns(null, "revenue by region", null, 200);
+    expect(results.some((r) => r.patternSql.includes("GROUP BY region"))).toBe(true);
   });
 });
 

--- a/packages/api/src/lib/__tests__/pattern-injection.test.ts
+++ b/packages/api/src/lib/__tests__/pattern-injection.test.ts
@@ -521,9 +521,15 @@ describe("approval is an eligibility bypass, not a confidence write (#4571)", ()
     const before = await getRelevantPatterns("org-1", "What is the total revenue?");
     expect(before.length).toBe(0);
 
-    // A human approves it: auto_promoted → false (confidence UNCHANGED), and the
-    // approve path invalidates the org cache.
+    // A human approves it: auto_promoted → false (confidence UNCHANGED).
     mockApprovedPatterns = [{ ...mockApprovedPatterns[0], auto_promoted: false }];
+
+    // Negative control: WITHOUT invalidation the stale cached (machine, gated)
+    // copy is still served — this makes the invalidation load-bearing below.
+    const stale = await getRelevantPatterns("org-1", "What is the total revenue?");
+    expect(stale.length).toBe(0);
+
+    // The approve path invalidates the org cache → the next read reflects the flip.
     invalidatePatternCache("org-1");
 
     const after = await getRelevantPatterns("org-1", "What is the total revenue?");

--- a/packages/api/src/lib/db/__tests__/approved-patterns-injection-scoping-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/approved-patterns-injection-scoping-pg.test.ts
@@ -91,11 +91,13 @@ describeIfPg("getApprovedPatterns injection scoping (real Postgres, #4534)", () 
     description: string;
     sourceEntity: string;
     confidence?: number;
+    autoPromoted?: boolean;
+    lastSeenAt?: string | null;
   }): Promise<void> {
     await pool.query(
       `INSERT INTO learned_patterns
-         (org_id, type, status, pattern_sql, description, source_entity, confidence)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+         (org_id, type, status, pattern_sql, description, source_entity, confidence, auto_promoted, last_seen_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
       [
         row.orgId,
         row.type,
@@ -104,6 +106,8 @@ describeIfPg("getApprovedPatterns injection scoping (real Postgres, #4534)", () 
         row.description,
         row.sourceEntity,
         row.confidence ?? 0.9,
+        row.autoPromoted ?? false,
+        row.lastSeenAt ?? null,
       ],
     );
   }
@@ -194,6 +198,85 @@ describeIfPg("getApprovedPatterns injection scoping (real Postgres, #4534)", () 
         "SELECT * FROM shared_shape",
         "SELECT * FROM tenant_a_orders",
       ]);
+    },
+    PG_TIMEOUT_MS,
+  );
+});
+
+describeIfPg("getApprovedPatterns eligible-set ordering (real Postgres, #4571)", () => {
+  let pool: Pool;
+  const schemaName = `eligible_set_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL, options: `-c search_path=${schemaName}` });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    _resetPool(pool as unknown as InternalPool);
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    _resetPool(null);
+    _resetConfig();
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    await pool.query("DELETE FROM learned_patterns");
+  });
+
+  async function insert(row: {
+    patternSql: string;
+    confidence: number;
+    autoPromoted: boolean;
+    lastSeenAt?: string | null;
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO learned_patterns
+         (org_id, type, status, pattern_sql, description, source_entity, confidence, auto_promoted, last_seen_at)
+       VALUES ($1, 'query_pattern', 'approved', $2, 'd', 'e', $3, $4, $5)`,
+      ["org-a", row.patternSql, row.confidence, row.autoPromoted, row.lastSeenAt ?? null],
+    );
+  }
+
+  it(
+    "orders human-approved first, then confidence DESC, then last-observed DESC",
+    async () => {
+      // Machine, high confidence — but every human-approved row must still lead it.
+      await insert({ patternSql: "machine-high", confidence: 0.99, autoPromoted: true });
+      // Human, lowest confidence — leads the machine row but trails the 0.5 humans.
+      await insert({ patternSql: "human-low", confidence: 0.1, autoPromoted: false });
+      // Two human rows tie on confidence 0.5 → newer last_seen_at ranks first.
+      await insert({ patternSql: "human-old", confidence: 0.5, autoPromoted: false, lastSeenAt: "2026-01-01T00:00:00Z" });
+      await insert({ patternSql: "human-new", confidence: 0.5, autoPromoted: false, lastSeenAt: "2026-06-01T00:00:00Z" });
+
+      const rows = await getApprovedPatterns("org-a");
+      expect(rows.map((r) => r.pattern_sql)).toEqual([
+        "human-new", // human · 0.5 · newer
+        "human-old", // human · 0.5 · older
+        "human-low", // human · 0.1
+        "machine-high", // machine · 0.99 — last despite highest confidence
+      ]);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "the safety cap never truncates a low-confidence human-approved pattern (library > old 100-row cap)",
+    async () => {
+      // 120 higher-confidence machine rows would have pushed the human row past the
+      // old confidence-DESC LIMIT 100. Under the eligible-set ordering it sorts
+      // first, so the cap keeps it.
+      for (let i = 0; i < 120; i++) {
+        await insert({ patternSql: `machine-${i}`, confidence: 0.9, autoPromoted: true });
+      }
+      await insert({ patternSql: "human-low", confidence: 0.01, autoPromoted: false });
+
+      const rows = await getApprovedPatterns("org-a");
+      expect(rows[0].pattern_sql).toBe("human-low");
+      expect(rows.some((r) => r.pattern_sql === "human-low")).toBe(true);
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2318,8 +2318,9 @@ export interface ApprovedPatternRow {
    *  false for a human-approved pattern (#4571). Drives the eligible-set bypass:
    *  human-approved rows are eligible for injection regardless of confidence. */
   auto_promoted: boolean;
-  /** Last-observed timestamp (ISO text) or null until first observed. The
-   *  eligible-set saturation tiebreak among confidence ties (#4571). */
+  /** Last-observed timestamp as `timestamptz::text` (space-separated, not strict
+   *  ISO-8601; `Date.parse`-able), or null until first observed. The eligible-set
+   *  saturation tiebreak among confidence ties (#4571). */
   last_seen_at: string | null;
   [key: string]: unknown;
 }
@@ -2366,10 +2367,11 @@ export interface QuerySuggestionRow {
  * IS the default group, so only `connection_group_id IS NULL` rows match — this
  * keeps `us-prod` patterns out of a `eu-prod` agent session and vice-versa.
  *
- * Returns ALL approved query patterns for the scope — the confidence gate is NOT
- * applied here. Approval is an eligibility bypass, so a human-approved row must
- * reach the injection stage regardless of confidence; the gate applies to
- * machine-promoted rows and is enforced downstream by {@link selectEligiblePatterns}
+ * Applies NO confidence gate here (unlike a confidence-filtered fetch) — it
+ * returns every approved query pattern for the scope, up to the safety cap.
+ * Approval is an eligibility bypass, so a human-approved row must reach the
+ * injection stage regardless of confidence; the gate applies to machine-promoted
+ * rows and is enforced downstream by {@link selectEligiblePatterns}
  * (`getRelevantPatterns`). Ordered by the shared {@link ELIGIBLE_SET_ORDER_BY_SQL}
  * (human-approved first, then confidence DESC, then last-observed) and capped at
  * {@link ELIGIBLE_SET_SAFETY_CAP} — the ordering makes the cap keep every
@@ -2423,7 +2425,7 @@ export async function getApprovedPatterns(
   // `amendmentIdentityKey`), never a runnable query — injecting one as a query
   // pattern is garbage in the prompt. Mirrors the filter
   // `getPromoteDecayCandidates` already applies.
-  return internalQuery<ApprovedPatternRow>(
+  const rows = await internalQuery<ApprovedPatternRow>(
     `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence, avg_duration_ms, auto_promoted, last_seen_at::text AS last_seen_at
      FROM learned_patterns
      WHERE status = 'approved' AND type = 'query_pattern' AND ${orgClause} AND ${groupClause}
@@ -2431,6 +2433,19 @@ export async function getApprovedPatterns(
      LIMIT ${ELIGIBLE_SET_SAFETY_CAP}`,
     params,
   );
+
+  // Surface the PRD #4570 scaling-exit trigger: at exactly the cap the scope's
+  // approved-pattern library has hit the eligible-set ceiling and rows may be
+  // truncated at fetch — the actionable signal that full-text retrieval is due
+  // (silent truncation would otherwise be invisible to an operator).
+  if (rows.length === ELIGIBLE_SET_SAFETY_CAP) {
+    log.warn(
+      { orgId, connectionGroupId, cap: ELIGIBLE_SET_SAFETY_CAP },
+      "Approved-pattern eligible set hit the safety cap — scope is at the eligible-set ceiling (PRD #4570 full-text-retrieval trigger)",
+    );
+  }
+
+  return rows;
 }
 
 // ── Auto-promote / decay (PRD #3617 B-2, #3636) ─────────────────────

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2375,7 +2375,8 @@ export interface QuerySuggestionRow {
  * (`getRelevantPatterns`). Ordered by the shared {@link ELIGIBLE_SET_ORDER_BY_SQL}
  * (human-approved first, then confidence DESC, then last-observed) and capped at
  * {@link ELIGIBLE_SET_SAFETY_CAP} — the ordering makes the cap keep every
- * human-approved row plus the highest-confidence machine rows (#4571).
+ * human-approved row (up to the cap; see {@link ELIGIBLE_SET_SAFETY_CAP}) plus
+ * the highest-confidence machine rows (#4571).
  */
 export async function getApprovedPatterns(
   orgId: string | null,

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -26,6 +26,10 @@ import { resolveStatusClause } from "@atlas/api/lib/content-mode/port";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import { foldRollingMean } from "@atlas/api/lib/learn/rolling-mean";
 import {
+  ELIGIBLE_SET_ORDER_BY_SQL,
+  ELIGIBLE_SET_SAFETY_CAP,
+} from "@atlas/api/lib/learn/eligible-set";
+import {
   amendmentIdentityFromRow,
   amendmentIdentityKey,
   type AmendmentIdentityRow,
@@ -2310,6 +2314,13 @@ export interface ApprovedPatternRow {
   /** Rolling-mean wall-clock execution time (ms), or null until first observed
    *  (PRD #3617 B-0). Drives perf-weighted retrieval down-weighting (B-2). */
   avg_duration_ms: number | null;
+  /** True when the nightly auto-promote job promoted this row (machine road);
+   *  false for a human-approved pattern (#4571). Drives the eligible-set bypass:
+   *  human-approved rows are eligible for injection regardless of confidence. */
+  auto_promoted: boolean;
+  /** Last-observed timestamp (ISO text) or null until first observed. The
+   *  eligible-set saturation tiebreak among confidence ties (#4571). */
+  last_seen_at: string | null;
   [key: string]: unknown;
 }
 
@@ -2354,7 +2365,15 @@ export interface QuerySuggestionRow {
  * `entities/` scope). When `connectionGroupId` is null/omitted the active scope
  * IS the default group, so only `connection_group_id IS NULL` rows match — this
  * keeps `us-prod` patterns out of a `eu-prod` agent session and vice-versa.
- * Ordered by confidence DESC, capped at 100 rows.
+ *
+ * Returns ALL approved query patterns for the scope — the confidence gate is NOT
+ * applied here. Approval is an eligibility bypass, so a human-approved row must
+ * reach the injection stage regardless of confidence; the gate applies to
+ * machine-promoted rows and is enforced downstream by {@link selectEligiblePatterns}
+ * (`getRelevantPatterns`). Ordered by the shared {@link ELIGIBLE_SET_ORDER_BY_SQL}
+ * (human-approved first, then confidence DESC, then last-observed) and capped at
+ * {@link ELIGIBLE_SET_SAFETY_CAP} — the ordering makes the cap keep every
+ * human-approved row plus the highest-confidence machine rows (#4571).
  */
 export async function getApprovedPatterns(
   orgId: string | null,
@@ -2405,11 +2424,11 @@ export async function getApprovedPatterns(
   // pattern is garbage in the prompt. Mirrors the filter
   // `getPromoteDecayCandidates` already applies.
   return internalQuery<ApprovedPatternRow>(
-    `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence, avg_duration_ms
+    `SELECT id, org_id, connection_group_id, pattern_sql, description, source_entity, confidence, avg_duration_ms, auto_promoted, last_seen_at::text AS last_seen_at
      FROM learned_patterns
      WHERE status = 'approved' AND type = 'query_pattern' AND ${orgClause} AND ${groupClause}
-     ORDER BY confidence DESC
-     LIMIT 100`,
+     ORDER BY ${ELIGIBLE_SET_ORDER_BY_SQL}
+     LIMIT ${ELIGIBLE_SET_SAFETY_CAP}`,
     params,
   );
 }

--- a/packages/api/src/lib/learn/__tests__/eligible-set.test.ts
+++ b/packages/api/src/lib/learn/__tests__/eligible-set.test.ts
@@ -93,6 +93,16 @@ describe("compareEligibleOrder / selectEligiblePatterns — ordering", () => {
     const b = row({ id: "b", auto_promoted: false, confidence: 0.8, last_seen_at: null });
     expect(compareEligibleOrder(a, b)).toBe(0);
   });
+
+  test("last-observed tiebreak parses the real Postgres timestamptz::text format", () => {
+    // Production feeds `last_seen_at::text` — space-separated with a `+00` offset,
+    // NOT the strict-ISO `…T…Z` the other tests use. Pin that the comparator
+    // orders it chronologically (Date.parse handles it).
+    const older = row({ id: "older", auto_promoted: false, confidence: 0.8, last_seen_at: "2026-01-01 00:00:00+00" });
+    const newer = row({ id: "newer", auto_promoted: false, confidence: 0.8, last_seen_at: "2026-06-01 12:30:00+00" });
+    const ordered = selectEligiblePatterns([older, newer], THRESHOLD);
+    expect(ordered.map((r) => r.id)).toEqual(["newer", "older"]);
+  });
 });
 
 describe("selectEligiblePatterns — eligibility filter", () => {

--- a/packages/api/src/lib/learn/__tests__/eligible-set.test.ts
+++ b/packages/api/src/lib/learn/__tests__/eligible-set.test.ts
@@ -145,7 +145,7 @@ describe("shared ordering + cap constants", () => {
     // The two must agree by construction; pin the SQL fragment's shape so a change
     // to one is a visible diff against the other.
     expect(ELIGIBLE_SET_ORDER_BY_SQL).toBe(
-      "(auto_promoted = false) DESC, confidence DESC, last_seen_at DESC NULLS LAST",
+      "(auto_promoted = false) DESC, confidence DESC, learned_patterns.last_seen_at DESC NULLS LAST",
     );
   });
 

--- a/packages/api/src/lib/learn/__tests__/eligible-set.test.ts
+++ b/packages/api/src/lib/learn/__tests__/eligible-set.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from "bun:test";
+// eligible-set is PURE — zero db/settings/logger imports — so it imports directly
+// with no `mock.module()` at all (#4571), like `pattern-ranking` and
+// `rolling-mean`.
+import {
+  ELIGIBLE_SET_ORDER_BY_SQL,
+  ELIGIBLE_SET_SAFETY_CAP,
+  isHumanApproved,
+  isEligibleForInjection,
+  compareEligibleOrder,
+  selectEligiblePatterns,
+  type EligibilityFields,
+} from "@atlas/api/lib/learn/eligible-set";
+
+/** Minimal eligible-set row: an id (for identity asserts) plus the decision
+ *  fields. Extra fields ride through `selectEligiblePatterns`'s generic. */
+type Row = EligibilityFields & { id: string };
+
+function row(over: Partial<Row> & { id: string }): Row {
+  return {
+    confidence: 0.5,
+    auto_promoted: true, // machine by default; opt into human-approved explicitly
+    last_seen_at: null,
+    ...over,
+  };
+}
+
+const THRESHOLD = 0.7;
+
+describe("isHumanApproved", () => {
+  test("auto_promoted === false is human-approved", () => {
+    expect(isHumanApproved({ auto_promoted: false })).toBe(true);
+  });
+
+  test("auto_promoted === true is the machine road", () => {
+    expect(isHumanApproved({ auto_promoted: true })).toBe(false);
+  });
+
+  test("a partial row missing the flag is treated as machine (never grants the bypass)", () => {
+    // A fixture that forgot the flag must NOT accidentally earn the confidence
+    // bypass — fail closed to the gated road.
+    expect(isHumanApproved({} as { auto_promoted: boolean })).toBe(false);
+  });
+});
+
+describe("isEligibleForInjection — approval bypasses the confidence gate", () => {
+  test("a human-approved pattern below threshold is eligible (the bypass)", () => {
+    expect(isEligibleForInjection(row({ id: "h", auto_promoted: false, confidence: 0.01 }), THRESHOLD)).toBe(true);
+  });
+
+  test("a machine-promoted pattern below threshold is NOT eligible (the gate)", () => {
+    expect(isEligibleForInjection(row({ id: "m", auto_promoted: true, confidence: 0.69 }), THRESHOLD)).toBe(false);
+  });
+
+  test("a machine-promoted pattern at/above threshold is eligible", () => {
+    expect(isEligibleForInjection(row({ id: "m", auto_promoted: true, confidence: 0.7 }), THRESHOLD)).toBe(true);
+    expect(isEligibleForInjection(row({ id: "m2", auto_promoted: true, confidence: 0.95 }), THRESHOLD)).toBe(true);
+  });
+});
+
+describe("compareEligibleOrder / selectEligiblePatterns — ordering", () => {
+  test("human-approved first, even below a lower-confidence machine peer", () => {
+    const humanLow = row({ id: "human-low", auto_promoted: false, confidence: 0.1 });
+    const machineHigh = row({ id: "machine-high", auto_promoted: true, confidence: 0.99 });
+    const ordered = selectEligiblePatterns([machineHigh, humanLow], THRESHOLD);
+    expect(ordered.map((r) => r.id)).toEqual(["human-low", "machine-high"]);
+  });
+
+  test("within a road, confidence DESC", () => {
+    const a = row({ id: "a", auto_promoted: false, confidence: 0.4 });
+    const b = row({ id: "b", auto_promoted: false, confidence: 0.9 });
+    const c = row({ id: "c", auto_promoted: false, confidence: 0.6 });
+    const ordered = selectEligiblePatterns([a, b, c], THRESHOLD);
+    expect(ordered.map((r) => r.id)).toEqual(["b", "c", "a"]);
+  });
+
+  test("last-observed DESC breaks confidence ties (saturation tiebreak)", () => {
+    const older = row({ id: "older", auto_promoted: false, confidence: 0.8, last_seen_at: "2026-01-01T00:00:00Z" });
+    const newer = row({ id: "newer", auto_promoted: false, confidence: 0.8, last_seen_at: "2026-06-01T00:00:00Z" });
+    const ordered = selectEligiblePatterns([older, newer], THRESHOLD);
+    expect(ordered.map((r) => r.id)).toEqual(["newer", "older"]);
+  });
+
+  test("a never-observed (null last_seen_at) row sorts last among confidence ties", () => {
+    const seen = row({ id: "seen", auto_promoted: false, confidence: 0.8, last_seen_at: "2026-01-01T00:00:00Z" });
+    const unseen = row({ id: "unseen", auto_promoted: false, confidence: 0.8, last_seen_at: null });
+    const ordered = selectEligiblePatterns([unseen, seen], THRESHOLD);
+    expect(ordered.map((r) => r.id)).toEqual(["seen", "unseen"]);
+  });
+
+  test("compareEligibleOrder returns 0 for two never-observed confidence ties (stable, no NaN)", () => {
+    const a = row({ id: "a", auto_promoted: false, confidence: 0.8, last_seen_at: null });
+    const b = row({ id: "b", auto_promoted: false, confidence: 0.8, last_seen_at: null });
+    expect(compareEligibleOrder(a, b)).toBe(0);
+  });
+});
+
+describe("selectEligiblePatterns — eligibility filter", () => {
+  test("drops machine-promoted rows below threshold, keeps human-approved ones", () => {
+    const humanLow = row({ id: "human-low", auto_promoted: false, confidence: 0.05 });
+    const machineLow = row({ id: "machine-low", auto_promoted: true, confidence: 0.05 });
+    const machineHigh = row({ id: "machine-high", auto_promoted: true, confidence: 0.9 });
+    const eligible = selectEligiblePatterns([machineLow, machineHigh, humanLow], THRESHOLD);
+    expect(eligible.map((r) => r.id)).toEqual(["human-low", "machine-high"]);
+    expect(eligible.some((r) => r.id === "machine-low")).toBe(false);
+  });
+
+  test("no pre-relevance truncation can drop a human-approved pattern — library larger than the old 100-row cap", () => {
+    // Old behavior pre-cut to the top 100 by confidence DESC, which would push a
+    // low-confidence human-approved pattern out. The eligible set keeps it (and
+    // orders it first) regardless of how many higher-confidence machine rows exist.
+    const machineRows = Array.from({ length: 150 }, (_, i) =>
+      row({ id: `machine-${i}`, auto_promoted: true, confidence: 0.9 }),
+    );
+    const humanLow = row({ id: "human-low", auto_promoted: false, confidence: 0.01 });
+    const eligible = selectEligiblePatterns([...machineRows, humanLow], THRESHOLD);
+    expect(eligible).toHaveLength(151);
+    expect(eligible[0].id).toBe("human-low");
+    expect(eligible.some((r) => r.id === "human-low")).toBe(true);
+  });
+
+  test("does not mutate its input array", () => {
+    const input = [
+      row({ id: "a", auto_promoted: true, confidence: 0.9 }),
+      row({ id: "b", auto_promoted: false, confidence: 0.1 }),
+    ];
+    const snapshot = input.map((r) => r.id);
+    selectEligiblePatterns(input, THRESHOLD);
+    expect(input.map((r) => r.id)).toEqual(snapshot);
+  });
+});
+
+describe("shared ordering + cap constants", () => {
+  test("the SQL ORDER BY fragment matches the in-memory comparator's clauses", () => {
+    // The two must agree by construction; pin the SQL fragment's shape so a change
+    // to one is a visible diff against the other.
+    expect(ELIGIBLE_SET_ORDER_BY_SQL).toBe(
+      "(auto_promoted = false) DESC, confidence DESC, last_seen_at DESC NULLS LAST",
+    );
+  });
+
+  test("the safety cap is well above the old arbitrary 100-row pre-cut", () => {
+    expect(ELIGIBLE_SET_SAFETY_CAP).toBeGreaterThan(100);
+  });
+});

--- a/packages/api/src/lib/learn/__tests__/pattern-ranking.test.ts
+++ b/packages/api/src/lib/learn/__tests__/pattern-ranking.test.ts
@@ -15,6 +15,8 @@ function row(over: Partial<ApprovedPatternRow> & { id: string }): ApprovedPatter
     source_entity: "companies",
     confidence: 0.9,
     avg_duration_ms: null,
+    auto_promoted: true,
+    last_seen_at: null,
     ...over,
   };
 }

--- a/packages/api/src/lib/learn/eligible-set.ts
+++ b/packages/api/src/lib/learn/eligible-set.ts
@@ -40,19 +40,23 @@ export interface EligibilityFields {
   /** True when the nightly auto-promote job promoted this row (the machine road);
    *  false when a human approved it (the eligibility-bypass road). */
   readonly auto_promoted: boolean;
-  /** Last-observed timestamp (ISO string) or null until first observed. The
-   *  saturation tiebreak among confidence ties. */
+  /** Last-observed timestamp or null until first observed. In production this is
+   *  PostgreSQL `timestamptz::text` (space-separated, `+00` offset — not strict
+   *  ISO-8601), parsed leniently by `Date.parse`; unparseable/null sorts last.
+   *  The saturation tiebreak among confidence ties. */
   readonly last_seen_at: string | null;
 }
 
 /**
  * A generous per-(workspace, group) ceiling on the injectable set pulled from
  * the DB — replaces the old arbitrary 100-row confidence-DESC pre-cut (#4571).
- * High enough that the full eligible set of any real library fits (so no
- * human-approved pattern is ever truncated at fetch time, since they sort first
- * under {@link ELIGIBLE_SET_ORDER_BY_SQL}), while still bounding the pattern
- * cache's memory. Beyond this scale the recorded exit is full-text retrieval
- * (PRD #4570), adopted on evidence, not preemptively.
+ * High enough that the full eligible set of any real library fits: because
+ * human-approved rows sort first under {@link ELIGIBLE_SET_ORDER_BY_SQL}, the
+ * LIMIT drops only the lowest-confidence machine rows — no human-approved pattern
+ * is truncated at fetch time UNLESS a single (workspace, group) has more than
+ * this many human-approved patterns, the recorded exit to full-text retrieval
+ * (PRD #4570), adopted on evidence, not preemptively. Also bounds the pattern
+ * cache's memory.
  */
 export const ELIGIBLE_SET_SAFETY_CAP = 1000;
 
@@ -69,11 +73,14 @@ export const ELIGIBLE_SET_ORDER_BY_SQL =
 
 /**
  * Whether a human approved this pattern (as opposed to the nightly auto-promote
- * job). A pattern reaches `status = 'approved'` by exactly two roads: a human
- * review stamps `auto_promoted = false` (see `admin-learned-patterns.ts`), the
- * machine stamps `auto_promoted = true`. So `auto_promoted === false` IS "a
- * human approved this". A partial row missing the flag is treated as machine —
- * the gated road — so a fixture can never accidentally grant the bypass.
+ * job). A live review decision reaches `status = 'approved'` by two roads: a
+ * human review stamps `auto_promoted = false` (see `admin-learned-patterns.ts`),
+ * the machine stamps `auto_promoted = true` — so `auto_promoted === false` marks
+ * a human approval. (Workspace-bundle import replays an already-decided row
+ * carrying its recorded flag; a pre-#4571 bundle lacks it and fails closed to
+ * the machine road — see `admin-migrate.ts`.) A partial row missing the flag is
+ * likewise treated as machine, so a fixture can never accidentally grant the
+ * bypass.
  */
 export function isHumanApproved(row: Pick<EligibilityFields, "auto_promoted">): boolean {
   return row.auto_promoted === false;

--- a/packages/api/src/lib/learn/eligible-set.ts
+++ b/packages/api/src/lib/learn/eligible-set.ts
@@ -1,0 +1,135 @@
+/**
+ * The eligible set — the workspace-and-group's injectable learned query patterns,
+ * from which relevance picks per turn (#4571, CONTEXT.md § Learned query
+ * patterns).
+ *
+ * The ONE pure statement of injection eligibility + ordering, shared by both
+ * consumers so they can never drift (mirrors the briefing-assembly precedent in
+ * `semantic/expert/briefing.ts`):
+ *
+ *   - the SQL fetch (`getApprovedPatterns` in `db/internal.ts`) orders by
+ *     {@link ELIGIBLE_SET_ORDER_BY_SQL} under {@link ELIGIBLE_SET_SAFETY_CAP}, so
+ *     the LIMIT keeps human-approved rows and the highest-confidence machine rows;
+ *   - the in-memory relevance stage (`getRelevantPatterns` in `pattern-cache.ts`)
+ *     runs {@link selectEligiblePatterns} to apply the eligibility predicate and
+ *     the same ordering before keyword ranking.
+ *
+ * The domain rule this encodes (CONTEXT.md):
+ *   - **Approval is an eligibility bypass, not a confidence write.** A
+ *     human-approved pattern is eligible regardless of confidence.
+ *   - **Confidence gates the machine road only.** A machine-promoted pattern
+ *     must clear the confidence threshold to be eligible.
+ *   - **Ordering**: human-approved first (they never fall off any cap), then
+ *     confidence DESC, then last-observed DESC as the saturation tiebreak.
+ *
+ * PURE: no DB, no settings, no logger, no clock — a function of its inputs alone,
+ * so its tests import it directly with no `mock.module()` (like `rolling-mean.ts`
+ * and `pattern-ranking.ts`). It defines its own minimal {@link EligibilityFields}
+ * rather than importing the full `ApprovedPatternRow`, so it stays dependency-free
+ * and generic over any row that carries the three decision fields.
+ */
+
+/**
+ * The subset of a learned-pattern row the eligibility decision + ordering reads.
+ * A structural minimum so the helpers stay generic over `ApprovedPatternRow`
+ * (and any test fixture) without a runtime import of the DB layer.
+ */
+export interface EligibilityFields {
+  /** The machine's evidence meter (0–1). Gates the machine road only. */
+  readonly confidence: number;
+  /** True when the nightly auto-promote job promoted this row (the machine road);
+   *  false when a human approved it (the eligibility-bypass road). */
+  readonly auto_promoted: boolean;
+  /** Last-observed timestamp (ISO string) or null until first observed. The
+   *  saturation tiebreak among confidence ties. */
+  readonly last_seen_at: string | null;
+}
+
+/**
+ * A generous per-(workspace, group) ceiling on the injectable set pulled from
+ * the DB — replaces the old arbitrary 100-row confidence-DESC pre-cut (#4571).
+ * High enough that the full eligible set of any real library fits (so no
+ * human-approved pattern is ever truncated at fetch time, since they sort first
+ * under {@link ELIGIBLE_SET_ORDER_BY_SQL}), while still bounding the pattern
+ * cache's memory. Beyond this scale the recorded exit is full-text retrieval
+ * (PRD #4570), adopted on evidence, not preemptively.
+ */
+export const ELIGIBLE_SET_SAFETY_CAP = 1000;
+
+/**
+ * The canonical eligible-set ordering as a SQL `ORDER BY` fragment — human-
+ * approved first (`auto_promoted = false`), then confidence DESC, then
+ * last-observed DESC (NULLS LAST). {@link compareEligibleOrder} mirrors it
+ * clause-for-clause so the SQL fetch and the in-memory stage agree by
+ * construction. Referenced verbatim by `getApprovedPatterns`; it embeds no
+ * user input, so it is safe to interpolate.
+ */
+export const ELIGIBLE_SET_ORDER_BY_SQL =
+  "(auto_promoted = false) DESC, confidence DESC, last_seen_at DESC NULLS LAST";
+
+/**
+ * Whether a human approved this pattern (as opposed to the nightly auto-promote
+ * job). A pattern reaches `status = 'approved'` by exactly two roads: a human
+ * review stamps `auto_promoted = false` (see `admin-learned-patterns.ts`), the
+ * machine stamps `auto_promoted = true`. So `auto_promoted === false` IS "a
+ * human approved this". A partial row missing the flag is treated as machine —
+ * the gated road — so a fixture can never accidentally grant the bypass.
+ */
+export function isHumanApproved(row: Pick<EligibilityFields, "auto_promoted">): boolean {
+  return row.auto_promoted === false;
+}
+
+/**
+ * Whether a pattern is eligible for injection. Human approval is an
+ * unconditional eligibility grant (it bypasses the confidence gate); the gate
+ * applies ONLY to machine-promoted rows. This is the seam that makes an approved
+ * low-confidence pattern injectable on the next turn.
+ */
+export function isEligibleForInjection(row: EligibilityFields, confidenceThreshold: number): boolean {
+  return isHumanApproved(row) || row.confidence >= confidenceThreshold;
+}
+
+/** Numeric sort key for `last_seen_at` — the epoch millis, or -Infinity for
+ *  null/unparseable so those sort last under a DESC comparison (NULLS LAST). */
+function lastSeenRank(ts: string | null): number {
+  if (ts === null) return Number.NEGATIVE_INFINITY;
+  const parsed = Date.parse(ts);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+}
+
+/**
+ * Total order mirroring {@link ELIGIBLE_SET_ORDER_BY_SQL}: human-approved first,
+ * then confidence DESC, then last-observed DESC (NULLS LAST). Returns 0 on a
+ * genuine tie (both never-observed included) so the sort stays stable and never
+ * yields NaN.
+ */
+export function compareEligibleOrder(a: EligibilityFields, b: EligibilityFields): number {
+  // 1. Human-approved first — they never fall off any cap.
+  const humanRank = Number(isHumanApproved(b)) - Number(isHumanApproved(a));
+  if (humanRank !== 0) return humanRank;
+
+  // 2. Confidence DESC.
+  if (a.confidence !== b.confidence) return b.confidence - a.confidence;
+
+  // 3. Last-observed DESC, NULLS LAST — the saturation tiebreak.
+  const ra = lastSeenRank(a.last_seen_at);
+  const rb = lastSeenRank(b.last_seen_at);
+  if (ra === rb) return 0; // equal timestamps, or both null (both -Infinity)
+  return rb - ra;
+}
+
+/**
+ * The pure eligible-set selection: keep the injectable rows (human-approved
+ * unconditionally, machine-promoted only above the confidence threshold) and
+ * order them canonically. Generic over any row carrying {@link EligibilityFields}
+ * so it returns the caller's full row type unchanged for downstream ranking.
+ * Non-mutating (`toSorted`).
+ */
+export function selectEligiblePatterns<T extends EligibilityFields>(
+  rows: readonly T[],
+  confidenceThreshold: number,
+): T[] {
+  return rows
+    .filter((row) => isEligibleForInjection(row, confidenceThreshold))
+    .toSorted(compareEligibleOrder);
+}

--- a/packages/api/src/lib/learn/eligible-set.ts
+++ b/packages/api/src/lib/learn/eligible-set.ts
@@ -64,12 +64,15 @@ export const ELIGIBLE_SET_SAFETY_CAP = 1000;
  * The canonical eligible-set ordering as a SQL `ORDER BY` fragment — human-
  * approved first (`auto_promoted = false`), then confidence DESC, then
  * last-observed DESC (NULLS LAST). {@link compareEligibleOrder} mirrors it
- * clause-for-clause so the SQL fetch and the in-memory stage agree by
- * construction. Referenced verbatim by `getApprovedPatterns`; it embeds no
- * user input, so it is safe to interpolate.
+ * clause-for-clause. `last_seen_at` is table-qualified so the sort binds to the
+ * real `timestamptz` column (chronological) rather than the query's
+ * `last_seen_at::text` output alias (which would sort lexically) — that keeps it
+ * in agreement with the comparator's epoch-millis sort regardless of session
+ * timezone. Referenced verbatim by `getApprovedPatterns` (which selects `FROM
+ * learned_patterns`); it embeds no user input, so it is safe to interpolate.
  */
 export const ELIGIBLE_SET_ORDER_BY_SQL =
-  "(auto_promoted = false) DESC, confidence DESC, last_seen_at DESC NULLS LAST";
+  "(auto_promoted = false) DESC, confidence DESC, learned_patterns.last_seen_at DESC NULLS LAST";
 
 /**
  * Whether a human approved this pattern (as opposed to the nightly auto-promote

--- a/packages/api/src/lib/learn/pattern-cache.ts
+++ b/packages/api/src/lib/learn/pattern-cache.ts
@@ -25,6 +25,7 @@ import {
   getLatencyBudgetMs,
 } from "./learn-settings";
 import { extractKeywords, perfWeight, rankPatterns, type ScoredPattern } from "./pattern-ranking";
+import { selectEligiblePatterns } from "./eligible-set";
 import { getCachedPatterns, invalidatePatternCache, _resetPatternCache } from "./pattern-cache-store";
 
 // Public barrel — these moved into focused modules during the #3721 split (and
@@ -147,15 +148,18 @@ export async function getRelevantPatterns(
   const threshold = getConfidenceThreshold(orgId);
   const allPatterns = await getCachedPatterns(orgId, connectionGroupId);
 
-  // Filter by confidence threshold
-  const aboveThreshold = allPatterns.filter((p) => p.confidence >= threshold);
-  if (aboveThreshold.length === 0) return [];
+  // Select the eligible set: human-approved patterns bypass the confidence gate
+  // (approval is an eligibility grant, not a confidence write); machine-promoted
+  // patterns must clear the threshold. Ordering (human-approved first, then
+  // confidence, then last-observed) mirrors the SQL fetch so the two never drift.
+  const eligible = selectEligiblePatterns(allPatterns, threshold);
+  if (eligible.length === 0) return [];
 
   // Score by keyword relevance, down-weighting (not excluding) slow patterns.
   const questionKeywords = extractKeywords(question);
   if (questionKeywords.size === 0) return [];
 
-  const scored = rankPatterns(aboveThreshold, questionKeywords, {
+  const scored = rankPatterns(eligible, questionKeywords, {
     latencyBudgetMs: getLatencyBudgetMs(orgId),
     maxPatterns,
   });

--- a/packages/api/src/lib/residency/__tests__/export.test.ts
+++ b/packages/api/src/lib/residency/__tests__/export.test.ts
@@ -173,6 +173,24 @@ describe("exportWorkspaceBundle", () => {
     expect(bundle.manifest.counts.learnedPatterns).toBe(1);
   });
 
+  it("carries the machine-promoted flag (#4571) so a migrated pattern stays confidence-gated", async () => {
+    mockPoolQueryResults["FROM learned_patterns"] = {
+      rows: [
+        {
+          pattern_sql: "SELECT COUNT(*) FROM orders",
+          description: "Order count",
+          source_entity: "orders",
+          confidence: 0.9,
+          status: "approved",
+          auto_promoted: true,
+        },
+      ],
+    };
+
+    const bundle = await exportWorkspaceBundle("org-1");
+    expect(bundle.learnedPatterns[0].autoPromoted).toBe(true);
+  });
+
   it("exports org-scoped settings", async () => {
     mockPoolQueryResults["FROM settings"] = {
       rows: [

--- a/packages/api/src/lib/residency/__tests__/export.test.ts
+++ b/packages/api/src/lib/residency/__tests__/export.test.ts
@@ -157,6 +157,7 @@ describe("exportWorkspaceBundle", () => {
           source_entity: "users",
           confidence: 0.9,
           status: "approved",
+          auto_promoted: false,
         },
       ],
     };
@@ -166,6 +167,9 @@ describe("exportWorkspaceBundle", () => {
     expect(bundle.learnedPatterns).toHaveLength(1);
     expect(bundle.learnedPatterns[0].patternSql).toBe("SELECT COUNT(*) FROM users");
     expect(bundle.learnedPatterns[0].confidence).toBe(0.9);
+    // Human-approval provenance carried so the eligibility bypass survives the
+    // region migration (#4571).
+    expect(bundle.learnedPatterns[0].autoPromoted).toBe(false);
     expect(bundle.manifest.counts.learnedPatterns).toBe(1);
   });
 

--- a/packages/api/src/lib/residency/export.ts
+++ b/packages/api/src/lib/residency/export.ts
@@ -116,7 +116,7 @@ export async function exportWorkspaceBundle(
 
   // --- 3. Learned patterns ---
   const patternResult = await pool.query(
-    `SELECT pattern_sql, description, source_entity, confidence, status
+    `SELECT pattern_sql, description, source_entity, confidence, status, auto_promoted
      FROM learned_patterns WHERE org_id = $1
      ORDER BY created_at ASC`,
     [orgId],
@@ -128,6 +128,9 @@ export async function exportWorkspaceBundle(
     sourceEntity: (p.source_entity as string | null) ?? null,
     confidence: p.confidence as number,
     status: p.status as ExportedLearnedPattern["status"],
+    // Human vs machine approval road (#4571) — carried so the injection
+    // eligibility bypass survives region migration. Column is NOT NULL.
+    autoPromoted: Boolean(p.auto_promoted),
   }));
 
   // --- 4. Org-scoped settings ---

--- a/packages/cli/src/__tests__/operator-export-patterns.test.ts
+++ b/packages/cli/src/__tests__/operator-export-patterns.test.ts
@@ -90,6 +90,7 @@ describe("atlas-operator export — learned-pattern projection (#4569)", () => {
         reviewed_by: "admin-1",
         reviewed_at: "2026-07-10T12:00:00Z",
         repetition_count: 3,
+        auto_promoted: false,
       },
     ];
 
@@ -102,6 +103,30 @@ describe("atlas-operator export — learned-pattern projection (#4569)", () => {
     expect(p.reviewedBy).toBe("admin-1");
     expect(p.reviewedAt).toBe("2026-07-10T12:00:00Z");
     expect(p.repetitionCount).toBe(3);
+    // Human-approved provenance carried so the eligibility bypass survives (#4571).
+    expect(p.autoPromoted).toBe(false);
+  });
+
+  it("carries the machine-promoted flag (#4571) so a migrated pattern stays confidence-gated", async () => {
+    learnedRows = [
+      {
+        pattern_sql: "SELECT COUNT(*) FROM orders",
+        description: "Order count",
+        source_entity: "orders",
+        confidence: 0.9,
+        status: "approved",
+        type: "query_pattern",
+        amendment_payload: null,
+        connection_group_id: null,
+        reviewed_by: "atlas-auto-promote",
+        reviewed_at: "2026-07-10T12:00:00Z",
+        repetition_count: 6,
+        auto_promoted: true,
+      },
+    ];
+
+    const bundle = await runExport();
+    expect(bundle.learnedPatterns[0].autoPromoted).toBe(true);
   });
 
   it("defaults a legacy row (null type / null payload) to a query pattern", async () => {

--- a/packages/cli/src/commands/operator/export.ts
+++ b/packages/cli/src/commands/operator/export.ts
@@ -105,7 +105,7 @@ export async function handleExport(args: string[]): Promise<void> {
     // amendment instead of round-tripping as an orphaned query pattern.
     const patRows = await pool.query(
       `SELECT pattern_sql, description, source_entity, confidence, status,
-              type, amendment_payload, connection_group_id, reviewed_by, reviewed_at, repetition_count
+              type, amendment_payload, connection_group_id, reviewed_by, reviewed_at, repetition_count, auto_promoted
        FROM learned_patterns
        WHERE ${orgClause}
        ORDER BY created_at`,
@@ -124,6 +124,9 @@ export async function handleExport(args: string[]): Promise<void> {
         reviewedBy: (r.reviewed_by as string) ?? null,
         reviewedAt: r.reviewed_at ? String(r.reviewed_at) : null,
         repetitionCount: (r.repetition_count as number) ?? 1,
+        // Human vs machine approval road (#4571) — carried so the eligibility
+        // bypass survives migration. Column is NOT NULL, so coerce defensively.
+        autoPromoted: Boolean(r.auto_promoted),
       }),
     );
     console.log(`  Patterns:      ${learnedPatterns.length}`);

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -107,6 +107,16 @@ export interface ExportedLearnedPattern {
   reviewedAt?: string | null;
   /** Observed repetition count — pattern/amendment strength; absent ⇒ 1. */
   repetitionCount?: number;
+  /**
+   * Which road reached `status = 'approved'` (#4571): `false` = a human approved
+   * it, `true` = the nightly auto-promote job did. Carried so the injection
+   * eligibility bypass survives workspace migration — a human-approved pattern
+   * stays human-approved (injectable regardless of confidence), a machine-promoted
+   * one stays confidence-gated. Optional for backward-compat with pre-#4571
+   * bundles; the importer fails closed on absence (treats it as machine/gated) so
+   * an old bundle can never grant an unearned bypass.
+   */
+  autoPromoted?: boolean;
 }
 
 /** Exported setting key/value pair. */


### PR DESCRIPTION
## Summary

The payoff slice of the Learned-Patterns Elevation: **approving a query pattern is an injection-eligibility grant, not a confidence write** (CONTEXT.md § Learned query patterns). A human-approved pattern is now injectable immediately, regardless of its confidence; the confidence gate applies **only** to machine-promoted rows.

- **New pure module `lib/learn/eligible-set.ts`** — the single statement of injection eligibility + ordering, shared by both consumers so they can't drift (mirrors the briefing-assembly precedent):
  - the SQL fetch (`getApprovedPatterns`) orders by the shared `ELIGIBLE_SET_ORDER_BY_SQL` under `ELIGIBLE_SET_SAFETY_CAP`;
  - the in-memory relevance stage (`getRelevantPatterns`) runs `selectEligiblePatterns` to apply the eligibility predicate + the same ordering before keyword ranking.
- **Approval is an eligibility bypass:** human-approved (`auto_promoted = false`) rows are eligible regardless of confidence; machine-promoted rows still gate on the threshold. A partial/unknown row fails closed to the machine (gated) road.
- **Ordering:** human-approved first (they never fall off any cap), then confidence DESC, then last-observed DESC as the saturation tiebreak.
- **Removed the arbitrary 100-row confidence-DESC pre-cut** in favour of the full per-(workspace, group) eligible set under a high safety cap (`1000`); `getApprovedPatterns` warns when it hits the cap (the PRD #4570 full-text-retrieval trigger).
- **No code path lets a human action mutate confidence** — approve writes status/reviewer/`auto_promoted` only (single PATCH + bulk paths both pinned by a route seam test).
- **Bundle fidelity:** carried `auto_promoted` through the workspace/region migration bundle (`ExportedLearnedPattern.autoPromoted`, both exporters + import) so the eligibility bypass survives migration — without it, a re-imported machine-promoted row silently earned the bypass. Import fails closed on a pre-#4571 bundle.
- Keeps the existing keyword relevance scorer + short-TTL cache. Full-text retrieval is explicitly out of scope (the recorded scaling exit).

## Test plan

- [x] Eligible-set pure-module tests: human-approved-first ordering, bypass-below-threshold, last-observed tiebreak (incl. real Postgres `timestamptz::text` format), fail-closed on missing flag, no-truncation with a library > the old cap
- [x] Injection/cache seam: approving a low-confidence pattern makes it injectable next turn; machine-promoted low-confidence still gated; cache invalidation on status flip (with a negative control)
- [x] Route seam: approve (single + bulk) never writes `confidence`
- [x] Real-Postgres ordering + safety-cap no-truncation (`approved-patterns-injection-scoping-pg.test.ts`)
- [x] Migration round-trip: `autoPromoted` carried on both exporters + import (both roads + fail-closed default)
- [x] tsgo typecheck (api + cli) clean; 28/30 `/ci` gates green (the `test` gate's only failures were shared-dev-DB `-pg` contention — all pass in isolation — and one pre-existing flake that fails 6/6 on clean `main` vs 4/6 here)

Closes #4571