### PR TITLE
fix(mcp): keepalive heartbeat so hosted query tool doesn't drop transport on >120s runs (#4734)

### DIFF
--- a/packages/mcp/src/__tests__/progress.test.ts
+++ b/packages/mcp/src/__tests__/progress.test.ts
@@ -10,8 +10,10 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
   withProgressAndCancellation,
+  startHeartbeat,
   OperationCancelledError,
   type McpRequestExtra,
+  type ProgressReporter,
 } from "../progress.js";
 
 interface ProgressParams {
@@ -120,6 +122,75 @@ describe("withProgressAndCancellation", () => {
       expect(unhandled).toEqual([]);
     } finally {
       process.removeListener("unhandledRejection", handler);
+    }
+  });
+});
+
+describe("startHeartbeat (#4734)", () => {
+  /** Capture reporter.report calls into a list. */
+  function captureReporter(): {
+    reporter: ProgressReporter;
+    reports: { progress: number; message?: string }[];
+  } {
+    const reports: { progress: number; message?: string }[] = [];
+    const reporter: ProgressReporter = {
+      report: async (progress, o) => {
+        reports.push({ progress, ...(o?.message ? { message: o.message } : {}) });
+      },
+    };
+    return { reporter, reports };
+  }
+
+  it("emits a bounded, strictly-increasing (<1) progress sequence until stopped", async () => {
+    const { reporter, reports } = captureReporter();
+    const stop = startHeartbeat(reporter, { intervalMs: 5, message: "still working" });
+    await new Promise((r) => setTimeout(r, 32));
+    stop();
+    const countAtStop = reports.length;
+
+    // Several intervals elapsed → multiple heartbeats.
+    expect(countAtStop).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < reports.length; i++) {
+      expect(reports[i].progress).toBeGreaterThan(0);
+      expect(reports[i].progress).toBeLessThan(1); // bounded below the final(1)
+      if (i > 0) expect(reports[i].progress).toBeGreaterThan(reports[i - 1].progress);
+    }
+    expect(reports[0].message).toBe("still working");
+
+    // Stop clears the timer — no further emits.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(reports.length).toBe(countAtStop);
+  });
+
+  it("omits the message field when none is supplied", async () => {
+    const { reporter, reports } = captureReporter();
+    const stop = startHeartbeat(reporter, { intervalMs: 5 });
+    await new Promise((r) => setTimeout(r, 16));
+    stop();
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    expect(reports.every((r) => r.message === undefined)).toBe(true);
+  });
+
+  it("stays monotonic through withProgressAndCancellation's final emit", async () => {
+    // The wrapper emits start(0) then final(total ?? 1); the heartbeat's
+    // bounded-below-1 values must never break that ordering.
+    const { extra, progress } = fakeExtra({ progressToken: "tok" });
+    const result = await withProgressAndCancellation(
+      extra,
+      { endMessage: "done" },
+      async (reporter) => {
+        const stop = startHeartbeat(reporter, { intervalMs: 5 });
+        await new Promise((r) => setTimeout(r, 24));
+        stop();
+        return "ok";
+      },
+    );
+    expect(result).toBe("ok");
+    const values = progress.map((p) => p.progress);
+    expect(values[0]).toBe(0);
+    expect(values.at(-1)).toBe(1);
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeGreaterThanOrEqual(values[i - 1]);
     }
   });
 });

--- a/packages/mcp/src/__tests__/query-tool.test.ts
+++ b/packages/mcp/src/__tests__/query-tool.test.ts
@@ -124,7 +124,9 @@ void mock.module("@atlas/api/lib/billing/claim-gate", () => ({
 }));
 
 // Import after mocks are set up.
-const { registerQueryTool } = await import("../query-tool.js");
+const { registerQueryTool, _setQueryHeartbeatIntervalMsForTest } = await import(
+  "../query-tool.js"
+);
 
 function getContentText(content: unknown): string {
   const arr = content as Array<{ type: string; text: string }>;
@@ -159,6 +161,10 @@ describe("MCP query tool (#4094)", () => {
     mockExecuteAgentQuery.mockImplementation(async () => DEFAULT_RESULT);
     billingGateVerdict = { allowed: true };
     mockCheckAgentBillingGate.mockClear();
+    // #4734 — keep the keepalive interval long by default so the fast-resolving
+    // mocks in the rest of the suite never fire a stray heartbeat; the slow-run
+    // test shortens it locally.
+    _setQueryHeartbeatIntervalMsForTest(60_000);
   });
 
   it("is registered as a read-only, open-world tool advertising the error contract", async () => {
@@ -198,6 +204,60 @@ describe("MCP query tool (#4094)", () => {
 
     // Retained text block mirrors the structured payload.
     expect(JSON.parse(getContentText(result.content))).toEqual(result.structuredContent);
+  });
+
+  it("drives a keepalive heartbeat during a >interval run so the transport stays warm (#4734)", async () => {
+    // The POST SSE stream emits zero app bytes during the agent run, so without
+    // a heartbeat an intermediary idle-timeout (~120s) drops the transport. A
+    // run longer than the (shortened) heartbeat interval must produce interim
+    // progress notifications between the start(0) and final(1) emits.
+    _setQueryHeartbeatIntervalMsForTest(10);
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      await new Promise((r) => setTimeout(r, 55));
+      return DEFAULT_RESULT;
+    });
+
+    const { client } = await createTestClient();
+    const progresses: number[] = [];
+    const result = await client.callTool(
+      { name: "query", arguments: { question: "a slow question" } },
+      undefined,
+      { onprogress: (p) => progresses.push(p.progress) },
+    );
+
+    expect(result.isError).toBeFalsy();
+    // At least one interim heartbeat fired strictly between start and end — the
+    // bytes that keep the stream alive mid-run.
+    const interim = progresses.filter((v) => v > 0 && v < 1);
+    expect(interim.length).toBeGreaterThanOrEqual(1);
+    // The whole sequence is monotonically non-decreasing (start 0 → … → final 1).
+    expect(progresses[0]).toBe(0);
+    expect(progresses.at(-1)).toBe(1);
+    for (let i = 1; i < progresses.length; i++) {
+      expect(progresses[i]).toBeGreaterThanOrEqual(progresses[i - 1]);
+    }
+  });
+
+  it("clears the heartbeat timer once the query settles (no leaked interval)", async () => {
+    // After the query returns, no further progress notifications must fire — a
+    // leaked setInterval would keep emitting past settlement.
+    _setQueryHeartbeatIntervalMsForTest(10);
+    mockExecuteAgentQuery.mockImplementationOnce(async () => {
+      await new Promise((r) => setTimeout(r, 25));
+      return DEFAULT_RESULT;
+    });
+
+    const { client } = await createTestClient();
+    const progresses: number[] = [];
+    await client.callTool(
+      { name: "query", arguments: { question: "another slow question" } },
+      undefined,
+      { onprogress: (p) => progresses.push(p.progress) },
+    );
+    const countAtSettle = progresses.length;
+    // Wait several more intervals — a cleared timer emits nothing further.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(progresses.length).toBe(countAtSettle);
   });
 
   it("threads the question + connectionId into executeAgentQuery", async () => {

--- a/packages/mcp/src/progress.ts
+++ b/packages/mcp/src/progress.ts
@@ -119,3 +119,53 @@ export async function withProgressAndCancellation<T>(
     if (onAbort) extra.signal.removeEventListener("abort", onAbort);
   }
 }
+
+/** Default keepalive cadence (#4734) — comfortably under the ~120s edge idle window. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * Drive a keepalive heartbeat on a long-running dispatch (#4734).
+ *
+ * During a server-side agent run the POST Streamable-HTTP `text/event-stream`
+ * emits ZERO application bytes, so an intermediary idle-timeout (Railway
+ * edge/LB, ~120s) closes it before the run finishes → the client sees
+ * `transport dropped`. Emitting periodic `notifications/progress` puts bytes on
+ * the wire (they route onto the request stream via `relatedRequestId`) and keeps
+ * it warm. Pair with {@link withProgressAndCancellation}: call this inside the
+ * `work` callback with its `reporter`, and stop it in a `finally`.
+ *
+ * Progress is a bounded, strictly-increasing sequence (0.5, 0.667, 0.75, …)
+ * that approaches — but never reaches — 1, so the wrapper's final
+ * `progress(total ?? 1)` stays monotonic after any number of heartbeats. It is
+ * indeterminate (no `total`): a blind timer, not real agent-step progress
+ * (threading a step callback is a documented follow-up).
+ *
+ * NOTE: `reporter.report` only puts bytes on the wire when the client supplied
+ * a `progressToken` (see {@link withProgressAndCancellation} — no-op otherwise).
+ * Common hosted clients (Claude, Cursor) do, which covers the reported case; a
+ * transport-agnostic `: ping` frame would cover the rest but needs an
+ * SDK/transport hook (follow-up, out of scope).
+ *
+ * @returns a stop function — call it in a `finally` so the timer can never
+ *   outlive the work.
+ */
+export function startHeartbeat(
+  reporter: ProgressReporter,
+  opts?: { readonly intervalMs?: number; readonly message?: string },
+): () => void {
+  const intervalMs = opts?.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  let ticks = 0;
+  const timer = setInterval(() => {
+    ticks += 1;
+    // Bounded below 1 so a later final `progress(1)` is still monotonic.
+    // Fire-and-forget: `reporter.report` swallows emit failures (see `emit`
+    // above), so a failed keepalive never rejects here or fails the work.
+    void reporter.report(1 - 1 / (ticks + 1), {
+      ...(opts?.message ? { message: opts.message } : {}),
+    });
+  }, intervalMs);
+  // Don't let the keepalive timer, on its own, hold the runtime open — the
+  // work's promise is what the dispatch awaits. `unref` is Node/Bun-only.
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/packages/mcp/src/query-tool.ts
+++ b/packages/mcp/src/query-tool.ts
@@ -46,7 +46,11 @@ import { type McpTransport, type McpDeployMode } from "./telemetry.js";
 import { envelope, toEnvelopeResult, toStructuredContent } from "./error-envelope.js";
 import { createMcpDispatch } from "./mcp-dispatch.js";
 import { approvalRequiredResult, queryOutputShape } from "./structured-output.js";
-import { withProgressAndCancellation } from "./progress.js";
+import {
+  withProgressAndCancellation,
+  startHeartbeat,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+} from "./progress.js";
 
 // The question is free text the customer's LLM composed. Cap it so a hostile
 // client can't drive a megabyte prompt into the agent loop; generous enough
@@ -54,6 +58,16 @@ import { withProgressAndCancellation } from "./progress.js";
 // 1024, but a question legitimately carries more context than a filter term).
 const MAX_QUESTION_LEN = 4096;
 const MAX_CONNECTION_ID_LEN = 256;
+
+// #4734 — keepalive cadence for the (potentially minutes-long) agent run. A
+// module-level `let` (not a user-facing env knob) purely so the test can
+// shorten it without a real 15s wait; production always uses the default.
+let queryHeartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS;
+
+/** @internal test seam — override the #4734 query keepalive cadence. */
+export function _setQueryHeartbeatIntervalMsForTest(ms: number): void {
+  queryHeartbeatIntervalMs = ms;
+}
 
 /**
  * The hint attached to a `billing_blocked` envelope — adapts the wording of
@@ -162,16 +176,33 @@ export function registerQueryTool(
             result = await withProgressAndCancellation(
               extra,
               { startMessage: "Running Atlas agent", endMessage: "Answer ready" },
-              async (_reporter, _signal) =>
-                executeAgentQuery(question, requestId, {
-                  // The dispatch RequestContext already carries user + actor
-                  // (kind:mcp, toolName) + agentOrigin:"mcp" (#1858/#2067/#2072),
-                  // which `executeAgentQuery` inherits — so executeSQL audit rows
-                  // record actor_kind='mcp' and origin-scoped approval rules fire
-                  // for origin=mcp. Only connectionId isn't on the context, so
-                  // thread it explicitly (#4124).
-                  ...(connectionId ? { connectionId } : {}),
-                }),
+              async (reporter, _signal) => {
+                // #4734 — the POST SSE stream emits zero application bytes during
+                // the agent run, so an intermediary idle-timeout (Railway
+                // edge/LB, ~120s) closes it before a long run finishes → the
+                // client sees "transport dropped". Drive a keepalive heartbeat so
+                // periodic progress notifications keep the stream warm. Cleared
+                // in `finally` so the timer never outlives the query. (Only
+                // reaches the wire for progressToken-supplying clients — see
+                // startHeartbeat; a transport-agnostic `: ping` is a follow-up.)
+                const stopHeartbeat = startHeartbeat(reporter, {
+                  intervalMs: queryHeartbeatIntervalMs,
+                  message: "Atlas is still working on your question…",
+                });
+                try {
+                  return await executeAgentQuery(question, requestId, {
+                    // The dispatch RequestContext already carries user + actor
+                    // (kind:mcp, toolName) + agentOrigin:"mcp" (#1858/#2067/#2072),
+                    // which `executeAgentQuery` inherits — so executeSQL audit rows
+                    // record actor_kind='mcp' and origin-scoped approval rules fire
+                    // for origin=mcp. Only connectionId isn't on the context, so
+                    // thread it explicitly (#4124).
+                    ...(connectionId ? { connectionId } : {}),
+                  });
+                } finally {
+                  stopHeartbeat();
+                }
+              },
             );
           } catch (err) {
             // The billing/claim gates inside `executeAgentQuery` throw typed


### PR DESCRIPTION
## What & why

Fixes #4734. The hosted MCP `query` tool (server-side NL analyst agent) drops the transport on any run longer than ~120s. The `query` POST response is a Streamable-HTTP `text/event-stream`, but **during the agent run the stream emits zero application bytes**, so an intermediary idle-timeout (Railway edge/LB, ~120s) closes it → the client sees `MCP server "atlas" transport dropped mid-call`. Fast deterministic tools (`executeSQL`, `listEntities`) are unaffected only because they finish under the idle window.

The keepalive machinery existed but was never driven on this path: `query-tool.ts` wrapped the run in `withProgressAndCancellation` but **discarded the reporter** (`async (_reporter) => …`), emitting only `progress(0)` at start and `progress(1)` at end.

## The fix

- **`progress.ts` — `startHeartbeat(reporter, { intervalMs, message })`**: drives `reporter.report` on a `setInterval` (default 15s, well under the ~120s window). Progress is a **bounded, strictly-increasing** sequence (`1 − 1/(n+1)` → 0.5, 0.667, 0.75, …) that approaches but never reaches 1, so the wrapper's final `progress(1)` stays monotonic after any number of heartbeats. `timer.unref()` so the keepalive never holds the runtime open; returns a stop function.
- **`query-tool.ts`**: start the heartbeat around `executeAgentQuery`, clear it in a `finally` (no leaked timer). Those notifications route onto the POST SSE stream via `relatedRequestId` and keep it warm. Touches only this seam — no agent-core change.

### Caveats (documented, in-scope boundary)
1. `reporter.report` only puts bytes on the wire when the client sent a `progressToken` (`progress.ts`). Common hosted clients (Claude, Cursor) do, which resolves the reported case. A transport-agnostic `: ping` frame would cover the rest but needs an SDK/transport hook — **follow-up**, not in scope.
2. Progress is a blind timer, not real agent-step progress (threading a step callback `runAgent → executeAgentQuery → reporter` is a larger **follow-up**).

## Tests

- `progress.test.ts`: heartbeat helper — bounded strictly-increasing `<1`, `stop()` clears the timer (no further emits), and end-to-end monotonicity through `withProgressAndCancellation`'s final emit.
- `query-tool.test.ts`: a `>interval` run produces interim `notifications/progress` between start(0) and final(1) (monotonic); the timer is cleared on settle (no leaked interval). Interval shortened via an `@internal` test seam (`_setQueryHeartbeatIntervalMsForTest`), reset per-test — no real 15s wait.

## Scope
`@atlas/mcp` (private) — **no npm bump**. Prod-affecting via the API service that serves the hosted MCP; carried to prod by a later `/release`. Independent of #4732 and #4733.
