### PR TITLE
chore(db): drop dashboard_stage_changes — stage tracker phase 2

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -507,6 +507,13 @@ describe("migrateAuthTables", () => {
             // runs in every auth mode — must be in the already-applied set so
             // this "all applied" test sees zero new migrations.
             { name: "0175_dashboard_draft_card_cache.sql" },
+            // 0176 (#4561) — drop dashboard_stage_changes (stage tracker
+            // phase 2; readers/writers removed by #4555 in v0.0.55). Plain
+            // DROP TABLE on an Atlas-internal table, no Better Auth
+            // involvement, so it runs in every auth mode — must be in the
+            // already-applied set so this "all applied" test sees zero new
+            // migrations.
+            { name: "0176_drop_dashboard_stage_changes.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -920,147 +920,24 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // by the existing CHECK / index / round-trip tests above.
 
   // ─────────────────────────────────────────────────────────────────────
-  // 0083 — dashboard_stage_changes (#2365)
+  // 0176 — drop dashboard_stage_changes (#4561, stage tracker phase 2)
   //
-  // Per-user destructive-op staging on top of the #2364 draft. Four
-  // real-PG assertions matter:
-  //   1. Column shape — id uuid (default gen_random_uuid), dashboard_id
-  //      uuid + FK CASCADE, user_id text, kind/status text, payload jsonb,
-  //      timestamps NOT NULL / nullable as appropriate.
-  //   2. `kind` CHECK constraint — only `remove_card` / `edit_sql` accepted.
-  //   3. `status` CHECK constraint — only `pending` / `applied` /
-  //      `discarded` accepted.
-  //   4. Terminal-state timestamp invariants — pending forbids both
-  //      timestamps; applied requires applied_at + forbids discarded_at;
-  //      discarded vice versa.
-  //   5. ON DELETE CASCADE — dropping the dashboard drops every stage.
+  // The 0083 stage table (#2365) lost its last reader/writer in phase 1
+  // (#4555, v0.0.55 — destructive ops land in the draft with inline
+  // undo); 0176 drops it. The shape/CHECK/cascade tests that exercised
+  // the table are gone with it — the one real-PG assertion left is that
+  // the migration actually executes the DROP after 0083 created it
+  // (mirrors the 0086 slack_installations drop test below).
   // ─────────────────────────────────────────────────────────────────────
 
-  it("0080: dashboard_stage_changes column shape — uuid id, FK cascade, text user_id, jsonb payload (#2365)", async () => {
-    const { rows } = await pool.query<{
-      column_name: string;
-      data_type: string;
-      udt_name: string;
-      is_nullable: string;
-    }>(
-      `SELECT column_name, data_type, udt_name, is_nullable
-         FROM information_schema.columns
-        WHERE table_name = 'dashboard_stage_changes'
-          AND table_schema = current_schema()
-        ORDER BY ordinal_position`,
+  it("0176: dashboard_stage_changes is dropped (#4561, stage tracker phase 2)", async () => {
+    const { rows } = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+         WHERE table_schema = current_schema() AND table_name = 'dashboard_stage_changes'
+       ) AS exists`,
     );
-    const byName = new Map(rows.map((r) => [r.column_name, r]));
-    expect(byName.get("id")?.udt_name).toBe("uuid");
-    expect(byName.get("id")?.is_nullable).toBe("NO");
-    expect(byName.get("dashboard_id")?.udt_name).toBe("uuid");
-    expect(byName.get("dashboard_id")?.is_nullable).toBe("NO");
-    expect(byName.get("user_id")?.udt_name).toBe("text");
-    expect(byName.get("user_id")?.is_nullable).toBe("NO");
-    expect(byName.get("kind")?.udt_name).toBe("text");
-    expect(byName.get("kind")?.is_nullable).toBe("NO");
-    expect(byName.get("payload")?.udt_name).toBe("jsonb");
-    expect(byName.get("payload")?.is_nullable).toBe("NO");
-    expect(byName.get("status")?.udt_name).toBe("text");
-    expect(byName.get("status")?.is_nullable).toBe("NO");
-    expect(byName.get("created_at")?.is_nullable).toBe("NO");
-    expect(byName.get("updated_at")?.is_nullable).toBe("NO");
-    // Terminal-state timestamps are nullable until the row transitions.
-    expect(byName.get("applied_at")?.is_nullable).toBe("YES");
-    expect(byName.get("discarded_at")?.is_nullable).toBe("YES");
-  }, PG_TEST_TIMEOUT_MS);
-
-  it("0080: kind CHECK constraint rejects unknown kinds (#2365)", async () => {
-    const stamp = Date.now();
-    const orgId = `org-2365-kind-${stamp}`;
-    const dashRows = await pool.query<{ id: string }>(
-      `INSERT INTO dashboards (org_id, owner_id, title) VALUES ($1, 'u-2365', 'Kind chk') RETURNING id`,
-      [orgId],
-    );
-    const dashboardId = dashRows.rows[0]?.id as string;
-
-    // Valid kinds succeed.
-    await pool.query(
-      `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload)
-       VALUES ($1, $2, 'remove_card', '{"kind":"remove_card","cardId":"c-1"}'::jsonb)`,
-      [dashboardId, `u-2365-${stamp}`],
-    );
-    await pool.query(
-      `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload)
-       VALUES ($1, $2, 'edit_sql', '{"kind":"edit_sql","cardId":"c-1","newSql":"SELECT 1","currentSql":"SELECT 0"}'::jsonb)`,
-      [dashboardId, `u-2365-${stamp}`],
-    );
-
-    // Unknown kind → 23514 (check_violation).
-    let chkErr: { code?: string } | null = null;
-    try {
-      await pool.query(
-        `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload)
-         VALUES ($1, $2, 'edit_layout', '{}'::jsonb)`,
-        [dashboardId, `u-2365-${stamp}`],
-      );
-    } catch (err) {
-      chkErr = err as { code?: string };
-    }
-    expect(chkErr?.code).toBe("23514");
-  }, PG_TEST_TIMEOUT_MS);
-
-  it("0080: status CHECK + terminal-timestamp invariants (#2365)", async () => {
-    const stamp = Date.now();
-    const orgId = `org-2365-status-${stamp}`;
-    const dashRows = await pool.query<{ id: string }>(
-      `INSERT INTO dashboards (org_id, owner_id, title) VALUES ($1, 'u-2365', 'Status chk') RETURNING id`,
-      [orgId],
-    );
-    const dashboardId = dashRows.rows[0]?.id as string;
-    const userId = `u-2365-${stamp}`;
-
-    // pending with both timestamps NULL — succeeds (default).
-    const inserted = await pool.query<{ id: string }>(
-      `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload)
-       VALUES ($1, $2, 'remove_card', '{"kind":"remove_card","cardId":"c-1"}'::jsonb)
-       RETURNING id`,
-      [dashboardId, userId],
-    );
-    const stageId = inserted.rows[0]?.id as string;
-
-    // Flip to applied with applied_at set — succeeds.
-    await pool.query(
-      `UPDATE dashboard_stage_changes
-          SET status = 'applied', applied_at = now()
-        WHERE id = $1`,
-      [stageId],
-    );
-
-    // Trying to mark applied without applied_at — chk violation.
-    let bothNullErr: { code?: string } | null = null;
-    try {
-      const r = await pool.query<{ id: string }>(
-        `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload)
-         VALUES ($1, $2, 'remove_card', '{"kind":"remove_card","cardId":"c-2"}'::jsonb)
-         RETURNING id`,
-        [dashboardId, userId],
-      );
-      await pool.query(
-        `UPDATE dashboard_stage_changes SET status = 'applied' WHERE id = $1`,
-        [r.rows[0]?.id as string],
-      );
-    } catch (err) {
-      bothNullErr = err as { code?: string };
-    }
-    expect(bothNullErr?.code).toBe("23514");
-
-    // Unknown status → 23514.
-    let statusErr: { code?: string } | null = null;
-    try {
-      await pool.query(
-        `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload, status)
-         VALUES ($1, $2, 'remove_card', '{"kind":"remove_card","cardId":"c-3"}'::jsonb, 'rejected')`,
-        [dashboardId, userId],
-      );
-    } catch (err) {
-      statusErr = err as { code?: string };
-    }
-    expect(statusErr?.code).toBe("23514");
+    expect(rows[0]?.exists).toBe(false);
   }, PG_TEST_TIMEOUT_MS);
 
   // #2606 — every integration store renders `installed_at` via the same
@@ -1078,33 +955,6 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     const value = rows[0]?.installed_at;
     expect(typeof value).toBe("string");
     expect(() => z.string().datetime().parse(value)).not.toThrow();
-  }, PG_TEST_TIMEOUT_MS);
-
-  it("0080: ON DELETE CASCADE — dropping the parent dashboard drops every stage (#2365)", async () => {
-    const stamp = Date.now();
-    const orgId = `org-2365-cascade-${stamp}`;
-    const dashRows = await pool.query<{ id: string }>(
-      `INSERT INTO dashboards (org_id, owner_id, title) VALUES ($1, 'u-2365', 'Cascade test') RETURNING id`,
-      [orgId],
-    );
-    const dashboardId = dashRows.rows[0]?.id as string;
-    await pool.query(
-      `INSERT INTO dashboard_stage_changes (dashboard_id, user_id, kind, payload)
-       VALUES ($1, $2, 'remove_card', '{"kind":"remove_card","cardId":"c-1"}'::jsonb),
-              ($1, $3, 'edit_sql', '{"kind":"edit_sql","cardId":"c-2","newSql":"S","currentSql":"S"}'::jsonb)`,
-      [dashboardId, `u-2365-a-${stamp}`, `u-2365-b-${stamp}`],
-    );
-    const beforeCount = await pool.query<{ c: number }>(
-      `SELECT COUNT(*)::int AS c FROM dashboard_stage_changes WHERE dashboard_id = $1`,
-      [dashboardId],
-    );
-    expect(beforeCount.rows[0]?.c).toBe(2);
-    await pool.query(`DELETE FROM dashboards WHERE id = $1`, [dashboardId]);
-    const afterCount = await pool.query<{ c: number }>(
-      `SELECT COUNT(*)::int AS c FROM dashboard_stage_changes WHERE dashboard_id = $1`,
-      [dashboardId],
-    );
-    expect(afterCount.rows[0]?.c).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
   // 0084 — proactive_classification_review (#2622). The CHECK constraint

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -227,7 +227,9 @@ describe("runMigrations", () => {
     //   running profile per connection, re-storm fix) = 175.
     //   Plus 0175 (dashboard_draft_card_cache — the draft cache: a draft card's
     //   own cached rows + capture instant, ADR-0034 Decision 1, #4554) = 176.
-    expect(count).toBe(176);
+    //   Plus 0176 (drop dashboard_stage_changes — stage tracker phase 2 of the
+    //   two-phase drop, readers/writers removed by #4555 in v0.0.55, #4561) = 177.
+    expect(count).toBe(177);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -432,6 +434,7 @@ describe("runMigrations", () => {
         "0173_learned_pattern_injections.sql",
         "0174_connection_profile_baseline_started_at.sql",
         "0175_dashboard_draft_card_cache.sql",
+        "0176_drop_dashboard_stage_changes.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0176_drop_dashboard_stage_changes.sql
+++ b/packages/api/src/lib/db/migrations/0176_drop_dashboard_stage_changes.sql
@@ -1,0 +1,30 @@
+-- 0176 — Drop dashboard_stage_changes (stage tracker phase 2, #4561).
+--
+-- Phase 2 of the two-phase drop that retires the #2365 stage tracker
+-- (parent PRD #4553, ADR-0034). Phase 1 (#4555, shipped in v0.0.55)
+-- removed every reader and writer: the bound agent's destructive ops
+-- (`removeCard`, `updateCardSql`) now land in the caller's draft through
+-- the same apply path as every other edit, returning an inline-undo
+-- envelope instead of staging a ghost change. Nothing has read or
+-- written this table since v0.0.55.
+--
+-- Deploy safety (expand-contract): this migration ships at least one
+-- release AFTER v0.0.55, so during the N-1 ↔ N deploy-overlap window the
+-- draining old container is already stage-tracker-free code — no query
+-- can hit a missing relation. The Drizzle mirror (`dashboardStageChanges`
+-- in db/schema.ts) is removed in the same commit, per the drop-table
+-- discipline (see 0047_drop_mcp_tokens.sql for the pattern);
+-- check-schema-drift.sh subtracts explicitly-dropped tables.
+--
+-- Pending rows are not migrated anywhere: stages were per-user, transient
+-- ghost changes (accept/discard UX removed in phase 1), so any residual
+-- `pending` rows have been unreachable — invisible to every surface —
+-- since v0.0.55. Terminal rows were kept only for a hypothetical audit
+-- view that was never built; the audit trail for draft edits now lives in
+-- the draft/versioning path itself.
+--
+-- CASCADE is unnecessary — no FKs reference this table (it only points
+-- outward at dashboards). Attached indexes and CHECK constraints drop
+-- with the table.
+
+DROP TABLE IF EXISTS dashboard_stage_changes;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2257,56 +2257,11 @@ export const dashboardDraftCardCache = pgTable(
   ],
 );
 
-// 0083 — Per-user staged destructive ops on dashboards (#2365, PRD #2362).
-// The bound chat agent's `removeCard` and `updateCardSql` tools do NOT
-// mutate the draft directly; they queue a row here. Accepting a stage
-// applies the change to the draft via the versioning module; discarding
-// drops it. Terminal rows are kept (audit trail) so the table grows
-// per-edit-session and is GC'd at dashboard delete via ON DELETE CASCADE.
-//
-// Per-user scope — `user_id text` mirrors `dashboard_user_drafts.user_id`
-// so the table works in every auth mode without an FK into Better Auth's
-// managed `user` table.
-export const dashboardStageChanges = pgTable(
-  "dashboard_stage_changes",
-  {
-    id: uuid("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
-    dashboardId: uuid("dashboard_id").notNull().references(() => dashboards.id, { onDelete: "cascade" }),
-    userId: text("user_id").notNull(),
-    // `remove_card` payload: { cardId }.
-    // `edit_sql`    payload: { cardId, newSql, currentSql }.
-    kind: text("kind").notNull(),
-    payload: jsonb("payload").notNull(),
-    // `pending` / `applied` / `discarded`. Terminal-state rows are frozen
-    // — accept / discard helpers are no-ops on rows that aren't `pending`.
-    status: text("status").notNull().default("pending"),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-    appliedAt: timestamp("applied_at", { withTimezone: true }),
-    discardedAt: timestamp("discarded_at", { withTimezone: true }),
-  },
-  (t) => [
-    // Mirrors the migration's CHECK constraint on `kind`.
-    check("dashboard_stage_changes_kind_chk", sql`${t.kind} IN ('remove_card', 'edit_sql')`),
-    // Mirrors the migration's CHECK on `status`.
-    check("dashboard_stage_changes_status_chk", sql`${t.status} IN ('pending', 'applied', 'discarded')`),
-    // Terminal-state invariants: pending rows have both timestamps NULL;
-    // applied rows have applied_at set + discarded_at NULL; discarded
-    // rows have discarded_at set + applied_at NULL.
-    check(
-      "dashboard_stage_changes_timestamps_chk",
-      sql`(${t.status} = 'pending' AND ${t.appliedAt} IS NULL AND ${t.discardedAt} IS NULL)
-       OR (${t.status} = 'applied' AND ${t.appliedAt} IS NOT NULL AND ${t.discardedAt} IS NULL)
-       OR (${t.status} = 'discarded' AND ${t.discardedAt} IS NOT NULL AND ${t.appliedAt} IS NULL)`,
-    ),
-    // Per-user pending stages by dashboard — drives the overlay query on
-    // every render. Partial index keeps it tight (terminal rows excluded).
-    index("idx_dashboard_stage_changes_user_pending")
-      .on(t.dashboardId, t.userId, t.status)
-      .where(sql`status = 'pending'`),
-    index("idx_dashboard_stage_changes_dashboard").on(t.dashboardId),
-  ],
-);
+// dashboard_stage_changes (0083, #2365) was dropped by 0176 (#4561) —
+// stage tracker phase 2. Phase 1 (#4555, v0.0.55) moved the bound agent's
+// destructive ops onto the draft + inline-undo path, leaving no readers
+// or writers; the mirror is removed in the same commit as the drop
+// migration per the drop-table discipline.
 
 export const sandboxCredentials = pgTable(
   "sandbox_credentials",

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -19,7 +19,9 @@
  * envelope (`removed` / `sql_updated`) carrying the inverse draft edit; the
  * UI surfaces an Undo affordance that POSTs the inverse to
  * `/dashboards/[id]/draft/undo`. Nothing reads or writes
- * `dashboard_stage_changes` anymore — the draft is the single edit mechanism.
+ * `dashboard_stage_changes` anymore — the draft is the single edit
+ * mechanism; the table itself was dropped in migration 0176 (#4561,
+ * phase 2 of the two-phase drop).
  */
 
 import * as crypto from "crypto";


### PR DESCRIPTION
## Summary

- **Migration 0176** drops `dashboard_stage_changes` — phase 2 of the two-phase drop retiring the #2365 stage tracker (parent PRD #4553, ADR-0034).
- **Release boundary satisfied:** phase 1 (#4555 — destructive bound ops land in the draft with inline undo, removing every reader/writer of this table) shipped in tag **v0.0.55** (`a8c24cf8a`), and **v0.0.56** has since been tagged — so this drop lands at least one full release after phase 1, and no N-1 container in the deploy-overlap window can reference the relation.
- The Drizzle mirror (`dashboardStageChanges` pgTable) is removed from `schema.ts` **in the same commit** as the drop migration (drop-table discipline; `check-schema-drift.sh` subtracts explicitly-dropped tables — same pattern as `mcp_tokens`/0047).
- Both `--affected`-blind migration assertions updated: `migrate.test.ts` count 176→177 + applied-list entry, and the auth-mode `migrate.test.ts` already-applied list.
- `migrate-pg.test.ts`: the 0083 shape/CHECK/cascade tests (exercising dropped DDL) are replaced with a single real-PG drop assertion mirroring the 0086 `slack_installations` drop-test pattern.

## Test plan

- [x] `/review-panel` — CLEAN (round 1; one minor comment-direction nit fixed inline)
- [x] `scripts/check-schema-drift.sh` + `check-migration-rename-discipline.sh` pass
- [x] Real-PG migration smoke: `migrate-pg.test.ts` green against local Postgres (177 migrations replayed; 0083→0176 create→drop ordering exercised)
- [x] Local `/ci`: all 30 non-test gates green ×2; the full-suite `test` gate hit the documented WSL2 `-pg` load-flake (#4183, 3F000 scratch-schema race) — all 17 flagged files pass standalone (248 pass / 0 fail). Sharded `api-tests (1/4)–(4/4)` on CI are the arbiter for the `-pg` suites.
- [ ] CI green on head SHA (`gh pr checks --watch`)

Closes #4561