### PR TITLE
fix(dashboards): shared-view caption honors the as-of contract (#4565)

### DIFF
--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -277,6 +277,7 @@ void mock.module("@atlas/api/lib/dashboards", () => ({
   projectSharedDashboardView: realDashboards.projectSharedDashboardView,
   buildSharedParameterSummary: realDashboards.buildSharedParameterSummary,
   resolveSharedSnapshotInstant: realDashboards.resolveSharedSnapshotInstant,
+  resolveSharedDataInstant: realDashboards.resolveSharedDataInstant,
   setRefreshSchedule: mockSetRefreshSchedule,
   getDashboardsDueForRefresh: mock(() => Promise.resolve([])),
   lockDashboardForRefresh: mock(() => Promise.resolve(false)),

--- a/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
@@ -73,6 +73,7 @@ void mock.module("@atlas/api/lib/dashboards", () => ({
   buildSharedParameterSummary: undefined as never,
   projectSharedDashboardView: undefined as never,
   resolveSharedSnapshotInstant: undefined as never,
+  resolveSharedDataInstant: undefined as never,
   getDashboardsDueForRefresh: undefined as never,
   lockDashboardForRefresh: undefined as never,
   refreshDashboardCards: undefined as never,

--- a/packages/api/src/lib/__tests__/dashboards-shared-view.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-shared-view.test.ts
@@ -13,6 +13,7 @@ import {
   projectSharedDashboardView,
   buildSharedParameterSummary,
   resolveSharedSnapshotInstant,
+  resolveSharedDataInstant,
 } from "../dashboards";
 import { sharedDashboardViewSchema } from "@useatlas/schemas";
 import type { DashboardWithCards, DashboardCard } from "../dashboard-types";
@@ -214,6 +215,77 @@ describe("projectSharedDashboardView (#4316)", () => {
         cards: [{ ...fullCard, cachedAt: null }],
       });
       expect(instant.toISOString()).toBe("2026-04-03T00:00:00.000Z");
+    });
+  });
+
+  // #4565 — the data-capture instant that drives the "Data as of …" caption.
+  // Unlike resolveSharedSnapshotInstant it has NO updatedAt/createdAt fallback:
+  // a never-refreshed board reports `null` so the caption is omitted rather
+  // than mislabelling creation time as data time.
+  describe("resolveSharedDataInstant (#4565)", () => {
+    it("uses the newest of lastRefreshAt and every card's cachedAt", () => {
+      const instant = resolveSharedDataInstant({
+        ...fullDashboard,
+        lastRefreshAt: "2026-04-04T01:00:00.000Z",
+        cards: [
+          fullCard,
+          { ...fullCard, id: "card-2", cachedAt: "2026-05-10T12:00:00.000Z" },
+        ],
+      });
+      expect(instant?.toISOString()).toBe("2026-05-10T12:00:00.000Z");
+    });
+
+    it("returns null for a never-refreshed board with no cached cards (never creation time)", () => {
+      const instant = resolveSharedDataInstant({
+        ...fullDashboard,
+        lastRefreshAt: null,
+        cards: [{ ...fullCard, cachedAt: null }],
+      });
+      expect(instant).toBeNull();
+    });
+  });
+
+  describe("dataAsOf projection (#4565)", () => {
+    it("emits the data-capture instant, not the creation date", () => {
+      // A board created in Jan but refreshed in Apr must read as-of Apr.
+      const view = projectSharedDashboardView({
+        ...fullDashboard,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastRefreshAt: "2026-04-04T01:00:00.000Z",
+      });
+      expect(view.dataAsOf).toBe("2026-04-04T01:00:00.000Z");
+      expect(view.dataAsOf).not.toBe(view.createdAt);
+    });
+
+    it("moves with a fresher per-card cachedAt (the caption tracks the data)", () => {
+      const view = projectSharedDashboardView({
+        ...fullDashboard,
+        lastRefreshAt: "2026-04-04T01:00:00.000Z",
+        cards: [{ ...fullCard, cachedAt: "2026-06-15T09:00:00.000Z" }],
+      });
+      expect(view.dataAsOf).toBe("2026-06-15T09:00:00.000Z");
+    });
+
+    it("equals the instant the parameter summary was frozen against", () => {
+      // The single as-of contract: caption instant === summary frozen instant.
+      const view = projectSharedDashboardView({
+        ...fullDashboard,
+        lastRefreshAt: "2026-04-04T01:00:00.000Z",
+        cards: [{ ...fullCard, cachedAt: null }],
+        parameters: [{ key: "since", type: "date", default: "now - 30 days", label: "Since" }],
+      });
+      // 2026-04-04 − 30 days = 2026-03-05, resolved against dataAsOf.
+      expect(view.dataAsOf).toBe("2026-04-04T01:00:00.000Z");
+      expect(view.parameterSummary).toEqual([{ label: "Since", displayValue: "2026-03-05" }]);
+    });
+
+    it("is null for a never-refreshed board so the caption is omitted", () => {
+      const view = projectSharedDashboardView({
+        ...fullDashboard,
+        lastRefreshAt: null,
+        cards: [{ ...fullCard, cachedAt: null }],
+      });
+      expect(view.dataAsOf).toBeNull();
     });
   });
 

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -1036,17 +1036,16 @@ export function buildSharedParameterSummary(
 }
 
 /**
- * The instant a shared snapshot's data was frozen (#4538): the newest of the
+ * The instant the shown data itself was captured (#4565): the newest of the
  * dashboard-level `lastRefreshAt` and every card's `cachedAt` (a manual
  * per-card refresh stamps `cachedAt` without touching `lastRefreshAt`, so
- * neither alone is authoritative). Relative-date parameter summaries resolve
- * against this instant — never the view request's clock — so the summary
- * frame stays exactly as frozen as the `cachedRows` it labels. A
- * never-refreshed dashboard (no cached data to drift from) falls back to
- * `updatedAt`, then `createdAt` — any stable instant labels an empty snapshot
- * correctly.
+ * neither alone is authoritative), or `null` when the snapshot carries no
+ * cached data at all. Distinct from {@link resolveSharedSnapshotInstant} in
+ * that it does NOT fall back to `updatedAt`/`createdAt`: a never-refreshed
+ * board has no data instant to report, so the shared caption must be omitted
+ * rather than mislabelling the creation date as data time.
  */
-export function resolveSharedSnapshotInstant(dashboard: DashboardWithCards): Date {
+export function resolveSharedDataInstant(dashboard: DashboardWithCards): Date | null {
   const candidates = [
     dashboard.lastRefreshAt,
     ...dashboard.cards.map((card) => card.cachedAt),
@@ -1058,7 +1057,22 @@ export function resolveSharedSnapshotInstant(dashboard: DashboardWithCards): Dat
     if (Number.isNaN(parsed.getTime())) continue;
     if (newest === null || parsed > newest) newest = parsed;
   }
-  if (newest) return newest;
+  return newest;
+}
+
+/**
+ * The instant a shared snapshot's data was frozen (#4538): the data-capture
+ * instant ({@link resolveSharedDataInstant}) when present, else a stable
+ * fallback of `updatedAt`, then `createdAt`. Relative-date parameter summaries
+ * resolve against this instant — never the view request's clock — so the
+ * summary frame stays exactly as frozen as the `cachedRows` it labels. A
+ * never-refreshed dashboard (no cached data to drift from) falls back to
+ * `updatedAt`/`createdAt` — any stable instant labels an empty snapshot
+ * correctly.
+ */
+export function resolveSharedSnapshotInstant(dashboard: DashboardWithCards): Date {
+  const dataInstant = resolveSharedDataInstant(dashboard);
+  if (dataInstant) return dataInstant;
   const updated = new Date(dashboard.updatedAt);
   return Number.isNaN(updated.getTime()) ? new Date(dashboard.createdAt) : updated;
 }
@@ -1104,6 +1118,11 @@ export function projectSharedDashboardView(
     shareMode: dashboard.shareMode,
     cards: dashboard.cards.map(projectSharedCard),
     parameterSummary: buildSharedParameterSummary(dashboard.parameters, frozenAt),
+    // The data-capture instant the caption renders as "Data as of …" (#4565) —
+    // the SAME frozen instant the summary above resolves against whenever the
+    // snapshot carries data, so every temporal label on the page shares one
+    // instant. `null` (caption omitted) for a never-refreshed board.
+    dataAsOf: resolveSharedDataInstant(dashboard)?.toISOString() ?? null,
     createdAt: dashboard.createdAt,
     updatedAt: dashboard.updatedAt,
     lastRefreshAt: dashboard.lastRefreshAt,

--- a/packages/schemas/src/__tests__/dashboard.test.ts
+++ b/packages/schemas/src/__tests__/dashboard.test.ts
@@ -518,6 +518,15 @@ describe("sharedDashboardViewSchema (#4316)", () => {
     expect(sharedDashboardViewSchema.safeParse({ ...validView, shareMode: "org" }).success).toBe(true);
   });
 
+  test("accepts an optional dataAsOf capture instant, string or null (#4565)", () => {
+    expect(
+      sharedDashboardViewSchema.safeParse({ ...validView, dataAsOf: "2026-04-04T01:00:00.000Z" }).success,
+    ).toBe(true);
+    expect(sharedDashboardViewSchema.safeParse({ ...validView, dataAsOf: null }).success).toBe(true);
+    // Optional — a pre-#4565 payload that omits it still parses (validView itself).
+    expect(sharedDashboardViewSchema.safeParse(validView).success).toBe(true);
+  });
+
   test("rejects a snapshot that leaks orgId / ownerId / shareToken / refreshSchedule / parameters", () => {
     for (const stray of [
       { orgId: "org-1" },

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -524,6 +524,10 @@ export const sharedDashboardViewSchema = z
     // Optional for wire forward-compat only — the server projection always
     // emits it (see `SharedDashboardView.parameterSummary`).
     parameterSummary: z.array(sharedDashboardParameterSummaryItemSchema).optional(),
+    // The snapshot's data-capture instant (#4565) — nullable when the board
+    // carries no cached data. Optional for the same deploy-overlap fwd-compat as
+    // `parameterSummary` (see `SharedDashboardView.dataAsOf`).
+    dataAsOf: z.string().nullable().optional(),
     createdAt: z.string(),
     updatedAt: z.string(),
     lastRefreshAt: z.string().nullable(),

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -373,6 +373,17 @@ export interface SharedDashboardView {
    * client must tolerate its absence (`?? []`) across a deploy-overlap window.
    */
   parameterSummary?: SharedDashboardParameterSummaryItem[];
+  /**
+   * The instant the shown data was frozen (#4565) — the newest of the
+   * dashboard's `lastRefreshAt` and every card's `cachedAt`, i.e. the SAME
+   * capture instant the {@link parameterSummary} is resolved against, so every
+   * temporal framing on the shared page derives from one instant. `null` when
+   * the snapshot carries no cached data at all (a never-refreshed board), so the
+   * caption is omitted rather than mislabelling the creation date as data time.
+   * Optional for wire forward-compat only — a pre-#4565 API build omits it, so a
+   * newer web client must tolerate its absence across a deploy-overlap window.
+   */
+  dataAsOf?: string | null;
   createdAt: string;
   updatedAt: string;
   lastRefreshAt: string | null;

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/view.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/view.test.tsx
@@ -112,7 +112,7 @@ describe("SharedDashboardView — as-of caption (#4565)", () => {
           id: "c1",
           position: 0,
           title: "T",
-          kind: "table",
+          kind: "chart",
           chartConfig: null,
           content: null,
           annotations: [],

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/view.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/view.test.tsx
@@ -67,3 +67,44 @@ describe("SharedDashboardView — frozen parameter summary (#4316)", () => {
     expect(screen.queryByLabelText("Snapshot parameters")).toBeNull();
   });
 });
+
+describe("SharedDashboardView — as-of caption (#4565)", () => {
+  afterEach(cleanup);
+
+  test("shows 'Data as of' from dataAsOf, never 'Captured' / the creation date", () => {
+    render(
+      <SharedDashboardView
+        dashboard={dashboard({
+          // Created months ago, but the data was refreshed today.
+          createdAt: "2026-01-01T00:00:00.000Z",
+          dataAsOf: "2026-04-04T01:00:00.000Z",
+        })}
+      />,
+    );
+    const caption = screen.getByText(/Data as of/);
+    // Absolute date derives from dataAsOf (2026-04), not createdAt (2026-01).
+    expect(caption.getAttribute("datetime")).toBe("2026-04-04T01:00:00.000Z");
+    // The old creation-date caption is gone entirely.
+    expect(screen.queryByText(/Captured/)).toBeNull();
+  });
+
+  test("falls back to the freshest cache stamp when dataAsOf is absent (deploy overlap)", () => {
+    const legacy = dashboard({
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastRefreshAt: "2026-03-02T00:00:00.000Z",
+    });
+    delete (legacy as { dataAsOf?: unknown }).dataAsOf;
+    render(<SharedDashboardView dashboard={legacy} />);
+    // Resolves against lastRefreshAt (data time), never the Jan creation date.
+    expect(screen.getByText(/Data as of/).getAttribute("datetime")).toBe(
+      "2026-03-02T00:00:00.000Z",
+    );
+  });
+
+  test("omits the caption when the snapshot carries no data instant", () => {
+    // No dataAsOf, no lastRefreshAt, no cached cards — never falls back to createdAt.
+    render(<SharedDashboardView dashboard={dashboard({ dataAsOf: null })} />);
+    expect(screen.queryByText(/Data as of/)).toBeNull();
+    expect(screen.queryByText(/Captured/)).toBeNull();
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/view.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/view.test.tsx
@@ -88,7 +88,7 @@ describe("SharedDashboardView — as-of caption (#4565)", () => {
     expect(screen.queryByText(/Captured/)).toBeNull();
   });
 
-  test("falls back to the freshest cache stamp when dataAsOf is absent (deploy overlap)", () => {
+  test("falls back to lastRefreshAt when dataAsOf is absent (deploy overlap)", () => {
     const legacy = dashboard({
       createdAt: "2026-01-01T00:00:00.000Z",
       lastRefreshAt: "2026-03-02T00:00:00.000Z",
@@ -99,6 +99,48 @@ describe("SharedDashboardView — as-of caption (#4565)", () => {
     expect(screen.getByText(/Data as of/).getAttribute("datetime")).toBe(
       "2026-03-02T00:00:00.000Z",
     );
+  });
+
+  test("falls back to the freshest card cache stamp when dataAsOf and lastRefreshAt are both absent", () => {
+    // Oldest deploy-overlap case: no dataAsOf, no lastRefreshAt — the caption
+    // must still resolve against a card's cachedAt (data time), never createdAt.
+    const legacy = dashboard({
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastRefreshAt: null,
+      cards: [
+        {
+          id: "c1",
+          position: 0,
+          title: "T",
+          kind: "table",
+          chartConfig: null,
+          content: null,
+          annotations: [],
+          cachedColumns: ["a"],
+          cachedRows: [{ a: 1 }],
+          cachedAt: "2026-02-09T00:00:00.000Z",
+          layout: null,
+        },
+      ],
+    });
+    delete (legacy as { dataAsOf?: unknown }).dataAsOf;
+    render(<SharedDashboardView dashboard={legacy} />);
+    expect(screen.getByText(/Data as of/).getAttribute("datetime")).toBe(
+      "2026-02-09T00:00:00.000Z",
+    );
+  });
+
+  test("the 'Last refreshed' chip shares the caption's instant (one instant per page)", () => {
+    // No cards → the only <time> elements in the header are the caption and the
+    // "Last refreshed" chip; both must carry dataAsOf as their datetime.
+    const { container } = render(
+      <SharedDashboardView
+        dashboard={dashboard({ dataAsOf: "2026-04-04T01:00:00.000Z" })}
+      />,
+    );
+    const times = Array.from(container.querySelectorAll("time"));
+    expect(times.length).toBe(2);
+    for (const t of times) expect(t.getAttribute("datetime")).toBe("2026-04-04T01:00:00.000Z");
   });
 
   test("omits the caption when the snapshot carries no data instant", () => {

--- a/packages/web/src/app/shared/dashboard/[token]/view.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/view.tsx
@@ -11,16 +11,20 @@ import { isoOrUndefined, mostRecentCachedAt, tileSpanClass, timeAgo } from "./he
 import type { SharedDashboard } from "./types";
 
 export function SharedDashboardView({ dashboard }: { dashboard: SharedDashboard }) {
-  // `lastRefreshAt` (server-stamped) wins; fall back to the freshest card cache
-  // so older API builds still surface a freshness signal. If both are absent
-  // (no refresh has ever run), the chip is omitted.
-  const lastRefreshed = dashboard.lastRefreshAt ?? mostRecentCachedAt(dashboard.cards);
-  const lastRefreshedIso = isoOrUndefined(lastRefreshed);
-  const lastRefreshedLabel = timeAgo(lastRefreshed);
-  const capturedIso = isoOrUndefined(dashboard.createdAt);
-  const capturedDate = capturedIso
-    ? new Date(capturedIso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+  // The single instant every temporal label on this page derives from (#4565):
+  // the data's capture instant. Prefer the server-resolved `dataAsOf` (the SAME
+  // frozen instant the parameter summary was resolved against); fall back to the
+  // freshest client-visible cache stamp for pre-#4565 API builds that omit it.
+  // NEVER the creation date — a board created months ago but refreshed today is
+  // "as of" today. `null` (both the caption and the relative chip omitted) when
+  // no refresh has ever run and no card carries cached data.
+  const dataAsOf =
+    dashboard.dataAsOf ?? dashboard.lastRefreshAt ?? mostRecentCachedAt(dashboard.cards);
+  const dataAsOfIso = isoOrUndefined(dataAsOf);
+  const dataAsOfDate = dataAsOfIso
+    ? new Date(dataAsOfIso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
     : null;
+  const dataAsOfAgoLabel = timeAgo(dataAsOf);
   const tileCount = dashboard.cards.length;
   // #4316 — the frozen, display-only parameter summary. Older API builds that
   // predate the projection may omit `parameterSummary`; default to `[]` so the
@@ -46,10 +50,10 @@ export function SharedDashboardView({ dashboard }: { dashboard: SharedDashboard 
               >
                 Read-only
               </span>
-              {capturedDate && capturedIso && (
+              {dataAsOfDate && dataAsOfIso && (
                 <>
                   <span aria-hidden="true">&middot;</span>
-                  <time dateTime={capturedIso}>Captured {capturedDate}</time>
+                  <time dateTime={dataAsOfIso}>Data as of {dataAsOfDate}</time>
                 </>
               )}
             </div>
@@ -73,13 +77,13 @@ export function SharedDashboardView({ dashboard }: { dashboard: SharedDashboard 
             <span>
               {tileCount} tile{tileCount === 1 ? "" : "s"}
             </span>
-            {lastRefreshedLabel && lastRefreshedIso && (
+            {dataAsOfAgoLabel && dataAsOfIso && (
               <>
                 <span aria-hidden="true">&middot;</span>
                 <span className="inline-flex items-center gap-1">
                   <Clock className="size-3" aria-hidden="true" />
                   Last refreshed{" "}
-                  <time dateTime={lastRefreshedIso}>{lastRefreshedLabel}</time>
+                  <time dateTime={dataAsOfIso}>{dataAsOfAgoLabel}</time>
                 </span>
               </>
             )}


### PR DESCRIPTION
## Summary

The shared dashboard snapshot caption read **"Captured {creation date}"** — a board created months ago but refreshed today read "Captured Jan 2026," framing the data by when the board was *made*, not when its rows were *captured*.

- Replace it with **"Data as of {capture instant}"**, derived from the shown data's freeze instant.
- The API now emits a nullable `dataAsOf` on the shared-view projection — the newest of `lastRefreshAt` and every card's `cachedAt` via the new `resolveSharedDataInstant` — which is *exactly* the `frozenAt` the parameter summary (#4538) already resolves against, so **every temporal label on the page derives from one instant**. The existing "Last refreshed" relative chip is routed through the same instant.
- `resolveSharedSnapshotInstant` is refactored to build on `resolveSharedDataInstant` (data instant, else `updatedAt`/`createdAt`), so the summary keeps its empty-board fallback while the caption reports `null` (and is omitted) rather than mislabelling creation time as data time.
- `dataAsOf` is optional on the wire for pre-#4565 deploy-overlap; the web falls back to the freshest client-visible cache stamp, never the creation date.

Wire type (`@useatlas/types`) + Zod schema (`@useatlas/schemas`) moved in lockstep; `.strict()` round-trip guard preserved.

## Acceptance criteria

- [x] Shared-view caption shows the data's capture instant, never the creation date
- [x] When a refresh updates the rows, the caption moves with them (tracks `lastRefreshAt`/`cachedAt`)
- [x] No label on the shared page resolves against view time or creation time

## Test plan

- [x] `dashboards-shared-view.test.ts` — `resolveSharedDataInstant` selection + `dataAsOf` projection (incl. "equals the instant the parameter summary was frozen against")
- [x] `view.test.tsx` — caption renders `Data as of` from `dataAsOf`, never `Captured`; fallback legs (`lastRefreshAt`, card `cachedAt`); omitted when no data instant; "Last refreshed" chip shares the caption's instant
- [x] `schemas/dashboard.test.ts` — `dataAsOf` accepted as string / null / omitted
- [x] Full-surface `mock.module` blocks updated with the new export (mock-all-exports discipline)
- [x] Local `/ci`: type + all 30 drift/lint gates green; dashboards `-pg` suites green against real Postgres. Review panel CLEAN (2 rounds).

Closes #4565