### PR TITLE
fix(deploy): install PostgreSQL 18 client tools in the api image for the backup engine (#4457)

### DIFF
--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -114,6 +114,19 @@ RUN if [ "$INSTALL_NSJAIL" = "true" ]; then \
         libnl-route-3-200 libprotobuf32t64 \
       && rm -rf /var/lib/apt/lists/*; \
     fi
+# PostgreSQL 18 client tools — the backup engine (ee/src/backups, #4457)
+# spawns `pg_dump`/`psql`, and the client major must be >= the PG 18 internal
+# DBs (pg_dump refuses a newer server major). The base image's Debian ships an
+# older postgresql-client, so pin PGDG's postgresql-client-18.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates gnupg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
+    && . /etc/os-release \
+    && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+      > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends postgresql-client-18 \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail-builder /nsjail-out/ /usr/local/bin/
 # Shared types (workspace symlink target — needed at runtime by API + plugins)
 COPY --from=builder --chown=atlas:atlas /app/packages/types ./packages/types


### PR DESCRIPTION
## What

Adds PGDG `postgresql-client-18` to the `deploy/api/Dockerfile` runner stage.

## Why

Executing the #4457 (PR #4723) post-merge operator checklist surfaced a gap: the scheduled-backup engine spawns `pg_dump`/`psql` (`ee/src/backups/engine.ts:294`, `restore.ts:154`), but the api runner image never installed a postgres client. On the next release every backup cycle would fail with spawn `ENOENT` — visible via the `/health` `backups` degraded tripwire (boot-green-but-broken exactly as the tripwire is designed to catch, but still broken).

PGDG is required because the internal DBs run **PG 18** (`postgres-ssl:18.3` fleet standard) and `pg_dump` refuses a server major newer than itself; the base image's Debian ships an older default client.

## Verification

Ran the exact RUN block against the pinned base digest:

```
docker run --rm oven/bun:1.3.13@sha256:87416c977a... <this RUN block>
pg_dump (PostgreSQL) 18.4 (Debian 18.4-1.pgdg13+1)
psql (PostgreSQL) 18.4 (Debian 18.4-1.pgdg13+1)
```

Deploy-config-only diff (no TS surface); Deploy Validation + the full required check suite arbitrate.

## Operator context (already done, no action needed)

Per-region Railway buckets (`atlas-backups-{us,eu,apac,staging}` in iad/ams/sin/iad), disposable PG-18 scratch DBs (`backup-scratch-*`, region-pinned, volume-less), and `ATLAS_BACKUP_S3_*` + `ATLAS_BACKUP_VERIFY_SCRATCH_URL` reference vars are provisioned on api/api-eu/api-apac (staged, no redeploy — prod picks them up at the next release) and api-staging (soaks on next main deploy, i.e. this PR's merge).