### PR TITLE
fix(dashboards): org-scoped shares dead-end cross-origin — resolve the viewer session client-side (#4718)

### DIFF
--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-client.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-client.test.ts
@@ -75,6 +75,7 @@ describe("resolveOrgShareClient (#4718)", () => {
 
     await resolveOrgShareClient(TOKEN);
 
+    expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe(
       `https://api-eu.example.test/api/public/dashboards/${TOKEN}`,
     );
@@ -141,6 +142,31 @@ describe("resolveOrgShareClient (#4718)", () => {
     stubFetch(200, { totally: "wrong" });
     const errSpy = spyOn(console, "error").mockImplementation(() => {});
     expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "server-error" });
+    // The #4317 fingerprint-only discipline holds on this logging branch too.
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    errSpy.mockRestore();
+  });
+
+  test("a 200 whose body isn't JSON resolves to server-error — never a rejection", async () => {
+    // Locks the never-rejects contract `OrgShareResolver` builds its two-state
+    // model on, through the client seam (mapper totality is pinned directly in
+    // share-result.test.ts).
+    globalThis.fetch = mock(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("not json");
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    await expect(resolveOrgShareClient(TOKEN)).resolves.toEqual({
+      ok: false,
+      reason: "server-error",
+    });
     errSpy.mockRestore();
   });
 });

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-client.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-client.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { _resetApiUrl, applyRegionSignal } from "@/lib/api-url";
+import { hashShareTokenClient, resolveOrgShareClient } from "../org-share-client";
+
+// A fully-valid SharedDashboardView — the mapping validates the API response
+// against the strict `sharedDashboardViewSchema` SSOT, same as the SSR path.
+const okDashboard = {
+  title: "Revenue",
+  description: null,
+  shareMode: "org",
+  cards: [],
+  parameterSummary: [],
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-02T00:00:00.000Z",
+  lastRefreshAt: null,
+};
+
+const TOKEN = "abc123def456ghi789jkl";
+
+function stubFetch(status: number, body: unknown) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return calls;
+}
+
+describe("hashShareTokenClient (#4718)", () => {
+  test("matches the server-side node:crypto mirror (first 16 hex of SHA-256)", async () => {
+    const nodeHash = createHash("sha256").update(TOKEN).digest("hex").slice(0, 16);
+    expect(await hashShareTokenClient(TOKEN)).toBe(nodeHash);
+  });
+
+  test("returns a 16-hex fingerprint, never the raw token", async () => {
+    const h = await hashShareTokenClient("super-secret-token");
+    expect(h).toMatch(/^[0-9a-f]{16}$/);
+    expect(h).not.toContain("super-secret-token");
+  });
+});
+
+// #4718 — the three client-side org-share resolution outcomes from the issue's
+// acceptance criteria: success, login-required, membership-required. The
+// mapping is shared verbatim with the SSR fetch (`mapSharedDashboardResponse`),
+// so the #4690 split holds identically — now evaluated against the viewer's
+// REAL session because the browser fetch carries credentials.
+describe("resolveOrgShareClient (#4718)", () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    _resetApiUrl();
+  });
+
+  test("success: a credentialed viewer in the owning org gets the dashboard", async () => {
+    const calls = stubFetch(200, okDashboard);
+    const result = await resolveOrgShareClient(TOKEN);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.title).toBe("Revenue");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toContain(`/api/public/dashboards/${TOKEN}`);
+    expect(calls[0]!.init?.cache).toBe("no-store");
+  });
+
+  test("sends credentials: include against a cross-origin (regional) API base", async () => {
+    // Force the cross-origin topology deterministically via the regional signal
+    // (the same override `getApiUrl()` folds in for every client fetch).
+    expect(applyRegionSignal("eu", "https://api-eu.example.test")).toBe(true);
+    const calls = stubFetch(200, okDashboard);
+
+    await resolveOrgShareClient(TOKEN);
+
+    expect(calls[0]!.url).toBe(
+      `https://api-eu.example.test/api/public/dashboards/${TOKEN}`,
+    );
+    expect(calls[0]!.init?.credentials).toBe("include");
+  });
+
+  test("maps a 403 with error:auth_required (no session) to login-required", async () => {
+    stubFetch(403, { error: "auth_required" });
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "login-required" });
+  });
+
+  test("maps a 403 with error:forbidden (authenticated, wrong org) to membership-required", async () => {
+    stubFetch(403, { error: "forbidden" });
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({
+      ok: false,
+      reason: "membership-required",
+    });
+  });
+
+  test("maps a bare 401 to login-required regardless of body", async () => {
+    stubFetch(401, { error: "forbidden" });
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "login-required" });
+  });
+
+  test("maps a 404 to not-found and a 410 to expired (revoked/expired org links)", async () => {
+    stubFetch(404, {});
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "not-found" });
+    stubFetch(410, {});
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "expired" });
+  });
+
+  test("never logs the raw token — logs only its hash — on a server error (#4317)", async () => {
+    stubFetch(500, {});
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    await resolveOrgShareClient(TOKEN);
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(logged).toContain(await hashShareTokenClient(TOKEN));
+    errSpy.mockRestore();
+  });
+
+  test("never logs the raw token on a network error (fetch throws) (#4317)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await resolveOrgShareClient(TOKEN);
+    expect(result).toEqual({ ok: false, reason: "network-error" });
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(logged).toContain(await hashShareTokenClient(TOKEN));
+    errSpy.mockRestore();
+  });
+
+  test("rejects an unexpected response shape as server-error (schema SSOT holds client-side too)", async () => {
+    stubFetch(200, { totally: "wrong" });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "server-error" });
+    errSpy.mockRestore();
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-resolver.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-resolver.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { FetchResult } from "../share-result";
+import type { SharedDashboard } from "../types";
+
+// next/link needs no router for a plain anchor render — stub it to the bare <a>.
+void mock.module("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) =>
+    createElement("a", { href }, children),
+}));
+// SharedTile mounts a dynamic chart + useDarkMode at import; stub them so the
+// view renders in the test DOM without pulling recharts (same as view.test.tsx).
+void mock.module("@/ui/components/chart/result-chart", () => ({
+  ResultChart: () => <div data-testid="result-chart">chart</div>,
+}));
+void mock.module("next/dynamic", () => ({
+  default: () => () => <div data-testid="result-chart">chart</div>,
+}));
+void mock.module("@/ui/hooks/use-dark-mode", () => ({ useDarkMode: () => false }));
+
+// Drive the client resolution from a module-level mutable. Factory stays sync
+// (async mock.module factories deadlock under bun:test) and mocks ALL exports.
+let mockResolve: () => Promise<FetchResult> = () =>
+  Promise.resolve({ ok: false, reason: "login-required" });
+function setResult(result: FetchResult) {
+  mockResolve = () => Promise.resolve(result);
+}
+void mock.module("../org-share-client", () => ({
+  resolveOrgShareClient: () => mockResolve(),
+  hashShareTokenClient: async () => "deadbeefdeadbeef",
+}));
+
+import { OrgShareResolver } from "../org-share-resolver";
+
+const TOKEN = "abc123def456ghi789jkl";
+
+function dashboard(over: Partial<SharedDashboard> = {}): SharedDashboard {
+  return {
+    title: "Quarterly Revenue",
+    description: null,
+    shareMode: "org",
+    cards: [],
+    parameterSummary: [],
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-02T00:00:00.000Z",
+    lastRefreshAt: null,
+    ...over,
+  };
+}
+
+// #4718 — the client-side org-share resolution branch, at the component seam:
+// the resolver must render the SAME success/error surfaces the SSR path does,
+// with the #4690 login/membership split now driven by the viewer's real session.
+describe("OrgShareResolver (#4718)", () => {
+  afterEach(cleanup);
+
+  test("success: renders the shared dashboard view for an authenticated org member", async () => {
+    setResult({ ok: true, data: dashboard() });
+    render(<OrgShareResolver token={TOKEN} />);
+    expect(await screen.findByText("Quarterly Revenue")).toBeDefined();
+  });
+
+  test("login-required: renders the auth wall with the login redirect back to the share", async () => {
+    setResult({ ok: false, reason: "login-required" });
+    render(<OrgShareResolver token={TOKEN} />);
+    const login = await screen.findByText("Log in");
+    expect(login.closest("a")?.getAttribute("href")).toBe(
+      `/login?redirect=${encodeURIComponent(`/shared/dashboard/${TOKEN}`)}`,
+    );
+  });
+
+  test("membership-required: explains the org requirement and NEVER offers a login CTA", async () => {
+    setResult({ ok: false, reason: "membership-required" });
+    render(<OrgShareResolver token={TOKEN} />);
+    expect(
+      await screen.findByText(/don’t have access to this dashboard/i),
+    ).toBeDefined();
+    const loginHrefs = screen
+      .queryAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => h.startsWith("/login"));
+    expect(loginHrefs).toEqual([]);
+  });
+
+  test("embed variant renders the navigation-free embed error surface", async () => {
+    setResult({ ok: false, reason: "membership-required" });
+    render(<OrgShareResolver token={TOKEN} variant="embed" />);
+    expect(
+      await screen.findByText(/organization you’re not a member of/i),
+    ).toBeDefined();
+    // Navigation-free: no login/home/retry links inside a partner's iframe —
+    // only the external "Powered by Atlas" attribution anchor remains.
+    const internalLinks = screen
+      .queryAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => !h.startsWith("https://www.useatlas.dev"));
+    expect(internalLinks).toEqual([]);
+  });
+
+  test("shows an accessible resolving state while the client fetch is in flight", () => {
+    // Never-resolving promise pins the loading state.
+    mockResolve = () => new Promise(() => {});
+    render(<OrgShareResolver token={TOKEN} />);
+    expect(screen.getByRole("status")).toBeDefined();
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-resolver.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/org-share-resolver.test.tsx
@@ -17,7 +17,16 @@ void mock.module("@/ui/components/chart/result-chart", () => ({
 void mock.module("next/dynamic", () => ({
   default: () => () => <div data-testid="result-chart">chart</div>,
 }));
-void mock.module("@/ui/hooks/use-dark-mode", () => ({ useDarkMode: () => false }));
+// Mock ALL exports (repo testing rule) so a future import of any sibling
+// export under view.tsx's graph can't hit "Export named X not found".
+void mock.module("@/ui/hooks/use-dark-mode", () => ({
+  DEFAULT_BRAND_COLOR: "oklch(0.4 0.115 158)",
+  OKLCH_RE: /^oklch\(/,
+  setTheme: () => {},
+  applyBrandColor: () => {},
+  useDarkMode: () => false,
+  useThemeMode: () => "system",
+}));
 
 // Drive the client resolution from a module-level mutable. Factory stays sync
 // (async mock.module factories deadlock under bun:test) and mocks ALL exports.
@@ -53,7 +62,12 @@ function dashboard(over: Partial<SharedDashboard> = {}): SharedDashboard {
 // the resolver must render the SAME success/error surfaces the SSR path does,
 // with the #4690 login/membership split now driven by the viewer's real session.
 describe("OrgShareResolver (#4718)", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    // Restore the default resolver so a never-resolving pin (the loading-state
+    // test) can't leak into later tests.
+    setResult({ ok: false, reason: "login-required" });
+  });
 
   test("success: renders the shared dashboard view for an authenticated org member", async () => {
     setResult({ ok: true, data: dashboard() });
@@ -81,6 +95,19 @@ describe("OrgShareResolver (#4718)", () => {
       .map((a) => a.getAttribute("href") ?? "")
       .filter((h) => h.startsWith("/login"));
     expect(loginHrefs).toEqual([]);
+  });
+
+  test("embed variant keeps the #4690 split: login-required gets the sign-in copy, no links", async () => {
+    setResult({ ok: false, reason: "login-required" });
+    render(<OrgShareResolver token={TOKEN} variant="embed" />);
+    expect(
+      await screen.findByText(/sign in to atlas to view it/i),
+    ).toBeDefined();
+    const internalLinks = screen
+      .queryAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => !h.startsWith("https://www.useatlas.dev"));
+    expect(internalLinks).toEqual([]);
   });
 
   test("embed variant renders the navigation-free embed error surface", async () => {

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/share-result.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/share-result.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  isAuthWallReason,
+  mapSharedDashboardResponse,
+  resolveAuthReason,
+  type FailReason,
+} from "../share-result";
+
+function response(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+// #4718 — `isAuthWallReason` is the gate that decides which SSR failures hand
+// off to the client resolver. Pin it exhaustively: widening it would turn
+// public-share failures (e.g. server-error) into silent client re-fetches;
+// narrowing it would dead-end SaaS org viewers on the SSR false negative —
+// the exact bug #4718 fixes.
+describe("isAuthWallReason (#4718)", () => {
+  const expected: Record<FailReason, boolean> = {
+    "login-required": true,
+    "membership-required": true,
+    "not-found": false,
+    expired: false,
+    "server-error": false,
+    "network-error": false,
+  };
+
+  for (const [reason, isWall] of Object.entries(expected) as [FailReason, boolean][]) {
+    test(`${reason} → ${isWall}`, () => {
+      expect(isAuthWallReason(reason)).toBe(isWall);
+    });
+  }
+});
+
+// #4690 — direct pins of the auth-reason split (also exercised end-to-end via
+// fetch.test.ts and org-share-client.test.ts through the shared mapper).
+describe("resolveAuthReason (#4690)", () => {
+  test("401 is login-required regardless of body", async () => {
+    expect(await resolveAuthReason(response(401, { error: "forbidden" }))).toBe("login-required");
+  });
+
+  test("403 with error:forbidden is membership-required", async () => {
+    expect(await resolveAuthReason(response(403, { error: "forbidden" }))).toBe(
+      "membership-required",
+    );
+  });
+
+  test("403 with error:auth_required — or any unrecognized body — is login-required", async () => {
+    expect(await resolveAuthReason(response(403, { error: "auth_required" }))).toBe(
+      "login-required",
+    );
+    expect(await resolveAuthReason(response(403, { unexpected: true }))).toBe("login-required");
+  });
+});
+
+describe("mapSharedDashboardResponse totality (#4718)", () => {
+  test("a 200 whose body isn't JSON maps to server-error — never a rejection", async () => {
+    // The mapper is documented TOTAL: `OrgShareResolver`'s two-state model and
+    // the #4719 adopter rely on it never rejecting for any Response shape.
+    const res = {
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(mapSharedDashboardResponse(res, "deadbeefdeadbeef")).resolves.toEqual({
+      ok: false,
+      reason: "server-error",
+    });
+    errSpy.mockRestore();
+  });
+
+  test("schema-shape failures log issue paths, never response values", async () => {
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await mapSharedDashboardResponse(
+      response(200, { title: 42, secretValue: "do-not-log" }),
+      "deadbeefdeadbeef",
+    );
+
+    expect(result).toEqual({ ok: false, reason: "server-error" });
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(" ")).join(" ");
+    expect(logged).toContain("title");
+    expect(logged).not.toContain("do-not-log");
+    errSpy.mockRestore();
+  });
+});

--- a/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/embed.tsx
@@ -1,10 +1,12 @@
-// Server-only helpers for the shared-dashboard EMBED route. Kept out of
-// `page.tsx` so the theme resolver and the compact error view are unit-testable
-// without rendering the async RSC. The embed is a frame around the same shared
-// view (`../view.tsx`) — this file adds only the framable chrome (theme wrapper
-// + iframe-appropriate error states), never a second data surface.
+// Helpers for the shared-dashboard EMBED route. Kept out of `page.tsx` so the
+// theme resolver and the compact error view are unit-testable without rendering
+// the async RSC. The embed is a frame around the same shared view
+// (`../view.tsx`) — this file adds only the framable chrome (theme wrapper +
+// iframe-appropriate error states), never a second data surface. No server-only
+// imports may land here: `EmbedErrorView` also renders client-side via
+// `OrgShareResolver` on the org-share auth-wall branch (#4718).
 
-import type { FailReason } from "../fetch";
+import type { FailReason } from "../share-result";
 
 export type EmbedTheme = "light" | "dark";
 

--- a/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
@@ -69,10 +69,13 @@ export default async function SharedDashboardEmbedPage({ params, searchParams }:
         {result.ok ? (
           <SharedDashboardView dashboard={result.data} forcedDark={forcedDark} />
         ) : isAuthWallReason(result.reason) ? (
-          // Same client-side org-share hand-off as the standalone page (#4718):
-          // the iframe viewer's session is host-only on the API domain, so only
-          // a browser fetch with credentials can resolve an org share here. The
-          // embed variant keeps the navigation-free error surface.
+          // Same client-side org-share hand-off as the standalone page (#4718).
+          // Scope caveat: the session cookie is host-only AND SameSite=Lax
+          // (ADR-0024 §5), so the credentialed retry only helps when the embed
+          // is framed same-site (e.g. inside Atlas itself). In a third-party
+          // iframe the browser withholds the cookie and the resolver lands on
+          // the same navigation-free auth copy as before — the intended
+          // terminal state for an org share on a foreign page, not a bug.
           <OrgShareResolver token={token} variant="embed" forcedDark={forcedDark} />
         ) : (
           <EmbedErrorView reason={result.reason} />

--- a/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { SharedDashboardView } from "../view";
 import { fetchSharedDashboard } from "../fetch";
+import { isAuthWallReason } from "../share-result";
+import { OrgShareResolver } from "../org-share-resolver";
 import { EmbedErrorView, buildEmbedThemeForceScript, resolveEmbedTheme } from "./embed";
 
 // An embed is an iframe surface, not a page to index. The standalone
@@ -66,6 +68,12 @@ export default async function SharedDashboardEmbedPage({ params, searchParams }:
       <div className={forcedDark ? "dark" : undefined} data-theme={theme ?? "system"}>
         {result.ok ? (
           <SharedDashboardView dashboard={result.data} forcedDark={forcedDark} />
+        ) : isAuthWallReason(result.reason) ? (
+          // Same client-side org-share hand-off as the standalone page (#4718):
+          // the iframe viewer's session is host-only on the API domain, so only
+          // a browser fetch with credentials can resolve an org share here. The
+          // embed variant keeps the navigation-free error surface.
+          <OrgShareResolver token={token} variant="embed" forcedDark={forcedDark} />
         ) : (
           <EmbedErrorView reason={result.reason} />
         )}

--- a/packages/web/src/app/shared/dashboard/[token]/error-content.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/error-content.ts
@@ -5,7 +5,7 @@
 // rendering the async RSC. The embed surface (`embed.tsx`) keeps its own
 // navigation-free copy and does not consume this.
 
-import type { FailReason } from "./fetch";
+import type { FailReason } from "./share-result";
 
 /** Which primary CTA the error shell offers. */
 export type PrimaryAction =

--- a/packages/web/src/app/shared/dashboard/[token]/fetch.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/fetch.ts
@@ -6,8 +6,10 @@
 // The response→result mapping (status codes, #4690 auth-reason split, schema
 // validation) lives in `share-result.ts`, shared verbatim with the client-side
 // org-share resolution (`org-share-client.ts`, #4718) so the SSR and client
-// paths can never drift. This file adds only the server-side concerns:
-// `next/headers` forwarding and the `node:crypto` token hash.
+// paths can never drift. This module is SERVER-ONLY (it imports `next/headers`
+// + `node:crypto`) and adds the server-side concerns: header forwarding, the
+// `node:crypto` token hash, and the `cache()`-deduped fetch itself. Client
+// code imports the mapping/types from `share-result.ts`, never from here.
 
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
@@ -15,12 +17,6 @@ import { createHash } from "node:crypto";
 import { getApiBaseUrl } from "../../lib";
 import { mapSharedDashboardResponse } from "./share-result";
 import type { FetchResult } from "./share-result";
-
-// Historical import surface — the types + auth-reason resolver moved to
-// `share-result.ts` (#4718) but remain re-exported here so existing consumers
-// and tests keep importing from `./fetch`.
-export { isAuthWallReason, resolveAuthReason } from "./share-result";
-export type { FailReason, FetchResult } from "./share-result";
 
 /**
  * Short, non-reversible fingerprint of a share token for log correlation.
@@ -83,7 +79,7 @@ export async function fetchSharedDashboardRaw(token: string): Promise<FetchResul
   } catch (err) {
     console.error(
       `[shared-dashboard] Failed to fetch tokenHash=${hashShareToken(token)}:`,
-      err instanceof Error ? err.message : err,
+      err instanceof Error ? err.message : String(err),
     );
     return { ok: false, reason: "network-error" };
   }

--- a/packages/web/src/app/shared/dashboard/[token]/fetch.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/fetch.ts
@@ -2,30 +2,25 @@
 // module (not inlined in `page.tsx`) so the header-forwarding + token-hashing
 // logic is unit-testable without rendering the RSC, and so `generateMetadata`
 // and the page component share a SINGLE, de-duplicated fetch per view (#4317).
+//
+// The response→result mapping (status codes, #4690 auth-reason split, schema
+// validation) lives in `share-result.ts`, shared verbatim with the client-side
+// org-share resolution (`org-share-client.ts`, #4718) so the SSR and client
+// paths can never drift. This file adds only the server-side concerns:
+// `next/headers` forwarding and the `node:crypto` token hash.
 
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
 import { createHash } from "node:crypto";
-import { sharedDashboardViewSchema } from "@useatlas/schemas";
 import { getApiBaseUrl } from "../../lib";
-import type { SharedDashboard } from "./types";
+import { mapSharedDashboardResponse } from "./share-result";
+import type { FetchResult } from "./share-result";
 
-/** One of the {@link FetchResult} failure reasons — the discriminant the page
- *  and embed error shells switch on. Exported so both surfaces derive it from
- *  this single source rather than re-deriving the `Extract<…>` in each file. */
-export type FailReason =
-  | "not-found"
-  | "expired"
-  // The org-share auth wall is kept DISTINCT (not one `auth-required`): a viewer
-  // with no session (`login-required`) is offered a login redirect, while a viewer
-  // who is signed in but not a member of the sharing org (`membership-required`)
-  // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
-  | "login-required"
-  | "membership-required"
-  | "server-error"
-  | "network-error";
-
-export type FetchResult = { ok: true; data: SharedDashboard } | { ok: false; reason: FailReason };
+// Historical import surface — the types + auth-reason resolver moved to
+// `share-result.ts` (#4718) but remain re-exported here so existing consumers
+// and tests keep importing from `./fetch`.
+export { isAuthWallReason, resolveAuthReason } from "./share-result";
+export type { FailReason, FetchResult } from "./share-result";
 
 /**
  * Short, non-reversible fingerprint of a share token for log correlation.
@@ -34,7 +29,8 @@ export type FetchResult = { ok: true; data: SharedDashboard } | { ok: false; rea
  * `hashShareToken` (first 16 hex of SHA-256); duplicated because the web
  * package cannot import from `@atlas/api`. The API copy additionally guards
  * against non-string input — omitted here since callers always pass the
- * route's `token` string param.
+ * route's `token` string param. (`org-share-client.ts` carries the WebCrypto
+ * mirror for the browser, where `node:crypto` doesn't exist.)
  */
 export function hashShareToken(token: string): string {
   return createHash("sha256").update(token).digest("hex").slice(0, 16);
@@ -43,9 +39,10 @@ export function hashShareToken(token: string): string {
 /**
  * Build the headers the shared page forwards to the public dashboard API:
  *   - `cookie`: the viewer's session so ORG-scoped shares authenticate the
- *     viewer (an unauthenticated viewer gets a 403 from the API). Without this
- *     the RSC fetch carried no cookie and `authenticateRequest` 403'd every
- *     viewer — the end-to-end break this issue fixes.
+ *     viewer on a SAME-ORIGIN deploy. Under the SaaS cookie topology (ADR-0024)
+ *     the session cookie is host-only on the per-region API domain, so this jar
+ *     is structurally empty cross-origin — the auth wall then hands off to the
+ *     client-side resolver, which carries the viewer's real session (#4718).
  *   - `x-forwarded-for`: the viewer's REAL client IP so the API rate-limits per
  *     viewer, not per web-server IP (effective only when the API trusts the
  *     proxy header via `ATLAS_TRUST_PROXY`; otherwise `getClientIP` ignores it
@@ -62,35 +59,6 @@ export function buildForwardHeaders(input: {
   const viewerIp = input.forwardedFor ?? input.realIp;
   if (viewerIp) out["x-forwarded-for"] = viewerIp;
   return out;
-}
-
-/**
- * Disambiguate an org-share auth failure (HTTP 401/403) into the exact reason.
- *
- * The API returns 403 for BOTH the unauthenticated viewer (`error: "auth_required"`)
- * and the authenticated-but-wrong-org viewer (`error: "forbidden"`), so the status
- * code alone is insufficient — we read the body's `error` code. Only an explicit
- * `"forbidden"` is treated as `membership-required`; every other signal (an explicit
- * `auth_required`, a 401, or a missing/malformed body) defaults to `login-required`
- * so a no-session viewer is never dead-ended without a login path (#4690). Exported
- * for unit tests.
- */
-export async function resolveAuthReason(res: Response): Promise<"login-required" | "membership-required"> {
-  // A 401 is unambiguously "no session" regardless of body.
-  if (res.status === 401) return "login-required";
-  let errorCode: string | undefined;
-  try {
-    const body: unknown = await res.json();
-    if (body && typeof body === "object" && "error" in body) {
-      const code = (body as { error?: unknown }).error;
-      if (typeof code === "string") errorCode = code;
-    }
-  } catch {
-    // Malformed/empty body — fall through to the safe `login-required` default
-    // below rather than misclassifying a no-session viewer as wrong-org.
-    // intentionally ignored: absence of a parseable error code is itself the signal.
-  }
-  return errorCode === "forbidden" ? "membership-required" : "login-required";
 }
 
 /** Uncached fetch. Exported for unit tests; production callers use the
@@ -111,36 +79,7 @@ export async function fetchSharedDashboardRaw(token: string): Promise<FetchResul
       // would be incorrect regardless.
       { cache: "no-store", headers: forwardHeaders },
     );
-    if (!res.ok) {
-      if (res.status === 404) return { ok: false, reason: "not-found" };
-      if (res.status === 410) return { ok: false, reason: "expired" };
-      // The org-share auth wall. The API (`dashboards.ts`) returns 403 for BOTH the
-      // no-session and the wrong-org viewer, distinguished only by the response
-      // body's `error` code — NOT by the status. So a 403 alone can't tell them
-      // apart; we read the body. (A future 401 is also honored, so this stays
-      // correct if the API ever adopts stricter HTTP semantics.) See #4690.
-      if (res.status === 401 || res.status === 403) {
-        return { ok: false, reason: await resolveAuthReason(res) };
-      }
-      console.error(
-        `[shared-dashboard] API returned ${res.status} for tokenHash=${hashShareToken(token)}`,
-      );
-      return { ok: false, reason: "server-error" };
-    }
-    // Validate against the shared-view SSOT schema (`@useatlas/schemas`) rather
-    // than trust-casting the raw JSON — the `.strict()` schema also rejects any
-    // stray field the API projection might leak.
-    const parsed = sharedDashboardViewSchema.safeParse(await res.json());
-    if (!parsed.success) {
-      console.error(
-        `[shared-dashboard] Unexpected response shape for tokenHash=${hashShareToken(token)}`,
-      );
-      return { ok: false, reason: "server-error" };
-    }
-    // No cast: `parsed.data` (SharedDashboardViewWire) is structurally the
-    // SharedDashboard SSOT type, so any future schema/type drift fails the build
-    // here rather than being papered over.
-    return { ok: true, data: parsed.data };
+    return await mapSharedDashboardResponse(res, hashShareToken(token));
   } catch (err) {
     console.error(
       `[shared-dashboard] Failed to fetch tokenHash=${hashShareToken(token)}:`,

--- a/packages/web/src/app/shared/dashboard/[token]/org-share-client.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/org-share-client.ts
@@ -5,15 +5,15 @@
 // `fetch.ts` is structurally empty cross-origin and every org share hit the
 // auth wall regardless of the viewer's real session. When SSR lands on that
 // wall, the page mounts `OrgShareResolver`, which calls this module: a browser
-// fetch with `credentials: "include"` (the same pattern the share-status fetch
-// in `share-dialog.tsx` uses), so the API sees the viewer's REAL session and
-// the login-required / membership-required split (#4690) is evaluated
-// truthfully. A client fetch is inherently per-viewer, so the SSR path's
-// `x-forwarded-for` rate-limit forwarding has no analogue here.
+// fetch with credentials (the same pattern the dashboard share-status fetch in
+// `(workspace)/dashboards/[id]/share-dialog.tsx` uses), so the API sees the
+// viewer's REAL session and the login-required / membership-required split
+// (#4690) is evaluated truthfully. A client fetch is inherently per-viewer, so
+// the SSR path's `x-forwarded-for` rate-limit forwarding has no analogue here.
 //
 // This module must stay importable from client components — no `next/headers`,
-// no `node:crypto`. The shared-conversation parity issue (#4719) adopts this
-// same resolution pattern.
+// no `node:crypto`. The shared-conversation parity issue (#4719) is expected
+// to adopt this same resolution pattern.
 
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { mapSharedDashboardResponse } from "./share-result";
@@ -45,8 +45,19 @@ export async function hashShareTokenClient(token: string): Promise<string> {
  * self-hosted). The response mapping is `mapSharedDashboardResponse`, the
  * exact function the SSR path uses, so both paths return identical
  * {@link FetchResult}s for identical API responses.
+ *
+ * NEVER rejects — thrown fetches map to `network-error` — which is what lets
+ * `OrgShareResolver` model resolution as just "in flight | FetchResult".
  */
 export async function resolveOrgShareClient(token: string): Promise<FetchResult> {
+  // Fingerprint once, up front, so the catch below can never itself throw
+  // (a rejecting `subtle.digest` in an exotic iframe context must not mask the
+  // real fetch error or break the never-rejects contract).
+  const tokenHash = await hashShareTokenClient(token).catch(
+    // intentionally ignored: a failed fingerprint must never block resolving
+    // the share; the placeholder is the documented degraded mode.
+    () => "unavailable(hash-failed)",
+  );
   try {
     const res = await fetch(`${getApiUrl()}/api/public/dashboards/${encodeURIComponent(token)}`, {
       // No cache — same rationale as the SSR fetch: revoked links must die
@@ -54,11 +65,11 @@ export async function resolveOrgShareClient(token: string): Promise<FetchResult>
       cache: "no-store",
       credentials: isCrossOrigin() ? "include" : "same-origin",
     });
-    return await mapSharedDashboardResponse(res, await hashShareTokenClient(token), LOG_LABEL);
+    return await mapSharedDashboardResponse(res, tokenHash, LOG_LABEL);
   } catch (err) {
     console.error(
-      `${LOG_LABEL} Failed to fetch tokenHash=${await hashShareTokenClient(token)}:`,
-      err instanceof Error ? err.message : err,
+      `${LOG_LABEL} Failed to fetch tokenHash=${tokenHash}:`,
+      err instanceof Error ? err.message : String(err),
     );
     return { ok: false, reason: "network-error" };
   }

--- a/packages/web/src/app/shared/dashboard/[token]/org-share-client.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/org-share-client.ts
@@ -1,0 +1,65 @@
+// Client-side resolution of an ORG-scoped dashboard share (#4718).
+//
+// Under ADR-0024 the SaaS session cookie is host-only on the per-region API
+// domain — the browser never sends it to the web origin, so the RSC forward in
+// `fetch.ts` is structurally empty cross-origin and every org share hit the
+// auth wall regardless of the viewer's real session. When SSR lands on that
+// wall, the page mounts `OrgShareResolver`, which calls this module: a browser
+// fetch with `credentials: "include"` (the same pattern the share-status fetch
+// in `share-dialog.tsx` uses), so the API sees the viewer's REAL session and
+// the login-required / membership-required split (#4690) is evaluated
+// truthfully. A client fetch is inherently per-viewer, so the SSR path's
+// `x-forwarded-for` rate-limit forwarding has no analogue here.
+//
+// This module must stay importable from client components — no `next/headers`,
+// no `node:crypto`. The shared-conversation parity issue (#4719) adopts this
+// same resolution pattern.
+
+import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { mapSharedDashboardResponse } from "./share-result";
+import type { FetchResult } from "./share-result";
+
+const LOG_LABEL = "[shared-dashboard/client]";
+
+/**
+ * Browser-safe mirror of `hashShareToken` (`fetch.ts`, itself mirroring the
+ * API's copy): first 16 hex of SHA-256 — async because WebCrypto is. Log lines
+ * on this surface carry this fingerprint, NEVER the cleartext token (#4317).
+ * Returns a fixed placeholder when WebCrypto is unavailable (insecure-context
+ * browsers): an unfingerprinted log line beats logging a bearer credential.
+ */
+export async function hashShareTokenClient(token: string): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) return "unavailable(insecure-context)";
+  const digest = await subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16);
+}
+
+/**
+ * Re-resolve an org-scoped share from the browser with the viewer's real
+ * credentials. Targets the client-resolved API base (`@/lib/api-url` — the
+ * regional override when an `atlas_region` signal is active, else the
+ * build-time default; empty string → same-origin relative fetch on
+ * self-hosted). The response mapping is `mapSharedDashboardResponse`, the
+ * exact function the SSR path uses, so both paths return identical
+ * {@link FetchResult}s for identical API responses.
+ */
+export async function resolveOrgShareClient(token: string): Promise<FetchResult> {
+  try {
+    const res = await fetch(`${getApiUrl()}/api/public/dashboards/${encodeURIComponent(token)}`, {
+      // No cache — same rationale as the SSR fetch: revoked links must die
+      // immediately, and the result is per-viewer.
+      cache: "no-store",
+      credentials: isCrossOrigin() ? "include" : "same-origin",
+    });
+    return await mapSharedDashboardResponse(res, await hashShareTokenClient(token), LOG_LABEL);
+  } catch (err) {
+    console.error(
+      `${LOG_LABEL} Failed to fetch tokenHash=${await hashShareTokenClient(token)}:`,
+      err instanceof Error ? err.message : err,
+    );
+    return { ok: false, reason: "network-error" };
+  }
+}

--- a/packages/web/src/app/shared/dashboard/[token]/org-share-resolver.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/org-share-resolver.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+// Client half of the org-share auth-wall fix (#4718). Mounted by the shared
+// page/embed RSCs ONLY when the SSR fetch hit the auth wall (`login-required` /
+// `membership-required`) — public shares and every other failure keep the pure
+// SSR path unchanged. On mount it re-resolves the share against the API with
+// the viewer's REAL credentials (`org-share-client.ts`) and renders the exact
+// success/error surfaces the SSR path renders, so the two paths are visually
+// indistinguishable. On a same-origin deploy (where the SSR cookie forward
+// already worked) the retry merely reconfirms the SSR verdict; on the SaaS
+// cross-origin topology it is the only fetch that can carry the session at all.
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { SharedDashboardView } from "./view";
+import { ErrorShell } from "./error-shell";
+import { resolveErrorContent } from "./error-content";
+import { EmbedErrorView } from "./embed/embed";
+import { resolveOrgShareClient } from "./org-share-client";
+import type { FetchResult } from "./share-result";
+
+export function OrgShareResolver({
+  token,
+  variant = "page",
+  forcedDark,
+}: {
+  token: string;
+  /** "embed" renders the iframe-appropriate, navigation-free error surface
+   *  (`EmbedErrorView`) instead of the standalone `ErrorShell`. */
+  variant?: "page" | "embed";
+  /** Embed-only forced theme, threaded through to the tiles exactly as the
+   *  embed RSC threads it on the SSR success path (see `view.tsx`). */
+  forcedDark?: boolean;
+}) {
+  // `null` = resolution in flight. `resolveOrgShareClient` never rejects (it
+  // maps thrown fetches to `network-error`), so no separate error state.
+  const [result, setResult] = useState<FetchResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void resolveOrgShareClient(token).then((r) => {
+      if (!cancelled) setResult(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (result === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-zinc-950 print:bg-white">
+        <div
+          role="status"
+          className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"
+        >
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Checking access&hellip;
+        </div>
+      </div>
+    );
+  }
+
+  if (result.ok) {
+    return <SharedDashboardView dashboard={result.data} forcedDark={forcedDark} />;
+  }
+
+  return variant === "embed" ? (
+    <EmbedErrorView reason={result.reason} />
+  ) : (
+    <ErrorShell token={token} content={resolveErrorContent(result.reason)} />
+  );
+}

--- a/packages/web/src/app/shared/dashboard/[token]/org-share-resolver.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/org-share-resolver.tsx
@@ -38,9 +38,19 @@ export function OrgShareResolver({
 
   useEffect(() => {
     let cancelled = false;
-    void resolveOrgShareClient(token).then((r) => {
-      if (!cancelled) setResult(r);
-    });
+    resolveOrgShareClient(token)
+      .then((r) => {
+        if (!cancelled) setResult(r);
+      })
+      .catch((err: unknown) => {
+        // Belt to the never-rejects suspenders above: an unexpected rejection
+        // must surface as an error page, never strand the viewer on the spinner.
+        console.error(
+          "[shared-dashboard/client] org-share resolution rejected unexpectedly:",
+          err instanceof Error ? err.message : String(err),
+        );
+        if (!cancelled) setResult({ ok: false, reason: "network-error" });
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/web/src/app/shared/dashboard/[token]/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next";
 import { truncate } from "../../lib";
 import { SharedDashboardView } from "./view";
 import { fetchSharedDashboard } from "./fetch";
+import { isAuthWallReason } from "./share-result";
 import { resolveErrorContent } from "./error-content";
 import { ErrorShell } from "./error-shell";
+import { OrgShareResolver } from "./org-share-resolver";
 
 // ---------------------------------------------------------------------------
 // Metadata (OG tags)
@@ -57,6 +59,17 @@ export default async function SharedDashboardPage({
   const result = await fetchSharedDashboard(token);
 
   if (!result.ok) {
+    // The org-share auth wall. Under the SaaS cookie topology (ADR-0024) the
+    // session cookie is host-only on the per-region API domain, so the RSC
+    // fetch's cookie forward is structurally empty cross-origin and this SSR
+    // verdict may be a false negative for a logged-in viewer. Hand off to the
+    // client resolver, which retries with `credentials: "include"` and renders
+    // the same view — the #4690 login/membership split re-evaluated against
+    // the viewer's REAL session (#4718). Every other failure (and the public-
+    // share success path) stays pure SSR, unchanged.
+    if (isAuthWallReason(result.reason)) {
+      return <OrgShareResolver token={token} />;
+    }
     return <ErrorShell token={token} content={resolveErrorContent(result.reason)} />;
   }
 

--- a/packages/web/src/app/shared/dashboard/[token]/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/page.tsx
@@ -63,10 +63,10 @@ export default async function SharedDashboardPage({
     // session cookie is host-only on the per-region API domain, so the RSC
     // fetch's cookie forward is structurally empty cross-origin and this SSR
     // verdict may be a false negative for a logged-in viewer. Hand off to the
-    // client resolver, which retries with `credentials: "include"` and renders
-    // the same view — the #4690 login/membership split re-evaluated against
-    // the viewer's REAL session (#4718). Every other failure (and the public-
-    // share success path) stays pure SSR, unchanged.
+    // client resolver, which retries with the viewer's browser credentials and
+    // renders the same view — the #4690 login/membership split re-evaluated
+    // against the viewer's REAL session (#4718). Every other failure (and the
+    // public-share success path) stays pure SSR, unchanged.
     if (isAuthWallReason(result.reason)) {
       return <OrgShareResolver token={token} />;
     }

--- a/packages/web/src/app/shared/dashboard/[token]/share-result.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/share-result.ts
@@ -25,15 +25,17 @@ export type FailReason =
 
 export type FetchResult = { ok: true; data: SharedDashboard } | { ok: false; reason: FailReason };
 
+/** The two org-share auth-wall reasons (#4690). Single statement of the pair so
+ *  {@link isAuthWallReason} and {@link resolveAuthReason} can never disagree. */
+export type AuthWallReason = Extract<FailReason, "login-required" | "membership-required">;
+
 /**
  * Whether a failure is the org-share auth wall — the branch the page hands off
  * to the client-side resolver (#4718), since under the SaaS cookie topology
  * (ADR-0024) an SSR auth-wall verdict may be a false negative for a viewer
  * whose session cookie is host-only on the API domain.
  */
-export function isAuthWallReason(
-  reason: FailReason,
-): reason is "login-required" | "membership-required" {
+export function isAuthWallReason(reason: FailReason): reason is AuthWallReason {
   return reason === "login-required" || reason === "membership-required";
 }
 
@@ -48,15 +50,14 @@ export function isAuthWallReason(
  * so a no-session viewer is never dead-ended without a login path (#4690). Exported
  * for unit tests.
  */
-export async function resolveAuthReason(res: Response): Promise<"login-required" | "membership-required"> {
+export async function resolveAuthReason(res: Response): Promise<AuthWallReason> {
   // A 401 is unambiguously "no session" regardless of body.
   if (res.status === 401) return "login-required";
   let errorCode: string | undefined;
   try {
     const body: unknown = await res.json();
-    if (body && typeof body === "object" && "error" in body) {
-      const code = (body as { error?: unknown }).error;
-      if (typeof code === "string") errorCode = code;
+    if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
+      errorCode = body.error;
     }
   } catch {
     // Malformed/empty body — fall through to the safe `login-required` default
@@ -76,8 +77,10 @@ export async function resolveAuthReason(res: Response): Promise<"login-required"
  * than computed here) because the server and client hash via different crypto
  * APIs (`node:crypto` vs WebCrypto), and this module may import neither.
  *
- * May reject (e.g. a success response whose body isn't JSON); callers wrap in
- * their own try/catch and map to `network-error`, exactly as before extraction.
+ * TOTAL over its inputs: every branch — including a success response whose
+ * body isn't JSON — resolves to a {@link FetchResult}, never a rejection.
+ * `OrgShareResolver`'s two-state model and any future adopter (#4719) rely on
+ * that; callers still keep their own try/catch for the `fetch()` call itself.
  */
 export async function mapSharedDashboardResponse(
   res: Response,
@@ -98,12 +101,29 @@ export async function mapSharedDashboardResponse(
     console.error(`${logLabel} API returned ${res.status} for tokenHash=${tokenHash}`);
     return { ok: false, reason: "server-error" };
   }
+  // A 200 whose body isn't JSON is the API's fault, not the network's — map it
+  // to server-error here rather than rejecting into the caller's catch.
+  let raw: unknown;
+  try {
+    raw = await res.json();
+  } catch (err) {
+    console.error(
+      `${logLabel} Non-JSON success body for tokenHash=${tokenHash}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, reason: "server-error" };
+  }
   // Validate against the shared-view SSOT schema (`@useatlas/schemas`) rather
   // than trust-casting the raw JSON — the `.strict()` schema also rejects any
   // stray field the API projection might leak.
-  const parsed = sharedDashboardViewSchema.safeParse(await res.json());
+  const parsed = sharedDashboardViewSchema.safeParse(raw);
   if (!parsed.success) {
-    console.error(`${logLabel} Unexpected response shape for tokenHash=${tokenHash}`);
+    // Log issue paths + codes only — never the response values, which are the
+    // dashboard's data — so a projection drift is diagnosable from the log line.
+    const issues = parsed.error.issues.map((i) => `${i.path.join(".")}:${i.code}`).join(", ");
+    console.error(
+      `${logLabel} Unexpected response shape for tokenHash=${tokenHash}: ${issues}`,
+    );
     return { ok: false, reason: "server-error" };
   }
   // No cast: `parsed.data` (SharedDashboardViewWire) is structurally the

--- a/packages/web/src/app/shared/dashboard/[token]/share-result.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/share-result.ts
@@ -1,0 +1,113 @@
+// Universal (server + client) response mapping for the shared-dashboard fetch.
+// Extracted from `fetch.ts` (#4718) so the client-side org-share resolution
+// (`org-share-client.ts`) shares the EXACT status→reason mapping and schema
+// validation the SSR fetch uses — the two paths cannot drift. This module must
+// stay importable from client components: no server-only imports
+// (`next/headers`, `node:crypto`) may ever land here.
+
+import { sharedDashboardViewSchema } from "@useatlas/schemas";
+import type { SharedDashboard } from "./types";
+
+/** One of the {@link FetchResult} failure reasons — the discriminant the page
+ *  and embed error shells switch on. Both surfaces derive it from this single
+ *  source rather than re-deriving the `Extract<…>` in each file. */
+export type FailReason =
+  | "not-found"
+  | "expired"
+  // The org-share auth wall is kept DISTINCT (not one `auth-required`): a viewer
+  // with no session (`login-required`) is offered a login redirect, while a viewer
+  // who is signed in but not a member of the sharing org (`membership-required`)
+  // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
+  | "login-required"
+  | "membership-required"
+  | "server-error"
+  | "network-error";
+
+export type FetchResult = { ok: true; data: SharedDashboard } | { ok: false; reason: FailReason };
+
+/**
+ * Whether a failure is the org-share auth wall — the branch the page hands off
+ * to the client-side resolver (#4718), since under the SaaS cookie topology
+ * (ADR-0024) an SSR auth-wall verdict may be a false negative for a viewer
+ * whose session cookie is host-only on the API domain.
+ */
+export function isAuthWallReason(
+  reason: FailReason,
+): reason is "login-required" | "membership-required" {
+  return reason === "login-required" || reason === "membership-required";
+}
+
+/**
+ * Disambiguate an org-share auth failure (HTTP 401/403) into the exact reason.
+ *
+ * The API returns 403 for BOTH the unauthenticated viewer (`error: "auth_required"`)
+ * and the authenticated-but-wrong-org viewer (`error: "forbidden"`), so the status
+ * code alone is insufficient — we read the body's `error` code. Only an explicit
+ * `"forbidden"` is treated as `membership-required`; every other signal (an explicit
+ * `auth_required`, a 401, or a missing/malformed body) defaults to `login-required`
+ * so a no-session viewer is never dead-ended without a login path (#4690). Exported
+ * for unit tests.
+ */
+export async function resolveAuthReason(res: Response): Promise<"login-required" | "membership-required"> {
+  // A 401 is unambiguously "no session" regardless of body.
+  if (res.status === 401) return "login-required";
+  let errorCode: string | undefined;
+  try {
+    const body: unknown = await res.json();
+    if (body && typeof body === "object" && "error" in body) {
+      const code = (body as { error?: unknown }).error;
+      if (typeof code === "string") errorCode = code;
+    }
+  } catch {
+    // Malformed/empty body — fall through to the safe `login-required` default
+    // below rather than misclassifying a no-session viewer as wrong-org.
+    // intentionally ignored: absence of a parseable error code is itself the signal.
+  }
+  return errorCode === "forbidden" ? "membership-required" : "login-required";
+}
+
+/**
+ * Map a public-dashboard API response to a {@link FetchResult}. Shared verbatim
+ * by the SSR fetch (`fetch.ts`) and the client-side org-share resolution
+ * (`org-share-client.ts`).
+ *
+ * `tokenHash` is the caller's pre-computed share-token fingerprint — log lines
+ * here carry it, NEVER the cleartext token (#4317). It is passed in (rather
+ * than computed here) because the server and client hash via different crypto
+ * APIs (`node:crypto` vs WebCrypto), and this module may import neither.
+ *
+ * May reject (e.g. a success response whose body isn't JSON); callers wrap in
+ * their own try/catch and map to `network-error`, exactly as before extraction.
+ */
+export async function mapSharedDashboardResponse(
+  res: Response,
+  tokenHash: string,
+  logLabel = "[shared-dashboard]",
+): Promise<FetchResult> {
+  if (!res.ok) {
+    if (res.status === 404) return { ok: false, reason: "not-found" };
+    if (res.status === 410) return { ok: false, reason: "expired" };
+    // The org-share auth wall. The API (`dashboards.ts`) returns 403 for BOTH the
+    // no-session and the wrong-org viewer, distinguished only by the response
+    // body's `error` code — NOT by the status. So a 403 alone can't tell them
+    // apart; we read the body. (A future 401 is also honored, so this stays
+    // correct if the API ever adopts stricter HTTP semantics.) See #4690.
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, reason: await resolveAuthReason(res) };
+    }
+    console.error(`${logLabel} API returned ${res.status} for tokenHash=${tokenHash}`);
+    return { ok: false, reason: "server-error" };
+  }
+  // Validate against the shared-view SSOT schema (`@useatlas/schemas`) rather
+  // than trust-casting the raw JSON — the `.strict()` schema also rejects any
+  // stray field the API projection might leak.
+  const parsed = sharedDashboardViewSchema.safeParse(await res.json());
+  if (!parsed.success) {
+    console.error(`${logLabel} Unexpected response shape for tokenHash=${tokenHash}`);
+    return { ok: false, reason: "server-error" };
+  }
+  // No cast: `parsed.data` (SharedDashboardViewWire) is structurally the
+  // SharedDashboard SSOT type, so any future schema/type drift fails the build
+  // here rather than being papered over.
+  return { ok: true, data: parsed.data };
+}

--- a/packages/web/src/app/shared/dashboard/[token]/view.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/view.tsx
@@ -1,7 +1,12 @@
-// server-only — do not add "use client" to this file. The header's `timeAgo`
-// runs once at request time and per-tile `cachedLabel` strings are pre-computed
-// here and shipped to <SharedTile> as plain props. If this becomes a client
-// component, `Date.now()` will diverge between SSR and CSR for those values.
+// Shared success surface for BOTH render modes: an RSC on the SSR path (public
+// shares) and a client render inside `OrgShareResolver` after the client-side
+// org-share resolution (#4718). Do not add "use client": on the SSR path the
+// header's `timeAgo` and per-tile `cachedLabel` strings must be computed once
+// at request time and shipped to <SharedTile> as plain props — making the whole
+// module a client component would recompute those `Date.now()`-derived values
+// at hydration and diverge between SSR and CSR. The resolver path is safe: the
+// view mounts only AFTER data arrives (client-only, no server pass), so there
+// is no hydration to mismatch.
 
 import Link from "next/link";
 import { ArrowUpRight, Clock, LayoutDashboard } from "lucide-react";


### PR DESCRIPTION
Closes #4718 (audit L9, milestone v0.0.58 — Dashboard & Sharing Residue).

## Problem

`/shared/dashboard/[token]` resolved org-scoped shares by forwarding the **web-origin cookie jar** from the RSC fetch (`buildForwardHeaders`). Under ADR-0024 the SaaS session cookie is **host-only on the per-region API domain** — the browser never sends it to the web host — so the forward is structurally empty cross-origin: every org share 403'd (`auth_required`) and the #4690 auth wall told logged-in members to "Log in". Same-origin deploys masked the bug.

## Fix

- **Public shares unchanged** — pure SSR, `cache: "no-store"`.
- When SSR hits the auth wall (`login-required` / `membership-required`, gated by the new `isAuthWallReason`), the page and embed mount **`OrgShareResolver`** (client), which refetches via **`resolveOrgShareClient`** with `credentials: isCrossOrigin() ? "include" : "same-origin"` against the client-resolved API base (`@/lib/api-url`, regional signal honored) — the same pattern the dashboard share-status fetch uses — and renders the exact same success/error surfaces.
- The **#4690 split is preserved** and now evaluated against the viewer's real session.
- **`share-result.ts`** — the status→reason mapping + strict-schema validation extracted from `fetch.ts` and shared verbatim by both paths, so SSR and client verdicts agree by construction. The mapper is total (never rejects). Exported cleanly for the shared-conversation parity adoption (#4719).
- **Token hygiene (#4317)** — new client paths log only a fingerprint via a WebCrypto `hashShareTokenClient` mirror (parity with the `node:crypto` copy is test-pinned); never the cleartext token.
- **Embed scope caveat documented**: with `SameSite=Lax` host-only cookies, the credentialed retry helps same-site framings; a third-party iframe intentionally degrades to the navigation-free auth copy.

## Tests

- `org-share-client.test.ts` — success / login-required / membership-required (the AC trio), 401, 404/410, cross-origin credentials+URL via the real region signal, schema rejection, fingerprint-only logging on every branch, never-rejects.
- `org-share-resolver.test.tsx` — rendered surfaces per outcome (login CTA wiring, no login CTA on membership-required, embed navigation-free variants, accessible loading state).
- `share-result.test.ts` — `isAuthWallReason` exhaustive pin, `resolveAuthReason` direct pins, mapper totality, no-response-values-in-logs.
- Existing `fetch.test.ts` (SSR path) untouched and green.

## Gates

- Internal review panel: round 1 findings fixed (total mapper, throw-proof catch, defensive `.catch`, dead re-export removed, comment accuracy); round 2 **CLEAN**.
- `/ci` local wrapper: **all 31 gates PASS** (type, lint, lint-type-aware, drift gates, full isolated test suite).

Generated with [Claude Code](https://claude.com/claude-code)