### PR TITLE
fix(web): data-table stale render under React Compiler (seen-once toggle + bulk-select)

### DIFF
--- a/e2e/browser/learned-patterns.spec.ts
+++ b/e2e/browser/learned-patterns.spec.ts
@@ -79,6 +79,11 @@ interface SeedOpts {
   avgDurationMs?: number | null;
   /** Extra description suffix so several seeded rows stay distinguishable. */
   tag?: string;
+  /**
+   * repetition_count. Default `SEEN` (3, above the seen-once floor). Pass `1` to
+   * seed a seen-once row the default queue hides and "Show seen-once" reveals.
+   */
+  repetitionCount?: number;
 }
 
 /**
@@ -98,6 +103,7 @@ async function seedPattern(c: Client, orgId: string, opts: SeedOpts = {}): Promi
     autoPromoted = false,
     avgDurationMs = null,
     tag = "",
+    repetitionCount = SEEN,
   } = opts;
   const reviewed = status !== "pending";
   const description = `${MARKER}${tag ? ` ${tag}` : ""}`;
@@ -109,7 +115,7 @@ async function seedPattern(c: Client, orgId: string, opts: SeedOpts = {}): Promi
         created_at, updated_at)
      VALUES
        (gen_random_uuid(), 'query_pattern', $2, $1, 'orders', NULL, $3,
-        ${SEEN}, $4, $5, 'agent',
+        ${repetitionCount}, $4, $5, 'agent',
         $6, $7, $8, $9, $10,
         now(), now())
      RETURNING id`,
@@ -478,5 +484,60 @@ test.describe("learned-patterns cockpit — full curation loop", () => {
     await expect(sheet.getByText("Auto-approved")).toBeVisible();
     await expect(sheet.getByText("Atlas auto-promotion")).toBeVisible();
     await expect(sheet.getByText("Reviewed by: Unknown")).toBeHidden();
+  });
+
+  // The two tests below guard a React-Compiler stale-render class that ONLY
+  // manifests in a compiler build (this browser lane), never in `bun test` —
+  // the compiler doesn't run there. TanStack Table's `table` is a stable
+  // reference whose row model/selection mutate in place; a memoized consumer
+  // keyed on the unchanged ref never re-renders, so the DOM lags the data. The
+  // fix is the render-relevant-slice Proxy in `useServerDataTable` (which hands
+  // consumers a fresh table reference when the table actually changes); these
+  // assert its effect end to end. Reproduced live on staging: unchecking the
+  // toggle left the API's 2 rows behind a stale 15-row render; row checkboxes
+  // never showed as checked.
+
+  test("seen-once toggle round-trips: reveal, then hide again on uncheck (#4581)", async ({ page }) => {
+    await withInternalDb(async (c) => {
+      // A repeated row (always shown) + a seen-once row (hidden by default).
+      await seedPattern(c, orgId, { tag: "repeated", confidence: 0.5 });
+      await seedPattern(c, orgId, { tag: "seenonce", confidence: 0.5, repetitionCount: 1 });
+    });
+    await page.goto("/admin/learned-patterns");
+
+    // Default view: the repeated row shows; the seen-once row is hidden.
+    await expect(seededRow(page, "repeated")).toBeVisible();
+    await expect(seededRow(page, "seenonce")).toHaveCount(0);
+
+    const toggle = page.getByRole("button", { name: /show seen-once/i });
+
+    // Check → the seen-once row is revealed.
+    await toggle.click();
+    await expect(seededRow(page, "seenonce")).toBeVisible();
+
+    // Uncheck → it hides again. The bug: the table kept the stale revealed rows
+    // even though the refetch (and the button/URL) had reverted.
+    await toggle.click();
+    await expect(seededRow(page, "seenonce")).toHaveCount(0);
+    await expect(seededRow(page, "repeated")).toBeVisible();
+  });
+
+  test("row selection re-renders the table: checkbox checks + bulk bar appears", async ({ page }) => {
+    await withInternalDb(async (c) => {
+      await seedPattern(c, orgId, { tag: "sel-a", confidence: 0.5 });
+      await seedPattern(c, orgId, { tag: "sel-b", confidence: 0.5 });
+    });
+    await page.goto("/admin/learned-patterns");
+
+    const row = seededRow(page, "sel-a");
+    await expect(row).toBeVisible();
+    const checkbox = row.getByRole("checkbox", { name: /select row/i });
+
+    // Selecting the row must visibly check the box and surface the bulk bar. The
+    // bug: `setRowSelection` fired but the memoized table never re-rendered, so
+    // the checkbox stayed unchecked and bulk actions never appeared.
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+    await expect(page.getByRole("button", { name: /approve 1/i })).toBeVisible();
   });
 });

--- a/packages/web/src/ui/hooks/use-server-data-table.ts
+++ b/packages/web/src/ui/hooks/use-server-data-table.ts
@@ -217,7 +217,7 @@ export function useServerDataTable<TData, TResponse = unknown>(
   const total = selected?.total ?? 0;
   const pageCount = Math.max(1, Math.ceil(total / perPage));
 
-  const { table } = useDataTable<TData>({
+  const { table: baseTable } = useDataTable<TData>({
     data: rows,
     columns,
     pageCount,
@@ -227,6 +227,27 @@ export function useServerDataTable<TData, TResponse = unknown>(
     },
     getRowId: opts.getRowId,
   });
+
+  // TanStack's `table` is a stable reference whose row model and state
+  // (selection, pagination, sorting, visibility) mutate in place. Under React
+  // Compiler that stable ref lets memoized consumers (`ServerDataTable` →
+  // `DataTable`) skip re-rendering when only the table's internals change — the
+  // table holds the right rows while the DOM shows stale ones (verified: the
+  // seen-once toggle not un-revealing, selection checkboxes not updating).
+  // TanStack documents a `"use no memo"` opt-out, but that's a Babel-plugin
+  // directive and this app builds with Turbopack (SWC), so we don't rely on it.
+  //
+  // Instead, hand consumers a transparent Proxy of the table whose *reference*
+  // changes whenever a render-relevant slice does — bundler- and
+  // compiler-agnostic. The Proxy forwards every access to the real table (whose
+  // methods close over it, so the data stays live), so behaviour is identical:
+  // only identity-based memoization is defeated, exactly when the table changed.
+  const s = baseTable.getState();
+  const table = React.useMemo(
+    () => new Proxy(baseTable, {}),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps ARE the render-relevant slices; `baseTable` is stable
+    [baseTable, rows, s.rowSelection, s.pagination, s.sorting, s.columnVisibility, s.columnFilters],
+  );
 
   return {
     ...binding,


### PR DESCRIPTION
## Problem

Two symptoms reported in the learned-patterns cockpit, one root cause:

1. **Unchecking "Show seen-once" didn't undo the filter** — the seen-once rows stayed on screen (#4581).
2. **Bulk-select didn't work** — row checkboxes never showed as checked and the bulk action bar didn't appear (#4575); the table felt "messed up."

## Root cause

TanStack Table's `table` object is a **stable reference** whose row model and selection state mutate **in place**. React Compiler memoizes the shared `ServerDataTable` → `DataTable` consumers keyed on that unchanging `table` reference, so they **skip re-rendering when only the table's internals change**. The table instance holds the correct data while the DOM renders a stale view.

Proven live on **staging** via fiber inspection: after unchecking the toggle, the active query and the table instance both held **2 rows**, but the DOM rendered a stale **15**. Not a data bug — a render skip.

## Fix

One centralized change in `useServerDataTable`: hand consumers a **transparent `Proxy` of the table whose reference changes** whenever a render-relevant slice (data, selection, pagination, sorting, visibility) changes. The Proxy forwards every access to the real table (whose methods close over it, so data stays live), so behaviour is identical — it only defeats identity-based memoization, exactly when the table actually changed.

- **Bundler/compiler-agnostic.** TanStack documents a `"use no memo"` opt-out, but that's a Babel-plugin directive and this app builds with **Turbopack (SWC)**, which doesn't apply it. The Proxy works regardless.
- **Centralized.** Fixes all six admin server-data tables (`sessions`, `audit`, `users`, `scheduled-tasks`, `scheduled-tasks/runs`, `learned-patterns`) and any future consumer from one place — no per-component discipline. No consumer relies on table-reference stability.

## Validation

- Reproduced the bug on staging (deployed code) via fiber inspection.
- Validated the fix locally in a **real compiler build** (Turbopack dev): toggle round-trips (1 → 2 → 1), selection checkboxes check and the "Approve N" bulk bar appears, and other tables (Sessions) render unchanged.
- Existing tests green: 51 cockpit component tests, 10 `useServerDataTable` tests, 8 `DataTable` tests; lint clean.

## Tests

Extends the milestone's browser spec (`e2e/browser/learned-patterns.spec.ts`) with a seen-once seed option and two regression tests: the toggle round-trip and row-selection re-render. **`bun test` cannot catch this class** — React Compiler only runs in the Next build, not the unit runner — so the guard lives in the browser lane.

## Notes

- Separate DX bug discovered while validating: `packages/web/next.config.ts` sets `Cache-Control: immutable` on `/_next/static/*` **unconditionally**, which breaks Turbopack dev HMR (stale chunks) and is likely the cause of the intermittent `lucide-react ... module factory is not available` errors. Not fixed here — flagged for a follow-up.
- Blocks the **v0.0.50 — Learned-Patterns Elevation** closeout (this is a defect in #4581 / #4575); the milestone stays open until this merges.
