### PR TITLE
fix(web): dev-guard the immutable Cache-Control on /_next/static

### DIFF
--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -34,6 +34,13 @@ const nextConfig: NextConfig = {
   // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
   // SECURITY-HEADERS-START
   async headers() {
+    // In dev, Turbopack serves `/_next/static/*` chunks under STABLE (unhashed)
+    // filenames, so the production `immutable` policy below would pin the
+    // browser to stale chunks across recompiles — broken HMR, and source edits
+    // that silently never reach the running page. Guard it: dev revalidates,
+    // prod keeps `immutable`. `next build` / `next start` set NODE_ENV to
+    // "production"; `next dev` does not.
+    const isDev = process.env.NODE_ENV !== "production";
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
@@ -108,15 +115,19 @@ const nextConfig: NextConfig = {
       },
       {
         // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
-        // content-addressed and safe to cache forever. Next.js sets this by
-        // default for files it serves directly, but declaring it explicitly
-        // here keeps the policy stable regardless of how the standalone server
-        // is wrapped (Railway, Docker, reverse proxies).
+        // content-addressed and safe to cache forever in production. Next.js
+        // sets this by default for files it serves directly, but declaring it
+        // explicitly here keeps the policy stable regardless of how the
+        // standalone server is wrapped (Railway, Docker, reverse proxies).
+        // In dev the filenames are stable but the content is not, so revalidate
+        // instead of pinning `immutable` (see `isDev` at the top of headers()).
         source: "/_next/static/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: isDev
+              ? "no-cache"
+              : "public, max-age=31536000, immutable",
           },
         ],
       },

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -32,6 +32,13 @@ const nextConfig: NextConfig = {
   // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
   // SECURITY-HEADERS-START
   async headers() {
+    // In dev, Turbopack serves `/_next/static/*` chunks under STABLE (unhashed)
+    // filenames, so the production `immutable` policy below would pin the
+    // browser to stale chunks across recompiles — broken HMR, and source edits
+    // that silently never reach the running page. Guard it: dev revalidates,
+    // prod keeps `immutable`. `next build` / `next start` set NODE_ENV to
+    // "production"; `next dev` does not.
+    const isDev = process.env.NODE_ENV !== "production";
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
@@ -106,15 +113,19 @@ const nextConfig: NextConfig = {
       },
       {
         // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
-        // content-addressed and safe to cache forever. Next.js sets this by
-        // default for files it serves directly, but declaring it explicitly
-        // here keeps the policy stable regardless of how the standalone server
-        // is wrapped (Railway, Docker, reverse proxies).
+        // content-addressed and safe to cache forever in production. Next.js
+        // sets this by default for files it serves directly, but declaring it
+        // explicitly here keeps the policy stable regardless of how the
+        // standalone server is wrapped (Railway, Docker, reverse proxies).
+        // In dev the filenames are stable but the content is not, so revalidate
+        // instead of pinning `immutable` (see `isDev` at the top of headers()).
         source: "/_next/static/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: isDev
+              ? "no-cache"
+              : "public, max-age=31536000, immutable",
           },
         ],
       },

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -41,6 +41,13 @@ const nextConfig: NextConfig = {
   // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
   // SECURITY-HEADERS-START
   async headers() {
+    // In dev, Turbopack serves `/_next/static/*` chunks under STABLE (unhashed)
+    // filenames, so the production `immutable` policy below would pin the
+    // browser to stale chunks across recompiles — broken HMR, and source edits
+    // that silently never reach the running page. Guard it: dev revalidates,
+    // prod keeps `immutable`. `next build` / `next start` set NODE_ENV to
+    // "production"; `next dev` does not.
+    const isDev = process.env.NODE_ENV !== "production";
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
@@ -115,15 +122,19 @@ const nextConfig: NextConfig = {
       },
       {
         // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
-        // content-addressed and safe to cache forever. Next.js sets this by
-        // default for files it serves directly, but declaring it explicitly
-        // here keeps the policy stable regardless of how the standalone server
-        // is wrapped (Railway, Docker, reverse proxies).
+        // content-addressed and safe to cache forever in production. Next.js
+        // sets this by default for files it serves directly, but declaring it
+        // explicitly here keeps the policy stable regardless of how the
+        // standalone server is wrapped (Railway, Docker, reverse proxies).
+        // In dev the filenames are stable but the content is not, so revalidate
+        // instead of pinning `immutable` (see `isDev` at the top of headers()).
         source: "/_next/static/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: isDev
+              ? "no-cache"
+              : "public, max-age=31536000, immutable",
           },
         ],
       },

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -92,6 +92,13 @@ const nextConfig: NextConfig = {
   // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
   // SECURITY-HEADERS-START
   async headers() {
+    // In dev, Turbopack serves `/_next/static/*` chunks under STABLE (unhashed)
+    // filenames, so the production `immutable` policy below would pin the
+    // browser to stale chunks across recompiles — broken HMR, and source edits
+    // that silently never reach the running page. Guard it: dev revalidates,
+    // prod keeps `immutable`. `next build` / `next start` set NODE_ENV to
+    // "production"; `next dev` does not.
+    const isDev = process.env.NODE_ENV !== "production";
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com",
@@ -166,15 +173,19 @@ const nextConfig: NextConfig = {
       },
       {
         // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
-        // content-addressed and safe to cache forever. Next.js sets this by
-        // default for files it serves directly, but declaring it explicitly
-        // here keeps the policy stable regardless of how the standalone server
-        // is wrapped (Railway, Docker, reverse proxies).
+        // content-addressed and safe to cache forever in production. Next.js
+        // sets this by default for files it serves directly, but declaring it
+        // explicitly here keeps the policy stable regardless of how the
+        // standalone server is wrapped (Railway, Docker, reverse proxies).
+        // In dev the filenames are stable but the content is not, so revalidate
+        // instead of pinning `immutable` (see `isDev` at the top of headers()).
         source: "/_next/static/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: isDev
+              ? "no-cache"
+              : "public, max-age=31536000, immutable",
           },
         ],
       },


### PR DESCRIPTION
## Summary
In dev, Turbopack serves `/_next/static/*` chunks under **stable (unhashed)** filenames, but `next.config.ts` `headers()` set `public, max-age=31536000, immutable` on them **unconditionally**. The browser then permanently caches the stale chunk across recompiles, so **source edits silently never reach the running page** (broken HMR), and it's the likely cause of intermittent `lucide-react … module factory is not available` dev errors. Next.js itself warns about this at boot: *"Custom Cache-Control headers detected … can break Next.js development behavior."*

This trap has cost real time and even **fabricated a false bug report** — #4639 ("nav pending-count badge never renders") was a reporter running a stale pre-badge chunk; on a clean build the badge renders fine.

## Fix
Guard the header on `NODE_ENV`:
```ts
const isDev = process.env.NODE_ENV !== "production";
// /_next/static/:path*
value: isDev ? "no-cache" : "public, max-age=31536000, immutable",
```
- **dev** (`next dev`, NODE_ENV≠production) → `no-cache` — the browser revalidates every load, so a recompiled chunk is always fresh.
- **prod** (`next build`/`next start`) → unchanged `immutable` — URLs are content-hashed, safe to cache forever.

## Verification
`next dev`, real chunk:
```
$ curl -sI http://localhost:3000/_next/static/chunks/...css | grep -i cache-control
Cache-Control: no-cache          # was: public, max-age=31536000, immutable
```

## Scaffold mirror
The `headers()` policy is byte-mirrored into the 3 scaffold `next.config.ts` files and enforced by `scripts/check-security-headers-drift.sh`. The identical guard is applied to all four; the drift check passes locally.

## Test plan
- [x] `next dev` chunk returns `no-cache` (verified); prod branch keeps `immutable`
- [x] `scripts/check-security-headers-drift.sh` passes (3 mirrors match canonical)
- [x] web `tsgo` + oxlint clean on all 4 files

Root-cause fix for #4639. Relates to the React-Compiler / stale-render class (#4641) whose validation this trap also masked.