### PR TITLE
feat(semantic-improve): scale the coverage view for large multi-connection groups

### DIFF
--- a/packages/web/src/app/admin/semantic/improve/__tests__/coverage-view.test.tsx
+++ b/packages/web/src/app/admin/semantic/improve/__tests__/coverage-view.test.tsx
@@ -10,6 +10,12 @@
  *   - AC4: a connection still profiling renders a loading state, not an empty one.
  *   - An errored connection surfaces its reason.
  *
+ * Plus the #4652 scale behaviors: sections collapse to their summary line by
+ * default (an active filter force-expands them), the search/state filters narrow
+ * the table list, and long lists mount in `COVERAGE_TABLE_PAGE_SIZE` chunks
+ * behind a "Show more" tail. Pre-#4652 suites pass `defaultOpen: true` — they
+ * pin row/column behavior, not the collapse.
+ *
  * The presentational components are rendered directly (no fetch), mirroring the
  * launchers suite that renders `AnchorLaunchers` / `ActiveAnchorChip` directly.
  */
@@ -19,7 +25,10 @@ import { render, cleanup, fireEvent } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import {
   ConnectionCoverageSection,
+  CoverageFilterBar,
+  COVERAGE_TABLE_PAGE_SIZE,
   type ColumnAnchorRequest,
+  type TableCoverageState,
   type WireConnectionCoverage,
   type WireTableCoverage,
 } from "../coverage";
@@ -74,6 +83,7 @@ describe("ConnectionCoverageSection — covered column launches the anchor (#452
         connection: connection(),
         onColumnAnchor,
         disabled: false,
+        defaultOpen: true,
       }),
     );
 
@@ -96,6 +106,7 @@ describe("ConnectionCoverageSection — covered column launches the anchor (#452
         connection: connection(),
         onColumnAnchor,
         disabled: false,
+        defaultOpen: true,
       }),
     );
     fireEvent.click(getByText("orders"));
@@ -113,7 +124,7 @@ describe("ConnectionCoverageSection — covered column launches the anchor (#452
       },
     });
     const { getByText } = render(
-      createElement(ConnectionCoverageSection, { connection: flat, onColumnAnchor, disabled: false }),
+      createElement(ConnectionCoverageSection, { connection: flat, onColumnAnchor, disabled: false, defaultOpen: true }),
     );
     fireEvent.click(getByText("orders"));
     fireEvent.click(getByText("status"));
@@ -133,7 +144,7 @@ describe("ConnectionCoverageSection — all three states + summary (AC1)", () =>
       },
     });
     const { getByText } = render(
-      createElement(ConnectionCoverageSection, { connection: ready, onColumnAnchor: () => {}, disabled: false }),
+      createElement(ConnectionCoverageSection, { connection: ready, onColumnAnchor: () => {}, disabled: false, defaultOpen: true }),
     );
     // Summary chips reflect the three states (AC1).
     expect(getByText("3 covered")).toBeDefined();
@@ -189,7 +200,7 @@ describe("ConnectionCoverageSection — uncovered routes to enrich, never an ame
       },
     });
     const { getByText, queryByText } = render(
-      createElement(ConnectionCoverageSection, { connection: uncovered, onColumnAnchor: () => {}, disabled: false }),
+      createElement(ConnectionCoverageSection, { connection: uncovered, onColumnAnchor: () => {}, disabled: false, defaultOpen: true }),
     );
     fireEvent.click(getByText("audit_log"));
     const enrich = getByText("Enrich").closest("a");
@@ -223,5 +234,208 @@ describe("ConnectionCoverageSection — non-ready statuses", () => {
       }),
     );
     expect(getByText(/could not resolve a live connection/i)).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #4652 — scale behaviors for large multi-connection groups
+// ---------------------------------------------------------------------------
+
+/** A connection whose coverage holds the given tables (summary values arbitrary). */
+function connectionWithTables(tables: WireTableCoverage[]): WireConnectionCoverage {
+  return connection({
+    coverage: {
+      tables,
+      summary: { coveredTables: 0, partialTables: tables.length, uncoveredTables: 0, totalTables: tables.length },
+    },
+  });
+}
+
+describe("ConnectionCoverageSection — collapse-by-default (#4652)", () => {
+  test("starts collapsed: the summary line renders, the table rows do not", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connection({
+          coverage: {
+            tables: [table()],
+            summary: { coveredTables: 3, partialTables: 2, uncoveredTables: 1, totalTables: 6 },
+          },
+        }),
+        onColumnAnchor: () => {},
+        disabled: false,
+      }),
+    );
+    // The summary line IS the collapsed view…
+    expect(getByText("3 covered")).toBeDefined();
+    expect(getByText("2 partial")).toBeDefined();
+    expect(getByText("1 uncovered")).toBeDefined();
+    // …and no table row has mounted.
+    expect(queryByText("orders")).toBeNull();
+  });
+
+  test("clicking the connection header expands the table list", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connection(),
+        onColumnAnchor: () => {},
+        disabled: false,
+      }),
+    );
+    expect(queryByText("orders")).toBeNull();
+    fireEvent.click(getByText("conn_1"));
+    expect(getByText("orders")).toBeDefined();
+  });
+
+  test("an active filter force-expands a collapsed section", () => {
+    const { getByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connection(),
+        onColumnAnchor: () => {},
+        disabled: false,
+        query: "ord",
+      }),
+    );
+    // No header click — the search alone surfaces the matching row.
+    expect(getByText("orders")).toBeDefined();
+  });
+});
+
+describe("ConnectionCoverageSection — search + state filters (#4652)", () => {
+  test("the query narrows to matching tables and reports the match count", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connectionWithTables([
+          table({ table: "orders" }),
+          // The fixture's default entity is "orders" — override it so this
+          // table matches neither by name nor by entity.
+          table({ table: "customers", entity: "customers" }),
+        ]),
+        onColumnAnchor: () => {},
+        disabled: false,
+        defaultOpen: true,
+        query: "ord",
+      }),
+    );
+    expect(getByText("orders")).toBeDefined();
+    expect(queryByText("customers")).toBeNull();
+    expect(getByText(/1 match/)).toBeDefined();
+  });
+
+  test("the query also matches on the modeling entity name", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connectionWithTables([
+          table({ table: "ord_hdr", entity: "orders" }),
+          table({ table: "customers", entity: "customers" }),
+        ]),
+        onColumnAnchor: () => {},
+        disabled: false,
+        defaultOpen: true,
+        query: "orders",
+      }),
+    );
+    expect(getByText("ord_hdr")).toBeDefined();
+    expect(queryByText("customers")).toBeNull();
+  });
+
+  test("the state filter narrows to that coverage state", () => {
+    const stateFilter: TableCoverageState = "uncovered";
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connectionWithTables([
+          table({ table: "orders", state: "partial" }),
+          table({ table: "audit_log", entity: null, state: "uncovered" }),
+        ]),
+        onColumnAnchor: () => {},
+        disabled: false,
+        defaultOpen: true,
+        stateFilter,
+      }),
+    );
+    expect(getByText("audit_log")).toBeDefined();
+    expect(queryByText("orders")).toBeNull();
+  });
+
+  test("a filter with no matches renders the no-match line, not an empty void", () => {
+    const { getByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connection(),
+        onColumnAnchor: () => {},
+        disabled: false,
+        defaultOpen: true,
+        query: "zzz_nothing",
+      }),
+    );
+    expect(getByText(/No tables match the current filter/i)).toBeDefined();
+  });
+});
+
+describe("ConnectionCoverageSection — chunked rendering (#4652)", () => {
+  const manyTables = Array.from({ length: COVERAGE_TABLE_PAGE_SIZE + 10 }, (_, i) =>
+    table({ table: `t_${String(i).padStart(3, "0")}` }),
+  );
+
+  test("a long list mounts only the first page behind a Show more tail", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connectionWithTables(manyTables),
+        onColumnAnchor: () => {},
+        disabled: false,
+        defaultOpen: true,
+      }),
+    );
+    expect(getByText("t_000")).toBeDefined();
+    expect(getByText(`t_${String(COVERAGE_TABLE_PAGE_SIZE - 1).padStart(3, "0")}`)).toBeDefined();
+    // The first row past the page boundary has NOT mounted.
+    expect(queryByText(`t_${String(COVERAGE_TABLE_PAGE_SIZE).padStart(3, "0")}`)).toBeNull();
+    expect(getByText(/Show 10 more/)).toBeDefined();
+  });
+
+  test("Show more mounts the next chunk", () => {
+    const { getByText, queryByText } = render(
+      createElement(ConnectionCoverageSection, {
+        connection: connectionWithTables(manyTables),
+        onColumnAnchor: () => {},
+        disabled: false,
+        defaultOpen: true,
+      }),
+    );
+    fireEvent.click(getByText(/Show 10 more/));
+    expect(getByText(`t_${String(COVERAGE_TABLE_PAGE_SIZE + 9).padStart(3, "0")}`)).toBeDefined();
+    // Everything mounted — the tail is gone.
+    expect(queryByText(/Show .* more/)).toBeNull();
+  });
+});
+
+describe("CoverageFilterBar (#4652)", () => {
+  test("typing fires onQueryChange; a state chip fires onStateFilterChange", () => {
+    const onQueryChange = mock((_q: string) => {});
+    const onStateFilterChange = mock((_s: TableCoverageState | null) => {});
+    const { getByLabelText, getByText } = render(
+      createElement(CoverageFilterBar, {
+        query: "",
+        onQueryChange,
+        stateFilter: null,
+        onStateFilterChange,
+      }),
+    );
+    fireEvent.change(getByLabelText("Filter tables by name"), { target: { value: "ord" } });
+    expect(onQueryChange).toHaveBeenCalledWith("ord");
+    fireEvent.click(getByText("uncovered"));
+    expect(onStateFilterChange).toHaveBeenCalledWith("uncovered");
+  });
+
+  test("clicking the active state chip clears the filter back to all", () => {
+    const onStateFilterChange = mock((_s: TableCoverageState | null) => {});
+    const { getByText } = render(
+      createElement(CoverageFilterBar, {
+        query: "",
+        onQueryChange: () => {},
+        stateFilter: "uncovered",
+        onStateFilterChange,
+      }),
+    );
+    fireEvent.click(getByText("uncovered"));
+    expect(onStateFilterChange).toHaveBeenCalledWith(null);
   });
 });

--- a/packages/web/src/app/admin/semantic/improve/coverage.tsx
+++ b/packages/web/src/app/admin/semantic/improve/coverage.tsx
@@ -14,6 +14,15 @@
  * affordance. A connection without a baseline reports `profiling`; the view shows
  * a loading state and polls until the backfill lands.
  *
+ * Scale for large multi-connection groups (#4652): a 3-region group can be 350+
+ * near-identical table rows in one scroll, so the view layers three composing
+ * affordances — a table-name search + coverage-state filter bar (view-wide),
+ * collapse-by-default connection sections that lead with their summary line
+ * (auto-expanded while a filter is active, and for a lone connection), and
+ * chunked incremental rendering so a long expanded list never mounts all its
+ * rows at once. Filter/collapse state is plain `useState`, deliberately outside
+ * the polled data path, so the profiling poll can't reset it.
+ *
  * The presentational pieces (`ConnectionCoverageSection`, `CoverageTableRow`) are
  * exported for direct render-testing without driving the fetch, mirroring how the
  * page exports `AnchorLaunchers` / `ActiveAnchorChip`.
@@ -24,7 +33,9 @@ import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { wizardGenerateHref } from "../../../wizard/wizard-generate-entry";
 import {
   CheckCircle2,
@@ -35,6 +46,7 @@ import {
   Loader2,
   Database,
   AlertTriangle,
+  Search,
   Sparkles,
 } from "lucide-react";
 import Link from "next/link";
@@ -240,44 +252,151 @@ function CoverageColumnChip({
   );
 }
 
-/** One connection's coverage section — its status + summary + table rows. */
+/**
+ * How many table rows a list mounts before offering "Show more" (#4652) — keeps
+ * a ~119-table connection from rendering every row (and its column chips) at
+ * once. Exported so the render tests aren't pinned to a magic number.
+ */
+export const COVERAGE_TABLE_PAGE_SIZE = 50;
+
+/** True when the table survives the view-wide name search + state filter. */
+function tableMatchesFilter(
+  table: WireTableCoverage,
+  query: string,
+  stateFilter: TableCoverageState | null,
+): boolean {
+  if (stateFilter !== null && table.state !== stateFilter) return false;
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return true;
+  return (
+    table.table.toLowerCase().includes(needle) ||
+    (table.entity !== null && table.entity.toLowerCase().includes(needle))
+  );
+}
+
+/**
+ * A connection's table rows, mounted in chunks of `COVERAGE_TABLE_PAGE_SIZE`
+ * with a "Show more" tail (#4652). The parent keys this component by the filter
+ * signature so a filter change resets the visible window without an effect.
+ */
+function CoverageTableList({
+  tables,
+  installId,
+  onColumnAnchor,
+  disabled,
+}: {
+  tables: WireTableCoverage[];
+  installId: string;
+  onColumnAnchor: (req: ColumnAnchorRequest, label: string) => void;
+  disabled: boolean;
+}) {
+  const [visibleCount, setVisibleCount] = useState(COVERAGE_TABLE_PAGE_SIZE);
+  const visible = tables.slice(0, visibleCount);
+  const hidden = tables.length - visible.length;
+
+  return (
+    <div className="space-y-1.5">
+      {visible.map((table) => (
+        <CoverageTableRow
+          key={table.table}
+          table={table}
+          installId={installId}
+          onColumnAnchor={onColumnAnchor}
+          disabled={disabled}
+        />
+      ))}
+      {hidden > 0 && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="w-full text-xs text-muted-foreground"
+          onClick={() => setVisibleCount((count) => count + COVERAGE_TABLE_PAGE_SIZE)}
+        >
+          Show {Math.min(hidden, COVERAGE_TABLE_PAGE_SIZE)} more ({hidden} hidden)
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One connection's coverage section — its status + summary + table rows.
+ *
+ * Collapsed to its summary line by default (#4652) so a multi-connection group
+ * never mounts N×119 rows at once; the caller opts a lone connection into
+ * `defaultOpen`. An active search/state filter force-expands the section —
+ * search results must be visible to be useful — and collapsing returns to the
+ * user's manual choice once the filter clears.
+ */
 export function ConnectionCoverageSection({
   connection,
   onColumnAnchor,
   disabled,
+  defaultOpen = false,
+  query = "",
+  stateFilter = null,
 }: {
   connection: WireConnectionCoverage;
   onColumnAnchor: (req: ColumnAnchorRequest, label: string) => void;
   disabled: boolean;
+  defaultOpen?: boolean;
+  query?: string;
+  stateFilter?: TableCoverageState | null;
 }) {
   const { coverage } = connection;
+  const [open, setOpen] = useState(defaultOpen);
+  const filtering = query.trim() !== "" || stateFilter !== null;
+  const expanded = open || filtering;
+  const hasTables = connection.status === "ready" && coverage !== null && coverage.tables.length > 0;
+  const filteredTables = hasTables
+    ? coverage.tables.filter((table) => tableMatchesFilter(table, query, stateFilter))
+    : [];
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  /*
+   * Label each row by the CONNECTION identity, not just the group: a group
+   * with several members (e.g. a 3-region `g_prod` of `us-prod`/`eu-prod`/
+   * `apac-prod`) otherwise renders as identical-looking duplicate rows. The
+   * group is shown as shared context only when it differs from the
+   * connection id — a connection with no explicit `group_id` defaults its
+   * wire `group` to the `installId` (COALESCE), so the label is suppressed.
+   */
+  const identity = (
+    <>
+      <Database className="size-4 opacity-70" />
+      <span className="font-mono font-medium">{connection.installId}</span>
+      {connection.dbType && (
+        <Badge variant="secondary" className="text-[10px]">
+          {connection.dbType}
+        </Badge>
+      )}
+      {connection.group !== connection.installId && (
+        <span className="text-[11px] text-muted-foreground">
+          group <span className="font-mono">{connection.group}</span>
+        </span>
+      )}
+      {connection.freshness && (
+        <span className="text-[11px] text-muted-foreground">{connection.freshness}</span>
+      )}
+    </>
+  );
+
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2 text-sm">
-        <Database className="size-4 opacity-70" />
-        {/*
-         * Label each row by the CONNECTION identity, not just the group: a group
-         * with several members (e.g. a 3-region `g_prod` of `us-prod`/`eu-prod`/
-         * `apac-prod`) otherwise renders as identical-looking duplicate rows. The
-         * group is shown as shared context only when it differs from the
-         * connection id — a connection with no explicit `group_id` defaults its
-         * wire `group` to the `installId` (COALESCE), so the label is suppressed.
-         */}
-        <span className="font-mono font-medium">{connection.installId}</span>
-        {connection.dbType && (
-          <Badge variant="secondary" className="text-[10px]">
-            {connection.dbType}
-          </Badge>
-        )}
-        {connection.group !== connection.installId && (
-          <span className="text-[11px] text-muted-foreground">
-            group <span className="font-mono">{connection.group}</span>
-          </span>
-        )}
-        {connection.freshness && (
-          <span className="text-[11px] text-muted-foreground">{connection.freshness}</span>
-        )}
-      </div>
+      {hasTables ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full items-center gap-2 rounded-md text-left text-sm hover:bg-muted/50"
+        >
+          <Chevron className="size-3.5 shrink-0 opacity-60" />
+          {identity}
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 text-sm">{identity}</div>
+      )}
 
       {connection.status === "profiling" && (
         <div className="flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-xs text-muted-foreground">
@@ -295,28 +414,36 @@ export function ConnectionCoverageSection({
 
       {connection.status === "ready" && coverage && (
         <>
-          <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+          {/* The summary line stays visible while collapsed — it IS the collapsed view. */}
+          <div className="flex flex-wrap items-center gap-3 pl-5.5 text-[11px] text-muted-foreground">
             <span className="text-green-600 dark:text-green-400">{coverage.summary.coveredTables} covered</span>
             <span className="text-yellow-600 dark:text-yellow-400">{coverage.summary.partialTables} partial</span>
             <span>{coverage.summary.uncoveredTables} uncovered</span>
             <span>· {coverage.summary.totalTables} tables</span>
+            {filtering && hasTables && (
+              <span>
+                · {filteredTables.length} {filteredTables.length === 1 ? "match" : "matches"}
+              </span>
+            )}
           </div>
           {coverage.tables.length === 0 ? (
             <p className="py-2 text-xs text-muted-foreground">
               This connection&rsquo;s baseline profile has no tables.
             </p>
+          ) : !expanded ? null : filteredTables.length === 0 ? (
+            <p className="py-2 text-xs text-muted-foreground">
+              No tables match the current filter.
+            </p>
           ) : (
-            <div className="space-y-1.5">
-              {coverage.tables.map((table) => (
-                <CoverageTableRow
-                  key={table.table}
-                  table={table}
-                  installId={connection.installId}
-                  onColumnAnchor={onColumnAnchor}
-                  disabled={disabled}
-                />
-              ))}
-            </div>
+            // Keyed by the filter signature so a filter change resets the
+            // "Show more" window instead of carrying a stale count over.
+            <CoverageTableList
+              key={`${query}\u0000${stateFilter ?? ""}`}
+              tables={filteredTables}
+              installId={connection.installId}
+              onColumnAnchor={onColumnAnchor}
+              disabled={disabled}
+            />
           )}
         </>
       )}
@@ -328,11 +455,65 @@ export function ConnectionCoverageSection({
 // Fetching view
 // ---------------------------------------------------------------------------
 
+const STATE_FILTER_VALUES: readonly TableCoverageState[] = ["covered", "partial", "uncovered"];
+
+/**
+ * The view-wide search + coverage-state filter bar (#4652). Presentational —
+ * exported for direct render-testing without driving the fetch.
+ */
+export function CoverageFilterBar({
+  query,
+  onQueryChange,
+  stateFilter,
+  onStateFilterChange,
+}: {
+  query: string;
+  onQueryChange: (query: string) => void;
+  stateFilter: TableCoverageState | null;
+  onStateFilterChange: (state: TableCoverageState | null) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="relative w-full max-w-xs">
+        <Search className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Filter tables…"
+          aria-label="Filter tables by name"
+          className="h-8 pl-8 text-xs"
+        />
+      </div>
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        size="sm"
+        spacing={1}
+        value={stateFilter ?? ""}
+        onValueChange={(value: string) => {
+          const next = STATE_FILTER_VALUES.find((s) => s === value) ?? null;
+          onStateFilterChange(next);
+        }}
+        aria-label="Filter tables by coverage state"
+      >
+        {STATE_FILTER_VALUES.map((state) => (
+          <ToggleGroupItem key={state} value={state} className="h-8 text-xs">
+            {STATE_META[state].label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+}
+
 /**
  * The coverage view — fetches the per-connection overview and polls while any
  * connection is still profiling (the lazy backfill). `onColumnAnchor` launches a
  * column-anchored conversation; `disabled` mirrors the page's `isLoading` so a
  * click can't race an in-flight turn.
+ *
+ * Filter/collapse state lives here in plain `useState`, outside the polled data
+ * path, so the 4s profiling poll re-fetch can't reset what the user typed.
  */
 export function CoverageView({
   onColumnAnchor,
@@ -344,6 +525,8 @@ export function CoverageView({
   const { data, loading, error, refetch } = useAdminFetch<CoverageOverviewResponse>(
     "/api/v1/admin/semantic-improve/coverage",
   );
+  const [query, setQuery] = useState("");
+  const [stateFilter, setStateFilter] = useState<TableCoverageState | null>(null);
 
   // Poll while any connection is still profiling — the lazy backfill lands
   // asynchronously, so re-fetch until `profiling` clears (or an error does).
@@ -375,12 +558,26 @@ export function CoverageView({
           </div>
         )}
 
+        {connections.length > 0 && (
+          <CoverageFilterBar
+            query={query}
+            onQueryChange={setQuery}
+            stateFilter={stateFilter}
+            onStateFilterChange={setStateFilter}
+          />
+        )}
+
         {connections.map((connection) => (
           <ConnectionCoverageSection
             key={connection.installId}
             connection={connection}
             onColumnAnchor={onColumnAnchor}
             disabled={disabled}
+            // A lone connection opens straight away — collapse-by-default is
+            // about not mounting N×119 rows for multi-connection groups (#4652).
+            defaultOpen={connections.length === 1}
+            query={query}
+            stateFilter={stateFilter}
           />
         ))}
       </div>


### PR DESCRIPTION
Fixes #4652.

The Semantic-Improve **Coverage** tab rendered one flat section per connection, each a full physical-table list — a 3-region group (us-prod/eu-prod/apac-prod × ~119 tables) was 350+ rows in one scroll. This layers the issue's three composing baseline directions onto `CoverageView`, all client-side (no wire-contract change):

## What changed

**1. Search + state filters (view-wide)**
- A table-name search box (matches physical table name *or* modeling entity name, case-insensitive) plus `covered` / `partial` / `uncovered` filter chips (shadcn `Input` + `ToggleGroup`, single-select, click-again-to-clear).
- Each connection's summary line gains a live `· N matches` count while a filter is active; zero matches renders "No tables match the current filter." instead of an empty void.

**2. Collapse-by-default per connection**
- Each connection section header is now a toggle button; sections start collapsed showing the identity row + the `X covered / Y partial / Z uncovered / N tables` summary line, so N×119 rows never mount at once.
- A lone connection defaults open (the common self-hosted case — collapsing a single section is pure friction; the AC targets multi-connection groups).
- An active filter force-expands sections (search results must be visible to be useful); clearing the filter returns to the user's manual open/closed choice.

**3. Chunked incremental rendering**
- Expanded lists mount `COVERAGE_TABLE_PAGE_SIZE` (50) rows behind a "Show N more (M hidden)" tail — long lists never render all rows at once. The list is keyed by the filter signature so a filter change resets the window (plain remount, no effect — avoids the #4641 React-Compiler stale-derivation class).

**State placement:** filter + collapse state is plain `useState` in `CoverageView`/section components, deliberately outside the polled data path — the 4s profiling poll re-fetch can't reset what the user typed. Not nuqs: the improve page's tab itself is `useState`, so a deep-linked filter couldn't restore its surrounding view anyway.

**Preserved (pinned by tests):** covered-column click → `onColumnAnchor` launch; uncovered → Enrich deep-link only (ADR-0032 — no add-entity affordance); profiling/error states; poll-until-profiled loop.

The group-level divergence pivot from the issue is left as the stretch follow-up — the three shipped affordances already make a 350+-row group navigable in a couple of interactions.

## Tests

`coverage-view.test.tsx`: 20 pass (was 9). New suites pin collapse-by-default (summary visible, rows unmounted, header click expands, filter force-expands), search narrowing + entity-name matching + match count, state filtering, the no-match message, chunked rendering (page boundary + Show-more), and `CoverageFilterBar` interactions (including click-again-to-clear). Pre-#4652 suites pass `defaultOpen: true` — they pin row/column behavior, not the collapse.

## Visual verification (local self-hosted dev)

Drove the Coverage tab live against the dev seed DB (52 tables on the `default` connection):
- Filter bar renders; typing `order` narrowed 52 → 5 with `· 5 matches`; `+ covered` chip composed down to 1 match.
- 52 tables chunked to 50 + "Show 2 more (2 hidden)"; Show-more mounted the rest.
- Covered `orders` row expanded to interactive column chips (anchor entry intact); uncovered `order_events` row showed the Enrich deep-link (`/wizard?connectionId=default&step=2`).
- Header click collapsed the section to its summary line.

## Checks

- `bun run lint`, `bun run type` clean; full `/ci` (`scripts/ci-local.sh`) green — see thread.
- No docs update needed: the docs describe the `/coverage` endpoint, not the tab's interaction mechanics.
