### PR TITLE
fix(backups): register pg_dump exit-code listener before the pipeline await

### DIFF
--- a/ee/src/backups/engine-exit-latch.test.ts
+++ b/ee/src/backups/engine-exit-latch.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression: the scheduled-backup create pipeline must not hang on the
+ * pg_dump exit-code wait.
+ *
+ * The bug (found diagnosing every prod region stuck with zero verified
+ * backups): `performBackup` attached its `pgDump.on("close", …)` listener
+ * *after* `await Promise.all([put, pipeline])`. But `close` is a one-shot
+ * event that fires as soon as the pipeline drains pg_dump's stdout — and the
+ * S3 `writer.end()` round-trip delays `Promise.all` ~150ms past that. So the
+ * listener attached afterwards always missed the already-fired event and
+ * awaited forever; the 2h fiber timeout then interrupted the cycle, stranding
+ * the row `in_progress` (no error, no size — interruption skips `tapError`).
+ *
+ * This test reproduces the exact ordering with REAL streams (not the
+ * instant-resolve mocks in engine.test.ts, which re-fire `close` on every
+ * listener attach and so can never catch this): a one-shot `EventEmitter`
+ * process whose `close` fires right after stdout EOF, and a `storage.put`
+ * that resolves *after* that. Against the buggy ordering `createBackup` never
+ * settles (the timeout race below fails fast instead of hanging the suite);
+ * with the exit latch registered before the pipeline it completes.
+ *
+ * NB: this file intentionally does NOT mock `zlib` / `stream/promises` — the
+ * real gzip + pipeline are what make the `close`-before-`Promise.all`
+ * ordering faithful.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { Effect } from "effect";
+import { EventEmitter } from "events";
+import { Readable } from "stream";
+import { createEEMock } from "../__mocks__/internal";
+
+const ee = createEEMock();
+mock.module("../index", () => ee.enterpriseMock);
+mock.module("@atlas/api/lib/db/internal", () => ee.internalDBMock);
+mock.module("../lib/db-guard", () => ({
+  requireInternalDB: (label: string, factory?: () => Error) => {
+    if (!(ee.internalDBMock.hasInternalDB as () => boolean)())
+      throw factory?.() ?? new Error(`Internal database required for ${label}.`);
+  },
+  requireInternalDBEffect: (label: string, factory?: () => Error) =>
+    (ee.internalDBMock.hasInternalDB as () => boolean)()
+      ? Effect.void
+      : Effect.fail(factory?.() ?? new Error(`Internal database required for ${label}.`)),
+}));
+mock.module("@atlas/api/lib/logger", () => ee.loggerMock);
+
+// Storage driver whose put resolves AFTER the process 'close' fires — the
+// real S3 writer.end() round-trip is exactly this "settles slightly later".
+const storageMock = {
+  kind: "local" as const,
+  put: mock(async (_path: string, source: AsyncIterable<Buffer | string>) => {
+    let sizeBytes = 0;
+    for await (const chunk of source) {
+      sizeBytes += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
+    }
+    // Resolve on a later macrotask so the one-shot 'close' (scheduled via
+    // setImmediate below) has already fired by the time Promise.all settles.
+    await new Promise((r) => setTimeout(r, 20));
+    return { sizeBytes };
+  }),
+  getStream: mock(async () => Readable.from([])),
+  list: mock(async () => [] as string[]),
+  remove: mock(async () => {}),
+};
+mock.module("./storage", () => ({
+  getBackupStorage: () => storageMock,
+  isS3BackupStorageConfigured: () => false,
+  createLocalBackupStorage: () => storageMock,
+  createS3BackupStorage: () => storageMock,
+  _resetBackupStorage: () => {},
+}));
+
+// Faithful one-shot process: real stdout Readable, `close` emitted exactly
+// once right after stdout EOF (mirrors pg_dump exiting when its stdout is
+// drained). A real EventEmitter gives correct one-shot semantics — a late
+// listener misses the event, which is the whole point.
+function makeProc(): EventEmitter & { stdout: Readable; stderr: Readable } {
+  const proc = new EventEmitter() as EventEmitter & { stdout: Readable; stderr: Readable };
+  proc.stdout = Readable.from([Buffer.from("-- pg_dump output\nSELECT 1;\n")]);
+  proc.stderr = Readable.from([]);
+  proc.stdout.once("end", () => setImmediate(() => proc.emit("close", 0)));
+  return proc;
+}
+mock.module("child_process", () => ({ spawn: () => makeProc() }));
+
+const { createBackup, _resetTableReady } = await import("./engine");
+
+const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect as Effect.Effect<A, never>);
+
+const ENSURE_TABLE_QUERIES = 8;
+const ensureTableEmpties = (): Record<string, unknown>[][] =>
+  Array.from({ length: ENSURE_TABLE_QUERIES }, () => []);
+const defaultConfigRow = { schedule: "0 3 * * *", retention_days: 30, storage_path: "./backups" };
+
+describe("createBackup — pg_dump exit-code latch (no hang when close fires before Promise.all)", () => {
+  let priorDatabaseUrl: string | undefined;
+
+  beforeEach(() => {
+    ee.reset();
+    _resetTableReady();
+    storageMock.put.mockClear();
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/testdb";
+  });
+
+  afterEach(() => {
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+  });
+
+  it("completes even though the process 'close' fires before the storage put settles", async () => {
+    // Query order: ensureTable (8) + getBackupConfig SELECT (1)
+    //   + INSERT ... RETURNING id (1) + countSourceBaseTables (1)
+    //   + completed UPDATE (1) = 12.
+    ee.queueMockRows(
+      ...ensureTableEmpties(),
+      [defaultConfigRow],
+      [{ id: "b1" }],
+      [{ count: "1" }],
+      [],
+    );
+
+    const result = await Promise.race([
+      run(createBackup()),
+      new Promise<never>((_, rej) =>
+        setTimeout(
+          () =>
+            rej(
+              new Error(
+                "createBackup did not settle within 5s — exit-code latch regression: " +
+                  "the pg_dump 'close' listener was attached after Promise.all and missed the one-shot event",
+              ),
+            ),
+          5000,
+        ),
+      ),
+    ]);
+
+    expect(result.status).toBe("completed");
+    expect(storageMock.put).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ee/src/backups/engine.ts
+++ b/ee/src/backups/engine.ts
@@ -307,6 +307,26 @@ const performBackup = (
       spawnError = err instanceof Error ? err : new Error(String(err));
     });
 
+    // Latch the exit code NOW, while pg_dump is still running — never after
+    // the pipeline await below. `close` is a one-shot event that fires as
+    // soon as the pipeline drains pg_dump's stdout (observed ~150ms before
+    // `Promise.all` settles, because the S3 `writer.end()` round-trip runs
+    // after stdout EOF). A `close` listener attached *after* that await
+    // always misses the already-fired event and waits forever — the 2h fiber
+    // timeout then interrupts the cycle, stranding the row `in_progress` with
+    // no error and no size (every scheduled backup in prod hung this way).
+    // Resolve-only on BOTH events: `error` (ENOENT/EACCES) is already
+    // captured in `spawnError` above and may fire without a following
+    // `close`, so it must also settle this latch or the await re-hangs.
+    let exitCode: number | null = null;
+    const exitClosed = new Promise<void>((resolve) => {
+      pgDump.on("close", (code) => {
+        exitCode = code;
+        resolve();
+      });
+      pgDump.on("error", () => resolve());
+    });
+
     const gzip = createGzip();
     const gzipped = new PassThrough();
 
@@ -340,20 +360,19 @@ const performBackup = (
       catch: (err) => spawnError ?? (err instanceof Error ? err : new Error(String(err))),
     });
 
-    const exitCode = yield* Effect.tryPromise({
-      try: () =>
-        new Promise<number>((resolve, reject) => {
-          // 'close' never fires when the spawn itself failed — reject with
-          // the captured cause instead of hanging on a resolve-only wait.
-          if (spawnError) {
-            reject(spawnError);
-            return;
-          }
-          pgDump.on("close", resolve);
-          pgDump.on("error", (err) => reject(err instanceof Error ? err : new Error(String(err))));
-        }),
+    // Awaits the pre-registered latch — already settled by now (pg_dump
+    // exited during the pipeline above), so this is an immediate read, not a
+    // fresh listen that could miss the event.
+    yield* Effect.tryPromise({
+      try: () => exitClosed,
       catch: (err) => spawnError ?? (err instanceof Error ? err : new Error(String(err))),
     });
+
+    // A spawn failure (or an `error`-without-`close`) leaves `exitCode` null:
+    // surface the captured spawn error rather than a misleading exit code.
+    if (spawnError) {
+      return yield* Effect.fail(spawnError);
+    }
 
     if (exitCode !== 0) {
       return yield* Effect.fail(new Error(`pg_dump exited with code ${exitCode}: ${stderr.slice(0, 500)}`));


### PR DESCRIPTION
## Problem

**Scheduled backups have never once succeeded in production.** All 3 regions (`api`/`api-eu`/`api-apac`) report `backups: degraded` on `/health`, each with a single backup row stuck `in_progress` since the first fiber tick — no `size_bytes`, no `error_message`, no `verified` backup ever recorded.

Found while investigating the `degraded` health signal after the v0.0.60 deploy.

## Root cause — event-ordering bug in `performBackup` (`ee/src/backups/engine.ts`)

The create pipeline is `pg_dump → gzip → storage.put(S3)`. The engine attached its exit-code listener **after** the pipeline await:

```ts
const sizeBytes = await Promise.all([storagePut, pipeline]);   // ← S3 end() round-trip
// ...
const exitCode = await new Promise(res => pgDump.on("close", res));  // ← too late
```

`close` is a **one-shot** event that fires the moment the pipeline drains pg_dump's stdout. The S3 `writer.end()` round-trip then delays `Promise.all` past it. A listener attached afterward never fires → the cycle hangs on the exit-code wait → the 2h fiber timeout interrupts it → interruption skips `tapError`, so neither the `completed` nor the `failed` UPDATE runs → the row is stranded `in_progress` forever (until the 6h stale-claim reaper marks it failed, and the window is never retried).

**Confirmed by in-container reproduction against the real prod internal DB + S3 bucket:**
```
[5ms]     pipeline+put starting
[632ms]   Promise.all done, bytes=381965  close_already_fired=true (closeAt=481ms)
[15634ms] EXITCODE-WAIT-HUNG-15s  <-- reproduced
```
pg_dump 18.4 and the S3 upload each work in isolation (~130ms / <1s) — only the composition hangs. Verified the corrected ordering resolves immediately (`exitCode=0` at Promise.all completion).

## Fix

Register a **resolve-only** exit latch immediately after `spawn`, while pg_dump is still running, and read the settled value after the pipeline:

```ts
let exitCode: number | null = null;
const exitClosed = new Promise<void>((resolve) => {
  pgDump.on("close", (code) => { exitCode = code; resolve(); });
  pgDump.on("error", () => resolve());  // spawnError already captured; unblock either way
});
```

The `error` branch keeps a spawn failure (ENOENT/EACCES, which may fire without a following `close`) from re-introducing the hang; the captured `spawnError` is still surfaced as the failure cause.

## Tests

New `engine-exit-latch.test.ts` uses **real** streams + a one-shot `EventEmitter` process whose `close` fires before the storage put settles — it **times out against the old ordering** and passes with the latch. (The existing `engine.test.ts` mocks re-fire `close` on every listener attach and resolve put instantly, so they structurally could not catch this.) All 7 backup test files pass; local `/ci` 31/31 green.

## Post-deploy note

The currently-stranded `in_progress` rows hold their daily-window claim; the next daily window (03:00 UTC) will run correctly on the fixed build. To get a verified backup sooner, the stranded rows can be marked `failed` so the window frees up — I can do that separately.