### PR TITLE
fix(types): classify subscription_required so the ChatErrorCode coverage test passes (#4700)

### DIFF
--- a/packages/types/src/__tests__/errors.test.ts
+++ b/packages/types/src/__tests__/errors.test.ts
@@ -427,6 +427,7 @@ describe("isRetryableError", () => {
     "org_not_found",
     "plan_limit_exceeded",
     "trial_expired",
+    "subscription_required",
     "workspace_suspended",
     "workspace_deleted",
     "conversation_budget_exceeded",
@@ -468,7 +469,7 @@ describe("parseChatError retryable", () => {
   });
 
   test("retryable is false for all permanent error codes", () => {
-    for (const code of ["auth_error", "session_expired", "configuration_error", "no_datasource", "invalid_request", "provider_model_not_found", "provider_auth_error", "validation_error", "not_found", "forbidden", "forbidden_role", "org_not_found", "plan_limit_exceeded", "trial_expired", "workspace_suspended", "workspace_deleted"] as const) {
+    for (const code of ["auth_error", "session_expired", "configuration_error", "no_datasource", "invalid_request", "provider_model_not_found", "provider_auth_error", "validation_error", "not_found", "forbidden", "forbidden_role", "org_not_found", "plan_limit_exceeded", "trial_expired", "subscription_required", "workspace_suspended", "workspace_deleted"] as const) {
       const err = new Error(JSON.stringify({ error: code, message: "fail" }));
       const info = parseChatError(err, authMode);
       expect(info.retryable).toBe(false);


### PR DESCRIPTION
Closes #4700.

## Problem
`errors.test.ts`'s `every ChatErrorCode is classified` invariant was red on `main` (confirmed at `cab793ee9`). `subscription_required` was added to `CHAT_ERROR_CODES` but never added to the test's `retryableCodes`/`nonRetryableCodes` arrays, so `all.has(code)` returned false — failing the whole file in the isolated runner.

## Fix
- Added `subscription_required` to `nonRetryableCodes` (the `isRetryableError` classification array).
- Added it to the parallel `parseChatError` permanent-codes list so the two classification arrays stay consistent and can't drift apart.

### Why non-retryable
The source-of-truth `RETRYABLE_MAP` in `errors.ts` already pins `subscription_required: false`, and `matchError` never emits it — it's a billing/entitlement wall (subscription ended), not a transient failure. Retrying will not help. No behavior change to `matchError` or `RETRYABLE_MAP`; this only aligns the test's hardcoded arrays with the already-correct source of truth.

## Verification
- `bun test packages/types/src/__tests__/errors.test.ts` → 79 pass, 0 fail (was 1 fail on base).
- `bun run type` → exit 0. `bun run lint` → clean for touched file.

Spotted while working on #4463 (PR #4699); #4699 edits a different region of this file (an acquire-timeout case), so no overlap.