### PR TITLE
fix(mcp): describeEntity resolves group-scoped entities via org-scoped DB path (#4733)

### DIFF
--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, it, mock, beforeEach } from "bun:test";
+// #4733 — describeEntity resolves through the DB-canonical path (getAdminEntity
+// + listEntityRows) when an internal DB is configured; `resolveEntity` branches
+// on `hasInternalDB()` === `!!DATABASE_URL`, mirroring `listEntities`. Pin it so
+// these tests deterministically exercise the SaaS/DB path regardless of ambient
+// env. (`??=` import-time hoist — permitted by the test-discipline gate.) The
+// no-DB disk path (`getEntityByName`) is covered by lookups.test.ts + the
+// canonical MCP eval.
+process.env.DATABASE_URL ??= "postgres://mcp-semantic-tools-unit-test/db";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -93,14 +101,99 @@ const mockFindMetricById = mock<(...args: unknown[]) => unknown>(
 
 void mock.module("@atlas/api/lib/semantic/lookups", () => ({
   // #2150: `listEntities` was consolidated into `semantic/entities.ts` and
-  // is mocked there now (see the entities mock below). lookups still owns
-  // `getEntityByName`, `searchGlossary`, and `findMetricById` — the other
-  // three semantic-tools dispatches.
+  // is mocked there now (see the entities mock below). #4733: `describeEntity`
+  // moved off the disk-only `getEntityByName` onto the org-scoped DB path
+  // (`getAdminEntity`, mocked below); `getEntityByName` stays exported so the
+  // module mock is complete for any transitive importer. lookups still owns
+  // `searchGlossary` and `findMetricById` — two of the semantic-tools dispatches.
   getEntityByName: mockGetEntityByName,
   searchGlossary: mockSearchGlossary,
   findMetricById: mockFindMetricById,
   loadGlossaryTerms: mock(() => []),
   loadMetricDefinitions: mock(() => []),
+}));
+
+// --- #4733: DB-backed entity fixture for describeEntity ---
+//
+// On SaaS entities live only in `semantic_entities` (keyed by connection
+// group), so `describeEntity` resolves through the org-scoped `getAdminEntity`
+// (DB-canonical, published mode) with a `listEntityRows` table-name fallback —
+// NOT the disk-only `getEntityByName`. This fixture models that DB source:
+//   - `User`/`users` and `orders`/`orders` mirror the pre-#4733 disk entities.
+//   - `Conversation`/`conversations` is a group-scoped (`g_prod`) entity like
+//     the ones the live bug missed — describable by name AND table.
+// `getAdminEntity` resolves by the `name` column only; a table-name miss falls
+// back to scanning these rows for a parsed-YAML `table` match.
+interface EntityFixture {
+  readonly name: string;
+  readonly table: string;
+  readonly group: string | null;
+}
+const ENTITY_FIXTURE: readonly EntityFixture[] = [
+  { name: "User", table: "users", group: null },
+  { name: "orders", table: "orders", group: null },
+  { name: "Conversation", table: "conversations", group: "g_prod" },
+];
+
+function fixtureEntity(f: EntityFixture) {
+  return { name: f.name, table: f.table, dimensions: [{ name: "id" }] };
+}
+function fixtureRow(f: EntityFixture, id: number) {
+  return {
+    id: `se_${id}`,
+    org_id: "org_sem",
+    entity_type: "entity" as const,
+    name: f.name,
+    yaml_content: `name: ${f.name}\ntable: ${f.table}\ndimensions:\n  - name: id\n`,
+    connection_group_id: f.group,
+    status: "published" as const,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+// Stub of the Data.TaggedError (#4733) — same `_tag`/`groups` shape the SUT's
+// `instanceof AmbiguousEntityError` narrows on, so a mocked throw is caught and
+// mapped to the ambiguity envelope instead of leaking as `internal_error`.
+class MockAmbiguousEntityError extends Error {
+  readonly _tag = "AmbiguousEntityError";
+  readonly groups: ReadonlyArray<string | null>;
+  constructor(opts: { message: string; groups: ReadonlyArray<string | null> }) {
+    super(opts.message);
+    this.name = "AmbiguousEntityError";
+    this.groups = opts.groups;
+  }
+}
+
+// `getAdminEntity({ name, connectionGroupId? })` — resolves by the `name`
+// column against the fixture (published, DB source), matching group when the
+// caller scopes the re-resolve. Returns `null` for a name-column miss (drives
+// the table fallback / unknown path). Overridable per-test for throw cases.
+const mockGetAdminEntity = mock<(...args: unknown[]) => Promise<unknown>>(
+  async (opts: unknown) => {
+    const { name, connectionGroupId } = opts as {
+      name: string;
+      connectionGroupId?: string | null;
+    };
+    const match = ENTITY_FIXTURE.find(
+      (f) =>
+        f.name === name &&
+        (connectionGroupId === undefined || f.group === connectionGroupId),
+    );
+    return match
+      ? { entity: fixtureEntity(match), status: "published", source: "db" }
+      : null;
+  },
+);
+
+// `listEntityRows(orgId, "entity", "published")` — the org's published rows the
+// table-name fallback scans. Returns the full fixture by default.
+const mockListEntityRows = mock<(...args: unknown[]) => Promise<unknown>>(
+  async () => ENTITY_FIXTURE.map((f, i) => fixtureRow(f, i)),
+);
+
+void mock.module("@atlas/api/lib/semantic/admin-source", () => ({
+  getAdminEntity: mockGetAdminEntity,
 }));
 
 // #2150: the consolidated `listEntities(opts)` lives in `semantic/entities.ts`
@@ -110,9 +203,13 @@ void mock.module("@atlas/api/lib/semantic/lookups", () => ({
 // returned.
 void mock.module("@atlas/api/lib/semantic/entities", () => ({
   listEntities: mockListEntities,
+  // #4733 — the table-name fallback in describeEntity scans these rows; the
+  // SUT also imports `AmbiguousEntityError` from here (re-exported from
+  // effect/errors) to narrow the multi-group throw.
+  listEntityRows: mockListEntityRows,
+  AmbiguousEntityError: MockAmbiguousEntityError,
   // The other entities exports aren't used by the SUT; provide minimal
   // stubs so any transitive importer doesn't see undefined exports.
-  listEntityRows: mock(async () => []),
   listEntitiesWithOverlay: mock(async () => []),
   getEntity: mock(async () => null),
   upsertEntity: mock(async () => {}),
@@ -254,6 +351,27 @@ describe("MCP semantic tools", () => {
   beforeEach(() => {
     mockListEntities.mockClear();
     mockGetEntityByName.mockClear();
+    // #4733 — reset the DB-path mocks to their documented base implementation so
+    // a `mockImplementationOnce` (throw / ambiguity) can't leak across tests.
+    mockGetAdminEntity.mockClear();
+    mockGetAdminEntity.mockImplementation(async (opts: unknown) => {
+      const { name, connectionGroupId } = opts as {
+        name: string;
+        connectionGroupId?: string | null;
+      };
+      const match = ENTITY_FIXTURE.find(
+        (f) =>
+          f.name === name &&
+          (connectionGroupId === undefined || f.group === connectionGroupId),
+      );
+      return match
+        ? { entity: fixtureEntity(match), status: "published", source: "db" }
+        : null;
+    });
+    mockListEntityRows.mockClear();
+    mockListEntityRows.mockImplementation(async () =>
+      ENTITY_FIXTURE.map((f, i) => fixtureRow(f, i)),
+    );
     mockSearchGlossary.mockClear();
     mockFindMetricById.mockClear();
     mockExecuteSQLExecute.mockClear();
@@ -312,14 +430,17 @@ describe("MCP semantic tools", () => {
   });
 
   it("describeEntity returns an internal_error envelope when the lookup throws", async () => {
-    mockGetEntityByName.mockImplementationOnce(() => {
+    // #4733 — a non-ambiguity throw (e.g. malformed YAML / DB fault) from the
+    // org-scoped resolver propagates to the dispatch catch → internal_error,
+    // matching the REST route's 500 for malformed entity content.
+    mockGetAdminEntity.mockImplementationOnce(async () => {
       throw new Error("yaml parse failed");
     });
 
     const { client } = await createTestClient();
     const result = await client.callTool({
       name: "describeEntity",
-      arguments: { name: "users" },
+      arguments: { name: "User" },
     });
 
     expect(result.isError).toBe(true);
@@ -390,6 +511,74 @@ describe("MCP semantic tools", () => {
     const parsed = JSON.parse(getContentText(result.content));
     expect(parsed.found).toBe(true);
     expect(parsed.entity.table).toBe("users");
+  });
+
+  // #4733 — the regression: on SaaS, entities live only in `semantic_entities`
+  // (group-scoped). describeEntity must resolve a group-scoped entity the same
+  // as listEntities surfaces it — by its `name` field AND by its `table`, via
+  // the org-scoped DB path (getAdminEntity + listEntityRows table fallback).
+  it("describeEntity resolves a group-scoped entity by its name (DB path)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "Conversation" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.found).toBe(true);
+    expect(parsed.entity.table).toBe("conversations");
+    // Resolved by the `name` column — no need to fall through to the row scan.
+    expect(mockGetAdminEntity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Conversation",
+        orgId: TEST_ACTOR.activeOrganizationId,
+        mode: "published",
+      }),
+    );
+  });
+
+  it("describeEntity resolves a group-scoped entity by its table name (fallback)", async () => {
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "conversations" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.found).toBe(true);
+    expect(parsed.entity.table).toBe("conversations");
+    expect(parsed.entity.name).toBe("Conversation");
+    // The name-column lookup missed ("conversations" is a table, not a name),
+    // so the table fallback scanned the org's published rows.
+    expect(mockListEntityRows).toHaveBeenCalledWith(
+      TEST_ACTOR.activeOrganizationId,
+      "entity",
+      "published",
+    );
+  });
+
+  it("describeEntity maps a multi-group name to a validation_failed envelope, not a silent pick", async () => {
+    // #4733 — an unscoped name that exists in >1 connection group throws
+    // AmbiguousEntityError from getEntity; the SUT narrows it to a typed
+    // envelope (mirroring the REST route's 409) instead of picking one.
+    mockGetAdminEntity.mockImplementationOnce(async () => {
+      throw new MockAmbiguousEntityError({
+        message: 'Entity "Order" exists in 2 environments.',
+        groups: ["g_prod", "g_eu"],
+      });
+    });
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "Order" },
+    });
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope).not.toBeNull();
+    expect(envelope!.code).toBe("validation_failed");
+    expect(envelope!.message).toContain("multiple connection groups");
+    expect(envelope!.message).toContain("g_prod");
+    expect(envelope!.hint).toContain("listEntities");
   });
 
   it("describeEntity returns an unknown_entity envelope when the entity does not exist", async () => {
@@ -1151,7 +1340,9 @@ describe("MCP semantic tools", () => {
 
   it("describeEntity stamps actor: mcp + toolName", async () => {
     let observed: ReturnType<typeof getRequestContext>;
-    mockGetEntityByName.mockImplementationOnce(() => {
+    // #4733 — the org-scoped resolver runs inside the dispatch's request
+    // context, so capturing it from getAdminEntity proves the actor binding.
+    mockGetAdminEntity.mockImplementationOnce(async () => {
       observed = getRequestContext();
       return null;
     });

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -124,6 +124,12 @@ void mock.module("@atlas/api/lib/semantic/lookups", () => ({
 void mock.module("@atlas/api/lib/semantic/entities", () => ({
   listEntities: async () => [],
   listEntityRows: async () => [],
+  // #4733 — describeEntity now narrows the multi-group throw via this
+  // re-export; without it the `entities.ts` re-export chain fails to load.
+  AmbiguousEntityError: class AmbiguousEntityError extends Error {
+    readonly _tag = "AmbiguousEntityError";
+    readonly groups: ReadonlyArray<string | null> = [];
+  },
   listEntitiesWithOverlay: async () => [],
   getEntity: async () => null,
   upsertEntity: async () => {},
@@ -143,6 +149,21 @@ void mock.module("@atlas/api/lib/semantic/entities", () => ({
   restoreSingleConnection: async () => ({ status: "not_found" as const }),
   DEMO_CONNECTION_ID: "__demo__",
   SEMANTIC_ENTITY_STATUSES: ["published", "draft", "draft_delete", "archived"] as const,
+}));
+
+// #4733 — describeEntity resolves through the org-scoped `getAdminEntity`
+// (DB-canonical) rather than the disk-only `getEntityByName`. Stub it so this
+// telemetry test (which only asserts spans/counters fire) stays hermetic — no
+// real disk/DB read. Resolving "users" keeps the six-tool coverage span green.
+void mock.module("@atlas/api/lib/semantic/admin-source", () => ({
+  getAdminEntity: async ({ name }: { name: string }) =>
+    name === "users" || name === "User"
+      ? {
+          entity: { name: "User", table: "users", dimensions: [{ name: "id" }] },
+          status: "published",
+          source: "db",
+        }
+      : null,
 }));
 
 // Don't mock @atlas/api/lib/config: its many runtime exports would require

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -27,7 +27,15 @@ import { z } from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
-import { listEntities } from "@atlas/api/lib/semantic/entities";
+import {
+  listEntities,
+  listEntityRows,
+  AmbiguousEntityError,
+} from "@atlas/api/lib/semantic/entities";
+import { getAdminEntity } from "@atlas/api/lib/semantic/admin-source";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { loadYaml } from "@atlas/api/lib/semantic/yaml";
+import type { EntityShapeT } from "@atlas/api/lib/semantic/shapes";
 import {
   getEntityByName,
   searchGlossary,
@@ -123,6 +131,119 @@ export function registerSemanticTools(
   const dispatch: typeof dispatcher.dispatch = (...args) =>
     dispatcher.dispatch(...args);
 
+  // Resolve one entity by its `name` field OR its `table` name (#4733). The
+  // source branch mirrors `listEntities` below EXACTLY (`opts.orgId &&
+  // hasInternalDB()`), so any identifier `listEntities` advertises is
+  // describable through the same source:
+  //   - SaaS (internal DB): entities live only in `semantic_entities`, keyed by
+  //     connection group — `getEntityByName` was disk-only, so every describe of
+  //     a group-scoped entity missed (the divergence the DB-backed `listEntities`
+  //     closed, #2142). Resolve DB-canonically via `getAdminEntity` (name column)
+  //     + a `listEntityRows` table fallback.
+  //   - Self-hosted (no internal DB): entities are authored on disk. Resolve via
+  //     `getEntityByName` (name / table / file-stem scan) exactly as pre-#4733.
+  //     Note we must NOT reuse `getAdminEntity`'s disk path here: it keys on the
+  //     FILE STEM (`discoverEntities`), so an entity addressed by its YAML `name`
+  //     — the identifier `listEntities` advertises — would miss. And on SaaS the
+  //     disk fixture is the pod's baked-in demo, never the tenant's data, so the
+  //     disk scan is confined to the no-DB branch.
+  type EntityResolution =
+    | { readonly kind: "found"; readonly entity: EntityShapeT | Record<string, unknown> }
+    | { readonly kind: "unknown" }
+    | { readonly kind: "ambiguous"; readonly groups: readonly (string | null)[] };
+
+  async function resolveEntity(
+    nameOrTable: string,
+    requestId: string,
+  ): Promise<EntityResolution> {
+    // Self-hosted / no internal DB: disk is the authored source of truth.
+    if (!(workspaceId && hasInternalDB())) {
+      const entity = getEntityByName(nameOrTable);
+      return entity ? { kind: "found", entity } : { kind: "unknown" };
+    }
+
+    // SaaS / DB-canonical. Primary: resolve by the `semantic_entities.name`
+    // column (published mode so drafts stay hidden — external MCP clients never
+    // run developer-mode). An unscoped multi-group name throws
+    // `AmbiguousEntityError`, mirrored to a typed envelope by the caller (as the
+    // REST route does, `semantic.ts:216`).
+    try {
+      const byName = await getAdminEntity({
+        name: nameOrTable,
+        orgId: workspaceId,
+        mode: "published",
+        requestId,
+      });
+      if (byName) return { kind: "found", entity: byName.entity };
+    } catch (err) {
+      if (err instanceof AmbiguousEntityError) {
+        return { kind: "ambiguous", groups: err.groups };
+      }
+      throw err;
+    }
+
+    // Table-name fallback: `getAdminEntity` matches the name column only, but
+    // the tool contract advertises `name` accepts an entity name OR a table
+    // name (`inputSchema` below) — the pre-#4733 disk scan matched
+    // `raw.table === name`. Scan the org's published rows for a parsed-YAML
+    // `table` match.
+    const rows = await listEntityRows(workspaceId, "entity", "published");
+    const tableMatches = rows.filter((row) => {
+      try {
+        const parsed = loadYaml(row.yaml_content);
+        return (
+          !!parsed &&
+          typeof parsed === "object" &&
+          (parsed as Record<string, unknown>).table === nameOrTable
+        );
+      } catch {
+        // intentionally ignored: a single malformed sibling row must not block
+        // table-resolution of the others; its own name-column read surfaces the
+        // parse error where it is actionable.
+        return false;
+      }
+    });
+    if (tableMatches.length === 0) return { kind: "unknown" };
+
+    // A table shared across distinct connection groups is ambiguous by the same
+    // rule as a shared name — surface it as a typed envelope, never a silent
+    // pick (multi-member groups share the same definition, collapsing to one
+    // group here so they resolve rather than falsely reporting ambiguity).
+    const groups = new Set(tableMatches.map((row) => row.connection_group_id ?? null));
+    if (groups.size > 1) return { kind: "ambiguous", groups: [...groups] };
+
+    // Re-resolve by the matched row's canonical name, scoped to its own group
+    // so this second lookup can't itself throw an ambiguity.
+    const match = tableMatches[0];
+    const detail = await getAdminEntity({
+      name: match.name,
+      orgId: workspaceId,
+      connectionGroupId: match.connection_group_id ?? null,
+      mode: "published",
+      requestId,
+    });
+    return detail ? { kind: "found", entity: detail.entity } : { kind: "unknown" };
+  }
+
+  // Shared envelope for a name that resolved to more than one connection group.
+  // `describeEntity`'s input schema carries no group selector, so the agent's
+  // recovery is to list the distinct entities and describe one by a name that
+  // is unique — `validation_failed` (terminal, client-side) says the bare name
+  // is insufficient to identify a single entity.
+  const ambiguousEntityEnvelope = (
+    name: string,
+    groups: readonly (string | null)[],
+  ) =>
+    envelope(
+      "validation_failed",
+      `Entity "${name}" exists in multiple connection groups (${groups
+        .map((g) => g ?? "default")
+        .join(", ")}); the name alone is ambiguous.`,
+      {
+        hint: "Call listEntities to see the distinct entities and describe one by a name that is unique to its group.",
+      },
+    );
+
   // --- listEntities ---
   server.registerTool(
     "listEntities" satisfies SemanticToolName,
@@ -200,7 +321,7 @@ export function registerSemanticTools(
       dispatch(
         "describeEntity",
         { requiresWrite: false, requiresBoundOrg: false, minRole: "member" },
-        async () => {
+        async (requestId) => {
           // The MCP raw-shape inputSchema can't express a cross-field
           // "exactly one of" refinement, so enforce it here. Both-or-neither
           // is a client mistake, not a catalog miss — return `validation_failed`
@@ -219,8 +340,13 @@ export function registerSemanticTools(
 
           // Single-name path — wire shape unchanged for existing clients.
           if (name !== undefined) {
-            const entity = getEntityByName(name);
-            if (!entity) {
+            const resolution = await resolveEntity(name, requestId);
+            if (resolution.kind === "ambiguous") {
+              return toEnvelopeResult(
+                ambiguousEntityEnvelope(name, resolution.groups),
+              );
+            }
+            if (resolution.kind === "unknown") {
               // Unknown-entity isn't really a "tool failed" condition for the
               // agent — the agent's recovery is "call listEntities and pick a
               // known one." Emit it as a typed envelope so the recovery is
@@ -234,13 +360,15 @@ export function registerSemanticTools(
                 ),
               );
             }
-            return toJsonContent({ found: true, entity });
+            return toJsonContent({ found: true, entity: resolution.entity });
           }
 
           // Batch path — dedupe (preserving first-seen order) and resolve each.
           // A miss is not a tool failure here: resolved entities come back in
-          // `entities`, misses in `notFound`, so the agent recovers per-name
-          // instead of losing the whole batch to one bad name.
+          // `entities`, misses (unknown OR ambiguous) in `notFound`, so the
+          // agent recovers per-name via listEntities instead of losing the
+          // whole batch to one bad name — and never receives a silently-picked
+          // entity for an ambiguous one.
           const requested = names ?? [];
           const seen = new Set<string>();
           const ordered: string[] = [];
@@ -251,13 +379,18 @@ export function registerSemanticTools(
             }
           }
 
-          const entities: NonNullable<ReturnType<typeof getEntityByName>>[] = [];
+          // Resolutions are independent — resolve concurrently (each may issue
+          // its own DB read) and reassemble in the requested order.
+          const resolutions = await Promise.all(
+            ordered.map((n) => resolveEntity(n, requestId)),
+          );
+          const entities: (EntityShapeT | Record<string, unknown>)[] = [];
           const notFound: string[] = [];
-          for (const n of ordered) {
-            const entity = getEntityByName(n);
-            if (entity) entities.push(entity);
+          ordered.forEach((n, i) => {
+            const resolution = resolutions[i];
+            if (resolution.kind === "found") entities.push(resolution.entity);
             else notFound.push(n);
-          }
+          });
 
           return toJsonContent({
             count: entities.length,


### PR DESCRIPTION
## What & why

Fixes #4733. On SaaS, semantic entities live only in the org-scoped `semantic_entities` DB (keyed by connection group). `listEntities` (MCP) reads that DB path, but `describeEntity` still called the **disk-only** `getEntityByName` — so every describe of a group-scoped entity that `listEntities` surfaces returned `unknown_entity`, by name **and** by table. Same divergence the DB-backed `listEntities` closed (#2142); `describeEntity` was never brought onto the DB path.

Observed live against hosted prod: `listEntities` → 23 entities all `source: "g_prod"`; `describeEntity({name:"Conversation"})` → `{code:"unknown_entity"}`.

## The fix (`packages/mcp/src/semantic-tools.ts`)

Both call sites (single + batch) resolve through a shared `resolveEntity()` that branches on the **same** source condition as `listEntities` (`orgId && hasInternalDB()`):

- **SaaS (internal DB):** `getAdminEntity({ name, orgId, mode: "published", requestId })` (DB-canonical, name column) + a `listEntityRows` **table-name fallback** (the tool advertises `name` accepts an entity name *or* a table name). A name/table spanning >1 connection group → typed `validation_failed` envelope (no group selector to disambiguate on), never a silent pick — mirrors the REST route's 409 (`semantic.ts:216`). Drafts hidden via `published` mode.
- **Self-hosted (no DB):** keep `getEntityByName` (name / table / file-stem scan) **exactly as pre-#4733**. Crucially we do **not** reuse `getAdminEntity`'s disk path — it keys on the *file stem* (`discoverEntities`), so an entity addressed by its YAML `name` (the identifier `listEntities` advertises) would miss. Confining the disk scan to the no-DB branch also means a SaaS pod never resolves against its baked-in demo fixture.

Batch resolves concurrently; malformed-YAML throws propagate to the dispatch catch → `internal_error`.

> Caught by the `canonical-mcp-eval` in CI: the eval runs with `DATABASE_URL` unset (disk path), where an earlier revision that resolved everything through `getAdminEntity`'s stem-keyed disk path regressed `describeEntity("Orders")`. Now green locally (`DATABASE_URL= bun test …canonical-mcp-eval.evalspec.ts` → 7/7).

## Tests

- `semantic-tools.test.ts`: pins `DATABASE_URL` to exercise the DB path; proves a group-scoped entity is describable by **name** and **table**, and a multi-group name → `validation_failed`.
- `telemetry.test.ts`: adds the `AmbiguousEntityError` re-export + a hermetic `admin-source` mock (the new import otherwise broke its partial `entities` mock).
- No-DB disk path stays covered by `lookups.test.ts` + the canonical MCP eval.

## Scope
`@atlas/mcp` (private) + read into `@atlas/api` — **no npm bump**. Prod-affecting via the API service that serves the hosted MCP; carried to prod by a later `/release`.
