### PR TITLE
feat(cache): surface hit age + governance-safe bypassCache at executeSQL (#4546)

### DIFF
--- a/packages/api/src/lib/multi-env-merger/__tests__/index.test.ts
+++ b/packages/api/src/lib/multi-env-merger/__tests__/index.test.ts
@@ -281,3 +281,33 @@ describe("mergeMemberResults — envContributions ordering", () => {
     ]);
   });
 });
+
+describe("mergeMemberResults — per-leg cache/masking propagation (#4546)", () => {
+  it("carries each successful leg's cached + maskingApplied onto its contribution", () => {
+    const inputs: MemberExecutionResult[] = [
+      // A cache-hit, PII-masked leg.
+      { connectionId: "us-int", columns: ["a"], rows: [{ a: 1 }], durationMs: 5, cached: true, maskingApplied: true },
+      // A live, unmasked leg.
+      { connectionId: "eu", columns: ["a"], rows: [{ a: 2 }], durationMs: 40, cached: false, maskingApplied: false },
+    ];
+    const merged = mergeMemberResults(inputs);
+
+    const us = merged.envContributions.find((c) => c.connectionId === "us-int")!;
+    const eu = merged.envContributions.find((c) => c.connectionId === "eu")!;
+    expect(us.cached).toBe(true);
+    expect(us.maskingApplied).toBe(true);
+    expect(eu.cached).toBe(false);
+    expect(eu.maskingApplied).toBe(false);
+  });
+
+  it("omits cached/maskingApplied on an errored leg (it never reached those layers)", () => {
+    const inputs: MemberExecutionResult[] = [
+      { connectionId: "down", error: "boom", durationMs: 2 },
+    ];
+    const merged = mergeMemberResults(inputs);
+    const c = merged.envContributions[0]!;
+    expect(c.error).toBe("boom");
+    expect(c.cached).toBeUndefined();
+    expect(c.maskingApplied).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/multi-env-merger/index.ts
+++ b/packages/api/src/lib/multi-env-merger/index.ts
@@ -52,6 +52,15 @@ export interface MemberExecutionResult {
   readonly error?: string;
   /** Wall-clock duration of the per-member execution, in ms. */
   readonly durationMs: number;
+  /**
+   * `true` iff this member's rows came from the Query Cache. Propagated onto
+   * the {@link ConnectionContribution} so a fanout reports per-leg cache state
+   * honestly instead of hardcoding `cached: false` (#4546). Omitted when the
+   * member errored.
+   */
+  readonly cached?: boolean;
+  /** `true` iff PII masking transformed this member's rows (#4546). Omitted when the member errored. */
+  readonly maskingApplied?: boolean;
 }
 
 /**
@@ -154,6 +163,12 @@ export function mergeMemberResults(
         rowCount: m.rows?.length ?? 0,
         error: m.error ?? null,
         durationMs: m.durationMs,
+        // Per-leg cache/masking honesty (#4546). Only meaningful for a
+        // successful leg; a leg that errored carries neither (it never
+        // reached the cache or masking layers), so we omit the field rather
+        // than assert a misleading `false`.
+        ...(m.error === undefined && m.cached !== undefined && { cached: m.cached }),
+        ...(m.error === undefined && m.maskingApplied !== undefined && { maskingApplied: m.maskingApplied }),
       }) satisfies ConnectionContribution,
   );
 

--- a/packages/api/src/lib/tools/__tests__/sql-cache-elevation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-cache-elevation.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tool-seam tests for the Query Cache elevation (#4546, milestone v0.0.56):
+ *
+ *   - a cache HIT carries a `cacheAgeMs` field derived from the entry's stored
+ *     write timestamp (so the result card can render "cached · Xm ago" and the
+ *     agent can caveat time-sensitive answers), and
+ *   - the `bypassCache: true` input SKIPS the cache read (executes live) but
+ *     KEEPS the write, so the fresh result re-freshens the shared entry for
+ *     everyone on the same key — governance-safe because the live path re-runs
+ *     every gate.
+ *
+ * Harness mirrors `sql-cache-audit.test.ts`: a mock pg.Pool injected via
+ * `_resetPool` captures audit INSERTs, and the cache mock is STATEFUL — `set`
+ * overwrites the in-memory entry `get` returns — so a bypass write followed by
+ * a normal read proves "overwrites the entry, subsequent identical queries hit
+ * the refreshed entry".
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock, type Mock } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { CacheEntry, CacheScope } from "@atlas/api/lib/cache/types";
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResult = any;
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["companies", "people"]),
+  _resetWhitelists: () => {},
+}));
+
+let queryFn: Mock<(sql: string, timeout: number) => Promise<{ columns: string[]; rows: Record<string, unknown>[] }>>;
+
+const mockConn = {
+  query: (...args: [string, number]) => queryFn(...args),
+  close: async () => {},
+};
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => mockConn,
+    connections: {
+      get: () => mockConn,
+      getDefault: () => mockConn,
+      getForOrg: () => mockConn,
+    },
+  }),
+);
+
+void mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (
+    _name: string,
+    _attrs: Record<string, unknown>,
+    fn: () => Promise<unknown>,
+  ) => fn(),
+  withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+
+void mock.module("@atlas/api/lib/db/source-rate-limit", () => ({
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  withSourceSlot: (_sourceId: string, effect: any) => effect,
+}));
+
+// Stateful cache mock. `cachedEntry` is what a read returns; `set` OVERWRITES
+// it (and records the write), so a `bypassCache` write becomes visible to a
+// later normal read — modeling the shared-entry re-freshen. `get`/`set` are
+// async on purpose (mirrors the real CacheBackend contract + the phantom-hit
+// guard).
+let cachedEntry: CacheEntry | null = null;
+let cacheSets: Array<{ key: string; entry: CacheEntry; scope: CacheScope }> = [];
+
+void mock.module("@atlas/api/lib/cache/index", () => ({
+  getCache: () => ({
+    get: async () => cachedEntry,
+    set: async (key: string, entry: CacheEntry, scope: CacheScope) => {
+      cacheSets.push({ key, entry, scope });
+      cachedEntry = entry; // overwrite so a subsequent read sees the fresh rows
+    },
+    delete: async () => false,
+    flush: async () => {},
+    flushByOrg: async () => 0,
+    stats: async () => ({ hits: 0, misses: 0, entryCount: 0, maxSize: 1000, ttl: 300000 }),
+  }),
+  buildCacheKey: () => "mock-key",
+  cacheEnabled: () => true,
+  getDefaultTtl: () => 300000,
+  flushCache: async () => {},
+  flushCacheByOrg: async () => 0,
+  setCacheBackend: async () => {},
+  validateCacheBackend: async () => ({ ok: true }),
+  _resetCache: () => {},
+}));
+
+const { executeSQL } = await import("@atlas/api/lib/tools/sql");
+
+const mockPool: InternalPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+describe("executeSQL cache elevation — age on hit + bypassCache (#4546)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+
+  beforeEach(() => {
+    cacheSets = [];
+    cachedEntry = null;
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/atlas";
+    _resetPool(mockPool);
+    queryFn = mock(() =>
+      Promise.resolve({
+        columns: ["id", "name"],
+        rows: [{ id: 2, name: "FRESH" }],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    if (origDatasource) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    _resetPool(null);
+  });
+
+  const exec = (sql: string, bypassCache?: boolean) =>
+    executeSQL.execute!(
+      { sql, explanation: "test", ...(bypassCache !== undefined && { bypassCache }) },
+      { toolCallId: "test", messages: [], abortSignal: undefined as never },
+    ) as Promise<AnyResult>;
+
+  it("a cache hit carries cacheAgeMs derived from the entry's write timestamp", async () => {
+    cachedEntry = {
+      columns: ["id", "name"],
+      rows: [{ id: 1, name: "Acme" }],
+      cachedAt: Date.now() - 180_000, // written ~3 minutes ago
+      ttl: 300_000,
+      executionMs: 42,
+    };
+
+    const result = await exec("SELECT id, name FROM companies");
+
+    expect(result.success).toBe(true);
+    expect(result.cached).toBe(true);
+    // Never touches the datasource on a hit.
+    expect(queryFn).not.toHaveBeenCalled();
+    // Age reflects the ~3-minute-old write timestamp (generous upper bound
+    // absorbs test wall-clock; lower bound proves it isn't 0/undefined).
+    expect(typeof result.cacheAgeMs).toBe("number");
+    expect(result.cacheAgeMs).toBeGreaterThanOrEqual(179_000);
+    expect(result.cacheAgeMs).toBeLessThan(200_000);
+    // The 1-element single-env contribution reports the same cache state.
+    expect(result.envContributions).toHaveLength(1);
+    expect(result.envContributions[0].cached).toBe(true);
+  });
+
+  it("a live (miss) execution has no cacheAgeMs and reports cached:false per leg", async () => {
+    cachedEntry = null; // miss → executes live
+    const result = await exec("SELECT id, name FROM companies");
+
+    expect(result.success).toBe(true);
+    expect(result.cached).toBe(false);
+    expect(result.cacheAgeMs).toBeUndefined();
+    expect(result.envContributions[0].cached).toBe(false);
+  });
+
+  it("bypassCache:true skips the read (executes live) but keeps the write", async () => {
+    // A stale entry is present — a normal read would serve it. Bypass must not.
+    cachedEntry = {
+      columns: ["id", "name"],
+      rows: [{ id: 1, name: "STALE" }],
+      cachedAt: Date.now() - 10_000,
+      ttl: 300_000,
+      executionMs: 99,
+    };
+
+    const result = await exec("SELECT id, name FROM companies", true);
+
+    expect(result.success).toBe(true);
+    // Executed live: the datasource WAS hit and the FRESH rows are served,
+    // not the stale cached ones.
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(result.cached).toBe(false);
+    expect(result.cacheAgeMs).toBeUndefined();
+    expect(result.rows).toEqual([{ id: 2, name: "FRESH" }]);
+
+    // The WRITE is kept: exactly one fresh entry written back, carrying the
+    // fresh rows + scope tags (#4548) — governance-safe re-freshen for the key.
+    expect(cacheSets).toHaveLength(1);
+    expect(cacheSets[0].entry.rows).toEqual([{ id: 2, name: "FRESH" }]);
+    expect(typeof cacheSets[0].scope.connectionId).toBe("string");
+    expect(cacheSets[0].scope.connectionId.length).toBeGreaterThan(0);
+  });
+
+  it("after a bypass write, a subsequent identical query hits the refreshed entry", async () => {
+    // Start with a stale entry.
+    cachedEntry = {
+      columns: ["id", "name"],
+      rows: [{ id: 1, name: "STALE" }],
+      cachedAt: Date.now() - 10_000,
+      ttl: 300_000,
+      executionMs: 99,
+    };
+
+    // 1) Bypass: executes live, overwrites the entry with FRESH rows.
+    const bypassed = await exec("SELECT id, name FROM companies", true);
+    expect(bypassed.cached).toBe(false);
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    // 2) Normal read of the same key: hits the REFRESHED entry (fresh rows),
+    // without a second datasource round-trip.
+    const rehit = await exec("SELECT id, name FROM companies");
+    expect(rehit.success).toBe(true);
+    expect(rehit.cached).toBe(true);
+    expect(rehit.rows).toEqual([{ id: 2, name: "FRESH" }]);
+    // Still only ONE datasource execution total — the second call was a hit.
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    // A just-written entry is near-zero age.
+    expect(result_ageIsFresh(rehit.cacheAgeMs)).toBe(true);
+  });
+
+  it("clamps cacheAgeMs to 0 when the entry's timestamp is in the future (clock skew)", async () => {
+    // A replica whose clock ran ahead can stamp `cachedAt` in the future
+    // relative to the reader. The age must never go negative.
+    cachedEntry = {
+      columns: ["id", "name"],
+      rows: [{ id: 1, name: "Acme" }],
+      cachedAt: Date.now() + 5_000,
+      ttl: 300_000,
+      executionMs: 10,
+    };
+
+    const result = await exec("SELECT id, name FROM companies");
+    expect(result.cached).toBe(true);
+    expect(result.cacheAgeMs).toBe(0);
+  });
+
+  it("without bypass, a present entry is served (control for the bypass tests)", async () => {
+    cachedEntry = {
+      columns: ["id", "name"],
+      rows: [{ id: 1, name: "STALE" }],
+      cachedAt: Date.now() - 10_000,
+      ttl: 300_000,
+      executionMs: 99,
+    };
+
+    const result = await exec("SELECT id, name FROM companies");
+    expect(result.cached).toBe(true);
+    expect(queryFn).not.toHaveBeenCalled();
+    expect(result.rows).toEqual([{ id: 1, name: "STALE" }]);
+  });
+});
+
+/** A freshly-written entry's age should be small (seconds), never undefined. */
+function result_ageIsFresh(ageMs: unknown): boolean {
+  return typeof ageMs === "number" && ageMs >= 0 && ageMs < 5_000;
+}

--- a/packages/api/src/lib/tools/__tests__/sql-cache-fanout-propagation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-cache-fanout-propagation.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tool-seam test for per-leg cache honesty in a cross-environment fanout
+ * (#4546). Before this slice, `executeSqlFanout` hardcoded `cached: false` on
+ * the merged result, so an ALL-HIT fanout masqueraded as a fresh zero-second
+ * query. Now each leg's own `cached` rides through the merger onto its
+ * `ConnectionContribution`, and the merged top-level `cached` is true only when
+ * EVERY successful leg was a hit.
+ *
+ * Harness mirrors `sql-fanout-audit.test.ts` (two-member group routing so
+ * `scope: "all"` fans out), with a per-connection cache mock: `buildCacheKey`
+ * folds the connection id into the key, so each leg can independently hit or
+ * miss.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock, type Mock } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { CacheEntry } from "@atlas/api/lib/cache/types";
+
+// oxlint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResult = any;
+
+void mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+type QueryResult = { columns: string[]; rows: Record<string, unknown>[] };
+let queryFn: Mock<(sql: string, timeout?: number) => Promise<QueryResult>>;
+// Connection ids that should reject their query (simulate a down member) — used
+// by the partial-failure test to prove a fanout with one errored leg does NOT
+// wear a "cached" chip.
+let failingConns: Set<string>;
+
+function mockDBFor(connId: string) {
+  return {
+    query: (...args: [string, number]) =>
+      failingConns.has(connId)
+        ? Promise.reject(new Error(`connection ${connId} is down`))
+        : queryFn(...args),
+    close: async () => {},
+  };
+}
+
+void mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => mockDBFor("default"),
+    connections: {
+      get: (id: string) => mockDBFor(id ?? "default"),
+      getDefault: () => mockDBFor("default"),
+      getForOrg: (_orgId: string, id?: string) => mockDBFor(id ?? "default"),
+      getTargetHost: () => "localhost:5432",
+      describe: () => [
+        { id: "us-int", dbType: "postgres" as const },
+        { id: "eu", dbType: "postgres" as const },
+      ],
+    },
+  }),
+);
+
+void mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (
+    _name: string,
+    _attrs: Record<string, unknown>,
+    fn: () => Promise<unknown>,
+  ) => fn(),
+  withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+
+void mock.module("@atlas/api/lib/db/source-rate-limit", () => ({
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  withSourceSlot: (_sourceId: string, effect: any) => effect,
+}));
+
+// Per-connection cache: the key folds in the connection id so each leg hits or
+// misses independently. `entriesByConn` is the fixture each test populates.
+let entriesByConn: Map<string, CacheEntry>;
+
+void mock.module("@atlas/api/lib/cache/index", () => ({
+  getCache: () => ({
+    get: async (key: string) => entriesByConn.get(key) ?? null,
+    set: async () => {},
+    delete: async () => false,
+    flush: async () => {},
+    flushByOrg: async () => 0,
+    stats: async () => ({ hits: 0, misses: 0, entryCount: 0, maxSize: 1000, ttl: 300000 }),
+  }),
+  buildCacheKey: (_sql: string, connId: string) => `k:${connId}`,
+  cacheEnabled: () => true,
+  getDefaultTtl: () => 300000,
+  flushCache: async () => {},
+  flushCacheByOrg: async () => 0,
+  setCacheBackend: async () => {},
+  validateCacheBackend: async () => ({ ok: true }),
+  _resetCache: () => {},
+}));
+
+// Two members so `scope: "all"` produces a real fanout.
+void mock.module("@atlas/api/lib/env-routing/lookup", () => ({
+  loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) => ({
+    groupId: "prod",
+    members: ["us-int", "eu"] as const,
+    primaryMember: "us-int",
+    currentMember,
+    degraded: false,
+  }),
+}));
+
+const { executeSQL } = await import("@atlas/api/lib/tools/sql");
+
+const mockPool: InternalPool = {
+  query: async () => ({ rows: [] }),
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+function hitEntry(rows: Record<string, unknown>[], ageMs: number): CacheEntry {
+  return { columns: ["id"], rows, cachedAt: Date.now() - ageMs, ttl: 300_000, executionMs: 50 };
+}
+
+const fanoutAll = () =>
+  executeSQL.execute!(
+    { sql: "SELECT id FROM orders", explanation: "test", connectionId: "us-int", scope: "all" },
+    { toolCallId: "test", messages: [], abortSignal: undefined as never },
+  ) as Promise<AnyResult>;
+
+function contribByConn(result: AnyResult, connId: string) {
+  return (result.envContributions as Array<{ connectionId: string; cached?: boolean; maskingApplied?: boolean; error: string | null }>).find(
+    (c) => c.connectionId === connId,
+  )!;
+}
+
+describe("executeSQL fanout — per-leg cache honesty (#4546)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+  const origDatasource = process.env.ATLAS_DATASOURCE_URL;
+
+  beforeEach(() => {
+    entriesByConn = new Map();
+    failingConns = new Set();
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/atlas";
+    _resetPool(mockPool);
+    queryFn = mock(() => Promise.resolve({ columns: ["id"], rows: [{ id: 99 }] }));
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    if (origDatasource) process.env.ATLAS_DATASOURCE_URL = origDatasource;
+    else delete process.env.ATLAS_DATASOURCE_URL;
+    _resetPool(null);
+  });
+
+  it("an all-hit fanout reports cached:true, an age, and per-leg cached:true — not a fresh 0s query", async () => {
+    entriesByConn.set("k:us-int", hitEntry([{ id: 1 }], 120_000)); // 2 min old
+    entriesByConn.set("k:eu", hitEntry([{ id: 2 }], 240_000)); // 4 min old (oldest)
+
+    const result = await fanoutAll();
+
+    expect(result.success).toBe(true);
+    // Never touched a datasource — both legs were hits.
+    expect(queryFn).not.toHaveBeenCalled();
+    // Top-level honesty: the merged table IS cached (was hardcoded false before).
+    expect(result.cached).toBe(true);
+    // Age is the OLDEST cached leg (4 min), so the caveat reflects the stalest data.
+    expect(typeof result.cacheAgeMs).toBe("number");
+    expect(result.cacheAgeMs).toBeGreaterThanOrEqual(239_000);
+    expect(result.cacheAgeMs).toBeLessThan(260_000);
+    // Per-leg honesty.
+    expect(contribByConn(result, "us-int").cached).toBe(true);
+    expect(contribByConn(result, "eu").cached).toBe(true);
+    // Masking untouched (no classified tables) but present + honest per leg.
+    expect(contribByConn(result, "us-int").maskingApplied).toBe(false);
+    expect(contribByConn(result, "eu").maskingApplied).toBe(false);
+  });
+
+  it("a mixed fanout (one hit, one live) reports cached:false top-level and per-leg honestly", async () => {
+    entriesByConn.set("k:us-int", hitEntry([{ id: 1 }], 60_000)); // hit
+    // eu has no entry → executes live
+
+    const result = await fanoutAll();
+
+    expect(result.success).toBe(true);
+    // The live leg ran exactly once.
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    // Not every leg hit → the merged result is NOT cached, and no aggregate age.
+    expect(result.cached).toBe(false);
+    expect(result.cacheAgeMs).toBeUndefined();
+    // Per-leg truth: us-int cached, eu live.
+    expect(contribByConn(result, "us-int").cached).toBe(true);
+    expect(contribByConn(result, "eu").cached).toBe(false);
+  });
+
+  it("a partial-failure fanout (one leg errored) is NOT reported as cached, even if the surviving legs all hit", async () => {
+    entriesByConn.set("k:us-int", hitEntry([{ id: 1 }], 60_000)); // surviving leg is a hit
+    failingConns.add("eu"); // eu errors (no cache entry, its query rejects)
+
+    const result = await fanoutAll();
+
+    // One leg succeeded → still a success:true partial result (agent sees the
+    // per-leg failure), NOT the all-errored branch.
+    expect(result.success).toBe(true);
+    // The crux: the merged table is partial, so it must NOT claim a clean
+    // "cached · Xm ago" chip even though the only successful leg was a hit.
+    expect(result.cached).toBe(false);
+    expect(result.cacheAgeMs).toBeUndefined();
+    // Per-leg honesty is preserved: the survivor reports its hit; the failed
+    // leg carries an error and omits cache/masking (never reached those layers).
+    expect(contribByConn(result, "us-int").cached).toBe(true);
+    expect(contribByConn(result, "us-int").error).toBeNull();
+    const eu = contribByConn(result, "eu");
+    expect(eu.error).not.toBeNull();
+    expect(eu.cached).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -28,11 +28,13 @@ Use this when the typed tools (\`listEntities\`, \`describeEntity\`, \`searchGlo
 
 Don't use this for catalog discovery, single-entity introspection, glossary lookup, or executing canonical metrics — the typed tools are faster and return structured JSON.`;
 
-export const EXECUTE_SQL_TOOL_DESCRIPTION = `Execute a single read-only SELECT against an Atlas-registered datasource. The query is parsed, table-whitelist-checked against the semantic layer, RLS-injected, auto-LIMITed, and run under a statement timeout — DDL/DML, multi-statement input, and unknown tables are rejected before execution. Result shape: \`{ "columns": ["..."], "rows": [{ "col": "value" }], "row_count": N, "truncated": false }\`.
+export const EXECUTE_SQL_TOOL_DESCRIPTION = `Execute a single read-only SELECT against an Atlas-registered datasource. It is parsed, table-whitelist-checked, RLS-injected, auto-LIMITed, and run under a statement timeout; DDL/DML, multi-statement input, and unknown tables are rejected. Returns \`{ columns, rows, row_count, truncated, cached, cacheAgeMs }\`.
 
-Use this when no canonical metric covers the question, when you need ad-hoc breakdowns, or when a virtual dimension or query pattern requires SQL the agent must compose. Always call \`describeEntity\` to read exact column names and joins. Example call: \`{ "sql": "SELECT status, count(*) FROM orders GROUP BY 1", "explanation": "order count by status" }\`.
+Identical queries are briefly cached; a hit sets \`cached: true\` plus \`cacheAgeMs\` (row age in ms) — caveat time-sensitive answers as of that age, not current numbers. Set \`bypassCache: true\` only when the user explicitly asks for fresh or current data; it re-runs live under every governance gate.
 
-Don't use this for catalog discovery (use \`listEntities\`), schema lookup (use \`describeEntity\`), glossary disambiguation (use \`searchGlossary\`), or any question whose metric id exists under \`semantic/metrics/\` (use \`runMetric\`). Avoid retrying the same SQL after a validation or RLS error — fix the query.`;
+Use this when no canonical metric covers the question or you need ad-hoc breakdowns; call \`describeEntity\` for exact columns and joins. Example call: \`{ "sql": "SELECT status, count(*) FROM orders GROUP BY 1", "explanation": "orders by status" }\`.
+
+Don't use this for catalog discovery (\`listEntities\`), schema lookup (\`describeEntity\`), glossary disambiguation (\`searchGlossary\`), or an existing metric (\`runMetric\`). Avoid retrying failed SQL — fix the query.`;
 
 export const LIST_ENTITIES_TOOL_DESCRIPTION = `Return the catalog of semantic-layer entities (tables and views) declared for this workspace. Each row carries \`{ name, table, description, source }\`; an optional case-insensitive \`filter\` substring narrows the result against name, table, and description. Example call: \`{ "filter": "order" }\`. Example response: \`{ "count": 3, "entities": [{ "name": "orders", "table": "orders", "description": "...", "source": "default" }] }\`.
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -48,7 +48,8 @@ import { appendRowLimit, hasLimitClause } from "./auto-limit";
 import { type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { resolveExecutionTarget, type ExecutionTarget } from "@atlas/api/lib/group-reach/execution-target";
 import { resolveSqlExecutionPlan } from "./sql-execution-plan";
-import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
+import { mergeMemberResults, type ConnectionContribution } from "@atlas/api/lib/multi-env-merger";
+import type { ExecuteSqlSuccessResult, ExecuteSqlFailureResult } from "@useatlas/types";
 import {
   ApprovalGate,
   MaskingPolicy,
@@ -1273,6 +1274,14 @@ interface ExecutedSqlResult {
   readonly rows: Record<string, unknown>[];
   readonly truncated: boolean;
   readonly cached: boolean;
+  /**
+   * Age of the served rows in ms — `Date.now()` minus the cache entry's write
+   * timestamp (`cachedAt`) — present only on a cache hit (#4546). The chat
+   * result card renders it as "cached · Xm ago"; the tool description tells
+   * the agent to caveat time-sensitive answers by it. Undefined on a live
+   * execution (miss/bypass), where the rows are current by definition.
+   */
+  readonly cacheAgeMs?: number;
   readonly maskingApplied: boolean;
   readonly executionMs: number;
   readonly metadata?: Record<string, unknown>;
@@ -1593,7 +1602,20 @@ type SqlPipelinePreStep =
        */
       readonly values: Record<string, string | number | null>;
     }
-  | { readonly kind: "check-cache" };
+  | {
+      readonly kind: "check-cache";
+      /**
+       * When `true`, SKIP the cache READ (always execute live) but KEEP the
+       * cache WRITE, so the fresh result re-freshens the shared entry for
+       * everyone on the same key (#4546). Governance-safe by construction: the
+       * live path re-runs every gate (approval, RLS, whitelist, masking), so
+       * bypass costs performance only — it never lowers governance. Set from
+       * the `bypassCache` tool input, which the model sends only when the user
+       * explicitly asks for fresh or current data. Absent/false = normal
+       * read-then-write behavior.
+       */
+      readonly bypassCache?: boolean;
+    };
 
 export interface SqlPipelineOptions {
   readonly sql: string;
@@ -1916,12 +1938,21 @@ export function runSqlPipelineEffect(
         const claims = ctx?.user?.claims;
         const cacheKey = buildCacheKey(normalizedSql, connId, cacheOrgId, claims);
         cacheWrite = { key: cacheKey, scope: { orgId: cacheOrgId, connectionId: connId } };
+        // Bypass (#4546): skip the cache READ (always execute live) but keep
+        // `cacheWrite` above, so the fresh result re-freshens the shared entry
+        // for everyone on this key. Governance-safe by construction — the live
+        // path below re-runs EVERY gate (approval, RLS, whitelist, masking);
+        // bypass costs performance only, never governance. A bypass reads as a
+        // miss here (`cached = null`), falling straight through to execution.
+        //
         // Awaited via Effect so an async backend's read actually resolves
         // before we branch — an unawaited Promise is truthy and would read as a
         // phantom hit, serving `undefined` rows for every query. Fail open: a
         // read rejection logs, drops the write (so we don't try to write back to
         // a broken backend), and falls through to a live execution.
-        const cached = yield* Effect.tryPromise({
+        const cached = preStep.bypassCache
+          ? null
+          : yield* Effect.tryPromise({
           // `async () =>` (not a bare arrow) so the try always yields a
           // Promise — tolerating a backend (or test mock) whose `get` is
           // sync-shaped, while still awaiting a real async backend's result.
@@ -2000,6 +2031,18 @@ export function runSqlPipelineEffect(
                 success: true, explanation, row_count: cachedRows.length,
                 columns: cached.columns, rows: cachedRows,
                 truncated: cachedTruncated, cached: true,
+                // #4546 — age of the served rows: now minus the entry's write
+                // timestamp. Surfaces "cached · Xm ago" in the result card and
+                // lets the agent caveat time-sensitive answers by it. Clamped
+                // at 0 against clock skew between write and read. Attached only
+                // when `cachedAt` is finite: an external backend (Redis) can
+                // deserialize an entry with a missing/NaN `cachedAt` despite
+                // the required type (mirrors the `executionMs` caveat in
+                // cache/types.ts), and `Math.max(0, NaN)` is NaN → JSON `null`,
+                // handing the agent a garbage age. Omit rather than mislead.
+                ...(Number.isFinite(cached.cachedAt) && {
+                  cacheAgeMs: Math.max(0, Date.now() - cached.cachedAt),
+                }),
                 maskingApplied: cachedMaskingApplied,
                 // Cost of *serving this hit* (~0, no DB round-trip) — NOT the
                 // original execution cost. The query's real duration is
@@ -2291,6 +2334,7 @@ async function executeSqlForConnection({
   routingMode,
   routingReason,
   executionTarget,
+  bypassCache,
 }: {
   readonly sql: string;
   readonly explanation: string;
@@ -2303,12 +2347,18 @@ async function executeSqlForConnection({
   readonly routingReason?: RoutingReason;
   /** See {@link SqlPipelineOptions.executionTarget}. Per-leg; never shared. */
   readonly executionTarget?: ExecutionTarget;
+  /**
+   * When `true`, skip the cache READ (execute live) but keep the WRITE (#4546).
+   * Threaded into the `check-cache` pre-step. Every leg of a fanout inherits
+   * the same value so a bypass is uniform across environments.
+   */
+  readonly bypassCache?: boolean;
 }): Promise<Record<string, unknown>> {
   const pipeline = runSqlPipelineEffect({
     sql,
     explanation,
     connId,
-    preStep: { kind: "check-cache" },
+    preStep: { kind: "check-cache", bypassCache },
     parentAuditId,
     routingMode,
     routingReason,
@@ -2391,8 +2441,14 @@ async function executeSqlFanout(args: {
    * audit rows.
    */
   readonly fanoutReason: RoutingReason;
+  /**
+   * Cache-bypass flag from the tool input (#4546). Applied uniformly to every
+   * leg — a bypass skips each leg's cache read but keeps its write, so all
+   * legs re-freshen their shared entries.
+   */
+  readonly bypassCache?: boolean;
 }): Promise<Record<string, unknown>> {
-  const { sql, explanation, legs, fanoutReason } = args;
+  const { sql, explanation, legs, fanoutReason, bypassCache } = args;
   const connectionIds = legs.map((leg) => leg.connectionId);
 
   // Write the parent audit row up front so each leg's audit insert can
@@ -2457,6 +2513,7 @@ async function executeSqlFanout(args: {
         routingMode: "all",
         routingReason: fanoutReason,
         executionTarget: leg,
+        bypassCache,
       });
     }),
   );
@@ -2483,6 +2540,12 @@ async function executeSqlFanout(args: {
         columns: (value["columns"] as readonly string[] | undefined) ?? [],
         rows: (value["rows"] as readonly Record<string, unknown>[] | undefined) ?? [],
         durationMs,
+        // Per-leg cache/masking honesty (#4546): carry each leg's own signals
+        // through the merger onto its `ConnectionContribution` so an all-hit
+        // fanout can't masquerade as fresh, and a mixed fanout reports each
+        // env truthfully. Read from the leaf tool response by key.
+        cached: value["cached"] === true,
+        maskingApplied: value["maskingApplied"] === true,
       };
     }
     const errorMessage = typeof value["error"] === "string" ? (value["error"] as string) : "Query failed";
@@ -2498,6 +2561,27 @@ async function executeSqlFanout(args: {
     0,
   );
 
+  // Honest per-fanout cache/masking (#4546). The merged table is `cached` only
+  // when EVERY leg SUCCEEDED and was a hit: a single live leg makes the whole
+  // result fresh, and a single ERRORED leg makes the table partial — neither
+  // may wear a clean "cached · Xm ago" chip. (The pre-#4546 hardcoded
+  // `cached: false` was one falsehood; reporting `cached: true` while a leg
+  // failed is the opposite.) A partial failure is still surfaced per-leg in
+  // `envContributions`, so the agent sees exactly which env failed. Masking is
+  // applied when ANY successful leg masked. The age (for the chip + the agent's
+  // caveat) is the OLDEST cached leg, so the caveat reflects the stalest data.
+  const successfulContribs = merged.envContributions.filter((c) => c.error === null);
+  const allLegsSucceeded = successfulContribs.length === merged.envContributions.length;
+  const allLegsCached = successCount > 0 && allLegsSucceeded && successfulContribs.every((c) => c.cached === true);
+  const anyLegMasked = successfulContribs.some((c) => c.maskingApplied === true);
+  const oldestCachedAgeMs = allLegsCached
+    ? settled.reduce((max, o) => {
+        if (o.status !== "fulfilled") return max;
+        const age = o.value["cacheAgeMs"];
+        return typeof age === "number" && age > max ? age : max;
+      }, 0)
+    : undefined;
+
   // All members errored → surface as success=false with a summary message
   // so the agent's recovery loop kicks in. Partial failures stay
   // success=true with envContributions describing which env failed.
@@ -2511,9 +2595,12 @@ async function executeSqlFanout(args: {
       error: `All ${merged.envContributions.length} environments failed — ${messages.join("; ")}`,
       envContributions: merged.envContributions,
       executionMs: totalExecutionMs,
-    };
+    } satisfies ExecuteSqlFailureResult;
   }
 
+  // `satisfies` links this literal to the wire type so a field-name typo on the
+  // one result path that previously had zero compile-time checking (the new
+  // numeric `cacheAgeMs` is easy to misspell) fails the build (#4546 review).
   return {
     success: true,
     explanation,
@@ -2521,11 +2608,12 @@ async function executeSqlFanout(args: {
     columns: merged.columns,
     rows: merged.rows,
     truncated: false,
-    cached: false,
-    maskingApplied: false,
+    cached: allLegsCached,
+    ...(oldestCachedAgeMs !== undefined && { cacheAgeMs: oldestCachedAgeMs }),
+    maskingApplied: anyLegMasked,
     envContributions: merged.envContributions,
     executionMs: totalExecutionMs,
-  };
+  } satisfies ExecuteSqlSuccessResult;
 }
 
 export const executeSQL = tool({
@@ -2554,9 +2642,15 @@ export const executeSQL = tool({
       .describe(
         "Cross-environment routing override (PRD #2515). \"this\" or omitted runs against the conversation's current member; \"all\" fans out across every member of the active environment group; a member connection id routes to that specific environment. Only applies when the active group has more than one member.",
       ),
+    bypassCache: z
+      .boolean()
+      .optional()
+      .describe(
+        "Set to `true` ONLY when the user explicitly asks for fresh, current, real-time, or up-to-date data. Identical queries are otherwise served from a short-lived result cache; a hit returns `cached: true` with a `cacheAgeMs` age. Bypass re-runs the query live (still under every governance gate — validation, RLS, whitelist, masking) and re-freshens the shared cache entry for everyone. Omit for normal reads; it only costs performance.",
+      ),
   }),
 
-  execute: async ({ sql, explanation, group, connectionId, scope }) => {
+  execute: async ({ sql, explanation, group, connectionId, scope, bypassCache }) => {
     // Read the request context ONCE and hand it to the planner (#4350). The
     // planner folds the whole cascade — reach gate (ADR-0022) → group-target
     // member → current member → routing-mode fast-path → routing plan →
@@ -2593,6 +2687,7 @@ export const executeSQL = tool({
           routingMode: plan.routingMode,
           routingReason: plan.routingReason,
           executionTarget: plan.executionTarget,
+          bypassCache,
         });
         return attachSingleEnvContribution(result, connId);
       }
@@ -2602,6 +2697,7 @@ export const executeSQL = tool({
           explanation,
           legs: plan.legs,
           fanoutReason: plan.fanoutReason,
+          bypassCache,
         });
       default: {
         const _exhaustive: never = plan;
@@ -2646,8 +2742,23 @@ function attachSingleEnvContribution(
       ? (result["error"] as string)
       : "Execution failed (no error message available)";
   }
+  // Mirror the fanout's per-leg honesty (#4546) on the single-env 1-element
+  // contribution so consumers read `cached`/`maskingApplied` uniformly across
+  // both wire shapes. Only meaningful on success — a failed execution never
+  // reached the cache or masking layers, so those fields stay omitted.
+  const contribution: ConnectionContribution =
+    error === null
+      ? {
+          connectionId,
+          rowCount,
+          error,
+          durationMs,
+          cached: result["cached"] === true,
+          maskingApplied: result["maskingApplied"] === true,
+        }
+      : { connectionId, rowCount, error, durationMs };
   return {
     ...result,
-    envContributions: [{ connectionId, rowCount, error, durationMs }],
+    envContributions: [contribution],
   };
 }

--- a/packages/types/src/execute-sql.ts
+++ b/packages/types/src/execute-sql.ts
@@ -34,6 +34,19 @@ export interface ConnectionContribution {
   readonly error: string | null;
   /** Wall-clock duration of this member's execution in milliseconds. */
   readonly durationMs: number;
+  /**
+   * `true` iff THIS member's rows were served from the Query Cache rather than
+   * executed live. Per-leg honesty (#4546): a fanout must not hardcode
+   * `cached: false` — an all-hit fanout would otherwise masquerade as a fresh
+   * zero-second query. Omitted (undefined) when the member errored.
+   */
+  readonly cached?: boolean;
+  /**
+   * `true` iff PII masking transformed THIS member's rows. Per-leg so a mixed
+   * fanout (one masked env, one not) reports each honestly. Omitted when the
+   * member errored.
+   */
+  readonly maskingApplied?: boolean;
 }
 
 /**
@@ -56,6 +69,15 @@ export interface ExecuteSqlSuccessResult {
   readonly rows: readonly Record<string, unknown>[];
   readonly truncated?: boolean;
   readonly cached?: boolean;
+  /**
+   * Age of the served rows in milliseconds — `Date.now()` minus the cache
+   * entry's write timestamp — present only on a cache hit (`cached: true`).
+   * The result card renders it as "cached · Xm ago" and the agent caveats
+   * time-sensitive answers "as of ~N minutes ago" rather than asserting stale
+   * numbers as current (#4546). Absent on a live/miss execution. For a fanout,
+   * this is the age of the OLDEST cached leg when every successful leg hit.
+   */
+  readonly cacheAgeMs?: number;
   readonly maskingApplied?: boolean;
   readonly executionMs?: number;
   readonly envContributions?: readonly ConnectionContribution[];

--- a/packages/web/src/ui/__tests__/sql-result-card.test.tsx
+++ b/packages/web/src/ui/__tests__/sql-result-card.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test, mock } from "bun:test";
 import { render, fireEvent } from "@testing-library/react";
-import { SQLResultCard } from "../components/chat/sql-result-card";
+import { SQLResultCard, formatCacheAge } from "../components/chat/sql-result-card";
 
 // Mock next/dynamic to render children synchronously (avoids async chunk loading)
 void mock.module("next/dynamic", () => ({
@@ -224,5 +224,80 @@ describe("SQLResultCard", () => {
     );
     expect(container.textContent).toContain("1 row");
     expect(container.textContent).not.toContain("1 rows");
+  });
+
+  // #4546 — a cache hit surfaces its staleness as "cached · Xm ago" instead of
+  // an invisible bare "cached".
+  test("renders 'cached · Xm ago' when the result is a cache hit with an age", () => {
+    const { container } = render(
+      <SQLResultCard
+        part={makePart({
+          output: {
+            success: true,
+            columns: ["id"],
+            rows: [{ id: 1 }],
+            executionMs: 0,
+            cached: true,
+            cacheAgeMs: 180_000, // 3 minutes
+          },
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("cached · 3m ago");
+  });
+
+  test("falls back to bare 'cached' when a hit carries no age", () => {
+    const { container } = render(
+      <SQLResultCard
+        part={makePart({
+          output: {
+            success: true,
+            columns: ["id"],
+            rows: [{ id: 1 }],
+            executionMs: 0,
+            cached: true,
+            // no cacheAgeMs (legacy/external entry)
+          },
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("cached");
+    expect(container.textContent).not.toContain("ago");
+  });
+
+  test("a live (uncached) result shows its duration, not 'cached'", () => {
+    const { container } = render(
+      <SQLResultCard
+        part={makePart({
+          output: {
+            success: true,
+            columns: ["id"],
+            rows: [{ id: 1 }],
+            executionMs: 1500,
+            cached: false,
+          },
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("1.5s");
+    expect(container.textContent).not.toContain("cached");
+  });
+});
+
+describe("formatCacheAge (#4546)", () => {
+  test("renders seconds under a minute", () => {
+    expect(formatCacheAge(0)).toBe("0s ago");
+    expect(formatCacheAge(59_000)).toBe("59s ago");
+  });
+
+  test("rolls to minutes at 60s and stays minutes under an hour", () => {
+    expect(formatCacheAge(60_000)).toBe("1m ago");
+    expect(formatCacheAge(180_000)).toBe("3m ago");
+    expect(formatCacheAge(3_540_000)).toBe("59m ago");
+  });
+
+  test("rolls to hours at an hour", () => {
+    expect(formatCacheAge(3_600_000)).toBe("1h ago");
+    expect(formatCacheAge(7_200_000)).toBe("2h ago");
   });
 });

--- a/packages/web/src/ui/components/chat/sql-result-card.tsx
+++ b/packages/web/src/ui/components/chat/sql-result-card.tsx
@@ -46,6 +46,20 @@ const AddToDashboardDialog = dynamic(
   { ssr: false, loading: () => null },
 );
 
+/**
+ * Format a cache-entry age (ms since the rows were written) into a compact
+ * "Xs ago" / "Xm ago" / "Xh ago" label for the "cached · …" chip (#4546), so a
+ * cache hit surfaces its staleness instead of an invisible "cached". Sensible
+ * units: seconds under a minute, minutes under an hour, hours beyond.
+ */
+export function formatCacheAge(ms: number): string {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.round(minutes / 60)}h ago`;
+}
+
 /** Build a human-readable comparison string, e.g. "was 3.4s" or "was 512 rows · 3.4s" (row count shown only when changed). */
 function formatPreviousExecution(
   prev: PreviousExecution,
@@ -179,7 +193,14 @@ function SQLResultCardInner({
           {rows.length} row{rows.length !== 1 ? "s" : ""}
           {result.truncated ? "+" : ""}
           {typeof result.executionMs === "number" && Number.isFinite(result.executionMs) && (
-            <> · {result.cached ? "cached" : `${(result.executionMs / 1000).toFixed(1)}s`}</>
+            <>
+              {" · "}
+              {result.cached
+                ? typeof result.cacheAgeMs === "number" && Number.isFinite(result.cacheAgeMs)
+                  ? `cached · ${formatCacheAge(result.cacheAgeMs)}`
+                  : "cached"
+                : `${(result.executionMs / 1000).toFixed(1)}s`}
+            </>
           )}
           {previousExecution && (() => {
             const comparison = formatPreviousExecution(previousExecution, rows.length);


### PR DESCRIPTION
## What

Slice 2 of milestone **v0.0.56 — Admin Cache Elevation** (#89), closing #4546. Builds on the async `CacheBackend` contract merged in #4548 (scope-tagged `set`, org index). Governance boundary per ADR-0033; vocabulary per CONTEXT.md § Query Cache.

A Query Cache hit stops being invisible staleness — it now carries its age, the agent is told what caching means, fanout reports per-leg honesty, and a `bypassCache` escape hatch re-freshens the shared entry without lowering governance.

## Changes

- **Hit age** — hit responses carry `cacheAgeMs` (`Date.now()` − the entry's stored `cachedAt`, clamped at 0; omitted when `cachedAt` is non-finite, mirroring the `executionMs` external-backend caveat). The chat result card renders **"cached · Xm ago"** (seconds/minutes/hours) instead of a bare "cached" chip.
- **Tool description** — `EXECUTE_SQL_TOOL_DESCRIPTION` now documents that caching exists and what `cached`/`cacheAgeMs`/`bypassCache` mean, so the agent caveats time-sensitive answers ("as of ~3 minutes ago") instead of asserting stale numbers as current. Kept within the 80–150-word rubric.
- **`bypassCache` input** — described for the model as "set only when the user explicitly asks for fresh or current data." SKIPS the cache **read** but KEEPS the **write**, so the fresh result re-freshens the shared entry for everyone on the key. **Governance-safe by construction**: the live path re-runs every gate (approval, RLS, whitelist, masking); bypass costs performance only, never governance.
- **Fanout per-leg honesty** — `ConnectionContribution` gains `cached`/`maskingApplied`, propagated through the merger per leg (audit L1 fix — no more hardcoded `cached: false`). Top-level `cached`/`cacheAgeMs` are true only when **every leg succeeded and hit** (oldest cached leg's age), so an all-hit fanout can't masquerade as a fresh 0s query and a partial failure never wears a clean cached chip. Added `satisfies ExecuteSqlSuccessResult`/`ExecuteSqlFailureResult` on the fanout returns to compile-time-link the new numeric field.

## Wire types

Additive optional fields only (`@useatlas/types`): `cacheAgeMs?` on `ExecuteSqlSuccessResult`; `cached?`/`maskingApplied?` on `ConnectionContribution`. No published-package version bump needed (no scaffold-bound source imports a new value symbol).

## Tests

Tool-seam + unit coverage: age-on-hit, clock-skew clamp, `bypassCache` read-skip/write-keep, refreshed-entry re-hit, all-hit vs mixed vs partial-failure fanout propagation, merger per-leg propagation (incl. `maskingApplied`), and web `formatCacheAge` boundaries + the cached-render branch.

## Review

Internal review panel (silent-failure / type-design / test-coverage / comment-accuracy) run before opening: **no CRITICAL/HIGH**. Applied the LOW/MEDIUM improvements inline (partial-failure fanout honesty, `cacheAgeMs` NaN guard, `satisfies` on fanout returns, description shape listing, and the added partial-failure/clock-skew/web tests).

## CI

`scripts/ci-local.sh`: **30/31 gates pass** (type, lint, lint-type-aware, all drift gates, full `@atlas/api` suite incl. the new tests). The one `test`-gate failure is the pre-existing #1472 env false-fail — `@atlas/mcp`'s `smoke.test.ts` needs a provisioned/migrated internal Postgres (billing gate + prompt loader hit `ECONNREFUSED`); this diff touches **0** MCP files and the failure is pure DB provisioning, which passes on remote CI's `api-tests` shards.