### PR TITLE
fix(deploy): watch packages/mcp in api services so hosted-MCP fixes deploy

### DIFF
--- a/deploy/api-apac/railway.json
+++ b/deploy/api-apac/railway.json
@@ -9,6 +9,7 @@
       "package.json",
       "patches/**",
       "packages/api/**",
+      "packages/mcp/**",
       "packages/react/**",
       "packages/types/**",
       "packages/schemas/**",

--- a/deploy/api-eu/railway.json
+++ b/deploy/api-eu/railway.json
@@ -9,6 +9,7 @@
       "package.json",
       "patches/**",
       "packages/api/**",
+      "packages/mcp/**",
       "packages/react/**",
       "packages/types/**",
       "packages/schemas/**",

--- a/deploy/api/railway.json
+++ b/deploy/api/railway.json
@@ -9,6 +9,7 @@
       "package.json",
       "patches/**",
       "packages/api/**",
+      "packages/mcp/**",
       "packages/react/**",
       "packages/types/**",
       "packages/schemas/**",


### PR DESCRIPTION
## What & why

The api service (all 3 regions: `api`, `api-eu`, `api-apac`) **serves the hosted MCP** — it depends on `@atlas/mcp` (`workspace:*`) and bundles `packages/mcp` into its image via the monorepo Docker build. But `deploy/api*/railway.json` `watchPatterns` **omitted `packages/mcp/**`**, so a change confined to `packages/mcp/**` produces `skippedReason: "No changes to watched files"` on the prod-branch push and **never rebuilds/deploys**.

Caught while shipping **v0.0.63** (#4733 + #4734, both `packages/mcp`-only): all 4 tag-gated services (`api`/`api-eu`/`api-apac`/`web`) `SKIPPED` the `prod` push, leaving v0.0.62's build (`227eb0db8`) live. The hosted-MCP fixes were merged, tagged, and released — but not running.

## The fix

Add `packages/mcp/**` to the `watchPatterns` of `api`, `api-eu`, `api-apac`. This commit is itself a `deploy/api*/**` change (already watched), so **releasing it rebuilds the api services and carries the pending MCP fixes (v0.0.63) to prod** in the same deploy.

## Why the `railway-watch` gate didn't catch it

`scripts/check-railway-watch.sh` verifies every explicit Dockerfile `COPY <src>` is watched — but `packages/mcp/package.json` is covered by `packages/**/package.json`, and the full mcp **source** arrives via the broad `COPY . .` the gate deliberately skips. So the gate can't see that a bundled workspace-dep's source must be watched.

## Follow-up (not in this PR)

Audit the api `watchPatterns` against its full workspace-dependency closure — `@atlas/okf-bundle`, `@useatlas/chat`, `@useatlas/twenty`, `@atlas/oauth-helper` may have the same latent gap — and consider extending `check-railway-watch.sh` to assert the closure. Filing as an issue.

## Scope
Deploy config only. No code change. Prod-affecting: the next release rebuilds the api services.