### PR TITLE
feat(learn): workspace-scoped auto-promotion knob — SaaS-first promote/decay scheduler (#4582)

### DIFF
--- a/packages/api/src/lib/db/__tests__/promote-decay-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/promote-decay-pg.test.ts
@@ -84,20 +84,23 @@ describeIfPg("promote/decay DB helpers (real Postgres, #3636)", () => {
     type?: string;
     confidence?: number;
     repetitionCount?: number;
+    orgId?: string | null;
+    updatedAt?: string;
   }): Promise<string> {
     const res = await pool.query<{ id: string }>(
       `INSERT INTO learned_patterns
-        (org_id, pattern_sql, status, type, auto_promoted, confidence, repetition_count)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
+        (org_id, pattern_sql, status, type, auto_promoted, confidence, repetition_count, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8::timestamptz, now()))
        RETURNING id`,
       [
-        ORG,
+        opts.orgId === undefined ? ORG : opts.orgId,
         opts.sql,
         opts.status,
         opts.type ?? "query_pattern",
         opts.autoPromoted ?? false,
         opts.confidence ?? 0.9,
         opts.repetitionCount ?? 10,
+        opts.updatedAt ?? null,
       ],
     );
     return res.rows[0].id;
@@ -176,9 +179,47 @@ describeIfPg("promote/decay DB helpers (real Postgres, #3636)", () => {
       await seed({ sql: "SELECT 13", status: "rejected" }); // excluded
       await seed({ sql: "SELECT 14", status: "pending", type: "semantic_amendment" }); // excluded
 
-      const candidates = await getPromoteDecayCandidates();
+      const candidates = await getPromoteDecayCandidates(ORG);
       const ids = candidates.map((c) => c.id).sort();
       expect(ids).toEqual([pending, machine].sort());
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "candidate scope is per-workspace — a different org's rows are excluded (#4582)",
+    async () => {
+      const mine = await seed({ sql: "SELECT 20", status: "pending", orgId: ORG });
+      await seed({ sql: "SELECT 21", status: "pending", orgId: "other-org" });
+      // A NULL-org (self-hosted-shaped) row must not bleed into an org scan.
+      await seed({ sql: "SELECT 22", status: "pending", orgId: null });
+
+      const scoped = await getPromoteDecayCandidates(ORG);
+      expect(scoped.map((c) => c.id)).toEqual([mine]);
+
+      // A null scope sees only the NULL-org row, never the org-stamped ones.
+      const nullScoped = await getPromoteDecayCandidates(null);
+      expect(nullScoped.map((c) => c.org_id)).toEqual([null]);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "candidate order is freshest-touched first, so the cap keeps fresh rows (#4582)",
+    async () => {
+      // Insert oldest → newest by updated_at; the scan must return newest first
+      // so a `LIMIT` truncation drops the STALEST rows, never the fresh ones a
+      // tenant is actively re-running.
+      const stale = await seed({ sql: "SELECT 30", status: "pending", updatedAt: "2020-01-01T00:00:00Z" });
+      const mid = await seed({ sql: "SELECT 31", status: "pending", updatedAt: "2023-01-01T00:00:00Z" });
+      const fresh = await seed({ sql: "SELECT 32", status: "pending", updatedAt: "2026-01-01T00:00:00Z" });
+
+      const all = await getPromoteDecayCandidates(ORG);
+      expect(all.map((c) => c.id)).toEqual([fresh, mid, stale]);
+
+      // Under a cap of 2, the two freshest survive; the stalest is deferred.
+      const capped = await getPromoteDecayCandidates(ORG, 2);
+      expect(capped.map((c) => c.id)).toEqual([fresh, mid]);
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2510,32 +2510,54 @@ export interface PromoteDecayCandidateRow {
 }
 
 /**
- * Fetch the rows the nightly promote/decay job evaluates: pending query
- * patterns (promotion candidates) and approved query patterns the job itself
- * promoted (decay candidates). `semantic_amendment` rows are excluded — they
- * keep human review. The apply step (`promoteLearnedPatterns` /
- * `demoteLearnedPatterns`) keys updates by `id` and never writes `org_id` or
- * `connection_group_id`, so a single global scan can never move a pattern across
- * tenants (#3610/#3611) — which is why this projection doesn't even select the
- * scope columns; each row's own `org_id` (for cache invalidation) is returned by
- * the apply step's `RETURNING`.
+ * Fetch the rows the promote/decay job evaluates for ONE workspace: that
+ * workspace's pending query patterns (promotion candidates) and the approved
+ * query patterns the job itself promoted (decay candidates). `semantic_amendment`
+ * rows are excluded — they keep human review. The apply step
+ * (`promoteLearnedPatterns` / `demoteLearnedPatterns`) still keys updates by `id`
+ * and never writes `org_id` / `connection_group_id`, so it can never move a
+ * pattern across tenants (#3610/#3611); each row's own `org_id` (for cache
+ * invalidation) rides along on the projection and the apply step's `RETURNING`.
  *
- * Capped at `limit` rows (oldest-touched first) so a runaway table can't make
- * one tick unbounded; the scheduler logs when the cap is hit.
+ * Workspace scope (#4582): the SaaS-first tick iterates opted-in workspaces and
+ * evaluates each in isolation, so `orgId` scopes the scan — `null` is the
+ * self-hosted single implicit workspace (its patterns carry a NULL org, matching
+ * the eligible-set retrieval's null-org scoping). Isolating the scan per
+ * workspace is what makes the freshest-first cap below fair: a single global
+ * scan would let one noisy tenant's churn crowd a quiet tenant's rows out past
+ * the cap.
+ *
+ * Capped at `limit` rows so a runaway table can't make one tick unbounded. The
+ * order is `updated_at DESC` — freshest-touched first — so when the cap bites it
+ * keeps the patterns a tenant is actively re-running (the ones worth promoting)
+ * rather than starving them behind stale rows (#4582); the scheduler logs when
+ * the cap is hit.
  */
 export async function getPromoteDecayCandidates(
+  orgId: string | null,
   limit = 10000,
 ): Promise<PromoteDecayCandidateRow[]> {
   if (!hasInternalDB()) return [];
+  // `$1` is always the limit (referenced by LIMIT below); the org filter, when
+  // present, is `$2`. A null org narrows to the single-tenant NULL-org rows.
+  const params: Array<string | number> = [limit];
+  let orgClause: string;
+  if (orgId === null) {
+    orgClause = "org_id IS NULL";
+  } else {
+    params.push(orgId);
+    orgClause = `org_id = $${params.length}`;
+  }
   return internalQuery<PromoteDecayCandidateRow>(
     `SELECT id, org_id, type, status, confidence, repetition_count,
             avg_duration_ms, last_seen_at::text AS last_seen_at, auto_promoted
      FROM learned_patterns
      WHERE type = 'query_pattern'
        AND (status = 'pending' OR (status = 'approved' AND auto_promoted = true))
-     ORDER BY updated_at ASC
+       AND ${orgClause}
+     ORDER BY updated_at DESC
      LIMIT $1`,
-    [limit],
+    params,
   );
 }
 

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2528,8 +2528,9 @@ export interface PromoteDecayCandidateRow {
  * the cap.
  *
  * Capped at `limit` rows so a runaway table can't make one tick unbounded. The
- * order is `updated_at DESC` — freshest-touched first — so when the cap bites it
- * keeps the patterns a tenant is actively re-running (the ones worth promoting)
+ * order is `updated_at DESC` — most-recently-touched first (a re-run bumps
+ * `updated_at` via `incrementPatternCount`, the dominant writer for pending
+ * rows) — so when the cap bites it keeps the fresh patterns worth promoting
  * rather than starving them behind stale rows (#4582); the scheduler logs when
  * the cap is hit.
  */

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1857,7 +1857,13 @@ export function makeSchedulerLive(
         startLog: "Semantic expert scheduler started",
       });
 
-      // ── Periodic fiber: learned-pattern auto-promote/decay (#3636) ──
+      // ── Periodic fiber: learned-pattern auto-promote/decay (#3636, #4582) ──
+      // SaaS-first: NO platform enable gate. The retired master switch was
+      // boot-consumed, so it could never hot-reload a workspace opting in; the
+      // fiber now always runs and resolves the opted-in workspaces per tick (the
+      // workspace-scoped ATLAS_LEARN_PROMOTE_DECAY_ENABLED trust dial, off by
+      // default), so the dial takes effect on the next tick with no restart. The
+      // tick no-ops cheaply when no workspace opted in or there's no internal DB.
       yield* registerPeriodicFiber({
         name: "promote_decay",
         intervalMs: () => {
@@ -1866,17 +1872,6 @@ export function makeSchedulerLive(
             getPromoteDecaySchedulerIntervalMs: () => number;
           };
           return getPromoteDecaySchedulerIntervalMs();
-        },
-        gate: {
-          check: () => {
-            // oxlint-disable-next-line @typescript-eslint/no-require-imports
-            const { isPromoteDecaySchedulerEnabled } = require("@atlas/api/lib/learn/promote-decay-scheduler") as {
-              isPromoteDecaySchedulerEnabled: () => boolean;
-            };
-            return isPromoteDecaySchedulerEnabled();
-          },
-          failLog: "Promote/decay scheduler module not available — skipping",
-          skipLog: "Learned-pattern auto-promote/decay scheduler not started — feature disabled",
         },
         tick: Effect.tryPromise({
           try: async () => {

--- a/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
-import { loadSettings, _resetSettingsCache } from "@atlas/api/lib/settings";
+import {
+  loadSettings,
+  _resetSettingsCache,
+  getSettingDefinition,
+} from "@atlas/api/lib/settings";
+import type { ResolvedConfig } from "@atlas/api/lib/config";
+import { _setConfigForTest, _resetConfig } from "@atlas/api/lib/config";
 
 // ---------------------------------------------------------------------------
 // Mock internal DB. `dbAvailable` / `settingsRows` drive the settings tier
-// chain (same shape as the expert-scheduler test). `candidates` feeds the tick;
-// `promotedIds` / `demotedIds` capture what the tick asked the DB to flip.
+// chain (same shape as the expert-scheduler test). `internalQuery` branches on
+// the SQL so the SaaS opt-in enumeration (`SELECT DISTINCT s.org_id …`) returns
+// `optedInOrgRows` while `loadSettings()` still gets `settingsRows`.
+//
+// `candidatesByOrg` feeds per-workspace scans; `candidateFetchCalls` records the
+// orgId each `getPromoteDecayCandidates` was asked for (the #4582 per-workspace
+// contract). `promotedIds` / `demotedIds` capture what the tick asked the DB to
+// flip; `promoteOrgs` / `demoteOrgs` are the RETURNING org ids the tick evicts
+// caches for.
 // ---------------------------------------------------------------------------
 let dbAvailable = false;
 let settingsRows: Array<{
@@ -15,29 +28,45 @@ let settingsRows: Array<{
   org_id: string | null;
 }> = [];
 
-let candidates: Array<Record<string, unknown>> = [];
+let optedInOrgRows: Array<{ org_id: string }> = [];
+
+let candidatesByOrg = new Map<string | null, Array<Record<string, unknown>>>();
+let defaultCandidates: Array<Record<string, unknown>> = [];
+let candidateFetchCalls: Array<string | null> = [];
+
 let promotedIds: readonly string[] = [];
 let demotedIds: readonly string[] = [];
 let invalidatedOrgs: Array<string | null> = [];
+let promoteOrgs: Array<string | null> = ["org-a"];
+let demoteOrgs: Array<string | null> = ["org-b"];
 let failPromote = false;
 let failDemote = false;
 
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => dbAvailable,
   getInternalDB: () => ({ query: async () => ({ rows: [] }), end: async () => {}, on: () => {} }),
-  internalQuery: async () => settingsRows,
+  internalQuery: async (sql: string) => {
+    if (typeof sql === "string" && sql.includes("SELECT DISTINCT s.org_id")) {
+      return optedInOrgRows;
+    }
+    return settingsRows;
+  },
   internalExecute: () => {},
   getApprovedPatterns: async () => [],
-  getPromoteDecayCandidates: async () => candidates,
+  getPromoteDecayCandidates: async (orgId: string | null) => {
+    candidateFetchCalls.push(orgId);
+    const explicit = candidatesByOrg.get(orgId);
+    return explicit ?? defaultCandidates;
+  },
   promoteLearnedPatterns: async (ids: readonly string[]) => {
     if (failPromote) throw new Error("boom");
     promotedIds = ids;
-    return { count: ids.length, orgIds: ids.length > 0 ? ["org-a"] : [] };
+    return { count: ids.length, orgIds: ids.length > 0 ? promoteOrgs : [] };
   },
   demoteLearnedPatterns: async (ids: readonly string[]) => {
     if (failDemote) throw new Error("kaboom");
     demotedIds = ids;
-    return { count: ids.length, orgIds: ids.length > 0 ? ["org-b"] : [] };
+    return { count: ids.length, orgIds: ids.length > 0 ? demoteOrgs : [] };
   },
   getEncryptionKey: () => null,
   encryptSecret: (v: string) => v,
@@ -46,9 +75,7 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 // The scheduler only touches pattern-cache via a dynamic import of
-// invalidatePatternCache (in runPromoteDecayTick), which we observe here. It no
-// longer reads any default constant from pattern-cache (those moved to
-// learn-settings, #3722), so this mock stubs only the invalidation hook.
+// invalidatePatternCache (in the per-workspace tick), which we observe here.
 void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
   invalidatePatternCache: (orgId: string | null) => {
     invalidatedOrgs.push(orgId);
@@ -60,10 +87,11 @@ void mock.module("@atlas/api/lib/logger", () => ({
 }));
 
 const {
-  isPromoteDecaySchedulerEnabled,
+  isPromoteDecayEnabledForWorkspace,
   getPromoteDecaySchedulerIntervalMs,
   resolvePromoteDecayThresholds,
   runPromoteDecayTick,
+  PROMOTE_DECAY_ENABLED_KEY,
   DEFAULT_PROMOTE_DECAY_INTERVAL_MS,
 } = await import("@atlas/api/lib/learn/promote-decay-scheduler");
 
@@ -83,16 +111,35 @@ function candidateRow(over: Record<string, unknown>): Record<string, unknown> {
   };
 }
 
+/** Fully-typed `ResolvedConfig` so a `deployMode` typo can't compile silently. */
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
 beforeEach(() => {
   delete process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED;
   delete process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS;
   _resetSettingsCache();
+  _resetConfig();
   dbAvailable = false;
   settingsRows = [];
-  candidates = [];
+  optedInOrgRows = [];
+  candidatesByOrg = new Map();
+  defaultCandidates = [];
+  candidateFetchCalls = [];
   promotedIds = [];
   demotedIds = [];
   invalidatedOrgs = [];
+  promoteOrgs = ["org-a"];
+  demoteOrgs = ["org-b"];
   failPromote = false;
   failDemote = false;
 });
@@ -101,28 +148,60 @@ afterEach(() => {
   delete process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED;
   delete process.env.ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS;
   _resetSettingsCache();
+  _resetConfig();
 });
 
-describe("isPromoteDecaySchedulerEnabled", () => {
+// ── Workspace-scoped enablement resolver (#4582) ──────────────────────
+describe("isPromoteDecayEnabledForWorkspace", () => {
   it("is off by default", () => {
-    expect(isPromoteDecaySchedulerEnabled()).toBe(false);
+    expect(isPromoteDecayEnabledForWorkspace(null)).toBe(false);
+    expect(isPromoteDecayEnabledForWorkspace("ws-1")).toBe(false);
   });
 
-  it("turns on for 'true' / '1'", () => {
+  it("turns on for 'true' / '1' via the env/default tier (self-hosted opt-in)", () => {
     process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "true";
-    expect(isPromoteDecaySchedulerEnabled()).toBe(true);
+    expect(isPromoteDecayEnabledForWorkspace(null)).toBe(true);
     process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "1";
-    expect(isPromoteDecaySchedulerEnabled()).toBe(true);
+    expect(isPromoteDecayEnabledForWorkspace(null)).toBe(true);
   });
 
-  it("a platform DB override beats the env var (#3392 pattern)", async () => {
-    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "false";
+  it("a per-workspace DB override opts in one workspace and leaves others off", async () => {
     dbAvailable = true;
     settingsRows = [
-      { key: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED", value: "true", updated_at: "2026-01-01", updated_by: null, org_id: null },
+      {
+        key: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
+        value: "true",
+        updated_at: "2026-01-01",
+        updated_by: null,
+        org_id: "ws-1",
+      },
     ];
     await loadSettings();
-    expect(isPromoteDecaySchedulerEnabled()).toBe(true);
+    expect(isPromoteDecayEnabledForWorkspace("ws-1")).toBe(true);
+    expect(isPromoteDecayEnabledForWorkspace("ws-2")).toBe(false);
+    expect(isPromoteDecayEnabledForWorkspace(null)).toBe(false);
+  });
+});
+
+// The SaaS enumeration filters `WHERE s.key = $1` bound to
+// PROMOTE_DECAY_ENABLED_KEY. If settings.ts renames the registry key/envVar
+// without updating the constant, enumeration silently matches ZERO workspaces
+// (promotion never runs for any tenant) with no other failure. This crosses the
+// constant against the REAL registry (this test uses the unmocked settings
+// module) so drift ships red. It also pins the web-toggle contract: the key is a
+// workspace-scoped boolean, so the data-driven Workspace Settings page renders
+// it as a toggle (#4582).
+describe("ATLAS_LEARN_PROMOTE_DECAY_ENABLED registry ↔ constant (#4582)", () => {
+  it("the registry has a workspace-scoped boolean entry keyed by the exported constant", () => {
+    const def = getSettingDefinition(PROMOTE_DECAY_ENABLED_KEY);
+    expect(def).toBeDefined();
+    expect(def?.scope).toBe("workspace");
+    expect(def?.type).toBe("boolean");
+    expect(def?.envVar).toBe(PROMOTE_DECAY_ENABLED_KEY);
+    // Not requiresRestart and not hidden from SaaS workspace admins — the two
+    // properties that make it a live, self-service toggle on the settings page.
+    expect(def?.requiresRestart).toBeFalsy();
+    expect(def?.saasVisible).not.toBe(false);
   });
 });
 
@@ -168,18 +247,33 @@ describe("resolvePromoteDecayThresholds", () => {
   });
 });
 
-describe("runPromoteDecayTick", () => {
+// ── Self-hosted (single implicit workspace, degenerate case) ──────────
+describe("runPromoteDecayTick — self-hosted", () => {
+  beforeEach(() => {
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+    dbAvailable = true;
+  });
+
   it("no-ops without an internal DB", async () => {
     dbAvailable = false;
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "true";
     const r = await runPromoteDecayTick();
-    expect(r).toEqual({ candidates: 0, promoted: 0, demoted: 0, errors: 0 });
+    expect(r).toEqual({ workspacesConsidered: 0, candidates: 0, promoted: 0, demoted: 0, errors: 0 });
+    expect(candidateFetchCalls).toEqual([]);
+  });
+
+  it("no-ops (no scan) when the single workspace has NOT opted in", async () => {
+    // knob unset → off by default
+    const r = await runPromoteDecayTick();
+    expect(r.workspacesConsidered).toBe(0);
+    expect(candidateFetchCalls).toEqual([]);
     expect(promotedIds).toEqual([]);
     expect(demotedIds).toEqual([]);
   });
 
-  it("promotes qualifying rows, demotes stale auto-promoted rows, leaves human approvals", async () => {
-    dbAvailable = true;
-    candidates = [
+  it("promotes / demotes / spares human approvals for the opted-in NULL-org workspace", async () => {
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "true";
+    defaultCandidates = [
       candidateRow({ id: "promote-me" }),
       candidateRow({ id: "demote-me", status: "approved", auto_promoted: true, last_seen_at: daysAgo(60) }),
       // Human approval — never auto-demoted even if stale.
@@ -190,31 +284,30 @@ describe("runPromoteDecayTick", () => {
 
     const r = await runPromoteDecayTick();
 
+    // The self-hosted degenerate path scans exactly the single NULL-org workspace.
+    expect(candidateFetchCalls).toEqual([null]);
     expect(promotedIds).toEqual(["promote-me"]);
     expect(demotedIds).toEqual(["demote-me"]);
+    expect(r.workspacesConsidered).toBe(1);
     expect(r.candidates).toBe(4);
     expect(r.promoted).toBe(1);
     expect(r.demoted).toBe(1);
     expect(r.errors).toBe(0);
-    // Affected workspaces are cache-invalidated.
     expect(invalidatedOrgs).toContain("org-a");
     expect(invalidatedOrgs).toContain("org-b");
   });
 
   it("records an error instead of throwing when a query rejects", async () => {
-    dbAvailable = true;
-    candidates = [candidateRow({ id: "x" })];
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "true";
+    defaultCandidates = [candidateRow({ id: "x" })];
     failPromote = true;
     const r = await runPromoteDecayTick();
     expect(r.errors).toBe(1);
   });
 
   it("preserves the successful side when the other batch throws (no Promise.all masking)", async () => {
-    // promote succeeds, demote throws: the committed promotion's count must
-    // survive AND its cache must still be invalidated — a Promise.all would lose
-    // both by unwinding to the outer catch (#3636 review).
-    dbAvailable = true;
-    candidates = [
+    process.env.ATLAS_LEARN_PROMOTE_DECAY_ENABLED = "true";
+    defaultCandidates = [
       candidateRow({ id: "promote-me" }),
       candidateRow({ id: "demote-me", status: "approved", auto_promoted: true, last_seen_at: daysAgo(60) }),
     ];
@@ -228,5 +321,54 @@ describe("runPromoteDecayTick", () => {
     expect(promotedIds).toEqual(["promote-me"]);
     // The successful promote still invalidated its workspace's cache.
     expect(invalidatedOrgs).toContain("org-a");
+  });
+});
+
+// ── SaaS (iterate opted-in workspaces) ────────────────────────────────
+describe("runPromoteDecayTick — SaaS", () => {
+  beforeEach(() => {
+    _setConfigForTest(configWithDeployMode("saas"));
+    dbAvailable = true;
+  });
+
+  it("iterates ONLY the opted-in workspaces; opted-out workspaces are never scanned", async () => {
+    optedInOrgRows = [{ org_id: "ws-1" }, { org_id: "ws-2" }];
+    // ws-3 is intentionally NOT in the opted-in set.
+    candidatesByOrg.set("ws-1", [candidateRow({ id: "p1" })]);
+    candidatesByOrg.set("ws-2", []);
+    promoteOrgs = ["ws-1"];
+
+    const r = await runPromoteDecayTick();
+
+    // Exactly the two opted-in workspaces were scanned, in enumeration order.
+    expect(candidateFetchCalls).toEqual(["ws-1", "ws-2"]);
+    expect(candidateFetchCalls).not.toContain("ws-3");
+    expect(candidateFetchCalls).not.toContain(null);
+    expect(r.workspacesConsidered).toBe(2);
+    expect(promotedIds).toEqual(["p1"]);
+    expect(r.promoted).toBe(1);
+    expect(invalidatedOrgs).toContain("ws-1");
+  });
+
+  it("no-ops when no workspace has opted in (empty enumeration)", async () => {
+    optedInOrgRows = [];
+    const r = await runPromoteDecayTick();
+    expect(r.workspacesConsidered).toBe(0);
+    expect(candidateFetchCalls).toEqual([]);
+  });
+
+  it("a failure in one workspace does not abort the sweep of the others", async () => {
+    optedInOrgRows = [{ org_id: "ws-1" }, { org_id: "ws-2" }];
+    candidatesByOrg.set("ws-1", [candidateRow({ id: "p1" })]);
+    candidatesByOrg.set("ws-2", [candidateRow({ id: "p2" })]);
+    // promote throws for BOTH — but each workspace is settled independently, so
+    // both are still considered and each records its own error.
+    failPromote = true;
+
+    const r = await runPromoteDecayTick();
+
+    expect(r.workspacesConsidered).toBe(2);
+    expect(candidateFetchCalls).toEqual(["ws-1", "ws-2"]);
+    expect(r.errors).toBe(2);
   });
 });

--- a/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
+++ b/packages/api/src/lib/learn/__tests__/promote-decay-scheduler.test.ts
@@ -29,10 +29,16 @@ let settingsRows: Array<{
 }> = [];
 
 let optedInOrgRows: Array<{ org_id: string }> = [];
+// Captured from the SaaS opt-in enumeration query so a test can assert it binds
+// the right key and keeps its tenant-safety filters (#4582).
+let enumerationSql: string | null = null;
+let enumerationParams: unknown[] | null = null;
+let enumerationThrows = false;
 
 let candidatesByOrg = new Map<string | null, Array<Record<string, unknown>>>();
 let defaultCandidates: Array<Record<string, unknown>> = [];
 let candidateFetchCalls: Array<string | null> = [];
+let failCandidateFetch = false;
 
 let promotedIds: readonly string[] = [];
 let demotedIds: readonly string[] = [];
@@ -41,12 +47,16 @@ let promoteOrgs: Array<string | null> = ["org-a"];
 let demoteOrgs: Array<string | null> = ["org-b"];
 let failPromote = false;
 let failDemote = false;
+let errorLogs: string[] = [];
 
 void mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => dbAvailable,
   getInternalDB: () => ({ query: async () => ({ rows: [] }), end: async () => {}, on: () => {} }),
-  internalQuery: async (sql: string) => {
+  internalQuery: async (sql: string, params?: unknown[]) => {
     if (typeof sql === "string" && sql.includes("SELECT DISTINCT s.org_id")) {
+      enumerationSql = sql;
+      enumerationParams = params ?? null;
+      if (enumerationThrows) throw new Error("enumeration boom");
       return optedInOrgRows;
     }
     return settingsRows;
@@ -55,6 +65,7 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getApprovedPatterns: async () => [],
   getPromoteDecayCandidates: async (orgId: string | null) => {
     candidateFetchCalls.push(orgId);
+    if (failCandidateFetch) throw new Error("candidate fetch boom");
     const explicit = candidatesByOrg.get(orgId);
     return explicit ?? defaultCandidates;
   },
@@ -83,7 +94,14 @@ void mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
 }));
 
 void mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: (_obj: unknown, msg?: string) => {
+      errorLogs.push(typeof msg === "string" ? msg : "");
+    },
+    debug: () => {},
+  }),
 }));
 
 const {
@@ -132,9 +150,13 @@ beforeEach(() => {
   dbAvailable = false;
   settingsRows = [];
   optedInOrgRows = [];
+  enumerationSql = null;
+  enumerationParams = null;
+  enumerationThrows = false;
   candidatesByOrg = new Map();
   defaultCandidates = [];
   candidateFetchCalls = [];
+  failCandidateFetch = false;
   promotedIds = [];
   demotedIds = [];
   invalidatedOrgs = [];
@@ -142,6 +164,7 @@ beforeEach(() => {
   demoteOrgs = ["org-b"];
   failPromote = false;
   failDemote = false;
+  errorLogs = [];
 });
 
 afterEach(() => {
@@ -355,6 +378,46 @@ describe("runPromoteDecayTick — SaaS", () => {
     const r = await runPromoteDecayTick();
     expect(r.workspacesConsidered).toBe(0);
     expect(candidateFetchCalls).toEqual([]);
+  });
+
+  it("the opt-in enumeration binds the promote key and keeps its tenant-safety filters", async () => {
+    optedInOrgRows = [{ org_id: "ws-1" }];
+    await runPromoteDecayTick();
+    // Bound to the exported key, not a stray literal — a rename that broke this
+    // would enroll ZERO tenants with no other signal.
+    expect(enumerationParams).toEqual([PROMOTE_DECAY_ENABLED_KEY]);
+    // The three clauses that keep the sweep org-safe: only explicit workspace
+    // overrides (never a platform/self-hosted NULL-org row), only truthy values,
+    // and joined to a live organization (a deleted workspace's stale row drops).
+    expect(enumerationSql).toContain("s.org_id IS NOT NULL");
+    expect(enumerationSql).toContain("value IN ('true', '1')");
+    expect(enumerationSql).toContain("JOIN organization");
+  });
+
+  it("an enumeration failure is contained — NO NULL-org fallthrough", async () => {
+    // If a future refactor added `catch { return [null] }` to the resolver, a DB
+    // blip during enumeration would trigger a cross-tenant NULL-org scan. Pin
+    // that the failure is counted and the sweep is skipped entirely instead.
+    enumerationThrows = true;
+    const r = await runPromoteDecayTick();
+    expect(r.errors).toBe(1);
+    expect(r.workspacesConsidered).toBe(0);
+    expect(candidateFetchCalls).not.toContain(null);
+    expect(candidateFetchCalls).toEqual([]);
+  });
+
+  it("escalates to an error log when EVERY considered workspace fails systemically", async () => {
+    // A schema drift / DB outage fails each workspace's candidate fetch at the
+    // outer catch. Per-workspace warns alone would bury a whole-feature outage,
+    // so the tick summary must escalate to error (panel review).
+    optedInOrgRows = [{ org_id: "ws-1" }, { org_id: "ws-2" }];
+    failCandidateFetch = true;
+
+    const r = await runPromoteDecayTick();
+
+    expect(r.workspacesConsidered).toBe(2);
+    expect(r.errors).toBe(2);
+    expect(errorLogs.some((m) => m.includes("every considered workspace failed"))).toBe(true);
   });
 
   it("a failure in one workspace does not abort the sweep of the others", async () => {

--- a/packages/api/src/lib/learn/learn-settings.ts
+++ b/packages/api/src/lib/learn/learn-settings.ts
@@ -17,10 +17,18 @@
  *   - `ATLAS_LEARN_CONFIDENCE_THRESHOLD`
  *   - `ATLAS_LEARN_LATENCY_BUDGET_MS`
  *
+ * **Workspace-scoped auto-promotion opt-in** (read per tick via
+ * `getSettingAuto(key, orgId)` — the SaaS-first trust dial, #4582):
+ *   - `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` — whether auto-promotion runs for a
+ *     workspace, off by default. Moved OUT of platform scope (#4582): the single
+ *     platform fiber now iterates the workspaces that opted in, so this is a
+ *     per-workspace, hot-reloaded dial, not a boot-consumed master switch.
+ *     Mirrors `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`.
+ *
  * **Platform-scoped** (read with `getSetting(key)` — no orgId — because the
- * nightly auto-promote/decay job is a single process-global fiber forked once at
- * boot by `makeSchedulerLive`, so there is no per-workspace tick):
- *   - `ATLAS_LEARN_PROMOTE_DECAY_ENABLED`     (boot-consumed, requiresRestart)
+ * auto-promote/decay job is a single process-global fiber forked once at boot by
+ * `makeSchedulerLive`, so its CADENCE and GATE TUNING are operator policy,
+ * uniform across the workspaces the tick iterates):
  *   - `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` (boot-consumed, requiresRestart)
  *   - `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS`
  *   - `ATLAS_LEARN_DECAY_UNSEEN_DAYS`
@@ -108,7 +116,30 @@ export function getLatencyBudgetMs(orgId?: string | null): number {
 }
 
 // ---------------------------------------------------------------------------
-// Platform-scoped promote/decay knobs
+// Workspace-scoped auto-promotion opt-in (#4582)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether auto-promotion is enabled for a workspace (#4582). Workspace-scoped
+ * and hot-reloaded: a workspace admin flips it from Admin → Settings and it
+ * takes effect on the next scheduler tick with no restart. Resolution is the
+ * standard tier chain — workspace override > platform override > env >
+ * default(false) — so on self-hosted the single implicit workspace opts in via
+ * the env var (or a platform override) with no per-workspace row to set, and on
+ * SaaS each workspace opts in with its own DB override.
+ *
+ * This replaces the retired platform-scoped, boot-consumed master switch: the
+ * trust dial now belongs to the workspace, mirroring
+ * `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`. Keep the literal key on the call line so
+ * `scripts/check-settings-readers.sh` (R1) sees a runtime reader.
+ */
+export function isPromoteDecayEnabledForWorkspace(orgId?: string | null): boolean {
+  const v = getSettingAuto("ATLAS_LEARN_PROMOTE_DECAY_ENABLED", orgId ?? undefined);
+  return v === "true" || v === "1";
+}
+
+// ---------------------------------------------------------------------------
+// Platform-scoped promote/decay knobs (fiber cadence + gate tuning)
 // ---------------------------------------------------------------------------
 
 /**
@@ -120,15 +151,6 @@ function parseNumeric(raw: string | undefined, fallback: number, min: number): n
   if (raw === undefined) return fallback;
   const parsed = parseFloat(raw);
   return Number.isFinite(parsed) && parsed >= min ? parsed : fallback;
-}
-
-/**
- * Whether the nightly promote/decay job is enabled. Platform-scoped, consumed
- * once at boot (requiresRestart): platform DB override > env > default.
- */
-export function isPromoteDecaySchedulerEnabled(): boolean {
-  const v = getSetting("ATLAS_LEARN_PROMOTE_DECAY_ENABLED");
-  return v === "true" || v === "1";
 }
 
 /**

--- a/packages/api/src/lib/learn/learn-settings.ts
+++ b/packages/api/src/lib/learn/learn-settings.ts
@@ -17,13 +17,17 @@
  *   - `ATLAS_LEARN_CONFIDENCE_THRESHOLD`
  *   - `ATLAS_LEARN_LATENCY_BUDGET_MS`
  *
- * **Workspace-scoped auto-promotion opt-in** (read per tick via
- * `getSettingAuto(key, orgId)` — the SaaS-first trust dial, #4582):
+ * **Workspace-scoped auto-promotion opt-in** — the SaaS-first trust dial (#4582):
  *   - `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` — whether auto-promotion runs for a
  *     workspace, off by default. Moved OUT of platform scope (#4582): the single
  *     platform fiber now iterates the workspaces that opted in, so this is a
  *     per-workspace, hot-reloaded dial, not a boot-consumed master switch.
- *     Mirrors `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`.
+ *     Mirrors `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`. Read two ways: the self-hosted
+ *     degenerate workspace resolves it through `getSettingAuto(key, null)`
+ *     (the `isPromoteDecayEnabledForWorkspace` resolver below); the SaaS tick
+ *     enumerates opted-in workspaces straight from the `settings` table
+ *     (`listPromoteDecayOrgIds` in the scheduler) so an env/platform default
+ *     can't opt a specific tenant in.
  *
  * **Platform-scoped** (read with `getSetting(key)` — no orgId — because the
  * auto-promote/decay job is a single process-global fiber forked once at boot by

--- a/packages/api/src/lib/learn/promote-decay-scheduler.ts
+++ b/packages/api/src/lib/learn/promote-decay-scheduler.ts
@@ -1,49 +1,74 @@
 /**
- * Nightly auto-promote / decay scheduler for learned query patterns
- * (PRD #3617 B-2, #3636).
+ * SaaS-first per-workspace auto-promote / decay scheduler for learned query
+ * patterns (PRD #3617 B-2, #3636; workspace opt-in #4582).
  *
- * Once a tick (default 24h) this:
- *   - PROMOTES pending `query_pattern` rows that clear a tunable gate
- *     (confidence + repetition + latency budget) from pending → approved, so
- *     the learning loop maintains itself without an admin in the loop.
- *   - DECAYS (DEMOTES, never deletes) auto-promoted rows that have gone unseen
- *     past a tunable window back to pending, so the injected set stays fresh.
+ * One platform fiber, forked once at boot (`makeSchedulerLive`), iterates the
+ * workspaces that opted into auto-promotion — the workspace-scoped
+ * `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` trust dial, off by default. Self-hosted's
+ * single implicit workspace is the degenerate case of the same per-workspace
+ * tick, not a different model (mirrors the semantic-expert scheduler, #4516).
+ * Each workspace's tick:
+ *   - PROMOTES its pending `query_pattern` rows that clear a tunable gate
+ *     (confidence + repetition + latency budget + recency) from pending →
+ *     approved, so the learning loop maintains itself without an admin.
+ *   - DECAYS (DEMOTES, never deletes) its auto-promoted rows unseen past a
+ *     tunable window back to pending, so the injected set stays fresh.
  *
- * The decision is the pure {@link decidePromoteDecay} function; this module owns
- * only the I/O — fetching candidates, applying the result, and invalidating the
- * retrieval cache for affected workspaces. The fiber that calls
- * {@link runPromoteDecayTick} on a schedule is wired in `lib/effect/layers.ts`,
- * modeled on the semantic-expert scheduler.
+ * The decision is the pure {@link decidePromoteDecay} function, unchanged — its
+ * #3636 invariants (recency gate; decay never touches a human approval; human
+ * review clears the auto-promoted flag; rejected rows stay frozen) are preserved.
+ * This module owns only the I/O: resolving the opted-in workspaces, fetching
+ * each workspace's candidates, applying the result, and invalidating the
+ * retrieval cache for affected workspaces.
+ *
+ * The retired platform-scoped, env-only, restart-required master switch
+ * (`ATLAS_LEARN_PROMOTE_DECAY_ENABLED` at platform scope, boot-consumed) is
+ * gone: the fiber now always runs and gates per-workspace at runtime, so a
+ * workspace opting in takes effect on the next tick with no redeploy. The gate
+ * TUNING and the fiber CADENCE stay platform-scoped operator policy — only the
+ * on/off dial is per-workspace.
  *
  * `semantic_amendment` rows are deliberately out of scope — they rewrite YAML on
  * approval and keep human review (mirrors the expert auto-approve carve-out).
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { isSaasModeForGuard } from "@atlas/api/lib/settings";
 // Type-only import — erased at compile time, so it does NOT eagerly load
-// db/internal and the dynamic import + mock seam in runPromoteDecayTick stays
-// intact. Reusing the row type keeps `toCandidate` from drifting from the SQL.
+// db/internal and the dynamic import + mock seam in the tick stays intact.
+// Reusing the row type keeps `toCandidate` from drifting from the SQL.
 import type { PromoteDecayCandidateRow } from "@atlas/api/lib/db/internal";
 import {
   decidePromoteDecay,
   type PromoteDecayCandidate,
+  type PromoteDecayThresholds,
 } from "@atlas/api/lib/learn/promote-decay";
 import {
-  isPromoteDecaySchedulerEnabled,
+  isPromoteDecayEnabledForWorkspace,
   getPromoteDecaySchedulerIntervalMs,
   getPromoteDecayThresholds,
   DEFAULT_PROMOTE_DECAY_INTERVAL_MS,
 } from "@atlas/api/lib/learn/learn-settings";
 
-// The ATLAS_LEARN_* reads moved to the single learn-settings resolver (#3722).
-// Re-export them from this module's public surface so layers.ts (the boot
-// fiber) and the scheduler test keep importing them from here unchanged.
+// The ATLAS_LEARN_* reads live in the single learn-settings resolver (#3722).
+// Re-export the fiber's cadence + gate resolvers from this module's public
+// surface so layers.ts (the boot fiber) and the scheduler test keep importing
+// them from here unchanged.
 export {
-  isPromoteDecaySchedulerEnabled,
+  isPromoteDecayEnabledForWorkspace,
   getPromoteDecaySchedulerIntervalMs,
   getPromoteDecayThresholds as resolvePromoteDecayThresholds,
   DEFAULT_PROMOTE_DECAY_INTERVAL_MS,
 };
+
+/**
+ * The workspace-scoped opt-in key, exported so the SaaS enumeration query below
+ * and `settings.ts` stay in lockstep. A guard test in the scheduler test
+ * cross-checks this constant against the real registry (`getSettingDefinition`)
+ * so a rename can't silently make the enumeration match ZERO workspaces —
+ * auto-promotion never running for any tenant, with no other failure signal.
+ */
+export const PROMOTE_DECAY_ENABLED_KEY = "ATLAS_LEARN_PROMOTE_DECAY_ENABLED";
 
 const log = createLogger("promote-decay-scheduler");
 
@@ -52,12 +77,25 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** Upper bound on rows evaluated per tick — a runaway-table backstop. The
- *  scheduler logs when the cap is hit so a silently-truncated tick is visible. */
+/** Upper bound on rows evaluated per workspace per tick — a runaway-table
+ *  backstop. The scheduler logs when the cap is hit so a silently-truncated
+ *  tick is visible. Because the scan is freshest-first (#4582), hitting the cap
+ *  defers the oldest-touched rows, never the fresh ones a tenant is re-running. */
 const CANDIDATE_LIMIT = 10000;
 
-/** Summary of a single tick. */
+/** Summary of a single tick — the sum across every workspace it iterated. */
 export interface PromoteDecayTickResult {
+  /** Workspaces the tick iterated (1 on the self-hosted degenerate path, 0 when
+   *  nothing opted in). */
+  workspacesConsidered: number;
+  candidates: number;
+  promoted: number;
+  demoted: number;
+  errors: number;
+}
+
+/** Per-workspace counters — folded into the tick total. */
+interface WorkspaceCounters {
   candidates: number;
   promoted: number;
   demoted: number;
@@ -84,106 +122,113 @@ function toCandidate(row: PromoteDecayCandidateRow): PromoteDecayCandidate {
 }
 
 /**
- * Run a single promote/decay tick.
+ * Resolve the workspaces this tick should process.
+ *
+ * SaaS-first (#4582): on SaaS, iterate the workspaces that opted in (the
+ * workspace-scoped `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` knob, off by default). On
+ * self-hosted the whole deployment is one implicit workspace (NULL org) — the
+ * degenerate case — opted in iff that workspace's knob resolves true (the env
+ * var or a platform override, since there is no per-workspace DB row to set).
+ *
+ * NOTE: this deploy-mode branch SELECTS an iteration strategy (enumerate
+ * per-workspace vs. one degenerate workspace); the per-tick opt-in + id-keyed
+ * apply steps are what make running on SaaS org-safe by construction.
+ */
+async function resolvePromoteDecayWorkspaces(): Promise<Array<string | null>> {
+  if (!isSaasModeForGuard()) {
+    return isPromoteDecayEnabledForWorkspace(null) ? [null] : [];
+  }
+  return listPromoteDecayOrgIds();
+}
+
+/**
+ * Enumerate the workspaces that opted into auto-promotion. Reads the settings
+ * table directly (one row per workspace override) joined to `organization` so a
+ * stale override for a deleted workspace is dropped.
+ *
+ * "opted in" means "has an explicit workspace-scoped DB override set to true" —
+ * this deliberately does NOT route through getSetting()'s env/default tier: an
+ * env var or platform default cannot opt a *specific* tenant into promotion. So
+ * a platform-level `ATLAS_LEARN_PROMOTE_DECAY_ENABLED=true` on SaaS enrolls
+ * nobody by design; enrollment is always a per-workspace admin action (mirrors
+ * the autonomous-improve enumeration, #4516).
+ */
+async function listPromoteDecayOrgIds(): Promise<string[]> {
+  const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
+  if (!hasInternalDB()) return [];
+
+  const rows = await internalQuery<{ org_id: string }>(
+    `SELECT DISTINCT s.org_id AS org_id
+       FROM settings s
+       JOIN organization o ON o.id = s.org_id
+      WHERE s.key = $1 AND s.value IN ('true', '1') AND s.org_id IS NOT NULL`,
+    [PROMOTE_DECAY_ENABLED_KEY],
+  );
+  return rows.map((r) => r.org_id);
+}
+
+/**
+ * Run a single promote/decay tick across all opted-in workspaces.
  *
  * 1. Bail if there's no internal DB (self-hosted without one).
- * 2. Fetch promotion + decay candidates (scoped to `query_pattern`).
- * 3. Apply the pure decision against the resolved gate.
- * 4. Promote / demote the resulting id sets (each guarded so a concurrent admin
- *    action can't be clobbered — see the DB helpers).
- * 5. Invalidate the retrieval cache for every affected workspace.
+ * 2. Resolve the opted-in workspace set; bail if empty.
+ * 3. Resolve the gate thresholds ONCE (platform-scoped operator policy, uniform
+ *    across workspaces — only the on/off opt-in is per-workspace).
+ * 4. For each workspace, run its tick independently — a per-workspace failure is
+ *    logged and never aborts the sweep.
  *
  * Never throws — errors are logged and surfaced in `result.errors`.
  */
 export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
-  const result: PromoteDecayTickResult = { candidates: 0, promoted: 0, demoted: 0, errors: 0 };
+  const result: PromoteDecayTickResult = {
+    workspacesConsidered: 0,
+    candidates: 0,
+    promoted: 0,
+    demoted: 0,
+    errors: 0,
+  };
 
   try {
-    const {
-      hasInternalDB,
-      getPromoteDecayCandidates,
-      promoteLearnedPatterns,
-      demoteLearnedPatterns,
-    } = await import("@atlas/api/lib/db/internal");
-
+    const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
     if (!hasInternalDB()) {
       log.debug("No internal DB — skipping promote/decay tick");
       return result;
     }
 
-    const candidates = await getPromoteDecayCandidates(CANDIDATE_LIMIT);
-    result.candidates = candidates.length;
-    if (candidates.length === CANDIDATE_LIMIT) {
-      log.warn(
-        { limit: CANDIDATE_LIMIT },
-        "Promote/decay candidate scan hit its cap — some rows were not evaluated this tick",
-      );
-    }
-    if (candidates.length === 0) {
-      log.debug("Promote/decay tick: no candidates");
+    const workspaces = await resolvePromoteDecayWorkspaces();
+    if (workspaces.length === 0) {
+      log.debug("Promote/decay tick: no opted-in workspaces");
       return result;
     }
 
+    // Gate thresholds are platform-scoped operator policy, uniform across the
+    // workspaces the tick iterates. Resolve once and reuse — only the on/off
+    // opt-in is per-workspace, never the gate tuning.
     const thresholds = getPromoteDecayThresholds();
-    const { promote, demote } = decidePromoteDecay(
-      candidates.map(toCandidate),
-      thresholds,
-      Date.now(),
-    );
 
-    // Settle promote and demote INDEPENDENTLY. A `Promise.all` would reject as
-    // soon as either side throws and unwind to the outer catch — losing the
-    // OTHER side's already-committed count AND skipping cache invalidation for
-    // its just-flipped rows, leaving stale agent context until the 5-min TTL
-    // lapses (#3636 review). Each batch DB write is its own transaction, so a
-    // success on one side is durable regardless of the other.
-    const affected = new Set<string | null>();
-    const [promoteRes, demoteRes] = await Promise.allSettled([
-      promoteLearnedPatterns(promote),
-      demoteLearnedPatterns(demote),
-    ]);
-    if (promoteRes.status === "fulfilled") {
-      result.promoted = promoteRes.value.count;
-      for (const orgId of promoteRes.value.orgIds) affected.add(orgId);
-    } else {
-      result.errors++;
-      log.error(
-        { err: errorMessage(promoteRes.reason), ids: promote.length },
-        "Auto-promote batch failed",
-      );
-    }
-    if (demoteRes.status === "fulfilled") {
-      result.demoted = demoteRes.value.count;
-      for (const orgId of demoteRes.value.orgIds) affected.add(orgId);
-    } else {
-      result.errors++;
-      log.error(
-        { err: errorMessage(demoteRes.reason), ids: demote.length },
-        "Auto-demote batch failed",
-      );
-    }
-
-    // A promotion/demotion changes which patterns the agent sees, so evict the
-    // 5-min retrieval cache for every affected workspace (mirrors the admin
-    // approve/reject path). Imported here, not at module top, to avoid a cycle
-    // through the settings → internal → pattern-cache graph. Wrapped on its own
-    // so a cache-import/invalidation failure is logged distinctly rather than
-    // masquerading as a tick-wide failure that discards the committed counts.
-    if (affected.size > 0) {
+    // Sequential, not Promise.all: a background sweep over a normally-small set —
+    // serializing keeps the per-workspace DB work from bursting the internal
+    // pool alongside live traffic (matches the expert scheduler).
+    for (const orgId of workspaces) {
+      result.workspacesConsidered++;
       try {
-        const { invalidatePatternCache } = await import("@atlas/api/lib/learn/pattern-cache");
-        for (const orgId of affected) invalidatePatternCache(orgId);
+        const ws = await runWorkspacePromoteDecayTick(orgId, thresholds);
+        result.candidates += ws.candidates;
+        result.promoted += ws.promoted;
+        result.demoted += ws.demoted;
+        result.errors += ws.errors;
       } catch (err) {
         result.errors++;
-        log.error(
-          { err: errorMessage(err) },
-          "Promote/decay cache invalidation failed — rows were flipped but cache stays stale until TTL",
+        log.warn(
+          { err: errorMessage(err), orgId },
+          "Promote/decay tick failed for workspace — will retry next tick",
         );
       }
     }
 
     log.info(
       {
+        workspacesConsidered: result.workspacesConsidered,
         candidates: result.candidates,
         promoted: result.promoted,
         demoted: result.demoted,
@@ -192,12 +237,94 @@ export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
       "Promote/decay tick complete",
     );
   } catch (err) {
-    log.error(
-      { err: errorMessage(err) },
-      "Promote/decay tick failed",
-    );
+    log.error({ err: errorMessage(err) }, "Promote/decay tick failed");
     result.errors++;
   }
 
   return result;
+}
+
+/**
+ * Run one workspace's promote/decay tick.
+ *
+ * `orgId` is the workspace owner — a real id on SaaS, `null` on the self-hosted
+ * degenerate path. Fetches that workspace's candidates (freshest-first, capped),
+ * applies the pure decision against the shared gate, promotes/demotes the id
+ * sets, and evicts the retrieval cache for every affected workspace.
+ *
+ * Promote and demote settle INDEPENDENTLY. A `Promise.all` would reject as soon
+ * as either side throws and unwind, losing the OTHER side's already-committed
+ * count AND skipping cache invalidation for its just-flipped rows, leaving stale
+ * agent context until the 5-min TTL lapses (#3636 review). Each batch DB write
+ * is its own transaction, so a success on one side is durable regardless of the
+ * other.
+ */
+async function runWorkspacePromoteDecayTick(
+  orgId: string | null,
+  thresholds: PromoteDecayThresholds,
+): Promise<WorkspaceCounters> {
+  const counters: WorkspaceCounters = { candidates: 0, promoted: 0, demoted: 0, errors: 0 };
+
+  const { getPromoteDecayCandidates, promoteLearnedPatterns, demoteLearnedPatterns } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+
+  const candidates = await getPromoteDecayCandidates(orgId, CANDIDATE_LIMIT);
+  counters.candidates = candidates.length;
+  if (candidates.length === CANDIDATE_LIMIT) {
+    log.warn(
+      { orgId, limit: CANDIDATE_LIMIT },
+      "Promote/decay candidate scan hit its cap for workspace — freshest rows kept, oldest-touched beyond the cap deferred to a later tick",
+    );
+  }
+  if (candidates.length === 0) return counters;
+
+  const { promote, demote } = decidePromoteDecay(candidates.map(toCandidate), thresholds, Date.now());
+
+  const affected = new Set<string | null>();
+  const [promoteRes, demoteRes] = await Promise.allSettled([
+    promoteLearnedPatterns(promote),
+    demoteLearnedPatterns(demote),
+  ]);
+  if (promoteRes.status === "fulfilled") {
+    counters.promoted = promoteRes.value.count;
+    for (const affectedOrg of promoteRes.value.orgIds) affected.add(affectedOrg);
+  } else {
+    counters.errors++;
+    log.error(
+      { err: errorMessage(promoteRes.reason), orgId, ids: promote.length },
+      "Auto-promote batch failed",
+    );
+  }
+  if (demoteRes.status === "fulfilled") {
+    counters.demoted = demoteRes.value.count;
+    for (const affectedOrg of demoteRes.value.orgIds) affected.add(affectedOrg);
+  } else {
+    counters.errors++;
+    log.error(
+      { err: errorMessage(demoteRes.reason), orgId, ids: demote.length },
+      "Auto-demote batch failed",
+    );
+  }
+
+  // A promotion/demotion changes which patterns the agent sees, so evict the
+  // 5-min retrieval cache for every affected workspace (mirrors the admin
+  // approve/reject path). Imported here, not at module top, to avoid a cycle
+  // through the settings → internal → pattern-cache graph. Wrapped on its own so
+  // a cache-import/invalidation failure is logged distinctly rather than
+  // masquerading as a tick-wide failure that discards the committed counts.
+  if (affected.size > 0) {
+    try {
+      const { invalidatePatternCache } = await import("@atlas/api/lib/learn/pattern-cache");
+      for (const affectedOrg of affected) invalidatePatternCache(affectedOrg);
+    } catch (err) {
+      counters.errors++;
+      log.error(
+        { err: errorMessage(err), orgId },
+        "Promote/decay cache invalidation failed — rows were flipped but cache stays stale until TTL",
+      );
+    }
+  }
+
+  return counters;
 }

--- a/packages/api/src/lib/learn/promote-decay-scheduler.ts
+++ b/packages/api/src/lib/learn/promote-decay-scheduler.ts
@@ -6,8 +6,11 @@
  * workspaces that opted into auto-promotion — the workspace-scoped
  * `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` trust dial, off by default. Self-hosted's
  * single implicit workspace is the degenerate case of the same per-workspace
- * tick, not a different model (mirrors the semantic-expert scheduler, #4516).
- * Each workspace's tick:
+ * tick, not a different model. The per-workspace ITERATION mirrors the
+ * semantic-expert scheduler (#4516); ENABLEMENT mirrors
+ * `ATLAS_AUTONOMOUS_IMPROVE_ENABLED` — but unlike the expert fiber (which keeps
+ * a platform master switch), this fiber drops its platform enable-gate entirely
+ * and gates only per-workspace. Each workspace's tick:
  *   - PROMOTES its pending `query_pattern` rows that clear a tunable gate
  *     (confidence + repetition + latency budget + recency) from pending →
  *     approved, so the learning loop maintains itself without an admin.
@@ -209,6 +212,15 @@ export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
     // Sequential, not Promise.all: a background sweep over a normally-small set —
     // serializing keeps the per-workspace DB work from bursting the internal
     // pool alongside live traffic (matches the expert scheduler).
+    //
+    // `workspacesFailed` counts only workspaces whose ENTIRE tick threw here
+    // (candidate fetch / decision / import failed) — distinct from the inner
+    // promote/demote/cache errors, which are logged at error level and folded
+    // into `result.errors`. When every considered workspace fails this way the
+    // cause is systemic (schema drift, internal-DB outage, a decision regression),
+    // so the tick summary escalates to error rather than reporting "complete" —
+    // a per-workspace warn alone would bury a whole-feature outage (panel review).
+    let workspacesFailed = 0;
     for (const orgId of workspaces) {
       result.workspacesConsidered++;
       try {
@@ -219,6 +231,7 @@ export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
         result.errors += ws.errors;
       } catch (err) {
         result.errors++;
+        workspacesFailed++;
         log.warn(
           { err: errorMessage(err), orgId },
           "Promote/decay tick failed for workspace — will retry next tick",
@@ -226,16 +239,21 @@ export async function runPromoteDecayTick(): Promise<PromoteDecayTickResult> {
       }
     }
 
-    log.info(
-      {
-        workspacesConsidered: result.workspacesConsidered,
-        candidates: result.candidates,
-        promoted: result.promoted,
-        demoted: result.demoted,
-        errors: result.errors,
-      },
-      "Promote/decay tick complete",
-    );
+    const summary = {
+      workspacesConsidered: result.workspacesConsidered,
+      candidates: result.candidates,
+      promoted: result.promoted,
+      demoted: result.demoted,
+      errors: result.errors,
+    };
+    if (workspacesFailed > 0 && workspacesFailed === result.workspacesConsidered) {
+      log.error(
+        summary,
+        "Promote/decay tick: every considered workspace failed — auto-promotion is not running (systemic error, not a per-workspace hiccup)",
+      );
+    } else {
+      log.info(summary, "Promote/decay tick complete");
+    }
   } catch (err) {
     log.error({ err: errorMessage(err) }, "Promote/decay tick failed");
     result.errors++;

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1125,7 +1125,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     key: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",
     section: "Dynamic Learning",
     label: "Auto-Promote / Decay Interval",
-    description: "Hours between nightly auto-promote/decay runs.",
+    description: "Hours between auto-promote/decay runs.",
     type: "number",
     default: "24",
     envVar: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",
@@ -1138,7 +1138,7 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     section: "Dynamic Learning",
     label: "Auto-Promote Min Repetitions",
     description:
-      "Minimum times a pending pattern must have been seen before the nightly job will auto-promote it (alongside the confidence threshold and latency budget).",
+      "Minimum times a pending pattern must have been seen before the auto-promote job will promote it (alongside the confidence threshold and latency budget).",
     type: "number",
     default: "5",
     envVar: "ATLAS_LEARN_PROMOTE_MIN_REPETITIONS",

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1103,22 +1103,23 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_LEARN_LATENCY_BUDGET_MS",
     scope: "workspace",
   },
-  // Nightly auto-promote/decay job (#3636). The enable + interval pair is a
-  // single process-global fiber forked once at boot (makeSchedulerLive), so
-  // they are PLATFORM-scoped + requiresRestart — mirrors the expert scheduler.
-  // The gate knobs below are read once per tick (no orgId), hence platform too.
+  // Auto-promote/decay job (#3636, #4582). The enable dial is now the
+  // WORKSPACE'S OWN trust dial: workspace-scoped, off by default, hot-reloaded —
+  // one platform fiber iterates the workspaces that opted in (mirrors
+  // ATLAS_AUTONOMOUS_IMPROVE_ENABLED). The fiber CADENCE (`_INTERVAL_HOURS`) is
+  // still a single process-global fiber forked once at boot (makeSchedulerLive),
+  // hence PLATFORM-scoped + requiresRestart; the gate knobs below are operator
+  // policy read once per tick (no orgId), hence platform too.
   {
     key: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
     section: "Dynamic Learning",
-    label: "Auto-Promote / Decay Job",
+    label: "Auto-Promote Learned Patterns",
     description:
-      "Enable the nightly job that auto-promotes high-confidence, fast, frequently-seen learned patterns and demotes stale auto-promoted ones. Human approvals are never demoted; semantic amendments are never auto-promoted.",
+      "Let Atlas auto-promote this workspace's high-confidence, fast, frequently-seen learned patterns and demote stale auto-promoted ones on its own cadence (off by default). Human approvals are never demoted; semantic amendments are never auto-promoted.",
     type: "boolean",
     default: "false",
     envVar: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
-    requiresRestart: true,
-    scope: "platform",
-    saasVisible: false,
+    scope: "workspace",
   },
   {
     key: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",

--- a/packages/web/src/app/admin/settings/__tests__/promote-decay-toggle.test.tsx
+++ b/packages/web/src/app/admin/settings/__tests__/promote-decay-toggle.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Web seam for the workspace auto-promotion toggle (#4582).
+ *
+ * The auto-promote/decay trust dial is a workspace-scoped boolean in the
+ * settings registry, so the DATA-DRIVEN Workspace Settings page renders it as an
+ * editable toggle with no bespoke component (mirrors ATLAS_AUTONOMOUS_IMPROVE_
+ * ENABLED). This is its "own settings surface" — distinct from the learned-
+ * patterns cockpit. These tests pin that seam: a workspace-scoped boolean for
+ * the promote-decay key surfaces under Intelligence and is editable, while a
+ * platform-scoped sibling never leaks onto the workspace page.
+ */
+
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+
+// The promote-decay workspace toggle + a platform-scoped sibling that must be
+// filtered off the workspace page. Full SettingWithValue shape so the page's
+// grouping/rendering exercises the real contract.
+const settingsResponse = {
+  manageable: true,
+  settings: [
+    {
+      key: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
+      section: "Intelligence",
+      label: "Auto-Promote Learned Patterns",
+      description: "Let Atlas auto-promote this workspace's learned patterns.",
+      type: "boolean",
+      default: "false",
+      envVar: "ATLAS_LEARN_PROMOTE_DECAY_ENABLED",
+      scope: "workspace",
+      currentValue: "false",
+      source: "default",
+    },
+    {
+      // Platform-scoped fiber cadence — must NOT render on the workspace page.
+      key: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",
+      section: "Intelligence",
+      label: "Auto-Promote / Decay Interval",
+      description: "Hours between runs.",
+      type: "number",
+      default: "24",
+      envVar: "ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS",
+      scope: "platform",
+      currentValue: "24",
+      source: "default",
+    },
+  ],
+};
+
+let deployMode: "saas" | "self-hosted" = "saas";
+
+void mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => ({ deployMode, loading: false, error: null, resolved: true }),
+}));
+
+void mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: () => ({
+    data: settingsResponse,
+    loading: false,
+    error: null,
+    refetch: () => {},
+  }),
+  friendlyError: (err: { message?: string }) => err?.message ?? "error",
+}));
+
+void mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: async () => ({ ok: true }),
+    saving: false,
+    error: null,
+    clearError: () => {},
+    reset: () => {},
+    isMutating: () => false,
+  }),
+}));
+
+void mock.module("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { session: { activeOrganizationId: "ws_test", activeOrganizationName: "Test WS" } },
+    }),
+  },
+}));
+
+const SettingsPage = (await import("../page")).default;
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(NuqsAdapter, null, createElement(QueryClientProvider, { client }, children));
+}
+
+afterEach(() => {
+  cleanup();
+  deployMode = "saas";
+});
+
+describe("/admin/settings — workspace auto-promotion toggle (#4582)", () => {
+  test("renders the promote-decay toggle under Intelligence for a workspace admin", () => {
+    const { container } = render(createElement(SettingsPage), { wrapper });
+    const text = container.textContent ?? "";
+    expect(text).toContain("Auto-Promote Learned Patterns");
+    expect(text).toContain("Intelligence");
+    // Manageable → the row exposes an Edit affordance (the toggle is editable).
+    expect(text).toContain("Edit");
+  });
+
+  test("the platform-scoped interval key never leaks onto the workspace page", () => {
+    const { container } = render(createElement(SettingsPage), { wrapper });
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("Auto-Promote / Decay Interval");
+  });
+
+  test("the toggle also surfaces on self-hosted", () => {
+    deployMode = "self-hosted";
+    const { container } = render(createElement(SettingsPage), { wrapper });
+    expect(container.textContent ?? "").toContain("Auto-Promote Learned Patterns");
+  });
+});


### PR DESCRIPTION
## What

Auto-promotion of learned query patterns becomes the **workspace's own trust dial** (PRD #4570, milestone v0.0.50): a workspace-scoped settings-registry knob (`ATLAS_LEARN_PROMOTE_DECAY_ENABLED`), **off by default**, runtime-controllable from the admin console with hot reload — the same SaaS-first posture as `ATLAS_AUTONOMOUS_IMPROVE_ENABLED`.

The platform-scoped, env-only, restart-required master switch **retires**.

## How

- **One platform fiber, no boot enable-gate.** The `promote_decay` fiber now always runs and resolves the opted-in workspace set **per tick** — a workspace opting in takes effect on the next tick with no restart (the retired switch was boot-consumed and could never hot-reload). SaaS enumerates workspaces with an explicit workspace-scoped DB override (`SELECT DISTINCT s.org_id …`, mirroring the autonomous-improve enumeration); self-hosted's single implicit NULL-org workspace is the degenerate case of the same per-workspace tick.
- **Candidate scan is now workspace-scoped and freshest-first.** `getPromoteDecayCandidates(orgId, limit)` filters to one workspace and orders `updated_at DESC`, so when the cap bites it keeps the patterns a tenant is actively re-running instead of starving them behind stale rows (flips the old stalest-first truncation).
- **Decision core unchanged.** `decidePromoteDecay` and its #3636 invariants are preserved verbatim — recency gate; decay never demotes a human approval; human review clears the auto-promoted flag; rejected rows stay frozen. Cache eviction on promotion/decay is unchanged.
- **Web toggle.** The workspace-scoped boolean auto-surfaces as an editable toggle on the data-driven Workspace Settings page (`/admin/settings`, Intelligence section) — its own settings surface, not the learned-patterns cockpit.

## Acceptance criteria

- [x] Opted-in workspace's eligible pending patterns promote on the tick; opted-out workspaces untouched (scheduler seam tests)
- [x] Knob is workspace-scoped, visible in the admin console, takes effect without a restart
- [x] Env-only platform switch removed (same env var re-homed to workspace scope — the self-hosted fallback tier)
- [x] #3636 invariants still pinned; cache eviction unchanged
- [x] Candidate scan ordering no longer drops the freshest rows past the cap
- [x] Settings + scheduler + web seam tests

## Tests

- `promote-decay-scheduler.test.ts` — per-workspace iteration (opted-in vs opted-out, self-hosted + SaaS enumeration), registry↔constant contract, independent promote/demote settle
- `promote-decay-pg.test.ts` — real-Postgres freshest-first ordering under the cap + per-workspace scoping (plus the unchanged #3636 idempotency/invariant coverage)
- `promote-decay-toggle.test.tsx` — web settings-page toggle seam

Closes #4582

https://claude.ai/code/session_01JydkmLY5XyLBtXMAmzviGE