### PR TITLE
fix(mcp): cap query agent run with a soft deadline + query_timeout envelope (#4734)

### DIFF
--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -423,6 +423,8 @@ question: "top 5 customers by revenue last quarter"
 
 It returns a prose `answer` plus the exact SQL it ran and the result rows. Because it runs a second, server-side LLM it **spends your Atlas plan tokens** and additionally clears the claim gate (unclaimed-trial metering).
 
+The agent run is capped by a **90-second server-side soft deadline** — MCP clients impose their own request-timeout ceiling (commonly ~120s) that no server keepalive can extend, so Atlas stops the run just under it and returns a `query_timeout` [error envelope](#error-contract) rather than letting the transport drop with the response lost. Narrow the question (shorter time range, fewer breakdowns, one metric at a time) or drop down to `executeSQL` for a specific slice.
+
 ### explore
 
 Read files from the semantic layer directory. Accepts bash commands scoped to the `semantic/` directory.
@@ -632,7 +634,7 @@ The envelope is serialized as the `text` of the first content block. Use `parseA
 |------|-----------------|---------------------------|
 | `validation_failed` | The SQL guard rejected (regex, AST, table whitelist), or `runMetric` was called with a non-empty `filters` object. | Rewrite the query; do **not** retry the same SQL. |
 | `rls_denied` | Row-level security rejected the query for the bound actor. | Surface the failure to the user — the agent cannot retry under another identity. |
-| `query_timeout` | `statement_timeout` fired. | Suggest a simpler query (tighter `WHERE`/`LIMIT`) or break the work up. |
+| `query_timeout` | `statement_timeout` fired on a datasource query (`executeSQL`, `runMetric`), **or** a `query` agent run hit the server-side soft deadline (90s) and was stopped before the client's request timeout would have dropped the response. | Suggest a simpler query (tighter `WHERE`/`LIMIT`) or a narrower question, or break the work up. |
 | `unknown_entity` | `describeEntity` was called with an entity that doesn't exist, `executeSQL` referenced a table missing from the semantic whitelist, or a `connectionId` was specified that isn't registered. | Call `listEntities` to discover what exists, then retry with a real name (or check the connection id). |
 | `unknown_metric` | `runMetric` was called with an id missing from `metrics/*.yml`. | Fall back to `executeSQL`, or pick a different metric id. |
 | `ambiguous_term` | `searchGlossary` matched a glossary entry with `status: ambiguous`. | **Do not silently pick a mapping.** Surface `possible_mappings` to the user and ask which they meant. |

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -143,6 +143,15 @@ export interface ExecuteAgentQueryOptions {
    * workspace's house voice, defaulting to the analyst-grade body.
    */
   answerStyle?: AnswerStyle;
+  /**
+   * #4734 — abort the agent run (forwarded to {@link runAgent} → `streamText`).
+   * The MCP `query` tool sets a soft server-side deadline just under the client's
+   * request-timeout ceiling: a synchronous MCP tool call can't run for minutes
+   * against a client that hard-times-out, so on the deadline the run is aborted
+   * and a `query_timeout` envelope is returned to the client BEFORE the transport
+   * would drop. Also carries a client-initiated cancel through to stop LLM spend.
+   */
+  abortSignal?: AbortSignal;
 }
 
 /**
@@ -289,6 +298,7 @@ export async function executeAgentQuery(
       tools: toolRegistry,
       ...(options?.conversationId && { conversationId: options.conversationId }),
       ...(options?.answerStyle && { answerStyle: options.answerStyle }),
+      ...(options?.abortSignal && { abortSignal: options.abortSignal }),
     });
 
     const [text, steps, totalUsage] = await Promise.all([

--- a/packages/api/src/lib/tools/descriptions.ts
+++ b/packages/api/src/lib/tools/descriptions.ts
@@ -137,6 +137,10 @@ export const RUN_METRIC_ERROR_CODES = [
 export const QUERY_ERROR_CODES = [
   "billing_blocked",
   "rate_limited",
+  // #4734 — the run exceeded the server-side soft deadline (set just under the
+  // client's request-timeout ceiling) and was aborted, so the caller gets an
+  // actionable envelope instead of a dropped transport with a lost response.
+  "query_timeout",
   "internal_error",
 ] as const satisfies readonly AtlasMcpToolErrorCode[];
 

--- a/packages/mcp/src/__tests__/query-tool.test.ts
+++ b/packages/mcp/src/__tests__/query-tool.test.ts
@@ -301,6 +301,40 @@ describe("MCP query tool (#4094)", () => {
     expect(envelope!.hint).toContain("Narrow the question");
   });
 
+  it("returns query_timeout even when the aborted run RESOLVES with a partial answer (#4734)", async () => {
+    // The AI SDK treats an abort after ≥1 completed step as a graceful stream
+    // end and resolves `text`/`steps` from what it recorded, so the run comes
+    // back truncated instead of throwing. That must not be surfaced as a normal
+    // answer — the client would get a silently-incomplete result.
+    _setQueryDeadlineMsForTest(20);
+    mockExecuteAgentQuery.mockImplementationOnce(async (...args: unknown[]) => {
+      const opts = args[2] as { abortSignal?: AbortSignal };
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, 5000);
+        opts.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(t);
+            resolve(); // graceful settle — the partial-answer path
+          },
+          { once: true },
+        );
+      });
+      return { ...DEFAULT_RESULT, answer: "partial, truncated answer" };
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "an intractably broad question" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("query_timeout");
+    expect(getContentText(result.content)).not.toContain("partial, truncated answer");
+  });
+
   it("threads an abortSignal into executeAgentQuery so the deadline can cancel the run (#4734)", async () => {
     const { client } = await createTestClient();
     await client.callTool({ name: "query", arguments: { question: "anything" } });

--- a/packages/mcp/src/__tests__/query-tool.test.ts
+++ b/packages/mcp/src/__tests__/query-tool.test.ts
@@ -124,9 +124,11 @@ void mock.module("@atlas/api/lib/billing/claim-gate", () => ({
 }));
 
 // Import after mocks are set up.
-const { registerQueryTool, _setQueryHeartbeatIntervalMsForTest } = await import(
-  "../query-tool.js"
-);
+const {
+  registerQueryTool,
+  _setQueryHeartbeatIntervalMsForTest,
+  _setQueryDeadlineMsForTest,
+} = await import("../query-tool.js");
 
 function getContentText(content: unknown): string {
   const arr = content as Array<{ type: string; text: string }>;
@@ -165,6 +167,9 @@ describe("MCP query tool (#4094)", () => {
     // mocks in the rest of the suite never fire a stray heartbeat; the slow-run
     // test shortens it locally.
     _setQueryHeartbeatIntervalMsForTest(60_000);
+    // #4734 — keep the soft deadline long by default so fast mocks never trip it;
+    // the deadline test shortens it locally.
+    _setQueryDeadlineMsForTest(60_000);
   });
 
   it("is registered as a read-only, open-world tool advertising the error contract", async () => {
@@ -258,6 +263,58 @@ describe("MCP query tool (#4094)", () => {
     // Wait several more intervals — a cleared timer emits nothing further.
     await new Promise((r) => setTimeout(r, 40));
     expect(progresses.length).toBe(countAtSettle);
+  });
+
+  it("returns a query_timeout envelope (not a dropped transport) when the run exceeds the soft deadline (#4734)", async () => {
+    // The real fix: a synchronous MCP call can't outlive the client's request
+    // ceiling, so the server aborts at the soft deadline and returns an
+    // actionable envelope BEFORE the transport would drop. The agent
+    // (executeAgentQuery → runAgent → streamText) rejects on abort, which the
+    // mock models by honoring the threaded abortSignal.
+    _setQueryDeadlineMsForTest(20);
+    mockExecuteAgentQuery.mockImplementationOnce(async (...args: unknown[]) => {
+      const opts = args[2] as { abortSignal?: AbortSignal };
+      await new Promise<void>((resolve, reject) => {
+        const t = setTimeout(resolve, 5000); // would run "forever" relative to the 20ms cap
+        opts.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(t);
+            reject(new DOMException("aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+      return DEFAULT_RESULT;
+    });
+
+    const { client } = await createTestClient();
+    const result = await client.callTool({
+      name: "query",
+      arguments: { question: "an intractably broad question" },
+    });
+
+    expect(result.isError).toBe(true);
+    const envelope = parseAtlasMcpToolError(getContentText(result.content));
+    expect(envelope!.code).toBe("query_timeout");
+    expect(envelope!.message).toMatch(/took longer than \d+s/);
+    expect(envelope!.hint).toContain("Narrow the question");
+  });
+
+  it("threads an abortSignal into executeAgentQuery so the deadline can cancel the run (#4734)", async () => {
+    const { client } = await createTestClient();
+    await client.callTool({ name: "query", arguments: { question: "anything" } });
+
+    const calls = mockExecuteAgentQuery.mock.calls;
+    const options = (calls[calls.length - 1] as unknown[])[2] as Record<string, unknown>;
+    expect(options.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("advertises the query_timeout code in its error contract (#4734)", async () => {
+    const { client } = await createTestClient();
+    const { tools } = await client.listTools();
+    const query = tools.find((t) => t.name === "query");
+    expect(query?.description).toContain("`query_timeout`");
   });
 
   it("threads the question + connectionId into executeAgentQuery", async () => {

--- a/packages/mcp/src/query-tool.ts
+++ b/packages/mcp/src/query-tool.ts
@@ -34,6 +34,7 @@ import { z } from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
+import type { AtlasMcpToolError } from "@useatlas/types/mcp";
 // Type-only — erased at compile time, so it does NOT pull the `runAgent` graph
 // into registration (the reason `executeAgentQuery` itself is lazy-imported).
 import type { AgentQueryResult } from "@atlas/api/lib/agent-query";
@@ -82,6 +83,23 @@ let queryDeadlineMs = DEFAULT_QUERY_DEADLINE_MS;
 /** @internal test seam — override the #4734 query soft-deadline. */
 export function _setQueryDeadlineMsForTest(ms: number): void {
   queryDeadlineMs = ms;
+}
+
+/**
+ * #4734 — the envelope returned when the soft deadline aborted the run. Shared
+ * by both deadline exits: the abort can either reject the run (no step had
+ * finished) or resolve it with a truncated partial answer (the AI SDK resolves
+ * `text`/`steps` from what was recorded once at least one step completed), and
+ * a truncated answer must not be dressed up as a successful one.
+ */
+function queryTimeoutEnvelope(): AtlasMcpToolError {
+  return envelope(
+    "query_timeout",
+    `This question took longer than ${Math.round(queryDeadlineMs / 1000)}s and was stopped before the connection would time out. It was too complex to answer in a single request.`,
+    {
+      hint: "Narrow the question — a shorter time range, fewer breakdowns, or one metric at a time — or use executeSQL for a specific slice of the data.",
+    },
+  );
 }
 
 /**
@@ -235,15 +253,7 @@ export function registerQueryTool(
             // an actionable envelope instead of a lost response. Checked FIRST so
             // an abort-induced throw isn't misclassified as an internal_error.
             if (deadlineFired) {
-              return toEnvelopeResult(
-                envelope(
-                  "query_timeout",
-                  `This question took longer than ${Math.round(queryDeadlineMs / 1000)}s and was stopped before the connection would time out. It was too complex to answer in a single request.`,
-                  {
-                    hint: "Narrow the question — a shorter time range, fewer breakdowns, or one metric at a time — or use executeSQL for a specific slice of the data.",
-                  },
-                ),
-              );
+              return toEnvelopeResult(queryTimeoutEnvelope());
             }
             // The billing/claim gates inside `executeAgentQuery` throw typed
             // errors (mirroring the `/api/v1/query` route). Map each onto the
@@ -299,6 +309,16 @@ export function registerQueryTool(
             // client cancelled — so neither outlives the dispatch.
             clearTimeout(deadlineTimer);
             extra.signal.removeEventListener("abort", onClientAbort);
+          }
+
+          // #4734 — the deadline can also land on the *resolve* path: the AI SDK
+          // treats an abort after ≥1 completed step as a graceful stream end and
+          // resolves `text`/`steps` from what it recorded, so `executeAgentQuery`
+          // returns a truncated answer rather than throwing. Returning that as a
+          // normal result would hand the client a silently-incomplete answer with
+          // no signal that the run was cut short — same envelope, either exit.
+          if (deadlineFired) {
+            return toEnvelopeResult(queryTimeoutEnvelope());
           }
 
           // Approval branch: one of the agent's SELECTs hit an approval rule and

--- a/packages/mcp/src/query-tool.ts
+++ b/packages/mcp/src/query-tool.ts
@@ -69,6 +69,21 @@ export function _setQueryHeartbeatIntervalMsForTest(ms: number): void {
   queryHeartbeatIntervalMs = ms;
 }
 
+// #4734 — soft server-side deadline for the whole agent run. Verified live:
+// keepalive/heartbeat alone don't stop a >120s drop, because the MCP CLIENT
+// imposes its own request-timeout ceiling (~120s) that no server keepalive can
+// extend, and a generic client won't poll an async job. So we cap the run just
+// UNDER that ceiling and return a `query_timeout` envelope BEFORE the transport
+// would drop — an actionable result for every client instead of a lost response.
+// 90s leaves margin under the observed ~120s ceiling; overridable for tests.
+const DEFAULT_QUERY_DEADLINE_MS = 90_000;
+let queryDeadlineMs = DEFAULT_QUERY_DEADLINE_MS;
+
+/** @internal test seam — override the #4734 query soft-deadline. */
+export function _setQueryDeadlineMsForTest(ms: number): void {
+  queryDeadlineMs = ms;
+}
+
 /**
  * The hint attached to a `billing_blocked` envelope — adapts the wording of
  * billing-gate.ts (claim/setup framing for the agent path; the mapping *logic*
@@ -166,25 +181,33 @@ export function registerQueryTool(
             "@atlas/api/lib/billing/claim-gate"
           );
 
+          // #4734 — soft server-side deadline. A synchronous MCP tool call can't
+          // outlive the client's own request-timeout ceiling (~120s, verified
+          // live — no server keepalive extends it), so cap the run just under it
+          // and abort, returning a `query_timeout` envelope BEFORE the transport
+          // drops. `deadlineFired` disambiguates our abort from a client cancel.
+          const runAbort = new AbortController();
+          let deadlineFired = false;
+          const deadlineTimer = setTimeout(() => {
+            deadlineFired = true;
+            runAbort.abort();
+          }, queryDeadlineMs);
+          // Carry a client-initiated cancel through to actually stop LLM spend
+          // (the shared dispatch still surfaces the cancel as OperationCancelledError).
+          const onClientAbort = (): void => runAbort.abort();
+          extra.signal.addEventListener("abort", onClientAbort, { once: true });
+
           let result: AgentQueryResult;
           try {
-            // #3500 — progress start/end around the (potentially long) agent
-            // run. #3575 — `executeAgentQuery` takes no abort signal, so the
-            // client-cancel path cuts the dispatch loose at the MCP boundary
-            // (the shared dispatch re-throws OperationCancelledError); the agent
-            // drains server-side. The signal is intentionally not threaded.
+            // #3500 — progress start/end around the (potentially long) agent run.
             result = await withProgressAndCancellation(
               extra,
               { startMessage: "Running Atlas agent", endMessage: "Answer ready" },
               async (reporter, _signal) => {
-                // #4734 — the POST SSE stream emits zero application bytes during
-                // the agent run, so an intermediary idle-timeout (Railway
-                // edge/LB, ~120s) closes it before a long run finishes → the
-                // client sees "transport dropped". Drive a keepalive heartbeat so
-                // periodic progress notifications keep the stream warm. Cleared
-                // in `finally` so the timer never outlives the query. (Only
-                // reaches the wire for progressToken-supplying clients — see
-                // startHeartbeat; a transport-agnostic `: ping` is a follow-up.)
+                // Keepalive heartbeat — keeps the stream warm for progressToken
+                // clients / against an edge idle-timeout. Complementary to the
+                // deadline cap above (which handles the client's hard ceiling)
+                // and the transport-level SSE keepalive (session-store.ts).
                 const stopHeartbeat = startHeartbeat(reporter, {
                   intervalMs: queryHeartbeatIntervalMs,
                   message: "Atlas is still working on your question…",
@@ -196,8 +219,10 @@ export function registerQueryTool(
                     // which `executeAgentQuery` inherits — so executeSQL audit rows
                     // record actor_kind='mcp' and origin-scoped approval rules fire
                     // for origin=mcp. Only connectionId isn't on the context, so
-                    // thread it explicitly (#4124).
+                    // thread it explicitly (#4124). The deadline signal (#4734)
+                    // aborts the run at the cap.
                     ...(connectionId ? { connectionId } : {}),
+                    abortSignal: runAbort.signal,
                   });
                 } finally {
                   stopHeartbeat();
@@ -205,6 +230,21 @@ export function registerQueryTool(
               },
             );
           } catch (err) {
+            // #4734 — our soft deadline fired: the run was aborted before the
+            // client's request-timeout would have dropped the transport. Return
+            // an actionable envelope instead of a lost response. Checked FIRST so
+            // an abort-induced throw isn't misclassified as an internal_error.
+            if (deadlineFired) {
+              return toEnvelopeResult(
+                envelope(
+                  "query_timeout",
+                  `This question took longer than ${Math.round(queryDeadlineMs / 1000)}s and was stopped before the connection would time out. It was too complex to answer in a single request.`,
+                  {
+                    hint: "Narrow the question — a shorter time range, fewer breakdowns, or one metric at a time — or use executeSQL for a specific slice of the data.",
+                  },
+                ),
+              );
+            }
             // The billing/claim gates inside `executeAgentQuery` throw typed
             // errors (mirroring the `/api/v1/query` route). Map each onto the
             // closed MCP envelope catalog rather than letting the shared
@@ -253,6 +293,12 @@ export function registerQueryTool(
             // Anything else (provider/LLM errors, unexpected throws) → let the
             // shared dispatch surface a typed `internal_error` with request_id.
             throw err;
+          } finally {
+            // #4734 — always release the deadline timer + the client-abort
+            // listener, whether the run succeeded, timed out, errored, or the
+            // client cancelled — so neither outlives the dispatch.
+            clearTimeout(deadlineTimer);
+            extra.signal.removeEventListener("abort", onClientAbort);
           }
 
           // Approval branch: one of the agent's SELECTs hit an approval rule and

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -25,8 +25,10 @@
  *   query is permanently broken; the agent should rewrite it, not retry.
  * - `rls_denied` — row-level security rejected the query for the bound
  *   actor. Retrying with the same identity will not help; surface to user.
- * - `query_timeout` — `statement_timeout` fired. Suggest a simpler query
- *   or a tighter `LIMIT`. Not retryable as-is.
+ * - `query_timeout` — `statement_timeout` fired on a datasource query, or a
+ *   `query` agent run hit the server-side soft deadline and was stopped
+ *   before the client's request timeout would drop the response (#4734).
+ *   Suggest a simpler query / narrower question. Not retryable as-is.
  * - `unknown_entity` — the requested entity is not in the semantic layer
  *   (also covers unregistered connection ids and missing datasource
  *   config — all "agent specified the wrong identifier" failures). The


### PR DESCRIPTION
## Corrected root cause (verified live against prod)

The `query` >120s drop is **not** the Railway edge idle-timeout the issue assumed — two server-side fixes proved that:
- v0.0.63 progress heartbeat → still dropped live.
- v0.0.66 transport-level SSE `:ping` keepalive → still dropped live, at the same ~120s.

A **short** query completes cleanly; only long runs drop, consistently at ~120s, regardless of server keepalive. That's the signature of the **MCP client's own request-timeout ceiling** (~120s) — which no server-side keepalive can extend, and which a generic client won't sidestep by polling an async job (it doesn't implement polling).

## The all-client fix

A synchronous MCP tool call simply can't outlive the client's request ceiling. So **cap the agent run server-side just under it (90s) and return a typed `query_timeout` envelope** before the transport would drop — an actionable result for *every* client instead of a lost response:

> `query_timeout` — "This question took longer than 90s and was stopped before the connection would time out… Narrow the question (shorter range, fewer breakdowns) or use executeSQL for a specific slice."

- `agent-query.ts`: thread an optional `abortSignal` through `executeAgentQuery` → `runAgent` (which already forwards it to `streamText`).
- `query-tool.ts`: a deadline `AbortController` (90s, test-overridable); on the deadline-fired abort, return `query_timeout`; also carry a **client cancel** through to actually stop LLM spend; clear timer + listener in `finally`.
- `descriptions.ts`: advertise `query_timeout` in `QUERY_ERROR_CODES`.

The SSE keepalive (#4740) and progress heartbeat (#4736) **stay** — they extend how long *is* available for clients whose timeout is idle-based or resets on progress. The deadline is the backstop for a hard client ceiling.

## Tests
- `query-tool.test.ts`: run exceeds the (shortened) deadline → `query_timeout` envelope, not a drop; `abortSignal` threaded into `executeAgentQuery`; error contract advertises `query_timeout`.
- Full mcp suite 38/38, canonical eval 7/7, affected api tests 9/9, tsgo clean.
- **Will verify live: the heavy query returns a clean `query_timeout` at ~90s instead of dropping.**

## Follow-up
A true async-job `query` (return a job id, poll for the result) would let long queries *complete* for clients that implement polling — worth a design if there's demand. This PR makes the common case honest and drop-free for all clients.

## Scope
`@atlas/mcp` + `@atlas/api` — no npm bump. Prod-affecting; deploys via the #4737 watch-path fix.