### PR TITLE
fix(dashboards): enforce first-publish privacy gate on write/share/delete paths (#4537)

### DIFF
--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -200,7 +200,7 @@ const mockGetDashboard = mock((): Promise<unknown> =>
 const mockListDashboards = mock((): Promise<unknown> =>
   Promise.resolve({ ok: true, data: { dashboards: [], total: 0 } }),
 );
-const mockUpdateDashboard = mock((): Promise<unknown> =>
+const mockUpdateDashboard = mock((..._args: unknown[]): Promise<unknown> =>
   Promise.resolve({ ok: true }),
 );
 const mockDeleteDashboard = mock((): Promise<unknown> =>
@@ -801,8 +801,7 @@ describe("dashboard routes", () => {
       expect(mockSetRefreshSchedule).toHaveBeenCalledTimes(1);
       expect(mockSetRefreshSchedule.mock.calls[0]?.[1]).toEqual({ orgId: "org-1", viewerId: "u1" });
       expect(mockUpdateDashboard).toHaveBeenCalledTimes(1);
-      const updateArgs = (mockUpdateDashboard as Mock<(...args: unknown[]) => Promise<unknown>>).mock.calls[0];
-      expect(updateArgs?.[1]).toEqual({ orgId: "org-1", viewerId: "u1" });
+      expect(mockUpdateDashboard.mock.calls[0]?.[1]).toEqual({ orgId: "org-1", viewerId: "u1" });
     });
 
     it("rejects a parameter update that orphans a card's placeholder (#2267)", async () => {
@@ -871,6 +870,27 @@ describe("dashboard routes", () => {
       );
       expect(response.status).toBe(204);
       expect(mockDeleteDashboard).toHaveBeenCalledWith(VALID_ID, { orgId: "org-1", viewerId: "u1" });
+    });
+
+    it("a userless caller is stopped by the org gate and never reaches deleteDashboard (#4537)", async () => {
+      // `viewerId: undefined` would bypass the write gate (the system
+      // opt-out), and the handlers' `user?.id ?? "anonymous"` fallback is
+      // only defense-in-depth: this router's requireOrgContext() rejects a
+      // user-less caller outright. Pin that fail-closed ordering — if the
+      // middleware ever starts admitting user-less requests, this fails and
+      // forces the fallback semantics to be re-examined.
+      mockAuthenticateRequest.mockResolvedValue({
+        authenticated: true as const,
+        mode: "none" as const,
+        user: undefined,
+      });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}`, {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(400);
+      expect(mockDeleteDashboard).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -233,6 +233,11 @@ const mockGetShareStatus = mock((): Promise<unknown> =>
 const mockGetSharedDashboard = mock((): Promise<unknown> =>
   Promise.resolve({ ok: false, reason: "not_found" }),
 );
+// #4537 — captured so tests can assert the caller's viewerId is threaded into
+// the write-side gate (the PATCH refresh-schedule path).
+const mockSetRefreshSchedule = mock((..._args: unknown[]): Promise<unknown> =>
+  Promise.resolve({ ok: true }),
+);
 
 // #2424 — captured so individual tests can override with
 // `mockResolvedValueOnce("not_found")` to exercise the 400 reject path.
@@ -271,7 +276,7 @@ void mock.module("@atlas/api/lib/dashboards", () => ({
   // to the real projection, not undefined (CLAUDE.md mock-all-exports rule).
   projectSharedDashboardView: realDashboards.projectSharedDashboardView,
   buildSharedParameterSummary: realDashboards.buildSharedParameterSummary,
-  setRefreshSchedule: mock(() => Promise.resolve({ ok: true })),
+  setRefreshSchedule: mockSetRefreshSchedule,
   getDashboardsDueForRefresh: mock(() => Promise.resolve([])),
   lockDashboardForRefresh: mock(() => Promise.resolve(false)),
   refreshDashboardCards: mockRefreshDashboardCards,
@@ -591,6 +596,8 @@ describe("dashboard routes", () => {
     mockGetShareStatus.mockResolvedValue({ ok: true, data: { shared: false, token: null, expiresAt: null, shareMode: "public" } });
     mockGetSharedDashboard.mockReset();
     mockGetSharedDashboard.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockSetRefreshSchedule.mockReset();
+    mockSetRefreshSchedule.mockResolvedValue({ ok: true });
     mockRunUserQueryPipeline.mockReset();
     mockRunUserQueryPipeline.mockResolvedValue({
       kind: "ok",
@@ -771,6 +778,33 @@ describe("dashboard routes", () => {
       expect(response.status).toBe(404);
     });
 
+    it("threads the caller's viewerId into the parameter + schedule writes (#4537)", async () => {
+      // The write-side first-publish gate lives in the lib SQL; the route's
+      // contribution is passing the acting identity through. Without it a
+      // same-org non-owner could write to a colleague's never-published board.
+      mockAuthenticateRequest.mockResolvedValue({
+        authenticated: true as const,
+        mode: "simple-key" as const,
+        user: { id: "u1", label: "test@test.com", mode: "simple-key" as const, role: "admin" as const, activeOrganizationId: "org-1" },
+      });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            parameters: [{ key: "date_from", type: "date", default: null, label: "From" }],
+            refreshSchedule: "0 * * * *",
+          }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(mockSetRefreshSchedule).toHaveBeenCalledTimes(1);
+      expect(mockSetRefreshSchedule.mock.calls[0]?.[1]).toEqual({ orgId: "org-1", viewerId: "u1" });
+      expect(mockUpdateDashboard).toHaveBeenCalledTimes(1);
+      const updateArgs = (mockUpdateDashboard as Mock<(...args: unknown[]) => Promise<unknown>>).mock.calls[0];
+      expect(updateArgs?.[1]).toEqual({ orgId: "org-1", viewerId: "u1" });
+    });
+
     it("rejects a parameter update that orphans a card's placeholder (#2267)", async () => {
       const cardWithParam = { ...mockCardData, sql: "SELECT * FROM orders WHERE created_at >= :date_from" };
       mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [cardWithParam] } });
@@ -827,6 +861,16 @@ describe("dashboard routes", () => {
         }),
       );
       expect(response.status).toBe(404);
+    });
+
+    it("threads the caller's viewerId into deleteDashboard (#4537)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}`, {
+          method: "DELETE",
+        }),
+      );
+      expect(response.status).toBe(204);
+      expect(mockDeleteDashboard).toHaveBeenCalledWith(VALID_ID, { orgId: "org-1", viewerId: "u1" });
     });
   });
 
@@ -2033,6 +2077,8 @@ describe("dashboard routes", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { token: string };
       expect(body.token).toBe("share-token-123");
+      // #4537 — the acting identity must reach the write-side gate.
+      expect(mockShareDashboard.mock.calls[0]?.[1]).toEqual({ orgId: "org-1", viewerId: "u1" });
     });
 
     // Regression for #1737 — the DB CHECK (chk_org_scoped_share, 0034)
@@ -2164,6 +2210,8 @@ describe("dashboard routes", () => {
         }),
       );
       expect(response.status).toBe(204);
+      // #4537 — the acting identity must reach the write-side gate.
+      expect(mockUnshareDashboard).toHaveBeenCalledWith(VALID_ID, { orgId: "org-1", viewerId: "u1" });
     });
   });
 
@@ -2175,6 +2223,8 @@ describe("dashboard routes", () => {
       expect(response.status).toBe(200);
       const body = (await response.json()) as { shared: boolean };
       expect(body.shared).toBe(false);
+      // #4537 — status carries the share token; the viewer gates the read.
+      expect(mockGetShareStatus).toHaveBeenCalledWith(VALID_ID, { orgId: "org-1", viewerId: "u1" });
     });
   });
 

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -1759,7 +1759,7 @@ authed.openapi(
           if (!cronCheck.valid) {
             return c.json({ error: "invalid_request", message: `Invalid cron expression: ${cronCheck.error}` }, 400);
           }
-          const schedResult = yield* Effect.promise(() => setRefreshSchedule(id, { orgId }, parsed.refreshSchedule!, computeNextRun));
+          const schedResult = yield* Effect.promise(() => setRefreshSchedule(id, { orgId, viewerId: user?.id ?? "anonymous" }, parsed.refreshSchedule!, computeNextRun));
           if (!schedResult.ok) {
             const fail = crudFailResponse(schedResult.reason, requestId);
             return c.json(fail.body, fail.status);
@@ -1767,7 +1767,7 @@ authed.openapi(
         } else {
           // Disabling auto-refresh (null)
           const { computeNextRun } = yield* Effect.promise(() => import("@atlas/api/lib/scheduled-tasks"));
-          const schedResult = yield* Effect.promise(() => setRefreshSchedule(id, { orgId }, null, computeNextRun));
+          const schedResult = yield* Effect.promise(() => setRefreshSchedule(id, { orgId, viewerId: user?.id ?? "anonymous" }, null, computeNextRun));
           if (!schedResult.ok) {
             const fail = crudFailResponse(schedResult.reason, requestId);
             return c.json(fail.body, fail.status);
@@ -1782,7 +1782,7 @@ authed.openapi(
       // private content edit).
       if (parsed.parameters !== undefined) {
         const result = yield* Effect.promise(() =>
-          updateDashboard(id, { orgId }, { parameters: parsed.parameters }),
+          updateDashboard(id, { orgId, viewerId: user?.id ?? "anonymous" }, { parameters: parsed.parameters }),
         );
         if (!result.ok) {
           const fail = crudFailResponse(result.reason, requestId);
@@ -1815,7 +1815,7 @@ authed.openapi(
           }
           return c.json(edit.view, 200);
         }
-        const result = yield* Effect.promise(() => updateDashboard(id, { orgId }, metaUpdates));
+        const result = yield* Effect.promise(() => updateDashboard(id, { orgId, viewerId: user?.id ?? "anonymous" }, metaUpdates));
         if (!result.ok) {
           const fail = crudFailResponse(result.reason, requestId);
           return c.json(fail.body, fail.status);
@@ -1843,13 +1843,15 @@ authed.openapi(
 authed.openapi(deleteDashboardRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
-    const { orgId } = yield* AuthContext;
+    const { orgId, user } = yield* AuthContext;
     const { id } = c.req.valid("param");
     if (!UUID_RE.test(id)) {
       return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
     }
 
-    const result = yield* Effect.promise(() => deleteDashboard(id, { orgId }));
+    // #4537 — the viewer gates the delete: a never-published board 404s for
+    // anyone but its creator, exactly like the read paths.
+    const result = yield* Effect.promise(() => deleteDashboard(id, { orgId, viewerId: user?.id ?? "anonymous" }));
     if (!result.ok) {
       const fail = crudFailResponse(result.reason, requestId);
       return c.json(fail.body, fail.status);
@@ -2634,7 +2636,7 @@ authed.openapi(
   async (c) => {
     return runEffect(c, Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
-      const { orgId } = yield* AuthContext;
+      const { orgId, user } = yield* AuthContext;
       const { id } = c.req.valid("param");
       if (!UUID_RE.test(id)) {
         return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
@@ -2686,7 +2688,7 @@ authed.openapi(
         parsed = validated.data;
       }
 
-      const result = yield* Effect.promise(() => shareDashboard(id, { orgId }, {
+      const result = yield* Effect.promise(() => shareDashboard(id, { orgId, viewerId: user?.id ?? "anonymous" }, {
         expiresIn: parsed.expiresIn ?? null,
         shareMode: parsed.shareMode ?? "public",
         rotate: parsed.rotate ?? false,
@@ -2714,13 +2716,13 @@ authed.openapi(
 authed.openapi(unshareDashboardRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
-    const { orgId } = yield* AuthContext;
+    const { orgId, user } = yield* AuthContext;
     const { id } = c.req.valid("param");
     if (!UUID_RE.test(id)) {
       return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
     }
 
-    const result = yield* Effect.promise(() => unshareDashboard(id, { orgId }));
+    const result = yield* Effect.promise(() => unshareDashboard(id, { orgId, viewerId: user?.id ?? "anonymous" }));
     if (!result.ok) {
       const fail = crudFailResponse(result.reason, requestId);
       return c.json(fail.body, fail.status);
@@ -2736,13 +2738,13 @@ authed.openapi(unshareDashboardRoute, async (c) => {
 authed.openapi(getShareStatusRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
-    const { orgId } = yield* AuthContext;
+    const { orgId, user } = yield* AuthContext;
     const { id } = c.req.valid("param");
     if (!UUID_RE.test(id)) {
       return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
     }
 
-    const result = yield* Effect.promise(() => getShareStatus(id, { orgId }));
+    const result = yield* Effect.promise(() => getShareStatus(id, { orgId, viewerId: user?.id ?? "anonymous" }));
     if (!result.ok) {
       const fail = crudFailResponse(result.reason, requestId);
       return c.json(fail.body, fail.status);

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -1754,12 +1754,13 @@ authed.openapi(
       // Handle refreshSchedule separately (needs cron validation + next_refresh_at)
       if (parsed.refreshSchedule !== undefined) {
         if (parsed.refreshSchedule) {
+          const schedule = parsed.refreshSchedule;
           const { validateCronExpression, computeNextRun } = yield* Effect.promise(() => import("@atlas/api/lib/scheduled-tasks"));
-          const cronCheck = validateCronExpression(parsed.refreshSchedule);
+          const cronCheck = validateCronExpression(schedule);
           if (!cronCheck.valid) {
             return c.json({ error: "invalid_request", message: `Invalid cron expression: ${cronCheck.error}` }, 400);
           }
-          const schedResult = yield* Effect.promise(() => setRefreshSchedule(id, { orgId, viewerId: user?.id ?? "anonymous" }, parsed.refreshSchedule!, computeNextRun));
+          const schedResult = yield* Effect.promise(() => setRefreshSchedule(id, { orgId, viewerId: user?.id ?? "anonymous" }, schedule, computeNextRun));
           if (!schedResult.ok) {
             const fail = crudFailResponse(schedResult.reason, requestId);
             return c.json(fail.body, fail.status);

--- a/packages/api/src/lib/__tests__/dashboards-first-publish-pg.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-first-publish-pg.test.ts
@@ -25,6 +25,12 @@ import {
   getDashboard,
   listDashboards,
   cleanupAbandonedDashboards,
+  updateDashboard,
+  deleteDashboard,
+  shareDashboard,
+  unshareDashboard,
+  getShareStatus,
+  setRefreshSchedule,
 } from "@atlas/api/lib/dashboards";
 import {
   bindConversationToDashboard,
@@ -266,6 +272,121 @@ describeIfPg("dashboard first-publish visibility gate (real Postgres, #4320)", (
     // Marker is now set to created_at and the board is org-visible.
     expect(await firstPublishedAt(id)).not.toBeNull();
     expect((await getDashboard(id, { orgId: ORG, viewerId: TEAMMATE })).ok).toBe(true);
+  });
+
+  describe("write-side gate (#4537)", () => {
+    // The read gate (#4320) made a never-published board invisible to
+    // teammates — but every mutation/share/delete path scoped by org only, so
+    // a same-org teammate who learned the UUID could still delete it, mint a
+    // share link on it, or leak its share token. These tests pin the write
+    // paths to the SAME visibility semantics as the reads: not_found for a
+    // non-owner while never-published, unchanged once published.
+
+    const nextRun = () => new Date(Date.now() + 60_000);
+
+    async function createPrivateBoard(): Promise<string> {
+      const created = await createDashboard({ ownerId: CREATOR, orgId: ORG, title: "Private board" });
+      expect(created.ok).toBe(true);
+      if (!created.ok) throw new Error("createDashboard failed in fixture");
+      return created.data.id;
+    }
+
+    it("a teammate cannot soft-delete another user's never-published dashboard; the owner can", async () => {
+      const id = await createPrivateBoard();
+
+      const asTeammate = await deleteDashboard(id, { orgId: ORG, viewerId: TEAMMATE });
+      expect(asTeammate).toEqual({ ok: false, reason: "not_found" });
+      // The blind delete must not have landed — the creator still reads it.
+      expect((await getDashboard(id, { orgId: ORG, viewerId: CREATOR })).ok).toBe(true);
+
+      const asCreator = await deleteDashboard(id, { orgId: ORG, viewerId: CREATOR });
+      expect(asCreator).toEqual({ ok: true });
+    });
+
+    it("a teammate cannot mint a share link on a never-published dashboard; the owner can", async () => {
+      const id = await createPrivateBoard();
+
+      const asTeammate = await shareDashboard(id, { orgId: ORG, viewerId: TEAMMATE });
+      expect(asTeammate).toEqual({ ok: false, reason: "not_found" });
+      // The org-scoped share path (separate pre-check query) is gated too.
+      const asTeammateOrg = await shareDashboard(id, { orgId: ORG, viewerId: TEAMMATE }, { shareMode: "org" });
+      expect(asTeammateOrg).toEqual({ ok: false, reason: "not_found" });
+      // No token was written by either attempt.
+      const rows = await pool.query<{ share_token: string | null }>(
+        `SELECT share_token FROM dashboards WHERE id = $1`,
+        [id],
+      );
+      expect(rows.rows[0]?.share_token).toBeNull();
+
+      const asCreator = await shareDashboard(id, { orgId: ORG, viewerId: CREATOR });
+      expect(asCreator.ok).toBe(true);
+    });
+
+    it("a teammate cannot read or revoke the share status of a never-published dashboard", async () => {
+      const id = await createPrivateBoard();
+      const shared = await shareDashboard(id, { orgId: ORG, viewerId: CREATOR });
+      expect(shared.ok).toBe(true);
+
+      // Status (and thereby the token) must not leak to a teammate.
+      const statusAsTeammate = await getShareStatus(id, { orgId: ORG, viewerId: TEAMMATE });
+      expect(statusAsTeammate).toEqual({ ok: false, reason: "not_found" });
+
+      // Nor can the teammate blind-revoke the owner's link.
+      const unshareAsTeammate = await unshareDashboard(id, { orgId: ORG, viewerId: TEAMMATE });
+      expect(unshareAsTeammate).toEqual({ ok: false, reason: "not_found" });
+      const statusAsCreator = await getShareStatus(id, { orgId: ORG, viewerId: CREATOR });
+      expect(statusAsCreator.ok && statusAsCreator.data.shared).toBe(true);
+
+      const unshareAsCreator = await unshareDashboard(id, { orgId: ORG, viewerId: CREATOR });
+      expect(unshareAsCreator).toEqual({ ok: true });
+    });
+
+    it("a teammate cannot write parameters or the refresh schedule of a never-published dashboard", async () => {
+      const id = await createPrivateBoard();
+
+      const paramsAsTeammate = await updateDashboard(
+        id,
+        { orgId: ORG, viewerId: TEAMMATE },
+        { parameters: [{ key: "region", label: "Region", type: "text", default: "us" }] },
+      );
+      expect(paramsAsTeammate).toEqual({ ok: false, reason: "not_found" });
+
+      const schedAsTeammate = await setRefreshSchedule(id, { orgId: ORG, viewerId: TEAMMATE }, "0 * * * *", nextRun);
+      expect(schedAsTeammate).toEqual({ ok: false, reason: "not_found" });
+
+      const paramsAsCreator = await updateDashboard(
+        id,
+        { orgId: ORG, viewerId: CREATOR },
+        { parameters: [{ key: "region", label: "Region", type: "text", default: "us" }] },
+      );
+      expect(paramsAsCreator).toEqual({ ok: true });
+      const schedAsCreator = await setRefreshSchedule(id, { orgId: ORG, viewerId: CREATOR }, "0 * * * *", nextRun);
+      expect(schedAsCreator).toEqual({ ok: true });
+    });
+
+    it("published dashboards accept teammate writes unchanged", async () => {
+      const id = await createPrivateBoard();
+      await firstPublish(id);
+
+      expect((await shareDashboard(id, { orgId: ORG, viewerId: TEAMMATE })).ok).toBe(true);
+      expect((await getShareStatus(id, { orgId: ORG, viewerId: TEAMMATE })).ok).toBe(true);
+      expect((await unshareDashboard(id, { orgId: ORG, viewerId: TEAMMATE })).ok).toBe(true);
+      expect(
+        (await updateDashboard(id, { orgId: ORG, viewerId: TEAMMATE }, { parameters: [] })).ok,
+      ).toBe(true);
+      expect(
+        (await setRefreshSchedule(id, { orgId: ORG, viewerId: TEAMMATE }, "0 * * * *", nextRun)).ok,
+      ).toBe(true);
+      expect((await deleteDashboard(id, { orgId: ORG, viewerId: TEAMMATE })).ok).toBe(true);
+    });
+
+    it("omitting viewerId (system/owner-internal caller) still bypasses the write gate", async () => {
+      // Mirrors the read-path opt-out: system callers (sweep, publish
+      // internals) pass no viewerId and must still resolve never-published rows.
+      const id = await createPrivateBoard();
+      expect((await setRefreshSchedule(id, { orgId: ORG }, "0 * * * *", nextRun)).ok).toBe(true);
+      expect((await deleteDashboard(id, { orgId: ORG })).ok).toBe(true);
+    });
   });
 
   describe("abandoned-shell cleanup", () => {

--- a/packages/api/src/lib/__tests__/dashboards-first-publish-pg.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-first-publish-pg.test.ts
@@ -381,8 +381,11 @@ describeIfPg("dashboard first-publish visibility gate (real Postgres, #4320)", (
     });
 
     it("omitting viewerId (system/owner-internal caller) still bypasses the write gate", async () => {
-      // Mirrors the read-path opt-out: system callers (sweep, publish
-      // internals) pass no viewerId and must still resolve never-published rows.
+      // Mirrors the read-path opt-out: an omitted viewerId bypasses the gate.
+      // No production WRITE caller relies on this today (the sweep and the
+      // refresh scheduler run their own SQL; publish internals only read) —
+      // this pins the contract so a future system caller isn't gated by
+      // accident.
       const id = await createPrivateBoard();
       expect((await setRefreshSchedule(id, { orgId: ORG }, "0 * * * *", nextRun)).ok).toBe(true);
       expect((await deleteDashboard(id, { orgId: ORG })).ok).toBe(true);

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -214,8 +214,9 @@ export function rowToCard(r: Record<string, unknown>): DashboardCard {
  * omitted — that's the deliberate opt-out for system/owner-internal callers
  * (the publish merge's own baseline load, auto-refresh, agent tools acting on
  * an already-bound board) that must still resolve a never-published row. Every
- * USER-FACING read surface passes `viewerId` so the gate is enforced at the
- * request boundary, where the acting identity lives.
+ * USER-FACING surface — reads AND the write/share/delete paths (#4537) —
+ * passes `viewerId` so the gate is enforced at the request boundary, where the
+ * acting identity lives.
  */
 function firstPublishVisibilityClause(
   viewerId: string | null | undefined,
@@ -455,7 +456,7 @@ export async function listDashboards(opts?: {
 
 export async function updateDashboard(
   id: string,
-  scope: { orgId?: string | null },
+  scope: { orgId?: string | null; viewerId?: string | null },
   updates: {
     title?: string;
     description?: string | null;
@@ -492,11 +493,16 @@ export async function updateDashboard(
 
   const org = orgScopeClause(scope.orgId, params, paramIdx);
   paramIdx = org.nextIdx;
+  // #4537 — write-side mirror of the read gate: a never-published dashboard
+  // only accepts writes from its creator.
+  const vis = firstPublishVisibilityClause(scope.viewerId, params, paramIdx);
+  paramIdx = vis.nextIdx;
+  const visClause = vis.clause ? ` AND ${vis.clause}` : "";
 
   try {
     const rows = await internalQuery<{ id: string }>(
       `UPDATE dashboards SET ${setClauses.join(", ")}
-       WHERE id = $${paramIdx} AND ${org.clause} AND deleted_at IS NULL
+       WHERE id = $${paramIdx} AND ${org.clause}${visClause} AND deleted_at IS NULL
        RETURNING id`,
       [...params, id],
     );
@@ -509,15 +515,19 @@ export async function updateDashboard(
 
 export async function deleteDashboard(
   id: string,
-  scope: { orgId?: string | null },
+  scope: { orgId?: string | null; viewerId?: string | null },
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const params: unknown[] = [id];
     const org = orgScopeClause(scope.orgId, params, 2);
+    // #4537 — a non-owner must not be able to blind-delete a never-published
+    // board (it would strand the creator's in-flight draft unreachable).
+    const vis = firstPublishVisibilityClause(scope.viewerId, params, org.nextIdx);
+    const visClause = vis.clause ? ` AND ${vis.clause}` : "";
     const rows = await internalQuery<{ id: string }>(
       `UPDATE dashboards SET deleted_at = now(), updated_at = now()
-       WHERE id = $1 AND ${org.clause} AND deleted_at IS NULL
+       WHERE id = $1 AND ${org.clause}${visClause} AND deleted_at IS NULL
        RETURNING id`,
       params,
     );
@@ -795,7 +805,7 @@ export type ShareDashboardResult =
  */
 export async function shareDashboard(
   id: string,
-  scope: { orgId?: string | null },
+  scope: { orgId?: string | null; viewerId?: string | null },
   opts?: { expiresIn?: ShareExpiryKey | null; shareMode?: ShareMode; rotate?: boolean },
 ): Promise<ShareDashboardResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
@@ -824,8 +834,12 @@ export async function shareDashboard(
       // scope in the future should still hit this guard.
       const params: unknown[] = [id];
       const lookupOrg = orgScopeClause(scope.orgId, params, 2);
+      // #4537 — the pre-check must 404 the same way the share write does, or
+      // it becomes an existence oracle for never-published boards.
+      const lookupVis = firstPublishVisibilityClause(scope.viewerId, params, lookupOrg.nextIdx);
+      const lookupVisClause = lookupVis.clause ? ` AND ${lookupVis.clause}` : "";
       const orgRows = await internalQuery<{ org_id: string | null }>(
-        `SELECT org_id FROM dashboards WHERE id = $1 AND ${lookupOrg.clause} AND deleted_at IS NULL`,
+        `SELECT org_id FROM dashboards WHERE id = $1 AND ${lookupOrg.clause}${lookupVisClause} AND deleted_at IS NULL`,
         params,
       );
       if (orgRows.length === 0) return { ok: false, reason: "not_found" };
@@ -844,11 +858,15 @@ export async function shareDashboard(
     // first-time-share case, where there is no existing link to preserve.
     const params: unknown[] = [candidateToken, expiresAt, shareMode, rotate, id];
     const org = orgScopeClause(scope.orgId, params, 6, "src");
+    // #4537 — a non-owner must not mint (or rotate) a share link on a
+    // never-published board they cannot read.
+    const vis = firstPublishVisibilityClause(scope.viewerId, params, org.nextIdx, "src");
+    const visClause = vis.clause ? ` AND ${vis.clause}` : "";
 
     const rows = await internalQuery<{ share_token: string; old_token: string | null }>(
       `WITH prev AS (
          SELECT src.id, src.share_token AS old_token FROM dashboards src
-         WHERE src.id = $5 AND ${org.clause} AND src.deleted_at IS NULL
+         WHERE src.id = $5 AND ${org.clause}${visClause} AND src.deleted_at IS NULL
        )
        UPDATE dashboards d
        SET share_token = CASE WHEN $4::boolean OR prev.old_token IS NULL THEN $1 ELSE prev.old_token END,
@@ -873,15 +891,18 @@ export async function shareDashboard(
 
 export async function unshareDashboard(
   id: string,
-  scope: { orgId?: string | null },
+  scope: { orgId?: string | null; viewerId?: string | null },
 ): Promise<CrudResult> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const params: unknown[] = [id];
     const org = orgScopeClause(scope.orgId, params, 2);
+    // #4537 — only the creator may revoke a never-published board's share.
+    const vis = firstPublishVisibilityClause(scope.viewerId, params, org.nextIdx);
+    const visClause = vis.clause ? ` AND ${vis.clause}` : "";
     const rows = await internalQuery<{ id: string }>(
       `UPDATE dashboards SET share_token = NULL, share_expires_at = NULL, updated_at = now()
-       WHERE id = $1 AND ${org.clause} AND deleted_at IS NULL
+       WHERE id = $1 AND ${org.clause}${visClause} AND deleted_at IS NULL
        RETURNING id`,
       params,
     );
@@ -894,15 +915,19 @@ export async function unshareDashboard(
 
 export async function getShareStatus(
   id: string,
-  scope: { orgId?: string | null },
+  scope: { orgId?: string | null; viewerId?: string | null },
 ): Promise<CrudDataResult<{ shared: boolean; token: string | null; expiresAt: string | null; shareMode: ShareMode }>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const params: unknown[] = [id];
     const org = orgScopeClause(scope.orgId, params, 2);
+    // #4537 — the status response carries the share TOKEN; leaking it to a
+    // non-owner of a never-published board is a live-link disclosure.
+    const vis = firstPublishVisibilityClause(scope.viewerId, params, org.nextIdx);
+    const visClause = vis.clause ? ` AND ${vis.clause}` : "";
     const rows = await internalQuery<Record<string, unknown>>(
       `SELECT share_token, share_expires_at, share_mode FROM dashboards
-       WHERE id = $1 AND ${org.clause} AND deleted_at IS NULL`,
+       WHERE id = $1 AND ${org.clause}${visClause} AND deleted_at IS NULL`,
       params,
     );
     if (rows.length === 0) return { ok: false, reason: "not_found" };
@@ -1385,7 +1410,7 @@ async function getDashboardUnscoped(
  */
 export async function setRefreshSchedule(
   dashboardId: string,
-  scope: { orgId?: string | null },
+  scope: { orgId?: string | null; viewerId?: string | null },
   schedule: string | null,
   computeNextRun: (expr: string, after?: Date) => Date | null,
 ): Promise<CrudResult> {
@@ -1402,10 +1427,13 @@ export async function setRefreshSchedule(
     }
     const params: unknown[] = [schedule, nextRefresh, dashboardId];
     const org = orgScopeClause(scope.orgId, params, 4);
+    // #4537 — only the creator may (re)schedule a never-published board.
+    const vis = firstPublishVisibilityClause(scope.viewerId, params, org.nextIdx);
+    const visClause = vis.clause ? ` AND ${vis.clause}` : "";
 
     const rows = await internalQuery<{ id: string }>(
       `UPDATE dashboards SET refresh_schedule = $1, next_refresh_at = $2, updated_at = now()
-       WHERE id = $3 AND ${org.clause} AND deleted_at IS NULL
+       WHERE id = $3 AND ${org.clause}${visClause} AND deleted_at IS NULL
        RETURNING id`,
       params,
     );

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -508,7 +508,10 @@ export async function updateDashboard(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "updateDashboard failed");
+    log.error(
+      { dashboardId: id, orgId: scope.orgId ?? null, viewerGated: scope.viewerId != null, err: errorMessage(err) },
+      "updateDashboard failed",
+    );
     return { ok: false, reason: "error" };
   }
 }
@@ -533,7 +536,10 @@ export async function deleteDashboard(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "deleteDashboard failed");
+    log.error(
+      { dashboardId: id, orgId: scope.orgId ?? null, viewerGated: scope.viewerId != null, err: errorMessage(err) },
+      "deleteDashboard failed",
+    );
     return { ok: false, reason: "error" };
   }
 }
@@ -834,8 +840,10 @@ export async function shareDashboard(
       // scope in the future should still hit this guard.
       const params: unknown[] = [id];
       const lookupOrg = orgScopeClause(scope.orgId, params, 2);
-      // #4537 — the pre-check must 404 the same way the share write does, or
-      // it becomes an existence oracle for never-published boards.
+      // #4537 — gated for the same reason as the relaxed-scope guard above:
+      // an ungated pre-check on a scope-relaxed callsite would answer
+      // invalid_org_scope (400) instead of not_found for someone else's
+      // never-published board — an existence oracle.
       const lookupVis = firstPublishVisibilityClause(scope.viewerId, params, lookupOrg.nextIdx);
       const lookupVisClause = lookupVis.clause ? ` AND ${lookupVis.clause}` : "";
       const orgRows = await internalQuery<{ org_id: string | null }>(
@@ -884,7 +892,10 @@ export async function shareDashboard(
     const rotated = oldToken !== null && token !== oldToken;
     return { ok: true, data: { token, expiresAt, shareMode, rotated } };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "shareDashboard failed");
+    log.error(
+      { dashboardId: id, orgId: scope.orgId ?? null, viewerGated: scope.viewerId != null, err: errorMessage(err) },
+      "shareDashboard failed",
+    );
     return { ok: false, reason: "error" };
   }
 }
@@ -908,7 +919,10 @@ export async function unshareDashboard(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "unshareDashboard failed");
+    log.error(
+      { dashboardId: id, orgId: scope.orgId ?? null, viewerGated: scope.viewerId != null, err: errorMessage(err) },
+      "unshareDashboard failed",
+    );
     return { ok: false, reason: "error" };
   }
 }
@@ -943,7 +957,10 @@ export async function getShareStatus(
       },
     };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "getShareStatus failed");
+    log.error(
+      { dashboardId: id, orgId: scope.orgId ?? null, viewerGated: scope.viewerId != null, err: errorMessage(err) },
+      "getShareStatus failed",
+    );
     return { ok: false, reason: "error" };
   }
 }
@@ -1439,7 +1456,10 @@ export async function setRefreshSchedule(
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
-    log.error({ err: errorMessage(err) }, "setRefreshSchedule failed");
+    log.error(
+      { dashboardId, orgId: scope.orgId ?? null, viewerGated: scope.viewerId != null, err: errorMessage(err) },
+      "setRefreshSchedule failed",
+    );
     return { ok: false, reason: "error" };
   }
 }


### PR DESCRIPTION
Fixes #4537

## Problem

ADR-0029's first-publish gate makes a never-published dashboard (`first_published_at IS NULL`) private to its creator — but only the READ paths enforced it (`firstPublishVisibilityClause`, #4320). Every mutation/share/delete path scoped by org only, so a same-org teammate who learned the UUID could:

- **blind soft-delete** the board (`deleteDashboard`) — stranding the creator's in-flight `dashboard_user_drafts` row unreachable (unpublished work lost)
- **mint a public/org share link** on it (`shareDashboard`)
- **leak its share token** (`getShareStatus`) or revoke the owner's link (`unshareDashboard`)
- overwrite its parameters (`updateDashboard`) or refresh schedule (`setRefreshSchedule`)

## Fix

Thread `viewerId` + `firstPublishVisibilityClause` into all six write/share/delete functions, mirroring the read gate's exact semantics:

- `scope` widened to `{ orgId?, viewerId? }` on `updateDashboard`, `deleteDashboard`, `shareDashboard` (both the org-scope pre-check query and the share CTE — the pre-check would otherwise be an existence oracle), `unshareDashboard`, `getShareStatus`, `setRefreshSchedule`
- Route handlers pass `viewerId: user?.id ?? "anonymous"`, identical to the read paths
- Non-owners get the same `not_found` → **404** the reads return (never a 403 that would confirm existence)
- Omitting `viewerId` keeps the documented system-caller opt-out (sweep, publish internals, auto-refresh) — unchanged
- Published dashboards: behavior unchanged (clause passes for any org member once `first_published_at` is stamped)

## Tests

- **Real-Postgres regression suite** (`dashboards-first-publish-pg.test.ts`, new `write-side gate (#4537)` describe, 6 tests): written FIRST and confirmed red against the unfixed code — same-org non-owner cannot delete/share/unshare/read-status/write-params/schedule a never-published board; the owner can; published boards accept teammate writes unchanged; the no-`viewerId` system opt-out still bypasses
- **Route tests** (`dashboards.test.ts`, 4 new/extended): pin that each handler threads the authenticated viewer into the lib call, so the route layer can't silently drop the gate

## Verification

- `/ci` (`scripts/ci-local.sh`): **all 31 gates PASS** (an earlier run with `TEST_DATABASE_URL` exported to the full suite mass-flaked unrelated `-pg` suites via local Postgres contention; each passes in isolation — known WSL2 load-flake, not this diff)
- Dashboard `-pg` suites run explicitly against real Postgres: green
- Remote on `main`: CI, Deploy Validation, Railway staging all green

## Coordination

Open PR #4653 touches other regions of these two files (`formatParameterDisplayValue`, PATCH orphan-guard). This PR leaves those regions untouched; #4653 was still OPEN at push time. If it merges first, the only overlap is trivial context adjacency in the test-file mock block.