### PR TITLE
fix(dashboards): gate topbar Edit affordances on the grid's stacked signal (#4689)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -138,6 +138,11 @@ export default function DashboardViewPage() {
   // server overlays the draft only when one exists (non-forking); a viewer or
   // a board with no draft still gets published, so this never leaks.
   const [editing, setEditing] = useState(false);
+  // #4689 — true while the grid is in its narrow, non-draggable stacked layout.
+  // Reported up by `DashboardGrid` (the sole owner of the width measurement) and
+  // handed to the topbar so its Edit affordances gate on the same signal the
+  // grid stacks on, never a pointer/viewport proxy that disagrees at <640px.
+  const [gridStacked, setGridStacked] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
   // #4322 — creation-to-bound continuity. The `createDashboard` handoff link
   // carries the originating conversation id; the drawer resumes that
@@ -1264,6 +1269,7 @@ export default function DashboardViewPage() {
               }
               editing={editing}
               onEditingChange={setEditing}
+              stacked={gridStacked}
               density={density}
               onDensityChange={setDensity}
             />
@@ -1436,6 +1442,7 @@ export default function DashboardViewPage() {
                   renderPhases={renderPhases}
                   pendingRefreshIds={pendingRefreshIds}
                   onRetryCard={handleRetryCard}
+                  onStackedChange={setGridStacked}
                   onLayoutChange={handleLayoutChange}
                   onRefresh={handleRefreshCard}
                   onDuplicate={handleDuplicate}

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -97,6 +97,28 @@ describe("DashboardGrid", () => {
     expect(container.querySelector(".dash-drag-handle")).toBeNull();
   });
 
+  test("#4689 — reports stacked=true up to the parent when measured width is below MOBILE_BREAKPOINT", () => {
+    widthOverride = 500;
+    let stacked: boolean | null = null;
+    render(<DashboardGrid {...baseProps} onStackedChange={(v) => { stacked = v; }} />);
+    expect<boolean | null>(stacked).toBe(true);
+  });
+
+  test("#4689 — reports stacked=false up to the parent when measured width is at or above MOBILE_BREAKPOINT", () => {
+    widthOverride = 1024;
+    let stacked: boolean | null = null;
+    render(<DashboardGrid {...baseProps} onStackedChange={(v) => { stacked = v; }} />);
+    expect<boolean | null>(stacked).toBe(false);
+  });
+
+  test("#4689 — the breakpoint is exclusive: exactly MOBILE_BREAKPOINT (640) is NOT stacked (off-by-one guard)", () => {
+    widthOverride = 640;
+    let stacked: boolean | null = null;
+    render(<DashboardGrid {...baseProps} onStackedChange={(v) => { stacked = v; }} />);
+    // `width < MOBILE_BREAKPOINT` — 640 is the freeform grid, 639 would stack.
+    expect<boolean | null>(stacked).toBe(false);
+  });
+
   test("renders the RGL freeform grid when measured width is at or above MOBILE_BREAKPOINT", () => {
     widthOverride = 1024;
     render(<DashboardGrid {...baseProps} />);

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar-touch.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-topbar-touch.test.tsx
@@ -111,3 +111,45 @@ describe("DashboardTopBar — touch (#4323)", () => {
     expect(hint.textContent).toContain("Editing is desktop-only");
   });
 });
+
+describe("DashboardTopBar — stacked (narrow) grid (#4689)", () => {
+  afterEach(() => {
+    cleanup();
+    coarse = false;
+  });
+
+  test("a fine-pointer narrow window (grid stacked) hides the toggle and reads 'widen the window', NOT 'desktop-only'", () => {
+    coarse = false;
+    render(<DashboardTopBar {...baseProps} stacked={true} />, { wrapper });
+    // The drag/resize toggle is gone — the stacked grid can't honor a drag.
+    expect(screen.queryByRole("group", { name: "Mode" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Edit/ })).toBeNull();
+    // Reason tracks the signal: a resized DESKTOP browser is not "desktop-only".
+    expect(screen.queryByTestId("edit-desktop-only-hint")).toBeNull();
+    const hint = screen.getByTestId("edit-too-narrow-hint");
+    expect(hint.textContent).toContain("Widen the window to edit");
+  });
+
+  test("stacked suppresses the 'drag tiles' help even when editing is still true (held from a prior wide session)", () => {
+    coarse = false;
+    render(<DashboardTopBar {...baseProps} stacked={true} editing={true} />, { wrapper });
+    expect(screen.queryByText(/drag tiles to rearrange/)).toBeNull();
+    expect(screen.queryByText("Add from chat")).toBeNull();
+  });
+
+  test("a coarse pointer wins the hint copy even when also stacked", () => {
+    coarse = true;
+    render(<DashboardTopBar {...baseProps} stacked={true} />, { wrapper });
+    const hint = screen.getByTestId("edit-desktop-only-hint");
+    expect(hint.textContent).toContain("Editing is desktop-only");
+    expect(screen.queryByTestId("edit-too-narrow-hint")).toBeNull();
+  });
+
+  test("a fine pointer with a wide (non-stacked) grid keeps the View/Edit toggle", () => {
+    coarse = false;
+    render(<DashboardTopBar {...baseProps} stacked={false} />, { wrapper });
+    expect(screen.getByRole("group", { name: "Mode" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Edit/ })).toBeTruthy();
+    expect(screen.queryByTestId("edit-too-narrow-hint")).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -65,6 +65,14 @@ interface DashboardGridProps {
   pendingRefreshIds?: ReadonlySet<string>;
   /** #4321 — retry a single tile's parameter-bound render (stale / errored). */
   onRetryCard?: (cardId: string) => void;
+  /**
+   * #4689 — reports whether the grid is CURRENTLY in its non-draggable, single-
+   * column stacked layout (measured width < `MOBILE_BREAKPOINT`). The grid is the
+   * sole owner of that width measurement, so the topbar subscribes to this rather
+   * than re-deriving "narrow" from a different signal (pointer / viewport media
+   * query) that could disagree with where the grid actually stacks.
+   */
+  onStackedChange?: (stacked: boolean) => void;
   onLayoutChange: (cardId: string, layout: DashboardCardLayout) => void;
   onRefresh: (cardId: string) => void;
   onDuplicate: (cardId: string) => void;
@@ -88,6 +96,7 @@ export function DashboardGrid({
   renderPhases,
   pendingRefreshIds,
   onRetryCard,
+  onStackedChange,
   onLayoutChange,
   onRefresh,
   onDuplicate,
@@ -97,6 +106,19 @@ export function DashboardGrid({
 }: DashboardGridProps) {
   const { width, containerRef, mounted } = useContainerWidth();
   const [fullscreenId, setFullscreenId] = useState<string | null>(null);
+
+  // Below MOBILE_BREAKPOINT the freeform RGL grid degrades into a read-only,
+  // single-column stack (no drag handles / no resize). This one measured signal
+  // is the single source of truth for whether the grid is in its non-draggable
+  // stacked LAYOUT (distinct from the separate `editing` gate on draggability).
+  const isMobile = mounted && width > 0 && width < MOBILE_BREAKPOINT;
+
+  // #4689 — surface the stacked state to the parent so the topbar suppresses its
+  // Edit affordances on the exact same signal the grid stacks on (not a pointer /
+  // viewport proxy that disagrees in the narrow-desktop-window band).
+  useEffect(() => {
+    onStackedChange?.(isMobile);
+  }, [isMobile, onStackedChange]);
   // React Compiler memoizes pure derives; manual useMemo was forbidden
   // by CLAUDE.md for perf-only cases.
   const placed = withAutoLayout(cards);
@@ -161,8 +183,6 @@ export function DashboardGrid({
   }
 
   if (placed.length === 0) return null;
-
-  const isMobile = mounted && width > 0 && width < MOBILE_BREAKPOINT;
 
   return (
     <div

--- a/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
@@ -65,6 +65,15 @@ interface DashboardTopBarProps {
   chatSlot?: React.ReactNode;
   editing: boolean;
   onEditingChange: (next: boolean) => void;
+  /**
+   * #4689 — true when the grid has collapsed to its non-draggable, single-column
+   * stacked layout (measured container width < `MOBILE_BREAKPOINT`). Reported up
+   * from `DashboardGrid`, the sole owner of that width measurement, so the topbar
+   * gates its layout-Edit affordances on the SAME signal the grid stacks on —
+   * never the width-vs-pointer mismatch that let a narrow-but-mouse-driven window
+   * advertise drag/resize over a stack that can't deliver it.
+   */
+  stacked?: boolean;
   density: Density;
   onDensityChange: (next: Density) => void;
 }
@@ -88,6 +97,7 @@ export function DashboardTopBar({
   chatSlot,
   editing,
   onEditingChange,
+  stacked = false,
   density,
   onDensityChange,
 }: DashboardTopBarProps) {
@@ -100,6 +110,13 @@ export function DashboardTopBar({
   // explain in one line where to edit. (Tracks the INPUT, not the viewport — a
   // wide touch tablet still can't usefully drag-arrange.)
   const coarsePointer = useCoarsePointer();
+
+  // #4689 — the layout-Edit affordances (View/Edit toggle + the "drag tiles"
+  // help footer) are drag/resize interactions the grid only delivers in its
+  // freeform mode. Suppress them whenever the grid can't: a coarse pointer OR a
+  // stacked (narrow) grid. `stacked` tracks the grid's measured width, so a
+  // narrow-but-mouse-driven window no longer promises a drag the stack can't do.
+  const suppressEditing = coarsePointer || stacked;
 
   // Resync the draft when the canonical title changes (e.g. after a server save
   // resolves) so a subsequent edit starts from the up-to-date value.
@@ -171,15 +188,18 @@ export function DashboardTopBar({
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        {coarsePointer ? (
-          // #4323 — viewing-first on touch: the Edit affordance is hidden (not
-          // shown-and-inert) with a one-line explanation of where to edit.
+        {suppressEditing ? (
+          // #4323 / #4689 — the Edit affordance is hidden (not shown-and-inert)
+          // with a one-line explanation of why. The reason follows the signal
+          // that suppressed it: a coarse pointer reads "desktop-only"; a
+          // fine-pointer-but-narrow window (grid stacked) reads "widen to edit"
+          // — never "desktop-only", which is false on a resized desktop browser.
           <span
-            data-testid="edit-desktop-only-hint"
+            data-testid={coarsePointer ? "edit-desktop-only-hint" : "edit-too-narrow-hint"}
             className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 bg-zinc-100/60 px-2 py-1 text-xs text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400"
           >
             <Eye className="size-3.5" aria-hidden="true" />
-            Editing is desktop-only
+            {coarsePointer ? "Editing is desktop-only" : "Widen the window to edit"}
           </span>
         ) : (
           <div
@@ -307,7 +327,7 @@ export function DashboardTopBar({
           Delete
         </Button>
 
-        {editing && (
+        {editing && !suppressEditing && (
           <Button variant="outline" size="sm" asChild>
             <Link href="/">
               <Plus className="mr-1.5 size-3.5" />
@@ -317,7 +337,12 @@ export function DashboardTopBar({
         )}
       </div>
 
-      {editing && (
+      {/* #4689 — the drag/resize help is gated on `!suppressEditing`, not just
+          `editing`: the grid can be stacked (or on a coarse pointer) while the
+          page still holds `editing=true` from a prior wide session, and the
+          stacked grid delivers no drag. Suppressing here keeps the chrome from
+          promising an interaction the grid can't honor. */}
+      {editing && !suppressEditing && (
         <div className="basis-full pt-1 text-[11px] text-zinc-500 dark:text-zinc-400">
           Editing — drag tiles to rearrange, drag the bottom-right corner to resize. Press{" "}
           <kbd className="rounded border border-zinc-300 bg-zinc-100 px-1 font-mono text-[10px] dark:border-zinc-700 dark:bg-zinc-900">


### PR DESCRIPTION
Closes #4689

## Problem
The View/Edit affordance and the grid's mobile-stack behavior were gated on **two different signals** that disagreed in the narrow-desktop-window region:

- The topbar hid the Edit toggle only on a **coarse pointer** (`useCoarsePointer()`), reading "Editing is desktop-only".
- The grid degrades to a **non-draggable single-column stack** on **measured width < `MOBILE_BREAKPOINT` (640px)**.

So on a narrow but mouse-driven window (fine pointer, <640px — a resized desktop browser), the topbar advertised *"drag tiles to rearrange"* over a stacked, non-draggable list. The chrome promised an interaction the grid couldn't deliver.

## Fix
`DashboardGrid` is the sole owner of the width measurement, so it becomes the single source of truth for "the grid is in its non-draggable stacked layout":

- `DashboardGrid` reports its stacked state up via a new `onStackedChange?(stacked)` callback (derived from the same `width < MOBILE_BREAKPOINT` signal it already stacks on).
- The page threads it into the topbar as `stacked`.
- The topbar suppresses its Edit affordances (View/Edit toggle **and** the "drag tiles" help footer + "Add from chat") on `coarsePointer || stacked` — one signal, so advertised == deliverable.
- The narrow-desktop hint reads **"Widen the window to edit"** rather than the false "Editing is desktop-only".

Because both consumers now read the grid's own measurement, no pointer/viewport proxy can disagree with where the grid actually stacks (a viewport media query would have re-introduced the gap by the persistent sidebar's width).

## Acceptance criteria
- [x] Stacked (width < `MOBILE_BREAKPOINT`) mode no longer advertises drag/resize editing — toggle hidden + "drag tiles" help suppressed.
- [x] Coarse-pointer (touch) path unchanged — still "Editing is desktop-only".
- [x] No regression for wide desktop (fine pointer, ≥640px) editing.

## Tests
- `dashboard-grid.test.tsx`: grid reports `stacked` true/false across the breakpoint (500 / 640 / 1024; 640 pins the exclusive boundary).
- `dashboard-topbar-touch.test.tsx`: fine-pointer narrow window hides the toggle and reads "Widen the window to edit" (not "desktop-only"); stacked suppresses the drag help even with `editing=true` held from a prior wide session; coarse pointer wins the hint copy; wide non-stacked keeps the toggle.

Internal review panel: CLEAN (all four axes). Local `/ci`: all 31 gates green (incl. full test suite).