### PR TITLE
fix(dashboards): embed ?theme= themes charts + discoverable light/dark control (#4686)

### DIFF
--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-dialog-embed.test.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-dialog-embed.test.tsx
@@ -98,6 +98,52 @@ describe("DashboardShareDialog — Embed tab (#4564)", () => {
     expect(clipboardText).toContain("<iframe");
   });
 
+  test("the appearance control defaults to System (no ?theme=) and regenerates the snippet per choice (#4686)", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "public" });
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole("tab", { name: "Embed" }));
+    });
+
+    const snippet = (await screen.findByLabelText("Embed snippet")) as HTMLTextAreaElement;
+    // Default = System → no forced theme param.
+    expect(snippet.value).toContain("/shared/dashboard/tok_live/embed\"");
+    expect(snippet.value).not.toContain("?theme=");
+
+    // Selecting Dark bakes ?theme=dark into the snippet.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("radio", { name: /Dark/ }));
+    });
+    await waitFor(() => expect(snippet.value).toContain("/embed?theme=dark"));
+
+    // Selecting Light swaps it to ?theme=light.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("radio", { name: /Light/ }));
+    });
+    await waitFor(() => expect(snippet.value).toContain("/embed?theme=light"));
+  });
+
+  test("re-clicking the active appearance keeps the selection (Radix deselect guard) (#4686)", async () => {
+    await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "public" });
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByRole("tab", { name: "Embed" }));
+    });
+    const snippet = (await screen.findByLabelText("Embed snippet")) as HTMLTextAreaElement;
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("radio", { name: /Dark/ }));
+    });
+    await waitFor(() => expect(snippet.value).toContain("/embed?theme=dark"));
+
+    // Re-click the active item — Radix emits "" (deselect). The guard must keep
+    // "dark" selected so the snippet never carries an empty/blank ?theme=.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("radio", { name: /Dark/ }));
+    });
+    expect(snippet.value).toContain("/embed?theme=dark");
+    expect(snippet.value).not.toContain("?theme=\"");
+    expect(snippet.value).not.toContain("?theme=&");
+  });
+
   test("the embed caption is shareMode-aware — an org share warns viewers must sign in", async () => {
     await openDialogWithStatus({ shared: true, token: "tok_live", expiresAt: null, shareMode: "org" });
 

--- a/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-embed.test.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/__tests__/share-embed.test.ts
@@ -19,4 +19,17 @@ describe("buildEmbedSnippet (#4564)", () => {
     expect(code).not.toContain('a"b');
     expect(code).toContain('a&quot;b/embed');
   });
+
+  test("omits ?theme= by default so the embed follows the visitor's system (#4686)", () => {
+    const code = buildEmbedSnippet("https://app.example.com/shared/dashboard/tok_live");
+    expect(code).toContain('src="https://app.example.com/shared/dashboard/tok_live/embed"');
+    expect(code).not.toContain("?theme=");
+  });
+
+  test("appends the forced ?theme= param when a light/dark appearance is chosen (#4686)", () => {
+    const dark = buildEmbedSnippet("https://app.example.com/shared/dashboard/tok_live", "dark");
+    expect(dark).toContain('src="https://app.example.com/shared/dashboard/tok_live/embed?theme=dark"');
+    const light = buildEmbedSnippet("https://app.example.com/shared/dashboard/tok_live", "light");
+    expect(light).toContain("/embed?theme=light");
+  });
 });

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
@@ -33,9 +33,10 @@ import { buildEmbedSnippet, type EmbedThemeParam } from "./share-embed";
 
 /** Embed-tab theme control: "system" emits no `?theme=` param (visitor's own
  *  preference drives the frame); "light"/"dark" force a fixed appearance. The
- *  tuple is the SSOT for both the rendered toggle items and the `onValueChange`
- *  narrowing, so an added/renamed choice can't silently drift; `satisfies` pins
- *  every member to a valid `"system" | EmbedThemeParam`. */
+ *  tuple is the SSOT for the `EmbedThemeChoice` type and the `onValueChange`
+ *  narrowing (`asEmbedThemeChoice`); the rendered `<ToggleGroupItem>` values are
+ *  authored to match by hand. `satisfies` pins every member to a valid
+ *  `"system" | EmbedThemeParam`. */
 const EMBED_THEME_CHOICES = ["system", "light", "dark"] as const satisfies readonly (
   | "system"
   | EmbedThemeParam
@@ -399,9 +400,7 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
                       variant="outline"
                       size="sm"
                       value={embedTheme}
-                      // Radix emits "" when the active item is re-clicked (deselect);
-                      // asEmbedThemeChoice returns undefined there, so a theme stays
-                      // selected and the snippet never carries an empty ?theme=.
+                      // Empty deselect value is ignored — see asEmbedThemeChoice.
                       onValueChange={(v) => {
                         const next = asEmbedThemeChoice(v);
                         if (next) setEmbedTheme(next);

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
@@ -32,8 +32,24 @@ import { deriveExpiryKey } from "./share-expiry";
 import { buildEmbedSnippet, type EmbedThemeParam } from "./share-embed";
 
 /** Embed-tab theme control: "system" emits no `?theme=` param (visitor's own
- *  preference drives the frame); "light"/"dark" force a fixed appearance. */
-type EmbedThemeChoice = "system" | EmbedThemeParam;
+ *  preference drives the frame); "light"/"dark" force a fixed appearance. The
+ *  tuple is the SSOT for both the rendered toggle items and the `onValueChange`
+ *  narrowing, so an added/renamed choice can't silently drift; `satisfies` pins
+ *  every member to a valid `"system" | EmbedThemeParam`. */
+const EMBED_THEME_CHOICES = ["system", "light", "dark"] as const satisfies readonly (
+  | "system"
+  | EmbedThemeParam
+)[];
+type EmbedThemeChoice = (typeof EMBED_THEME_CHOICES)[number];
+
+/** Narrow Radix's `string` back onto the choice union. Radix emits `""` when the
+ *  active item is re-clicked (deselect); returning `undefined` there lets the
+ *  caller keep the current selection rather than blanking it. */
+function asEmbedThemeChoice(value: string): EmbedThemeChoice | undefined {
+  return (EMBED_THEME_CHOICES as readonly string[]).includes(value)
+    ? (value as EmbedThemeChoice)
+    : undefined;
+}
 
 const EXPIRY_LABELS: Record<ShareExpiryKey, string> = {
   "1h": "1 hour",
@@ -384,8 +400,12 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
                       size="sm"
                       value={embedTheme}
                       // Radix emits "" when the active item is re-clicked (deselect);
-                      // keep a theme always selected so the snippet stays valid.
-                      onValueChange={(v) => v && setEmbedTheme(v as EmbedThemeChoice)}
+                      // asEmbedThemeChoice returns undefined there, so a theme stays
+                      // selected and the snippet never carries an empty ?theme=.
+                      onValueChange={(v) => {
+                        const next = asEmbedThemeChoice(v);
+                        if (next) setEmbedTheme(next);
+                      }}
                       className="w-full"
                       aria-label="Embed appearance"
                     >

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-dialog.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Share2, Copy, Check, Link2Off, Globe, Lock, Loader2, RefreshCw, Code } from "lucide-react";
+import { Share2, Copy, Check, Link2Off, Globe, Lock, Loader2, RefreshCw, Code, Monitor, Sun, Moon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Select,
   SelectContent,
@@ -28,7 +29,11 @@ import type { ShareMode, ShareExpiryKey } from "@/ui/lib/types";
 import { SHARE_EXPIRY_OPTIONS } from "@/ui/lib/types";
 import { useAtlasConfig } from "@/ui/context";
 import { deriveExpiryKey } from "./share-expiry";
-import { buildEmbedSnippet } from "./share-embed";
+import { buildEmbedSnippet, type EmbedThemeParam } from "./share-embed";
+
+/** Embed-tab theme control: "system" emits no `?theme=` param (visitor's own
+ *  preference drives the frame); "light"/"dark" force a fixed appearance. */
+type EmbedThemeChoice = "system" | EmbedThemeParam;
 
 const EXPIRY_LABELS: Record<ShareExpiryKey, string> = {
   "1h": "1 hour",
@@ -55,6 +60,9 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
   const [shared, setShared] = useState(false);
   const [copied, setCopied] = useState(false);
   const [copiedEmbed, setCopiedEmbed] = useState(false);
+  // Embed appearance the snippet bakes in. Default "system" = no `?theme=` param
+  // so the frame follows the visitor's own light/dark preference (#4686).
+  const [embedTheme, setEmbedTheme] = useState<EmbedThemeChoice>("system");
   const [error, setError] = useState<string | null>(null);
   const [expiresIn, setExpiresIn] = useState<ShareExpiryKey>("7d");
   const [shareMode, setShareMode] = useState<ShareMode>("public");
@@ -175,7 +183,9 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
   // The iframe snippet for the Embed tab — points at the SAME share token's
   // framable `/embed` route (#4564), so revoking the link kills the embed too.
   // Built by the pure `buildEmbedSnippet` helper (escaping pinned in its test).
-  const embedCode = shareUrl ? buildEmbedSnippet(shareUrl) : "";
+  const embedCode = shareUrl
+    ? buildEmbedSnippet(shareUrl, embedTheme === "system" ? undefined : embedTheme)
+    : "";
 
   async function copyText(text: string, flash: (v: boolean) => void) {
     try {
@@ -365,6 +375,36 @@ export function DashboardShareDialog({ dashboardId }: DashboardShareDialogProps)
                 </TabsContent>
 
                 <TabsContent value="embed" className="mt-4 grid gap-3">
+                  <div className="grid gap-2">
+                    <Label htmlFor="dashboard-embed-theme">Appearance</Label>
+                    <ToggleGroup
+                      id="dashboard-embed-theme"
+                      type="single"
+                      variant="outline"
+                      size="sm"
+                      value={embedTheme}
+                      // Radix emits "" when the active item is re-clicked (deselect);
+                      // keep a theme always selected so the snippet stays valid.
+                      onValueChange={(v) => v && setEmbedTheme(v as EmbedThemeChoice)}
+                      className="w-full"
+                      aria-label="Embed appearance"
+                    >
+                      <ToggleGroupItem value="system" className="flex-1 gap-1.5">
+                        <Monitor className="size-3.5" /> System
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="light" className="flex-1 gap-1.5">
+                        <Sun className="size-3.5" /> Light
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="dark" className="flex-1 gap-1.5">
+                        <Moon className="size-3.5" /> Dark
+                      </ToggleGroupItem>
+                    </ToggleGroup>
+                    <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+                      {embedTheme === "system"
+                        ? "Follows each viewer's own light/dark setting."
+                        : `Always renders in ${embedTheme} mode, regardless of the viewer's setting.`}
+                    </p>
+                  </div>
                   <Label htmlFor="dashboard-embed-code">Embed snippet</Label>
                   <Textarea
                     id="dashboard-embed-code"

--- a/packages/web/src/app/(workspace)/dashboards/[id]/share-embed.ts
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/share-embed.ts
@@ -4,14 +4,23 @@
  * unit-testable without rendering the dialog (mirrors share-expiry.ts).
  */
 
+/** The forced-theme choices the Embed tab can bake into the snippet. `undefined`
+ *  (the default) emits no `?theme=` param so the embed follows the visitor's own
+ *  system preference. */
+export type EmbedThemeParam = "light" | "dark";
+
 /**
  * Build the iframe snippet that embeds a shared dashboard. It points at the
  * share token's framable `/embed` route — SAME snapshot, SAME revocation/expiry
  * as the standalone shared page — so revoking the link kills the embed too.
  * The URL is `&quot;`-escaped so a token can never break out of the `src="…"`
  * double-quoted attribute.
+ *
+ * `theme` forces the embed's light/dark appearance via `?theme=`; omitting it
+ * (the default) lets the visitor's system preference drive the frame.
  */
-export function buildEmbedSnippet(shareUrl: string): string {
-  const src = `${shareUrl.replace(/"/g, "&quot;")}/embed`;
+export function buildEmbedSnippet(shareUrl: string, theme?: EmbedThemeParam): string {
+  const base = `${shareUrl.replace(/"/g, "&quot;")}/embed`;
+  const src = theme ? `${base}?theme=${theme}` : base;
   return `<iframe src="${src}" width="100%" height="600" frameborder="0" style="border:0;border-radius:8px" title="Atlas dashboard"></iframe>`;
 }

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
@@ -3,13 +3,16 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type { SharedCard } from "../types";
 
 // The text branch never mounts a chart, but `dynamic(...)` + `useDarkMode` run
-// at import — stub them so jsdom doesn't try to evaluate recharts.
-void mock.module("@/ui/components/chart/result-chart", () => ({
-  ResultChart: () => <div data-testid="result-chart">chart</div>,
-}));
-void mock.module("next/dynamic", () => ({
-  default: () => () => <div data-testid="result-chart">chart</div>,
-}));
+// at import — stub them so jsdom doesn't try to evaluate recharts. The chart stub
+// echoes its resolved `dark` prop so the forced-theme threading is assertable
+// (#4686). `next/dynamic` returns the same stub the direct import path uses.
+function ChartStub({ dark }: { dark?: boolean }) {
+  return <div data-testid="result-chart" data-dark={String(dark)} />;
+}
+void mock.module("@/ui/components/chart/result-chart", () => ({ ResultChart: ChartStub }));
+void mock.module("next/dynamic", () => ({ default: () => ChartStub }));
+// The VISITOR's system theme resolves light here; a forced embed theme must win
+// over it, which is exactly what the #4686 threading test pins.
 void mock.module("@/ui/hooks/use-dark-mode", () => ({ useDarkMode: () => false }));
 
 import { SharedTile } from "../tile";
@@ -58,5 +61,62 @@ describe("SharedTile — text cards (#3138)", () => {
       <SharedTile card={card} spanClass="col-span-2" cachedLabel={null} cachedIso={undefined} />,
     );
     expect(container.querySelector("img")).toBeNull();
+  });
+});
+
+const chartCard: SharedCard = {
+  id: "c1",
+  title: "Signups by week",
+  kind: "chart",
+  chartConfig: { type: "bar", categoryColumn: "week", valueColumns: ["signups"] },
+  content: null,
+  annotations: [],
+  cachedColumns: ["week", "signups"],
+  cachedRows: [
+    { week: "2026-06-01", signups: 12 },
+    { week: "2026-06-08", signups: 18 },
+  ],
+  cachedAt: "2026-06-08T00:00:00.000Z",
+  position: 0,
+  layout: null,
+};
+
+describe("SharedTile — forced embed theme threads into the chart (#4686)", () => {
+  afterEach(cleanup);
+
+  // The chart mounts through `next/dynamic`, so its stub resolves on the next
+  // microtask — `findByTestId` waits it out. `data-dark` echoes the resolved
+  // `dark` prop the tile hands the chart.
+  test("forcedDark=true renders a dark chart even though the visitor's system is light", async () => {
+    // useDarkMode() is mocked to `false` (light visitor); the forced embed theme
+    // must override it so the JS-themed chart agrees with the dark chrome.
+    render(
+      <SharedTile card={chartCard} spanClass="col-span-1" cachedLabel={null} cachedIso={undefined} forcedDark />,
+    );
+    const chart = await screen.findByTestId("result-chart");
+    expect(chart.getAttribute("data-dark")).toBe("true");
+  });
+
+  test("forcedDark=false renders a light chart regardless of the visitor's own theme", async () => {
+    render(
+      <SharedTile
+        card={chartCard}
+        spanClass="col-span-1"
+        cachedLabel={null}
+        cachedIso={undefined}
+        forcedDark={false}
+      />,
+    );
+    const chart = await screen.findByTestId("result-chart");
+    expect(chart.getAttribute("data-dark")).toBe("false");
+  });
+
+  test("no forcedDark (standalone shared page) falls back to the visitor's system theme", async () => {
+    render(
+      <SharedTile card={chartCard} spanClass="col-span-1" cachedLabel={null} cachedIso={undefined} />,
+    );
+    // Mocked visitor system = light → the chart follows it when unforced.
+    const chart = await screen.findByTestId("result-chart");
+    expect(chart.getAttribute("data-dark")).toBe("false");
   });
 });

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
@@ -11,12 +11,13 @@ function ChartStub({ dark }: { dark?: boolean }) {
 }
 void mock.module("@/ui/components/chart/result-chart", () => ({ ResultChart: ChartStub }));
 void mock.module("next/dynamic", () => ({ default: () => ChartStub }));
-// The VISITOR's system theme resolves light here; a forced embed theme must win
-// over it, which is exactly what the #4686 threading test pins. Mock ALL exports
-// (mock-all-exports discipline) so a future importer of another symbol doesn't
-// silently get `undefined`.
+// The VISITOR's system theme. Mutable so the unforced test can flip it and prove
+// the tile actually READS it (a forced theme must win over it — the #4686
+// threading contract). Mock ALL exports (mock-all-exports discipline) so a future
+// importer of another symbol doesn't silently get `undefined`.
+let mockSystemDark = false;
 void mock.module("@/ui/hooks/use-dark-mode", () => ({
-  useDarkMode: () => false,
+  useDarkMode: () => mockSystemDark,
   useThemeMode: () => "system",
   setTheme: () => {},
   applyBrandColor: () => {},
@@ -120,12 +121,18 @@ describe("SharedTile — forced embed theme threads into the chart (#4686)", () 
     expect(chart.getAttribute("data-dark")).toBe("false");
   });
 
-  test("no forcedDark (standalone shared page) falls back to the visitor's system theme", async () => {
-    render(
-      <SharedTile card={chartCard} spanClass="col-span-1" cachedLabel={null} cachedIso={undefined} />,
-    );
-    // Mocked visitor system = light → the chart follows it when unforced.
-    const chart = await screen.findByTestId("result-chart");
-    expect(chart.getAttribute("data-dark")).toBe("false");
+  test("no forcedDark (standalone shared page) follows the visitor's system theme", async () => {
+    // Flip the mocked visitor system to DARK so this asserts the tile actually
+    // READS systemDark on the unforced path (not just a hardcoded default).
+    mockSystemDark = true;
+    try {
+      render(
+        <SharedTile card={chartCard} spanClass="col-span-1" cachedLabel={null} cachedIso={undefined} />,
+      );
+      const chart = await screen.findByTestId("result-chart");
+      expect(chart.getAttribute("data-dark")).toBe("true");
+    } finally {
+      mockSystemDark = false;
+    }
   });
 });

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
@@ -12,8 +12,17 @@ function ChartStub({ dark }: { dark?: boolean }) {
 void mock.module("@/ui/components/chart/result-chart", () => ({ ResultChart: ChartStub }));
 void mock.module("next/dynamic", () => ({ default: () => ChartStub }));
 // The VISITOR's system theme resolves light here; a forced embed theme must win
-// over it, which is exactly what the #4686 threading test pins.
-void mock.module("@/ui/hooks/use-dark-mode", () => ({ useDarkMode: () => false }));
+// over it, which is exactly what the #4686 threading test pins. Mock ALL exports
+// (mock-all-exports discipline) so a future importer of another symbol doesn't
+// silently get `undefined`.
+void mock.module("@/ui/hooks/use-dark-mode", () => ({
+  useDarkMode: () => false,
+  useThemeMode: () => "system",
+  setTheme: () => {},
+  applyBrandColor: () => {},
+  DEFAULT_BRAND_COLOR: "oklch(0.4 0.115 158)",
+  OKLCH_RE: /^oklch\(/,
+}));
 
 import { SharedTile } from "../tile";
 

--- a/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/__tests__/embed.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
-import { EmbedErrorView, resolveEmbedTheme } from "../embed";
+import { EmbedErrorView, buildEmbedThemeForceScript, resolveEmbedTheme } from "../embed";
 
 describe("resolveEmbedTheme", () => {
   test("resolves 'dark' and 'light' verbatim", () => {
@@ -8,10 +8,12 @@ describe("resolveEmbedTheme", () => {
     expect(resolveEmbedTheme("light")).toBe("light");
   });
 
-  test("defaults to 'light' for empty/absent values without warning", () => {
+  test("returns undefined (follow visitor system) for empty/absent values without warning", () => {
+    // No `?theme=` param → the embed follows the visitor's own system preference
+    // rather than forcing a theme (#4686). Absence is expected, not an error.
     const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-    expect(resolveEmbedTheme(undefined)).toBe("light");
-    expect(resolveEmbedTheme("")).toBe("light");
+    expect(resolveEmbedTheme(undefined)).toBeUndefined();
+    expect(resolveEmbedTheme("")).toBeUndefined();
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
@@ -20,11 +22,26 @@ describe("resolveEmbedTheme", () => {
     expect(resolveEmbedTheme(["dark", "light"])).toBe("dark");
   });
 
-  test("warns and falls back to 'light' on an unrecognized value", () => {
+  test("warns and follows the visitor system on an unrecognized value", () => {
     const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-    expect(resolveEmbedTheme("neon")).toBe("light");
+    expect(resolveEmbedTheme("neon")).toBeUndefined();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+describe("buildEmbedThemeForceScript", () => {
+  // The forced-theme override script pushes the resolved theme onto
+  // `documentElement` so a `?theme=` param wins over the visitor's own
+  // system/localStorage preference (the root theme-init would otherwise stamp it).
+  test("toggles the .dark class to the forced boolean", () => {
+    expect(buildEmbedThemeForceScript(true)).toContain('classList.toggle("dark",true)');
+    expect(buildEmbedThemeForceScript(false)).toContain('classList.toggle("dark",false)');
+  });
+
+  test("is wrapped in a try/catch so a locked-down document can't throw", () => {
+    expect(buildEmbedThemeForceScript(true)).toStartWith("try{");
+    expect(buildEmbedThemeForceScript(true)).toContain("catch");
   });
 });
 

--- a/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
@@ -9,19 +9,37 @@ import type { FetchResult } from "../fetch";
 export type EmbedTheme = "light" | "dark";
 
 /**
- * Resolve the optional `?theme=` query param. An iframe on a foreign origin has
- * no reliable system-theme signal, so the host picks via the URL (mirrors the
- * shared-conversation embed). Anything unrecognized falls back to "light" with a
- * warning rather than silently guessing.
+ * Resolve the optional `?theme=` query param into an explicit forced theme, or
+ * `undefined` when the host wants the embed to follow the visitor's own system
+ * preference. An iframe on a foreign origin has no reliable system-theme signal,
+ * so the host opts into a fixed theme via the URL; omitting the param (the
+ * default snippet) lets the visitor's `prefers-color-scheme` drive both chrome
+ * and charts. Anything unrecognized follows the system with a warning rather
+ * than silently forcing a guess.
  */
-export function resolveEmbedTheme(raw: string | string[] | undefined): EmbedTheme {
+export function resolveEmbedTheme(raw: string | string[] | undefined): EmbedTheme | undefined {
   const value = Array.isArray(raw) ? raw[0] : raw;
   if (value === "dark") return "dark";
-  if (value == null || value === "" || value === "light") return "light";
+  if (value === "light") return "light";
+  if (value == null || value === "") return undefined;
   console.warn(
-    `[shared-dashboard/embed] Unrecognized ?theme= value (got ${JSON.stringify(value)}); falling back to "light".`,
+    `[shared-dashboard/embed] Unrecognized ?theme= value (got ${JSON.stringify(value)}); following the visitor's system theme.`,
   );
-  return "light";
+  return undefined;
+}
+
+/**
+ * Pre-paint inline script for a forced-theme embed. It toggles `documentElement`'s
+ * `.dark` to the resolved theme so a `?theme=` param OVERRIDES the visitor's own
+ * system/localStorage preference — which the root `theme-init` script would
+ * otherwise stamp onto `documentElement`. Without this, the project's
+ * `&:is(.dark *)` dark variant fires off any `.dark` ancestor, so a forced
+ * `?theme=light` embed loaded by a dark-OS visitor would still render dark chrome.
+ * Emitted only when a theme is forced; a no-param embed keeps following the
+ * visitor. Runs before the framed content paints, so there is no theme flash.
+ */
+export function buildEmbedThemeForceScript(dark: boolean): string {
+  return `try{document.documentElement.classList.toggle("dark",${dark})}catch(e){}`;
 }
 
 type FailReason = Extract<FetchResult, { ok: false }>["reason"];

--- a/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { SharedDashboardView } from "../view";
 import { fetchSharedDashboard } from "../fetch";
-import { EmbedErrorView, resolveEmbedTheme } from "./embed";
+import { EmbedErrorView, buildEmbedThemeForceScript, resolveEmbedTheme } from "./embed";
 
 // An embed is an iframe surface, not a page to index. The standalone
 // `/shared/dashboard/[token]` route owns the OG/discovery metadata; this frame
@@ -23,19 +24,40 @@ interface PageProps {
 export default async function SharedDashboardEmbedPage({ params, searchParams }: PageProps) {
   const { token } = await params;
   const { theme: themeParam } = await searchParams;
+  // `undefined` → no `?theme=` param: the embed follows the visitor's own system
+  // preference (the root `theme-init` script stamps `documentElement`, and the
+  // tiles read `useDarkMode()`). Otherwise the param forces a fixed theme.
   const theme = resolveEmbedTheme(themeParam);
+  const forcedDark = theme === undefined ? undefined : theme === "dark";
   const result = await fetchSharedDashboard(token);
+
+  // The proxy mints a per-request CSP nonce on `x-nonce`; stamp it onto our inline
+  // theme-force script so it executes under the nonce-based `script-src` (mirrors
+  // the root layout's no-flash theme script).
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
 
   // Tailwind's dark variant here is `&:is(.dark *)` — the element bearing `.dark`
   // doesn't match it, only descendants do — so the wrapper carries `.dark` and the
-  // inner shell's `dark:` modifiers fire against the host-selected theme.
+  // inner shell's `dark:` modifiers fire against the forced theme. The forced
+  // theme is ALSO threaded into the tiles (`forcedDark`) so the JS-themed charts
+  // agree with the chrome, and pushed onto `documentElement` (below) so a forced
+  // `?theme=light` can override a dark-OS visitor.
   return (
-    <div className={theme === "dark" ? "dark" : ""} data-theme={theme}>
-      {result.ok ? (
-        <SharedDashboardView dashboard={result.data} />
-      ) : (
-        <EmbedErrorView reason={result.reason} />
+    <>
+      {forcedDark !== undefined && (
+        <script
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: buildEmbedThemeForceScript(forcedDark) }}
+        />
       )}
-    </div>
+      <div className={forcedDark ? "dark" : undefined} data-theme={theme ?? "system"}>
+        {result.ok ? (
+          <SharedDashboardView dashboard={result.data} forcedDark={forcedDark} />
+        ) : (
+          <EmbedErrorView reason={result.reason} />
+        )}
+      </div>
+    </>
   );
 }

--- a/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
@@ -35,13 +35,25 @@ export default async function SharedDashboardEmbedPage({ params, searchParams }:
   // theme-force script so it executes under the nonce-based `script-src` (mirrors
   // the root layout's no-flash theme script).
   const nonce = (await headers()).get("x-nonce") ?? undefined;
+  if (!nonce && forcedDark !== undefined && process.env.NODE_ENV !== "production") {
+    // No x-nonce means the CSP proxy didn't run for this render. Under a
+    // nonce-based `script-src` (no 'unsafe-inline') the inline theme-force
+    // script below is then silently CSP-blocked → the forced `?theme=` embed
+    // renders with the WRONG chrome theme (the #4686 bug) and no other
+    // breadcrumb. Surface it loudly in dev, exactly as RootLayout does; prod
+    // stays resilient (React omits the nonce and the static next.config.ts CSP
+    // still permits the inline script).
+    console.warn(
+      "[shared-dashboard/embed] no x-nonce header — the CSP proxy may not have run; the inline theme-force script may be CSP-blocked.",
+    );
+  }
 
   // Tailwind's dark variant here is `&:is(.dark *)` — the element bearing `.dark`
   // doesn't match it, only descendants do — so the wrapper carries `.dark` and the
   // inner shell's `dark:` modifiers fire against the forced theme. The forced
   // theme is ALSO threaded into the tiles (`forcedDark`) so the JS-themed charts
-  // agree with the chrome, and pushed onto `documentElement` (below) so a forced
-  // `?theme=light` can override a dark-OS visitor.
+  // agree with the chrome, and pushed onto `documentElement` (via the inline
+  // theme-force script) so a forced `?theme=light` can override a dark-OS visitor.
   return (
     <>
       {forcedDark !== undefined && (

--- a/packages/web/src/app/shared/dashboard/[token]/tile.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/tile.tsx
@@ -35,10 +35,11 @@ export interface SharedTileProps {
   cachedIso: string | undefined;
   /**
    * Forced chart theme for the embed surface. The chrome themes off the embed's
-   * `.dark` wrapper, but the chart is JS-themed (`useDarkMode()` reads the
-   * VISITOR's `documentElement`/`prefers-color-scheme`, not the wrapper), so a
-   * forced `?theme=` embed must pass its resolved theme here or the chart would
-   * disagree with the chrome. `undefined` → follow the visitor's system theme.
+   * `.dark` wrapper, but the chart is JS-themed (`useDarkMode()` resolves from
+   * the visitor's OWN preference — localStorage mode + `prefers-color-scheme` —
+   * never the wrapper's `.dark` class), so a forced `?theme=` embed must pass its
+   * resolved theme here or the chart would disagree with the chrome. `undefined`
+   * → follow the visitor's system theme.
    */
   forcedDark?: boolean;
 }

--- a/packages/web/src/app/shared/dashboard/[token]/tile.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/tile.tsx
@@ -33,10 +33,19 @@ export interface SharedTileProps {
   /** Pre-computed on the server so SSR text matches client text exactly (no `Date.now()` drift). */
   cachedLabel: string | null;
   cachedIso: string | undefined;
+  /**
+   * Forced chart theme for the embed surface. The chrome themes off the embed's
+   * `.dark` wrapper, but the chart is JS-themed (`useDarkMode()` reads the
+   * VISITOR's `documentElement`/`prefers-color-scheme`, not the wrapper), so a
+   * forced `?theme=` embed must pass its resolved theme here or the chart would
+   * disagree with the chrome. `undefined` → follow the visitor's system theme.
+   */
+  forcedDark?: boolean;
 }
 
-export function SharedTile({ card, spanClass, cachedLabel, cachedIso }: SharedTileProps) {
-  const dark = useDarkMode();
+export function SharedTile({ card, spanClass, cachedLabel, cachedIso, forcedDark }: SharedTileProps) {
+  const systemDark = useDarkMode();
+  const dark = forcedDark ?? systemDark;
 
   // #3138 — a text / section-block card renders sanitized markdown (no data, no
   // chart, no cached-at footer) so a shared-link viewer sees the same headers

--- a/packages/web/src/app/shared/dashboard/[token]/view.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/view.tsx
@@ -10,7 +10,19 @@ import { SharedTile } from "./tile";
 import { isoOrUndefined, mostRecentCachedAt, tileSpanClass, timeAgo } from "./helpers";
 import type { SharedDashboard } from "./types";
 
-export function SharedDashboardView({ dashboard }: { dashboard: SharedDashboard }) {
+export function SharedDashboardView({
+  dashboard,
+  forcedDark,
+}: {
+  dashboard: SharedDashboard;
+  /**
+   * Forced theme for the embed surface: the tile charts (`useDarkMode()` reads
+   * the visitor's own system pref, not the embed's `.dark` wrapper) render dark
+   * iff this is `true`. `undefined` on the standalone shared page → each tile
+   * follows the visitor's system theme.
+   */
+  forcedDark?: boolean;
+}) {
   // The single instant every temporal label on this page derives from (#4565):
   // the data's capture instant. Prefer the server-resolved `dataAsOf` (the SAME
   // frozen instant the parameter summary was resolved against); fall back to the
@@ -142,6 +154,7 @@ export function SharedDashboardView({ dashboard }: { dashboard: SharedDashboard 
                     spanClass={spanClass}
                     cachedLabel={timeAgo(card.cachedAt)}
                     cachedIso={isoOrUndefined(card.cachedAt)}
+                    forcedDark={forcedDark}
                   />
                 </ResultCardErrorBoundary>
               );


### PR DESCRIPTION
Closes #4686

## Problem
The share dialog's Embed tab forced theme only via a `.dark` wrapper: the chrome themed but tile charts read `useDarkMode()` (the visitor's own localStorage mode + `prefers-color-scheme`, never the wrapper), so a forced `?theme=dark` rendered dark chrome around light charts — and a forced `?theme=light` couldn't override a dark-OS visitor at all (the `&:is(.dark *)` dark variant fires off any `.dark` ancestor, incl. the root theme-init's `documentElement` stamp). The `?theme=` param was also undiscoverable.

## Fix
- Thread the resolved embed theme into `SharedDashboardView` -> `SharedTile` -> `ResultChart` so charts agree with the chrome.
- Emit a pre-paint inline script that forces `documentElement`'s `.dark` to the resolved theme so `?theme=` overrides the visitor's own preference; no-param now follows the visitor's system for both chrome and charts.
- Add a discoverable System/Light/Dark `ToggleGroup` to the Embed tab that regenerates the snippet with the matching `?theme=` (default = no param).

KPI sparkline / DataTable are CSS-themed (`dark:` variants) and ride the wrapper; only the JS-themed `ResultChart` needed the thread.

## Tests
- `resolveEmbedTheme` new tri-state (light/dark/undefined=system) + `buildEmbedThemeForceScript`.
- `SharedTile` forced-theme threading (forced dark/light wins over visitor; unforced follows visitor).
- `buildEmbedSnippet` `?theme=` param; Embed-tab ToggleGroup interaction incl. the Radix deselect guard.

Internal review panel: CLEAN after 2 rounds (silent-failure / type-design / test-coverage / comment).