### PR TITLE
feat(dashboards): surface-native creation — "New dashboard" opens the bound editor on the canvas

### DIFF
--- a/apps/docs/content/docs/guides/dashboards.mdx
+++ b/apps/docs/content/docs/guides/dashboards.mdx
@@ -28,7 +28,7 @@ The card is saved with its SQL, chart configuration, and current result data.
 
 ### From the Dashboards Surface
 
-Navigate to `/dashboards` and click **New dashboard** (from the dashboard switcher, the **View all** modal, or the empty state). Enter a title and the new board opens on its canvas with the [bound editor](#chat-as-editor) already open — describe what you want to see and the agent builds the charts right there. Prefer an empty board? Close the drawer: the dashboard stays a normal empty canvas you can fill by pinning results from chat.
+Navigate to `/dashboards` and create a board from any surface origin: **New dashboard** in the dashboard switcher, **New** in the **View all** modal, or **Create your first dashboard** on the empty state. Enter a title and the new board opens on its canvas with the [bound editor](#chat-as-editor) already open — describe what you want to see and the agent builds the charts right there. Prefer an empty board? Close the drawer: the dashboard stays a normal empty canvas you can fill by pinning results from chat.
 
 ---
 

--- a/apps/docs/content/docs/guides/dashboards.mdx
+++ b/apps/docs/content/docs/guides/dashboards.mdx
@@ -26,9 +26,9 @@ Dashboards let you pin query results from chat and organize them into persistent
 
 The card is saved with its SQL, chart configuration, and current result data.
 
-### From the Dashboard List
+### From the Dashboards Surface
 
-Navigate to `/dashboards` to see all dashboards. Click **New Dashboard** to create an empty one, then add cards from chat.
+Navigate to `/dashboards` and click **New dashboard** (from the dashboard switcher, the **View all** modal, or the empty state). Enter a title and the new board opens on its canvas with the [bound editor](#chat-as-editor) already open — describe what you want to see and the agent builds the charts right there. Prefer an empty board? Close the drawer: the dashboard stays a normal empty canvas you can fill by pinning results from chat.
 
 ---
 

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useQueryState } from "nuqs";
 import { toast } from "sonner";
-import Link from "next/link";
 import { MessagesSquare, Plus, Sparkles, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BoundChatDrawer } from "@/ui/components/dashboards/bound-chat-drawer";
@@ -1281,14 +1280,24 @@ export default function DashboardViewPage() {
             )}
 
             {dashboard.cards.length === 0 ? (
+              // #4563 — surface-native creation: the empty canvas invites
+              // building via the bound editor right here, never a "go to
+              // chat" bounce. Pinning from chat remains as a quiet hint for
+              // the manual path.
               <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
                 <h2 className="text-2xl font-semibold tracking-tight">An empty canvas</h2>
                 <p className="max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
-                  Run a query in chat, then click <span className="font-medium">Add to Dashboard</span> to drop your first tile here.
+                  Open the editor and describe what you want to see — the agent
+                  builds the charts right here.
                 </p>
-                <Button asChild size="sm" className="mt-2">
-                  <Link href="/">Go to chat</Link>
+                <Button size="sm" className="mt-2" onClick={() => setChatOpen(true)}>
+                  <MessagesSquare className="mr-1.5 size-3.5" aria-hidden="true" />
+                  Describe your dashboard
                 </Button>
+                <p className="max-w-sm text-xs text-zinc-400 dark:text-zinc-500">
+                  Prefer to build by hand? Pin any chat result with{" "}
+                  <span className="font-medium">Add to Dashboard</span>.
+                </p>
               </div>
             ) : (
               <div className={`dash-density-${density} flex-1 px-3 py-4 sm:overflow-auto sm:px-5`}>

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -32,6 +32,7 @@ import { DashboardParameterBar, type ParameterValues } from "@/ui/components/das
 import { DashboardFilterChips } from "@/ui/components/dashboards/dashboard-filter-chips";
 import {
   DASHBOARD_PARAMS_KEY,
+  OPEN_CHAT_PARAM,
   dashboardParamsParser,
   parseOverrides,
   withOverride,
@@ -305,7 +306,7 @@ export default function DashboardViewPage() {
   // drawer once so the same conversation resumes in bound mode, then
   // strip the param so a refresh doesn't keep reopening it.
   useEffect(() => {
-    if (searchParams.get("openChat") !== "true") return;
+    if (searchParams.get(OPEN_CHAT_PARAM) !== "true") return;
     // #4322 — the handoff link carries `conversationId` so the originating
     // conversation carries into bound mode. Capture it before stripping the
     // URL; absent (e.g. a hand-typed `?openChat=true`) → fresh session.

--- a/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/search-params.ts
@@ -23,6 +23,15 @@ import type { ParameterValues } from "@/ui/components/dashboards/dashboard-param
 /** URL query key holding the JSON-encoded dashboard parameter override map. */
 export const DASHBOARD_PARAMS_KEY = "dparams";
 
+/**
+ * URL query key that auto-opens the bound editor on arrival (`?openChat=true`)
+ * — the shared entry of the main-chat `createDashboard` handoff (#2369) and
+ * surface-native creation (#4563). Consumed once by the canvas page's
+ * auto-open effect, then stripped from the URL. Shared as a constant so the
+ * producers (creation navigation) and the consumer can't drift.
+ */
+export const OPEN_CHAT_PARAM = "openChat";
+
 /** nuqs parser for {@link DASHBOARD_PARAMS_KEY}. Shared by the page (drilldown
  *  writes) and the parameter bar (manual changes) so both subscribe to the
  *  same key. */

--- a/packages/web/src/app/(workspace)/dashboards/__tests__/page.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/__tests__/page.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, test, mock, afterEach, beforeEach } from "bun:test";
 
 const replaceCalls: string[] = [];
+const pushCalls: string[] = [];
 
 void mock.module("next/navigation", () => ({
   useRouter: () => ({
-    push: () => {},
+    push: (url: string) => pushCalls.push(url),
     replace: (url: string) => replaceCalls.push(url),
     back: () => {},
   }),
@@ -17,7 +18,11 @@ void mock.module("next/navigation", () => ({
 
 import { render, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import DashboardsPage from "../page";
-import { dashboardsWrapper, stubDashboardsFetch } from "../../../../ui/components/dashboards/__tests__/_fixtures";
+import {
+  dashboardsWrapper,
+  stubDashboardsFetch,
+  stubDashboardsFetchWithCreate,
+} from "../../../../ui/components/dashboards/__tests__/_fixtures";
 
 const originalFetch = globalThis.fetch;
 
@@ -43,6 +48,7 @@ function stubDashboardsStatus(status: number, body: unknown = {}) {
 describe("DashboardsPage (redirect index)", () => {
   beforeEach(() => {
     replaceCalls.length = 0;
+    pushCalls.length = 0;
   });
   afterEach(() => {
     cleanup();
@@ -72,6 +78,49 @@ describe("DashboardsPage (redirect index)", () => {
     await screen.findByText("No dashboards yet");
     // The genuine empty state is NOT a redirect — no navigation should fire.
     expect(replaceCalls).toHaveLength(0);
+  });
+
+  // #4563 — surface-native creation: the empty state invites building right
+  // here (no "Go to chat" bounce), and creating lands on the new board's
+  // canvas with the bound editor open (`?openChat=true`).
+  test("the empty state has no 'Go to chat' bounce", async () => {
+    stubDashboardsFetch([]);
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+
+    await screen.findByText("No dashboards yet");
+    expect(screen.queryByText(/Go to chat/i)).toBeNull();
+  });
+
+  test("creating from the empty state navigates to the canvas with the bound editor open", async () => {
+    stubDashboardsFetchWithCreate([], {
+      id: "d-9",
+      title: "Fresh",
+      updatedAt: "2026-07-16T10:00:00Z",
+      cardCount: 0,
+    });
+
+    render(<DashboardsPage />, { wrapper: dashboardsWrapper });
+    await screen.findByText("No dashboards yet");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Create your first dashboard/ }),
+    );
+    const input = await screen.findByPlaceholderText("Dashboard title");
+    fireEvent.change(input, { target: { value: "Fresh" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(pushCalls).toContain("/dashboards/d-9?openChat=true"),
+    );
+
+    // The redirect-index effect must stand down after the creation handoff:
+    // the post-creation list refetch makes `targetId` flip to the new board,
+    // and an un-gated `router.replace("/dashboards/d-9")` would clobber the
+    // `?openChat=true` push before the canvas consumed it (the drawer would
+    // silently not open — caught live, 2026-07-16).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(replaceCalls).not.toContain("/dashboards/d-9");
   });
 
   test("bounces an unauthenticated visitor (401) to /login", async () => {

--- a/packages/web/src/app/(workspace)/dashboards/__tests__/page.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/__tests__/page.test.tsx
@@ -114,12 +114,17 @@ describe("DashboardsPage (redirect index)", () => {
       expect(pushCalls).toContain("/dashboards/d-9?openChat=true"),
     );
 
-    // The redirect-index effect must stand down after the creation handoff:
-    // the post-creation list refetch makes `targetId` flip to the new board,
-    // and an un-gated `router.replace("/dashboards/d-9")` would clobber the
+    // The redirect-index effect must CONVERGE after the creation handoff: the
+    // post-creation list refetch flips `targetId` to the new board, and an
+    // un-gated `router.replace("/dashboards/d-9")` would clobber the
     // `?openChat=true` push before the canvas consumed it (the drawer would
-    // silently not open — caught live, 2026-07-16).
-    await new Promise((r) => setTimeout(r, 50));
+    // silently not open — caught live, 2026-07-16). Instead the effect
+    // re-issues the same intent-preserving URL — waiting for that converged
+    // replace is the deterministic signal that the refetch → effect chain has
+    // run, so the bare-URL assertion below can't pass vacuously on a slow box.
+    await waitFor(() =>
+      expect(replaceCalls).toContain("/dashboards/d-9?openChat=true"),
+    );
     expect(replaceCalls).not.toContain("/dashboards/d-9");
   });
 

--- a/packages/web/src/app/(workspace)/dashboards/empty-state.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/empty-state.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { LayoutDashboard, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -10,7 +9,24 @@ import {
   defaultOnDashboardCreated,
 } from "@/ui/components/dashboards/new-dashboard-dialog";
 
-export function DashboardsEmptyState() {
+interface DashboardsEmptyStateProps {
+  /**
+   * Called synchronously before the creation navigation fires, so the parent
+   * redirect-index page can stand down its own `router.replace` — the
+   * post-creation list refetch would otherwise race the `?openChat=true` push
+   * and strip the editor-open intent (#4563).
+   */
+  onCreationNavigate?: () => void;
+}
+
+/**
+ * #4563 — the dashboards surface is a first-class creation origin: the empty
+ * state invites creating right here (the new board opens with the bound
+ * editor ready), instead of bouncing the user to main chat.
+ */
+export function DashboardsEmptyState({
+  onCreationNavigate,
+}: DashboardsEmptyStateProps) {
   const router = useRouter();
   const [createOpen, setCreateOpen] = useState(false);
 
@@ -25,25 +41,23 @@ export function DashboardsEmptyState() {
             No dashboards yet
           </h1>
           <p className="mb-6 max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
-            Ask a question in chat, get a result, and click the Dashboard button
-            to pin it here.
+            Create a dashboard and describe what you want to see — the agent
+            builds the charts right on the canvas.
           </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Button variant="outline" size="sm" asChild>
-              <Link href="/">Go to chat</Link>
-            </Button>
-            <Button size="sm" onClick={() => setCreateOpen(true)}>
-              <Plus className="mr-1.5 size-3.5" />
-              Create your first dashboard
-            </Button>
-          </div>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1.5 size-3.5" />
+            Create your first dashboard
+          </Button>
         </div>
       </div>
 
       <NewDashboardDialog
         open={createOpen}
         onOpenChange={setCreateOpen}
-        onCreated={defaultOnDashboardCreated(router)}
+        onCreated={(d) => {
+          onCreationNavigate?.();
+          defaultOnDashboardCreated(router)(d);
+        }}
       />
     </>
   );

--- a/packages/web/src/app/(workspace)/dashboards/empty-state.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/empty-state.tsx
@@ -12,9 +12,10 @@ import {
 interface DashboardsEmptyStateProps {
   /**
    * Called synchronously before the creation navigation fires, so the parent
-   * redirect-index page can stand down its own `router.replace` — the
-   * post-creation list refetch would otherwise race the `?openChat=true` push
-   * and strip the editor-open intent (#4563).
+   * redirect-index page can convert its own `router.replace` into the same
+   * intent-preserving `?openChat=true` navigation — the post-creation list
+   * refetch would otherwise race the push and strip the editor-open intent
+   * (#4563).
    */
   onCreationNavigate?: () => void;
 }

--- a/packages/web/src/app/(workspace)/dashboards/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/page.tsx
@@ -8,6 +8,7 @@ import { friendlyError } from "@/ui/lib/fetch-error";
 import { DashboardsEmptyState } from "./empty-state";
 import { DashboardListSkeleton } from "@/ui/components/dashboards/dashboard-skeleton";
 import { selectMostRecentDashboardId } from "./select-recent";
+import { OPEN_CHAT_PARAM } from "./[id]/search-params";
 import type { Dashboard } from "@/ui/lib/types";
 
 /**
@@ -42,7 +43,7 @@ export default function DashboardsPage() {
 
   // #4563 — set when the empty state navigates to a just-created board (with
   // `?openChat=true` so the bound editor opens on arrival). The post-creation
-  // list refetch flips `targetId` to that same board, and without this gate
+  // list refetch flips `targetId` to that same board, and without this flag
   // the redirect effect below would race the creation push with a plain
   // `router.replace("/dashboards/{id}")` — stripping the editor-open intent
   // before the canvas consumed it.
@@ -53,9 +54,18 @@ export default function DashboardsPage() {
       router.replace("/login?redirect=/dashboards");
       return;
     }
-    if (targetId && !creationHandoff) {
-      router.replace(`/dashboards/${targetId}`);
-    }
+    if (!targetId) return;
+    // #4563 — during a creation handoff, converge on the same
+    // intent-preserving URL the empty state pushed instead of standing down:
+    // the replace is idempotent with the push (whichever navigation lands,
+    // the canvas opens the bound editor), so the redirect can neither strip
+    // the intent nor strand the index on the skeleton if the push is
+    // superseded.
+    router.replace(
+      creationHandoff
+        ? `/dashboards/${targetId}?${OPEN_CHAT_PARAM}=true`
+        : `/dashboards/${targetId}`,
+    );
   }, [isAuthError, targetId, router, creationHandoff]);
 
   // Auth bounce, dashboard redirect, or creation handoff in flight — show the

--- a/packages/web/src/app/(workspace)/dashboards/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
@@ -40,21 +40,29 @@ export default function DashboardsPage() {
     ? selectMostRecentDashboardId(data.dashboards ?? [])
     : null;
 
+  // #4563 — set when the empty state navigates to a just-created board (with
+  // `?openChat=true` so the bound editor opens on arrival). The post-creation
+  // list refetch flips `targetId` to that same board, and without this gate
+  // the redirect effect below would race the creation push with a plain
+  // `router.replace("/dashboards/{id}")` — stripping the editor-open intent
+  // before the canvas consumed it.
+  const [creationHandoff, setCreationHandoff] = useState(false);
+
   useEffect(() => {
     if (isAuthError) {
       router.replace("/login?redirect=/dashboards");
       return;
     }
-    if (targetId) {
+    if (targetId && !creationHandoff) {
       router.replace(`/dashboards/${targetId}`);
     }
-  }, [isAuthError, targetId, router]);
+  }, [isAuthError, targetId, router, creationHandoff]);
 
-  // Auth bounce or dashboard redirect in flight — show the layout-matching
-  // skeleton (not a blank frame) so the redirect never flashes an empty screen
-  // (#4323). The empty/error chrome is still gated below so it can't flash
-  // before navigation lands.
-  if (isAuthError || targetId) return <DashboardListSkeleton />;
+  // Auth bounce, dashboard redirect, or creation handoff in flight — show the
+  // layout-matching skeleton (not a blank frame) so the redirect never flashes
+  // an empty screen (#4323). The empty/error chrome is still gated below so it
+  // can't flash before navigation lands.
+  if (isAuthError || targetId || creationHandoff) return <DashboardListSkeleton />;
 
   if (error) {
     return (
@@ -82,5 +90,9 @@ export default function DashboardsPage() {
   if (loading || !data) return <DashboardListSkeleton />;
 
   // Loaded with no dashboards.
-  return <DashboardsEmptyState />;
+  return (
+    <DashboardsEmptyState
+      onCreationNavigate={() => setCreationHandoff(true)}
+    />
+  );
 }

--- a/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
@@ -88,3 +88,48 @@ export function stubDashboardsFetch(rows: DashboardRow[]) {
     throw new Error(`Unexpected fetch: ${url}`);
   }) as typeof fetch;
 }
+
+/**
+ * Like {@link stubDashboardsFetch}, but also answers `POST /api/v1/dashboards`
+ * with the given `created` row — for the surface-native creation-navigation
+ * tests (#4563). Faithful to the real API: once the POST has fired, subsequent
+ * GETs include the created row (this is what makes the redirect-index page's
+ * post-creation refetch → `router.replace` race reproducible in tests).
+ * Returns the list of parsed POST bodies received so tests can pin the create
+ * payload.
+ */
+export function stubDashboardsFetchWithCreate(
+  rows: DashboardRow[],
+  created: DashboardRow,
+): unknown[] {
+  const createBodies: unknown[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const method =
+      init?.method ?? (input instanceof Request ? input.method : "GET");
+    if (url.endsWith("/api/v1/dashboards") && method === "POST") {
+      createBodies.push(init?.body ? JSON.parse(String(init.body)) : null);
+      return new Response(JSON.stringify(buildDashboardWireRow(created)), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.endsWith("/api/v1/dashboards")) {
+      const visible = createBodies.length > 0 ? [...rows, created] : rows;
+      return new Response(
+        JSON.stringify({
+          dashboards: visible.map(buildDashboardWireRow),
+          total: visible.length,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    throw new Error(`Unexpected fetch: ${method} ${url}`);
+  }) as typeof fetch;
+  return createBodies;
+}

--- a/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
@@ -54,7 +54,10 @@ export function buildDashboardWireRow(r: DashboardRow): Dashboard {
     description: null,
     shareToken: null,
     shareExpiresAt: null,
-    shareMode: "private",
+    // Unshared on the wire = null token + the "public" default the API emits
+    // (`share_mode ?? "public"` in lib/dashboards.ts) — "private" is not a
+    // ShareMode; typing this fixture as Dashboard is what caught that drift.
+    shareMode: "public",
     refreshSchedule: null,
     lastRefreshAt: null,
     nextRefreshAt: null,

--- a/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/_fixtures.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AtlasProvider, type AtlasAuthClient } from "@/ui/context";
+import type { Dashboard } from "@/ui/lib/types";
 
 /**
- * Shared test fixtures for the dashboards switcher / view-all modal tests.
- * Both surfaces hit the same `/api/v1/dashboards` list endpoint and need the
- * same Atlas + Query providers — keeping the stub auth client, wrapper, and
- * fetch stubber here avoids drift between the two suites.
+ * Shared test fixtures for the dashboards surface tests (switcher, view-all
+ * modal, redirect index, new-dashboard dialog). They all hit the same
+ * `/api/v1/dashboards` endpoint and need the same Atlas + Query providers —
+ * keeping the stub auth client, wrapper, and fetch stubbers here avoids drift
+ * between the suites.
  */
 
 export const stubAuthClient: AtlasAuthClient = {
@@ -42,8 +44,10 @@ export interface DashboardRow {
   cardCount: number;
 }
 
-/** Build a full Dashboard wire-shape stub from a minimal row. */
-export function buildDashboardWireRow(r: DashboardRow) {
+/** Build a full Dashboard wire-shape stub from a minimal row. Typed as the
+ *  wire type so a `Dashboard` field addition is a compile error here instead
+ *  of silent fixture drift. */
+export function buildDashboardWireRow(r: DashboardRow): Dashboard {
   return {
     id: r.id,
     title: r.title,
@@ -54,6 +58,7 @@ export function buildDashboardWireRow(r: DashboardRow) {
     refreshSchedule: null,
     lastRefreshAt: null,
     nextRefreshAt: null,
+    parameters: [],
     cardCount: r.cardCount,
     createdAt: r.updatedAt,
     updatedAt: r.updatedAt,
@@ -75,7 +80,7 @@ export function stubDashboardsFetch(rows: DashboardRow[]) {
         ? input
         : input instanceof URL
           ? input.toString()
-          : (input as Request).url;
+          : input.url;
     if (url.endsWith("/api/v1/dashboards")) {
       return new Response(
         JSON.stringify({
@@ -109,7 +114,7 @@ export function stubDashboardsFetchWithCreate(
         ? input
         : input instanceof URL
           ? input.toString()
-          : (input as Request).url;
+          : input.url;
     const method =
       init?.method ?? (input instanceof Request ? input.method : "GET");
     if (url.endsWith("/api/v1/dashboards") && method === "POST") {

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-switcher.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-switcher.test.tsx
@@ -26,7 +26,11 @@ void mock.module("next/link", () => ({
 
 import { render, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { DashboardSwitcher } from "../dashboard-switcher";
-import { dashboardsWrapper, stubDashboardsFetch } from "./_fixtures";
+import {
+  dashboardsWrapper,
+  stubDashboardsFetch,
+  stubDashboardsFetchWithCreate,
+} from "./_fixtures";
 
 const originalFetch = globalThis.fetch;
 
@@ -96,6 +100,28 @@ describe("DashboardSwitcher", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog", { name: /New dashboard/i })).toBeTruthy();
     });
+  });
+
+  // #4563 — surface-native creation: creating from the switcher lands on the
+  // new board's canvas with the bound editor open (`?openChat=true`, the same
+  // entry the main-chat `createDashboard` handoff uses).
+  test("creating from the switcher navigates to the new canvas with the bound editor open", async () => {
+    stubDashboardsFetchWithCreate(
+      [{ id: "d-1", title: "Now", updatedAt: "2026-04-25T10:00:00Z", cardCount: 0 }],
+      { id: "d-new", title: "Fresh", updatedAt: "2026-04-25T11:00:00Z", cardCount: 0 },
+    );
+
+    render(<DashboardSwitcher currentId="d-1" />, { wrapper: dashboardsWrapper });
+    openSwitcher();
+    fireEvent.click(await screen.findByRole("menuitem", { name: /New dashboard/ }));
+
+    const input = await screen.findByPlaceholderText("Dashboard title");
+    fireEvent.change(input, { target: { value: "Fresh" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(navigateCalls).toContain("/dashboards/d-new?openChat=true"),
+    );
   });
 
   test("renders an error + retry when the list fetch fails", async () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/new-dashboard-dialog.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/new-dashboard-dialog.test.tsx
@@ -52,7 +52,7 @@ describe("NewDashboardDialog", () => {
         title: "Revenue",
         updatedAt: "2026-07-16T10:00:00Z",
         cardCount: 0,
-      }) as Dashboard,
+      }),
     );
 
     expect(push).toEqual(["/dashboards/d-9?openChat=true"]);
@@ -86,6 +86,37 @@ describe("NewDashboardDialog", () => {
     // along; the editor-open intent lives in the navigation, not the create.
     expect(bodies).toEqual([{ title: "Revenue" }]);
     expect(created[0].id).toBe("d-9");
+  });
+
+  test("a failed create surfaces the error, keeps the dialog open, and never navigates", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ message: "Internal error" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+    const created: Dashboard[] = [];
+    const openChanges: boolean[] = [];
+
+    render(
+      <NewDashboardDialog
+        open
+        onOpenChange={(next) => openChanges.push(next)}
+        onCreated={(d) => created.push(d)}
+      />,
+      { wrapper: dashboardsWrapper },
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard title"), {
+      target: { value: "Revenue" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    // The server-authored message surfaces inline; the dialog stays open and
+    // onCreated never fires — a failed create must not navigate to (or set a
+    // creation handoff for) a board that doesn't exist.
+    await screen.findByText(/Internal error/);
+    expect(created).toHaveLength(0);
+    expect(openChanges).not.toContain(false);
   });
 
   test("Create stays disabled until a non-blank title is entered", () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/new-dashboard-dialog.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/new-dashboard-dialog.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, test, mock, afterEach, beforeEach } from "bun:test";
+
+const pushCalls: string[] = [];
+
+void mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: (url: string) => pushCalls.push(url),
+    replace: () => {},
+    back: () => {},
+  }),
+  usePathname: () => "/dashboards",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  redirect: () => {},
+  notFound: () => {},
+}));
+
+import { render, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  NewDashboardDialog,
+  defaultOnDashboardCreated,
+} from "../new-dashboard-dialog";
+import {
+  dashboardsWrapper,
+  buildDashboardWireRow,
+  stubDashboardsFetchWithCreate,
+} from "./_fixtures";
+import type { Dashboard } from "@/ui/lib/types";
+
+const originalFetch = globalThis.fetch;
+
+describe("NewDashboardDialog", () => {
+  beforeEach(() => {
+    pushCalls.length = 0;
+  });
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+  });
+
+  // #4563 — surface-native creation: every surface origin (switcher, list
+  // empty state, view-all modal) lands on the new board's canvas with the
+  // bound editor OPEN, via the same `?openChat=true` entry the main-chat
+  // `createDashboard` handoff uses.
+  test("defaultOnDashboardCreated navigates to the canvas with the bound editor open", () => {
+    const push: string[] = [];
+    const navigate = defaultOnDashboardCreated({ push: (u: string) => push.push(u) });
+
+    navigate(
+      buildDashboardWireRow({
+        id: "d-9",
+        title: "Revenue",
+        updatedAt: "2026-07-16T10:00:00Z",
+        cardCount: 0,
+      }) as Dashboard,
+    );
+
+    expect(push).toEqual(["/dashboards/d-9?openChat=true"]);
+  });
+
+  test("creating via the dialog POSTs the title and hands the created dashboard to onCreated", async () => {
+    const bodies = stubDashboardsFetchWithCreate([], {
+      id: "d-9",
+      title: "Revenue",
+      updatedAt: "2026-07-16T10:00:00Z",
+      cardCount: 0,
+    });
+    const created: Dashboard[] = [];
+
+    render(
+      <NewDashboardDialog
+        open
+        onOpenChange={() => {}}
+        onCreated={(d) => created.push(d)}
+      />,
+      { wrapper: dashboardsWrapper },
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard title"), {
+      target: { value: "Revenue" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(created).toHaveLength(1));
+    // The manual title-only path is exactly this payload — nothing else rides
+    // along; the editor-open intent lives in the navigation, not the create.
+    expect(bodies).toEqual([{ title: "Revenue" }]);
+    expect(created[0].id).toBe("d-9");
+  });
+
+  test("Create stays disabled until a non-blank title is entered", () => {
+    render(
+      <NewDashboardDialog open onOpenChange={() => {}} onCreated={() => {}} />,
+      { wrapper: dashboardsWrapper },
+    );
+
+    const create = screen.getByRole("button", { name: "Create" });
+    expect(create.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard title"), {
+      target: { value: "   " },
+    });
+    expect(create.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/view-all-modal.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/view-all-modal.test.tsx
@@ -26,7 +26,11 @@ void mock.module("next/link", () => ({
 
 import { render, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { ViewAllDashboardsModal } from "../view-all-modal";
-import { dashboardsWrapper, stubDashboardsFetch } from "./_fixtures";
+import {
+  dashboardsWrapper,
+  stubDashboardsFetch,
+  stubDashboardsFetchWithCreate,
+} from "./_fixtures";
 
 const originalFetch = globalThis.fetch;
 
@@ -80,6 +84,29 @@ describe("ViewAllDashboardsModal", () => {
     fireEvent.click(older);
     await waitFor(() => expect(navigateCalls).toContain("/dashboards/d-2"));
     expect(openState).toBe(false);
+  });
+
+  // #4563 — surface-native creation from the view-all modal follows the same
+  // policy as the switcher / empty state: land on the new canvas with the
+  // bound editor open.
+  test("creating from the modal navigates to the new canvas with the bound editor open", async () => {
+    stubDashboardsFetchWithCreate(
+      [{ id: "d-1", title: "Now", updatedAt: "2026-04-25T10:00:00Z", cardCount: 0 }],
+      { id: "d-new", title: "Fresh", updatedAt: "2026-04-25T11:00:00Z", cardCount: 0 },
+    );
+    render(
+      <ViewAllDashboardsModal open onOpenChange={() => {}} currentId="d-1" />,
+      { wrapper: dashboardsWrapper },
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "New" }));
+    const input = await screen.findByPlaceholderText("Dashboard title");
+    fireEvent.change(input, { target: { value: "Fresh" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(navigateCalls).toContain("/dashboards/d-new?openChat=true"),
+    );
   });
 
   test("search input only renders above the threshold", async () => {

--- a/packages/web/src/ui/components/dashboards/new-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/dashboards/new-dashboard-dialog.tsx
@@ -15,12 +15,18 @@ import {
 } from "@/components/ui/dialog";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
+import { OPEN_CHAT_PARAM } from "@/app/(workspace)/dashboards/[id]/search-params";
 import type { Dashboard } from "@/ui/lib/types";
 
 interface NewDashboardDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Dialog has no opinion about navigation — every call site supplies its own policy. */
+  /**
+   * Dialog has no opinion about navigation — every call site supplies its own
+   * policy. NB: the dialog's description copy promises the
+   * {@link defaultOnDashboardCreated} landing (canvas with the editor open,
+   * #4563) — a call site with a different landing must rethink that copy too.
+   */
   onCreated: (dashboard: Dashboard) => void;
 }
 
@@ -110,5 +116,5 @@ export function NewDashboardDialog({
 export function defaultOnDashboardCreated(
   router: Pick<ReturnType<typeof useRouter>, "push">,
 ): (d: Dashboard) => void {
-  return (d) => router.push(`/dashboards/${d.id}?openChat=true`);
+  return (d) => router.push(`/dashboards/${d.id}?${OPEN_CHAT_PARAM}=true`);
 }

--- a/packages/web/src/ui/components/dashboards/new-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/dashboards/new-dashboard-dialog.tsx
@@ -67,7 +67,8 @@ export function NewDashboardDialog({
         <DialogHeader>
           <DialogTitle>New dashboard</DialogTitle>
           <DialogDescription>
-            Pin saved query results to a new dashboard for ongoing monitoring.
+            Name your dashboard — you&rsquo;ll land on its canvas with the
+            editor open, ready to describe what you want to see.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-3 py-2">
@@ -98,8 +99,16 @@ export function NewDashboardDialog({
   );
 }
 
+/**
+ * #4563 — surface-native creation. Every surface origin (switcher, list empty
+ * state, view-all modal) lands on the new board's canvas with the bound
+ * editor OPEN, via the same `?openChat=true` entry the main-chat
+ * `createDashboard` handoff uses (#2369) — no `conversationId`, so the drawer
+ * opens a fresh session. Closing the drawer keeps a normal empty board, so
+ * the manual title-only path is unchanged.
+ */
 export function defaultOnDashboardCreated(
   router: Pick<ReturnType<typeof useRouter>, "push">,
 ): (d: Dashboard) => void {
-  return (d) => router.push(`/dashboards/${d.id}`);
+  return (d) => router.push(`/dashboards/${d.id}?openChat=true`);
 }

--- a/packages/web/src/ui/components/dashboards/view-all-modal.tsx
+++ b/packages/web/src/ui/components/dashboards/view-all-modal.tsx
@@ -29,7 +29,7 @@ import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { cn } from "@/lib/utils";
 import { sortDashboardsByRecent } from "@/app/(workspace)/dashboards/select-recent";
-import { NewDashboardDialog } from "./new-dashboard-dialog";
+import { NewDashboardDialog, defaultOnDashboardCreated } from "./new-dashboard-dialog";
 import { timeAgo } from "./time-ago";
 import type { Dashboard } from "@/ui/lib/types";
 
@@ -97,7 +97,9 @@ export function ViewAllDashboardsModal({
 
   function handleCreated(d: Dashboard) {
     onOpenChange(false);
-    router.push(`/dashboards/${d.id}`);
+    // #4563 — same surface-native policy as the switcher / empty state: land
+    // on the new canvas with the bound editor open.
+    defaultOnDashboardCreated(router)(d);
   }
 
   return (


### PR DESCRIPTION
Closes #4563. Part of v0.0.55 Dashboard Second Elevation (PRD #4553). Web-only slice.

## What

Makes the dashboards surface a first-class creation origin. "New dashboard" — from the **switcher**, the **list empty state**, and the **View all modal** — now navigates to the new board's canvas with the **bound editor open**, via the same `?openChat=true` entry the main-chat `createDashboard` handoff uses (#2369). All three origins route through one policy function (`defaultOnDashboardCreated`), with the param name shared as `OPEN_CHAT_PARAM` in `[id]/search-params.ts` so producers and the canvas consumer can't drift.

- **List empty state** rewritten around creating right there ("Create a dashboard and describe what you want to see…") — the "Go to chat" bounce is gone
- **Canvas empty state** invites building via the bound editor in place ("Describe your dashboard" opens the drawer) with a quiet hint for the manual pin-from-chat path — no "Go to chat" bounce
- **Manual title-only path unchanged**: closing the drawer keeps a normal empty board
- **Main-chat `createDashboard` handoff unchanged** (second origin)

## Race fix (caught during live verification)

`/dashboards` is a redirect-only index: the post-creation list refetch (via `useAdminMutation`'s query invalidation) flips `targetId` to the new board and the redirect effect's plain `router.replace("/dashboards/{id}")` clobbered the `?openChat=true` push before the canvas consumed it — the drawer silently didn't open. Fix: during a creation handoff the effect **converges** on the same intent-preserving URL instead of standing down, so it's idempotent with the push (can neither strip the intent nor strand the index on the skeleton). Pinned by a deterministic regression test that reproduces the refetch → effect chain mechanically.

## Tests

- `new-dashboard-dialog.test.tsx` (new): navigation policy pins `?openChat=true`; create POSTs exactly `{ title }`; failed create surfaces the error, stays open, never navigates; Create disabled on blank title
- Switcher / view-all / empty-state creation each asserted to land on `/dashboards/{id}?openChat=true`
- Redirect-race regression test (converge, no bare-URL clobber)
- `buildDashboardWireRow` now typed as `Dashboard` — immediately caught that `shareMode: "private"` was fixture fiction (wire is `"public" | "org"`, unshared = null token + `"public"`)

## Verification

- Live e2e (bun run dev + browser): empty state → create → canvas with drawer open ✓; switcher → same ✓; direct `?openChat=true` nav ✓; close drawer → plain empty board, reload does not reopen ✓; canvas "Describe your dashboard" opens drawer in place ✓
- Internal review panel: round 1 CHANGES REQUESTED → fixes applied → round 2 CLEAN
- `/ci` (scripts/ci-local.sh): all 31 gates green
- Docs: `guides/dashboards.mdx` creation section updated with each origin's actual button label