### PR TITLE
feat(dashboards): framable shared-view embed + Embed tab + shareMode-aware copy

### DIFF
--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -56,6 +56,26 @@ const nextConfig: NextConfig = {
       "worker-src 'self' blob:",
     ].join("; ");
 
+    // The embed CSP is the global CSP with `frame-ancestors` widened to `*`.
+    // The `csp.replace(...)` is brittle: if the global directive
+    // `frame-ancestors 'self'` is reworded or reordered, this becomes a silent
+    // no-op and the embed regresses to the global frame-ancestors. The runtime
+    // check fails the Next build if that happens. Computed once and shared by
+    // every embed route below so the conversation and dashboard embeds can never
+    // drift apart.
+    const embedCsp = (() => {
+      const replaced = csp.replace(
+        "frame-ancestors 'self'",
+        "frame-ancestors *",
+      );
+      if (replaced === csp) {
+        throw new Error(
+          "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+        );
+      }
+      return replaced;
+    })();
+
     return [
       {
         source: "/:path*",
@@ -71,32 +91,19 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Embed view must remain framable from any origin. CSP frame-ancestors
-        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
-        // global X-Frame-Options DENY is harmlessly ignored on this path.
-        //
-        // The `csp.replace(...)` below is brittle: if the global directive
-        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
-        // silent no-op and the embed regresses to the global frame-ancestors.
-        // The runtime check below fails the Next build if that happens.
+        // Shared-conversation embed view must remain framable from any origin.
+        // CSP frame-ancestors takes precedence over X-Frame-Options per the W3C
+        // CSP spec, so the global X-Frame-Options DENY is harmlessly ignored on
+        // this path.
         source: "/shared/:token/embed",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: (() => {
-              const replaced = csp.replace(
-                "frame-ancestors 'self'",
-                "frame-ancestors *",
-              );
-              if (replaced === csp) {
-                throw new Error(
-                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
-                );
-              }
-              return replaced;
-            })(),
-          },
-        ],
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
+      },
+      {
+        // Shared-dashboard embed view — same any-origin framing posture as the
+        // conversation embed above (decided 2026-07-10; the embed is a frame
+        // around the shared dashboard view, never a second sharing surface).
+        source: "/shared/dashboard/:token/embed",
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
       },
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -54,6 +54,26 @@ const nextConfig: NextConfig = {
       "worker-src 'self' blob:",
     ].join("; ");
 
+    // The embed CSP is the global CSP with `frame-ancestors` widened to `*`.
+    // The `csp.replace(...)` is brittle: if the global directive
+    // `frame-ancestors 'self'` is reworded or reordered, this becomes a silent
+    // no-op and the embed regresses to the global frame-ancestors. The runtime
+    // check fails the Next build if that happens. Computed once and shared by
+    // every embed route below so the conversation and dashboard embeds can never
+    // drift apart.
+    const embedCsp = (() => {
+      const replaced = csp.replace(
+        "frame-ancestors 'self'",
+        "frame-ancestors *",
+      );
+      if (replaced === csp) {
+        throw new Error(
+          "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+        );
+      }
+      return replaced;
+    })();
+
     return [
       {
         source: "/:path*",
@@ -69,32 +89,19 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Embed view must remain framable from any origin. CSP frame-ancestors
-        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
-        // global X-Frame-Options DENY is harmlessly ignored on this path.
-        //
-        // The `csp.replace(...)` below is brittle: if the global directive
-        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
-        // silent no-op and the embed regresses to the global frame-ancestors.
-        // The runtime check below fails the Next build if that happens.
+        // Shared-conversation embed view must remain framable from any origin.
+        // CSP frame-ancestors takes precedence over X-Frame-Options per the W3C
+        // CSP spec, so the global X-Frame-Options DENY is harmlessly ignored on
+        // this path.
         source: "/shared/:token/embed",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: (() => {
-              const replaced = csp.replace(
-                "frame-ancestors 'self'",
-                "frame-ancestors *",
-              );
-              if (replaced === csp) {
-                throw new Error(
-                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
-                );
-              }
-              return replaced;
-            })(),
-          },
-        ],
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
+      },
+      {
+        // Shared-dashboard embed view — same any-origin framing posture as the
+        // conversation embed above (decided 2026-07-10; the embed is a frame
+        // around the shared dashboard view, never a second sharing surface).
+        source: "/shared/dashboard/:token/embed",
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
       },
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -63,6 +63,26 @@ const nextConfig: NextConfig = {
       "worker-src 'self' blob:",
     ].join("; ");
 
+    // The embed CSP is the global CSP with `frame-ancestors` widened to `*`.
+    // The `csp.replace(...)` is brittle: if the global directive
+    // `frame-ancestors 'self'` is reworded or reordered, this becomes a silent
+    // no-op and the embed regresses to the global frame-ancestors. The runtime
+    // check fails the Next build if that happens. Computed once and shared by
+    // every embed route below so the conversation and dashboard embeds can never
+    // drift apart.
+    const embedCsp = (() => {
+      const replaced = csp.replace(
+        "frame-ancestors 'self'",
+        "frame-ancestors *",
+      );
+      if (replaced === csp) {
+        throw new Error(
+          "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+        );
+      }
+      return replaced;
+    })();
+
     return [
       {
         source: "/:path*",
@@ -78,32 +98,19 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Embed view must remain framable from any origin. CSP frame-ancestors
-        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
-        // global X-Frame-Options DENY is harmlessly ignored on this path.
-        //
-        // The `csp.replace(...)` below is brittle: if the global directive
-        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
-        // silent no-op and the embed regresses to the global frame-ancestors.
-        // The runtime check below fails the Next build if that happens.
+        // Shared-conversation embed view must remain framable from any origin.
+        // CSP frame-ancestors takes precedence over X-Frame-Options per the W3C
+        // CSP spec, so the global X-Frame-Options DENY is harmlessly ignored on
+        // this path.
         source: "/shared/:token/embed",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: (() => {
-              const replaced = csp.replace(
-                "frame-ancestors 'self'",
-                "frame-ancestors *",
-              );
-              if (replaced === csp) {
-                throw new Error(
-                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
-                );
-              }
-              return replaced;
-            })(),
-          },
-        ],
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
+      },
+      {
+        // Shared-dashboard embed view — same any-origin framing posture as the
+        // conversation embed above (decided 2026-07-10; the embed is a frame
+        // around the shared dashboard view, never a second sharing surface).
+        source: "/shared/dashboard/:token/embed",
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
       },
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -74,10 +74,12 @@ const nextConfig: NextConfig = {
   //   block is drift-locked to the scaffolds, so the nonce posture is added
   //   in the proxy, NOT by editing the directives below. See #3899.
   //
-  // The `/shared/:token/embed` route inherits everything except frame-ancestors,
-  // which it overrides to `*` so customers can embed shared conversations.
-  // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
-  // setting both globally is safe — the embed override wins where it matches.
+  // The `/shared/:token/embed` (shared conversation) and
+  // `/shared/dashboard/:token/embed` (shared dashboard) routes inherit
+  // everything except frame-ancestors, which they override to `*` so customers
+  // can embed shared conversations and dashboards. Browsers ignore
+  // X-Frame-Options when CSP `frame-ancestors` is present, so setting both
+  // globally is safe — the embed overrides win where they match.
   //
   // Cache-Control (issue #2488): the entry HTML must never be served stale
   // across deploys — a tab on the previous bundle would request hashed chunks
@@ -114,6 +116,26 @@ const nextConfig: NextConfig = {
       "worker-src 'self' blob:",
     ].join("; ");
 
+    // The embed CSP is the global CSP with `frame-ancestors` widened to `*`.
+    // The `csp.replace(...)` is brittle: if the global directive
+    // `frame-ancestors 'self'` is reworded or reordered, this becomes a silent
+    // no-op and the embed regresses to the global frame-ancestors. The runtime
+    // check fails the Next build if that happens. Computed once and shared by
+    // every embed route below so the conversation and dashboard embeds can never
+    // drift apart.
+    const embedCsp = (() => {
+      const replaced = csp.replace(
+        "frame-ancestors 'self'",
+        "frame-ancestors *",
+      );
+      if (replaced === csp) {
+        throw new Error(
+          "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
+        );
+      }
+      return replaced;
+    })();
+
     return [
       {
         source: "/:path*",
@@ -129,32 +151,19 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Embed view must remain framable from any origin. CSP frame-ancestors
-        // takes precedence over X-Frame-Options per the W3C CSP spec, so the
-        // global X-Frame-Options DENY is harmlessly ignored on this path.
-        //
-        // The `csp.replace(...)` below is brittle: if the global directive
-        // `frame-ancestors 'self'` is reworded or reordered, this becomes a
-        // silent no-op and the embed regresses to the global frame-ancestors.
-        // The runtime check below fails the Next build if that happens.
+        // Shared-conversation embed view must remain framable from any origin.
+        // CSP frame-ancestors takes precedence over X-Frame-Options per the W3C
+        // CSP spec, so the global X-Frame-Options DENY is harmlessly ignored on
+        // this path.
         source: "/shared/:token/embed",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: (() => {
-              const replaced = csp.replace(
-                "frame-ancestors 'self'",
-                "frame-ancestors *",
-              );
-              if (replaced === csp) {
-                throw new Error(
-                  "next.config.ts: embed CSP override no-op'd — `frame-ancestors 'self'` not found in global CSP. Update the replace() target.",
-                );
-              }
-              return replaced;
-            })(),
-          },
-        ],
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
+      },
+      {
+        // Shared-dashboard embed view — same any-origin framing posture as the
+        // conversation embed above (decided 2026-07-10; the embed is a frame
+        // around the shared dashboard view, never a second sharing surface).
+        source: "/shared/dashboard/:token/embed",
+        headers: [{ key: "Content-Security-Policy", value: embedCsp }],
       },
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-dialog-embed.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-dialog-embed.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Covers the #4564 additions to the dashboard share dialog:
+ *   - the Embed tab emits a working iframe snippet pointing at the share token's
+ *     framable `/embed` route, and "Copy embed code" writes that snippet;
+ *   - the dialog copy is shareMode-aware — an org share no longer claims
+ *     "Anyone with the link" (audit L1).
+ *
+ * Harness mirrors share-dialog-expiry-sync.test.tsx: real dialog, mocked
+ * transport (useAdminMutation + global fetch for status), AtlasProvider wrapper.
+ */
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import React, { type ReactNode } from "react";
+import { render, screen, cleanup, fireEvent, act, waitFor } from "@testing-library/react";
+import type { AtlasConfig, AtlasAuthClient } from "@/ui/context";
+
+void mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: async () => ({ ok: true, data: { token: "tok_live", expiresAt: null, shareMode: "public" } }),
+    saving: false,
+    error: null,
+    clearError: () => {},
+    reset: () => {},
+  }),
+}));
+
+const { DashboardShareDialog } = await import("../share-dialog");
+const { AtlasProvider } = await import("@/ui/context");
+
+const testConfig: AtlasConfig = {
+  apiUrl: "",
+  isCrossOrigin: false,
+  authClient: {} as unknown as AtlasAuthClient,
+};
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return React.createElement(AtlasProvider, { config: testConfig, children });
+}
+
+const originalFetch = globalThis.fetch;
+let clipboardText: string | null = null;
+
+beforeEach(() => {
+  clipboardText = null;
+  // navigator.clipboard is a readonly accessor in jsdom — define it directly.
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: async (text: string) => {
+        clipboardText = text;
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+async function openDialogWithStatus(status: {
+  shared: boolean;
+  token: string | null;
+  expiresAt: string | null;
+  shareMode: "public" | "org";
+}): Promise<void> {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(status), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+
+  render(React.createElement(DashboardShareDialog, { dashboardId: "dash_1" }), { wrapper: Wrapper });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /Share/ }));
+  });
+  await waitFor(() => expect(screen.getByRole("tab", { name: "Embed" })).toBeDefined());
+}
+
+describe("DashboardShareDialog — Embed tab (#4564)", () => {
+  test("emits an iframe snippet pointing at the token's /embed route, and copies it", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "public" });
+
+    await act(async () => {
+      // Radix activates a tab on mousedown; jsdom's click doesn't move focus so
+      // automatic (focus-driven) activation never fires — mousedown does.
+      fireEvent.mouseDown(screen.getByRole("tab", { name: "Embed" }));
+    });
+
+    const snippet = (await screen.findByLabelText("Embed snippet")) as HTMLTextAreaElement;
+    expect(snippet.value).toContain("<iframe");
+    expect(snippet.value).toContain(`${window.location.origin}/shared/dashboard/tok_live/embed`);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Copy embed code/ }));
+    });
+    await waitFor(() => expect(clipboardText).not.toBeNull());
+    expect(clipboardText).toContain("/shared/dashboard/tok_live/embed");
+    expect(clipboardText).toContain("<iframe");
+  });
+
+  test("the embed caption is shareMode-aware — an org share warns viewers must sign in", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "org" });
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole("tab", { name: "Embed" }));
+    });
+    await screen.findByLabelText("Embed snippet");
+
+    expect(
+      screen.getByText(/must be signed in to your organization for this embed to load/i),
+    ).toBeDefined();
+    expect(screen.queryByText(/Anyone who can load the host page/i)).toBeNull();
+  });
+});
+
+describe("DashboardShareDialog — shareMode-aware copy (#4564, audit L1)", () => {
+  test("an org share does NOT claim 'Anyone with the link'", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "org" });
+
+    expect(
+      screen.getByText(/Only authenticated members of your organization can view/i),
+    ).toBeDefined();
+    expect(screen.queryByText(/Anyone with the link/i)).toBeNull();
+  });
+
+  test("a public share keeps the 'Anyone with the link' copy", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "public" });
+
+    expect(screen.getByText(/Anyone with the link can view this dashboard/i)).toBeDefined();
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-embed.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-embed.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { buildEmbedSnippet } from "../share-embed";
+
+describe("buildEmbedSnippet (#4564)", () => {
+  test("targets the share token's /embed sub-route", () => {
+    const code = buildEmbedSnippet("https://app.example.com/shared/dashboard/tok_live");
+    expect(code).toContain('src="https://app.example.com/shared/dashboard/tok_live/embed"');
+    expect(code).toStartWith("<iframe");
+    expect(code).toEndWith("></iframe>");
+  });
+
+  test("escapes double quotes so a token cannot break out of the src attribute", () => {
+    // A stray quote in the URL must not close the attribute early — pin the
+    // security invariant the comment claims.
+    const code = buildEmbedSnippet('https://app.example.com/shared/dashboard/a"b');
+    expect(code).toContain("&quot;");
+    // Exactly two real `"` delimiters remain (the ones around src) — the injected
+    // one is now `&quot;`, so it can't terminate the attribute.
+    expect(code).not.toContain('a"b');
+    expect(code).toContain('a&quot;b/embed');
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Share2, Copy, Check, Link2Off, Globe, Lock, Loader2, RefreshCw } from "lucide-react";
+import { Share2, Copy, Check, Link2Off, Globe, Lock, Loader2, RefreshCw, Code } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
   SelectContent,
@@ -26,6 +28,7 @@ import type { ShareMode, ShareExpiryKey } from "@/ui/lib/types";
 import { SHARE_EXPIRY_OPTIONS } from "@/ui/lib/types";
 import { useAtlasConfig } from "@/ui/context";
 import { deriveExpiryKey } from "./share-expiry";
+import { buildEmbedSnippet } from "./share-embed";
 
 const EXPIRY_LABELS: Record<ShareExpiryKey, string> = {
   "1h": "1 hour",
@@ -51,6 +54,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [shared, setShared] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedEmbed, setCopiedEmbed] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expiresIn, setExpiresIn] = useState<ShareExpiryKey>("7d");
   const [shareMode, setShareMode] = useState<ShareMode>("public");
@@ -106,6 +110,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
     if (open) {
       setError(null);
       setCopied(false);
+      setCopiedEmbed(false);
       setConfirmingRotate(false);
       // fire-and-forget: refresh share status on dialog open; component state updates on resolve
       void fetchShareStatus();
@@ -167,29 +172,46 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
     }
   }
 
-  async function handleCopy() {
-    if (!shareUrl) return;
+  // The iframe snippet for the Embed tab — points at the SAME share token's
+  // framable `/embed` route (#4564), so revoking the link kills the embed too.
+  // Built by the pure `buildEmbedSnippet` helper (escaping pinned in its test).
+  const embedCode = shareUrl ? buildEmbedSnippet(shareUrl) : "";
+
+  async function copyText(text: string, flash: (v: boolean) => void) {
     try {
-      await navigator.clipboard.writeText(shareUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback for insecure contexts (non-HTTPS iframes, embedded widgets)
+      await navigator.clipboard.writeText(text);
+      flash(true);
+      setTimeout(() => flash(false), 2000);
+    } catch (err) {
+      // Fallback for insecure contexts (non-HTTPS iframes, embedded widgets).
+      // Log why the primary path failed so a "copy doesn't work" report has a
+      // signal (permissions-policy vs insecure-context vs focus).
+      console.debug(
+        "[dashboard-share] clipboard.writeText failed, falling back to execCommand:",
+        err instanceof Error ? err.message : String(err),
+      );
       try {
-        const input = document.createElement("input");
-        input.value = shareUrl;
+        const input = document.createElement("textarea");
+        input.value = text;
         document.body.appendChild(input);
         input.select();
-        document.execCommand("copy");
+        // execCommand signals failure by returning false WITHOUT throwing — so a
+        // silent false here would flash a false "Copied". Route it to the same
+        // manual-copy hint as a thrown error.
+        const ok = document.execCommand("copy");
         document.body.removeChild(input);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (!ok) throw new Error("execCommand('copy') returned false");
+        flash(true);
+        setTimeout(() => flash(false), 2000);
       } catch {
-        // intentionally ignored: clipboard unavailable — user can select and copy manually
-        setError("Could not copy to clipboard. Please select and copy the link manually.");
+        // clipboard unavailable — surface a manual-copy hint (not a silent swallow)
+        setError("Could not copy to clipboard. Please select and copy it manually.");
       }
     }
   }
+
+  const handleCopy = () => (shareUrl ? copyText(shareUrl, setCopied) : undefined);
+  const handleCopyEmbed = () => (embedCode ? copyText(embedCode, setCopiedEmbed) : undefined);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -204,8 +226,10 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
           <DialogTitle>Share Dashboard</DialogTitle>
           <DialogDescription>
             {shared
-              ? "Anyone with the link can view this dashboard's cached results."
-              : "Create a public link to share this dashboard."}
+              ? shareMode === "org"
+                ? "Only authenticated members of your organization can view this dashboard's cached results."
+                : "Anyone with the link can view this dashboard's cached results."
+              : "Create a link to share this dashboard."}
           </DialogDescription>
         </DialogHeader>
 
@@ -217,7 +241,12 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
         ) : (
           <div className="grid gap-4 py-2">
             {shared && shareUrl ? (
-              <>
+              <Tabs defaultValue="link">
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="link">Link</TabsTrigger>
+                  <TabsTrigger value="embed">Embed</TabsTrigger>
+                </TabsList>
+                <TabsContent value="link" className="mt-4 grid gap-4">
                 <div className="flex gap-2">
                   <Input value={shareUrl} readOnly className="font-mono text-xs" />
                   <Button variant="outline" size="icon" onClick={handleCopy} title="Copy link">
@@ -333,7 +362,33 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
                     </div>
                   </div>
                 )}
-              </>
+                </TabsContent>
+
+                <TabsContent value="embed" className="mt-4 grid gap-3">
+                  <Label htmlFor="dashboard-embed-code">Embed snippet</Label>
+                  <Textarea
+                    id="dashboard-embed-code"
+                    value={embedCode}
+                    readOnly
+                    rows={3}
+                    className="resize-none font-mono text-xs"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                  <Button variant="outline" size="sm" onClick={handleCopyEmbed} className="justify-self-start">
+                    {copiedEmbed ? (
+                      <Check className="mr-1.5 size-3.5 text-green-500" />
+                    ) : (
+                      <Code className="mr-1.5 size-3.5" />
+                    )}
+                    {copiedEmbed ? "Copied" : "Copy embed code"}
+                  </Button>
+                  <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+                    {shareMode === "org"
+                      ? "Viewers must be signed in to your organization for this embed to load."
+                      : "Anyone who can load the host page can view this embedded dashboard."}
+                  </p>
+                </TabsContent>
+              </Tabs>
             ) : (
               <>
                 <div className="grid gap-2">

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-embed.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-embed.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure builder for the dashboard share dialog's Embed-tab iframe snippet (#4564),
+ * factored out of the client component so the attribute-escaping invariant is
+ * unit-testable without rendering the dialog (mirrors share-expiry.ts).
+ */
+
+/**
+ * Build the iframe snippet that embeds a shared dashboard. It points at the
+ * share token's framable `/embed` route — SAME snapshot, SAME revocation/expiry
+ * as the standalone shared page — so revoking the link kills the embed too.
+ * The URL is `&quot;`-escaped so a token can never break out of the `src="…"`
+ * double-quoted attribute.
+ */
+export function buildEmbedSnippet(shareUrl: string): string {
+  const src = `${shareUrl.replace(/"/g, "&quot;")}/embed`;
+  return `<iframe src="${src}" width="100%" height="600" frameborder="0" style="border:0;border-radius:8px" title="Atlas dashboard"></iframe>`;
+}

--- a/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { EmbedErrorView, resolveEmbedTheme } from "../embed";
+
+describe("resolveEmbedTheme", () => {
+  test("resolves 'dark' and 'light' verbatim", () => {
+    expect(resolveEmbedTheme("dark")).toBe("dark");
+    expect(resolveEmbedTheme("light")).toBe("light");
+  });
+
+  test("defaults to 'light' for empty/absent values without warning", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveEmbedTheme(undefined)).toBe("light");
+    expect(resolveEmbedTheme("")).toBe("light");
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test("takes the first entry of a repeated query param", () => {
+    expect(resolveEmbedTheme(["dark", "light"])).toBe("dark");
+  });
+
+  test("warns and falls back to 'light' on an unrecognized value", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    expect(resolveEmbedTheme("neon")).toBe("light");
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("EmbedErrorView", () => {
+  afterEach(cleanup);
+
+  // Each fail reason maps to a distinct, navigation-free message. `expired` and
+  // `not-found` are how a revoked link "kills the embed" — the AC path.
+  const cases: Array<[Parameters<typeof EmbedErrorView>[0]["reason"], RegExp]> = [
+    ["expired", /expired/i],
+    ["not-found", /could not be found/i],
+    ["auth-required", /organization/i],
+    ["network-error", /reach Atlas/i],
+    ["server-error", /Could not load/i],
+  ];
+
+  test.each(cases)("reason %s renders its message", (reason, matcher) => {
+    render(<EmbedErrorView reason={reason} />);
+    expect(screen.getByText(matcher)).toBeDefined();
+    cleanup();
+  });
+
+  test("never renders a login/retry link inside the frame (partner-safe chrome)", () => {
+    render(<EmbedErrorView reason="auth-required" />);
+    // Only the 'Powered by Atlas' attribution anchor is allowed; no in-frame nav.
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]?.getAttribute("href")).toBe("https://www.useatlas.dev");
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
@@ -1,0 +1,84 @@
+// Server-only helpers for the shared-dashboard EMBED route. Kept out of
+// `page.tsx` so the theme resolver and the compact error view are unit-testable
+// without rendering the async RSC. The embed is a frame around the same shared
+// view (`../view.tsx`) — this file adds only the framable chrome (theme wrapper
+// + iframe-appropriate error states), never a second data surface.
+
+import type { FetchResult } from "../fetch";
+
+export type EmbedTheme = "light" | "dark";
+
+/**
+ * Resolve the optional `?theme=` query param. An iframe on a foreign origin has
+ * no reliable system-theme signal, so the host picks via the URL (mirrors the
+ * shared-conversation embed). Anything unrecognized falls back to "light" with a
+ * warning rather than silently guessing.
+ */
+export function resolveEmbedTheme(raw: string | string[] | undefined): EmbedTheme {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === "dark") return "dark";
+  if (value == null || value === "" || value === "light") return "light";
+  console.warn(
+    `[shared-dashboard/embed] Unrecognized ?theme= value (got ${JSON.stringify(value)}); falling back to "light".`,
+  );
+  return "light";
+}
+
+type FailReason = Extract<FetchResult, { ok: false }>["reason"];
+
+/**
+ * Compact, navigation-free error state for the embed. Unlike the standalone
+ * page's `ErrorShell`, it never renders login/retry links — a link inside a
+ * partner's iframe would either dead-end or hijack their frame. Revoked/expired
+ * shares surface here, which is how the embed "dies" when the link does.
+ */
+export function EmbedErrorView({ reason }: { reason: FailReason }) {
+  // Exhaustive switch (not a ternary chain) so a future `FetchResult` reason
+  // fails the build here instead of silently rendering the generic message.
+  let message: string;
+  switch (reason) {
+    case "auth-required":
+      message = "This dashboard is shared within an organization. Sign in to Atlas to view it.";
+      break;
+    case "expired":
+      message = "This dashboard share link has expired.";
+      break;
+    case "not-found":
+      message = "This dashboard could not be found.";
+      break;
+    case "network-error":
+      message = "Could not reach Atlas. Please try again later.";
+      break;
+    case "server-error":
+      message = "Could not load this dashboard. Please try again later.";
+      break;
+    default:
+      reason satisfies never;
+      message = "Could not load this dashboard. Please try again later.";
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="flex flex-1 items-center justify-center px-4 focus:outline-none"
+      >
+        <div className="text-center">
+          <h1 className="sr-only">Atlas dashboard embed unavailable</h1>
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">{message}</p>
+        </div>
+      </main>
+      <footer className="border-t border-zinc-200 px-4 py-3 text-center dark:border-zinc-800 print:hidden">
+        <a
+          href="https://www.useatlas.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[11px] text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          Powered by Atlas
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { SharedDashboardView } from "../view";
+import { fetchSharedDashboard } from "../fetch";
+import { EmbedErrorView, resolveEmbedTheme } from "./embed";
+
+// An embed is an iframe surface, not a page to index. The standalone
+// `/shared/dashboard/[token]` route owns the OG/discovery metadata; this frame
+// stays out of search results.
+export const metadata: Metadata = { robots: { index: false, follow: false } };
+
+interface PageProps {
+  params: Promise<{ token: string }>;
+  searchParams: Promise<{ theme?: string | string[] }>;
+}
+
+// Framable presentation of the shared dashboard view (#4564). SAME token, SAME
+// data-only snapshot DTO (`fetchSharedDashboard` → `sharedDashboardViewSchema`),
+// SAME revocation/expiry as the standalone page — the only differences are the
+// any-origin `frame-ancestors *` header this route carries (next.config.ts /
+// csp.ts `isEmbedRoute`) and the optional `?theme=` wrapper. The embed is a
+// frame around the shared view, never a second sharing surface, so it renders
+// the exact `SharedDashboardView` component the standalone page does.
+export default async function SharedDashboardEmbedPage({ params, searchParams }: PageProps) {
+  const { token } = await params;
+  const { theme: themeParam } = await searchParams;
+  const theme = resolveEmbedTheme(themeParam);
+  const result = await fetchSharedDashboard(token);
+
+  // Tailwind's dark variant here is `&:is(.dark *)` — the element bearing `.dark`
+  // doesn't match it, only descendants do — so the wrapper carries `.dark` and the
+  // inner shell's `dark:` modifiers fire against the host-selected theme.
+  return (
+    <div className={theme === "dark" ? "dark" : ""} data-theme={theme}>
+      {result.ok ? (
+        <SharedDashboardView dashboard={result.data} />
+      ) : (
+        <EmbedErrorView reason={result.reason} />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/csp.test.ts
+++ b/packages/web/src/lib/csp.test.ts
@@ -70,6 +70,11 @@ describe("frameAncestorsFor", () => {
     expect(frameAncestorsFor("/shared/abc123/embed/")).toBe("*");
   });
 
+  it("widens to '*' on the shared-dashboard embed sub-route (#4564)", () => {
+    expect(frameAncestorsFor("/shared/dashboard/abc123/embed")).toBe("*");
+    expect(frameAncestorsFor("/shared/dashboard/abc123/embed/")).toBe("*");
+  });
+
   it("keeps 'self' for the app/admin shell — guards the clickjacking boundary (the security decision under test)", () => {
     // A regression returning "*" here would make every admin page embeddable
     // from any origin. This is the assertion that catches an inverted ternary.
@@ -77,6 +82,9 @@ describe("frameAncestorsFor", () => {
     expect(frameAncestorsFor("/")).toBe("'self'");
     expect(frameAncestorsFor("/shared/abc123")).toBe("'self'");
     expect(frameAncestorsFor("/admin/abc123/embed")).toBe("'self'");
+    // The standalone shared-dashboard PAGE stays non-framable — only its /embed
+    // sub-route widens. (AC: "the standard share page remains non-framable".)
+    expect(frameAncestorsFor("/shared/dashboard/abc123")).toBe("'self'");
   });
 });
 
@@ -86,14 +94,24 @@ describe("isEmbedRoute", () => {
     expect(isEmbedRoute("/shared/abc123/embed/")).toBe(true);
   });
 
-  it("does NOT match the shared conversation page itself (only the embed sub-route widens frame-ancestors)", () => {
+  it("matches the shared-dashboard embed view with and without a trailing slash (#4564)", () => {
+    expect(isEmbedRoute("/shared/dashboard/abc123/embed")).toBe(true);
+    expect(isEmbedRoute("/shared/dashboard/abc123/embed/")).toBe(true);
+  });
+
+  it("does NOT match the shared conversation or dashboard page itself (only the embed sub-route widens frame-ancestors)", () => {
     expect(isEmbedRoute("/shared/abc123")).toBe(false);
     expect(isEmbedRoute("/shared/abc123/")).toBe(false);
+    expect(isEmbedRoute("/shared/dashboard/abc123")).toBe(false);
+    expect(isEmbedRoute("/shared/dashboard/abc123/")).toBe(false);
   });
 
   it("does not match deeper paths or token segments containing slashes", () => {
     expect(isEmbedRoute("/shared/abc123/embed/extra")).toBe(false);
     expect(isEmbedRoute("/shared/a/b/embed")).toBe(false);
+    // `dashboard/` is the ONLY extra segment admitted — no deeper nesting.
+    expect(isEmbedRoute("/shared/dashboard/abc123/embed/extra")).toBe(false);
+    expect(isEmbedRoute("/shared/dashboard/a/b/embed")).toBe(false);
   });
 
   it("does not match unrelated or look-alike routes (no frame-ancestors widening leak)", () => {

--- a/packages/web/src/lib/csp.ts
+++ b/packages/web/src/lib/csp.ts
@@ -34,11 +34,12 @@ export type CspEnv = "dev" | "prod";
  * `style-src` keeps `'unsafe-inline'` (Tailwind + Next inline critical CSS);
  * nonce'ing styles is deliberately out of scope for this change.
  *
- * `frameAncestors` is `*` for the `/shared/:token/embed` view (must frame from
- * any origin so customers can embed shared conversations) and `'self'`
- * everywhere else (clickjacking protection for the app/admin shell). Browsers
- * honor CSP `frame-ancestors` over the `X-Frame-Options: DENY` set in
- * next.config.ts, so the embed path frames while every other path stays denied.
+ * `frameAncestors` is `*` for the embed views (`/shared/:token/embed` for shared
+ * conversations and `/shared/dashboard/:token/embed` for shared dashboards — both
+ * must frame from any origin so customers can embed them) and `'self'` everywhere
+ * else (clickjacking protection for the app/admin shell). Browsers honor CSP
+ * `frame-ancestors` over the `X-Frame-Options: DENY` set in next.config.ts, so
+ * the embed paths frame while every other path stays denied.
  */
 export function buildCsp(
   nonce: string,
@@ -68,12 +69,16 @@ export function buildCsp(
 }
 
 /**
- * The embed view (`/shared/<token>/embed`, optional trailing slash) inherits
- * the global CSP but widens `frame-ancestors` to `*`. Matched on the resolved
- * pathname only — query/hash are not part of `nextUrl.pathname`.
+ * The embed views inherit the global CSP but widen `frame-ancestors` to `*`.
+ * Two shapes qualify, both with an optional trailing slash:
+ *   - `/shared/<token>/embed`            — shared conversation embed
+ *   - `/shared/dashboard/<token>/embed`  — shared dashboard embed
+ * The optional `dashboard/` segment is the ONLY extra depth admitted; a token
+ * cannot itself contain a slash, so no deeper path widens. Matched on the
+ * resolved pathname only — query/hash are not part of `nextUrl.pathname`.
  */
 export function isEmbedRoute(pathname: string): boolean {
-  return /^\/shared\/[^/]+\/embed\/?$/.test(pathname);
+  return /^\/shared\/(?:dashboard\/)?[^/]+\/embed\/?$/.test(pathname);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a framable presentation of the shared dashboard view at `/shared/dashboard/[token]/embed` — **same token, same data-only snapshot DTO** (`fetchSharedDashboard` → `sharedDashboardViewSchema.strict()`), **same revocation/expiry** as the standalone page, with the conversation embed's any-origin `frame-ancestors *` posture. The embed reuses `SharedDashboardView` (a frame around the shared view, never a second sharing surface); the standalone share page stays non-framable.
- `csp.ts` `isEmbedRoute` + `next.config.ts` (and the 3 scaffold mirrors, byte-for-byte per `check-security-headers-drift.sh`) widen `frame-ancestors` to `*` for the dashboard embed route. `embedCsp` is computed once so the conversation + dashboard embeds can't drift.
- The dashboard share dialog gains an **Embed tab** emitting the iframe snippet (`buildEmbedSnippet`, attribute-escaping pinned in a unit test), and the dialog + embed copy is now **shareMode-aware** — org shares no longer claim "Anyone with the link" (parent PRD audit L1).

## Test plan
- [x] Route-seam: `csp.test.ts` asserts `frameAncestorsFor`/`isEmbedRoute` widen to `*` on `/shared/dashboard/<token>/embed` and stay `'self'` on the standalone `/shared/dashboard/<token>` page and app/admin shell.
- [x] DTO: embed reuses the `.strict()` `sharedDashboardViewSchema` path — no new fields by construction.
- [x] Component: `share-dialog-embed.test.tsx` covers the Embed tab snippet, copy-to-clipboard, and shareMode-aware dialog + embed captions; `share-embed.test.ts` pins the `&quot;` src-attribute escaping.
- [x] `EmbedErrorView` covers all five fetch fail reasons (revoked/expired "dies safely") with no in-frame nav links.
- [x] `/ci`: 30/31 gates green locally; the sole `test`-gate miss is the documented env-only `packages/mcp/smoke.test.ts` billing-gate DB dependency (#1472), unrelated to this web-only diff — GitHub `api-tests` shards run it against a migrated Postgres.

Builds on siblings #4565 (shared-view "Data as of" caption) and #4536 (share-dialog expiry sync); does not touch the createDashboard tool or dashboard canvas.

Closes #4564