### PR TITLE
docs(learn): learned-query-patterns lifecycle guide + admin-console corrections

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -396,12 +396,12 @@ Settings overrides require an internal database (`DATABASE_URL`). Without it, bo
 **Route:** `/admin/learned-patterns`
 
 <Callout type="info">
-Requires an internal database (`DATABASE_URL`). Patterns are proposed by the agent during conversations or by the `atlas-operator learn` CLI command. For the concepts behind this page — what approval means, the auto-promotion dial, and how patterns reach the agent — see the [Learned Query Patterns](/guides/learned-patterns) guide.
+Requires an internal database (`DATABASE_URL`). Query patterns are captured from the agent's successful queries during conversations. (The `atlas-operator learn` CLI is a separate offline loop for semantic-layer improvements and query suggestions — see the [CLI reference](/reference/cli#learn) — not learned patterns.) For the concepts behind this page — what approval means, the auto-promotion dial, and how patterns reach the agent — see the [Learned Query Patterns](/guides/learned-patterns) guide.
 </Callout>
 
 Review, approve, and manage the query patterns the agent has learned. **Approving a pattern makes it injectable immediately, regardless of its confidence** — approval is a grant of eligibility, not a change to the confidence score.
 
-- **Stats strip** — Live counts of pending, approved, rejected, and total patterns
+- **Stats strip** — Current counts of pending, approved, rejected, and total patterns
 - **Status filter** — All / Pending / Approved / Rejected
 - **Entity filter** — Filter by source entity (table)
 - **Confidence filter** — Restrict to a confidence range (e.g. review the weakest evidence first)
@@ -414,7 +414,7 @@ Review, approve, and manage the query patterns the agent has learned. **Approvin
 - **Confidence** — the machine's evidence meter, shown as a progress bar
 - **Avg latency** — the pattern's rolling-mean execution time
 - **Seen** — how many times the identical shape has been observed
-- **Source** — `Agent`, `CLI`, or `Expert`, depending on what proposed it
+- **Source** — `Agent` for a pattern the agent captured; `CLI` marks a pattern imported through an earlier operator path
 - **Created** — when the pattern was first captured
 
 **Detail sheet** — Click any row to open a side panel with the full SQL pattern, metadata (entity, source, confidence, times seen, avg latency, timestamps), review history (who reviewed and when), and the source queries that originated the pattern. Approve, reject, and delete are available here too.

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -396,32 +396,38 @@ Settings overrides require an internal database (`DATABASE_URL`). Without it, bo
 **Route:** `/admin/learned-patterns`
 
 <Callout type="info">
-Requires an internal database (`DATABASE_URL`). Patterns are proposed by the agent during conversations or by the `atlas-operator learn` CLI command.
+Requires an internal database (`DATABASE_URL`). Patterns are proposed by the agent during conversations or by the `atlas-operator learn` CLI command. For the concepts behind this page — what approval means, the auto-promotion dial, and how patterns reach the agent — see the [Learned Query Patterns](/guides/learned-patterns) guide.
 </Callout>
 
-Review, approve, and manage query patterns the agent has learned:
+Review, approve, and manage the query patterns the agent has learned. **Approving a pattern makes it injectable immediately, regardless of its confidence** — approval is a grant of eligibility, not a change to the confidence score.
 
-- **Stats** — Total patterns, pending review, approved, rejected
-- **Status filter** — Tabs to filter by All / Pending / Approved / Rejected
-- **Entity filter** — Dropdown to filter by source entity (table)
-- **Pattern table** — Status badge, SQL pattern (monospace, truncated), description, source entity, confidence (progress bar), repetition count, source (Agent or CLI), created date
+- **Stats strip** — Live counts of pending, approved, rejected, and total patterns
+- **Status filter** — All / Pending / Approved / Rejected
+- **Entity filter** — Filter by source entity (table)
+- **Confidence filter** — Restrict to a confidence range (e.g. review the weakest evidence first)
+- **Sorting** — Click the Confidence, Avg latency, Seen, or Created headers to reorder rows (server-side sorting)
 
-**Detail sheet** — Click any row to open a side panel with:
-- Full SQL pattern in a monospace block
-- Metadata (entity, source, confidence, repetitions, timestamps)
-- Review history (who reviewed, when)
-- Source queries that originated the pattern
+**Pattern table columns:**
+- **Status** — `Pending` / `Approved` / `Rejected`. A machine-promoted row shows a distinct violet **Auto-approved** badge, so auto-promotion never reads as a human sign-off
+- **Pattern SQL** — the normalized shape (monospace, truncated; full text in the detail sheet)
+- **Description** and **Entity** (source table)
+- **Confidence** — the machine's evidence meter, shown as a progress bar
+- **Avg latency** — the pattern's rolling-mean execution time
+- **Seen** — how many times the identical shape has been observed
+- **Source** — `Agent`, `CLI`, or `Expert`, depending on what proposed it
+- **Created** — when the pattern was first captured
+
+**Detail sheet** — Click any row to open a side panel with the full SQL pattern, metadata (entity, source, confidence, times seen, avg latency, timestamps), review history (who reviewed and when), and the source queries that originated the pattern. Approve, reject, and delete are available here too.
 
 **Actions (per pattern):**
-- **Approve** — Mark a pattern as approved
-- **Reject** — Mark a pattern as rejected
-- **Delete** — Permanently remove a pattern (with confirmation dialog)
+- **Approve** / **Reject** — set the pattern's status; the reviewer and timestamp are recorded
+- **Delete** — permanently remove a pattern (with a confirmation dialog)
 
 **Bulk actions:**
-- Select multiple patterns with checkboxes
-- **Approve selected** / **Reject selected** — Update all selected patterns at once (max 100 per operation)
+- Select patterns with the row checkboxes, then **Approve** or **Reject** the selection (max 100 per operation)
+- A bulk action that partially fails keeps only the failed rows selected and reports what didn't apply, so a failed review is never mistaken for a success
 
-All status changes record the reviewer and timestamp. Approve/reject use optimistic UI updates — the table updates immediately, reverting on failure.
+Review actions go through the server and the table refetches on success; a failure surfaces in an error banner above the table rather than silently reverting.
 
 ---
 
@@ -431,7 +437,7 @@ All status changes record the reviewer and timestamp. Approve/reject use optimis
 Requires an internal database (`DATABASE_URL`). Suggestions are auto-generated from query frequency — there's nothing to author by hand.
 </Callout>
 
-Query suggestions are the **contextual "questions you can ask"** Atlas surfaces to end users for a given table. They're distinct from [Learned Patterns](#learned-patterns): a learned pattern is a SQL template the agent reuses, while a suggestion is a user-facing prompt, **score-ranked** by how often the underlying query is run and how often the suggestion is clicked. They're stored in `query_suggestions` and served to the chat/table UI by the user-facing endpoints:
+Query suggestions are the **contextual "questions you can ask"** Atlas surfaces to end users for a given table. They're deliberately distinct from [Learned Patterns](#learned-patterns) — a learned pattern is agent-facing SQL the agent reuses, while a suggestion is a user-facing prompt, **score-ranked** by how often the underlying query is run and how often the suggestion is clicked. See [why the two are kept separate](/guides/learned-patterns#learned-patterns-vs-query-suggestions-by-design). They're stored in `query_suggestions` and served to the chat/table UI by the user-facing endpoints:
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/apps/docs/content/docs/guides/learned-patterns.mdx
+++ b/apps/docs/content/docs/guides/learned-patterns.mdx
@@ -1,0 +1,120 @@
+---
+title: Learned Query Patterns
+description: How Atlas captures successful SQL shapes, how approval and auto-promotion make them injectable, and how they reach the agent.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas learns from every query that works. When the agent answers a question with SQL that runs cleanly, the *shape* of that query is captured and — once it becomes eligible — injected into future agent prompts as reference SQL the agent can reuse for similar questions. This guide covers the full lifecycle: how a pattern is born, the two roads it can take to becoming injectable, and how it pays off.
+
+<Callout type="info">
+Learned patterns require an internal database (`DATABASE_URL`). Without one, capture and the review queue are unavailable — the agent still works, it just doesn't accumulate reusable patterns.
+</Callout>
+
+## What a learned pattern is
+
+A **learned query pattern** is the durable unit of learned query knowledge: a normalized SQL shape captured from a successful live execution, scoped to **one workspace and one connection group**. Because a pattern is scoped this way, one tenant's — or one datasource group's — patterns never leak into another's session.
+
+Patterns are proposed by:
+
+- **The agent**, during a conversation, whenever a query it ran succeeds.
+- **The `atlas-operator learn` CLI**, which analyzes the audit log and proposes patterns (and semantic-layer improvements) in bulk. See [operator subcommands](/reference/cli).
+
+Every pattern carries an **evidence trail**: how many times the identical shape has been seen (`repetitionCount`), a confidence score derived from that repetition, and a rolling-mean execution time so Atlas knows which patterns are fast.
+
+## The lifecycle
+
+```
+capture ──▶ pending ──▶ approved ──▶ injected
+                  │        ▲
+                  │        │
+                  └── auto-promoted
+```
+
+A pattern moves `pending → approved | rejected`. There are **two independent roads** from pending to approved (injectable) — a human road and a machine road — and they never overwrite each other's signal.
+
+| Stage | What it means |
+|-------|---------------|
+| **Captured** | A successful query's shape is written to the pattern store. A shape seen only once sits below the review threshold until it repeats. |
+| **Pending** | Captured and awaiting a decision. Visible in **Admin → Learned Patterns**. |
+| **Approved** | Injectable. Either a human approved it (see [Approval](#approval-an-eligibility-bypass)) or the workspace's auto-promotion dial promoted it (see [Auto-promotion](#auto-promotion-the-workspace-dial)). |
+| **Rejected** | A human declined it. Rejected patterns are frozen — never injected, never auto-promoted. |
+| **Injected** | Eligible **and** relevant to the current turn, so it was rendered into the agent's prompt (see [Injection](#injection-the-payoff)). |
+
+### Pattern identity
+
+What makes two observations the *same* pattern is the triple **(workspace, connection group, normalized SQL fingerprint)**, enforced by the database. A repeat observation **increments** the existing pattern's repetition count — it can never mint a second row. Two concurrent runs of the same query strengthen one pattern instead of inflating each other's weight.
+
+## Approval: an eligibility bypass
+
+Approving a pattern is a human grant of **injection eligibility**: *"this pattern is correct — inject it whenever it's relevant."*
+
+The key property: **an approved pattern is injectable immediately, regardless of its confidence.** Approval is not a vote that raises a score to clear a threshold — it *bypasses* the threshold entirely. A rare-but-important query you approve after seeing it once is just as eligible as one the machine has watched a hundred times.
+
+<Callout type="info">
+**Approval never rewrites confidence.** Confidence stays the machine's untouched evidence meter — a measure of how often the shape was actually observed, nothing more. Human approval and machine confidence are the two separate roads to eligibility; a human decision never moves the machine's meter, and the meter never encodes human trust.
+</Callout>
+
+This is why approval pays off where it used to do nothing: previously a valuable-but-rare pattern stayed below the confidence threshold forever no matter how many times an admin approved it. Now the human road is unconditional.
+
+## Auto-promotion: the workspace dial
+
+The machine road to eligibility is **auto-promotion**, and it is a **per-workspace dial that is off by default**.
+
+Capture is always on everywhere — it's free and deterministic. Auto-promotion is the one trust dial a workspace turns deliberately. When enabled, Atlas promotes a workspace's high-confidence, fast, frequently-seen patterns on its own cadence, and demotes stale auto-promoted ones so the injected set stays fresh.
+
+### Turning it on
+
+The dial lives in **Admin → Settings**, under **Dynamic Learning**, as **Auto-Promote Learned Patterns**. It is a workspace-scoped runtime setting: hot-reloaded (no redeploy, no operator, no restart), off by default, and something each workspace chooses for itself.
+
+<Callout type="info">
+This replaces a former platform-wide, env-only switch that required a restart. Auto-promotion is now tenant behavior a workspace admin controls directly — the same posture as [autonomous semantic improvement](/guides/semantic-expert). Self-hosted's single workspace is simply the degenerate case of the same loop.
+</Callout>
+
+The setting resolves in the usual precedence order — **workspace override > platform override > `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` env var > default (off)** — so a self-host can set a default via the env var, and any workspace can override it from the console.
+
+### The promotion gates
+
+When the dial is on, a pending pattern is auto-promoted to approved only when it clears **all three** gates:
+
+| Gate | Setting | Default |
+|------|---------|---------|
+| Confidence at or above threshold | `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` |
+| Seen at least N times | `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | `5` |
+| Average latency within budget | `ATLAS_LEARN_LATENCY_BUDGET_MS` | `5000` ms |
+
+A pattern whose latency has never been measured is **not** auto-promoted. Auto-promoted patterns are shown with a distinct **Auto-approved** badge (violet, with a sparkle) so machine approvals never masquerade as your sign-off.
+
+### Decay
+
+Auto-promotion's counterpart is **decay**: a pattern the job itself promoted that then goes unseen for longer than `ATLAS_LEARN_DECAY_UNSEEN_DAYS` (default `30`) is demoted back to pending, so the injected set never fills with stale shapes. **Decay never touches human approvals** — only a human removes a human-approved pattern.
+
+The job runs on a fixed cadence (`ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS`, default `24`) as a single process-global fiber; that cadence and the gate thresholds above are platform-scoped operator policy. Only the **enable** dial is per-workspace — one platform fiber iterates the workspaces that opted in.
+
+## Injection: the payoff
+
+Approval and auto-promotion make a pattern *eligible*. **Injection** is where eligibility pays off: for each agent turn, Atlas selects the eligible patterns that are **relevant** to what the user is asking and renders them into the agent's prompt as reference SQL.
+
+The **eligible set** for a workspace-and-group is every human-approved pattern (unconditionally) plus every machine-promoted pattern that clears the confidence threshold. It is ordered so human-approved patterns come first — they can never fall off a truncation edge — then by confidence, then by most-recently-seen. Relevance (keyword matching against the last few user turns, tunable via `ATLAS_LEARN_RETRIEVAL_TURNS`) then decides which eligible patterns actually enter a given turn.
+
+Injected patterns carry their typical latency into the prompt (`avg ~123ms`) so the agent can prefer a faster pattern when two answer the question equally well. Slower patterns are down-weighted in ranking but never excluded, so a slow-but-uniquely-relevant pattern still surfaces.
+
+### Seeing a pattern's standing
+
+The **Admin → Learned Patterns** cockpit surfaces each pattern's evidence so its payoff is observable rather than asserted: its status (and whether a human or the machine approved it), its confidence, how many times it's been seen, and its average latency. Sort or filter by any of these to find, for example, an approved pattern that has never gained repetitions — a candidate to refine its description or retire.
+
+## Learned patterns vs. query suggestions (by design)
+
+Atlas has two learning surfaces that look similar and are deliberately kept apart. This split is intentional, not an accident of history:
+
+| | **Learned patterns** | **Query suggestions** |
+|---|---|---|
+| **Audience** | The **agent** | The **end user** |
+| **What it is** | A reusable SQL shape injected into the agent's prompt | A "question you can ask" surfaced in the chat/table UI |
+| **How it ranks** | Human approval (bypass) + machine confidence, then relevance | Score, weighted by how often the underlying query runs and how often the suggestion is clicked |
+| **Where it's managed** | **Admin → Learned Patterns** | **Admin → Query Suggestions** |
+| **Stored in** | `learned_patterns` | `query_suggestions` |
+
+They serve different consumers with different currencies: a learned pattern is *reference SQL the agent trusts*, gated by curator approval; a suggestion is *a prompt a human might click*, ranked by engagement. Unifying them would force one pipeline to answer two questions it can't answer at once — "is this SQL correct enough for the agent to reuse?" and "is this phrasing appealing enough for a person to click?" Keeping them separate lets each be tuned for its own audience.
+
+See the [Admin Console guide](/guides/admin-console#learned-patterns) for the full UI walkthrough of both surfaces, and the [environment variables reference](/reference/environment-variables#dynamic-learning) for the complete list of tuning knobs.

--- a/apps/docs/content/docs/guides/learned-patterns.mdx
+++ b/apps/docs/content/docs/guides/learned-patterns.mdx
@@ -15,10 +15,11 @@ Learned patterns require an internal database (`DATABASE_URL`). Without one, cap
 
 A **learned query pattern** is the durable unit of learned query knowledge: a normalized SQL shape captured from a successful live execution, scoped to **one workspace and one connection group**. Because a pattern is scoped this way, one tenant's — or one datasource group's — patterns never leak into another's session.
 
-Patterns are proposed by:
+A pattern is captured automatically whenever **the agent** answers a question with SQL that runs cleanly during a conversation — that is the live source of learned patterns.
 
-- **The agent**, during a conversation, whenever a query it ran succeeds.
-- **The `atlas-operator learn` CLI**, which analyzes the audit log and proposes patterns (and semantic-layer improvements) in bulk. See [operator subcommands](/reference/cli).
+<Callout type="info">
+Don't confuse this with the [`atlas-operator learn`](/reference/cli#learn) CLI, which is a separate offline loop: it reads the audit log and proposes *semantic-layer* YAML improvements and query suggestions — it does **not** create learned patterns. On the admin surface, a `CLI` source label marks patterns brought in through an earlier operator-import path.
+</Callout>
 
 Every pattern carries an **evidence trail**: how many times the identical shape has been seen (`repetitionCount`), a confidence score derived from that repetition, and a rolling-mean execution time so Atlas knows which patterns are fast.
 
@@ -35,8 +36,8 @@ A pattern moves `pending → approved | rejected`. There are **two independent r
 
 | Stage | What it means |
 |-------|---------------|
-| **Captured** | A successful query's shape is written to the pattern store. A shape seen only once sits below the review threshold until it repeats. |
-| **Pending** | Captured and awaiting a decision. Visible in **Admin → Learned Patterns**. |
+| **Captured** | A successful query's shape is written to the pattern store as a low-confidence `pending` row. An identical repeat increments that row rather than adding a new one. |
+| **Pending** | Captured and awaiting a decision — visible in **Admin → Learned Patterns** from the first capture. A shape seen only once is reviewable right away; it simply can't clear the *machine* promotion gates (confidence and repetition) until it repeats. |
 | **Approved** | Injectable. Either a human approved it (see [Approval](#approval-an-eligibility-bypass)) or the workspace's auto-promotion dial promoted it (see [Auto-promotion](#auto-promotion-the-workspace-dial)). |
 | **Rejected** | A human declined it. Rejected patterns are frozen — never injected, never auto-promoted. |
 | **Injected** | Eligible **and** relevant to the current turn, so it was rendered into the agent's prompt (see [Injection](#injection-the-payoff)). |

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -19,6 +19,7 @@
     "semantic-layer-wizard",
     "semantic-editor",
     "semantic-expert",
+    "learned-patterns",
     "knowledge-base",
     "connect-notion",
     "connect-confluence",

--- a/apps/docs/content/docs/guides/semantic-expert.mdx
+++ b/apps/docs/content/docs/guides/semantic-expert.mdx
@@ -346,17 +346,19 @@ The pending queue endpoints (`/pending`, `/pending-count`, `/amendments/:id/revi
 
 Separately from semantic-layer amendments, Atlas learns **successful query patterns** from real usage. When the agent answers a question with SQL that runs cleanly, the shape is captured in the `learned_patterns` table (`type = query_pattern`) and, once approved, injected into future agent prompts as *organizational knowledge* — reference SQL the agent can reuse for similar questions. Each pattern is scoped to its org **and** connection group, so one tenant's or one datasource group's patterns never leak into another's session.
 
+For the full lifecycle — what approval means (an eligibility bypass, not a confidence write), the per-workspace auto-promotion dial, and how patterns are injected — see the dedicated [Learned Query Patterns](/guides/learned-patterns) guide. The mechanics below cover retrieval and the promote/decay job.
+
 ### Performance-weighted retrieval
 
 Every pattern carries a rolling-mean execution time (`avg_duration_ms`). At retrieval time, Atlas ranks patterns by keyword relevance **down-weighted by latency**: a pattern whose average stays at or under the [`ATLAS_LEARN_LATENCY_BUDGET_MS`](/reference/environment-variables#dynamic-learning) budget ranks normally, while slower patterns are pushed down — but never excluded, so a slow-but-uniquely-relevant pattern still surfaces. The injected context shows each pattern's typical latency (`avg ~123ms`) so the agent can prefer a faster pattern when two answer the question equally well.
 
-### Nightly auto-promote / decay
+### Auto-promotion and decay
 
-By default every learned query pattern waits for an admin to approve it in **Admin → Learned Patterns**. Enable the nightly job (`ATLAS_LEARN_PROMOTE_DECAY_ENABLED`) to maintain the set automatically:
+By default every learned query pattern waits for a human to approve it in **Admin → Learned Patterns**. Each workspace can instead turn on **auto-promotion** — a per-workspace dial (`ATLAS_LEARN_PROMOTE_DECAY_ENABLED`, off by default, set from **Admin → Settings → Dynamic Learning**) that maintains the set automatically:
 
 - **Auto-promote** — a pending pattern is promoted to approved when it clears all three gates: confidence ≥ `ATLAS_LEARN_CONFIDENCE_THRESHOLD`, seen ≥ `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` times, and an average latency at or under `ATLAS_LEARN_LATENCY_BUDGET_MS`. A pattern whose latency has never been measured is **not** auto-promoted.
 - **Decay (demote, never delete)** — a pattern the job itself promoted that then goes unseen for longer than `ATLAS_LEARN_DECAY_UNSEEN_DAYS` is demoted back to pending, so the injected set stays fresh. **Human approvals are never auto-demoted** — only a human removes them.
 
 Auto-promoted patterns are shown with a distinct **Auto-approved** badge in the admin UI so machine approvals are always distinguishable from human ones. Semantic-layer amendments (`type = semantic_amendment`) are out of scope for this job — they always keep human review, as described above.
 
-This job is a single process-global background fiber (like the expert scheduler), so its enable/interval settings are platform-scoped and require a restart; the gate thresholds are read once per run.
+The **enable** dial is per-workspace and hot-reloaded — a workspace turns it on with no restart. The job's **cadence** (`ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS`) and its gate thresholds are platform-scoped operator policy: the job is a single process-global background fiber (like the expert scheduler) that iterates the opted-in workspaces, so interval changes require a restart and the gates are read once per run.

--- a/apps/docs/content/shared/reference/config.mdx
+++ b/apps/docs/content/shared/reference/config.mdx
@@ -364,19 +364,19 @@ The cache is automatically flushed on config reload. Manual flush is available v
 
 Tuning for how learned query patterns are retrieved and promoted into agent context.
 
-The first three are **workspace-scoped runtime settings**, not `atlas.config.ts` fields: they resolve as `workspace override > platform override > env var > default`, so each workspace can tune them from **Admin → Settings** with no redeploy (hot-reloaded in SaaS). Set the env var for a self-host default. The nightly auto-promote/decay knobs are **platform-scoped** (the job is one process-global fiber) — enable/interval changes require a restart, and the gate is read once per run.
+The first three settings plus the auto-promote **enable** dial are **workspace-scoped runtime settings**, not `atlas.config.ts` fields: they resolve as `workspace override > platform override > env var > default`, so each workspace can tune them from **Admin → Settings** with no redeploy (hot-reloaded in SaaS). Set the env var for a self-host default. The auto-promote/decay **interval** and the gate thresholds are **platform-scoped** (the job itself is one process-global fiber that iterates the workspaces that opted in) — interval changes require a restart, and the gates are read once per run.
 
 | Setting | Env var | Scope | Default | Description |
 |---------|---------|-------|---------|-------------|
 | Pattern Confidence Threshold | `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | Workspace | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval/auto-promotion. Lower values promote more aggressively; higher values require stronger evidence |
 | Pattern Retrieval Turns | `ATLAS_LEARN_RETRIEVAL_TURNS` | Workspace | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Widening the window lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
 | Pattern Latency Budget (ms) | `ATLAS_LEARN_LATENCY_BUDGET_MS` | Workspace | `5000` | Patterns at or under this average execution time rank normally; slower patterns are down-weighted in retrieval (never excluded). Also the auto-promotion latency ceiling |
-| Auto-Promote / Decay Job | `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | Platform (restart) | `false` | Enable the nightly job that auto-promotes qualifying pending patterns and demotes stale auto-promoted ones |
+| Auto-Promote Learned Patterns | `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | Workspace | `false` | Let this workspace auto-promote its high-confidence, fast, frequently-seen pending patterns and demote stale auto-promoted ones. Off by default; hot-reloaded (no restart); human approvals are never auto-demoted |
 | Auto-Promote / Decay Interval | `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` | Platform (restart) | `24` | Hours between auto-promote/decay runs |
 | Auto-Promote Min Repetitions | `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | Platform | `5` | Minimum times a pending pattern must be seen before auto-promotion |
 | Pattern Decay Window (days) | `ATLAS_LEARN_DECAY_UNSEEN_DAYS` | Platform | `30` | An auto-promoted pattern unseen this long is demoted to pending. Human approvals are never auto-demoted |
 
-See <AudienceLink saas="/guides/semantic-expert#learned-query-patterns">Learned query patterns</AudienceLink> for how performance-weighting and the nightly job work together.
+See <AudienceLink saas="/guides/learned-patterns">Learned query patterns</AudienceLink> for the full lifecycle — what approval means, the workspace auto-promotion dial, and how patterns are injected.
 
 ```bash
 ATLAS_LEARN_CONFIDENCE_THRESHOLD=0.7

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -701,12 +701,12 @@ The first three plus `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` are the self-host fallb
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval. Also the confidence gate for nightly auto-promotion |
+| `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval. Also the confidence gate for auto-promotion |
 | `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
-| `ATLAS_LEARN_LATENCY_BUDGET_MS` | `5000` | Patterns whose rolling-mean execution time stays at or under this budget rank normally in retrieval; slower patterns are down-weighted (never excluded). Also the latency ceiling for nightly auto-promotion |
+| `ATLAS_LEARN_LATENCY_BUDGET_MS` | `5000` | Patterns whose rolling-mean execution time stays at or under this budget rank normally in retrieval; slower patterns are down-weighted (never excluded). Also the latency ceiling for auto-promotion |
 | `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | `false` | Self-host default for the per-workspace auto-promotion dial: auto-promote a workspace's high-confidence, fast, frequently-seen pending patterns to approved and demote stale auto-promoted ones. Workspace-scoped and hot-reloaded — any workspace can override it from **Admin → Settings** with no restart |
 | `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` | `24` | Hours between auto-promote/decay runs. Platform-scoped; requires a restart |
-| `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | `5` | Minimum times a pending pattern must have been seen before the nightly job will auto-promote it (alongside the confidence and latency gates) |
+| `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | `5` | Minimum times a pending pattern must have been seen before the auto-promote job will promote it (alongside the confidence and latency gates) |
 | `ATLAS_LEARN_DECAY_UNSEEN_DAYS` | `30` | An auto-promoted pattern unseen for longer than this many days is demoted back to pending. Human-approved patterns are never auto-demoted |
 
 ---

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -697,14 +697,14 @@ same shared task rows.
 
 ## Dynamic Learning
 
-The first three are the self-host fallback tier for **workspace-scoped runtime settings** — they resolve from `workspace override > platform override > env var > default` and can be tuned per-workspace from **Admin → Settings** with no redeploy (see [Dynamic Learning config](/reference/config#dynamic-learning)). The nightly auto-promote/decay knobs are **platform-scoped**: the job is one process-global background fiber, so its enable/interval changes require a restart and its gate is read once per tick.
+The first three plus `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` are the self-host fallback tier for **workspace-scoped runtime settings** — they resolve from `workspace override > platform override > env var > default` and can be tuned per-workspace from **Admin → Settings** with no redeploy (see [Dynamic Learning config](/reference/config#dynamic-learning)). The auto-promote/decay **interval** and gate thresholds are **platform-scoped**: the job is one process-global background fiber that iterates the opted-in workspaces, so interval changes require a restart and the gates are read once per tick.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ATLAS_LEARN_CONFIDENCE_THRESHOLD` | `0.7` | Minimum confidence score (0–1) for a learned pattern to be eligible for retrieval. Also the confidence gate for nightly auto-promotion |
 | `ATLAS_LEARN_RETRIEVAL_TURNS` | `3` | Number of trailing user turns assembled into the learned-pattern retrieval query. Lets a keyword-less follow-up ("now break that down by region") still match patterns via the keywords of earlier turns |
 | `ATLAS_LEARN_LATENCY_BUDGET_MS` | `5000` | Patterns whose rolling-mean execution time stays at or under this budget rank normally in retrieval; slower patterns are down-weighted (never excluded). Also the latency ceiling for nightly auto-promotion |
-| `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | `false` | Enable the nightly job that auto-promotes high-confidence, fast, frequently-seen pending patterns to approved and demotes stale auto-promoted ones. Platform-scoped; requires a restart |
+| `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` | `false` | Self-host default for the per-workspace auto-promotion dial: auto-promote a workspace's high-confidence, fast, frequently-seen pending patterns to approved and demote stale auto-promoted ones. Workspace-scoped and hot-reloaded — any workspace can override it from **Admin → Settings** with no restart |
 | `ATLAS_LEARN_PROMOTE_DECAY_INTERVAL_HOURS` | `24` | Hours between auto-promote/decay runs. Platform-scoped; requires a restart |
 | `ATLAS_LEARN_PROMOTE_MIN_REPETITIONS` | `5` | Minimum times a pending pattern must have been seen before the nightly job will auto-promote it (alongside the confidence and latency gates) |
 | `ATLAS_LEARN_DECAY_UNSEEN_DAYS` | `30` | An auto-promoted pattern unseen for longer than this many days is demoted back to pending. Human-approved patterns are never auto-demoted |


### PR DESCRIPTION
Closes #4583 (milestone v0.0.50 — Learned-Patterns Elevation; PRD #4570).

## What

Adds a dedicated **Learned Query Patterns** guide and corrects stale learned-pattern docs against shipped behavior.

### New guide — `guides/learned-patterns.mdx`
Conceptual lifecycle `capture → pending → approved | auto-promoted → injected`:
- **What a learned pattern is** — normalized SQL shape, scoped to (workspace, connection group); DB-enforced identity (repeat observations increment, never duplicate).
- **Approval as an eligibility bypass** (#4571) — an approved pattern is injectable immediately regardless of confidence; approval never rewrites the machine's confidence meter.
- **The per-workspace auto-promotion dial** (#4582) — `ATLAS_LEARN_PROMOTE_DECAY_ENABLED`, off by default, workspace-scoped + hot-reloaded (retiring the old platform env switch); the three promotion gates and decay.
- **Injection** — eligible + relevant patterns rendered into the agent's prompt; how a pattern's standing is observed in the cockpit (no over-claim of unshipped per-turn attribution counters, #4573).
- **Learned patterns vs. query suggestions** — the agent-facing / user-facing split documented as an intentional decision.

### Corrections (verified against shipped code)
- `admin-console.mdx` — drop the fake **optimistic-UI** claim (list is server-owned and refetches; failures surface in an error banner); add the confidence-range filter, server-side sorting, Avg latency column, and the violet **Auto-approved** badge. Fix provenance (agent is the sole live source; the `atlas-operator learn` CLI is a separate offline loop, not a learned-pattern proposer) and drop the unreachable **Expert** source on this `query_pattern`-only surface (#4569).
- `config.mdx` + `environment-variables.mdx` — `ATLAS_LEARN_PROMOTE_DECAY_ENABLED` is now **workspace-scoped + hot-reloaded** (#4582), not platform/restart; drop residual "nightly" wording.
- `semantic-expert.mdx` — retire the "nightly platform job" framing for the enable dial; point to the new guide as the authoritative lifecycle doc.

## Verification
- Internal review panel (5 fresh-context reviewers) run twice; all findings addressed and re-verified against code.
- `scripts/check-docs-links.ts` PASS (internal links + anchors across 663 pages).
- `apps/docs/src/lib/__tests__` — 176 pass, 0 fail.
- Docs-only change; no `openapi.json` edits.

https://claude.ai/code/session_01JydkmLY5XyLBtXMAmzviGE