### PR TITLE
feat(dashboards): surface-gate createDashboard + strip screenshot base64 envelope (#4566)

### DIFF
--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -112,9 +112,22 @@ void mock.module("@atlas/api/lib/semantic", () => ({
   _resetWhitelists: () => {},
 }));
 
+// Mock ALL runtime exports (mock-all-exports discipline). #4566 made
+// `executeAgentQuery` always import the tool registry (to omit createDashboard
+// on this non-web surface), which pulls `tools/explore` into the load graph
+// even though `runAgent` is mocked — so this mock must cover every export the
+// registry touches, not just the two the route reads directly.
 void mock.module("@atlas/api/lib/tools/explore", () => ({
   getExploreBackendType: () => "just-bash",
   getActiveSandboxPluginId: () => null,
+  snapshotExploreSandboxEnv: () => ({}),
+  invalidateExploreBackend: () => {},
+  invalidateOrgExploreBackends: (_orgId: string) => {},
+  markNsjailFailed: () => {},
+  markSidecarFailed: () => {},
+  _formatSandboxPriorityFailureForTest: () => "",
+  // Registered by name in the registry but never executed (runAgent is mocked).
+  explore: {},
 }));
 
 void mock.module("@atlas/api/lib/auth/detect", () => ({

--- a/packages/api/src/lib/__tests__/agent-query.test.ts
+++ b/packages/api/src/lib/__tests__/agent-query.test.ts
@@ -19,9 +19,15 @@ import { describe, it, expect, mock } from "bun:test";
 import type { RequestActor } from "@atlas/api/lib/logger";
 
 const observedContexts: { requestId?: string; user?: { id: string; activeOrganizationId?: string } | undefined; actor?: RequestActor | undefined }[] = [];
+// #4566 — capture the tool names runAgent was handed so a test can assert the
+// non-web surface never receives createDashboard.
+const observedToolNames: string[][] = [];
 
 void mock.module("@atlas/api/lib/agent", () => ({
-  runAgent: mock(async () => {
+  runAgent: mock(async (arg?: { tools?: { getAll?: () => Record<string, unknown> } }) => {
+    observedToolNames.push(
+      arg?.tools?.getAll ? Object.keys(arg.tools.getAll()) : [],
+    );
     const { getRequestContext } = await import("@atlas/api/lib/logger");
     const ctx = getRequestContext();
     observedContexts.push({
@@ -140,5 +146,21 @@ describe("executeAgentQuery actor binding", () => {
     const result = await executeAgentQuery("no-conversation query", "req-4", { actor });
     expect(result.runId).toBe("run-mock-1");
     expect(result.conversationId).toBeUndefined();
+  });
+
+  // #4566 — the surface-gating enforcement point. executeAgentQuery serves the
+  // non-web surfaces (SDK / Slack / MCP / scheduler), none of which own a
+  // dashboards route, so runAgent must never be handed createDashboard. This
+  // pins the call-site wiring (`dashboardUrlResolver: null` + always passing an
+  // explicit registry) so a regression that reverts it fails here.
+  it("#4566: never offers createDashboard to the non-web surface, but keeps the core query tools", async () => {
+    observedToolNames.length = 0;
+    await executeAgentQuery("build me a dashboard", "req-nodash");
+    expect(observedToolNames).toHaveLength(1);
+    const names = observedToolNames[0];
+    expect(names).not.toContain("createDashboard");
+    // The core query capability is untouched — the surface stays useful.
+    expect(names).toContain("executeSQL");
+    expect(names).toContain("explore");
   });
 });

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -255,27 +255,38 @@ export async function executeAgentQuery(
       },
     ];
 
-    // Optionally include action tools
-    let toolRegistry;
+    // Build the tool registry for this surface. `executeAgentQuery` serves the
+    // non-web programmatic surfaces — the SDK query route, chat-platform
+    // adapters (Slack), the MCP query tool, and the scheduler. None of them own
+    // a dashboards route, so we pass `dashboardUrlResolver: null` to omit
+    // `createDashboard` entirely (#4566, PRD #4553 L2): a handoff link to
+    // `/dashboards/[id]` is unreachable from Slack or a scheduled digest, so the
+    // agent must never be offered the tool here. Action tools stay opt-in via
+    // ATLAS_ACTIONS_ENABLED. On a build failure we fall back to
+    // `nonDashboardRegistry` (NOT the dashboards-owning `defaultRegistry`) so the
+    // createDashboard omission holds on the error path too — and we always pass
+    // `tools` so `runAgent` never defaults to `defaultRegistry`.
+    const { buildRegistry, nonDashboardRegistry } = await import(
+      "@atlas/api/lib/tools/registry"
+    );
+    let toolRegistry = nonDashboardRegistry;
     const includeActions = process.env.ATLAS_ACTIONS_ENABLED === "true";
-    if (includeActions) {
-      try {
-        const { buildRegistry } = await import(
-          "@atlas/api/lib/tools/registry"
-        );
-        const result = await buildRegistry({ includeActions });
-        toolRegistry = result.registry;
-      } catch (err) {
-        log.error(
-          { err: err instanceof Error ? err : new Error(String(err)) },
-          "Failed to build tool registry — falling back to default tools",
-        );
-      }
+    try {
+      const result = await buildRegistry({
+        includeActions,
+        dashboardUrlResolver: null,
+      });
+      toolRegistry = result.registry;
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err : new Error(String(err)) },
+        "Failed to build tool registry — falling back to the non-dashboard core registry",
+      );
     }
 
     const result = await runAgent({
       messages,
-      ...(toolRegistry && { tools: toolRegistry }),
+      tools: toolRegistry,
       ...(options?.conversationId && { conversationId: options.conversationId }),
       ...(options?.answerStyle && { answerStyle: options.answerStyle }),
     });

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
@@ -591,20 +591,28 @@ describe("createBoundDashboardTools", () => {
       expect(result.kind).toBe("ok");
     });
 
-    it("emits a multimodal image-data part via toModelOutput", async () => {
+    it("emits a multimodal image-data part via toModelOutput without leaking bytes into the envelope", async () => {
       const tools = createBoundDashboardTools(ctxWithUser);
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       const tool = tools.screenshotDashboard as any;
-      const result = await runTool<{ kind: "ok"; _base64: string; mediaType: string }>(
-        tool,
-        {},
-      );
+      const result = await runTool<{
+        kind: "ok";
+        screenshotRef: string;
+        sizeBytes: number;
+      }>(tool, {});
       expect(result.kind).toBe("ok");
-      expect(typeof result._base64).toBe("string");
-      expect(result._base64.length).toBeGreaterThan(0);
+      // #4566 — the base64 PNG must be STRUCTURALLY absent from the JSON
+      // envelope (the wire result streamed + persisted). Only a nonce handle
+      // and metadata may ride along.
+      expect(result).not.toHaveProperty("_base64");
+      const envelope = JSON.stringify(result);
+      // A base64 PNG is long; the envelope stays tiny (nonce + metadata only).
+      expect(envelope.length).toBeLessThan(500);
+      expect(typeof result.screenshotRef).toBe("string");
+      expect(result.sizeBytes).toBeGreaterThan(0);
       // toModelOutput is what the AI SDK calls to assemble the multimodal turn.
-      // We assert the shape so a future SDK bump that changes the contract
-      // breaks this test loudly rather than silently degrading to text-only.
+      // It resolves the bytes from the closure side-channel — so the LLM still
+      // gets a real image part even though the envelope carried none.
       const modelOutput = tool.toModelOutput({
         toolCallId: "call-1",
         input: {},
@@ -615,7 +623,27 @@ describe("createBoundDashboardTools", () => {
       const imagePart = modelOutput.value[0];
       expect(imagePart.type).toBe("image-data");
       expect(imagePart.mediaType).toBe("image/png");
-      expect(imagePart.data).toBe(result._base64);
+      // Pin the EXACT bytes: the nonce round-trip must resolve the real PNG the
+      // side-channel stashed, not a placeholder — so a wrong-payload resolve
+      // fails loudly. (mock returns Buffer.from("FAKE-PNG").)
+      expect(imagePart.data).toBe(Buffer.from("FAKE-PNG").toString("base64"));
+    });
+
+    it("toModelOutput is one-shot — a second call degrades to error-text, never re-serves bytes", async () => {
+      const tools = createBoundDashboardTools(ctxWithUser);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      const tool = tools.screenshotDashboard as any;
+      const result = await runTool<{ kind: "ok"; screenshotRef: string }>(tool, {});
+      const args = { toolCallId: "call-1", input: {}, output: result };
+      // First conversion emits the image from the side-channel.
+      expect(tool.toModelOutput(args).type).toBe("content");
+      // The nonce was deleted; a re-conversion (or a persisted-result replay on a
+      // later request with a fresh empty map) can't find the bytes. It must NOT
+      // misreport success as a hard failure with a generic message — it returns
+      // an actionable error-text asking for a re-shoot.
+      const second = tool.toModelOutput(args);
+      expect(second.type).toBe("error-text");
+      expect(second.value).toMatch(/call screenshotdashboard again/i);
     });
   });
 });

--- a/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/create-dashboard.test.ts
@@ -80,7 +80,9 @@ void mock.module("@atlas/api/lib/dashboard-draft-cache", () => ({
   EMPTY_DRAFT_CARD_CACHE: new Map(),
 }));
 
-const { createDashboard, deriveTextCardTitle } = await import("@atlas/api/lib/tools/create-dashboard");
+const { createDashboard, makeCreateDashboardTool, deriveTextCardTitle } = await import(
+  "@atlas/api/lib/tools/create-dashboard"
+);
 
 // ---------------------------------------------------------------------------
 // Mock Postgres pool — distinguishes pool.query() from client.query() so the
@@ -173,6 +175,7 @@ async function run(args: ExecuteParams) {
           description: string | null;
           cardCount: number;
           draft: boolean;
+          dashboardUrl: string;
           cardOutcomes: {
             cardId: string;
             title: string;
@@ -263,6 +266,9 @@ describe("createDashboard tool", () => {
       expect(result.title).toBe("Revenue");
       expect(result.cardCount).toBe(2);
       expect(result.draft).toBe(true);
+      // #4566 — the default (workspace-bound) instance resolves the handoff to
+      // the workspace `/dashboards/[id]` route.
+      expect(result.dashboardUrl).toBe("/dashboards/dash-new");
     }
 
     // Validation ran per card.
@@ -305,6 +311,53 @@ describe("createDashboard tool", () => {
     expect(baseline.cards).toEqual([]);
     // No parameters declared → INSERT persists an empty array (#2267).
     expect(JSON.parse(dashParams[4] as string)).toEqual([]);
+  });
+
+  it("resolves the handoff URL via a custom host resolver (#4566)", async () => {
+    enableInternalDB();
+    setClientResults(
+      { rows: [] }, // BEGIN
+      {
+        rows: [
+          {
+            id: "dash-host",
+            title: "Revenue",
+            description: null,
+            updated_at: "2026-05-17T12:00:00Z",
+          },
+        ],
+      }, // INSERT dashboards RETURNING
+      { rows: [] }, // INSERT dashboard_user_drafts
+      { rows: [] }, // COMMIT
+    );
+
+    // A host that owns a DIFFERENT dashboards route opts in with its own
+    // resolver; the tool's handoff link must point at that host's route, not
+    // the workspace path.
+    const hostTool = makeCreateDashboardTool((id) => `https://host.example/boards/${id}`);
+    const fn = hostTool.execute as ExecuteFn;
+    const args: ExecuteParams = {
+      title: "Revenue",
+      cards: [
+        {
+          title: "Total revenue",
+          sql: "SELECT SUM(amount) AS total FROM orders",
+          chartConfig: { type: "table", categoryColumn: "total", valueColumns: ["total"] },
+        },
+      ],
+    };
+    const result = await runInCtx(async () => {
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      const out = (await fn(args, undefined as any)) as
+        | { kind: "ok"; dashboardUrl: string }
+        | { kind: "err"; error: string };
+      return out;
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.dashboardUrl).toBe("https://host.example/boards/dash-host");
+    }
   });
 
   // -------------------------------------------------------------------

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -39,7 +39,9 @@ void mock.module("@atlas/api/lib/tools/actions", () => ({
 const {
   ToolRegistry,
   defaultRegistry,
+  nonDashboardRegistry,
   buildRegistry,
+  WORKSPACE_DASHBOARD_URL_RESOLVER,
   INTENTIONAL_TOOL_SHADOWS,
   TOOL_SHADOW_REMEDIATIONS,
 } = await import("@atlas/api/lib/tools/registry");
@@ -286,6 +288,60 @@ describe("buildRegistry", () => {
     expect(() =>
       registry.register({ name: "extra", description: "X", tool: makeTool("x") })
     ).toThrow("Cannot register tools on a frozen registry");
+  });
+
+  // #4566 — createDashboard is surface-gated on the dashboard-URL resolver.
+  // Three registration states, covering every surface class the seam serves.
+  describe("createDashboard surface gating (#4566)", () => {
+    it("registers createDashboard when no resolver is given (workspace default)", async () => {
+      // Omitting the option means the built-in workspace resolver — the
+      // dashboards-owning surface (self-hosted / SaaS web) keeps the tool.
+      const { registry } = await buildRegistry();
+      expect(registry.get("createDashboard")).toBeDefined();
+    });
+
+    it("registers createDashboard when the workspace resolver is passed explicitly", async () => {
+      const { registry } = await buildRegistry({
+        dashboardUrlResolver: WORKSPACE_DASHBOARD_URL_RESOLVER,
+      });
+      expect(registry.get("createDashboard")).toBeDefined();
+    });
+
+    it("registers createDashboard when a custom host resolver is supplied", async () => {
+      const { registry } = await buildRegistry({
+        dashboardUrlResolver: (id) => `https://host.example/boards/${id}`,
+      });
+      expect(registry.get("createDashboard")).toBeDefined();
+    });
+
+    it("OMITS createDashboard when the surface owns no dashboards route (resolver: null)", async () => {
+      // An embed / SDK / Slack / scheduler surface passes null — the tool is
+      // never registered, so the agent can't propose an unreachable draft.
+      const { registry } = await buildRegistry({ dashboardUrlResolver: null });
+      expect(registry.get("createDashboard")).toBeUndefined();
+      const names = Object.keys(registry.getAll());
+      // Only createDashboard is dropped — the rest of the core set is intact.
+      // (Assert the delta, not an exact list: querySalesforce / executePython
+      // are env-gated and would break an exact-equality check on a dev box.)
+      expect(names).not.toContain("createDashboard");
+      for (const core of ["explore", "executeSQL", "searchKnowledge", "sendEmail", "createLinearIssue"]) {
+        expect(names).toContain(core);
+      }
+    });
+
+    it("the workspace resolver produces the workspace dashboards route", () => {
+      expect(WORKSPACE_DASHBOARD_URL_RESOLVER("abc-123")).toBe("/dashboards/abc-123");
+    });
+
+    // The exported fallback the non-web surfaces (and the buildRegistry error
+    // path in agent-query) land on — it must never carry createDashboard, so a
+    // build failure can't silently reintroduce the tool.
+    it("nonDashboardRegistry omits createDashboard but keeps the core query tools", () => {
+      expect(nonDashboardRegistry.get("createDashboard")).toBeUndefined();
+      expect(nonDashboardRegistry.get("executeSQL")).toBeDefined();
+      expect(nonDashboardRegistry.get("explore")).toBeDefined();
+      expect(nonDashboardRegistry.get("searchKnowledge")).toBeDefined();
+    });
   });
 
   it("getActions returns action tools with correct metadata", async () => {

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -227,6 +227,17 @@ export function createBoundDashboardTools(
 ): ToolSet {
   const { dashboardId, orgId, userId, cookieHeader } = ctx;
 
+  // #4566 — the screenshot's base64 PNG must never ride in the tool result's
+  // JSON envelope (audit L11): that envelope is streamed to the client and
+  // persisted in the message history, so a ~1-2 MB image string bloats every
+  // subsequent turn and leaks bytes the UI has no use for. Instead, `execute`
+  // stashes the bytes in this per-request closure map under a short nonce and
+  // returns only the nonce; `toModelOutput` (which runs in-process, same
+  // closure, right after execute) reads and deletes them to assemble the real
+  // multimodal image part. The wire envelope carries metadata only — the strip
+  // is structural, not a prompt instruction.
+  const screenshotPayloads = new Map<string, { data: string; mediaType: string }>();
+
   const getDashboardState = tool({
     description: `Read the current state of the dashboard you are editing. Returns the title, description, and a compact summary of every card (id, title, chart type, position, layout). Call this when you need a fresh read after several mutations. Card SQL is NOT returned — use \`getCardDetail\` for that.`,
     inputSchema: z.object({}).describe("No arguments"),
@@ -600,41 +611,69 @@ On success the result includes \`seed\` — the card's data outcome: \`rows\` (w
       if (!result.ok) {
         return { kind: "err" as const, error: result.message };
       }
-      // Compact JSON envelope alongside the image — the image-data part
-      // is attached by `toModelOutput` below so the LLM sees a real
-      // multimodal turn instead of a base64 string buried in JSON.
+      // #4566 — structurally keep the base64 PNG OUT of the JSON envelope.
+      // Stash the bytes in the closure map under a nonce; the envelope carries
+      // only the nonce (`screenshotRef`) + metadata. `toModelOutput` reads the
+      // bytes back and attaches them as a real multimodal image part, so the
+      // LLM still sees the image but the wire result never contains it.
+      const mediaType = "image/png" as const;
+      const screenshotRef = crypto.randomUUID();
+      screenshotPayloads.set(screenshotRef, {
+        data: result.png.toString("base64"),
+        mediaType,
+      });
       return {
         kind: "ok" as const,
-        mediaType: "image/png" as const,
+        mediaType,
         sizeBytes: result.png.length,
         cached: result.cached,
         durationMs: result.durationMs,
-        // Base64 payload — pulled out by toModelOutput. Not exposed to
-        // anything else (system prompt rules tell the agent not to
-        // echo it back to the user).
-        _base64: result.png.toString("base64"),
+        // Opaque handle the same-request `toModelOutput` resolves the image
+        // bytes from. NOT the bytes themselves — those never enter the envelope.
+        screenshotRef,
       };
     },
     toModelOutput: ({ output }) => {
       const typed = output as {
         kind: "ok" | "err";
-        _base64?: string;
-        mediaType?: string;
+        screenshotRef?: string;
         error?: string;
       };
-      if (typed.kind !== "ok" || !typed._base64) {
+      // A genuine screenshot failure — the tool already sanitized the message.
+      if (typed.kind !== "ok") {
         return {
           type: "error-text",
           value: typed.error ?? "screenshotDashboard failed",
         };
       }
+      const ref = typed.screenshotRef;
+      const payload = ref ? screenshotPayloads.get(ref) : undefined;
+      if (!ref || !payload) {
+        // Success envelope, but the side-channel bytes are gone: a re-conversion
+        // of a persisted result (fresh, empty map on a later request) or a
+        // duplicate `toModelOutput` after the one-shot delete. Don't misreport a
+        // successful screenshot as failed — log so the drop is debuggable and
+        // give the model an actionable re-shoot instruction.
+        log.warn(
+          { dashboardId, screenshotRef: ref },
+          "screenshot payload missing from side-channel — image dropped from model turn (#4566)",
+        );
+        return {
+          type: "error-text",
+          value:
+            "The dashboard screenshot could not be attached this turn. Call screenshotDashboard again.",
+        };
+      }
+      // One-shot: drop the bytes once assembled into the model turn so the
+      // closure map can't accumulate images across a long bound session.
+      screenshotPayloads.delete(ref);
       return {
         type: "content",
         value: [
           {
             type: "image-data",
-            data: typed._base64,
-            mediaType: typed.mediaType ?? "image/png",
+            data: payload.data,
+            mediaType: payload.mediaType,
           },
           {
             type: "text",

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -72,6 +72,28 @@ import {
 
 const log = createLogger("tool:create-dashboard");
 
+/**
+ * Given a just-committed dashboard id, return the URL the host's UI navigates
+ * to so the "Continue editing" handoff lands on a REACHABLE dashboard route
+ * (#4566, PRD #4553 L2). The workspace web app owns `/dashboards/[id]`; an
+ * embed/SDK host that owns a different route supplies its own resolver, and a
+ * host with no dashboards route opts out explicitly with `null` — in which case
+ * `createDashboard` is never registered (see `buildRegistry` in
+ * `tools/registry.ts`), so an unreachable draft is structurally impossible
+ * rather than a hard-coded workspace path handed to a surface that can't open
+ * it.
+ */
+export type DashboardUrlResolver = (dashboardId: string) => string;
+
+/**
+ * The workspace web app's resolver — the surface that owns `/dashboards/[id]`.
+ * Returns a workspace-relative path; the chat handoff card decorates it with
+ * the bound-editor `openChat` continuation. This is the default resolver for
+ * every dashboards-owning surface (self-hosted single-tenant web + SaaS web).
+ */
+export const WORKSPACE_DASHBOARD_URL_RESOLVER: DashboardUrlResolver = (dashboardId) =>
+  `/dashboards/${dashboardId}`;
+
 /** Chart/table/KPI config. The canonical schema lives in @useatlas/schemas so
  *  the optional `kpi` block (#3137) round-trips through every persist path
  *  instead of being stripped at one boundary. */
@@ -159,6 +181,12 @@ export type CreateDashboardResult =
       cardCount: number;
       /** Always `true` for this slice — cards are staged in the user's draft. */
       draft: true;
+      /**
+       * Host-resolved URL for the "Continue editing" handoff (#4566). Produced
+       * by the surface's {@link DashboardUrlResolver}, so the link always points
+       * at a route the host actually owns — never a hard-coded workspace path.
+       */
+      dashboardUrl: string;
       /**
        * Per-card seeding outcomes (#4558) — one entry per CHART card (text /
        * section cards fetch no data and are omitted), in card order. Each staged
@@ -248,7 +276,15 @@ async function seedStagedCards(
   }
 }
 
-export const createDashboard = tool({
+/**
+ * Build a `createDashboard` tool bound to a host's {@link DashboardUrlResolver}
+ * (#4566). The resolver is the surface's opt-in: only a host that owns a
+ * dashboards route supplies one, and the handoff link the tool returns
+ * (`dashboardUrl`) is that host's route — so the tool is never registered on a
+ * surface where its output would be unreachable.
+ */
+export function makeCreateDashboardTool(resolveDashboardUrl: DashboardUrlResolver) {
+  return tool({
   description: `Create a dashboard the user can keep editing in chat.
 
 Use this AFTER you have used executeSQL to confirm each card's query shape (so you know its column names). The tool commits a real dashboard row owned by the calling user. Initial cards are staged in the user's draft — they're NOT visible to other org members until the user clicks Publish.
@@ -579,6 +615,7 @@ The tool EXECUTES each chart card once as it builds the dashboard and returns \`
           description: description ?? null,
           cardCount: snapshotCards.length,
           draft: true,
+          dashboardUrl: resolveDashboardUrl(dashboardId),
           cardOutcomes,
         };
       } catch (txErr) {
@@ -610,4 +647,13 @@ The tool EXECUTES each chart card once as it builds the dashboard and returns \`
       };
     }
   },
-});
+  });
+}
+
+/**
+ * Workspace-web-bound `createDashboard` instance — the default the
+ * dashboards-owning surface registers. Kept as a named export so the
+ * `defaultRegistry` (and direct-import tests) resolve a ready tool without
+ * re-supplying the built-in resolver each time.
+ */
+export const createDashboard = makeCreateDashboardTool(WORKSPACE_DASHBOARD_URL_RESOLVER);

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -2,7 +2,12 @@ import type { ToolSet } from "ai";
 import { type AtlasAction, isAction } from "@atlas/api/lib/action-types";
 import { explore } from "./explore";
 import { executeSQL } from "./sql";
-import { createDashboard } from "./create-dashboard";
+import {
+  createDashboard,
+  makeCreateDashboardTool,
+  WORKSPACE_DASHBOARD_URL_RESOLVER,
+  type DashboardUrlResolver,
+} from "./create-dashboard";
 import { sendEmailTool, SEND_EMAIL_DESCRIPTION } from "@atlas/api/lib/integrations/email-tool";
 import {
   createLinearIssueTool,
@@ -15,8 +20,8 @@ import {
 } from "@atlas/api/lib/integrations/salesforce-tool";
 import { searchKnowledge, SEARCH_KNOWLEDGE_DESCRIPTION } from "./search-knowledge";
 
-export type { AtlasAction };
-export { isAction };
+export type { AtlasAction, DashboardUrlResolver };
+export { isAction, WORKSPACE_DASHBOARD_URL_RESOLVER };
 
 export interface AtlasTool {
   readonly name: string;
@@ -177,85 +182,127 @@ Use the createDashboard tool when the user wants a dashboard, not just a single 
 - The tool COMMITS a real dashboard owned by the calling user and stages the initial cards in the user's draft (not yet visible to other org members). The chat surfaces a "Continue editing on the dashboard" link to the new id; the same conversation resumes there in bound mode for further edits
 - If any card has invalid SQL the whole call is rejected — fix the failing card and call again with the full set`;
 
-// --- Default registry ---
+// --- Core tool registration ---
 
-const defaultRegistry = new ToolRegistry();
-
-defaultRegistry.register({
-  name: "explore",
-  description: EXPLORE_DESCRIPTION,
-  tool: explore,
-});
-
-defaultRegistry.register({
-  name: "executeSQL",
-  description: EXECUTE_SQL_DESCRIPTION,
-  tool: executeSQL,
-});
-
-defaultRegistry.register({
-  name: "createDashboard",
-  description: CREATE_DASHBOARD_DESCRIPTION,
-  tool: createDashboard,
-});
-
-// #4210 — layered knowledge-base search (frontmatter filter + Postgres FTS +
-// 1-hop graph expansion). Registered globally like the other execute-time-gated
-// tools: it reads the workspace + mode from request context inside execute — so
-// it stays discoverable everywhere without a boot-time gate. The two degraded
-// paths have deliberately different shapes: no active workspace returns an empty
-// result set (`{ results: [], neighbors: [] }`), while a deployment with no
-// internal DB returns a user-facing `{ error }`.
-defaultRegistry.register({
-  name: "searchKnowledge",
-  description: SEARCH_KNOWLEDGE_DESCRIPTION,
-  tool: searchKnowledge,
-});
-
-// First per-Workspace lazy-plugin tool (#2698). Registered globally
-// because the workspace + install check happens at execute time inside
-// the tool — keeping the tool discoverable across all Workspaces while
-// the "is the Email integration installed for this workspace" gate
-// runs in the loader.
-defaultRegistry.register({
-  name: "sendEmail",
-  description: SEND_EMAIL_DESCRIPTION,
-  tool: sendEmailTool,
-});
-
-// #2750 — Linear action target. Registered globally for the same reason
-// as `sendEmail` above: workspace + install check happens at execute
-// time, tool stays discoverable across all Workspaces, and the dual-
-// catalog (`catalog:linear` OAuth + `catalog:linear-apikey` form) dispatch
-// lives inside the tool's execute path.
-defaultRegistry.register({
-  name: "createLinearIssue",
-  description: CREATE_LINEAR_ISSUE_DESCRIPTION,
-  tool: createLinearIssueTool,
-});
-
-// #3311 — OAuth per-Workspace Salesforce query tool. Registered ONLY when the
-// Salesforce OAuth Connected App env is wired. The static-config `querySalesforce`
-// tool (`@useatlas/salesforce`, registered via the plugin context in self-host
-// static-url mode) needs a `salesforce://` url but NOT the OAuth env, so the two
-// modes don't normally coexist and this env gate keeps them apart.
-// KNOWN EDGE (#3326): if an operator sets BOTH a static url AND the OAuth env,
-// both register name `querySalesforce`; `ToolRegistry.merge(base, plugin)` gives
-// this base entry precedence, so the OAuth tool shadows the static one (and in
-// single-tenant self-host returns `no_workspace` on every call). The expected
-// deployments are mutually exclusive, so the conflict is surfaced — not
-// resolved: `api/server.ts` detects it at boot via `ToolRegistry.shadowedNames`
-// and logs an operator-facing error naming the remediation. Like sendEmail /
-// createLinearIssue, the workspace + install gate runs at execute time.
-if (isSalesforceOAuthConfigured()) {
-  defaultRegistry.register({
-    name: "querySalesforce",
-    description: QUERY_SALESFORCE_DESCRIPTION,
-    tool: querySalesforceTool,
+/**
+ * Register the always-on core tools into `registry`. Shared by every registry
+ * builder (`defaultRegistry`, `nonDashboardRegistry`, `buildRegistry`) so the
+ * core set is stated exactly once.
+ *
+ * `createDashboard` is surface-gated (#4566): a non-null `dashboardUrlResolver`
+ * registers it bound to that resolver's handoff route; `null` omits it because
+ * the surface owns no dashboards route and a handoff link would be unreachable.
+ * The other core tools are registered unconditionally and gated at execute time
+ * (workspace/install/context checks inside `execute`) — except `querySalesforce`,
+ * which is additionally env-gated on the Salesforce OAuth config (see its inline
+ * note below).
+ */
+function registerCoreTools(
+  registry: ToolRegistry,
+  dashboardUrlResolver: DashboardUrlResolver | null,
+): void {
+  registry.register({
+    name: "explore",
+    description: EXPLORE_DESCRIPTION,
+    tool: explore,
   });
+
+  registry.register({
+    name: "executeSQL",
+    description: EXECUTE_SQL_DESCRIPTION,
+    tool: executeSQL,
+  });
+
+  // #4566 — surface-gated. A resolver means this surface owns a dashboards
+  // route and can reach the handoff link; `null` means it can't, so the tool is
+  // left out rather than handing the agent a dead-end draft. The workspace
+  // resolver reuses the prebuilt singleton; a custom host resolver mints a
+  // fresh instance bound to its route.
+  if (dashboardUrlResolver) {
+    registry.register({
+      name: "createDashboard",
+      description: CREATE_DASHBOARD_DESCRIPTION,
+      tool:
+        dashboardUrlResolver === WORKSPACE_DASHBOARD_URL_RESOLVER
+          ? createDashboard
+          : makeCreateDashboardTool(dashboardUrlResolver),
+    });
+  }
+
+  // #4210 — layered knowledge-base search (frontmatter filter + Postgres FTS +
+  // 1-hop graph expansion). Registered globally like the other execute-time-gated
+  // tools: it reads the workspace + mode from request context inside execute — so
+  // it stays discoverable everywhere without a boot-time gate. The two degraded
+  // paths have deliberately different shapes: no active workspace returns an empty
+  // result set (`{ results: [], neighbors: [] }`), while a deployment with no
+  // internal DB returns a user-facing `{ error }`.
+  registry.register({
+    name: "searchKnowledge",
+    description: SEARCH_KNOWLEDGE_DESCRIPTION,
+    tool: searchKnowledge,
+  });
+
+  // First per-Workspace lazy-plugin tool (#2698). Registered globally
+  // because the workspace + install check happens at execute time inside
+  // the tool — keeping the tool discoverable across all Workspaces while
+  // the "is the Email integration installed for this workspace" gate
+  // runs in the loader.
+  registry.register({
+    name: "sendEmail",
+    description: SEND_EMAIL_DESCRIPTION,
+    tool: sendEmailTool,
+  });
+
+  // #2750 — Linear action target. Registered globally for the same reason
+  // as `sendEmail` above: workspace + install check happens at execute
+  // time, tool stays discoverable across all Workspaces, and the dual-
+  // catalog (`catalog:linear` OAuth + `catalog:linear-apikey` form) dispatch
+  // lives inside the tool's execute path.
+  registry.register({
+    name: "createLinearIssue",
+    description: CREATE_LINEAR_ISSUE_DESCRIPTION,
+    tool: createLinearIssueTool,
+  });
+
+  // #3311 — OAuth per-Workspace Salesforce query tool. Registered ONLY when the
+  // Salesforce OAuth Connected App env is wired. The static-config `querySalesforce`
+  // tool (`@useatlas/salesforce`, registered via the plugin context in self-host
+  // static-url mode) needs a `salesforce://` url but NOT the OAuth env, so the two
+  // modes don't normally coexist and this env gate keeps them apart.
+  // KNOWN EDGE (#3326): if an operator sets BOTH a static url AND the OAuth env,
+  // both register name `querySalesforce`; `ToolRegistry.merge(base, plugin)` gives
+  // this base entry precedence, so the OAuth tool shadows the static one (and in
+  // single-tenant self-host returns `no_workspace` on every call). The expected
+  // deployments are mutually exclusive, so the conflict is surfaced — not
+  // resolved: `api/server.ts` detects it at boot via `ToolRegistry.shadowedNames`
+  // and logs an operator-facing error naming the remediation. Like sendEmail /
+  // createLinearIssue, the workspace + install gate runs at execute time.
+  if (isSalesforceOAuthConfigured()) {
+    registry.register({
+      name: "querySalesforce",
+      description: QUERY_SALESFORCE_DESCRIPTION,
+      tool: querySalesforceTool,
+    });
+  }
 }
 
+// --- Default registry ---
+// The workspace surface (self-hosted single-tenant + SaaS web) — it owns
+// `/dashboards/[id]`, so `createDashboard` registers with the workspace resolver.
+
+const defaultRegistry = new ToolRegistry();
+registerCoreTools(defaultRegistry, WORKSPACE_DASHBOARD_URL_RESOLVER);
 defaultRegistry.freeze();
+
+// --- Non-dashboard registry (#4566) ---
+// Core tools MINUS createDashboard, for surfaces that own no dashboards route
+// (SDK / Slack / MCP / scheduler via `executeAgentQuery`). Also the
+// guaranteed-safe fallback when `buildRegistry` throws — so the createDashboard
+// omission holds even on the error path instead of falling through to the
+// dashboards-owning `defaultRegistry`.
+const nonDashboardRegistry = new ToolRegistry();
+registerCoreTools(nonDashboardRegistry, null);
+nonDashboardRegistry.freeze();
 
 // ---------------------------------------------------------------------------
 // Tool-name shadow policy (#3326)
@@ -306,54 +353,30 @@ interface BuildRegistryResult {
  */
 export async function buildRegistry(options?: {
   includeActions?: boolean;
+  /**
+   * Dashboard-URL resolver that gates `createDashboard` (#4566, PRD #4553 L2).
+   * - `undefined` (default) → the built-in {@link WORKSPACE_DASHBOARD_URL_RESOLVER};
+   *   the tool registers with the workspace `/dashboards/[id]` handoff, so
+   *   every dashboards-owning surface keeps `createDashboard` unchanged.
+   * - a custom resolver → the tool registers, and its handoff link points at
+   *   the host's own dashboards route.
+   * - `null` → the surface does NOT own a dashboards route; `createDashboard`
+   *   is omitted entirely so the agent never proposes an unreachable draft
+   *   (embed / SDK / Slack / scheduler).
+   */
+  dashboardUrlResolver?: DashboardUrlResolver | null;
 }): Promise<BuildRegistryResult> {
   const registry = new ToolRegistry();
   const warnings: string[] = [];
 
-  registry.register({
-    name: "explore",
-    description: EXPLORE_DESCRIPTION,
-    tool: explore,
-  });
-
-  registry.register({
-    name: "executeSQL",
-    description: EXECUTE_SQL_DESCRIPTION,
-    tool: executeSQL,
-  });
-
-  registry.register({
-    name: "createDashboard",
-    description: CREATE_DASHBOARD_DESCRIPTION,
-    tool: createDashboard,
-  });
-
-  registry.register({
-    name: "searchKnowledge",
-    description: SEARCH_KNOWLEDGE_DESCRIPTION,
-    tool: searchKnowledge,
-  });
-
-  registry.register({
-    name: "sendEmail",
-    description: SEND_EMAIL_DESCRIPTION,
-    tool: sendEmailTool,
-  });
-
-  registry.register({
-    name: "createLinearIssue",
-    description: CREATE_LINEAR_ISSUE_DESCRIPTION,
-    tool: createLinearIssueTool,
-  });
-
-  // #3311 — OAuth Salesforce query tool, OAuth-env-gated (see defaultRegistry above).
-  if (isSalesforceOAuthConfigured()) {
-    registry.register({
-      name: "querySalesforce",
-      description: QUERY_SALESFORCE_DESCRIPTION,
-      tool: querySalesforceTool,
-    });
-  }
+  // #4566 — surface-gated createDashboard. Omitting the option means the
+  // workspace default (dashboards-owning surface keeps the tool); `null` omits
+  // it (the surface owns no dashboards route).
+  const dashboardUrlResolver =
+    options?.dashboardUrlResolver === undefined
+      ? WORKSPACE_DASHBOARD_URL_RESOLVER
+      : options.dashboardUrlResolver;
+  registerCoreTools(registry, dashboardUrlResolver);
 
   if (process.env.ATLAS_PYTHON_ENABLED === "true") {
     if (!process.env.ATLAS_SANDBOX_URL) {
@@ -410,4 +433,4 @@ export async function buildRegistry(options?: {
   return { registry, warnings };
 }
 
-export { defaultRegistry };
+export { defaultRegistry, nonDashboardRegistry };

--- a/packages/web/src/ui/components/chat/__tests__/create-dashboard-card.test.tsx
+++ b/packages/web/src/ui/components/chat/__tests__/create-dashboard-card.test.tsx
@@ -65,4 +65,65 @@ describe("CreateDashboardCard — continuity handoff link", () => {
     );
     expect(hrefOf(container)).toContain(`conversationId=${encodeURIComponent("a/b?c")}`);
   });
+
+  // #4566 — the link base comes from the tool's host-resolved `dashboardUrl`,
+  // not a hard-coded workspace path.
+  test("uses the tool's resolved dashboardUrl as the handoff base", () => {
+    const hostPart = {
+      ...(okPart as Record<string, unknown>),
+      output: {
+        kind: "ok",
+        dashboardId: "dash-9",
+        title: "Sales",
+        description: null,
+        cardCount: 2,
+        draft: true,
+        dashboardUrl: "/analytics/boards/dash-9",
+      },
+    } as unknown;
+    const { container } = render(
+      <ChatConversationProvider conversationId="conv-42">
+        <CreateDashboardCard part={hostPart} />
+      </ChatConversationProvider>,
+    );
+    expect(hrefOf(container)).toBe(
+      "/analytics/boards/dash-9?openChat=true&conversationId=conv-42",
+    );
+  });
+
+  test("appends to a resolved dashboardUrl that already carries a query string", () => {
+    const hostPart = {
+      ...(okPart as Record<string, unknown>),
+      output: {
+        kind: "ok",
+        dashboardId: "dash-9",
+        title: "Sales",
+        description: null,
+        cardCount: 2,
+        draft: true,
+        dashboardUrl: "/analytics/boards/dash-9?embed=1",
+      },
+    } as unknown;
+    const { container } = render(<CreateDashboardCard part={hostPart} />);
+    expect(hrefOf(container)).toBe("/analytics/boards/dash-9?embed=1&openChat=true");
+  });
+
+  test("falls back to the workspace path when dashboardUrl is a non-string malformed value", () => {
+    const badPart = {
+      ...(okPart as Record<string, unknown>),
+      output: {
+        kind: "ok",
+        dashboardId: "dash-9",
+        title: "Sales",
+        description: null,
+        cardCount: 2,
+        draft: true,
+        // A malformed payload — the card narrows only kind/dashboardId/title, so
+        // this reaches the render guard, which must reject a non-string.
+        dashboardUrl: 123,
+      },
+    } as unknown;
+    const { container } = render(<CreateDashboardCard part={badPart} />);
+    expect(hrefOf(container)).toBe("/dashboards/dash-9?openChat=true");
+  });
 });

--- a/packages/web/src/ui/components/chat/create-dashboard-card.tsx
+++ b/packages/web/src/ui/components/chat/create-dashboard-card.tsx
@@ -27,6 +27,14 @@ interface CreateDashboardResultOk {
   description: string | null;
   cardCount: number;
   draft: boolean;
+  /**
+   * Host-resolved handoff URL (#4566). The tool computes it from the surface's
+   * dashboard-URL resolver, so the link points at the route this host actually
+   * owns instead of a hard-coded workspace path. Optional so a tool result
+   * streamed by an older API build (no `dashboardUrl`) still renders — the
+   * fallback below reconstructs the workspace path.
+   */
+  dashboardUrl?: string;
 }
 
 interface CreateDashboardResultErr {
@@ -113,6 +121,22 @@ export function CreateDashboardCard({ part }: { part: unknown }) {
 
   const cardLabel = `${result.cardCount} card${result.cardCount === 1 ? "" : "s"}`;
 
+  // #4566 — the handoff link comes from the tool's host-resolved `dashboardUrl`
+  // (the surface's dashboard-URL resolver), not a hard-coded workspace path.
+  // We decorate it with the bound-editor `openChat` continuation so the same
+  // conversation resumes on the dashboard. Fallback keeps an older API build's
+  // result (no `dashboardUrl`) working.
+  // Guard the type, not just presence: `asCreateDashboardResult` narrows only
+  // kind/dashboardId/title, so a malformed payload could carry a non-string
+  // `dashboardUrl`. Fall back to the workspace path unless it's a real string.
+  const baseUrl =
+    typeof result.dashboardUrl === "string"
+      ? result.dashboardUrl
+      : `/dashboards/${result.dashboardId}`;
+  const handoffParams = new URLSearchParams({ openChat: "true" });
+  if (conversationId) handoffParams.set("conversationId", conversationId);
+  const handoffHref = `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}${handoffParams.toString()}`;
+
   return (
     <div className="my-2 flex flex-col gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs dark:border-emerald-900/40 dark:bg-emerald-950/20">
       <div className="flex flex-wrap items-center gap-3 text-emerald-800 dark:text-emerald-300">
@@ -131,11 +155,7 @@ export function CreateDashboardCard({ part }: { part: unknown }) {
           className="ml-auto h-7 border-emerald-300 text-xs text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:text-emerald-200 dark:hover:bg-emerald-900/40"
         >
           <Link
-            href={
-              conversationId
-                ? `/dashboards/${result.dashboardId}?openChat=true&conversationId=${encodeURIComponent(conversationId)}`
-                : `/dashboards/${result.dashboardId}?openChat=true`
-            }
+            href={handoffHref}
             aria-label={`Continue editing dashboard ${result.title}`}
           >
             Continue editing


### PR DESCRIPTION
## Summary

Stops offering `createDashboard` where its output is unreachable (PRD #4553, audit L2 + L11).

- **Surface-gated registration.** A new `DashboardUrlResolver = (dashboardId) => string` gates the tool. `defaultRegistry` (the workspace surface) binds the built-in `/dashboards/[id]` resolver; `buildRegistry({ dashboardUrlResolver })` takes `undefined` → workspace default, a custom resolver → the host's route, `null` → omit the tool. A new frozen `nonDashboardRegistry` (core tools minus `createDashboard`) backs the non-web surfaces. Core-tool registration is consolidated into one `registerCoreTools` helper so the three registries can't drift.
- **Non-web surfaces omit the tool.** `executeAgentQuery` (SDK / Slack / MCP / scheduler) always builds with `dashboardUrlResolver: null`, initializes to `nonDashboardRegistry`, and always passes an explicit `tools` — so the omission holds even if `buildRegistry` throws (never falls through to the `createDashboard`-bearing `defaultRegistry`).
- **Handoff link is resolver-driven.** The tool returns `dashboardUrl` from its resolver; the chat handoff card uses it (type-guarded, with a workspace-path fallback for older API builds) instead of a hard-coded path.
- **Screenshot envelope hygiene (structural).** `screenshotDashboard`'s base64 PNG no longer rides in the JSON wire envelope — it's stashed in a per-request closure keyed by a nonce (`screenshotRef`); `toModelOutput` resolves + one-shot-deletes it to build the multimodal image part. The envelope carries metadata only.

## Test plan

- [x] `registry.test.ts` — all three registration states (workspace default / custom resolver / `null`-omitted) + `nonDashboardRegistry` omits `createDashboard`
- [x] `create-dashboard.test.ts` — `dashboardUrl` resolves for workspace default + a custom host resolver
- [x] `bound-dashboard.test.ts` — envelope has no base64 (structural: `not.toHaveProperty` + size bound), exact-byte image part, one-shot re-conversion degrades to actionable error-text
- [x] `agent-query.test.ts` — the non-web surface is never handed `createDashboard`, keeps the core query tools
- [x] `create-dashboard-card.test.tsx` — handoff href derived from `dashboardUrl` (incl. query-string append + non-string fallback)
- [x] Internal review panel (silent-failure / type-design / test-coverage / comment) clean after 2 rounds
- [x] `/ci`: 30/30 non-test gates + full 913-file API suite green (the lone red is the DB-less local MCP-smoke flake, #1472 — unrelated; smoke.test.ts references none of the changed modules)

## Follow-up

- `CreateDashboardResult` remains a hand-duplicated wire type (`create-dashboard.ts` ↔ web card); promoting it to `@useatlas/types` + `@useatlas/schemas` is a pre-existing SSOT cleanup left out of scope here to minimize overlap with the sibling dashboard PRs.

Closes #4566