### PR TITLE
fix(api): SaaS boot guard for pinned vercel-sandbox credentials (#4461)

### DIFF
--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -54,6 +54,7 @@ context (which are secrets, which are derived, what changes at runtime).
 | `ATLAS_REGION_EU_DB_URL` | Region routing | EU region internal Postgres URL for residency routing. |
 | `ATLAS_REGION_APAC_DB_URL` | Region routing | APAC region internal Postgres URL for residency routing. |
 | `ATLAS_STRICT_PLUGIN_SECRETS` | Plugin config | Strict mode: fail boot on a missing plugin secret rather than silently dropping the plugin. `PluginConfigGuardLive`. |
+| `VERCEL_TOKEN` | Sandbox | Vercel Sandbox API token (per-service secret; Railway shared vars don't auto-inherit). `SandboxCredsGuardLive` refuses to boot a SaaS region whose `sandbox.priority` pins vercel-sandbox without it — otherwise every explore/executePython call hard-fails at first use. Team + project IDs are non-secret `sandbox.vercel` config in atlas.config.ts. |
 | `ATLAS_SMTP_URL` | Platform email (DPA) | SMTP URL for platform transactional email — alternative to `RESEND_API_KEY`. DPA-gated by `DpaGuardLive`. |
 | `RESEND_API_KEY` | Platform email (DPA) | Resend API key for platform transactional email. SaaS platform email must be Resend (DPA). |
 | `TURNSTILE_SECRET_KEY` | Abuse protection | Cloudflare Turnstile secret for the contact form + `start_trial` MCP onboarding. `TurnstileGuardLive` refuses to boot a SaaS region without it (fail-closed verify would silently 403 every signup otherwise). |

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -50,6 +50,7 @@ describe("SAAS_ENV_KEYS", () => {
       ATLAS_REGION_EU_DB_URL: undefined,
       ATLAS_REGION_APAC_DB_URL: undefined,
       ATLAS_STRICT_PLUGIN_SECRETS: undefined,
+      VERCEL_TOKEN: undefined,
       ATLAS_SMTP_URL: undefined,
       RESEND_API_KEY: undefined,
       TURNSTILE_SECRET_KEY: undefined,

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -93,6 +93,7 @@ import type {
   InternalDatabaseRequiredError as TInternalDatabaseRequiredError,
   RateLimitRequiredError as TRateLimitRequiredError,
   TurnstileSecretRequiredError as TTurnstileSecretRequiredError,
+  SandboxCredentialsMissingError as TSandboxCredentialsMissingError,
   ProviderKeyMissingError as TProviderKeyMissingError,
   ProviderUnsupportedError as TProviderUnsupportedError,
   RegionMisconfiguredError as TRegionMisconfiguredError,
@@ -159,6 +160,8 @@ const {
   RateLimitRequiredError,
   TurnstileGuardLive,
   TurnstileSecretRequiredError,
+  SandboxCredsGuardLive,
+  SandboxCredentialsMissingError,
   ProviderKeyGuardLive,
   ProactiveProviderKeyGuardLive,
   ProviderKeyMissingError,
@@ -805,6 +808,178 @@ describe("TurnstileGuardLive", () => {
       );
       expect(Exit.isSuccess(exit)).toBe(true);
     });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  SandboxCredsGuardLive (#4461)
+// ══════════════════════════════════════════════════════════════════════
+
+describe("SandboxCredsGuardLive", () => {
+  // `VERCEL_TOKEN` is a SAAS_ENV_KEY (so `withCleanEnv` clears it), but the
+  // team + project IDs are NOT — they resolve from `sandbox.vercel` in
+  // atlas.config.ts (#3706) and env only as an override. Clear + optionally set
+  // them here so a dev machine's stray Vercel creds can't make a "fails when
+  // token missing" case pass for the wrong reason, and restore afterward.
+  function withVercelIds<T>(
+    ids: { teamId?: string; projectId?: string },
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const saved = {
+      teamId: process.env.VERCEL_TEAM_ID,
+      projectId: process.env.VERCEL_PROJECT_ID,
+    };
+    if (ids.teamId !== undefined) process.env.VERCEL_TEAM_ID = ids.teamId;
+    else delete process.env.VERCEL_TEAM_ID;
+    if (ids.projectId !== undefined) process.env.VERCEL_PROJECT_ID = ids.projectId;
+    else delete process.env.VERCEL_PROJECT_ID;
+    return run().finally(() => {
+      if (saved.teamId !== undefined) process.env.VERCEL_TEAM_ID = saved.teamId;
+      else delete process.env.VERCEL_TEAM_ID;
+      if (saved.projectId !== undefined) process.env.VERCEL_PROJECT_ID = saved.projectId;
+      else delete process.env.VERCEL_PROJECT_ID;
+    });
+  }
+
+  const VERCEL_PINNED = { deployMode: "saas", sandbox: { priority: ["vercel-sandbox"] } };
+
+  test("fails boot in SaaS when priority pins vercel-sandbox and VERCEL_TOKEN is unset", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({ teamId: "team_x", projectId: "prj_x" }, async () => {
+        // team + project present via env, token absent → partial → fail.
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(Layer.provide(makeTestConfigLayer(VERCEL_PINNED))),
+            ),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(SandboxCredentialsMissingError);
+        expect((failure as TSandboxCredentialsMissingError)._tag).toBe("SandboxCredentialsMissingError");
+        expect((failure as TSandboxCredentialsMissingError).message).toContain("#4461");
+        expect((failure as TSandboxCredentialsMissingError).message).toContain("VERCEL_TOKEN");
+        expect((failure as TSandboxCredentialsMissingError).missing).toEqual(["VERCEL_TOKEN"]);
+      }),
+    );
+  });
+
+  test("fails boot in SaaS when all three credentials are absent (reports the full set)", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({}, async () => {
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(Layer.provide(makeTestConfigLayer(VERCEL_PINNED))),
+            ),
+          ),
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+        expect(failure).toBeInstanceOf(SandboxCredentialsMissingError);
+        expect((failure as TSandboxCredentialsMissingError).missing).toEqual([
+          "VERCEL_TEAM_ID",
+          "VERCEL_PROJECT_ID",
+          "VERCEL_TOKEN",
+        ]);
+      }),
+    );
+  });
+
+  test("succeeds in SaaS when all Vercel credentials are present", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({ teamId: "team_x", projectId: "prj_x" }, async () => {
+        process.env.VERCEL_TOKEN = "vercel-token";
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(Layer.provide(makeTestConfigLayer(VERCEL_PINNED))),
+            ),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  test("no-ops in SaaS when priority is not configured (default chain, no pin)", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({}, async () => {
+        // No sandbox config at all → not pinned → guard inert even without creds.
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(Layer.provide(makeTestConfigLayer({ deployMode: "saas" }))),
+            ),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  test("no-ops in SaaS when priority includes a just-bash fallback (degrade allowed)", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({}, async () => {
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(
+                Layer.provide(
+                  makeTestConfigLayer({
+                    deployMode: "saas",
+                    sandbox: { priority: ["vercel-sandbox", "just-bash"] },
+                  }),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  test("no-ops in SaaS when priority pins a non-vercel backend", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({}, async () => {
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(
+                Layer.provide(
+                  makeTestConfigLayer({ deployMode: "saas", sandbox: { priority: ["sidecar"] } }),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
+  });
+
+  test("no-ops on self-hosted even when the priority pins vercel-sandbox with no creds", async () => {
+    await withCleanEnv(() =>
+      withVercelIds({}, async () => {
+        const exit = await Effect.runPromiseExit(
+          Effect.void.pipe(
+            Effect.provide(
+              SandboxCredsGuardLive.pipe(
+                Layer.provide(
+                  makeTestConfigLayer({
+                    deployMode: "self-hosted",
+                    sandbox: { priority: ["vercel-sandbox"] },
+                  }),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(Exit.isSuccess(exit)).toBe(true);
+      }),
+    );
   });
 });
 
@@ -2088,6 +2263,29 @@ describe("relaxSaasGuardForDev (ATLAS_DEPLOY_ENV=development)", () => {
           Effect.provide(
             TurnstileGuardLive.pipe(
               Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("SandboxCredsGuard: relaxes in saas+development when priority pins vercel-sandbox with no creds", async () => {
+    await withCleanEnv(async () => {
+      // The #4461 fail-boot shape: priority pins vercel-sandbox, credentials
+      // absent. `withCleanEnv` clears VERCEL_TOKEN; team/project stay unset.
+      process.env.ATLAS_DEPLOY_ENV = "development";
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            SandboxCredsGuardLive.pipe(
+              Layer.provide(
+                makeTestConfigLayer({
+                  deployMode: "saas",
+                  sandbox: { priority: ["vercel-sandbox"] },
+                }),
+              ),
             ),
           ),
         ),

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -58,6 +58,7 @@ import {
   InternalDbGuardLive,
   RateLimitGuardLive,
   TurnstileGuardLive,
+  SandboxCredsGuardLive,
   ProviderKeyGuardLive,
   ProactiveProviderKeyGuardLive,
   RegionGuardLive,
@@ -3663,6 +3664,14 @@ export function buildAppLayer(
   // outage that boots green. `Config`-only and reads env directly, so it fails
   // fast as a peer of the other env-checking guards.
   const turnstileGuardLayer = TurnstileGuardLive.pipe(Layer.provide(configLayer));
+  // #4461 — fails boot when sandbox.priority pins vercel-sandbox (the SaaS
+  // deny-all posture) but the Vercel Sandbox credentials are absent/partial.
+  // A missing/mis-stamped per-service VERCEL_TOKEN otherwise boots green while
+  // every explore/executePython call hard-fails at first use. `Config`-only
+  // (reads the resolved priority + env creds directly), so it fails fast as a
+  // peer of the other env-checking guards; inert unless the priority pins
+  // vercel-sandbox (self-hosted / differently-configured deploys pass).
+  const sandboxCredsGuardLayer = SandboxCredsGuardLive.pipe(Layer.provide(configLayer));
   // #3178/#3200 — fails boot when the env-only MAIN-CHAT provider's required
   // config is incomplete in SaaS (boot-green-then-503 otherwise). Validates
   // required env as a SET (`getMissingProviderConfig`). `Config`-only and reads
@@ -3763,6 +3772,7 @@ export function buildAppLayer(
     internalDbGuardLayer,
     rateLimitGuardLayer,
     turnstileGuardLayer,
+    sandboxCredsGuardLayer,
     providerKeyGuardLayer,
     proactiveProviderKeyGuardLayer,
     regionGuardLayer,

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -73,6 +73,19 @@ export interface SaasEnv {
   // Plugin config strict mode (PluginConfigGuardLive)
   readonly ATLAS_STRICT_PLUGIN_SECRETS: string | undefined;
 
+  // Vercel Sandbox credential (SandboxCredsGuardLive, #4461). SaaS pins
+  // `sandbox.priority: ["vercel-sandbox"]` in `deploy/api/atlas.config.ts`
+  // (deny-all, no fallback). The team + project IDs are non-secret config
+  // (`sandbox.vercel` in atlas.config.ts, #3706), so only `VERCEL_TOKEN` — the
+  // per-service Railway secret (shared vars don't auto-inherit) — is a boot
+  // input. A missing/mis-stamped token boots green while every
+  // explore/executePython call hard-fails at first use, so `SandboxCredsGuardLive`
+  // fails boot instead. Listed here so the boot-smoke fixture populates it and
+  // the guard reads it via the shared `vercelSandboxCredentialStatus` presence
+  // check (which reads `process.env.VERCEL_TOKEN` straight, same dynamic-read
+  // pattern as the provider/adapter keys).
+  readonly VERCEL_TOKEN: string | undefined;
+
   // Platform email DPA (DpaGuardLive → assertSaasPlatformEmailIsResend)
   readonly ATLAS_SMTP_URL: string | undefined;
   readonly RESEND_API_KEY: string | undefined;
@@ -151,6 +164,7 @@ export const SAAS_ENV_KEYS = [
   "ATLAS_REGION_EU_DB_URL",
   "ATLAS_REGION_APAC_DB_URL",
   "ATLAS_STRICT_PLUGIN_SECRETS",
+  "VERCEL_TOKEN",
   "ATLAS_SMTP_URL",
   "RESEND_API_KEY",
   "TURNSTILE_SECRET_KEY",
@@ -189,6 +203,7 @@ export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
     ATLAS_REGION_EU_DB_URL: env.ATLAS_REGION_EU_DB_URL,
     ATLAS_REGION_APAC_DB_URL: env.ATLAS_REGION_APAC_DB_URL,
     ATLAS_STRICT_PLUGIN_SECRETS: env.ATLAS_STRICT_PLUGIN_SECRETS,
+    VERCEL_TOKEN: env.VERCEL_TOKEN,
     ATLAS_SMTP_URL: env.ATLAS_SMTP_URL,
     RESEND_API_KEY: env.RESEND_API_KEY,
     TURNSTILE_SECRET_KEY: env.TURNSTILE_SECRET_KEY,
@@ -266,6 +281,14 @@ export function makeBootSmokeFixture(
     ATLAS_REGION_EU_DB_URL: databaseUrl,
     ATLAS_REGION_APAC_DB_URL: databaseUrl,
     ATLAS_STRICT_PLUGIN_SECRETS: undefined,
+    // SandboxCredsGuardLive (#4461) asserts presence only in SaaS when the
+    // priority pins vercel-sandbox — the Vercel SDK reads the token at
+    // per-request sandbox creation, never at boot, so any non-empty value
+    // satisfies the boot guard. The team + project IDs it pairs with come from
+    // `sandbox.vercel` in atlas.config.ts (non-secret config), so the token is
+    // the only env input. Not a secret — identical every CI run, like the other
+    // fixture placeholders.
+    VERCEL_TOKEN: "ci-fixture-vercel-token-not-a-secret",
     ATLAS_SMTP_URL: undefined,
     RESEND_API_KEY: "ci-fixture-resend-key-not-a-secret",
     // TurnstileGuardLive (#3795) asserts presence only (non-empty) in SaaS —

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -88,6 +88,7 @@
 import { Data, Effect, Layer } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
+import type { SandboxBackendName } from "@atlas/api/lib/config";
 import { Config, Settings } from "./layers";
 import { Migration, PluginRegistry } from "./services";
 import { readSaasEnv, type SaasEnv } from "./saas-env";
@@ -142,6 +143,7 @@ const PROVIDER_KEY_ISSUE_REF = "#3178";
 const BILLING_CONFIG_ISSUE_REF = "#3435";
 const MCP_SPINE_ISSUE_REF = "#3687";
 const TURNSTILE_ISSUE_REF = "#3795";
+const SANDBOX_CREDS_ISSUE_REF = "#4461";
 
 /**
  * Sentinel org id for the boot-time `mcp_action_policy` reachability probe. It
@@ -458,6 +460,33 @@ export class McpSpineIncoherentError extends Data.TaggedError("McpSpineIncoheren
   readonly message: string;
 }> {}
 
+/**
+ * SaaS region booted with `sandbox.priority` pinned to `vercel-sandbox` (the
+ * deny-all posture in `deploy/api/atlas.config.ts` — no `just-bash` fallback)
+ * but the Vercel Sandbox credentials are absent or only partially set (#4461).
+ * Without this guard the api boots green, `/health` stays green, and every
+ * `explore` / `executePython` call hard-fails at first use because the pinned
+ * (and only) sandbox backend can't authenticate — the same boot-green-then-
+ * broken class `ProviderKeyGuardLive` (#3178) and `ChatAdapterEnvGuardLive`
+ * (#2672) close, and `VERCEL_TOKEN` follows the same per-service-secret
+ * stamping pattern (Railway shared vars don't auto-inherit).
+ *
+ * `priority` is the resolved sandbox-priority list that tripped the guard and
+ * `missing` the SET of credential inputs that were absent (any of
+ * `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID`, `VERCEL_TOKEN`) — both exposed so the
+ * operator-actionable boot log names the gap without re-parsing `message`. The
+ * presence check is the SAME one the runtime detector uses
+ * (`vercelSandboxCredentialStatus` in `lib/tools/backends/detect.ts`), so the
+ * guard and the detector can't drift on what "credentials present" means.
+ * Self-hosted, and any SaaS deploy whose priority is not pinned to
+ * vercel-sandbox, never construct this.
+ */
+export class SandboxCredentialsMissingError extends Data.TaggedError("SandboxCredentialsMissingError")<{
+  readonly message: string;
+  readonly priority: readonly string[];
+  readonly missing: readonly string[];
+}> {}
+
 // ══════════════════════════════════════════════════════════════════════
 // ██  Helpers
 // ══════════════════════════════════════════════════════════════════════
@@ -736,6 +765,95 @@ export const TurnstileGuardLive: Layer.Layer<never, TurnstileSecretRequiredError
         }),
       );
     }
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  SandboxCredsGuardLive (#4461)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Whether the resolved sandbox priority pins `vercel-sandbox` as a required
+ * backend with no unsandboxed fallback — the SaaS deny-all posture
+ * (`sandbox.priority: ["vercel-sandbox"]` in `deploy/api/atlas.config.ts`).
+ *
+ * Mirrors `planSandboxSelection`'s fail-closed determination
+ * (`lib/tools/backends/selection.ts`): a `just-bash` entry means the deploy
+ * opted into degrade-on-exhaustion, so a missing credential is NOT fatal and
+ * the guard must not fire. Absent `vercel-sandbox` from the list entirely
+ * (self-hosted, a sidecar/nsjail-pinned deploy) → not pinned, so a differently
+ * -configured deploy is never blocked by this guard.
+ */
+function sandboxPriorityPinsVercel(
+  priority: readonly SandboxBackendName[] | undefined,
+): boolean {
+  if (!priority || priority.length === 0) return false;
+  if (!priority.includes("vercel-sandbox")) return false;
+  // `just-bash` in the list ⇒ an unsandboxed fallback is allowed, so a missing
+  // VERCEL_TOKEN degrades rather than hard-fails — don't fail boot.
+  if (priority.includes("just-bash")) return false;
+  return true;
+}
+
+/**
+ * Fail boot in SaaS when `sandbox.priority` pins `vercel-sandbox` (the deny-all
+ * posture, no `just-bash` fallback) but the Vercel Sandbox credentials are
+ * absent or only partially set (#4461).
+ *
+ * `deploy/api/atlas.config.ts` pins `sandbox.priority: ["vercel-sandbox"]` on
+ * SaaS with no fallback (correctly fail-closed), but nothing asserted the
+ * credentials at boot: a region with a missing / mis-stamped `VERCEL_TOKEN`
+ * (a per-service Railway secret — shared vars don't auto-inherit) boots green,
+ * `/health` stays green, and every `explore` / `executePython` call hard-fails
+ * at first use. This guard turns that silent latent outage into a loud boot
+ * failure — the same posture as `ProviderKeyGuardLive` (#3178) and
+ * `ChatAdapterEnvGuardLive` (#2672).
+ *
+ * Depends only on `Config` (reads the resolved priority from the config Tag and
+ * the credential presence from `process.env` / `atlas.config.ts` via the shared
+ * `vercelSandboxCredentialStatus`), so it fails as fast as the other env-only
+ * guards. The detector module is lazy-imported inside the Effect body (same
+ * wall-off rationale as the other guards) — reusing its presence check is what
+ * keeps the guard and the runtime detector from drifting on "credentials
+ * present". Self-hosted is inert (the pin is a SaaS carve-out), and so is any
+ * SaaS deploy whose priority isn't pinned to vercel-sandbox. Dev-relaxable so
+ * the SaaS code path boots locally without the Vercel secret.
+ */
+export const SandboxCredsGuardLive: Layer.Layer<never, SandboxCredentialsMissingError, Config> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    if (config.deployMode !== "saas") return;
+    if (relaxSaasGuardForDev("SandboxCreds")) return;
+
+    const priority = config.sandbox?.priority;
+    if (!sandboxPriorityPinsVercel(priority)) return;
+
+    const { vercelSandboxCredentialStatus } = yield* Effect.promise(
+      () => import("@atlas/api/lib/tools/backends/detect"),
+    );
+    const status = vercelSandboxCredentialStatus();
+    if (status.complete) return;
+
+    const missing: string[] = [];
+    if (!status.hasTeamId) missing.push("VERCEL_TEAM_ID");
+    if (!status.hasProjectId) missing.push("VERCEL_PROJECT_ID");
+    if (!status.hasToken) missing.push("VERCEL_TOKEN");
+
+    yield* Effect.fail(
+      new SandboxCredentialsMissingError({
+        priority: [...(priority ?? [])],
+        missing,
+        message:
+          `SaaS region booted with sandbox.priority pinned to vercel-sandbox (the deny-all posture — ` +
+          `no just-bash fallback) but the Vercel Sandbox credentials are incomplete — missing: ` +
+          `[${missing.join(", ")}]. The api boots green and /health stays green, yet every ` +
+          `explore/executePython call would hard-fail at first use because the pinned (and only) ` +
+          `sandbox backend can't authenticate. VERCEL_TEAM_ID and VERCEL_PROJECT_ID resolve from ` +
+          `sandbox.vercel in atlas.config.ts (non-secret); VERCEL_TOKEN is a per-service env secret ` +
+          `that Railway shared vars do NOT auto-inherit — stamp it on every regional api service. ` +
+          `See ${SANDBOX_CREDS_ISSUE_REF}.`,
+      }),
+    );
   }),
 );
 

--- a/packages/api/src/lib/tools/backends/__tests__/detect.test.ts
+++ b/packages/api/src/lib/tools/backends/__tests__/detect.test.ts
@@ -133,6 +133,66 @@ describe("Vercel sandbox detection", () => {
     });
   });
 
+  // The presence breakdown consumed by `SandboxCredsGuardLive` (#4461). Shares
+  // `resolveVercelSandboxCreds` with `vercelSandboxAccess`, so this pins that
+  // they agree on what "present" means and report the same env/config sources.
+  describe("vercelSandboxCredentialStatus", () => {
+    it("reports complete when all three credentials are present", async () => {
+      process.env.VERCEL_TEAM_ID = "team_123";
+      process.env.VERCEL_PROJECT_ID = "prj_123";
+      process.env.VERCEL_TOKEN = "vercel-token";
+
+      const { vercelSandboxCredentialStatus } = await detectModule();
+
+      expect(vercelSandboxCredentialStatus()).toEqual({
+        hasTeamId: true,
+        hasProjectId: true,
+        hasToken: true,
+        complete: true,
+      });
+    });
+
+    it("reports which inputs are missing on a partial (token-only) set", async () => {
+      process.env.VERCEL_TOKEN = "vercel-token";
+
+      const { vercelSandboxCredentialStatus } = await detectModule();
+
+      expect(vercelSandboxCredentialStatus()).toEqual({
+        hasTeamId: false,
+        hasProjectId: false,
+        hasToken: true,
+        complete: false,
+      });
+    });
+
+    it("counts config-sourced team + project IDs as present (token still env-only)", async () => {
+      process.env.VERCEL_TOKEN = "vercel-token";
+      mockConfig = {
+        sandbox: { vercel: { teamId: "team_cfg", projectId: "prj_cfg" } },
+      };
+
+      const { vercelSandboxCredentialStatus } = await detectModule();
+
+      expect(vercelSandboxCredentialStatus()).toEqual({
+        hasTeamId: true,
+        hasProjectId: true,
+        hasToken: true,
+        complete: true,
+      });
+    });
+
+    it("is incomplete when config supplies IDs but the env-only token is missing", async () => {
+      mockConfig = {
+        sandbox: { vercel: { teamId: "team_cfg", projectId: "prj_cfg" } },
+      };
+
+      const { vercelSandboxCredentialStatus } = await detectModule();
+
+      expect(vercelSandboxCredentialStatus().complete).toBe(false);
+      expect(vercelSandboxCredentialStatus().hasToken).toBe(false);
+    });
+  });
+
   describe("useVercelSandbox", () => {
     it("returns true on ATLAS_RUNTIME=vercel", async () => {
       process.env.ATLAS_RUNTIME = "vercel";

--- a/packages/api/src/lib/tools/backends/detect.ts
+++ b/packages/api/src/lib/tools/backends/detect.ts
@@ -37,6 +37,61 @@ export interface VercelSandboxAccess {
 let _partialCredsWarned = false;
 
 /**
+ * Presence breakdown of the three Vercel Sandbox credential inputs, resolved
+ * with the SAME env-or-config precedence {@link vercelSandboxAccess} uses.
+ * `complete` is true iff all three are present. Exists so the SaaS boot guard
+ * (`SandboxCredsGuardLive`, #4461) and the runtime detector agree — by
+ * construction — on what "credentials present" means, rather than duplicating
+ * the resolution and drifting.
+ */
+export interface VercelSandboxCredentialStatus {
+  readonly hasTeamId: boolean;
+  readonly hasProjectId: boolean;
+  readonly hasToken: boolean;
+  readonly complete: boolean;
+}
+
+/**
+ * Resolve the three credential values with env-first, config-second
+ * precedence. The SINGLE statement of "which sources count", shared by
+ * {@link vercelSandboxAccess} and {@link vercelSandboxCredentialStatus} so
+ * neither can drift from the other. `VERCEL_TOKEN` is env-only (the secret);
+ * team + project IDs also fall back to `sandbox.vercel` in `atlas.config.ts`
+ * (#3706 — non-secret, constant across regions). Empty-string env values
+ * collapse to `undefined` (absent) via `||`.
+ */
+function resolveVercelSandboxCreds(): {
+  teamId: string | undefined;
+  projectId: string | undefined;
+  token: string | undefined;
+} {
+  const vercelConfig = getConfig()?.sandbox?.vercel;
+  return {
+    teamId: process.env.VERCEL_TEAM_ID || vercelConfig?.teamId,
+    projectId: process.env.VERCEL_PROJECT_ID || vercelConfig?.projectId,
+    token: process.env.VERCEL_TOKEN || undefined,
+  };
+}
+
+/**
+ * The presence breakdown of the Vercel Sandbox credentials — same resolution
+ * as {@link vercelSandboxAccess}, but reporting WHICH inputs are missing
+ * instead of the redacted access object. Used by `SandboxCredsGuardLive`
+ * (#4461) to fail SaaS boot (rather than the runtime "all backends failed"
+ * message far downstream) when the priority pins vercel-sandbox but a
+ * credential is absent/partial.
+ */
+export function vercelSandboxCredentialStatus(): VercelSandboxCredentialStatus {
+  const { teamId, projectId, token } = resolveVercelSandboxCreds();
+  return {
+    hasTeamId: !!teamId,
+    hasProjectId: !!projectId,
+    hasToken: !!token,
+    complete: !!(teamId && projectId && token),
+  };
+}
+
+/**
  * Returns explicit Vercel Sandbox API credentials when running off-Vercel
  * (e.g. Railway, Fly, bare metal). When unset, `@vercel/sandbox` falls back
  * to `VERCEL_OIDC_TOKEN` which is only present on the Vercel platform.
@@ -53,10 +108,7 @@ let _partialCredsWarned = false;
  * failed" message far downstream.
  */
 export function vercelSandboxAccess(): VercelSandboxAccess | undefined {
-  const vercelConfig = getConfig()?.sandbox?.vercel;
-  const teamId = process.env.VERCEL_TEAM_ID || vercelConfig?.teamId;
-  const projectId = process.env.VERCEL_PROJECT_ID || vercelConfig?.projectId;
-  const token = process.env.VERCEL_TOKEN;
+  const { teamId, projectId, token } = resolveVercelSandboxCreds();
   const allSet = !!(teamId && projectId && token);
   if (!allSet) {
     const anySet = !!(teamId || projectId || token);

--- a/scripts/generate-saas-env-doc.ts
+++ b/scripts/generate-saas-env-doc.ts
@@ -107,6 +107,11 @@ const KEY_META: Record<SaasEnvKey, KeyMeta> = {
     purpose:
       "Strict mode: fail boot on a missing plugin secret rather than silently dropping the plugin. `PluginConfigGuardLive`.",
   },
+  VERCEL_TOKEN: {
+    category: "Sandbox",
+    purpose:
+      "Vercel Sandbox API token (per-service secret; Railway shared vars don't auto-inherit). `SandboxCredsGuardLive` refuses to boot a SaaS region whose `sandbox.priority` pins vercel-sandbox without it — otherwise every explore/executePython call hard-fails at first use. Team + project IDs are non-secret `sandbox.vercel` config in atlas.config.ts.",
+  },
   ATLAS_SMTP_URL: {
     category: "Platform email (DPA)",
     purpose:


### PR DESCRIPTION
Closes #4461. **v0.1.0 launch blocker.**

## Problem

`deploy/api/atlas.config.ts` pins `sandbox.priority: ["vercel-sandbox"]` on SaaS with no fallback (correctly fail-closed), but `VERCEL_TOKEN` was not in `SAAS_ENV_KEYS` and no boot guard asserted it. `detect.ts`'s `vercelSandboxAccess()` treats partial credentials as "unset" with only a `log.warn`. Net effect: a region with a missing/mis-stamped per-service `VERCEL_TOKEN` (Railway shared vars don't auto-inherit) boots green, `/health` stays green, and every `explore`/`executePython` call hard-fails at first use — the same boot-green-then-broken class `ProviderKeyGuardLive` (#3178) and `ChatAdapterEnvGuardLive` (#2672) were built to close.

## Fix

- **`SandboxCredsGuardLive`** (`saas-guards.ts`) — fails SaaS boot when the resolved sandbox priority pins `vercel-sandbox` with no `just-bash` fallback *and* the Vercel Sandbox credentials are absent/partial. Mirrors the existing guard family exactly (`Layer.effectDiscard`, `Data.TaggedError`, `Config`-only, fails closed). Wired into `buildAppLayer` as a peer of the other env-checking guards.
  - Only fires when the priority *actually* pins vercel-sandbox — self-hosted, a `just-bash`-fallback deploy, or a sidecar/nsjail-pinned deploy all pass. The `just-bash` determination mirrors `planSandboxSelection`'s fail-closed logic.
  - Dev-relaxable via `relaxSaasGuardForDev` like the other missing-prod-infra guards.
- **Shared presence SSOT** — factored the credential-presence resolution in `detect.ts` into `vercelSandboxCredentialStatus()`, which both `vercelSandboxAccess()` and the guard read, so guard and detector can't drift on what "credentials present" means.
- **`VERCEL_TOKEN` joins `SAAS_ENV_KEYS`** + `KEY_META`; regenerated the operator env doc — `scripts/check-saas-env-doc.sh` passes. Boot-smoke fixture populates a placeholder token.

### On `SAAS_IMMUTABLE_KEYS`

`VERCEL_TOKEN` is **not** added to `SAAS_IMMUTABLE_KEYS`. That set locks settings-registry keys that a platform admin could re-open via `setSetting` at runtime (`ATLAS_EMAIL_PROVIDER`, `ATLAS_DEPLOY_MODE`, `ATLAS_RATE_LIMIT_RPM`). `VERCEL_TOKEN` is a pure env secret read straight from `process.env` — never a settings key — so it has no runtime-mutation path to lock. This matches the precedent for other boot-guard *secrets* (`TURNSTILE_SECRET_KEY`, `AI_GATEWAY_API_KEY`, `SLACK_*`), none of which are immutable-listed.

## Tests

- `SandboxCredsGuardLive` describe block (Effect test layers, `Layer.provide`): fires when creds missing/partial + priority pinned; reports the missing set; no-ops when relaxed for dev; no-ops when priority is unpinned / has a just-bash fallback / pins a non-vercel backend; no-ops on self-hosted.
- `vercelSandboxCredentialStatus` unit tests in `detect.test.ts`.
- `saas-env.test.ts` exhaustiveness + `check-saas-env-doc.sh` cover the new key.

Full `bun run type`, `bun run lint`, and the affected isolated suite (93 files) pass.