### PR TITLE
fix(mcp): transport-agnostic SSE keepalive on POST tool-call stream (#4734)

### DIFF
--- a/packages/mcp/src/__tests__/stream-liveness.test.ts
+++ b/packages/mcp/src/__tests__/stream-liveness.test.ts
@@ -194,4 +194,69 @@ describe("trackResponseStreamLifetime", () => {
     await expect(reader.read()).rejects.toThrow("boom");
     expect(activityCount).toBe(0); // no chunks were enqueued before the error
   });
+
+  // ── #4734 — transport-agnostic SSE keepalive on the POST tool-call stream ──
+
+  const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  it("injects SSE keepalive frames while the source idles, without dropping or reordering data (#4734)", async () => {
+    const enc = new TextEncoder();
+    // Source emits two data frames, each after a ~40ms idle gap, then closes.
+    // With keepaliveMs=10 the wrapper should fill each gap with comment frames.
+    let step = 0;
+    const src = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        step++;
+        if (step === 1) {
+          await delay(40);
+          controller.enqueue(enc.encode("data: one\n\n"));
+          return;
+        }
+        if (step === 2) {
+          await delay(40);
+          controller.enqueue(enc.encode("data: two\n\n"));
+          return;
+        }
+        controller.close();
+      },
+    });
+
+    let activity = 0;
+    const tracked = trackResponseStreamLifetime(
+      sseResponse(src),
+      { onOpen: () => {}, onClose: () => {}, onActivity: () => { activity++; } },
+      { keepaliveMs: 10 },
+    );
+
+    const text = await new Response(tracked.body).text();
+
+    // Both data frames survive intact and in order — the keepalive race never
+    // abandons the pending read.
+    expect(text).toContain("data: one\n\n");
+    expect(text).toContain("data: two\n\n");
+    expect(text.indexOf("data: one")).toBeLessThan(text.indexOf("data: two"));
+    // At least one keepalive comment frame was injected during an idle gap.
+    expect(text).toContain(": keepalive\n\n");
+    // A keepalive counts as activity (keeps the idle sweep from evicting a
+    // mid-run session), so onActivity fired more than the two data chunks.
+    expect(activity).toBeGreaterThan(2);
+  });
+
+  it("injects NO keepalive frames when keepaliveMs is omitted (GET-stream behavior unchanged)", async () => {
+    const enc = new TextEncoder();
+    const src = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        await delay(30);
+        controller.enqueue(enc.encode("data: only\n\n"));
+        controller.close();
+      },
+    });
+    const tracked = trackResponseStreamLifetime(sseResponse(src), {
+      onOpen: () => {},
+      onClose: () => {},
+    });
+    const text = await new Response(tracked.body).text();
+    expect(text).toBe("data: only\n\n");
+    expect(text).not.toContain(": keepalive");
+  });
 });

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -141,6 +141,11 @@ export function resolveMaxSessions(explicit?: number): number {
 const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const MIN_SESSION_IDLE_TIMEOUT_MS = 60 * 1000; // 1 minute floor
 
+// #4734 — cadence for the POST tool-call SSE keepalive. Comfortably under the
+// ~120s intermediary (Railway edge/LB) idle window with margin for jitter, so a
+// long, quiet agent run keeps the stream warm and its response is never dropped.
+const POST_STREAM_KEEPALIVE_MS = 15 * 1000;
+
 /**
  * Test-only override. Bypasses the production floor so the cap-pressure
  * sweep can be driven end-to-end with sub-second timeouts. Production must
@@ -399,15 +404,23 @@ export class McpSessionStore {
       });
     }
     if (req.method === "POST") {
-      return trackResponseStreamLifetime(response, {
-        onOpen: () => {},
-        onClose: () => {
-          entry.lastSeenAt = Date.now();
+      return trackResponseStreamLifetime(
+        response,
+        {
+          onOpen: () => {},
+          onClose: () => {
+            entry.lastSeenAt = Date.now();
+          },
+          onActivity: () => {
+            entry.lastSeenAt = Date.now();
+          },
         },
-        onActivity: () => {
-          entry.lastSeenAt = Date.now();
-        },
-      });
+        // #4734 — inject an SSE keepalive on the POST tool-call stream so a
+        // long agent run (e.g. the `query` tool, minutes-long) can't be dropped
+        // by an intermediary idle-timeout while it produces no bytes. Works for
+        // every client, unlike the progressToken-gated progress heartbeat.
+        { keepaliveMs: POST_STREAM_KEEPALIVE_MS },
+      );
     }
     return response;
   }

--- a/packages/mcp/src/stream-liveness.ts
+++ b/packages/mcp/src/stream-liveness.ts
@@ -56,6 +56,24 @@ export interface StreamLifetimeHooks {
   readonly onActivity?: () => void;
 }
 
+/** SSE comment frame (#4734). A line starting with `:` is a comment — the SSE
+ * spec requires conformant parsers (incl. the MCP client's) to ignore it — so
+ * it puts bytes on the wire without ever surfacing as a JSON-RPC message. */
+const SSE_KEEPALIVE_FRAME = new TextEncoder().encode(": keepalive\n\n");
+
+export interface TrackStreamOptions {
+  /**
+   * #4734 — transport-agnostic keepalive. When set, the POST tool-call SSE
+   * stream emits an SSE comment frame ({@link SSE_KEEPALIVE_FRAME}) whenever the
+   * source produces nothing for `keepaliveMs`, so an intermediary idle-timeout
+   * (Railway edge/LB, ~120s) can't drop a long agent run before its result is
+   * sent. Unlike the progress-notification heartbeat (`progress.ts`), this works
+   * for EVERY client — it doesn't require the client to have sent a
+   * `progressToken`. Omit (GET notification streams) to skip the keepalive.
+   */
+  readonly keepaliveMs?: number;
+}
+
 /**
  * If `res` is an SSE (`text/event-stream`) streaming response, wrap its body
  * so `hooks.onOpen` fires now and `hooks.onClose` fires exactly once when the
@@ -64,11 +82,14 @@ export interface StreamLifetimeHooks {
  *
  * The wrapper is a pull-driven byte-for-byte pass-through: it preserves SSE
  * ordering and backpressure (an idle stream parks in `reader.read()` rather
- * than spinning), so the client sees an identical stream.
+ * than spinning), so the client sees an identical stream. With
+ * `opts.keepaliveMs` (#4734) it additionally injects an SSE comment frame each
+ * time the source idles that long — see {@link TrackStreamOptions}.
  */
 export function trackResponseStreamLifetime(
   res: Response,
   hooks: StreamLifetimeHooks,
+  opts?: TrackStreamOptions,
 ): Response {
   const body = res.body;
   const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
@@ -85,10 +106,53 @@ export function trackResponseStreamLifetime(
   };
 
   const reader = body.getReader();
+  const keepaliveMs = opts?.keepaliveMs;
+  type ReadResult = Awaited<ReturnType<typeof reader.read>>;
+
+  // A SINGLE in-flight read is retained across `pull` calls (`pendingRead`) so
+  // the keepalive race never abandons — and thus never drops — a chunk: when
+  // the timer wins we emit a comment frame and re-race the SAME still-pending
+  // read on the next pull, so `reader.read()` is called exactly once per chunk.
+  let pendingRead: Promise<ReadResult> | null = null;
+
   const tracked = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
-        const { done, value } = await reader.read();
+        if (!pendingRead) pendingRead = reader.read();
+
+        if (keepaliveMs !== undefined) {
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          const tick = new Promise<"__keepalive__">((resolve) => {
+            timer = setTimeout(() => resolve("__keepalive__"), keepaliveMs);
+          });
+          let raced: ReadResult | "__keepalive__";
+          try {
+            raced = await Promise.race([pendingRead, tick]);
+          } finally {
+            if (timer) clearTimeout(timer);
+          }
+          if (raced === "__keepalive__") {
+            // Source idled past the keepalive window — keep the connection warm
+            // (pendingRead is retained so its eventual chunk is not lost). A
+            // keepalive counts as liveness so the idle sweep doesn't evict a
+            // session that is mid-run but quiet.
+            controller.enqueue(SSE_KEEPALIVE_FRAME);
+            hooks.onActivity?.();
+            return;
+          }
+          pendingRead = null;
+          if (raced.done) {
+            controller.close();
+            finish();
+            return;
+          }
+          controller.enqueue(raced.value);
+          hooks.onActivity?.();
+          return;
+        }
+
+        const { done, value } = await pendingRead;
+        pendingRead = null;
         if (done) {
           controller.close();
           finish();
@@ -105,6 +169,7 @@ export function trackResponseStreamLifetime(
         // logging (controller.error only reaches the client), release the
         // liveness mark, then propagate. Normalize per the repo's caught-error
         // rule.
+        pendingRead = null;
         hooks.onError?.(err);
         finish();
         controller.error(err instanceof Error ? err : new Error(String(err)));


### PR DESCRIPTION
## What & why

**Caught live-testing prod.** After the progress-heartbeat fix (v0.0.63) shipped and deployed, a `query` that ran >120s **still** dropped the transport:

```
transport dropped mid-call; response for tool "query" was lost
```

The heartbeat (`progress.ts` `startHeartbeat`) only puts bytes on the wire when the client sent a `progressToken` — and the reporting client (and the Claude Code MCP client I tested with) doesn't send one for the `query` call. So the heartbeat was a no-op, the POST SSE stream stayed byte-idle during the agent run, and the intermediary idle-timeout (Railway edge/LB, ~120s) killed it. This is the caveat the first PR documented and deferred; live testing proved the deferred `:ping` keepalive is actually **required**.

## The fix (transport seam, works for every client)

`trackResponseStreamLifetime` (`stream-liveness.ts`) already wraps the POST SSE body as a pull-driven pass-through. It now injects an **SSE comment frame** (`: keepalive\n\n`) whenever the source idles past `keepaliveMs` (15s), wired in `session-store.ts`'s POST branch. SSE comment lines (leading `:`) are ignored by conformant parsers — including the MCP client's — so they keep the connection warm **without ever surfacing as a JSON-RPC message**, and independent of `progressToken`.

**No data loss:** the wrapper retains a *single* in-flight read across `pull` calls (`pendingRead`) and races that same promise against the keepalive timer — a keepalive tick never abandons a chunk, so `reader.read()` is still called exactly once per chunk (order + bytes preserved). A keepalive also counts as `onActivity`, so the idle-session sweep can't evict a mid-run-but-quiet session.

The progressToken heartbeat stays — it gives progressToken clients real progress UX, and its bytes naturally suppress the keepalive (source isn't idle).

## Tests
- `stream-liveness.test.ts`: keepalive frames injected during idle gaps with both data frames intact and in order; **no** keepalive when `keepaliveMs` is omitted (GET notification streams unchanged).
- Full mcp suite 38/38, tsgo clean.
- **Will re-verify the >120s query completes live against prod after deploy.**

## Scope
`@atlas/mcp` only — no npm bump. Prod-affecting; the api watch-path fix (#4737) now makes this deploy.