### PR TITLE
fix(mcp): describeEntity resolves entities by their YAML display name too (#4733 follow-up)

### DIFF
--- a/packages/mcp/src/__tests__/semantic-tools.test.ts
+++ b/packages/mcp/src/__tests__/semantic-tools.test.ts
@@ -117,22 +117,34 @@ void mock.module("@atlas/api/lib/semantic/lookups", () => ({
 //
 // On SaaS entities live only in `semantic_entities` (keyed by connection
 // group), so `describeEntity` resolves through the org-scoped `getAdminEntity`
-// (DB-canonical, published mode) with a `listEntityRows` table-name fallback —
-// NOT the disk-only `getEntityByName`. This fixture models that DB source:
-//   - `User`/`users` and `orders`/`orders` mirror the pre-#4733 disk entities.
-//   - `Conversation`/`conversations` is a group-scoped (`g_prod`) entity like
-//     the ones the live bug missed — describable by name AND table.
-// `getAdminEntity` resolves by the `name` column only; a table-name miss falls
-// back to scanning these rows for a parsed-YAML `table` match.
+// (DB-canonical, published mode) with a `listEntityRows` name/table fallback —
+// NOT the disk-only `getEntityByName`.
+//
+// CRUCIAL (verified live against prod): the `semantic_entities.name` COLUMN
+// holds the file STEM (`user`, `conversation`, `organization`) — NOT the YAML
+// `name` field (`User`, `Conversation`) that `listEntities` advertises, and
+// often NOT the `table` either (`conversation` stem vs `conversations` table).
+// So three distinct identifiers must be modelled: `column` (name column,
+// what getAdminEntity resolves by), `name` (YAML display name), `table`.
+//   - `User`: column `user`, name `User`, table `users` — all three differ.
+//   - `orders`: column/name `orders`, table `orders` — degenerate case.
+//   - `Conversation` (group-scoped `g_prod`): column `conversation`, name
+//     `Conversation`, table `conversations` — the live-bug shape.
+// `getAdminEntity` resolves by `column` only; a miss falls back to scanning
+// these rows for a parsed-YAML `name` OR `table` match.
 interface EntityFixture {
+  /** `semantic_entities.name` column value = file stem (getAdminEntity key). */
+  readonly column: string;
+  /** YAML `name` field — the identifier `listEntities` advertises. */
   readonly name: string;
+  /** YAML `table` field. */
   readonly table: string;
   readonly group: string | null;
 }
 const ENTITY_FIXTURE: readonly EntityFixture[] = [
-  { name: "User", table: "users", group: null },
-  { name: "orders", table: "orders", group: null },
-  { name: "Conversation", table: "conversations", group: "g_prod" },
+  { column: "user", name: "User", table: "users", group: null },
+  { column: "orders", name: "orders", table: "orders", group: null },
+  { column: "conversation", name: "Conversation", table: "conversations", group: "g_prod" },
 ];
 
 function fixtureEntity(f: EntityFixture) {
@@ -143,7 +155,8 @@ function fixtureRow(f: EntityFixture, id: number) {
     id: `se_${id}`,
     org_id: "org_sem",
     entity_type: "entity" as const,
-    name: f.name,
+    // The DB row's name column is the stem, not the YAML name.
+    name: f.column,
     yaml_content: `name: ${f.name}\ntable: ${f.table}\ndimensions:\n  - name: id\n`,
     connection_group_id: f.group,
     status: "published" as const,
@@ -166,9 +179,10 @@ class MockAmbiguousEntityError extends Error {
 }
 
 // `getAdminEntity({ name, connectionGroupId? })` — resolves by the `name`
-// column against the fixture (published, DB source), matching group when the
-// caller scopes the re-resolve. Returns `null` for a name-column miss (drives
-// the table fallback / unknown path). Overridable per-test for throw cases.
+// COLUMN (the file stem, `f.column`) against the fixture (published, DB source),
+// matching group when the caller scopes the re-resolve. Returns `null` for a
+// column miss (drives the name/table fallback / unknown path). Overridable
+// per-test for throw cases.
 const mockGetAdminEntity = mock<(...args: unknown[]) => Promise<unknown>>(
   async (opts: unknown) => {
     const { name, connectionGroupId } = opts as {
@@ -177,7 +191,7 @@ const mockGetAdminEntity = mock<(...args: unknown[]) => Promise<unknown>>(
     };
     const match = ENTITY_FIXTURE.find(
       (f) =>
-        f.name === name &&
+        f.column === name &&
         (connectionGroupId === undefined || f.group === connectionGroupId),
     );
     return match
@@ -361,7 +375,7 @@ describe("MCP semantic tools", () => {
       };
       const match = ENTITY_FIXTURE.find(
         (f) =>
-          f.name === name &&
+          f.column === name &&
           (connectionGroupId === undefined || f.group === connectionGroupId),
       );
       return match
@@ -515,9 +529,15 @@ describe("MCP semantic tools", () => {
 
   // #4733 — the regression: on SaaS, entities live only in `semantic_entities`
   // (group-scoped). describeEntity must resolve a group-scoped entity the same
-  // as listEntities surfaces it — by its `name` field AND by its `table`, via
-  // the org-scoped DB path (getAdminEntity + listEntityRows table fallback).
-  it("describeEntity resolves a group-scoped entity by its name (DB path)", async () => {
+  // way listEntities surfaces it — by its YAML `name` field, by its `table`, and
+  // by the DB name-column/stem — via the org-scoped DB path (getAdminEntity +
+  // listEntityRows name/table fallback).
+
+  it("describeEntity resolves a group-scoped entity by its YAML display name (the id listEntities advertises)", async () => {
+    // The live-bug case: `Conversation` is the name listEntities shows, but the
+    // `semantic_entities.name` COLUMN is the stem `conversation`, so the column
+    // lookup misses and the fallback must match the parsed-YAML `name`. This
+    // exact call (`{name:"Conversation"}`) still 404'd after the first #4733 fix.
     const { client } = await createTestClient();
     const result = await client.callTool({
       name: "describeEntity",
@@ -527,13 +547,13 @@ describe("MCP semantic tools", () => {
     const parsed = JSON.parse(getContentText(result.content));
     expect(parsed.found).toBe(true);
     expect(parsed.entity.table).toBe("conversations");
-    // Resolved by the `name` column — no need to fall through to the row scan.
-    expect(mockGetAdminEntity).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "Conversation",
-        orgId: TEST_ACTOR.activeOrganizationId,
-        mode: "published",
-      }),
+    expect(parsed.entity.name).toBe("Conversation");
+    // Column lookup ("Conversation" ≠ stem "conversation") missed → fallback
+    // scanned the org's published rows and matched the parsed-YAML `name`.
+    expect(mockListEntityRows).toHaveBeenCalledWith(
+      TEST_ACTOR.activeOrganizationId,
+      "entity",
+      "published",
     );
   });
 
@@ -548,13 +568,29 @@ describe("MCP semantic tools", () => {
     expect(parsed.found).toBe(true);
     expect(parsed.entity.table).toBe("conversations");
     expect(parsed.entity.name).toBe("Conversation");
-    // The name-column lookup missed ("conversations" is a table, not a name),
-    // so the table fallback scanned the org's published rows.
+    // The name-column lookup missed ("conversations" is the table, not the
+    // stem), so the fallback scanned the org's published rows.
     expect(mockListEntityRows).toHaveBeenCalledWith(
       TEST_ACTOR.activeOrganizationId,
       "entity",
       "published",
     );
+  });
+
+  it("describeEntity resolves a group-scoped entity by its DB name-column stem (fast path)", async () => {
+    // Describing by the exact name-column value resolves on the getAdminEntity
+    // fast path without scanning rows.
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "describeEntity",
+      arguments: { name: "conversation" },
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(getContentText(result.content));
+    expect(parsed.found).toBe(true);
+    expect(parsed.entity.table).toBe("conversations");
+    // Direct column hit — no fallback scan needed.
+    expect(mockListEntityRows).not.toHaveBeenCalled();
   });
 
   it("describeEntity maps a multi-group name to a validation_failed envelope, not a silent pick", async () => {

--- a/packages/mcp/src/semantic-tools.ts
+++ b/packages/mcp/src/semantic-tools.ts
@@ -182,39 +182,43 @@ export function registerSemanticTools(
       throw err;
     }
 
-    // Table-name fallback: `getAdminEntity` matches the name column only, but
-    // the tool contract advertises `name` accepts an entity name OR a table
-    // name (`inputSchema` below) — the pre-#4733 disk scan matched
-    // `raw.table === name`. Scan the org's published rows for a parsed-YAML
-    // `table` match.
+    // Name/table fallback. `getAdminEntity` resolves by the
+    // `semantic_entities.name` COLUMN only — and that column holds the file
+    // STEM (e.g. `conversation`, `organization`), NOT the entity's YAML `name`
+    // field (`Conversation`, `Organization`) that `listEntities` advertises.
+    // So a client describing an entity by the name it just saw in `listEntities`
+    // (or by its table) misses the column lookup above. Scan the org's published
+    // rows and match the parsed-YAML `name` OR `table` against the input — the
+    // two identifiers `listEntities` surfaces — so every listed entity is
+    // describable by either. (#4733 follow-up: verified live against prod, where
+    // `describeEntity({name:"Conversation"})` still 404'd after the first fix.)
     const rows = await listEntityRows(workspaceId, "entity", "published");
-    const tableMatches = rows.filter((row) => {
+    const matches = rows.filter((row) => {
       try {
         const parsed = loadYaml(row.yaml_content);
-        return (
-          !!parsed &&
-          typeof parsed === "object" &&
-          (parsed as Record<string, unknown>).table === nameOrTable
-        );
+        if (!parsed || typeof parsed !== "object") return false;
+        const p = parsed as Record<string, unknown>;
+        return p.name === nameOrTable || p.table === nameOrTable;
       } catch {
         // intentionally ignored: a single malformed sibling row must not block
-        // table-resolution of the others; its own name-column read surfaces the
-        // parse error where it is actionable.
+        // resolution of the others; its own name-column read surfaces the parse
+        // error where it is actionable.
         return false;
       }
     });
-    if (tableMatches.length === 0) return { kind: "unknown" };
+    if (matches.length === 0) return { kind: "unknown" };
 
-    // A table shared across distinct connection groups is ambiguous by the same
-    // rule as a shared name — surface it as a typed envelope, never a silent
-    // pick (multi-member groups share the same definition, collapsing to one
-    // group here so they resolve rather than falsely reporting ambiguity).
-    const groups = new Set(tableMatches.map((row) => row.connection_group_id ?? null));
+    // A name/table shared across distinct connection groups is ambiguous by the
+    // same rule as a shared name-column value — surface it as a typed envelope,
+    // never a silent pick (multi-member groups share the same definition,
+    // collapsing to one group here so they resolve rather than falsely
+    // reporting ambiguity).
+    const groups = new Set(matches.map((row) => row.connection_group_id ?? null));
     if (groups.size > 1) return { kind: "ambiguous", groups: [...groups] };
 
     // Re-resolve by the matched row's canonical name, scoped to its own group
     // so this second lookup can't itself throw an ambiguity.
-    const match = tableMatches[0];
+    const match = matches[0];
     const detail = await getAdminEntity({
       name: match.name,
       orgId: workspaceId,


### PR DESCRIPTION
## What & why

Follow-up to #4733, **caught by live-testing hosted prod** after v0.0.63/v0.0.64 shipped. The first fix made **table** lookups work on SaaS (they were all broken), but describing an entity by the **name `listEntities` advertises** still 404'd — the *exact* reported symptom:

```
describeEntity({name:"Conversation"}) → {code:"unknown_entity"}   // still broken
describeEntity({name:"conversations"}) → {found:true, ...}         // fixed by v0.0.63
```

## Root cause

`getAdminEntity` resolves by the `semantic_entities.name` **column**, which holds the file **stem** — not the YAML `name` field, and not always the `table`:

| listEntities shows | DB name column (stem) | table |
|---|---|---|
| `Conversation` | `conversation` | `conversations` |
| `Organization` | `organization` | `organization` |
| `AuditLog` | `audit_log` | `audit_log` |

(Confirmed live: `SELECT DISTINCT name FROM semantic_entities …` → `conversation`, `organization`, `audit_log`, …)

The v0.0.63 fallback matched only the parsed-YAML `table`, so a client passing the display name (`Conversation`, `Organization`) missed both the column lookup and the table fallback.

## The fix

The fallback now matches the parsed-YAML **`name` OR `table`** against the input, so every entity `listEntities` surfaces is describable by either identifier — and by the stem via the column fast path. One-line-ish change in `resolveEntity`.

## Why the unit tests didn't catch it

The mock resolved `getAdminEntity` by the YAML name, conflating it with the name column — so tests were green while prod failed. The fixture now models all three identifiers distinctly (`column`=stem, `name`=display, `table`) and asserts resolution by each, including the display-name-via-fallback case.

## Verification
- `bun test semantic-tools.test.ts telemetry.test.ts` → 74 pass
- `canonical-mcp-eval` (disk path, `DATABASE_URL` unset) → 7/7 (no regression)
- Full mcp suite → 38/38
- Will re-verify live against prod after deploy.

## Scope
`@atlas/mcp` only — no npm bump. Prod-affecting; carried by the next `/release` (the api watch-path fix from #4737 now makes mcp-only changes actually deploy).