### PR TITLE
fix(cache): deep-canonicalize claims in buildCacheKey so nested RLS claims discriminate keys (#4532)

### DIFF
--- a/packages/api/src/lib/cache/__tests__/cache.test.ts
+++ b/packages/api/src/lib/cache/__tests__/cache.test.ts
@@ -439,6 +439,30 @@ describe("buildCacheKey", () => {
     expect(a).toBe(b);
   });
 
+  it("claims differing only at a nested path = different key", () => {
+    // Regression for #4532: a JSON.stringify replacer array applied the
+    // top-level key whitelist at every depth, so nested claim objects
+    // serialized to `{}` and the discriminating value was erased. Two users
+    // whose RLS tenant lives at a nested claim path then collided on one key.
+    const a = buildCacheKey("SELECT 1", "default", "org1", {
+      app_metadata: { org_id: "org-42" },
+    });
+    const b = buildCacheKey("SELECT 1", "default", "org1", {
+      app_metadata: { org_id: "org-99" },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("nested claim key order does not affect hash", () => {
+    const a = buildCacheKey("SELECT 1", "default", "org1", {
+      app_metadata: { tenant: "acme", region: "us" },
+    });
+    const b = buildCacheKey("SELECT 1", "default", "org1", {
+      app_metadata: { region: "us", tenant: "acme" },
+    });
+    expect(a).toBe(b);
+  });
+
   it("no orgId produces different key than with orgId", () => {
     const a = buildCacheKey("SELECT 1", "default");
     const b = buildCacheKey("SELECT 1", "default", "org1");

--- a/packages/api/src/lib/cache/keys.ts
+++ b/packages/api/src/lib/cache/keys.ts
@@ -2,14 +2,52 @@
  * Cache key generation for query result caching.
  *
  * Keys are SHA-256 hashes of the trimmed SQL + connectionId + orgId + claims.
- * This ensures org-scoped isolation by construction.
+ *
+ * Isolation invariant: two requests share a cache entry only when *all four*
+ * key components match. orgId contributes to the key, but it is NOT the sole
+ * discriminator — it may be undefined (auth mode "none", or claims-only tenancy
+ * where the tenant lives inside `claims`), so isolation cannot rely on orgId
+ * "by construction". The claims serialization below therefore has to be
+ * faithful: the RLS discriminator may sit at a nested claim path
+ * (`resolveClaimPath` dot-paths, `lib/rls.ts`), and if the serialization drops
+ * nested values two users collide on one key and one is served the other's
+ * RLS-filtered rows for the cache TTL. That is why claims are canonicalized
+ * recursively rather than with a top-level replacer array.
  */
+
+/**
+ * Deep, order-insensitive canonical serialization of a claims value.
+ *
+ * Sorts object keys at *every* nesting level so key stability across
+ * property-insertion order is preserved, while every nested value stays part of
+ * the output. A `JSON.stringify` replacer array cannot be used here: it applies
+ * the top-level key whitelist at every depth, so a nested object like
+ * `{ app_metadata: { org_id: "org-42" } }` serializes to `{"app_metadata":{}}`
+ * and the discriminating value is erased (see the header note).
+ *
+ * Arrays preserve order (position is semantically meaningful); objects sort by
+ * key. Primitives round-trip through `JSON.stringify`.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`);
+  return `{${entries.join(",")}}`;
+}
 
 /**
  * Build a deterministic cache key from query parameters.
  *
  * Includes orgId in the key material so different organizations never
- * share cached results, even for identical SQL.
+ * share cached results, even for identical SQL. Claims are deep-canonicalized
+ * so nested claim values (e.g. a nested RLS tenant discriminator) are part of
+ * the key material — see the header note.
  */
 export function buildCacheKey(
   sql: string,
@@ -21,7 +59,7 @@ export function buildCacheKey(
     sql.trim(),
     connectionId,
     orgId ?? "",
-    claims ? JSON.stringify(claims, Object.keys(claims).sort()) : "",
+    claims ? canonicalize(claims) : "",
   ];
   const material = parts.join("\0");
   const hasher = new Bun.CryptoHasher("sha256");


### PR DESCRIPTION
Fixes #4532. This is a **`security`-labeled** fix — a latent cross-tenant cache leak.

## Problem

`buildCacheKey` (`packages/api/src/lib/cache/keys.ts`) serialized auth claims with a **replacer array**:

```ts
claims ? JSON.stringify(claims, Object.keys(claims).sort()) : "",
```

A `JSON.stringify` replacer array is applied at **every nesting level**, not just the top. So a nested claim erased its discriminating value:

```
{ app_metadata: { org_id: "org-42" } } -> {"app_metadata":{}}
{ app_metadata: { org_id: "org-99" } } -> {"app_metadata":{}}   // identical
```

When the RLS discriminator lives at a nested claim path — a supported config (`resolveClaimPath` dot-paths, `lib/rls.ts:33-40`) — two users collide on the same cache key and user B could be served user A's RLS-filtered rows for up to the cache TTL. Only incidentally shielded today by managed-auth mode spreading a top-level `sub`; simple-key mode with nested `ATLAS_AUTH_CLAIMS` re-opens it.

## Fix

- Replace the replacer-array serialization with an **order-insensitive recursive canonicalizer** (deep key-sort at every level). Nested claim values are now part of the key material; arrays preserve order (position is semantically meaningful); key stability across property-insertion order is preserved.
- Correct the `keys.ts` header note (was "org-scoped isolation by construction") to state the isolation invariant honestly for the undefined-orgId / nested-claims cases.

## Tests

Added to `packages/api/src/lib/cache/__tests__/cache.test.ts`:
- Two claims differing **only** at a nested path (`{app_metadata:{org_id:"org-42"}}` vs `org-99`) produce **different** keys.
- Nested claim key order does not affect the hash.

Existing flat-claim key-isolation tests still pass (37/37 in the file).

## Acceptance criteria
- [x] `buildCacheKey` deep-canonicalizes claims; nested values are part of the key.
- [x] Regression test: nested-path-only difference produces different keys.
- [x] Existing flat-claim key-isolation tests still pass; header note corrected.

## Testing / CI

`bash scripts/ci-local.sh`: 30/31 gates pass including the full `@atlas/api` suite. The lone failure is `@atlas/mcp` `smoke.test.ts` with `ECONNREFUSED 127.0.0.1:5432` — the known "mcp smoke needs a migrated local DB" environmental issue (#1472), unrelated to this change (which touches only `packages/api/src/lib/cache`).
