### PR TITLE
fix(web): shared conversation surface parity with the hardened dashboard share pattern (#4719)

### DIFF
--- a/packages/web/src/app/shared/[token]/__tests__/error-content.test.ts
+++ b/packages/web/src/app/shared/[token]/__tests__/error-content.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { resolveConversationErrorContent } from "../error-content";
+import type { FailReason } from "../share-result";
+
+// #4719 — the conversation surface's error copy feeds the shared `ErrorShell`
+// CTA policy. Pin the #4690 crux: `login-required` (and only it) gets the
+// login CTA; the signed-in wrong-org viewer is never dead-ended on "Log in".
+describe("resolveConversationErrorContent (#4719)", () => {
+  test("login-required is the ONLY reason that offers the login CTA", () => {
+    const reasons: FailReason[] = [
+      "login-required",
+      "membership-required",
+      "expired",
+      "not-found",
+      "server-error",
+      "network-error",
+    ];
+    for (const reason of reasons) {
+      const content = resolveConversationErrorContent(reason);
+      expect(content.primaryAction).toBe(reason === "login-required" ? "login" : "home");
+    }
+  });
+
+  test("auth-wall and not-found reasons never offer Try again; transient ones do", () => {
+    expect(resolveConversationErrorContent("login-required").showTryAgain).toBe(false);
+    expect(resolveConversationErrorContent("membership-required").showTryAgain).toBe(false);
+    expect(resolveConversationErrorContent("not-found").showTryAgain).toBe(false);
+    expect(resolveConversationErrorContent("expired").showTryAgain).toBe(true);
+    expect(resolveConversationErrorContent("network-error").showTryAgain).toBe(true);
+    expect(resolveConversationErrorContent("server-error").showTryAgain).toBe(true);
+  });
+
+  test("membership copy explains the org requirement, not a sign-in ask", () => {
+    const content = resolveConversationErrorContent("membership-required");
+    expect(content.heading).toContain("access");
+    expect(content.message).toContain("organization");
+    expect(content.message).not.toMatch(/sign in/i);
+  });
+
+  test("expired copy is distinct from not-found", () => {
+    expect(resolveConversationErrorContent("expired").heading).not.toBe(
+      resolveConversationErrorContent("not-found").heading,
+    );
+  });
+});

--- a/packages/web/src/app/shared/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/[token]/__tests__/fetch.test.ts
@@ -8,6 +8,7 @@ let mockHeaders: Record<string, string> = {};
 void mock.module("next/headers", () => ({
   cookies: async () => ({ toString: () => mockCookie }),
   headers: async () => ({ get: (k: string) => mockHeaders[k.toLowerCase()] ?? null }),
+  draftMode: async () => ({ isEnabled: false }),
 }));
 
 import { fetchSharedConversationRaw, hashShareToken } from "../fetch";
@@ -187,6 +188,38 @@ describe("fetchSharedConversationRaw (#4719)", () => {
     }
     const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
     expect(logged).toContain(hashShareToken(TOKEN));
+    errSpy.mockRestore();
+  });
+
+  test("redacts the token when a thrown error's message echoes the request URL (#4317)", async () => {
+    // WHATWG fetch echoes the full URL — token included — in e.g.
+    // "Failed to parse URL from <url>" on a misconfigured API base.
+    globalThis.fetch = mock(async () => {
+      throw new TypeError(`Failed to parse URL from https://bad host/api/public/conversations/${TOKEN}`);
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await fetchSharedConversationRaw(TOKEN);
+    expect(result).toEqual({ ok: false, reason: "network-error" });
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(" ")).join(" ");
+    expect(logged).toContain("[redacted-share-token]");
+    errSpy.mockRestore();
+  });
+
+  test("maps a malformed message element (messages: [null]) to server-error, never a view crash", async () => {
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    stubFetch(200, { ...okConversation, messages: [null] });
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({
+      ok: false,
+      reason: "server-error",
+    });
+    // The logged detail names the field only — never the response's values.
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(" ")).join(" ");
+    expect(logged).toContain("messages[0]");
     errSpy.mockRestore();
   });
 

--- a/packages/web/src/app/shared/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/[token]/__tests__/fetch.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+// next/headers is request-scoped; drive it from module-level mutables so each
+// test can set the viewer's cookie / forwarded IP.
+let mockCookie = "";
+let mockHeaders: Record<string, string> = {};
+
+void mock.module("next/headers", () => ({
+  cookies: async () => ({ toString: () => mockCookie }),
+  headers: async () => ({ get: (k: string) => mockHeaders[k.toLowerCase()] ?? null }),
+}));
+
+import { fetchSharedConversationRaw, hashShareToken } from "../fetch";
+
+const TOKEN = "abc123def456ghi789jkl";
+
+const okConversation = {
+  title: "Revenue Analysis",
+  surface: "web",
+  createdAt: "2026-03-12T00:00:00Z",
+  shareMode: "org",
+  messages: [
+    { role: "user", content: "What were our top customers?", createdAt: "2026-03-12T00:00:00Z" },
+    { role: "assistant", content: "Here are the results.", createdAt: "2026-03-12T00:00:01Z" },
+  ],
+};
+
+function stubFetch(status: number, body: unknown) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return calls;
+}
+
+// #4719 — the shared CONVERSATION surface adopts the hardened dashboard share
+// pattern: no-store (revoked links die immediately), viewer header forwarding
+// (org-share auth + per-viewer rate limiting), token-hash-only logging, and
+// the #4690 login/membership split via the shared response mapper.
+describe("fetchSharedConversationRaw (#4719)", () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    mockCookie = "";
+    mockHeaders = {};
+  });
+
+  test("fetches with cache: no-store — a revoked share must die immediately, no 60s window", async () => {
+    const calls = stubFetch(200, okConversation);
+    const result = await fetchSharedConversationRaw(TOKEN);
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.init?.cache).toBe("no-store");
+    // The old revalidate window is gone entirely.
+    expect((calls[0]!.init as { next?: unknown }).next).toBeUndefined();
+  });
+
+  test("forwards the viewer cookie + IP so org shares authenticate & rate-limit per viewer", async () => {
+    mockCookie = "atlas.session=xyz";
+    mockHeaders = { "x-forwarded-for": "9.9.9.9" };
+    const calls = stubFetch(200, okConversation);
+
+    const result = await fetchSharedConversationRaw(TOKEN);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.title).toBe("Revenue Analysis");
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers.cookie).toBe("atlas.session=xyz");
+    expect(headers["x-forwarded-for"]).toBe("9.9.9.9");
+  });
+
+  test("falls back to x-real-ip for the rate-limit attribution when no x-forwarded-for", async () => {
+    mockHeaders = { "x-real-ip": "2.2.2.2" };
+    const calls = stubFetch(200, okConversation);
+    await fetchSharedConversationRaw(TOKEN);
+    const headers = calls[0]!.init?.headers as Record<string, string>;
+    expect(headers["x-forwarded-for"]).toBe("2.2.2.2");
+  });
+
+  test("encodes the token in the fetch URL", async () => {
+    const calls = stubFetch(404, {});
+    await fetchSharedConversationRaw("tok/en+special");
+    expect(calls[0]!.url).toContain("tok%2Fen%2Bspecial");
+  });
+
+  // #4690 split, via the shared mapper: the API (`conversations.ts`) returns
+  // 403 for BOTH the no-session and the wrong-org viewer, distinguished only by
+  // the body's `error` code.
+  test("maps a 403 with error:auth_required (no session) to login-required", async () => {
+    stubFetch(403, { error: "auth_required" });
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({
+      ok: false,
+      reason: "login-required",
+    });
+  });
+
+  test("maps a 403 with error:forbidden (authenticated, wrong org) to membership-required", async () => {
+    stubFetch(403, { error: "forbidden" });
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({
+      ok: false,
+      reason: "membership-required",
+    });
+  });
+
+  test("maps a bare 401 to login-required regardless of body", async () => {
+    stubFetch(401, { error: "forbidden" });
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({
+      ok: false,
+      reason: "login-required",
+    });
+  });
+
+  test("maps a 404 to not-found and a 410 to expired (revoked/expired links)", async () => {
+    stubFetch(404, {});
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({ ok: false, reason: "not-found" });
+    stubFetch(410, {});
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({ ok: false, reason: "expired" });
+  });
+
+  test("maps a malformed body shape (no messages array) to server-error", async () => {
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    stubFetch(200, { error: "bad" });
+    expect(await fetchSharedConversationRaw(TOKEN)).toEqual({
+      ok: false,
+      reason: "server-error",
+    });
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test("a 200 whose body isn't JSON resolves to server-error — never a rejection", async () => {
+    globalThis.fetch = mock(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("not json");
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    await expect(fetchSharedConversationRaw(TOKEN)).resolves.toEqual({
+      ok: false,
+      reason: "server-error",
+    });
+    errSpy.mockRestore();
+  });
+
+  test("does not log for 404 responses", async () => {
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    stubFetch(404, {});
+    await fetchSharedConversationRaw(TOKEN);
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test("never logs the raw token — logs only its hash — on a server error (#4317)", async () => {
+    stubFetch(500, {});
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    await fetchSharedConversationRaw(TOKEN);
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(logged).toContain(hashShareToken(TOKEN));
+    errSpy.mockRestore();
+  });
+
+  test("never logs the raw token on a network error (fetch throws) (#4317)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await fetchSharedConversationRaw(TOKEN);
+    expect(result).toEqual({ ok: false, reason: "network-error" });
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(logged).toContain(hashShareToken(TOKEN));
+    errSpy.mockRestore();
+  });
+
+  test("never logs the raw token on a malformed-shape error (#4317)", async () => {
+    stubFetch(200, { error: "bad" });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    await fetchSharedConversationRaw(TOKEN);
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(logged).toContain(hashShareToken(TOKEN));
+    errSpy.mockRestore();
+  });
+});

--- a/packages/web/src/app/shared/[token]/__tests__/org-share-client.test.ts
+++ b/packages/web/src/app/shared/[token]/__tests__/org-share-client.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { _resetApiUrl, applyRegionSignal } from "@/lib/api-url";
+import { hashShareTokenClient, resolveOrgShareClient } from "../org-share-client";
+
+const TOKEN = "abc123def456ghi789jkl";
+
+const okConversation = {
+  title: "Revenue Analysis",
+  surface: "web",
+  createdAt: "2026-03-12T00:00:00Z",
+  shareMode: "org",
+  messages: [
+    { role: "user", content: "What were our top customers?", createdAt: "2026-03-12T00:00:00Z" },
+  ],
+};
+
+function stubFetch(status: number, body: unknown) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fn = mock(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return calls;
+}
+
+describe("hashShareTokenClient (#4719)", () => {
+  test("matches the server-side node:crypto mirror (first 16 hex of SHA-256)", async () => {
+    const nodeHash = createHash("sha256").update(TOKEN).digest("hex").slice(0, 16);
+    expect(await hashShareTokenClient(TOKEN)).toBe(nodeHash);
+  });
+});
+
+// #4719 — the three client-side org-share resolution outcomes from the issue's
+// acceptance criteria: success, login-required, membership-required. The
+// mapping is shared verbatim with the SSR fetch (`mapSharedConversationResponse`),
+// so the #4690 split holds identically — now evaluated against the viewer's
+// REAL session because the browser fetch carries credentials.
+describe("resolveOrgShareClient (conversation, #4719)", () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    _resetApiUrl();
+  });
+
+  test("success: a credentialed viewer in the owning org gets the conversation", async () => {
+    const calls = stubFetch(200, okConversation);
+    const result = await resolveOrgShareClient(TOKEN);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data.title).toBe("Revenue Analysis");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toContain(`/api/public/conversations/${TOKEN}`);
+    expect(calls[0]!.init?.cache).toBe("no-store");
+  });
+
+  test("sends credentials: include against a cross-origin (regional) API base", async () => {
+    // Force the cross-origin topology deterministically via the regional signal
+    // (the same override `getApiUrl()` folds in for every client fetch).
+    expect(applyRegionSignal("eu", "https://api-eu.example.test")).toBe(true);
+    const calls = stubFetch(200, okConversation);
+
+    await resolveOrgShareClient(TOKEN);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      `https://api-eu.example.test/api/public/conversations/${TOKEN}`,
+    );
+    expect(calls[0]!.init?.credentials).toBe("include");
+  });
+
+  test("maps a 403 with error:auth_required (no session) to login-required", async () => {
+    stubFetch(403, { error: "auth_required" });
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "login-required" });
+  });
+
+  test("maps a 403 with error:forbidden (authenticated, wrong org) to membership-required", async () => {
+    stubFetch(403, { error: "forbidden" });
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({
+      ok: false,
+      reason: "membership-required",
+    });
+  });
+
+  test("maps a 404 to not-found and a 410 to expired (revoked/expired org links)", async () => {
+    stubFetch(404, {});
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "not-found" });
+    stubFetch(410, {});
+    expect(await resolveOrgShareClient(TOKEN)).toEqual({ ok: false, reason: "expired" });
+  });
+
+  test("never logs the raw token — logs only its hash — on a network error (#4317)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await resolveOrgShareClient(TOKEN);
+    expect(result).toEqual({ ok: false, reason: "network-error" });
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join(" ");
+    expect(logged).toContain(await hashShareTokenClient(TOKEN));
+    errSpy.mockRestore();
+  });
+
+  test("a 200 whose body isn't JSON resolves to server-error — never a rejection", async () => {
+    // Locks the never-rejects contract `OrgShareResolver` builds its two-state
+    // model on, through the client seam.
+    globalThis.fetch = mock(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("not json");
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    await expect(resolveOrgShareClient(TOKEN)).resolves.toEqual({
+      ok: false,
+      reason: "server-error",
+    });
+    errSpy.mockRestore();
+  });
+});

--- a/packages/web/src/app/shared/[token]/__tests__/org-share-client.test.ts
+++ b/packages/web/src/app/shared/[token]/__tests__/org-share-client.test.ts
@@ -110,6 +110,23 @@ describe("resolveOrgShareClient (conversation, #4719)", () => {
     errSpy.mockRestore();
   });
 
+  test("redacts the token when a thrown error's message echoes the request URL (#4317)", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new TypeError(`Failed to parse URL from https://bad host/api/public/conversations/${TOKEN}`);
+    }) as unknown as typeof fetch;
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await resolveOrgShareClient(TOKEN);
+    expect(result).toEqual({ ok: false, reason: "network-error" });
+
+    for (const call of errSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(TOKEN);
+    }
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(" ")).join(" ");
+    expect(logged).toContain("[redacted-share-token]");
+    errSpy.mockRestore();
+  });
+
   test("a 200 whose body isn't JSON resolves to server-error — never a rejection", async () => {
     // Locks the never-rejects contract `OrgShareResolver` builds its two-state
     // model on, through the client seam.

--- a/packages/web/src/app/shared/[token]/__tests__/org-share-resolver.test.tsx
+++ b/packages/web/src/app/shared/[token]/__tests__/org-share-resolver.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ConversationFetchResult } from "../share-result";
+import type { SharedConversation } from "../../lib";
+
+// next/link needs no router for a plain anchor render — stub it to the bare <a>.
+void mock.module("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) =>
+    createElement("a", { href }, children),
+}));
+// The shared view renders assistant turns through the chat Markdown component,
+// which lazy-loads a syntax highlighter; stub it so the view renders in the
+// test DOM. It is the module's only export.
+void mock.module("@/ui/components/chat/markdown", () => ({
+  Markdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+// Drive the client resolution from a module-level mutable. Factory stays sync
+// (async mock.module factories deadlock under bun:test) and mocks ALL exports.
+let mockResolve: () => Promise<ConversationFetchResult> = () =>
+  Promise.resolve({ ok: false, reason: "login-required" });
+function setResult(result: ConversationFetchResult) {
+  mockResolve = () => Promise.resolve(result);
+}
+void mock.module("../org-share-client", () => ({
+  resolveOrgShareClient: () => mockResolve(),
+  hashShareTokenClient: async () => "deadbeefdeadbeef",
+}));
+
+import { OrgShareResolver } from "../org-share-resolver";
+
+const TOKEN = "abc123def456ghi789jkl";
+
+function convo(over: Partial<SharedConversation> = {}): SharedConversation {
+  return {
+    title: "Quarterly Revenue Q&A",
+    surface: "web",
+    createdAt: "2026-04-01T00:00:00.000Z",
+    messages: [
+      { role: "user", content: "Top customers?", createdAt: "2026-04-01T00:00:00.000Z" },
+      { role: "assistant", content: "Acme leads.", createdAt: "2026-04-01T00:00:01.000Z" },
+    ],
+    ...over,
+  };
+}
+
+// #4719 — the client-side org-share resolution branch, at the component seam:
+// the resolver must render the SAME success/error surfaces the SSR path does,
+// with the #4690 login/membership split now driven by the viewer's real session.
+describe("OrgShareResolver (conversation, #4719)", () => {
+  afterEach(() => {
+    cleanup();
+    // Restore the default resolver so a never-resolving pin (the loading-state
+    // test) can't leak into later tests.
+    setResult({ ok: false, reason: "login-required" });
+  });
+
+  test("success: renders the shared conversation view for an authenticated org member", async () => {
+    setResult({ ok: true, data: convo() });
+    render(<OrgShareResolver token={TOKEN} />);
+    expect(await screen.findByText("Quarterly Revenue Q&A")).toBeDefined();
+    expect(screen.getByText("Top customers?")).toBeDefined();
+  });
+
+  test("login-required: renders the auth wall with the login redirect back to the share", async () => {
+    setResult({ ok: false, reason: "login-required" });
+    render(<OrgShareResolver token={TOKEN} />);
+    const login = await screen.findByText("Log in");
+    expect(login.closest("a")?.getAttribute("href")).toBe(
+      `/login?redirect=${encodeURIComponent(`/shared/${TOKEN}`)}`,
+    );
+  });
+
+  test("membership-required: explains the org requirement and NEVER offers a login CTA", async () => {
+    setResult({ ok: false, reason: "membership-required" });
+    render(<OrgShareResolver token={TOKEN} />);
+    expect(
+      await screen.findByText(/don’t have access to this conversation/i),
+    ).toBeDefined();
+    const loginHrefs = screen
+      .queryAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => h.startsWith("/login"));
+    expect(loginHrefs).toEqual([]);
+  });
+
+  test("embed variant success renders the framable embed view, not the standalone page", async () => {
+    setResult({ ok: true, data: convo() });
+    render(<OrgShareResolver token={TOKEN} variant="embed" />);
+    // EmbedView renders the heading visually hidden and no "Try Atlas free" CTA
+    // (embed contract: attributable, never pushy).
+    expect(await screen.findByText("Top customers?")).toBeDefined();
+    expect(screen.queryByText("Try Atlas free")).toBeNull();
+  });
+
+  test("embed variant keeps the #4690 split: login-required gets the sign-in copy, no links", async () => {
+    setResult({ ok: false, reason: "login-required" });
+    render(<OrgShareResolver token={TOKEN} variant="embed" />);
+    expect(
+      await screen.findByText(/sign in to atlas to view it/i),
+    ).toBeDefined();
+    const internalLinks = screen
+      .queryAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => !h.startsWith("https://www.useatlas.dev"));
+    expect(internalLinks).toEqual([]);
+  });
+
+  test("embed variant renders the navigation-free membership copy", async () => {
+    setResult({ ok: false, reason: "membership-required" });
+    render(<OrgShareResolver token={TOKEN} variant="embed" />);
+    expect(
+      await screen.findByText(/organization you’re not a member of/i),
+    ).toBeDefined();
+    const internalLinks = screen
+      .queryAllByRole("link")
+      .map((a) => a.getAttribute("href") ?? "")
+      .filter((h) => !h.startsWith("https://www.useatlas.dev"));
+    expect(internalLinks).toEqual([]);
+  });
+
+  test("shows an accessible resolving state while the client fetch is in flight", () => {
+    // Never-resolving promise pins the loading state.
+    mockResolve = () => new Promise(() => {});
+    render(<OrgShareResolver token={TOKEN} />);
+    expect(screen.getByRole("status")).toBeDefined();
+  });
+});

--- a/packages/web/src/app/shared/[token]/__tests__/page-handoff.test.tsx
+++ b/packages/web/src/app/shared/[token]/__tests__/page-handoff.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ConversationFetchResult } from "../share-result";
+import type { SharedConversation } from "../../lib";
+
+// Drive both RSCs' data fetch from a module-level mutable. Factory stays sync
+// (async mock.module factories deadlock under bun:test) and mocks ALL exports
+// of `../fetch`.
+let mockResult: ConversationFetchResult = { ok: false, reason: "login-required" };
+void mock.module("../fetch", () => ({
+  fetchSharedConversation: () => Promise.resolve(mockResult),
+  fetchSharedConversationRaw: () => Promise.resolve(mockResult),
+  buildForwardHeaders: () => ({}),
+  hashShareToken: () => "deadbeefdeadbeef",
+}));
+
+import SharedConversationPage from "../page";
+import SharedConversationEmbedPage from "../embed/page";
+import { OrgShareResolver } from "../org-share-resolver";
+import { ErrorShell } from "../../error-shell";
+import { SharedConversationView } from "../view";
+import { EmbedView, EmbedErrorView } from "../embed/view";
+
+const TOKEN = "abc123def456ghi789jkl";
+
+function convo(): SharedConversation {
+  return {
+    title: "Quarterly Revenue Q&A",
+    surface: "web",
+    createdAt: "2026-04-01T00:00:00.000Z",
+    messages: [
+      { role: "user", content: "Top customers?", createdAt: "2026-04-01T00:00:00.000Z" },
+    ],
+  };
+}
+
+function pageProps() {
+  return { params: Promise.resolve({ token: TOKEN }) };
+}
+
+function embedProps() {
+  return {
+    params: Promise.resolve({ token: TOKEN }),
+    searchParams: Promise.resolve({}),
+  };
+}
+
+// #4719 — the load-bearing decision of the PR, at the page seam: ONLY the two
+// auth-wall reasons hand off to the client-side org-share resolver; every
+// other failure (and success) stays pure SSR. Regressing this branch back to
+// its pre-PR shape would dead-end every SaaS cross-origin org share on a false
+// login wall while all the component/mapper tests stay green.
+describe("shared conversation page hand-off (#4719)", () => {
+  test("auth-wall reasons mount the client resolver", async () => {
+    for (const reason of ["login-required", "membership-required"] as const) {
+      mockResult = { ok: false, reason };
+      const el = await SharedConversationPage(pageProps());
+      expect(el.type).toBe(OrgShareResolver);
+      expect(el.props.token).toBe(TOKEN);
+    }
+  });
+
+  test("non-auth failures render the SSR error shell, not the resolver", async () => {
+    for (const reason of ["not-found", "expired", "server-error", "network-error"] as const) {
+      mockResult = { ok: false, reason };
+      const el = await SharedConversationPage(pageProps());
+      expect(el.type).toBe(ErrorShell);
+      expect(el.props.sharePath).toBe(`/shared/${TOKEN}`);
+    }
+  });
+
+  test("success stays pure SSR — renders the shared view directly", async () => {
+    mockResult = { ok: true, data: convo() };
+    const el = await SharedConversationPage(pageProps());
+    expect(el.type).toBe(SharedConversationView);
+    expect(el.props.convo.title).toBe("Quarterly Revenue Q&A");
+  });
+});
+
+describe("shared conversation embed hand-off (#4719)", () => {
+  test("auth-wall reasons mount the client resolver in embed variant", async () => {
+    mockResult = { ok: false, reason: "membership-required" };
+    const el = await SharedConversationEmbedPage(embedProps());
+    expect(el.type).toBe(OrgShareResolver);
+    expect(el.props.variant).toBe("embed");
+    expect(el.props.token).toBe(TOKEN);
+  });
+
+  test("non-auth failures render the navigation-free embed error view", async () => {
+    mockResult = { ok: false, reason: "expired" };
+    const el = await SharedConversationEmbedPage(embedProps());
+    expect(el.type).toBe(EmbedErrorView);
+    expect(el.props.reason).toBe("expired");
+  });
+
+  test("success renders the embed view", async () => {
+    mockResult = { ok: true, data: convo() };
+    const el = await SharedConversationEmbedPage(embedProps());
+    expect(el.type).toBe(EmbedView);
+  });
+});

--- a/packages/web/src/app/shared/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/[token]/embed/page.tsx
@@ -20,7 +20,7 @@ export default async function SharedConversationEmbedPage({
   if (!result.ok) {
     // Same client-side org-share hand-off as the standalone page (#4719,
     // adopting #4718). Scope caveat: the session cookie is host-only AND
-    // SameSite=Lax (ADR-0024 §5), so the credentialed retry only helps when
+    // SameSite=Lax (ADR-0024, Decision), so the credentialed retry only helps when
     // the embed is framed same-site (e.g. inside Atlas itself). In a
     // third-party iframe the browser withholds the cookie and the resolver
     // lands on the same navigation-free auth copy as before — the intended

--- a/packages/web/src/app/shared/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/[token]/embed/page.tsx
@@ -1,4 +1,6 @@
-import { fetchSharedConversation } from "../../lib";
+import { fetchSharedConversation } from "../fetch";
+import { isAuthWallReason } from "../share-result";
+import { OrgShareResolver } from "../org-share-resolver";
 import { EmbedView, EmbedErrorView, resolveEmbedTheme } from "./view";
 
 interface PageProps {
@@ -16,6 +18,16 @@ export default async function SharedConversationEmbedPage({
 
   const result = await fetchSharedConversation(token);
   if (!result.ok) {
+    // Same client-side org-share hand-off as the standalone page (#4719,
+    // adopting #4718). Scope caveat: the session cookie is host-only AND
+    // SameSite=Lax (ADR-0024 §5), so the credentialed retry only helps when
+    // the embed is framed same-site (e.g. inside Atlas itself). In a
+    // third-party iframe the browser withholds the cookie and the resolver
+    // lands on the same navigation-free auth copy as before — the intended
+    // terminal state for an org share on a foreign page, not a bug.
+    if (isAuthWallReason(result.reason)) {
+      return <OrgShareResolver token={token} variant="embed" theme={theme} />;
+    }
     return <EmbedErrorView reason={result.reason} theme={theme} />;
   }
   return <EmbedView data={result.data} theme={theme} />;

--- a/packages/web/src/app/shared/[token]/embed/view.tsx
+++ b/packages/web/src/app/shared/[token]/embed/view.tsx
@@ -4,6 +4,7 @@ import {
   extractTextContent,
   truncate,
 } from "../../lib";
+import type { FailReason } from "../share-result";
 
 export type EmbedTheme = "light" | "dark";
 
@@ -89,17 +90,47 @@ export function EmbedView({ data, theme }: EmbedViewProps) {
 }
 
 interface EmbedErrorViewProps {
-  reason: "not-found" | "server-error" | "network-error";
+  reason: FailReason;
   theme: EmbedTheme;
 }
 
+/**
+ * Compact, navigation-free error state for the embed. It never renders
+ * login/retry links — a link inside a partner's iframe would either dead-end
+ * or hijack their frame. Revoked/expired shares surface here, which is how the
+ * embed "dies" when the link does.
+ */
 export function EmbedErrorView({ reason, theme }: EmbedErrorViewProps) {
-  const message =
-    reason === "not-found"
-      ? "Conversation not found."
-      : reason === "network-error"
-        ? "Could not reach the server."
-        : "Could not load conversation. Please try again later.";
+  // Exhaustive switch (not a ternary chain) so a future `FailReason` fails the
+  // build here instead of silently rendering the generic message.
+  let message: string;
+  switch (reason) {
+    // The embed is navigation-free (no in-frame login), so both auth reasons
+    // resolve to explanatory copy rather than a CTA — but they stay DISTINCT so a
+    // signed-in wrong-org viewer isn't told to "sign in" (#4690).
+    case "login-required":
+      message = "This conversation is shared within an organization. Sign in to Atlas to view it.";
+      break;
+    case "membership-required":
+      message =
+        "This conversation is shared within an organization you’re not a member of. Open it in Atlas with an account that has access.";
+      break;
+    case "expired":
+      message = "This conversation share link has expired.";
+      break;
+    case "not-found":
+      message = "Conversation not found.";
+      break;
+    case "network-error":
+      message = "Could not reach the server.";
+      break;
+    case "server-error":
+      message = "Could not load conversation. Please try again later.";
+      break;
+    default:
+      reason satisfies never;
+      message = "Could not load conversation. Please try again later.";
+  }
 
   return (
     <EmbedShell theme={theme}>

--- a/packages/web/src/app/shared/[token]/error-content.ts
+++ b/packages/web/src/app/shared/[token]/error-content.ts
@@ -1,10 +1,12 @@
 // Pure resolver mapping a shared-conversation fetch failure to the standalone
 // page's error-shell content (heading, message, and which actions to offer) —
 // mirror of the dashboard's `dashboard/[token]/error-content.ts` (#4719). The
-// copy is conversation-specific; the CTA policy it feeds (`login-required` and
-// only it gets the login redirect, #4690) is enforced by the shared
-// `ErrorShell` (`../error-shell.tsx`). The embed surface (`embed/view.tsx`)
-// keeps its own navigation-free copy and does not consume this.
+// copy is conversation-specific; the CTA policy (`login-required` and only it
+// gets the login redirect, #4690) is DECIDED here and pinned by
+// `__tests__/error-content.test.ts` — the shared `ErrorShell`
+// (`../error-shell.tsx`) only renders the chosen action. The embed surface
+// (`embed/view.tsx`) keeps its own navigation-free copy and does not consume
+// this.
 
 import type { FailReason } from "./share-result";
 import type { ErrorContent } from "../error-shell";

--- a/packages/web/src/app/shared/[token]/error-content.ts
+++ b/packages/web/src/app/shared/[token]/error-content.ts
@@ -1,0 +1,80 @@
+// Pure resolver mapping a shared-conversation fetch failure to the standalone
+// page's error-shell content (heading, message, and which actions to offer) —
+// mirror of the dashboard's `dashboard/[token]/error-content.ts` (#4719). The
+// copy is conversation-specific; the CTA policy it feeds (`login-required` and
+// only it gets the login redirect, #4690) is enforced by the shared
+// `ErrorShell` (`../error-shell.tsx`). The embed surface (`embed/view.tsx`)
+// keeps its own navigation-free copy and does not consume this.
+
+import type { FailReason } from "./share-result";
+import type { ErrorContent } from "../error-shell";
+
+export type { ErrorContent, PrimaryAction } from "../error-shell";
+
+/**
+ * Resolve the error shell's content for a failed shared-conversation fetch.
+ *
+ * The `login-required` / `membership-required` split is the crux of #4690: a
+ * logged-in viewer who is not a member of the sharing org is told about the
+ * membership requirement and pointed at Atlas, NOT dead-ended on a "Log in" CTA
+ * they already satisfy. A viewer with no session still gets the login redirect.
+ */
+export function resolveConversationErrorContent(reason: FailReason): ErrorContent {
+  switch (reason) {
+    case "login-required":
+      return {
+        heading: "Sign in to view this conversation",
+        message:
+          "This conversation is shared within an organization. Sign in with an account in that organization to view it.",
+        primaryAction: "login",
+        showTryAgain: false,
+      };
+    case "membership-required":
+      return {
+        heading: "You don’t have access to this conversation",
+        message:
+          "This conversation is shared within an organization you’re not a member of. Ask the owner to share it with you, or switch to an account in that organization.",
+        primaryAction: "home",
+        showTryAgain: false,
+      };
+    case "expired":
+      return {
+        heading: "Conversation link expired",
+        message: "This share link has expired. Ask the conversation owner to create a new one.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+    case "not-found":
+      return {
+        heading: "Conversation not found",
+        message: "This conversation may have been removed or the link may be invalid.",
+        primaryAction: "home",
+        showTryAgain: false,
+      };
+    case "network-error":
+      return {
+        heading: "Connection failed",
+        message: "Could not reach the server. Check your connection and try again.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+    case "server-error":
+      return {
+        heading: "Unable to load conversation",
+        message:
+          "Something went wrong on our end loading this conversation. Please try again in a moment.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+    default:
+      // Exhaustiveness: a future `FailReason` fails the build here rather than
+      // silently rendering a generic shell.
+      reason satisfies never;
+      return {
+        heading: "Unable to load conversation",
+        message: "Something went wrong loading this conversation. Please try again in a moment.",
+        primaryAction: "home",
+        showTryAgain: true,
+      };
+  }
+}

--- a/packages/web/src/app/shared/[token]/fetch.ts
+++ b/packages/web/src/app/shared/[token]/fetch.ts
@@ -13,6 +13,7 @@
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
 import { getApiBaseUrl } from "../lib";
+import { redactShareToken } from "../share-result";
 import { buildForwardHeaders, hashShareToken } from "../server-share";
 import { mapSharedConversationResponse } from "./share-result";
 import type { ConversationFetchResult } from "./share-result";
@@ -24,14 +25,17 @@ export { buildForwardHeaders, hashShareToken };
 export async function fetchSharedConversationRaw(
   token: string,
 ): Promise<ConversationFetchResult> {
-  try {
-    const [cookieStore, headerStore] = await Promise.all([cookies(), headers()]);
-    const forwardHeaders = buildForwardHeaders({
-      cookie: cookieStore.toString() || null,
-      forwardedFor: headerStore.get("x-forwarded-for"),
-      realIp: headerStore.get("x-real-ip"),
-    });
+  // Header collection stays OUTSIDE the try: a throw from `cookies()`/
+  // `headers()` is a request-scope programming error, not the viewer's
+  // connection — surfacing it beats misreporting it as `network-error`.
+  const [cookieStore, headerStore] = await Promise.all([cookies(), headers()]);
+  const forwardHeaders = buildForwardHeaders({
+    cookie: cookieStore.toString() || null,
+    forwardedFor: headerStore.get("x-forwarded-for"),
+    realIp: headerStore.get("x-real-ip"),
+  });
 
+  try {
     const res = await fetch(
       `${getApiBaseUrl()}/api/public/conversations/${encodeURIComponent(token)}`,
       // No cache — a revoked or expired share link must die immediately (the
@@ -44,7 +48,9 @@ export async function fetchSharedConversationRaw(
   } catch (err) {
     console.error(
       `[shared-conversation] Failed to fetch tokenHash=${hashShareToken(token)}:`,
-      err instanceof Error ? err.message : String(err),
+      // A thrown fetch can echo the request URL — token included — in its
+      // message; redact it so the #4317 hash-only discipline holds here too.
+      redactShareToken(err instanceof Error ? err.message : String(err), token),
     );
     return { ok: false, reason: "network-error" };
   }

--- a/packages/web/src/app/shared/[token]/fetch.ts
+++ b/packages/web/src/app/shared/[token]/fetch.ts
@@ -1,0 +1,58 @@
+// Server-only data fetch for the shared conversation surface (#4719) —
+// mirror of the dashboard's `dashboard/[token]/fetch.ts`. Kept in its own
+// module (not in `../lib.ts`) so the header-forwarding + token-hashing logic
+// is unit-testable without rendering the RSC, and so `generateMetadata` and
+// the page component share a SINGLE, de-duplicated fetch per view.
+//
+// The response→result mapping (status codes, #4690 auth-reason split) lives in
+// `share-result.ts`, shared verbatim with the client-side org-share resolution
+// (`org-share-client.ts`) so the SSR and client paths can never drift. This
+// module is SERVER-ONLY (`next/headers` + `node:crypto` via `../server-share`);
+// client code imports the mapping/types from `share-result.ts`, never from here.
+
+import { cache } from "react";
+import { cookies, headers } from "next/headers";
+import { getApiBaseUrl } from "../lib";
+import { buildForwardHeaders, hashShareToken } from "../server-share";
+import { mapSharedConversationResponse } from "./share-result";
+import type { ConversationFetchResult } from "./share-result";
+
+export { buildForwardHeaders, hashShareToken };
+
+/** Uncached fetch. Exported for unit tests; production callers use the
+ *  `cache()`-wrapped {@link fetchSharedConversation} so the fetch runs once. */
+export async function fetchSharedConversationRaw(
+  token: string,
+): Promise<ConversationFetchResult> {
+  try {
+    const [cookieStore, headerStore] = await Promise.all([cookies(), headers()]);
+    const forwardHeaders = buildForwardHeaders({
+      cookie: cookieStore.toString() || null,
+      forwardedFor: headerStore.get("x-forwarded-for"),
+      realIp: headerStore.get("x-real-ip"),
+    });
+
+    const res = await fetch(
+      `${getApiBaseUrl()}/api/public/conversations/${encodeURIComponent(token)}`,
+      // No cache — a revoked or expired share link must die immediately (the
+      // old `next: { revalidate: 60 }` kept serving it for up to a minute).
+      // The forwarded cookie/IP are per-viewer, so a shared cache would be
+      // incorrect regardless. Intra-render dedup is `cache()`'s job below.
+      { cache: "no-store", headers: forwardHeaders },
+    );
+    return await mapSharedConversationResponse(res, hashShareToken(token));
+  } catch (err) {
+    console.error(
+      `[shared-conversation] Failed to fetch tokenHash=${hashShareToken(token)}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, reason: "network-error" };
+  }
+}
+
+/**
+ * Fetch the shared conversation ONCE per view. `cache()` de-duplicates the
+ * call across `generateMetadata` and the page render within a single request,
+ * so dropping the old `revalidate: 60` doesn't reintroduce a double fetch.
+ */
+export const fetchSharedConversation = cache(fetchSharedConversationRaw);

--- a/packages/web/src/app/shared/[token]/org-share-client.ts
+++ b/packages/web/src/app/shared/[token]/org-share-client.ts
@@ -1,0 +1,33 @@
+// Client-side resolution of an ORG-scoped conversation share (#4719) — the
+// conversation surface's binding of the shared resolution machinery in
+// `../org-share-client.ts` (credentialed browser fetch against the
+// client-resolved API base, WebCrypto token fingerprint, never-rejects
+// contract), adopted from the dashboard surface (#4718).
+//
+// This module must stay importable from client components — no `next/headers`,
+// no `node:crypto`.
+
+import { resolveOrgShare } from "../org-share-client";
+import { mapSharedConversationResponse } from "./share-result";
+import type { ConversationFetchResult } from "./share-result";
+
+export { hashShareTokenClient } from "../org-share-client";
+
+/**
+ * Re-resolve an org-scoped conversation share from the browser with the
+ * viewer's real credentials. The response mapping is
+ * `mapSharedConversationResponse`, the exact function the SSR path uses, so
+ * both paths return identical {@link ConversationFetchResult}s for identical
+ * API responses. NEVER rejects — which is what lets `OrgShareResolver` model
+ * resolution as just "in flight | result".
+ */
+export async function resolveOrgShareClient(
+  token: string,
+): Promise<ConversationFetchResult> {
+  return resolveOrgShare({
+    token,
+    publicPath: "/api/public/conversations",
+    logLabel: "[shared-conversation/client]",
+    map: mapSharedConversationResponse,
+  });
+}

--- a/packages/web/src/app/shared/[token]/org-share-resolver.tsx
+++ b/packages/web/src/app/shared/[token]/org-share-resolver.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+// Client half of the org-share auth-wall fix for the shared CONVERSATION
+// surface (#4719), adopting the dashboard pattern (#4718). Mounted by the
+// shared page/embed RSCs ONLY when the SSR fetch hit the auth wall
+// (`login-required` / `membership-required`) — public shares and every other
+// failure keep the pure SSR path unchanged. On mount it re-resolves the share
+// against the API with the viewer's REAL credentials (`org-share-client.ts`)
+// and renders the exact success/error surfaces the SSR path renders, so the
+// two paths are visually indistinguishable. On a same-origin deploy (where the
+// SSR cookie forward already worked) the retry merely reconfirms the SSR
+// verdict; on the SaaS cross-origin topology it is the only fetch that can
+// carry the session at all.
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { ErrorShell } from "../error-shell";
+import { SharedConversationView } from "./view";
+import { resolveConversationErrorContent } from "./error-content";
+import { EmbedView, EmbedErrorView, type EmbedTheme } from "./embed/view";
+import { resolveOrgShareClient } from "./org-share-client";
+import type { ConversationFetchResult } from "./share-result";
+
+export function OrgShareResolver({
+  token,
+  variant = "page",
+  theme = "light",
+}: {
+  token: string;
+  /** "embed" renders the iframe-appropriate, navigation-free surfaces
+   *  (`EmbedView` / `EmbedErrorView`) instead of the standalone page views. */
+  variant?: "page" | "embed";
+  /** Embed-only forced theme, threaded through exactly as the embed RSC
+   *  threads it on the SSR success path (see `embed/view.tsx`). */
+  theme?: EmbedTheme;
+}) {
+  // `null` = resolution in flight. `resolveOrgShareClient` never rejects (it
+  // maps thrown fetches to `network-error`), so no separate error state.
+  const [result, setResult] = useState<ConversationFetchResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    resolveOrgShareClient(token)
+      .then((r) => {
+        if (!cancelled) setResult(r);
+      })
+      .catch((err: unknown) => {
+        // Belt to the never-rejects suspenders above: an unexpected rejection
+        // must surface as an error page, never strand the viewer on the spinner.
+        console.error(
+          "[shared-conversation/client] org-share resolution rejected unexpectedly:",
+          err instanceof Error ? err.message : String(err),
+        );
+        if (!cancelled) setResult({ ok: false, reason: "network-error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (result === null) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-zinc-950 print:bg-white">
+        <div
+          role="status"
+          className="flex items-center gap-2 text-sm text-zinc-500 dark:text-zinc-400"
+        >
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Checking access&hellip;
+        </div>
+      </div>
+    );
+  }
+
+  if (result.ok) {
+    return variant === "embed" ? (
+      <EmbedView data={result.data} theme={theme} />
+    ) : (
+      <SharedConversationView convo={result.data} />
+    );
+  }
+
+  return variant === "embed" ? (
+    <EmbedErrorView reason={result.reason} theme={theme} />
+  ) : (
+    <ErrorShell
+      sharePath={`/shared/${token}`}
+      content={resolveConversationErrorContent(result.reason)}
+    />
+  );
+}

--- a/packages/web/src/app/shared/[token]/page.tsx
+++ b/packages/web/src/app/shared/[token]/page.tsx
@@ -1,13 +1,11 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
-import { buttonVariants } from "@/components/ui/button";
-import { Markdown } from "@/ui/components/chat/markdown";
-import {
-  fetchSharedConversation,
-  extractTextContent,
-  truncate,
-} from "../lib";
+import { extractTextContent, truncate } from "../lib";
+import { ErrorShell } from "../error-shell";
+import { fetchSharedConversation } from "./fetch";
+import { isAuthWallReason } from "./share-result";
+import { resolveConversationErrorContent } from "./error-content";
+import { OrgShareResolver } from "./org-share-resolver";
+import { SharedConversationView } from "./view";
 
 export async function generateMetadata({
   params,
@@ -82,151 +80,24 @@ export default async function SharedConversationPage({
   const result = await fetchSharedConversation(token);
 
   if (!result.ok) {
-    const message =
-      result.reason === "not-found"
-        ? "This conversation may have been removed or the link may be invalid."
-        : result.reason === "network-error"
-          ? "Could not reach the server. Check your connection and try again."
-          : "This conversation may have expired or been deleted. Check the link and try again.";
-    const heading =
-      result.reason === "not-found"
-        ? "Conversation not found"
-        : result.reason === "network-error"
-          ? "Connection failed"
-          : "Unable to load conversation";
+    // The org-share auth wall. Under the SaaS cookie topology (ADR-0024) the
+    // session cookie is host-only on the per-region API domain, so the RSC
+    // fetch's cookie forward is structurally empty cross-origin and this SSR
+    // verdict may be a false negative for a logged-in viewer. Hand off to the
+    // client resolver, which retries with the viewer's browser credentials and
+    // renders the same view — the #4690 login/membership split re-evaluated
+    // against the viewer's REAL session (#4718/#4719). Every other failure
+    // (and the public-share success path) stays pure SSR, unchanged.
+    if (isAuthWallReason(result.reason)) {
+      return <OrgShareResolver token={token} />;
+    }
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
-            {heading}
-          </h1>
-          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{message}</p>
-          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-            <Link href="/" className={buttonVariants()}>
-              Go to Atlas
-            </Link>
-            {result.reason !== "not-found" && (
-              <Link
-                href={`/shared/${token}`}
-                className={buttonVariants({ variant: "outline" })}
-              >
-                Try again
-              </Link>
-            )}
-          </div>
-        </div>
-      </div>
+      <ErrorShell
+        sharePath={`/shared/${token}`}
+        content={resolveConversationErrorContent(result.reason)}
+      />
     );
   }
 
-  const convo = result.data;
-  const renderedMessages = convo.messages
-    .filter((m) => m.role === "user" || m.role === "assistant")
-    .map((msg) => ({ msg, text: extractTextContent(msg.content) }))
-    .filter(({ text }) => text.trim().length > 0);
-  const hiddenStepCount = convo.messages.length - renderedMessages.length;
-
-  const formattedDate = new Date(convo.createdAt).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-
-  return (
-    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
-      <main id="main" tabIndex={-1} className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 focus:outline-none print:p-0">
-        <header className="mb-6 border-b border-zinc-200 pb-4 dark:border-zinc-800 print:border-zinc-300">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex flex-wrap items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
-              <span className="font-medium text-zinc-900 dark:text-zinc-100">
-                Atlas
-              </span>
-              <span aria-hidden="true">&middot;</span>
-              <span
-                className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 print:bg-transparent print:px-0"
-                aria-label="This is a read-only snapshot"
-              >
-                Read-only
-              </span>
-              <span aria-hidden="true">&middot;</span>
-              <time dateTime={convo.createdAt}>Captured {formattedDate}</time>
-            </div>
-            <Link
-              href="/signup"
-              className="inline-flex items-center gap-1 text-sm font-medium text-teal-700 transition-colors hover:text-teal-800 dark:text-teal-300 dark:hover:text-teal-200 print:hidden"
-            >
-              Try Atlas free
-              <ArrowUpRight className="h-3.5 w-3.5" />
-            </Link>
-          </div>
-          {convo.title && (
-            <h1 className="mt-3 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
-              {convo.title}
-            </h1>
-          )}
-        </header>
-
-        {renderedMessages.length === 0 ? (
-          <p className="text-sm text-zinc-600 dark:text-zinc-400">
-            This conversation has no readable content.
-          </p>
-        ) : (
-          <div className="space-y-6">
-            {renderedMessages.map(({ msg, text }, i) => {
-              const isUser = msg.role === "user";
-              return (
-                <article
-                  key={i}
-                  className="space-y-1.5 print:break-inside-avoid"
-                  aria-label={isUser ? "User message" : "Atlas response"}
-                >
-                  <p
-                    className={`text-[10px] font-semibold uppercase tracking-wider ${
-                      isUser
-                        ? "text-zinc-500 dark:text-zinc-400"
-                        : "text-teal-700 dark:text-teal-300"
-                    }`}
-                  >
-                    {isUser ? "User" : "Atlas"}
-                  </p>
-                  {isUser ? (
-                    <p className="whitespace-pre-wrap text-zinc-900 dark:text-zinc-100">
-                      {text}
-                    </p>
-                  ) : (
-                    <div className="text-zinc-900 dark:text-zinc-100">
-                      {/* disallowImages (#3342 L-7): unauthenticated public surface — block
-                          LLM-markdown tracking pixels / viewer-IP leaks. */}
-                      <Markdown content={text} disallowImages />
-                    </div>
-                  )}
-                </article>
-              );
-            })}
-          </div>
-        )}
-
-        {hiddenStepCount > 0 && (
-          <p className="mt-8 border-t border-zinc-200 pt-4 text-xs text-zinc-600 dark:border-zinc-800 dark:text-zinc-400 print:hidden">
-            {hiddenStepCount} analysis step{hiddenStepCount === 1 ? "" : "s"} not shown.{" "}
-            <Link href="/signup" className="text-teal-700 hover:underline dark:text-teal-300">
-              View the full conversation in Atlas
-              <ArrowUpRight className="ml-0.5 inline h-3 w-3" aria-hidden="true" />
-            </Link>
-          </p>
-        )}
-      </main>
-
-      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
-        <a
-          href="https://www.useatlas.dev"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
-        >
-          Powered by Atlas
-        </a>
-      </footer>
-    </div>
-  );
+  return <SharedConversationView convo={result.data} />;
 }

--- a/packages/web/src/app/shared/[token]/share-result.ts
+++ b/packages/web/src/app/shared/[token]/share-result.ts
@@ -11,7 +11,7 @@ import {
   type ShareBodyValidation,
   type ShareFetchResult,
 } from "../share-result";
-import type { SharedConversation } from "../lib";
+import type { SharedConversation, SharedMessage } from "../lib";
 
 // The resource-agnostic reason vocabulary + auth-wall helpers, re-exported so
 // this surface's consumers keep one import site.
@@ -28,19 +28,38 @@ export type ConversationFetchResult = ShareFetchResult<SharedConversation>;
  * Structural validation of the public-conversation body. Unlike the dashboard
  * surface there is no wire schema in `@useatlas/schemas` for this projection
  * (the `SharedConversation` type lives here in web, and `messages[].content`
- * is deliberately opaque AI-SDK content) — so this keeps the surface's
- * long-standing structural contract: an object carrying a `messages` array.
- * `detail` never carries response values (they are the conversation's data).
+ * is deliberately opaque AI-SDK content) — so the envelope and each message
+ * are checked field-by-field and the result is CONSTRUCTED, never cast: a
+ * malformed body (e.g. `messages: [null]`) maps to the diagnosable
+ * `server-error` path instead of crashing the view. `detail` carries field
+ * names only, never response values (they are the conversation's data).
  */
 function validateSharedConversation(raw: unknown): ShareBodyValidation<SharedConversation> {
-  if (
-    !raw ||
-    typeof raw !== "object" ||
-    !Array.isArray((raw as { messages?: unknown }).messages)
-  ) {
-    return { ok: false, detail: "missing messages array" };
+  if (!raw || typeof raw !== "object") return { ok: false, detail: "body is not an object" };
+  const { title, surface, createdAt, messages } = raw as Record<string, unknown>;
+  if (title !== null && typeof title !== "string") {
+    return { ok: false, detail: "title is not a string or null" };
   }
-  return { ok: true, data: raw as SharedConversation };
+  if (typeof surface !== "string") return { ok: false, detail: "surface is not a string" };
+  if (typeof createdAt !== "string") return { ok: false, detail: "createdAt is not a string" };
+  if (!Array.isArray(messages)) return { ok: false, detail: "missing messages array" };
+  const parsedMessages: SharedMessage[] = [];
+  for (const [i, m] of messages.entries()) {
+    if (!m || typeof m !== "object") {
+      return { ok: false, detail: `messages[${i}] is not an object` };
+    }
+    const msg = m as Record<string, unknown>;
+    if (typeof msg.role !== "string") {
+      return { ok: false, detail: `messages[${i}].role is not a string` };
+    }
+    if (typeof msg.createdAt !== "string") {
+      return { ok: false, detail: `messages[${i}].createdAt is not a string` };
+    }
+    // `content` is deliberately opaque (`unknown`) — the views' extractors
+    // tolerate any shape.
+    parsedMessages.push({ role: msg.role, content: msg.content, createdAt: msg.createdAt });
+  }
+  return { ok: true, data: { title, surface, createdAt, messages: parsedMessages } };
 }
 
 /**

--- a/packages/web/src/app/shared/[token]/share-result.ts
+++ b/packages/web/src/app/shared/[token]/share-result.ts
@@ -1,0 +1,60 @@
+// Universal (server + client) response mapping for the shared-conversation
+// fetch (#4719) — the conversation surface's binding of the resource-agnostic
+// core in `../share-result.ts` (status mapping, #4690 auth-reason split,
+// totality), shared verbatim by the SSR fetch (`fetch.ts`) and the client-side
+// org-share resolution (`org-share-client.ts`) so the two paths can never
+// drift. Must stay importable from client components: no server-only imports
+// (`next/headers`, `node:crypto`) may ever land here.
+
+import {
+  mapSharedResponse,
+  type ShareBodyValidation,
+  type ShareFetchResult,
+} from "../share-result";
+import type { SharedConversation } from "../lib";
+
+// The resource-agnostic reason vocabulary + auth-wall helpers, re-exported so
+// this surface's consumers keep one import site.
+export {
+  isAuthWallReason,
+  resolveAuthReason,
+  type AuthWallReason,
+  type FailReason,
+} from "../share-result";
+
+export type ConversationFetchResult = ShareFetchResult<SharedConversation>;
+
+/**
+ * Structural validation of the public-conversation body. Unlike the dashboard
+ * surface there is no wire schema in `@useatlas/schemas` for this projection
+ * (the `SharedConversation` type lives here in web, and `messages[].content`
+ * is deliberately opaque AI-SDK content) — so this keeps the surface's
+ * long-standing structural contract: an object carrying a `messages` array.
+ * `detail` never carries response values (they are the conversation's data).
+ */
+function validateSharedConversation(raw: unknown): ShareBodyValidation<SharedConversation> {
+  if (
+    !raw ||
+    typeof raw !== "object" ||
+    !Array.isArray((raw as { messages?: unknown }).messages)
+  ) {
+    return { ok: false, detail: "missing messages array" };
+  }
+  return { ok: true, data: raw as SharedConversation };
+}
+
+/**
+ * Map a public-conversation API response to a {@link ConversationFetchResult}.
+ * TOTAL over its inputs (see `mapSharedResponse`) — `OrgShareResolver`'s
+ * two-state model relies on it never rejecting.
+ *
+ * `tokenHash` is the caller's pre-computed share-token fingerprint — log lines
+ * carry it, NEVER the cleartext token (#4317).
+ */
+export async function mapSharedConversationResponse(
+  res: Response,
+  tokenHash: string,
+  logLabel = "[shared-conversation]",
+): Promise<ConversationFetchResult> {
+  return mapSharedResponse(res, tokenHash, logLabel, validateSharedConversation);
+}

--- a/packages/web/src/app/shared/[token]/view.tsx
+++ b/packages/web/src/app/shared/[token]/view.tsx
@@ -1,0 +1,122 @@
+// The standalone shared-conversation success view. Extracted from `page.tsx`
+// (#4719) so the org-share resolver (`org-share-resolver.tsx`) can render the
+// EXACT surface the SSR path renders after resolving an org share client-side
+// — the two paths are visually indistinguishable. Client-safe by design: no
+// server-only imports may land here.
+
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import { Markdown } from "@/ui/components/chat/markdown";
+import { type SharedConversation, extractTextContent } from "../lib";
+
+export function SharedConversationView({ convo }: { convo: SharedConversation }) {
+  const renderedMessages = convo.messages
+    .filter((m) => m.role === "user" || m.role === "assistant")
+    .map((msg) => ({ msg, text: extractTextContent(msg.content) }))
+    .filter(({ text }) => text.trim().length > 0);
+  const hiddenStepCount = convo.messages.length - renderedMessages.length;
+
+  const formattedDate = new Date(convo.createdAt).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
+      <main id="main" tabIndex={-1} className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 focus:outline-none print:p-0">
+        <header className="mb-6 border-b border-zinc-200 pb-4 dark:border-zinc-800 print:border-zinc-300">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+              <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                Atlas
+              </span>
+              <span aria-hidden="true">&middot;</span>
+              <span
+                className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 print:bg-transparent print:px-0"
+                aria-label="This is a read-only snapshot"
+              >
+                Read-only
+              </span>
+              <span aria-hidden="true">&middot;</span>
+              <time dateTime={convo.createdAt}>Captured {formattedDate}</time>
+            </div>
+            <Link
+              href="/signup"
+              className="inline-flex items-center gap-1 text-sm font-medium text-teal-700 transition-colors hover:text-teal-800 dark:text-teal-300 dark:hover:text-teal-200 print:hidden"
+            >
+              Try Atlas free
+              <ArrowUpRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
+          {convo.title && (
+            <h1 className="mt-3 text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+              {convo.title}
+            </h1>
+          )}
+        </header>
+
+        {renderedMessages.length === 0 ? (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            This conversation has no readable content.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {renderedMessages.map(({ msg, text }, i) => {
+              const isUser = msg.role === "user";
+              return (
+                <article
+                  key={i}
+                  className="space-y-1.5 print:break-inside-avoid"
+                  aria-label={isUser ? "User message" : "Atlas response"}
+                >
+                  <p
+                    className={`text-[10px] font-semibold uppercase tracking-wider ${
+                      isUser
+                        ? "text-zinc-500 dark:text-zinc-400"
+                        : "text-teal-700 dark:text-teal-300"
+                    }`}
+                  >
+                    {isUser ? "User" : "Atlas"}
+                  </p>
+                  {isUser ? (
+                    <p className="whitespace-pre-wrap text-zinc-900 dark:text-zinc-100">
+                      {text}
+                    </p>
+                  ) : (
+                    <div className="text-zinc-900 dark:text-zinc-100">
+                      {/* disallowImages (#3342 L-7): unauthenticated public surface — block
+                          LLM-markdown tracking pixels / viewer-IP leaks. */}
+                      <Markdown content={text} disallowImages />
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+
+        {hiddenStepCount > 0 && (
+          <p className="mt-8 border-t border-zinc-200 pt-4 text-xs text-zinc-600 dark:border-zinc-800 dark:text-zinc-400 print:hidden">
+            {hiddenStepCount} analysis step{hiddenStepCount === 1 ? "" : "s"} not shown.{" "}
+            <Link href="/signup" className="text-teal-700 hover:underline dark:text-teal-300">
+              View the full conversation in Atlas
+              <ArrowUpRight className="ml-0.5 inline h-3 w-3" aria-hidden="true" />
+            </Link>
+          </p>
+        )}
+      </main>
+
+      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
+        <a
+          href="https://www.useatlas.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-zinc-500 transition-colors hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          Powered by Atlas
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/fetch.test.ts
@@ -8,6 +8,7 @@ let mockHeaders: Record<string, string> = {};
 void mock.module("next/headers", () => ({
   cookies: async () => ({ toString: () => mockCookie }),
   headers: async () => ({ get: (k: string) => mockHeaders[k.toLowerCase()] ?? null }),
+  draftMode: async () => ({ isEnabled: false }),
 }));
 
 import {

--- a/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/embed/page.tsx
@@ -71,7 +71,7 @@ export default async function SharedDashboardEmbedPage({ params, searchParams }:
         ) : isAuthWallReason(result.reason) ? (
           // Same client-side org-share hand-off as the standalone page (#4718).
           // Scope caveat: the session cookie is host-only AND SameSite=Lax
-          // (ADR-0024 §5), so the credentialed retry only helps when the embed
+          // (ADR-0024, Decision), so the credentialed retry only helps when the embed
           // is framed same-site (e.g. inside Atlas itself). In a third-party
           // iframe the browser withholds the cookie and the resolver lands on
           // the same navigation-free auth copy as before — the intended

--- a/packages/web/src/app/shared/dashboard/[token]/error-content.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/error-content.ts
@@ -6,24 +6,11 @@
 // navigation-free copy and does not consume this.
 
 import type { FailReason } from "./share-result";
+import type { ErrorContent } from "../../error-shell";
 
-/** Which primary CTA the error shell offers. */
-export type PrimaryAction =
-  // Login redirect back to the shared view — ONLY for `login-required`, where the
-  // viewer genuinely has no session. Never for `membership-required`.
-  | "login"
-  // Neutral "Go to Atlas" home link — the safe default for every other reason,
-  // including the signed-in wrong-org viewer.
-  | "home";
-
-export interface ErrorContent {
-  readonly heading: string;
-  readonly message: string;
-  readonly primaryAction: PrimaryAction;
-  /** Whether to also offer the "Try again" outline link — for non-terminal
-   *  failures (expired, network-error, server-error), not not-found or the auth wall. */
-  readonly showTryAgain: boolean;
-}
+// The content/CTA shape lives with the shared `ErrorShell` (`../../error-shell`,
+// #4719); re-exported so this surface's consumers keep one import site.
+export type { ErrorContent, PrimaryAction } from "../../error-shell";
 
 /**
  * Resolve the error shell's content for a failed shared-dashboard fetch.

--- a/packages/web/src/app/shared/dashboard/[token]/error-shell.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/error-shell.tsx
@@ -1,57 +1,13 @@
-// The standalone shared-dashboard error state. Extracted from `page.tsx` so the
-// CTA → href wiring is render-testable without invoking the async page RSC — in
-// particular the #4690 acceptance criterion that `login-required` (and only it)
-// produces the login redirect back to the shared view, while every other reason
-// offers the neutral "Go to Atlas" home link. Copy + which actions to show come
-// from `resolveErrorContent` (`error-content.ts`); this component only renders them.
+// The standalone shared-dashboard error state. The shell itself (layout + the
+// #4690 CTA policy: `login-required` and only it produces the login redirect
+// back to the shared view) is shared with the conversation surface via
+// `../../error-shell.tsx` (#4719); this wrapper binds it to the dashboard
+// share path. Copy + which actions to show come from `resolveErrorContent`
+// (`error-content.ts`).
 
-import Link from "next/link";
-import { buttonVariants } from "@/components/ui/button";
+import { ErrorShell as SharedErrorShell } from "../../error-shell";
 import type { ErrorContent } from "./error-content";
 
 export function ErrorShell({ token, content }: { token: string; content: ErrorContent }) {
-  return (
-    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
-      <main
-        id="main"
-        tabIndex={-1}
-        className="flex flex-1 items-center justify-center px-4 focus:outline-none"
-      >
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{content.heading}</h1>
-          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{content.message}</p>
-          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-            {content.primaryAction === "login" ? (
-              <Link
-                href={`/login?redirect=${encodeURIComponent(`/shared/dashboard/${token}`)}`}
-                className={buttonVariants()}
-              >
-                Log in
-              </Link>
-            ) : (
-              <Link href="/" className={buttonVariants()}>Go to Atlas</Link>
-            )}
-            {content.showTryAgain && (
-              <Link
-                href={`/shared/dashboard/${token}`}
-                className={buttonVariants({ variant: "outline" })}
-              >
-                Try again
-              </Link>
-            )}
-          </div>
-        </div>
-      </main>
-      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
-        <a
-          href="https://www.useatlas.dev"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
-        >
-          Powered by Atlas
-        </a>
-      </footer>
-    </div>
-  );
+  return <SharedErrorShell sharePath={`/shared/dashboard/${token}`} content={content} />;
 }

--- a/packages/web/src/app/shared/dashboard/[token]/fetch.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/fetch.ts
@@ -6,56 +6,21 @@
 // The response→result mapping (status codes, #4690 auth-reason split, schema
 // validation) lives in `share-result.ts`, shared verbatim with the client-side
 // org-share resolution (`org-share-client.ts`, #4718) so the SSR and client
-// paths can never drift. This module is SERVER-ONLY (it imports `next/headers`
-// + `node:crypto`) and adds the server-side concerns: header forwarding, the
-// `node:crypto` token hash, and the `cache()`-deduped fetch itself. Client
-// code imports the mapping/types from `share-result.ts`, never from here.
+// paths can never drift. The server-side concerns — viewer header forwarding
+// and the `node:crypto` token hash — live in `../../server-share.ts`, shared
+// with the conversation surface's fetch (#4719) and re-exported here for this
+// surface's consumers/tests. This module is SERVER-ONLY (it imports
+// `next/headers` via itself and `node:crypto` via `server-share`). Client code
+// imports the mapping/types from `share-result.ts`, never from here.
 
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
-import { createHash } from "node:crypto";
 import { getApiBaseUrl } from "../../lib";
+import { buildForwardHeaders, hashShareToken } from "../../server-share";
 import { mapSharedDashboardResponse } from "./share-result";
 import type { FetchResult } from "./share-result";
 
-/**
- * Short, non-reversible fingerprint of a share token for log correlation.
- * Share tokens are bearer credentials — logs on this surface must carry this
- * hash, NEVER the cleartext token (#4317). Algorithm-mirror of the API's
- * `hashShareToken` (first 16 hex of SHA-256); duplicated because the web
- * package cannot import from `@atlas/api`. The API copy additionally guards
- * against non-string input — omitted here since callers always pass the
- * route's `token` string param. (`org-share-client.ts` carries the WebCrypto
- * mirror for the browser, where `node:crypto` doesn't exist.)
- */
-export function hashShareToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex").slice(0, 16);
-}
-
-/**
- * Build the headers the shared page forwards to the public dashboard API:
- *   - `cookie`: the viewer's session so ORG-scoped shares authenticate the
- *     viewer on a SAME-ORIGIN deploy. Under the SaaS cookie topology (ADR-0024)
- *     the session cookie is host-only on the per-region API domain, so this jar
- *     is structurally empty cross-origin — the auth wall then hands off to the
- *     client-side resolver, which carries the viewer's real session (#4718).
- *   - `x-forwarded-for`: the viewer's REAL client IP so the API rate-limits per
- *     viewer, not per web-server IP (effective only when the API trusts the
- *     proxy header via `ATLAS_TRUST_PROXY`; otherwise `getClientIP` ignores it
- *     and all viewers share the anonymous ceiling — see F-73).
- * Pure + exported for unit tests. (#4317)
- */
-export function buildForwardHeaders(input: {
-  cookie: string | null;
-  forwardedFor: string | null;
-  realIp: string | null;
-}): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (input.cookie) out.cookie = input.cookie;
-  const viewerIp = input.forwardedFor ?? input.realIp;
-  if (viewerIp) out["x-forwarded-for"] = viewerIp;
-  return out;
-}
+export { buildForwardHeaders, hashShareToken };
 
 /** Uncached fetch. Exported for unit tests; production callers use the
  *  `cache()`-wrapped {@link fetchSharedDashboard} so the fetch runs once. */

--- a/packages/web/src/app/shared/dashboard/[token]/fetch.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/fetch.ts
@@ -10,12 +10,13 @@
 // and the `node:crypto` token hash — live in `../../server-share.ts`, shared
 // with the conversation surface's fetch (#4719) and re-exported here for this
 // surface's consumers/tests. This module is SERVER-ONLY (it imports
-// `next/headers` via itself and `node:crypto` via `server-share`). Client code
-// imports the mapping/types from `share-result.ts`, never from here.
+// `next/headers` directly and `node:crypto` via `../../server-share`). Client
+// code imports the mapping/types from `share-result.ts`, never from here.
 
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
 import { getApiBaseUrl } from "../../lib";
+import { redactShareToken } from "../../share-result";
 import { buildForwardHeaders, hashShareToken } from "../../server-share";
 import { mapSharedDashboardResponse } from "./share-result";
 import type { FetchResult } from "./share-result";
@@ -25,14 +26,17 @@ export { buildForwardHeaders, hashShareToken };
 /** Uncached fetch. Exported for unit tests; production callers use the
  *  `cache()`-wrapped {@link fetchSharedDashboard} so the fetch runs once. */
 export async function fetchSharedDashboardRaw(token: string): Promise<FetchResult> {
-  try {
-    const [cookieStore, headerStore] = await Promise.all([cookies(), headers()]);
-    const forwardHeaders = buildForwardHeaders({
-      cookie: cookieStore.toString() || null,
-      forwardedFor: headerStore.get("x-forwarded-for"),
-      realIp: headerStore.get("x-real-ip"),
-    });
+  // Header collection stays OUTSIDE the try: a throw from `cookies()`/
+  // `headers()` is a request-scope programming error, not the viewer's
+  // connection — surfacing it beats misreporting it as `network-error`.
+  const [cookieStore, headerStore] = await Promise.all([cookies(), headers()]);
+  const forwardHeaders = buildForwardHeaders({
+    cookie: cookieStore.toString() || null,
+    forwardedFor: headerStore.get("x-forwarded-for"),
+    realIp: headerStore.get("x-real-ip"),
+  });
 
+  try {
     const res = await fetch(
       `${getApiBaseUrl()}/api/public/dashboards/${encodeURIComponent(token)}`,
       // No cache — dashboard data may be sensitive and revoked links must die
@@ -44,7 +48,9 @@ export async function fetchSharedDashboardRaw(token: string): Promise<FetchResul
   } catch (err) {
     console.error(
       `[shared-dashboard] Failed to fetch tokenHash=${hashShareToken(token)}:`,
-      err instanceof Error ? err.message : String(err),
+      // A thrown fetch can echo the request URL — token included — in its
+      // message; redact it so the #4317 hash-only discipline holds here too.
+      redactShareToken(err instanceof Error ? err.message : String(err), token),
     );
     return { ok: false, reason: "network-error" };
   }

--- a/packages/web/src/app/shared/dashboard/[token]/org-share-client.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/org-share-client.ts
@@ -1,76 +1,30 @@
-// Client-side resolution of an ORG-scoped dashboard share (#4718).
-//
-// Under ADR-0024 the SaaS session cookie is host-only on the per-region API
-// domain — the browser never sends it to the web origin, so the RSC forward in
-// `fetch.ts` is structurally empty cross-origin and every org share hit the
-// auth wall regardless of the viewer's real session. When SSR lands on that
-// wall, the page mounts `OrgShareResolver`, which calls this module: a browser
-// fetch with credentials (the same pattern the dashboard share-status fetch in
-// `(workspace)/dashboards/[id]/share-dialog.tsx` uses), so the API sees the
-// viewer's REAL session and the login-required / membership-required split
-// (#4690) is evaluated truthfully. A client fetch is inherently per-viewer, so
-// the SSR path's `x-forwarded-for` rate-limit forwarding has no analogue here.
+// Client-side resolution of an ORG-scoped dashboard share (#4718). The
+// resolution machinery (credentialed browser fetch against the client-resolved
+// API base, WebCrypto token fingerprint, never-rejects contract) lives in
+// `../../org-share-client.ts`, shared with the conversation surface (#4719);
+// this module binds it to the dashboard's public API path and response mapper.
 //
 // This module must stay importable from client components — no `next/headers`,
-// no `node:crypto`. The shared-conversation parity issue (#4719) is expected
-// to adopt this same resolution pattern.
+// no `node:crypto`.
 
-import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { resolveOrgShare } from "../../org-share-client";
 import { mapSharedDashboardResponse } from "./share-result";
 import type { FetchResult } from "./share-result";
 
-const LOG_LABEL = "[shared-dashboard/client]";
+export { hashShareTokenClient } from "../../org-share-client";
 
 /**
- * Browser-safe mirror of `hashShareToken` (`fetch.ts`, itself mirroring the
- * API's copy): first 16 hex of SHA-256 — async because WebCrypto is. Log lines
- * on this surface carry this fingerprint, NEVER the cleartext token (#4317).
- * Returns a fixed placeholder when WebCrypto is unavailable (insecure-context
- * browsers): an unfingerprinted log line beats logging a bearer credential.
- */
-export async function hashShareTokenClient(token: string): Promise<string> {
-  const subtle = globalThis.crypto?.subtle;
-  if (!subtle) return "unavailable(insecure-context)";
-  const digest = await subtle.digest("SHA-256", new TextEncoder().encode(token));
-  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0"))
-    .join("")
-    .slice(0, 16);
-}
-
-/**
- * Re-resolve an org-scoped share from the browser with the viewer's real
- * credentials. Targets the client-resolved API base (`@/lib/api-url` — the
- * regional override when an `atlas_region` signal is active, else the
- * build-time default; empty string → same-origin relative fetch on
- * self-hosted). The response mapping is `mapSharedDashboardResponse`, the
+ * Re-resolve an org-scoped dashboard share from the browser with the viewer's
+ * real credentials. The response mapping is `mapSharedDashboardResponse`, the
  * exact function the SSR path uses, so both paths return identical
- * {@link FetchResult}s for identical API responses.
- *
- * NEVER rejects — thrown fetches map to `network-error` — which is what lets
- * `OrgShareResolver` model resolution as just "in flight | FetchResult".
+ * {@link FetchResult}s for identical API responses. NEVER rejects — which is
+ * what lets `OrgShareResolver` model resolution as just "in flight | FetchResult".
  */
 export async function resolveOrgShareClient(token: string): Promise<FetchResult> {
-  // Fingerprint once, up front, so the catch below can never itself throw
-  // (a rejecting `subtle.digest` in an exotic iframe context must not mask the
-  // real fetch error or break the never-rejects contract).
-  const tokenHash = await hashShareTokenClient(token).catch(
-    // intentionally ignored: a failed fingerprint must never block resolving
-    // the share; the placeholder is the documented degraded mode.
-    () => "unavailable(hash-failed)",
-  );
-  try {
-    const res = await fetch(`${getApiUrl()}/api/public/dashboards/${encodeURIComponent(token)}`, {
-      // No cache — same rationale as the SSR fetch: revoked links must die
-      // immediately, and the result is per-viewer.
-      cache: "no-store",
-      credentials: isCrossOrigin() ? "include" : "same-origin",
-    });
-    return await mapSharedDashboardResponse(res, tokenHash, LOG_LABEL);
-  } catch (err) {
-    console.error(
-      `${LOG_LABEL} Failed to fetch tokenHash=${tokenHash}:`,
-      err instanceof Error ? err.message : String(err),
-    );
-    return { ok: false, reason: "network-error" };
-  }
+  return resolveOrgShare({
+    token,
+    publicPath: "/api/public/dashboards",
+    logLabel: "[shared-dashboard/client]",
+    map: mapSharedDashboardResponse,
+  });
 }

--- a/packages/web/src/app/shared/dashboard/[token]/share-result.ts
+++ b/packages/web/src/app/shared/dashboard/[token]/share-result.ts
@@ -1,133 +1,65 @@
 // Universal (server + client) response mapping for the shared-dashboard fetch.
 // Extracted from `fetch.ts` (#4718) so the client-side org-share resolution
 // (`org-share-client.ts`) shares the EXACT status→reason mapping and schema
-// validation the SSR fetch uses — the two paths cannot drift. This module must
-// stay importable from client components: no server-only imports
-// (`next/headers`, `node:crypto`) may ever land here.
+// validation the SSR fetch uses — the two paths cannot drift. The
+// resource-agnostic core (status mapping, #4690 auth-reason split, totality)
+// was lifted to `../../share-result.ts` when the conversation surface adopted
+// the pattern (#4719); this module keeps only the dashboard-specific pieces:
+// the schema validation and the surface's default log label. Must stay
+// importable from client components: no server-only imports (`next/headers`,
+// `node:crypto`) may ever land here.
 
 import { sharedDashboardViewSchema } from "@useatlas/schemas";
+import {
+  mapSharedResponse,
+  type ShareBodyValidation,
+  type ShareFetchResult,
+} from "../../share-result";
 import type { SharedDashboard } from "./types";
 
-/** One of the {@link FetchResult} failure reasons — the discriminant the page
- *  and embed error shells switch on. Both surfaces derive it from this single
- *  source rather than re-deriving the `Extract<…>` in each file. */
-export type FailReason =
-  | "not-found"
-  | "expired"
-  // The org-share auth wall is kept DISTINCT (not one `auth-required`): a viewer
-  // with no session (`login-required`) is offered a login redirect, while a viewer
-  // who is signed in but not a member of the sharing org (`membership-required`)
-  // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
-  | "login-required"
-  | "membership-required"
-  | "server-error"
-  | "network-error";
+// The resource-agnostic reason vocabulary + auth-wall helpers, re-exported so
+// this surface's consumers keep one import site.
+export {
+  isAuthWallReason,
+  resolveAuthReason,
+  type AuthWallReason,
+  type FailReason,
+} from "../../share-result";
 
-export type FetchResult = { ok: true; data: SharedDashboard } | { ok: false; reason: FailReason };
+export type FetchResult = ShareFetchResult<SharedDashboard>;
 
-/** The two org-share auth-wall reasons (#4690). Single statement of the pair so
- *  {@link isAuthWallReason} and {@link resolveAuthReason} can never disagree. */
-export type AuthWallReason = Extract<FailReason, "login-required" | "membership-required">;
-
-/**
- * Whether a failure is the org-share auth wall — the branch the page hands off
- * to the client-side resolver (#4718), since under the SaaS cookie topology
- * (ADR-0024) an SSR auth-wall verdict may be a false negative for a viewer
- * whose session cookie is host-only on the API domain.
- */
-export function isAuthWallReason(reason: FailReason): reason is AuthWallReason {
-  return reason === "login-required" || reason === "membership-required";
-}
-
-/**
- * Disambiguate an org-share auth failure (HTTP 401/403) into the exact reason.
- *
- * The API returns 403 for BOTH the unauthenticated viewer (`error: "auth_required"`)
- * and the authenticated-but-wrong-org viewer (`error: "forbidden"`), so the status
- * code alone is insufficient — we read the body's `error` code. Only an explicit
- * `"forbidden"` is treated as `membership-required`; every other signal (an explicit
- * `auth_required`, a 401, or a missing/malformed body) defaults to `login-required`
- * so a no-session viewer is never dead-ended without a login path (#4690). Exported
- * for unit tests.
- */
-export async function resolveAuthReason(res: Response): Promise<AuthWallReason> {
-  // A 401 is unambiguously "no session" regardless of body.
-  if (res.status === 401) return "login-required";
-  let errorCode: string | undefined;
-  try {
-    const body: unknown = await res.json();
-    if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
-      errorCode = body.error;
-    }
-  } catch {
-    // Malformed/empty body — fall through to the safe `login-required` default
-    // below rather than misclassifying a no-session viewer as wrong-org.
-    // intentionally ignored: absence of a parseable error code is itself the signal.
+/** Validate a 200 body against the shared-view SSOT schema (`@useatlas/schemas`)
+ *  rather than trust-casting the raw JSON — the `.strict()` schema also rejects
+ *  any stray field the API projection might leak. On failure, `detail` carries
+ *  issue paths + codes only — never the response values, which are the
+ *  dashboard's data — so a projection drift is diagnosable from the log line. */
+function validateSharedDashboard(raw: unknown): ShareBodyValidation<SharedDashboard> {
+  const parsed = sharedDashboardViewSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      detail: parsed.error.issues.map((i) => `${i.path.join(".")}:${i.code}`).join(", "),
+    };
   }
-  return errorCode === "forbidden" ? "membership-required" : "login-required";
+  // No cast: `parsed.data` (SharedDashboardViewWire) is structurally the
+  // SharedDashboard SSOT type, so any future schema/type drift fails the build
+  // here rather than being papered over.
+  return { ok: true, data: parsed.data };
 }
 
 /**
  * Map a public-dashboard API response to a {@link FetchResult}. Shared verbatim
  * by the SSR fetch (`fetch.ts`) and the client-side org-share resolution
- * (`org-share-client.ts`).
+ * (`org-share-client.ts`). TOTAL over its inputs (see `mapSharedResponse`) —
+ * `OrgShareResolver`'s two-state model relies on it never rejecting.
  *
  * `tokenHash` is the caller's pre-computed share-token fingerprint — log lines
- * here carry it, NEVER the cleartext token (#4317). It is passed in (rather
- * than computed here) because the server and client hash via different crypto
- * APIs (`node:crypto` vs WebCrypto), and this module may import neither.
- *
- * TOTAL over its inputs: every branch — including a success response whose
- * body isn't JSON — resolves to a {@link FetchResult}, never a rejection.
- * `OrgShareResolver`'s two-state model and any future adopter (#4719) rely on
- * that; callers still keep their own try/catch for the `fetch()` call itself.
+ * carry it, NEVER the cleartext token (#4317).
  */
 export async function mapSharedDashboardResponse(
   res: Response,
   tokenHash: string,
   logLabel = "[shared-dashboard]",
 ): Promise<FetchResult> {
-  if (!res.ok) {
-    if (res.status === 404) return { ok: false, reason: "not-found" };
-    if (res.status === 410) return { ok: false, reason: "expired" };
-    // The org-share auth wall. The API (`dashboards.ts`) returns 403 for BOTH the
-    // no-session and the wrong-org viewer, distinguished only by the response
-    // body's `error` code — NOT by the status. So a 403 alone can't tell them
-    // apart; we read the body. (A future 401 is also honored, so this stays
-    // correct if the API ever adopts stricter HTTP semantics.) See #4690.
-    if (res.status === 401 || res.status === 403) {
-      return { ok: false, reason: await resolveAuthReason(res) };
-    }
-    console.error(`${logLabel} API returned ${res.status} for tokenHash=${tokenHash}`);
-    return { ok: false, reason: "server-error" };
-  }
-  // A 200 whose body isn't JSON is the API's fault, not the network's — map it
-  // to server-error here rather than rejecting into the caller's catch.
-  let raw: unknown;
-  try {
-    raw = await res.json();
-  } catch (err) {
-    console.error(
-      `${logLabel} Non-JSON success body for tokenHash=${tokenHash}:`,
-      err instanceof Error ? err.message : String(err),
-    );
-    return { ok: false, reason: "server-error" };
-  }
-  // Validate against the shared-view SSOT schema (`@useatlas/schemas`) rather
-  // than trust-casting the raw JSON — the `.strict()` schema also rejects any
-  // stray field the API projection might leak.
-  const parsed = sharedDashboardViewSchema.safeParse(raw);
-  if (!parsed.success) {
-    // Log issue paths + codes only — never the response values, which are the
-    // dashboard's data — so a projection drift is diagnosable from the log line.
-    const issues = parsed.error.issues.map((i) => `${i.path.join(".")}:${i.code}`).join(", ");
-    console.error(
-      `${logLabel} Unexpected response shape for tokenHash=${tokenHash}: ${issues}`,
-    );
-    return { ok: false, reason: "server-error" };
-  }
-  // No cast: `parsed.data` (SharedDashboardViewWire) is structurally the
-  // SharedDashboard SSOT type, so any future schema/type drift fails the build
-  // here rather than being papered over.
-  return { ok: true, data: parsed.data };
+  return mapSharedResponse(res, tokenHash, logLabel, validateSharedDashboard);
 }

--- a/packages/web/src/app/shared/error-shell.tsx
+++ b/packages/web/src/app/shared/error-shell.tsx
@@ -1,10 +1,11 @@
 // The standalone share-surface error state, shared by the dashboard and
 // conversation pages (#4690, #4719). Renders resource-specific copy (an
-// {@link ErrorContent} produced by each surface's `error-content.ts`) around
-// the one CTA policy that must not drift: `login-required` (and only it)
-// produces the login redirect back to the shared view, while every other
-// reason offers the neutral "Go to Atlas" home link. Client-safe by design —
-// the org-share resolvers (#4718) render it browser-side on the auth wall.
+// {@link ErrorContent} produced by each surface's `error-content.ts`) and the
+// CTA that surface resolved — the reason→action decision (`login-required`
+// and only it gets the login redirect) lives in each `error-content.ts` and
+// its tests, documented on {@link PrimaryAction} below; this component only
+// renders it. Client-safe by design — the org-share resolvers (#4718) render
+// it browser-side on the auth wall.
 
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";

--- a/packages/web/src/app/shared/error-shell.tsx
+++ b/packages/web/src/app/shared/error-shell.tsx
@@ -1,0 +1,80 @@
+// The standalone share-surface error state, shared by the dashboard and
+// conversation pages (#4690, #4719). Renders resource-specific copy (an
+// {@link ErrorContent} produced by each surface's `error-content.ts`) around
+// the one CTA policy that must not drift: `login-required` (and only it)
+// produces the login redirect back to the shared view, while every other
+// reason offers the neutral "Go to Atlas" home link. Client-safe by design —
+// the org-share resolvers (#4718) render it browser-side on the auth wall.
+
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+
+/** Which primary CTA the error shell offers. */
+export type PrimaryAction =
+  // Login redirect back to the shared view — ONLY for `login-required`, where the
+  // viewer genuinely has no session. Never for `membership-required`.
+  | "login"
+  // Neutral "Go to Atlas" home link — the safe default for every other reason,
+  // including the signed-in wrong-org viewer.
+  | "home";
+
+export interface ErrorContent {
+  readonly heading: string;
+  readonly message: string;
+  readonly primaryAction: PrimaryAction;
+  /** Whether to also offer the "Try again" outline link — for non-terminal
+   *  failures (expired, network-error, server-error), not not-found or the auth wall. */
+  readonly showTryAgain: boolean;
+}
+
+export function ErrorShell({
+  sharePath,
+  content,
+}: {
+  /** The shared view's own path (e.g. `/shared/dashboard/<token>`) — target of
+   *  both the login redirect and the "Try again" link. */
+  sharePath: string;
+  content: ErrorContent;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-white dark:bg-zinc-950 print:bg-white print:text-black">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="flex flex-1 items-center justify-center px-4 focus:outline-none"
+      >
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{content.heading}</h1>
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">{content.message}</p>
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+            {content.primaryAction === "login" ? (
+              <Link
+                href={`/login?redirect=${encodeURIComponent(sharePath)}`}
+                className={buttonVariants()}
+              >
+                Log in
+              </Link>
+            ) : (
+              <Link href="/" className={buttonVariants()}>Go to Atlas</Link>
+            )}
+            {content.showTryAgain && (
+              <Link href={sharePath} className={buttonVariants({ variant: "outline" })}>
+                Try again
+              </Link>
+            )}
+          </div>
+        </div>
+      </main>
+      <footer className="border-t border-zinc-200 px-4 py-4 text-center dark:border-zinc-800 print:hidden">
+        <a
+          href="https://www.useatlas.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
+        >
+          Powered by Atlas
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/packages/web/src/app/shared/lib.ts
+++ b/packages/web/src/app/shared/lib.ts
@@ -1,5 +1,8 @@
 // ---------------------------------------------------------------------------
-// Shared utilities for the public conversation route (/shared/[token] + embed)
+// Shared utilities for the public conversation route (/shared/[token] + embed).
+// The data fetch lives in `[token]/fetch.ts` (server-only, #4719); this module
+// stays free of server-only imports so client components (e.g. the org-share
+// resolver) can import the types + text helpers.
 // ---------------------------------------------------------------------------
 
 export interface SharedMessage {
@@ -15,51 +18,12 @@ export interface SharedConversation {
   messages: SharedMessage[];
 }
 
-type FetchResult =
-  | { ok: true; data: SharedConversation }
-  | { ok: false; reason: "not-found" | "server-error" | "network-error" };
-
 export function getApiBaseUrl(): string {
   return (
     process.env.NEXT_PUBLIC_ATLAS_API_URL ||
     process.env.ATLAS_API_URL ||
     "http://localhost:3001"
   ).replace(/\/+$/, "");
-}
-
-export async function fetchSharedConversation(
-  token: string,
-): Promise<FetchResult> {
-  try {
-    const res = await fetch(
-      `${getApiBaseUrl()}/api/public/conversations/${encodeURIComponent(token)}`,
-      // Cache for 60s — balances load vs. freshness when a share link is revoked.
-      // Next.js revalidate also deduplicates multiple fetches within a single
-      // render pass (e.g. generateMetadata + page component on the full page).
-      { next: { revalidate: 60 } },
-    );
-    if (!res.ok) {
-      if (res.status === 404) return { ok: false, reason: "not-found" };
-      console.error(
-        `[shared-conversation] API returned ${res.status} for token=${token}`,
-      );
-      return { ok: false, reason: "server-error" };
-    }
-    const data = await res.json();
-    if (!data || !Array.isArray(data.messages)) {
-      console.error(
-        `[shared-conversation] Unexpected response shape for token=${token}`,
-      );
-      return { ok: false, reason: "server-error" };
-    }
-    return { ok: true, data: data as SharedConversation };
-  } catch (err) {
-    console.error(
-      `[shared-conversation] Failed to fetch token=${token}:`,
-      err instanceof Error ? err.message : err,
-    );
-    return { ok: false, reason: "network-error" };
-  }
 }
 
 /**

--- a/packages/web/src/app/shared/lib.ts
+++ b/packages/web/src/app/shared/lib.ts
@@ -6,7 +6,11 @@
 // ---------------------------------------------------------------------------
 
 export interface SharedMessage {
-  role: "user" | "assistant" | "system" | "tool";
+  /** Message author role. Kept as `string` (not a closed union): the views
+   *  only branch on "user"/"assistant" and hide everything else, and the
+   *  boundary validation (`[token]/share-result.ts`) checks string-ness only —
+   *  a narrower type here would assert an invariant nothing enforces. */
+  role: string;
   content: unknown;
   createdAt: string;
 }

--- a/packages/web/src/app/shared/org-share-client.ts
+++ b/packages/web/src/app/shared/org-share-client.ts
@@ -1,0 +1,84 @@
+// Client-side resolution of an ORG-scoped share, generic over the surface
+// (#4718; generalized for the conversation surface in #4719).
+//
+// Under ADR-0024 the SaaS session cookie is host-only on the per-region API
+// domain — the browser never sends it to the web origin, so the RSC cookie
+// forward in each surface's `fetch.ts` is structurally empty cross-origin and
+// every org share hit the auth wall regardless of the viewer's real session.
+// When SSR lands on that wall, the surface mounts its `OrgShareResolver`,
+// which calls this module: a browser fetch with credentials (the same pattern
+// the dashboard share-status fetch in
+// `(workspace)/dashboards/[id]/share-dialog.tsx` uses), so the API sees the
+// viewer's REAL session and the login-required / membership-required split
+// (#4690) is evaluated truthfully. A client fetch is inherently per-viewer, so
+// the SSR path's `x-forwarded-for` rate-limit forwarding has no analogue here.
+//
+// This module must stay importable from client components — no `next/headers`,
+// no `node:crypto`.
+
+import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import type { ShareFetchResult } from "./share-result";
+
+/**
+ * Browser-safe mirror of `hashShareToken` (`server-share.ts`, itself mirroring
+ * the API's copy): first 16 hex of SHA-256 — async because WebCrypto is. Log
+ * lines on the share surfaces carry this fingerprint, NEVER the cleartext
+ * token (#4317). Returns a fixed placeholder when WebCrypto is unavailable
+ * (insecure-context browsers): an unfingerprinted log line beats logging a
+ * bearer credential.
+ */
+export async function hashShareTokenClient(token: string): Promise<string> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) return "unavailable(insecure-context)";
+  const digest = await subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16);
+}
+
+/**
+ * Re-resolve an org-scoped share from the browser with the viewer's real
+ * credentials. Targets the client-resolved API base (`@/lib/api-url` — the
+ * regional override when an `atlas_region` signal is active, else the
+ * build-time default; empty string → same-origin relative fetch on
+ * self-hosted). `map` is the surface's response mapper — the EXACT function
+ * its SSR path uses (built on `mapSharedResponse`), so both paths return
+ * identical {@link ShareFetchResult}s for identical API responses.
+ *
+ * NEVER rejects — thrown fetches map to `network-error` — which is what lets
+ * each `OrgShareResolver` model resolution as just "in flight | result".
+ */
+export async function resolveOrgShare<T>(opts: {
+  token: string;
+  /** Public API collection path for the surface, e.g. `/api/public/dashboards`. */
+  publicPath: string;
+  /** Log prefix, e.g. `[shared-dashboard/client]`. */
+  logLabel: string;
+  /** The surface's shared response→result mapper. */
+  map: (res: Response, tokenHash: string, logLabel: string) => Promise<ShareFetchResult<T>>;
+}): Promise<ShareFetchResult<T>> {
+  const { token, publicPath, logLabel, map } = opts;
+  // Fingerprint once, up front, so the catch below can never itself throw
+  // (a rejecting `subtle.digest` in an exotic iframe context must not mask the
+  // real fetch error or break the never-rejects contract).
+  const tokenHash = await hashShareTokenClient(token).catch(
+    // intentionally ignored: a failed fingerprint must never block resolving
+    // the share; the placeholder is the documented degraded mode.
+    () => "unavailable(hash-failed)",
+  );
+  try {
+    const res = await fetch(`${getApiUrl()}${publicPath}/${encodeURIComponent(token)}`, {
+      // No cache — same rationale as the SSR fetch: revoked links must die
+      // immediately, and the result is per-viewer.
+      cache: "no-store",
+      credentials: isCrossOrigin() ? "include" : "same-origin",
+    });
+    return await map(res, tokenHash, logLabel);
+  } catch (err) {
+    console.error(
+      `${logLabel} Failed to fetch tokenHash=${tokenHash}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, reason: "network-error" };
+  }
+}

--- a/packages/web/src/app/shared/org-share-client.ts
+++ b/packages/web/src/app/shared/org-share-client.ts
@@ -17,6 +17,7 @@
 // no `node:crypto`.
 
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { redactShareToken } from "./share-result";
 import type { ShareFetchResult } from "./share-result";
 
 /**
@@ -77,7 +78,9 @@ export async function resolveOrgShare<T>(opts: {
   } catch (err) {
     console.error(
       `${logLabel} Failed to fetch tokenHash=${tokenHash}:`,
-      err instanceof Error ? err.message : String(err),
+      // A thrown fetch can echo the request URL — token included — in its
+      // message; redact it so the #4317 hash-only discipline holds here too.
+      redactShareToken(err instanceof Error ? err.message : String(err), token),
     );
     return { ok: false, reason: "network-error" };
   }

--- a/packages/web/src/app/shared/server-share.ts
+++ b/packages/web/src/app/shared/server-share.ts
@@ -1,0 +1,49 @@
+// SERVER-ONLY helpers shared by the public share surfaces' SSR fetches
+// (dashboard `dashboard/[token]/fetch.ts`, conversation `[token]/fetch.ts`).
+// Lifted out of the dashboard fetch module when the conversation surface
+// adopted the same hardened pattern (#4719) so the token-hash logging
+// discipline (#4317) and the viewer header forwarding exist exactly once.
+// This module imports `node:crypto` and must never be imported from client
+// components — the browser mirror lives in `org-share-client.ts`
+// (`hashShareTokenClient`).
+
+import { createHash } from "node:crypto";
+
+/**
+ * Short, non-reversible fingerprint of a share token for log correlation.
+ * Share tokens are bearer credentials — logs on the share surfaces must carry
+ * this hash, NEVER the cleartext token (#4317). Algorithm-mirror of the API's
+ * `hashShareToken` (first 16 hex of SHA-256); duplicated because the web
+ * package cannot import from `@atlas/api`. The API copy additionally guards
+ * against non-string input — omitted here since callers always pass the
+ * route's `token` string param. (`org-share-client.ts` carries the WebCrypto
+ * mirror for the browser, where `node:crypto` doesn't exist.)
+ */
+export function hashShareToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
+
+/**
+ * Build the headers a shared page forwards to the public share API:
+ *   - `cookie`: the viewer's session so ORG-scoped shares authenticate the
+ *     viewer on a SAME-ORIGIN deploy. Under the SaaS cookie topology (ADR-0024)
+ *     the session cookie is host-only on the per-region API domain, so this jar
+ *     is structurally empty cross-origin — the auth wall then hands off to the
+ *     client-side resolver, which carries the viewer's real session (#4718).
+ *   - `x-forwarded-for`: the viewer's REAL client IP so the API rate-limits per
+ *     viewer, not per web-server IP (effective only when the API trusts the
+ *     proxy header via `ATLAS_TRUST_PROXY`; otherwise `getClientIP` ignores it
+ *     and all viewers share the anonymous ceiling — see F-73).
+ * Pure + exported for unit tests. (#4317)
+ */
+export function buildForwardHeaders(input: {
+  cookie: string | null;
+  forwardedFor: string | null;
+  realIp: string | null;
+}): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (input.cookie) out.cookie = input.cookie;
+  const viewerIp = input.forwardedFor ?? input.realIp;
+  if (viewerIp) out["x-forwarded-for"] = viewerIp;
+  return out;
+}

--- a/packages/web/src/app/shared/share-result.ts
+++ b/packages/web/src/app/shared/share-result.ts
@@ -1,0 +1,137 @@
+// Universal (server + client) response→result mapping shared by every public
+// share surface (/shared/dashboard/[token] and /shared/[token] + their embeds).
+// Extracted from the dashboard's `share-result.ts` (#4718) when the shared
+// CONVERSATION surface adopted the same hardened pattern (#4719), so the status
+// mapping, the #4690 auth-reason split, and the #4317 token-hash logging
+// discipline exist exactly ONCE — the surfaces cannot drift. Resource-specific
+// body validation is injected per surface (`validate`); everything else is
+// identical by construction.
+//
+// This module must stay importable from client components: no server-only
+// imports (`next/headers`, `node:crypto`) may ever land here.
+
+/** One of the share-fetch failure reasons — the discriminant the page and
+ *  embed error shells switch on. Both surfaces derive it from this single
+ *  source rather than re-deriving the `Extract<…>` in each file. */
+export type FailReason =
+  | "not-found"
+  | "expired"
+  // The org-share auth wall is kept DISTINCT (not one `auth-required`): a viewer
+  // with no session (`login-required`) is offered a login redirect, while a viewer
+  // who is signed in but not a member of the sharing org (`membership-required`)
+  // must not be dead-ended on a "Log in" CTA they've already satisfied (#4690).
+  | "login-required"
+  | "membership-required"
+  | "server-error"
+  | "network-error";
+
+/** Result of a public share fetch, generic over the surface's success DTO. */
+export type ShareFetchResult<T> = { ok: true; data: T } | { ok: false; reason: FailReason };
+
+/** The two org-share auth-wall reasons (#4690). Single statement of the pair so
+ *  {@link isAuthWallReason} and {@link resolveAuthReason} can never disagree. */
+export type AuthWallReason = Extract<FailReason, "login-required" | "membership-required">;
+
+/**
+ * Whether a failure is the org-share auth wall — the branch the page hands off
+ * to the client-side resolver (#4718), since under the SaaS cookie topology
+ * (ADR-0024) an SSR auth-wall verdict may be a false negative for a viewer
+ * whose session cookie is host-only on the API domain.
+ */
+export function isAuthWallReason(reason: FailReason): reason is AuthWallReason {
+  return reason === "login-required" || reason === "membership-required";
+}
+
+/**
+ * Disambiguate an org-share auth failure (HTTP 401/403) into the exact reason.
+ *
+ * The API returns 403 for BOTH the unauthenticated viewer (`error: "auth_required"`)
+ * and the authenticated-but-wrong-org viewer (`error: "forbidden"`), so the status
+ * code alone is insufficient — we read the body's `error` code. Only an explicit
+ * `"forbidden"` is treated as `membership-required`; every other signal (an explicit
+ * `auth_required`, a 401, or a missing/malformed body) defaults to `login-required`
+ * so a no-session viewer is never dead-ended without a login path (#4690). Exported
+ * for unit tests.
+ */
+export async function resolveAuthReason(res: Response): Promise<AuthWallReason> {
+  // A 401 is unambiguously "no session" regardless of body.
+  if (res.status === 401) return "login-required";
+  let errorCode: string | undefined;
+  try {
+    const body: unknown = await res.json();
+    if (body && typeof body === "object" && "error" in body && typeof body.error === "string") {
+      errorCode = body.error;
+    }
+  } catch {
+    // Malformed/empty body — fall through to the safe `login-required` default
+    // below rather than misclassifying a no-session viewer as wrong-org.
+    // intentionally ignored: absence of a parseable error code is itself the signal.
+  }
+  return errorCode === "forbidden" ? "membership-required" : "login-required";
+}
+
+/**
+ * Per-surface validation of a share fetch's 200 body. On failure, `detail` is a
+ * log-safe summary (issue paths/codes only — NEVER response values, which are
+ * the shared resource's data).
+ */
+export type ShareBodyValidation<T> = { ok: true; data: T } | { ok: false; detail: string };
+
+/**
+ * Map a public share API response to a {@link ShareFetchResult}. Shared verbatim
+ * by each surface's SSR fetch AND its client-side org-share resolution, so the
+ * SSR and client paths can never drift.
+ *
+ * `tokenHash` is the caller's pre-computed share-token fingerprint — log lines
+ * here carry it, NEVER the cleartext token (#4317). It is passed in (rather
+ * than computed here) because the server and client hash via different crypto
+ * APIs (`node:crypto` vs WebCrypto), and this module may import neither.
+ *
+ * TOTAL over its inputs: every branch — including a success response whose
+ * body isn't JSON — resolves to a {@link ShareFetchResult}, never a rejection.
+ * `OrgShareResolver`'s two-state model relies on that; callers still keep
+ * their own try/catch for the `fetch()` call itself.
+ */
+export async function mapSharedResponse<T>(
+  res: Response,
+  tokenHash: string,
+  logLabel: string,
+  validate: (raw: unknown) => ShareBodyValidation<T>,
+): Promise<ShareFetchResult<T>> {
+  if (!res.ok) {
+    if (res.status === 404) return { ok: false, reason: "not-found" };
+    if (res.status === 410) return { ok: false, reason: "expired" };
+    // The org-share auth wall. The API returns 403 for BOTH the no-session and
+    // the wrong-org viewer, distinguished only by the response body's `error`
+    // code — NOT by the status. So a 403 alone can't tell them apart; we read
+    // the body. (A future 401 is also honored, so this stays correct if the
+    // API ever adopts stricter HTTP semantics.) See #4690.
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, reason: await resolveAuthReason(res) };
+    }
+    console.error(`${logLabel} API returned ${res.status} for tokenHash=${tokenHash}`);
+    return { ok: false, reason: "server-error" };
+  }
+  // A 200 whose body isn't JSON is the API's fault, not the network's — map it
+  // to server-error here rather than rejecting into the caller's catch.
+  let raw: unknown;
+  try {
+    raw = await res.json();
+  } catch (err) {
+    console.error(
+      `${logLabel} Non-JSON success body for tokenHash=${tokenHash}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return { ok: false, reason: "server-error" };
+  }
+  const validated = validate(raw);
+  if (!validated.ok) {
+    // `detail` is log-safe by the ShareBodyValidation contract — issue
+    // paths/codes only, never the response's values.
+    console.error(
+      `${logLabel} Unexpected response shape for tokenHash=${tokenHash}: ${validated.detail}`,
+    );
+    return { ok: false, reason: "server-error" };
+  }
+  return { ok: true, data: validated.data };
+}

--- a/packages/web/src/app/shared/share-result.ts
+++ b/packages/web/src/app/shared/share-result.ts
@@ -71,6 +71,18 @@ export async function resolveAuthReason(res: Response): Promise<AuthWallReason> 
 }
 
 /**
+ * Redact a share token from a message that is about to be logged. The #4317
+ * discipline keeps the cleartext token out of our own log templates, but a
+ * thrown error can echo the request URL — token included — in its message
+ * (e.g. WHATWG fetch's `Failed to parse URL from <url>` on a misconfigured API
+ * base). Every catch that logs an error message on a share surface must pass
+ * it through here first.
+ */
+export function redactShareToken(message: string, token: string): string {
+  return token ? message.replaceAll(token, "[redacted-share-token]") : message;
+}
+
+/**
  * Per-surface validation of a share fetch's 200 body. On failure, `detail` is a
  * log-safe summary (issue paths/codes only — NEVER response values, which are
  * the shared resource's data).

--- a/packages/web/src/ui/__tests__/shared-embed.test.ts
+++ b/packages/web/src/ui/__tests__/shared-embed.test.ts
@@ -1,36 +1,9 @@
-import { describe, expect, test, mock, beforeEach, spyOn } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
+import { extractTextContent, truncate, getApiBaseUrl } from "../../app/shared/lib";
 
-// Mock fetch before importing the module
-const mockFetch = mock(() => Promise.resolve(new Response("", { status: 404 })));
-globalThis.fetch = mockFetch as unknown as typeof fetch;
-
-const {
-  extractTextContent,
-  truncate,
-  getApiBaseUrl,
-  fetchSharedConversation,
-} = await import("../../app/shared/lib");
-
-function jsonResponse(data: unknown, status = 200) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
-const sampleConversation = {
-  title: "Revenue Analysis",
-  surface: "web",
-  createdAt: "2026-03-12T00:00:00Z",
-  messages: [
-    { role: "user", content: "What were our top customers?", createdAt: "2026-03-12T00:00:00Z" },
-    { role: "assistant", content: "Here are the results.", createdAt: "2026-03-12T00:00:01Z" },
-  ],
-};
-
-beforeEach(() => {
-  mockFetch.mockReset();
-});
+// The data fetch moved to `app/shared/[token]/fetch.ts` (#4719) — its behavior
+// (no-store, header forwarding, token-hash logging, org-share auth split) is
+// covered by the colocated `app/shared/[token]/__tests__/fetch.test.ts`.
 
 describe("shared/lib utilities", () => {
   describe("extractTextContent", () => {
@@ -152,77 +125,4 @@ describe("shared/lib utilities", () => {
     });
   });
 
-  describe("fetchSharedConversation", () => {
-    test("returns conversation data on success", async () => {
-      mockFetch.mockResolvedValueOnce(jsonResponse(sampleConversation));
-
-      const result = await fetchSharedConversation("valid-token");
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.data.title).toBe("Revenue Analysis");
-        expect(result.data.messages).toHaveLength(2);
-      }
-    });
-
-    test("returns not-found for 404", async () => {
-      mockFetch.mockResolvedValueOnce(new Response("", { status: 404 }));
-
-      const result = await fetchSharedConversation("missing-token");
-
-      expect(result).toEqual({ ok: false, reason: "not-found" });
-    });
-
-    test("returns server-error for 500", async () => {
-      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response("", { status: 500 }));
-
-      const result = await fetchSharedConversation("error-token");
-
-      expect(result).toEqual({ ok: false, reason: "server-error" });
-      expect(errorSpy).toHaveBeenCalled();
-      errorSpy.mockRestore();
-    });
-
-    test("returns server-error for malformed response shape", async () => {
-      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(jsonResponse({ error: "bad" }));
-
-      const result = await fetchSharedConversation("malformed-token");
-
-      expect(result).toEqual({ ok: false, reason: "server-error" });
-      expect(errorSpy).toHaveBeenCalled();
-      errorSpy.mockRestore();
-    });
-
-    test("returns network-error when fetch throws", async () => {
-      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
-      mockFetch.mockRejectedValueOnce(new Error("DNS resolution failed"));
-
-      const result = await fetchSharedConversation("network-fail");
-
-      expect(result).toEqual({ ok: false, reason: "network-error" });
-      expect(errorSpy).toHaveBeenCalled();
-      errorSpy.mockRestore();
-    });
-
-    test("encodes token in fetch URL", async () => {
-      mockFetch.mockResolvedValueOnce(new Response("", { status: 404 }));
-
-      await fetchSharedConversation("tok/en+special");
-
-      const firstCall = mockFetch.mock.calls[0] as unknown as [string, ...unknown[]];
-      expect(firstCall[0]).toContain("tok%2Fen%2Bspecial");
-    });
-
-    test("does not log for 404 responses", async () => {
-      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
-      mockFetch.mockResolvedValueOnce(new Response("", { status: 404 }));
-
-      await fetchSharedConversation("not-found");
-
-      expect(errorSpy).not.toHaveBeenCalled();
-      errorSpy.mockRestore();
-    });
-  });
 });

--- a/packages/web/src/ui/__tests__/shared-page-metadata.test.ts
+++ b/packages/web/src/ui/__tests__/shared-page-metadata.test.ts
@@ -4,6 +4,14 @@ import { describe, expect, test, mock, beforeEach } from "bun:test";
 const mockFetch = mock(() => Promise.resolve(new Response("", { status: 404 })));
 globalThis.fetch = mockFetch as unknown as typeof fetch;
 
+// The page's data fetch (`[token]/fetch.ts`, #4719) reads the request-scoped
+// cookie/header stores to forward the viewer's session + IP; stub them so the
+// module renders outside a Next request scope.
+void mock.module("next/headers", () => ({
+  cookies: async () => ({ toString: () => "" }),
+  headers: async () => ({ get: () => null }),
+}));
+
 // Import generateMetadata from the page module
 const { generateMetadata } = await import("../../app/shared/[token]/page");
 

--- a/packages/web/src/ui/__tests__/shared-page-metadata.test.ts
+++ b/packages/web/src/ui/__tests__/shared-page-metadata.test.ts
@@ -10,6 +10,7 @@ globalThis.fetch = mockFetch as unknown as typeof fetch;
 void mock.module("next/headers", () => ({
   cookies: async () => ({ toString: () => "" }),
   headers: async () => ({ get: () => null }),
+  draftMode: async () => ({ isEnabled: false }),
 }));
 
 // Import generateMetadata from the page module


### PR DESCRIPTION
Closes #4719

The shared **conversation** surface (`/shared/[token]` + `/embed`) still carried the anti-patterns the dashboard share surface fixed under #4317/#4690/#4718. This brings it to full parity — by **lifting the hardened core into shared modules** both surfaces now consume, so they cannot drift again.

## What changed

1. **Revocation window closed** — `next: { revalidate: 60 }` → `cache: "no-store"` + React `cache()` intra-render dedup (`[token]/fetch.ts`). A revoked/expired share dies immediately; generateMetadata + page still fetch once per render.
2. **No cleartext bearer tokens in logs** — the three `token=${token}` `console.error` lines are gone; all log lines carry the 16-hex `hashShareToken` fingerprint (#4317 discipline). New `redactShareToken` additionally scrubs the token from *thrown-error messages* (WHATWG fetch echoes the request URL on e.g. a malformed API base) — applied to the dashboard surface too.
3. **Org-scoped shares work end-to-end** — SSR forwards the viewer cookie (`buildForwardHeaders`), and the 401/403 auth wall (`auth_required` vs `forbidden` body codes → `login-required` vs `membership-required`, #4690) hands off to a client-side `OrgShareResolver` that retries with the viewer's real credentials (`credentials: include` cross-origin) — the #4718 pattern, adopted for both page and embed. Login wall for logged-out viewers, membership wall for wrong-org viewers; no more generic "server-error" for every org share.
4. **Per-viewer rate limiting** — SSR fetch forwards `x-forwarded-for`/`x-real-ip` so the API rate-limits per viewer, not per web-server IP.

## Generalization (no-drift by construction)

New resource-agnostic modules under `packages/web/src/app/shared/`:
- `share-result.ts` — status→reason mapping, `FailReason`/`AuthWallReason`, `resolveAuthReason`, total `mapSharedResponse<T>`, `redactShareToken`
- `server-share.ts` — `hashShareToken` (node:crypto) + `buildForwardHeaders`
- `org-share-client.ts` — WebCrypto `hashShareTokenClient` + generic credentialed `resolveOrgShare<T>`
- `error-shell.tsx` — the standalone error state with the login-CTA policy rendering

The dashboard modules (`dashboard/[token]/{share-result,fetch,org-share-client,error-shell,error-content}`) are now thin delegates with unchanged export surfaces — all 87 pre-existing dashboard tests pass unmodified.

Also fixed inline from the internal review panel: structural field-by-field validation of the conversation body (no trust-cast; `messages: [null]` → `server-error`, never a view crash), network-error catch kept tight around `fetch()` (header-collection throws surface as the programming errors they are), honest `SharedMessage.role: string`, comment corrections.

## Tests

- `[token]/__tests__/fetch.test.ts` — no-store + revalidate tombstone, header forwarding, x-real-ip fallback, the three auth outcomes, 404/410 mapping, malformed shape/element → server-error, token-hash-only logging incl. URL-echo redaction
- `[token]/__tests__/org-share-client.test.ts` — client resolution: success / login-required / membership-required, cross-origin `credentials: include`, hash parity with node:crypto, redaction
- `[token]/__tests__/org-share-resolver.test.tsx` — rendered component seam, page + embed variants, navigation-free embed walls, loading state
- `[token]/__tests__/page-handoff.test.tsx` — the load-bearing page-seam gate: only auth-wall reasons mount the resolver (page + embed)
- `[token]/__tests__/error-content.test.ts` — login-CTA policy pins

No API change. `/ci` local: all 31 gates green. Internal review panel: clean (round-1 MEDIUMs fixed in-branch, verified by a follow-up pass).