### PR TITLE
feat(dashboards): one shared card-input union — text/section cards reach the bound editor (#4562)

### DIFF
--- a/packages/api/src/lib/__tests__/dashboard-text-card.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-text-card.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Direct unit coverage for `deriveTextCardTitle` (#4562) — the standalone SSOT
+ * both authoring tools share. Previously exercised only transitively through the
+ * tool suites; the blockquote-marker and length-cap branches had no coverage.
+ */
+import { describe, expect, it } from "bun:test";
+import { deriveTextCardTitle } from "@atlas/api/lib/dashboard-text-card";
+
+describe("deriveTextCardTitle", () => {
+  it("strips a leading heading marker", () => {
+    expect(deriveTextCardTitle("## Top of funnel")).toBe("Top of funnel");
+  });
+
+  it("strips a leading list bullet and takes the first non-empty line", () => {
+    expect(deriveTextCardTitle("\n\n- A bullet\nmore")).toBe("A bullet");
+  });
+
+  it("strips a leading blockquote marker", () => {
+    expect(deriveTextCardTitle("> quoted note")).toBe("quoted note");
+  });
+
+  it("caps the derived title at 120 characters", () => {
+    const long = "x".repeat(200);
+    expect(deriveTextCardTitle(long)).toHaveLength(120);
+  });
+
+  it("falls back to 'Section' on whitespace-only content", () => {
+    expect(deriveTextCardTitle("   \n  ")).toBe("Section");
+  });
+});

--- a/packages/api/src/lib/dashboard-text-card.ts
+++ b/packages/api/src/lib/dashboard-text-card.ts
@@ -1,0 +1,24 @@
+/**
+ * Text / section-card helpers (#3138, #4562).
+ *
+ * A tiny, dependency-free module so BOTH dashboard authoring tools
+ * (`createDashboard` and the bound editor's `addCard`) can derive a text card's
+ * row title without importing each other — importing one tool into the other
+ * pulls its whole tool-construction graph (SQL pipeline, seeding) into the
+ * consumer and disturbs partial `mock.module()` setups in the sibling test
+ * suites. Keep this module free of heavy imports.
+ */
+
+/**
+ * Derive a short row title for a text card whose `title` the agent left blank.
+ * Takes the first non-empty line, strips a leading markdown block marker
+ * (heading, list bullet, or blockquote), and caps the length. Used only for
+ * list / diff surfaces — the tile renders the full markdown, not this label.
+ */
+export function deriveTextCardTitle(content: string): string {
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/^\s*(?:#{1,6}\s+|[-*+]\s+|>\s+)/, "").trim();
+    if (line.length > 0) return line.slice(0, 120);
+  }
+  return "Section";
+}

--- a/packages/api/src/lib/dashboard-types.ts
+++ b/packages/api/src/lib/dashboard-types.ts
@@ -24,16 +24,12 @@ export type {
 export { CHART_TYPES } from "@useatlas/types";
 
 /**
- * Bounds of the dashboard tile grid (#1867). Lives in the api package — not
- * `@useatlas/types` — so a bump doesn't require an npm publish + template
- * version bump. Must mirror the constants in
+ * Bounds of the dashboard tile grid (#1867). The SSOT now lives in
+ * `@useatlas/schemas` (#4562) — beside the `dashboardCardLayoutInputSchema` that
+ * validates against it — and is re-exported here so existing
+ * `@atlas/api/lib/dashboard-types` importers are unchanged. Schemas is
+ * source-bundled (never npm-published), so this move keeps the "a bump needs no
+ * npm publish" property. Must mirror the constants in
  * `packages/web/src/ui/components/dashboards/grid-constants.ts`.
  */
-export const DASHBOARD_GRID = {
-  COLS: 24,
-  MIN_W: 3,
-  MAX_W: 24,
-  MIN_H: 4,
-  MAX_H: 200,
-  MAX_Y: 10_000,
-} as const;
+export { DASHBOARD_GRID } from "@useatlas/schemas";

--- a/packages/api/src/lib/dashboard-versioning.ts
+++ b/packages/api/src/lib/dashboard-versioning.ts
@@ -197,6 +197,11 @@ export type DraftChange =
          *  through the full SQL pipeline, not on store — same as `editSql`. */
         sql?: string;
         chartConfig?: DashboardChartConfig | null;
+        /** #4562 — replace a TEXT / section card's markdown body in place (the
+         *  bound editor's text-content edit). Undefined leaves it unchanged.
+         *  Only meaningful for a text card; the tool layer rejects a `content`
+         *  edit on a chart card before reaching here. */
+        content?: string;
         /** #3209 — replace the card's event markers. Undefined leaves them
          *  unchanged (the draft card keeps its current annotations). */
         annotations?: DashboardCardAnnotation[];
@@ -246,6 +251,8 @@ export function applyChangeToDraft(
               // the `editSql` change the stage tracker dispatches.
               ...(change.updates.sql !== undefined && { sql: change.updates.sql }),
               ...(change.updates.chartConfig !== undefined && { chartConfig: change.updates.chartConfig }),
+              // #4562 — a text-content edit replaces the section card's markdown.
+              ...(change.updates.content !== undefined && { content: change.updates.content }),
               ...(change.updates.annotations !== undefined && { annotations: change.updates.annotations }),
               ...(change.updates.layout !== undefined && { layout: change.updates.layout }),
               ...(change.updates.position !== undefined && { position: change.updates.position }),

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -6,7 +6,6 @@
  */
 
 import * as crypto from "crypto";
-import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
@@ -27,10 +26,13 @@ import type {
   SharedDashboardParameterSummaryItem,
   SharedDashboardView,
 } from "@atlas/api/lib/dashboard-types";
-import { DASHBOARD_GRID } from "@atlas/api/lib/dashboard-types";
 import { getSetting } from "@atlas/api/lib/settings";
 import { resolveDateExpression, DashboardParameterError } from "@atlas/api/lib/dashboard-parameters";
-import { dashboardParametersSchema, dashboardCardAnnotationsSchema } from "@useatlas/schemas";
+import {
+  dashboardParametersSchema,
+  dashboardCardAnnotationsSchema,
+  dashboardCardLayoutInputSchema,
+} from "@useatlas/schemas";
 import type { ShareMode, ShareExpiryKey } from "@useatlas/types/share";
 import { SHARE_EXPIRY_OPTIONS } from "@useatlas/types/share";
 import type { CrudResult, CrudDataResult, CrudFailReason } from "@atlas/api/lib/conversations";
@@ -47,16 +49,12 @@ const log = createLogger("dashboards");
 
 /**
  * Tile layout in the 24-col freeform grid. Single source for both write-time
- * Zod validation (route) and read-time DB-row validation (`rowToCard`).
+ * Zod validation (route) and read-time DB-row validation (`rowToCard`). The
+ * SSOT now lives in `@useatlas/schemas` as `dashboardCardLayoutInputSchema`
+ * (#4562, beside the shared card-input union that composes it); re-exported here
+ * under the historical name so every `CardLayoutSchema` import site is unchanged.
  */
-export const CardLayoutSchema = z.object({
-  x: z.number().int().min(0).max(DASHBOARD_GRID.COLS - 1),
-  y: z.number().int().min(0).max(DASHBOARD_GRID.MAX_Y),
-  w: z.number().int().min(DASHBOARD_GRID.MIN_W).max(DASHBOARD_GRID.MAX_W),
-  h: z.number().int().min(DASHBOARD_GRID.MIN_H).max(DASHBOARD_GRID.MAX_H),
-}).refine((l) => l.x + l.w <= DASHBOARD_GRID.COLS, {
-  message: `Tile extends past column ${DASHBOARD_GRID.COLS}`,
-});
+export const CardLayoutSchema = dashboardCardLayoutInputSchema;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard-drafts.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard-drafts.test.ts
@@ -170,9 +170,11 @@ describe("bound-dashboard tools — drafts", () => {
       });
 
       const result = await runTool<{ kind: string }>(tools.addCard, {
-        title: "Test",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        card: {
+          title: "Test",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        },
       });
       expect(result.kind).toBe("ok");
 
@@ -219,9 +221,11 @@ describe("bound-dashboard tools — drafts", () => {
       });
 
       const result = await runTool<{ kind: string }>(tools.addCard, {
-        title: "Scoped card",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        card: {
+          title: "Scoped card",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        },
       });
       expect(result.kind).toBe("ok");
 
@@ -269,9 +273,11 @@ describe("bound-dashboard tools — drafts", () => {
       });
 
       await runTool(tools.addCard, {
-        title: "Unscoped card",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        card: {
+          title: "Unscoped card",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        },
       });
 
       const saveCall = queryCalls.find((c) => c.sql.includes("UPDATE dashboard_user_drafts"));
@@ -294,9 +300,11 @@ describe("bound-dashboard tools — drafts", () => {
         // userId intentionally omitted.
       });
       const result = await runTool<{ kind: string; error?: string }>(tools.addCard, {
-        title: "Anon",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        card: {
+          title: "Anon",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        },
       });
       expect(result.kind).toBe("err");
       expect(result.error).toMatch(/sign/i);
@@ -388,14 +396,18 @@ describe("bound-dashboard tools — drafts", () => {
         userId: "user-1",
       });
       const tabA = await runTool<{ kind: string }>(tools.addCard, {
-        title: "Tab A",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        card: {
+          title: "Tab A",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        },
       });
       const tabB = await runTool<{ kind: string }>(tools.addCard, {
-        title: "Tab B",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        card: {
+          title: "Tab B",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["y"] },
+        },
       });
       expect(tabA.kind).toBe("ok");
       expect(tabB.kind).toBe("ok");

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard-seeding.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard-seeding.test.ts
@@ -164,9 +164,11 @@ describe("bound addCard — tool-side seeding (#4558)", () => {
 
     const tools = createBoundDashboardTools({ dashboardId: "dash-1", orgId: "org-1", userId: "user-1" });
     const result = await runTool<AddCardResult>(tools.addCard, {
-      title: "New",
-      sql: "SELECT a",
-      chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+      card: {
+        title: "New",
+        sql: "SELECT a",
+        chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+      },
     });
 
     expect(result.kind).toBe("ok");
@@ -193,9 +195,11 @@ describe("bound addCard — tool-side seeding (#4558)", () => {
 
     const tools = createBoundDashboardTools({ dashboardId: "dash-1", orgId: "org-1", userId: "user-1" });
     const result = await runTool<AddCardResult>(tools.addCard, {
-      title: "Broken",
-      sql: "SELECT a",
-      chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+      card: {
+        title: "Broken",
+        sql: "SELECT a",
+        chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+      },
     });
 
     // The card was still added (kind ok); only the seed reports the failure.
@@ -226,9 +230,11 @@ describe("bound addCard — tool-side seeding (#4558)", () => {
       connectionGroupId: "grp-empty",
     });
     const result = await runTool<AddCardResult>(tools.addCard, {
-      title: "Orphan",
-      sql: "SELECT a",
-      chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+      card: {
+        title: "Orphan",
+        sql: "SELECT a",
+        chartConfig: { type: "table", categoryColumn: "a", valueColumns: ["a"] },
+      },
     });
 
     // The card is added; seeding degrades to unseeded (canvas-mount render fills

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
@@ -302,9 +302,11 @@ describe("createBoundDashboardTools", () => {
     enableInternalDB();
     const tools = createBoundDashboardTools(ctx);
     const result = await runTool<{ kind: string; error?: string }>(tools.addCard, {
-      title: "Weekly signups",
-      sql: "SELECT COUNT(*) FROM users",
-      chartConfig: { type: "line", categoryColumn: "week", valueColumns: ["count"] },
+      card: {
+        title: "Weekly signups",
+        sql: "SELECT COUNT(*) FROM users",
+        chartConfig: { type: "line", categoryColumn: "week", valueColumns: ["count"] },
+      },
     });
     // SQL still validated up front, but the edit can't be attributed to a user
     // → drafts have no home for it → rejected, nothing persisted.
@@ -320,9 +322,11 @@ describe("createBoundDashboardTools", () => {
     enableInternalDB();
     const tools = createBoundDashboardTools(ctx);
     const result = await runTool<{ kind: "err"; error: string }>(tools.addCard, {
-      title: "Bad",
-      sql: "DROP TABLE users",
-      chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+      card: {
+        title: "Bad",
+        sql: "DROP TABLE users",
+        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+      },
     });
     expect(result.kind).toBe("err");
     expect(result.error).toMatch(/validation failed/i);
@@ -334,13 +338,15 @@ describe("createBoundDashboardTools", () => {
     enableInternalDB();
     const tools = createBoundDashboardTools(ctx);
     const result = await runTool<{ kind: "err"; error: string }>(tools.addCard, {
-      title: "Revenue",
-      sql: "SELECT SUM(amount) AS total FROM orders",
-      chartConfig: {
-        type: "kpi",
-        categoryColumn: "total",
-        valueColumns: ["total"],
-        kpi: { comparisonSql: "DROP TABLE orders" },
+      card: {
+        title: "Revenue",
+        sql: "SELECT SUM(amount) AS total FROM orders",
+        chartConfig: {
+          type: "kpi",
+          categoryColumn: "total",
+          valueColumns: ["total"],
+          kpi: { comparisonSql: "DROP TABLE orders" },
+        },
       },
     });
     expect(result.kind).toBe("err");
@@ -517,9 +523,11 @@ describe("createBoundDashboardTools", () => {
       setResults(...draftWriteResults([])); // fork empty draft, addCard appends
       const tools = createBoundDashboardTools(ctxWithUser);
       const result = await runTool<{ kind: "ok" }>(tools.addCard, {
-        title: "From-tool card",
-        sql: "SELECT 1",
-        chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+        card: {
+          title: "From-tool card",
+          sql: "SELECT 1",
+          chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+        },
       });
       expect(result.kind).toBe("ok");
       expect(invalidateScreenshotMock).toHaveBeenCalledWith("dash-1");
@@ -589,6 +597,95 @@ describe("createBoundDashboardTools", () => {
         title: "Conversion",
       });
       expect(result.kind).toBe("ok");
+    });
+
+    // #4562 — the bound editor reaches the shared card union: addCard can stage a
+    // text / section card, and updateCard can edit its markdown content. A text
+    // card has no SQL, so it skips validation + seeding entirely.
+    it("addCard stages a text / section card (with layout) — no SQL validation, no seed", async () => {
+      enableInternalDB();
+      setResults(...draftWriteResults([])); // fork empty draft, addCard appends
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{
+        kind: "ok";
+        card: { id: string; title: string; chartType: string };
+        seed?: unknown;
+      }>(tools.addCard, {
+        card: {
+          kind: "text",
+          content: "## Cohorts",
+          layout: { x: 0, y: 8, w: 24, h: 4 },
+        },
+      });
+      expect(result.kind).toBe("ok");
+      expect(result.card.chartType).toBe("text");
+      // Title derived from the markdown when none was supplied.
+      expect(result.card.title).toBe("Cohorts");
+      // A text card never runs SQL → validateSQL untouched, no seed reported.
+      expect(validateSQLMock).not.toHaveBeenCalled();
+      expect(result.seed).toBeUndefined();
+      // The staged draft carries the text card's content + null chart config.
+      const saved = queryCalls.find((c) => c.sql.includes("UPDATE dashboard_user_drafts"));
+      expect(saved).toBeTruthy();
+      expect(JSON.stringify(saved?.params)).toContain("## Cohorts");
+      expect(invalidateScreenshotMock).toHaveBeenCalledWith("dash-1");
+    });
+
+    it("updateCard edits a text / section card's markdown content", async () => {
+      enableInternalDB();
+      // readCurrentCard (draft read) confirms kind=text, then the draft write lands.
+      setResults(...draftReadResults([textSnapshotCard]), ...draftWriteResults([textSnapshotCard]));
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string; updated?: string[] }>(tools.updateCard, {
+        cardId: "card-1",
+        content: "## Top of funnel — updated",
+      });
+      expect(result.kind).toBe("ok");
+      expect(result.updated).toContain("content");
+      const saved = queryCalls.find((c) => c.sql.includes("UPDATE dashboard_user_drafts"));
+      expect(JSON.stringify(saved?.params)).toContain("Top of funnel — updated");
+    });
+
+    it("updateCard rejects a content edit on a chart card", async () => {
+      enableInternalDB();
+      setResults(...draftReadResults([chartSnapshotCard]));
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string; error?: string }>(tools.updateCard, {
+        cardId: "card-1",
+        content: "## not allowed on a chart",
+      });
+      expect(result.kind).toBe("err");
+      expect(result.error).toMatch(/chart card|no text content/i);
+    });
+
+    it("updateCard refuses a content edit when the card can't be read (never risks cross-kind corruption)", async () => {
+      enableInternalDB();
+      // Draft read finds NO card with this id → readCurrentCard fails → the
+      // content edit is refused rather than staged onto an unknown/chart card.
+      setResults(...draftReadResults([chartSnapshotCard]));
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string; error?: string }>(tools.updateCard, {
+        cardId: "missing-card",
+        content: "## header",
+      });
+      expect(result.kind).toBe("err");
+      // No draft write landed — the content mutation never reached apply.
+      const saved = queryCalls.find((c) => c.sql.includes("UPDATE dashboard_user_drafts"));
+      expect(saved).toBeFalsy();
+    });
+
+    it("updateCard rejects a payload carrying both content and chartConfig", async () => {
+      enableInternalDB();
+      // A text card: the content guard passes, then the chartConfig guard rejects
+      // (a text card has no chart) — the two fields are per-kind, never both.
+      setResults(...draftReadResults([textSnapshotCard]));
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string; error?: string }>(tools.updateCard, {
+        cardId: "card-1",
+        content: "## still text",
+        chartConfig: { type: "bar", categoryColumn: "x", valueColumns: ["y"] },
+      });
+      expect(result.kind).toBe("err");
     });
 
     it("emits a multimodal image-data part via toModelOutput without leaking bytes into the envelope", async () => {

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -22,10 +22,16 @@
 import * as crypto from "crypto";
 import { tool, type ToolSet } from "ai";
 import { z } from "zod";
-import { dashboardChartConfigSchema, dashboardCardAnnotationsSchema } from "@useatlas/schemas";
+import {
+  dashboardChartConfigSchema,
+  dashboardCardAnnotationsSchema,
+  dashboardCardInputSchema,
+  dashboardTextCardContentSchema,
+} from "@useatlas/schemas";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
+import { deriveTextCardTitle } from "@atlas/api/lib/dashboard-text-card";
 import {
   validateAutoComparison,
   resolveDashboardParameterValues,
@@ -321,22 +327,57 @@ export function createBoundDashboardTools(
   });
 
   const addCardTool = tool({
-    description: `Add a new card to the dashboard. Validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. The grid is 24 columns wide. Layout is optional — when omitted the card stages with no placement and the grid renderer auto-arranges it at view time. Pass a layout if you want a specific {x, y, w, h} on the 24-column grid.
+    description: `Add a new card to the dashboard — a SQL-backed chart card or a markdown text / section card.
 
-On success the result includes \`seed\` — the card's data outcome: \`rows\` (with a rowCount), \`empty\` (the query ran but returned nothing), \`error\` (the card WAS added but its query failed — \`message\` says why), or \`unseeded\` (added; data loads when the dashboard opens). If \`seed\` is \`empty\` or \`error\`, say so plainly and offer to fix it rather than claiming the card shows data.`,
+CHART CARD ({ title, sql, chartConfig }): validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. On success the result includes \`seed\` — the card's data outcome: \`rows\` (with a rowCount), \`empty\` (the query ran but returned nothing), \`error\` (the card WAS added but its query failed — \`message\` says why), or \`unseeded\` (added; data loads when the dashboard opens). If \`seed\` is \`empty\` or \`error\`, say so plainly and offer to fix it rather than claiming the card shows data.
+
+TEXT / SECTION CARD ({ kind: "text", content: "## ..." }): a markdown header / explainer that organizes the grid — no SQL, no chart, no data. Use it to group related charts under a heading ("Top of funnel", "Cohorts"): add a full-width text card (w: 24) above a cluster of charts. Keep content short — a heading and at most a sentence. A text card is never seeded (nothing to run), so its result carries no \`seed\`.
+
+The grid is 24 columns wide. Layout is optional — when omitted the card stages with no placement and the grid renderer auto-arranges it at view time. Pass a layout if you want a specific {x, y, w, h}.`,
     inputSchema: z.object({
-      title: z.string().min(1).max(200).describe("Card title (visible to the user)"),
-      sql: z.string().min(1).describe("Read-only SELECT query"),
-      chartConfig: ChartConfigSchema.describe("Chart type + column mapping"),
-      annotations: dashboardCardAnnotationsSchema
-        .optional()
-        .describe(
-          "Optional dated event markers ({ x, label, color? }) — vertical reference lines on a line/area card (e.g. a product launch). `x` must match a value on the card's time/category axis.",
-        ),
-      layout: CardLayoutSchema.optional().describe("Optional grid placement {x, y, w, h}"),
+      // #4562 — the shared card-input union (chart | text, + layout), declared
+      // once in @useatlas/schemas and consumed verbatim by createDashboard too.
+      // Nested under `card` (not a root union) so the tool's JSON schema keeps a
+      // `type: object` root, which the Anthropic tool-calling API requires.
+      card: dashboardCardInputSchema.describe(
+        'The card to add — a chart card { title, sql, chartConfig, layout? } or a text / section card { kind: "text", content, layout? }.',
+      ),
     }),
-    execute: async ({ title, sql, chartConfig, annotations, layout }) => {
+    execute: async ({ card }) => {
       try {
+        // ---- text / section card (#4562) — no SQL, no chart, never seeded ----
+        // A text card fetches no data, so it skips SQL validation and seeding
+        // entirely; it stages with `sql: ""`, `chartConfig: null`, its markdown
+        // in `content`, and no connection group (it never queries).
+        if (card.kind === "text") {
+          const textDraftCard: DashboardSnapshotCard = {
+            id: crypto.randomUUID(),
+            position: 0,
+            title: card.title?.trim() || deriveTextCardTitle(card.content),
+            sql: "",
+            chartConfig: null,
+            content: card.content,
+            annotations: [],
+            connectionGroupId: null,
+            layout: card.layout ?? null,
+          };
+          const appliedText = await maybeApplyToDraft(ctx, { kind: "addCard", card: textDraftCard });
+          if (!appliedText.ok) return { kind: "err" as const, error: appliedText.error };
+          // #2367 — user's draft view shifted, drop cached screenshots.
+          invalidateDashboardScreenshot(dashboardId);
+          return {
+            kind: "ok" as const,
+            card: {
+              id: textDraftCard.id,
+              title: textDraftCard.title,
+              chartType: "text" as const,
+              position: textDraftCard.position,
+            },
+          };
+        }
+
+        // ---- chart card (behavior unchanged) ----
+        const { title, sql, chartConfig, annotations, layout } = card;
         // #3137 — a KPI card's comparisonSql runs through the SAME guard at
         // render time; validate it up front alongside the primary so the bound
         // editor rejects a bad comparison query the same way createDashboard
@@ -420,11 +461,16 @@ On success the result includes \`seed\` — the card's data outcome: \`rows\` (w
   });
 
   const updateCardTool = tool({
-    description: `Update a card's title, chart type, layout, or event annotations. Pass only the fields you want to change. Does NOT support changing the SQL — that is a destructive op and arrives as a staged ghost change in a later slice. To change the SQL today, ask the user to remove and re-add the card.`,
+    description: `Update a card's title, chart type, layout, event annotations, or a text / section card's markdown content. Pass only the fields you want to change. \`content\` edits a TEXT card's markdown ("change the Cohorts header to say ..."); \`chartConfig\` edits a CHART card — the two are mutually exclusive per card kind. Does NOT support changing a chart card's SQL — that is a destructive op that arrives as a staged ghost change. To change a chart's SQL today, ask the user to remove and re-add the card.`,
     inputSchema: z.object({
       cardId: z.string().min(1).describe("Card id"),
       title: z.string().min(1).max(200).optional(),
       chartConfig: ChartConfigSchema.nullable().optional(),
+      content: dashboardTextCardContentSchema
+        .optional()
+        .describe(
+          'New markdown body for a TEXT / section card (e.g. "## Cohorts"). Only valid on a text card — rejected on a chart card. Rendered sanitized, no raw HTML.',
+        ),
       annotations: dashboardCardAnnotationsSchema
         .optional()
         .describe(
@@ -433,56 +479,80 @@ On success the result includes \`seed\` — the card's data outcome: \`rows\` (w
       layout: CardLayoutSchema.nullable().optional(),
       position: z.number().int().min(0).optional(),
     }),
-    execute: async ({ cardId, title, chartConfig, annotations, layout, position }) => {
+    execute: async ({ cardId, title, chartConfig, content, annotations, layout, position }) => {
       try {
         const updates: {
           title?: string;
           chartConfig?: z.infer<typeof ChartConfigSchema> | null;
+          content?: string;
           annotations?: z.infer<typeof dashboardCardAnnotationsSchema>;
           layout?: DashboardCardLayout | null;
           position?: number;
         } = {};
         if (title !== undefined) updates.title = title;
         if (chartConfig !== undefined) updates.chartConfig = chartConfig;
+        if (content !== undefined) updates.content = content;
         if (annotations !== undefined) updates.annotations = annotations;
         if (layout !== undefined) updates.layout = layout;
         if (position !== undefined) updates.position = position;
 
         if (Object.keys(updates).length === 0) {
-          return { kind: "err" as const, error: "No fields supplied — pass at least one of title, chartConfig, annotations, layout, position." };
+          return { kind: "err" as const, error: "No fields supplied — pass at least one of title, chartConfig, content, annotations, layout, position." };
         }
 
-        // #3138: a text / section-block card has no chart. Reject a chartConfig
-        // change on one rather than mutate the draft into a state publish would
-        // silently discard (text-card equality ignores chartConfig). Title /
-        // layout / position edits remain valid for text cards.
-        if (updates.chartConfig !== undefined) {
+        // #3138 / #4562 — chart config and text content are kind-specific: a
+        // text / section card has no chart to configure, and a chart card has no
+        // markdown body to edit. Reject a cross-kind edit rather than mutate the
+        // draft into a state publish would silently discard (card equality
+        // ignores the field that doesn't belong to the kind). Title / layout /
+        // position / annotations edits remain valid for both kinds. Read the
+        // current card once when either kind-specific field is being changed.
+        if (updates.chartConfig !== undefined || updates.content !== undefined) {
           const current = await readCurrentCard(cardId);
-          if (current.ok && current.kind === "text") {
-            return {
-              kind: "err" as const,
-              error: `Card ${cardId} is a text / section card — it has no chart to configure.`,
-            };
-          }
-          // #3137 — validate a new/changed KPI comparisonSql through the same
-          // guard before persisting (parity with addCard / createDashboard).
-          const comparisonSql = updates.chartConfig?.kpi?.comparisonSql;
-          if (comparisonSql) {
-            const comparisonValidation = await validateSQL(comparisonSql, undefined);
-            if (!comparisonValidation.valid) {
+          if (updates.content !== undefined) {
+            // A `content` edit must land ONLY on a CONFIRMED text card: writing
+            // content onto a chart card would flip its kind at publish (a card
+            // with non-null content reads as text). If the card can't be read,
+            // refuse rather than risk that cross-kind corruption — stricter than
+            // the chartConfig guard below, which can proceed on an unread card
+            // because a stray chartConfig on a text card is dropped at publish.
+            if (!current.ok) {
+              return { kind: "err" as const, error: current.error };
+            }
+            if (current.kind !== "text") {
               return {
                 kind: "err" as const,
-                error: `KPI comparison SQL validation failed: ${comparisonValidation.error}. Fix the query and retry.`,
+                error: `Card ${cardId} is a chart card — it has no text content to edit. Use chartConfig / annotations to change a chart.`,
               };
             }
           }
-          // #3207 — turning on autoComparison must agree with the card's
-          // EXISTING sql (updateCard never changes the query): it has to filter
-          // by both window params.
-          if (updates.chartConfig?.kpi?.autoComparison && current.ok) {
-            const updateAutoErr = validateAutoComparison(current.sql, updates.chartConfig.kpi);
-            if (updateAutoErr) {
-              return { kind: "err" as const, error: updateAutoErr };
+          if (updates.chartConfig !== undefined) {
+            if (current.ok && current.kind === "text") {
+              return {
+                kind: "err" as const,
+                error: `Card ${cardId} is a text / section card — it has no chart to configure.`,
+              };
+            }
+            // #3137 — validate a new/changed KPI comparisonSql through the same
+            // guard before persisting (parity with addCard / createDashboard).
+            const comparisonSql = updates.chartConfig?.kpi?.comparisonSql;
+            if (comparisonSql) {
+              const comparisonValidation = await validateSQL(comparisonSql, undefined);
+              if (!comparisonValidation.valid) {
+                return {
+                  kind: "err" as const,
+                  error: `KPI comparison SQL validation failed: ${comparisonValidation.error}. Fix the query and retry.`,
+                };
+              }
+            }
+            // #3207 — turning on autoComparison must agree with the card's
+            // EXISTING sql (updateCard never changes the query): it has to filter
+            // by both window params.
+            if (updates.chartConfig?.kpi?.autoComparison && current.ok) {
+              const updateAutoErr = validateAutoComparison(current.sql, updates.chartConfig.kpi);
+              if (updateAutoErr) {
+                return { kind: "err" as const, error: updateAutoErr };
+              }
             }
           }
         }
@@ -884,16 +954,19 @@ Use \`getDashboardState\` for a fresh read of the dashboard's title/description 
   getCardDetail: `### Inspect a card in detail
 Use \`getCardDetail(cardId)\` to fetch a card's full SQL, chartConfig, layout, and cached columns. The compact card summary in your system prompt only shows id/title/chart-type/position — call \`getCardDetail\` whenever you need the SQL or chartConfig to reason about, explain, or change a card.`,
 
-  addCard: `### Add a card
-Use \`addCard\` to create a new card. Always:
+  addCard: `### Add a card (chart or text / section)
+Use \`addCard\` to create a new card — either a SQL-backed chart card or a markdown text / section header.
+
+CHART card — always:
 1. Call \`explore\` + \`executeSQL\` first to confirm the SQL shape and column names.
 2. Build a chartConfig whose \`categoryColumn\` and \`valueColumns\` match the SQL output exactly.
 3. Optionally specify a layout {x, y, w, h} in the 24-col grid.
+The tool validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT created.
 
-The tool validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT created.`,
+TEXT / SECTION card — pass \`{ kind: "text", content: "## Cohorts" }\` (optionally a layout). It has no SQL or chart and fetches no data; use it to group related charts under a heading. Emit a full-width text card (w: 24) above each cluster of charts and keep the copy short.`,
 
-  updateCard: `### Rename / re-chart / re-place a card
-Use \`updateCard\` to change a card's title, chartConfig, layout, or position. Pass only the fields you want to change. Does NOT support SQL changes — those are destructive ops that arrive as staged ghost changes in a later slice.`,
+  updateCard: `### Rename / re-chart / re-place a card, or edit a section header
+Use \`updateCard\` to change a card's title, chartConfig, layout, position, or a text / section card's markdown \`content\`. Pass only the fields you want to change. \`content\` edits a TEXT card's markdown; \`chartConfig\` edits a CHART card — the two are per-kind and mutually exclusive. Does NOT support changing a chart card's SQL — those are destructive ops that arrive as staged ghost changes.`,
 
   updateLayout: `### Rearrange the grid
 Use \`updateLayout\` to move multiple cards at once. Supply the layouts array with one entry per card you want to place. Cards not listed stay where they are. Grid is 24 columns wide; (x + w) must be <= 24.`,

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -45,12 +45,12 @@ import { z } from "zod";
 import { CHART_TYPES } from "@useatlas/types";
 import {
   dashboardParametersSchema,
-  dashboardTextCardContentSchema,
-  dashboardChartConfigSchema,
-  dashboardCardAnnotationsSchema,
+  dashboardCreateCardInputSchema,
+  type DashboardCreateChartCardInputWire,
 } from "@useatlas/schemas";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { deriveTextCardTitle } from "@atlas/api/lib/dashboard-text-card";
 import { validateSQL } from "@atlas/api/lib/tools/sql";
 import {
   extractPlaceholderNames,
@@ -58,7 +58,6 @@ import {
   resolveDashboardParameterValues,
 } from "@atlas/api/lib/dashboard-parameters";
 import {
-  CardLayoutSchema,
   resolveCardConnectionId,
   NoGroupMembersError,
 } from "@atlas/api/lib/dashboards";
@@ -94,77 +93,27 @@ export type DashboardUrlResolver = (dashboardId: string) => string;
 export const WORKSPACE_DASHBOARD_URL_RESOLVER: DashboardUrlResolver = (dashboardId) =>
   `/dashboards/${dashboardId}`;
 
-/** Chart/table/KPI config. The canonical schema lives in @useatlas/schemas so
- *  the optional `kpi` block (#3137) round-trips through every persist path
- *  instead of being stripped at one boundary. */
-const ChartConfigSchema = dashboardChartConfigSchema;
-
-/** A SQL-backed chart/table card (the original kind). `kind` is optional and
- *  defaults to a chart so the long-standing `{ title, sql, chartConfig }` shape
- *  keeps working — only a text card has to name its kind. */
-const ChartCardSchema = z
-  .object({
-    kind: z.literal("chart").optional(),
-    title: z.string().min(1).max(200),
-    sql: z.string().min(1),
-    chartConfig: ChartConfigSchema,
-    annotations: dashboardCardAnnotationsSchema
-      .optional()
-      .describe(
-        "Optional dated event markers ({ x, label, color? }) drawn as vertical reference lines on a line/area card (e.g. a product launch). `x` must match a value on the card's time/category axis.",
-      ),
-    layout: CardLayoutSchema.optional(),
-    connectionId: z
-      .string()
-      .min(1)
-      .optional()
-      .describe("Source connection — omit for the default datasource."),
-  })
-  // Strict so a text card's `content` (or any stray key) can't ride along on a
-  // chart card and be silently dropped — fail fast instead.
-  .strict();
-
 /**
- * A markdown text / section-block card (#3138). No SQL, no chart — just a
- * header/explainer that groups the charts below it. `title` is optional (the
- * header usually lives in `content`); when omitted we derive a short row title
- * from the markdown for list/diff surfaces.
+ * The card-input union is declared ONCE in `@useatlas/schemas` (#4562, audit
+ * H3) and consumed by both this creation tool and the bound editor's `addCard`
+ * (the bound `updateCard` reuses only the text arm's `content` sub-schema), so a
+ * future card kind can never reach one tool and not the other.
+ * `createDashboard` takes the connection-aware variant — a chart card may name
+ * the `connectionId` it was authored against (validated against that
+ * connection's dialect); the bound editor infers its connection from the
+ * conversation group, so it consumes the plain `dashboardCardInputSchema`.
  */
-const TextCardSchema = z
-  .object({
-    kind: z.literal("text"),
-    title: z.string().min(1).max(200).optional(),
-    content: dashboardTextCardContentSchema.describe(
-      'Markdown section header / explainer, e.g. "## Top of funnel". Rendered sanitized — no raw HTML.',
-    ),
-    layout: CardLayoutSchema.optional(),
-  })
-  // Strict so a text card can't smuggle a `sql`/`chartConfig` past the
-  // validation it skips — a mixed payload is a caller bug, reject it.
-  .strict();
+const CardSchema = dashboardCreateCardInputSchema;
 
-/**
- * A card is either a chart or a text block. We use a plain union (not a
- * discriminated one) because a chart card may omit `kind` entirely — a card
- * with `content` and no `sql` is a text card, everything else is a chart.
- */
-const CardSchema = z.union([ChartCardSchema, TextCardSchema]);
+/** The chart arm of the creation-tool card union (carries `sql` + `connectionId`;
+ *  the text arm has neither) — the named schema's inferred type, so it stays in
+ *  lockstep with the union arm rather than shape-matching it. */
+type ChartCardInput = DashboardCreateChartCardInputWire;
 
-type ChartCardInput = z.infer<typeof ChartCardSchema>;
-
-/**
- * Derive a short row title for a text card whose `title` the agent left blank.
- * Takes the first non-empty line, strips a leading markdown block marker
- * (heading, list bullet, or blockquote), and caps the length. Used only for
- * list/diff surfaces — the tile renders the full markdown, not this label.
- */
-export function deriveTextCardTitle(content: string): string {
-  for (const rawLine of content.split("\n")) {
-    const line = rawLine.replace(/^\s*(?:#{1,6}\s+|[-*+]\s+|>\s+)/, "").trim();
-    if (line.length > 0) return line.slice(0, 120);
-  }
-  return "Section";
-}
+// Re-exported for back-compat with existing importers (create-dashboard.test).
+// The SSOT is the standalone `dashboard-text-card` module (#4562) so the bound
+// editor's `addCard` shares it without importing this tool.
+export { deriveTextCardTitle };
 
 export type CreateDashboardCardValidationError = {
   cardIndex: number;

--- a/packages/schemas/src/__tests__/dashboard.test.ts
+++ b/packages/schemas/src/__tests__/dashboard.test.ts
@@ -15,6 +15,10 @@ import {
   dashboardCardAnnotationSchema,
   dashboardCardAnnotationsSchema,
   DASHBOARD_ANNOTATIONS_MAX,
+  DASHBOARD_GRID,
+  dashboardCardLayoutInputSchema,
+  dashboardCardInputSchema,
+  dashboardCreateCardInputSchema,
   sharedDashboardCardSchema,
   sharedDashboardParameterSummaryItemSchema,
   sharedDashboardViewSchema,
@@ -433,6 +437,133 @@ describe("dashboardDrilldownConfigSchema", () => {
   test("rejects unknown keys (strict — no stray config rides along)", () => {
     expect(
       dashboardDrilldownConfigSchema.safeParse({ targetParam: "region", crossFilter: true }).success,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card input union (#4562 — one shared union for both authoring tools)
+// ---------------------------------------------------------------------------
+
+describe("dashboardCardLayoutInputSchema (#4562)", () => {
+  test("DASHBOARD_GRID is a 24-column grid", () => {
+    expect(DASHBOARD_GRID.COLS).toBe(24);
+  });
+
+  test("accepts an in-bounds placement", () => {
+    expect(dashboardCardLayoutInputSchema.safeParse({ x: 0, y: 0, w: 24, h: 8 }).success).toBe(true);
+    expect(dashboardCardLayoutInputSchema.safeParse({ x: 12, y: 3, w: 12, h: 8 }).success).toBe(true);
+  });
+
+  test("rejects a tile that overflows the column count (x + w > COLS)", () => {
+    expect(dashboardCardLayoutInputSchema.safeParse({ x: 20, y: 0, w: 12, h: 8 }).success).toBe(false);
+  });
+
+  test("rejects a width below the minimum", () => {
+    expect(
+      dashboardCardLayoutInputSchema.safeParse({ x: 0, y: 0, w: DASHBOARD_GRID.MIN_W - 1, h: 8 }).success,
+    ).toBe(false);
+  });
+});
+
+describe("dashboardCardInputSchema (#4562 — shared card union)", () => {
+  const chartConfig = { type: "line" as const, categoryColumn: "week", valueColumns: ["count"] };
+
+  test("round-trips a chart card without an explicit kind", () => {
+    const parsed = dashboardCardInputSchema.parse({
+      title: "Signups",
+      sql: "SELECT week, count(*) FROM users GROUP BY 1",
+      chartConfig,
+    });
+    // A card with sql + no content is a chart.
+    expect("sql" in parsed && parsed.sql.length > 0).toBe(true);
+    expect("content" in parsed).toBe(false);
+  });
+
+  test("round-trips a chart card with an explicit kind + layout + annotations", () => {
+    const parsed = dashboardCardInputSchema.parse({
+      kind: "chart",
+      title: "Signups",
+      sql: "SELECT 1",
+      chartConfig,
+      annotations: [{ x: "2026-01", label: "Launch" }],
+      layout: { x: 0, y: 0, w: 12, h: 8 },
+    });
+    expect(parsed.kind).toBe("chart");
+  });
+
+  test("round-trips a text / section card with layout", () => {
+    const parsed = dashboardCardInputSchema.parse({
+      kind: "text",
+      content: "## Top of funnel",
+      layout: { x: 0, y: 0, w: 24, h: 4 },
+    });
+    expect(parsed.kind).toBe("text");
+    expect("content" in parsed && parsed.content).toBe("## Top of funnel");
+  });
+
+  test("rejects a chart card carrying a text card's content (strict)", () => {
+    expect(
+      dashboardCardInputSchema.safeParse({ title: "X", sql: "SELECT 1", chartConfig, content: "## nope" })
+        .success,
+    ).toBe(false);
+  });
+
+  test("rejects a text card smuggling sql (strict)", () => {
+    expect(
+      dashboardCardInputSchema.safeParse({ kind: "text", content: "## h", sql: "SELECT 1" }).success,
+    ).toBe(false);
+  });
+
+  test("rejects a text card with empty content", () => {
+    expect(dashboardCardInputSchema.safeParse({ kind: "text", content: "   " }).success).toBe(false);
+  });
+
+  test("rejects a chart card's connectionId (creation-only field)", () => {
+    // The base union has no connectionId — only the creation variant does.
+    expect(
+      dashboardCardInputSchema.safeParse({ title: "X", sql: "SELECT 1", chartConfig, connectionId: "c1" })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe("dashboardCreateCardInputSchema (#4562 — creation variant)", () => {
+  const chartConfig = { type: "table" as const, categoryColumn: "x", valueColumns: ["y"] };
+
+  test("accepts a chart card naming a connectionId", () => {
+    const parsed = dashboardCreateCardInputSchema.parse({
+      title: "Orders",
+      sql: "SELECT 1",
+      chartConfig,
+      connectionId: "conn-prod",
+    });
+    expect("connectionId" in parsed && parsed.connectionId).toBe("conn-prod");
+  });
+
+  test("still round-trips a text card (no connectionId on the text arm)", () => {
+    const parsed = dashboardCreateCardInputSchema.parse({ kind: "text", content: "## Cohorts" });
+    expect(parsed.kind).toBe("text");
+  });
+
+  test("a text card cannot carry a connectionId (strict)", () => {
+    expect(
+      dashboardCreateCardInputSchema.safeParse({ kind: "text", content: "## h", connectionId: "c1" })
+        .success,
+    ).toBe(false);
+  });
+
+  test("the chart arm stays strict through .extend — rejects an unknown key", () => {
+    // Pins the Zod-4 behavior that `.extend()` preserves the base arm's
+    // `.strict()`, so a future bump can't silently start allowing stray keys.
+    expect(
+      dashboardCreateCardInputSchema.safeParse({
+        title: "X",
+        sql: "SELECT 1",
+        chartConfig,
+        connectionId: "c1",
+        bogus: true,
+      }).success,
     ).toBe(false);
   });
 });

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -447,6 +447,147 @@ export const dashboardChartConfigSchema = z.object({
 export type DashboardChartConfigWire = z.infer<typeof dashboardChartConfigSchema>;
 
 // ---------------------------------------------------------------------------
+// Tile layout + the shared CARD INPUT UNION (#4562, PRD #4553 audit H3)
+//
+// ONE declaration of "a card the agent can author" — a SQL-backed chart card or
+// a markdown text / section card, each carrying an optional grid layout —
+// consumed by BOTH the `createDashboard` creation tool and the bound editor's
+// `addCard` (the bound `updateCard` reuses the text arm's `content` sub-schema
+// for its partial-update field, not the whole union). Before #4562 each tool
+// declared its own card schema, so the bound editor silently lacked the
+// text-card kind the creation tool had (audit H3): a future card kind could
+// reach one tool and not the other. Declaring the arms + union here once
+// structurally prevents that asymmetry — a new kind added to an arm reaches
+// every consumer.
+//
+// The authoring grid bounds (`DASHBOARD_GRID`) live here (the SSOT) rather than
+// in `@atlas/api` so the layout schema can validate against them without the
+// schemas package importing the api package. `@atlas/api/lib/dashboard-types`
+// re-exports `DASHBOARD_GRID` and `@atlas/api/lib/dashboards` re-exports the
+// layout schema as `CardLayoutSchema`, so existing import sites are unchanged.
+// Must mirror the web renderer's `grid-constants.ts`; schemas is source-bundled
+// (never npm-published), so a bump here needs no version bump.
+// ---------------------------------------------------------------------------
+
+/** Bounds of the dashboard tile grid (#1867). */
+export const DASHBOARD_GRID = {
+  COLS: 24,
+  MIN_W: 3,
+  MAX_W: 24,
+  MIN_H: 4,
+  MAX_H: 200,
+  MAX_Y: 10_000,
+} as const;
+
+/**
+ * Authoring tile layout in the 24-col freeform grid. Single source for both
+ * write-time Zod validation (the agent tools + REST route) and read-time DB-row
+ * validation (`rowToCard`). `x + w` may not exceed the column count.
+ */
+export const dashboardCardLayoutInputSchema = z
+  .object({
+    x: z.number().int().min(0).max(DASHBOARD_GRID.COLS - 1),
+    y: z.number().int().min(0).max(DASHBOARD_GRID.MAX_Y),
+    w: z.number().int().min(DASHBOARD_GRID.MIN_W).max(DASHBOARD_GRID.MAX_W),
+    h: z.number().int().min(DASHBOARD_GRID.MIN_H).max(DASHBOARD_GRID.MAX_H),
+  })
+  .refine((l) => l.x + l.w <= DASHBOARD_GRID.COLS, {
+    message: `Tile extends past column ${DASHBOARD_GRID.COLS}`,
+  });
+export type DashboardCardLayoutInputWire = z.infer<typeof dashboardCardLayoutInputSchema>;
+
+/**
+ * A SQL-backed chart / table / KPI card — the original card kind. `kind` is
+ * optional and defaults to a chart so the long-standing
+ * `{ title, sql, chartConfig }` shape keeps working; only a text card must name
+ * its kind. `.strict()` so a text card's `content` (or any stray key) can't ride
+ * along on a chart card and be silently dropped — fail fast instead.
+ */
+export const dashboardChartCardInputSchema = z
+  .object({
+    kind: z.literal("chart").optional(),
+    title: z.string().min(1).max(200).describe("Card title (visible to the user)"),
+    sql: z.string().min(1).describe("Read-only SELECT query backing the card"),
+    chartConfig: dashboardChartConfigSchema.describe("Chart type + column mapping"),
+    annotations: dashboardCardAnnotationsSchema
+      .optional()
+      .describe(
+        "Optional dated event markers ({ x, label, color? }) drawn as vertical reference lines on a line/area card (e.g. a product launch). `x` must match a value on the card's time/category axis.",
+      ),
+    layout: dashboardCardLayoutInputSchema
+      .optional()
+      .describe("Optional grid placement { x, y, w, h } on the 24-column grid."),
+  })
+  .strict();
+export type DashboardChartCardInputWire = z.infer<typeof dashboardChartCardInputSchema>;
+
+/**
+ * A markdown text / section-block card (#3138). No SQL, no chart — a header /
+ * explainer that groups the charts around it. `title` is optional (the heading
+ * usually lives in `content`); when omitted a short row title is derived from
+ * the markdown for list/diff surfaces. `.strict()` so a text card can't smuggle
+ * a `sql` / `chartConfig` past the validation it skips — a mixed payload is a
+ * caller bug, reject it.
+ */
+export const dashboardTextCardInputSchema = z
+  .object({
+    kind: z.literal("text"),
+    title: z.string().min(1).max(200).optional(),
+    content: dashboardTextCardContentSchema.describe(
+      'Markdown section header / explainer, e.g. "## Top of funnel". Rendered sanitized — no raw HTML.',
+    ),
+    layout: dashboardCardLayoutInputSchema
+      .optional()
+      .describe("Optional grid placement { x, y, w, h } on the 24-column grid."),
+  })
+  .strict();
+export type DashboardTextCardInputWire = z.infer<typeof dashboardTextCardInputSchema>;
+
+/**
+ * The shared card-input union. A card is EITHER a chart or a text block. A plain
+ * (non-discriminated) union because a chart card may omit `kind` entirely — a
+ * card with `content` and no `sql` is a text card, everything else is a chart.
+ * Consumed VERBATIM by the bound editor's `addCard`; the creation tool consumes
+ * the connection-aware {@link dashboardCreateCardInputSchema} variant below.
+ */
+export const dashboardCardInputSchema = z.union([
+  dashboardChartCardInputSchema,
+  dashboardTextCardInputSchema,
+]);
+export type DashboardCardInputWire = z.infer<typeof dashboardCardInputSchema>;
+
+/**
+ * Creation-tool chart arm — the base chart card plus the optional source
+ * `connectionId` the `createDashboard` tool validates each card's SQL against.
+ * A NAMED export (rather than an inline `.extend`) so consumers can derive the
+ * chart-card type directly (`z.infer`) instead of shape-matching the union.
+ * `.extend()` preserves the base arm's `.strict()` in Zod 4, so a stray key is
+ * still rejected.
+ */
+export const dashboardCreateChartCardInputSchema = dashboardChartCardInputSchema.extend({
+  connectionId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Source connection — omit for the default datasource."),
+});
+export type DashboardCreateChartCardInputWire = z.infer<typeof dashboardCreateChartCardInputSchema>;
+
+/**
+ * Creation-tool variant of the card union. Identical to
+ * {@link dashboardCardInputSchema} except a chart card may name the source
+ * `connectionId` it was authored against. The bound editor infers the connection
+ * from the conversation's group instead, so it has no such field. Declared here
+ * beside the base union so a future card kind is added in ONE place and reaches
+ * both tools.
+ */
+export const dashboardCreateCardInputSchema = z.union([
+  dashboardCreateChartCardInputSchema,
+  dashboardTextCardInputSchema,
+]);
+export type DashboardCreateCardInputWire = z.infer<typeof dashboardCreateCardInputSchema>;
+
+// ---------------------------------------------------------------------------
 // Shared-view projection (#4316 — data-only snapshot)
 //
 // SSOT for the payload the public / org share endpoint serializes. Mirrors

--- a/packages/web/src/ui/components/dashboards/grid-constants.ts
+++ b/packages/web/src/ui/components/dashboards/grid-constants.ts
@@ -1,8 +1,9 @@
 /**
- * Web-side grid constants. Must mirror `DASHBOARD_GRID` in
- * `packages/api/src/lib/dashboard-types.ts` (the Zod schema there gates persisted
- * layouts). They aren't in `@useatlas/types` because that would require an npm
- * publish + template ref bump for every change.
+ * Web-side grid constants. Must mirror `DASHBOARD_GRID` in `@useatlas/schemas`
+ * (#4562 — the SSOT, beside the `dashboardCardLayoutInputSchema` that gates
+ * persisted layouts; re-exported through `@atlas/api/lib/dashboard-types`). They
+ * aren't in `@useatlas/types` because that would require an npm publish +
+ * template ref bump for every change; `@useatlas/schemas` is source-bundled.
  */
 
 export const COLS = 24;


### PR DESCRIPTION
## Summary

Extracts the dashboard **card-input union** (chart card | text card, + layout) into `@useatlas/schemas` as a single SSOT consumed by both authoring tools, closing audit H3 (PRD #4553): a future card kind now reaches both tools or neither, and the bound editor gains the text/section-card reach only creation had.

- **`packages/schemas/src/dashboard.ts`** — declares the arms + union once: `dashboardChartCardInputSchema`, `dashboardTextCardInputSchema`, `dashboardCardInputSchema` (base union, consumed verbatim by the bound `addCard`), plus `dashboardCreateChartCardInputSchema` / `dashboardCreateCardInputSchema` (chart arm extended with the creation-only `connectionId`, consumed by `createDashboard`). `DASHBOARD_GRID` + the authoring layout schema (`dashboardCardLayoutInputSchema`) move here as the SSOT; `@atlas/api/lib/dashboard-types` re-exports `DASHBOARD_GRID` and `@atlas/api/lib/dashboards` re-exports it as `CardLayoutSchema`, so every existing import site is unchanged.
- **Bound `addCard`** now accepts a text/section card (via the shared union, nested under a `card` field so the tool's JSON schema keeps a `type: object` root — Anthropic tool-calling requires it). A text card skips SQL validation + seeding (it fetches no data). **`updateCard`** now edits a text card's `content`; a content edit requires a **confirmed** text card so it can never flip a chart card's kind at publish.
- **`createDashboard`** drops its three local card schemas for the shared `dashboardCreateCardInputSchema`; chart-card behavior (validation, seeding, persistence) is unchanged. `deriveTextCardTitle` extracted to a dependency-free `dashboard-text-card` module both tools share (avoids a tool→tool import that disturbed sibling partial-mock test setups).
- `DraftChange.updateCard.updates` gains `content`; `applyChangeToDraft` applies it.

## Test plan

- [x] Wire-schema round-trip tests for both kinds + the base/creation `connectionId` asymmetry + strict cross-contamination rejects (`packages/schemas/src/__tests__/dashboard.test.ts`)
- [x] Bound editor: text-card `addCard` (derived title, no seed, no SQL validation, persisted content), `updateCard` content edit, cross-kind rejects (content-on-chart, unreadable-card refusal, both-fields-supplied), chart-card behavior unchanged (`bound-dashboard*.test.ts`)
- [x] Direct unit test for `deriveTextCardTitle` (heading/bullet/blockquote/cap/fallback)
- [x] Internal `/review-panel` (4 specialists) — CLEAN; applied the optional strengthening findings
- [x] `/ci` — 30/31 gates pass; the lone red `@atlas/mcp smoke.test.ts` is the documented #1472 env-only flake (ECONNREFUSED to local Postgres; MCP-untouched by this diff; passes on remote CI's real Postgres)
- [ ] Remote CI (`api-tests` shards against real Postgres) green on head SHA

Builds on #4558 (tool-side seeding, PR #4671).

Closes #4562