### PR TITLE
polish(admin): impeccable audit pass on the Query Cache page

### DIFF
--- a/packages/web/src/app/admin/cache/page.tsx
+++ b/packages/web/src/app/admin/cache/page.tsx
@@ -34,6 +34,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
@@ -180,6 +181,9 @@ function CacheConfigCard({
 
   const ttlNum = Number(ttlInput);
   const ttlValid = ttlInput.trim() !== "" && Number.isFinite(ttlNum) && ttlNum >= 1;
+  // Empty is a transient typing state (Save just disables); only a non-empty
+  // value that can't be saved gets flagged as invalid.
+  const ttlInvalid = ttlInput.trim() !== "" && !ttlValid;
   const ttlDirty = ttlValid && ttlNum !== ttlMs;
 
   return (
@@ -237,6 +241,8 @@ function CacheConfigCard({
               step={1000}
               value={ttlInput}
               disabled={saveTtl.saving}
+              aria-invalid={ttlInvalid || undefined}
+              aria-describedby={ttlInvalid ? "cache-ttl-error" : "cache-ttl-help"}
               onChange={(e) => setTtlInput(e.target.value)}
               className="max-w-[220px]"
             />
@@ -247,8 +253,18 @@ function CacheConfigCard({
             >
               {saveTtl.saving ? "Saving…" : "Save"}
             </Button>
+            {/* Nobody thinks in raw milliseconds — echo the entered value in
+                human units while it differs from what's saved. */}
+            {ttlDirty && (
+              <span className="text-sm text-muted-foreground">= {formatTtl(ttlNum)}</span>
+            )}
           </div>
-          <p className="text-xs text-muted-foreground">
+          {ttlInvalid && (
+            <p id="cache-ttl-error" className="text-xs text-destructive">
+              Enter a whole number of milliseconds, at least 1.
+            </p>
+          )}
+          <p id="cache-ttl-help" className="text-xs text-muted-foreground">
             Currently {formatTtl(ttlMs)}. Applies to newly cached results.
             {!isSaas &&
               " You can also set ATLAS_CACHE_ENABLED / ATLAS_CACHE_TTL via environment variables."}
@@ -309,9 +325,10 @@ function CacheEntriesCard({ onChanged }: { onChanged: () => void }) {
         {loading ? (
           <p className="text-sm text-muted-foreground">Loading entries...</p>
         ) : error ? (
-          <p className="text-sm text-muted-foreground">
-            Couldn&apos;t load entries: {error.message}
-          </p>
+          <ErrorBanner
+            message={`Couldn't load cached entries: ${error.message}`}
+            onRetry={refetch}
+          />
         ) : entries === undefined ? (
           // `undefined` = no parsed payload (transient refetch state) — only
           // the wire's explicit `null` means backend-unavailable.
@@ -411,9 +428,12 @@ export default function CachePage() {
   // Warming: caching is on but no access has ever been recorded — render an
   // honest "warming up" panel instead of a 0.0% rate that reads as broken.
   const warming = data ? data.enabled && data.since === null : false;
+  // `null` = fill is unknowable (entry count or capacity unreported by the
+  // cache backend) — rendered "—", never a confident 0.0% that reads as an
+  // empty cache.
   const fillPercent = data && data.maxSize !== null && data.maxSize > 0 && data.entryCount !== null
     ? (data.entryCount / data.maxSize) * 100
-    : 0;
+    : null;
   const flushDisabledReason = data
     ? !data.enabled
       ? "Cache is disabled"
@@ -435,21 +455,6 @@ export default function CachePage() {
 
       <ErrorBoundary>
         <TooltipProvider>
-          <MutationErrorSurface
-            error={flushError}
-            feature="Cache"
-            onRetry={clearFlushError}
-          />
-          {flushMessage && (
-            <div
-              role="status"
-              aria-live="polite"
-              className="mb-6 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-300"
-            >
-              {flushMessage}
-            </div>
-          )}
-
           <AdminContentWrapper
             loading={loading}
             error={error}
@@ -509,7 +514,7 @@ export default function CachePage() {
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <div className="flex items-baseline gap-2">
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
                     <span className="text-4xl font-bold tracking-tight">
                       {data.hitRate === null ? "—" : formatPercent(data.hitRate)}
                     </span>
@@ -580,9 +585,11 @@ export default function CachePage() {
                     {isPlatform && (
                       <StatItem
                         label="Fill"
-                        value={`${fillPercent.toFixed(1)}%`}
+                        value={fillPercent === null ? "—" : `${fillPercent.toFixed(1)}%`}
                         icon={Activity}
-                        description="How much of the cache's capacity is in use"
+                        description={fillPercent === null
+                          ? "Fill unavailable — this cache backend doesn't report entry count or capacity"
+                          : "How much of the cache's capacity is in use"}
                       />
                     )}
                     <StatItem
@@ -592,7 +599,7 @@ export default function CachePage() {
                       description="How long a cached result stays fresh before it expires"
                     />
                   </div>
-                  {isPlatform && (
+                  {isPlatform && fillPercent !== null && (
                     <Progress
                       value={fillPercent}
                       className="h-2"
@@ -618,21 +625,43 @@ export default function CachePage() {
                       : "Remove this workspace's cached query results. Queries hit the database directly until the cache is repopulated."}
                   </CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-4">
+                  {/* Flush feedback lives in this card, next to the button
+                      that caused it — a banner at the top of the page is
+                      off-screen when the user is down here. */}
+                  <MutationErrorSurface
+                    error={flushError}
+                    feature="Cache"
+                    onRetry={clearFlushError}
+                  />
+                  {flushMessage && (
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      className="rounded-md border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-300"
+                    >
+                      {flushMessage}
+                    </div>
+                  )}
                   <AlertDialog>
                     {flushDisabledReason ? (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          {/* span wrapper: disabled buttons don't fire pointer
-                              events in Safari/Firefox, so the tooltip trigger
-                              must sit on an enabled element. tabIndex makes
-                              the explanation keyboard-reachable — Radix opens
-                              the tooltip on focus (#4549 a11y). */}
-                          <span className="inline-block" tabIndex={0}>
-                            <Button variant="destructive" disabled>
-                              Flush Cache
-                            </Button>
-                          </span>
+                          {/* aria-disabled, not disabled: a disabled button
+                              loses pointer events in Safari/Firefox (no
+                              tooltip) and a focusable span wrapper has no
+                              accessible name. This keeps the button itself
+                              hoverable + focusable, announced with its name
+                              and disabled state, with the reason attached via
+                              Radix's aria-describedby (#4549 a11y). No
+                              AlertDialogTrigger, so activation is a no-op. */}
+                          <Button
+                            variant="destructive"
+                            aria-disabled="true"
+                            className="cursor-not-allowed opacity-50 hover:bg-destructive dark:hover:bg-destructive/60"
+                          >
+                            Flush Cache
+                          </Button>
                         </TooltipTrigger>
                         <TooltipContent>{flushDisabledReason}</TooltipContent>
                       </Tooltip>


### PR DESCRIPTION
## Summary

Deliberate design/a11y audit (`/impeccable audit`) of the admin Query Cache page reworked in #4708/#4709 for v0.0.56 (PRD #4544). All fixes are presentation-only — the hand-synced wire schemas against `packages/api/src/api/routes/admin-cache.ts` are untouched, and the entries table keeps its shipped plain treatment (the "heat" elevation stays a future slice per the PRD grill).

Audit score: 17/20 (Good). No layout-architecture findings, so nothing filed for the closeout owner.

## Fixes

- **Fill stat honesty (P1)** — platform view rendered a confident "0.0%" fill + empty gauge when `entryCount`/`maxSize` are structurally unreported (plugin backend), reading as "empty cache". Now renders "—" with an honest description and no gauge — matching the page's own null-never-zero discipline.
- **Disabled-flush tooltip a11y (P1)** — the `tabIndex={0}` span wrapper was keyboard-reachable but announced nothing (no role/name). The button itself is now the tooltip trigger via `aria-disabled` (not `disabled`): hoverable in Safari/Firefox, focusable, announced as "Flush Cache, button, disabled" with the reason via Radix `aria-describedby`. Activation stays a no-op (no `AlertDialogTrigger` in that branch). Playwright's `toBeDisabled` accepts `aria-disabled="true"`.
- **Flush feedback proximity (P2)** — the flush error surface and "Flushed N entries" banner mounted at the top of the page, off-screen from the Flush card at the bottom. Both now live inside the Flush card.
- **Entries load-failure state (P2)** — was a muted paragraph visually identical to the empty state, with no retry. Now the shared `ErrorBanner` (role=alert, destructive styling, Retry → refetch).
- **Hit-rate readout wrap (P2)** — `flex items-baseline` couldn't wrap; "84.0% since Jul 8 · 62% last hour" overflowed narrow viewports. Added `flex-wrap`.
- **TTL input feedback (P2)** — invalid values (0, negative, non-numeric) silently greyed out Save; raw milliseconds are unfriendly. Added `aria-invalid` + inline error, a live "= 5m" human-units preview while dirty, and `aria-describedby` wiring to the helper/error text.

## Deliberately left alone

- Duplicated "Loading entries..." branches (transient-`undefined` vs wire-`null` distinction is intentional and commented)
- The unreachable `since === null` ternary in the non-warming branch (serves as the type guard for the nullable field)
- Hardcoded emerald success accents (the established admin idiom across 6+ pages)
- Card ordering (config → hit rate → storage → entries → destructive last) — verified correct as-is

## Testing

- `bash scripts/ci-local.sh` — all 31 gates green (type, lint, lint-type-aware, full test suite included)
- Wire schemas diffed against the server copies in `admin-cache.ts` — in sync, unchanged