### PR TITLE
fix(dashboards): text section-header tiles floor at a shorter TEXT_MIN_H (#4687)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -6400,7 +6400,7 @@
                               },
                               "h": {
                                 "type": "integer",
-                                "minimum": 4,
+                                "minimum": 2,
                                 "maximum": 200
                               }
                             },
@@ -6843,7 +6843,7 @@
                       },
                       "h": {
                         "type": "integer",
-                        "minimum": 4,
+                        "minimum": 2,
                         "maximum": 200
                       }
                     },
@@ -7259,7 +7259,7 @@
                       },
                       "h": {
                         "type": "integer",
-                        "minimum": 4,
+                        "minimum": 2,
                         "maximum": 200
                       }
                     },

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -4415,6 +4415,39 @@ describe("dashboard routes", () => {
       expect(change.card?.annotations).toEqual([]);
     });
 
+    // #4687 — the restore body is kind-blind, so its layout floors at the
+    // absolute TEXT_MIN_H (2); a text card's short banner restores rather than
+    // being rejected by the chart floor. Proves DraftUndoCardSchema.layout uses
+    // the text schema (a chart-floored schema would 422 on h=2).
+    it("restore_card accepts a text card's short banner layout (h=2) (#4687)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/draft/undo`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            kind: "restore_card",
+            card: {
+              id: VALID_CARD_ID,
+              position: 0,
+              title: "Section",
+              sql: "",
+              chartConfig: null,
+              content: "## Top of funnel",
+              connectionGroupId: null,
+              layout: { x: 0, y: 0, w: 24, h: 2 },
+            },
+          }),
+        }),
+      );
+      expect(response.status).toBe(204);
+      const [, , change] = mockApplyEditToDraft.mock.calls[0] as unknown as [
+        string,
+        unknown,
+        { card?: { layout?: { h: number } } },
+      ];
+      expect(change.card?.layout?.h).toBe(2);
+    });
+
     it("restore_card is idempotent — a card already in the draft is a no-op (no re-add)", async () => {
       mockLoadDraft.mockResolvedValue({
         snapshot: { dashboardId: VALID_ID, title: "x", description: null, cards: [{ id: VALID_CARD_ID }] },

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -1132,6 +1132,43 @@ describe("dashboard routes", () => {
       expect(addArgs[0].sql).toBe("");
     });
 
+    it("accepts a text card at the short banner height (h=2) via REST (#4687)", async () => {
+      mockAddCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Section",
+            kind: "text",
+            content: "## Top of funnel",
+            layout: { x: 0, y: 0, w: 24, h: 2 },
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      const addArgs = mockAddCard.mock.calls[0] as unknown as [{ layout?: { h: number } }];
+      expect(addArgs[0].layout?.h).toBe(2);
+    });
+
+    it("returns 422 for a chart card below MIN_H (h=2) and never calls addCard (#4687)", async () => {
+      mockAddCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Signups",
+            sql: "SELECT 1",
+            chartConfig: { type: "line", categoryColumn: "week", valueColumns: ["count"] },
+            layout: { x: 0, y: 0, w: 24, h: 2 },
+          }),
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(mockAddCard).not.toHaveBeenCalled();
+    });
+
     it("returns 422 for a text card with no content and never calls addCard (#4318)", async () => {
       mockAddCard.mockClear();
       const response = await app.fetch(
@@ -1241,6 +1278,36 @@ describe("dashboard routes", () => {
       expect(response.status).toBe(200);
       const args = mockUpdateCard.mock.calls[0] as unknown as [string, string, { sql?: string }];
       expect(args[2].sql).toBe("SELECT COUNT(*) FROM orders");
+    });
+
+    // #4687 — the drag-to-save path is kind-blind and floors at the absolute
+    // TEXT_MIN_H (2), so a text card's short banner saves; a layout below the
+    // floor (h=1) is still rejected before ever reaching updateCard.
+    it("forwards a short banner layout (h=2) to updateCard (#4687)", async () => {
+      mockUpdateCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ layout: { x: 0, y: 0, w: 24, h: 2 } }),
+        }),
+      );
+      expect(response.status).toBe(200);
+      const args = mockUpdateCard.mock.calls[0] as unknown as [string, string, { layout?: { h: number } }];
+      expect(args[2].layout?.h).toBe(2);
+    });
+
+    it("returns 422 for a layout below the absolute floor (h=1) and never calls updateCard (#4687)", async () => {
+      mockUpdateCard.mockClear();
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/cards/${VALID_CARD_ID}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ layout: { x: 0, y: 0, w: 24, h: 1 } }),
+        }),
+      );
+      expect(response.status).toBe(422);
+      expect(mockUpdateCard).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -39,13 +39,13 @@ import {
   getShareStatus,
   getSharedDashboard,
   setRefreshSchedule,
-  CardLayoutSchema,
+  TextCardLayoutSchema,
   resolveCardConnectionId,
   NoGroupMembersError,
   type CrudFailReason,
   type SharedDashboardFailReason,
 } from "@atlas/api/lib/dashboards";
-import { CHART_TYPES } from "@atlas/api/lib/dashboard-types";
+import { CHART_TYPES, DASHBOARD_GRID } from "@atlas/api/lib/dashboard-types";
 import type { DashboardCard, DashboardWithCards } from "@atlas/api/lib/dashboard-types";
 import {
   forkOrLoadDraft,
@@ -135,7 +135,11 @@ const AddCardSchema = z
     /** Group-scoped execution target (1.4.4). Resolved to a physical
      * connection at view time via the group's primary member. */
     connectionGroupId: z.string().nullable().optional(),
-    layout: CardLayoutSchema.nullable().optional(),
+    // #4687 — validate against the SHORTER text-card height floor here (this
+    // schema carries `kind`), then re-assert the taller chart floor for a chart
+    // card in the superRefine below. A text card's one-line banner (h=2) passes;
+    // a chart card still floors at `MIN_H` (4).
+    layout: TextCardLayoutSchema.nullable().optional(),
   })
   .superRefine((v, ctx) => {
     const kind = v.kind ?? "chart";
@@ -156,6 +160,15 @@ const AddCardSchema = z
       }
       if (v.content !== undefined) {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: "`content` is only valid on a text card.", path: ["content"] });
+      }
+      // #4687 — the layout field is validated against the shorter text floor;
+      // a chart card keeps the taller MIN_H (4) floor.
+      if (v.layout != null && v.layout.h < DASHBOARD_GRID.MIN_H) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `A chart card's height must be at least ${DASHBOARD_GRID.MIN_H} rows.`,
+          path: ["layout", "h"],
+        });
       }
     }
   });
@@ -181,7 +194,14 @@ const UpdateCardSchema = z.object({
    *  explicit array (including `[]` to clear) replaces them. */
   annotations: dashboardCardAnnotationsSchema.optional(),
   position: z.number().int().min(0).optional(),
-  layout: CardLayoutSchema.nullable().optional(),
+  // #4687 — the drag-to-save path carries no card `kind` (same reason `sql` on a
+  // text card isn't rejected here — no kind context without an extra read), so
+  // the layout floors at the absolute minimum (`TEXT_MIN_H`, 2) to accept a text
+  // card's shorter banner. This does NOT re-assert the chart floor server-side:
+  // the UI's per-kind resize `minH` keeps a *dragged* chart at >= `MIN_H` (4),
+  // but a direct PATCH could persist a short chart — which then renders short
+  // (valid geometry, matched by `rowToCard`'s kind-blind read), never lost.
+  layout: TextCardLayoutSchema.nullable().optional(),
 });
 
 const ShareSchema = z.object({
@@ -548,7 +568,9 @@ const DraftUndoCardSchema = z.object({
   content: z.string().nullable().optional(),
   annotations: dashboardCardAnnotationsSchema.optional(),
   connectionGroupId: z.string().nullable(),
-  layout: CardLayoutSchema.nullable(),
+  // #4687 — re-materializes a previously-valid card (chart or text); floors at
+  // the shorter text height so a text card's h=2 undo restores correctly.
+  layout: TextCardLayoutSchema.nullable(),
 });
 
 const DraftUndoBodySchema = z.discriminatedUnion("kind", [

--- a/packages/api/src/lib/__tests__/dashboard-export.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-export.test.ts
@@ -45,6 +45,7 @@ void mock.module("@atlas/api/lib/dashboards", () => ({
   getSharedDashboard: undefined as never,
   setRefreshSchedule: undefined as never,
   CardLayoutSchema: { safeParse: () => ({ success: false }) },
+  TextCardLayoutSchema: { safeParse: () => ({ success: false }) },
   resolveCardConnectionId: undefined as never,
   NoGroupMembersError: class {},
 }));

--- a/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-render-resource.test.ts
@@ -67,6 +67,7 @@ void mock.module("@atlas/api/lib/dashboards", () => ({
   getSharedDashboard: undefined as never,
   setRefreshSchedule: undefined as never,
   CardLayoutSchema: { safeParse: () => ({ success: false }) },
+  TextCardLayoutSchema: { safeParse: () => ({ success: false }) },
   resolveCardConnectionId: undefined as never,
   rowToCard: undefined as never,
   loadGroupSnapshot: undefined as never,

--- a/packages/api/src/lib/__tests__/dashboard-screenshot.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-screenshot.test.ts
@@ -62,6 +62,7 @@ void mock.module("@atlas/api/lib/dashboards", () => ({
   getSharedDashboard: undefined as never,
   setRefreshSchedule: undefined as never,
   CardLayoutSchema: { safeParse: () => ({ success: false }) },
+  TextCardLayoutSchema: { safeParse: () => ({ success: false }) },
   resolveCardConnectionId: undefined as never,
   NoGroupMembersError: class {},
 }));

--- a/packages/api/src/lib/__tests__/dashboards-row-to-card.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-row-to-card.test.ts
@@ -59,6 +59,33 @@ describe("rowToCard layout parsing", () => {
   });
 });
 
+// #4687 — read-time layout validation is a kind-BLIND geometry guard flooring
+// at the absolute TEXT_MIN_H (2), so a short layout that the kind-blind write
+// seams (drag-to-save PATCH, bound-editor tools) legitimately accepted is never
+// silently discarded on read-back. The per-kind chart floor (MIN_H, 4) is an
+// authoring/UI concern, NOT re-litigated here — a short chart renders short
+// (valid geometry) rather than losing its placement.
+describe("rowToCard kind-blind layout geometry floor (#4687)", () => {
+  const bannerLayout = { x: 0, y: 0, w: 24, h: 2 };
+
+  test("preserves a short banner height on a text card", () => {
+    const card = rowToCard({ ...baseRow, content: "## Top of funnel", sql: "", layout: bannerLayout });
+    expect(card.kind).toBe("text");
+    expect(card.layout).toEqual(bannerLayout);
+  });
+
+  test("preserves the same short height on a chart card (read never silently discards accepted geometry)", () => {
+    const card = rowToCard({ ...baseRow, layout: bannerLayout });
+    expect(card.kind).toBe("chart");
+    expect(card.layout).toEqual(bannerLayout);
+  });
+
+  test("still discards a height below the absolute TEXT_MIN_H floor", () => {
+    expect(rowToCard({ ...baseRow, content: "## H", sql: "", layout: { x: 0, y: 0, w: 24, h: 1 } }).layout).toBeNull();
+    expect(rowToCard({ ...baseRow, layout: { x: 0, y: 0, w: 24, h: 1 } }).layout).toBeNull();
+  });
+});
+
 describe("rowToCard chart_config / KPI round-trip (#3137, #3207)", () => {
   test("round-trips a KPI auto-comparison config (object form)", () => {
     const chartConfig: DashboardChartConfig = {

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -32,6 +32,7 @@ import {
   dashboardParametersSchema,
   dashboardCardAnnotationsSchema,
   dashboardCardLayoutInputSchema,
+  dashboardTextCardLayoutInputSchema,
 } from "@useatlas/schemas";
 import type { ShareMode, ShareExpiryKey } from "@useatlas/types/share";
 import { SHARE_EXPIRY_OPTIONS } from "@useatlas/types/share";
@@ -55,6 +56,23 @@ const log = createLogger("dashboards");
  * under the historical name so every `CardLayoutSchema` import site is unchanged.
  */
 export const CardLayoutSchema = dashboardCardLayoutInputSchema;
+
+/**
+ * Text / section-header card layout (#4687) — the same bounds as
+ * {@link CardLayoutSchema} but with the shorter `TEXT_MIN_H` (2) height floor,
+ * so a one-line banner validates at a tight height.
+ *
+ * This is also the ABSOLUTE geometry floor used by every KIND-BLIND layout seam
+ * (there is no card `kind` on the wire to pick a stricter floor): `rowToCard`
+ * read-back, the REST drag-to-save PATCH (`UpdateCardSchema`), the REST add-card
+ * layout field, and the bound-editor `updateCard` / `updateLayout` tools. On
+ * those seams a chart card is NOT floored at `MIN_H` (4) — that per-kind floor
+ * is a KIND-AWARE concern held by the create / add-card authoring paths (the
+ * schema chart arm + the add-card `superRefine`) and the UI's per-kind resize
+ * `minH`. A chart written short through a kind-blind seam therefore renders
+ * short (valid geometry) rather than being silently discarded on read-back.
+ */
+export const TextCardLayoutSchema = dashboardTextCardLayoutInputSchema;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -160,11 +178,20 @@ export function rowToCard(r: Record<string, unknown>): DashboardCard {
     }
   }
 
+  // #4687 — read-time layout validation is a GEOMETRY guard (bounds + shape),
+  // NOT the per-kind height policy. It floors at the ABSOLUTE minimum any card
+  // can occupy (`TextCardLayoutSchema`, TEXT_MIN_H) so a layout the kind-blind
+  // write seams (REST drag-to-save PATCH, the bound-editor tools) legitimately
+  // accepted is never silently discarded here on read-back. The per-kind chart
+  // floor (`MIN_H`, 4) is enforced where `kind` is authoritative — the create /
+  // add-card authoring paths and the UI's per-kind resize `minH` — not
+  // re-litigated on read. Discards only structurally-malformed layouts (missing
+  // fields, NaN, out-of-bounds x/y/w, `x + w` overflow, `h` below TEXT_MIN_H).
   let layout: DashboardCardLayout | null = null;
   if (r.layout) {
     try {
       const raw = typeof r.layout === "string" ? JSON.parse(r.layout) : r.layout;
-      const parsed = CardLayoutSchema.safeParse(raw);
+      const parsed = TextCardLayoutSchema.safeParse(raw);
       if (parsed.success) {
         layout = parsed.data;
       } else {

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -63,14 +63,18 @@ export const CardLayoutSchema = dashboardCardLayoutInputSchema;
  * so a one-line banner validates at a tight height.
  *
  * This is also the ABSOLUTE geometry floor used by every KIND-BLIND layout seam
- * (there is no card `kind` on the wire to pick a stricter floor): `rowToCard`
- * read-back, the REST drag-to-save PATCH (`UpdateCardSchema`), the REST add-card
- * layout field, and the bound-editor `updateCard` / `updateLayout` tools. On
- * those seams a chart card is NOT floored at `MIN_H` (4) — that per-kind floor
- * is a KIND-AWARE concern held by the create / add-card authoring paths (the
- * schema chart arm + the add-card `superRefine`) and the UI's per-kind resize
- * `minH`. A chart written short through a kind-blind seam therefore renders
- * short (valid geometry) rather than being silently discarded on read-back.
+ * (no card `kind` on the wire to pick a stricter floor, so a chart card is NOT
+ * floored at `MIN_H` here): `rowToCard` read-back, the REST drag-to-save PATCH
+ * (`UpdateCardSchema`), the draft-undo restore (`DraftUndoCardSchema`), and the
+ * bound-editor `updateCard` / `updateLayout` tools. A chart written short through
+ * one of those renders short (valid geometry) rather than being silently
+ * discarded on read-back.
+ *
+ * The taller per-kind chart floor (`MIN_H`, 4) is enforced only where `kind` is
+ * KIND-AWARE: the create path (via its chart-arm schema directly), the REST
+ * add-card path (whose layout *field* uses this base schema so a text banner
+ * passes, but whose `superRefine` re-asserts `MIN_H` for a chart card), and the
+ * UI's per-kind resize `minH`.
  */
 export const TextCardLayoutSchema = dashboardTextCardLayoutInputSchema;
 

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
@@ -417,9 +417,44 @@ describe("createBoundDashboardTools", () => {
       results: { cardId: string; ok: boolean; reason?: string }[];
     }>(tools.updateLayout, {
       layouts: [
-        // x+w = 30, exceeds 24-col grid → rejected by CardLayoutSchema.refine
+        // x+w = 30, exceeds 24-col grid → rejected by TextCardLayoutSchema.refine
         { cardId: "card-1", x: 12, y: 0, w: 18, h: 8 },
       ],
+    });
+    expect(result.kind).toBe("partial");
+    expect(result.results[0].ok).toBe(false);
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  // #4687 — this kind-blind agent seam floors at the absolute TEXT_MIN_H (2), so
+  // a short banner placement is well-formed (it reaches the draft path rather
+  // than failing the geometry pre-pass), while a height below the floor (h=1) is
+  // rejected as malformed before touching the DB.
+  it("updateLayout accepts a short banner height (h=2) as well-formed (#4687)", async () => {
+    enableInternalDB();
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{
+      kind: "ok" | "partial";
+      results: { cardId: string; ok: boolean; reason?: string }[];
+    }>(tools.updateLayout, {
+      layouts: [{ cardId: "card-1", x: 0, y: 0, w: 24, h: 2 }],
+    });
+    // Well-formed → owned by the draft path, which rejects this anonymous edit
+    // with a sign-in reason (NOT a geometry-validation message), proving h=2
+    // passed the layout schema rather than being dropped in the malformed pass.
+    expect(result.kind).toBe("partial");
+    expect(result.results.some((r) => !r.ok && /sign in/i.test(r.reason ?? ""))).toBe(true);
+    expect(queryCalls.map((c) => c.sql).join("\n")).not.toContain("UPDATE dashboard_cards");
+  });
+
+  it("updateLayout rejects a height below TEXT_MIN_H (h=1) without hitting the DB (#4687)", async () => {
+    enableInternalDB();
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{
+      kind: "ok" | "partial";
+      results: { cardId: string; ok: boolean; reason?: string }[];
+    }>(tools.updateLayout, {
+      layouts: [{ cardId: "card-1", x: 0, y: 0, w: 24, h: 1 }],
     });
     expect(result.kind).toBe("partial");
     expect(result.results[0].ok).toBe(false);

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -44,7 +44,7 @@ import {
   getDashboard,
   resolveCardConnectionId,
   NoGroupMembersError,
-  CardLayoutSchema,
+  TextCardLayoutSchema,
 } from "@atlas/api/lib/dashboards";
 import type { DashboardWithCards } from "@atlas/api/lib/dashboard-types";
 import { seedDraftCards, type CardSeedOutcome } from "@atlas/api/lib/dashboard-seeding";
@@ -478,7 +478,13 @@ The grid is 24 columns wide. Layout is optional — when omitted the card stages
         .describe(
           "Replace the card's dated event markers ({ x, label, color? }). Pass [] to clear them. Vertical reference lines on a line/area card.",
         ),
-      layout: CardLayoutSchema.nullable().optional(),
+      // #4687 — the bound editor addresses cards by id (no kind on the tool
+      // input), so this seam is kind-blind; floor at the absolute TEXT_MIN_H (2)
+      // so a text / section card validates as a banner. The taller chart floor
+      // (MIN_H, 4) is NOT enforced here — it's a kind-aware authoring/UI concern
+      // (the create/add-card paths + the grid's resize `minH`); a chart set
+      // short via this agent tool renders short (valid geometry), never lost.
+      layout: TextCardLayoutSchema.nullable().optional(),
       position: z.number().int().min(0).optional(),
     }),
     execute: async ({ cardId, title, chartConfig, content, annotations, layout, position }) => {
@@ -601,7 +607,11 @@ The grid is 24 columns wide. Layout is optional — when omitted the card stages
       const malformed: { cardId: string; reason: string }[] = [];
       for (const placement of layouts) {
         const { cardId, x, y, w, h } = placement;
-        const v = CardLayoutSchema.safeParse({ x, y, w, h });
+        // #4687 — kind-blind (cards addressed by id); floors at the absolute
+        // TEXT_MIN_H (2) so a text / section card can be placed as a banner. The
+        // chart floor (MIN_H, 4) is not enforced on this kind-blind agent seam;
+        // a chart placed short renders short (valid geometry), never discarded.
+        const v = TextCardLayoutSchema.safeParse({ x, y, w, h });
         if (!v.success) {
           malformed.push({ cardId, reason: v.error.issues[0]?.message ?? "invalid layout" });
           continue;

--- a/packages/schemas/src/__tests__/dashboard.test.ts
+++ b/packages/schemas/src/__tests__/dashboard.test.ts
@@ -17,6 +17,7 @@ import {
   DASHBOARD_ANNOTATIONS_MAX,
   DASHBOARD_GRID,
   dashboardCardLayoutInputSchema,
+  dashboardTextCardLayoutInputSchema,
   dashboardCardInputSchema,
   dashboardCreateCardInputSchema,
   sharedDashboardCardSchema,
@@ -464,6 +465,40 @@ describe("dashboardCardLayoutInputSchema (#4562)", () => {
       dashboardCardLayoutInputSchema.safeParse({ x: 0, y: 0, w: DASHBOARD_GRID.MIN_W - 1, h: 8 }).success,
     ).toBe(false);
   });
+
+  // #4687 — a chart / KPI / table card floors at MIN_H (4); a text /
+  // section-header card floors at the shorter TEXT_MIN_H (2) so a one-line
+  // header reads as a banner, not an empty box.
+  test("TEXT_MIN_H is a shorter floor than the chart MIN_H", () => {
+    expect(DASHBOARD_GRID.TEXT_MIN_H).toBe(2);
+    expect(DASHBOARD_GRID.TEXT_MIN_H).toBeLessThan(DASHBOARD_GRID.MIN_H);
+  });
+
+  test("chart layout rejects a height below MIN_H", () => {
+    expect(
+      dashboardCardLayoutInputSchema.safeParse({ x: 0, y: 0, w: 24, h: DASHBOARD_GRID.MIN_H - 1 }).success,
+    ).toBe(false);
+    expect(
+      dashboardCardLayoutInputSchema.safeParse({ x: 0, y: 0, w: 24, h: DASHBOARD_GRID.MIN_H }).success,
+    ).toBe(true);
+  });
+
+  test("text layout accepts the shorter TEXT_MIN_H height a chart layout rejects", () => {
+    const banner = { x: 0, y: 0, w: 24, h: DASHBOARD_GRID.TEXT_MIN_H };
+    expect(dashboardTextCardLayoutInputSchema.safeParse(banner).success).toBe(true);
+    expect(dashboardCardLayoutInputSchema.safeParse(banner).success).toBe(false);
+  });
+
+  test("text layout still enforces the shared width / column bounds", () => {
+    // Below TEXT_MIN_H is still rejected.
+    expect(
+      dashboardTextCardLayoutInputSchema.safeParse({ x: 0, y: 0, w: 24, h: DASHBOARD_GRID.TEXT_MIN_H - 1 }).success,
+    ).toBe(false);
+    // x + w overflow is still rejected.
+    expect(
+      dashboardTextCardLayoutInputSchema.safeParse({ x: 20, y: 0, w: 12, h: DASHBOARD_GRID.TEXT_MIN_H }).success,
+    ).toBe(false);
+  });
 });
 
 describe("dashboardCardInputSchema (#4562 — shared card union)", () => {
@@ -500,6 +535,26 @@ describe("dashboardCardInputSchema (#4562 — shared card union)", () => {
     });
     expect(parsed.kind).toBe("text");
     expect("content" in parsed && parsed.content).toBe("## Top of funnel");
+  });
+
+  // #4687 — the text arm floors at the shorter TEXT_MIN_H; the chart arm keeps
+  // MIN_H, so the same banner height is accepted for text and rejected for chart.
+  test("a text card accepts a short banner height the chart arm rejects", () => {
+    const parsed = dashboardCardInputSchema.parse({
+      kind: "text",
+      content: "## Top of funnel",
+      layout: { x: 0, y: 0, w: 24, h: DASHBOARD_GRID.TEXT_MIN_H },
+    });
+    expect(parsed.kind).toBe("text");
+
+    expect(
+      dashboardCardInputSchema.safeParse({
+        title: "Signups",
+        sql: "SELECT 1",
+        chartConfig,
+        layout: { x: 0, y: 0, w: 24, h: DASHBOARD_GRID.TEXT_MIN_H },
+      }).success,
+    ).toBe(false);
   });
 
   test("rejects a chart card carrying a text card's content (strict)", () => {

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -469,32 +469,66 @@ export type DashboardChartConfigWire = z.infer<typeof dashboardChartConfigSchema
 // (never npm-published), so a bump here needs no version bump.
 // ---------------------------------------------------------------------------
 
-/** Bounds of the dashboard tile grid (#1867). */
+/**
+ * Bounds of the dashboard tile grid (#1867).
+ *
+ * `MIN_H` (4) is the height floor for a SQL-backed chart / KPI / table card.
+ * `TEXT_MIN_H` (2, #4687) is the shorter floor for a markdown text /
+ * section-header card, so a one-line `## Section` header reads as a tight banner
+ * over the charts grouped beneath it instead of a ~180px empty box. Every other
+ * bound (columns, widths, max height) is shared across both kinds.
+ */
 export const DASHBOARD_GRID = {
   COLS: 24,
   MIN_W: 3,
   MAX_W: 24,
   MIN_H: 4,
+  TEXT_MIN_H: 2,
   MAX_H: 200,
   MAX_Y: 10_000,
 } as const;
 
 /**
- * Authoring tile layout in the 24-col freeform grid. Single source for both
- * write-time Zod validation (the agent tools + REST route) and read-time DB-row
- * validation (`rowToCard`). `x + w` may not exceed the column count.
+ * Build a tile-layout schema whose only per-kind knob is the height floor
+ * `minH`. `x + w` may not exceed the column count; every other bound is shared.
+ * Two instances are exported below — a chart floor (`MIN_H`) and a shorter text
+ * floor (`TEXT_MIN_H`) — so a text card's shorter height validates while chart
+ * cards keep the taller floor, with no duplicated bounds to drift.
  */
-export const dashboardCardLayoutInputSchema = z
-  .object({
-    x: z.number().int().min(0).max(DASHBOARD_GRID.COLS - 1),
-    y: z.number().int().min(0).max(DASHBOARD_GRID.MAX_Y),
-    w: z.number().int().min(DASHBOARD_GRID.MIN_W).max(DASHBOARD_GRID.MAX_W),
-    h: z.number().int().min(DASHBOARD_GRID.MIN_H).max(DASHBOARD_GRID.MAX_H),
-  })
-  .refine((l) => l.x + l.w <= DASHBOARD_GRID.COLS, {
-    message: `Tile extends past column ${DASHBOARD_GRID.COLS}`,
-  });
+function makeCardLayoutInputSchema(minH: number) {
+  return z
+    .object({
+      x: z.number().int().min(0).max(DASHBOARD_GRID.COLS - 1),
+      y: z.number().int().min(0).max(DASHBOARD_GRID.MAX_Y),
+      w: z.number().int().min(DASHBOARD_GRID.MIN_W).max(DASHBOARD_GRID.MAX_W),
+      h: z.number().int().min(minH).max(DASHBOARD_GRID.MAX_H),
+    })
+    .refine((l) => l.x + l.w <= DASHBOARD_GRID.COLS, {
+      message: `Tile extends past column ${DASHBOARD_GRID.COLS}`,
+    });
+}
+
+/**
+ * Authoring tile layout for a chart / KPI / table card — floors at `MIN_H` (4).
+ * Single source for both write-time Zod validation (the agent tools + REST
+ * route) and read-time DB-row validation (`rowToCard`). Re-exported through
+ * `@atlas/api/lib/dashboards` as the historical `CardLayoutSchema`.
+ */
+export const dashboardCardLayoutInputSchema = makeCardLayoutInputSchema(DASHBOARD_GRID.MIN_H);
 export type DashboardCardLayoutInputWire = z.infer<typeof dashboardCardLayoutInputSchema>;
+
+/**
+ * Authoring tile layout for a text / section-header card (#4687) — identical to
+ * {@link dashboardCardLayoutInputSchema} except the height floors at the shorter
+ * `TEXT_MIN_H` (2). Used by the text arm of the card union, and (as the absolute
+ * geometry floor) by every KIND-BLIND backend seam that must accept a text
+ * card's shorter height without knowing the card's kind: `rowToCard` read-back,
+ * the REST add-card + drag-to-save layout paths, and the bound-editor
+ * `updateCard` / `updateLayout` tools. The taller per-kind chart floor (`MIN_H`)
+ * is enforced by the chart arm below + the add-card `superRefine`, never here.
+ */
+export const dashboardTextCardLayoutInputSchema = makeCardLayoutInputSchema(DASHBOARD_GRID.TEXT_MIN_H);
+export type DashboardTextCardLayoutInputWire = z.infer<typeof dashboardTextCardLayoutInputSchema>;
 
 /**
  * A SQL-backed chart / table / KPI card — the original card kind. `kind` is
@@ -536,7 +570,9 @@ export const dashboardTextCardInputSchema = z
     content: dashboardTextCardContentSchema.describe(
       'Markdown section header / explainer, e.g. "## Top of funnel". Rendered sanitized — no raw HTML.',
     ),
-    layout: dashboardCardLayoutInputSchema
+    // #4687 — a text card floors at the shorter `TEXT_MIN_H` (2) so a one-line
+    // header reads as a banner, not an empty box; chart cards keep `MIN_H` (4).
+    layout: dashboardTextCardLayoutInputSchema
       .optional()
       .describe("Optional grid placement { x, y, w, h } on the 24-column grid."),
   })

--- a/packages/schemas/src/dashboard.ts
+++ b/packages/schemas/src/dashboard.ts
@@ -521,11 +521,13 @@ export type DashboardCardLayoutInputWire = z.infer<typeof dashboardCardLayoutInp
  * Authoring tile layout for a text / section-header card (#4687) — identical to
  * {@link dashboardCardLayoutInputSchema} except the height floors at the shorter
  * `TEXT_MIN_H` (2). Used by the text arm of the card union, and (as the absolute
- * geometry floor) by every KIND-BLIND backend seam that must accept a text
- * card's shorter height without knowing the card's kind: `rowToCard` read-back,
- * the REST add-card + drag-to-save layout paths, and the bound-editor
- * `updateCard` / `updateLayout` tools. The taller per-kind chart floor (`MIN_H`)
- * is enforced by the chart arm below + the add-card `superRefine`, never here.
+ * geometry floor) by every KIND-BLIND backend seam that accepts a layout without
+ * a card `kind` on the wire: `rowToCard` read-back, the REST drag-to-save PATCH,
+ * the draft-undo restore, and the bound-editor `updateCard` / `updateLayout`
+ * tools. The taller per-kind chart floor (`MIN_H`) is enforced only where the
+ * kind is known — the chart arm below, plus the REST add-card path's
+ * `superRefine` (whose layout *field* still uses this schema so a text banner
+ * passes) — never here.
  */
 export const dashboardTextCardLayoutInputSchema = makeCardLayoutInputSchema(DASHBOARD_GRID.TEXT_MIN_H);
 export type DashboardTextCardLayoutInputWire = z.infer<typeof dashboardTextCardLayoutInputSchema>;

--- a/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { DashboardCard } from "@/ui/lib/types";
 import { nextTileLayout, withAutoLayout } from "../auto-layout";
-import { COLS, DEFAULT_TEXT_TILE_H, DEFAULT_TILE_H } from "../grid-constants";
+import { COLS, DEFAULT_TEXT_TILE_H, DEFAULT_TILE_H, TEXT_MIN_H } from "../grid-constants";
 
 const DEFAULT_CARD: Omit<DashboardCard, "id" | "position" | "layout"> = {
   dashboardId: "d1",
@@ -69,6 +69,15 @@ describe("withAutoLayout", () => {
   test("an unplaced text card lays out full-width", () => {
     const [placed] = withAutoLayout([textCard({ id: "t1", position: 0 })]);
     expect(placed.resolvedLayout).toEqual({ x: 0, y: 0, w: COLS, h: DEFAULT_TEXT_TILE_H });
+  });
+
+  // #4687 — the default text-tile band is a SHORT banner (TEXT_MIN_H), not a
+  // full chart-height box, so a one-line header doesn't render as an empty box.
+  test("an unplaced text card defaults to the short banner height", () => {
+    const [placed] = withAutoLayout([textCard({ id: "t1", position: 0 })]);
+    expect(DEFAULT_TEXT_TILE_H).toBe(TEXT_MIN_H);
+    expect(placed.resolvedLayout.h).toBe(TEXT_MIN_H);
+    expect(placed.resolvedLayout.h).toBeLessThan(DEFAULT_TILE_H);
   });
 
   test("a text card breaks the 2-col chart pairing into a fresh row beneath it", () => {

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import type { DashboardCard, DashboardCardLayout, KpiComparisonResult } from "@/ui/lib/types";
 import type { TileRenderPhase } from "./tile-status";
-import { COLS, ROW_H, GAP, MIN_W, MIN_H, MOBILE_BREAKPOINT } from "./grid-constants";
+import { COLS, ROW_H, GAP, MIN_W, MIN_H, TEXT_MIN_H, MOBILE_BREAKPOINT } from "./grid-constants";
 import { withAutoLayout } from "./auto-layout";
 import { DashboardTile } from "./dashboard-tile";
 
@@ -154,7 +154,9 @@ export function DashboardGrid({
     w: p.resolvedLayout.w,
     h: p.resolvedLayout.h,
     minW: MIN_W,
-    minH: MIN_H,
+    // #4687 — a text / section-header card resizes down to the shorter
+    // TEXT_MIN_H so it reads as a banner; chart cards keep the taller MIN_H.
+    minH: p.kind === "text" ? TEXT_MIN_H : MIN_H,
     maxW: COLS,
   }));
 

--- a/packages/web/src/ui/components/dashboards/grid-constants.ts
+++ b/packages/web/src/ui/components/dashboards/grid-constants.ts
@@ -10,6 +10,11 @@ export const COLS = 24;
 export const MIN_W = 3;
 export const MIN_H = 4;
 
+// #4687: a text / section-header card floors at a shorter height than a chart /
+// KPI / table card (MIN_H) so a one-line `## Section` header reads as a tight
+// banner instead of a ~180px empty box. Mirrors `DASHBOARD_GRID.TEXT_MIN_H`.
+export const TEXT_MIN_H = 2;
+
 export const ROW_H = 40;
 export const GAP = 10;
 
@@ -18,9 +23,9 @@ export const DEFAULT_TILE_H = 10;
 
 // #3138: a text / section-block card with no stored layout lays out as a
 // full-width (COLS) band — a header that spans the charts grouped under it —
-// at the shortest persistable height (MIN_H, so a drag-to-save still validates
-// against the backend CardLayoutSchema).
-export const DEFAULT_TEXT_TILE_H = MIN_H;
+// at the shortest persistable text height (#4687: TEXT_MIN_H, so a drag-to-save
+// still validates against the backend text-card layout schema).
+export const DEFAULT_TEXT_TILE_H = TEXT_MIN_H;
 
 // Below this measured container width, the freeform RGL grid degrades into a
 // single-column read-only stack — a 24-col layout on a 375px viewport produces


### PR DESCRIPTION
Closes #4687

## Problem
A markdown text / section-header card (#3138) inherited the shared grid `MIN_H=4` floor, so a one-line `## Section` header rendered as a ~180px mostly-empty box instead of a tight banner over the charts grouped beneath it (`ROW_H=40` → 160px+).

## Fix
Per-kind height floor: `TEXT_MIN_H` (2) for text/section cards, while chart / KPI / table cards keep `MIN_H` (4).

- **SSOT:** a `makeCardLayoutInputSchema(minH)` factory derives both `dashboardCardLayoutInputSchema` (chart, floor 4) and `dashboardTextCardLayoutInputSchema` (text, floor 2) from `DASHBOARD_GRID` so the shared bounds can't drift. `grid-constants.ts` mirrors `DASHBOARD_GRID.TEXT_MIN_H`.
- **Chart floor stays enforced where kind is authoritative:** the schema chart arm + the REST add-card `superRefine` (re-asserts `MIN_H` for a chart card) + the UI's per-kind resize `minH`.
- **Kind-blind backend seams** (`rowToCard` read-back, REST drag-to-save PATCH, draft-undo restore, bound-editor `updateCard`/`updateLayout`) floor at the absolute `TEXT_MIN_H`, so a layout the write side accepted is never silently discarded on read — read validates geometry, not the per-kind height policy.
- The auto-layout default text band + the mobile stack use the shorter floor; the `TextTile` body top-aligns with `overflow-auto` (no clipping of multi-line markdown).

## Acceptance criteria
- [x] A section-header text card occupies a shorter row band (`TEXT_MIN_H=2`).
- [x] Backend layout validation accepts the shorter text-card height — schema + `rowToCard` + drag-to-save all agree (no cross-package drift).
- [x] Chart/KPI/table cards keep the `MIN_H=4` floor (schema chart arm + add-card superRefine + UI minH).
- [x] `TextTile` top-aligns cleanly at the shorter height without clipping.

## Tests
Schema (text vs chart floor, boundaries), `rowToCard` (kind-blind geometry, preserve accepted heights, discard below floor), REST add-card + PATCH drag-to-save (h=2 accepted, h=1 → 422), bound-editor `updateLayout` (h=2 well-formed, h=1 rejected), DraftUndo h=2 restore, web auto-layout default band.

Reviewed via the internal review panel (3 rounds → CLEAN): fixed a write/read floor asymmetry (kind-blind read) and docblock accuracy.