### PR TITLE
feat(dashboards): canvas renders the caller's draft whenever they have one (#4556)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/draft-view.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/draft-view.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Canvas draft-view decision (#4556). Pins the pinned Canvas contract: the canvas
+ * renders the caller's draft whenever they HAVE one, the published state
+ * otherwise — driven off the caller's actual draft status, not just an open
+ * editor/drawer. The regression this locks: arriving at a never-published,
+ * agent-built board via bookmark/switcher (View mode, no editor) used to fetch
+ * the empty published copy while the banner announced a draft — the two
+ * contradicting each other on one screen.
+ */
+import { describe, expect, test } from "bun:test";
+import { resolveShowDraftView } from "../draft-view";
+
+describe("resolveShowDraftView (#4556)", () => {
+  test("bookmark arrival at a board with a draft renders the draft (View mode, no editor)", () => {
+    // The core case: the returning viewer has a draft but nothing is open. The
+    // canvas must show the draft's cards, matching the "Draft" banner.
+    expect(
+      resolveShowDraftView({ editing: false, chatOpen: false, hasDraft: true }),
+    ).toBe(true);
+  });
+
+  test("a caller with no draft sees published, unchanged", () => {
+    expect(
+      resolveShowDraftView({ editing: false, chatOpen: false, hasDraft: false }),
+    ).toBe(false);
+  });
+
+  test("draft status still in flight shows published (no draft yet) until it resolves", () => {
+    // First paint before the async status fetch lands: treat undefined as "no
+    // draft yet" so we don't flash a draft view for a caller who has none.
+    expect(
+      resolveShowDraftView({ editing: false, chatOpen: false, hasDraft: undefined }),
+    ).toBe(false);
+  });
+
+  test("editing shows the draft even before the status fetch lands", () => {
+    // The inline editor edits the draft; it must show it immediately, without
+    // waiting on the status round-trip.
+    expect(
+      resolveShowDraftView({ editing: true, chatOpen: false, hasDraft: undefined }),
+    ).toBe(true);
+  });
+
+  test("open chat drawer shows the draft even before the status fetch lands", () => {
+    // A fresh createDashboard handoff: cards were just staged into the draft
+    // while the published view is still empty, so the drawer must show the draft.
+    expect(
+      resolveShowDraftView({ editing: false, chatOpen: true, hasDraft: undefined }),
+    ).toBe(true);
+  });
+
+  test("the banner and the canvas can never disagree: both read the same hasDraft", () => {
+    // The banner shows "Draft" iff hasDraft; the canvas shows the draft iff this
+    // returns true. For a passive viewer (no editor/drawer) the two are exactly
+    // the same boolean, so they cannot contradict each other.
+    for (const hasDraft of [true, false]) {
+      const bannerSaysDraft = hasDraft;
+      const canvasShowsDraft = resolveShowDraftView({
+        editing: false,
+        chatOpen: false,
+        hasDraft,
+      });
+      expect(canvasShowsDraft).toBe(bannerSaysDraft);
+    }
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/draft-view.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/draft-view.test.ts
@@ -1,5 +1,5 @@
 /**
- * Canvas draft-view decision (#4556). Pins the pinned Canvas contract: the canvas
+ * Canvas draft-view decision (#4556). Pins the Canvas contract: the canvas
  * renders the caller's draft whenever they HAVE one, the published state
  * otherwise — driven off the caller's actual draft status, not just an open
  * editor/drawer. The regression this locks: arriving at a never-published,

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/draft-view.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/draft-view.test.ts
@@ -49,6 +49,20 @@ describe("resolveShowDraftView (#4556)", () => {
     ).toBe(true);
   });
 
+  test("editing keeps showing the draft even once status resolves to no-draft", () => {
+    // Opening the editor forks a draft server-side; the canvas must show it even
+    // in the window where the status still reports hasDraft: false.
+    expect(
+      resolveShowDraftView({ editing: true, chatOpen: false, hasDraft: false }),
+    ).toBe(true);
+  });
+
+  test("open chat drawer keeps showing the draft even once status resolves to no-draft", () => {
+    expect(
+      resolveShowDraftView({ editing: false, chatOpen: true, hasDraft: false }),
+    ).toBe(true);
+  });
+
   test("the banner and the canvas can never disagree: both read the same hasDraft", () => {
     // The banner shows "Draft" iff hasDraft; the canvas shows the draft iff this
     // returns true. For a passive viewer (no editor/drawer) the two are exactly

--- a/packages/web/src/app/(workspace)/dashboards/[id]/draft-view.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/draft-view.ts
@@ -1,0 +1,38 @@
+/**
+ * Canvas draft-view decision (#4556, ADR-0034 / CONTEXT.md § Dashboard editing).
+ *
+ * The pinned Canvas contract: the canvas renders the caller's DRAFT whenever they
+ * have one, the published state otherwise. This is the single, pure statement of
+ * that rule — the page keys its dashboard fetch (`?view=draft` vs. published) off
+ * it, and the draft-status banner reads the SAME `hasDraft`, so the two can never
+ * disagree (the bug this fixed: a returning viewer of a never-published,
+ * agent-built board saw an empty published copy underneath a "Draft — unpublished
+ * changes" banner — two elements contradicting each other on one screen).
+ *
+ * `editing` and `chatOpen` remain in the OR because both edit the draft and must
+ * show it even in the brief window before the async draft-status fetch lands —
+ * e.g. a fresh `createDashboard` handoff whose cards were just staged into the
+ * draft while the published view is still empty.
+ */
+export interface DraftViewInputs {
+  /** The board is open in the inline editor. */
+  readonly editing: boolean;
+  /** The bound chat drawer is open (every edit lands in the draft). */
+  readonly chatOpen: boolean;
+  /**
+   * The caller has a draft for this board. Undefined while the lightweight
+   * `GET /:id/draft/status` presence check is still in flight — treated as "no
+   * draft yet" so first paint shows published, then flips to draft the moment
+   * the status resolves (the URL is the fetch cache key, so the view re-fetches).
+   */
+  readonly hasDraft: boolean | undefined;
+}
+
+/**
+ * Whether the canvas should render the caller's draft view rather than the
+ * published view. Drives both the dashboard fetch's `view=draft` cache key and
+ * (via the same `hasDraft`) the draft-status banner, so they stay in lockstep.
+ */
+export function resolveShowDraftView({ editing, chatOpen, hasDraft }: DraftViewInputs): boolean {
+  return editing || chatOpen || hasDraft === true;
+}

--- a/packages/web/src/app/(workspace)/dashboards/[id]/draft-view.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/draft-view.ts
@@ -6,8 +6,9 @@
  * that rule — the page keys its dashboard fetch (`?view=draft` vs. published) off
  * it, and the draft-status banner reads the SAME `hasDraft`, so the two can never
  * disagree (the bug this fixed: a returning viewer of a never-published,
- * agent-built board saw an empty published copy underneath a "Draft — unpublished
- * changes" banner — two elements contradicting each other on one screen).
+ * agent-built board saw an empty published copy while the draft-status banner
+ * announced unpublished changes — two elements contradicting each other on one
+ * screen).
  *
  * `editing` and `chatOpen` remain in the OR because both edit the draft and must
  * show it even in the brief window before the async draft-status fetch lands —

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -156,19 +156,12 @@ export default function DashboardViewPage() {
   } = useAdminFetch<DraftStatusResponse>(`/api/v1/dashboards/${id}/draft/status`);
   useVisibilityGatedPoll(refetchDraftStatus, DRAFT_STATUS_POLL_MS);
 
-  // #4315 / #4322 / #4556 — the canvas renders the caller's DRAFT whenever they
-  // have one, the published state otherwise. The switch is driven off the caller's
-  // actual draft status (`hasDraft`), NOT just an open editor/drawer: a user
-  // returning to a never-published agent-built board via bookmark/switcher (no
-  // editor open, View mode) must see the draft's cards, not an empty published
-  // copy underneath a "Draft — unpublished changes" banner. Driving both the
-  // banner and the canvas off the same `hasDraft` means they can never disagree.
-  // `editing` / `chatOpen` stay in the OR because both edit the draft and must
-  // show it even in the brief window before the status fetch lands (e.g. a fresh
-  // `createDashboard` handoff whose cards were just staged into the draft). The
-  // URL is the fetch cache key, so the view re-fetches the moment `hasDraft`
-  // resolves; the server overlays the draft only when one exists (non-forking),
-  // so a viewer or a board with no draft still gets published — this never leaks.
+  // #4556 — the canvas renders the caller's DRAFT whenever they HAVE one (keyed
+  // off `hasDraft`, not just an open editor/drawer), published otherwise. Contract
+  // + the returning-viewer regression it fixes live in `draft-view.ts`. Call-site
+  // specifics: the URL is the fetch cache key below, so the view re-fetches the
+  // moment `hasDraft` resolves; the server overlays the draft only when one exists
+  // (non-forking), so a viewer or a draftless board still gets published — no leak.
   const showDraftView = resolveShowDraftView({ editing, chatOpen, hasDraft: draftStatus?.hasDraft });
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(
     showDraftView ? `/api/v1/dashboards/${id}?view=draft` : `/api/v1/dashboards/${id}`,
@@ -208,10 +201,6 @@ export default function DashboardViewPage() {
   // parameter / mutation errors below.
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
-  // #2363 — bound chat drawer state (`chatOpen` / `resumeConversationId`)
-  // and #2521 draft state (`draftStatus` / `refetchDraftStatus`) are declared
-  // above, before the dashboard fetch, so #4322's + #4556's draft-view switch
-  // can key off the drawer being open and the caller's draft status.
 
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const [publishModalOpen, setPublishModalOpen] = useState(false);
@@ -378,9 +367,11 @@ export default function DashboardViewPage() {
     // #4567 — add THIS card to the in-flight set (never replace it), so a second
     // concurrent refresh doesn't clobber the first tile's spinner.
     setRefreshingCardIds((prev) => withRefreshing(prev, cardId));
-    // #4315 — while editing, a single-card refresh runs the DRAFT SQL (server
-    // returns fresh rows without persisting to the published cache).
-    const viewSuffix = editing ? "?view=draft" : "";
+    // #4315 / #4556 — a single-card refresh runs against the SAME view the canvas
+    // shows (`showDraftView`: the draft whenever the caller has one, published
+    // otherwise), so a refreshed tile can't disagree with the board around it. The
+    // server returns fresh rows without persisting to the published cache.
+    const viewSuffix = showDraftView ? "?view=draft" : "";
     try {
       await mutate({ path: `/api/v1/dashboards/${id}/cards/${cardId}/refresh${viewSuffix}`, method: "POST" });
     } finally {
@@ -489,8 +480,10 @@ export default function DashboardViewPage() {
     }
 
     try {
-      // #4315 — export the DRAFT card's data while editing (runs the draft SQL).
-      const viewParam = editing ? "&view=draft" : "";
+      // #4315 / #4556 — export the data for the view the canvas shows
+      // (`showDraftView`: draft when the caller has one, published otherwise), so
+      // the CSV matches the tile the user is looking at.
+      const viewParam = showDraftView ? "&view=draft" : "";
       const res = await fetch(
         `${apiUrl}/api/v1/dashboards/${id}/cards/${card.id}/render?format=csv${viewParam}`,
         {
@@ -924,8 +917,10 @@ export default function DashboardViewPage() {
         apiUrl,
         dashboardId: id,
         isCrossOrigin,
-        // #4315 — the canvas shows the draft while editing; render its SQL.
-        view: editing ? "draft" : "published",
+        // #4315 / #4556 — render the SAME view the canvas shows (`showDraftView`:
+        // draft whenever the caller has one, published otherwise) so parameter
+        // overlays land on the same card set the tiles display.
+        view: showDraftView ? "draft" : "published",
       });
       // A newer change superseded this batch — discard its results.
       if (seq !== paramReqSeq.current) return;
@@ -990,7 +985,9 @@ export default function DashboardViewPage() {
         apiUrl,
         dashboardId: id,
         isCrossOrigin,
-        view: editing ? "draft" : "published",
+        // #4315 / #4556 — retry re-renders the visible tile, so it must use the
+        // same view the canvas shows (`showDraftView`).
+        view: showDraftView ? "draft" : "published",
       });
       if (seq !== paramReqSeq.current) return;
       if (entry.ok) {
@@ -1072,8 +1069,10 @@ export default function DashboardViewPage() {
       setComparisons({});
       return;
     }
-    // #4315 — while editing, the KPI comparison runs the draft card's SQL too.
-    const viewParam = editing ? "?view=draft" : "";
+    // #4315 / #4556 — the KPI comparison runs against the view the canvas shows
+    // (`showDraftView`: draft whenever the caller has one), so the delta chip
+    // matches the draft tile's primary value rather than the published copy's.
+    const viewParam = showDraftView ? "?view=draft" : "";
     const entries = await Promise.all(
       kpiCards.map(async (card): Promise<[string, KpiComparisonResult | null]> => {
         try {

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
   normalizeDrilldownValue,
 } from "./search-params";
 import { activeFilters, incompatibleCardIds } from "./cross-filter";
+import { resolveShowDraftView } from "./draft-view";
 import { renderDashboardCard, renderDashboardCards, isRenderableCard } from "./dashboard-card-render";
 import {
   MOUNT_RENDER_CONCURRENCY,
@@ -144,12 +145,31 @@ export default function DashboardViewPage() {
   // when the drawer is opened from "Edit with chat" (a fresh session).
   const [resumeConversationId, setResumeConversationId] = useState<string | null>(null);
 
-  // #4322 — the bound chat drawer edits the DRAFT (every `addCard` lands
-  // there, per #4315), so while it's open the canvas must show the draft too:
-  // that's what makes cards materialize live during a build AND why a
-  // dashboard is non-empty on arrival from `createDashboard` (its cards were
-  // staged into the draft, and the published view is still empty).
-  const showDraftView = editing || chatOpen;
+  // #2521 — draft state. Fetched up here (before the dashboard fetch) so #4556's
+  // draft-view switch can key off the caller's actual draft status. `useAdminFetch`
+  // also powers the badge + baseline-drift detection; we poll on window focus + a
+  // 30s tick so a teammate's publish surfaces quickly without blowing the request
+  // budget.
+  const {
+    data: draftStatus,
+    refetch: refetchDraftStatus,
+  } = useAdminFetch<DraftStatusResponse>(`/api/v1/dashboards/${id}/draft/status`);
+  useVisibilityGatedPoll(refetchDraftStatus, DRAFT_STATUS_POLL_MS);
+
+  // #4315 / #4322 / #4556 — the canvas renders the caller's DRAFT whenever they
+  // have one, the published state otherwise. The switch is driven off the caller's
+  // actual draft status (`hasDraft`), NOT just an open editor/drawer: a user
+  // returning to a never-published agent-built board via bookmark/switcher (no
+  // editor open, View mode) must see the draft's cards, not an empty published
+  // copy underneath a "Draft — unpublished changes" banner. Driving both the
+  // banner and the canvas off the same `hasDraft` means they can never disagree.
+  // `editing` / `chatOpen` stay in the OR because both edit the draft and must
+  // show it even in the brief window before the status fetch lands (e.g. a fresh
+  // `createDashboard` handoff whose cards were just staged into the draft). The
+  // URL is the fetch cache key, so the view re-fetches the moment `hasDraft`
+  // resolves; the server overlays the draft only when one exists (non-forking),
+  // so a viewer or a board with no draft still gets published — this never leaks.
+  const showDraftView = resolveShowDraftView({ editing, chatOpen, hasDraft: draftStatus?.hasDraft });
   const { data: dashboard, loading, error, refetch } = useAdminFetch<DashboardWithCards>(
     showDraftView ? `/api/v1/dashboards/${id}?view=draft` : `/api/v1/dashboards/${id}`,
   );
@@ -188,18 +208,10 @@ export default function DashboardViewPage() {
   // parameter / mutation errors below.
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
-  // #2363 — bound chat drawer state (`chatOpen` / `resumeConversationId`
-  // declared above, before the dashboard fetch, so #4322's draft-view switch
-  // can key off the drawer being open).
-
-  // #2521 — draft state. `useAdminFetch` powers the badge + baseline-drift
-  // detection; we poll on window focus + a 30s tick so a teammate's
-  // publish surfaces quickly without blowing the request budget.
-  const {
-    data: draftStatus,
-    refetch: refetchDraftStatus,
-  } = useAdminFetch<DraftStatusResponse>(`/api/v1/dashboards/${id}/draft/status`);
-  useVisibilityGatedPoll(refetchDraftStatus, DRAFT_STATUS_POLL_MS);
+  // #2363 — bound chat drawer state (`chatOpen` / `resumeConversationId`)
+  // and #2521 draft state (`draftStatus` / `refetchDraftStatus`) are declared
+  // above, before the dashboard fetch, so #4322's + #4556's draft-view switch
+  // can key off the drawer being open and the caller's draft status.
 
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const [publishModalOpen, setPublishModalOpen] = useState(false);

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -382,10 +382,14 @@ export default function DashboardViewPage() {
 
   async function handleRefreshAll() {
     setRefreshingAll(true);
-    // #4559 — while editing, Refresh-all runs the DRAFT cards' SQL and writes
-    // the caller's private draft cache; the published cards' cached data is
-    // left untouched (mirrors the single-card draft refresh above).
-    const viewSuffix = editing ? "?view=draft" : "";
+    // #4559 / #4556 — Refresh-all runs against the SAME view the canvas shows
+    // (`showDraftView`: the draft whenever the caller has one, published
+    // otherwise). In the draft view it runs the draft cards' SQL and writes the
+    // caller's private draft cache, leaving the published cards' cached data
+    // untouched (mirrors the single-card draft refresh above). #4559 made the
+    // endpoint draft-aware; #4556 widens the trigger from `editing` to
+    // `showDraftView` so a passive draft viewer's bulk refresh lands too.
+    const viewSuffix = showDraftView ? "?view=draft" : "";
     await mutate({ path: `/api/v1/dashboards/${id}/refresh${viewSuffix}`, method: "POST" });
     setRefreshingAll(false);
   }


### PR DESCRIPTION
## Summary

Conform the canvas to the pinned Canvas contract (`CONTEXT.md` § Dashboard editing / ADR-0034): it renders the caller's **draft whenever they HAVE one**, the published state otherwise. Previously the draft view was gated on editing/chat-open, so a user returning to a never-published, agent-built board via bookmark/switcher (View mode, no editor) saw the empty **published** copy underneath a "Draft" banner announcing unpublished changes — two elements contradicting each other on one screen.

- **Drive the draft-view switch off the caller's actual draft status** (`hasDraft`), extracted into a pure, unit-tested `resolveShowDraftView` helper (`draft-view.ts`). `editing` / `chatOpen` stay in the OR so a fresh `createDashboard` handoff still shows the draft before the status fetch lands.
- **Move the draft/status fetch above the dashboard fetch** so its `hasDraft` can key the `view=draft` cache key. The draft-status banner reads the **same** `hasDraft`, so banner and canvas can never disagree.
- **#4557's canvas-mount draft render rides along automatically** (gated on `showDraftView`), so never-run draft cards render on bookmark arrival too.
- **All seven card-data view selections now key off the one `showDraftView` contract** (single-card refresh, CSV export, parameter-batch render, retry render, KPI comparison, dashboard fetch, and bulk Refresh-all) — so per-card data can never disagree with the canvas around it. This includes reconciling with **#4559** (draft-aware Refresh-all): its draft-cache-writing endpoint is now triggered by `showDraftView`, not just `editing`.

## Review panel

Internal `/review-panel` ran 2 rounds → CLEAN. Round 1 caught five card-ops still keyed on `editing`; round 2 confirmed the fix complete and surfaced the bulk-refresh gap — which sibling #4559 independently closed (its endpoint), reconciled here on rebase (follow-up #4679 filed then closed as superseded).

## Test plan

- [x] `resolveShowDraftView` unit tests cover: bookmark arrival with a draft → draft; no draft → published; in-flight status → published; editing/chatOpen before status lands → draft; editing/chatOpen with hasDraft:false → draft; banner/canvas agreement invariant
- [x] `@atlas/web` full suite green (303/303); typecheck clean
- [x] Local `/ci`: 30/31 gates green (sole failure is the documented `@atlas/mcp` smoke.test.ts unmigrated-local-DB env issue, #1472 — zero overlap with this web-only diff; runs against a real DB in remote CI)

Closes #4556