### PR TITLE
fix(web): keyboard-openable rows in the shared server data table

### DIFF
--- a/packages/web/src/components/data-table/data-table-expandable.tsx
+++ b/packages/web/src/components/data-table/data-table-expandable.tsx
@@ -13,7 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getColumnPinningStyle } from "@/lib/data-table";
+import { getColumnPinningStyle, interactiveRowProps } from "@/lib/data-table";
 import { cn } from "@/lib/utils";
 
 interface ExpandableDataTableProps<TData> extends React.ComponentProps<"div"> {
@@ -79,8 +79,9 @@ export function ExpandableDataTable<TData>({
                   <Fragment key={row.id}>
                     <TableRow
                       data-state={row.getIsSelected() && "selected"}
-                      className={onRowClick ? "cursor-pointer" : undefined}
-                      onClick={onRowClick ? () => onRowClick(row) : undefined}
+                      {...(onRowClick
+                        ? interactiveRowProps(() => onRowClick(row))
+                        : {})}
                     >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell

--- a/packages/web/src/components/data-table/data-table.test.tsx
+++ b/packages/web/src/components/data-table/data-table.test.tsx
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, fireEvent } from "@testing-library/react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  type ColumnDef,
+  type Row,
+} from "@tanstack/react-table";
+import { DataTable } from "./data-table";
+import { ExpandableDataTable } from "./data-table-expandable";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const data: Item[] = [
+  { id: "1", name: "Alpha" },
+  { id: "2", name: "Beta" },
+];
+
+function makeColumns(withNestedButton = false): ColumnDef<Item>[] {
+  const cols: ColumnDef<Item>[] = [
+    {
+      id: "name",
+      accessorKey: "name",
+      header: () => "Name",
+      cell: ({ row }) => row.original.name,
+    },
+  ];
+  if (withNestedButton) {
+    cols.push({
+      id: "actions",
+      header: () => null,
+      cell: () => (
+        <button type="button" data-testid="nested-btn">
+          Act
+        </button>
+      ),
+    });
+  }
+  return cols;
+}
+
+/**
+ * Renders the shared `DataTable` around a real TanStack table instance. Uses the
+ * plain row models directly (no nuqs/react-query) so the seam test exercises the
+ * component in isolation.
+ */
+function Harness({
+  onRowClick,
+  withNestedButton,
+}: {
+  onRowClick?: (row: Row<Item>, event: MouseEvent | KeyboardEvent) => void;
+  withNestedButton?: boolean;
+}) {
+  const table = useReactTable({
+    data,
+    columns: makeColumns(withNestedButton),
+    getRowId: (r) => r.id,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+  return <DataTable table={table} onRowClick={onRowClick} />;
+}
+
+/** The expandable sibling — its row rows share the same `interactiveRowProps`. */
+function ExpandableHarness({
+  onRowClick,
+}: {
+  onRowClick?: (row: Row<Item>) => void;
+}) {
+  const table = useReactTable({
+    data,
+    columns: makeColumns(),
+    getRowId: (r) => r.id,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+  return (
+    <ExpandableDataTable
+      table={table}
+      onRowClick={onRowClick}
+      isRowExpanded={(row) => row.id === "1"}
+      renderExpandedRow={() => <div data-testid="expanded">details</div>}
+    />
+  );
+}
+
+describe("DataTable (shared server table) — interactive rows", () => {
+  afterEach(cleanup);
+
+  test("rows are inert (no button role, not focusable) when onRowClick is omitted", () => {
+    const { container } = render(<Harness />);
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(2);
+    for (const row of rows) {
+      expect(row.getAttribute("role")).toBeNull();
+      expect(row.getAttribute("tabindex")).toBeNull();
+    }
+  });
+
+  test("onRowClick makes rows focusable buttons", () => {
+    const { container } = render(<Harness onRowClick={() => {}} />);
+    const firstRow = container.querySelector("tbody tr")!;
+    expect(firstRow.getAttribute("role")).toBe("button");
+    expect(firstRow.getAttribute("tabindex")).toBe("0");
+    expect(firstRow.className).toContain("cursor-pointer");
+  });
+
+  test("clicking a row forwards the row object + event", () => {
+    const onRowClick = mock((_row: Row<Item>, _e: MouseEvent | KeyboardEvent) => {});
+    const { container } = render(<Harness onRowClick={onRowClick} />);
+    const firstRow = container.querySelector("tbody tr")!;
+    fireEvent.click(firstRow);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0]?.[0]?.original).toEqual(data[0]);
+  });
+
+  test("Enter and Space on a focused row activate it (keyboard a11y)", () => {
+    const onRowClick = mock((_row: Row<Item>, _e: MouseEvent | KeyboardEvent) => {});
+    const { container } = render(<Harness onRowClick={onRowClick} />);
+    const firstRow = container.querySelector("tbody tr")!;
+    fireEvent.keyDown(firstRow, { key: "Enter" });
+    fireEvent.keyDown(firstRow, { key: " " });
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+    // The row forwards its own row object on keyboard activation.
+    expect(onRowClick.mock.calls[0]?.[0]?.original).toEqual(data[0]);
+  });
+
+  test("keydown bubbling from a nested control does NOT activate the row", () => {
+    // Rows may contain their own interactive controls (checkbox, action menu).
+    // Enter/Space on one bubbles to the row's onKeyDown, but the row must only
+    // activate when it is itself the keydown target — otherwise the row's
+    // preventDefault would also swallow the nested control's own activation.
+    const onRowClick = mock((_row: Row<Item>, _e: MouseEvent | KeyboardEvent) => {});
+    const { container } = render(
+      <Harness onRowClick={onRowClick} withNestedButton />,
+    );
+    const nested = container.querySelector<HTMLButtonElement>(
+      '[data-testid="nested-btn"]',
+    )!;
+    fireEvent.keyDown(nested, { key: "Enter" });
+    fireEvent.keyDown(nested, { key: " " });
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  test("non-activating keys on a focused row do nothing", () => {
+    const onRowClick = mock((_row: Row<Item>, _e: MouseEvent | KeyboardEvent) => {});
+    const { container } = render(<Harness onRowClick={onRowClick} />);
+    const firstRow = container.querySelector("tbody tr")!;
+    fireEvent.keyDown(firstRow, { key: "a" });
+    fireEvent.keyDown(firstRow, { key: "Tab" });
+    fireEvent.keyDown(firstRow, { key: "ArrowDown" });
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  test("Space on the row is consumed, but a nested control's Space is left intact", () => {
+    // `fireEvent` returns false when a handler called preventDefault on the
+    // (cancelable) event, true otherwise. The row must preventDefault its own
+    // Space (so activation doesn't also scroll the page), yet must NOT touch a
+    // Space that bubbled up from a nested control — else it would swallow that
+    // control's own activation.
+    const { container } = render(
+      <Harness onRowClick={() => {}} withNestedButton />,
+    );
+    const firstRow = container.querySelector("tbody tr")!;
+    const nested = container.querySelector<HTMLButtonElement>(
+      '[data-testid="nested-btn"]',
+    )!;
+    expect(fireEvent.keyDown(firstRow, { key: " " })).toBe(false);
+    expect(fireEvent.keyDown(nested, { key: " " })).toBe(true);
+  });
+
+  test("expandable variant: data rows are focusable buttons; the expanded row is inert", () => {
+    const onRowClick = mock((_row: Row<Item>) => {});
+    const { container } = render(<ExpandableHarness onRowClick={onRowClick} />);
+    const dataRow = container.querySelector("tbody tr")!;
+    expect(dataRow.getAttribute("role")).toBe("button");
+    expect(dataRow.getAttribute("tabindex")).toBe("0");
+    fireEvent.keyDown(dataRow, { key: "Enter" });
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0]?.[0]?.original).toEqual(data[0]);
+
+    // The rendered expanded-content row must stay a plain, non-interactive row.
+    const expandedRow = container
+      .querySelector('[data-testid="expanded"]')!
+      .closest("tr")!;
+    expect(expandedRow.getAttribute("role")).toBeNull();
+    expect(expandedRow.getAttribute("tabindex")).toBeNull();
+  });
+});

--- a/packages/web/src/components/data-table/data-table.tsx
+++ b/packages/web/src/components/data-table/data-table.tsx
@@ -10,13 +10,24 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getColumnPinningStyle } from "@/lib/data-table";
+import { getColumnPinningStyle, interactiveRowProps } from "@/lib/data-table";
 import { cn } from "@/lib/utils";
 
 interface DataTableProps<TData> extends React.ComponentProps<"div"> {
   table: TanstackTable<TData>;
   actionBar?: React.ReactNode;
-  onRowClick?: (row: Row<TData>, event: React.MouseEvent) => void;
+  /**
+   * Opt-in row activation (e.g. open a detail sheet). When set, each row becomes
+   * a focusable `role="button"` that fires on click *and* on Enter/Space, so
+   * keyboard and screen-reader users can open the same detail the pointer does.
+   * The event is a `MouseEvent` on click and a `KeyboardEvent` on key activation
+   * — consumers that guard nested controls read only `event.target`, common to
+   * both.
+   */
+  onRowClick?: (
+    row: Row<TData>,
+    event: React.MouseEvent | React.KeyboardEvent,
+  ) => void;
 }
 
 export function DataTable<TData>({
@@ -63,8 +74,9 @@ export function DataTable<TData>({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
-                  className={onRowClick ? "cursor-pointer" : undefined}
-                  onClick={(e) => onRowClick?.(row, e)}
+                  {...(onRowClick
+                    ? interactiveRowProps((e) => onRowClick(row, e))
+                    : {})}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell

--- a/packages/web/src/lib/data-table.ts
+++ b/packages/web/src/lib/data-table.ts
@@ -36,6 +36,56 @@ export function getColumnPinningStyle<TData>({
   };
 }
 
+/**
+ * Props that turn a table `<tr>` into a keyboard-operable button. A clickable
+ * row is otherwise pointer-only — no focus, no Enter/Space — so keyboard and
+ * screen-reader users can't reach a row-opened detail view at all. Spreading
+ * these onto the row gives it `role="button"`, tab focus, a focus-visible ring,
+ * and Enter/Space activation, all wired to the same `onActivate` the click uses.
+ *
+ * The keydown only fires `onActivate` when the row is itself the event target,
+ * so Enter/Space on a nested control (a selection checkbox, a row action menu)
+ * keeps its own default instead of being hijacked (and swallowed by the row's
+ * `preventDefault`) into opening the row.
+ *
+ * `role="button"` on the row mirrors the clickable-row contract established for
+ * the chat data table (#3212). It overrides the `<tr>`'s implicit `role="row"`,
+ * a deliberate trade for these row-opens-a-detail-sheet admin tables; the target
+ * guard above is what keeps the row's own nested controls operable despite it.
+ *
+ * Shared by the plain and expandable data tables so both keep one identical
+ * keyboard contract: each calls this with its row's activation callback (the
+ * plain table forwards the event, the expandable one omits it), so the helper —
+ * not the caller — owns the `onClick`/`onKeyDown` wiring. A non-interactive row
+ * spreads `{}` instead and is left untouched.
+ */
+export function interactiveRowProps(
+  onActivate: (event: React.MouseEvent | React.KeyboardEvent) => void,
+): {
+  role: "button";
+  tabIndex: 0;
+  className: string;
+  onClick: React.MouseEventHandler;
+  onKeyDown: React.KeyboardEventHandler;
+} {
+  return {
+    role: "button",
+    tabIndex: 0,
+    className:
+      "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+    onClick: onActivate,
+    onKeyDown: (event) => {
+      if (
+        (event.key === "Enter" || event.key === " ") &&
+        event.target === event.currentTarget
+      ) {
+        event.preventDefault();
+        onActivate(event);
+      }
+    },
+  };
+}
+
 export function getFilterOperators(filterVariant: FilterVariant) {
   const operatorMap: Record<
     FilterVariant,

--- a/packages/web/src/ui/components/admin/server-data-table.tsx
+++ b/packages/web/src/ui/components/admin/server-data-table.tsx
@@ -60,8 +60,15 @@ interface ServerDataTableExpandableProps<TData> {
 /** Plain-table variant: renders via `DataTable`, with optional row-click + bulk bar. */
 interface ServerDataTablePlainProps<TData> {
   expandable?: never;
-  /** Plain row-click (e.g. open a detail sheet). */
-  onRowClick?: (row: Row<TData>, event: React.MouseEvent) => void;
+  /**
+   * Plain row-click (e.g. open a detail sheet). Fires on pointer click and on
+   * keyboard Enter/Space, so the event is a `MouseEvent` or a `KeyboardEvent`;
+   * guards that inspect the row's nested controls read only `event.target`.
+   */
+  onRowClick?: (
+    row: Row<TData>,
+    event: React.MouseEvent | React.KeyboardEvent,
+  ) => void;
   /** Bulk action bar rendered by `DataTable` when rows are selected. */
   actionBar?: ReactNode;
 }


### PR DESCRIPTION
## What

Clickable rows in the shared `DataTable` (and its expandable sibling) were pointer-only — `onClick` + `cursor-pointer`, no focus, no key handler. On the learned-patterns cockpit, the detail sheet is the **only** place full pattern SQL, source queries, and reviewer context are readable, so a keyboard or screen-reader admin could not review at all.

Clickable rows now gain the standard keyboard contract in the shared component, so every consumer benefits.

## How

- Extract one `interactiveRowProps()` helper (`lib/data-table.ts`) that gives a clickable row `role="button"`, tab focus, a focus-visible ring, and Enter/Space activation — all wired to the same handler the click uses. Both data-table variants spread it, so the contract can't drift between them.
- The keydown only fires when the row is itself the event target (`event.target === event.currentTarget`), so Enter/Space on a nested control (selection checkbox, row action menu) keeps its own default instead of being swallowed by the row's `preventDefault`.
- `role="button"` on the row mirrors the clickable-row contract established for the chat data table (#3212).
- Broaden the plain `onRowClick` event to `MouseEvent | KeyboardEvent`; existing inline consumers (learned-patterns, prompts) read only `event.target`, common to both. Non-interactive tables (no `onRowClick`) are untouched.

## Acceptance criteria

- [x] A keyboard-only user can focus a row and open the learned-patterns detail sheet (Enter/Space activation)
- [x] Appropriate role/ARIA on interactive rows; non-interactive tables unaffected
- [x] No behavior regression on other admin tables using the shared component (expandable + plain variants both covered; scheduled-tasks/prompts consumers unchanged)
- [x] Web seam test for keyboard activation

## Tests

New `packages/web/src/components/data-table/data-table.test.tsx` (8 tests): inert-when-no-handler, focusable-button when handler set, click forwards row+event, Enter/Space activation, nested-control keydown does NOT activate (guards nested controls), non-activating keys no-op, `preventDefault` semantics (row-self consumed / nested intact), and an expandable-variant smoke test (data row is a button, expanded content row stays inert).

Internal review panel (silent-failure / type-design / test-coverage / comment): clean, no must-fix; advisory items folded in.

Closes #4575

https://claude.ai/code/session_01JydkmLY5XyLBtXMAmzviGE