### PR TITLE
fix(mcp): emit canonical Streamable-HTTP config (type:http, no /sse) across installer, SDK, wizard, docs

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -59,7 +59,8 @@ The resulting block looks like:
 {
   "mcpServers": {
     "atlas": {
-      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse",
+      "type": "http",
+      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>",
       "headers": { "Authorization": "Bearer eyJhbGciOiJSUzI1NiIs…" }
     }
   }
@@ -73,7 +74,7 @@ The `code_verifier` and registered `client_id` stay in memory — only the JWT i
 Standards-compliant MCP clients (Claude Desktop, ChatGPT, Cursor, Gemini, Anthropic agents) can connect directly without the wizard or the CLI — they bootstrap via DCR + PKCE on their own. Just point the agent at your workspace MCP URL:
 
 ```
-https://mcp.useatlas.dev/mcp/{workspace_id}/sse
+https://mcp.useatlas.dev/mcp/{workspace_id}
 ```
 
 The agent does discovery, registration, and the OAuth dance unattended. This is the right path if your agent vendor publishes "paste an MCP URL" UX.
@@ -94,7 +95,8 @@ Open `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o
 {
   "mcpServers": {
     "atlas": {
-      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse",
+      "type": "http",
+      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>",
       "headers": { "Authorization": "Bearer <jwt>" }
     }
   }
@@ -108,8 +110,8 @@ Claude Desktop also supports DCR natively — point it at the URL alone and it w
 The CLI ships an `mcp add` subcommand that writes to the right scope automatically:
 
 ```bash
-claude mcp add atlas --scope user --transport sse \
-  https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse \
+claude mcp add atlas --scope user --transport http \
+  https://mcp.useatlas.dev/mcp/<your_workspace_id> \
   --header "Authorization: Bearer <jwt>"
 ```
 
@@ -127,7 +129,8 @@ Open `~/.continue/config.json` and add the wizard's `mcpServers.atlas` block und
 {
   "mcpServers": {
     "atlas": {
-      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse",
+      "type": "http",
+      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>",
       "headers": { "Authorization": "Bearer <jwt>" }
     }
   }
@@ -149,7 +152,7 @@ VS Code's GitHub Copilot Chat reads `.vscode/mcp.json` from the workspace root (
   "servers": {
     "atlas": {
       "type": "http",
-      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>/sse",
+      "url": "https://mcp.useatlas.dev/mcp/<your_workspace_id>",
       "headers": { "Authorization": "Bearer <jwt>" }
     }
   }
@@ -386,7 +389,7 @@ It returns:
 ```json
 {
   "workspaceId": "org_…",
-  "connectUrl": "https://mcp.useatlas.dev/mcp/org_…/sse",
+  "connectUrl": "https://mcp.useatlas.dev/mcp/org_…",
   "state": "grace"
 }
 ```
@@ -826,8 +829,10 @@ This section is hosted-only. Self-hosted stdio installs don't speak HTTP, so URL
 ### URL pattern
 
 ```
-https://mcp.useatlas.dev/mcp/{workspace_id}/sse
+https://mcp.useatlas.dev/mcp/{workspace_id}
 ```
+
+This is the canonical Streamable-HTTP path. The legacy `/mcp/{workspace_id}/sse` alias still resolves to the same endpoint (it predates the transport rename), but it only works with a Streamable-HTTP client — a client that treats the `/sse` suffix as a request for the deprecated HTTP+SSE transport will 400 on its first request. Always write the canonical path.
 
 The brand `mcp.useatlas.dev` hostname is the canonical surface every client config writes against. Per-region siblings exist for cross-region targeting:
 
@@ -893,14 +898,14 @@ Atlas's authorization server lives at `/api/auth`. Three discovery documents dri
 
 A standards-compliant MCP client:
 
-1. Hits the resource URL `/mcp/{workspace_id}/sse` without a bearer
+1. Hits the resource URL `/mcp/{workspace_id}` without a bearer
 2. Receives a `401` with `WWW-Authenticate: Bearer realm="Atlas MCP", resource_metadata="…"` pointing at the protected-resource document
 3. Reads the document, finds Atlas's `/api/auth` issuer
 4. Registers as a public OAuth client via `POST /api/auth/oauth2/register` (DCR — no admin pre-issuance required)
 5. Sends the user through `/api/auth/oauth2/authorize` with PKCE + `scope=openid mcp:read offline_access`
 6. The user signs in (if needed), reviews and approves on `/oauth2/consent`
 7. Client exchanges the code at `/api/auth/oauth2/token` and gets a JWT access token + refresh token
-8. Reconnects to `/mcp/{workspace_id}/sse` with `Authorization: Bearer <jwt>`
+8. Reconnects to `/mcp/{workspace_id}` with `Authorization: Bearer <jwt>`
 
 ```http
 Authorization: Bearer eyJhbGciOiJSUzI1NiIs…
@@ -940,7 +945,7 @@ Atlas supports two scoping modes per OAuth client:
 The agent is bound to its origin workspace. The path workspace MUST match the JWT's singular `workspace_id` claim:
 
 ```http
-GET /mcp/org_b/sse                 ← path workspace
+GET /mcp/org_b                     ← path workspace
 Authorization: Bearer <jwt>        ← workspace_id claim = org_a
 → 403 cross_workspace_denied
 ```

--- a/apps/docs/content/docs/platform-ops/mcp-load-test-tokens.mdx
+++ b/apps/docs/content/docs/platform-ops/mcp-load-test-tokens.mdx
@@ -5,7 +5,7 @@ description: Mint short-lived bearer JWTs for k6-driven MCP load testing
 
 `POST /api/v1/me/load-test/mcp-token` mints a short-lived,
 MCP-scoped JWT bearer for the caller's own active workspace. k6 (or
-any HTTP client) can then carry it against `/mcp/{workspace_id}/sse`
+any HTTP client) can then carry it against `/mcp/{workspace_id}`
 to exercise the hosted MCP surface under load. The token is signed by
 the same regional Better Auth JWKS the OAuth 2.1 path uses — the MCP
 edge verifier (`verifyAccessToken`) resolves the matching public key

--- a/apps/docs/content/shared/sdk/mcp.mdx
+++ b/apps/docs/content/shared/sdk/mcp.mdx
@@ -179,7 +179,8 @@ if (workspaces.length > 1) {
 
 `buildConfig` opts into the multi-workspace block by accepting the
 `workspaces` array. The emitted config still pins one workspace in the
-URL (the hosted MCP edge mounts at `/mcp/{workspace_id}/sse`), but it
+URL (the hosted MCP edge mounts at `/mcp/{workspace_id}` — the canonical
+Streamable-HTTP path, and every block carries `type: "http"`), but it
 gains an `env: { ATLAS_DEFAULT_WORKSPACE }` slot — the forward-compat
 hint MCP-client framework wrappers will bridge into the
 `X-Atlas-Default-Workspace` header. Per-request overrides happen via
@@ -195,7 +196,8 @@ const config = buildConfig({
   workspaces,            // opt into the multi-workspace block
 });
 // config.mcpServers.atlas → {
-//   url: "https://mcp.useatlas.dev/mcp/<ws>/sse",
+//   type: "http",
+//   url: "https://mcp.useatlas.dev/mcp/<ws>",
 //   headers: { Authorization: "Bearer <token>" },
 //   env: { ATLAS_DEFAULT_WORKSPACE: "<ws>" },
 // }

--- a/bun.lock
+++ b/bun.lock
@@ -441,7 +441,7 @@
     },
     "packages/sdk": {
       "name": "@useatlas/sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@useatlas/types": "^0.1.0",
       },
@@ -705,7 +705,7 @@
     },
     "plugins/mcp": {
       "name": "@useatlas/mcp",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "bin": {
         "atlas-mcp": "./bin/cli.ts",
       },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for the Atlas text-to-SQL agent API",
   "type": "module",
   "scripts": {

--- a/packages/sdk/src/__tests__/mcp.test.ts
+++ b/packages/sdk/src/__tests__/mcp.test.ts
@@ -611,7 +611,8 @@ describe("buildConfig", () => {
       kind: "wrapped",
       mcpServers: {
         atlas: {
-          url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+          type: "http",
+          url: `${API_URL}/mcp/${WORKSPACE_ID}`,
           headers: { Authorization: "Bearer access-token-xyz" },
         },
       },
@@ -621,29 +622,45 @@ describe("buildConfig", () => {
   test("cursor uses the wrapped shape", () => {
     const cfg = buildConfig({ client: "cursor", ...args });
     if (cfg.kind !== "wrapped") throw new Error("expected wrapped");
-    expect(cfg.mcpServers.atlas.url).toBe(`${API_URL}/mcp/${WORKSPACE_ID}/sse`);
+    expect(cfg.mcpServers.atlas.url).toBe(`${API_URL}/mcp/${WORKSPACE_ID}`);
     expect(cfg.mcpServers.atlas.headers.Authorization).toBe("Bearer access-token-xyz");
   });
 
   test("continue uses the wrapped shape", () => {
     const cfg = buildConfig({ client: "continue", ...args });
     if (cfg.kind !== "wrapped") throw new Error("expected wrapped");
-    expect(cfg.mcpServers.atlas.url).toBe(`${API_URL}/mcp/${WORKSPACE_ID}/sse`);
+    expect(cfg.mcpServers.atlas.url).toBe(`${API_URL}/mcp/${WORKSPACE_ID}`);
   });
 
   test("chatgpt uses the wrapped shape", () => {
     const cfg = buildConfig({ client: "chatgpt", ...args });
     if (cfg.kind !== "wrapped") throw new Error("expected wrapped");
-    expect(cfg.mcpServers.atlas.url).toBe(`${API_URL}/mcp/${WORKSPACE_ID}/sse`);
+    expect(cfg.mcpServers.atlas.url).toBe(`${API_URL}/mcp/${WORKSPACE_ID}`);
   });
 
   test("generic returns the bare {url, headers} block", () => {
     const cfg = buildConfig({ client: "generic", ...args });
     expect(cfg).toEqual({
       kind: "bare",
-      url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+      type: "http",
+      url: `${API_URL}/mcp/${WORKSPACE_ID}`,
       headers: { Authorization: "Bearer access-token-xyz" },
     });
+  });
+
+  test("pins type:http and the canonical (no /sse) URL so clients don't fall back to legacy HTTP+SSE", () => {
+    // Regression: a `/sse` URL + missing `type` drove path-keyed clients
+    // (Claude Code, VS Code) onto the deprecated HTTP+SSE transport, which
+    // the hosted endpoint no longer speaks — first request 400s.
+    const wrapped = buildConfig({ client: "claude-desktop", ...args });
+    if (wrapped.kind !== "wrapped") throw new Error("expected wrapped");
+    expect(wrapped.mcpServers.atlas.type).toBe("http");
+    expect(wrapped.mcpServers.atlas.url.endsWith("/sse")).toBe(false);
+
+    const bare = buildConfig({ client: "generic", ...args });
+    if (bare.kind !== "bare") throw new Error("expected bare");
+    expect(bare.type).toBe("http");
+    expect(bare.url.endsWith("/sse")).toBe(false);
   });
 
   test("custom serverName parameter overrides 'atlas'", () => {
@@ -657,7 +674,8 @@ describe("buildConfig", () => {
     const cfg = buildConfig({ client: "generic", ...args, apiUrl: `${API_URL}/` });
     expect(cfg).toEqual({
       kind: "bare",
-      url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+      type: "http",
+      url: `${API_URL}/mcp/${WORKSPACE_ID}`,
       headers: { Authorization: "Bearer access-token-xyz" },
     });
   });
@@ -669,14 +687,14 @@ describe("buildConfig", () => {
       workspaceId: "a/b c",
     });
     if (cfg.kind !== "bare") throw new Error("expected bare");
-    expect(cfg.url).toBe(`${API_URL}/mcp/${encodeURIComponent("a/b c")}/sse`);
+    expect(cfg.url).toBe(`${API_URL}/mcp/${encodeURIComponent("a/b c")}`);
   });
 
   // ── Multi-workspace shape (#2196) ────────────────────────────────────
   //
   // Passing `workspaces` (a non-empty array of granted ids) opts into the
   // multi-workspace block — the URL still pins one workspace as the
-  // default (server still requires `/mcp/{ws}/sse`), but an `env:
+  // default (canonical `/mcp/{ws}` path, no `/sse`), but an `env:
   // { ATLAS_DEFAULT_WORKSPACE }` slot is emitted alongside the headers
   // so future MCP-client frameworks can bridge it into the
   // `X-Atlas-Default-Workspace` header. Mirrors `buildHostedServerConfig`
@@ -694,7 +712,8 @@ describe("buildConfig", () => {
       kind: "wrapped",
       mcpServers: {
         atlas: {
-          url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+          type: "http",
+          url: `${API_URL}/mcp/${WORKSPACE_ID}`,
           headers: { Authorization: "Bearer access-token-xyz" },
           env: { ATLAS_DEFAULT_WORKSPACE: WORKSPACE_ID },
         },
@@ -712,7 +731,8 @@ describe("buildConfig", () => {
     });
     expect(cfg).toEqual({
       kind: "bare",
-      url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+      type: "http",
+      url: `${API_URL}/mcp/${WORKSPACE_ID}`,
       headers: { Authorization: "Bearer access-token-xyz" },
       env: { ATLAS_DEFAULT_WORKSPACE: WORKSPACE_ID },
     });
@@ -747,7 +767,8 @@ describe("buildConfig", () => {
     });
     if (cfg.kind !== "wrapped") throw new Error("expected wrapped");
     expect(cfg.mcpServers.atlas).toEqual({
-      url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+      type: "http",
+      url: `${API_URL}/mcp/${WORKSPACE_ID}`,
       headers: { Authorization: "Bearer access-token-xyz" },
     });
     expect("env" in cfg.mcpServers.atlas).toBe(false);
@@ -787,7 +808,8 @@ describe("buildConfig", () => {
       kind: "wrapped",
       mcpServers: {
         atlas: {
-          url: `${API_URL}/mcp/${WORKSPACE_ID}/sse`,
+          type: "http",
+          url: `${API_URL}/mcp/${WORKSPACE_ID}`,
           headers: { Authorization: "Bearer access-token-xyz" },
         },
       },

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -301,10 +301,10 @@ export interface BuildConfigOptions {
   /**
    * Workspace pinned in the connection URL. Even for multi-workspace
    * tokens this is required — the hosted MCP edge mounts at
-   * `/mcp/{workspace_id}/sse`. For multi-workspace setups pass the
-   * default-workspace id (typically the singular claim from
-   * `completeConnect`); per-request overrides happen via the
-   * `X-Atlas-Workspace` header.
+   * `/mcp/{workspace_id}` (canonical Streamable-HTTP path, no `/sse`). For
+   * multi-workspace setups pass the default-workspace id (typically the
+   * singular claim from `completeConnect`); per-request overrides happen
+   * via the `X-Atlas-Workspace` header.
    */
   workspaceId: string;
   /** Override the `mcpServers["..."]` key. Defaults to `"atlas"`. */
@@ -322,10 +322,11 @@ export interface BuildConfigOptions {
    * **Wire-shape note.** [#2073's recommendation A](https://github.com/AtlasDevHQ/atlas/issues/2073)
    * sketched `url: "https://mcp.useatlas.dev/sse"` without a workspace
    * in the path, but the implemented hosted MCP endpoint mounts at
-   * `/mcp/{workspace_id}/sse` and resolves per-request overrides via
-   * the `X-Atlas-Workspace` header. The SDK emits the implemented
-   * shape — a single config block, one default workspace in the
-   * path, and the env hint for per-request overrides.
+   * `/mcp/{workspace_id}` (canonical Streamable-HTTP path) and resolves
+   * per-request overrides via the `X-Atlas-Workspace` header. The SDK
+   * emits the implemented shape — a single config block, `type: "http"`,
+   * one default workspace in the path, and the env hint for per-request
+   * overrides.
    *
    * Omit (or pass an empty array) for the legacy single-workspace
    * shape — backward-compatible with every caller pre-#2196.
@@ -334,6 +335,16 @@ export interface BuildConfigOptions {
 }
 
 export interface McpHttpServer {
+  /**
+   * Transport discriminator — always `"http"` (Streamable HTTP). Pins the
+   * transport for clients that key off it explicitly (Claude Code, VS
+   * Code); without it those clients guess from the URL and a bare `{ url }`
+   * defaulted them to the deprecated HTTP+SSE transport, which the hosted
+   * endpoint no longer speaks, so the first request 400s. Clients that
+   * auto-detect (Cursor, Continue) ignore the field. Matches the CLI's
+   * hosted-config writer in `plugins/mcp/src/init/config-merge.ts`.
+   */
+  type: "http";
   url: string;
   headers: { Authorization: string };
   /**
@@ -514,7 +525,12 @@ export function buildConfig(options: BuildConfigOptions): McpClientConfig {
   const apiUrl = stripTrailingSlashes(options.apiUrl);
   // workspaceId is opaque server-issued; encode it defensively so a
   // value containing path-sensitive characters can't reshape the URL.
-  const url = `${apiUrl}/mcp/${encodeURIComponent(options.workspaceId)}/sse`;
+  //
+  // Canonical Streamable-HTTP path — deliberately NOT the legacy `/sse`
+  // alias. The `type: "http"` block below pins the transport, but a `/sse`
+  // suffix would still lead path-keyed clients into the deprecated HTTP+SSE
+  // transport (which the hosted endpoint no longer speaks) and 400.
+  const url = `${apiUrl}/mcp/${encodeURIComponent(options.workspaceId)}`;
   // Multi-workspace opt-in (#2196): non-empty `workspaces` emits the
   // env hint. Empty / omitted preserves the legacy single-workspace
   // shape. Loudly reject the embedder-error case where the picked
@@ -530,11 +546,13 @@ export function buildConfig(options: BuildConfigOptions): McpClientConfig {
   }
   const block: McpHttpServer = isMultiWorkspace
     ? {
+        type: "http",
         url,
         headers: { Authorization: `Bearer ${options.accessToken}` },
         env: { ATLAS_DEFAULT_WORKSPACE: options.workspaceId },
       }
     : {
+        type: "http",
         url,
         headers: { Authorization: `Bearer ${options.accessToken}` },
       };
@@ -549,11 +567,12 @@ export function buildConfig(options: BuildConfigOptions): McpClientConfig {
       return isMultiWorkspace
         ? {
             kind: "bare",
+            type: block.type,
             url: block.url,
             headers: block.headers,
             env: block.env,
           }
-        : { kind: "bare", url: block.url, headers: block.headers };
+        : { kind: "bare", type: block.type, url: block.url, headers: block.headers };
     case "claude-desktop":
     case "cursor":
     case "continue":

--- a/packages/web/src/app/settings/ai-agents/connect-wizard.tsx
+++ b/packages/web/src/app/settings/ai-agents/connect-wizard.tsx
@@ -134,7 +134,7 @@ export function ConnectWizard({ open, onClose }: ConnectWizardProps) {
 
   const apiBase = useMemo(() => {
     // `getApiUrl()` returns "" in same-origin Next.js rewrite mode (no
-    // `NEXT_PUBLIC_ATLAS_API_URL` set). Pasting `/mcp/<id>/sse` (a relative
+    // `NEXT_PUBLIC_ATLAS_API_URL` set). Pasting `/mcp/<id>` (a relative
     // path) into Claude Desktop / Cursor / ChatGPT silently fails — the
     // agents require an absolute URL. `window.location.origin` is the
     // browser-side absolute base for same-origin deployments. SSR has no
@@ -158,8 +158,13 @@ export function ConnectWizard({ open, onClose }: ConnectWizardProps) {
     // Workspace id is part of the URL — without it the agent can't bind to
     // a workspace. Fall back to a placeholder so the JSON parses; the user
     // sees the placeholder and knows something's missing.
-    if (!orgId) return `${mcpBase}/mcp/<your_workspace_id>/sse`;
-    return `${mcpBase}/mcp/${orgId}/sse`;
+    //
+    // Canonical Streamable-HTTP path — deliberately NOT the legacy `/sse`
+    // alias. A `/sse` suffix leads clients that key transport off the path
+    // (or the `type: "sse"` block) into the deprecated HTTP+SSE transport,
+    // which the hosted endpoint no longer speaks, so the first request 400s.
+    if (!orgId) return `${mcpBase}/mcp/<your_workspace_id>`;
+    return `${mcpBase}/mcp/${orgId}`;
   }, [apiBase, orgId]);
 
   const configJson = useMemo(() => {
@@ -167,6 +172,11 @@ export function ConnectWizard({ open, onClose }: ConnectWizardProps) {
       {
         mcpServers: {
           atlas: {
+            // Pin the Streamable-HTTP transport explicitly so clients that
+            // key off it (Claude Code, VS Code) don't fall back to legacy
+            // HTTP+SSE and 400 on connect. Clients that auto-detect (Cursor,
+            // ChatGPT) ignore the field.
+            type: "http",
             url: mcpUrl,
           },
         },

--- a/plugins/mcp/__tests__/init/config-merge.test.ts
+++ b/plugins/mcp/__tests__/init/config-merge.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildHostedServerConfig,
   buildServerConfig,
   mergeMcpServerConfig,
   writeConfigWithBackup,
@@ -34,6 +35,31 @@ describe("buildServerConfig", () => {
     for (const a of cfg.args) {
       expect(a.startsWith("/")).toBe(false);
     }
+  });
+});
+
+describe("buildHostedServerConfig", () => {
+  it("pins the Streamable-HTTP transport type so path-agnostic clients don't fall back to HTTP+SSE", () => {
+    const cfg = buildHostedServerConfig({
+      url: "https://mcp.useatlas.dev/mcp/ws_alpha",
+      accessToken: "jwt.token.here",
+    });
+    expect(cfg.type).toBe("http");
+    // Canonical endpoint — never the legacy `/sse` alias.
+    expect(cfg.url).toBe("https://mcp.useatlas.dev/mcp/ws_alpha");
+    expect(cfg.url.endsWith("/sse")).toBe(false);
+    expect(cfg.headers?.Authorization).toBe("Bearer jwt.token.here");
+    expect(cfg.env).toBeUndefined();
+  });
+
+  it("adds the ATLAS_DEFAULT_WORKSPACE env hint only for multi-workspace agents", () => {
+    const cfg = buildHostedServerConfig({
+      url: "https://mcp.useatlas.dev/mcp/ws_alpha",
+      accessToken: "jwt",
+      defaultWorkspaceId: "ws_alpha",
+    });
+    expect(cfg.type).toBe("http");
+    expect(cfg.env).toEqual({ ATLAS_DEFAULT_WORKSPACE: "ws_alpha" });
   });
 });
 

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -223,7 +223,7 @@ describe("runHostedAuthFlow — happy path", () => {
     // Bearer is a branded string; compare as plain string for the assertion.
     expect(out.refreshToken as string | null).toBe("r-1");
     expect(out.workspaceId).toBe("ws_alpha");
-    expect(out.mcpUrl).toBe(`${FAKE_API}/mcp/ws_alpha/sse`);
+    expect(out.mcpUrl).toBe(`${FAKE_API}/mcp/ws_alpha`);
     // Listener was stopped on success.
     expect(controller().stopped).toBe(true);
   });
@@ -897,7 +897,10 @@ describe("runInit --hosted (print-only)", () => {
       const res = await pending;
       expect(res.exitCode).toBe(0);
       const out = cap.logs.join("\n");
-      expect(out).toContain(`"url": "${FAKE_API}/mcp/ws_alpha/sse"`);
+      expect(out).toContain(`"url": "${FAKE_API}/mcp/ws_alpha"`);
+      // Streamable-HTTP transport is pinned explicitly so path-agnostic
+      // clients (Claude Code, VS Code) don't fall back to legacy HTTP+SSE.
+      expect(out).toContain('"type": "http"');
       expect(out).toContain('"Authorization": "Bearer ');
       // bunx form is for --local, not hosted.
       expect(out).not.toContain('"command": "bunx"');
@@ -931,7 +934,8 @@ describe("runInit --hosted --write", () => {
       const res = await pending;
       expect(res.exitCode).toBe(0);
       const written = JSON.parse(readFileSync(target, "utf8"));
-      expect(written.mcpServers.atlas.url).toBe(`${FAKE_API}/mcp/ws_alpha/sse`);
+      expect(written.mcpServers.atlas.url).toBe(`${FAKE_API}/mcp/ws_alpha`);
+      expect(written.mcpServers.atlas.type).toBe("http");
       expect(written.mcpServers.atlas.headers.Authorization).toMatch(/^Bearer /);
       // No local-style command — hosted is a remote server pointer.
       expect(written.mcpServers.atlas.command).toBeUndefined();
@@ -978,7 +982,8 @@ describe("runInit --hosted --write — preserves siblings + writes .bak", () => 
       // Sibling server preserved.
       expect(written.mcpServers.other).toEqual({ command: "x", args: ["y"] });
       // Hosted block added.
-      expect(written.mcpServers.atlas.url).toBe(`${FAKE_API}/mcp/ws_alpha/sse`);
+      expect(written.mcpServers.atlas.url).toBe(`${FAKE_API}/mcp/ws_alpha`);
+      expect(written.mcpServers.atlas.type).toBe("http");
       // Unrelated top-level keys preserved.
       expect(written.unrelatedTopLevel).toEqual({ keep: true });
       // .bak written.

--- a/plugins/mcp/package.json
+++ b/plugins/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "mcpName": "io.github.AtlasDevHQ/atlas",
   "description": "Atlas MCP plugin + bunx installer for Claude Desktop / Cursor / Continue",
   "type": "module",

--- a/plugins/mcp/src/init/config-merge.ts
+++ b/plugins/mcp/src/init/config-merge.ts
@@ -24,11 +24,19 @@ export interface StdioServerConfig {
 }
 
 /**
- * HTTP/SSE server pointer — used by `init --hosted` against
+ * Streamable-HTTP server pointer — used by `init --hosted` against
  * `app.useatlas.dev` (or a self-hosted instance with managed auth). MCP
  * clients (Claude Desktop, Cursor, Continue) all accept this `url` +
  * `headers` shape for remote MCP servers; the bearer is the JWT minted
  * by the OAuth 2.1 loopback flow in `init/hosted.ts`.
+ *
+ * `type: "http"` pins the transport to Streamable HTTP for the clients
+ * that key off it explicitly (Claude Code, VS Code): without it those
+ * clients guess from the URL, and a bare `{ url }` was defaulting them
+ * to the deprecated HTTP+SSE transport — which the hosted endpoint no
+ * longer speaks, so the first request 400s. Clients that auto-detect
+ * transport (Cursor, Continue) ignore the field. The `url` is always the
+ * canonical `/mcp/{workspaceId}` path — never the legacy `/sse` alias.
  *
  * `env` is a forward-compat slot for the cross-workspace identity flow
  * (#2073). Today's MCP clients don't bridge stdio-style env into HTTP
@@ -38,6 +46,8 @@ export interface StdioServerConfig {
  * every request without re-running this CLI.
  */
 export interface HttpServerConfig {
+  /** Transport discriminator — always Streamable HTTP for hosted Atlas. */
+  type: "http";
   url: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
@@ -83,7 +93,7 @@ export function buildServerConfig(opts: BuildOpts = {}): StdioServerConfig {
 }
 
 interface BuildHostedOpts {
-  /** The hosted MCP endpoint URL — e.g. `https://api.useatlas.dev/mcp/<workspace>/sse`. */
+  /** The canonical hosted MCP endpoint URL — e.g. `https://mcp.useatlas.dev/mcp/<workspace>` (no `/sse`). */
   url: string;
   /** OAuth 2.1 access token (JWT). Written verbatim into the Authorization header. */
   accessToken: string;
@@ -99,6 +109,7 @@ interface BuildHostedOpts {
 
 export function buildHostedServerConfig(opts: BuildHostedOpts): HttpServerConfig {
   const cfg: HttpServerConfig = {
+    type: "http",
     url: opts.url,
     headers: { Authorization: `Bearer ${opts.accessToken}` },
   };

--- a/plugins/mcp/src/init/hosted.ts
+++ b/plugins/mcp/src/init/hosted.ts
@@ -153,7 +153,14 @@ export interface HostedFlowResult {
    * missing claim) means single-workspace user — no prompt.
    */
   workspaceIds: string[];
-  /** `${apiUrl}/mcp/${workspaceId}/sse` — what the MCP client connects to. */
+  /**
+   * `${apiUrl}/mcp/${workspaceId}` — the canonical Streamable-HTTP endpoint
+   * the MCP client connects to. Deliberately *not* the legacy `/sse` alias:
+   * a `/sse` URL leads clients that key transport off the path (or a
+   * `type: "sse"` block) into the deprecated HTTP+SSE transport, which the
+   * hosted endpoint no longer speaks — the first request 400s. See
+   * `packages/api/src/lib/mcp/connect-url.ts` for the matching product-side URL.
+   */
   mcpUrl: string;
 }
 
@@ -398,7 +405,7 @@ export async function runHostedAuthFlow(
         : null,
       workspaceId,
       workspaceIds,
-      mcpUrl: `${apiUrl}/mcp/${workspaceId}/sse`,
+      mcpUrl: `${apiUrl}/mcp/${workspaceId}`,
     };
   } finally {
     // Cancel the timer FIRST so a 5-min hang can't survive an early


### PR DESCRIPTION
## What & why

Hosted MCP clients that followed Atlas's **own setup surfaces** got a config that speaks the deprecated **HTTP+SSE** transport against an endpoint that only speaks **Streamable HTTP**: OAuth + DCR + PKCE completed, then the first request **400'd**. (This is the next layer below the v0.0.60 consent-404 fix.)

Root cause: a `/sse` connect URL **plus a missing transport `type`**. Clients that key transport off the path or a `type` field (Claude Code, VS Code) read `/sse` / typeless config as a request for legacy HTTP+SSE → bare `GET /sse` with no `mcp-session-id` → 400. The server keeps `/mcp/{id}/sse` only as a back-compat **Streamable-HTTP alias** (#4169) — the path works, the *transport type* is what breaks.

The product's own URL builder (`packages/api/src/lib/mcp/connect-url.ts`) was already canonical. The handoff scoped this "docs + installer only" — but two additional **live surfaces** also emitted the broken shape (see below).

## Every surface now emits canonical `/mcp/{workspaceId}` + `type: "http"`

| Surface | Change |
|---|---|
| **Installer** `@useatlas/mcp` | `runHostedAuthFlow` mcpUrl drops `/sse`; `HttpServerConfig` gains `type: "http"`; `buildHostedServerConfig` sets it. **0.0.2 → 0.0.3** |
| **SDK** `@useatlas/sdk` | `buildConfig` drops `/sse`, emits `type: "http"` (`McpHttpServer` stays byte-identical to the installer writer, as its own doc requires). **0.1.0 → 0.1.1** |
| **Web** | Settings → AI Agents "Connect new agent" wizard built its **own** `/sse` URL + a typeless block → now canonical + `type: "http"`. *(Handoff assumed this surface was correct; it wasn't.)* |
| **Docs** | `guides/mcp.mdx`: Claude Code line → `--transport http` (no `/sse`) + every hosted JSON example gains `type` / drops `/sse`; SDK + load-test docs. |

**Left intact (deliberately):** self-hosted `--transport sse` (the standalone Bun server's *own* listener) and the legacy-alias explainer notes.

## Transport-type choice

`type: "http"` (Streamable HTTP) pins the transport for clients that key off it explicitly (Claude Code, VS Code); clients that auto-detect (Cursor, Continue, ChatGPT) ignore the field. So it's a strict improvement everywhere.

## Release sequencing

Both published packages are bumped in **this** PR (the bumping PR is exempt from `check-unpublished-versions`). Dependency refs stay pinned — only the private `@atlas/mcp` refs `@useatlas/mcp` (`workspace:*`), and the `^0.1.0` template refs tolerate the SDK patch. **After merge:** push `mcp-v0.0.3` and `sdk-v0.1.1` tags (≤3 per push) so `publish.yml` publishes them.

## Tests
- `plugins/mcp/__tests__/init/{config-merge,hosted}.test.ts` — assert `type: "http"` + canonical URL; new `buildHostedServerConfig` unit test.
- `packages/sdk/src/__tests__/mcp.test.ts` — all `buildConfig` shapes updated; new regression test locking `type:http` + no-`/sse`.

## Verification
- `plugins/mcp` init suite (86 pass) + `packages/sdk` mcp suite (39 pass) green.
- `bun run type` + `bun run lint` clean.
- Handoff's flagged import concern (`packages/mcp/bin/init.ts` → `@useatlas/mcp/cli`) verified a **non-issue** — `@useatlas/mcp` exports `./cli`.
