### PR TITLE
fix(dashboards): dashboard tiles render ResultChart plot-only, pinned to card type (#4688)

### DIFF
--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
@@ -1,14 +1,35 @@
+import type React from "react";
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type { SharedCard } from "../types";
 
 // The text branch never mounts a chart, but `dynamic(...)` + `useDarkMode` run
-// at import — stub them so jsdom doesn't try to evaluate recharts.
+// at import — stub them so jsdom doesn't try to evaluate recharts. The ResultChart
+// stub surfaces `embedded` / `chartType` (#4688) via data-attrs so a chart-card
+// test can assert the shared tile suppresses ResultChart's chrome + pins the type.
+// The next/dynamic stub invokes the loader (so the real mocked ResultChart is what
+// renders) and falls back until it resolves — the test `rerender`s past that.
 void mock.module("@/ui/components/chart/result-chart", () => ({
-  ResultChart: () => <div data-testid="result-chart">chart</div>,
+  ResultChart: ({ embedded, chartType }: { embedded?: boolean; chartType?: string }) => (
+    <div
+      data-testid="result-chart"
+      data-embedded={embedded ? "true" : "false"}
+      data-chart-type={chartType ?? ""}
+    >
+      chart
+    </div>
+  ),
 }));
 void mock.module("next/dynamic", () => ({
-  default: () => () => <div data-testid="result-chart">chart</div>,
+  default: (loader: () => Promise<{ default: React.ComponentType }>) => {
+    let Comp: React.ComponentType | null = null;
+    void loader().then((m) => {
+      Comp = m.default;
+    });
+    return function DynStub(props: Record<string, unknown>) {
+      return Comp ? <Comp {...props} /> : <div data-testid="result-chart-loading">loading</div>;
+    };
+  },
 }));
 void mock.module("@/ui/hooks/use-dark-mode", () => ({ useDarkMode: () => false }));
 
@@ -58,5 +79,43 @@ describe("SharedTile — text cards (#3138)", () => {
       <SharedTile card={card} spanClass="col-span-2" cachedLabel={null} cachedIso={undefined} />,
     );
     expect(container.querySelector("img")).toBeNull();
+  });
+});
+
+describe("SharedTile — chart cards (#4688 chrome-in-chrome)", () => {
+  afterEach(cleanup);
+
+  const chartCard: SharedCard = {
+    id: "c1",
+    title: "Signups by week",
+    kind: "chart",
+    chartConfig: { type: "bar", categoryColumn: "week", valueColumns: ["signups"] },
+    content: null,
+    annotations: [],
+    cachedColumns: ["week", "signups"],
+    cachedRows: [
+      { week: "2026-01-05", signups: 10 },
+      { week: "2026-01-12", signups: 24 },
+    ],
+    cachedAt: "2026-04-25T12:00:00Z",
+    position: 0,
+    layout: null,
+  };
+
+  test("renders ResultChart in embedded mode and pins it to the card's chart type", async () => {
+    // The card is saved `type: "bar"`; the shared tile owns the title/frame, so
+    // ResultChart renders the plot only (embedded) pinned to bar — not the data's
+    // auto-detected line.
+    const props = { card: chartCard, spanClass: "col-span-2", cachedLabel: null, cachedIso: undefined };
+    const { rerender } = render(<SharedTile {...props} />);
+    // Flush the dynamic loader promise, then re-render so DynStub swaps its
+    // fallback for the resolved (mocked) ResultChart.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    rerender(<SharedTile {...props} />);
+    const chart = screen.getByTestId("result-chart");
+    expect(chart.getAttribute("data-embedded")).toBe("true");
+    expect(chart.getAttribute("data-chart-type")).toBe("bar");
   });
 });

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
@@ -108,9 +108,10 @@ describe("SharedTile — chart cards (#4688 chrome-in-chrome)", () => {
     // auto-detected line.
     const props = { card: chartCard, spanClass: "col-span-2", cachedLabel: null, cachedIso: undefined };
     const { rerender } = render(<SharedTile {...props} />);
-    // Flush the dynamic loader promise, then re-render so DynStub swaps its
-    // fallback for the resolved (mocked) ResultChart.
+    // Flush the dynamic loader's promise chain (import() → .then), then re-render
+    // so DynStub swaps its fallback for the resolved (mocked) ResultChart.
     await act(async () => {
+      await Promise.resolve();
       await Promise.resolve();
     });
     rerender(<SharedTile {...props} />);

--- a/packages/web/src/app/shared/dashboard/[token]/tile.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/tile.tsx
@@ -7,6 +7,7 @@ import { useDarkMode } from "@/ui/hooks/use-dark-mode";
 import { DataTable } from "@/ui/components/chat/data-table";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { KpiCard } from "@/ui/components/dashboards/kpi-card";
+import { asEmbeddedChartType } from "@/ui/components/chart/chart-detection";
 import { ResultCardErrorBoundary } from "@/ui/components/chat/result-card-base";
 import type { SharedCard } from "./types";
 
@@ -99,6 +100,8 @@ export function SharedTile({ card, spanClass, cachedLabel, cachedIso }: SharedTi
                     headers={columns}
                     rows={stringRows}
                     dark={dark}
+                    embedded
+                    chartType={asEmbeddedChartType(chartType)}
                     thresholds={card.chartConfig?.thresholds}
                     annotations={card.annotations}
                   />

--- a/packages/web/src/ui/__tests__/chart-detection.test.ts
+++ b/packages/web/src/ui/__tests__/chart-detection.test.ts
@@ -5,6 +5,8 @@ import {
   transformData,
   categoryFromChartClick,
   categoryFromPieClick,
+  asEmbeddedChartType,
+  pickChartRecommendation,
   type ChartRecommendation,
   type ClassifiedColumn,
 } from "../components/chart/chart-detection";
@@ -603,5 +605,75 @@ describe("categoryFromPieClick", () => {
     expect(categoryFromPieClick({}, "region")).toBeNull();
     expect(categoryFromPieClick({ payload: { region: "" } }, "region")).toBeNull();
     expect(categoryFromPieClick({ payload: { region: null } }, "region")).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  asEmbeddedChartType (#4688 — dashboard tile chart-type pinning)     */
+/* ------------------------------------------------------------------ */
+
+describe("asEmbeddedChartType", () => {
+  test("passes through the render-union chart types a tile can pin", () => {
+    expect(asEmbeddedChartType("bar")).toBe("bar");
+    expect(asEmbeddedChartType("line")).toBe("line");
+    expect(asEmbeddedChartType("pie")).toBe("pie");
+    expect(asEmbeddedChartType("area")).toBe("area");
+    expect(asEmbeddedChartType("scatter")).toBe("scatter");
+    expect(asEmbeddedChartType("stacked-bar")).toBe("stacked-bar");
+  });
+
+  test("maps non-chart-body persisted types (table / kpi) to undefined", () => {
+    // table/kpi cards never mount a ResultChart body (DataTable / KpiCard instead).
+    expect(asEmbeddedChartType("table")).toBeUndefined();
+    expect(asEmbeddedChartType("kpi")).toBeUndefined();
+  });
+
+  test("maps absent / bogus values to undefined (auto-detect)", () => {
+    expect(asEmbeddedChartType(null)).toBeUndefined();
+    expect(asEmbeddedChartType(undefined)).toBeUndefined();
+    expect(asEmbeddedChartType("")).toBeUndefined();
+    expect(asEmbeddedChartType("donut")).toBeUndefined();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  pickChartRecommendation (#4688 — honor the card's configured type)  */
+/* ------------------------------------------------------------------ */
+
+describe("pickChartRecommendation", () => {
+  // date + numeric data auto-detects to `line` first, with `bar` also available.
+  const headers = ["week", "signups"];
+  const rows = [
+    ["2026-01-05", "10"],
+    ["2026-01-12", "24"],
+    ["2026-01-19", "31"],
+  ];
+
+  function recs() {
+    const result = detectCharts(headers, rows);
+    if (!result.chartable) throw new Error("expected chartable data");
+    return result.recommendations;
+  }
+
+  test("undefined chartType returns the top auto-detected recommendation", () => {
+    const recommendations = recs();
+    expect(pickChartRecommendation(recommendations, undefined)).toBe(recommendations[0]);
+    // The auto-detected default for date+numeric is a time-series line.
+    expect(recommendations[0].type).toBe("line");
+  });
+
+  test("honors a pinned type over the auto-detected default", () => {
+    const recommendations = recs();
+    const picked = pickChartRecommendation(recommendations, "bar");
+    expect(picked.type).toBe("bar");
+    // ...and it is NOT the auto-detected default (which is line).
+    expect(picked).not.toBe(recommendations[0]);
+  });
+
+  test("falls back to the top recommendation when the pinned type has no match", () => {
+    const recommendations = recs();
+    // `pie` is never recommended for this date+numeric data.
+    expect(recommendations.some((r) => r.type === "pie")).toBe(false);
+    expect(pickChartRecommendation(recommendations, "pie")).toBe(recommendations[0]);
   });
 });

--- a/packages/web/src/ui/components/chart/__tests__/result-chart.test.tsx
+++ b/packages/web/src/ui/components/chart/__tests__/result-chart.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ResultChart } from "../result-chart";
+
+// recharts' ResponsiveContainer measures via ResizeObserver, which jsdom lacks.
+// A no-op stub lets the component mount; the plot itself renders at 0×0 (recharts
+// warns, doesn't throw) — fine here, since every assertion targets the CHROME
+// (caption + type toggle) that renders OUTSIDE the responsive container.
+class StubResizeObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver =
+    StubResizeObserver;
+});
+
+// date + numeric data auto-detects to a time-series `line` first, with `area` and
+// `bar` also recommended — so the type toggle has >1 option and a pin to `bar`
+// is meaningfully DIFFERENT from the auto-detected default.
+const headers = ["week", "signups"];
+const rows = [
+  ["2026-01-05", "10"],
+  ["2026-01-12", "24"],
+  ["2026-01-19", "31"],
+];
+const AUTO_CAPTION = "Time-series: week vs signups";
+
+describe("ResultChart — chat surface (chrome kept, #4688 AC3)", () => {
+  afterEach(cleanup);
+
+  test("renders its caption bar and the Line/Area/Bar type toggle by default", () => {
+    render(<ResultChart headers={headers} rows={rows} dark={false} />);
+    // Caption (the top recommendation's `reason`) is shown.
+    expect(screen.getByText(AUTO_CAPTION)).toBeTruthy();
+    // The type toggle renders a button per unique recommended type.
+    expect(screen.getByRole("button", { name: "Line" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Area" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Bar" })).toBeTruthy();
+  });
+});
+
+describe("ResultChart — dashboard tile (embedded, #4688 AC1)", () => {
+  afterEach(cleanup);
+
+  test("suppresses the caption bar and the type toggle in embedded mode", () => {
+    render(<ResultChart headers={headers} rows={rows} dark={false} embedded />);
+    // No chat-explainer caption on a titled tile.
+    expect(screen.queryByText(AUTO_CAPTION)).toBeNull();
+    // No inner Line/Area/Bar toggle — the tile fixes the type.
+    expect(screen.queryByRole("button", { name: "Line" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Area" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Bar" })).toBeNull();
+  });
+
+  test("still renders the plot when pinned to a type that diverges from auto-detect", () => {
+    // Data auto-detects to `line`; pinning `bar` must render (not blank the tile
+    // or fall into the error boundary), with no toggle/caption chrome. (The plot
+    // itself paints at 0×0 in jsdom, so we assert on the mount + the absence of
+    // the error fallback rather than the SVG.)
+    render(<ResultChart headers={headers} rows={rows} dark={false} embedded chartType="bar" />);
+    expect(screen.queryByText(AUTO_CAPTION)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Line" })).toBeNull();
+    // The ErrorBoundary fallback would appear only if the pinned render threw.
+    expect(screen.queryByText(/Unable to render chart/)).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/chart/chart-detection.ts
+++ b/packages/web/src/ui/components/chart/chart-detection.ts
@@ -40,6 +40,50 @@ type ChartableResult = {
 export type ChartDetectionResult = NonChartableResult | ChartableResult;
 
 /* ------------------------------------------------------------------ */
+/*  Tile chart-type pinning (#4688)                                     */
+/* ------------------------------------------------------------------ */
+
+/** The render-union chart types a dashboard tile can PIN itself to. */
+const RENDER_CHART_TYPES: ReadonlySet<ChartType> = new Set([
+  "bar",
+  "line",
+  "pie",
+  "area",
+  "stacked-bar",
+  "scatter",
+]);
+
+/**
+ * #4688 — narrow a persisted `chartConfig.type` (the `@useatlas/types` ChartType:
+ * bar/line/pie/area/scatter/table/kpi) down to the render-union {@link ChartType}
+ * used to PIN a dashboard tile's chart to its configured type. `table`/`kpi` never
+ * reach a chart body (the tile renders a DataTable / KpiCard instead), so they —
+ * and any value outside the render set — map to `undefined`, meaning "no pin,
+ * auto-detect". Pure + string-tolerant so a loosely-parsed cached config (the
+ * un-Zod'd `rowToCard` read path) can't force a bogus type onto the chart.
+ */
+export function asEmbeddedChartType(type: string | null | undefined): ChartType | undefined {
+  return type != null && RENDER_CHART_TYPES.has(type as ChartType) ? (type as ChartType) : undefined;
+}
+
+/**
+ * #4688 — pick which recommendation a chart renders. When `chartType` is set (a
+ * dashboard tile pinned to its `chartConfig.type`) return the matching
+ * recommendation, so the tile honors its saved type instead of the data's
+ * auto-detected default. When the current data yields no recommendation for that
+ * type (the config type no longer fits the rows), fall back to the top
+ * auto-detected recommendation — a divergent tile still renders SOME chart rather
+ * than nothing. `undefined` chartType (the chat surface) → the top recommendation.
+ */
+export function pickChartRecommendation(
+  recommendations: readonly [ChartRecommendation, ...ChartRecommendation[]],
+  chartType: ChartType | undefined,
+): ChartRecommendation {
+  if (!chartType) return recommendations[0];
+  return recommendations.find((r) => r.type === chartType) ?? recommendations[0];
+}
+
+/* ------------------------------------------------------------------ */
 /*  Color palettes (Tailwind weights)                                   */
 /* ------------------------------------------------------------------ */
 

--- a/packages/web/src/ui/components/chart/chart-detection.ts
+++ b/packages/web/src/ui/components/chart/chart-detection.ts
@@ -43,27 +43,37 @@ export type ChartDetectionResult = NonChartableResult | ChartableResult;
 /*  Tile chart-type pinning (#4688)                                     */
 /* ------------------------------------------------------------------ */
 
-/** The render-union chart types a dashboard tile can PIN itself to. */
-const RENDER_CHART_TYPES: ReadonlySet<ChartType> = new Set([
+/**
+ * The render-union chart types a dashboard tile can PIN itself to. `satisfies
+ * readonly ChartType[]` makes a typo'd member a compile error (so the pin set
+ * can't silently list a type the renderer doesn't know); the Set is typed
+ * `ReadonlySet<string>` so its `.has()` accepts a raw string with no cast.
+ */
+const RENDER_CHART_TYPES_LIST = [
   "bar",
   "line",
   "pie",
   "area",
   "stacked-bar",
   "scatter",
-]);
+] as const satisfies readonly ChartType[];
+const RENDER_CHART_TYPES: ReadonlySet<string> = new Set(RENDER_CHART_TYPES_LIST);
 
 /**
  * #4688 — narrow a persisted `chartConfig.type` (the `@useatlas/types` ChartType:
  * bar/line/pie/area/scatter/table/kpi) down to the render-union {@link ChartType}
- * used to PIN a dashboard tile's chart to its configured type. `table`/`kpi` never
+ * used to PIN a dashboard tile's chart to its configured type. The render union is
+ * intentionally broader than the persisted one (it also carries the detection-only
+ * `stacked-bar`), so this is a narrowing on the persisted side: `table`/`kpi` never
  * reach a chart body (the tile renders a DataTable / KpiCard instead), so they —
  * and any value outside the render set — map to `undefined`, meaning "no pin,
  * auto-detect". Pure + string-tolerant so a loosely-parsed cached config (the
- * un-Zod'd `rowToCard` read path) can't force a bogus type onto the chart.
+ * un-Zod'd `rowToCard` read path) can't force a bogus type onto the chart. The
+ * return cast is sound: it only runs after the Set-membership check confirms the
+ * string IS a render `ChartType`.
  */
 export function asEmbeddedChartType(type: string | null | undefined): ChartType | undefined {
-  return type != null && RENDER_CHART_TYPES.has(type as ChartType) ? (type as ChartType) : undefined;
+  return type != null && RENDER_CHART_TYPES.has(type) ? (type as ChartType) : undefined;
 }
 
 /**

--- a/packages/web/src/ui/components/chart/result-chart.tsx
+++ b/packages/web/src/ui/components/chart/result-chart.tsx
@@ -816,8 +816,9 @@ export function ResultChart({
    * data's auto-detected default. Pass a card's `chartConfig.type` (narrowed via
    * `asEmbeddedChartType`); when the current data has no recommendation for that
    * type the top auto-detected one is used instead (a divergent tile still draws
-   * a chart). Omitted → auto-detect (the chat surface). Only meaningful with
-   * `embedded`, since the in-chart toggle it would otherwise fight is suppressed.
+   * a chart). Omitted → auto-detect (the chat surface). Intended to be paired with
+   * `embedded`: passing it alone still pins the chart but leaves the (now inert)
+   * in-chart toggle visible, which is not a supported combination.
    */
   chartType?: ChartType;
 }) {

--- a/packages/web/src/ui/components/chart/result-chart.tsx
+++ b/packages/web/src/ui/components/chart/result-chart.tsx
@@ -30,6 +30,7 @@ import {
   transformData,
   categoryFromChartClick,
   categoryFromPieClick,
+  pickChartRecommendation,
   resolveThresholdLines,
   resolveAnnotationLines,
   CHART_COLORS_LIGHT,
@@ -765,6 +766,8 @@ export function ResultChart({
   selectedCategory,
   thresholds,
   annotations,
+  embedded = false,
+  chartType,
 }: {
   headers: string[];
   rows: string[][];
@@ -799,6 +802,24 @@ export function ResultChart({
    * chat surface and on cards with none, so the chart renders exactly as before.
    */
   annotations?: AnnotationInput[];
+  /**
+   * #4688 — dashboard-tile mode. When true, ResultChart renders the PLOT ONLY:
+   * its own caption bar ("Time-series: …"), the Line/Area/Bar type toggle, and
+   * its border frame are suppressed. A dashboard tile already owns the title +
+   * border and the card config pins the chart type, so ResultChart's own chrome
+   * would be chrome-in-chrome. The chat surface omits this → keeps toggle +
+   * caption. Defaults to false (unchanged chat behaviour).
+   */
+  embedded?: boolean;
+  /**
+   * #4688 — pin the rendered chart to the card's configured type instead of the
+   * data's auto-detected default. Pass a card's `chartConfig.type` (narrowed via
+   * `asEmbeddedChartType`); when the current data has no recommendation for that
+   * type the top auto-detected one is used instead (a divergent tile still draws
+   * a chart). Omitted → auto-detect (the chat surface). Only meaningful with
+   * `embedded`, since the in-chart toggle it would otherwise fight is suppressed.
+   */
+  chartType?: ChartType;
 }) {
   const result = useMemo(
     () => detectionResult ?? detectCharts(headers, rows),
@@ -809,8 +830,43 @@ export function ResultChart({
 
   if (!result.chartable) return null;
 
-  const currentType = activeType ?? result.recommendations[0].type;
-  const currentRec = result.recommendations.find((r) => r.type === currentType) ?? result.recommendations[0];
+  // #4688 — a pinned `chartType` (a dashboard tile) fixes the rendered chart to
+  // the card's configured type and takes precedence over the in-chart toggle
+  // (`activeType`, chat-surface only). No pin → the toggle / auto-detect path.
+  const pinnedRec = chartType ? pickChartRecommendation(result.recommendations, chartType) : null;
+  const currentType = pinnedRec?.type ?? activeType ?? result.recommendations[0].type;
+  const currentRec =
+    pinnedRec ?? result.recommendations.find((r) => r.type === currentType) ?? result.recommendations[0];
+
+  const chartBody = (
+    <ErrorBoundary
+      key={currentType}
+      fallback={
+        <div className="rounded-lg border border-yellow-300 bg-yellow-50 px-3 py-2 text-xs text-yellow-700 dark:border-yellow-900/50 dark:bg-yellow-950/20 dark:text-yellow-400">
+          Unable to render chart. Switch to Table view to see your data.
+        </div>
+      }
+    >
+      <ChartRenderer
+        rows={rows}
+        rec={currentRec}
+        defaultData={result.data}
+        defaultRec={result.recommendations[0]}
+        dark={dark}
+        onCategoryClick={onCategoryClick}
+        selectedCategory={selectedCategory}
+        thresholds={thresholds}
+        annotations={annotations}
+      />
+    </ErrorBoundary>
+  );
+
+  // #4688 — dashboard tiles render the plot only: no caption bar, no type toggle,
+  // no frame (the tile already provides all three). The single wrapping div keeps
+  // the height target the tile's ChartSlot `[&>div]:h-full` selector expects.
+  if (embedded) {
+    return <div className="h-full">{chartBody}</div>;
+  }
 
   return (
     <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
@@ -822,26 +878,7 @@ export function ResultChart({
           onChange={setActiveType}
         />
       </div>
-      <ErrorBoundary
-        key={currentType}
-        fallback={
-          <div className="rounded-lg border border-yellow-300 bg-yellow-50 px-3 py-2 text-xs text-yellow-700 dark:border-yellow-900/50 dark:bg-yellow-950/20 dark:text-yellow-400">
-            Unable to render chart. Switch to Table view to see your data.
-          </div>
-        }
-      >
-        <ChartRenderer
-          rows={rows}
-          rec={currentRec}
-          defaultData={result.data}
-          defaultRec={result.recommendations[0]}
-          dark={dark}
-          onCategoryClick={onCategoryClick}
-          selectedCategory={selectedCategory}
-          thresholds={thresholds}
-          annotations={annotations}
-        />
-      </ErrorBoundary>
+      {chartBody}
     </div>
   );
 }

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -14,18 +14,26 @@ void mock.module("@/ui/components/chart/result-chart", () => ({
     onCategoryClick,
     thresholds,
     annotations,
+    embedded,
+    chartType,
   }: {
     onCategoryClick?: (value: string, categoryKey: string) => void;
     thresholds?: { value: number; color?: string; label?: string }[];
     annotations?: { x: string; label: string; color?: string }[];
+    embedded?: boolean;
+    chartType?: string;
   }) => (
     <>
-      {/* Fires with the card's configured category column ("stage") — matches. */}
+      {/* Fires with the card's configured category column ("stage") — matches.
+          #4688 — `embedded` / `chartType` surface via data-attrs so a test can
+          assert the tile suppresses ResultChart's chrome + pins the type. */}
       <button
         type="button"
         data-testid="result-chart"
         data-thresholds={JSON.stringify(thresholds ?? null)}
         data-annotations={JSON.stringify(annotations ?? null)}
+        data-embedded={embedded ? "true" : "false"}
+        data-chart-type={chartType ?? ""}
         onClick={() => onCategoryClick?.("Discovery", "stage")}
       >
         chart
@@ -171,6 +179,22 @@ describe("DashboardTile", () => {
     });
     const chart = screen.getByTestId("result-chart");
     expect(JSON.parse(chart.getAttribute("data-annotations") ?? "null")).toEqual(annotations);
+    restore();
+  });
+
+  test("renders ResultChart in embedded mode and pins it to the card's chart type (#4688)", async () => {
+    const restore = setBoundingRect(600, 300);
+    (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver = StubResizeObserver;
+    // baseCard is configured `type: "bar"` — the tile must pin ResultChart to it
+    // (not the data's auto-detect) AND suppress ResultChart's own caption/toggle
+    // chrome via `embedded`.
+    render(<DashboardTile {...baseProps} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const chart = screen.getByTestId("result-chart");
+    expect(chart.getAttribute("data-embedded")).toBe("true");
+    expect(chart.getAttribute("data-chart-type")).toBe("bar");
     restore();
   });
 

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -35,6 +35,8 @@ import {
 import { DataTable } from "@/ui/components/chat/data-table";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { KpiCard } from "./kpi-card";
+import { asEmbeddedChartType } from "@/ui/components/chart/chart-detection";
+import type { ChartType as RenderChartType } from "@/ui/components/chart/chart-detection";
 import { useDarkMode } from "@/ui/hooks/use-dark-mode";
 import { useNow } from "@/ui/hooks/use-now";
 import { cn } from "@/lib/utils";
@@ -604,6 +606,7 @@ function ChartTile({
               columns={columns}
               stringRows={stringRows}
               dark={dark}
+              chartType={asEmbeddedChartType(card.chartConfig?.type)}
               onCategoryClick={onCategoryClick}
               selectedCategory={selectedValue}
               thresholds={card.chartConfig?.thresholds}
@@ -726,6 +729,7 @@ function ChartSlot({
   columns,
   stringRows,
   dark,
+  chartType,
   onCategoryClick,
   selectedCategory,
   thresholds,
@@ -735,6 +739,12 @@ function ChartSlot({
   columns: string[];
   stringRows: string[][];
   dark: boolean;
+  /**
+   * #4688 — the card's configured chart type (narrowed to the render union),
+   * pinning the tile's chart so it honors its saved type instead of ResultChart's
+   * data auto-detection. Undefined → auto-detect.
+   */
+  chartType?: RenderChartType;
   /** #3212 — forwarded to ResultChart; undefined → chart is inert on click. */
   onCategoryClick?: (value: string, categoryKey: string) => void;
   /** #3213 — forwarded to ResultChart; the active cross-filter's category value. */
@@ -781,6 +791,8 @@ function ChartSlot({
           headers={columns}
           rows={stringRows}
           dark={dark}
+          embedded
+          chartType={chartType}
           onCategoryClick={onCategoryClick}
           selectedCategory={selectedCategory}
           thresholds={thresholds}


### PR DESCRIPTION
## Summary

Dashboard chart tiles reuse the chat `ResultChart`, which carried **its own** caption bar (`"Time-series: X vs Y"`) + Line/Area/Bar type toggle and auto-detected its chart type from the data. Inside a titled tile — which already owns a header (title, Chart/Table toggle, refresh/fullscreen/⋯) and a footer (age caption, row count) — that's chrome-in-chrome, and the inner toggle could **contradict the card's configured type** (a card saved `chartConfig.type: "bar"` rendered as a line, because ResultChart re-detected from the data).

- `ResultChart` gains two props: `embedded` (renders the **plot only** — suppresses its caption bar, the type toggle, and its border frame) and `chartType` (**pins** the render to the card's configured type, falling back to auto-detect when the data no longer supports that type, so a divergent tile still draws a chart rather than nothing).
- **Both** dashboard surfaces opt in: the live tile (`dashboard-tile.tsx` → `ChartSlot`) and the framable shared-view embed (`shared/dashboard/[token]/tile.tsx`), which had the identical defect. The chat surface (`sql-result-card`, `python-result-card`) is untouched — `embedded` defaults to `false`, so it keeps its toggle + caption.
- Pure, tested seam in `chart-detection.ts`: `asEmbeddedChartType` (narrow the persisted `@useatlas/types` type → the render union; `table`/`kpi`/bogus → `undefined`) and `pickChartRecommendation` (honor the pinned type, fall back to the top recommendation).

## Acceptance criteria
- [x] On a dashboard tile, ResultChart renders the plot only — its caption bar + Line/Area/Bar toggle are suppressed (`embedded` prop).
- [x] The rendered chart type honors the card's `chartConfig.type` rather than data auto-detection (`chartType` prop → `pickChartRecommendation`).
- [x] The chat surface is unaffected (keeps toggle/caption).

## Test plan
- [x] `chart-detection.test.ts` — `asEmbeddedChartType` (render-union passthrough, table/kpi/null/bogus → undefined) + `pickChartRecommendation` (honors pin over auto-detect; falls back to top rec when pin has no match).
- [x] `result-chart.test.tsx` (new, real component) — embedded suppresses caption + toggle (AC1); non-embedded keeps both (AC3); a divergent pinned type still renders without hitting the error boundary.
- [x] `dashboard-tile.test.tsx` + shared `tile.test.tsx` — both surfaces forward `embedded` + the card's `chartType`.
- [x] `bash scripts/ci-local.sh` — all 31 gates green (type, lint, lint-type-aware, full test suite, drift gates).

Closes #4688