### PR TITLE
feat(dashboards): View is read-only — mutating tile controls move to Edit; scoped shortcuts

### DIFF
--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -4035,6 +4035,40 @@ describe("dashboard routes", () => {
       expect(body.cards[0].cachedAt).toBe("2026-07-10T00:00:00.000Z");
     });
 
+    // #4560 — a browsing gesture must never fork a draft row. Viewing the draft
+    // overlay and inspecting the draft-status badge both read through
+    // `loadDraft` (non-forking); only an explicit definition edit (or opening
+    // the draft editor via GET /:id/draft) may `forkOrLoadDraft`. These lock the
+    // read seam so a passive view can never create a `dashboard_user_drafts` row.
+    it("GET /:id?view=draft never forks a draft — reads through loadDraft only (#4560)", async () => {
+      mockLoadDraft.mockResolvedValue(draftOnlyRow);
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}?view=draft`),
+      );
+      expect(response.status).toBe(200);
+      expect(mockLoadDraft).toHaveBeenCalledWith("u1", VALID_ID);
+      expect(mockForkOrLoadDraft).not.toHaveBeenCalled();
+    });
+
+    it("GET /:id?view=draft with NO draft returns published and still never forks (#4560)", async () => {
+      mockLoadDraft.mockResolvedValue(null);
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}?view=draft`),
+      );
+      expect(response.status).toBe(200);
+      expect(mockForkOrLoadDraft).not.toHaveBeenCalled();
+    });
+
+    it("GET /:id/draft/status never forks a draft — the presence check is non-forking (#4560)", async () => {
+      mockLoadDraft.mockResolvedValue(null);
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/draft/status`),
+      );
+      expect(response.status).toBe(200);
+      expect((await response.json()) as { hasDraft: boolean }).toEqual({ hasDraft: false });
+      expect(mockForkOrLoadDraft).not.toHaveBeenCalled();
+    });
+
     it("render?view=draft 404s when the card was removed in the draft (never runs published)", async () => {
       // A draft exists, but its snapshot no longer contains VALID_CARD_ID.
       mockLoadDraft.mockResolvedValue({

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/mode-shortcut.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/mode-shortcut.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { shouldIgnoreModeShortcut } from "../mode-shortcut";
+
+/**
+ * #4560 — the canvas View/Edit shortcut (`e` / `Escape`) is page-surface only:
+ * a keystroke aimed at an interactive control (Select typeahead, an open
+ * dropdown's Escape, a focused toolbar button) must not toggle the mode.
+ */
+describe("shouldIgnoreModeShortcut (#4560)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("does not suppress on a bare, non-interactive page surface", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    expect(shouldIgnoreModeShortcut(div)).toBe(false);
+  });
+
+  test("suppresses inside text-entry fields", () => {
+    for (const tag of ["input", "textarea", "select"] as const) {
+      const el = document.createElement(tag);
+      document.body.appendChild(el);
+      expect(shouldIgnoreModeShortcut(el)).toBe(true);
+    }
+  });
+
+  test("suppresses on a contenteditable surface", () => {
+    const el = document.createElement("div");
+    el.contentEditable = "true";
+    document.body.appendChild(el);
+    expect(shouldIgnoreModeShortcut(el)).toBe(true);
+  });
+
+  test("suppresses on a toolbar button (and its nested icon)", () => {
+    const button = document.createElement("button");
+    const icon = document.createElement("span");
+    button.appendChild(icon);
+    document.body.appendChild(button);
+    // The event target can be the button itself or a child of it.
+    expect(shouldIgnoreModeShortcut(button)).toBe(true);
+    expect(shouldIgnoreModeShortcut(icon)).toBe(true);
+  });
+
+  test("suppresses on an SVG icon nested inside a toolbar button (closest walks past the SVG)", () => {
+    // Lucide icons render as <svg> (an SVGElement, not HTMLElement); a keydown
+    // that lands on one inside a button must still be treated as the button's.
+    const button = document.createElement("button");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    button.appendChild(svg);
+    document.body.appendChild(button);
+    expect(shouldIgnoreModeShortcut(svg)).toBe(true);
+  });
+
+  test("does not suppress on a bare SVG that has no interactive ancestor", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    document.body.appendChild(svg);
+    expect(shouldIgnoreModeShortcut(svg)).toBe(false);
+  });
+
+  test("suppresses inside a Select trigger (role=combobox) — `e` is typeahead there", () => {
+    const trigger = document.createElement("div");
+    trigger.setAttribute("role", "combobox");
+    document.body.appendChild(trigger);
+    expect(shouldIgnoreModeShortcut(trigger)).toBe(true);
+  });
+
+  test("suppresses inside an open dropdown/select popover (menu / listbox / option)", () => {
+    for (const role of ["menu", "menuitem", "listbox", "option"] as const) {
+      const el = document.createElement("div");
+      el.setAttribute("role", role);
+      document.body.appendChild(el);
+      expect(shouldIgnoreModeShortcut(el)).toBe(true);
+    }
+  });
+
+  test("returns false for a null / non-element target", () => {
+    expect(shouldIgnoreModeShortcut(null)).toBe(false);
+  });
+});

--- a/packages/web/src/app/(workspace)/dashboards/[id]/mode-shortcut.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/mode-shortcut.ts
@@ -1,0 +1,60 @@
+/**
+ * Canvas View/Edit shortcut scoping (#4560, ADR-0034 / CONTEXT.md § Dashboard
+ * editing — "View / Edit (canvas modes)").
+ *
+ * The page binds a global keyboard shortcut on the canvas — `e` toggles
+ * View/Edit, `Escape` exits to View. "Global" means it listens on `window`, so
+ * a keystroke meant for an interactive control — typeahead in an open Select, a
+ * keypress while a toolbar button holds focus — would ALSO drive the mode. That
+ * is the defect this predicate closes: the shortcut fires only when focus is on
+ * the page surface, never inside a control that owns the key itself.
+ *
+ * Kept a pure, DOM-only predicate so the scoping rule is unit-testable without
+ * mounting the whole dashboard page.
+ */
+
+/**
+ * The controls whose focus swallows the mode shortcut. A match — the target IS
+ * one, or is nested inside one (via `closest`) — means the keystroke belongs to
+ * that control. Contenteditable surfaces are NOT listed here; they're matched
+ * separately by `shouldIgnoreModeShortcut` via `HTMLElement.isContentEditable`
+ * (which also reflects editability inherited from an ancestor).
+ *
+ *   - `input` / `textarea` — text entry.
+ *   - `select` — a native option picker, where typing is typeahead.
+ *   - `button` / `[role="button"]` — a toolbar control (refresh, fullscreen,
+ *     the tile-actions trigger); `e`/`Escape` there must not drive the canvas.
+ *   - `[role="combobox"]` — a Radix Select / Combobox trigger, where typing `e`
+ *     is typeahead into the options, not "enter Edit".
+ *   - `[role="menu"]` / `[role="menuitem"]` / `[role="listbox"]` / `[role="option"]`
+ *     — an OPEN Select / dropdown popover: `Escape` closes it (Radix owns the
+ *     key), and a letter is typeahead.
+ */
+const INTERACTIVE_SELECTOR = [
+  "input",
+  "textarea",
+  "select",
+  "button",
+  "[role='button']",
+  "[role='combobox']",
+  "[role='menu']",
+  "[role='menuitem']",
+  "[role='listbox']",
+  "[role='option']",
+].join(",");
+
+/**
+ * Whether a keydown on `target` should be IGNORED by the canvas View/Edit
+ * shortcut. True when focus sits on (or inside) an interactive control or an
+ * editable field — the keystroke is the control's, not the page's.
+ *
+ * Narrows to `Element` (not `HTMLElement`) so an SVG target — a Lucide icon
+ * inside a toolbar button is an `SVGElement` — still walks `closest` to its
+ * interactive ancestor; `isContentEditable` is an `HTMLElement`-only property,
+ * so it's checked under that narrower guard.
+ */
+export function shouldIgnoreModeShortcut(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target instanceof HTMLElement && target.isContentEditable) return true;
+  return target.closest(INTERACTIVE_SELECTOR) !== null;
+}

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -41,6 +41,7 @@ import {
 } from "./search-params";
 import { activeFilters, incompatibleCardIds } from "./cross-filter";
 import { resolveShowDraftView } from "./draft-view";
+import { shouldIgnoreModeShortcut } from "./mode-shortcut";
 import { renderDashboardCard, renderDashboardCards, isRenderableCard } from "./dashboard-card-render";
 import {
   MOUNT_RENDER_CONCURRENCY,
@@ -346,12 +347,12 @@ export default function DashboardViewPage() {
     if (!chatOpen) setResumeConversationId(null);
   }, [chatOpen]);
 
-  // Skip when typing in inputs.
+  // #4560 — the View/Edit toggle is a page-surface shortcut: skip it whenever
+  // focus is on an interactive control or an editable field, so `e` typeahead
+  // in a Select and `Escape` closing an open dropdown never toggle the canvas.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
+      if (shouldIgnoreModeShortcut(e.target)) return;
       if (e.key === "e" || e.key === "E") {
         e.preventDefault();
         setEditing((prev) => !prev);

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -7,8 +7,24 @@ import type { DashboardCard } from "@/ui/lib/types";
 // under test.
 let widthOverride = 1024;
 void mock.module("react-grid-layout", () => ({
-  GridLayout: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="rgl-root">{children}</div>
+  // Surface the drag/resize gating (`enabled: editing`) as data-attributes so a
+  // test can assert the View-mode read-only contract (#4560) without a real RGL.
+  GridLayout: ({
+    children,
+    dragConfig,
+    resizeConfig,
+  }: {
+    children: React.ReactNode;
+    dragConfig?: { enabled?: boolean };
+    resizeConfig?: { enabled?: boolean };
+  }) => (
+    <div
+      data-testid="rgl-root"
+      data-drag-enabled={String(!!dragConfig?.enabled)}
+      data-resize-enabled={String(!!resizeConfig?.enabled)}
+    >
+      {children}
+    </div>
   ),
   useContainerWidth: () => ({ width: widthOverride, mounted: true, containerRef: { current: null } }),
   noCompactor: () => [],
@@ -85,6 +101,25 @@ describe("DashboardGrid", () => {
     widthOverride = 1024;
     render(<DashboardGrid {...baseProps} />);
     expect(screen.getByTestId("rgl-root")).toBeTruthy();
+  });
+
+  test("#4560 — View mode (editing=false) disables drag AND resize on the freeform grid", () => {
+    widthOverride = 1024;
+    render(<DashboardGrid {...baseProps} editing={false} />);
+    const root = screen.getByTestId("rgl-root");
+    expect(root.getAttribute("data-drag-enabled")).toBe("false");
+    expect(root.getAttribute("data-resize-enabled")).toBe("false");
+    // The read-only canvas also renders no drag handle on its tiles.
+    expect(root.querySelector(".dash-drag-handle")).toBeNull();
+  });
+
+  test("#4560 — Edit mode (editing=true) enables drag AND resize on the freeform grid", () => {
+    widthOverride = 1024;
+    render(<DashboardGrid {...baseProps} editing={true} />);
+    const root = screen.getByTestId("rgl-root");
+    expect(root.getAttribute("data-drag-enabled")).toBe("true");
+    expect(root.getAttribute("data-resize-enabled")).toBe("true");
+    expect(root.querySelector(".dash-drag-handle")).toBeTruthy();
   });
 
   test("#4567 — two concurrent tile refreshes both spin; neither clobbers the other", () => {

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -177,7 +177,9 @@ describe("DashboardTile", () => {
   test("tile-head action buttons expose accessible names so screen readers can reach them", () => {
     const restore = setBoundingRect(600, 300);
     (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
-    render(<DashboardTile {...baseProps} />);
+    // onExportCsv is wired (as the page always does) so the tile-actions menu
+    // renders in View — the export is a non-mutating affordance.
+    render(<DashboardTile {...baseProps} onExportCsv={noop} />);
     expect(screen.getByRole("button", { name: "Refresh tile" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Fullscreen" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Tile actions" })).toBeTruthy();
@@ -307,7 +309,7 @@ describe("DashboardTile — KPI cards", () => {
   });
 
   test("keeps the tile chrome — refresh / fullscreen / actions reachable", () => {
-    render(<DashboardTile {...baseProps} card={kpiCard} />);
+    render(<DashboardTile {...baseProps} card={kpiCard} onExportCsv={noop} />);
     expect(screen.getByRole("button", { name: "Refresh tile" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Fullscreen" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Tile actions" })).toBeTruthy();
@@ -519,9 +521,10 @@ describe("DashboardTile — CSV export (#3210)", () => {
 
   test("the item is hidden when no onExportCsv handler is wired", async () => {
     (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
-    render(<DashboardTile {...baseProps} card={baseCard} />);
+    // In Edit mode the menu still opens (Rename is present) — only the CSV item
+    // is gone. (In View with no export handler the menu wouldn't render at all.)
+    render(<DashboardTile {...baseProps} card={baseCard} editing />);
     openTileMenu();
-    // The menu still opens (Rename is always present) — only the CSV item is gone.
     await screen.findByRole("menuitem", { name: /Rename/ });
     expect(screen.queryByRole("menuitem", { name: /Download CSV/ })).toBeNull();
   });
@@ -532,5 +535,66 @@ describe("DashboardTile — CSV export (#3210)", () => {
     // Text tiles render no tile-actions menu at all — the affordance can't appear.
     expect(screen.queryByRole("button", { name: "Tile actions" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: /Download CSV/ })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// View is read-only for the DEFINITION — mutating cluster moves to Edit (#4560)
+// ---------------------------------------------------------------------------
+
+describe("DashboardTile — View/Edit affordance gating (#4560)", () => {
+  afterEach(cleanup);
+
+  function openTileMenu() {
+    const trigger = screen.getByRole("button", { name: "Tile actions" });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+  }
+
+  test("View mode hides the mutating cluster (Rename / Duplicate / Remove); CSV stays", async () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    render(<DashboardTile {...baseProps} card={baseCard} editing={false} onExportCsv={noop} />);
+    // The non-mutating affordances (refresh, fullscreen) are always reachable.
+    expect(screen.getByRole("button", { name: "Refresh tile" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Fullscreen" })).toBeTruthy();
+    // The actions menu opens for the non-mutating CSV export only.
+    openTileMenu();
+    expect(await screen.findByRole("menuitem", { name: /Download CSV/ })).toBeTruthy();
+    expect(screen.queryByRole("menuitem", { name: /Rename/ })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /Duplicate/ })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /Remove/ })).toBeNull();
+  });
+
+  test("View mode with no export handler renders no actions menu at all (never an empty dropdown)", () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    render(<DashboardTile {...baseProps} card={baseCard} editing={false} />);
+    expect(screen.queryByRole("button", { name: "Tile actions" })).toBeNull();
+  });
+
+  test("Edit mode exposes the full mutating cluster (Rename / Duplicate / Remove)", async () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    render(<DashboardTile {...baseProps} card={baseCard} editing onExportCsv={noop} />);
+    openTileMenu();
+    expect(await screen.findByRole("menuitem", { name: /Rename/ })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Duplicate/ })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Remove/ })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: /Download CSV/ })).toBeTruthy();
+  });
+
+  test("Remove / Duplicate fire their handlers when selected in Edit mode", async () => {
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    const onDelete = mock((_card: DashboardCard) => {});
+    const onDuplicate = mock((_id: string) => {});
+    render(
+      <DashboardTile {...baseProps} card={baseCard} editing onDelete={onDelete} onDuplicate={onDuplicate} />,
+    );
+    openTileMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Duplicate/ }));
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+    expect(onDuplicate.mock.calls[0][0]).toBe(baseCard.id);
+    openTileMenu();
+    fireEvent.click(await screen.findByRole("menuitem", { name: /Remove/ }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete.mock.calls[0][0].id).toBe(baseCard.id);
   });
 });

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -558,39 +558,54 @@ function ChartTile({
             >
               {fullscreen ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="size-7" aria-label="Tile actions">
-                  <MoreHorizontal className="size-3.5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="text-xs">
-                <DropdownMenuItem onSelect={() => { setTitleDraft(card.title); setTitleEditing(true); }}>
-                  <Pencil className="mr-2 size-3.5" />
-                  Rename
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onDuplicate(card.id)}>
-                  <Copy className="mr-2 size-3.5" />
-                  Duplicate
-                </DropdownMenuItem>
-                {/* #3210 — export the card's current parameter-bound result as
-                    CSV. Disabled until the tile has rendered rows to export. */}
-                {onExportCsv && (
-                  <DropdownMenuItem onSelect={() => onExportCsv(card)} disabled={!hasData}>
-                    <Download className="mr-2 size-3.5" />
-                    Download CSV
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onSelect={() => onDelete(card)}
-                  className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400"
-                >
-                  <Trash2 className="mr-2 size-3.5" />
-                  Remove
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            {/* #4560 — View is read-only for the card DEFINITION: the mutating
+                cluster (Rename / Duplicate / Remove) lives only in Edit mode.
+                Download CSV is a non-mutating export, so it stays in both. The
+                menu itself is rendered only when it would hold at least one item
+                (editing, or an export handler) — never an empty dropdown. */}
+            {(editing || onExportCsv) && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon" className="size-7" aria-label="Tile actions">
+                    <MoreHorizontal className="size-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="text-xs">
+                  {editing && (
+                    <DropdownMenuItem onSelect={() => { setTitleDraft(card.title); setTitleEditing(true); }}>
+                      <Pencil className="mr-2 size-3.5" />
+                      Rename
+                    </DropdownMenuItem>
+                  )}
+                  {editing && (
+                    <DropdownMenuItem onSelect={() => onDuplicate(card.id)}>
+                      <Copy className="mr-2 size-3.5" />
+                      Duplicate
+                    </DropdownMenuItem>
+                  )}
+                  {/* #3210 — export the card's current parameter-bound result as
+                      CSV. Disabled until the tile has rendered rows to export. */}
+                  {onExportCsv && (
+                    <DropdownMenuItem onSelect={() => onExportCsv(card)} disabled={!hasData}>
+                      <Download className="mr-2 size-3.5" />
+                      Download CSV
+                    </DropdownMenuItem>
+                  )}
+                  {editing && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={() => onDelete(card)}
+                        className="text-red-600 focus:text-red-600 dark:text-red-400 dark:focus:text-red-400"
+                      >
+                        <Trash2 className="mr-2 size-3.5" />
+                        Remove
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Enforces the pinned **View / Edit (canvas modes)** contract (ADR-0034, CONTEXT.md § Dashboard editing) — View is strictly read-only for the dashboard *definition*.

- **Tile action cluster gated by mode** — Rename / Duplicate / Remove render only in Edit; the tile-actions menu renders only when it holds at least one item (`editing || onExportCsv`), never an empty dropdown. Refresh, fullscreen, CSV export, and drilldown stay available in View (non-mutating affordances). Drag/resize was already `enabled: editing` on the freeform grid — now directly tested in both modes.
- **Scoped `e` / `Escape` shortcut** — extracted a pure, unit-tested predicate `shouldIgnoreModeShortcut(target)`. A keystroke on an interactive control or editable field — Select typeahead, an open dropdown's `Escape`, a focused toolbar button, an SVG icon inside one — no longer toggles the canvas. Replaces the old inline `input/textarea/contentEditable` check (and its `as HTMLElement` cast).
- **Non-forking read seam locked** — `GET /:id?view=draft` and `/:id/draft/status` read through `loadDraft` (never `forkOrLoadDraft`), so a browsing gesture creates no `dashboard_user_drafts` row. Only an explicit definition edit / draft-editor open forks.

Builds on #4556 / #4557 / #4567 (draft-view + canvas-mount + interaction polish).

## Test plan

- [x] Component: View hides Remove/Rename/Duplicate, keeps refresh/fullscreen/CSV; Edit exposes the full cluster and fires handlers
- [x] Component: RGL drag+resize disabled in View, enabled in Edit
- [x] Unit: `shouldIgnoreModeShortcut` across text fields, contenteditable, buttons, combobox, open menu/listbox/option, nested SVG icon, null
- [x] Route seam: `?view=draft` (with/without draft) and `/draft/status` never call `forkOrLoadDraft`
- [x] `/review-panel` clean (4 axes); `/ci` green except the documented environmental MCP-smoke flake (`prompt_items` table-missing — needs a migrated local DB, #1472; unrelated to this diff, exercised by remote `api-tests` against real Postgres)

Closes #4560