### PR TITLE
fix(api): semantic-enrich helper warnings via injected sink, not console (#4465)

### DIFF
--- a/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
@@ -217,10 +217,14 @@ void mock.module("@atlas/api/lib/semantic/sync", () => ({
   reconcileAllOrgs: async () => {},
 }));
 
-// Record warn calls so the #4465 test can assert helper warnings reach pino
-// (with request-scoped context) instead of console.
+// Record warn calls so the #4465 test can assert helper warnings ride the
+// route logger (the pino seam) with request-scoped context, not console.
+// Spread the real module so every other logger export stays intact
+// (AGENTS.md: mock.module must mock every named export).
+import * as _loggerActual from "@atlas/api/lib/logger";
 const mockLogWarn = mock((_ctx: unknown, _msg?: string) => {});
 void mock.module("@atlas/api/lib/logger", () => ({
+  ..._loggerActual,
   createLogger: () => ({ info: () => {}, warn: mockLogWarn, error: () => {}, debug: () => {} }),
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }));
@@ -413,8 +417,8 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
   });
 
   it("helper warnings during /enrich reach pino, never console (#4465)", async () => {
-    // The shared enrich helpers used to console.warn — bypassing pino, requestId
-    // correlation, and redaction on this server request path. Drive the
+    // The shared enrich helpers used to console.warn — bypassing pino and
+    // requestId correlation on this server request path. Drive the
     // unparseable-response branch and assert the warning rides the route logger.
     const consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -431,10 +435,15 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
       // No console.* fired during the request (#4465 acceptance criterion) —
       // the helper warning went through the injected pino sink instead.
       expect(consoleWarnSpy).not.toHaveBeenCalled();
-      const warned = mockLogWarn.mock.calls.some(
+      const warnCall = mockLogWarn.mock.calls.find(
         ([, msg]) => typeof msg === "string" && msg.includes("did not contain a ```yaml block"),
       );
-      expect(warned).toBe(true);
+      expect(warnCall).toBeDefined();
+      // The sink carries the request-scoped correlation context, and the route
+      // prefixes the operation name.
+      expect(warnCall?.[1]).toStartWith("Wizard enrich: ");
+      expect(warnCall?.[0]).toMatchObject({ connectionId: "analytics", tableName: "orders" });
+      expect((warnCall?.[0] as { requestId?: string }).requestId).toBeDefined();
     } finally {
       mockResponseText = ENRICH_RESPONSE;
       consoleWarnSpy.mockRestore();

--- a/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
+++ b/packages/api/src/api/__tests__/wizard-enrich-mock-llm.test.ts
@@ -21,7 +21,7 @@
  * (the real engine runs) and resolves the model through the AI test layer.
  */
 
-import { describe, expect, it, beforeEach, mock, type Mock } from "bun:test";
+import { describe, expect, it, beforeEach, mock, spyOn, type Mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { MockLanguageModelV3 } from "ai/test";
 import type { LanguageModel } from "ai";
@@ -38,9 +38,13 @@ process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test
 const ENRICH_RESPONSE =
   "```yaml\ndescription: |\n  Enriched by the mock LLM: ClickHouse orders.\nuse_cases:\n  - Analyze order volume over time\n```";
 
+// Mutable so a test can drive the unparseable-response path (#4465); reset it
+// back to ENRICH_RESPONSE in a finally.
+let mockResponseText = ENRICH_RESPONSE;
+
 const mockModel = new MockLanguageModelV3({
   doGenerate: async (_options: LanguageModelV3CallOptions) => ({
-    content: [{ type: "text" as const, text: ENRICH_RESPONSE }],
+    content: [{ type: "text" as const, text: mockResponseText }],
     finishReason: { unified: "stop" as const, raw: "end_turn" },
     usage: {
       inputTokens: { total: 50, noCache: 50, cacheRead: 0, cacheWrite: 0 },
@@ -213,8 +217,11 @@ void mock.module("@atlas/api/lib/semantic/sync", () => ({
   reconcileAllOrgs: async () => {},
 }));
 
+// Record warn calls so the #4465 test can assert helper warnings reach pino
+// (with request-scoped context) instead of console.
+const mockLogWarn = mock((_ctx: unknown, _msg?: string) => {});
 void mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+  createLogger: () => ({ info: () => {}, warn: mockLogWarn, error: () => {}, debug: () => {} }),
   withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }));
 
@@ -340,6 +347,7 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
     mockModel.doGenerateCalls.length = 0;
     mockCheckAgentBillingGate.mockClear();
     mockLogUsageEvent.mockClear();
+    mockLogWarn.mockClear();
   });
 
   it("phase 1 — mechanical generate emits entity YAML and makes NO LLM call", async () => {
@@ -402,6 +410,35 @@ describe("wizard two-phase generate via the mock-LLM test layer (#3621 AC#6, cli
     expect(llmParams[0]).toBe("org-1"); // org scope
     expect(llmParams[1]).toBe("analytics"); // install_id = the connection
     expect(JSON.parse(llmParams[3] as string)).toEqual({ tables: ["orders"] });
+  });
+
+  it("helper warnings during /enrich reach pino, never console (#4465)", async () => {
+    // The shared enrich helpers used to console.warn — bypassing pino, requestId
+    // correlation, and redaction on this server request path. Drive the
+    // unparseable-response branch and assert the warning rides the route logger.
+    const consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      mockResponseText = "Sorry, I cannot help with that.";
+      const res = await postJson("/api/v1/wizard/enrich", {
+        connectionId: "analytics",
+        tableName: "orders",
+        yaml: "table: orders\n",
+      });
+      expect(res.status).toBe(200);
+      const data = await json(res);
+      // Soft skip: the row keeps its mechanical baseline.
+      expect(data.enriched).toBe(false);
+      // No console.* fired during the request (#4465 acceptance criterion) —
+      // the helper warning went through the injected pino sink instead.
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      const warned = mockLogWarn.mock.calls.some(
+        ([, msg]) => typeof msg === "string" && msg.includes("did not contain a ```yaml block"),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      mockResponseText = ENRICH_RESPONSE;
+      consoleWarnSpy.mockRestore();
+    }
   });
 
   it("the AtlasAiModel test layer is the model source (sanity: layer resolves our mock)", async () => {

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -1007,7 +1007,9 @@ wizard.openapi(enrichRoute, async (c) => {
         // Pass dbType so the prompt emits query_patterns in the datasource's
         // dialect (PostgreSQL vs MySQL), not always PostgreSQL. The warn sink
         // routes the engine's YAML-helper warnings through pino (#4465) —
-        // request-correlated and redacted, instead of raw console on a server path.
+        // request-correlated structured logging instead of raw console on a
+        // server path. (Pino redaction covers fields, not the msg string —
+        // don't route secret-bearing text through this sink.)
         const enriched = await enrichEntityYaml(baselineYaml, profile, model, undefined, dbType, (message) =>
           log.warn({ requestId, connectionId, tableName }, `Wizard enrich: ${message}`),
         );

--- a/packages/api/src/api/routes/wizard.ts
+++ b/packages/api/src/api/routes/wizard.ts
@@ -1005,8 +1005,12 @@ wizard.openapi(enrichRoute, async (c) => {
           return { error: "no_profile" as const };
         }
         // Pass dbType so the prompt emits query_patterns in the datasource's
-        // dialect (PostgreSQL vs MySQL), not always PostgreSQL.
-        const enriched = await enrichEntityYaml(baselineYaml, profile, model, undefined, dbType);
+        // dialect (PostgreSQL vs MySQL), not always PostgreSQL. The warn sink
+        // routes the engine's YAML-helper warnings through pino (#4465) —
+        // request-correlated and redacted, instead of raw console on a server path.
+        const enriched = await enrichEntityYaml(baselineYaml, profile, model, undefined, dbType, (message) =>
+          log.warn({ requestId, connectionId, tableName }, `Wizard enrich: ${message}`),
+        );
         return { ok: true as const, enriched };
       },
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),

--- a/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
@@ -275,6 +275,62 @@ describe("enrichEntityYaml (in-memory primitive, #3236)", () => {
     // The display name still flows through for the "valid <dialect>" instruction.
     expect(prompt).toContain("valid Sparksql");
   });
+
+  // #4465 — the shared YAML helpers must not console.warn on the server path:
+  // the wizard route injects a pino-backed sink so warnings carry requestId and
+  // go through redaction. The CLI path passes no sink and keeps console output.
+  describe("warning sink injection (#4465)", () => {
+    it("routes the missing-yaml-block warning through the injected sink, not console", async () => {
+      mockGenerateText.mockImplementationOnce(async () => ({
+        text: "Sorry, I cannot help with that.",
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      }));
+      const warnings: string[] = [];
+      const { enriched } = await enrichEntityYaml(
+        ENTITY_YAML,
+        ordersProfile,
+        { modelId: "x" } as never,
+        undefined,
+        undefined,
+        (message) => warnings.push(message),
+      );
+      expect(enriched).toBe(false);
+      expect(warnings.some((m) => m.includes("did not contain a ```yaml block"))).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("routes the YAML-parse-error warning through the injected sink, not console", async () => {
+      // A fenced block whose body throws in the YAML parser (unclosed flow seq).
+      mockGenerateText.mockImplementationOnce(async () => ({
+        text: "```yaml\nfoo: [unclosed\n```",
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      }));
+      const warnings: string[] = [];
+      const { enriched } = await enrichEntityYaml(
+        ENTITY_YAML,
+        ordersProfile,
+        { modelId: "x" } as never,
+        undefined,
+        undefined,
+        (message) => warnings.push(message),
+      );
+      expect(enriched).toBe(false);
+      expect(warnings.some((m) => m.includes("YAML parse error"))).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("defaults to console.warn with the pre-#4465 CLI formatting when no sink is given", async () => {
+      mockGenerateText.mockImplementationOnce(async () => ({
+        text: "Sorry, I cannot help with that.",
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      }));
+      await enrichEntityYaml(ENTITY_YAML, ordersProfile, { modelId: "x" } as never);
+      // Byte-identical to the old CLI output: 4-space indent + "Note: " prefix.
+      expect(warnSpy).toHaveBeenCalledWith(
+        "    Note: LLM response did not contain a ```yaml block, attempting to parse raw response",
+      );
+    });
+  });
 });
 
 describe("enrichEntity (per-table primitive)", () => {

--- a/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/enrich-engine.test.ts
@@ -277,8 +277,8 @@ describe("enrichEntityYaml (in-memory primitive, #3236)", () => {
   });
 
   // #4465 — the shared YAML helpers must not console.warn on the server path:
-  // the wizard route injects a pino-backed sink so warnings carry requestId and
-  // go through redaction. The CLI path passes no sink and keeps console output.
+  // the wizard route injects a pino-backed sink so warnings carry requestId
+  // context. The CLI path passes no sink and keeps console output.
   describe("warning sink injection (#4465)", () => {
     it("routes the missing-yaml-block warning through the injected sink, not console", async () => {
       mockGenerateText.mockImplementationOnce(async () => ({

--- a/packages/api/src/lib/semantic/enrich/index.ts
+++ b/packages/api/src/lib/semantic/enrich/index.ts
@@ -52,8 +52,8 @@ function addUsage(accumulator: TokenUsage, usage: Partial<TokenUsage>): void {
  * Warning sink for the shared YAML helpers (#4465). These helpers run on BOTH
  * the CLI (`atlas init --enrich`, where console output is the UX) and a server
  * request path (the wizard `/enrich` route), so they must never write to
- * console directly — the API caller injects a pino-backed sink to keep
- * requestId correlation and redaction; the CLI keeps the console default.
+ * console directly — the API caller injects a pino-backed sink for requestId
+ * correlation and structured logging; the CLI keeps the console default.
  */
 export type EnrichWarnSink = (message: string) => void;
 
@@ -435,6 +435,8 @@ Important:
 
     addUsage(usage, result.usage);
 
+    // CLI-only path (reachable only via enrichSemanticLayer) — console IS the
+    // UX here; a future server caller must thread a sink like enrichEntityYaml (#4465).
     const yamlText = extractYamlBlock(result.text, consoleWarnSink);
     const enriched = safeParse(yamlText, consoleWarnSink);
 
@@ -544,6 +546,8 @@ Important:
 
     addUsage(usage, result.usage);
 
+    // CLI-only path (reachable only via enrichSemanticLayer) — console IS the
+    // UX here; a future server caller must thread a sink like enrichEntityYaml (#4465).
     const yamlText = extractYamlBlock(result.text, consoleWarnSink);
     const enriched = safeParse(yamlText, consoleWarnSink);
 

--- a/packages/api/src/lib/semantic/enrich/index.ts
+++ b/packages/api/src/lib/semantic/enrich/index.ts
@@ -49,10 +49,22 @@ function addUsage(accumulator: TokenUsage, usage: Partial<TokenUsage>): void {
 // ---------------------------------------------------------------------------
 
 /**
+ * Warning sink for the shared YAML helpers (#4465). These helpers run on BOTH
+ * the CLI (`atlas init --enrich`, where console output is the UX) and a server
+ * request path (the wizard `/enrich` route), so they must never write to
+ * console directly — the API caller injects a pino-backed sink to keep
+ * requestId correlation and redaction; the CLI keeps the console default.
+ */
+export type EnrichWarnSink = (message: string) => void;
+
+/** Default sink — the CLI's console UX (byte-identical to the pre-#4465 output). */
+const consoleWarnSink: EnrichWarnSink = (message) => console.warn(`    ${message}`);
+
+/**
  * Extract YAML content from an LLM response that wraps output in
  * ```yaml ... ``` code blocks.
  */
-function extractYamlBlock(text: string): string {
+function extractYamlBlock(text: string, warn: EnrichWarnSink): string {
   // Match ```yaml or ```yml fenced blocks
   const match = text.match(/```ya?ml[ \t]*\r?\n([\s\S]*?)```/);
   if (match) return match[1].trim();
@@ -62,14 +74,14 @@ function extractYamlBlock(text: string): string {
   if (generic) return generic[1].trim();
 
   // Last resort: try to parse the whole response as YAML
-  console.warn("    Note: LLM response did not contain a ```yaml block, attempting to parse raw response");
+  warn("Note: LLM response did not contain a ```yaml block, attempting to parse raw response");
   return text.trim();
 }
 
 /**
  * Safely parse YAML, returning null on failure.
  */
-function safeParse(text: string): Record<string, unknown> | null {
+function safeParse(text: string, warn: EnrichWarnSink): Record<string, unknown> | null {
   try {
     const parsed = loadYaml(text);
     if (parsed && typeof parsed === "object") {
@@ -77,7 +89,7 @@ function safeParse(text: string): Record<string, unknown> | null {
     }
     return null;
   } catch (err) {
-    console.warn(`    YAML parse error: ${err instanceof Error ? err.message : String(err)}`);
+    warn(`YAML parse error: ${err instanceof Error ? err.message : String(err)}`);
     return null;
   }
 }
@@ -220,7 +232,10 @@ export async function enrichEntityYaml(
   profile: TableProfile,
   model: ReturnType<typeof getModel>,
   usage?: TokenUsage,
-  dbType?: string
+  dbType?: string,
+  // #4465 — API callers inject a request-scoped pino sink; the default keeps
+  // the CLI's console output.
+  warn: EnrichWarnSink = consoleWarnSink
 ): Promise<EnrichEntityYamlResult> {
   const profileText = formatTableProfile(profile);
   // The generated query_patterns are saved into the semantic layer for THIS
@@ -304,8 +319,8 @@ Important:
     outputTokens: result.usage.outputTokens ?? 0,
   };
 
-  const yamlText = extractYamlBlock(result.text);
-  const enriched = safeParse(yamlText);
+  const yamlText = extractYamlBlock(result.text, warn);
+  const enriched = safeParse(yamlText, warn);
 
   if (!enriched) {
     // Successful call, unusable response — keep the mechanical baseline.
@@ -420,8 +435,8 @@ Important:
 
     addUsage(usage, result.usage);
 
-    const yamlText = extractYamlBlock(result.text);
-    const enriched = safeParse(yamlText);
+    const yamlText = extractYamlBlock(result.text, consoleWarnSink);
+    const enriched = safeParse(yamlText, consoleWarnSink);
 
     if (!enriched) {
       console.log("    Warning: Could not parse LLM response for glossary, skipping merge");
@@ -529,8 +544,8 @@ Important:
 
     addUsage(usage, result.usage);
 
-    const yamlText = extractYamlBlock(result.text);
-    const enriched = safeParse(yamlText);
+    const yamlText = extractYamlBlock(result.text, consoleWarnSink);
+    const enriched = safeParse(yamlText, consoleWarnSink);
 
     if (!enriched) {
       console.log(`    Warning: Could not parse LLM response for ${fileName}, skipping merge`);


### PR DESCRIPTION
## Summary
- `extractYamlBlock`/`safeParse` in the shared enrich engine called `console.warn` directly; on the wizard `/enrich` server path that bypassed pino — no requestId correlation, wrong stream/format for log aggregation
- The helpers now take an `EnrichWarnSink`; `enrichEntityYaml` threads an optional sink param whose default preserves the CLI's console output byte-identically, and the wizard route injects a request-scoped `log.warn({ requestId, connectionId, tableName }, ...)`
- CLI-only call sites (`enrichGlossary`/`enrichMetric`) keep the console sink explicitly, with signpost comments that a future server caller must thread a sink

## Test plan
- [x] `enrich-engine.test.ts`: both warning branches (missing yaml fence, YAML parse error) reach the injected sink and `console.warn` stays silent; the no-sink default keeps the pre-change CLI output byte-identical
- [x] `wizard-enrich-mock-llm.test.ts`: driving `/enrich` with an unparseable LLM response returns 200 + `enriched: false`, fires no `console.warn`, and the route logger receives the warning with `requestId`/`connectionId`/`tableName` and the `Wizard enrich: ` prefix
- [x] Local `/ci`: all 31 gates green (type, lint, lint-type-aware, full isolated test suite, drift gates)

## Review notes
Internal review panel (4 specialists) ran pre-PR: verdict CLEAN, advisories applied inline (comment accuracy on pino redaction scope, logger mock-all-exports, tighter pino assertions). Declined: collapsing `enrichEntityYaml`'s trailing optionals into an options object — advisory-only, ~15 call-site churn, and positional style matches the existing file idiom.

Closes #4465