### PR TITLE
fix(api): bound connectionTimeoutMillis on all pg pools so acquire fails fast (#4463)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -361,6 +361,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 
 # ATLAS_POOL_WARMUP=2           # Default: 2 — warmup probes per connection at startup (0 = disabled)
 # ATLAS_POOL_DRAIN_THRESHOLD=5  # Default: 5 — consecutive query errors before pool drain/recreate
+# ATLAS_CONNECT_TIMEOUT=10000   # Default: 10s in ms, clamped 1000–60000. Bound on acquiring a pooled DB connection (pg connectionTimeoutMillis / mysql2 connectTimeout) for analytics + internal pools. Without it a saturated pool or an unreachable-but-routable DB hangs requests instead of failing fast
 # ATLAS_ORG_WHITELIST_TTL_MS=60000  # Default: 60000 (60s) — TTL for the per-org semantic-layer table-whitelist cache. Longer = fewer semantic scans, slower visibility of newly-added entities. Invalid/<=0 falls back to 60s
 
 # === Row-Level Security (optional) ===

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -225,6 +225,7 @@ Query safety, SQL validation, and security-disclosure settings. See <AudienceLin
 | `ATLAS_STRICT_PLUGIN_SECRETS` | `false` | F-42 / #1835: when `true`, plugin admin write paths reject PUTs whose catalog schema is corrupt or carries per-key secret/passthrough drift. SaaS regions opt in; self-hosted defaults to off. Tolerant idempotent passthrough is the baseline |
 | `ATLAS_POOL_WARMUP` | `2` | Number of warmup probes per connection at startup. Set to `0` to disable warmup |
 | `ATLAS_POOL_DRAIN_THRESHOLD` | `5` | Consecutive query errors before the pool is automatically drained and recreated |
+| `ATLAS_CONNECT_TIMEOUT` | `10000` | Bound (ms, clamped `1000`–`60000`) on acquiring a pooled database connection — pg `connectionTimeoutMillis` / mysql2 `connectTimeout`, applied to analytics **and** internal pools. Without it a saturated pool or an unreachable-but-routable database hangs requests instead of failing fast with a structured `rate_limited` error |
 | `ATLAS_CACHE_ENABLED` | `true` | Enable query result caching. Set to `false` to disable |
 | `ATLAS_CACHE_TTL` | `300000` | Cache TTL in milliseconds (default: 5 minutes) |
 | `ATLAS_CACHE_MAX_SIZE` | `1000` | Maximum number of cached query results |

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -410,11 +410,11 @@ type SSOEnforceableMode = Exclude<AuthMode, "none" | "simple-key">;
  * Bound on how long the audit-row write may block the auth path.
  *
  * The audit row is the security control (see `checkSSOEnforcement`),
- * so we await its commit before returning the 403 — but the internal
- * Postgres pool has no `connectionTimeoutMillis` / `statement_timeout`
- * defaults, which means an unreachable-but-routable DB or a stuck pool
- * could otherwise stall every blocked SSO login for the full TCP
- * keepalive window. Cap it: if the write hasn't committed within this
+ * so we await its commit before returning the 403. The internal Postgres
+ * pool now sets a bounded `connectionTimeoutMillis` (#4463), so an
+ * unreachable-but-routable DB or a stuck pool fails the acquire within that
+ * bound rather than stalling for the full TCP keepalive window — but this
+ * cap is tighter and independent: if the write hasn't committed within this
  * deadline, throw and let the surrounding catch fail closed with 500.
  */
 const AUDIT_WRITE_TIMEOUT_MS = 5_000;

--- a/packages/api/src/lib/db/__tests__/pool-config.test.ts
+++ b/packages/api/src/lib/db/__tests__/pool-config.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  CONNECT_TIMEOUT_DEFAULT_MS,
+  CONNECT_TIMEOUT_MAX_MS,
+  CONNECT_TIMEOUT_MIN_MS,
+  getConnectTimeoutMs,
+} from "@atlas/api/lib/db/pool-config";
+
+describe("getConnectTimeoutMs (#4463)", () => {
+  const original = process.env.ATLAS_CONNECT_TIMEOUT;
+  afterEach(() => {
+    if (original === undefined) delete process.env.ATLAS_CONNECT_TIMEOUT;
+    else process.env.ATLAS_CONNECT_TIMEOUT = original;
+  });
+
+  test("defaults to CONNECT_TIMEOUT_DEFAULT_MS when unset", () => {
+    delete process.env.ATLAS_CONNECT_TIMEOUT;
+    expect(getConnectTimeoutMs()).toBe(CONNECT_TIMEOUT_DEFAULT_MS);
+  });
+
+  test("honours a valid override within bounds", () => {
+    process.env.ATLAS_CONNECT_TIMEOUT = "7500";
+    expect(getConnectTimeoutMs()).toBe(7500);
+  });
+
+  test("never returns 0 — a stray 0 falls back to the default, not pg's infinite-hang", () => {
+    process.env.ATLAS_CONNECT_TIMEOUT = "0";
+    expect(getConnectTimeoutMs()).toBe(CONNECT_TIMEOUT_DEFAULT_MS);
+    expect(getConnectTimeoutMs()).toBeGreaterThan(0);
+  });
+
+  test("clamps a below-floor value up to the minimum", () => {
+    process.env.ATLAS_CONNECT_TIMEOUT = "50";
+    expect(getConnectTimeoutMs()).toBe(CONNECT_TIMEOUT_MIN_MS);
+  });
+
+  test("clamps an absurd value down to the maximum", () => {
+    process.env.ATLAS_CONNECT_TIMEOUT = "999999999";
+    expect(getConnectTimeoutMs()).toBe(CONNECT_TIMEOUT_MAX_MS);
+  });
+
+  test("falls back to the default for non-numeric or negative input", () => {
+    process.env.ATLAS_CONNECT_TIMEOUT = "not-a-number";
+    expect(getConnectTimeoutMs()).toBe(CONNECT_TIMEOUT_DEFAULT_MS);
+    process.env.ATLAS_CONNECT_TIMEOUT = "-500";
+    expect(getConnectTimeoutMs()).toBe(CONNECT_TIMEOUT_DEFAULT_MS);
+  });
+});

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -23,6 +23,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getConnectTimeoutMs } from "@atlas/api/lib/db/pool-config";
 import { getConfig } from "@atlas/api/lib/config";
 import type { HealthStatus } from "@atlas/api/lib/connection-types";
 
@@ -204,6 +205,13 @@ export interface ConnectionConfig {
   maxConnections?: number;
   /** Idle timeout in milliseconds before a connection is closed. Default 30000. Only applies to PostgreSQL pools. */
   idleTimeoutMs?: number;
+  /**
+   * Bound (ms) on acquiring a pooled connection — `connectionTimeoutMillis` for
+   * pg, `connectTimeout` for mysql2. Defaults to {@link getConnectTimeoutMs}
+   * (env `ATLAS_CONNECT_TIMEOUT`, bounded) so a saturated pool or an
+   * unreachable-but-routable datasource fails fast instead of hanging (#4463).
+   */
+  connectTimeoutMs?: number;
 }
 
 /** Regex for valid SQL identifiers (used for schema name validation). */
@@ -316,6 +324,10 @@ function createPostgresDB(config: ConnectionConfig): DBConnection {
     connectionString: connString,
     max: config.maxConnections ?? 10,
     idleTimeoutMillis: config.idleTimeoutMs ?? 30000,
+    // Fail fast on a saturated pool or an unreachable-but-routable host instead
+    // of queueing pool.connect() forever — the statement timeout only starts
+    // AFTER a client is acquired, so it can't cap a hung acquire (#4463).
+    connectionTimeoutMillis: config.connectTimeoutMs ?? getConnectTimeoutMs(),
   });
   pool.on("error", (err: Error) => {
     log.error({ err }, "Analytics pool idle client error");
@@ -436,6 +448,9 @@ function createMySQLDB(config: ConnectionConfig): DBConnection {
     uri: config.url,
     connectionLimit: config.maxConnections ?? 10,
     idleTimeout: config.idleTimeoutMs ?? 30000,
+    // mysql2's equivalent of pg's connectionTimeoutMillis: bounds the TCP+
+    // handshake so an unreachable-but-routable host fails fast (#4463).
+    connectTimeout: config.connectTimeoutMs ?? getConnectTimeoutMs(),
     supportBigNumbers: true,
     bigNumberStrings: true,
   });

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -24,6 +24,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { normalizeError } from "@atlas/api/lib/effect/errors";
 import { resolveStatusClause } from "@atlas/api/lib/content-mode/port";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { getConnectTimeoutMs } from "@atlas/api/lib/db/pool-config";
 import { foldRollingMean } from "@atlas/api/lib/learn/rolling-mean";
 import { REPEATED_PATTERN_MIN_REPETITIONS } from "@atlas/api/lib/learn/pattern-tiers";
 import {
@@ -370,6 +371,9 @@ export function makeInternalDBLive(): Layer.Layer<InternalDB> {
         connectionString: connString,
         max: 5,
         idleTimeoutMillis: 30000,
+        // Fail fast when the internal DB is unreachable-but-routable instead of
+        // stalling every login for the OS TCP keepalive window (#4463).
+        connectionTimeoutMillis: getConnectTimeoutMs(),
       });
       pool.on("error", (err: unknown) => {
         log.error(
@@ -565,6 +569,8 @@ export function getInternalDB(): InternalPool {
     connectionString: connString,
     max: 5,
     idleTimeoutMillis: 30000,
+    // Fail fast when the internal DB is unreachable-but-routable (#4463).
+    connectionTimeoutMillis: getConnectTimeoutMs(),
   }) as InternalPool;
   _pool.on("error", (err: unknown) => {
     log.error(
@@ -609,6 +615,8 @@ function getStripeLockPool(): InternalPool {
     connectionString: connString,
     max: 5,
     idleTimeoutMillis: 30000,
+    // Fail fast when the internal DB is unreachable-but-routable (#4463).
+    connectionTimeoutMillis: getConnectTimeoutMs(),
   }) as InternalPool;
   _lockPool.on("error", (err: unknown) => {
     log.error(

--- a/packages/api/src/lib/db/pool-config.ts
+++ b/packages/api/src/lib/db/pool-config.ts
@@ -1,0 +1,40 @@
+/**
+ * Bounded, config-driven connection-acquire timeout shared by every long-lived
+ * database pool: pg pools set it as `connectionTimeoutMillis`, mysql2 pools as
+ * `connectTimeout`.
+ *
+ * Without it, `pg` defaults to `0` — *no* timeout — so a saturated pool queues
+ * `pool.connect()` indefinitely and an unreachable-but-routable database stalls
+ * every request for the OS TCP keepalive window instead of failing fast. The
+ * statement timeout only starts *after* a client is acquired, so it can't help
+ * a request that never gets one. (#4463)
+ *
+ * Read from the `ATLAS_CONNECT_TIMEOUT` env var (milliseconds) at pool
+ * construction — env, not the settings registry, because the value is consumed
+ * exactly once when the pool is built (a pre-pool boot input, like
+ * `ATLAS_POOL_WARMUP`), never re-read per query, so a hot-reloadable setting
+ * would never take effect on an already-constructed pool.
+ *
+ * The result is clamped to `[MIN, MAX]` so a stray `0` (or negative / NaN)
+ * can never re-introduce the infinite-hang behaviour, and an absurdly large
+ * value can't defeat the fail-fast guarantee.
+ */
+
+/** Default acquire timeout when `ATLAS_CONNECT_TIMEOUT` is unset. */
+export const CONNECT_TIMEOUT_DEFAULT_MS = 10_000;
+/** Floor: guarantees a strictly-positive timeout so pg never falls back to 0 (no timeout). */
+export const CONNECT_TIMEOUT_MIN_MS = 1_000;
+/** Ceiling: bounds worst-case fail-fast latency regardless of a misconfigured value. */
+export const CONNECT_TIMEOUT_MAX_MS = 60_000;
+
+/**
+ * Resolve the bounded pool acquire/connect timeout in milliseconds.
+ *
+ * Applied as `connectionTimeoutMillis` on every pg pool (analytics + internal)
+ * and `connectTimeout` on every mysql2 pool.
+ */
+export function getConnectTimeoutMs(): number {
+  const raw = Number(process.env.ATLAS_CONNECT_TIMEOUT);
+  const value = Number.isFinite(raw) && raw > 0 ? raw : CONNECT_TIMEOUT_DEFAULT_MS;
+  return Math.min(CONNECT_TIMEOUT_MAX_MS, Math.max(CONNECT_TIMEOUT_MIN_MS, Math.floor(value)));
+}

--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -66,6 +66,18 @@ describe("matchError", () => {
     expect(isRetryableError(result.code)).toBe(true);
   });
 
+  test("maps pg pool acquire timeout to rate_limited, not provider_timeout (#4463)", () => {
+    // The exact message pg throws when a bounded `connectionTimeoutMillis`
+    // fires (saturated pool or unreachable-but-routable host). Must take the
+    // pool-exhausted branch, not the generic timeout branch that follows it.
+    const err = new Error("timeout exceeded when trying to connect");
+    const result = matchError(err) as MatchedError;
+    expect(result).not.toBeNull();
+    expect(result.code).toBe("rate_limited");
+    expect(result.message).toContain("pool exhausted");
+    expect(isRetryableError(result.code)).toBe(true);
+  });
+
   // --- ECONNREFUSED ---
 
   test("matches ECONNREFUSED with host:port", () => {

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -405,8 +405,14 @@ export function matchError(
   const msg = error instanceof Error ? error.message : String(error);
   const subsystem = opts?.subsystem ?? "datasource";
 
-  // Pool exhaustion — too many active database connections (transient)
-  if (/too many (clients already|connections)|connection pool exhausted|remaining connection slots are reserved/i.test(msg)) {
+  // Pool exhaustion — too many active database connections (transient).
+  // "timeout exceeded when trying to connect" is pg's message when a bounded
+  // `connectionTimeoutMillis` fires: the pool is saturated (no free client
+  // within the bound) or the host is unreachable-but-routable. Either way it is
+  // a capacity/backpressure signal — surface it as retryable `rate_limited`,
+  // BEFORE the generic timeout branch below would mislabel it `provider_timeout`
+  // (#4463). Kept ahead of that branch by ordering.
+  if (/too many (clients already|connections)|connection pool exhausted|remaining connection slots are reserved|timeout exceeded when trying to connect/i.test(msg)) {
     return {
       code: "rate_limited",
       message: "Database connection pool exhausted — try again in a few seconds, or reduce concurrent queries",


### PR DESCRIPTION
Fixes #4463.

## Problem

No pg pool (analytics or internal) set `connectionTimeoutMillis`, and no mysql2 pool set `connectTimeout`. `pg` defaults to `0` — **no** timeout — so:

- a saturated pool queued `pool.connect()` **indefinitely** (the statement timeout only starts *after* a client is acquired, so it never caps a hung acquire), and
- an unreachable-but-routable DB stalled every request for the OS TCP keepalive window — every login through the internal pool, as `lib/auth/middleware.ts` itself acknowledged.

`matchError`'s pool-exhausted → `rate_limited` mapping only caught the server-side "too many clients already" case, never client-side queueing. The retry path already listed pg's `"timeout exceeded when trying to connect"` in `TRANSIENT_CONNECT_MESSAGES` — a message that can only fire once `connectionTimeoutMillis` is set.

## Fix

- **`lib/db/pool-config.ts`** (new): `getConnectTimeoutMs()` reads `ATLAS_CONNECT_TIMEOUT` (ms), default **10s**, clamped `[1000, 60000]` so a stray `0`/negative/NaN can never re-introduce the infinite-hang behavior. Env (not settings registry) because it's consumed once at pool construction, like `ATLAS_POOL_WARMUP`.
- Applied as `connectionTimeoutMillis` on **every** pg pool — analytics (`connection.ts`) + the **three** internal pools (`internal.ts`: Effect-managed, lazy fallback, Stripe-lock) — and as `connectTimeout` on the mysql2 pool. Analytics pools accept a per-datasource `connectTimeoutMs` override via `ConnectionConfig`.
- **`matchError`** (`@useatlas/types`): map pg's `"timeout exceeded when trying to connect"` into the pool-exhausted → `rate_limited` branch, ahead of the generic timeout branch that would otherwise mislabel it `provider_timeout`. An acquire timeout now surfaces as a structured, retryable error instead of a hang.
- Refreshed the auth-middleware comment: the internal pool now bounds the acquire within `ATLAS_CONNECT_TIMEOUT`, so the 5s audit-write cap is tighter/independent rather than the only guard.
- Documented `ATLAS_CONNECT_TIMEOUT` in `.env.example` + the env-vars reference.

## Acceptance criteria

- [x] All pg pools set a bounded `connectionTimeoutMillis` (config-driven default, clamped).
- [x] Acquire timeout surfaces as a structured `rate_limited`-style error (requestId flows via the existing chat/tool error envelope), not a hang.
- [x] Auth path fails closed within the bound on unreachable internal DB (pool-level bound + the independent 5s audit cap).
- [x] MySQL checked — mysql2 `connectTimeout` set consistently.

## Tests

- `packages/types/src/__tests__/errors.test.ts` — pg acquire-timeout maps to `rate_limited`, not `provider_timeout`.
- `packages/api/src/lib/db/__tests__/pool-config.test.ts` — default, override, and clamp behavior (never returns 0).
- Affected api suite (454 files) + `bun run type` + `lint` + type-aware lint all green.

## Note

Spotted an unrelated **pre-existing** failure on `main` while running the types suite: `errors.test.ts > isRetryableError > "every ChatErrorCode is classified"` fails independently of this change (a `ChatErrorCode` is missing from the test's local retryable/non-retryable sets). Left untouched — filing separately.