### PR TITLE
fix(dashboards): distinguish 401 from 403 on shared-view auth wall (#4690)

### DIFF
--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/error-content.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/error-content.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { resolveErrorContent } from "../error-content";
+
+// #4690 — the standalone shared-dashboard page must NOT conflate 401 and 403.
+// These tests pin the acceptance criteria:
+//   - 401 (login-required) keeps the login redirect.
+//   - 403 (membership-required) never presents a bare "Log in" as the only action
+//     and explains the membership requirement, offering a home ("Go to Atlas")
+//     path instead.
+describe("resolveErrorContent (#4690)", () => {
+  test("login-required (401) keeps the login redirect and a distinct heading", () => {
+    const c = resolveErrorContent("login-required");
+    expect(c.primaryAction).toBe("login");
+    expect(c.heading).toMatch(/sign in/i);
+    expect(c.heading).not.toMatch(/authentication required/i);
+    expect(c.showTryAgain).toBe(false);
+  });
+
+  test("membership-required (403) does NOT offer login — points at Atlas instead", () => {
+    const c = resolveErrorContent("membership-required");
+    // The crux of the bug: a signed-in wrong-org viewer must not be dead-ended on
+    // a "Log in" CTA. Primary action is the neutral home link.
+    expect(c.primaryAction).toBe("home");
+    expect(c.primaryAction).not.toBe("login");
+    // Copy explains the membership requirement rather than telling them to log in.
+    expect(c.message).toMatch(/not a member|member of/i);
+    expect(c.message).not.toMatch(/log in|sign in/i);
+    expect(c.showTryAgain).toBe(false);
+  });
+
+  test("the two auth reasons resolve to distinct headings and messages", () => {
+    const login = resolveErrorContent("login-required");
+    const membership = resolveErrorContent("membership-required");
+    expect(login.heading).not.toBe(membership.heading);
+    expect(login.message).not.toBe(membership.message);
+  });
+
+  test("transient failures offer Try again; not-found does not", () => {
+    expect(resolveErrorContent("expired").showTryAgain).toBe(true);
+    expect(resolveErrorContent("network-error").showTryAgain).toBe(true);
+    expect(resolveErrorContent("server-error").showTryAgain).toBe(true);
+    expect(resolveErrorContent("not-found").showTryAgain).toBe(false);
+  });
+
+  test("only login-required uses the login CTA; every other reason goes home", () => {
+    const reasons = [
+      "membership-required",
+      "expired",
+      "not-found",
+      "network-error",
+      "server-error",
+    ] as const;
+    for (const r of reasons) {
+      expect(resolveErrorContent(r).primaryAction).toBe("home");
+    }
+    expect(resolveErrorContent("login-required").primaryAction).toBe("login");
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/error-shell.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/error-shell.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+
+// next/link needs no router for a plain anchor render — stub it to the bare <a>.
+void mock.module("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) =>
+    createElement("a", { href }, children),
+}));
+
+import { ErrorShell } from "../error-shell";
+import { resolveErrorContent } from "../error-content";
+
+const TOKEN = "abc123def456ghi789jkl";
+
+// #4690 — render-level pin of the CTA → href wiring the resolver decides. The
+// resolver tests lock login-vs-home; these lock that the standalone shell turns
+// that decision into the right anchors (the login-redirect-back is the AC).
+describe("ErrorShell CTA wiring (#4690)", () => {
+  afterEach(cleanup);
+
+  function hrefs() {
+    return screen
+      .getAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => h !== "https://www.useatlas.dev"); // drop the attribution anchor
+  }
+
+  test("login-required renders the login redirect back to the shared view", () => {
+    render(<ErrorShell token={TOKEN} content={resolveErrorContent("login-required")} />);
+    const links = hrefs();
+    expect(links).toContain(
+      `/login?redirect=${encodeURIComponent(`/shared/dashboard/${TOKEN}`)}`,
+    );
+    // No login prompt on the wrong-org path is asserted below; here, no bare home CTA.
+    cleanup();
+  });
+
+  test("membership-required offers 'Go to Atlas' (home) and NEVER a login link", () => {
+    render(<ErrorShell token={TOKEN} content={resolveErrorContent("membership-required")} />);
+    const links = hrefs();
+    expect(links).toContain("/");
+    expect(links.some((h) => h.startsWith("/login"))).toBe(false);
+    expect(screen.getByText(/go to atlas/i)).toBeDefined();
+    cleanup();
+  });
+
+  test("transient failure (server-error) shows a 'Try again' link back to the view", () => {
+    render(<ErrorShell token={TOKEN} content={resolveErrorContent("server-error")} />);
+    const links = hrefs();
+    expect(links).toContain(`/shared/dashboard/${TOKEN}`);
+    cleanup();
+  });
+
+  test("not-found shows neither a login nor a 'Try again' link — only 'Go to Atlas'", () => {
+    render(<ErrorShell token={TOKEN} content={resolveErrorContent("not-found")} />);
+    const links = hrefs();
+    expect(links).toEqual(["/"]);
+    cleanup();
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
@@ -122,6 +122,16 @@ describe("fetchSharedDashboardRaw (#4317)", () => {
     expect(result).toEqual({ ok: false, reason: "login-required" });
   });
 
+  test("a 401 is login-required regardless of body — never reclassified as wrong-org", async () => {
+    // Locks the status===401 short-circuit: even a (contradictory) forbidden body
+    // can't turn a no-session 401 into membership-required.
+    stubFetch(401, { error: "forbidden" });
+    expect(await fetchSharedDashboardRaw("abc123def456ghi789jkl")).toEqual({
+      ok: false,
+      reason: "login-required",
+    });
+  });
+
   test("defaults an unrecognized/malformed 403 body to login-required (never dead-ends a no-session viewer)", async () => {
     // A 403 whose body carries no `forbidden` code must not be misclassified as
     // wrong-org — the safe default keeps a login path open (#4690).

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
@@ -100,19 +100,53 @@ describe("fetchSharedDashboardRaw (#4317)", () => {
     expect(headers["x-forwarded-for"]).toBe("9.9.9.9");
   });
 
-  // #4690: 401 (no session) and 403 (authenticated, wrong org) are DISTINCT
-  // reasons — not one `auth-required` — so the page can offer a login redirect
-  // only when there's genuinely no session.
-  test("maps a 401 (no viewer session) to login-required", async () => {
+  // #4690: the no-session viewer and the wrong-org viewer are DISTINCT reasons —
+  // not one `auth-required` — so the page offers a login redirect only when
+  // there's genuinely no session. The API (`dashboards.ts`) returns 403 for BOTH,
+  // distinguished by the body `error` code, so the fetch layer reads the body.
+  test("maps a 403 with error:auth_required (no session) to login-required", async () => {
+    stubFetch(403, { error: "auth_required" });
+    const result = await fetchSharedDashboardRaw("abc123def456ghi789jkl");
+    expect(result).toEqual({ ok: false, reason: "login-required" });
+  });
+
+  test("maps a 403 with error:forbidden (authenticated, wrong org) to membership-required", async () => {
+    stubFetch(403, { error: "forbidden" });
+    const result = await fetchSharedDashboardRaw("abc123def456ghi789jkl");
+    expect(result).toEqual({ ok: false, reason: "membership-required" });
+  });
+
+  test("maps a bare 401 (no session, stricter HTTP semantics) to login-required", async () => {
     stubFetch(401, { error: "auth_required" });
     const result = await fetchSharedDashboardRaw("abc123def456ghi789jkl");
     expect(result).toEqual({ ok: false, reason: "login-required" });
   });
 
-  test("maps a 403 (authenticated, not a member of the sharing org) to membership-required", async () => {
-    stubFetch(403, { error: "forbidden" });
-    const result = await fetchSharedDashboardRaw("abc123def456ghi789jkl");
-    expect(result).toEqual({ ok: false, reason: "membership-required" });
+  test("defaults an unrecognized/malformed 403 body to login-required (never dead-ends a no-session viewer)", async () => {
+    // A 403 whose body carries no `forbidden` code must not be misclassified as
+    // wrong-org — the safe default keeps a login path open (#4690).
+    stubFetch(403, { unexpected: true });
+    expect(await fetchSharedDashboardRaw("abc123def456ghi789jkl")).toEqual({
+      ok: false,
+      reason: "login-required",
+    });
+    // Body that isn't even JSON (res.json() throws) → same safe default.
+    const throwingBody = mock(async (url: string, init?: RequestInit) => {
+      void url;
+      void init;
+      return {
+        ok: false,
+        status: 403,
+        json: async () => {
+          throw new Error("not json");
+        },
+      } as Response;
+    });
+    globalThis.fetch = throwingBody as unknown as typeof fetch;
+    expect(await fetchSharedDashboardRaw("abc123def456ghi789jkl")).toEqual({
+      ok: false,
+      reason: "login-required",
+    });
   });
 
   test("maps a 410 to expired and a 404 to not-found", async () => {

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
@@ -100,10 +100,19 @@ describe("fetchSharedDashboardRaw (#4317)", () => {
     expect(headers["x-forwarded-for"]).toBe("9.9.9.9");
   });
 
-  test("maps a 403 (no viewer session) to auth-required", async () => {
-    stubFetch(403, { error: "auth_required" });
+  // #4690: 401 (no session) and 403 (authenticated, wrong org) are DISTINCT
+  // reasons — not one `auth-required` — so the page can offer a login redirect
+  // only when there's genuinely no session.
+  test("maps a 401 (no viewer session) to login-required", async () => {
+    stubFetch(401, { error: "auth_required" });
     const result = await fetchSharedDashboardRaw("abc123def456ghi789jkl");
-    expect(result).toEqual({ ok: false, reason: "auth-required" });
+    expect(result).toEqual({ ok: false, reason: "login-required" });
+  });
+
+  test("maps a 403 (authenticated, not a member of the sharing org) to membership-required", async () => {
+    stubFetch(403, { error: "forbidden" });
+    const result = await fetchSharedDashboardRaw("abc123def456ghi789jkl");
+    expect(result).toEqual({ ok: false, reason: "membership-required" });
   });
 
   test("maps a 410 to expired and a 404 to not-found", async () => {

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
@@ -150,7 +150,7 @@ describe("fetchSharedDashboardRaw (#4317)", () => {
         json: async () => {
           throw new Error("not json");
         },
-      } as Response;
+      } as unknown as Response;
     });
     globalThis.fetch = throwingBody as unknown as typeof fetch;
     expect(await fetchSharedDashboardRaw("abc123def456ghi789jkl")).toEqual({

--- a/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
@@ -49,11 +49,17 @@ describe("EmbedErrorView", () => {
     cleanup();
   });
 
-  test("never renders a login/retry link inside the frame (partner-safe chrome)", () => {
-    render(<EmbedErrorView reason="membership-required" />);
-    // Only the 'Powered by Atlas' attribution anchor is allowed; no in-frame nav.
-    const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(1);
-    expect(links[0]?.getAttribute("href")).toBe("https://www.useatlas.dev");
-  });
+  // Both auth reasons must stay navigation-free — `login-required` is the one most
+  // likely to tempt a future edit into adding an in-frame "Sign in" CTA (#4690).
+  test.each(["login-required", "membership-required"] as const)(
+    "reason %s never renders a login/retry link inside the frame (partner-safe chrome)",
+    (reason) => {
+      render(<EmbedErrorView reason={reason} />);
+      // Only the 'Powered by Atlas' attribution anchor is allowed; no in-frame nav.
+      const links = screen.getAllByRole("link");
+      expect(links).toHaveLength(1);
+      expect(links[0]?.getAttribute("href")).toBe("https://www.useatlas.dev");
+      cleanup();
+    },
+  );
 });

--- a/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
@@ -36,7 +36,9 @@ describe("EmbedErrorView", () => {
   const cases: Array<[Parameters<typeof EmbedErrorView>[0]["reason"], RegExp]> = [
     ["expired", /expired/i],
     ["not-found", /could not be found/i],
-    ["auth-required", /organization/i],
+    // #4690: 401 vs 403 keep distinct copy — the wrong-org viewer isn't told to sign in.
+    ["login-required", /sign in to atlas/i],
+    ["membership-required", /not a member/i],
     ["network-error", /reach Atlas/i],
     ["server-error", /Could not load/i],
   ];
@@ -48,7 +50,7 @@ describe("EmbedErrorView", () => {
   });
 
   test("never renders a login/retry link inside the frame (partner-safe chrome)", () => {
-    render(<EmbedErrorView reason="auth-required" />);
+    render(<EmbedErrorView reason="membership-required" />);
     // Only the 'Powered by Atlas' attribution anchor is allowed; no in-frame nav.
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(1);

--- a/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
@@ -37,8 +37,15 @@ export function EmbedErrorView({ reason }: { reason: FailReason }) {
   // fails the build here instead of silently rendering the generic message.
   let message: string;
   switch (reason) {
-    case "auth-required":
+    // The embed is navigation-free (no in-frame login), so both auth reasons
+    // resolve to explanatory copy rather than a CTA — but they stay DISTINCT so a
+    // signed-in wrong-org viewer isn't told to "sign in" (#4690).
+    case "login-required":
       message = "This dashboard is shared within an organization. Sign in to Atlas to view it.";
+      break;
+    case "membership-required":
+      message =
+        "This dashboard is shared within an organization you’re not a member of. Open it in Atlas with an account that has access.";
       break;
     case "expired":
       message = "This dashboard share link has expired.";

--- a/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
@@ -4,7 +4,7 @@
 // view (`../view.tsx`) — this file adds only the framable chrome (theme wrapper
 // + iframe-appropriate error states), never a second data surface.
 
-import type { FetchResult } from "../fetch";
+import type { FailReason } from "../fetch";
 
 export type EmbedTheme = "light" | "dark";
 
@@ -23,8 +23,6 @@ export function resolveEmbedTheme(raw: string | string[] | undefined): EmbedThem
   );
   return "light";
 }
-
-type FailReason = Extract<FetchResult, { ok: false }>["reason"];
 
 /**
  * Compact, navigation-free error state for the embed. Unlike the standalone

--- a/packages/web/src/app/shared/dashboard/[token]/error-content.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/error-content.ts
@@ -1,39 +1,36 @@
 // Pure resolver mapping a shared-dashboard fetch failure to the standalone
 // page's error-shell content (heading, message, and which actions to offer).
-// Extracted from `page.tsx` so the copy + CTA choice per reason is unit-testable
-// without rendering the async RSC — same testability seam as `fetch.ts` and
-// `embed.ts`. The embed surface (`embed.tsx`) keeps its own navigation-free copy
-// and does not consume this.
+// Extracted from `page.tsx` for the same extract-for-testability motive as
+// `fetch.ts`: the copy + CTA choice per reason is unit-tested directly, without
+// rendering the async RSC. The embed surface (`embed.tsx`) keeps its own
+// navigation-free copy and does not consume this.
 
-import type { FetchResult } from "./fetch";
-
-type FailReason = Extract<FetchResult, { ok: false }>["reason"];
+import type { FailReason } from "./fetch";
 
 /** Which primary CTA the error shell offers. */
 export type PrimaryAction =
-  // Login redirect back to the shared view — ONLY for `login-required` (401),
-  // where the viewer genuinely has no session. Never for `membership-required`.
+  // Login redirect back to the shared view — ONLY for `login-required`, where the
+  // viewer genuinely has no session. Never for `membership-required`.
   | "login"
   // Neutral "Go to Atlas" home link — the safe default for every other reason,
-  // including the signed-in wrong-org viewer (#4690).
+  // including the signed-in wrong-org viewer.
   | "home";
 
 export interface ErrorContent {
-  heading: string;
-  message: string;
-  primaryAction: PrimaryAction;
+  readonly heading: string;
+  readonly message: string;
+  readonly primaryAction: PrimaryAction;
   /** Whether to also offer the "Try again" outline link (transient failures only). */
-  showTryAgain: boolean;
+  readonly showTryAgain: boolean;
 }
 
 /**
  * Resolve the error shell's content for a failed shared-dashboard fetch.
  *
  * The `login-required` / `membership-required` split is the crux of #4690: a
- * logged-in viewer who is not a member of the sharing org (403) is told about the
+ * logged-in viewer who is not a member of the sharing org is told about the
  * membership requirement and pointed at Atlas, NOT dead-ended on a "Log in" CTA
- * they already satisfy. A viewer with no session at all (401) still gets the login
- * redirect.
+ * they already satisfy. A viewer with no session still gets the login redirect.
  */
 export function resolveErrorContent(reason: FailReason): ErrorContent {
   switch (reason) {

--- a/packages/web/src/app/shared/dashboard/[token]/error-content.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/error-content.ts
@@ -20,7 +20,8 @@ export interface ErrorContent {
   readonly heading: string;
   readonly message: string;
   readonly primaryAction: PrimaryAction;
-  /** Whether to also offer the "Try again" outline link (transient failures only). */
+  /** Whether to also offer the "Try again" outline link — for non-terminal
+   *  failures (expired, network-error, server-error), not not-found or the auth wall. */
   readonly showTryAgain: boolean;
 }
 

--- a/packages/web/src/app/shared/dashboard/[token]/error-content.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/error-content.ts
@@ -1,0 +1,95 @@
+// Pure resolver mapping a shared-dashboard fetch failure to the standalone
+// page's error-shell content (heading, message, and which actions to offer).
+// Extracted from `page.tsx` so the copy + CTA choice per reason is unit-testable
+// without rendering the async RSC — same testability seam as `fetch.ts` and
+// `embed.ts`. The embed surface (`embed.tsx`) keeps its own navigation-free copy
+// and does not consume this.
+
+import type { FetchResult } from "./fetch";
+
+type FailReason = Extract<FetchResult, { ok: false }>["reason"];
+
+/** Which primary CTA the error shell offers. */
+export type PrimaryAction =
+  // Login redirect back to the shared view — ONLY for `login-required` (401),
+  // where the viewer genuinely has no session. Never for `membership-required`.
+  | "login"
+  // Neutral "Go to Atlas" home link — the safe default for every other reason,
+  // including the signed-in wrong-org viewer (#4690).
+  | "home";
+
+export interface ErrorContent {
+  heading: string;
+  message: string;
+  primaryAction: PrimaryAction;
+  /** Whether to also offer the "Try again" outline link (transient failures only). */
+  showTryAgain: boolean;
+}
+
+/**
+ * Resolve the error shell's content for a failed shared-dashboard fetch.
+ *
+ * The `login-required` / `membership-required` split is the crux of #4690: a
+ * logged-in viewer who is not a member of the sharing org (403) is told about the
+ * membership requirement and pointed at Atlas, NOT dead-ended on a "Log in" CTA
+ * they already satisfy. A viewer with no session at all (401) still gets the login
+ * redirect.
+ */
+export function resolveErrorContent(reason: FailReason): ErrorContent {
+  switch (reason) {
+    case "login-required":
+      return {
+        heading: "Sign in to view this dashboard",
+        message:
+          "This dashboard is shared within an organization. Sign in with an account in that organization to view it.",
+        primaryAction: "login",
+        showTryAgain: false,
+      };
+    case "membership-required":
+      return {
+        heading: "You don’t have access to this dashboard",
+        message:
+          "This dashboard is shared within an organization you’re not a member of. Ask the owner to share it with you, or switch to an account in that organization.",
+        primaryAction: "home",
+        showTryAgain: false,
+      };
+    case "expired":
+      return {
+        heading: "Dashboard link expired",
+        message: "This share link has expired. Ask the dashboard owner to create a new one.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+    case "not-found":
+      return {
+        heading: "Dashboard not found",
+        message: "This dashboard may have been removed or the link may be invalid.",
+        primaryAction: "home",
+        showTryAgain: false,
+      };
+    case "network-error":
+      return {
+        heading: "Connection failed",
+        message: "We couldn’t reach Atlas. Check your connection and try again.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+    case "server-error":
+      return {
+        heading: "Unable to load dashboard",
+        message: "Something went wrong on our end loading this dashboard. Please try again in a moment.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+    default:
+      // Exhaustiveness: a future `FetchResult` reason fails the build here rather
+      // than silently rendering a generic shell.
+      reason satisfies never;
+      return {
+        heading: "Unable to load dashboard",
+        message: "Something went wrong loading this dashboard. Please try again in a moment.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+  }
+}

--- a/packages/web/src/app/shared/dashboard/[token]/error-shell.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/error-shell.tsx
@@ -1,0 +1,57 @@
+// The standalone shared-dashboard error state. Extracted from `page.tsx` so the
+// CTA → href wiring is render-testable without invoking the async page RSC — in
+// particular the #4690 acceptance criterion that `login-required` (and only it)
+// produces the login redirect back to the shared view, while every other reason
+// offers the neutral "Go to Atlas" home link. Copy + which actions to show come
+// from `resolveErrorContent` (`error-content.ts`); this component only renders them.
+
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import type { ErrorContent } from "./error-content";
+
+export function ErrorShell({ token, content }: { token: string; content: ErrorContent }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="flex flex-1 items-center justify-center px-4 focus:outline-none"
+      >
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{content.heading}</h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{content.message}</p>
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+            {content.primaryAction === "login" ? (
+              <Link
+                href={`/login?redirect=${encodeURIComponent(`/shared/dashboard/${token}`)}`}
+                className={buttonVariants()}
+              >
+                Log in
+              </Link>
+            ) : (
+              <Link href="/" className={buttonVariants()}>Go to Atlas</Link>
+            )}
+            {content.showTryAgain && (
+              <Link
+                href={`/shared/dashboard/${token}`}
+                className={buttonVariants({ variant: "outline" })}
+              >
+                Try again
+              </Link>
+            )}
+          </div>
+        </div>
+      </main>
+      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
+        <a
+          href="https://www.useatlas.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          Powered by Atlas
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/packages/web/src/app/shared/dashboard/[token]/fetch.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/fetch.ts
@@ -10,22 +10,22 @@ import { sharedDashboardViewSchema } from "@useatlas/schemas";
 import { getApiBaseUrl } from "../../lib";
 import type { SharedDashboard } from "./types";
 
-export type FetchResult =
-  | { ok: true; data: SharedDashboard }
-  | {
-      ok: false;
-      reason:
-        | "not-found"
-        | "expired"
-        // 401 vs 403 are kept DISTINCT (not one `auth-required`): a viewer with no
-        // session (`login-required`) is offered a login redirect, while a viewer who
-        // is signed in but not a member of the sharing org (`membership-required`)
-        // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
-        | "login-required"
-        | "membership-required"
-        | "server-error"
-        | "network-error";
-    };
+/** One of the {@link FetchResult} failure reasons — the discriminant the page
+ *  and embed error shells switch on. Exported so both surfaces derive it from
+ *  this single source rather than re-deriving the `Extract<…>` in each file. */
+export type FailReason =
+  | "not-found"
+  | "expired"
+  // The org-share auth wall is kept DISTINCT (not one `auth-required`): a viewer
+  // with no session (`login-required`) is offered a login redirect, while a viewer
+  // who is signed in but not a member of the sharing org (`membership-required`)
+  // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
+  | "login-required"
+  | "membership-required"
+  | "server-error"
+  | "network-error";
+
+export type FetchResult = { ok: true; data: SharedDashboard } | { ok: false; reason: FailReason };
 
 /**
  * Short, non-reversible fingerprint of a share token for log correlation.
@@ -64,6 +64,35 @@ export function buildForwardHeaders(input: {
   return out;
 }
 
+/**
+ * Disambiguate an org-share auth failure (HTTP 401/403) into the exact reason.
+ *
+ * The API returns 403 for BOTH the unauthenticated viewer (`error: "auth_required"`)
+ * and the authenticated-but-wrong-org viewer (`error: "forbidden"`), so the status
+ * code alone is insufficient — we read the body's `error` code. Only an explicit
+ * `"forbidden"` is treated as `membership-required`; every other signal (an explicit
+ * `auth_required`, a 401, or a missing/malformed body) defaults to `login-required`
+ * so a no-session viewer is never dead-ended without a login path (#4690). Exported
+ * for unit tests.
+ */
+export async function resolveAuthReason(res: Response): Promise<"login-required" | "membership-required"> {
+  // A 401 is unambiguously "no session" regardless of body.
+  if (res.status === 401) return "login-required";
+  let errorCode: string | undefined;
+  try {
+    const body: unknown = await res.json();
+    if (body && typeof body === "object" && "error" in body) {
+      const code = (body as { error?: unknown }).error;
+      if (typeof code === "string") errorCode = code;
+    }
+  } catch {
+    // Malformed/empty body — fall through to the safe `login-required` default
+    // below rather than misclassifying a no-session viewer as wrong-org.
+    // intentionally ignored: absence of a parseable error code is itself the signal.
+  }
+  return errorCode === "forbidden" ? "membership-required" : "login-required";
+}
+
 /** Uncached fetch. Exported for unit tests; production callers use the
  *  `cache()`-wrapped {@link fetchSharedDashboard} so the fetch runs once. */
 export async function fetchSharedDashboardRaw(token: string): Promise<FetchResult> {
@@ -85,10 +114,14 @@ export async function fetchSharedDashboardRaw(token: string): Promise<FetchResul
     if (!res.ok) {
       if (res.status === 404) return { ok: false, reason: "not-found" };
       if (res.status === 410) return { ok: false, reason: "expired" };
-      // 401 = no session (offer login); 403 = authenticated but not a member of the
-      // sharing org (explain membership, don't force a redundant login). See #4690.
-      if (res.status === 401) return { ok: false, reason: "login-required" };
-      if (res.status === 403) return { ok: false, reason: "membership-required" };
+      // The org-share auth wall. The API (`dashboards.ts`) returns 403 for BOTH the
+      // no-session and the wrong-org viewer, distinguished only by the response
+      // body's `error` code — NOT by the status. So a 403 alone can't tell them
+      // apart; we read the body. (A future 401 is also honored, so this stays
+      // correct if the API ever adopts stricter HTTP semantics.) See #4690.
+      if (res.status === 401 || res.status === 403) {
+        return { ok: false, reason: await resolveAuthReason(res) };
+      }
       console.error(
         `[shared-dashboard] API returned ${res.status} for tokenHash=${hashShareToken(token)}`,
       );

--- a/packages/web/src/app/shared/dashboard/[token]/fetch.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/fetch.ts
@@ -14,7 +14,17 @@ export type FetchResult =
   | { ok: true; data: SharedDashboard }
   | {
       ok: false;
-      reason: "not-found" | "expired" | "auth-required" | "server-error" | "network-error";
+      reason:
+        | "not-found"
+        | "expired"
+        // 401 vs 403 are kept DISTINCT (not one `auth-required`): a viewer with no
+        // session (`login-required`) is offered a login redirect, while a viewer who
+        // is signed in but not a member of the sharing org (`membership-required`)
+        // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
+        | "login-required"
+        | "membership-required"
+        | "server-error"
+        | "network-error";
     };
 
 /**
@@ -75,7 +85,10 @@ export async function fetchSharedDashboardRaw(token: string): Promise<FetchResul
     if (!res.ok) {
       if (res.status === 404) return { ok: false, reason: "not-found" };
       if (res.status === 410) return { ok: false, reason: "expired" };
-      if (res.status === 401 || res.status === 403) return { ok: false, reason: "auth-required" };
+      // 401 = no session (offer login); 403 = authenticated but not a member of the
+      // sharing org (explain membership, don't force a redundant login). See #4690.
+      if (res.status === 401) return { ok: false, reason: "login-required" };
+      if (res.status === 403) return { ok: false, reason: "membership-required" };
       console.error(
         `[shared-dashboard] API returned ${res.status} for tokenHash=${hashShareToken(token)}`,
       );

--- a/packages/web/src/app/shared/dashboard/[token]/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/page.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { buttonVariants } from "@/components/ui/button";
 import { truncate } from "../../lib";
 import { SharedDashboardView } from "./view";
 import { fetchSharedDashboard } from "./fetch";
-import { resolveErrorContent, type ErrorContent } from "./error-content";
+import { resolveErrorContent } from "./error-content";
+import { ErrorShell } from "./error-shell";
 
 // ---------------------------------------------------------------------------
 // Metadata (OG tags)
@@ -48,59 +47,6 @@ export async function generateMetadata({
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
-
-function ErrorShell({
-  token,
-  content,
-}: {
-  token: string;
-  content: ErrorContent;
-}) {
-  return (
-    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
-      <main
-        id="main"
-        tabIndex={-1}
-        className="flex flex-1 items-center justify-center px-4 focus:outline-none"
-      >
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{content.heading}</h1>
-          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{content.message}</p>
-          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-            {content.primaryAction === "login" ? (
-              <Link
-                href={`/login?redirect=${encodeURIComponent(`/shared/dashboard/${token}`)}`}
-                className={buttonVariants()}
-              >
-                Log in
-              </Link>
-            ) : (
-              <Link href="/" className={buttonVariants()}>Go to Atlas</Link>
-            )}
-            {content.showTryAgain && (
-              <Link
-                href={`/shared/dashboard/${token}`}
-                className={buttonVariants({ variant: "outline" })}
-              >
-                Try again
-              </Link>
-            )}
-          </div>
-        </div>
-      </main>
-      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
-        <a
-          href="https://www.useatlas.dev"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
-        >
-          Powered by Atlas
-        </a>
-      </footer>
-    </div>
-  );
-}
 
 export default async function SharedDashboardPage({
   params,

--- a/packages/web/src/app/shared/dashboard/[token]/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/page.tsx
@@ -3,7 +3,8 @@ import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { truncate } from "../../lib";
 import { SharedDashboardView } from "./view";
-import { fetchSharedDashboard, type FetchResult } from "./fetch";
+import { fetchSharedDashboard } from "./fetch";
+import { resolveErrorContent, type ErrorContent } from "./error-content";
 
 // ---------------------------------------------------------------------------
 // Metadata (OG tags)
@@ -48,18 +49,12 @@ export async function generateMetadata({
 // Page
 // ---------------------------------------------------------------------------
 
-type FailReason = Extract<FetchResult, { ok: false }>["reason"];
-
 function ErrorShell({
   token,
-  heading,
-  message,
-  reason,
+  content,
 }: {
   token: string;
-  heading: string;
-  message: string;
-  reason: FailReason;
+  content: ErrorContent;
 }) {
   return (
     <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
@@ -69,10 +64,10 @@ function ErrorShell({
         className="flex flex-1 items-center justify-center px-4 focus:outline-none"
       >
         <div className="text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{heading}</h1>
-          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{message}</p>
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{content.heading}</h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{content.message}</p>
           <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-            {reason === "auth-required" ? (
+            {content.primaryAction === "login" ? (
               <Link
                 href={`/login?redirect=${encodeURIComponent(`/shared/dashboard/${token}`)}`}
                 className={buttonVariants()}
@@ -82,7 +77,7 @@ function ErrorShell({
             ) : (
               <Link href="/" className={buttonVariants()}>Go to Atlas</Link>
             )}
-            {reason !== "not-found" && reason !== "auth-required" && (
+            {content.showTryAgain && (
               <Link
                 href={`/shared/dashboard/${token}`}
                 className={buttonVariants({ variant: "outline" })}
@@ -116,27 +111,7 @@ export default async function SharedDashboardPage({
   const result = await fetchSharedDashboard(token);
 
   if (!result.ok) {
-    const heading =
-      result.reason === "auth-required" ? "Authentication required"
-        : result.reason === "expired" ? "Dashboard link expired"
-        : result.reason === "not-found" ? "Dashboard not found"
-        : result.reason === "network-error" ? "Connection failed"
-        : "Unable to load dashboard";
-    const message =
-      result.reason === "auth-required" ? "This dashboard is shared within an organization. Please log in to view it."
-        : result.reason === "expired" ? "This share link has expired. Ask the dashboard owner to create a new one."
-        : result.reason === "not-found" ? "This dashboard may have been removed or the link may be invalid."
-        : result.reason === "network-error" ? "We couldn’t reach Atlas. Check your connection and try again."
-        : "Something went wrong on our end loading this dashboard. Please try again in a moment.";
-
-    return (
-      <ErrorShell
-        token={token}
-        heading={heading}
-        message={message}
-        reason={result.reason}
-      />
-    );
+    return <ErrorShell token={token} content={resolveErrorContent(result.reason)} />;
   }
 
   return <SharedDashboardView dashboard={result.data} />;


### PR DESCRIPTION
Closes #4690

## Problem
The shared-dashboard fetch collapsed the org-share auth wall into a single `auth-required` reason with one "Log in" CTA, so a viewer already logged in but not a member of the sharing org dead-ended on "Log in" — which they had already satisfied.

## Fix
The public dashboards API (`dashboards.ts:3284`/`:3302`) returns **403 for both** the no-session and the wrong-org viewer, distinguished only by the response body's `error` code (`auth_required` vs `forbidden`) — so the status code alone can't tell them apart.

- `fetch.ts`: new `resolveAuthReason()` reads the body's `error` code → `login-required` (no session) vs `membership-required` (authenticated, wrong org). Only an explicit `forbidden` is wrong-org; every other signal (missing/malformed body, a bare 401) safely defaults to `login-required` so a no-session viewer is never dead-ended.
- `error-content.ts`: pure `resolveErrorContent()` maps each reason → heading/message/`primaryAction`/`showTryAgain`. `login-required` keeps the login redirect; `membership-required` explains the membership requirement and offers "Go to Atlas" instead.
- `error-shell.tsx`: extracted from `page.tsx` so the CTA→href wiring is render-testable.
- `embed.tsx`: distinct navigation-free copy for the two reasons (exhaustive switch preserved).

## Acceptance criteria
- [x] 401/no-session and 403/wrong-org distinguished with distinct headings/copy
- [x] the wrong-org case does not present a bare "Log in" CTA and offers "Go to Atlas"
- [x] the no-session case keeps the login redirect

## Tests
- `fetch.test.ts`: 403+`auth_required`→login-required, 403+`forbidden`→membership-required, bare 401→login-required (regardless of body), malformed/unparseable 403→safe login-required default.
- `error-content.test.ts`: per-reason heading/copy/CTA + the "only login-required uses login" invariant.
- `error-shell.test.tsx`: render-level login-redirect href, wrong-org home link + no login link, try-again, not-found.
- `embed.test.tsx`: partner-safe (no in-frame nav) for both auth reasons.

Internal review panel: CLEAN (2 rounds — round 1 caught the 401/403-vs-body-code contract, fixed).