### PR TITLE
fix(api): run the stale region-migration reaper on a periodic fiber (#4459)

### DIFF
--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -236,7 +236,7 @@ residency: {
 
 ### Automatic recovery from a crashed migration
 
-A migrating workspace is write-locked while its migration row is `in_progress`. If the API process crashes mid-migration, a background reaper fails the stuck row automatically: any migration `in_progress` for longer than **5 minutes** is marked `failed` (with a `stale_timeout` audit event), which releases the workspace write-lock. The reaper sweeps every minute, so the worst-case lock window after a crash is about 6 minutes — no operator action is required. The failed migration can then be retried with the retry endpoint below.
+A migrating workspace is write-locked while its migration row is `in_progress`. If the API process crashes mid-migration, a background reaper fails the stuck row automatically: any migration still `in_progress` more than **5 minutes** after it was requested is marked `failed` (with a `region_migration_failed` audit log entry, reason `stale_timeout`), which releases the workspace write-lock. The reaper sweeps every minute, so the worst-case lock window after a crash is about 6 minutes — no operator action is required. The failed migration can then be retried with the retry endpoint below; the retry restarts the staleness clock, so a retried migration gets the full window again.
 
 ### Retry and cancel
 

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -234,6 +234,10 @@ residency: {
 }
 ```
 
+### Automatic recovery from a crashed migration
+
+A migrating workspace is write-locked while its migration row is `in_progress`. If the API process crashes mid-migration, a background reaper fails the stuck row automatically: any migration `in_progress` for longer than **5 minutes** is marked `failed` (with a `stale_timeout` audit event), which releases the workspace write-lock. The reaper sweeps every minute, so the worst-case lock window after a crash is about 6 minutes — no operator action is required. The failed migration can then be retried with the retry endpoint below.
+
 ### Retry and cancel
 
 Failed migrations can be retried. Pending migrations can be cancelled:

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -236,7 +236,7 @@ residency: {
 
 ### Automatic recovery from a crashed migration
 
-A migrating workspace is write-locked while its migration row is `in_progress`. If the API process crashes mid-migration, a background reaper fails the stuck row automatically: any migration still `in_progress` more than **5 minutes** after it was requested is marked `failed` (with a `region_migration_failed` audit log entry, reason `stale_timeout`), which releases the workspace write-lock. The reaper sweeps every minute, so the worst-case lock window after a crash is about 6 minutes — no operator action is required. The failed migration can then be retried with the retry endpoint below; the retry restarts the staleness clock, so a retried migration gets the full window again.
+A migrating workspace is write-locked while its migration row is `in_progress`. If the API process crashes mid-migration, a background reaper fails the stuck row automatically: any migration still `in_progress` more than **5 minutes** after it was requested is marked `failed` (with a `region_migration_failed` audit event in the service logs, reason `stale_timeout`), which releases the workspace write-lock. The reaper sweeps every minute, so the worst-case lock window after a crash is about 6 minutes — no operator action is required. The failed migration can then be retried with the retry endpoint below; the retry restarts the staleness clock, so a retried migration gets the full window again.
 
 ### Retry and cancel
 

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -628,6 +628,13 @@ let mockResetThrow: Error | null = null;
 void mock.module("@atlas/api/lib/residency/migrate", () => ({
   triggerMigrationExecution: () => {},
   failStaleMigrations: () => Promise.resolve({ found: 0, reaped: 0 }),
+  // Mock ALL named exports — an unmocked name throws "Export named X not
+  // found" the moment a new import lands (known partial-mock failure class).
+  executeRegionMigration: () =>
+    Promise.resolve({ success: true, migrationId: "mig-mock" }),
+  getCleanupDueMigrations: () => Promise.resolve([]),
+  STALE_THRESHOLD_MS: 5 * 60 * 1000,
+  STALE_MIGRATION_REAP_INTERVAL_MS: 60 * 1000,
   resetMigrationForRetry: () => {
     if (mockResetThrow) return Promise.reject(mockResetThrow);
     return Promise.resolve(mockResetResult);

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -627,7 +627,7 @@ let mockResetThrow: Error | null = null;
 
 void mock.module("@atlas/api/lib/residency/migrate", () => ({
   triggerMigrationExecution: () => {},
-  failStaleMigrations: () => Promise.resolve(0),
+  failStaleMigrations: () => Promise.resolve({ found: 0, reaped: 0 }),
   resetMigrationForRetry: () => {
     if (mockResetThrow) return Promise.reject(mockResetThrow);
     return Promise.resolve(mockResetResult);

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -758,7 +758,10 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
       // Trigger background execution (Phase 2)
       scheduleMigrationExecution(migrationId, requestId);
 
-      // Also check for stale migrations while we're here
+      // Opportunistic stale-migration check for instant recovery at request
+      // time. The bounded-window guarantee lives on the
+      // `region_migration_stale_reap` periodic fiber (#4459, effect/layers.ts)
+      // — this call is belt-and-braces, not the recovery path.
       failStaleMigrations().catch((err) => {
         log.warn({ err: err instanceof Error ? err.message : String(err) }, "Stale migration check failed");
       });

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -436,6 +436,7 @@ describe("makeSchedulerLive", () => {
         "share_token_cleanup",
         "orphan_task_reconcile",
         "agent_runs_retention_sweep",
+        "region_migration_stale_reap",
       ],
     },
     {
@@ -728,6 +729,30 @@ describe("makeSchedulerLive", () => {
       // ...and the memory sweep must come first in source order (the tick runs
       // its yields sequentially, so source order is execution order).
       expect(memoryIdx).toBeLessThan(terminalIdx);
+    });
+  });
+
+  // ── region_migration_stale_reap tick body (#4459) ─────────────────────────
+  // The registration wiring guard above proves a `name:
+  // "region_migration_stale_reap"` registration exists, but not that its tick
+  // actually invokes the reaper — a refactor could leave the fiber ticking a
+  // no-op while a crashed migration keeps the workspace write-locked forever
+  // (the exact regression #4459 fixed: the reaper used to run ONLY when an
+  // admin happened to request another migration). Same structural source-scan
+  // pattern as the #3757 sweep-order guard.
+  describe("region_migration_stale_reap tick invokes failStaleMigrations (#4459)", () => {
+    test("the tick body references failStaleMigrations", () => {
+      const registrationIdx = layersSource.indexOf(
+        'name: "region_migration_stale_reap"',
+      );
+      expect(registrationIdx).toBeGreaterThan(-1);
+      // The reaper call must appear inside the registration block (the next
+      // ~2000 chars is generous for one registerPeriodicFiber spec literal).
+      const registrationBlock = layersSource.slice(
+        registrationIdx,
+        registrationIdx + 2000,
+      );
+      expect(registrationBlock).toContain("failStaleMigrations");
     });
   });
 });

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -535,7 +535,7 @@ describe("makeSchedulerLive", () => {
       expect(layersSource).toMatch(/SCHEDULER_SPAN_NAMES\[spec\.name\]/);
       // The helper has two spanning branches (spanResultAttributes inverts
       // the recovery ordering); de-spanning either one — e.g. the default
-      // branch that serves 19 of 21 fibers — must fail here, not just the
+      // branch that serves most fibers — must fail here, not just the
       // rarely-exercised attribute branch.
       expect(layersSource.match(/withEffectSpan\s*\(\s*span\b/g) ?? []).toHaveLength(2);
     });
@@ -747,11 +747,12 @@ describe("makeSchedulerLive", () => {
         'name: "region_migration_stale_reap"',
       );
       expect(registrationIdx).toBeGreaterThan(-1);
-      // The reaper call must appear inside the registration block (the next
-      // ~2000 chars is generous for one registerPeriodicFiber spec literal).
+      // The reaper call must appear inside the registration block (the spec
+      // literal runs ~1,900 chars from the anchor; 3000 leaves headroom for
+      // comment growth without reaching the next registration).
       const registrationBlock = layersSource.slice(
         registrationIdx,
-        registrationIdx + 2000,
+        registrationIdx + 3000,
       );
       expect(registrationBlock).toContain("failStaleMigrations");
     });
@@ -767,7 +768,7 @@ describe("makeSchedulerLive", () => {
       );
       const registrationBlock = layersSource.slice(
         registrationIdx,
-        registrationIdx + 2000,
+        registrationIdx + 3000,
       );
       expect(registrationBlock).toContain("STALE_MIGRATION_REAP_INTERVAL_MS");
     });

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -418,9 +418,10 @@ describe("makeSchedulerLive", () => {
     {
       // Cleanup/sweep fibers. Eight were retrofitted by #2945;
       // `orphan_task_reconcile` (#2944) shipped with its span and attaches
-      // the orphan count as a result attribute (one of the two
-      // `spanResultAttributes` fibers — the other is `unclaimed_grace_reap`
-      // in the work record, #3796).
+      // the orphan count as a result attribute, as does
+      // `region_migration_stale_reap` (#4459, stale-found/reaped counts);
+      // the work record adds `unclaimed_grace_reap` (#3796) and the three
+      // #4195 DB/refresh jobs.
       constName: "SCHEDULER_CLEANUP_SPAN_NAMES",
       record: SCHEDULER_CLEANUP_SPAN_NAMES as Record<string, string>,
       expectedKeys: [
@@ -753,6 +754,22 @@ describe("makeSchedulerLive", () => {
         registrationIdx + 2000,
       );
       expect(registrationBlock).toContain("failStaleMigrations");
+    });
+
+    test("the cadence is wired to STALE_MIGRATION_REAP_INTERVAL_MS", () => {
+      // The bounded-window guarantee (unlock ≤ threshold + one interval) is
+      // pinned in migrate.test.ts against the CONSTANT — this ties the fiber
+      // to that constant, so a re-hardcoded interval (e.g. hourly) can't
+      // silently void the guarantee while the invariant test stays green.
+      // Same shape as the #4130 settings-backed cadence guard above.
+      const registrationIdx = layersSource.indexOf(
+        'name: "region_migration_stale_reap"',
+      );
+      const registrationBlock = layersSource.slice(
+        registrationIdx,
+        registrationIdx + 2000,
+      );
+      expect(registrationBlock).toContain("STALE_MIGRATION_REAP_INTERVAL_MS");
     });
   });
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -177,7 +177,7 @@ function withFiberDeathLog<A, E, R>(
 //
 // Membership splits into two single-source records, by fiber kind:
 //
-//   • SCHEDULER_CLEANUP_SPAN_NAMES — 12 cleanup/sweep fibers (they evict
+//   • SCHEDULER_CLEANUP_SPAN_NAMES — 13 cleanup/sweep fibers (they evict
 //     expired in-memory or DB state). Eight were retrofitted with a span by
 //     #2945 (the TTL/ratelimit/state sweeps below); the ninth,
 //     `orphan_task_reconcile` (#2944), shipped with its span from day one and
@@ -192,6 +192,11 @@ function withFiberDeathLog<A, E, R>(
 //     durable-session runs past the retention window. The twelfth,
 //     `region_probe_rate_sweep` (#3973, ADR-0024 §3), evicts expired per-IP
 //     buckets from the login front-door's hashed-email existence-probe limiter.
+//     The thirteenth, `region_migration_stale_reap` (#4459, ADR-0024), fails
+//     region migrations stuck `in_progress` past the stale threshold so a
+//     crashed migration releases its workspace write-lock without waiting for
+//     an admin to request another migration (it attaches the reaped count as
+//     a result attribute, like `orphan_task_reconcile`).
 //
 //   • SCHEDULER_WORK_SPAN_NAMES — background-work fibers (they perform
 //     recurring side-effecting work rather than evicting state):
@@ -249,6 +254,7 @@ export const SCHEDULER_CLEANUP_SPAN_NAMES = {
   share_token_cleanup: "atlas.scheduler.share_token_cleanup",
   orphan_task_reconcile: "atlas.scheduler.orphan_task_reconcile",
   agent_runs_retention_sweep: "atlas.scheduler.agent_runs_retention_sweep",
+  region_migration_stale_reap: "atlas.scheduler.region_migration_stale_reap",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // Per-tick spans for the background-work fibers (#2987). Same wrap shape and
@@ -2526,6 +2532,61 @@ export function makeSchedulerLive(
           message: "agent_runs retention sweep tick failed",
           viaCause: true,
         },
+      });
+
+      // ── Periodic fiber: stale region-migration reaper (#4459, ADR-0024) ──
+      // Fails `region_migrations` rows stuck `in_progress` past the stale
+      // threshold. A migrating workspace is write-locked
+      // (`isWorkspaceMigrating`), so if the API process crashes mid-migration
+      // the lock would otherwise persist until an admin happened to request
+      // ANOTHER migration — previously the only call site of
+      // `failStaleMigrations` (the request route still calls it
+      // opportunistically for instant recovery at request time; this fiber is
+      // the bounded-window guarantee). Cadence ≤ threshold, pinned by
+      // `migrate.test.ts`, so the worst-case unlock window is threshold + one
+      // interval (~6 min) with no operator action. Gated on an internal DB —
+      // without one there are no `region_migrations` rows to reap.
+      //
+      // Error ordering: `spanResultAttributes` attaches the reaped count, so
+      // the span wraps the RAW tick (a failed tick records ERROR, not a
+      // status-OK span with a fabricated zero) and loop-liveness recovery is
+      // applied OUTSIDE it — the orphan_task_reconcile pattern.
+      yield* registerPeriodicFiber({
+        name: "region_migration_stale_reap",
+        intervalMs: () => {
+          // oxlint-disable-next-line @typescript-eslint/no-require-imports -- read the interval constant synchronously at build time (same pattern as orphan_task_reconcile)
+          const { STALE_MIGRATION_REAP_INTERVAL_MS } = require("@atlas/api/lib/residency/migrate") as {
+            STALE_MIGRATION_REAP_INTERVAL_MS: number;
+          };
+          return STALE_MIGRATION_REAP_INTERVAL_MS;
+        },
+        gate: {
+          check: () => {
+            // oxlint-disable-next-line @typescript-eslint/no-require-imports -- sync gate check at layer build time; dynamic import would force the whole gen async for a boolean
+            const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+              hasInternalDB: () => boolean;
+            };
+            return hasInternalDB();
+          },
+          skipLog: "No internal database — stale region-migration reaper not started",
+        },
+        tick: Effect.tryPromise({
+          try: async () => {
+            const { failStaleMigrations } = await import(
+              "@atlas/api/lib/residency/migrate"
+            );
+            return failStaleMigrations();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }),
+        spanResultAttributes: (failedCount) => ({
+          "atlas.region_migration.stale_failed": failedCount,
+        }),
+        onTickFailure: {
+          level: "warn",
+          message: "Stale region-migration reap tick failed — will retry next interval",
+        },
+        startLog: "Stale region-migration reaper started",
       });
 
       // ── Periodic fiber: orphan plugin-task reconcile (#2944) — hourly ──

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -169,7 +169,8 @@ function withFiberDeathLog<A, E, R>(
 // error itself goes to `log.warn`). These spans answer "is the fiber still
 // ticking?" via presence/absence + cadence, NOT "did this tick error?". The
 // exceptions are the `spanResultAttributes` fibers — `orphan_task_reconcile`
-// (#2944), `unclaimed_grace_reap` (#3796), and the three #4195 DB/refresh jobs
+// (#2944), `unclaimed_grace_reap` (#3796), `region_migration_stale_reap`
+// (#4459), and the three #4195 DB/refresh jobs
 // (`byot_catalog_refresh`, `openapi_spec_refresh`, `openapi_install_rediscover`)
 // — which deliberately invert the ordering (raw tick spanned, recovery applied
 // OUTSIDE) to keep their result attributes truthful; see `registerPeriodicFiber`
@@ -181,8 +182,9 @@ function withFiberDeathLog<A, E, R>(
 //     expired in-memory or DB state). Eight were retrofitted with a span by
 //     #2945 (the TTL/ratelimit/state sweeps below); the ninth,
 //     `orphan_task_reconcile` (#2944), shipped with its span from day one and
-//     additionally attaches the orphan count as a result attribute (the sole
-//     `spanResultAttributes` fiber in THIS record — the work record adds
+//     additionally attaches the orphan count as a result attribute (one of
+//     two `spanResultAttributes` fibers in THIS record, with
+//     `region_migration_stale_reap` — the work record adds
 //     `unclaimed_grace_reap` plus the three #4195 DB/refresh jobs; the
 //     scheduler engine uses that 4th arg elsewhere, inside its own module).
 //     The tenth,
@@ -195,8 +197,8 @@ function withFiberDeathLog<A, E, R>(
 //     The thirteenth, `region_migration_stale_reap` (#4459, ADR-0024), fails
 //     region migrations stuck `in_progress` past the stale threshold so a
 //     crashed migration releases its workspace write-lock without waiting for
-//     an admin to request another migration (it attaches the reaped count as
-//     a result attribute, like `orphan_task_reconcile`).
+//     an admin to request another migration (it attaches the stale-found and
+//     reaped counts as result attributes, like `orphan_task_reconcile`).
 //
 //   • SCHEDULER_WORK_SPAN_NAMES — background-work fibers (they perform
 //     recurring side-effecting work rather than evicting state):
@@ -2536,7 +2538,9 @@ export function makeSchedulerLive(
 
       // ── Periodic fiber: stale region-migration reaper (#4459, ADR-0024) ──
       // Fails `region_migrations` rows stuck `in_progress` past the stale
-      // threshold. A migrating workspace is write-locked
+      // threshold (anchored to `requested_at` — no started_at column — so the
+      // retry reset refreshes it; see `resetMigrationForRetry`). A migrating
+      // workspace is write-locked
       // (`isWorkspaceMigrating`), so if the API process crashes mid-migration
       // the lock would otherwise persist until an admin happened to request
       // ANOTHER migration — previously the only call site of
@@ -2568,6 +2572,8 @@ export function makeSchedulerLive(
             };
             return hasInternalDB();
           },
+          failLog:
+            "Stale region-migration reaper gate check failed — crashed migrations will NOT auto-unlock",
           skipLog: "No internal database — stale region-migration reaper not started",
         },
         tick: Effect.tryPromise({
@@ -2575,12 +2581,15 @@ export function makeSchedulerLive(
             const { failStaleMigrations } = await import(
               "@atlas/api/lib/residency/migrate"
             );
+            // Throws when stale rows were found but NONE could be reaped —
+            // that tick must surface as span ERROR + warn, not a quiet zero.
             return failStaleMigrations();
           },
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
         }),
-        spanResultAttributes: (failedCount) => ({
-          "atlas.region_migration.stale_failed": failedCount,
+        spanResultAttributes: (result) => ({
+          "atlas.region_migration.stale_found": result.found,
+          "atlas.region_migration.stale_reaped": result.reaped,
         }),
         onTickFailure: {
           level: "warn",
@@ -2593,8 +2602,8 @@ export function makeSchedulerLive(
       // Counts `scheduled_tasks` whose `plugin_id` has no live
       // `workspace_plugins` row — the residue a non-atomic plugin uninstall
       // leaves when the post-DELETE task cleanup fails. The count rides the
-      // per-tick span as a result attribute (the only one of these cleanup
-      // fibers that attaches one), so an operator querying traces sees orphan
+      // per-tick span as a result attribute (one of two cleanup fibers that
+      // attach one — see `region_migration_stale_reap` above), so an operator querying traces sees orphan
       // accumulation; a `log.warn` fires on the same tick when > 0. The
       // destructive sweep is gated behind `ATLAS_ORPHAN_TASK_RECONCILE`
       // (default off — measure-only); the module no-ops when the internal DB

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -14,7 +14,9 @@ let mockQueryResults: Record<string, unknown[]> = {};
 // Per-SQL injection: when set, internalQuery rejects on the first call whose
 // SQL contains the pattern. Used to exercise transient-failure paths on a
 // specific statement without breaking unrelated queries.
-let mockInternalQueryRejectPattern: { pattern: string; error: Error } | null = null;
+// `times` limits how many matching calls reject (undefined = every match) —
+// lets a test poison only the FIRST of several identical UPDATEs (#4459).
+let mockInternalQueryRejectPattern: { pattern: string; error: Error; times?: number } | null = null;
 let mockPoolQueryResult = { rows: [{ id: "org-1" }] };
 let mockPoolQueryError: Error | null = null;
 const capturedQueries: Array<{ sql: string; params: unknown[] }> = [];
@@ -39,7 +41,12 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   internalQuery: (sql: string, params: unknown[]) => {
     capturedQueries.push({ sql, params });
     if (mockInternalQueryRejectPattern && sql.includes(mockInternalQueryRejectPattern.pattern)) {
-      return Promise.reject(mockInternalQueryRejectPattern.error);
+      const reject = mockInternalQueryRejectPattern;
+      if (reject.times === undefined) return Promise.reject(reject.error);
+      if (reject.times > 0) {
+        reject.times--;
+        return Promise.reject(reject.error);
+      }
     }
     // Match query to result based on SQL pattern
     for (const [key, value] of Object.entries(mockQueryResults)) {
@@ -432,15 +439,15 @@ describe("failStaleMigrations", () => {
     );
   });
 
-  it("returns 0 when internal DB is not available", async () => {
+  it("returns zero counts when internal DB is not available", async () => {
     mockHasInternalDB = false;
-    const count = await failStaleMigrations();
-    expect(count).toBe(0);
+    const result = await failStaleMigrations();
+    expect(result).toEqual({ found: 0, reaped: 0 });
   });
 
-  it("returns 0 when no stale migrations exist", async () => {
-    const count = await failStaleMigrations();
-    expect(count).toBe(0);
+  it("returns zero counts when no stale migrations exist", async () => {
+    const result = await failStaleMigrations();
+    expect(result).toEqual({ found: 0, reaped: 0 });
   });
 
   it("fails stale migrations", async () => {
@@ -449,13 +456,51 @@ describe("failStaleMigrations", () => {
     ];
     mockQueryResults["UPDATE region_migrations"] = [];
 
-    const count = await failStaleMigrations();
-    expect(count).toBe(1);
+    const result = await failStaleMigrations();
+    expect(result).toEqual({ found: 1, reaped: 1 });
 
     const failedUpdate = capturedQueries.find(
       (q) => q.sql.includes("UPDATE region_migrations") && q.params.includes("failed"),
     );
     expect(failedUpdate).toBeDefined();
+  });
+
+  // #4459 — one poisoned row must not block reaping the rest: the loop logs
+  // the per-row failure and continues, so one stuck migration can't keep
+  // every OTHER crashed workspace write-locked.
+  it("continues past a row whose UPDATE fails and reaps the rest", async () => {
+    mockQueryResults["status = 'in_progress'"] = [
+      { id: "mig-stale-1", workspace_id: "org-1" },
+      { id: "mig-stale-2", workspace_id: "org-2" },
+    ];
+    mockInternalQueryRejectPattern = {
+      pattern: "UPDATE region_migrations",
+      error: new Error("permission denied"),
+      times: 1,
+    };
+
+    const result = await failStaleMigrations();
+    expect(result).toEqual({ found: 2, reaped: 1 });
+
+    const attemptedUpdates = capturedQueries.filter(
+      (q) => q.sql.includes("UPDATE region_migrations") && q.params.includes("failed"),
+    );
+    expect(attemptedUpdates).toHaveLength(2);
+  });
+
+  // #4459 — stale rows found but NONE reapable is a failure, not a quiet
+  // zero: the periodic fiber's tick must reject so the span records ERROR
+  // and the warn-log recovery path fires (the workspace is still locked).
+  it("throws when stale rows are found but none can be marked failed", async () => {
+    mockQueryResults["status = 'in_progress'"] = [
+      { id: "mig-stale", workspace_id: "org-1" },
+    ];
+    mockInternalQueryRejectPattern = {
+      pattern: "UPDATE region_migrations",
+      error: new Error("permission denied"),
+    };
+
+    await expect(failStaleMigrations()).rejects.toThrow(/remain write-locked/);
   });
 });
 
@@ -539,6 +584,11 @@ describe("resetMigrationForRetry", () => {
       (q) => q.sql.includes("status = 'pending'"),
     );
     expect(resetQuery).toBeDefined();
+    // #4459 — the reset must restart the staleness clock: failStaleMigrations
+    // anchors its threshold to requested_at, and the reaper now sweeps every
+    // minute, so a retry that kept the ORIGINAL requested_at would re-enter
+    // in_progress already stale and be killed within one sweep.
+    expect(resetQuery!.sql).toContain("requested_at = NOW()");
   });
 
   // Once Phase 3 has flipped the workspace into the destination region,

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -502,6 +502,17 @@ describe("failStaleMigrations", () => {
 
     await expect(failStaleMigrations()).rejects.toThrow(/remain write-locked/);
   });
+
+  // The stale SELECT has no catch — a failure there must propagate so the
+  // fiber tick records span ERROR instead of a quiet healthy-looking zero.
+  it("propagates a failure of the stale SELECT itself", async () => {
+    mockInternalQueryRejectPattern = {
+      pattern: "WHERE status = 'in_progress'",
+      error: new Error("connection reset"),
+    };
+
+    await expect(failStaleMigrations()).rejects.toThrow("connection reset");
+  });
 });
 
 describe("getCleanupDueMigrations", () => {

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -418,6 +418,20 @@ describe("executeRegionMigration", () => {
 describe("failStaleMigrations", () => {
   beforeEach(resetMocks);
 
+  // #4459 — the reaper runs on a periodic fiber (region_migration_stale_reap
+  // in effect/layers.ts). The sweep interval must not exceed the stale
+  // threshold, so a workspace whose migration crashed is unlocked within a
+  // bounded window of at most threshold + one interval (~6 min today) without
+  // operator action.
+  it("exports a reap cadence that bounds the unlock window (#4459)", async () => {
+    const { STALE_MIGRATION_REAP_INTERVAL_MS, STALE_THRESHOLD_MS } =
+      await import("../migrate");
+    expect(STALE_MIGRATION_REAP_INTERVAL_MS).toBeGreaterThan(0);
+    expect(STALE_MIGRATION_REAP_INTERVAL_MS).toBeLessThanOrEqual(
+      STALE_THRESHOLD_MS,
+    );
+  });
+
   it("returns 0 when internal DB is not available", async () => {
     mockHasInternalDB = false;
     const count = await failStaleMigrations();

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -427,11 +427,23 @@ export function triggerMigrationExecution(migrationId: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Find and fail migrations stuck in "in_progress" for longer than the threshold.
- * Returns the number of migrations marked as failed.
+ * Find and fail migrations stuck in "in_progress" past the stale threshold.
+ * Staleness is anchored to `requested_at` (there is no started_at column), so
+ * the retry reset MUST refresh `requested_at` — see `resetMigrationForRetry`.
+ *
+ * Returns `found` (stale rows detected) and `reaped` (rows successfully marked
+ * failed) separately so the `region_migration_stale_reap` fiber's span can
+ * distinguish "nothing stale" from "stale but couldn't reap" (#4459). Throws
+ * when rows were found but NONE could be reaped — the workspace write-lock is
+ * still stuck, which callers must surface as a failure (span ERROR + warn),
+ * not a quiet zero. Partial success stays non-throwing: the per-row error is
+ * already logged and the next sweep retries the stragglers.
  */
-export async function failStaleMigrations(): Promise<number> {
-  if (!hasInternalDB()) return 0;
+export async function failStaleMigrations(): Promise<{
+  found: number;
+  reaped: number;
+}> {
+  if (!hasInternalDB()) return { found: 0, reaped: 0 };
 
   const staleThresholdSec = STALE_THRESHOLD_MS / 1000;
   const staleRows = await internalQuery<{ id: string; workspace_id: string }>(
@@ -441,18 +453,18 @@ export async function failStaleMigrations(): Promise<number> {
     [staleThresholdSec],
   );
 
-  let failedCount = 0;
+  let reaped = 0;
   for (const row of staleRows) {
     try {
       await updateMigrationStatus(row.id, "failed", {
-        errorMessage: "Migration timed out — stuck in progress for over 5 minutes",
+        errorMessage: `Migration timed out — stuck in progress for over ${STALE_THRESHOLD_MS / 60_000} minutes`,
         completedAt: new Date().toISOString(),
       });
       logMigrationEvent("region_migration_failed", row.id, {
         workspaceId: row.workspace_id,
         reason: "stale_timeout",
       });
-      failedCount++;
+      reaped++;
       log.warn({ migrationId: row.id, workspaceId: row.workspace_id }, "Stale migration marked as failed");
     } catch (err) {
       log.error(
@@ -462,7 +474,13 @@ export async function failStaleMigrations(): Promise<number> {
     }
   }
 
-  return failedCount;
+  if (staleRows.length > 0 && reaped === 0) {
+    throw new Error(
+      `Found ${staleRows.length} stale region migration(s) but could not mark any as failed — affected workspaces remain write-locked`,
+    );
+  }
+
+  return { found: staleRows.length, reaped };
 }
 
 // ---------------------------------------------------------------------------
@@ -584,8 +602,15 @@ export async function resetMigrationForRetry(
   }
 
   try {
+    // `requested_at = NOW()` restarts the staleness clock: the reaper
+    // (`failStaleMigrations`, swept every minute by the
+    // `region_migration_stale_reap` fiber) anchors its threshold to
+    // `requested_at`, so without this reset a retry started more than
+    // STALE_THRESHOLD_MS after the original request would re-enter
+    // `in_progress` already "stale" and be killed within one sweep (#4459).
     await internalQuery(
-      `UPDATE region_migrations SET status = 'pending', error_message = NULL, completed_at = NULL
+      `UPDATE region_migrations SET status = 'pending', error_message = NULL, completed_at = NULL,
+              requested_at = NOW()
        WHERE id = $1`,
       [migrationId],
     );

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -26,8 +26,24 @@ const CLEANUP_GRACE_PERIOD_DAYS = 7;
 
 const log = createLogger("region-migration");
 
-/** Stale migration threshold: 5 minutes. */
-const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+/**
+ * Stale migration threshold: 5 minutes.
+ *
+ * Exported for the `region_migration_stale_reap` periodic fiber (#4459) and
+ * its bounded-window contract test. Keep the operator-facing copy in
+ * `data-residency.mdx` in sync if this changes.
+ */
+export const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Cadence of the `region_migration_stale_reap` periodic fiber (#4459).
+ *
+ * Must not exceed {@link STALE_THRESHOLD_MS}: a workspace whose migration
+ * crashed mid-flight stays write-locked (`isWorkspaceMigrating`) until the
+ * reaper fails the row, so the sweep interval bounds the worst-case unlock
+ * window at threshold + one interval (~6 min today) with no operator action.
+ */
+export const STALE_MIGRATION_REAP_INTERVAL_MS = 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Migration steps (for logging)


### PR DESCRIPTION
Closes #4459.

## Problem

`failStaleMigrations` was invoked only from the new-migration request path (`admin-residency.ts`). If the API process crashed mid-migration, the `region_migrations` row stayed `in_progress` and the workspace remained write-locked (`isWorkspaceMigrating`) with no periodic process to release it — recovery required an admin to happen to request *another* migration.

## Fix

- **New periodic fiber `region_migration_stale_reap`** registered via `registerPeriodicFiber` (the #4130 seam): 60s cadence, gated on the internal DB, per-tick span `atlas.scheduler.region_migration_stale_reap` with `stale_found` / `stale_reaped` result attributes (raw tick spanned, recovery outside — the `orphan_task_reconcile` pattern, so a failed tick records ERROR, not a fabricated status-OK zero).
- **`failStaleMigrations` returns `{ found, reaped }` and throws when rows were found but none could be reaped** — total reap failure surfaces as span ERROR + warn instead of a quiet zero while workspaces stay locked. One poisoned row no longer masks the others (per-row failures continue the loop).
- **Retry-path staleness bug fixed**: staleness is anchored to `requested_at` (no `started_at` column), so `resetMigrationForRetry` now sets `requested_at = NOW()`. Without this, a retry started >5 min after the original request would re-enter `in_progress` already "stale" and be killed within one sweep of the new fiber.
- The opportunistic request-path call stays as belt-and-braces; the fiber owns the bounded-window guarantee.
- Runbook (`data-residency.mdx`) documents the automatic recovery: threshold 5 min from request, 60s sweep, worst-case unlock ~6 min, retry restarts the clock.

## Acceptance criteria

- [x] `failStaleMigrations` runs on a periodic fiber with the required per-tick span, not just opportunistically
- [x] A workspace whose migration crashed is unlocked within a bounded window (≤ threshold + one sweep ≈ 6 min) without operator action — the interval ≤ threshold invariant is pinned by a contract test
- [x] The stale threshold is consistent with the runbook in `data-residency.mdx` (timeout message is now derived from `STALE_THRESHOLD_MS`)

## Tests

- `layers.test.ts`: 13th cleanup-fiber record entry + registration-wiring scan; new structural guards that the tick invokes `failStaleMigrations` and the cadence is wired to `STALE_MIGRATION_REAP_INTERVAL_MS`
- `migrate.test.ts`: bounded-window invariant (interval ≤ threshold); per-row failure continues reaping the rest; total failure rejects; SELECT failure propagates; retry resets the staleness clock
- `admin-residency.test.ts`: mock completed to all named exports of `residency/migrate`

## Verification

- Internal review panel (4 specialists): 2 rounds → CLEAN
- `scripts/ci-local.sh`: all 31 gates PASS (incl. full test suite, type, lint, type-aware lint)