### PR TITLE
fix(learned-patterns): governance parity — bulk + description audit, fail-closed org scope

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -277,6 +277,18 @@ export function buildInternalDbMockDefaults(deps: {
     stampClaimedAmendmentApproved: mock(async () => false),
     releaseClaimedAmendment: mock(async () => false),
     rejectPendingAmendment: mock(async () => false),
+    // Shared org-scope helper (#4510), adopted by the learned-patterns route in
+    // #4580. Returns the SELF-HOSTED clause, matching this harness's pinned
+    // `isSaasModeForGuard: () => false` (Settings mock below). The full
+    // SaaS/self-hosted branch matrix — including the SaaS org-less withhold — is
+    // pinned against the REAL helper in
+    // db/__tests__/semantic-amendment-saas-scoping.test.ts, so route suites
+    // don't need to re-drive deploy mode here. Present so a route's `import
+    // { amendmentOrgScope }` never SyntaxErrors at load time under this mock.
+    amendmentOrgScope: (orgId: string | null, placeholder: string) =>
+      orgId
+        ? { withhold: false, clause: `(org_id = ${placeholder} OR org_id IS NULL)` }
+        : { withhold: false, clause: "org_id IS NULL" },
     AMENDMENT_CLAIM_STALE_MINUTES: 10,
     hardDeleteWorkspace: mock(async () => ({})),
   

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -149,6 +149,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -148,6 +148,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -141,6 +141,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   isPlaintextUrl: (value: string) => /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value),
   _resetEncryptionKeyCache: mock(() => {}),
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-learned-patterns-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-audit.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Governance-parity audit suite for `admin-learned-patterns.ts` — #4580
+ * (PRD #4570).
+ *
+ * Pins every write route to the canonical `ADMIN_ACTIONS.pattern.*` vocabulary
+ * and the metadata shape forensic queries expect. The two governance gaps this
+ * PRD closes:
+ *   1. Bulk decisions were forensically SILENT — a bulk approve/reject of up to
+ *      100 patterns wrote no audit rows. They now write ONE row per decided
+ *      pattern using the SAME `pattern.approve` / `pattern.reject` vocabulary as
+ *      the single-decision PATCH path (one vocabulary per concept now that
+ *      amendments are folded out of this route, #4569).
+ *   2. Description-only edits changed the human-facing text other reviewers
+ *      trust with no trace. They now write a `pattern.update_description` row.
+ *
+ * Test pattern modeled on `admin-prompts-audit.test.ts` (F-35).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// ---------------------------------------------------------------------------
+// Mocks — set up before app import
+// ---------------------------------------------------------------------------
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+});
+
+interface AuditEntry {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  status?: "success" | "failure";
+  scope?: "platform" | "workspace";
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+const mockLogAdminAction: Mock<(entry: AuditEntry) => void> = mock(() => {});
+
+void mock.module("@atlas/api/lib/audit", async () => {
+  // Mock every barrel export (docs/development/testing.md "Mock all exports"):
+  // spread the real `ADMIN_ACTIONS` + error-scrub helpers so a transitive
+  // `import { errorMessage }` never SyntaxErrors at app-load time; only the two
+  // write functions are spied.
+  const actions = await import("@atlas/api/lib/audit/actions");
+  const scrub = await import("@atlas/api/lib/audit/error-scrub");
+  return {
+    logAdminAction: mockLogAdminAction,
+    logAdminActionAwait: mock(async () => {}),
+    ADMIN_ACTIONS: actions.ADMIN_ACTIONS,
+    errorMessage: scrub.errorMessage,
+    causeToError: scrub.causeToError,
+  };
+});
+
+const { app } = await import("../index");
+
+afterAll(() => mocks.cleanup());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function req(method: string, urlPath: string, body?: unknown) {
+  const url = `http://localhost/api/v1/admin/learned-patterns${urlPath}`;
+  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+  return app.fetch(new Request(url, init));
+}
+
+function auditCalls(actionType?: string): AuditEntry[] {
+  const all = mockLogAdminAction.mock.calls.map((c) => c[0]!);
+  return actionType ? all.filter((e) => e.actionType === actionType) : all;
+}
+
+function mockRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "pat-1",
+    org_id: "org-1",
+    pattern_sql: "SELECT COUNT(*) FROM orders",
+    description: "Order count",
+    source_entity: "orders",
+    source_queries: ["audit-1"],
+    confidence: 0.8,
+    repetition_count: 5,
+    status: "pending",
+    proposed_by: "agent",
+    reviewed_by: null,
+    created_at: "2026-03-18T00:00:00Z",
+    updated_at: "2026-03-18T00:00:00Z",
+    reviewed_at: null,
+    type: "query_pattern",
+    amendment_payload: null,
+    connection_group_id: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "admin@test.com", role: "admin", activeOrganizationId: "org-1" },
+    }),
+  );
+  mocks.hasInternalDB = true;
+  mockLogAdminAction.mockClear();
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /:id — description-only edit audit (#4580 AC: description edit audited)
+// ---------------------------------------------------------------------------
+
+describe("PATCH /:id — description edit audit (#4580)", () => {
+  function mockExistThenUpdate(updatedOverrides: Record<string, unknown>) {
+    let call = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.resolve([mockRow()]); // existence SELECT
+      return Promise.resolve([mockRow(updatedOverrides)]); // UPDATE RETURNING *
+    });
+  }
+
+  it("emits pattern.update_description on a description-only edit", async () => {
+    mockExistThenUpdate({ description: "Updated" });
+    const res = await req("PATCH", "/pat-1", { description: "Updated" });
+    expect(res.status).toBe(200);
+
+    const desc = auditCalls("pattern.update_description");
+    expect(desc).toHaveLength(1);
+    expect(desc[0].targetType).toBe("pattern");
+    expect(desc[0].targetId).toBe("pat-1");
+    expect(desc[0].metadata).toMatchObject({ patternId: "pat-1" });
+    // A description-only edit is not a decision — no approve/reject row.
+    expect(auditCalls("pattern.approve")).toHaveLength(0);
+    expect(auditCalls("pattern.reject")).toHaveLength(0);
+  });
+
+  it("does NOT emit update_description when only status changes", async () => {
+    mockExistThenUpdate({ status: "approved", reviewed_by: "admin-1", reviewed_at: "2026-03-18T00:00:00Z" });
+    const res = await req("PATCH", "/pat-1", { status: "approved" });
+    expect(res.status).toBe(200);
+
+    expect(auditCalls("pattern.update_description")).toHaveLength(0);
+    expect(auditCalls("pattern.approve")).toHaveLength(1);
+  });
+
+  it("emits BOTH rows when a PATCH changes description AND status (two governance events)", async () => {
+    mockExistThenUpdate({ description: "Updated", status: "approved", reviewed_by: "admin-1" });
+    const res = await req("PATCH", "/pat-1", { description: "Updated", status: "approved" });
+    expect(res.status).toBe(200);
+
+    expect(auditCalls("pattern.update_description")).toHaveLength(1);
+    expect(auditCalls("pattern.approve")).toHaveLength(1);
+    expect(auditCalls("pattern.reject")).toHaveLength(0);
+  });
+
+  it("emits pattern.approve / pattern.reject with patternId metadata on a status decision", async () => {
+    mockExistThenUpdate({ status: "rejected", reviewed_by: "admin-1" });
+    const res = await req("PATCH", "/pat-1", { status: "rejected" });
+    expect(res.status).toBe(200);
+    const reject = auditCalls("pattern.reject");
+    expect(reject).toHaveLength(1);
+    expect(reject[0].targetType).toBe("pattern");
+    expect(reject[0].targetId).toBe("pat-1");
+    expect(reject[0].metadata).toMatchObject({ patternId: "pat-1" });
+  });
+
+  it("writes NO audit row when the pattern does not exist (404)", async () => {
+    mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const res = await req("PATCH", "/missing", { description: "Updated" });
+    expect(res.status).toBe(404);
+    expect(auditCalls()).toHaveLength(0);
+  });
+
+  it("emits ONLY update_description when a PATCH edits description AND un-approves to pending", async () => {
+    // An un-approve (approved → pending) is not an approve/reject decision, so
+    // description + pending emits the description row and NO decision row.
+    mockExistThenUpdate({ description: "Updated", status: "pending", reviewed_by: "admin-1" });
+    const res = await req("PATCH", "/pat-1", { description: "Updated", status: "pending" });
+    expect(res.status).toBe(200);
+    expect(auditCalls("pattern.update_description")).toHaveLength(1);
+    expect(auditCalls("pattern.approve")).toHaveLength(0);
+    expect(auditCalls("pattern.reject")).toHaveLength(0);
+  });
+
+  it("writes NO audit row when the row is deleted before the update lands (404)", async () => {
+    // Existence check passes, but the UPDATE ... RETURNING * comes back empty
+    // (a concurrent delete). Audit fires only after a confirmed mutation.
+    let call = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.resolve([mockRow()]); // existence
+      return Promise.resolve([]); // UPDATE returns nothing
+    });
+    const res = await req("PATCH", "/pat-1", { description: "Updated" });
+    expect(res.status).toBe(404);
+    expect(auditCalls()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /:id — audit (existing behavior, pinned for completeness)
+// ---------------------------------------------------------------------------
+
+describe("DELETE /:id — audit", () => {
+  it("emits pattern.delete with patternId metadata", async () => {
+    let call = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.resolve([mockRow()]);
+      return Promise.resolve([]);
+    });
+    const res = await req("DELETE", "/pat-1");
+    expect(res.status).toBe(200);
+    const del = auditCalls("pattern.delete");
+    expect(del).toHaveLength(1);
+    expect(del[0].targetId).toBe("pat-1");
+    expect(del[0].metadata).toMatchObject({ patternId: "pat-1" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /bulk — one audit row per decided pattern (#4580 AC: bulk audit rows)
+// ---------------------------------------------------------------------------
+
+describe("POST /bulk — audit rows (#4580)", () => {
+  it("writes ONE pattern.approve row per updated pattern, with matching targetIds", async () => {
+    // Every existence SELECT finds the row; every UPDATE succeeds.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT")) return Promise.resolve([{ id: "x", type: "query_pattern" }]);
+      return Promise.resolve([]);
+    });
+
+    const res = await req("POST", "/bulk", { ids: ["pat-1", "pat-2", "pat-3"], status: "approved" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { updated: string[] };
+    expect(body.updated).toEqual(["pat-1", "pat-2", "pat-3"]);
+
+    const approve = auditCalls("pattern.approve");
+    expect(approve).toHaveLength(3);
+    expect(approve.map((e) => e.targetId).sort()).toEqual(["pat-1", "pat-2", "pat-3"]);
+    for (const e of approve) {
+      expect(e.targetType).toBe("pattern");
+      expect(e.metadata).toMatchObject({ patternId: e.targetId });
+    }
+    // Bulk uses the SAME vocabulary as single decisions — never a distinct
+    // "bulk" action type.
+    expect(auditCalls("pattern.reject")).toHaveLength(0);
+  });
+
+  it("uses pattern.reject vocabulary for a bulk reject", async () => {
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT")) return Promise.resolve([{ id: "x", type: "query_pattern" }]);
+      return Promise.resolve([]);
+    });
+    const res = await req("POST", "/bulk", { ids: ["pat-1", "pat-2"], status: "rejected" });
+    expect(res.status).toBe(200);
+    expect(auditCalls("pattern.reject")).toHaveLength(2);
+    expect(auditCalls("pattern.approve")).toHaveLength(0);
+  });
+
+  it("audits ONLY the ids that changed — notFound ids leave no row", async () => {
+    let selectCall = 0;
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT")) {
+        selectCall++;
+        // First id exists, second is missing.
+        return Promise.resolve(selectCall === 1 ? [{ id: "pat-1", type: "query_pattern" }] : []);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await req("POST", "/bulk", { ids: ["pat-1", "pat-missing"], status: "approved" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { updated: string[]; notFound: string[] };
+    expect(body.updated).toEqual(["pat-1"]);
+    expect(body.notFound).toEqual(["pat-missing"]);
+
+    const approve = auditCalls("pattern.approve");
+    expect(approve).toHaveLength(1);
+    expect(approve[0].targetId).toBe("pat-1");
+  });
+
+  it("writes NO audit rows when nothing was updated", async () => {
+    // Every SELECT is empty → all notFound, zero updated.
+    mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const res = await req("POST", "/bulk", { ids: ["a", "b"], status: "approved" });
+    expect(res.status).toBe(200);
+    expect(auditCalls()).toHaveLength(0);
+  });
+
+  it("audits only the succeeding id when a sibling's UPDATE throws mid-bulk", async () => {
+    // Both ids pass the existence check; the UPDATE for "pat-err" throws. The
+    // erroring id lands in `errors` with NO audit row; its sibling succeeds and
+    // gets exactly one.
+    mocks.mockInternalQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      if (sql.includes("SELECT")) return Promise.resolve([{ id: "x", type: "query_pattern" }]);
+      // UPDATE — params are [status, reviewerId, id].
+      if ((params as unknown[])[2] === "pat-err") return Promise.reject(new Error("update boom"));
+      return Promise.resolve([]);
+    });
+
+    const res = await req("POST", "/bulk", { ids: ["pat-ok", "pat-err"], status: "approved" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { updated: string[]; errors?: Array<{ id: string }> };
+    expect(body.updated).toEqual(["pat-ok"]);
+    expect(body.errors?.map((e) => e.id)).toEqual(["pat-err"]);
+
+    const approve = auditCalls("pattern.approve");
+    expect(approve).toHaveLength(1);
+    expect(approve[0].targetId).toBe("pat-ok");
+  });
+});

--- a/packages/api/src/api/__tests__/admin-learned-patterns-fail-closed.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-fail-closed.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Fail-closed org-scope handling for `admin-learned-patterns.ts` — #4580.
+ *
+ * The security core of #4580: when the shared org-scope helper WITHHOLDS
+ * (`{ withhold: true }` — the SaaS org-less arm, where falling back to
+ * `org_id IS NULL` would broaden the scan to every global-scope row), each route
+ * handler must return its EMPTY value (empty page / 404 / notFound) WITHOUT
+ * issuing a scoped query. The old local helper fell open there; this pins that
+ * the new one never does.
+ *
+ * `requireOrgContext` 400s an org-less request before any handler, so this path
+ * is structurally unreachable in production — it is defense-in-depth. But it is
+ * the literal fail-closed guarantee, so we drive it directly by injecting a
+ * withhold-always `amendmentOrgScope` via the harness's `internal` override
+ * (the real branch matrix that DECIDES when to withhold is pinned against the
+ * real helper in `db/__tests__/semantic-amendment-saas-scoping.test.ts`).
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+  // Force the fail-closed arm on every handler: the shared helper withholds.
+  internal: { amendmentOrgScope: () => ({ withhold: true }) },
+});
+
+const { app } = await import("../index");
+
+function req(method: string, urlPath: string, body?: unknown) {
+  const url = `http://localhost/api/v1/admin/learned-patterns${urlPath}`;
+  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+  return app.fetch(new Request(url, init));
+}
+
+/** SQL strings issued against the learned_patterns table this request. */
+function learnedPatternSql(): string[] {
+  return mocks.mockInternalQuery.mock.calls
+    .map((c) => c[0] as string)
+    .filter((s) => s.includes("learned_patterns"));
+}
+
+afterAll(() => mocks.cleanup());
+
+beforeEach(() => {
+  mocks.mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+  );
+  mocks.hasInternalDB = true;
+  mocks.mockInternalQuery.mockReset();
+  // Any scoped query that DID run would return a row — so a test that still
+  // sees the empty shape proves the handler short-circuited before querying.
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ id: "pat-1", count: "5", type: "query_pattern" }]));
+  mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+});
+
+describe("learned-patterns fail-closed org scope — withhold short-circuits every handler (#4580)", () => {
+  it("LIST returns an empty page and never queries learned_patterns", async () => {
+    const res = await req("GET", "/");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { patterns: unknown[]; total: number };
+    expect(body.patterns).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(learnedPatternSql()).toHaveLength(0);
+  });
+
+  it("GET /:id 404s without querying", async () => {
+    const res = await req("GET", "/pat-1");
+    expect(res.status).toBe(404);
+    expect(learnedPatternSql()).toHaveLength(0);
+  });
+
+  it("PATCH 404s without querying (existence check short-circuits)", async () => {
+    const res = await req("PATCH", "/pat-1", { description: "x" });
+    expect(res.status).toBe(404);
+    expect(learnedPatternSql()).toHaveLength(0);
+  });
+
+  it("DELETE 404s without querying", async () => {
+    const res = await req("DELETE", "/pat-1");
+    expect(res.status).toBe(404);
+    expect(learnedPatternSql()).toHaveLength(0);
+  });
+
+  it("bulk treats every id as notFound, updates nothing, and never queries", async () => {
+    const res = await req("POST", "/bulk", { ids: ["pat-1", "pat-2"], status: "approved" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { updated: string[]; notFound: string[] };
+    expect(body.updated).toEqual([]);
+    expect(body.notFound).toEqual(["pat-1", "pat-2"]);
+    expect(learnedPatternSql()).toHaveLength(0);
+  });
+});

--- a/packages/api/src/api/__tests__/admin-learned-patterns-org-scope.test.ts
+++ b/packages/api/src/api/__tests__/admin-learned-patterns-org-scope.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Org-scope governance for `admin-learned-patterns.ts` — #4580 (PRD #4570).
+ *
+ * #4580 converges the route's org filter onto the shared helper
+ * `amendmentOrgScope` (the SaaS-vs-self-hosted `org_id` conditional). This has
+ * two effects: (1) on the org-LESS SaaS arm it fails CLOSED (WITHHOLD) instead of
+ * the old fall-open `org_id IS NULL`; (2) on the self-hosted + org arm — the
+ * operative path here, since `requireOrgContext` guarantees an org — it WIDENS
+ * from the old `org_id = $N` to `(org_id = $N OR org_id IS NULL)`, matching the
+ * agent-injection surface so admins can review the NULL-org "global" patterns the
+ * agent already uses. These tests assert, at the route seam, that EVERY scoped
+ * read/write threads the helper's clause and binds the active org at the right
+ * positional slot.
+ *
+ * Scope: this harness pins self-hosted (`isSaasModeForGuard: () => false`), so
+ * the clause here is the self-hosted arm `(org_id = $N OR org_id IS NULL)`. Three
+ * things are pinned elsewhere so they aren't re-driven here:
+ *   - the SaaS narrowing (drop the NULL arm) is pinned against the REAL helper in
+ *     `db/__tests__/semantic-amendment-saas-scoping.test.ts`;
+ *   - the org-less WITHHOLD handling (empty page / 404 / notFound, no query) is
+ *     pinned in `admin-learned-patterns-fail-closed.test.ts`;
+ *   - the structural proof that the route routes through the helper and inlines
+ *     no fail-open clause lives in the saas-scoping reader-enumeration block.
+ * The org-less path is unreachable through the route anyway: `requireOrgContext`
+ * 400s it before any handler (covered in `admin-learned-patterns.test.ts`).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "simple-key",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  },
+});
+
+const { app } = await import("../index");
+
+function req(method: string, urlPath: string, body?: unknown) {
+  const url = `http://localhost/api/v1/admin/learned-patterns${urlPath}`;
+  const init: RequestInit = { method, headers: { Authorization: "Bearer test" } };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+  return app.fetch(new Request(url, init));
+}
+
+/** Every SQL string the route issued this request. */
+function issuedSql(): string[] {
+  return mocks.mockInternalQuery.mock.calls.map((c) => c[0] as string);
+}
+
+afterAll(() => mocks.cleanup());
+
+beforeEach(() => {
+  mocks.mockAuthenticateRequest.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "simple-key",
+      user: { id: "admin-1", mode: "simple-key", label: "Admin", role: "admin", activeOrganizationId: "org-1" },
+    }),
+  );
+  mocks.hasInternalDB = true;
+  mocks.mockInternalQuery.mockReset();
+  mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([{ count: "0" }]));
+  mocks.mockCheckRateLimit.mockImplementation(() => ({ allowed: true }));
+});
+
+describe("learned-patterns org scope threads the shared helper's clause (#4580)", () => {
+  it("LIST scopes with the shared-helper clause AND binds the active org param", async () => {
+    const res = await req("GET", "/");
+    expect(res.status).toBe(200);
+    const sqls = issuedSql();
+    expect(sqls.length).toBeGreaterThanOrEqual(1);
+    // Both the COUNT and the SELECT carry the helper's clause — no handler
+    // hand-rolls an org predicate.
+    expect(sqls.every((s) => s.includes("(org_id = $1 OR org_id IS NULL)"))).toBe(true);
+    const params = mocks.mockInternalQuery.mock.calls[0][1] as unknown[];
+    expect(params).toContain("org-1");
+  });
+
+  it("GET /:id threads the clause after the id param (id = $1, org = $2)", async () => {
+    mocks.mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const res = await req("GET", "/pat-1");
+    expect(res.status).toBe(404);
+    const sqls = issuedSql();
+    expect(sqls.some((s) => s.includes("WHERE id = $1") && s.includes("(org_id = $2 OR org_id IS NULL)"))).toBe(true);
+    const params = mocks.mockInternalQuery.mock.calls[0][1] as unknown[];
+    expect(params).toEqual(["pat-1", "org-1"]);
+  });
+
+  it("PATCH scopes BOTH the existence check and the UPDATE through the helper", async () => {
+    let call = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.resolve([{ id: "pat-1" }]); // existence
+      return Promise.resolve([
+        { id: "pat-1", org_id: "org-1", pattern_sql: "SELECT 1", status: "approved", confidence: 0.5, repetition_count: 1, type: "query_pattern", amendment_payload: null, created_at: "2026-07-10T00:00:00Z", updated_at: "2026-07-10T00:00:00Z" },
+      ]);
+    });
+    const res = await req("PATCH", "/pat-1", { status: "approved" });
+    expect(res.status).toBe(200);
+    const sqls = issuedSql();
+    const selectSql = sqls.find((s) => s.startsWith("SELECT id FROM learned_patterns"));
+    const updateSql = sqls.find((s) => s.includes("UPDATE learned_patterns"));
+    expect(selectSql).toContain("(org_id = $2 OR org_id IS NULL)");
+    expect(updateSql).toContain("org_id = $");
+    expect(updateSql).toContain("OR org_id IS NULL");
+    // The org param is bound on the UPDATE too (last positional slot).
+    const updateCall = mocks.mockInternalQuery.mock.calls.find((c) => (c[0] as string).includes("UPDATE"))!;
+    expect(updateCall[1] as unknown[]).toContain("org-1");
+  });
+
+  it("DELETE scopes both the existence check and the DELETE through the helper", async () => {
+    let call = 0;
+    mocks.mockInternalQuery.mockImplementation(() => {
+      call++;
+      if (call === 1) return Promise.resolve([{ id: "pat-1" }]);
+      return Promise.resolve([]);
+    });
+    const res = await req("DELETE", "/pat-1");
+    expect(res.status).toBe(200);
+    const sqls = issuedSql();
+    expect(sqls.some((s) => s.includes("DELETE FROM learned_patterns") && s.includes("OR org_id IS NULL"))).toBe(true);
+  });
+
+  it("bulk scopes each existence check + UPDATE through the helper and binds the org", async () => {
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT")) return Promise.resolve([{ id: "pat-1", type: "query_pattern" }]);
+      return Promise.resolve([]);
+    });
+    const res = await req("POST", "/bulk", { ids: ["pat-1"], status: "approved" });
+    expect(res.status).toBe(200);
+    const sqls = issuedSql();
+    expect(sqls.some((s) => s.includes("UPDATE learned_patterns") && s.includes("OR org_id IS NULL"))).toBe(true);
+    const updateCall = mocks.mockInternalQuery.mock.calls.find((c) => (c[0] as string).includes("UPDATE"))!;
+    expect(updateCall[1] as unknown[]).toContain("org-1");
+  });
+});

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -105,6 +105,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-usage.test.ts
+++ b/packages/api/src/api/__tests__/admin-usage.test.ts
@@ -139,6 +139,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin-workspace.test.ts
+++ b/packages/api/src/api/__tests__/admin-workspace.test.ts
@@ -191,6 +191,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -328,6 +328,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   insertLearnedPattern: () => {},
   incrementPatternCount: () => {},
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/api/routes/admin-learned-patterns.ts
+++ b/packages/api/src/api/routes/admin-learned-patterns.ts
@@ -12,7 +12,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
-import { internalQuery, queryEffect } from "@atlas/api/lib/db/internal";
+import { internalQuery, queryEffect, amendmentOrgScope, type AmendmentOrgScope } from "@atlas/api/lib/db/internal";
 import { LEARNED_PATTERN_STATUSES, type LearnedPattern } from "@useatlas/types";
 import {
   LearnedPatternSchema,
@@ -81,16 +81,41 @@ function toLearnedPattern(row: Record<string, unknown>): LearnedPattern {
   };
 }
 
-function orgFilter(
-  orgId: string | null | undefined,
-  params: unknown[],
-  paramIdx: number,
-): { clause: string; nextIdx: number } {
-  if (orgId) {
-    params.push(orgId);
-    return { clause: `org_id = $${paramIdx}`, nextIdx: paramIdx + 1 };
-  }
-  return { clause: `org_id IS NULL`, nextIdx: paramIdx };
+/**
+ * Tenant org-scope for this route's `learned_patterns` reads and writes, via the
+ * shared helper `amendmentOrgScope` (#4487/#4510). The `learned_patterns` table
+ * holds both `semantic_amendment` and `query_pattern` rows; this route is the
+ * `query_pattern` reader/writer and adopts the same helper the amendment DB
+ * readers use, so scoping can't fork a second model (#4580). The agent-injection
+ * reader `getApprovedPatterns` keeps a behaviorally-aligned inlined copy over the
+ * same table (it carries an extra connection-group clause), so this route's
+ * review surface and the agent's injection surface now scope identically.
+ *
+ * The conditional flips with deploy mode. Adopting the helper changes behavior
+ * on two axes vs. the old local `orgFilter`:
+ *   - self-hosted + org  → `(org_id = $N OR org_id IS NULL)`. The old helper
+ *     emitted `org_id = $N` only, EXCLUDING legacy NULL-org rows;
+ *     `requireOrgContext` guarantees an org here, so this is the operative path,
+ *     and adopting the helper deliberately WIDENS it to also match NULL-org
+ *     ("global scope") rows — parity with what the agent already injects on
+ *     self-hosted.
+ *   - SaaS + org         → `org_id = $N` only — a NULL-org row never surfaces in
+ *     a tenant workspace (#4487).
+ *   - org-less           → this is the FAIL-CLOSED fix. The old helper fell OPEN
+ *     to `org_id IS NULL` (broadening to every global row); the shared helper
+ *     WITHHOLDS on SaaS (`{ withhold: true }`), so the caller returns its empty
+ *     value (empty list / 404 / notFound) without touching the DB.
+ *     `requireOrgContext` already 400s an org-less request, so `withhold` is
+ *     defense-in-depth — but if it ever fires we never broaden scope on the way
+ *     out.
+ *
+ * Binds `orgId` into `params` at the next positional slot only when the helper's
+ * clause references it (never on the org-less self-hosted `org_id IS NULL` arm).
+ */
+function orgScope(orgId: string | null | undefined, params: unknown[]): AmendmentOrgScope {
+  const scope = amendmentOrgScope(orgId ?? null, `$${params.length + 1}`);
+  if (!scope.withhold && orgId) params.push(orgId);
+  return scope;
 }
 
 const VALID_STATUSES = new Set<string>(LEARNED_PATTERN_STATUSES);
@@ -446,10 +471,14 @@ adminLearnedPatterns.openapi(listPatternsRoute, async (c) => {
 
     const whereParts: string[] = [];
     const params: unknown[] = [];
-    const org = orgFilter(orgId, params, params.length + 1);
-    whereParts.push(org.clause);
+    const scope = orgScope(orgId, params);
+    // Fail closed: an org-less scope on SaaS withholds rather than broaden to
+    // NULL-org rows. `requireOrgContext` makes this defensive; return an empty
+    // page without querying if it ever fires.
+    if (scope.withhold) return c.json({ patterns: [], total: 0, limit, offset }, 200);
+    whereParts.push(scope.clause);
     whereParts.push(QUERY_PATTERN_SCOPE);
-    let nextIdx = org.nextIdx;
+    let nextIdx = params.length + 1;
 
     if (status) { params.push(status); whereParts.push(`status = $${nextIdx}`); nextIdx++; }
     if (sourceEntity) { params.push(sourceEntity); whereParts.push(`source_entity = $${nextIdx}`); nextIdx++; }
@@ -482,8 +511,9 @@ adminLearnedPatterns.openapi(getPatternRoute, async (c) => {
 
     const { id } = c.req.valid("param");
     const params: unknown[] = [id];
-    const org = orgFilter(orgId, params, params.length + 1);
-    const rows = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${org.clause}`, params);
+    const scope = orgScope(orgId, params);
+    if (scope.withhold) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
+    const rows = yield* queryEffect<Record<string, unknown>>(`SELECT * FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${scope.clause}`, params);
     if (rows.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
     return c.json(toLearnedPattern(rows[0]), 200);
   }), { label: "get learned pattern" });
@@ -505,8 +535,9 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
     // 404 here — its status is never writable through this route, so #4506's
     // "the seam is the only writer of `approved`" holds by construction.
     const checkParams: unknown[] = [id];
-    const org = orgFilter(orgId, checkParams, checkParams.length + 1);
-    const existing = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${org.clause}`, checkParams);
+    const checkScope = orgScope(orgId, checkParams);
+    if (checkScope.withhold) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
+    const existing = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${checkScope.clause}`, checkParams);
     if (existing.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
 
     const setClauses: string[] = ["updated_at = now()"];
@@ -521,9 +552,9 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
 
     updateParams.push(id);
     const idIdx = paramIdx;
-    paramIdx++;
-    const updateOrg = orgFilter(orgId, updateParams, paramIdx);
-    const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${QUERY_PATTERN_SCOPE} AND ${updateOrg.clause} RETURNING *`, updateParams);
+    const updateScope = orgScope(orgId, updateParams);
+    if (updateScope.withhold) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
+    const updated = yield* queryEffect<Record<string, unknown>>(`UPDATE learned_patterns SET ${setClauses.join(", ")} WHERE id = $${idIdx} AND ${QUERY_PATTERN_SCOPE} AND ${updateScope.clause} RETURNING *`, updateParams);
     if (updated.length === 0) return c.json({ error: "not_found", message: "Pattern was deleted before update completed." }, 404);
 
     // Any status flip changes which patterns the agent sees: the approved set
@@ -536,12 +567,32 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
       invalidatePatternCache(orgId ?? null);
     }
 
+    const ipAddress = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+
+    // Governance parity (#4580): a description edit changes the human-facing
+    // text other reviewers trust, so it earns its own forensic row — audited
+    // independently of any status change. A PATCH that edits the description AND
+    // makes an approve/reject decision emits two rows (one decision + one
+    // description edit), each a distinct governance event. (An un-approve to
+    // `pending` is not an approve/reject decision, so that + a description edit
+    // emits only the description row — the pending-flip audit gap is pre-existing
+    // and out of scope for #4580.)
+    if (description !== undefined) {
+      logAdminAction({
+        actionType: ADMIN_ACTIONS.pattern.updateDescription,
+        targetType: "pattern",
+        targetId: id,
+        ipAddress,
+        metadata: { patternId: id },
+      });
+    }
+
     if (status === "approved") {
       logAdminAction({
         actionType: ADMIN_ACTIONS.pattern.approve,
         targetType: "pattern",
         targetId: id,
-        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        ipAddress,
         metadata: { patternId: id },
       });
     } else if (status === "rejected") {
@@ -549,7 +600,7 @@ adminLearnedPatterns.openapi(updatePatternRoute, async (c) => {
         actionType: ADMIN_ACTIONS.pattern.reject,
         targetType: "pattern",
         targetId: id,
-        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        ipAddress,
         metadata: { patternId: id },
       });
     }
@@ -569,13 +620,15 @@ adminLearnedPatterns.openapi(deletePatternRoute, async (c) => {
     const { id } = c.req.valid("param");
     // Scoped to query_pattern rows (#4569): an amendment id is a 404 here.
     const checkParams: unknown[] = [id];
-    const org = orgFilter(orgId, checkParams, checkParams.length + 1);
-    const existing = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${org.clause}`, checkParams);
+    const checkScope = orgScope(orgId, checkParams);
+    if (checkScope.withhold) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
+    const existing = yield* queryEffect<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${checkScope.clause}`, checkParams);
     if (existing.length === 0) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
 
     const deleteParams: unknown[] = [id];
-    const deleteOrg = orgFilter(orgId, deleteParams, deleteParams.length + 1);
-    yield* queryEffect(`DELETE FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${deleteOrg.clause}`, deleteParams);
+    const deleteScope = orgScope(orgId, deleteParams);
+    if (deleteScope.withhold) return c.json({ error: "not_found", message: "Learned pattern not found." }, 404);
+    yield* queryEffect(`DELETE FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${deleteScope.clause}`, deleteParams);
     invalidatePatternCache(orgId ?? null);
 
     logAdminAction({
@@ -615,14 +668,18 @@ adminLearnedPatterns.openapi(bulkStatusRoute, async (c) => {
           // status, so #4506's "the seam is the only writer of `approved`"
           // holds for amendment rows.
           const checkParams: unknown[] = [id];
-          const org = orgFilter(orgId, checkParams, checkParams.length + 1);
-          const existing = await internalQuery<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${org.clause}`, checkParams);
+          const checkScope = orgScope(orgId, checkParams);
+          // Fail closed (#4580): an org-less SaaS scope withholds — treat as
+          // not_found rather than broaden the scan to NULL-org rows.
+          if (checkScope.withhold) return "not_found" as const;
+          const existing = await internalQuery<Record<string, unknown>>(`SELECT id FROM learned_patterns WHERE id = $1 AND ${QUERY_PATTERN_SCOPE} AND ${checkScope.clause}`, checkParams);
           if (existing.length === 0) return "not_found" as const;
 
           const updateParams: unknown[] = [status, user?.id ?? null, id];
-          const updateOrg = orgFilter(orgId, updateParams, updateParams.length + 1);
+          const updateScope = orgScope(orgId, updateParams);
+          if (updateScope.withhold) return "not_found" as const;
           // Clear auto_promoted on a human review (see single-update path, #3636).
-          await internalQuery(`UPDATE learned_patterns SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now(), auto_promoted = false WHERE id = $3 AND ${QUERY_PATTERN_SCOPE} AND ${updateOrg.clause}`, updateParams);
+          await internalQuery(`UPDATE learned_patterns SET status = $1, reviewed_by = $2, reviewed_at = now(), updated_at = now(), auto_promoted = false WHERE id = $3 AND ${QUERY_PATTERN_SCOPE} AND ${updateScope.clause}`, updateParams);
           return "updated" as const;
         },
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
@@ -643,6 +700,25 @@ adminLearnedPatterns.openapi(bulkStatusRoute, async (c) => {
     // 5-min TTL cache — only when at least one row actually changed (#3612).
     if (updated.length > 0) {
       invalidatePatternCache(orgId ?? null);
+    }
+
+    // Governance parity (#4580): a bulk decision is forensically identical to a
+    // stack of single decisions — one audit row per decided pattern, using the
+    // SAME `pattern.approve` / `pattern.reject` vocabulary as the PATCH path (one
+    // vocabulary per concept now that amendments are folded out of this route,
+    // #4569). Emitted only for rows that actually changed; notFound / errored
+    // ids leave no row, exactly like a single decision that 404s. The bulk
+    // schema pins `status` to approved|rejected, so this maps exhaustively.
+    const bulkAction = status === "approved" ? ADMIN_ACTIONS.pattern.approve : ADMIN_ACTIONS.pattern.reject;
+    const ipAddress = c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null;
+    for (const id of updated) {
+      logAdminAction({
+        actionType: bulkAction,
+        targetType: "pattern",
+        targetId: id,
+        ipAddress,
+        metadata: { patternId: id },
+      });
     }
 
     return c.json({ updated, notFound, ...(errors.length > 0 ? { errors } : {}) }, 200);

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -306,10 +306,23 @@ export const ADMIN_ACTIONS = {
     improveReject: "semantic.improve_reject",
     improveReconsider: "semantic.improve_reconsider",
   },
+  /**
+   * Learned query-pattern review governance (#4580, PRD #4570). `approve` /
+   * `reject` are the SINGLE- and BULK-decision vocabulary — one audit row per
+   * decided pattern, one vocabulary per concept now that `semantic_amendment`
+   * rows are folded out of this route (#4569; amendment decisions live under
+   * `semantic.improve_*`). `delete` covers the hard delete. `updateDescription`
+   * covers a description edit (fires whenever a PATCH sets `description`): the
+   * human-facing text other reviewers trust changed with no forensic trace
+   * before this (F-35-style content-governance
+   * gap) — this row is that trail. All are `targetType: "pattern"`, `targetId`
+   * the pattern id; metadata carries `{ patternId }`.
+   */
   pattern: {
     approve: "pattern.approve",
     reject: "pattern.reject",
     delete: "pattern.delete",
+    updateDescription: "pattern.update_description",
   },
   /**
    * `test` is distinct from `email_provider.test` so compliance queries

--- a/packages/api/src/lib/auth/__tests__/sessions.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sessions.test.ts
@@ -128,6 +128,10 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   isPlaintextUrl: () => true,
   _resetEncryptionKeyCache: mock(() => {}),
   getApprovedPatterns: mock(async () => []),
+  // #4580 — the learned-patterns route (loaded at app boot) imports this shared
+  // org-scope helper; provide it so its named import doesn't SyntaxError here.
+  amendmentOrgScope: (orgId: string | null, ph: string) =>
+    orgId ? { withhold: false, clause: `(org_id = ${ph} OR org_id IS NULL)` } : { withhold: false, clause: "org_id IS NULL" },
   upsertSuggestion: mock(() => Promise.resolve("created")),
   getSuggestionsByTables: mock(() => Promise.resolve([])),
   getPopularSuggestions: mock(() => Promise.resolve([])),

--- a/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
+++ b/packages/api/src/lib/db/__tests__/semantic-amendment-saas-scoping.test.ts
@@ -47,6 +47,7 @@ import {
 } from "../internal";
 import type { ResolvedConfig } from "../../config";
 import { _setConfigForTest, _resetConfig } from "../../config";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
 
 interface Captured {
   sql: string;
@@ -590,5 +591,55 @@ describe("shared org-scope helper — reader/inserter enumeration (#4510)", () =
       )
       .map((f) => f.name);
     expect(inserters).toEqual(["insertSemanticAmendment"]);
+  });
+});
+
+describe("shared org-scope helper — learned-patterns route adoption (#4580)", () => {
+  // The `learned_patterns` table holds BOTH `semantic_amendment` and
+  // `query_pattern` rows. `amendmentOrgScope` is the shared SaaS-vs-self-hosted
+  // `org_id` conditional; the amendment DB readers (above) route through it, and
+  // #4580 makes the admin learned-patterns ROUTE (the `query_pattern`
+  // reader/writer) join them rather than keep its old fail-OPEN `org_id IS NULL`
+  // fallback. (`getApprovedPatterns` keeps a behaviorally-aligned inlined copy
+  // for the agent-injection path — pinned by its own tests, not this block.)
+  // This block is the route's seat in the enumeration: it reads the route source
+  // and pins that every org-scoped read/write derives its filter from the shared
+  // helper and no handler inlines a raw org clause.
+  const routeSource = readFileSync(
+    join(import.meta.dir, "..", "..", "..", "api", "routes", "admin-learned-patterns.ts"),
+    "utf8",
+  );
+  const stripComments = (s: string) =>
+    s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+  const routeCode = stripComments(routeSource);
+
+  it("routes every org filter through the shared amendmentOrgScope helper", () => {
+    expect(routeCode).toContain("amendmentOrgScope(");
+    // Imported from the DB layer, not re-implemented locally.
+    expect(routeSource).toMatch(/import\s*\{[^}]*amendmentOrgScope[^}]*\}\s*from\s*["']@atlas\/api\/lib\/db\/internal["']/);
+  });
+
+  it("no handler inlines a raw org_id scope clause (bypassing the helper, failing open)", () => {
+    // The old fail-open fallback was a literal `org_id IS NULL` and a raw
+    // `org_id = $N` splice. After adoption both live ONLY inside
+    // amendmentOrgScope's runtime clause, never in the route source. (Row-field
+    // reads like `row.org_id` are neither pattern, so they don't false-trip.)
+    // `\d+` (not `\d`) so a re-inlined double-digit placeholder can't slip past.
+    expect(routeCode).not.toContain("org_id IS NULL");
+    expect(routeCode).not.toMatch(/org_id\s*=\s*\$\d+/);
+  });
+
+  it("the test-harness mock's self-hosted arm stays byte-identical to the real helper", () => {
+    // Route suites assert the mock's clause string, so a drift between the
+    // hand-written harness stub (`buildInternalDbMockDefaults`) and the real
+    // `amendmentOrgScope` would leave those suites green against a fiction. Pin
+    // the mock's self-hosted output to the real helper's under self-hosted
+    // config, so a change to the real clause fails HERE and forces the mock (and
+    // the 8 inline copies it documents) to be updated in lockstep.
+    setDeployMode("self-hosted");
+    const mockScope = buildInternalDbMockDefaults({ internalQuery: async () => [] })
+      .amendmentOrgScope as (orgId: string | null, ph: `$${number}`) => unknown;
+    expect(mockScope("org-a", "$1")).toEqual(amendmentOrgScope("org-a", "$1"));
+    expect(mockScope(null, "$1")).toEqual(amendmentOrgScope(null, "$1"));
   });
 });


### PR DESCRIPTION
## Summary

Governance parity on the admin learned-patterns route (`admin-learned-patterns.ts`), per PRD #4570. Three parts:

1. **Bulk audit rows** — `POST /bulk` approve/reject now writes **one audit row per decided pattern**, using the SAME `pattern.approve` / `pattern.reject` vocabulary as single decisions (one vocabulary per concept now that amendments are folded out of this route, #4569). A bulk decision of up to 100 patterns was forensically silent before.
2. **Description-edit audit** — a description PATCH now writes a `pattern.update_description` row (new action in `ADMIN_ACTIONS.pattern`). The text other reviewers trust changed with no trace before. A PATCH that edits the description *and* makes an approve/reject decision emits two rows (one decision + one description edit).
3. **Fail-closed org scope** — the route's fail-OPEN `orgFilter` (fell back to `org_id IS NULL` whenever org context was falsy) converges on the shared **fail-closed** helper `amendmentOrgScope` from the #4502/#4510 work (a discriminated `{ withhold } | { clause }` — `.clause` is unreachable until the caller narrows past `withhold`, so fail-closed is enforced by the type). On SaaS an org-less scope **withholds** instead of broadening to global rows; on self-hosted an org'd read now also matches legacy NULL-org rows, aligning the review surface with the agent-injection surface (`getApprovedPatterns`). The route joins the helper's **reader-enumeration test**.

**Behavior note:** on self-hosted + org this *widens* the scan from `org_id = $N` to `(org_id = $N OR org_id IS NULL)` — deliberate parity so admins can review the NULL-org "global" patterns the agent already injects. The fail-closed change is specifically the org-less SaaS arm.

## Test plan
- [x] Route audit suite (`admin-learned-patterns-audit.test.ts`): bulk one-row-per-decision + same vocabulary; description-edit row; both-fields → two rows; un-approve-to-pending → description row only; existence-miss / deleted-before-update / bulk-errored-id → no audit; zero-updated → no audit
- [x] Fail-closed suite (`admin-learned-patterns-fail-closed.test.ts`): each handler returns empty page / 404 / notFound on `withhold` **without** querying
- [x] Org-scope suite (`admin-learned-patterns-org-scope.test.ts`): every handler threads the shared helper's clause + binds the org at the right slot
- [x] Reader-enumeration + mock-drift guard added to `semantic-amendment-saas-scoping.test.ts`
- [x] `bun run type` clean; oxlint clean; full `@atlas/api` suite 903/903 green via `scripts/ci-local.sh`

Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy): no CRITICAL/HIGH; type-design APPROVE. MEDIUM/LOW advisories (fail-closed branch coverage, mock-drift guard, comment-accuracy) addressed inline.

Coordinates with #4571 (`getApprovedPatterns`, merged as #4629) — different functions; no `db/internal.ts` change here.

Closes #4580