### PR TITLE
fix(dashboards): canvas interaction polish — per-tile refresh, stable suggestion ids, surgical invalidation, live age captions (#4567)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -48,6 +48,13 @@ import { DraftStatusBanner } from "@/ui/components/dashboards/draft-status-banne
 import { PublishDiffModal } from "@/ui/components/dashboards/publish-diff-modal";
 import { diffDashboards, type DashboardDiff } from "@/ui/components/dashboards/dashboard-diff";
 import { nextTileLayout, withAutoLayout } from "@/ui/components/dashboards/auto-layout";
+import {
+  withRefreshing,
+  withoutRefreshing,
+  attachSuggestionIds,
+  dropSuggestion,
+  type SuggestionItem,
+} from "@/ui/components/dashboards/canvas-interactions";
 import { hasKpiComparison, kpiComparisonSignature } from "@/ui/components/dashboards/kpi-card";
 import { StageProvider } from "@/ui/components/dashboards/stage-context";
 import type { StagedChange } from "@/ui/lib/types";
@@ -151,14 +158,21 @@ export default function DashboardViewPage() {
 
   const { mutate, error: mutationError } = useAdminMutation({ invalidates: refetch });
 
-  const [refreshingCardId, setRefreshingCardId] = useState<string | null>(null);
+  // #4567 — ids of tiles whose single-card refresh is in flight. A SET (not one
+  // id) so two concurrent refreshes each keep their own spinner; a slower one
+  // finishing never clears a faster one that's still running.
+  const [refreshingCardIds, setRefreshingCardIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [deleteCardTarget, setDeleteCardTarget] = useState<DashboardCard | null>(null);
   const [deleteDashboard, setDeleteDashboard] = useState(false);
-  const [suggestions, setSuggestions] = useState<DashboardSuggestion[]>([]);
+  const [suggestions, setSuggestions] = useState<SuggestionItem[]>([]);
   const [suggestingCards, setSuggestingCards] = useState(false);
   const [suggestError, setSuggestError] = useState<string | null>(null);
-  const [addingSuggestion, setAddingSuggestion] = useState<number | null>(null);
+  // #4567 — the clientId of the suggestion whose "Add" is in flight (not its
+  // index): the array can reindex under it while the add is running.
+  const [addingSuggestion, setAddingSuggestion] = useState<string | null>(null);
 
   const [density, setDensity] = useState<Density>("comfortable");
   // #3211 — whole-dashboard export state. `exportError` surfaces a failed
@@ -341,12 +355,18 @@ export default function DashboardViewPage() {
   }, []);
 
   async function handleRefreshCard(cardId: string) {
-    setRefreshingCardId(cardId);
+    // #4567 — add THIS card to the in-flight set (never replace it), so a second
+    // concurrent refresh doesn't clobber the first tile's spinner.
+    setRefreshingCardIds((prev) => withRefreshing(prev, cardId));
     // #4315 — while editing, a single-card refresh runs the DRAFT SQL (server
     // returns fresh rows without persisting to the published cache).
     const viewSuffix = editing ? "?view=draft" : "";
-    await mutate({ path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh${viewSuffix}`, method: "POST" });
-    setRefreshingCardId(null);
+    try {
+      await mutate({ path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh${viewSuffix}`, method: "POST" });
+    } finally {
+      // Remove only THIS card — the others may still be refreshing.
+      setRefreshingCardIds((prev) => withoutRefreshing(prev, cardId));
+    }
   }
 
   async function handleRefreshAll() {
@@ -594,7 +614,9 @@ export default function DashboardViewPage() {
       const result = await mutate({ path: `/api/v1/dashboards/${id}/suggest`, method: "POST" });
       if (result.ok && result.data) {
         const data = result.data as { suggestions?: DashboardSuggestion[] };
-        setSuggestions(data.suggestions ?? []);
+        // #4567 — mint a stable client id per suggestion up front so every
+        // later accept / dismiss keys on identity rather than array position.
+        setSuggestions(attachSuggestionIds(data.suggestions ?? []));
       } else {
         setSuggestError("Failed to generate suggestions. Please try again.");
       }
@@ -607,10 +629,10 @@ export default function DashboardViewPage() {
     }
   }
 
-  async function handleAcceptSuggestion(index: number) {
-    const suggestion = suggestions[index];
+  async function handleAcceptSuggestion(clientId: string) {
+    const suggestion = suggestions.find((s) => s.clientId === clientId);
     if (!suggestion || !dashboard) return;
-    setAddingSuggestion(index);
+    setAddingSuggestion(clientId);
     try {
       const placed = withAutoLayout(dashboard.cards).map((c) => c.resolvedLayout);
       const result = await mutate({
@@ -623,14 +645,16 @@ export default function DashboardViewPage() {
           layout: nextTileLayout(placed),
         },
       });
-      if (result.ok) setSuggestions((prev) => prev.filter((_, i) => i !== index));
+      // #4567 — remove the ACCEPTED suggestion by id, so a concurrent dismiss /
+      // add that reindexed the list can't drop the wrong one.
+      if (result.ok) setSuggestions((prev) => dropSuggestion(prev, clientId));
     } finally {
       setAddingSuggestion(null);
     }
   }
 
-  function handleDismissSuggestion(index: number) {
-    setSuggestions((prev) => prev.filter((_, i) => i !== index));
+  function handleDismissSuggestion(clientId: string) {
+    setSuggestions((prev) => dropSuggestion(prev, clientId));
   }
 
   async function handleTitleChange(next: string) {
@@ -1231,9 +1255,9 @@ export default function DashboardViewPage() {
                   </Button>
                 </div>
                 <div className="space-y-2">
-                  {suggestions.map((suggestion, idx) => (
+                  {suggestions.map((suggestion) => (
                     <Card
-                      key={`suggestion-${idx}`}
+                      key={suggestion.clientId}
                       className="border-dashed border-primary/40 bg-primary/5 dark:border-primary/30 dark:bg-primary/5"
                     >
                       <div className="flex items-start gap-3 px-4 py-3">
@@ -1256,18 +1280,18 @@ export default function DashboardViewPage() {
                           <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => handleAcceptSuggestion(idx)}
-                            disabled={addingSuggestion === idx}
+                            onClick={() => handleAcceptSuggestion(suggestion.clientId)}
+                            disabled={addingSuggestion === suggestion.clientId}
                             className="h-7 border-primary/40 text-primary hover:bg-primary/10"
                           >
                             <Plus className="mr-1 size-3" />
-                            {addingSuggestion === idx ? "Adding..." : "Add"}
+                            {addingSuggestion === suggestion.clientId ? "Adding..." : "Add"}
                           </Button>
                           <Button
                             variant="ghost"
                             size="icon"
                             className="size-7 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
-                            onClick={() => handleDismissSuggestion(idx)}
+                            onClick={() => handleDismissSuggestion(suggestion.clientId)}
                             title="Dismiss suggestion"
                           >
                             <XCircle className="size-3.5" />
@@ -1305,7 +1329,7 @@ export default function DashboardViewPage() {
                 <DashboardGrid
                   cards={cardsForGrid}
                   editing={editing}
-                  refreshingId={refreshingCardId}
+                  refreshingIds={refreshingCardIds}
                   stages={stages}
                   comparisons={comparisons}
                   onDrilldown={handleDrilldown}

--- a/packages/web/src/ui/components/dashboards/__tests__/bound-chat-drawer.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/bound-chat-drawer.test.tsx
@@ -167,3 +167,61 @@ describe("BoundChatDrawer — conversation continuity", () => {
     expect(queryByText(/Tell the agent what to change/i)).toBeNull();
   });
 });
+
+describe("BoundChatDrawer — surgical board invalidation (#4567)", () => {
+  const toolMsg = (name: string, kind: string): FakeMsg =>
+    ({
+      id: "a1",
+      role: "assistant",
+      parts: [{ type: `tool-${name}`, state: "output-available", toolCallId: "call-1", output: { kind } }],
+    }) as unknown as FakeMsg;
+
+  test("a successful mutation tool fires onDashboardMutated once", async () => {
+    chatMessages = [toolMsg("addCard", "ok")];
+    const spy = mock(() => {});
+    renderDrawer({ onDashboardMutated: spy });
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+  });
+
+  test("a pure read tool does NOT fire onDashboardMutated (no flash-reload)", () => {
+    chatMessages = [toolMsg("getDashboardState", "ok")];
+    const spy = mock(() => {});
+    renderDrawer({ onDashboardMutated: spy });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("a failed mutation (kind: err) does NOT fire onDashboardMutated", () => {
+    chatMessages = [toolMsg("addCard", "err")];
+    const spy = mock(() => {});
+    renderDrawer({ onDashboardMutated: spy });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test("a re-render with a NEW callback identity does not refire for the same mutation", async () => {
+    chatMessages = [toolMsg("addCard", "ok")];
+    const spy1 = mock(() => {});
+    const { rerender } = render(
+      <BoundChatDrawer
+        open
+        onOpenChange={() => {}}
+        dashboardId="dash-1"
+        dashboardTitle="Sales"
+        onDashboardMutated={spy1}
+      />,
+    );
+    await waitFor(() => expect(spy1).toHaveBeenCalledTimes(1));
+    // Same messages (same signature), fresh callback identity — the ref-guard
+    // must suppress a second refetch for a mutation already handled.
+    const spy2 = mock(() => {});
+    rerender(
+      <BoundChatDrawer
+        open
+        onOpenChange={() => {}}
+        dashboardId="dash-1"
+        dashboardTitle="Sales"
+        onDashboardMutated={spy2}
+      />,
+    );
+    expect(spy2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/bound-tool-invalidation.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/bound-tool-invalidation.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+import { boundMutationSignature } from "../bound-tool-invalidation";
+
+/** Build an assistant message from raw tool-part descriptors. */
+function assistant(
+  parts: { name: string; state: string; callId: string; kind?: string }[],
+): UIMessage {
+  return {
+    id: "m1",
+    role: "assistant",
+    parts: parts.map((p) => ({
+      type: `tool-${p.name}`,
+      toolCallId: p.callId,
+      state: p.state,
+      ...(p.kind !== undefined ? { output: { kind: p.kind } } : {}),
+    })),
+  } as unknown as UIMessage;
+}
+
+describe("boundMutationSignature", () => {
+  test("a pure read completion produces no signature (no refetch)", () => {
+    const msg = assistant([
+      { name: "getDashboardState", state: "output-available", callId: "c1", kind: "ok" },
+    ]);
+    expect(boundMutationSignature(msg)).toBe("");
+  });
+
+  test("explore / executeSQL reads produce no signature", () => {
+    const msg = assistant([
+      { name: "explore", state: "output-available", callId: "c1", kind: "ok" },
+      { name: "executeSQL", state: "output-available", callId: "c2", kind: "ok" },
+    ]);
+    expect(boundMutationSignature(msg)).toBe("");
+  });
+
+  test("a successful mutation produces a non-empty, stable signature", () => {
+    const msg = assistant([
+      { name: "addCard", state: "output-available", callId: "c1", kind: "ok" },
+    ]);
+    const sig = boundMutationSignature(msg);
+    expect(sig).not.toBe("");
+    // Stable for the same input.
+    expect(boundMutationSignature(msg)).toBe(sig);
+  });
+
+  test("a FAILED mutation (kind: err) produces no signature", () => {
+    const msg = assistant([
+      { name: "addCard", state: "output-available", callId: "c1", kind: "err" },
+    ]);
+    expect(boundMutationSignature(msg)).toBe("");
+  });
+
+  test("a THROWN mutation (state: output-error) produces no signature", () => {
+    const msg = assistant([
+      { name: "updateCard", state: "output-error", callId: "c1" },
+    ]);
+    expect(boundMutationSignature(msg)).toBe("");
+  });
+
+  test("an in-flight mutation (state: input-available) produces no signature", () => {
+    const msg = assistant([
+      { name: "addCard", state: "input-available", callId: "c1" },
+    ]);
+    expect(boundMutationSignature(msg)).toBe("");
+  });
+
+  test("staged ops (removeCard/updateCardSql → stage_required) count as mutations", () => {
+    const remove = assistant([
+      { name: "removeCard", state: "output-available", callId: "c1", kind: "stage_required" },
+    ]);
+    const editSql = assistant([
+      { name: "updateCardSql", state: "output-available", callId: "c2", kind: "stage_required" },
+    ]);
+    expect(boundMutationSignature(remove)).not.toBe("");
+    expect(boundMutationSignature(editSql)).not.toBe("");
+  });
+
+  test("updateLayout partial success counts (some cards moved)", () => {
+    const msg = assistant([
+      { name: "updateLayout", state: "output-available", callId: "c1", kind: "partial" },
+    ]);
+    expect(boundMutationSignature(msg)).not.toBe("");
+  });
+
+  test("a read + a successful mutation in one turn → the mutation drives it", () => {
+    const readOnly = assistant([
+      { name: "getDashboardState", state: "output-available", callId: "c1", kind: "ok" },
+    ]);
+    const readThenWrite = assistant([
+      { name: "getDashboardState", state: "output-available", callId: "c1", kind: "ok" },
+      { name: "addCard", state: "output-available", callId: "c2", kind: "ok" },
+    ]);
+    expect(boundMutationSignature(readOnly)).toBe("");
+    expect(boundMutationSignature(readThenWrite)).not.toBe("");
+    // The read's completion does not change the signature vs. the write alone.
+    expect(boundMutationSignature(readThenWrite)).toBe(
+      boundMutationSignature(
+        assistant([{ name: "addCard", state: "output-available", callId: "c2", kind: "ok" }]),
+      ),
+    );
+  });
+
+  test("a read completing after a mutation does NOT retrigger (signature unchanged)", () => {
+    // Turn 1: mutation lands.
+    const afterMutation = assistant([
+      { name: "addCard", state: "output-available", callId: "c1", kind: "ok" },
+    ]);
+    // Turn 1': a subsequent read in the SAME message completes — signature must
+    // be identical, so the effect keyed on it does not fire again.
+    const afterMutationPlusRead = assistant([
+      { name: "addCard", state: "output-available", callId: "c1", kind: "ok" },
+      { name: "getDashboardState", state: "output-available", callId: "c2", kind: "ok" },
+    ]);
+    expect(boundMutationSignature(afterMutationPlusRead)).toBe(
+      boundMutationSignature(afterMutation),
+    );
+  });
+
+  test("undefined / user message → no signature", () => {
+    expect(boundMutationSignature(undefined)).toBe("");
+    expect(
+      boundMutationSignature({ id: "u1", role: "user", parts: [] } as unknown as UIMessage),
+    ).toBe("");
+  });
+
+  test("distinct successful mutations yield distinct signatures (each fires once)", () => {
+    const first = assistant([
+      { name: "addCard", state: "output-available", callId: "c1", kind: "ok" },
+    ]);
+    const second = assistant([
+      { name: "addCard", state: "output-available", callId: "c2", kind: "ok" },
+    ]);
+    expect(boundMutationSignature(first)).not.toBe(boundMutationSignature(second));
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/canvas-interactions.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/canvas-interactions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import {
+  withRefreshing,
+  withoutRefreshing,
+  attachSuggestionIds,
+  dropSuggestion,
+  makeClientId,
+  type SuggestionItem,
+} from "../canvas-interactions";
+import type { DashboardSuggestion } from "@/ui/lib/types";
+
+const rawSuggestion = (title: string): DashboardSuggestion => ({
+  title,
+  sql: `SELECT '${title}'`,
+  chartConfig: { type: "bar" } as DashboardSuggestion["chartConfig"],
+  reason: `because ${title}`,
+});
+
+describe("per-tile refresh tracking (#4567 L3)", () => {
+  test("two concurrent refreshes converge to a set of BOTH ids", () => {
+    let set: ReadonlySet<string> = new Set();
+    set = withRefreshing(set, "c1");
+    set = withRefreshing(set, "c2");
+    expect([...set].sort()).toEqual(["c1", "c2"]);
+  });
+
+  test("the SLOWER refresh settling first leaves the other's spinner intact", () => {
+    // c1 and c2 both in flight; c1 settles first — c2 must stay refreshing.
+    let set: ReadonlySet<string> = new Set(["c1", "c2"]);
+    set = withoutRefreshing(set, "c1");
+    expect(set.has("c1")).toBe(false);
+    expect(set.has("c2")).toBe(true); // <- the bug a single `refreshingId` had
+  });
+
+  test("add is idempotent and copy-on-write (no in-place mutation)", () => {
+    const start: ReadonlySet<string> = new Set(["c1"]);
+    const same = withRefreshing(start, "c1");
+    expect(same).toBe(start); // already present → same reference
+    const grown = withRefreshing(start, "c2");
+    expect(grown).not.toBe(start);
+    expect(start.has("c2")).toBe(false); // original untouched
+  });
+
+  test("removing an absent id is a no-op returning the same reference", () => {
+    const start: ReadonlySet<string> = new Set(["c1"]);
+    expect(withoutRefreshing(start, "nope")).toBe(start);
+  });
+});
+
+describe("stable-id suggestions (#4567 L4)", () => {
+  test("attachSuggestionIds mints one id per suggestion", () => {
+    const items = attachSuggestionIds([rawSuggestion("A"), rawSuggestion("B")]);
+    expect(items).toHaveLength(2);
+    expect(items[0].clientId).not.toBe(items[1].clientId);
+    expect(items[0].title).toBe("A");
+  });
+
+  test("an injected id factory drives the ids (deterministic in tests)", () => {
+    let n = 0;
+    const items = attachSuggestionIds([rawSuggestion("A"), rawSuggestion("B")], () => `id-${n++}`);
+    expect(items.map((s) => s.clientId)).toEqual(["id-0", "id-1"]);
+  });
+
+  test("dropSuggestion removes the CLICKED item by identity, never by index", () => {
+    // The regression: dismiss the middle item; index-keying would drop the wrong
+    // one after any prior reindex. Identity keying always hits the target.
+    const items: SuggestionItem[] = attachSuggestionIds(
+      [rawSuggestion("A"), rawSuggestion("B"), rawSuggestion("C")],
+      (() => {
+        let n = 0;
+        return () => `id-${n++}`;
+      })(),
+    );
+    const afterDismissB = dropSuggestion(items, "id-1");
+    expect(afterDismissB.map((s) => s.title)).toEqual(["A", "C"]);
+  });
+
+  test("dismissing while another add is in flight acts on each clicked item after reindex", () => {
+    // Simulate: [A,B,C]; accept A removes it (reindex → [B,C]); now the pending
+    // "Adding…" was keyed on B's id — dismissing B still hits B, not the new index-1.
+    let n = 0;
+    const items = attachSuggestionIds(
+      [rawSuggestion("A"), rawSuggestion("B"), rawSuggestion("C")],
+      () => `id-${n++}`,
+    );
+    const [idA, idB] = [items[0].clientId, items[1].clientId];
+    const afterAcceptA = dropSuggestion(items, idA); // [B, C]
+    const afterDismissB = dropSuggestion(afterAcceptA, idB); // must be [C]
+    expect(afterDismissB.map((s) => s.title)).toEqual(["C"]);
+  });
+
+  test("makeClientId returns distinct non-empty ids", () => {
+    const a = makeClientId();
+    const b = makeClientId();
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+  });
+
+  test("makeClientId falls back when crypto.randomUUID is unavailable (non-secure context)", () => {
+    const realCrypto = globalThis.crypto;
+    try {
+      // Simulate an insecure context: randomUUID absent. Suggestions must still
+      // get an id rather than the whole list failing.
+      Object.defineProperty(globalThis, "crypto", { value: {}, configurable: true });
+      const id = makeClientId();
+      expect(id).toMatch(/^sug-/);
+      expect(makeClientId()).not.toBe(id); // still distinct via the counter
+    } finally {
+      Object.defineProperty(globalThis, "crypto", { value: realCrypto, configurable: true });
+    }
+  });
+
+  test("makeClientId falls back when crypto.randomUUID throws", () => {
+    const realCrypto = globalThis.crypto;
+    try {
+      Object.defineProperty(globalThis, "crypto", {
+        value: {
+          randomUUID: () => {
+            throw new Error("insecure context");
+          },
+        },
+        configurable: true,
+      });
+      expect(makeClientId()).toMatch(/^sug-/);
+    } finally {
+      Object.defineProperty(globalThis, "crypto", { value: realCrypto, configurable: true });
+    }
+  });
+});

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -49,13 +49,15 @@ const card: DashboardCard = {
 const baseProps = {
   cards: [card],
   editing: false,
-  refreshingId: null,
+  refreshingIds: new Set<string>(),
   onLayoutChange: noop,
   onRefresh: noop,
   onDuplicate: noop,
   onDelete: noop,
   onUpdateTitle: noop,
 };
+
+const secondCard: DashboardCard = { ...card, id: "card-2", title: "Revenue by month" };
 
 describe("DashboardGrid", () => {
   afterEach(cleanup);
@@ -83,6 +85,35 @@ describe("DashboardGrid", () => {
     widthOverride = 1024;
     render(<DashboardGrid {...baseProps} />);
     expect(screen.getByTestId("rgl-root")).toBeTruthy();
+  });
+
+  test("#4567 — two concurrent tile refreshes both spin; neither clobbers the other", () => {
+    widthOverride = 1024;
+    render(
+      <DashboardGrid
+        {...baseProps}
+        cards={[card, secondCard]}
+        refreshingIds={new Set(["card-1", "card-2"])}
+      />,
+    );
+    // Both tiles' refresh buttons reflect their own in-flight state (a single
+    // `refreshingId` could only mark one). `disabled` is the tile's refresh gate.
+    const refreshButtons = screen.getAllByRole("button", { name: "Refresh tile" });
+    expect(refreshButtons).toHaveLength(2);
+    for (const btn of refreshButtons) expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("#4567 — a refresh in flight on one tile leaves the other's refresh idle", () => {
+    widthOverride = 1024;
+    render(
+      <DashboardGrid
+        {...baseProps}
+        cards={[card, secondCard]}
+        refreshingIds={new Set(["card-1"])}
+      />,
+    );
+    const refreshButtons = screen.getAllByRole("button", { name: "Refresh tile" });
+    expect(refreshButtons.filter((b) => (b as HTMLButtonElement).disabled)).toHaveLength(1);
   });
 
   test("fullscreen opens a real modal dialog (focus trap / backdrop / aria-modal), not a CSS overlay", () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/time-ago.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/time-ago.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { timeAgo } from "../time-ago";
+
+const NOW = new Date("2026-07-17T12:00:00Z").getTime();
+
+describe("timeAgo", () => {
+  test("null → 'never'", () => {
+    expect(timeAgo(null, NOW)).toBe("never");
+  });
+
+  test("a malformed timestamp → 'never', never 'Invalid Date'", () => {
+    expect(timeAgo("not-a-date", NOW)).toBe("never");
+  });
+
+  test("under a minute in the past → 'just now'", () => {
+    expect(timeAgo(new Date(NOW - 30_000).toISOString(), NOW)).toBe("just now");
+  });
+
+  test("minute / hour / day buckets", () => {
+    expect(timeAgo(new Date(NOW - 5 * 60_000).toISOString(), NOW)).toBe("5m ago");
+    expect(timeAgo(new Date(NOW - 3 * 60 * 60_000).toISOString(), NOW)).toBe("3h ago");
+    expect(timeAgo(new Date(NOW - 4 * 24 * 60 * 60_000).toISOString(), NOW)).toBe("4d ago");
+  });
+
+  test("#4567 — a clock-skewed FUTURE timestamp never reads 'just now'", () => {
+    const future = new Date(NOW + 45_000).toISOString();
+    expect(timeAgo(future, NOW)).not.toBe("just now");
+    expect(timeAgo(future, NOW)).toBe("moments ago");
+  });
+
+  test("#4567 — a far-future timestamp is still not 'just now' (skew never masks)", () => {
+    const farFuture = new Date(NOW + 2 * 60 * 60_000).toISOString();
+    expect(timeAgo(farFuture, NOW)).toBe("moments ago");
+  });
+
+  test("#4567 — the injected `now` drives the label (live-tick friendly)", () => {
+    const iso = new Date(NOW).toISOString();
+    // Same timestamp, a later `now` → an older caption. This is what makes the
+    // caption tick without the underlying data changing.
+    expect(timeAgo(iso, NOW)).toBe("just now");
+    expect(timeAgo(iso, NOW + 90_000)).toBe("1m ago");
+  });
+});

--- a/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
+++ b/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
@@ -24,7 +24,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useChat } from "@ai-sdk/react";
-import { DefaultChatTransport, type UIMessage, isToolUIPart } from "ai";
+import { DefaultChatTransport, type UIMessage } from "ai";
 import {
   Sheet,
   SheetContent,
@@ -44,6 +44,7 @@ import { AgentTurn } from "@/ui/components/chat/agent-turn";
 import { WorkingActivity, showPreStreamActivity } from "@/ui/components/chat/working-activity";
 import { FollowUpChips } from "@/ui/components/chat/follow-up-chips";
 import { StageProvider } from "@/ui/components/dashboards/stage-context";
+import { boundMutationSignature } from "@/ui/components/dashboards/bound-tool-invalidation";
 import { parseSuggestions } from "@/ui/lib/helpers";
 import { transformMessages } from "@useatlas/types/conversation";
 import type { Message } from "@useatlas/types/conversation";
@@ -74,11 +75,12 @@ interface BoundChatDrawerProps {
   dashboardId: string;
   dashboardTitle: string;
   /**
-   * Called whenever a tool completes — the dashboard view re-fetches so
-   * the new card / updated title / new layout shows up immediately. The
-   * drawer doesn't try to be surgical about which tools warrant
-   * a refetch; every tool result triggers one. Plenty of room for
-   * smarter invalidation in a follow-up.
+   * #4567 — called when a bound MUTATION tool completes SUCCESSFULLY (a new
+   * card / updated title / new layout / staged change), so the dashboard view
+   * re-fetches and the change shows up immediately. Surgical by design: a pure
+   * read (`getDashboardState`, …) or a failed mutation does NOT fire this, so a
+   * plain question in the drawer never flash-reloads the board. The read-vs-
+   * write decision lives in `boundMutationSignature`.
    */
   onDashboardMutated?: () => void;
   /**
@@ -288,34 +290,25 @@ export function BoundChatDrawer({
     seededConversationRef.current = resumeConversationId;
   }, [open, resumeConversationId, resumeQuery.data, resumeQuery.error, setMessages]);
 
-  // Refetch the dashboard whenever a tool result lands. The bound editor
-  // tools mutate cards/title/layout — viewers expect the canvas to
-  // update without a manual reload. We watch the tool-part status on
-  // the latest assistant message rather than running on every render
-  // (cheap, but explicit).
-  const lastMsg = messages[messages.length - 1];
-  const lastMsgId = lastMsg?.id;
-  // Pure derived string. React Compiler memoizes; manual useMemo
-  // was forbidden by CLAUDE.md for perf-only cases.
-  let lastMsgToolFingerprint = "";
-  if (lastMsg && lastMsg.role === "assistant") {
-    for (const part of lastMsg.parts ?? []) {
-      if (!isToolUIPart(part)) continue;
-      const p = part as { state?: string; toolCallId?: string };
-      lastMsgToolFingerprint += `${p.toolCallId ?? ""}:${p.state ?? ""};`;
-    }
-  }
+  // #4567 — refetch the board surgically: only when a MUTATION tool on the
+  // latest assistant turn completed successfully. A pure read
+  // (`getDashboardState`, `explore`, …) or a failed mutation changes nothing on
+  // the canvas, so it must not flash-reload every tile. The signature is a pure
+  // derived string (React Compiler memoizes; manual useMemo is forbidden by
+  // CLAUDE.md for perf-only cases) that changes exactly when a new successful
+  // mutation lands — see `boundMutationSignature`.
+  const mutationSignature = boundMutationSignature(messages[messages.length - 1]);
 
+  // Fire at most once per DISTINCT signature: without this, an `onDashboardMutated`
+  // that changes identity between renders would re-run the effect and refetch the
+  // board again for a mutation already handled.
+  const lastFiredSignatureRef = useRef("");
   useEffect(() => {
-    if (!onDashboardMutated || !lastMsgToolFingerprint) return;
-    // The fingerprint changes when a tool transitions to a terminal
-    // state ("output-available" / "output-error"). Treat any change as
-    // potential dashboard mutation — false positives are cheap (an
-    // extra GET) and false negatives leave the canvas stale.
-    if (lastMsgToolFingerprint.includes("output-available")) {
-      onDashboardMutated();
-    }
-  }, [lastMsgToolFingerprint, lastMsgId, onDashboardMutated]);
+    if (!onDashboardMutated || !mutationSignature) return;
+    if (lastFiredSignatureRef.current === mutationSignature) return;
+    lastFiredSignatureRef.current = mutationSignature;
+    onDashboardMutated();
+  }, [mutationSignature, onDashboardMutated]);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();

--- a/packages/web/src/ui/components/dashboards/bound-tool-invalidation.ts
+++ b/packages/web/src/ui/components/dashboards/bound-tool-invalidation.ts
@@ -1,0 +1,77 @@
+import { isToolUIPart, getToolName, type UIMessage } from "ai";
+
+/**
+ * Surgical board-invalidation for the bound chat drawer (#4567, PRD #4553 L5).
+ *
+ * The bound editor runs both READ tools (`getDashboardState`, `getCardDetail`,
+ * plus the base `explore` / `executeSQL`) and MUTATION tools that change what
+ * the canvas shows. Refetching the whole board on EVERY tool completion means a
+ * plain question ("what is card 1 counting?") flash-reloads twelve tiles, and a
+ * mutation that FAILED refetches even though nothing changed.
+ *
+ * The rule: refetch only when a mutation tool completes SUCCESSFULLY. That
+ * includes the staged ops (`removeCard` / `updateCardSql`) whose success is a
+ * `stage_required` envelope — staging doesn't alter the published board but it
+ * does update the pending/ghost view the canvas renders, so it warrants a
+ * refetch just like a direct draft edit. This module is the single pure
+ * statement of that rule so the drawer effect stays a one-liner and the
+ * decision is unit-testable without mounting a chat.
+ */
+
+/**
+ * Bound-editor tools that change dashboard state — they either commit to the
+ * caller's draft (`addCard` / `updateCard` / `updateLayout` /
+ * `updateDashboardMeta`) or stage a destructive change (`removeCard` /
+ * `updateCardSql`). These are the MUTATING SAFE-ops plus the two staged ops from
+ * `packages/api/src/lib/tools/bound-dashboard.ts`; the read SAFE-ops
+ * (`getDashboardState`, `getCardDetail`) and the base `explore` / `executeSQL`
+ * are intentionally excluded — a read never warrants a board refetch.
+ */
+export const BOUND_MUTATION_TOOLS: ReadonlySet<string> = new Set([
+  "addCard",
+  "updateCard",
+  "updateLayout",
+  "updateDashboardMeta",
+  "removeCard",
+  "updateCardSql",
+]);
+
+/**
+ * A stable signature of the SUCCESSFUL mutation-tool completions in a message.
+ * A tool part contributes only when ALL of:
+ *   - it is a mutation tool (in {@link BOUND_MUTATION_TOOLS}) — excludes reads;
+ *   - its state is `output-available` — excludes in-flight and thrown
+ *     (`output-error`) calls;
+ *   - its result envelope's `kind` is not `"err"` — excludes mutations that ran
+ *     but returned a handled failure (e.g. `addCard` → `{ kind: "err" }`), which
+ *     changed nothing.
+ *
+ * The signature changes exactly when a NEW successful mutation lands (tool call
+ * ids are unique), so a caller can fire a surgical refetch off a change to it —
+ * and never off a pure read or a failed mutation. Empty string = nothing to do.
+ */
+export function boundMutationSignature(message: UIMessage | undefined): string {
+  if (!message || message.role !== "assistant") return "";
+  let signature = "";
+  for (const part of message.parts ?? []) {
+    // Narrows `part` to the SDK's `ToolUIPart` discriminated union — `state` is
+    // the discriminant and `toolCallId: string` is always present.
+    if (!isToolUIPart(part)) continue;
+    // Terminal SUCCESS only. The `output-available` arm carries `output`;
+    // `output-error` (the tool threw) and in-flight states are excluded here.
+    if (part.state !== "output-available") continue;
+    let name = "";
+    try {
+      name = getToolName(part);
+    } catch {
+      // intentionally ignored: an unrecognizable tool part can't be a known mutation
+      continue;
+    }
+    if (!BOUND_MUTATION_TOOLS.has(name)) continue;
+    // A handled-failure envelope ran the tool but mutated nothing — skip it.
+    const kind = (part.output as { kind?: unknown } | null | undefined)?.kind;
+    if (kind === "err") continue;
+    signature += `${part.toolCallId}:${typeof kind === "string" ? kind : ""};`;
+  }
+  return signature;
+}

--- a/packages/web/src/ui/components/dashboards/canvas-interactions.ts
+++ b/packages/web/src/ui/components/dashboards/canvas-interactions.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure state transitions for the dashboard canvas's interaction polish (#4567,
+ * PRD #4553 L3–L4). The page's handlers are thin wrappers over these so the
+ * actual regression surfaces — per-tile refresh tracking and IDENTITY-keyed
+ * suggestion accept/dismiss — are unit-testable without mounting the page.
+ */
+
+import type { DashboardSuggestion } from "@/ui/lib/types";
+
+// ---------------------------------------------------------------------------
+// Per-tile refresh tracking (L3) — a SET, so two concurrent refreshes each
+// keep their own spinner; a slower one settling never clears a faster one.
+// ---------------------------------------------------------------------------
+
+/** Add `id` to the in-flight refresh set (immutable copy-on-write). */
+export function withRefreshing(prev: ReadonlySet<string>, id: string): ReadonlySet<string> {
+  if (prev.has(id)) return prev;
+  const next = new Set(prev);
+  next.add(id);
+  return next;
+}
+
+/** Remove ONLY `id` from the in-flight refresh set — the others stay in flight. */
+export function withoutRefreshing(prev: ReadonlySet<string>, id: string): ReadonlySet<string> {
+  if (!prev.has(id)) return prev;
+  const next = new Set(prev);
+  next.delete(id);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Stable-id suggestions (L4) — accept/dismiss key on a minted identity, never
+// array index, so a concurrent add/dismiss reindexing the list can't act on the
+// wrong item.
+// ---------------------------------------------------------------------------
+
+/** An AI suggestion plus a client-minted stable id for identity-keyed actions. */
+export type SuggestionItem = DashboardSuggestion & { clientId: string };
+
+/**
+ * Mint a stable client id. Prefers `crypto.randomUUID`, falling back to a
+ * counter + random suffix when it's unavailable — `randomUUID` is absent
+ * (undefined) outside a secure context, e.g. a self-hosted origin served over
+ * plain HTTP, which the `typeof` guard handles; the `try/catch` is defensive
+ * belt-and-suspenders against an unexpected throw. Either way, a suggestion list
+ * that came back fine from the server must never fail to render over an id.
+ */
+let idCounter = 0;
+export function makeClientId(): string {
+  try {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // intentionally ignored: fall through to the non-crypto id below
+  }
+  idCounter += 1;
+  return `sug-${Date.now().toString(36)}-${idCounter}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Attach a stable client id to each raw suggestion (id factory injectable for tests). */
+export function attachSuggestionIds(
+  raw: readonly DashboardSuggestion[],
+  idFactory: () => string = makeClientId,
+): SuggestionItem[] {
+  return raw.map((s) => ({ ...s, clientId: idFactory() }));
+}
+
+/** Drop the suggestion with `clientId` — identity match, never a positional index. */
+export function dropSuggestion(list: readonly SuggestionItem[], clientId: string): SuggestionItem[] {
+  return list.filter((s) => s.clientId !== clientId);
+}

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -24,7 +24,12 @@ import { DashboardTile } from "./dashboard-tile";
 interface DashboardGridProps {
   cards: DashboardCard[];
   editing: boolean;
-  refreshingId: string | null;
+  /**
+   * #4567 — ids of tiles whose single-card refresh is CURRENTLY in flight. A set
+   * (not one id) so two concurrent refreshes each keep their own spinner —
+   * neither clobbers the other. Empty → nothing refreshing.
+   */
+  refreshingIds: ReadonlySet<string>;
   /**
    * #2365 — per-user pending destructive stages. Drives the ghost
    * overlay: cards with a `remove_card` stage render with a
@@ -83,7 +88,7 @@ interface DashboardGridProps {
 export function DashboardGrid({
   cards,
   editing,
-  refreshingId,
+  refreshingIds,
   stages,
   comparisons,
   onDrilldown,
@@ -201,7 +206,7 @@ export function DashboardGrid({
                 card={card}
                 editing={false}
                 fullscreen={false}
-                isRefreshing={refreshingId === card.id}
+                isRefreshing={refreshingIds.has(card.id)}
                 stage={stagesByCardId.get(card.id) ?? null}
                 comparison={comparisons?.[card.id] ?? null}
                 onDrilldown={onDrilldown}
@@ -249,7 +254,7 @@ export function DashboardGrid({
                 card={card}
                 editing={editing}
                 fullscreen={false}
-                isRefreshing={refreshingId === card.id}
+                isRefreshing={refreshingIds.has(card.id)}
                 stage={stagesByCardId.get(card.id) ?? null}
                 comparison={comparisons?.[card.id] ?? null}
                 onDrilldown={onDrilldown}
@@ -299,7 +304,7 @@ export function DashboardGrid({
                 card={fullscreenCard}
                 editing={false}
                 fullscreen
-                isRefreshing={refreshingId === fullscreenCard.id}
+                isRefreshing={refreshingIds.has(fullscreenCard.id)}
                 stage={stagesByCardId.get(fullscreenCard.id) ?? null}
                 comparison={comparisons?.[fullscreenCard.id] ?? null}
                 onDrilldown={onDrilldown}

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -36,6 +36,7 @@ import { DataTable } from "@/ui/components/chat/data-table";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { KpiCard } from "./kpi-card";
 import { useDarkMode } from "@/ui/hooks/use-dark-mode";
+import { useNow } from "@/ui/hooks/use-now";
 import { cn } from "@/lib/utils";
 import { timeAgo } from "./time-ago";
 import {
@@ -288,6 +289,10 @@ function ChartTile({
   onExportCsv,
 }: DashboardTileProps) {
   const dark = useDarkMode();
+  // #4567 — a ticking clock drives the age caption LIVE: it advances "just now"
+  // → "1m ago" → … on its own, with no external re-render. The same `now` feeds
+  // the caption label and its colour tone so they never disagree.
+  const now = useNow();
   const [titleEditing, setTitleEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState(card.title);
 
@@ -309,7 +314,7 @@ function ChartTile({
   // (never had data) — never a silent revert, never a page banner.
   const everRun = card.cachedAt != null || renderPhase === "ok";
   const status: TileStatus = resolveTileStatus({ renderPhase, hasData, everRun, pendingRefresh });
-  const captionTone = tileCaptionTone(status, card.cachedAt);
+  const captionTone = tileCaptionTone(status, card.cachedAt, now);
   // `stale`/`loading` keep rendering the retained data body, but dimmed so the
   // viewer reads it as "not the current filtered result".
   const showData = hasData && (statusShowsData(status) || status === "loading");
@@ -644,7 +649,7 @@ function ChartTile({
           <Clock className="size-2.5" aria-hidden="true" />
           {status === "stale" && <span className="font-medium">Stale · </span>}
           {status === "errored" && <span className="font-medium">Failed</span>}
-          {status !== "errored" && timeAgo(card.cachedAt)}
+          {status !== "errored" && timeAgo(card.cachedAt, now)}
         </span>
         <span className="flex items-center gap-2">
           {footerRetry && (

--- a/packages/web/src/ui/components/dashboards/time-ago.ts
+++ b/packages/web/src/ui/components/dashboards/time-ago.ts
@@ -6,10 +6,22 @@
  * The admin surfaces use `<RelativeTimestamp>` (with a tooltip + Intl
  * RelativeTimeFormat) instead — this helper stays plain-string + no provider
  * required for use inside dropdowns and grid tiles.
+ *
+ * `now` is injectable so a caller can drive a LIVE caption from a ticking clock
+ * (`useNow`) — the same `now` renders every tile consistently and makes the
+ * function pure for unit tests.
  */
-export function timeAgo(iso: string | null): string {
+export function timeAgo(iso: string | null, now: number = Date.now()): string {
   if (!iso) return "never";
-  const diff = Date.now() - new Date(iso).getTime();
+  const ts = new Date(iso).getTime();
+  // A malformed timestamp is not "0m ago" — treat it as unknown rather than
+  // rendering "Invalid Date".
+  if (Number.isNaN(ts)) return "never";
+  const diff = now - ts;
+  // Clock skew: the capture instant is AHEAD of our clock. Never report "just
+  // now" for a future timestamp — that would mask a large skew (or a bad
+  // timestamp) as ordinary freshness. Label it as very-recent but distinct.
+  if (diff < 0) return "moments ago";
   const mins = Math.floor(diff / 60_000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -17,5 +29,5 @@ export function timeAgo(iso: string | null): string {
   if (hrs < 24) return `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
   if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString();
+  return new Date(ts).toLocaleDateString();
 }

--- a/packages/web/src/ui/hooks/__tests__/use-now.test.tsx
+++ b/packages/web/src/ui/hooks/__tests__/use-now.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, mock, setSystemTime, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useNow } from "../use-now";
+
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+
+afterEach(() => {
+  globalThis.setInterval = realSetInterval;
+  globalThis.clearInterval = realClearInterval;
+  setSystemTime(); // restore the real clock
+  cleanup();
+});
+
+describe("useNow", () => {
+  test("captures the clock at mount and advances it on each interval tick", () => {
+    const t0 = new Date("2026-07-17T12:00:00Z");
+    setSystemTime(t0);
+
+    let tick: (() => void) | null = null;
+    globalThis.setInterval = mock((fn: () => void) => {
+      tick = fn;
+      return 7 as unknown as ReturnType<typeof setInterval>;
+    }) as unknown as typeof setInterval;
+    globalThis.clearInterval = mock(() => {}) as unknown as typeof clearInterval;
+
+    const { result } = renderHook(() => useNow(30_000));
+    expect(result.current).toBe(t0.getTime());
+
+    // The clock moves, then the interval fires → the returned value advances,
+    // which is what makes a caption tick with no external re-render trigger.
+    setSystemTime(new Date(t0.getTime() + 90_000));
+    act(() => tick?.());
+    expect(result.current).toBe(t0.getTime() + 90_000);
+  });
+
+  test("clears its interval on unmount (no leaked per-tile timer)", () => {
+    globalThis.setInterval = mock(() => 42 as unknown as ReturnType<typeof setInterval>) as unknown as typeof setInterval;
+    const clearSpy = mock(() => {});
+    globalThis.clearInterval = clearSpy as unknown as typeof clearInterval;
+
+    const { unmount } = renderHook(() => useNow());
+    unmount();
+    expect(clearSpy).toHaveBeenCalledWith(42);
+  });
+});

--- a/packages/web/src/ui/hooks/use-now.ts
+++ b/packages/web/src/ui/hooks/use-now.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Re-renders the caller on a fixed cadence and returns the current epoch-ms.
+ *
+ * Drives "live" relative-time captions (e.g. a dashboard tile's age caption) so
+ * they tick from "just now" → "1m ago" → … without any external re-render
+ * trigger. The lazy initializer captures `Date.now()` once at mount (not on
+ * every render); the interval then advances it and the interval clears on
+ * unmount. Captions bucket to minute resolution, so the brief SSR-vs-hydration
+ * clock difference resolves to the same string in practice.
+ *
+ * Default 30s — fine-grained enough for minute-resolution captions while
+ * staying cheap even with a few dozen tiles each holding their own tick.
+ */
+export function useNow(intervalMs = 30_000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(timer);
+  }, [intervalMs]);
+  return now;
+}


### PR DESCRIPTION
Closes #4567 (parent PRD #4553, milestone v0.0.55). Purely-frontend canvas interaction polish — the audit's interaction LOWs (L3–L6) as one slice. All changes are within `packages/web`.

## What changed

- **Per-tile refresh state (L3):** `refreshingCardId: string | null` → a `refreshingIds: ReadonlySet<string>`. Two concurrent tile refreshes each keep their own spinner; a slower one settling no longer clears a faster one still running.
- **Stable suggestion ids (L4):** suggestion accept/dismiss/`Adding…` now key on a minted `clientId`, never the array index — a concurrent add/dismiss reindexing the list can't act on the wrong item.
- **Surgical invalidation (L5):** the bound chat drawer refetches the board only when a bound **mutation** tool completes **successfully** (`boundMutationSignature`) — a pure read (`getDashboardState`, `explore`, …) or a failed mutation (`kind: "err"` / `output-error`) no longer flash-reloads every tile. A ref-guard fires it at most once per distinct mutation.
- **Live / skew-safe age captions (L6):** captions tick live via a new `useNow` hook; `timeAgo` now takes an injectable `now`, returns `"moments ago"` (never `"just now"`) for a clock-skewed future timestamp, and `"never"` for a malformed one.

The interaction logic is extracted into pure, unit-tested helpers (`canvas-interactions.ts`, `bound-tool-invalidation.ts`) so the page handlers stay thin.

## Acceptance criteria

- [x] Two concurrent tile refreshes both show spinners; neither clobbers the other
- [x] Dismissing one suggestion while another is being added acts on the clicked items
- [x] A read-only bound-tool completion does not refetch the board; a successful mutation does
- [x] Age captions update without a re-render trigger and never show "just now" for a future timestamp

## Tests

New/updated: `canvas-interactions.test.ts` (per-tile refresh convergence + reindex-race + crypto-fallback), `bound-tool-invalidation.test.ts` (read vs successful/failed/staged mutation), `time-ago.test.ts` (future → `moments ago`, injected `now`), `use-now.test.tsx` (tick + interval cleanup), `dashboard-grid.test.tsx` (two concurrent spinners), `bound-chat-drawer.test.tsx` (surgical fire-once). All pass; zero type/lint regressions.

## Review

Internal review panel (silent-failure / type-design / test-coverage / comment) run twice — converged **CLEAN** in 2 rounds (round-1 findings all addressed: hardened id-mint for non-secure contexts, narrowed SDK types, extracted+tested the AC1/AC2 logic, comment fixes). Local `/ci`: 30/31 gates green; the lone failure is `@atlas/mcp/smoke.test.ts` on `relation "prompt_items" does not exist` — a local-DB-not-migrated env issue (#1472), impossible for this web-only diff to cause, and run against a migrated Postgres in GitHub CI.
