### PR TITLE
fix(web): admin data-table horizontal overflow + nav-badge render guards (#4639)

### DIFF
--- a/e2e/browser/learned-patterns.spec.ts
+++ b/e2e/browser/learned-patterns.spec.ts
@@ -294,27 +294,26 @@ test.describe("learned-patterns cockpit — full curation loop", () => {
     await page.goto("/admin/learned-patterns");
     await expect(seededRow(page, "wide-0")).toBeVisible();
 
-    const metrics = await page.evaluate(() => {
-      const el = document.querySelector('[data-slot="table-container"]') as HTMLElement | null;
-      const inset = document.querySelector('[data-slot="sidebar-inset"]') as HTMLElement | null;
-      const de = document.documentElement;
-      return {
-        viewport: window.innerWidth,
-        docOverflowPx: de.scrollWidth - de.clientWidth,
-        containerRight: el ? Math.round(el.getBoundingClientRect().right) : null,
-        insetRight: inset ? Math.round(inset.getBoundingClientRect().right) : null,
-        scrollsInternally: el ? el.scrollWidth > el.clientWidth : null,
-      };
-    });
+    // Measure via Playwright locators (boundingBox / typed `el` in
+    // locator.evaluate) rather than bare DOM globals — the e2e type program
+    // has no `dom` lib, so `document`/`window` don't type-check in a callback.
+    const viewport = page.viewportSize()!.width;
+    const insetBox = await page.locator('[data-slot="sidebar-inset"]').boundingBox();
+    const container = page.locator('[data-slot="table-container"]');
+    const containerBox = await container.boundingBox();
+    const docOverflowPx = await page
+      .locator("html")
+      .evaluate((el) => el.scrollWidth - el.clientWidth);
+    const scrollsInternally = await container.evaluate((el) => el.scrollWidth > el.clientWidth);
 
     // The whole page never gains a horizontal scrollbar…
-    expect(metrics.docOverflowPx).toBeLessThanOrEqual(1);
+    expect(docOverflowPx).toBeLessThanOrEqual(1);
     // …and the content column + table card stay within the screen (the bug put
     // them ~256px past the right edge).
-    expect(metrics.insetRight).toBeLessThanOrEqual(metrics.viewport + 1);
-    expect(metrics.containerRight).toBeLessThanOrEqual(metrics.viewport + 1);
+    expect(Math.round(insetBox!.x + insetBox!.width)).toBeLessThanOrEqual(viewport + 1);
+    expect(Math.round(containerBox!.x + containerBox!.width)).toBeLessThanOrEqual(viewport + 1);
     // The wide content is still fully reachable — it scrolls inside the card.
-    expect(metrics.scrollsInternally).toBe(true);
+    expect(scrollsInternally).toBe(true);
   });
 
   test("sorting by confidence reorders the queue (server-driven sort param + visual order)", async ({ page }) => {

--- a/e2e/browser/learned-patterns.spec.ts
+++ b/e2e/browser/learned-patterns.spec.ts
@@ -249,9 +249,8 @@ test.describe("learned-patterns cockpit — full curation loop", () => {
 
     // Discoverability: land on a sibling Intelligence page (the group is expanded
     // there), follow the Learned Patterns nav entry to the cockpit, and see the
-    // seeded queue. NOTE: the numeric pending-count BADGE glyph does not render
-    // even when the count is > 0 — filed separately (cockpit-visibility); this
-    // leg asserts the endpoint + the nav entry that feed it, not the badge glyph.
+    // seeded queue. This leg asserts the endpoint + the nav entry; the badge
+    // glyph itself is asserted by the dedicated test below (#4639).
     await page.goto("/admin/prompts");
     const navLink = page.getByRole("link", { name: "Learned Patterns" });
     await expect(navLink).toBeVisible();
@@ -259,6 +258,63 @@ test.describe("learned-patterns cockpit — full curation loop", () => {
     await expect(page).toHaveURL(/\/admin\/learned-patterns/);
     await expect(seededRow(page, "nav-a")).toBeVisible();
     await expect(seededRow(page, "nav-b")).toBeVisible();
+  });
+
+  // #4639 — the badge GLYPH. The test above asserts the endpoint feeding the
+  // badge; this asserts the badge actually reaches the DOM (the count > 0 render
+  // that was never tested, which is why a missing badge slipped). Land on a
+  // sibling Intelligence page so the group is expanded and the sub-entry + its
+  // badge are in the DOM (mirrors the discoverability leg above).
+  test("the nav badge renders the pending-count glyph (#4639)", async ({ page }) => {
+    await withInternalDb(async (c) => {
+      await seedPattern(c, orgId, { tag: "badge-a", confidence: 0.4 });
+      await seedPattern(c, orgId, { tag: "badge-b", confidence: 0.6 });
+    });
+    await page.goto("/admin/prompts");
+    const navLink = page.getByRole("link", { name: /Learned Patterns/ });
+    await expect(navLink).toBeVisible();
+    // The badge is the rounded-full count span inside the nav link (#4578). The
+    // poll fires on mount; give it a moment to resolve and paint the glyph.
+    await expect(navLink.locator("span.rounded-full")).toHaveText("2");
+  });
+
+  // Layout regression: a wide table must scroll INSIDE its own card, never push
+  // the admin content column past the viewport's right edge. The flex content
+  // column (`SidebarInset`) needs `min-w-0` — without it a flex item's default
+  // `min-width: auto` (min-content ≈ the widest child) makes a wide table force
+  // the whole column ~sidebar-width off-screen to the right. Asserts the table
+  // container stays within the viewport while still scrolling its overflow.
+  test("a wide table stays within the viewport, scrolling inside its card (not off-screen)", async ({ page }) => {
+    await withInternalDb(async (c) => {
+      // Several rows so the full (wide) column set renders.
+      for (let i = 0; i < 4; i++) {
+        await seedPattern(c, orgId, { tag: `wide-${i}`, confidence: 0.3 + i * 0.1, avgDurationMs: 500 + i });
+      }
+    });
+    await page.goto("/admin/learned-patterns");
+    await expect(seededRow(page, "wide-0")).toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const el = document.querySelector('[data-slot="table-container"]') as HTMLElement | null;
+      const inset = document.querySelector('[data-slot="sidebar-inset"]') as HTMLElement | null;
+      const de = document.documentElement;
+      return {
+        viewport: window.innerWidth,
+        docOverflowPx: de.scrollWidth - de.clientWidth,
+        containerRight: el ? Math.round(el.getBoundingClientRect().right) : null,
+        insetRight: inset ? Math.round(inset.getBoundingClientRect().right) : null,
+        scrollsInternally: el ? el.scrollWidth > el.clientWidth : null,
+      };
+    });
+
+    // The whole page never gains a horizontal scrollbar…
+    expect(metrics.docOverflowPx).toBeLessThanOrEqual(1);
+    // …and the content column + table card stay within the screen (the bug put
+    // them ~256px past the right edge).
+    expect(metrics.insetRight).toBeLessThanOrEqual(metrics.viewport + 1);
+    expect(metrics.containerRight).toBeLessThanOrEqual(metrics.viewport + 1);
+    // The wide content is still fully reachable — it scrolls inside the card.
+    expect(metrics.scrollsInternally).toBe(true);
   });
 
   test("sorting by confidence reorders the queue (server-driven sort param + visual order)", async ({ page }) => {

--- a/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
+++ b/packages/web/src/ui/__tests__/admin-sidebar.test.tsx
@@ -68,7 +68,7 @@ void mock.module("@/components/ui/separator", () => {
   return { Separator: () => React.createElement("hr") };
 });
 
-import { render } from "@testing-library/react";
+import { render, waitFor, within } from "@testing-library/react";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { AtlasProvider, type AtlasAuthClient } from "../context";
 import { AdminSidebar } from "../components/admin/admin-sidebar";
@@ -178,5 +178,35 @@ describe("AdminSidebar", () => {
   test("polls the learned-patterns reviewable-pending count for an admin, not for a non-admin", () => {
     expect(renderWithFetchSpy(AdminWrapper).polledLearnedCount).toBe(true);
     expect(renderWithFetchSpy(Wrapper).polledLearnedCount).toBe(false);
+  });
+
+  // #4639 — the poll requesting the count is necessary but not sufficient: the
+  // returned count must actually reach the render as a badge glyph. The other
+  // learned-patterns tests mock `count: 0` and only assert the request fired, so
+  // badge *rendering with count > 0* was untested — which is why the missing
+  // badge slipped. This renders with the endpoint returning a non-zero count and
+  // asserts the badge span appears on the Learned Patterns entry.
+  test("renders the learned-patterns pending badge when the count endpoint returns > 0 (#4639)", async () => {
+    const fetchSpy = mock(async (url: string | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ count: String(url).includes(LEARNED_PENDING_COUNT_URL) ? 2 : 0 }),
+    }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const { container } = render(<AdminSidebar />, { wrapper: AdminWrapper });
+      const link = await waitFor(() => {
+        const el = container.querySelector('a[href="/admin/learned-patterns"]');
+        if (!el) throw new Error("learned-patterns nav entry not rendered");
+        return el as HTMLElement;
+      });
+      // The badge glyph shows the count once the poll resolves.
+      await waitFor(() => {
+        expect(within(link).getByText("2")).toBeTruthy();
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/web/src/ui/components/admin/admin-layout.tsx
+++ b/packages/web/src/ui/components/admin/admin-layout.tsx
@@ -177,7 +177,15 @@ function AdminLayoutInner({ children }: { children: ReactNode }) {
   return (
     <SidebarProvider className="!min-h-0 h-full">
       <AdminSidebar />
-      <SidebarInset id="main" tabIndex={-1}>
+      {/*
+        `min-w-0` lets this flex column shrink below its content's intrinsic
+        width. Without it a flex item defaults to `min-width: auto` (min-content
+        ≈ the widest child), so a wide admin table forces the whole main column
+        past the viewport's right edge instead of the table scrolling inside its
+        own card. With `min-w-0` the column stays within the available width and
+        the table's internal `overflow-x-auto` handles the overflow.
+      */}
+      <SidebarInset id="main" tabIndex={-1} className="min-w-0">
         <AdminTopBar />
         <ScrollArea className="flex-1">
           {gateBlocking ? (


### PR DESCRIPTION
## Summary

Two admin-console cockpit fixes surfaced while closing out **v0.0.50 — Learned-Patterns Elevation** (#87). Both validated in a fresh browser context via the test runner.

### 1. Data-table horizontal overflow (the reported bug)
A wide admin table pushed the whole main content column **~256px (sidebar width) past the viewport's right edge** — far columns were clipped off-screen instead of scrolling inside the table card.

**Root cause:** `SidebarInset` (the flex content column) had no `min-w-0`, so its default `min-width: auto` (min-content ≈ the widest child) refused to shrink to the available width. A wide table forced the column wider than the screen.

**Fix:** `min-w-0` on the content column so it shrinks to available width; the table's existing internal `overflow-x-auto` then handles the overflow — the table scrolls *inside its own card* and nothing runs off-screen. Applies to **all 6 admin data tables**, not just the cockpit.

New browser regression test asserts the table container + content column stay within the viewport while still scrolling their overflow. Negative-checked: without `min-w-0` it fails at exactly `insetRight = 1536` (256px off-screen).

### 2. #4639 nav pending-count badge — **not a product bug**
The "badge never renders despite count > 0" report was a **dev-server stale-chunk artifact** (Turbopack uses stable chunk filenames but `next.config.ts` serves them `immutable`, so the reporter's browser ran pre-badge code). On a clean build the badge renders correctly — confirmed live.

The badge glyph render (count > 0) was previously untested (existing tests mock `count: 0` and only assert the poll fired), which is why the false report looked plausible. This adds the missing guards so a *real* badge regression would be caught:
- a bun component-render assertion (`admin-sidebar.test.tsx`)
- a browser-lane badge-glyph assertion (`learned-patterns.spec.ts`)
- corrects the now-false "badge does not render" note in the existing discoverability test

> **Follow-up (not in this PR):** the true root cause of the stale-chunk masquerade is the `immutable` Cache-Control on `/_next/static/*` applying in dev (`next.config.ts:173`). Dev-guarding it is a separate, sensitive change (SECURITY-HEADERS block + scaffold mirror + drift gate) worth its own PR.

## Test plan
- [x] `learned-patterns.spec.ts` — 13/13 pass on a clean build (incl. new badge + overflow tests)
- [x] `admin-sidebar.test.tsx` — 8/8 pass
- [x] Overflow guard negative-checked (fails without `min-w-0`)
- [x] oxlint + tsgo clean on changed files

Relates to #4639, #4570 (PRD acceptance: "the queue announces itself with a badge").