### PR TITLE
fix(dashboards): sync share expiry control to the live share's real lifetime (#4536)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-dialog-expiry-sync.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-dialog-expiry-sync.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Regression guard for #4536 at the WIRING seam — the pure `deriveExpiryKey`
+ * mapping is pinned in `share-expiry.test.ts`, but the actual bug lived in the
+ * one line that calls it: `setExpiresIn(deriveExpiryKey(status.expiresAt))`
+ * inside `fetchShareStatus`. Without that sync the "Link expires" control keeps
+ * its `"7d"` mount default, so a trial admin who opens the dialog only to flip
+ * visibility re-POSTs `expiresIn: "7d"` and silently collapses a "Never" link to
+ * one that dies in 7 days.
+ *
+ * This test drives the real dialog (real deriveExpiryKey, mocked transport) and
+ * asserts the write half of the contract: opening on a NO-EXPIRY share and
+ * clicking "Update settings" WITHOUT touching the expiry control must send
+ * `expiresIn: "never"`, never `"7d"`. If the sync line is deleted or reordered,
+ * this goes red while the pure-function suite stays green.
+ */
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import React, { type ReactNode } from "react";
+import { render, screen, cleanup, fireEvent, act, waitFor } from "@testing-library/react";
+import type { AtlasConfig, AtlasAuthClient } from "@/ui/context";
+
+interface CapturedCall {
+  path: string;
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+let mutateCalls: CapturedCall[] = [];
+
+void mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: async (opts: { path: string; method?: string; body?: Record<string, unknown> }) => {
+      mutateCalls.push({ path: opts.path, method: opts.method, body: opts.body });
+      return { ok: true, data: { token: "tok_new", expiresAt: null, shareMode: "org" } };
+    },
+    saving: false,
+    error: null,
+    clearError: () => {},
+    reset: () => {},
+  }),
+}));
+
+const { DashboardShareDialog } = await import("../share-dialog");
+const { AtlasProvider } = await import("@/ui/context");
+
+// Minimal AtlasConfig — the share path reads only apiUrl/isCrossOrigin; authClient
+// is never touched here (the mutation hook is mocked, status fetch uses global fetch).
+// `as unknown as AtlasAuthClient` (not `as never`) keeps any future authClient
+// access type-visible instead of silently satisfying it.
+const testConfig: AtlasConfig = {
+  apiUrl: "",
+  isCrossOrigin: false,
+  authClient: {} as unknown as AtlasAuthClient,
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return React.createElement(AtlasProvider, { config: testConfig, children });
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  mutateCalls = [];
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+async function openDialogWithStatus(status: {
+  shared: boolean;
+  token: string | null;
+  expiresAt: string | null;
+  shareMode: "public" | "org";
+}): Promise<void> {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(status), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+
+  render(React.createElement(DashboardShareDialog, { dashboardId: "dash_1" }), { wrapper: Wrapper });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /Share/ }));
+  });
+  // Wait for fetchShareStatus to resolve and the shared-view controls to render.
+  await waitFor(() => expect(screen.getByRole("button", { name: /Update settings/ })).toBeDefined());
+}
+
+describe("DashboardShareDialog — expiry sync on open (#4536)", () => {
+  test("a no-expiry share: visibility-only 'Update settings' sends expiresIn 'never', not the '7d' default", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "public" });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Update settings/ }));
+    });
+
+    await waitFor(() => expect(mutateCalls.length).toBeGreaterThan(0));
+    const shareCall = mutateCalls.find((c) => c.path.endsWith("/share"));
+    expect(shareCall).toBeDefined();
+    // The core regression: the control synced to the share's real (no-)expiry, so
+    // the re-POST preserves it instead of stamping the stale "7d" mount default.
+    expect(shareCall?.body?.expiresIn).toBe("never");
+    // Token-preserving edit — not a rotation.
+    expect(shareCall?.body?.rotate).toBe(false);
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-expiry.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-expiry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression pin for #4536 — editing a live share's visibility silently reset
+ * its expiry to 7 days because the "Link expires" control never synced to the
+ * share's real `expiresAt` and re-POSTed its `"7d"` mount default.
+ *
+ * `deriveExpiryKey` is the fix: it maps a share's absolute `expiresAt` back to a
+ * dropdown bucket so the control reflects the real lifetime (never disagreeing
+ * with the summary) and a visibility-only "Update settings" round-trips the
+ * ORIGINAL lifetime instead of collapsing it to 7 days.
+ */
+import { describe, expect, test } from "bun:test";
+import { deriveExpiryKey } from "../share-expiry";
+
+const NOW = new Date("2026-07-17T12:00:00.000Z").getTime();
+const iso = (msFromNow: number) => new Date(NOW + msFromNow).toISOString();
+
+const HOUR = 3600_000;
+const DAY = 86_400_000;
+
+describe("deriveExpiryKey", () => {
+  test("a no-expiry share maps to 'never' (the core #4536 harm: Never must not become 7d)", () => {
+    expect(deriveExpiryKey(null, NOW)).toBe("never");
+  });
+
+  test("a freshly-minted 30-day share reads as '30d', not the stale '7d' default", () => {
+    // Barely-aged 30d link (a few seconds elapsed since mint).
+    expect(deriveExpiryKey(iso(30 * DAY - 5000), NOW)).toBe("30d");
+  });
+
+  test("an aged 30-day share (28 days left) still recovers '30d'", () => {
+    // Smallest bucket that still covers 28 days is 30d — never rounds down to 7d.
+    expect(deriveExpiryKey(iso(28 * DAY), NOW)).toBe("30d");
+  });
+
+  test("a fresh 7-day share reads as '7d'", () => {
+    expect(deriveExpiryKey(iso(7 * DAY - 5000), NOW)).toBe("7d");
+  });
+
+  test("a 24-hour share reads as '24h'", () => {
+    expect(deriveExpiryKey(iso(24 * HOUR - 5000), NOW)).toBe("24h");
+  });
+
+  test("a 1-hour share reads as '1h'", () => {
+    expect(deriveExpiryKey(iso(HOUR - 5000), NOW)).toBe("1h");
+  });
+
+  test("remaining time between buckets rounds UP to the covering bucket (never down)", () => {
+    // 2 days left: too big for 24h, so the smallest covering bucket is 7d.
+    expect(deriveExpiryKey(iso(2 * DAY), NOW)).toBe("7d");
+  });
+
+  test("an exact-boundary remaining time maps to that bucket (>= is inclusive)", () => {
+    // Exactly 1h/24h left — the `>=` comparison must keep it in its own bucket,
+    // not spill up to the next one.
+    expect(deriveExpiryKey(iso(HOUR), NOW)).toBe("1h");
+    expect(deriveExpiryKey(iso(24 * HOUR), NOW)).toBe("24h");
+  });
+
+  test("remaining exactly 0 hits the expired fallback, not '1h' via the >= scan", () => {
+    expect(deriveExpiryKey(iso(0), NOW)).toBe("1h");
+  });
+
+  test("KNOWN-LOSSY: a heavily-aged 30d link (<7d left) derives '7d' by design", () => {
+    // Accepted limitation (see share-expiry.ts module doc): once a share has aged
+    // past one bucket-step, its original bucket can't be recovered — only the
+    // smallest bucket that still covers the remaining time. 5 days left → "7d".
+    // This is monotonic (never rounds DOWN into a shorter lifetime) and never
+    // reintroduces the null→7d harm; a null/"never" link stays immune.
+    expect(deriveExpiryKey(iso(5 * DAY), NOW)).toBe("7d");
+  });
+
+  test("an already-expired instant falls back to the smallest concrete bucket", () => {
+    expect(deriveExpiryKey(iso(-DAY), NOW)).toBe("1h");
+  });
+
+  test("a future-dated instant beyond 30 days caps at the largest bucket", () => {
+    expect(deriveExpiryKey(iso(90 * DAY), NOW)).toBe("30d");
+  });
+
+  test("an unparseable timestamp does not masquerade as a fresh 7-day link", () => {
+    expect(deriveExpiryKey("not-a-date", NOW)).toBe("never");
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
@@ -25,6 +25,7 @@ import { friendlyError } from "@/ui/lib/fetch-error";
 import type { ShareMode, ShareExpiryKey } from "@/ui/lib/types";
 import { SHARE_EXPIRY_OPTIONS } from "@/ui/lib/types";
 import { useAtlasConfig } from "@/ui/context";
+import { deriveExpiryKey } from "./share-expiry";
 
 const EXPIRY_LABELS: Record<ShareExpiryKey, string> = {
   "1h": "1 hour",
@@ -86,6 +87,10 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
         setShareUrl(`${window.location.origin}/shared/dashboard/${status.token}`);
         setExpiresAt(status.expiresAt);
         setShareMode(status.shareMode);
+        // Sync the "Link expires" control to the share's real lifetime so a
+        // visibility-only edit can't reset expiry (#4536). See deriveExpiryKey
+        // (share-expiry.ts) for the bucket-rounding rationale.
+        setExpiresIn(deriveExpiryKey(status.expiresAt));
       } else {
         setShareUrl(null);
         setExpiresAt(null);

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-expiry.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-expiry.ts
@@ -1,0 +1,83 @@
+/**
+ * Reconstruct the share-expiry dropdown key from a live share's absolute
+ * `expiresAt` (#4536).
+ *
+ * The share dialog's "Link expires" `Select` is keyed by a coarse bucket
+ * (`1h`/`24h`/`7d`/`30d`/`never`), but the API only round-trips the concrete
+ * `expiresAt` timestamp. When the dialog opens on an EXISTING share the control
+ * has no bucket to show, so it used to sit on its `"7d"` mount default —
+ * contradicting the summary line (which renders the real `expiresAt`) and, worse,
+ * silently re-POSTing `expiresIn: "7d"` on a visibility-only edit, quietly
+ * shrinking a "Never"/"30 days" link down to 7 days.
+ *
+ * This maps the timestamp back to a bucket so the control agrees with the
+ * summary and a visibility-only "Update settings" preserves the original
+ * lifetime instead of resetting it:
+ *   - `null`            → `"never"` (no-expiry links stay no-expiry)
+ *   - a future instant  → the SMALLEST predefined bucket that still covers the
+ *                         remaining time. Because the remaining time is always
+ *                         ≤ the bucket a share was minted with, this recovers the
+ *                         original creation bucket for any share younger than one
+ *                         bucket-step, and never rounds DOWN into a shorter
+ *                         lifetime than the link actually has.
+ *   - an already-past / clock-skewed instant → the smallest timed bucket, so the
+ *                         control still shows a concrete value.
+ *
+ * Framework-free + `now`-injectable so the mapping is unit-testable without
+ * mounting the dialog.
+ */
+import type { ShareExpiryKey } from "@/ui/lib/types";
+import { SHARE_EXPIRY_OPTIONS } from "@/ui/lib/types";
+
+/** The timed buckets — every `ShareExpiryKey` except the null-duration `never`. */
+type TimedExpiryKey = Exclude<ShareExpiryKey, "never">;
+
+// Timed buckets (excluding `never`), ascending by duration. Derived from the
+// SSOT const so a new bucket flows through without a second list to drift.
+const TIMED_KEYS_ASC: TimedExpiryKey[] = (Object.keys(SHARE_EXPIRY_OPTIONS) as ShareExpiryKey[])
+  .filter((k): k is TimedExpiryKey => SHARE_EXPIRY_OPTIONS[k] !== null)
+  .sort((a, b) => (SHARE_EXPIRY_OPTIONS[a] ?? 0) - (SHARE_EXPIRY_OPTIONS[b] ?? 0));
+
+// Totality of `deriveExpiryKey` rests on there being ≥1 timed bucket; if the
+// SSOT const ever lost them, the index reads below would return `undefined`
+// typed as a valid key — an unsound lie. Fail loudly at import instead.
+if (TIMED_KEYS_ASC.length === 0) {
+  throw new Error("SHARE_EXPIRY_OPTIONS has no timed buckets — deriveExpiryKey cannot be total");
+}
+
+const LARGEST_TIMED_KEY: TimedExpiryKey = TIMED_KEYS_ASC[TIMED_KEYS_ASC.length - 1];
+const SMALLEST_TIMED_KEY: TimedExpiryKey = TIMED_KEYS_ASC[0];
+
+/**
+ * Derive the expiry dropdown key that best represents an existing share's
+ * `expiresAt`. See module doc for the rounding rationale.
+ */
+export function deriveExpiryKey(
+  expiresAt: string | null,
+  now: number = Date.now(),
+): ShareExpiryKey {
+  if (expiresAt === null) return "never";
+
+  const expiresMs = new Date(expiresAt).getTime();
+  if (Number.isNaN(expiresMs)) {
+    // A malformed `expiresAt` means the share API drifted its serialization —
+    // surface it rather than swallow it. `"never"` is the non-shrinking fallback
+    // (it can't collapse the link to 7d, the #4536 harm); its only downside is a
+    // later visibility-only re-POST could extend a truly-expiring link, which is
+    // strictly safer than silently shortening one.
+    console.debug("deriveExpiryKey: unparseable share expiresAt, defaulting to 'never'", { expiresAt });
+    return "never";
+  }
+
+  const remainingSeconds = (expiresMs - now) / 1000;
+  // Already expired / clock skew — show the smallest concrete bucket.
+  if (remainingSeconds <= 0) return SMALLEST_TIMED_KEY;
+
+  // Smallest bucket that still covers the remaining lifetime (never rounds down).
+  for (const key of TIMED_KEYS_ASC) {
+    const seconds = SHARE_EXPIRY_OPTIONS[key];
+    if (seconds !== null && seconds >= remainingSeconds) return key;
+  }
+  // Remaining exceeds every timed bucket (future-dated beyond 30d): cap at largest.
+  return LARGEST_TIMED_KEY;
+}


### PR DESCRIPTION
## Summary
- Editing a live dashboard share's visibility silently reset its expiry to 7 days: the "Link expires" `Select` never synced to the fetched share's real `expiresAt`, so it sat on its `"7d"` mount default. A visibility-only "Update settings" then re-POSTed `expiresIn: "7d"`, collapsing a "Never"/"30 days" link to one dying in 7 days — and the dropdown contradicted the summary line on screen.
- Fix: derive the expiry bucket from the share's real `expiresAt` on open (`deriveExpiryKey` — a pure, `now`-injectable helper in `share-expiry.ts`): `null → never`; otherwise the smallest bucket that still covers the remaining time, so it **never rounds down** into a shorter lifetime. Control and summary now agree, and a visibility-only edit preserves the original lifetime instead of resetting it.
- Malformed `expiresAt` is logged (`console.debug`) and falls back to the non-shrinking `never`; a module-load guard keeps `deriveExpiryKey` total.

Satisfies acceptance criteria #1 (control reflects the real expiry) and #3 (summary and control never disagree).

## Test plan
- [x] `share-expiry.test.ts` — pure mapping: `null→never`, every bucket, exact-boundary (`>=` inclusivity), remaining-0 fallback, known-lossy aged case, unparseable timestamp
- [x] `share-dialog-expiry-sync.test.tsx` — drives the real dialog (mocked transport): a no-expiry share's visibility-only "Update settings" POSTs `expiresIn: "never"`, not `"7d"` (pins the actual wiring seam)
- [x] `bun run type` green; internal review panel CLEAN (2 rounds)

Note: local `ci-local.sh` `test` gate shows `@atlas/mcp smoke.test.ts` failing with `relation "organization" does not exist` — an env-only missing-internal-DB artifact (#1472); this branch touches zero mcp files and the remote `api-tests` shards run it against a migrated Postgres.

Closes #4536