### PR TITLE
test(mcp): stub the billing agent-gate in smoke.test.ts

### DIFF
--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -64,6 +64,22 @@ void mock.module("@atlas/api/lib/mcp/action-policy", () => ({
   setMcpActionCategoryStatus: async () => {},
 }));
 
+// Gate-2 billing gate (#3437, #4370): the MCP dispatch path consults
+// `checkAgentBillingGate` before any datasource query (executeSQL / runMetric).
+// The real gate reads the internal DB (`organization` / `settings`) and FAILS
+// CLOSED when that DB is missing or unmigrated, short-circuiting to
+// `internal_error` before the mocked `executeSQL` ever runs. Stub it all-allowed
+// so these smoke tests stay hermetic. Mock ALL runtime exports so a sibling test
+// loading the real module doesn't inherit a partial mock (CLAUDE.md); the
+// module's other exports (`AgentBillingBlock`, `AgentBillingGateResult`) are
+// types and erase at runtime.
+void mock.module("@atlas/api/lib/billing/agent-gate", () => ({
+  checkAgentBillingGate: mock(async (_orgId: string | undefined) => ({ allowed: true as const })),
+  BillingBlockedError: class BillingBlockedError extends Error {
+    override readonly name = "BillingBlockedError";
+  },
+}));
+
 void mock.module("@atlas/api/lib/tools/explore", () => ({
   explore: {
     description: "Explore the semantic layer",

--- a/packages/mcp/src/__tests__/smoke.test.ts
+++ b/packages/mcp/src/__tests__/smoke.test.ts
@@ -64,7 +64,7 @@ void mock.module("@atlas/api/lib/mcp/action-policy", () => ({
   setMcpActionCategoryStatus: async () => {},
 }));
 
-// Gate-2 billing gate (#3437, #4370): the MCP dispatch path consults
+// Gate-0 billing gate (#3437; stub added by #4370): the dispatch path consults
 // `checkAgentBillingGate` before any datasource query (executeSQL / runMetric).
 // The real gate reads the internal DB (`organization` / `settings`) and FAILS
 // CLOSED when that DB is missing or unmigrated, short-circuiting to


### PR DESCRIPTION
## Summary

- `packages/mcp/src/__tests__/smoke.test.ts` was the only MCP test that did **not** stub `@atlas/api/lib/billing/agent-gate`, so its `executeSQL` dispatch ran the real gate-0 billing enforcement gate.
- That gate reads the internal DB (`organization` / `settings`) and **fails closed** when the DB is missing or unmigrated, short-circuiting to `internal_error "Unable to verify workspace status"` before the mocked `executeSQL` ever ran — 3 of the 5 tests failed on any local run with an unmigrated `DATABASE_URL`.
- Green in CI (CI runs against a real migrated Postgres), so this was a latent **test-isolation gap**, not a live break — but it made `scripts/ci-local.sh` red locally and diverged from the pattern every sibling MCP test follows.
- Adds the same all-allowed stub `tools.test.ts` uses, mocking both runtime exports (`checkAgentBillingGate`, `BillingBlockedError`) per the mock-all-exports rule. Test-only change; no production code touched.

## Test plan

- [x] Reproduced the failure: `DATABASE_URL=<unmigrated> bun test src/__tests__/smoke.test.ts` → 3 fail, matching the issue's reported assertions (`:168`, `:210`, `:227`)
- [x] After the fix, passes both with an unmigrated `DATABASE_URL` **and** with `DATABASE_URL` unset — 5 pass / 0 fail
- [x] Full isolated MCP suite green (38/38 files) — confirms no mock leakage into siblings
- [x] `bash scripts/ci-local.sh` — all 31 gates PASS (incl. `type`, `lint`, `lint-type-aware`, `test-discipline`, full test suite)

## Notes

The comment labels this **gate 0**, matching the codebase's established numbering (`datasource-tools.ts`, `dispatch-gate.ts`): billing = 0, action-policy = 1, `mcp:write` = 2, RBAC = 3.

Closes #4370