### PR TITLE
fix(mcp): advertise offline_access in scopes_supported so DCR clients get refresh tokens (#4728)

### DIFF
--- a/apps/docs/src/app/.well-known/oauth-protected-resource/resource-metadata.generated.json
+++ b/apps/docs/src/app/.well-known/oauth-protected-resource/resource-metadata.generated.json
@@ -8,7 +8,8 @@
   ],
   "scopes_supported": [
     "mcp:read",
-    "mcp:write"
+    "mcp:write",
+    "offline_access"
   ],
   "resource_documentation": "https://docs.useatlas.dev/api-reference",
   "resource_name": "Atlas API",

--- a/apps/www/public/.well-known/oauth-protected-resource.json
+++ b/apps/www/public/.well-known/oauth-protected-resource.json
@@ -8,7 +8,8 @@
   ],
   "scopes_supported": [
     "mcp:read",
-    "mcp:write"
+    "mcp:write",
+    "offline_access"
   ],
   "resource_documentation": "https://docs.useatlas.dev/api-reference",
   "resource_name": "Atlas API",

--- a/apps/www/public/auth.md
+++ b/apps/www/public/auth.md
@@ -45,6 +45,7 @@ Request the scopes you need at registration:
 
 - `mcp:read` — query workspace data through the hosted MCP endpoint
 - `mcp:write` — perform write operations (reserved for future mutation tools)
+- `offline_access` — receive a refresh token so the connection survives access-token expiry
 
 ## Self-serve: provision a trial workspace
 

--- a/packages/api/scripts/check-auth-md-discovery-parity.ts
+++ b/packages/api/scripts/check-auth-md-discovery-parity.ts
@@ -139,8 +139,9 @@ export interface ResolvedHosts {
 
 /**
  * The protected-resource metadata's `scopes_supported` is a hardcoded literal
- * in `well-known.ts` (it lists the `mcp:*` subset the MCP resource server
- * advertises). It is not exported, so we extract the literal from source — the
+ * in `well-known.ts` (the `mcp:*` scopes plus `offline_access` the MCP
+ * resource server advertises). It is not exported, so we extract the literal
+ * from source — the
  * same read-the-source discipline every other drift gate uses. The set the
  * `.well-known` document advertises must equal the set `/auth.md` names, or an
  * agent and a `.well-known`-trusting client disagree on which scopes to
@@ -184,13 +185,15 @@ function wellKnownAdvertisedScopes(): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * The `mcp:*` subset of the canonical scope union, mapped to the
- * `AuthMdScope` shape the builder expects — the same derivation
- * `api/routes/auth-md.ts:mcpScopes()` performs. Grant blurbs are irrelevant to
- * parity (they're prose), so we pass a placeholder; only scope *names* matter.
+ * The documented scope set (`mcp:*` subset plus `offline_access`), mapped to
+ * the `AuthMdScope` shape the builder expects — the same derivation
+ * `api/routes/auth-md.ts:documentedScopes()` performs. Grant blurbs are
+ * irrelevant to parity (they're prose), so we pass a placeholder; only scope
+ * *names* matter.
  */
-function mcpScopesFromCanonical(): AuthMdScope[] {
-  return ATLAS_OAUTH_SCOPES.filter((s) => s.startsWith("mcp:")).map((name) => ({
+function documentedScopesFromCanonical(): AuthMdScope[] {
+  const mcp = ATLAS_OAUTH_SCOPES.filter((s) => s.startsWith("mcp:"));
+  return [...mcp, "offline_access"].map((name) => ({
     name,
     grants: "—",
   }));
@@ -221,7 +224,7 @@ function renderAuthMd(apiBase: string): string {
       authServerUri: buildAuthServerUri(req),
       issuerBaseUri: buildIssuerBaseUri(req),
       resourceUri: buildResourceUri(req),
-      scopes: mcpScopesFromCanonical(),
+      scopes: documentedScopesFromCanonical(),
       onboardingPath: ONBOARDING_MCP_PATH,
       docsUrl: ATLAS_DOCS_URL,
     }),
@@ -258,9 +261,14 @@ function fail(message: string): never {
 export function scopeParityViolations(doc: string, advertised: readonly string[]): string[] {
   const out: string[] = [];
   const advertisedSet = new Set(advertised);
-  // Every `mcp:<word>` token the prose names. The brand host `.../mcp` is not a
-  // scope (no colon), so this pattern can't false-match it.
-  const namedInDoc = new Set(doc.match(/mcp:[a-z][a-z0-9_]*/g) ?? []);
+  // Every `mcp:<word>` token the prose names, plus `offline_access` — the one
+  // non-`mcp:*` scope the protected-resource metadata advertises (DCR clients
+  // register with exactly the advertised list, so it must appear in both
+  // surfaces; see well-known.ts). The brand host `.../mcp` is not a scope
+  // (no colon), so this pattern can't false-match it.
+  const namedInDoc = new Set(
+    doc.match(/mcp:[a-z][a-z0-9_]*|\boffline_access\b/g) ?? [],
+  );
 
   for (const scope of namedInDoc) {
     if (!advertisedSet.has(scope)) {

--- a/packages/api/scripts/check-auth-md-discovery-parity.ts
+++ b/packages/api/scripts/check-auth-md-discovery-parity.ts
@@ -51,8 +51,9 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { buildAuthMd, type AuthMdScope } from "@atlas/api/lib/mcp/auth-md";
+import { buildAuthMd } from "@atlas/api/lib/mcp/auth-md";
 import { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
+import { documentedScopes } from "@atlas/api/api/routes/auth-md";
 import {
   buildAuthServerUri,
   buildIssuerBaseUri,
@@ -185,21 +186,6 @@ function wellKnownAdvertisedScopes(): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * The documented scope set (`mcp:*` subset plus `offline_access`), mapped to
- * the `AuthMdScope` shape the builder expects — the same derivation
- * `api/routes/auth-md.ts:documentedScopes()` performs. Grant blurbs are
- * irrelevant to parity (they're prose), so we pass a placeholder; only scope
- * *names* matter.
- */
-function documentedScopesFromCanonical(): AuthMdScope[] {
-  const mcp = ATLAS_OAUTH_SCOPES.filter((s) => s.startsWith("mcp:"));
-  return [...mcp, "offline_access"].map((name) => ({
-    name,
-    grants: "—",
-  }));
-}
-
-/**
  * Drive the shared host helpers + builder for a fixed resolved API base. The
  * route resolves hosts from the request via the shared helpers; we drive the
  * SAME helpers through the env var the route's resolution honors, then hand the
@@ -224,7 +210,10 @@ function renderAuthMd(apiBase: string): string {
       authServerUri: buildAuthServerUri(req),
       issuerBaseUri: buildIssuerBaseUri(req),
       resourceUri: buildResourceUri(req),
-      scopes: documentedScopesFromCanonical(),
+      // The REAL derivation the route serves — imported, not hand-mirrored —
+      // so this gate can't pass against a scope set the live /auth.md doesn't
+      // actually emit.
+      scopes: documentedScopes(),
       onboardingPath: ONBOARDING_MCP_PATH,
       docsUrl: ATLAS_DOCS_URL,
     }),
@@ -294,6 +283,38 @@ export function scopeParityViolations(doc: string, advertised: readonly string[]
     }
   }
   return out;
+}
+
+/**
+ * Advertised⇒issuable invariant: every scope the `.well-known`
+ * protected-resource metadata advertises must be a member of the canonical
+ * scope union the authorization server can actually issue (`ATLAS_OAUTH_SCOPES`).
+ *
+ * This is the backstop the compile-time `satisfies` tethers in `well-known.ts`
+ * / `generate-apex-discovery.ts` can't give the SOURCE-PARSED advertised list:
+ * rename `offline_access` in the canonical union but not in the advertised
+ * literal and the two surfaces still agree with each other (scope parity
+ * passes), yet authorize would 401 every refresh-token request with
+ * `invalid_scope` — DCR clients register with the advertised list, and the
+ * authorize endpoint validates against `ATLAS_OAUTH_SCOPES`. This fails the
+ * gate instead, naming the orphaned scope. Host-independent, so it runs once.
+ * (`/auth.md`'s named scopes are covered transitively: `scopeParityViolations`
+ * already forces them to equal the advertised set.)
+ */
+export function issuableScopeViolations(advertised: readonly string[]): string[] {
+  const issuable = new Set<string>(ATLAS_OAUTH_SCOPES);
+  return advertised
+    .filter((scope) => !issuable.has(scope))
+    .map(
+      (scope) =>
+        `The .well-known protected-resource metadata advertises scope ` +
+        `\`${scope}\`, which is NOT in the canonical scope union ` +
+        `ATLAS_OAUTH_SCOPES (issuable: [${ATLAS_OAUTH_SCOPES.join(", ")}]). ` +
+        `The authorization server cannot issue it, so a DCR client that ` +
+        `registers with the advertised list fails authorize with ` +
+        `\`invalid_scope\`. Re-add the scope to ATLAS_OAUTH_SCOPES, or stop ` +
+        `advertising it in well-known.ts.`,
+    );
 }
 
 /**
@@ -410,6 +431,9 @@ export function collectViolations(input: {
   // early return above guarantees at least one fixture, so `fixtures[0]` is
   // present (no empty-doc fallback needed).
   out.push(...scopeParityViolations(input.fixtures[0].doc, input.advertisedScopes));
+  // Advertised⇒issuable is host-independent too: the advertised set must be a
+  // subset of what the auth server can issue, or DCR clients break at authorize.
+  out.push(...issuableScopeViolations(input.advertisedScopes));
   return out;
 }
 

--- a/packages/api/scripts/generate-apex-discovery.ts
+++ b/packages/api/scripts/generate-apex-discovery.ts
@@ -36,6 +36,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { renderAuthMd } from "@atlas/api/api/routes/auth-md";
+import type { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
 
 // ---------------------------------------------------------------------------
 // Canonical inputs
@@ -63,7 +64,12 @@ interface ProtectedResourceMetadata {
   readonly resource: string;
   readonly authorization_servers: readonly string[];
   readonly bearer_methods_supported: readonly string[];
-  readonly scopes_supported: readonly string[];
+  // Tethered to the canonical scope union (not plain `string[]`) so the
+  // `as const satisfies ProtectedResourceMetadata` on the const below fails to
+  // compile if an advertised scope is renamed/dropped in `ATLAS_OAUTH_SCOPES`
+  // — the apex mirror can't silently advertise a scope the auth server can't
+  // issue (#4728).
+  readonly scopes_supported: readonly (typeof ATLAS_OAUTH_SCOPES)[number][];
   readonly resource_documentation: string;
   readonly resource_name: string;
   readonly resource_policy_uri: string;

--- a/packages/api/scripts/generate-apex-discovery.ts
+++ b/packages/api/scripts/generate-apex-discovery.ts
@@ -89,10 +89,12 @@ export const API_PROTECTED_RESOURCE = {
   // resource. RFC 9728 §2 lists `scopes_supported` as OPTIONAL, but agent
   // readiness scanners (and the MCP authorization spec) expect it, and the
   // sibling per-workspace MCP protected-resource metadata advertises the same
-  // `mcp:*` set (well-known.ts). These are the data-access scopes the Atlas
-  // authorization server issues; the OIDC sign-in scopes (openid/profile/email)
-  // are advertised by the auth-server metadata, not the resource.
-  scopes_supported: ["mcp:read", "mcp:write"],
+  // set (well-known.ts). `offline_access` is included because DCR clients
+  // register with exactly the advertised list and the authorize endpoint
+  // validates against the client row's scopes — omitting it breaks refresh
+  // tokens with `invalid_scope`. The OIDC sign-in scopes (openid/profile/
+  // email) are advertised by the auth-server metadata, not the resource.
+  scopes_supported: ["mcp:read", "mcp:write", "offline_access"],
   resource_documentation: "https://docs.useatlas.dev/api-reference",
   resource_name: "Atlas API",
   resource_policy_uri: "https://www.useatlas.dev/privacy",

--- a/packages/api/src/api/__tests__/apex-discovery-generator.test.ts
+++ b/packages/api/src/api/__tests__/apex-discovery-generator.test.ts
@@ -50,9 +50,12 @@ describe("apex-discovery generator", () => {
     expect(API_PROTECTED_RESOURCE.bearer_methods_supported).toEqual(["header"]);
     // scopes_supported is what an agent-readiness scanner (and the MCP auth
     // spec) look for; it mirrors the sibling MCP protected-resource metadata.
+    // `offline_access` is load-bearing: DCR clients register with exactly
+    // this list, and dropping it breaks refresh tokens with `invalid_scope`.
     expect(API_PROTECTED_RESOURCE.scopes_supported).toEqual([
       "mcp:read",
       "mcp:write",
+      "offline_access",
     ]);
     expect(API_PROTECTED_RESOURCE.resource_policy_uri).toBe(
       "https://www.useatlas.dev/privacy",

--- a/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
+++ b/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
@@ -24,6 +24,7 @@ import { describe, it, expect } from "bun:test";
 
 import {
   scopeParityViolations,
+  issuableScopeViolations,
   hostParityViolations,
   endpointParityViolations,
   collectViolations,
@@ -31,6 +32,7 @@ import {
   FORBIDDEN_FRAGMENTS,
   type ResolvedHosts,
 } from "../../../scripts/check-auth-md-discovery-parity";
+import { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
 
 // A minimal in-parity document: it names exactly the resolved hosts, exactly
 // the advertised scopes, and only `.well-known` paths the router serves. The
@@ -184,6 +186,46 @@ describe("auth-md discovery parity — scope drift fails, naming the scope", () 
     expect(violations.length).toBeGreaterThan(0);
     expect(violations.some((v) => v.includes("offline_access"))).toBe(true);
     expect(violations.join("\n")).toContain("never names");
+  });
+});
+
+describe("auth-md discovery parity — advertised scope must be issuable", () => {
+  it("passes when every advertised scope is in the canonical union", () => {
+    // ADVERTISED_SCOPES is a subset of what the auth server issues.
+    expect(issuableScopeViolations(ADVERTISED_SCOPES)).toEqual([]);
+  });
+
+  it("every advertised scope is actually a member of ATLAS_OAUTH_SCOPES", () => {
+    // The real advertised set the surfaces ship must be issuable — this is the
+    // invariant that #4728 violated (a scope advertised but effectively not
+    // requestable). Locks it against the live canonical union, not a fixture.
+    const issuable = new Set<string>(ATLAS_OAUTH_SCOPES);
+    for (const scope of ADVERTISED_SCOPES) {
+      expect(issuable.has(scope)).toBe(true);
+    }
+  });
+
+  it("fails, naming the scope, when an advertised scope is not issuable", () => {
+    // Simulates renaming `offline_access` in ATLAS_OAUTH_SCOPES without updating
+    // the advertised literal: the two discovery surfaces still agree with each
+    // other, but authorize would reject it with `invalid_scope`.
+    const violations = issuableScopeViolations([
+      "mcp:read",
+      "mcp:write",
+      "offline_access",
+      "mcp:bogus",
+    ]);
+    expect(violations.length).toBe(1);
+    expect(violations[0]).toContain("mcp:bogus");
+    expect(violations[0]).toContain("invalid_scope");
+  });
+
+  it("is wired into collectViolations", () => {
+    const violations = collectViolations({
+      fixtures: [{ label: "us region", doc: FAITHFUL_DOC, hosts: HOSTS }],
+      advertisedScopes: ["mcp:read", "mcp:write", "offline_access", "mcp:bogus"],
+    });
+    expect(violations.some((v) => v.includes("mcp:bogus"))).toBe(true);
   });
 });
 

--- a/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
+++ b/packages/api/src/api/__tests__/auth-md-discovery-parity.test.ts
@@ -45,7 +45,7 @@ const HOSTS: ResolvedHosts = {
   resourceUri: "https://mcp.useatlas.dev/mcp",
 };
 
-const ADVERTISED_SCOPES = ["mcp:read", "mcp:write"] as const;
+const ADVERTISED_SCOPES = ["mcp:read", "mcp:write", "offline_access"] as const;
 
 const FAITHFUL_DOC = [
   "# auth.md",
@@ -53,7 +53,7 @@ const FAITHFUL_DOC = [
   "- MCP resource server: `https://mcp.useatlas.dev/mcp`",
   "Metadata: `https://api.useatlas.dev/.well-known/oauth-authorization-server/api/auth`",
   "Per-workspace: `/.well-known/oauth-protected-resource/mcp/{workspace_id}`",
-  "Scopes: `mcp:read`, `mcp:write`.",
+  "Scopes: `mcp:read`, `mcp:write`, `offline_access`.",
   "Go deeper: https://docs.useatlas.dev",
 ].join("\n");
 
@@ -172,6 +172,17 @@ describe("auth-md discovery parity — scope drift fails, naming the scope", () 
     const violations = scopeParityViolations(doc, ADVERTISED_SCOPES);
     expect(violations.length).toBeGreaterThan(0);
     expect(violations.some((v) => v.includes("mcp:write"))).toBe(true);
+    expect(violations.join("\n")).toContain("never names");
+  });
+
+  it("fails when the prose drops offline_access while .well-known advertises it", () => {
+    // Regression for the DCR refresh-token break: `offline_access` is the one
+    // non-`mcp:*` advertised scope, and the doc-token pattern must see it —
+    // otherwise the doc silently drifts from what DCR clients register with.
+    const doc = FAITHFUL_DOC.replace(", `offline_access`", "");
+    const violations = scopeParityViolations(doc, ADVERTISED_SCOPES);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.some((v) => v.includes("offline_access"))).toBe(true);
     expect(violations.join("\n")).toContain("never names");
   });
 });

--- a/packages/api/src/api/__tests__/well-known.test.ts
+++ b/packages/api/src/api/__tests__/well-known.test.ts
@@ -183,7 +183,15 @@ describe("well-known — managed auth mode", () => {
       // every RFC-8707 token request 401s in production.
       expect(body.resource).toMatch(/\/mcp$/);
       expect(body.resource).not.toContain("/mcp/org_xyz");
-      expect(body.scopes_supported).toEqual(["mcp:read", "mcp:write"]);
+      // `offline_access` is load-bearing here: DCR clients register with
+      // exactly this advertised list and the authorize endpoint validates
+      // against the client row's scopes, so dropping it breaks every
+      // refresh-token request with `invalid_scope`.
+      expect(body.scopes_supported).toEqual([
+        "mcp:read",
+        "mcp:write",
+        "offline_access",
+      ]);
       expect(body.bearer_methods_supported).toEqual(["header"]);
     } finally {
       await handle.close();

--- a/packages/api/src/api/routes/auth-md.ts
+++ b/packages/api/src/api/routes/auth-md.ts
@@ -47,8 +47,17 @@ type McpScope = Extract<(typeof ATLAS_OAUTH_SCOPES)[number], `mcp:${string}`>;
  * the authorize endpoint validates against the client row's scopes — see
  * `well-known.ts`), and the parity gate requires the doc and the metadata to
  * name the same set.
+ *
+ * The `offline_access` arm is derived via `Extract` rather than hardcoded so it
+ * stays tethered to the canonical union: rename or drop `offline_access` in
+ * `ATLAS_OAUTH_SCOPES` and this narrows to just `McpScope`, turning the
+ * `SCOPE_GRANTS` key and the `documentedScopes()` array into compile errors —
+ * the guard that stops #4728 (a DCR scope silently missing from a surface) from
+ * reappearing.
  */
-type DocumentedScope = McpScope | "offline_access";
+type DocumentedScope =
+  | McpScope
+  | Extract<(typeof ATLAS_OAUTH_SCOPES)[number], "offline_access">;
 
 export const authMd = new Hono();
 
@@ -81,12 +90,21 @@ const SCOPE_GRANTS: Partial<Record<DocumentedScope, string>> = {
     "receive a refresh token so the connection survives access-token expiry",
 };
 
-function documentedScopes(): AuthMdScope[] {
+/**
+ * The scope set /auth.md documents. Exported so the discovery-parity gate
+ * (`scripts/check-auth-md-discovery-parity.ts`) drives the SAME derivation the
+ * live route serves rather than hand-mirroring it — a copy would be its own
+ * drift vector.
+ */
+export function documentedScopes(): AuthMdScope[] {
   const mcp = ATLAS_OAUTH_SCOPES.filter((s): s is McpScope =>
     s.startsWith("mcp:"),
   );
-  // mcp:* first (they are what the doc is about), offline_access last.
-  return [...mcp, "offline_access" as const].map((name) => ({
+  // mcp:* first (they are what the doc is about), offline_access last. Typed as
+  // DocumentedScope[] so dropping/renaming `offline_access` in the canonical
+  // union is a compile error here, not a silent surface divergence.
+  const documented: DocumentedScope[] = [...mcp, "offline_access"];
+  return documented.map((name) => ({
     name,
     grants: SCOPE_GRANTS[name] ?? "an Atlas MCP capability",
   }));

--- a/packages/api/src/api/routes/auth-md.ts
+++ b/packages/api/src/api/routes/auth-md.ts
@@ -37,8 +37,18 @@ import {
   buildResourceUri,
 } from "./well-known";
 
-/** The `mcp:*` subset of the canonical scope union — the scopes /auth.md documents. */
+/** The `mcp:*` subset of the canonical scope union. */
 type McpScope = Extract<(typeof ATLAS_OAUTH_SCOPES)[number], `mcp:${string}`>;
+
+/**
+ * The scopes /auth.md documents: the `mcp:*` set plus `offline_access`.
+ * `offline_access` is included because the protected-resource metadata must
+ * advertise it (DCR clients register with exactly the advertised list, and
+ * the authorize endpoint validates against the client row's scopes — see
+ * `well-known.ts`), and the parity gate requires the doc and the metadata to
+ * name the same set.
+ */
+type DocumentedScope = McpScope | "offline_access";
 
 export const authMd = new Hono();
 
@@ -55,25 +65,30 @@ const ATLAS_DOCS_URL = "https://docs.useatlas.dev";
 const ONBOARDING_MCP_PATH = "/mcp/onboarding";
 
 /**
- * Human-readable grants for the MCP scopes, keyed off the canonical scope
- * token. Only the `mcp:*` scopes are documented in `/auth.md` — the file is
- * about connecting an MCP actor, not the OIDC sign-in scopes. Deriving the
- * *set* from `ATLAS_OAUTH_SCOPES` (rather than re-listing the scopes by
- * hand) is what makes a newly-added `mcp:*` scope surface automatically; a
- * scope without a grant blurb here still appears, with a generic line.
+ * Human-readable grants for the documented scopes, keyed off the canonical
+ * scope token. The `mcp:*` scopes plus `offline_access` are documented in
+ * `/auth.md` — the file is about connecting an MCP actor, not the OIDC
+ * sign-in scopes. Deriving the *set* from `ATLAS_OAUTH_SCOPES` (rather than
+ * re-listing the scopes by hand) is what makes a newly-added `mcp:*` scope
+ * surface automatically; a scope without a grant blurb here still appears,
+ * with a generic line.
  */
-const MCP_SCOPE_GRANTS: Partial<Record<McpScope, string>> = {
+const SCOPE_GRANTS: Partial<Record<DocumentedScope, string>> = {
   "mcp:read": "query workspace data through the hosted MCP endpoint",
   "mcp:write":
     "perform write operations (reserved for future mutation tools)",
+  offline_access:
+    "receive a refresh token so the connection survives access-token expiry",
 };
 
-function mcpScopes(): AuthMdScope[] {
-  return ATLAS_OAUTH_SCOPES.filter(
-    (s): s is McpScope => s.startsWith("mcp:"),
-  ).map((name) => ({
+function documentedScopes(): AuthMdScope[] {
+  const mcp = ATLAS_OAUTH_SCOPES.filter((s): s is McpScope =>
+    s.startsWith("mcp:"),
+  );
+  // mcp:* first (they are what the doc is about), offline_access last.
+  return [...mcp, "offline_access" as const].map((name) => ({
     name,
-    grants: MCP_SCOPE_GRANTS[name] ?? "an Atlas MCP capability",
+    grants: SCOPE_GRANTS[name] ?? "an Atlas MCP capability",
   }));
 }
 
@@ -94,7 +109,7 @@ export function renderAuthMd(req: Request): string {
     authServerUri: buildAuthServerUri(req),
     issuerBaseUri: buildIssuerBaseUri(req),
     resourceUri: buildResourceUri(req),
-    scopes: mcpScopes(),
+    scopes: documentedScopes(),
     onboardingPath: ONBOARDING_MCP_PATH,
     docsUrl: ATLAS_DOCS_URL,
   });

--- a/packages/api/src/api/routes/well-known.ts
+++ b/packages/api/src/api/routes/well-known.ts
@@ -417,11 +417,17 @@ wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", async (c) => {
         resource: buildResourceUri(c.req.raw),
         authorization_servers: [buildAuthServerUri(c.req.raw)],
         bearer_methods_supported: ["header"],
-        scopes_supported: ["mcp:read", "mcp:write"],
+        // `offline_access` must be advertised alongside the `mcp:*` scopes:
+        // DCR clients (Claude Code among them) register with exactly this
+        // list, and `@better-auth/oauth-provider` validates authorize-time
+        // scope requests against the CLIENT row's scopes (`client.scopes ??
+        // opts.scopes`), not the server's. Omitting it makes every client
+        // that wants a refresh token fail authorize with `invalid_scope`.
+        scopes_supported: ["mcp:read", "mcp:write", "offline_access"],
       },
       // Silence the OIDC-scopes warning — the MCP resource server
-      // intentionally lists `mcp:*` only. The auth server still
-      // advertises openid/profile/email separately.
+      // intentionally omits the sign-in scopes (openid/profile/email);
+      // the auth server advertises those separately.
       { silenceWarnings: { oidcScopes: true } },
     );
 

--- a/packages/api/src/api/routes/well-known.ts
+++ b/packages/api/src/api/routes/well-known.ts
@@ -38,6 +38,7 @@
  */
 
 import { Hono } from "hono";
+import type { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
 import { createLogger } from "@atlas/api/lib/logger";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
@@ -423,7 +424,14 @@ wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", async (c) => {
         // scope requests against the CLIENT row's scopes (`client.scopes ??
         // opts.scopes`), not the server's. Omitting it makes every client
         // that wants a refresh token fail authorize with `invalid_scope`.
-        scopes_supported: ["mcp:read", "mcp:write", "offline_access"],
+        // `satisfies` tethers each literal to the canonical scope union so a
+        // rename there (e.g. of `offline_access`) is a compile error, not a
+        // silent advertise-a-scope-the-server-can't-issue drift (#4728).
+        scopes_supported: [
+          "mcp:read",
+          "mcp:write",
+          "offline_access",
+        ] satisfies readonly (typeof ATLAS_OAUTH_SCOPES)[number][],
       },
       // Silence the OIDC-scopes warning — the MCP resource server
       // intentionally omits the sign-in scopes (openid/profile/email);

--- a/packages/api/src/lib/mcp/__tests__/auth-md.test.ts
+++ b/packages/api/src/lib/mcp/__tests__/auth-md.test.ts
@@ -19,6 +19,7 @@ const BASE_OPTS: BuildAuthMdOptions = {
   scopes: [
     { name: "mcp:read", grants: "query workspace data through the MCP endpoint" },
     { name: "mcp:write", grants: "reserved for future write paths" },
+    { name: "offline_access", grants: "receive a refresh token" },
   ],
   onboardingPath: "/mcp/onboarding",
   docsUrl: "https://docs.useatlas.dev",


### PR DESCRIPTION
Closes #4728.

## Problem

Connecting Claude Code to the hosted MCP endpoint dies at OAuth consent with `invalid_scope: The following scopes are invalid: offline_access` (found dogfooding prod, 2026-07-18).

DCR clients register with **exactly** the scope list the protected-resource metadata advertises (`scopes_supported: ["mcp:read", "mcp:write"]`), and `@better-auth/oauth-provider` validates authorize-time scope requests against the **client row's** scopes (`client.scopes ?? opts.scopes`) — not the server's full `ATLAS_OAUTH_SCOPES` (which does include `offline_access`). So the `offline_access` every refresh-token-wanting client adds at authorize is rejected. Our docs promise `scope=openid mcp:read offline_access` and our own SDK defaults to `["mcp:read", "offline_access"]` — neither flow works from a DCR-registered client.

## Fix

Advertise `offline_access` alongside the `mcp:*` scopes everywhere the resource metadata surfaces, and keep every parity gate in lockstep:

- `well-known.ts` — the dynamic per-workspace MCP protected-resource metadata (+ comment explaining why the scope is load-bearing)
- `generate-apex-discovery.ts` — the apex/docs static mirror; artifacts regenerated (`apps/www/public/{auth.md,.well-known/oauth-protected-resource.json}`, docs generated JSON)
- `api/routes/auth-md.ts` — `/auth.md` now documents `offline_access` (`documentedScopes()` = `mcp:*` + `offline_access`)
- `check-auth-md-discovery-parity.ts` — the doc-token pattern recognizes `offline_access` so scope parity stays bidirectional; render fixture matches the route derivation

Tests: apex/auth-md/parity/well-known expectations updated + a regression case pinning the "doc drops offline_access" direction.

## Remediation note

Client rows registered before this fix keep their narrow scope list. Post-deploy: remove + re-add the MCP server in the client (fresh DCR picks up the fixed metadata), or an operator widens `scopes` on the affected `oauthClient` row.

## Verification

- `/ci` (`scripts/ci-local.sh`): all 31 gates green
- `check-auth-md-discovery-parity.ts`: OK across both region fixtures with the new scope set
- Full end-to-end (Claude Code OAuth dance against prod): after next `/release` — tracked in #4728 acceptance criteria