### PR TITLE
feat(dashboards): canvas-mount draft render for never-run tiles (#4557)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/mount-render.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/mount-render.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure-helper coverage for the canvas-mount draft render (#4557) — the run/skip
+ * policy gate, the never-run selection, the ok/err phase mapping, and the
+ * bounded fan-out that keeps a wide board from stampeding the datasource.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  MOUNT_RENDER_CONCURRENCY,
+  flipLoadingToError,
+  mountRenderPhaseFor,
+  runBounded,
+  selectMountRenderCards,
+  shouldRunMountRender,
+} from "../mount-render";
+import type { CardRenderEntry } from "../dashboard-card-render";
+import type { DashboardCard } from "@/ui/lib/types";
+
+function card(overrides: Partial<DashboardCard> & { id: string }): DashboardCard {
+  return {
+    dashboardId: "dash-1",
+    position: 0,
+    title: overrides.id,
+    kind: "chart",
+    sql: "SELECT 1",
+    chartConfig: null,
+    content: null,
+    annotations: [],
+    cachedColumns: null,
+    cachedRows: null,
+    cachedAt: null,
+    connectionGroupId: null,
+    layout: null,
+    createdAt: "2026-07-17T00:00:00.000Z",
+    updatedAt: "2026-07-17T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("shouldRunMountRender (#4557)", () => {
+  const base = { showDraftView: true, hasDashboard: true, overridesActive: false };
+
+  test("runs when the draft view is shown, the board is loaded, and no overrides are active", () => {
+    expect(shouldRunMountRender(base)).toBe(true);
+  });
+
+  test("does NOT run on a published-only view (AC: published-only unaffected)", () => {
+    expect(shouldRunMountRender({ ...base, showDraftView: false })).toBe(false);
+  });
+
+  test("does NOT run before the board has loaded", () => {
+    expect(shouldRunMountRender({ ...base, hasDashboard: false })).toBe(false);
+  });
+
+  test("does NOT run when parameter overrides are active (the bar batch renders every card)", () => {
+    expect(shouldRunMountRender({ ...base, overridesActive: true })).toBe(false);
+  });
+});
+
+describe("mountRenderPhaseFor (#4557)", () => {
+  test("a successful render maps to the `ok` phase", () => {
+    const entry: CardRenderEntry = { cardId: "a", ok: true, columns: ["x"], rows: [{ x: 1 }] };
+    expect(mountRenderPhaseFor(entry)).toBe("ok");
+  });
+
+  test("a failed render maps to the `error` phase (→ errored tile + retry, no silent blank)", () => {
+    const entry: CardRenderEntry = { cardId: "a", ok: false, error: "boom" };
+    expect(mountRenderPhaseFor(entry)).toBe("error");
+  });
+});
+
+describe("flipLoadingToError (#4557)", () => {
+  test("flips only the still-loading ids to error", () => {
+    const phases = { a: "loading", b: "ok", c: "loading" } as const;
+    expect(flipLoadingToError(phases, ["a", "b", "c"])).toEqual({ a: "error", b: "ok", c: "error" });
+  });
+
+  test("leaves already-settled ids untouched and returns a fresh object", () => {
+    const phases = { a: "ok", b: "error" } as const;
+    const out = flipLoadingToError(phases, ["a", "b"]);
+    expect(out).toEqual({ a: "ok", b: "error" });
+    expect(out).not.toBe(phases);
+  });
+
+  test("ignores ids absent from the phase map", () => {
+    expect(flipLoadingToError({ a: "loading" }, ["missing"])).toEqual({ a: "loading" });
+  });
+});
+
+describe("selectMountRenderCards (#4557)", () => {
+  test("selects a never-run chart card (no cache, not yet attempted)", () => {
+    const cards = [card({ id: "a", cachedAt: null })];
+    expect(selectMountRenderCards(cards, new Set()).map((c) => c.id)).toEqual(["a"]);
+  });
+
+  test("selects a card with an undefined cachedAt (loose `== null` catches both null and undefined)", () => {
+    // `cachedAt` is `string | null` on the wire, but the loose null-check is
+    // deliberate — a future `=== null` "cleanup" would wrongly skip this card.
+    const cards = [card({ id: "a", cachedAt: undefined as unknown as null })];
+    expect(selectMountRenderCards(cards, new Set()).map((c) => c.id)).toEqual(["a"]);
+  });
+
+  test("excludes an already-seeded card (cachedAt set) — does not re-execute on mount", () => {
+    const cards = [card({ id: "seeded", cachedAt: "2026-07-17T00:00:00.000Z" })];
+    expect(selectMountRenderCards(cards, new Set())).toEqual([]);
+  });
+
+  test("excludes a text/section card — it has no SQL to render", () => {
+    const cards = [card({ id: "note", kind: "text", sql: "", content: "# hi", cachedAt: null })];
+    expect(selectMountRenderCards(cards, new Set())).toEqual([]);
+  });
+
+  test("excludes a card already attempted this session — no auto-retry loop", () => {
+    const cards = [card({ id: "a", cachedAt: null })];
+    expect(selectMountRenderCards(cards, new Set(["a"]))).toEqual([]);
+  });
+
+  test("selects only the never-run subset of a mixed board", () => {
+    const cards = [
+      card({ id: "seeded", cachedAt: "2026-07-17T00:00:00.000Z" }),
+      card({ id: "never-run-1", cachedAt: null }),
+      card({ id: "note", kind: "text", sql: "", content: "x", cachedAt: null }),
+      card({ id: "never-run-2", cachedAt: null }),
+      card({ id: "attempted", cachedAt: null }),
+    ];
+    expect(selectMountRenderCards(cards, new Set(["attempted"])).map((c) => c.id)).toEqual([
+      "never-run-1",
+      "never-run-2",
+    ]);
+  });
+});
+
+describe("runBounded (#4557)", () => {
+  test("runs every item", async () => {
+    const seen: number[] = [];
+    await runBounded([1, 2, 3, 4, 5], 2, async (n) => {
+      seen.push(n);
+    });
+    expect(seen.toSorted((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("never exceeds the concurrency limit", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+    await runBounded(items, 4, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+    });
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(1); // actually overlapped, not serialized
+  });
+
+  test("clamps a limit below 1 to a single worker", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runBounded([1, 2, 3], 0, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 3));
+      inFlight -= 1;
+    });
+    expect(peak).toBe(1);
+  });
+
+  test("handles an empty list without spawning a worker", async () => {
+    let calls = 0;
+    await runBounded([], MOUNT_RENDER_CONCURRENCY, async () => {
+      calls += 1;
+    });
+    expect(calls).toBe(0);
+  });
+
+  test("propagates a rejecting task rather than swallowing it", () => {
+    return expect(
+      runBounded([1], 1, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/mount-render.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/mount-render.ts
@@ -1,0 +1,131 @@
+/**
+ * Canvas-mount draft render (#4557, ADR-0034 Decision 1) — the lazy half of the
+ * seeding decision.
+ *
+ * Tool-side seeding (#4558) executes each staged card inside the `createDashboard`
+ * / bound `addCard` call and writes the draft cache, so a chat-built board
+ * arrives showing real data. But a card can be left UNSEEDED — the seeding
+ * wall-clock budget elapsed, a transient execution failure, or a legacy draft
+ * built before seeding existed. Those cards land on the canvas as "Never run"
+ * tiles with no data home.
+ *
+ * This module is the fallback: when the draft holder's canvas mounts, any
+ * never-run draft card fires its OWN draft render, so arrival after an agent
+ * build shows data (or an honest per-tile errored / empty state) rather than a
+ * wall of "Never run". Kept pure + framework-free so the two load-bearing
+ * decisions — WHICH cards to render, and the bounded concurrency that keeps a
+ * wide board from firing a dozen simultaneous renders at the datasource — are
+ * unit-testable without mounting the page. The page's effect is a thin wrapper
+ * that feeds `renderDashboardCard` through `runBounded`.
+ */
+import type { DashboardCard } from "@/ui/lib/types";
+import type { CardRenderEntry } from "./dashboard-card-render";
+import { isRenderableCard } from "./dashboard-card-render";
+import type { TileRenderPhase } from "@/ui/components/dashboards/tile-status";
+
+/**
+ * How many mount renders run at once. A never-run board arrives with every tile
+ * unseeded (the whole tool-side batch missed its budget), so an unbounded
+ * `Promise.all` would fan a dozen concurrent queries at the datasource on mount.
+ * Four keeps the canvas populating promptly without a thundering herd — well
+ * under a typical connection pool while still overlapping the round-trips.
+ */
+export const MOUNT_RENDER_CONCURRENCY = 4;
+
+/**
+ * Select the never-run cards that need a canvas-mount draft render. A card
+ * qualifies when it is SQL-backed (renderable — not a `text` section block,
+ * which has no query) AND has never produced data (`cachedAt == null`, i.e. no
+ * draft cache yet). `attempted` excludes cards this session already fired a
+ * mount render for — so:
+ *
+ *   - a dashboard refetch (draft status settling, a sibling mutation, an agent
+ *     adding a card mid-session) never re-executes an in-flight card, and
+ *   - a mount render that FAILED is not auto-retried into a loop — its tile
+ *     reads `errored` with a one-click manual retry instead.
+ *
+ * Already-seeded tiles (`cachedAt != null`) are never selected, so they do not
+ * re-execute on mount.
+ */
+export function selectMountRenderCards(
+  cards: readonly DashboardCard[],
+  attempted: ReadonlySet<string>,
+): DashboardCard[] {
+  return cards.filter(
+    (card) => isRenderableCard(card) && card.cachedAt == null && !attempted.has(card.id),
+  );
+}
+
+/**
+ * Whether the canvas-mount draft render should run this pass. The POLICY gate,
+ * separate from the data-readiness check (`dashboard` loaded) the caller keeps:
+ *
+ *   - `showDraftView` — only the draft holder's draft view fires mount renders;
+ *     a published-only view is untouched (AC: "Published-only views are
+ *     unaffected").
+ *   - `!overridesActive` — when parameter overrides are active in the URL, the
+ *     parameter bar's mount batch already renders every card (never-run ones
+ *     included), so firing here too would double-execute.
+ *   - `hasDashboard` — nothing to render until the board has loaded.
+ */
+export function shouldRunMountRender(input: {
+  showDraftView: boolean;
+  hasDashboard: boolean;
+  overridesActive: boolean;
+}): boolean {
+  return input.showDraftView && input.hasDashboard && !input.overridesActive;
+}
+
+/**
+ * Map a settled card-render entry to the tile's render phase. A success reads
+ * `ok` (the tile flips to fresh / empty from its freshly overlaid rows); a
+ * failure reads `error` — which, on a never-run card with no prior data,
+ * resolves to the tile's `errored` state with the existing one-click retry, so a
+ * failed mount render is never a silent blank (AC: "A failed mount-render shows
+ * the tile's errored state with one-click retry").
+ */
+export function mountRenderPhaseFor(entry: CardRenderEntry): TileRenderPhase {
+  return entry.ok ? "ok" : "error";
+}
+
+/**
+ * Flip every still-`loading` tile in `ids` to `error` (immutable copy). The
+ * defensive path for a rejection escaping the contractually-no-throw render
+ * helper: rather than stranding those tiles on the loading placeholder forever,
+ * they read `errored` + retry. Tiles that already settled (`ok` / `error`) are
+ * left untouched.
+ */
+export function flipLoadingToError(
+  phases: Readonly<Record<string, TileRenderPhase>>,
+  ids: readonly string[],
+): Record<string, TileRenderPhase> {
+  const next = { ...phases };
+  for (const id of ids) {
+    if (next[id] === "loading") next[id] = "error";
+  }
+  return next;
+}
+
+/**
+ * Run `task` over `items` with at most `limit` in flight at once. Resolves once
+ * every task settles. `task` is expected to be no-throw (the render helper maps
+ * every failure to a result it handles itself); a rejection propagates rather
+ * than being swallowed, so a caller can log it.
+ */
+export async function runBounded<T>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  const max = Math.max(1, Math.floor(limit));
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      await task(items[index]);
+    }
+  }
+  const workerCount = Math.min(max, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -41,6 +41,14 @@ import {
 } from "./search-params";
 import { activeFilters, incompatibleCardIds } from "./cross-filter";
 import { renderDashboardCard, renderDashboardCards, isRenderableCard } from "./dashboard-card-render";
+import {
+  MOUNT_RENDER_CONCURRENCY,
+  flipLoadingToError,
+  mountRenderPhaseFor,
+  runBounded,
+  selectMountRenderCards,
+  shouldRunMountRender,
+} from "./mount-render";
 import { foldRenderEntries, mergeOverlays, phaseTag, type TileOverlay } from "./tile-phases";
 import type { TileRenderPhase } from "@/ui/components/dashboards/tile-status";
 import { pendingRefreshesRemaining } from "@/ui/components/dashboards/tile-status";
@@ -1116,6 +1124,91 @@ export default function DashboardViewPage() {
   const dparamsActive = (dashboard?.parameters.length ?? 0) > 0 && Boolean(searchParams.get("dparams"));
   const exportReady =
     !loading && !error && Boolean(dashboard) && !paramLoading && (!dparamsActive || paramSettledOnce);
+
+  // #4557 — canvas-mount draft render (ADR-0034 Decision 1, the lazy half of the
+  // seeding decision). Cards this session already fired a mount render for,
+  // keyed by dashboard id so switching boards resets the set. A ref (not state)
+  // — mutating it must not re-render, and the effect below reads its latest
+  // value synchronously.
+  const mountRenderState = useRef<{ dashboardId: string; attempted: Set<string> }>({
+    dashboardId: id,
+    attempted: new Set<string>(),
+  });
+
+  // #4557 — when the draft holder's canvas shows the draft view, any never-run
+  // draft card (unseeded by tool-side seeding #4558 — budget hit, transient
+  // failure, or a legacy draft) fires its OWN draft render, so arrival after an
+  // agent build shows data (or an honest errored/empty tile) rather than a wall
+  // of "Never run". Bounded concurrency (no datasource stampede); a failed
+  // render lands in the tile's `errored` state with the existing one-click retry
+  // (`handleRetryCard`), never a page banner. Gated on `showDraftView`, so a
+  // published-only view is untouched. Skipped when active parameter overrides
+  // are in the URL — the parameter bar's mount batch already renders every card
+  // (including the never-run ones), so firing here too would double-execute.
+  const overridesActive = Object.keys(overrides).length > 0;
+  useEffect(() => {
+    if (!shouldRunMountRender({ showDraftView, hasDashboard: !!dashboard, overridesActive })) return;
+    if (!dashboard) return; // narrowing — guaranteed by hasDashboard above
+    // Reset the attempted set when we've switched to a different board.
+    if (mountRenderState.current.dashboardId !== dashboard.id) {
+      mountRenderState.current = { dashboardId: dashboard.id, attempted: new Set<string>() };
+    }
+    const attempted = mountRenderState.current.attempted;
+    const targets = selectMountRenderCards(dashboard.cards, attempted);
+    if (targets.length === 0) return;
+
+    // Mark every target attempted up front so a refetch mid-flight can't re-fire
+    // an in-flight card, and a failed render isn't auto-retried into a loop.
+    for (const card of targets) attempted.add(card.id);
+    // Share the parameter batch's sequence guard: if a parameter change / clear
+    // lands while these renders are in flight, discard the results rather than
+    // overlaying a superseded window.
+    const seq = paramReqSeq.current;
+    const currentOverrides = parseOverrides(dparamsRaw);
+
+    setRenderPhases((prev) => {
+      const next = { ...prev };
+      for (const card of targets) next[card.id] = "loading";
+      return next;
+    });
+
+    void runBounded(targets, MOUNT_RENDER_CONCURRENCY, async (card) => {
+      const entry = await renderDashboardCard(card, currentOverrides, {
+        apiUrl,
+        dashboardId: id,
+        isCrossOrigin,
+        view: "draft",
+      });
+      if (seq !== paramReqSeq.current) return;
+      // ok → the tile flips fresh/empty from the overlaid rows; error → a
+      // never-run card with no prior data reads `errored` (+ one-click retry),
+      // never a silent blank. The mapping is the pure `mountRenderPhaseFor`.
+      if (entry.ok) {
+        const renderedAt = new Date().toISOString();
+        setParamResults((prev) => ({
+          ...prev,
+          [card.id]: { columns: entry.columns, rows: entry.rows, renderedAt },
+        }));
+        if (entry.comparison !== undefined) {
+          setComparisons((prev) => ({ ...prev, [card.id]: entry.comparison ?? null }));
+        }
+      }
+      setRenderPhases((prev) => ({ ...prev, [card.id]: mountRenderPhaseFor(entry) }));
+    }).catch((err) => {
+      // `renderDashboardCard` is contractually no-throw, so this is defensive.
+      // Never swallow: log and flip the in-flight tiles to `error` (→ errored +
+      // retry) rather than stranding them on the loading placeholder.
+      console.debug("[dashboard] mount draft render failed", {
+        dashboardId: id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      setRenderPhases((prev) => flipLoadingToError(prev, targets.map((card) => card.id)));
+    });
+    // Re-runs on dashboard refetch (new never-run cards) and on entering the
+    // draft view; the attempted set makes each fire at most once. apiUrl / id /
+    // isCrossOrigin / dparamsRaw are read at fire time and must not re-trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dashboard, showDraftView, overridesActive]);
 
   return (
     <StageProvider value={{ dashboardId: id, onStagesChanged: handleStagesChanged }}>


### PR DESCRIPTION
## Summary

The lazy half of the seeding decision ([ADR-0034](docs/adr/0034-dashboard-draft-cache-single-edit-mechanism.md) Decision 1), building on the draft cache (#4554) and tool-side seeding (#4558) already on `main`.

Any draft card left **unseeded** by tool-side seeding — the seeding wall-clock budget elapsed, a transient execution failure, or a legacy draft built before seeding existed — auto-fires a **draft render when the draft holder's canvas mounts**. So arrival after an agent build shows data (or an honest per-tile errored / empty state) instead of a wall of "Never run".

- **`mount-render.ts`** (new, pure, unit-tested):
  - `selectMountRenderCards` — never-run (`cachedAt == null`), renderable (not `text`), not-yet-attempted this session.
  - `shouldRunMountRender` — the policy gate (draft view shown, board loaded, no active param overrides).
  - `mountRenderPhaseFor` / `flipLoadingToError` — the ok→`ok` / err→`error` phase mapping (AC "no silent blank") and the defensive loading→error flip.
  - `runBounded` — bounded concurrency (limit 4), so a wide never-run board doesn't stampede the datasource.
- **`page.tsx`** effect wires these: fires for never-run draft cards while showing the draft view; success overlays fresh rows (tile → fresh/empty), failure sets the tile's `errored` state with the **existing one-click retry** (`handleRetryCard`) — never a page banner. Reuses the existing `paramReqSeq` sequence guard so a concurrent parameter change discards superseded results. Skipped when parameter overrides are active (the parameter bar's mount batch already renders every card).

## Scoping notes
- Gated on the existing `showDraftView` (editing/chat-open, incl. the `?openChat=true` arrival), so **published-only views are unaffected**. When the sibling "render the draft whenever `hasDraft`" work (#4556) broadens that condition, this mount render rides along automatically. Kept tight to the canvas-mount/draft-render path; integrates cleanly with #4567's per-tile refresh / stable-suggestion / surgical-invalidation work already on `main`.

## Acceptance criteria
- [x] Never-run draft tiles trigger a draft render on canvas mount for the draft holder
- [x] A failed mount-render shows the tile's errored state with one-click retry; no silent blank
- [x] Already-seeded tiles do not re-execute on mount
- [x] Published-only views are unaffected

## Test plan
- [x] `mount-render.test.ts` — 20 unit tests: selection (never-run / seeded / text / attempted / mixed / undefined cache), run/skip policy gate (published-only, pre-load, overrides-active), phase mapping, loading→error flip, bounded concurrency (peak≤limit, real overlap, clamp<1, empty, rejection-propagation).
- [x] `bun run type` (web) + `oxlint` clean.
- [x] `scripts/ci-local.sh`: 30/30 gates green. The lone `test` gate flags `@atlas/mcp` `smoke.test.ts` — the documented local-env case (needs a migrated internal DB, #1472); `packages/mcp` is byte-identical to `main`, so GitHub `api-tests` shards run it green against a real Postgres.

Closes #4557