### PR TITLE
fix(dashboards): draft Refresh-all 503s on thrown draft load instead of silently writing published cache

### DIFF
--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -2426,7 +2426,7 @@ describe("dashboard routes", () => {
       mockRunUserQueryPipeline.mockClear();
       mockRefreshCard.mockClear();
       mockSaveDraftCardCache.mockClear();
-      // The threw-vs-absent distinction: a TRANSIENT loadDraft error is not
+      // The threw-vs-absent distinction: a TRANSIENT draft-load error is not
       // "no draft". Falling back to published here would execute the
       // published cards and persist the SHARED published cache with a 200
       // while the caller's draft tiles stay stale.
@@ -2436,6 +2436,7 @@ describe("dashboard routes", () => {
         new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/refresh?view=draft`, { method: "POST" }),
       );
       expect(response.status).toBe(503);
+      expect(mockLoadDraftChecked).toHaveBeenCalledWith("u1", VALID_ID);
       const body = (await response.json()) as { error: string; requestId?: string };
       expect(body.error).toBe("drafts_unavailable");
       expect(typeof body.requestId).toBe("string");

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -307,6 +307,14 @@ const mockApplyEditToDraft = mock(
 const mockLoadDraft = mock(
   (..._args: unknown[]): Promise<DraftRowT | null> => Promise.resolve(null),
 );
+// #4685 — the bulk Refresh-all draft branch uses the checked loader so a
+// thrown load is distinguishable from an absent draft. Controllable so the
+// route tests can simulate both outcomes.
+type LoadDraftResultT = import("@atlas/api/lib/dashboard-versioning").LoadDraftResult;
+const mockLoadDraftChecked = mock(
+  (..._args: unknown[]): Promise<LoadDraftResultT> =>
+    Promise.resolve({ ok: true, draft: null }),
+);
 // #4554 — controllable fork for the GET /:id/draft route test (the real one
 // opens a pg pool; a route-wiring test only needs the returned row).
 const mockForkOrLoadDraft = mock(
@@ -324,6 +332,7 @@ void mock.module("@atlas/api/lib/dashboard-versioning", () => ({
   ...realVersioning,
   applyEditToDraft: mockApplyEditToDraft,
   loadDraft: mockLoadDraft,
+  loadDraftChecked: mockLoadDraftChecked,
   forkOrLoadDraft: mockForkOrLoadDraft,
   publishDraft: mockPublishDraft,
 }));
@@ -618,6 +627,8 @@ describe("dashboard routes", () => {
     mockApplyEditToDraft.mockResolvedValue({ ok: false, reason: "no_db" });
     mockLoadDraft.mockReset();
     mockLoadDraft.mockResolvedValue(null);
+    mockLoadDraftChecked.mockReset();
+    mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: null });
     mockForkOrLoadDraft.mockReset();
     mockForkOrLoadDraft.mockResolvedValue(null);
     mockLoadDraftCardCache.mockReset();
@@ -2262,7 +2273,7 @@ describe("dashboard routes", () => {
       mockRunUserQueryPipeline.mockClear();
       mockRefreshCard.mockClear();
       mockSaveDraftCardCache.mockClear();
-      mockLoadDraft.mockResolvedValue(refreshAllDraftRow());
+      mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: refreshAllDraftRow() });
       // Published dashboard has NO cards — the cards refreshed come entirely
       // from the materialized draft view (a draft-only card is refreshable).
       mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [] } });
@@ -2292,7 +2303,7 @@ describe("dashboard routes", () => {
       mockRefreshCard.mockClear();
       mockSaveDraftCardCache.mockClear();
       // view=draft requested, but the caller has no draft row → published path.
-      mockLoadDraft.mockResolvedValue(null);
+      mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: null });
       mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [mockCardData] } });
       const response = await app.fetch(
         new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/refresh?view=draft`, { method: "POST" }),
@@ -2324,7 +2335,7 @@ describe("dashboard routes", () => {
         connectionGroupId: null,
         layout: null,
       });
-      mockLoadDraft.mockResolvedValue(row);
+      mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: row });
       mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [] } });
       const response = await app.fetch(
         new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/refresh?view=draft`, { method: "POST" }),
@@ -2340,7 +2351,7 @@ describe("dashboard routes", () => {
 
     it("refresh?view=draft returns 409 draft_gone when the draft vanished mid-refresh (#4559)", async () => {
       mockRefreshCard.mockClear();
-      mockLoadDraft.mockResolvedValue(refreshAllDraftRow());
+      mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: refreshAllDraftRow() });
       // The draft was published/discarded while the bulk refresh ran — the
       // save's `WHERE EXISTS` guard reports `no_draft` for every remaining card.
       mockSaveDraftCardCache.mockResolvedValue({ ok: false, reason: "no_draft" });
@@ -2358,7 +2369,7 @@ describe("dashboard routes", () => {
 
     it("refresh?view=draft returns 503 when the draft cache is unavailable — never writes published (#4559)", async () => {
       mockRefreshCard.mockClear();
-      mockLoadDraft.mockResolvedValue(refreshAllDraftRow());
+      mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: refreshAllDraftRow() });
       mockSaveDraftCardCache.mockResolvedValue({ ok: false, reason: "no_db" });
       mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [] } });
       const response = await app.fetch(
@@ -2388,7 +2399,7 @@ describe("dashboard routes", () => {
         connectionGroupId: null,
         layout: null,
       });
-      mockLoadDraft.mockResolvedValue(row);
+      mockLoadDraftChecked.mockResolvedValue({ ok: true, draft: row });
       mockSaveDraftCardCache.mockResolvedValueOnce({ ok: true, cachedAt: "2026-07-16T00:00:00.000Z" });
       mockSaveDraftCardCache.mockResolvedValueOnce({ ok: false, reason: "error" });
       mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [] } });
@@ -2409,6 +2420,29 @@ describe("dashboard routes", () => {
       // the published cache was never written.
       expect(mockRunUserQueryPipeline).toHaveBeenCalledTimes(2);
       expect(mockRefreshCard).not.toHaveBeenCalled();
+    });
+
+    it("refresh?view=draft returns 503 when the draft LOAD throws — never executes or writes the published cache (#4685)", async () => {
+      mockRunUserQueryPipeline.mockClear();
+      mockRefreshCard.mockClear();
+      mockSaveDraftCardCache.mockClear();
+      // The threw-vs-absent distinction: a TRANSIENT loadDraft error is not
+      // "no draft". Falling back to published here would execute the
+      // published cards and persist the SHARED published cache with a 200
+      // while the caller's draft tiles stay stale.
+      mockLoadDraftChecked.mockResolvedValue({ ok: false, reason: "load_failed" });
+      mockGetDashboard.mockResolvedValueOnce({ ok: true, data: { ...mockDashboardData, cards: [mockCardData] } });
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/dashboards/${VALID_ID}/refresh?view=draft`, { method: "POST" }),
+      );
+      expect(response.status).toBe(503);
+      const body = (await response.json()) as { error: string; requestId?: string };
+      expect(body.error).toBe("drafts_unavailable");
+      expect(typeof body.requestId).toBe("string");
+      // Nothing ran and nothing was persisted — neither cache was touched.
+      expect(mockRunUserQueryPipeline).not.toHaveBeenCalled();
+      expect(mockRefreshCard).not.toHaveBeenCalled();
+      expect(mockSaveDraftCardCache).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -50,6 +50,7 @@ import type { DashboardCard, DashboardWithCards } from "@atlas/api/lib/dashboard
 import {
   forkOrLoadDraft,
   loadDraft,
+  loadDraftChecked,
   discardDraft,
   publishDraft,
   rebaseDraft,
@@ -1157,14 +1158,16 @@ async function resolveDraftExecCard(
   cardId: string,
 ): Promise<DraftExecResolution> {
   if (view !== "draft" || !shouldRouteToDraft(userId)) return { kind: "published" };
-  // Note: `loadDraft` returns null for BOTH "no draft" and "load threw" (it
-  // logs + swallows). Both resolve to `{ kind: "published" }` here, so the
-  // caller runs the PUBLISHED card exactly as a plain published-view request
-  // would (the render path stays read-only; the refresh path still persists the
-  // published cache — the same write any published refresh does, never a draft
-  // write). The draft-first invariant is safe either way, but a transient
-  // draft-load error will quietly fall back to published under the draft view
-  // rather than surfacing to the user.
+  // Note: the lenient `loadDraft` collapses BOTH "no draft" and "load threw"
+  // (it logs + swallows) to null. Both resolve to `{ kind: "published" }`
+  // here — a DELIBERATE per-card trade-off: the caller runs the PUBLISHED
+  // card exactly as a plain published-view request would (the render path
+  // stays read-only; the refresh path still persists the published cache —
+  // the same write any published refresh does, never a draft write). The
+  // draft-first invariant is safe either way; the worst case is one card
+  // quietly showing published data under the draft view. The BULK Refresh-all
+  // branch must NOT take this shortcut — it uses `loadDraftChecked` and fails
+  // the whole operation on a load error (#4685).
   const draft = await loadDraft(userId, published.id);
   if (!draft) return { kind: "published" };
   // Resolution only needs the card's DEFINITION (sql/config/target) — cached
@@ -2501,19 +2504,36 @@ authed.openapi(refreshAllCardsRoute, async (c) => {
     // viewing their draft, execute the DRAFT cards' SQL/config (their private
     // working copies) and persist each result to the caller's DRAFT CACHE —
     // never the published cards' shared cache. Mirrors the single-card refresh's
-    // draft branch (#4554). `loadDraft` returning null (no draft, or a
-    // swallowed load error) falls back to the published cards exactly as a
-    // published-view refresh does — never another user's draft. The draft view
-    // is materialized WITHOUT the draft cache (`EMPTY_DRAFT_CARD_CACHE`) because
-    // execution needs only each card's definition, not its cached rows.
+    // draft branch (#4554). A genuinely ABSENT draft falls back to the
+    // published cards exactly as a published-view refresh does — never another
+    // user's draft. The draft view is materialized WITHOUT the draft cache
+    // (`EMPTY_DRAFT_CARD_CACHE`) because execution needs only each card's
+    // definition, not its cached rows.
     const uid = user?.id;
     let draftHolderId: string | null = null;
     let cards = dashResult.data.cards;
     if (view === "draft" && shouldRouteToDraft(uid)) {
-      const draft = yield* Effect.promise(() => loadDraft(uid, id));
-      if (draft) {
+      // #4685 — this is a WRITE path, so it must tell "no draft" apart from
+      // "the draft load THREW". Folding a transient load error into the
+      // published fallback would execute the published cards, rewrite the
+      // SHARED published cache under teammates, and report 200 while the
+      // caller's draft tiles stay stale. Fail the whole operation instead;
+      // nothing has been executed or persisted yet.
+      const draftResult = yield* Effect.promise(() => loadDraftChecked(uid, id));
+      if (!draftResult.ok) {
+        return c.json(
+          {
+            error: "drafts_unavailable",
+            message:
+              "Your draft could not be loaded, so nothing was refreshed. Retry in a moment.",
+            requestId,
+          },
+          503,
+        );
+      }
+      if (draftResult.draft) {
         draftHolderId = uid;
-        cards = materializeDraftView(dashResult.data, draft.snapshot, EMPTY_DRAFT_CARD_CACHE).cards;
+        cards = materializeDraftView(dashResult.data, draftResult.draft.snapshot, EMPTY_DRAFT_CARD_CACHE).cards;
       }
     }
 

--- a/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
@@ -24,6 +24,7 @@ import {
   type PublishOp,
   toSnapshot,
   loadDraft,
+  loadDraftChecked,
   forkOrLoadDraft,
   saveDraft,
   applyEditToDraft,
@@ -1006,6 +1007,42 @@ describe("dashboard-versioning DB helpers", () => {
       queryThrow = new Error("connection refused");
       const result = await loadDraft("u1", "dash-1");
       expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // loadDraftChecked (#4685 — threw vs absent is observable)
+  // -------------------------------------------------------------------------
+
+  describe("loadDraftChecked", () => {
+    it("treats a missing internal DB as ABSENT, not an error", async () => {
+      const result = await loadDraftChecked("u1", "dash-1");
+      expect(result).toEqual({ ok: true, draft: null });
+    });
+
+    it("returns ok with a null draft when no row exists (absent)", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+      const result = await loadDraftChecked("u1", "dash-1");
+      expect(result).toEqual({ ok: true, draft: null });
+    });
+
+    it("returns ok with the parsed draft row when one exists", async () => {
+      enableInternalDB();
+      const snap = snapshot([card("c1")]);
+      setResults({ rows: [draftRow({ draft: snap })] });
+      const result = await loadDraftChecked("u1", "dash-1");
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("unreachable");
+      expect(result.draft?.userId).toBe("u1");
+      expect(result.draft?.snapshot.cards[0].id).toBe("c1");
+    });
+
+    it("returns ok:false on a DB error — never conflated with absent (#4685)", async () => {
+      enableInternalDB();
+      queryThrow = new Error("connection refused");
+      const result = await loadDraftChecked("u1", "dash-1");
+      expect(result).toEqual({ ok: false, reason: "load_failed" });
     });
   });
 

--- a/packages/api/src/lib/dashboard-versioning.ts
+++ b/packages/api/src/lib/dashboard-versioning.ts
@@ -703,20 +703,38 @@ function rowToDraft(r: Record<string, unknown>): DraftRow {
 }
 
 /**
+ * Discriminated result for draft loads that must tell "no draft exists"
+ * apart from "the load THREW" (#4685). `ok: true, draft: null` means the
+ * draft is genuinely absent (no row, or no internal DB on this deployment
+ * — drafts structurally don't exist without one); `ok: false` means the
+ * read failed (already logged) and the caller must NOT treat the draft as
+ * absent — on a write path that conflation silently redirects the work at
+ * the published data instead.
+ */
+export type LoadDraftResult =
+  | { readonly ok: true; readonly draft: DraftRow | null }
+  | { readonly ok: false; readonly reason: "load_failed" };
+
+/**
  * Load the current draft row (snapshot + baseline timestamp) for a
- * user+dashboard pair. Returns `null` when no draft exists or when
- * the internal DB is unavailable.
+ * user+dashboard pair, distinguishing "absent" from "load threw" (#4685).
+ * WRITE paths that branch on draft-vs-published (e.g. the bulk draft
+ * Refresh-all) must use this instead of `loadDraft`, so a transient DB
+ * error surfaces instead of quietly falling back to mutating published
+ * state.
  *
  * Org-scoping happens at the route layer (the route loads the dashboard
  * scoped to the caller's orgId BEFORE touching drafts). This helper
  * doesn't take an orgId because the FK + the route gate already make
  * cross-org reads impossible.
  */
-export async function loadDraft(
+export async function loadDraftChecked(
   userId: string,
   dashboardId: string,
-): Promise<DraftRow | null> {
-  if (!hasInternalDB()) return null;
+): Promise<LoadDraftResult> {
+  // No internal DB = drafts don't exist on this deployment — genuinely
+  // absent, not a failure.
+  if (!hasInternalDB()) return { ok: true, draft: null };
   try {
     // #4325 — read `published_baseline_at` as text so it keeps the stored
     // microseconds. `rowToDraft`'s `String(...)` on a JS `Date` truncates to
@@ -729,12 +747,26 @@ export async function loadDraft(
         WHERE user_id = $1 AND dashboard_id = $2`,
       [userId, dashboardId],
     );
-    if (rows.length === 0) return null;
-    return rowToDraft(rows[0]);
+    if (rows.length === 0) return { ok: true, draft: null };
+    return { ok: true, draft: rowToDraft(rows[0]) };
   } catch (err) {
     log.error({ err: errorMessage(err), userId, dashboardId }, "loadDraft failed");
-    return null;
+    return { ok: false, reason: "load_failed" };
   }
+}
+
+/**
+ * Lenient variant of `loadDraftChecked`: collapses BOTH "no draft exists"
+ * and "the load threw" (logged inside) to `null`. Fine for READ paths,
+ * where the worst case of the conflation is rendering published data under
+ * a draft view; write paths must use `loadDraftChecked` (#4685).
+ */
+export async function loadDraft(
+  userId: string,
+  dashboardId: string,
+): Promise<DraftRow | null> {
+  const result = await loadDraftChecked(userId, dashboardId);
+  return result.ok ? result.draft : null;
 }
 
 /**

--- a/packages/api/src/lib/dashboard-versioning.ts
+++ b/packages/api/src/lib/dashboard-versioning.ts
@@ -708,7 +708,7 @@ function rowToDraft(r: Record<string, unknown>): DraftRow {
  * draft is genuinely absent (no row, or no internal DB on this deployment
  * — drafts structurally don't exist without one); `ok: false` means the
  * read failed (already logged) and the caller must NOT treat the draft as
- * absent — on a write path that conflation silently redirects the work at
+ * absent — on a write path that conflation silently redirects the work to
  * the published data instead.
  */
 export type LoadDraftResult =
@@ -718,10 +718,13 @@ export type LoadDraftResult =
 /**
  * Load the current draft row (snapshot + baseline timestamp) for a
  * user+dashboard pair, distinguishing "absent" from "load threw" (#4685).
- * WRITE paths that branch on draft-vs-published (e.g. the bulk draft
- * Refresh-all) must use this instead of `loadDraft`, so a transient DB
- * error surfaces instead of quietly falling back to mutating published
- * state.
+ * WRITE paths where "absent" redirects the operation at published state
+ * (e.g. the bulk draft Refresh-all) must use this instead of `loadDraft`,
+ * so a transient DB error surfaces instead of quietly falling back to
+ * mutating published state. Sole sanctioned lenient write path: the
+ * single-card refresh via `resolveDraftExecCard` — its fallback write is
+ * the one published-cache row a plain published refresh would write anyway
+ * (see the note there).
  *
  * Org-scoping happens at the route layer (the route loads the dashboard
  * scoped to the caller's orgId BEFORE touching drafts). This helper
@@ -750,7 +753,7 @@ export async function loadDraftChecked(
     if (rows.length === 0) return { ok: true, draft: null };
     return { ok: true, draft: rowToDraft(rows[0]) };
   } catch (err) {
-    log.error({ err: errorMessage(err), userId, dashboardId }, "loadDraft failed");
+    log.error({ err: errorMessage(err), userId, dashboardId }, "dashboard draft load failed");
     return { ok: false, reason: "load_failed" };
   }
 }
@@ -759,7 +762,12 @@ export async function loadDraftChecked(
  * Lenient variant of `loadDraftChecked`: collapses BOTH "no draft exists"
  * and "the load threw" (logged inside) to `null`. Fine for READ paths,
  * where the worst case of the conflation is rendering published data under
- * a draft view; write paths must use `loadDraftChecked` (#4685).
+ * a draft view, and for write paths where a conflated "absent" fails
+ * closed later (`publishDraft`/`rebaseDraft` report `no_draft` rather than
+ * touching published state). Write paths where "absent" redirects the
+ * operation at published state must use `loadDraftChecked` (#4685) — the
+ * single-card refresh is the one documented exception (see
+ * `resolveDraftExecCard`).
  */
 export async function loadDraft(
   userId: string,


### PR DESCRIPTION
## Summary
- `loadDraft` collapsed "no draft exists" and "the load threw" to `null`; the bulk draft Refresh-all branch (#4559) treated a thrown load as "no draft" and fell back to executing the PUBLISHED cards and persisting the SHARED published cache with a 200 — stale draft tiles, silently rewritten published cache.
- New `loadDraftChecked` returns a discriminated `LoadDraftResult` (`{ ok: true, draft | null }` vs `{ ok: false, reason: "load_failed" }`); `loadDraft` becomes the documented lenient wrapper for read paths (and write paths that fail closed on a conflated "absent").
- The bulk draft Refresh-all branch now surfaces `503 drafts_unavailable` + `requestId` on a load error, before anything executes or persists; a genuinely absent draft keeps the clean published fallback. The single-card path (`resolveDraftExecCard`) keeps its documented lenient trade-off.

## Test plan
- [x] Unit: `loadDraftChecked` threw-vs-absent (no DB → absent; empty rows → absent; row → draft; throw → `{ ok: false, reason: "load_failed" }`)
- [x] Route: draft-view Refresh-all with a thrown load → 503 `drafts_unavailable` + `requestId`, zero pipeline runs, zero published/draft cache writes
- [x] Route: absent draft still falls back to published (unchanged 200 behavior); existing #4559 draft-refresh suite rewired to the checked seam and green
- [x] `/ci`: all 31 local gates pass

Closes #4685