### PR TITLE
fix(learned-patterns): cockpit failure honesty — errors surface where the admin acts (#4574)

### DIFF
--- a/packages/web/src/app/admin/learned-patterns/__tests__/action-error-state.test.ts
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/action-error-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { renderSurface, type ActionError } from "../action-error-state";
+
+/**
+ * `renderSurface` is the honesty guard for the cockpit (#4574): it decides where
+ * a pinned mutation error renders from the action + which overlays are open.
+ * The load-bearing cases are the *orphaned* ones — a sheet/delete error whose
+ * target overlay was dismissed mid-flight, or replaced by a different item.
+ * Those must fall back to the always-mounted page banner so a late failure is
+ * never swallowed behind, or mis-rendered into, the wrong surface.
+ */
+
+const err = (action: ActionError["action"]): ActionError => ({
+  error: { message: "boom" },
+  action,
+});
+
+describe("renderSurface", () => {
+  test("null error → null (nothing renders)", () => {
+    expect(renderSurface(null, "lp-1", "lp-1")).toBeNull();
+  });
+
+  test("a row-menu status error always renders on the page", () => {
+    expect(
+      renderSurface(err({ kind: "status", id: "lp-1", status: "approved", surface: "page" }), null, null),
+    ).toBe("page");
+  });
+
+  test("a sheet status error renders in the sheet only while that pattern's sheet is open", () => {
+    const e = err({ kind: "status", id: "lp-1", status: "approved", surface: "sheet" });
+    expect(renderSurface(e, "lp-1", null)).toBe("sheet");
+  });
+
+  test("a sheet error falls back to the page when the sheet was dismissed mid-flight", () => {
+    const e = err({ kind: "status", id: "lp-1", status: "approved", surface: "sheet" });
+    // openSheetId null → the sheet closed before the failure landed.
+    expect(renderSurface(e, null, null)).toBe("page");
+  });
+
+  test("a sheet error falls back to the page when a DIFFERENT pattern's sheet is open", () => {
+    const e = err({ kind: "status", id: "lp-1", status: "approved", surface: "sheet" });
+    // Prevents pattern A's error rendering inside — and retrying from — B's sheet.
+    expect(renderSurface(e, "lp-2", null)).toBe("page");
+  });
+
+  test("a delete error renders in the dialog only while that pattern's dialog is open", () => {
+    const e = err({ kind: "delete", id: "lp-1" });
+    expect(renderSurface(e, null, "lp-1")).toBe("delete");
+  });
+
+  test("a delete error falls back to the page when the dialog is closed or targets another item", () => {
+    const e = err({ kind: "delete", id: "lp-1" });
+    expect(renderSurface(e, null, null)).toBe("page");
+    expect(renderSurface(e, null, "lp-2")).toBe("page");
+  });
+
+  test("a bulk error always renders on the page", () => {
+    expect(renderSurface(err({ kind: "bulk", status: "rejected" }), "lp-1", "lp-1")).toBe("page");
+  });
+});

--- a/packages/web/src/app/admin/learned-patterns/__tests__/action-error.test.tsx
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/action-error.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { ActionErrorAlert } from "../action-error";
+
+/**
+ * Cockpit failure-honesty (#4574): the two affordances must be labelled for
+ * what they do. The old page banner shipped a lone "Retry" whose handler only
+ * called `setActionError(null)` — a dismiss masquerading as a retry. These pins
+ * fail if the labels are swapped or the handlers are crossed.
+ */
+afterEach(() => {
+  cleanup();
+});
+
+function findButton(label: string): HTMLButtonElement {
+  const btn = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!btn) throw new Error(`button "${label}" not found`);
+  return btn as HTMLButtonElement;
+}
+
+describe("ActionErrorAlert", () => {
+  test("renders the friendly error copy inside an alert region", () => {
+    render(
+      <ActionErrorAlert
+        error={{ message: "Approve failed", requestId: "req-lp-1" }}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    const alert = document.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toContain("Approve failed");
+    // friendlyError threads the requestId through for a status-less failure.
+    expect(alert?.textContent).toContain("req-lp-1");
+  });
+
+  test('"Retry" runs onRetry only — never the dismiss handler', () => {
+    const onRetry = mock(() => {});
+    const onDismiss = mock(() => {});
+    render(
+      <ActionErrorAlert
+        error={{ message: "Reject failed" }}
+        onRetry={onRetry}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(findButton("Retry"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  test('"Dismiss" runs onDismiss only — it does not retry', () => {
+    const onRetry = mock(() => {});
+    const onDismiss = mock(() => {});
+    render(
+      <ActionErrorAlert
+        error={{ message: "Delete failed" }}
+        onRetry={onRetry}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(findButton("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  test("exposes exactly one Retry and one Dismiss affordance", () => {
+    render(
+      <ActionErrorAlert
+        error={{ message: "boom" }}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    const labels = Array.from(document.querySelectorAll("button")).map((b) =>
+      b.textContent?.trim(),
+    );
+    expect(labels.filter((l) => l === "Retry")).toHaveLength(1);
+    expect(labels.filter((l) => l === "Dismiss")).toHaveLength(1);
+  });
+});

--- a/packages/web/src/app/admin/learned-patterns/__tests__/cockpit-failure-honesty.test.tsx
+++ b/packages/web/src/app/admin/learned-patterns/__tests__/cockpit-failure-honesty.test.tsx
@@ -1,0 +1,389 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+
+/**
+ * Cockpit failure honesty (#4574): an approve / reject / delete that fails must
+ * surface the error INSIDE the surface the admin acted in — the detail sheet or
+ * the delete confirmation dialog — not in a page-body banner rendered behind the
+ * open overlay. A failed review that looks like a success is the exact bug this
+ * page fixes, so these are DOM-level pins on *where* the alert lands and on the
+ * honest Retry / Dismiss affordances.
+ */
+
+void mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/learned-patterns",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const stubAuthClient: AtlasAuthClient = {
+  signIn: { email: async () => ({}) },
+  signUp: { email: async () => ({}) },
+  signOut: async () => {},
+  useSession: () => ({ data: null, isPending: false }),
+};
+
+const LearnedPatternsPage = (await import("../page")).default;
+
+let testQueryClient: QueryClient;
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    NuqsAdapter,
+    null,
+    createElement(
+      QueryClientProvider,
+      { client: testQueryClient },
+      createElement(
+        AtlasProvider,
+        {
+          config: {
+            apiUrl: "http://localhost:3001",
+            isCrossOrigin: false as const,
+            authClient: stubAuthClient,
+          },
+          children,
+        },
+      ),
+    ),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const PATTERN = {
+  id: "lp-1",
+  orgId: null,
+  patternSql: "SELECT 1",
+  description: "Top customers by revenue",
+  sourceEntity: "orders",
+  sourceQueries: null,
+  confidence: 0.9,
+  repetitionCount: 3,
+  status: "pending" as const,
+  proposedBy: "agent" as const,
+  reviewedBy: null,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+  reviewedAt: null,
+  type: "query_pattern" as const,
+  amendmentPayload: null,
+  autoPromoted: false,
+  avgDurationMs: 12,
+};
+
+const LIST_ENVELOPE = { patterns: [PATTERN], total: 1, limit: 50, offset: 0 };
+
+interface MutationHandlers {
+  /** Response for PATCH /learned-patterns/:id (status change). */
+  patch?: () => Response;
+  /** Response for DELETE /learned-patterns/:id. */
+  del?: () => Response;
+  /** Response for POST /learned-patterns/bulk. */
+  bulk?: () => Response;
+}
+
+/**
+ * All GETs to the list base path (the list itself + the aux stats/entities
+ * fetches) return the same envelope. PATCH / DELETE delegate to caller
+ * handlers; the returned `counters.patch` / `counters.del` tallies prove a
+ * genuine Retry re-issues the mutation rather than silently dismissing it.
+ */
+function mockLearnedPatternsApi(handlers: MutationHandlers) {
+  const counters = { patch: 0, del: 0, bulk: 0 };
+  globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+    const isItemPath = /\/api\/v1\/admin\/learned-patterns\/lp-1$/.test(url);
+
+    if (method === "POST" && url.endsWith("/api/v1/admin/learned-patterns/bulk")) {
+      counters.bulk += 1;
+      if (!handlers.bulk) throw new Error(`unexpected POST ${url}`);
+      return Promise.resolve(handlers.bulk());
+    }
+    if (method === "PATCH" && isItemPath) {
+      counters.patch += 1;
+      if (!handlers.patch) throw new Error(`unexpected PATCH ${url}`);
+      return Promise.resolve(handlers.patch());
+    }
+    if (method === "DELETE" && isItemPath) {
+      counters.del += 1;
+      if (!handlers.del) throw new Error(`unexpected DELETE ${url}`);
+      return Promise.resolve(handlers.del());
+    }
+    if (method === "GET" && url.includes("/api/v1/admin/learned-patterns")) {
+      return Promise.resolve(jsonResponse(LIST_ENVELOPE));
+    }
+    throw new Error(`unexpected ${method} ${url}`);
+  }) as unknown as typeof fetch;
+  return counters;
+}
+
+const SHEET = '[data-slot="sheet-content"]';
+const DELETE_DIALOG = '[data-slot="alert-dialog-content"]';
+
+function findButtonIn(root: ParentNode, label: string): HTMLButtonElement | undefined {
+  return Array.from(root.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement | undefined;
+}
+
+/** Open the detail sheet by clicking the row's (non-button) description cell. */
+async function openDetailSheet() {
+  const cell = await waitFor(() => {
+    const el = Array.from(document.querySelectorAll("td")).find((td) =>
+      td.textContent?.includes("Top customers by revenue"),
+    );
+    if (!el) throw new Error("pattern row not rendered");
+    return el;
+  });
+  await act(async () => {
+    fireEvent.click(cell);
+  });
+  await waitFor(() => {
+    const sheet = document.querySelector(SHEET);
+    if (!sheet || !findButtonIn(sheet, "Approve")) throw new Error("sheet not open");
+  });
+}
+
+describe("/admin/learned-patterns cockpit failure honesty (#4574)", () => {
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    testQueryClient.clear();
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("a failed Approve from the sheet renders the error inside the sheet, not behind it", async () => {
+    mockLearnedPatternsApi({
+      patch: () =>
+        jsonResponse({ message: "Pattern is locked", requestId: "req-lp-500" }, 500),
+    });
+
+    render(<LearnedPatternsPage />, { wrapper: Wrapper });
+    await openDetailSheet();
+
+    const sheet = document.querySelector(SHEET)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(sheet, "Approve")!);
+    });
+
+    // The alert lands inside the still-open sheet — the whole point of the fix.
+    const alert = await waitFor(() => {
+      const el = document.querySelector(`${SHEET} [role="alert"]`);
+      if (!el) throw new Error("in-sheet alert not rendered");
+      return el;
+    });
+    expect(alert.textContent).toContain("Pattern is locked");
+    expect(alert.textContent).toContain("req-lp-500");
+
+    // Sheet is still open and the action button is back to being actionable —
+    // a failed review is never mistaken for a completed one.
+    expect(document.querySelector(SHEET)).not.toBeNull();
+    expect(findButtonIn(document.querySelector(SHEET)!, "Approve")).toBeDefined();
+    // Exactly one alert — no duplicate page-body banner rendered behind the sheet.
+    expect(document.querySelectorAll('[role="alert"]')).toHaveLength(1);
+  });
+
+  test('the in-sheet "Retry" genuinely re-issues the mutation; "Dismiss" only clears', async () => {
+    const counters = mockLearnedPatternsApi({
+      patch: () => jsonResponse({ message: "Transient failure" }, 503),
+    });
+
+    render(<LearnedPatternsPage />, { wrapper: Wrapper });
+    await openDetailSheet();
+
+    const sheet = document.querySelector(SHEET)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(sheet, "Approve")!);
+    });
+    await waitFor(() => {
+      if (!document.querySelector(`${SHEET} [role="alert"]`)) throw new Error("no alert");
+    });
+    expect(counters.patch).toBe(1);
+
+    // Retry fires the PATCH again (still failing) — a real retry, not a dismiss.
+    const alertRoot = document.querySelector(`${SHEET} [role="alert"]`)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(alertRoot, "Retry")!);
+    });
+    await waitFor(() => {
+      if (counters.patch < 2) throw new Error("retry did not re-issue the mutation");
+    });
+    expect(counters.patch).toBe(2);
+
+    // Dismiss clears the alert without issuing another request.
+    const afterRetry = document.querySelector(`${SHEET} [role="alert"]`)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(afterRetry, "Dismiss")!);
+    });
+    await waitFor(() => {
+      if (document.querySelector(`${SHEET} [role="alert"]`)) throw new Error("alert not dismissed");
+    });
+    expect(counters.patch).toBe(2);
+    // Sheet stays open after dismiss.
+    expect(document.querySelector(SHEET)).not.toBeNull();
+  });
+
+  test("a successful Approve closes/updates without any error surface", async () => {
+    mockLearnedPatternsApi({
+      patch: () => jsonResponse({ ...PATTERN, status: "approved" }),
+    });
+
+    render(<LearnedPatternsPage />, { wrapper: Wrapper });
+    await openDetailSheet();
+
+    const sheet = document.querySelector(SHEET)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(sheet, "Approve")!);
+    });
+
+    // No error alert anywhere; the sheet reflects the new approved status.
+    await waitFor(() => {
+      const s = document.querySelector(SHEET);
+      if (!s || !s.textContent?.includes("Approved")) throw new Error("status not updated");
+    });
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  test("a failed Delete keeps the confirm dialog open with the error inside it, and Retry re-issues", async () => {
+    const counters = mockLearnedPatternsApi({
+      del: () => jsonResponse({ message: "Delete blocked", requestId: "req-del-9" }, 409),
+    });
+
+    render(<LearnedPatternsPage />, { wrapper: Wrapper });
+    await openDetailSheet();
+
+    // Sheet → Delete opens the confirm dialog.
+    const sheet = document.querySelector(SHEET)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(sheet, "Delete")!);
+    });
+    const dialog = await waitFor(() => {
+      const el = document.querySelector(DELETE_DIALOG);
+      if (!el) throw new Error("delete dialog not open");
+      return el;
+    });
+
+    // Confirm the delete → it fails.
+    await act(async () => {
+      fireEvent.click(findButtonIn(dialog, "Delete")!);
+    });
+
+    // Error renders inside the dialog and the dialog stays open (not silently
+    // closed as if the delete had gone through).
+    const alert = await waitFor(() => {
+      const el = document.querySelector(`${DELETE_DIALOG} [role="alert"]`);
+      if (!el) throw new Error("in-dialog alert not rendered");
+      return el;
+    });
+    expect(alert.textContent).toContain("Delete blocked");
+    expect(document.querySelector(DELETE_DIALOG)).not.toBeNull();
+    expect(counters.del).toBe(1);
+
+    // The in-dialog Retry genuinely re-issues the DELETE (still failing).
+    await act(async () => {
+      fireEvent.click(findButtonIn(alert, "Retry")!);
+    });
+    await waitFor(() => {
+      if (counters.del < 2) throw new Error("delete retry did not re-issue");
+    });
+    expect(counters.del).toBe(2);
+    expect(document.querySelector(DELETE_DIALOG)).not.toBeNull();
+  });
+
+  test("a successful Delete closes the confirm dialog with no error surface", async () => {
+    mockLearnedPatternsApi({ del: () => new Response(null, { status: 204 }) });
+
+    render(<LearnedPatternsPage />, { wrapper: Wrapper });
+    await openDetailSheet();
+
+    const sheet = document.querySelector(SHEET)!;
+    await act(async () => {
+      fireEvent.click(findButtonIn(sheet, "Delete")!);
+    });
+    const dialog = await waitFor(() => {
+      const el = document.querySelector(DELETE_DIALOG);
+      if (!el) throw new Error("delete dialog not open");
+      return el;
+    });
+
+    await act(async () => {
+      fireEvent.click(findButtonIn(dialog, "Delete")!);
+    });
+
+    // The success path must close the dialog (the preventDefault guard only
+    // holds it open on failure) and surface no error.
+    await waitFor(() => {
+      if (document.querySelector(DELETE_DIALOG)) throw new Error("dialog did not close on success");
+    });
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  test("a bulk approve partial-failure surfaces a page banner whose Retry re-issues the bulk call", async () => {
+    // Server returns 200 with the failed row in `notFound` — a partial success
+    // the page must not read as a clean sweep.
+    const counters = mockLearnedPatternsApi({
+      bulk: () => jsonResponse({ updated: [], notFound: ["lp-1"], errors: [] }),
+    });
+
+    render(<LearnedPatternsPage />, { wrapper: Wrapper });
+
+    // Select the row, then run a bulk approve from the toolbar.
+    const checkbox = await waitFor(() => {
+      const el = document.querySelector('[aria-label="Select row"]');
+      if (!el) throw new Error("row checkbox not rendered");
+      return el as HTMLElement;
+    });
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+    const bulkApprove = await waitFor(() => {
+      const el = Array.from(document.querySelectorAll("button")).find((b) =>
+        b.textContent?.trim().startsWith("Approve 1"),
+      );
+      if (!el) throw new Error("bulk approve button not shown");
+      return el as HTMLButtonElement;
+    });
+    await act(async () => {
+      fireEvent.click(bulkApprove);
+    });
+
+    // Partial failure → page-body alert (no overlay open, so the page surface is
+    // correct and visible).
+    const alert = await waitFor(() => {
+      const el = document.querySelector('[role="alert"]');
+      if (!el) throw new Error("bulk partial-failure alert not rendered");
+      return el;
+    });
+    expect(counters.bulk).toBe(1);
+
+    // Retry re-issues the bulk POST (selection was narrowed to the failed id).
+    await act(async () => {
+      fireEvent.click(findButtonIn(alert, "Retry")!);
+    });
+    await waitFor(() => {
+      if (counters.bulk < 2) throw new Error("bulk retry did not re-issue");
+    });
+    expect(counters.bulk).toBe(2);
+  });
+});

--- a/packages/web/src/app/admin/learned-patterns/action-error-state.ts
+++ b/packages/web/src/app/admin/learned-patterns/action-error-state.ts
@@ -1,0 +1,62 @@
+import type { LearnedPatternStatus } from "@/ui/lib/types";
+import type { FetchError } from "@/ui/lib/fetch-error";
+
+/**
+ * Failure-honesty state for the learned-patterns cockpit (#4574).
+ *
+ * A mutation error is pinned to the *action* the admin took, and where it
+ * renders is *derived* at render time from that action plus which overlays are
+ * currently on screen (`renderSurface`) — never stored. Deriving it is what
+ * keeps a late-arriving failure honest: if the admin dismissed the sheet /
+ * dialog while the request was in flight, the error can't pin to an unmounted
+ * overlay (invisible) or bleed into a *different* item's sheet (and mis-retry
+ * from it). It falls back to the page banner, which is always mounted.
+ */
+
+/** Surface an error can render in, so it lands where the admin acted. */
+export type ErrorSurface = "page" | "sheet" | "delete";
+
+/** A status change fires from the row menu (page) or inside the detail sheet. */
+export type StatusSurface = "page" | "sheet";
+
+/**
+ * The failed action, replayable by the honest "Retry". A descriptor (not a
+ * captured closure) so retry always runs through the current-render handler and
+ * can't fire a stale mutation.
+ */
+export type RetryableAction =
+  | { kind: "status"; id: string; status: LearnedPatternStatus; surface: StatusSurface }
+  | { kind: "delete"; id: string }
+  | { kind: "bulk"; status: LearnedPatternStatus };
+
+export interface ActionError {
+  error: FetchError;
+  action: RetryableAction;
+}
+
+/**
+ * Where an error actually renders. Normally its own surface, but a sheet or
+ * delete error whose target overlay is no longer the one on screen (dismissed
+ * mid-flight, or a different item opened) falls back to the always-mounted page
+ * banner — so a late failure stays visible and can never render into, or retry
+ * from, the wrong overlay.
+ *
+ * @param openSheetId  id of the pattern whose detail sheet is open, or null
+ * @param openDeleteId id of the pattern whose delete dialog is open, or null
+ */
+export function renderSurface(
+  actionError: ActionError | null,
+  openSheetId: string | null,
+  openDeleteId: string | null,
+): ErrorSurface | null {
+  if (!actionError) return null;
+  const { action } = actionError;
+  switch (action.kind) {
+    case "status":
+      return action.surface === "sheet" && openSheetId === action.id ? "sheet" : "page";
+    case "delete":
+      return openDeleteId === action.id ? "delete" : "page";
+    case "bulk":
+      return "page";
+  }
+}

--- a/packages/web/src/app/admin/learned-patterns/action-error.tsx
+++ b/packages/web/src/app/admin/learned-patterns/action-error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+
+/**
+ * Cockpit failure-honesty surface for approve / reject / delete mutations.
+ *
+ * The shared `ErrorBanner` (what the old cockpit banner used) exposes a single
+ * action button with one caller-supplied `onRetry` — which is exactly how the
+ * old banner shipped a "Retry" that only called `setActionError(null)`, a
+ * dismiss wearing a retry's clothes (#4574). This surface spells the two
+ * affordances apart so neither can lie:
+ *
+ * - **Retry** genuinely re-runs the failed mutation (`onRetry`).
+ * - **Dismiss** clears the error and does nothing else (`onDismiss`).
+ *
+ * Rendered directly inside the surface the admin acted in — the detail sheet,
+ * the delete confirmation dialog, or the page body — so a failed review is seen
+ * where the click happened instead of behind the open overlay. `friendlyError`
+ * (the shared copy idiom) keeps the server message + requestId intact.
+ */
+export function ActionErrorAlert({
+  error,
+  onRetry,
+  onDismiss,
+  className,
+}: {
+  error: FetchError;
+  onRetry: () => void;
+  onDismiss: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-wrap items-center justify-between gap-3 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3",
+        className,
+      )}
+    >
+      <p className="text-sm text-red-800 dark:text-red-300">{friendlyError(error)}</p>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/admin/learned-patterns/page.tsx
+++ b/packages/web/src/app/admin/learned-patterns/page.tsx
@@ -47,9 +47,10 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { ActionErrorAlert } from "./action-error";
+import { renderSurface, type ActionError, type StatusSurface } from "./action-error-state";
 import { bulkPartialSummary, RelativeTimestamp } from "@/ui/components/admin/queue";
-import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+import { buildFetchError } from "@/ui/lib/fetch-error";
 import { useInProgressSet } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
@@ -89,7 +90,14 @@ export default function LearnedPatternsPage() {
   // Mutation-error surface (list-load errors come from the module below). The
   // `fetchKey` cache-buster now refreshes only the aux stats/entities fetches;
   // the paginated list refetches through the module + admin-fetch invalidation.
-  const [actionError, setActionError] = useState<FetchError | null>(null);
+  //
+  // A mutation failure is pinned to the surface the admin acted in — the detail
+  // `sheet`, the `delete` confirmation dialog, or the `page` body (row-menu /
+  // bulk actions) — so the error renders where the click happened instead of in
+  // a page banner behind the open overlay (#4574). The `action` descriptor lets
+  // the honest "Retry" re-run the exact failed mutation via the current-render
+  // handlers, so there are no stale-closure surprises.
+  const [actionError, setActionError] = useState<ActionError | null>(null);
   const [fetchKey, setFetchKey] = useState(0);
 
   const [params, setParams] = useQueryStates(learnedPatternsSearchParams);
@@ -166,7 +174,13 @@ export default function LearnedPatternsPage() {
     return () => { cancelled = true; };
   }, [apiUrl, credentials, fetchKey]);
 
-  async function updatePatternStatus(id: string, status: LearnedPatternStatus) {
+  // `surface` decides where a failure renders: "sheet" when the admin clicked
+  // Approve/Reject inside the detail sheet, "page" when from the row menu.
+  async function updatePatternStatus(
+    id: string,
+    status: LearnedPatternStatus,
+    surface: StatusSurface = "page",
+  ) {
     setActionError(null);
     inProgress.start(id);
 
@@ -181,7 +195,9 @@ export default function LearnedPatternsPage() {
       },
     });
 
-    if (!result.ok) setActionError(result.error);
+    if (!result.ok) {
+      setActionError({ error: result.error, action: { kind: "status", id, status, surface } });
+    }
     setFetchKey((k) => k + 1); // refresh aux stats/entities counts
     inProgress.stop(id);
   }
@@ -196,11 +212,13 @@ export default function LearnedPatternsPage() {
 
     if (result.ok) {
       if (detailPattern?.id === id) setDetailPattern(null);
+      setDeleteTarget(null); // close the confirm dialog only on success
     } else {
-      setActionError(result.error);
+      // Keep the confirm dialog open and surface the error inside it so a failed
+      // delete can't be mistaken for a completed one.
+      setActionError({ error: result.error, action: { kind: "delete", id } });
     }
     setFetchKey((k) => k + 1); // refresh aux stats/entities counts
-    setDeleteTarget(null);
     inProgress.stop(id);
   }
 
@@ -213,7 +231,7 @@ export default function LearnedPatternsPage() {
 
     if (!result.ok) {
       // Whole-request failure — keep selection so the operator can retry.
-      setActionError(result.error);
+      setActionError({ error: result.error, action: { kind: "bulk", status } });
       setFetchKey((k) => k + 1);
       return;
     }
@@ -233,7 +251,10 @@ export default function LearnedPatternsPage() {
 
     if (failedIds.size > 0) {
       const noun = status === "approved" ? "approvals" : status === "rejected" ? "rejections" : "updates";
-      setActionError({ message: bulkPartialSummary(data, selected.length, noun) });
+      setActionError({
+        error: buildFetchError({ message: bulkPartialSummary(data, selected.length, noun) }),
+        action: { kind: "bulk", status },
+      });
       // Narrow selection to failed IDs so retry hits exactly the unfinished work.
       table.setRowSelection(Object.fromEntries([...failedIds].map((id) => [id, true])));
     } else {
@@ -241,6 +262,44 @@ export default function LearnedPatternsPage() {
     }
 
     setFetchKey((k) => k + 1); // refresh aux stats/entities counts
+  }
+
+  // Honest "Retry" — re-run the exact failed mutation through the current-render
+  // handlers (each clears `actionError` at its start). "Dismiss" is a separate,
+  // truthfully-labelled affordance that just clears the error.
+  function retryAction() {
+    const action = actionError?.action;
+    if (!action) return;
+    switch (action.kind) {
+      case "status":
+        void updatePatternStatus(action.id, action.status, action.surface);
+        break;
+      case "delete":
+        void deletePattern(action.id);
+        break;
+      case "bulk":
+        void bulkUpdateStatus(action.status);
+        break;
+      default: {
+        // Exhaustiveness guard — a new RetryableAction kind is a compile error
+        // here rather than silently replaying as a bulk op.
+        const _never: never = action;
+        void _never;
+      }
+    }
+  }
+
+  function dismissError() {
+    setActionError(null);
+  }
+
+  // Opening a detail sheet or the delete dialog drops any lingering error from a
+  // prior action, so it can't sit behind — or bleed into — the new overlay (the
+  // exact "error hidden behind the modal" anti-pattern this cockpit fixes). A
+  // fresh action clears its own slot at the start anyway, so nothing in-flight
+  // is lost.
+  function clearActionError() {
+    setActionError(null);
   }
 
   const columns: ColumnDef<LearnedPattern>[] = (() => {
@@ -274,7 +333,7 @@ export default function LearnedPatternsPage() {
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="text-destructive"
-                onClick={() => setDeleteTarget(pattern)}
+                onClick={() => { clearActionError(); setDeleteTarget(pattern); }}
               >
                 <Trash2 className="mr-2 size-4" />
                 Delete
@@ -322,6 +381,15 @@ export default function LearnedPatternsPage() {
   });
 
   const selectedCount = table.getSelectedRowModel().rows.length;
+  // Where the pinned error renders — derived at render time from the action plus
+  // which overlays are open, never stored. A sheet/delete error whose overlay
+  // was dismissed mid-flight (or replaced by a different item) falls back to the
+  // page banner instead of vanishing behind or into the wrong surface.
+  const errorSurface = renderSurface(
+    actionError,
+    detailPattern?.id ?? null,
+    deleteTarget?.id ?? null,
+  );
   const hasFilters =
     !!params.status ||
     !!params.source_entity ||
@@ -443,10 +511,11 @@ export default function LearnedPatternsPage() {
               )}
             </div>
 
-            {actionError && (
-              <ErrorBanner
-                message={friendlyError(actionError)}
-                onRetry={() => setActionError(null)}
+            {actionError && errorSurface === "page" && (
+              <ActionErrorAlert
+                error={actionError.error}
+                onRetry={retryAction}
+                onDismiss={dismissError}
               />
             )}
 
@@ -467,13 +536,22 @@ export default function LearnedPatternsPage() {
               onClearFilters={() => setParams({ status: "", source_entity: "", min_confidence: "", max_confidence: "", page: 1 })}
               onRowClick={(row, e) => {
                 if ((e.target as HTMLElement).closest('[role="checkbox"], button')) return;
+                clearActionError();
                 setDetailPattern(row.original);
               }}
             />
           </div>
         </ErrorBoundary>
 
-        <Sheet open={!!detailPattern} onOpenChange={(open) => { if (!open) setDetailPattern(null); }}>
+        <Sheet
+          open={!!detailPattern}
+          onOpenChange={(open) => {
+            if (!open) setDetailPattern(null);
+            // A lingering in-sheet error isn't cleared here: `renderSurface`
+            // reroutes it to the page banner once the sheet is gone, so a late
+            // failure stays visible instead of silently vanishing on close.
+          }}
+        >
           <SheetContent className="sm:max-w-lg overflow-y-auto">
             {detailPattern && (
               <>
@@ -572,11 +650,19 @@ export default function LearnedPatternsPage() {
                     </div>
                   )}
 
+                  {actionError && errorSurface === "sheet" && (
+                    <ActionErrorAlert
+                      error={actionError.error}
+                      onRetry={retryAction}
+                      onDismiss={dismissError}
+                    />
+                  )}
+
                   <div className="flex gap-2 border-t pt-4">
                     {detailPattern.status !== "approved" && (
                       <Button
                         size="sm"
-                        onClick={() => updatePatternStatus(detailPattern.id, "approved")}
+                        onClick={() => updatePatternStatus(detailPattern.id, "approved", "sheet")}
                         disabled={inProgress.has(detailPattern.id)}
                       >
                         <Check className="mr-1.5 size-3.5" />
@@ -587,7 +673,7 @@ export default function LearnedPatternsPage() {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => updatePatternStatus(detailPattern.id, "rejected")}
+                        onClick={() => updatePatternStatus(detailPattern.id, "rejected", "sheet")}
                         disabled={inProgress.has(detailPattern.id)}
                       >
                         <X className="mr-1.5 size-3.5" />
@@ -599,6 +685,7 @@ export default function LearnedPatternsPage() {
                       size="sm"
                       className="text-destructive hover:text-destructive"
                       onClick={() => {
+                        setActionError(null);
                         setDetailPattern(null);
                         setDeleteTarget(detailPattern);
                       }}
@@ -616,7 +703,11 @@ export default function LearnedPatternsPage() {
 
         <AlertDialog
           open={!!deleteTarget}
-          onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+          onOpenChange={(open) => {
+            // Cancel / Escape / outside-click closes; `renderSurface` reroutes any
+            // lingering in-dialog error to the page banner so it stays visible.
+            if (!open) setDeleteTarget(null);
+          }}
         >
           <AlertDialogContent>
             <AlertDialogHeader>
@@ -625,11 +716,29 @@ export default function LearnedPatternsPage() {
                 This will permanently delete this pattern. This action cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
+
+            {actionError && errorSurface === "delete" && (
+              <ActionErrorAlert
+                error={actionError.error}
+                onRetry={retryAction}
+                onDismiss={dismissError}
+              />
+            )}
+
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogCancel disabled={!!deleteTarget && inProgress.has(deleteTarget.id)}>
+                Cancel
+              </AlertDialogCancel>
               <AlertDialogAction
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                onClick={() => { if (deleteTarget) void deletePattern(deleteTarget.id); }}
+                disabled={!!deleteTarget && inProgress.has(deleteTarget.id)}
+                // preventDefault stops Radix from auto-closing the dialog: a
+                // failed delete must keep the dialog open to show the error, and
+                // `deletePattern` closes it itself only on success (#4574).
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (deleteTarget) void deletePattern(deleteTarget.id);
+                }}
               >
                 Delete
               </AlertDialogAction>


### PR DESCRIPTION
Closes #4574 (milestone v0.0.50 — Learned-Patterns Elevation).

## What shipped
Cockpit failure honesty on the learned-patterns admin page:
- Approve/reject mutation failures now surface **inside the sheet the admin acted in** (or as a toast), so a failed review is never mistaken for a success (previously errors rendered behind the modal).
- Error-banner buttons are labeled for what they actually do — "Retry" genuinely retries the mutation, "Dismiss" dismisses (no more "Retry"-is-really-dismiss mislabeling).

New: `action-error.tsx`, `action-error-state.ts` + tests (`cockpit-failure-honesty.test.tsx`, `action-error.test.tsx`, `action-error-state.test.ts`); `page.tsx` wires the failure-inside-sheet behavior.

Web-only change. Rebased cleanly onto latest main (auto-merged with #4577's sort/filter in `page.tsx` — different regions).

https://claude.ai/code/session_01JydkmLY5XyLBtXMAmzviGE