### PR TITLE
fix(semantic-improve): attach CORS to the improve chat stream + guard the class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,12 @@ jobs:
       - name: Adversarial fixtures for the web vacuous-type-program guard (#4447/#4450)
         run: bash scripts/__tests__/check-type-program-not-vacuous.test.sh
 
+      - name: Check streaming agent responses attach CORS headers (#2037)
+        run: bash scripts/check-streaming-cors.sh
+
+      - name: Adversarial fixtures for the streaming-CORS gate (#2037)
+        run: bash scripts/__tests__/check-streaming-cors.test.sh
+
       - name: Check no legacy `connections` / `connection_groups` SQL outside migrations (#2744)
         run: bash scripts/check-no-legacy-connections-sql.sh
 

--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -390,6 +390,25 @@ describe("admin-semantic-improve", () => {
       });
     }
 
+    it("attaches CORS headers to the streamed response (raw Response bypasses the middleware)", async () => {
+      // The streaming Response created by createUIMessageStreamResponse skips the
+      // CORS middleware (whose queued headers only merge onto c.json/c.body), so
+      // a cross-origin POST would arrive without Access-Control-Allow-Origin and
+      // the browser blocks it even though the preflight passed. Regression guard
+      // for the improve chat missing the corsResponseHeaders() spread chat.ts/
+      // demo.ts both carry (#2037).
+      const res = await adminSemanticImprove.request("/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Origin: "https://app.useatlas.dev" },
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      // Present (either the echoed origin or the wildcard, per the resolved config).
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBeTruthy();
+    });
+
     it("runs the expert agent with the persona in the role position, never as a warning", async () => {
       const res = await postChat();
       expect(res.status).toBe(200);

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -20,6 +20,7 @@ import {
 } from "ai";
 import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { corsResponseHeaders } from "@atlas/api/lib/cors";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import type { Context as HonoContext } from "hono";
 import { runAgent } from "@atlas/api/lib/agent";
@@ -284,6 +285,12 @@ adminSemanticImprove.openapi(chatStreamRoute, async (c) =>
             headers: {
               "X-Accel-Buffering": "no",
               "Cache-Control": "no-cache, no-transform",
+              // A raw streaming Response bypasses the CORS middleware (whose queued
+              // headers only merge onto c.json/c.body responses), so a cross-origin
+              // POST would arrive without Access-Control-Allow-Origin and the browser
+              // blocks it even though the preflight passed. Re-attach the CORS headers
+              // here, exactly as chat.ts / demo.ts do for their streams (#2037).
+              ...corsResponseHeaders(c.req.header("Origin") ?? ""),
             },
           });
         } catch (err) {

--- a/packages/api/src/lib/semantic/expert/__tests__/categories.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/categories.test.ts
@@ -309,6 +309,32 @@ describe("findMissingJoins", () => {
     expect(results[0].confidence).toBe(0.6);
   });
 
+  test("a join with a missing `sql` doesn't crash the briefing (prod TypeError guard)", () => {
+    // Runtime data carried a join with no `sql` (malformed entity), and the
+    // `j.sql.split("=")` threw `undefined is not an object`, crashing the whole
+    // semantic-improve briefing assembly. One bad join must be skipped, not fatal.
+    const ctx = makeContext({
+      profiles: [makeProfile({
+        table_name: "orders",
+        foreign_keys: [{ from_column: "user_id", to_table: "users", to_column: "id", source: "constraint" }],
+      })],
+      entities: [
+        makeEntity({
+          name: "orders",
+          // The `sql` is absent at runtime despite the type declaring it required.
+          joins: [{ name: "broken" } as ParsedEntity["joins"][number]],
+        }),
+        makeEntity({ name: "users" }),
+      ],
+    });
+
+    // Must not throw; the FK is still suggested because the broken join is skipped
+    // (it contributes no existing target table).
+    const results = findMissingJoins(ctx);
+    expect(results.length).toBe(1);
+    expect(results[0].confidence).toBe(0.95);
+  });
+
   test("recognizes simple `a.x = b.x` joins as existing", () => {
     // Pins the join-SQL parser: a join with the exact `lhs.col = rhs.col`
     // shape must be recognized so the same FK isn't re-suggested.

--- a/packages/api/src/lib/semantic/expert/categories.ts
+++ b/packages/api/src/lib/semantic/expert/categories.ts
@@ -243,11 +243,18 @@ export function findMissingJoins(ctx: AnalysisContext): AnalysisResult[] {
     for (const entity of findEntitiesForTable(ctx.entities, profile.table_name)) {
       const existingJoinTables = new Set(
         entity.joins.map((j) => {
+          // Runtime data can carry a join with no `sql` (a malformed/partial
+          // entity), despite the type declaring `sql: string` — a `.split` on it
+          // throws `undefined is not an object` and crashes the whole briefing
+          // (prod TypeError, seen on the improve chat). One bad join must not sink
+          // the briefing: treat a non-string sql as "no target table" and skip it.
+          const joinSql = (j as { sql?: string }).sql;
+          if (typeof joinSql !== "string") return "";
           // Extract target table from join SQL like "table_a.col = table_b.col".
           // Split on the literal `=` (not `\s*=\s*`) and trim each side instead —
           // a `\s*` quantifier in a split regex tries every position, giving
           // O(n²) on inputs of long whitespace runs (CodeQL js/polynomial-redos).
-          const parts = j.sql.split("=");
+          const parts = joinSql.split("=");
           if (parts.length !== 2) return "";
           const lhs = parts[0].trim().match(/^(\w+)\.\w+$/);
           const rhs = parts[1].trim().match(/^(\w+)\.\w+$/);

--- a/scripts/__tests__/check-streaming-cors.test.sh
+++ b/scripts/__tests__/check-streaming-cors.test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Adversarial fixture suite for scripts/check-streaming-cors.sh.
+#
+# Locks in that the guard (a) FAILS when a file calls
+# createUIMessageStreamResponse() without referencing corsResponseHeaders,
+# (b) PASSES when the CORS spread is present, and (c) does NOT false-positive on
+# a comment that merely mentions the name in prose (the guard keys on the call
+# syntax `createUIMessageStreamResponse(`, not the bare identifier).
+#
+# Each fixture runs against a throwaway tree via STREAMING_CORS_ROOT so the real
+# codebase is never touched.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-streaming-cors.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# run_fixture <label> <expect: pass|fail> <file-contents>
+run_fixture() {
+  local label="$1" expect="$2" contents="$3"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/api/routes"
+  printf '%s\n' "$contents" > "$tmp/api/routes/fixture.ts"
+
+  local rc=0
+  STREAMING_CORS_ROOT="$tmp" bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+  rm -rf "$tmp"
+
+  if [ "$expect" = "pass" ] && [ "$rc" -eq 0 ]; then
+    echo "  ✓ $label"; PASS=$((PASS + 1))
+  elif [ "$expect" = "fail" ] && [ "$rc" -eq 1 ]; then
+    echo "  ✓ $label"; PASS=$((PASS + 1))
+  else
+    echo "  ✗ $label — expected $expect, got exit $rc"; FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "check-streaming-cors adversarial fixtures:"
+
+# (a) A raw streaming response with no CORS → must FAIL.
+run_fixture "call without corsResponseHeaders fails" fail \
+'return createUIMessageStreamResponse({ stream, headers: { "Cache-Control": "no-cache" } });'
+
+# (b) The call WITH the CORS spread → must PASS.
+run_fixture "call with corsResponseHeaders passes" pass \
+'import { corsResponseHeaders } from "@atlas/api/lib/cors";
+return createUIMessageStreamResponse({ stream, headers: { ...corsResponseHeaders(o) } });'
+
+# (c) A comment merely naming the constructor (no call syntax) → must PASS.
+run_fixture "prose mention (no call) does not false-positive" pass \
+'// createUIMessageStreamResponse returns a raw Response — see cors.ts.
+return c.json({ ok: true });'
+
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/check-streaming-cors.sh
+++ b/scripts/check-streaming-cors.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Guard: every streaming agent response attaches CORS headers.
+#
+# The Vercel AI SDK's `createUIMessageStreamResponse()` returns a RAW `Response`
+# object. Hono's CORS middleware queues its headers via `c.header()` and only
+# merges them onto responses built through `c.json()`/`c.body()`/`c.text()` — a
+# raw returned (or `throw new HTTPException(200, { res })`-thrown) Response
+# bypasses that merge entirely. So a cross-origin streaming POST arrives WITHOUT
+# `Access-Control-Allow-Origin` and the browser blocks it even though the OPTIONS
+# preflight (handled by the middleware) succeeded.
+#
+# The fix each streaming endpoint must apply is to spread
+# `corsResponseHeaders(c.req.header("Origin") ?? "")` into the response headers
+# (see `packages/api/src/lib/cors.ts`). `chat.ts` and `demo.ts` do; the
+# semantic-improve `/chat` endpoint forgot, which broke the improve chat in prod
+# (#2037 was the original fix; this guard stops a fourth endpoint reintroducing
+# it).
+#
+# Rule: any file that CALLS `createUIMessageStreamResponse(` must also reference
+# `corsResponseHeaders` (the import + the spread). A file that only mentions the
+# name in prose (comments) does not match — we key on the call syntax
+# `createUIMessageStreamResponse(`, not the bare identifier.
+#
+# A regression here means a new streaming endpoint returned a raw Response
+# without CORS. Add `...corsResponseHeaders(c.req.header("Origin") ?? "")` to its
+# response headers.
+
+set -euo pipefail
+
+# Root is overridable so the adversarial fixture suite can point the same logic
+# at a throwaway tree (scripts/__tests__/check-streaming-cors.test.sh).
+SEARCH_ROOT="${STREAMING_CORS_ROOT:-packages/api/src}"
+CALL_PATTERN='createUIMessageStreamResponse[[:space:]]*\('
+
+# Files that actually CALL the streaming-response constructor (not just import or
+# mention it). `grep -l` on the call syntax; excludes test files — the guard is
+# about production endpoints (tests may construct responses for assertions).
+mapfile -t offenders < <(
+  grep -rlE "$CALL_PATTERN" "$SEARCH_ROOT" --include='*.ts' 2>/dev/null \
+    | grep -vE '(__tests__/|\.test\.ts$)' \
+    | while read -r f; do
+        if ! grep -q 'corsResponseHeaders' "$f"; then echo "$f"; fi
+      done
+)
+
+if [ "${#offenders[@]}" -gt 0 ]; then
+  echo "❌ Streaming CORS guard: these files call createUIMessageStreamResponse() but never reference corsResponseHeaders:"
+  for f in "${offenders[@]}"; do echo "   - $f"; done
+  echo
+  echo "A raw streaming Response bypasses the CORS middleware. Add the CORS spread to its headers:"
+  echo '    return createUIMessageStreamResponse({'
+  echo '      stream,'
+  echo '      headers: { ...corsResponseHeaders(c.req.header("Origin") ?? "") },'
+  echo '    });'
+  echo "See packages/api/src/lib/cors.ts and packages/api/src/api/routes/chat.ts."
+  exit 1
+fi
+
+echo "✅ Streaming CORS guard: all createUIMessageStreamResponse() call sites attach corsResponseHeaders."

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -193,6 +193,7 @@ launch oauth-helper-drift        bash scripts/check-oauth-helper-drift.sh
 launch ee-imports                bash scripts/check-ee-imports.sh
 launch twenty-resolver           bash scripts/check-twenty-resolver-imports.sh
 launch no-admin-plugin           bash scripts/check-no-admin-plugin.sh
+launch streaming-cors            bash scripts/check-streaming-cors.sh
 launch no-legacy-connections     bash scripts/check-no-legacy-connections-sql.sh
 launch test-discipline           bash scripts/check-test-discipline.sh
 launch settings-readers          bash scripts/check-settings-readers.sh


### PR DESCRIPTION
## Symptom

Opening an improvement conversation on the Semantic-Improve screen failed in prod:

```
Access to fetch at 'https://api.useatlas.dev/api/v1/admin/semantic-improve/chat'
from origin 'https://app.useatlas.dev' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## Root cause (CORS)

The `/chat` endpoint returns a **raw streaming `Response`** via the Vercel AI SDK's `createUIMessageStreamResponse()`. Hono's CORS middleware queues headers with `c.header()` and only merges them onto responses built through `c.json()`/`c.body()`/`c.text()` — a raw returned Response bypasses that merge. So:

- the **preflight** `OPTIONS` (middleware-handled) returns `Access-Control-Allow-Origin` fine (verified against prod), but
- the actual streamed **POST** response ships without it, and the browser blocks it → `net::ERR_FAILED` + the CORS message.

`lib/cors.ts` exists precisely for this — `chat.ts` and `demo.ts` spread `corsResponseHeaders(c.req.header("Origin") ?? "")` into their streams. The newer improve `/chat` **forgot**. Fix: add the spread.

## Systemic guard (so it can't happen a fourth time)

`scripts/check-streaming-cors.sh`: any file that **calls** `createUIMessageStreamResponse(` must also reference `corsResponseHeaders`. Keys on the call syntax, not the bare identifier, so a prose mention doesn't false-positive. Wired into `ci.yml` and `ci-local.sh`, with an adversarial fixture suite (`scripts/__tests__/check-streaming-cors.test.sh`) covering fail / pass / no-false-positive.

## Also fixed (same prod trace)

The prod logs showed a caught-but-real briefing crash: `findMissingJoins` did `j.sql.split("=")` where a join's `sql` was `undefined` at runtime (the type declares it required, but the data violated it), throwing `undefined is not an object` and sinking the whole briefing assembly. It was caught (chat started **without** front-loaded context — degraded), but it's a real robustness bug. Guard the non-string `sql` and skip that one join.

## Tests
- `admin-semantic-improve.test.ts`: `/chat` streamed response carries `Access-Control-Allow-Origin` (regression guard for the missing spread).
- `categories.test.ts`: a join with a missing `sql` no longer crashes `findMissingJoins`.
- `check-streaming-cors.test.sh`: adversarial fixtures for the new gate.
- `bun run type` green; lint clean; 11 affected API tests pass; new guard + fixtures pass.

## Notes
- The `corsResponseHeaders` origin resolution is unchanged; only the improve endpoint now applies it.
- The briefing fix is defensive at the crash site; the underlying "a join with no sql" data anomaly (a malformed entity) is separate and not addressed here.