### PR TITLE
fix(semantic-improve): stop coverage backfill re-storm exhausting the target DB

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve-briefing.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve-briefing.test.ts
@@ -70,6 +70,8 @@ void mock.module("@atlas/api/lib/semantic/connection-profile", () => ({
   recordBaselineError: async () => {},
   recordLlmProfileRun: async () => {},
   getConnectionProfileState: async () => null,
+  claimBaselineSlot: async () => true,
+  BASELINE_CLAIM_TTL_SECONDS: 300,
 }));
 
 void mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve-coverage.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve-coverage.test.ts
@@ -82,6 +82,8 @@ void mock.module("@atlas/api/lib/semantic/connection-profile", () => ({
   upsertBaselineProfile: async () => {},
   recordBaselineError: async () => {},
   recordLlmProfileRun: async () => {},
+  claimBaselineSlot: async () => true,
+  BASELINE_CLAIM_TTL_SECONDS: 300,
 }));
 
 void mock.module("@atlas/api/lib/datasources/connection-baseline", () => ({

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -496,6 +496,11 @@ describe("migrateAuthTables", () => {
             // already-applied set so this "all applied" test sees zero new
             // migrations.
             { name: "0173_learned_pattern_injections.sql" },
+            // 0174 (coverage re-storm fix) — connection_profile_state
+            // .baseline_started_at in-flight claim marker. Additive nullable
+            // column, runs in every auth mode — must be in the already-applied
+            // set so this "all applied" test sees zero new migrations.
+            { name: "0174_connection_profile_baseline_started_at.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/datasources/__tests__/connection-baseline.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/connection-baseline.test.ts
@@ -290,10 +290,31 @@ describe("ensureConnectionBaseline — lazy backfill", () => {
     ];
     const state = await ensureConnectionBaseline(
       { orgId: "org_1", installId: "cn", dbType: "postgres" },
-      { resolveConnection: okResolver(conn) },
+      { resolveConnection: okResolver(conn), claimSlot: async () => true },
     );
     expect(dbCalls.some((c) => c.sql.includes("INSERT INTO connection_profile_state"))).toBe(true);
     expect(state?.baseline?.tableCount).toBe(1);
+  });
+
+  it("does NOT run a profile when the in-flight claim is lost (a peer attempt is already running)", async () => {
+    // The atomic claim (migration 0174) is what stops the coverage view's 4s poll
+    // from launching overlapping profiles: a lost claim means someone else holds a
+    // fresh one, so this call returns the current state WITHOUT re-profiling.
+    let resolved = false;
+    selectRows = [[]]; // 1st read: no baseline yet
+    const state = await ensureConnectionBaseline(
+      { orgId: "org_1", installId: "cn", dbType: "postgres" },
+      {
+        resolveConnection: async () => {
+          resolved = true;
+          return { kind: "not_found" };
+        },
+        claimSlot: async () => false, // claim lost — another attempt in flight
+      },
+    );
+    expect(resolved).toBe(false); // no live-connection work
+    expect(dbCalls.every((c) => !c.sql.includes("INSERT INTO"))).toBe(true);
+    expect(state).toBeNull(); // returns the (unbaselined) existing state
   });
 
   it("re-attempts when the last baseline only FAILED (error row, no success facts)", async () => {
@@ -324,6 +345,7 @@ describe("ensureConnectionBaseline — lazy backfill", () => {
           resolved = true;
           return okResolver(conn)();
         },
+        claimSlot: async () => true,
       },
     );
     expect(resolved).toBe(true); // retried

--- a/packages/api/src/lib/datasources/__tests__/connection-baseline.test.ts
+++ b/packages/api/src/lib/datasources/__tests__/connection-baseline.test.ts
@@ -98,7 +98,7 @@ describe("profileConnectionOnCreate — the on-create hook seam", () => {
     const runBaseline = mock(async () => {});
     const decision = await profileConnectionOnCreate(
       { orgId: "org_1", installId: "cn_pg", connectionGroupId: "g", dbType: "postgres" },
-      { resolveCapability: async () => native, runBaseline },
+      { resolveCapability: async () => native, runBaseline, claimSlot: async () => true },
     );
     expect(decision).toEqual({ action: "scheduled" });
     expect(runBaseline).toHaveBeenCalledTimes(1);
@@ -108,6 +108,18 @@ describe("profileConnectionOnCreate — the on-create hook seam", () => {
       connectionGroupId: "g",
       dbType: "postgres",
     });
+  });
+
+  it("skips scheduling when the in-flight claim is lost (a peer is already profiling)", async () => {
+    // The claim collapses ALL profile initiators to one: if a concurrent lazy
+    // backfill already holds the claim, the on-create hook does NOT double-profile.
+    const runBaseline = mock(async () => {});
+    const decision = await profileConnectionOnCreate(
+      { orgId: "org_1", installId: "cn_pg", dbType: "postgres" },
+      { resolveCapability: async () => native, runBaseline, claimSlot: async () => false },
+    );
+    expect(decision).toEqual({ action: "skipped", reason: "already-profiling" });
+    expect(runBaseline).not.toHaveBeenCalled();
   });
 
   it("does NOT profile a REST/OpenAPI datasource", async () => {

--- a/packages/api/src/lib/datasources/connection-baseline.ts
+++ b/packages/api/src/lib/datasources/connection-baseline.ts
@@ -33,6 +33,7 @@ import type {
   ResolveLiveConnectionResult,
 } from "@atlas/api/lib/datasources/mcp-lifecycle";
 import {
+  claimBaselineSlot,
   getConnectionProfileState,
   recordBaselineError,
   upsertBaselineProfile,
@@ -196,11 +197,25 @@ export async function runBaselineProfile(
  * load), not on every conversational turn. This is one connection on demand, NOT
  * a bulk sweep. Returns `null` when there's no internal DB. Never throws
  * ({@link runBaselineProfile} is total).
+ *
+ * IN-FLIGHT DEDUP (migration 0174): before profiling, an atomic
+ * {@link claimBaselineSlot} claims the connection. If the claim is lost — another
+ * caller (this poll, another replica) already has a fresh claim in flight — this
+ * returns the current state WITHOUT running a second profile. This is what stops
+ * the coverage view's 4-second poll from launching overlapping full-schema
+ * profiles that exhaust the target database's connection limit; the DB claim (not
+ * an in-process mutex) makes the dedup hold across replicas.
  */
 export async function ensureConnectionBaseline(
   target: BaselineProfileTarget,
   deps: {
     resolveConnection?: (orgId: string, installId: string) => Promise<ResolveLiveConnectionResult>;
+    claimSlot?: (input: {
+      orgId: string | null;
+      installId: string;
+      connectionGroupId?: string | null;
+      dbType: string;
+    }) => Promise<boolean>;
   } = {},
 ): Promise<ConnectionProfileState | null> {
   // Total by contract: the two state reads (not just the profile run) are
@@ -210,6 +225,16 @@ export async function ensureConnectionBaseline(
   try {
     const existing = await getConnectionProfileState(target.orgId, target.installId);
     if (existing?.baseline) return existing; // successful baseline already — no re-run
+    // Claim the in-flight slot atomically. A lost claim means another attempt is
+    // already running (this poll re-fired, or a peer replica) — do NOT re-storm.
+    const claimSlot = deps.claimSlot ?? claimBaselineSlot;
+    const claimed = await claimSlot({
+      orgId: target.orgId,
+      installId: target.installId,
+      connectionGroupId: target.connectionGroupId,
+      dbType: target.dbType,
+    });
+    if (!claimed) return existing;
     await runBaselineProfile(target, deps);
     return await getConnectionProfileState(target.orgId, target.installId);
   } catch (err) {

--- a/packages/api/src/lib/datasources/connection-baseline.ts
+++ b/packages/api/src/lib/datasources/connection-baseline.ts
@@ -210,12 +210,10 @@ export async function ensureConnectionBaseline(
   target: BaselineProfileTarget,
   deps: {
     resolveConnection?: (orgId: string, installId: string) => Promise<ResolveLiveConnectionResult>;
-    claimSlot?: (input: {
-      orgId: string | null;
-      installId: string;
-      connectionGroupId?: string | null;
-      dbType: string;
-    }) => Promise<boolean>;
+    // Derived from the concrete signature (minus the caller-irrelevant TTL knob)
+    // so the injectable can't drift from `claimBaselineSlot` — a renamed/added
+    // required field breaks this at compile time rather than at runtime.
+    claimSlot?: (input: Omit<Parameters<typeof claimBaselineSlot>[0], "ttlSeconds">) => Promise<boolean>;
   } = {},
 ): Promise<ConnectionProfileState | null> {
   // Total by contract: the two state reads (not just the profile run) are
@@ -234,13 +232,18 @@ export async function ensureConnectionBaseline(
       connectionGroupId: target.connectionGroupId,
       dbType: target.dbType,
     });
+    // Intentionally returns the pre-claim `existing` snapshot: if a peer replica
+    // finished a baseline in the read→claim window, the coverage view's next 4s
+    // poll converges — cheaper than an extra round-trip re-read here.
     if (!claimed) return existing;
     await runBaselineProfile(target, deps);
     return await getConnectionProfileState(target.orgId, target.installId);
   } catch (err) {
+    // The try now spans the state read, the claim WRITE, and the profile run —
+    // name all three so a claim/profile write failure isn't mislabelled as a read.
     log.warn(
       { err: errorMessage(err), installId: target.installId },
-      "ensureConnectionBaseline: profile-state read failed — returning null",
+      "ensureConnectionBaseline failed (state read / claim / profile) — returning null",
     );
     return null;
   }
@@ -249,7 +252,10 @@ export async function ensureConnectionBaseline(
 /** Outcome of the on-create hook — observable so the creation seam + tests can assert. */
 export type OnCreateBaselineDecision =
   | { readonly action: "scheduled" }
-  | { readonly action: "skipped"; readonly reason: "not-profilable" | "no-internal-db" | "error" };
+  | {
+      readonly action: "skipped";
+      readonly reason: "not-profilable" | "no-internal-db" | "error" | "already-profiling";
+    };
 
 /**
  * On-create hook: baseline-profile a newly-created profilable connection without
@@ -257,18 +263,30 @@ export type OnCreateBaselineDecision =
  * skipped) and FIRE-AND-FORGET — the baseline runs in the background so it never
  * blocks or fails the install; its own success/failure is recorded durably and
  * the lazy backfill retries on first need. Never throws.
+ *
+ * Claims the in-flight slot (migration 0174) BEFORE scheduling, so the create
+ * hook and a concurrent coverage-view backfill can't both profile the same fresh
+ * connection — the claim collapses ALL profile initiators to one, not just the
+ * poll re-fires. A lost claim means a peer is already profiling → skip.
  */
 export async function profileConnectionOnCreate(
   target: BaselineProfileTarget,
   deps: {
     resolveCapability?: (dbType: string) => Promise<ProfileCapability>;
     runBaseline?: (target: BaselineProfileTarget) => Promise<void>;
+    claimSlot?: (input: Omit<Parameters<typeof claimBaselineSlot>[0], "ttlSeconds">) => Promise<boolean>;
   } = {},
 ): Promise<OnCreateBaselineDecision> {
   try {
     if (!hasInternalDB()) return { action: "skipped", reason: "no-internal-db" };
     const plan = await planConnectionBaseline(target.dbType, deps);
     if (!plan.profilable) return { action: "skipped", reason: "not-profilable" };
+
+    // Claim before scheduling — a concurrent lazy backfill would otherwise launch
+    // a second profile of the same connection. runBaselineProfile releases the
+    // claim on its terminal write (success upsert / recorded error).
+    const claimSlot = deps.claimSlot ?? claimBaselineSlot;
+    if (!(await claimSlot(target))) return { action: "skipped", reason: "already-profiling" };
 
     const runBaseline = deps.runBaseline ?? runBaselineProfile;
     void runBaseline(target).catch((err) =>

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -222,7 +222,10 @@ describe("runMigrations", () => {
     //   status/type CHECK constraints, #4572) = 173.
     //   Plus 0173 (learned_pattern_injections — per-turn injection attribution
     //   substrate + per-pattern usage counts, #4573) = 174.
-    expect(count).toBe(174);
+    //   Plus 0174 (connection_profile_state.baseline_started_at — in-flight claim
+    //   marker collapsing the coverage view's poll-driven baseline backfill to one
+    //   running profile per connection, re-storm fix) = 175.
+    expect(count).toBe(175);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -425,6 +428,7 @@ describe("runMigrations", () => {
         "0171_connection_profile_state.sql",
         "0172_learned_patterns_identity.sql",
         "0173_learned_pattern_injections.sql",
+        "0174_connection_profile_baseline_started_at.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0174_connection_profile_baseline_started_at.sql
+++ b/packages/api/src/lib/db/migrations/0174_connection_profile_baseline_started_at.sql
@@ -1,0 +1,37 @@
+-- 0174 — in-flight claim marker for baseline profiling (coverage re-storm fix).
+--
+-- The coverage view (#4521) lazily backfills a connection's baseline profile and
+-- the client polls every 4s while any connection is still profiling. The lazy
+-- backfill (`ensureConnectionBaseline`) only short-circuited on a SUCCESSFUL
+-- baseline — a connection with neither a success nor a recorded error was
+-- re-profiled on EVERY poll, with no in-flight guard. A group with N members
+-- (e.g. a 3-region `g_prod`) therefore launched N overlapping full-schema
+-- profiles every 4 seconds; the overlapping runs opened live connections to the
+-- target database until it hit `max_connections` ("sorry, too many clients
+-- already"). See the coverage re-storm investigation.
+--
+-- `baseline_started_at` is the atomic claim marker: a caller stamps it before
+-- profiling and clears it (→ NULL) on either terminal outcome (success upsert or
+-- recorded error). A single guarded UPSERT (`claimBaselineSlot` in
+-- `connection-profile.ts`) claims the slot ONLY when there's no successful
+-- baseline and no fresh claim within a staleness TTL, so repeated poll-driven
+-- backfill calls collapse to one running profile per connection ACROSS replicas
+-- (the DB row is the shared lock, not an in-process mutex). A claim older than
+-- the TTL is treated as abandoned (a crashed run) and re-claimable, so a stuck
+-- claim can never wedge a connection permanently.
+--
+-- Additive-only: a single nullable column on an existing table, no constraint
+-- changes — safe in one release (the two-phase-drop discipline governs only
+-- DROP COLUMN / DROP TABLE). The Drizzle mirror in `db/schema.ts`
+-- (`connectionProfileState.baselineStartedAt`) lands in the SAME PR so
+-- `check-schema-drift` stays green. NULL default = no claim in flight; every
+-- existing row reads as "not claiming", which is correct.
+--
+-- Not Better-Auth-managed, so this file does NOT join MANAGED_AUTH_MIGRATIONS
+-- (db/internal.ts). Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE connection_profile_state
+  ADD COLUMN IF NOT EXISTS baseline_started_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN connection_profile_state.baseline_started_at IS
+  'In-flight baseline-profile claim (coverage re-storm fix): stamped before a profile run, cleared to NULL on success or recorded error. A single guarded UPSERT claims the slot only when no baseline exists and no fresh claim is within the staleness TTL, collapsing poll-driven backfill calls to one running profile per connection across replicas. A claim older than the TTL is re-claimable (abandoned/crashed run).';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -603,6 +603,12 @@ export const connectionProfileState = pgTable(
     baselineTableCount: integer("baseline_table_count"),
     baselineProfiledAt: timestamp("baseline_profiled_at", { withTimezone: true }),
     baselineError: text("baseline_error"),
+    // In-flight claim marker (migration 0174) — stamped before a baseline profile
+    // run, cleared to NULL on either terminal outcome (success upsert / recorded
+    // error). The atomic `claimBaselineSlot` UPSERT keys on it so poll-driven
+    // backfill calls collapse to one running profile per connection across
+    // replicas (the coverage re-storm fix).
+    baselineStartedAt: timestamp("baseline_started_at", { withTimezone: true }),
     // LLM tier — enrichment run tracking (never automatic, billing-gated).
     llmProfiledAt: timestamp("llm_profiled_at", { withTimezone: true }),
     llmProfileScope: jsonb("llm_profile_scope"),

--- a/packages/api/src/lib/semantic/__tests__/connection-profile-pg.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/connection-profile-pg.test.ts
@@ -29,6 +29,7 @@ import {
   type InternalPool,
 } from "@atlas/api/lib/db/internal";
 import {
+  claimBaselineSlot,
   upsertBaselineProfile,
   recordBaselineError,
   recordLlmProfileRun,
@@ -176,6 +177,57 @@ describeIfPg("connection profile-tier store — live Postgres round-trip (#4509)
     const state = await getConnectionProfileState(null, installId);
     expect(state?.baseline?.tableCount).toBe(1);
     expect(state?.llm?.scope).toEqual({ tables: ["t"] });
+  });
+
+  // ── The in-flight claim (migration 0174) — the re-storm fix's core invariant.
+  // String-matching the guarded UPSERT proves intent but CANNOT prove the WHERE
+  // predicate + `make_interval` TTL actually gate concurrent claims; a drift there
+  // silently lets two profiles run and reinstates the `too many clients` re-storm
+  // with every unit test green. These execute the real UPSERT to pin it.
+
+  it("claimBaselineSlot: a fresh claim is won once, then blocked while it is held", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    const installId = "cn_claim";
+    // First claim on a brand-new connection wins (INSERT).
+    expect(await claimBaselineSlot({ orgId, installId, connectionGroupId: "g", dbType: "postgres" })).toBe(true);
+    // A second claim while the first is fresh is BLOCKED — this is the dedup that
+    // stops the 4s poll from launching a second overlapping profile.
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(false);
+    // Exactly one row exists (the claim didn't duplicate).
+    const rows = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM connection_profile_state WHERE org_id = $1 AND install_id = $2`,
+      [orgId, installId],
+    );
+    expect(rows.rows[0].n).toBe("1");
+  });
+
+  it("claimBaselineSlot: a claim older than the TTL is re-claimable (a crashed run self-heals)", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    const installId = "cn_stale";
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(true);
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(false); // fresh → blocked
+    // Age the claim past the TTL (simulate an abandoned/crashed run) deterministically.
+    await pool.query(
+      `UPDATE connection_profile_state SET baseline_started_at = now() - interval '10 minutes'
+        WHERE org_id = $1 AND install_id = $2`,
+      [orgId, installId],
+    );
+    // Default TTL is 300s; a 10-minute-old claim is abandoned → re-claimable.
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(true);
+  });
+
+  it("claimBaselineSlot: an error releases the claim (re-attemptable); a success blocks it permanently", async () => {
+    const orgId = `org-${Math.floor(Math.random() * 1e9)}`;
+    const installId = "cn_lifecycle";
+    // Claim → fail → the recorded error must RELEASE the claim so a fixed
+    // connection re-attempts on the next need.
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(true);
+    await recordBaselineError({ orgId, installId, dbType: "postgres", error: "permission denied" });
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(true); // released → re-claimable
+    // A successful baseline must BLOCK all further claims permanently (the
+    // `baseline_profiled_at IS NULL` guard) — no re-storm once profiled.
+    await upsertBaselineProfile({ orgId, installId, dbType: "postgres", profiles: [fakeProfile("orders")] });
+    expect(await claimBaselineSlot({ orgId, installId, dbType: "postgres" })).toBe(false);
   });
 
   it("listConnectionProfileStates scopes to the workspace", async () => {

--- a/packages/api/src/lib/semantic/__tests__/connection-profile.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/connection-profile.test.ts
@@ -26,6 +26,8 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const {
+  claimBaselineSlot,
+  BASELINE_CLAIM_TTL_SECONDS,
   upsertBaselineProfile,
   recordBaselineError,
   recordLlmProfileRun,
@@ -55,6 +57,47 @@ beforeEach(() => {
   nextRows = [];
 });
 
+describe("claimBaselineSlot — atomic in-flight guard (migration 0174)", () => {
+  it("claims only when no baseline exists and no fresh claim is in flight, returning true on a won claim", async () => {
+    nextRows = [{ id: "row-1" }]; // the guarded UPSERT returned a row → claim won
+    const claimed = await claimBaselineSlot({
+      orgId: "org_1",
+      installId: "us-prod",
+      connectionGroupId: "g_prod",
+      dbType: "postgres",
+    });
+    expect(claimed).toBe(true);
+    const { sql, params } = dbCalls[0];
+    expect(sql).toContain("INSERT INTO connection_profile_state");
+    expect(sql).toContain("baseline_started_at = now()");
+    // Guards: no successful baseline yet AND no fresh claim within the TTL.
+    expect(sql).toContain("baseline_profiled_at IS NULL");
+    expect(sql).toContain("make_interval(secs => $5)");
+    expect(sql).toContain("RETURNING id");
+    expect(params[1]).toBe("us-prod");
+    expect(params[4]).toBe(BASELINE_CLAIM_TTL_SECONDS);
+  });
+
+  it("returns false when the guarded UPSERT matches nothing (a peer holds a fresh claim)", async () => {
+    nextRows = []; // WHERE failed — no row updated/inserted
+    expect(
+      await claimBaselineSlot({ orgId: "org_1", installId: "cn", dbType: "postgres" }),
+    ).toBe(false);
+  });
+
+  it("honours an explicit ttlSeconds override", async () => {
+    nextRows = [{ id: "row-1" }];
+    await claimBaselineSlot({ orgId: "o", installId: "c", dbType: "postgres", ttlSeconds: 42 });
+    expect(dbCalls[0].params[4]).toBe(42);
+  });
+
+  it("returns false (no DB call) when no internal DB is configured", async () => {
+    mockHasDB = false;
+    expect(await claimBaselineSlot({ orgId: "o", installId: "c", dbType: "postgres" })).toBe(false);
+    expect(dbCalls).toHaveLength(0);
+  });
+});
+
 describe("upsertBaselineProfile", () => {
   it("writes the baseline tier keyed on the COALESCE sentinel, stamping now() and clearing the error", async () => {
     await upsertBaselineProfile({
@@ -72,6 +115,8 @@ describe("upsertBaselineProfile", () => {
     expect(sql).toContain("ON CONFLICT (COALESCE(org_id, '__self_hosted__'), install_id)");
     expect(sql).toContain("baseline_profiled_at = now()");
     expect(sql).toContain("baseline_error = NULL");
+    // Releases the in-flight claim so a future genuine re-profile can re-claim.
+    expect(sql).toContain("baseline_started_at = NULL");
     // Touches ONLY the baseline tier on conflict (leaves the LLM tier alone).
     expect(sql).not.toContain("llm_profiled_at");
     expect(params[0]).toBe("org_1");
@@ -111,6 +156,8 @@ describe("recordBaselineError", () => {
     });
     const { sql, params } = dbCalls[0];
     expect(sql).toContain("baseline_error = EXCLUDED.baseline_error");
+    // Releases the in-flight claim so the connection is re-attempted on next need.
+    expect(sql).toContain("baseline_started_at = NULL");
     expect(sql).not.toContain("baseline_profiled_at");
     expect(sql).not.toContain("baseline_profiles");
     expect(params[4]).toBe("permission denied for schema public");

--- a/packages/api/src/lib/semantic/connection-profile.ts
+++ b/packages/api/src/lib/semantic/connection-profile.ts
@@ -82,9 +82,13 @@ function normGroup(connectionGroupId: string | null | undefined): string | null 
 /**
  * Default staleness TTL for an in-flight baseline claim (seconds). A claim older
  * than this is treated as ABANDONED (a crashed/killed run) and re-claimable, so a
- * connection can never wedge permanently in "profiling". Sized comfortably above a
- * real baseline run (a ~120-table schema profiled in a few minutes) so a genuinely
- * in-flight run is never mistaken for abandoned.
+ * connection can never wedge permanently in "profiling".
+ *
+ * INVARIANT: this MUST stay above the worst-case real profile duration. A run that
+ * legitimately exceeds the TTL is mistaken for abandoned and re-claimed while still
+ * live, re-admitting one overlapping profile per TTL — a bounded partial return of
+ * the re-storm. 300s clears a ~120-table schema (profiled in a few minutes) with
+ * margin; a much larger warehouse would need this raised (or a progress heartbeat).
  */
 export const BASELINE_CLAIM_TTL_SECONDS = 300;
 

--- a/packages/api/src/lib/semantic/connection-profile.ts
+++ b/packages/api/src/lib/semantic/connection-profile.ts
@@ -80,9 +80,68 @@ function normGroup(connectionGroupId: string | null | undefined): string | null 
 }
 
 /**
+ * Default staleness TTL for an in-flight baseline claim (seconds). A claim older
+ * than this is treated as ABANDONED (a crashed/killed run) and re-claimable, so a
+ * connection can never wedge permanently in "profiling". Sized comfortably above a
+ * real baseline run (a ~120-table schema profiled in a few minutes) so a genuinely
+ * in-flight run is never mistaken for abandoned.
+ */
+export const BASELINE_CLAIM_TTL_SECONDS = 300;
+
+/**
+ * Atomically claim the in-flight baseline slot for one connection — the guard
+ * that collapses poll-driven backfill calls to ONE running profile per
+ * connection across replicas (the coverage re-storm fix, migration 0174).
+ *
+ * A single guarded UPSERT stamps `baseline_started_at = now()` and returns the
+ * row ONLY when the claim is won: no successful baseline exists yet AND no fresh
+ * claim is in flight within {@link BASELINE_CLAIM_TTL_SECONDS}. When another
+ * caller already holds a fresh claim (or a baseline already succeeded), the
+ * `WHERE` fails, no row is returned, and the caller MUST NOT run a profile.
+ *
+ * Correct under a race: two replicas both UPSERT a brand-new connection — one
+ * INSERTs (claim won), the other conflicts and its `DO UPDATE ... WHERE` sees the
+ * winner's fresh `baseline_started_at` and matches nothing (claim lost). Exactly
+ * one runs. Returns `false` when there's no internal DB (nowhere to profile).
+ */
+export async function claimBaselineSlot(input: {
+  orgId: string | null;
+  installId: string;
+  connectionGroupId?: string | null;
+  dbType: string;
+  ttlSeconds?: number;
+}): Promise<boolean> {
+  if (!hasInternalDB()) return false;
+  const rows = await internalQuery<{ id: string }>(
+    `INSERT INTO connection_profile_state
+       (org_id, install_id, connection_group_id, db_type, baseline_started_at)
+     VALUES ($1, $2, $3, $4, now())
+     ON CONFLICT ${ON_CONFLICT}
+     DO UPDATE SET baseline_started_at = now(),
+                   connection_group_id = EXCLUDED.connection_group_id,
+                   db_type = EXCLUDED.db_type,
+                   updated_at = now()
+       WHERE connection_profile_state.baseline_profiled_at IS NULL
+         AND (connection_profile_state.baseline_started_at IS NULL
+              OR connection_profile_state.baseline_started_at
+                   < now() - make_interval(secs => $5))
+     RETURNING id`,
+    [
+      input.orgId,
+      input.installId,
+      normGroup(input.connectionGroupId),
+      input.dbType,
+      input.ttlSeconds ?? BASELINE_CLAIM_TTL_SECONDS,
+    ],
+  );
+  return rows.length > 0;
+}
+
+/**
  * Store a fresh baseline profile for one connection. Upserts ONLY the baseline
- * columns (leaves the LLM tier untouched), stamps `baseline_profiled_at = now()`
- * and CLEARS any prior `baseline_error`.
+ * columns (leaves the LLM tier untouched), stamps `baseline_profiled_at = now()`,
+ * CLEARS any prior `baseline_error`, and RELEASES the in-flight claim
+ * (`baseline_started_at → NULL`) so a future genuine re-profile can re-claim.
  */
 export async function upsertBaselineProfile(input: {
   orgId: string | null;
@@ -106,6 +165,7 @@ export async function upsertBaselineProfile(input: {
                    baseline_table_count = EXCLUDED.baseline_table_count,
                    baseline_profiled_at = now(),
                    baseline_error = NULL,
+                   baseline_started_at = NULL,
                    updated_at = now()`,
     [
       input.orgId,
@@ -122,7 +182,9 @@ export async function upsertBaselineProfile(input: {
  * Record a baseline-profile FAILURE for one connection — the visible reason the
  * auto/backfill profile couldn't complete. Leaves any prior successful baseline
  * (payload + `baseline_profiled_at`) intact: a re-profile that fails keeps the
- * last good facts and surfaces the new error.
+ * last good facts and surfaces the new error. RELEASES the in-flight claim
+ * (`baseline_started_at → NULL`) so the connection is re-attempted on next need
+ * rather than blocked by a stale claim.
  */
 export async function recordBaselineError(input: {
   orgId: string | null;
@@ -142,6 +204,7 @@ export async function recordBaselineError(input: {
      DO UPDATE SET connection_group_id = EXCLUDED.connection_group_id,
                    db_type = EXCLUDED.db_type,
                    baseline_error = EXCLUDED.baseline_error,
+                   baseline_started_at = NULL,
                    updated_at = now()`,
     [input.orgId, input.installId, normGroup(input.connectionGroupId), input.dbType, input.error],
   );

--- a/packages/api/src/lib/semantic/expert/__tests__/briefing-inputs.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/briefing-inputs.test.ts
@@ -64,6 +64,8 @@ void mock.module("@atlas/api/lib/semantic/connection-profile", () => ({
   recordBaselineError: async () => {},
   recordLlmProfileRun: async () => {},
   getConnectionProfileState: async () => null,
+  claimBaselineSlot: async () => true,
+  BASELINE_CLAIM_TTL_SECONDS: 300,
 }));
 
 void mock.module("@atlas/api/lib/logger", () => {

--- a/packages/web/src/app/admin/semantic/improve/__tests__/coverage-view.test.tsx
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/coverage-view.test.tsx
@@ -144,6 +144,36 @@ describe("ConnectionCoverageSection — all three states + summary (AC1)", () =>
   });
 });
 
+describe("ConnectionCoverageSection — row is labelled by connection identity, not just group", () => {
+  test("a group member shows its own install id plus the shared group as context", () => {
+    // A 3-region `g_prod` group renders one row per member; each must be
+    // distinguishable, so the label leads with the connection id and shows the
+    // group only as context.
+    const { getByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connection({ installId: "eu-prod", group: "g_prod" }),
+        onColumnAnchor: () => {},
+        disabled: false,
+      }),
+    );
+    expect(getByText("eu-prod")).toBeDefined();
+    expect(getByText("g_prod")).toBeDefined();
+  });
+
+  test("a group-of-one (group === installId) does not repeat the group as context", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connection({ installId: "solo", group: "solo" }),
+        onColumnAnchor: () => {},
+        disabled: false,
+      }),
+    );
+    expect(getByText("solo")).toBeDefined();
+    // No redundant "group solo" context label.
+    expect(queryByText(/^group$/)).toBeNull();
+  });
+});
+
 describe("ConnectionCoverageSection — uncovered routes to enrich, never an amendment (ADR-0032)", () => {
   test("an uncovered table exposes an Enrich deep-link and no add-entity affordance", () => {
     const uncovered = connection({

--- a/packages/web/src/app/admin/semantic/improve/__tests__/coverage-view.test.tsx
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/coverage-view.test.tsx
@@ -161,16 +161,20 @@ describe("ConnectionCoverageSection — row is labelled by connection identity, 
   });
 
   test("a group-of-one (group === installId) does not repeat the group as context", () => {
-    const { getByText, queryByText } = render(
+    const { getByText, getAllByText, queryByText } = render(
       createElement(ConnectionCoverageSection, {
         connection: connection({ installId: "solo", group: "solo" }),
         onColumnAnchor: () => {},
         disabled: false,
       }),
     );
+    // The identity renders exactly once — not once as the label AND again as a
+    // redundant group-context chip.
+    expect(getAllByText("solo")).toHaveLength(1);
+    // The "group" context word (rendered as a `group <mono>` span when shown) is
+    // absent entirely.
     expect(getByText("solo")).toBeDefined();
-    // No redundant "group solo" context label.
-    expect(queryByText(/^group$/)).toBeNull();
+    expect(queryByText(/group/)).toBeNull();
   });
 });
 

--- a/packages/web/src/app/admin/semantic/improve/coverage.tsx
+++ b/packages/web/src/app/admin/semantic/improve/coverage.tsx
@@ -260,7 +260,8 @@ export function ConnectionCoverageSection({
          * with several members (e.g. a 3-region `g_prod` of `us-prod`/`eu-prod`/
          * `apac-prod`) otherwise renders as identical-looking duplicate rows. The
          * group is shown as shared context only when it differs from the
-         * connection id (a group-of-one collapses `group === installId`).
+         * connection id — a connection with no explicit `group_id` defaults its
+         * wire `group` to the `installId` (COALESCE), so the label is suppressed.
          */}
         <span className="font-mono font-medium">{connection.installId}</span>
         {connection.dbType && (

--- a/packages/web/src/app/admin/semantic/improve/coverage.tsx
+++ b/packages/web/src/app/admin/semantic/improve/coverage.tsx
@@ -255,11 +255,23 @@ export function ConnectionCoverageSection({
     <div className="space-y-2">
       <div className="flex items-center gap-2 text-sm">
         <Database className="size-4 opacity-70" />
-        <span className="font-medium">{connection.group}</span>
+        {/*
+         * Label each row by the CONNECTION identity, not just the group: a group
+         * with several members (e.g. a 3-region `g_prod` of `us-prod`/`eu-prod`/
+         * `apac-prod`) otherwise renders as identical-looking duplicate rows. The
+         * group is shown as shared context only when it differs from the
+         * connection id (a group-of-one collapses `group === installId`).
+         */}
+        <span className="font-mono font-medium">{connection.installId}</span>
         {connection.dbType && (
           <Badge variant="secondary" className="text-[10px]">
             {connection.dbType}
           </Badge>
+        )}
+        {connection.group !== connection.installId && (
+          <span className="text-[11px] text-muted-foreground">
+            group <span className="font-mono">{connection.group}</span>
+          </span>
         )}
         {connection.freshness && (
           <span className="text-[11px] text-muted-foreground">{connection.freshness}</span>


### PR DESCRIPTION
## What & why

Investigating a prod workspace whose Semantic-Improve **Coverage** tab showed three identical-looking `g_prod / postgres` rows, two stuck "Profiling this connection's schema…" forever. Two real problems:

### 1. Backfill re-storm → connection exhaustion (the bug)

The Coverage view lazily backfills each connection's baseline profile and the client **polls every 4s** while any connection is still profiling. `ensureConnectionBaseline` only short-circuited on a **successful** baseline — a connection with neither a success nor a recorded error was re-profiled on **every poll**, with no in-flight guard.

A multi-member group (here a 3-region `g_prod`: `us-prod` / `eu-prod` / `apac-prod`) therefore launched N overlapping full-schema (~120-table) profiles every 4 seconds. The overlapping runs opened live connections to the target DB until it hit `max_connections`:

```
apac-prod  g_prod  postgres  ERROR  →  "sorry, too many clients already"
eu-prod    g_prod  postgres  baseline OK (123 tables)
us-prod    g_prod  postgres  baseline OK (119 tables)
```

Confirmed against the prod region DB: all three resolved within ~12 min (two baselines, one connection-exhaustion error) — **not** an infinite loop, but a genuine self-inflicted load spike. For a real customer with a large group, opening this admin page would hammer *their* production database.

**Fix:** an atomic DB-backed in-flight claim (`baseline_started_at`, migration 0174). A single guarded UPSERT (`claimBaselineSlot`) claims a connection only when it has no baseline and no fresh claim within a staleness TTL (300s), so poll-driven backfill calls collapse to **one running profile per connection across replicas** — the DB row is the shared lock, not an in-process mutex (prod is multi-replica). The claim is released on either terminal outcome (success upsert / recorded error); a claim older than the TTL is treated as abandoned and re-claimable, so a crashed run can't wedge a connection permanently.

### 2. Duplicate-looking rows (cosmetic)

The view rendered one row per connection but labelled each **only** by group name, so a group's members collapsed into identical rows ("why three `g_prod`?"). These were three intentional regional connections, not duplicates. Now each row leads with its connection id and shows the group as shared context only when it differs (a group-of-one collapses `group === installId`).

## Changes

- **Migration 0174** — additive nullable `connection_profile_state.baseline_started_at` + Drizzle mirror in the same PR (`check-schema-drift` green).
- `claimBaselineSlot()` in `connection-profile.ts`; both terminal writes release the claim.
- `ensureConnectionBaseline` claims before profiling; a lost claim returns the current state without re-running.
- Coverage row label disambiguation (frontend-only; both fields already on the wire type).

## Tests

- Store: claim won/lost, TTL override, no-DB; claim release asserted on both terminal writes.
- Orchestration: claim-gate skips the profile when the claim is lost; existing profile-on-first-need / retry-after-error paths inject `claimSlot: true`.
- Frontend: row labelled by connection id + group context; group-of-one omits the redundant group label.
- `migrate.test.ts` count 174→175 + list entry.
- `bun run type` green; lint clean (touched files); 19 affected API tests pass incl. real-PG `connection-profile-pg`.

## Considered, scoped out

A statement/connection timeout on the profiler (defense-in-depth against a *hang*). The observed failure terminated cleanly (connection exhaustion, not a hang), and that change reaches into the MCP-shared connection resolver — out of proportion here. Worth a follow-up.