### PR TITLE
fix(billing): model picker writes the workspace model-config seam, not platform ATLAS_MODEL

### DIFF
--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -15,6 +15,14 @@ import {
   mock,
   type Mock,
 } from "bun:test";
+import { Effect, Layer } from "effect";
+
+// --- Enterprise gate: flip the env var so the real `isEnterpriseEnabled`
+// resolves true and the `ConditionalEELayer` loads the mocked
+// `@atlas/ee/layers` below (same pattern as admin-model-config.test.ts).
+// Module-top env setup — must be set before the imports below read env at
+// module-load time; `??=` keeps the assignment hoisted.
+process.env.ATLAS_ENTERPRISE_ENABLED ??= "true";
 
 // --- Auth mock ---
 
@@ -149,6 +157,38 @@ void mock.module("@atlas/api/lib/settings", () => ({
   _resetSettingsCache: mock(() => {}),
 }));
 
+// --- ModelRouter mock (#4645) ---
+//
+// `currentModel` resolves the workspace model config FIRST (mirroring the
+// agent loop), so the billing tests need a controllable `ModelRouter`. The
+// route reaches it via the `ModelRouter` Tag provided by the module-level
+// EnterpriseRuntime, whose `ConditionalEELayer` lazy-imports
+// `@atlas/ee/layers` — mock the aggregator and bind the Tag to a test fn
+// (same pattern as admin-model-config.test.ts).
+const mockGetWorkspaceModelConfig: Mock<(orgId: string) => unknown> = mock(() =>
+  Effect.succeed(null),
+);
+
+void mock.module("@atlas/ee/layers", () => ({
+  EELayer: Layer.unwrapEffect(
+    Effect.sync(() => {
+      // oxlint-disable-next-line @typescript-eslint/no-require-imports
+      const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      return Layer.succeed(services.ModelRouter, {
+        available: true,
+        getWorkspaceModelConfig: mockGetWorkspaceModelConfig as never,
+        getWorkspaceModelConfigRaw: (() => Effect.succeed(null)) as never,
+        setWorkspaceModelConfig: (() => Effect.die(new Error("not under test"))) as never,
+        deleteWorkspaceModelConfig: (() => Effect.die(new Error("not under test"))) as never,
+        testModelConfig: (() => Effect.die(new Error("not under test"))) as never,
+        reconcileModelDeprecation: (() =>
+          Effect.succeed({ status: "healthy" as const, suggestion: null })) as never,
+        parseBedrockCredentialBundle: () => null,
+      } as never);
+    }),
+  ),
+}));
+
 // --- Logger mock ---
 
 void mock.module("@atlas/api/lib/logger", () => ({
@@ -203,6 +243,7 @@ describe("billing routes", () => {
     mockGetWorkspaceDetails.mockImplementation(() => Promise.resolve({ ...mockWorkspace }));
     mockUpdateWorkspaceByot.mockImplementation(() => Promise.resolve(true));
     mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockGetWorkspaceModelConfig.mockImplementation(() => Effect.succeed(null));
     // The shared seat-count source (#3430) keeps a module-level last-known
     // cache. Reset it so one test's member count can't leak into the next as a
     // last-known fallback.
@@ -540,6 +581,54 @@ describe("billing routes", () => {
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
       const body = await res.json() as any;
       expect(body.currentModel).toBe("anthropic/claude-opus-4.8");
+    });
+
+    // ── Workspace model config precedence (#4645) ────────────────────
+    //
+    // The agent loop resolves the workspace model config (ModelRouter) BEFORE
+    // the platform ATLAS_MODEL setting — both the BYOT rows and the billing
+    // page's gateway-on-platform-credits picks live there. `currentModel`
+    // must mirror that order or the picker advertises a model the engine
+    // won't run.
+
+    it("prefers the workspace model config over the setting for currentModel (#4645)", async () => {
+      mockSettingLiveValue = "anthropic/claude-sonnet-5"; // platform setting present…
+      mockGetWorkspaceModelConfig.mockImplementation(() =>
+        Effect.succeed({
+          id: "cfg-1",
+          orgId: "org-1",
+          provider: "gateway",
+          model: "anthropic/claude-opus-4.8", // …but the workspace pick wins
+          apiKeyMasked: null,
+          apiKeyStatus: "platform_credits",
+          baseUrl: null,
+          bedrockRegion: null,
+          modelStatus: "healthy",
+          modelSuggestedReplacement: null,
+          createdAt: "2026-07-01T00:00:00Z",
+          updatedAt: "2026-07-01T00:00:00Z",
+        }),
+      );
+
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      expect(body.currentModel).toBe("anthropic/claude-opus-4.8");
+    });
+
+    it("degrades to the platform default when the workspace config read fails (#4645)", async () => {
+      mockGetWorkspaceModelConfig.mockImplementation(() =>
+        Effect.fail(new Error("model config table unreachable")),
+      );
+
+      const res = await request("/api/v1/billing");
+      expect(res.status).toBe(200);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+      const body = await res.json() as any;
+      // Same value as the nothing-saved SSOT case — the page must not 500
+      // because the EE model-config read blipped.
+      expect(body.currentModel).toBe(resolveModelId(undefined, undefined));
     });
 
     // ── Subscription visibility (#3429) ────────────────────────────

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -22,6 +22,7 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
   AuthContext,
+  ModelRouter,
 } from "@atlas/api/lib/effect/services";
 import { validationHook } from "./validation-hook";
 import {
@@ -226,9 +227,23 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     const plan = getPlanDefinition(workspace.plan_tier);
     const limits = getPlanLimits(workspace.plan_tier);
 
-    // Fetch seat count, connection count, subscription, and the saved model +
-    // provider settings in parallel
-    const [seatCount, connectionCountResult, subResult, currentModelSetting, providerSetting] = yield* Effect.promise(() => Promise.all([
+    // Fetch seat count, connection count, subscription, the saved model +
+    // provider settings, and the workspace model config in parallel. The
+    // workspace config (EE ModelRouter; Noop layer yields null) is what the
+    // agent loop resolves FIRST — both the BYOT rows and the billing page's
+    // gateway-on-platform-credits picks live there (#4645). Read failures
+    // degrade to the platform-default path rather than failing the page.
+    const workspaceModelConfigEffect = ModelRouter.pipe(
+      Effect.flatMap((router) => router.getWorkspaceModelConfig(orgId)),
+      Effect.catchAll((err) => {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), orgId },
+          "Failed to read workspace model config for billing page — falling back to platform default",
+        );
+        return Effect.succeed(null);
+      }),
+    );
+    const [[seatCount, connectionCountResult, subResult, currentModelSetting, providerSetting], workspaceModelConfig] = yield* Effect.all([Effect.promise(() => Promise.all([
       // Seat count from the SHARED source (#3430) — the same `member` count
       // enforcement and /admin/usage read, so the budget shown here matches the
       // actual 429 threshold. getSeatCount serves the last-known value on a
@@ -349,25 +364,31 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         );
         return undefined;
       }),
-    ]));
+    ])), workspaceModelConfigEffect], { concurrency: "unbounded" });
 
     const connectionCount = connectionCountResult[0]?.count ?? 0;
     const subscription = subResult.length > 0 ? subResult[0] : null;
-    // SSOT (#3098): currentModel is exactly what the agent loop resolves for
-    // this workspace — the saved ATLAS_MODEL if present, else the provider's
-    // default (gateway → Sonnet 4.6). The billing "Default AI model" picker
-    // displays this verbatim, so it can never advertise a model the engine
-    // won't actually run. Falls back to the plan's recommended model only if
-    // resolution throws (e.g. an openai-compatible provider with no model set).
+    // SSOT (#3098, #4645): currentModel is exactly what the agent loop
+    // resolves for this workspace — the workspace model config if one exists
+    // (BYOT rows AND gateway-on-platform-credits picks from the billing
+    // page), else the platform ATLAS_MODEL setting, else the provider's
+    // default. The billing "Default AI model" picker displays this verbatim,
+    // so it can never advertise a model the engine won't actually run. Falls
+    // back to the plan's recommended model only if resolution throws (e.g.
+    // an openai-compatible provider with no model set).
     let currentModel: string;
-    try {
-      currentModel = resolveModelId(providerSetting, currentModelSetting);
-    } catch (err) {
-      log.debug(
-        { err: err instanceof Error ? err.message : String(err), orgId },
-        "Model resolution failed for billing currentModel — using plan default",
-      );
-      currentModel = currentModelSetting || plan.defaultModel || "default";
+    if (workspaceModelConfig) {
+      currentModel = workspaceModelConfig.model;
+    } else {
+      try {
+        currentModel = resolveModelId(providerSetting, currentModelSetting);
+      } catch (err) {
+        log.debug(
+          { err: err instanceof Error ? err.message : String(err), orgId },
+          "Model resolution failed for billing currentModel — using plan default",
+        );
+        currentModel = currentModelSetting || plan.defaultModel || "default";
+      }
     }
 
     // Per-seat token budget, retained for the wire's `limits.totalTokenBudget`

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -233,11 +233,23 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     // agent loop resolves FIRST — both the BYOT rows and the billing page's
     // gateway-on-platform-credits picks live there (#4645). Read failures
     // degrade to the platform-default path rather than failing the page.
+    // Known display gap on this fallback: for a BYOT workspace, a transient
+    // read failure makes the page show the platform default while the row
+    // copy still says "managed by your provider configuration" (plan.byot is
+    // independent of this read). Accepted for now — the agent loop degrades
+    // the same way on its raw read (lib/agent.ts), so display and engine
+    // stay in lockstep; a `currentModelDegraded` wire field would be the
+    // full fix. The `tag` in the log keeps an EnterpriseError (licensing
+    // misconfiguration) distinguishable from a DB blip.
     const workspaceModelConfigEffect = ModelRouter.pipe(
       Effect.flatMap((router) => router.getWorkspaceModelConfig(orgId)),
       Effect.catchAll((err) => {
         log.warn(
-          { err: err instanceof Error ? err.message : String(err), orgId },
+          {
+            err: err instanceof Error ? err.message : String(err),
+            tag: typeof err === "object" && err !== null && "_tag" in err ? String((err as { _tag: unknown })._tag) : undefined,
+            orgId,
+          },
           "Failed to read workspace model config for billing page — falling back to platform default",
         );
         return Effect.succeed(null);

--- a/packages/web/src/app/admin/billing/__tests__/model-row-workspace-seam.test.tsx
+++ b/packages/web/src/app/admin/billing/__tests__/model-row-workspace-seam.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Regression guard for #4645.
+ *
+ * The billing page's "Default AI model" picker (ModelRow) must write the
+ * per-workspace model-config seam (`PUT /api/v1/admin/model-config`,
+ * gateway-on-platform-credits) — NOT the `ATLAS_MODEL` settings key. That
+ * key is platform-scoped, so the settings route 403s every workspace admin
+ * ("is a platform-level setting and cannot be modified by workspace
+ * admins"), and a platform-admin write would land on the GLOBAL row and
+ * change the model for every workspace in the region. The bug shipped
+ * unnoticed because platform-admin test accounts passed the gate.
+ *
+ * Also guards the BYOT carve-out: a BYOT workspace's model lives in its own
+ * provider configuration (ModelProviderSection under the BYOT toggle);
+ * ModelRow must go read-only there so a gateway write can't clobber the
+ * saved BYOT provider row.
+ *
+ * Interaction-level coverage (actually picking a model through the Radix
+ * Select) belongs to the browser suite — these tests pin the wiring: which
+ * endpoint the mutation is registered against and which affordances render.
+ */
+
+import { describe, expect, test, mock, afterEach } from "bun:test";
+import { render, cleanup } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import type { BillingStatus } from "@useatlas/schemas";
+
+void mock.module("next/navigation", () => ({
+  usePathname: () => "/admin/billing",
+  useRouter: () => ({ push: () => {}, replace: () => {}, back: () => {} }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// --- Billing data via useAdminFetch ---
+
+let billingData: BillingStatus | null = null;
+void mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: (path: string) => ({
+    data: path === "/api/v1/billing" ? billingData : null,
+    loading: false,
+    error: null,
+    refetch: () => {},
+  }),
+  useInProgressSet: () => new Set<string>(),
+  friendlyError: (err: { message?: string }) => err?.message ?? "error",
+}));
+
+// --- Mutation capture: record every path/method the page registers ---
+
+interface CapturedMutationConfig {
+  path: string;
+  method?: string;
+}
+const capturedMutations: CapturedMutationConfig[] = [];
+void mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: (config: CapturedMutationConfig) => {
+    capturedMutations.push(config);
+    return {
+      mutate: async () => ({ ok: true }),
+      saving: false,
+      error: null,
+      clearError: () => {},
+      reset: () => {},
+    };
+  },
+}));
+
+// --- Sibling hooks the page mounts (not under test) ---
+
+void mock.module("@/ui/hooks/use-deploy-mode", () => ({
+  useDeployMode: () => ({ deployMode: "saas", error: null, resolved: true }),
+}));
+void mock.module("@/ui/hooks/use-billing-portal", () => ({
+  useBillingPortal: () => ({ openPortal: () => {}, opening: false, error: null }),
+}));
+void mock.module("@/ui/hooks/use-plan-checkout", () => ({
+  usePlanCheckout: () => ({
+    startCheckout: () => {},
+    pendingPlan: null,
+    error: null,
+    clearError: () => {},
+  }),
+}));
+
+// The inline BYOT provider section runs its own fetches/mutations — stub it
+// to a marker so its registrations don't pollute `capturedMutations`.
+void mock.module("@/ui/components/admin/model-provider-section", () => ({
+  ModelProviderSection: () =>
+    createElement("div", { "data-testid": "model-provider-section" }),
+}));
+void mock.module("@/ui/components/admin/trial-countdown-banner", () => ({
+  TRIAL_BANNER_PLAN_ANCHOR_ID: "trial-banner-plan-anchor",
+  TrialCountdownBanner: () => null,
+}));
+
+const BillingPage = (await import("../page")).default;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(NuqsAdapter, null, children);
+}
+
+function makeBillingData(overrides: { byot: boolean }): BillingStatus {
+  return {
+    workspaceId: "org-1",
+    plan: {
+      tier: "starter",
+      displayName: "Starter",
+      pricePerSeat: 39,
+      includedUsageDollarsPerSeat: 20,
+      defaultModel: "anthropic/claude-sonnet-5",
+      byot: overrides.byot,
+      trialEndsAt: null,
+    },
+    limits: {
+      tokenBudgetPerSeat: 2_000_000,
+      totalTokenBudget: 2_000_000,
+      totalUsageDollars: 20,
+      maxSeats: 10,
+      maxConnections: 1,
+      maxChatIntegrations: 1,
+    },
+    usage: {
+      queryCount: 10,
+      tokenCount: 1000,
+      seatCount: 1,
+      costUsd: 0.5,
+      usageDollarsPercent: 2,
+      usageOverageStatus: "ok",
+      periodStart: "2026-07-01T00:00:00.000Z",
+      periodEnd: "2026-08-01T00:00:00.000Z",
+      periodSource: "utc-month",
+    },
+    seats: { count: 1, max: 10 },
+    connections: { count: 1, max: 1 },
+    currentModel: "anthropic/claude-sonnet-5",
+    subscription: null,
+    availablePlans: [],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  billingData = null;
+  capturedMutations.length = 0;
+});
+
+describe("billing ModelRow — workspace model-config seam (#4645)", () => {
+  test("registers the model mutation against /api/v1/admin/model-config, never the ATLAS_MODEL setting", () => {
+    billingData = makeBillingData({ byot: false });
+    const { container } = render(createElement(BillingPage), { wrapper });
+
+    expect(container.textContent).toContain("Default AI model");
+    const paths = capturedMutations.map((m) => m.path);
+    expect(paths).toContain("/api/v1/admin/model-config");
+    // The exact bug: this path is platform-scoped and 403s workspace admins.
+    expect(paths.some((p) => p.includes("/admin/settings/ATLAS_MODEL"))).toBe(false);
+
+    const modelConfig = capturedMutations.find(
+      (m) => m.path === "/api/v1/admin/model-config",
+    );
+    expect(modelConfig?.method).toBe("PUT");
+  });
+
+  test("non-BYOT workspace gets the Change affordance", () => {
+    billingData = makeBillingData({ byot: false });
+    const { getByRole } = render(createElement(BillingPage), { wrapper });
+    expect(getByRole("button", { name: /change/i })).toBeTruthy();
+  });
+
+  test("BYOT workspace: ModelRow is read-only so a gateway write can't clobber the provider config", () => {
+    billingData = makeBillingData({ byot: true });
+    const { container, queryByRole } = render(createElement(BillingPage), { wrapper });
+
+    expect(container.textContent).toContain("Default AI model");
+    expect(container.textContent).toContain("managed by your provider configuration");
+    // No expand/change affordance on the model row.
+    expect(queryByRole("button", { name: /change/i })).toBeNull();
+    // The BYOT provider section is the model-management surface instead.
+    expect(container.querySelector('[data-testid="model-provider-section"]')).toBeTruthy();
+  });
+});

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -947,8 +947,13 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
   const currentModel = canonicalizeModel(data.currentModel);
   const currentLabel = modelLabel(currentModel);
 
+  // #4645 — the pick writes a per-workspace gateway row on platform credits
+  // (`workspace_model_config`), the same seam the agent loop resolves first.
+  // It must NOT write the `ATLAS_MODEL` setting: that key is platform-scoped,
+  // so the write 403s for workspace admins — and a platform-admin write would
+  // land on the global row and change the model for every workspace.
   const { mutate, saving, error, clearError } = useAdminMutation({
-    path: "/api/v1/admin/settings/ATLAS_MODEL",
+    path: "/api/v1/admin/model-config",
     method: "PUT",
     invalidates: onSaved,
   });
@@ -957,7 +962,21 @@ function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void 
     useDisclosure({ onCollapseCleanup: clearError });
 
   async function handleModelChange(value: string) {
-    await mutate({ body: { value } });
+    await mutate({ body: { provider: "gateway", model: value } });
+  }
+
+  // A BYOT workspace's model lives in its own provider configuration (the
+  // section under the BYOT toggle below) — writing a gateway row from here
+  // would clobber that config, so the row goes read-only.
+  if (data.plan.byot) {
+    return (
+      <CompactRow
+        icon={Bot}
+        title="Default AI model"
+        description={`${currentLabel} — managed by your provider configuration below`}
+        status="disconnected"
+      />
+    );
   }
 
   if (!expanded) {


### PR DESCRIPTION
Fixes #4645.

## Problem

On prod, no workspace admin can change their workspace's model: the billing page's "Default AI model" picker PUT the **platform-scoped** `ATLAS_MODEL` settings key, so the settings write gate correctly 403s ("is a platform-level setting and cannot be modified by workspace admins"). Worse, a platform-admin write landed on the **global** settings row — changing the default model for every workspace in the region — and the engine never reads `ATLAS_MODEL` per-org anyway (agent-loop resolution is workspace model config → platform default).

## Fix

**Write side (`packages/web/.../billing/page.tsx`)** — `ModelRow` now PUTs `/api/v1/admin/model-config` with `{provider: "gateway", model}`: a per-workspace gateway row on **platform credits** (`workspace_model_config`), the exact seam the agent loop resolves first. Workspace-admin-writable (`admin:settings` permission), org-scoped by construction. BYOT workspaces get a read-only row so a gateway write can't clobber their provider config (the BYOT section owns the model there).

**Read side (`packages/api/.../routes/billing.ts`)** — `GET /api/v1/billing` `currentModel` now consults `ModelRouter.getWorkspaceModelConfig(orgId)` before the `ATLAS_MODEL` setting, mirroring agent-loop resolution order (it previously also misreported for BYOT workspaces). Read failures log (with error tag) and degrade to the platform default — the same degrade the agent loop applies, so display and engine stay in lockstep.

## Tests

- `billing.test.ts`: +2 — workspace config wins over the setting; read failure degrades to platform default (ModelRouter mocked via `@atlas/ee/layers`, same pattern as `admin-model-config.test.ts`). 31/31 pass.
- New `model-row-workspace-seam.test.tsx`: pins the mutation to `PUT /api/v1/admin/model-config`, asserts the settings path is never registered, covers the BYOT read-only carve-out. 3/3 pass.
- `/ci`: all 30 local gates green (first run's lone `mcp/smoke.test.ts` failure was the known needs-migrated-DB env signature; green with `db:up`).
- Review panel: code-reviewer + silent-failure-hunter passes clean; the silent-failure mediums (error-tag logging, BYOT transient-mislabel documentation) applied in the second commit.

## Notes

- Interaction-level coverage (picking through the Radix Select) belongs to the browser suite; these tests pin the endpoint wiring and affordances.
- A `currentModelDegraded` wire field would fully close the BYOT transient-mislabel display gap — documented at the fallback site, deliberately out of scope for this hotfix.