### PR TITLE
fix(cache): await the flush attribution row before flushing (#4533)

### DIFF
--- a/packages/api/src/api/__tests__/admin-cache.test.ts
+++ b/packages/api/src/api/__tests__/admin-cache.test.ts
@@ -19,10 +19,33 @@ import {
   mock,
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+import {
+  errorMessage as realErrorMessage,
+  causeToError as realCauseToError,
+} from "@atlas/api/lib/audit/error-scrub";
 
 // --- Unified mocks ---
 
 let mockCacheEnabled = true;
+
+// Audit mock — override only the two log entry points so a test can drive the
+// audit write into failure (#4533: flush attribution IS the security control,
+// so the row must commit before the flush takes effect). ADMIN_ACTIONS and the
+// error-scrub helpers stay real (imported from their own, un-mocked modules) so
+// the rest of the app behaves identically.
+const mockLogAdminAction = mock(() => {});
+const mockLogAdminActionAwait = mock((): Promise<void> => Promise.resolve());
+
+const auditMockFactory = () => ({
+  ADMIN_ACTIONS: REAL_ADMIN_ACTIONS,
+  logAdminAction: mockLogAdminAction,
+  logAdminActionAwait: mockLogAdminActionAwait,
+  errorMessage: realErrorMessage,
+  causeToError: realCauseToError,
+});
+
+void mock.module("@atlas/api/lib/audit", auditMockFactory);
 const mockCacheStats = mock(() => ({ hits: 42, misses: 8, entryCount: 15, maxSize: 1000, ttl: 300000 }));
 const mockFlushCache = mock(() => {});
 const mockGetCache = mock(() => ({
@@ -143,6 +166,10 @@ describe("admin cache routes", () => {
     mockCacheEnabled = true;
     mockCacheStats.mockClear();
     mockFlushCache.mockClear();
+    mockFlushCache.mockImplementation(() => {});
+    mockLogAdminAction.mockClear();
+    mockLogAdminActionAwait.mockClear();
+    mockLogAdminActionAwait.mockImplementation(() => Promise.resolve());
     mockGetCache.mockImplementation(() => ({
       get: () => null,
       set: () => {},
@@ -305,6 +332,38 @@ describe("admin cache routes", () => {
       const body = await res.json() as Record<string, unknown>;
       expect(body.error).toBe("internal_error");
       expect(body.requestId).toBeDefined();
+    });
+
+    // #4533 — attribution IS the security control on this process-global surface.
+    it("commits the audit row before the flush takes effect", async () => {
+      let flushHappenedDuringAudit = false;
+      mockLogAdminActionAwait.mockImplementation(() => {
+        flushHappenedDuringAudit = mockFlushCache.mock.calls.length > 0;
+        return Promise.resolve();
+      });
+      const res = await app.fetch(cacheRequest("/api/v1/admin/cache/flush", "POST"));
+      expect(res.status).toBe(200);
+      // The audit row is awaited BEFORE flushCache() runs.
+      expect(flushHappenedDuringAudit).toBe(false);
+      expect(mockLogAdminActionAwait).toHaveBeenCalledTimes(1);
+      expect(mockFlushCache).toHaveBeenCalledTimes(1);
+    });
+
+    // #4533 — a flush must NOT silently succeed when its attribution row can't
+    // commit (e.g. audit circuit-breaker open / internal DB down). The audit
+    // write is awaited first, so its rejection surfaces a 500 (with requestId)
+    // and the flush never runs.
+    it("does not silently succeed when the audit write fails", async () => {
+      mockLogAdminActionAwait.mockImplementation(() =>
+        Promise.reject(new Error("admin_action_log insert failed")),
+      );
+      const res = await app.fetch(cacheRequest("/api/v1/admin/cache/flush", "POST"));
+      expect(res.status).toBe(500);
+      const body = await res.json() as Record<string, unknown>;
+      expect(body.error).toBe("internal_error");
+      expect(body.requestId).toBeDefined();
+      // The flush is gated on the committed audit row — it never took effect.
+      expect(mockFlushCache).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/api/routes/admin-cache.ts
+++ b/packages/api/src/api/routes/admin-cache.ts
@@ -16,7 +16,7 @@
 
 import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
-import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { logAdminActionAwait, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter } from "./admin-router";
@@ -92,18 +92,24 @@ adminCache.openapi(flushCacheRoute, async (c) => runHandler(c, "flush cache", as
     return c.json({ ok: false, flushed: 0, message: "Cache is disabled" }, 200);
   }
   const count = getCache().stats().entryCount;
-  flushCache();
-  log.info({ requestId, userId: authResult.user?.id, flushed: count }, "Cache flushed via admin API");
-  // Fire-and-forget audit row — process-global blast radius makes
-  // attribution the security control here. See header docblock.
-  // Cache is a process-singleton so `targetId: "default"` mirrors the
-  // SLA / backup-config pattern for non-row-keyed admin surfaces.
-  logAdminAction({
+  // Attribution IS the security control here: flush is process-global (clears
+  // every workspace's entries on this runtime), so a fleet-wide invalidation
+  // must always be attributable to a specific admin. Commit the audit row
+  // BEFORE the flush takes effect — via `logAdminActionAwait` (not
+  // fire-and-forget `logAdminAction`, whose insert is swallowed by a
+  // circuit breaker) — so a circuit-open / DB-down window can never leave a
+  // successful flush with no committed record. A rejection propagates to
+  // runHandler as a 500 (with requestId) rather than a silent 200; the flush
+  // never runs. Cache is a process-singleton so `targetId: "default"` mirrors
+  // the SLA / backup-config pattern for non-row-keyed admin surfaces.
+  await logAdminActionAwait({
     actionType: ADMIN_ACTIONS.cache.flush,
     targetType: "cache",
     targetId: "default",
     metadata: { flushed: count },
   });
+  flushCache();
+  log.info({ requestId, userId: authResult.user?.id, flushed: count }, "Cache flushed via admin API");
   return c.json({ ok: true, flushed: count, message: "Cache flushed" }, 200);
 }));
 


### PR DESCRIPTION
## Summary

**Security fix.** Closes #4533.

The cache-flush route's own header docblock declares that, because `flushCache()` is process-global (it clears every workspace's entries on the runtime, not just the caller's), **attribution is the security control** — every flush must be attributable to a specific admin via a `cache.flush` `admin_action_log` row.

But the handler wrote that row with fire-and-forget `logAdminAction`, whose insert path (`internalExecute`) swallows its own async errors behind a circuit breaker. During a circuit-open / internal-DB-down window the flush **succeeded with no committed audit row** (only a pino line) — the one control the docblock leans on could silently be absent exactly when the internal DB is unhealthy.

## Fix

- Switch to `logAdminActionAwait` — the primitive already documented in `lib/audit/admin.ts` for the "the audit row **is** the security control" shape — and `await` it **before** `flushCache()` takes effect.
- A rejection from the audit write now propagates to `runHandler`, which returns a **500 with `requestId`** rather than a silent 200. The flush never runs when its attribution row can't commit.

## Acceptance criteria

- [x] Flush awaits the committed audit row before taking effect; an audit-write failure does not yield a 200.
- [x] A rejection surfaces an error (with `requestId`) to the admin, not silent success.
- [x] Regression tests in `admin-cache.test.ts` pin both invariants (audit commits before flush; a failing audit write does not silently succeed — 500, flush not called). Both new tests were confirmed to fail against the pre-fix route.

## Testing

- `bun test packages/api/src/api/__tests__/admin-cache.test.ts` — 17 pass.
- `tsgo --noEmit` clean; oxlint clean on changed files.
