### PR TITLE
feat(dashboards): tool-side seeding — execute cards, report per-card outcomes (#4558)

### DIFF
--- a/packages/api/src/lib/__tests__/dashboard-seeding.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-seeding.test.ts
@@ -64,8 +64,14 @@ const saveDraftCardCacheMock = mock(
   },
 );
 
+// Mock ALL runtime exports (mock-all-exports discipline) so a future loaded
+// graph that reaches another export doesn't fail with "Export named X not
+// found". seedDraftCards only calls saveDraftCardCache; the rest are inert.
 void mock.module("@atlas/api/lib/dashboard-draft-cache", () => ({
   saveDraftCardCache: saveDraftCardCacheMock,
+  loadDraftCardCache: mock(() => Promise.resolve(new Map())),
+  seedDraftCardCacheFromPublished: mock(() => Promise.resolve()),
+  EMPTY_DRAFT_CARD_CACHE: new Map(),
 }));
 
 const { seedDraftCards, SEED_WALL_CLOCK_BUDGET_MS } = await import(

--- a/packages/api/src/lib/__tests__/dashboard-seeding.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-seeding.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for tool-side seeding (#4558, ADR-0034 Decision 1) — the shared
+ * `seedDraftCards` batch used by `createDashboard` and the bound `addCard`.
+ *
+ * Pinned behavior (the acceptance criteria, at the module seam):
+ *   - Each card runs through `runUserQueryPipeline` (the full validation / RLS /
+ *     audit / masking guard) with its SQL, connection, and the shared resolved
+ *     parameter values — never a privileged side-channel.
+ *   - A card that returns rows is cached and reported `rows` (with rowCount);
+ *     zero rows → `empty`.
+ *   - A card whose pipeline outcome is non-ok is reported `error` and the batch
+ *     still resolves for every other card (fail-soft — never throws).
+ *   - A card still running when the wall-clock budget elapses is reported
+ *     `unseeded` and its cache is never written.
+ *   - A successful execution whose cache write fails is reported `unseeded`
+ *     (staged, to be filled by the canvas-mount render) — never silently "rows".
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import type { UserQueryOutcome } from "@atlas/api/lib/tools/sql";
+import type { SaveDraftCardCacheResult } from "@atlas/api/lib/dashboard-draft-cache";
+
+// ---- mock the two collaborators (sync factories — bun deadlocks on async) ----
+
+/** Per-call queue of pipeline behaviors, keyed by the card's SQL. */
+const pipelineBySql = new Map<string, () => Promise<UserQueryOutcome>>();
+const pipelineCalls: { sql: string; connectionId?: string; parameters?: Record<string, unknown> }[] =
+  [];
+
+const runUserQueryPipelineMock = mock(
+  (opts: { sql: string; connectionId?: string; parameters?: Record<string, unknown> }) => {
+    pipelineCalls.push({
+      sql: opts.sql,
+      connectionId: opts.connectionId,
+      parameters: opts.parameters,
+    });
+    const behavior = pipelineBySql.get(opts.sql);
+    if (!behavior) {
+      return Promise.resolve<UserQueryOutcome>({
+        kind: "query_failed",
+        message: "no behavior registered for this sql",
+      });
+    }
+    return behavior();
+  },
+);
+
+void mock.module("@atlas/api/lib/tools/sql", () => ({
+  runUserQueryPipeline: runUserQueryPipelineMock,
+}));
+
+const saveCalls: { cardId: string; columns: string[]; rows: unknown[] }[] = [];
+let saveResult: SaveDraftCardCacheResult = { ok: true, cachedAt: "2026-07-17T00:00:00.000Z" };
+
+const saveDraftCardCacheMock = mock(
+  (
+    _userId: string,
+    _dashboardId: string,
+    cardId: string,
+    result: { columns: string[]; rows: Record<string, unknown>[] },
+  ) => {
+    saveCalls.push({ cardId, columns: result.columns, rows: result.rows });
+    return Promise.resolve(saveResult);
+  },
+);
+
+void mock.module("@atlas/api/lib/dashboard-draft-cache", () => ({
+  saveDraftCardCache: saveDraftCardCacheMock,
+}));
+
+const { seedDraftCards, SEED_WALL_CLOCK_BUDGET_MS } = await import(
+  "@atlas/api/lib/dashboard-seeding"
+);
+
+// ---- helpers ------------------------------------------------------------
+
+function okOutcome(rows: Record<string, unknown>[]): UserQueryOutcome {
+  return {
+    kind: "ok",
+    columns: rows.length > 0 ? Object.keys(rows[0]) : ["n"],
+    rows,
+    rowCount: rows.length,
+    executionMs: 1,
+    truncated: false,
+    maskingApplied: false,
+  };
+}
+
+function registerOk(sql: string, rows: Record<string, unknown>[]) {
+  pipelineBySql.set(sql, () => Promise.resolve(okOutcome(rows)));
+}
+
+const BASE = { userId: "user-1", dashboardId: "dash-1", parameters: {} };
+
+beforeEach(() => {
+  pipelineBySql.clear();
+  pipelineCalls.length = 0;
+  saveCalls.length = 0;
+  saveResult = { ok: true, cachedAt: "2026-07-17T00:00:00.000Z" };
+  runUserQueryPipelineMock.mockClear();
+  saveDraftCardCacheMock.mockClear();
+});
+
+describe("seedDraftCards", () => {
+  it("returns [] and runs nothing for an empty batch", async () => {
+    const outcomes = await seedDraftCards({ ...BASE, cards: [] });
+    expect(outcomes).toEqual([]);
+    expect(pipelineCalls).toHaveLength(0);
+    expect(saveCalls).toHaveLength(0);
+  });
+
+  it("caches a card that returns rows and reports rows + rowCount", async () => {
+    registerOk("SELECT a", [{ a: 1 }, { a: 2 }]);
+    const outcomes = await seedDraftCards({
+      ...BASE,
+      cards: [{ cardId: "c1", title: "A", sql: "SELECT a", connectionId: null }],
+    });
+    expect(outcomes).toEqual([{ cardId: "c1", title: "A", status: "rows", rowCount: 2 }]);
+    expect(saveCalls).toEqual([{ cardId: "c1", columns: ["a"], rows: [{ a: 1 }, { a: 2 }] }]);
+  });
+
+  it("reports empty (and still caches) when the query returns zero rows", async () => {
+    registerOk("SELECT none", []);
+    const outcomes = await seedDraftCards({
+      ...BASE,
+      cards: [{ cardId: "c1", title: "Empty", sql: "SELECT none", connectionId: null }],
+    });
+    expect(outcomes).toEqual([{ cardId: "c1", title: "Empty", status: "empty" }]);
+    // Even an empty result is cached — an honest "0 rows" tile, not "never run".
+    expect(saveCalls).toHaveLength(1);
+  });
+
+  it("runs each card through the full pipeline with its connection + shared params", async () => {
+    registerOk("SELECT a", [{ a: 1 }]);
+    registerOk("SELECT b", [{ b: 1 }]);
+    await seedDraftCards({
+      userId: "user-1",
+      dashboardId: "dash-1",
+      parameters: { date_from: "2026-01-01", date_to: "2026-02-01" },
+      cards: [
+        { cardId: "c1", title: "A", sql: "SELECT a", connectionId: "conn-x" },
+        { cardId: "c2", title: "B", sql: "SELECT b", connectionId: null },
+      ],
+    });
+    const byId = new Map(pipelineCalls.map((c) => [c.sql, c]));
+    expect(byId.get("SELECT a")?.connectionId).toBe("conn-x");
+    // A null connection is passed as "no connectionId" (pipeline defaults it).
+    expect(byId.get("SELECT b")?.connectionId).toBeUndefined();
+    expect(byId.get("SELECT a")?.parameters).toEqual({
+      date_from: "2026-01-01",
+      date_to: "2026-02-01",
+    });
+  });
+
+  it("is fail-soft: a non-ok pipeline outcome is reported error, siblings still seed", async () => {
+    registerOk("SELECT good", [{ a: 1 }]);
+    pipelineBySql.set("SELECT bad", () =>
+      Promise.resolve<UserQueryOutcome>({
+        kind: "query_failed",
+        message: 'column "missing" does not exist',
+      }),
+    );
+    const outcomes = await seedDraftCards({
+      ...BASE,
+      cards: [
+        { cardId: "c1", title: "Good", sql: "SELECT good", connectionId: null },
+        { cardId: "c2", title: "Bad", sql: "SELECT bad", connectionId: null },
+      ],
+    });
+    expect(outcomes[0]).toEqual({ cardId: "c1", title: "Good", status: "rows", rowCount: 1 });
+    expect(outcomes[1]).toEqual({
+      cardId: "c2",
+      title: "Bad",
+      status: "error",
+      message: 'column "missing" does not exist',
+    });
+    // The failing card was NOT cached; the good one was.
+    expect(saveCalls.map((s) => s.cardId)).toEqual(["c1"]);
+  });
+
+  it("never throws when the pipeline rejects — reports error", async () => {
+    pipelineBySql.set("SELECT boom", () => Promise.reject(new Error("kaboom")));
+    const outcomes = await seedDraftCards({
+      ...BASE,
+      cards: [{ cardId: "c1", title: "Boom", sql: "SELECT boom", connectionId: null }],
+    });
+    expect(outcomes[0].status).toBe("error");
+    expect(saveCalls).toHaveLength(0);
+  });
+
+  it("leaves a card unseeded (not failed) when the wall-clock budget elapses", async () => {
+    registerOk("SELECT fast", [{ a: 1 }]);
+    // Slow card resolves well after the tiny budget → the deadline wins.
+    pipelineBySql.set(
+      "SELECT slow",
+      () => new Promise((resolve) => setTimeout(() => resolve(okOutcome([{ a: 1 }])), 200)),
+    );
+    const outcomes = await seedDraftCards({
+      ...BASE,
+      budgetMs: 10,
+      cards: [
+        { cardId: "c1", title: "Fast", sql: "SELECT fast", connectionId: null },
+        { cardId: "c2", title: "Slow", sql: "SELECT slow", connectionId: null },
+      ],
+    });
+    expect(outcomes[0]).toEqual({ cardId: "c1", title: "Fast", status: "rows", rowCount: 1 });
+    expect(outcomes[1]).toEqual({ cardId: "c2", title: "Slow", status: "unseeded" });
+    // The timed-out card is never cached.
+    expect(saveCalls.map((s) => s.cardId)).toEqual(["c1"]);
+  });
+
+  it("reports unseeded (never a false rows) when the cache write fails", async () => {
+    registerOk("SELECT a", [{ a: 1 }]);
+    saveResult = { ok: false, reason: "no_draft" };
+    const outcomes = await seedDraftCards({
+      ...BASE,
+      cards: [{ cardId: "c1", title: "A", sql: "SELECT a", connectionId: null }],
+    });
+    expect(outcomes[0]).toEqual({ cardId: "c1", title: "A", status: "unseeded" });
+  });
+
+  it("exposes a sane default wall-clock budget", () => {
+    expect(SEED_WALL_CLOCK_BUDGET_MS).toBeGreaterThan(0);
+    expect(SEED_WALL_CLOCK_BUDGET_MS).toBeLessThanOrEqual(30_000);
+  });
+});

--- a/packages/api/src/lib/dashboard-seeding.ts
+++ b/packages/api/src/lib/dashboard-seeding.ts
@@ -43,7 +43,7 @@ const log = createLogger("dashboard-seeding");
  * Wall-clock budget (ms) for one seeding batch. Cards execute concurrently, so
  * this bounds the whole batch, not each card. A card still running when it
  * elapses is left staged-unseeded (the canvas-mount render fills it in later),
- * never failed. Chosen a touch below the default per-statement timeout
+ * never failed. Chosen well below (half of) the default per-statement timeout
  * (`ATLAS_QUERY_TIMEOUT`, 30s) so a single pathological card can't hold the
  * tool call open for the full statement timeout while the rest of the board
  * waits.
@@ -62,6 +62,12 @@ export interface SeedCardSpec {
   readonly sql: string;
   readonly connectionId: string | null;
 }
+
+/** A seed card before its connection is resolved. Callers that resolve one
+ *  connection for the whole batch (createDashboard) build these, then stamp the
+ *  resolved `connectionId` on each — so the field set can't drift from
+ *  {@link SeedCardSpec}. */
+export type SeedCardInput = Omit<SeedCardSpec, "connectionId">;
 
 export interface SeedDraftCardsOptions {
   readonly userId: string;
@@ -84,10 +90,11 @@ export interface SeedDraftCardsOptions {
  * rather than sniffing `rowCount`:
  *   - `rows`     — executed and cached; `rowCount` rows.
  *   - `empty`    — executed and cached; zero rows (an honest empty tile).
- *   - `error`    — execution (or the cache write) failed; the card is still
- *                  staged. `message` is a scrubbed, agent-actionable reason.
- *   - `unseeded` — the wall-clock budget elapsed before this card finished; it
- *                  is staged-not-seeded and the canvas-mount render will fill it.
+ *   - `error`    — execution / validation failed; the card is still staged.
+ *                  `message` is a scrubbed, agent-actionable reason.
+ *   - `unseeded` — the wall-clock budget elapsed before this card finished, OR
+ *                  it executed but its draft-cache write failed; either way the
+ *                  card is staged-not-seeded and the canvas-mount render fills it.
  */
 export type CardSeedOutcome = {
   readonly cardId: string;
@@ -121,9 +128,11 @@ function createDeadline(ms: number): Deadline {
   };
 }
 
-/** Map a non-ok pipeline outcome to a compact, agent-actionable message. */
+/** Map a non-ok pipeline outcome to a compact, agent-actionable message. Every
+ *  non-ok variant carries a `message`, so it's read directly (fall back to the
+ *  `kind` only on the degenerate empty-string case). */
 function outcomeErrorMessage(outcome: Exclude<UserQueryOutcome, { kind: "ok" }>): string {
-  const message = "message" in outcome && outcome.message ? outcome.message : outcome.kind;
+  const message = outcome.message || outcome.kind;
   return message.length > MAX_SEED_ERROR_LEN
     ? `${message.slice(0, MAX_SEED_ERROR_LEN)}…`
     : message;
@@ -136,27 +145,28 @@ async function seedOneCard(
 ): Promise<CardSeedOutcome> {
   const base = { cardId: card.cardId, title: card.title } as const;
 
-  let raced: UserQueryOutcome | typeof TIMEOUT;
-  try {
-    raced = await Promise.race([
-      runUserQueryPipeline({
-        sql: card.sql,
-        ...(card.connectionId ? { connectionId: card.connectionId } : {}),
-        explanation: `Dashboard seed: ${card.title}`,
-        parameters: opts.parameters,
-      }),
-      deadline,
-    ]);
-  } catch (err) {
-    // runUserQueryPipeline maps its errors onto the outcome union, so a
-    // rejection here is unexpected — treat it as a fail-soft per-card error,
-    // never letting it bubble up and fail the whole build.
+  // Attach the failure handler to the pipeline promise BEFORE racing it: if the
+  // deadline wins and this card is reported `unseeded`, the still-running
+  // pipeline can later reject with a defect (an unexpected throw not covered by
+  // its own `catchAll`). Without a handler on the losing promise that becomes a
+  // process-level unhandledRejection; here it is logged and folded into a
+  // benign outcome, so a timed-out card can never crash the tool call.
+  const exec: Promise<UserQueryOutcome> = runUserQueryPipeline({
+    sql: card.sql,
+    ...(card.connectionId ? { connectionId: card.connectionId } : {}),
+    explanation: `Dashboard seed: ${card.title}`,
+    parameters: opts.parameters,
+  }).catch((err) => {
     log.warn(
       { err: errorMessage(err), dashboardId: opts.dashboardId, cardId: card.cardId },
-      "seedDraftCards: card execution threw unexpectedly",
+      "seedDraftCards: pipeline rejected (defect)",
     );
-    return { ...base, status: "error", message: "Execution failed unexpectedly." };
-  }
+    return { kind: "query_failed", message: "Execution failed unexpectedly." } as const;
+  });
+
+  // Neither `exec` (its rejections are absorbed above) nor `deadline` rejects,
+  // so this race resolves rather than throws.
+  const raced: UserQueryOutcome | typeof TIMEOUT = await Promise.race([exec, deadline]);
 
   if (raced === TIMEOUT) {
     return { ...base, status: "unseeded" };

--- a/packages/api/src/lib/dashboard-seeding.ts
+++ b/packages/api/src/lib/dashboard-seeding.ts
@@ -1,0 +1,223 @@
+/**
+ * Tool-side seeding (#4558, ADR-0034 Decision 1) — the build-time half of the
+ * seeding decision.
+ *
+ * `createDashboard` and the bound `addCard` execute each staged card's SQL
+ * ONCE inside the tool call and persist the result as the card's initial
+ * DRAFT CACHE (`saveDraftCardCache`, #4554), so a chat-built board arrives
+ * showing real data instead of a grid of "Never run" tiles. The tool result
+ * carries a per-card outcome (rows / empty / error / unseeded) so the agent can
+ * self-correct in the SAME turn instead of announcing a board with broken
+ * cards.
+ *
+ * Three invariants, all from the ADR + the issue's acceptance criteria:
+ *
+ *   - **Full SQL pipeline.** Every card runs through `runUserQueryPipeline` —
+ *     the exact validation / RLS / audit / masking guard `executeSQL` and the
+ *     single-card draft refresh use. Seeding is never a privileged side-channel.
+ *   - **Fail-soft per card.** A card whose SQL fails at execution is still
+ *     staged (the caller has already written the draft snapshot); it is only
+ *     reported `error` here — a failed seed NEVER fails the build.
+ *   - **Wall-clock budget.** The whole batch is bounded by a single wall clock
+ *     ({@link SEED_WALL_CLOCK_BUDGET_MS}); a card still in flight when the
+ *     budget elapses is left staged-unseeded and reported `unseeded`, to be
+ *     populated by the canvas-mount draft render (#4557). Zero agent-step cost
+ *     regardless of board size — the seeding runs concurrently inside one tool
+ *     call, so the 25-step agent budget is untouched.
+ *
+ * The budget is an internal safety valve, not operator configuration, so it is
+ * a module constant — no new environment variable (per the issue's acceptance
+ * criteria) and no redeploy-gated knob. Per the PRD it becomes a
+ * settings-registry knob (never an env var) only IF a concrete tuning need
+ * appears.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { runUserQueryPipeline, type UserQueryOutcome } from "@atlas/api/lib/tools/sql";
+import { saveDraftCardCache } from "@atlas/api/lib/dashboard-draft-cache";
+
+const log = createLogger("dashboard-seeding");
+
+/**
+ * Wall-clock budget (ms) for one seeding batch. Cards execute concurrently, so
+ * this bounds the whole batch, not each card. A card still running when it
+ * elapses is left staged-unseeded (the canvas-mount render fills it in later),
+ * never failed. Chosen a touch below the default per-statement timeout
+ * (`ATLAS_QUERY_TIMEOUT`, 30s) so a single pathological card can't hold the
+ * tool call open for the full statement timeout while the rest of the board
+ * waits.
+ */
+export const SEED_WALL_CLOCK_BUDGET_MS = 15_000;
+
+/** Longest per-card error message echoed back to the agent (defensive cap — the
+ *  pipeline already scrubs secrets, this just keeps the tool envelope compact). */
+const MAX_SEED_ERROR_LEN = 300;
+
+/** One card to seed: its stable draft id, its title, its SQL, and the physical
+ *  connection it should run against (null → the workspace default datasource). */
+export interface SeedCardSpec {
+  readonly cardId: string;
+  readonly title: string;
+  readonly sql: string;
+  readonly connectionId: string | null;
+}
+
+export interface SeedDraftCardsOptions {
+  readonly userId: string;
+  readonly dashboardId: string;
+  readonly cards: readonly SeedCardSpec[];
+  /**
+   * Resolved DEFAULT dashboard parameter values (shared by every card),
+   * produced by `resolveDashboardParameterValues`. The seed renders each card
+   * with its parameters' defaults — the same values the persisted-cache render
+   * uses — never an interactive override.
+   */
+  readonly parameters: Record<string, string | number | null>;
+  /** Whole-batch wall-clock budget in ms. Defaults to {@link SEED_WALL_CLOCK_BUDGET_MS}. */
+  readonly budgetMs?: number;
+}
+
+/**
+ * The outcome of seeding one card, reported back to the agent in the tool
+ * result. A tagged union so the agent (and our tests) can branch on `status`
+ * rather than sniffing `rowCount`:
+ *   - `rows`     — executed and cached; `rowCount` rows.
+ *   - `empty`    — executed and cached; zero rows (an honest empty tile).
+ *   - `error`    — execution (or the cache write) failed; the card is still
+ *                  staged. `message` is a scrubbed, agent-actionable reason.
+ *   - `unseeded` — the wall-clock budget elapsed before this card finished; it
+ *                  is staged-not-seeded and the canvas-mount render will fill it.
+ */
+export type CardSeedOutcome = {
+  readonly cardId: string;
+  readonly title: string;
+} & (
+  | { readonly status: "rows"; readonly rowCount: number }
+  | { readonly status: "empty" }
+  | { readonly status: "error"; readonly message: string }
+  | { readonly status: "unseeded" }
+);
+
+/** A sentinel distinct from every {@link UserQueryOutcome} object, so the race
+ *  winner is discriminated by identity, not by sniffing shape. */
+const TIMEOUT = Symbol("seed-budget-elapsed");
+
+interface Deadline {
+  readonly promise: Promise<typeof TIMEOUT>;
+  readonly cancel: () => void;
+}
+
+function createDeadline(ms: number): Deadline {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<typeof TIMEOUT>((resolve) => {
+    timer = setTimeout(() => resolve(TIMEOUT), ms);
+  });
+  return {
+    promise,
+    cancel: () => {
+      if (timer) clearTimeout(timer);
+    },
+  };
+}
+
+/** Map a non-ok pipeline outcome to a compact, agent-actionable message. */
+function outcomeErrorMessage(outcome: Exclude<UserQueryOutcome, { kind: "ok" }>): string {
+  const message = "message" in outcome && outcome.message ? outcome.message : outcome.kind;
+  return message.length > MAX_SEED_ERROR_LEN
+    ? `${message.slice(0, MAX_SEED_ERROR_LEN)}…`
+    : message;
+}
+
+async function seedOneCard(
+  opts: SeedDraftCardsOptions,
+  card: SeedCardSpec,
+  deadline: Promise<typeof TIMEOUT>,
+): Promise<CardSeedOutcome> {
+  const base = { cardId: card.cardId, title: card.title } as const;
+
+  let raced: UserQueryOutcome | typeof TIMEOUT;
+  try {
+    raced = await Promise.race([
+      runUserQueryPipeline({
+        sql: card.sql,
+        ...(card.connectionId ? { connectionId: card.connectionId } : {}),
+        explanation: `Dashboard seed: ${card.title}`,
+        parameters: opts.parameters,
+      }),
+      deadline,
+    ]);
+  } catch (err) {
+    // runUserQueryPipeline maps its errors onto the outcome union, so a
+    // rejection here is unexpected — treat it as a fail-soft per-card error,
+    // never letting it bubble up and fail the whole build.
+    log.warn(
+      { err: errorMessage(err), dashboardId: opts.dashboardId, cardId: card.cardId },
+      "seedDraftCards: card execution threw unexpectedly",
+    );
+    return { ...base, status: "error", message: "Execution failed unexpectedly." };
+  }
+
+  if (raced === TIMEOUT) {
+    return { ...base, status: "unseeded" };
+  }
+
+  if (raced.kind !== "ok") {
+    return { ...base, status: "error", message: outcomeErrorMessage(raced) };
+  }
+
+  // Persist to the caller's DRAFT cache (never the published card cache, never
+  // the shared Query Cache) — the draft card's own data home (ADR-0034).
+  const saved = await saveDraftCardCache(opts.userId, opts.dashboardId, card.cardId, {
+    columns: raced.columns,
+    rows: raced.rows,
+  });
+  if (!saved.ok) {
+    // The rows executed but couldn't be persisted (no draft row / no DB /
+    // transient error). The card is staged; report it unseeded so the agent
+    // knows the canvas-mount render — not this tool call — will surface the
+    // data. Logged, never silently dropped.
+    log.warn(
+      {
+        reason: saved.reason,
+        dashboardId: opts.dashboardId,
+        cardId: card.cardId,
+      },
+      "seedDraftCards: executed but could not persist draft cache",
+    );
+    return { ...base, status: "unseeded" };
+  }
+
+  return raced.rows.length === 0
+    ? { ...base, status: "empty" }
+    : { ...base, status: "rows", rowCount: raced.rows.length };
+}
+
+/**
+ * Seed a batch of staged draft cards: execute each card's SQL concurrently
+ * through the full user-query pipeline, bounded by one wall clock, fail-soft
+ * per card, and persist each success as the card's draft cache. Returns a
+ * per-card outcome in the SAME order as `opts.cards`.
+ *
+ * The caller MUST have already staged these cards into the user's draft (the
+ * draft row is the FK anchor `saveDraftCardCache` writes against) — this runs
+ * AFTER the snapshot commit, so a seed failure can never leave the build
+ * half-committed.
+ */
+export async function seedDraftCards(
+  opts: SeedDraftCardsOptions,
+): Promise<CardSeedOutcome[]> {
+  if (opts.cards.length === 0) return [];
+
+  const budgetMs = opts.budgetMs ?? SEED_WALL_CLOCK_BUDGET_MS;
+  const deadline = createDeadline(budgetMs);
+  try {
+    return await Promise.all(
+      opts.cards.map((card) => seedOneCard(opts, card, deadline.promise)),
+    );
+  } finally {
+    // Clear the timer so a fast batch doesn't hold the event loop for the full
+    // budget after every card already resolved.
+    deadline.cancel();
+  }
+}

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard-seeding.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard-seeding.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Bound-editor seeding test (#4558, ADR-0034 Decision 1).
+ *
+ * The bound `addCard` executes the card it just staged once through the full
+ * SQL pipeline and reports the outcome as `seed` on its result, so the agent
+ * self-corrects instead of claiming a card works when its query returned
+ * nothing. This is the single-card twin of `createDashboard`'s batch seeding.
+ *
+ * Unlike the other bound-dashboard suites (which keep `runUserQueryPipeline`
+ * unreachable), this file gives it a controllable mock and lets the REAL
+ * draft-cache write land in the stub pool — so the addCard → seed wire is
+ * exercised end to end against a recorded query sequence.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { _resetPool, type InternalPool } from "../../db/internal";
+import type { UserQueryOutcome } from "@atlas/api/lib/tools/sql";
+
+const validateSQLMock = mock(async (_sql: string) => ({
+  valid: true as const,
+  classification: { tablesAccessed: [], columnsAccessed: [] },
+}));
+
+let pipelineOutcome: UserQueryOutcome = {
+  kind: "ok",
+  columns: ["a"],
+  rows: [{ a: 1 }, { a: 2 }],
+  rowCount: 2,
+  executionMs: 1,
+  truncated: false,
+  maskingApplied: false,
+};
+const runUserQueryPipelineMock = mock(() => Promise.resolve(pipelineOutcome));
+
+void mock.module("@atlas/api/lib/tools/sql", () => ({
+  validateSQL: validateSQLMock,
+  executeSQL: undefined as never,
+  runUserQueryPipeline: runUserQueryPipelineMock,
+}));
+
+const invalidateScreenshotMock = mock((_dashboardId: string) => {});
+void mock.module("@atlas/api/lib/dashboard-screenshot", () => ({
+  screenshotDashboard: async () => ({ ok: false as const, message: "not used" }),
+  invalidateDashboardScreenshot: invalidateScreenshotMock,
+  closeScreenshotBrowser: async () => {},
+  _resetScreenshotCache: () => {},
+  _screenshotCacheSize: () => 0,
+  _setRenderFn: () => {},
+}));
+
+const { createBoundDashboardTools } = await import("../bound-dashboard");
+
+// ---- stub pool (records pool.query in order) ----------------------------
+interface QueryResult {
+  rows: Record<string, unknown>[];
+}
+let queryCalls: { sql: string; params?: unknown[] }[] = [];
+let queryResults: QueryResult[] = [];
+let queryResultIndex = 0;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+function enableInternalDB() {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+}
+function setResults(...results: QueryResult[]) {
+  queryResults = results;
+  queryResultIndex = 0;
+}
+
+const dashboardRow = {
+  id: "dash-1",
+  org_id: "org-1",
+  owner_id: "user-1",
+  title: "Demo",
+  description: null,
+  parameters: [],
+  share_token: null,
+  share_expires_at: null,
+  share_mode: "public",
+  refresh_schedule: null,
+  last_refresh_at: null,
+  next_refresh_at: null,
+  card_count: 0,
+  created_at: "2026-05-17T00:00:00.000Z",
+  updated_at: "2026-05-17T00:00:00.000Z",
+};
+
+const baselineSnap = { dashboardId: "dash-1", title: "Demo", description: null, cards: [] };
+const existingDraftRow = {
+  user_id: "user-1",
+  dashboard_id: "dash-1",
+  draft: baselineSnap,
+  baseline: baselineSnap,
+  published_baseline_at: "2026-05-17T00:00:00.000Z",
+  created_at: "2026-05-17T00:00:00.000Z",
+  updated_at: "2026-05-17T00:00:00.000Z",
+};
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+async function runTool<T = unknown>(tool: any, args: unknown): Promise<T> {
+  if (!tool?.execute) throw new Error("tool has no execute");
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await tool.execute(args, undefined as any)) as T;
+}
+
+interface AddCardResult {
+  kind: string;
+  error?: string;
+  card?: { id: string; title: string };
+  seed?: { cardId: string; title: string; status: string; rowCount?: number; message?: string };
+}
+
+describe("bound addCard — tool-side seeding (#4558)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryResults = [];
+    queryResultIndex = 0;
+    validateSQLMock.mockClear();
+    runUserQueryPipelineMock.mockClear();
+    pipelineOutcome = {
+      kind: "ok",
+      columns: ["a"],
+      rows: [{ a: 1 }, { a: 2 }],
+      rowCount: 2,
+      executionMs: 1,
+      truncated: false,
+      maskingApplied: false,
+    };
+    delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  it("seeds the new card and reports rows on the result", async () => {
+    enableInternalDB();
+    // getDashboard (dash + cards), loadDraft (existing), saveDraft UPDATE,
+    // saveDraftCardCache INSERT…RETURNING.
+    setResults(
+      { rows: [dashboardRow] },
+      { rows: [] }, // cards
+      { rows: [existingDraftRow] },
+      { rows: [{ user_id: "user-1" }] },
+      { rows: [{ card_id: "seeded" }] },
+    );
+
+    const tools = createBoundDashboardTools({ dashboardId: "dash-1", orgId: "org-1", userId: "user-1" });
+    const result = await runTool<AddCardResult>(tools.addCard, {
+      title: "New",
+      sql: "SELECT a",
+      chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+    });
+
+    expect(result.kind).toBe("ok");
+    expect(result.seed).toEqual({
+      cardId: result.card!.id,
+      title: "New",
+      status: "rows",
+      rowCount: 2,
+    });
+    // The seed ran through the full pipeline and wrote the draft cache.
+    expect(runUserQueryPipelineMock).toHaveBeenCalledTimes(1);
+    expect(queryCalls.some((q) => /INSERT INTO dashboard_draft_card_cache/.test(q.sql))).toBe(true);
+  });
+
+  it("is fail-soft: a failed seed still adds the card and reports error", async () => {
+    enableInternalDB();
+    pipelineOutcome = { kind: "query_failed", message: 'relation "nope" does not exist' };
+    setResults(
+      { rows: [dashboardRow] },
+      { rows: [] },
+      { rows: [existingDraftRow] },
+      { rows: [{ user_id: "user-1" }] },
+    );
+
+    const tools = createBoundDashboardTools({ dashboardId: "dash-1", orgId: "org-1", userId: "user-1" });
+    const result = await runTool<AddCardResult>(tools.addCard, {
+      title: "Broken",
+      sql: "SELECT a",
+      chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+    });
+
+    // The card was still added (kind ok); only the seed reports the failure.
+    expect(result.kind).toBe("ok");
+    expect(result.card?.title).toBe("Broken");
+    expect(result.seed?.status).toBe("error");
+    expect(result.seed?.message).toBe('relation "nope" does not exist');
+    // A failed seed never writes the draft cache.
+    expect(queryCalls.some((q) => /INSERT INTO dashboard_draft_card_cache/.test(q.sql))).toBe(false);
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard-seeding.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard-seeding.test.ts
@@ -206,4 +206,36 @@ describe("bound addCard — tool-side seeding (#4558)", () => {
     // A failed seed never writes the draft cache.
     expect(queryCalls.some((q) => /INSERT INTO dashboard_draft_card_cache/.test(q.sql))).toBe(false);
   });
+
+  it("degrades to unseeded (never fails the add) when the card's connection group has no members", async () => {
+    enableInternalDB();
+    // getDashboard (dash + cards), loadDraft, saveDraft, then the group snapshot
+    // read for connection resolution returns NO members → NoGroupMembersError.
+    setResults(
+      { rows: [dashboardRow] },
+      { rows: [] },
+      { rows: [existingDraftRow] },
+      { rows: [{ user_id: "user-1" }] },
+      { rows: [] }, // workspace_plugins group-member lookup → empty
+    );
+
+    const tools = createBoundDashboardTools({
+      dashboardId: "dash-1",
+      orgId: "org-1",
+      userId: "user-1",
+      connectionGroupId: "grp-empty",
+    });
+    const result = await runTool<AddCardResult>(tools.addCard, {
+      title: "Orphan",
+      sql: "SELECT a",
+      chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+    });
+
+    // The card is added; seeding degrades to unseeded (canvas-mount render fills
+    // it), and the pipeline is never reached because the connection can't resolve.
+    expect(result.kind).toBe("ok");
+    expect(result.seed?.status).toBe("unseeded");
+    expect(runUserQueryPipelineMock).toHaveBeenCalledTimes(0);
+    expect(queryCalls.some((q) => /INSERT INTO dashboard_draft_card_cache/.test(q.sql))).toBe(false);
+  });
 });

--- a/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
@@ -37,10 +37,41 @@ const validateSQLMock = mock(async (sql: string, _connectionId?: string) => {
   return { valid: true as const, classification: { tablesAccessed: [], columnsAccessed: [] } };
 });
 
+// #4558 — createDashboard now seeds each staged card via runUserQueryPipeline
+// (through the shared dashboard-seeding module). Give the test a controllable
+// pipeline keyed by SQL so seeding outcomes can be asserted, plus a stub for
+// the draft-cache write so seeding never touches the mock transaction pool.
+type PipeOutcome =
+  | { kind: "ok"; columns: string[]; rows: Record<string, unknown>[]; rowCount: number; executionMs: number; truncated: boolean; maskingApplied: boolean }
+  | { kind: "query_failed"; message: string };
+
+const pipelineBySql = new Map<string, PipeOutcome>();
+function pipelineOk(rows: Record<string, unknown>[]): PipeOutcome {
+  return {
+    kind: "ok",
+    columns: rows.length > 0 ? Object.keys(rows[0]) : ["n"],
+    rows,
+    rowCount: rows.length,
+    executionMs: 1,
+    truncated: false,
+    maskingApplied: false,
+  };
+}
+const runUserQueryPipelineMock = mock((opts: { sql: string }) =>
+  Promise.resolve(pipelineBySql.get(opts.sql) ?? pipelineOk([{ n: 1 }])),
+);
+
 void mock.module("@atlas/api/lib/tools/sql", () => ({
   validateSQL: validateSQLMock,
   executeSQL: undefined as never,
-  runUserQueryPipeline: undefined as never,
+  runUserQueryPipeline: runUserQueryPipelineMock,
+}));
+
+const saveDraftCardCacheMock = mock(() =>
+  Promise.resolve({ ok: true as const, cachedAt: "2026-07-17T00:00:00.000Z" }),
+);
+void mock.module("@atlas/api/lib/dashboard-draft-cache", () => ({
+  saveDraftCardCache: saveDraftCardCacheMock,
 }));
 
 const { createDashboard, deriveTextCardTitle } = await import("@atlas/api/lib/tools/create-dashboard");
@@ -136,6 +167,13 @@ async function run(args: ExecuteParams) {
           description: string | null;
           cardCount: number;
           draft: boolean;
+          cardOutcomes: {
+            cardId: string;
+            title: string;
+            status: "rows" | "empty" | "error" | "unseeded";
+            rowCount?: number;
+            message?: string;
+          }[];
         }
       | {
           kind: "err";
@@ -162,6 +200,9 @@ describe("createDashboard tool", () => {
     clientThrowOnCall = new Map();
     clientQueryCount = 0;
     validateSQLMock.mockClear();
+    runUserQueryPipelineMock.mockClear();
+    saveDraftCardCacheMock.mockClear();
+    pipelineBySql.clear();
     delete process.env.DATABASE_URL;
     _resetPool(null);
   });
@@ -258,6 +299,103 @@ describe("createDashboard tool", () => {
     expect(baseline.cards).toEqual([]);
     // No parameters declared → INSERT persists an empty array (#2267).
     expect(JSON.parse(dashParams[4] as string)).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------
+  // Tool-side seeding (#4558, ADR-0034 Decision 1)
+  // -------------------------------------------------------------------
+
+  it("seeds each chart card and reports per-card outcomes (rows / empty)", async () => {
+    enableInternalDB();
+    setClientResults(
+      { rows: [] }, // BEGIN
+      { rows: [{ id: "dash-seed", title: "Board", description: null, updated_at: "2026-07-17" }] },
+      { rows: [] }, // INSERT drafts
+      { rows: [] }, // COMMIT
+    );
+    pipelineBySql.set("SELECT a", pipelineOk([{ a: 1 }, { a: 2 }, { a: 3 }]));
+    pipelineBySql.set("SELECT b", pipelineOk([])); // empty
+
+    const result = await run({
+      title: "Board",
+      cards: [
+        { title: "A", sql: "SELECT a", chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] } },
+        { title: "B", sql: "SELECT b", chartConfig: { type: "table", categoryColumn: "b", valueColumns: ["b"] } },
+      ],
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.cardOutcomes).toEqual([
+      { cardId: expect.any(String), title: "A", status: "rows", rowCount: 3 },
+      { cardId: expect.any(String), title: "B", status: "empty" },
+    ]);
+    // Each card ran through the pipeline and was cached.
+    expect(runUserQueryPipelineMock).toHaveBeenCalledTimes(2);
+    expect(saveDraftCardCacheMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("is fail-soft: a card whose seed execution fails is still staged and the build succeeds", async () => {
+    enableInternalDB();
+    setClientResults(
+      { rows: [] },
+      { rows: [{ id: "dash-fs", title: "Board", description: null, updated_at: "2026-07-17" }] },
+      { rows: [] },
+      { rows: [] },
+    );
+    pipelineBySql.set("SELECT ok", pipelineOk([{ a: 1 }]));
+    pipelineBySql.set("SELECT boom", { kind: "query_failed", message: 'column "x" does not exist' });
+
+    const result = await run({
+      title: "Board",
+      cards: [
+        { title: "Good", sql: "SELECT ok", chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] } },
+        { title: "Bad", sql: "SELECT boom", chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] } },
+      ],
+    });
+
+    // The build committed (transaction ran, COMMIT fired) despite the bad card.
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.cardCount).toBe(2);
+    expect(clientQueryCalls.at(-1)?.sql).toBe("COMMIT");
+    expect(result.cardOutcomes[0]).toEqual({ cardId: expect.any(String), title: "Good", status: "rows", rowCount: 1 });
+    expect(result.cardOutcomes[1]).toEqual({
+      cardId: expect.any(String),
+      title: "Bad",
+      status: "error",
+      message: 'column "x" does not exist',
+    });
+    // The failing card was never cached.
+    expect(saveDraftCardCacheMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not seed text / section cards (no data to fetch)", async () => {
+    enableInternalDB();
+    setClientResults(
+      { rows: [] },
+      { rows: [{ id: "dash-mix", title: "Board", description: null, updated_at: "2026-07-17" }] },
+      { rows: [] },
+      { rows: [] },
+    );
+    pipelineBySql.set("SELECT a", pipelineOk([{ a: 1 }]));
+
+    const result = await run({
+      title: "Board",
+      cards: [
+        { kind: "text", content: "## Section" },
+        { title: "A", sql: "SELECT a", chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] } },
+      ],
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    // Two cards staged, but only the chart card is seeded / reported.
+    expect(result.cardCount).toBe(2);
+    expect(result.cardOutcomes).toEqual([
+      { cardId: expect.any(String), title: "A", status: "rows", rowCount: 1 },
+    ]);
+    expect(runUserQueryPipelineMock).toHaveBeenCalledTimes(1);
   });
 
   // -------------------------------------------------------------------

--- a/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
@@ -70,8 +70,14 @@ void mock.module("@atlas/api/lib/tools/sql", () => ({
 const saveDraftCardCacheMock = mock(() =>
   Promise.resolve({ ok: true as const, cachedAt: "2026-07-17T00:00:00.000Z" }),
 );
+// Mock ALL runtime exports (mock-all-exports discipline) even though seeding
+// only calls saveDraftCardCache — a future loaded graph reaching another export
+// must not fail with "Export named X not found".
 void mock.module("@atlas/api/lib/dashboard-draft-cache", () => ({
   saveDraftCardCache: saveDraftCardCacheMock,
+  loadDraftCardCache: mock(() => Promise.resolve(new Map())),
+  seedDraftCardCacheFromPublished: mock(() => Promise.resolve()),
+  EMPTY_DRAFT_CARD_CACHE: new Map(),
 }));
 
 const { createDashboard, deriveTextCardTitle } = await import("@atlas/api/lib/tools/create-dashboard");
@@ -368,6 +374,52 @@ describe("createDashboard tool", () => {
     });
     // The failing card was never cached.
     expect(saveDraftCardCacheMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades to all-unseeded (never fails the committed build) when the connection group has no members", async () => {
+    enableInternalDB();
+    setClientResults(
+      { rows: [] },
+      { rows: [{ id: "dash-ng", title: "Board", description: null, updated_at: "2026-07-17" }] },
+      { rows: [] },
+      { rows: [] },
+    );
+    // The default mock pool.query returns { rows: [] }, so the group-member
+    // lookup finds no members → resolveCardConnectionId throws
+    // NoGroupMembersError → seeding degrades to unseeded (the build still ok).
+    pipelineBySql.set("SELECT a", pipelineOk([{ a: 1 }]));
+
+    const result = await withRequestContext(
+      { requestId: "test-req", user: TEST_USER, connectionGroupId: "grp-empty" },
+      async () => {
+        const fn = createDashboard.execute as ExecuteFn;
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        return (await fn(
+          {
+            title: "Board",
+            cards: [
+              { title: "A", sql: "SELECT a", chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] } },
+            ],
+            // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any,
+          // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+          undefined as any,
+        )) as {
+          kind: string;
+          cardCount?: number;
+          cardOutcomes?: { cardId: string; title: string; status: string; rowCount?: number }[];
+        };
+      },
+    );
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    // The dashboard committed …
+    expect(clientQueryCalls.at(-1)?.sql).toBe("COMMIT");
+    // … but no card was seeded (group can't resolve) — the pipeline never ran.
+    expect(result.cardOutcomes).toEqual([{ cardId: expect.any(String), title: "A", status: "unseeded" }]);
+    expect(runUserQueryPipelineMock).toHaveBeenCalledTimes(0);
+    expect(saveDraftCardCacheMock).toHaveBeenCalledTimes(0);
   });
 
   it("does not seed text / section cards (no data to fetch)", async () => {

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -153,8 +153,9 @@ async function maybeApplyToDraft(
     return { ok: false, error: "Could not persist draft update." };
   }
   // Return the dashboard the fork read consumed so a caller that immediately
-  // seeds the new card (#4558 `addCard`) reuses it — its parameters +
-  // connection group — instead of a second getDashboard round-trip.
+  // seeds the new card (#4558 `addCard`) reuses it — its `orgId` (to scope
+  // connection resolution) + parameter defaults — instead of a second
+  // getDashboard round-trip.
   return { ok: true, dashboard: published.data };
 }
 

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -26,12 +26,19 @@ import { dashboardChartConfigSchema, dashboardCardAnnotationsSchema } from "@use
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
-import { validateAutoComparison } from "@atlas/api/lib/dashboard-parameters";
+import {
+  validateAutoComparison,
+  resolveDashboardParameterValues,
+} from "@atlas/api/lib/dashboard-parameters";
 import {
   getCard,
   getDashboard,
+  resolveCardConnectionId,
+  NoGroupMembersError,
   CardLayoutSchema,
 } from "@atlas/api/lib/dashboards";
+import type { DashboardWithCards } from "@atlas/api/lib/dashboard-types";
+import { seedDraftCards, type CardSeedOutcome } from "@atlas/api/lib/dashboard-seeding";
 import type { DashboardCard, DashboardCardKind, DashboardCardLayout } from "@atlas/api/lib/dashboard-types";
 import { buildCardSummary } from "@atlas/api/lib/bound-chat-context";
 import {
@@ -107,7 +114,7 @@ export interface BoundDashboardToolContext {
 async function maybeApplyToDraft(
   ctx: BoundDashboardToolContext,
   change: import("@atlas/api/lib/dashboard-versioning").DraftChange,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true; dashboard: DashboardWithCards } | { ok: false; error: string }> {
   // #4315 — close the anonymous-bound bypass. An edit that can't be attributed
   // to a user can't land in a private draft, so we REJECT rather than write to
   // published (there is no direct-published fall-through anymore, #4324).
@@ -145,7 +152,67 @@ async function maybeApplyToDraft(
   if (!saved) {
     return { ok: false, error: "Could not persist draft update." };
   }
-  return { ok: true };
+  // Return the dashboard the fork read consumed so a caller that immediately
+  // seeds the new card (#4558 `addCard`) reuses it — its parameters +
+  // connection group — instead of a second getDashboard round-trip.
+  return { ok: true, dashboard: published.data };
+}
+
+/**
+ * Seed a single card `addCard` just staged into the draft (#4558, ADR-0034
+ * Decision 1) — the bound-editor twin of `createDashboard`'s batch seeding.
+ * Executes the card once through the full SQL pipeline and caches the result as
+ * the card's draft data, returning a per-card outcome. NEVER throws: `addCard`
+ * has already succeeded (the card is staged), so a seeding fault degrades to
+ * `unseeded` (the canvas-mount render fills it in) rather than turning a
+ * committed add into an error.
+ */
+async function seedAddedCard(
+  ctx: BoundDashboardToolContext,
+  cardId: string,
+  title: string,
+  sql: string,
+  dashboard: DashboardWithCards,
+): Promise<CardSeedOutcome> {
+  const unseeded: CardSeedOutcome = { cardId, title, status: "unseeded" };
+  // Unattributed edits never reach here (maybeApplyToDraft rejects a missing
+  // userId first), but guard so seeding can't run without a draft owner.
+  if (!ctx.userId) return unseeded;
+  try {
+    let connectionId: string | null;
+    try {
+      connectionId = await resolveCardConnectionId(
+        { connectionGroupId: ctx.connectionGroupId ?? null },
+        dashboard.orgId,
+      );
+    } catch (err) {
+      // A group with zero members can't be seeded (the same fault a refresh
+      // would hit) — leave the card staged-unseeded rather than failing.
+      if (err instanceof NoGroupMembersError) {
+        log.warn(
+          { groupId: err.groupId, dashboardId: ctx.dashboardId, cardId },
+          "addCard seeding: card's connection group has no members",
+        );
+        return unseeded;
+      }
+      throw err;
+    }
+
+    const parameters = resolveDashboardParameterValues(dashboard.parameters, undefined);
+    const [outcome] = await seedDraftCards({
+      userId: ctx.userId,
+      dashboardId: ctx.dashboardId,
+      cards: [{ cardId, title, sql, connectionId }],
+      parameters,
+    });
+    return outcome ?? unseeded;
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), dashboardId: ctx.dashboardId, cardId },
+      "addCard seeding failed — card left for canvas-mount render",
+    );
+    return unseeded;
+  }
 }
 
 /**
@@ -242,7 +309,9 @@ export function createBoundDashboardTools(
   });
 
   const addCardTool = tool({
-    description: `Add a new card to the dashboard. Validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. The grid is 24 columns wide. Layout is optional — when omitted the card stages with no placement and the grid renderer auto-arranges it at view time. Pass a layout if you want a specific {x, y, w, h} on the 24-column grid.`,
+    description: `Add a new card to the dashboard. Validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. The grid is 24 columns wide. Layout is optional — when omitted the card stages with no placement and the grid renderer auto-arranges it at view time. Pass a layout if you want a specific {x, y, w, h} on the 24-column grid.
+
+On success the result includes \`seed\` — the card's data outcome: \`rows\` (with a rowCount), \`empty\` (the query ran but returned nothing), \`error\` (the card WAS added but its query failed — \`message\` says why), or \`unseeded\` (added; data loads when the dashboard opens). If \`seed\` is \`empty\` or \`error\`, say so plainly and offer to fix it rather than claiming the card shows data.`,
     inputSchema: z.object({
       title: z.string().min(1).max(200).describe("Card title (visible to the user)"),
       sql: z.string().min(1).describe("Read-only SELECT query"),
@@ -316,6 +385,11 @@ export function createBoundDashboardTools(
         if (!applied.ok) return { kind: "err" as const, error: applied.error };
         // #2367 — user's draft view shifted, drop cached screenshots.
         invalidateDashboardScreenshot(dashboardId);
+        // #4558 — the card is now staged in the draft; seed its draft cache so
+        // the tile shows real data the moment the user looks, and report the
+        // outcome (rows / empty / error / unseeded) so the agent self-corrects
+        // instead of claiming a card works when its query returned nothing.
+        const seed = await seedAddedCard(ctx, draftCard.id, title, sql, applied.dashboard);
         return {
           kind: "ok" as const,
           card: {
@@ -324,6 +398,7 @@ export function createBoundDashboardTools(
             chartType: draftCard.chartConfig?.type ?? "table",
             position: draftCard.position,
           },
+          seed,
         };
       } catch (err) {
         log.warn({ err: errorMessage(err), dashboardId }, "addCard tool failed unexpectedly");

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -64,7 +64,11 @@ import {
 } from "@atlas/api/lib/dashboards";
 import { hasInternalDB, getInternalDB } from "@atlas/api/lib/db/internal";
 import type { DashboardSnapshot, DashboardSnapshotCard } from "@atlas/api/lib/dashboard-versioning";
-import { seedDraftCards, type CardSeedOutcome } from "@atlas/api/lib/dashboard-seeding";
+import {
+  seedDraftCards,
+  type CardSeedOutcome,
+  type SeedCardInput,
+} from "@atlas/api/lib/dashboard-seeding";
 
 const log = createLogger("tool:create-dashboard");
 
@@ -189,7 +193,7 @@ async function seedStagedCards(
     orgId: string | null;
     connectionGroupId: string | null;
   },
-  seedCards: { cardId: string; title: string; sql: string }[],
+  seedCards: SeedCardInput[],
   parameters: z.infer<typeof dashboardParametersSchema> | undefined,
   title: string,
 ): Promise<CardSeedOutcome[]> {
@@ -478,7 +482,7 @@ The tool EXECUTES each chart card once as it builds the dashboard and returns \`
         // they never become seed specs. Every chart card is stamped with the
         // conversation's group, so the batch resolves one physical connection
         // (below) — the SAME resolution a later refresh uses.
-        const seedCards: { cardId: string; title: string; sql: string }[] = [];
+        const seedCards: SeedCardInput[] = [];
         const snapshotCards: DashboardSnapshotCard[] = cards.map((card, position) => {
           const id = crypto.randomUUID();
           if (card.kind === "text") {

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -52,10 +52,19 @@ import {
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
-import { extractPlaceholderNames, validateAutoComparison } from "@atlas/api/lib/dashboard-parameters";
-import { CardLayoutSchema } from "@atlas/api/lib/dashboards";
+import {
+  extractPlaceholderNames,
+  validateAutoComparison,
+  resolveDashboardParameterValues,
+} from "@atlas/api/lib/dashboard-parameters";
+import {
+  CardLayoutSchema,
+  resolveCardConnectionId,
+  NoGroupMembersError,
+} from "@atlas/api/lib/dashboards";
 import { hasInternalDB, getInternalDB } from "@atlas/api/lib/db/internal";
 import type { DashboardSnapshot, DashboardSnapshotCard } from "@atlas/api/lib/dashboard-versioning";
+import { seedDraftCards, type CardSeedOutcome } from "@atlas/api/lib/dashboard-seeding";
 
 const log = createLogger("tool:create-dashboard");
 
@@ -146,6 +155,15 @@ export type CreateDashboardResult =
       cardCount: number;
       /** Always `true` for this slice — cards are staged in the user's draft. */
       draft: true;
+      /**
+       * Per-card seeding outcomes (#4558) — one entry per CHART card (text /
+       * section cards fetch no data and are omitted), in card order. Each staged
+       * card's SQL is executed once inside this tool call and its result cached
+       * as the draft card's initial data; a card that errored or hit the
+       * wall-clock budget is still staged (the build succeeds) and reported here
+       * so the agent can self-correct instead of announcing a broken board.
+       */
+      cardOutcomes: CardSeedOutcome[];
     }
   | {
       kind: "err";
@@ -153,6 +171,78 @@ export type CreateDashboardResult =
       /** Populated only when the failure was per-card SQL validation; empty otherwise. */
       validationErrors?: CreateDashboardCardValidationError[];
     };
+
+/**
+ * Seed the just-staged chart cards (#4558). Resolves the batch's physical
+ * connection from the conversation's group and the dashboard's parameter
+ * DEFAULTS once (both shared by every card — every seed card carries the same
+ * group), then runs the batch through {@link seedDraftCards}. Never throws — a
+ * seeding failure must not turn a committed dashboard into an error envelope,
+ * so a connection-resolution, parameter-resolution, or batch-level fault
+ * degrades to "every card unseeded" (the canvas-mount render fills them in)
+ * rather than propagating.
+ */
+async function seedStagedCards(
+  ctx: {
+    ownerId: string;
+    dashboardId: string;
+    orgId: string | null;
+    connectionGroupId: string | null;
+  },
+  seedCards: { cardId: string; title: string; sql: string }[],
+  parameters: z.infer<typeof dashboardParametersSchema> | undefined,
+  title: string,
+): Promise<CardSeedOutcome[]> {
+  const { ownerId, dashboardId, orgId, connectionGroupId } = ctx;
+  if (seedCards.length === 0) return [];
+  const unseeded = (): CardSeedOutcome[] =>
+    seedCards.map((s) => ({ cardId: s.cardId, title: s.title, status: "unseeded" as const }));
+  try {
+    // Resolve the group's primary member — the exact connection a later refresh
+    // runs against, so the seeded rows and the first refresh agree. A group
+    // with no members can't be seeded (the same fault a refresh would hit).
+    let connectionId: string | null;
+    try {
+      connectionId = await resolveCardConnectionId({ connectionGroupId }, orgId);
+    } catch (err) {
+      if (err instanceof NoGroupMembersError) {
+        log.warn(
+          { groupId: err.groupId, dashboardId, title },
+          "createDashboard: card connection group has no members — cards left unseeded",
+        );
+        return unseeded();
+      }
+      throw err;
+    }
+
+    let paramValues: Record<string, string | number | null>;
+    try {
+      paramValues = resolveDashboardParameterValues(parameters ?? null, undefined);
+    } catch (err) {
+      // A malformed parameter default (rare — the render path resolves the same
+      // way) can't be seeded against; leave the cards for the canvas render
+      // rather than reporting spurious per-card binding errors.
+      log.warn(
+        { err: errorMessage(err), dashboardId, title },
+        "createDashboard: could not resolve parameter defaults for seeding",
+      );
+      return unseeded();
+    }
+
+    return await seedDraftCards({
+      userId: ownerId,
+      dashboardId,
+      cards: seedCards.map((s) => ({ ...s, connectionId })),
+      parameters: paramValues,
+    });
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), dashboardId, title },
+      "createDashboard: seeding batch failed — cards left for canvas-mount render",
+    );
+    return unseeded();
+  }
+}
 
 export const createDashboard = tool({
   description: `Create a dashboard the user can keep editing in chat.
@@ -180,7 +270,9 @@ GOAL LINES (thresholds): for any GOAL-BEARING metric — one with a target, budg
 
 PARAMETERS (date ranges + filters): pass a \`parameters\` array to give the dashboard a top-level filter bar that every card binds to. Each parameter is { key, type, default, label } where type is "date" | "text" | "number". In card SQL, reference a parameter as \`:<key>\` (e.g. \`:date_from\`, \`:date_to\`, \`:region\`). For ANY "last N days" / "this quarter" / "year to date" query, declare \`date_from\` + \`date_to\` parameters and write \`WHERE created_at >= :date_from AND created_at < :date_to\` instead of hardcoding the dates — that keeps the dashboard useful for months instead of ageing in days. Date defaults accept ISO dates or relative expressions like "now - 30 days" / "now - 1 month" / "now". Every \`:placeholder\` a card uses MUST be declared in \`parameters\` (values are bound server-side as real query parameters, never interpolated).
 
-If any card has invalid SQL or references an undeclared parameter, the whole call is rejected — no dashboard row is created. Fix the failing card and call again.`,
+If any card has invalid SQL or references an undeclared parameter, the whole call is rejected — no dashboard row is created. Fix the failing card and call again.
+
+The tool EXECUTES each chart card once as it builds the dashboard and returns \`cardOutcomes\` — a per-card result of \`rows\` (with a rowCount), \`empty\` (zero rows), \`error\` (the card is still created, but its query failed — the \`message\` says why), or \`unseeded\` (the card is created; its data loads when the dashboard opens). Read \`cardOutcomes\` after a successful call: if a card came back \`empty\` or \`error\`, tell the user plainly and offer to fix it — don't describe a card as showing data it didn't return.`,
 
   inputSchema: z.object({
     title: z.string().min(1).max(200).describe("Dashboard title"),
@@ -380,10 +472,18 @@ If any card has invalid SQL or references an undeclared parameter, the whole cal
         // `sql: ""`, `chartConfig: null`, and its markdown in `content`. It
         // carries no connection group (it never queries). Chart cards keep
         // the conversation's environment scope.
+        // Collected alongside the snapshot so tool-side seeding (#4558) can run
+        // each chart card's SQL once after COMMIT and cache the result as the
+        // card's initial draft data. Text / section cards fetch no data, so
+        // they never become seed specs. Every chart card is stamped with the
+        // conversation's group, so the batch resolves one physical connection
+        // (below) — the SAME resolution a later refresh uses.
+        const seedCards: { cardId: string; title: string; sql: string }[] = [];
         const snapshotCards: DashboardSnapshotCard[] = cards.map((card, position) => {
+          const id = crypto.randomUUID();
           if (card.kind === "text") {
             return {
-              id: crypto.randomUUID(),
+              id,
               position,
               title: card.title?.trim() || deriveTextCardTitle(card.content),
               sql: "",
@@ -393,8 +493,9 @@ If any card has invalid SQL or references an undeclared parameter, the whole cal
               layout: card.layout ?? null,
             };
           }
+          seedCards.push({ cardId: id, title: card.title, sql: card.sql });
           return {
-            id: crypto.randomUUID(),
+            id,
             position,
             title: card.title,
             sql: card.sql,
@@ -452,6 +553,21 @@ If any card has invalid SQL or references an undeclared parameter, the whole cal
           "createDashboard committed — cards staged in user draft",
         );
 
+        // ---- tool-side seeding (#4558, ADR-0034 Decision 1) ----
+        // The cards are now staged in the user's draft (the FK anchor the
+        // draft-cache write needs). Execute each chart card once, concurrently,
+        // bounded by a wall clock, fail-soft per card — persisting each result
+        // as the card's initial draft cache and reporting per-card outcomes so
+        // the agent sees rows / empty / error / unseeded instead of announcing a
+        // board it never validated. Seeding runs AFTER COMMIT so a failing card
+        // can never roll the committed dashboard back.
+        const cardOutcomes = await seedStagedCards(
+          { ownerId, dashboardId, orgId, connectionGroupId: conversationGroupId },
+          seedCards,
+          parameters,
+          title,
+        );
+
         return {
           kind: "ok",
           dashboardId,
@@ -459,6 +575,7 @@ If any card has invalid SQL or references an undeclared parameter, the whole cal
           description: description ?? null,
           cardCount: snapshotCards.length,
           draft: true,
+          cardOutcomes,
         };
       } catch (txErr) {
         // Best-effort rollback. A rollback failure is logged but doesn't


### PR DESCRIPTION
## Summary

Tool-side seeding (ADR-0034 Decision 1) — the build-time half of the seeding decision. `createDashboard` and the bound `addCard` now **execute each staged card once inside the tool call**, persist the result as the card's initial **draft cache** (#4554), and report **per-card outcomes** so the agent self-corrects in the same turn instead of announcing a board of "Never run" tiles.

- **New `lib/dashboard-seeding.ts`** — `seedDraftCards`: runs each card through the full `runUserQueryPipeline` guard (validation / RLS / audit / masking — same as `executeSQL`), **concurrent**, bounded by one **wall clock**, **fail-soft per card**. Returns a `CardSeedOutcome` tagged union: `rows` (rowCount) / `empty` / `error` (staged, reason) / `unseeded` (budget hit or cache-write failed → canvas-mount render fills it).
- **`createDashboard`** seeds the batch after COMMIT (a seed failure can't roll back the committed dashboard) and returns `cardOutcomes`. **Bound `addCard`** seeds the single card and returns `seed`. Both resolve the connection via the card's group — the same resolution a later refresh uses, so seeded rows match the first refresh.
- **No new environment variable** — the wall-clock budget is a module constant (an internal safety valve); per ADR-0034 it becomes a settings-registry knob (never env) only if a concrete tuning need appears.
- `maybeApplyToDraft` now returns the dashboard it read so `addCard` reuses it (no duplicate `getDashboard` round-trip).

Text / section cards fetch no data and are never seeded.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — new `dashboard-seeding.test.ts` (module seam: rows/empty/error/unseeded, budget exhaustion, cache-write-failure, pipeline args), extended `create-dashboard.test.ts` + new `bound-dashboard-seeding.test.ts` (tool seams: per-card outcomes, fail-soft build/add succeeds, no-members group → all unseeded, text cards not seeded)
- [x] `bun run tsgo --noEmit` clean; `bun run lint` clean
- [x] `/ci` — `@atlas/api` 913/913 pass; all drift/lint/type gates green (the lone red `@atlas/mcp smoke.test.ts` is the documented #1472 env-only flake — needs a migrated local DB, MCP-free diff, passes on remote CI's real Postgres)
- [ ] Remote CI (`api-tests` shards against real Postgres) green on head SHA

Closes #4558