### PR TITLE
fix(mcp): pin OAuth login/consent pages to the web origin (consent 404)

### DIFF
--- a/packages/api/src/api/__tests__/well-known.test.ts
+++ b/packages/api/src/api/__tests__/well-known.test.ts
@@ -198,6 +198,27 @@ describe("well-known — managed auth mode", () => {
     }
   });
 
+  it("serves the workspace-less /.well-known/oauth-protected-resource/mcp alias with identical metadata", async () => {
+    // RFC 9728 §3.1 path-insertion default: a client MAY construct the
+    // metadata URL from the resource (`.../mcp`) without following the 401
+    // `WWW-Authenticate` pointer, yielding this workspace-less segment.
+    // It must return the same region-scoped document as the canonical
+    // `/:workspace_id` route (workspace_id is decorative — used only for
+    // log correlation), so a pointer-skipping client discovers the auth
+    // server instead of 404ing.
+    const handle = await startServer();
+    try {
+      const [aliased, canonical] = await Promise.all([
+        fetch(`${handle.url}/.well-known/oauth-protected-resource/mcp`),
+        fetch(`${handle.url}/.well-known/oauth-protected-resource/mcp/org_xyz`),
+      ]);
+      expect(aliased.status).toBe(200);
+      expect(await aliased.json()).toEqual(await canonical.json());
+    } finally {
+      await handle.close();
+    }
+  });
+
   it("advertises mcp.useatlas.dev as the resource when ATLAS_PUBLIC_API_URL points at the us-region api host", async () => {
     // #2068 — mcp.useatlas.dev is the canonical hostname for the
     // hosted MCP endpoint. The protected-resource metadata must

--- a/packages/api/src/api/routes/well-known.ts
+++ b/packages/api/src/api/routes/well-known.ts
@@ -37,7 +37,7 @@
  * authenticated routes; these are public-discovery endpoints by design.
  */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import type { ATLAS_OAUTH_SCOPES } from "@atlas/api/lib/auth/oauth-scopes";
 import { createLogger } from "@atlas/api/lib/logger";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
@@ -372,16 +372,28 @@ wellKnown.get("/openid-configuration/api/auth", async (c) => {
   }
 });
 
-// ── /.well-known/oauth-protected-resource/mcp/:workspace_id ─────────
+// ── /.well-known/oauth-protected-resource/mcp[/:workspace_id] ───────
 // RFC 9728. Per the MCP authorization spec, the resource server (us)
-// publishes one document per protected resource so the client can
+// publishes a document for the protected resource so the client can
 // discover the auth server before making an authenticated request.
 //
-// `workspace_id` in the path is the resource identifier — clients
-// reading this document learn that token audience must match the
-// returned `resource` URI exactly. `bearer_methods_supported: ["header"]`
-// reflects what the hosted MCP path accepts (no body / query bearers).
-wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", async (c) => {
+// Two routes, one handler:
+//   - `/oauth-protected-resource/mcp/:workspace_id` — the canonical path
+//     the 401 `WWW-Authenticate: … resource_metadata=…` pointer hands out
+//     (see hosted.ts `wwwAuthenticateHeader`). Spec-compliant clients
+//     follow the pointer and land here.
+//   - `/oauth-protected-resource/mcp` — a workspace-less alias. RFC 9728
+//     §3.1 says a client MAY *construct* the metadata URL from the resource
+//     (`https://mcp.useatlas.dev/mcp`) by path-insertion — which yields
+//     exactly this segment, with NO workspace suffix. A client that skips
+//     the `WWW-Authenticate` pointer and builds the default URL would
+//     otherwise 404. Serving identical metadata here is a defensive hedge.
+//
+// `bearer_methods_supported: ["header"]` reflects what the hosted MCP path
+// accepts (no body / query bearers). The metadata itself is region-scoped,
+// not workspace-scoped (see the `resource` comment below), so both routes
+// return the same document — `workspace_id` is used only for log correlation.
+const handleProtectedResourceMetadata = async (c: Context): Promise<Response> => {
   const requestId = crypto.randomUUID();
   const outcome = await loadAuthAndHelpers();
   if (outcome.kind === "not-managed") return notManagedResponse();
@@ -390,12 +402,6 @@ wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", async (c) => {
   }
 
   const workspaceId = c.req.param("workspace_id");
-  if (!workspaceId) {
-    return new Response(
-      JSON.stringify({ error: "bad_request", message: "Missing workspace_id", requestId }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
-  }
 
   try {
     // Same structural-cast pattern as the auth-server / openid handlers
@@ -450,7 +456,12 @@ wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", async (c) => {
     );
     return metadataUnavailableResponse(requestId);
   }
-});
+};
+
+wellKnown.get("/oauth-protected-resource/mcp/:workspace_id", handleProtectedResourceMetadata);
+// RFC 9728 §3.1 path-insertion default (no workspace suffix) — see the
+// handler doc above for why this alias exists.
+wellKnown.get("/oauth-protected-resource/mcp", handleProtectedResourceMetadata);
 
 // ── /.well-known/agent-configuration ────────────────────────────────
 // Agent Auth Protocol discovery document (§6.1), gated by #4409's

--- a/packages/api/src/lib/auth/__tests__/oauth-provider-pages-origin.test.ts
+++ b/packages/api/src/lib/auth/__tests__/oauth-provider-pages-origin.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression (MCP consent 404): the OAuth 2.1 provider's `loginPage`,
+ * `consentPage`, and `postLogin.page` MUST be absolute against the web-app
+ * origin whenever the API and web app live on different hosts (SaaS:
+ * api.useatlas.dev vs app.useatlas.dev; local dev: :3001 vs :3000).
+ *
+ * Better Auth's oauthProvider uses these values verbatim as the 302
+ * `Location`. A browser resolves a relative path (`/login`) against the
+ * *response* origin — the API — so a bare "/login" 404s on the API host. This
+ * only bit a fresh MCP flow (no session, `prompt=consent`): a returning user
+ * with a live session + prior consent skips both pages, which is why it hid
+ * for so long. Same cross-origin trap `rewriteVerificationCallbackURL` fixes
+ * for email links.
+ *
+ * The paired combined-origin assertion (getWebOrigin() → null, e.g. the
+ * nextjs-standalone deploy where the API serves the web app on its own origin)
+ * guards the inverse: the relative path must survive there, so a "just always
+ * prefix" edit that broke the single-origin deploy would flip it.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+// getWebOrigin is web-origin.ts's only export — mock it whole so a partial
+// mock can't surface as a cross-file SyntaxError under bun's parallel workers.
+// buildPlugins() reads getWebOrigin() at call time (not import time), so
+// flipping `webOrigin` between cases is enough — no per-case remock needed.
+let webOrigin: string | null = "https://app.useatlas.dev";
+void mock.module("@atlas/api/lib/web-origin", () => ({
+  getWebOrigin: () => webOrigin,
+}));
+
+const { buildPlugins } = await import("../server");
+
+type OAuthProviderOptions = {
+  loginPage?: string;
+  consentPage?: string;
+  postLogin?: { page?: string };
+};
+
+function oauthProviderOptions(): OAuthProviderOptions {
+  const plugin = (buildPlugins() as Array<{ id?: string; options?: unknown }>).find(
+    (p) => p?.id === "oauth-provider",
+  );
+  expect(plugin, "oauth-provider plugin must be registered").toBeDefined();
+  return (plugin as { options: OAuthProviderOptions }).options;
+}
+
+describe("oauthProvider login/consent page origin", () => {
+  it("pins pages to the web origin when API and web are different hosts", () => {
+    webOrigin = "https://app.useatlas.dev";
+    const opts = oauthProviderOptions();
+    expect(opts.loginPage).toBe("https://app.useatlas.dev/login");
+    expect(opts.consentPage).toBe("https://app.useatlas.dev/oauth2/consent");
+    expect(opts.postLogin?.page).toBe("https://app.useatlas.dev/oauth2/post-login");
+  });
+
+  it("falls back to relative paths on a combined-origin deploy (getWebOrigin null)", () => {
+    webOrigin = null;
+    const opts = oauthProviderOptions();
+    expect(opts.loginPage).toBe("/login");
+    expect(opts.consentPage).toBe("/oauth2/consent");
+    expect(opts.postLogin?.page).toBe("/oauth2/post-login");
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2655,14 +2655,30 @@ export function buildPlugins() {
   // `oauthConsent`, `jwks`) lands automatically through Better Auth's
   // `ctx.runMigrations()` at boot — see migrate.ts.
   plugins.push(jwt());
+  // The login/consent screens live in the web app (packages/web), which in
+  // SaaS is a *different origin* than this API (app.useatlas.dev vs
+  // api.useatlas.dev) — and even in local dev (web :3000 vs API :3001).
+  // Better Auth's oauthProvider uses these values verbatim as the 302
+  // `Location`, and browsers resolve a relative path against the *response*
+  // origin (the API), so a bare "/login" lands on `api.useatlas.dev/login`
+  // and 404s. This is the same cross-origin redirect trap that
+  // `rewriteVerificationCallbackURL` fixes for email links — it only bit a
+  // fresh MCP flow (no session, `prompt=consent`), since a returning user
+  // with a live session + prior consent skips both pages. Pin them to the
+  // web origin; fall back to the relative path only for the combined-origin
+  // deploy (nextjs-standalone) where `getWebOrigin()` is null and the API
+  // serves the web app on its own origin. See #2024, #4728.
+  const oauthWebOrigin = getWebOrigin();
+  const oauthPage = (path: string): string =>
+    oauthWebOrigin ? `${oauthWebOrigin}${path}` : path;
   plugins.push(
     oauthProvider({
       // Where the user is sent when they hit /oauth2/authorize without
       // a session. Existing managed-auth login page handles it.
-      loginPage: "/login",
+      loginPage: oauthPage("/login"),
       // Consent screen for the user-grants-scopes step. Page lives in
       // packages/web at src/app/oauth2/consent/page.tsx.
-      consentPage: "/oauth2/consent",
+      consentPage: oauthPage("/oauth2/consent"),
       // Required for MCP onboarding — Claude Desktop / ChatGPT / Cursor
       // dynamically register as public clients without prior credentials.
       // See `resolveAllowUnauthDcr` for the deprecation-tracking note.
@@ -2704,7 +2720,11 @@ export function buildPlugins() {
       // The `page` field is required by Better Auth's options shape
       // but is never navigated to under this `shouldRedirect` value.
       postLogin: {
-        page: "/oauth2/post-login",
+        // Absolute for the same cross-origin reason as loginPage/consentPage.
+        // Currently never navigated to (`shouldRedirect: () => false`), but
+        // keeping it web-origin-pinned means flipping that flag can't
+        // reintroduce the API-origin 404.
+        page: oauthPage("/oauth2/post-login"),
         consentReferenceId: async ({ session }) =>
           readActiveOrgId(session as Parameters<typeof readActiveOrgId>[0]),
         shouldRedirect: () => false,


### PR DESCRIPTION
## Problem

A fresh hosted-MCP OAuth flow 404s at the consent step. The `/oauth2/authorize` endpoint works (302) — it redirects to a **relative** `/login`, which a browser resolves against the *response* origin (the API, `api.useatlas.dev`). The login/consent pages live in the **web** app (`app.useatlas.dev/login`, `/oauth2/consent` — both 200), a different host in SaaS (and a different port in local dev), so the redirect lands on `api.useatlas.dev/login` → **404**.

It only bit a fresh flow (no session, `prompt=consent`); a returning user with a live session + prior consent skips both pages, which is why it went unnoticed since the original OAuth provider PR (#2024).

This is the same cross-origin redirect trap `rewriteVerificationCallbackURL` already fixes for verify-email / password-reset links — the OAuth pages just never got the same treatment.

## Fix

`packages/api/src/lib/auth/server.ts` — pin `loginPage`, `consentPage`, and `postLogin.page` to the web origin via the existing `getWebOrigin()`, falling back to the relative path only for the combined-origin `nextjs-standalone` deploy (where `getWebOrigin()` is `null` and the API serves the web app on its own origin).

```ts
const oauthWebOrigin = getWebOrigin();
const oauthPage = (path: string): string =>
  oauthWebOrigin ? `${oauthWebOrigin}${path}` : path;
// loginPage: oauthPage("/login"), consentPage: oauthPage("/oauth2/consent"), ...
```

## Also: RFC 9728 workspace-less PRM alias

While investigating discovery, added `/.well-known/oauth-protected-resource/mcp` (no `workspace_id` segment) as an alias returning identical region-scoped metadata. Rationale: RFC 9728 §3.1 lets a client *construct* the metadata URL from the resource (`https://mcp.useatlas.dev/mcp`) by path-insertion — which yields exactly this workspace-less segment. A client that skips the 401 `WWW-Authenticate: … resource_metadata=…` pointer and builds the default URL would otherwise 404. The `workspace_id` segment is decorative (the resource is region-scoped, isolation runs through the JWT claim), so both routes share one handler.

Verified the rest of the discovery chain is already spec-correct and live-green: AS metadata at `/.well-known/oauth-authorization-server/api/auth` (RFC 8414 path-insertion for the `/api/auth` issuer), PRM at `/.well-known/oauth-protected-resource/mcp/{workspaceId}`.

## Tests

- `oauth-provider-pages-origin.test.ts` — asserts absolute pages when API/web are different hosts, and the relative-path fallback for the combined-origin deploy.
- `well-known.test.ts` — new case asserting the workspace-less alias returns identical metadata to the canonical route.

Both pass via the isolated runner; `tsgo` clean.

Refs #2024, #4728.