### PR TITLE
fix(settings): lock RESEND_API_KEY + ATLAS_PROVIDER as SaaS-immutable (#4462)

### DIFF
--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -360,7 +360,7 @@ Global settings that affect all workspaces — security policies, LLM provider, 
 - **Brand color** — A dedicated card lets you preview and set the primary brand color in oklch format, with a live color swatch. Changes apply immediately
 - **Live vs Restart** — Settings marked **Live** take effect immediately. Settings marked **Requires restart** need a server restart (self-hosted only — on **app.useatlas.dev**, most settings are hot-reloadable)
 - **Secrets** — Sensitive settings (API keys, database URLs) are masked and read-only. Manage these via environment variables
-- **Boot-guard settings on app.useatlas.dev** — A few keys are validated by a boot guard and are therefore **env-managed on the hosted platform**: `ATLAS_EMAIL_PROVIDER`, `RESEND_API_KEY`, `ATLAS_PROVIDER`, `ATLAS_RATE_LIMIT_RPM`, `ATLAS_DEPLOY_MODE`. Saving or clearing one returns a 409 there — rotate the value in the environment and restart so the guard re-validates. Self-hosted keeps all of them runtime-editable
+- **Boot-guard settings on app.useatlas.dev** — A few keys are validated by a boot guard and are therefore **env-managed on the hosted platform**: `ATLAS_EMAIL_PROVIDER`, `RESEND_API_KEY`, `ATLAS_PROVIDER`, `ATLAS_RATE_LIMIT_RPM`, `ATLAS_DEPLOY_MODE`. Saving or clearing one is rejected there (409 `saas_immutable`) — rotate the value in the environment and restart so the guard re-validates. Self-hosted keeps all of them runtime-editable
 
 | Section | Setting | Description |
 |---------|---------|-------------|

--- a/apps/docs/content/docs/guides/admin-console.mdx
+++ b/apps/docs/content/docs/guides/admin-console.mdx
@@ -360,6 +360,7 @@ Global settings that affect all workspaces — security policies, LLM provider, 
 - **Brand color** — A dedicated card lets you preview and set the primary brand color in oklch format, with a live color swatch. Changes apply immediately
 - **Live vs Restart** — Settings marked **Live** take effect immediately. Settings marked **Requires restart** need a server restart (self-hosted only — on **app.useatlas.dev**, most settings are hot-reloadable)
 - **Secrets** — Sensitive settings (API keys, database URLs) are masked and read-only. Manage these via environment variables
+- **Boot-guard settings on app.useatlas.dev** — A few keys are validated by a boot guard and are therefore **env-managed on the hosted platform**: `ATLAS_EMAIL_PROVIDER`, `RESEND_API_KEY`, `ATLAS_PROVIDER`, `ATLAS_RATE_LIMIT_RPM`, `ATLAS_DEPLOY_MODE`. Saving or clearing one returns a 409 there — rotate the value in the environment and restart so the guard re-validates. Self-hosted keeps all of them runtime-editable
 
 | Section | Setting | Description |
 |---------|---------|-------------|

--- a/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
+++ b/apps/docs/content/docs/platform-ops/saas-environment-variables.mdx
@@ -122,6 +122,14 @@ them — changing them *is* a deploy:
 |---|---|
 | `ATLAS_RATE_LIMIT_RPM` | `RateLimitGuardLive` refuses to boot a region without a positive value (DDoS floor). Hot-reload would re-open the hole. |
 | `ATLAS_EMAIL_PROVIDER` | DPA guard runs at boot; hot-reload would bypass it. (Changed via Admin → Email provider, takes effect next boot.) |
+| `RESEND_API_KEY` | `DpaGuardLive` validates the *resolved* platform email transport at boot (registry override → env). Clearing a registry override at runtime would silently flip the transport to the `ATLAS_SMTP_URL` bridge — or to nothing at all — behind the guard. Rotate the env value and restart. |
+| `ATLAS_PROVIDER` | `ProactiveProviderKeyGuardLive` validates the settings-resolved proactive LLM provider at boot. A runtime override applies immediately (the `requiresRestart` flag is a display hint, not a deferral), so an unkeyed provider would fail every proactive answer while `/health` stays green. |
+
+The rule behind that table — and the thing to check when adding a boot guard:
+
+> A platform-scoped setting validated by a SaaS boot guard is either in
+> `SAAS_IMMUTABLE_KEYS` or explicitly re-guarded on write. A restart *hint* is
+> never a guard.
 
 > `ATLAS_DEPLOY_MODE` and `ATLAS_ENTERPRISE_ENABLED` are **not** set on SaaS — `deploy/api/atlas.config.ts` resolves both (`deployMode: "saas"`, `enterprise.enabled: true`) and the resolution paths consult the config file first. Dropped from the Railway services in #3702. `ATLAS_DEPLOY_MODE` is nonetheless the third member of `SAAS_IMMUTABLE_KEYS` — locked from runtime mutation so a settings write can never flip a region's deploy mode.
 
@@ -137,7 +145,7 @@ Railway:
 - **Rate limiting** — per-user / chat / admin RPM (the base RPM floor excepted), contact-form RPM
 - **Demo** — demo RPM + demo agent max steps
 - **Abuse prevention** — query-rate / window / error-rate / unique-tables / throttle-delay / escalation-cooldown thresholds
-- **Agent** — max steps, conversation step cap, provider, model, log level
+- **Agent** — max steps, conversation step cap, model, log level (the *provider* is boot-guarded — see above)
 - **Security** — RLS column/claim, table whitelist, CORS origin, allowed email domains, SCIM policy
 - **Sessions** — idle / absolute timeout
 - **OAuth** — access / refresh token TTLs (restart-applied), install state-token TTL

--- a/docs/development/saas-env-audit.md
+++ b/docs/development/saas-env-audit.md
@@ -323,6 +323,43 @@ items and re-baselined the counts:
   ratchet decision was split out to #4620 (`ready-for-human`); its findings
   fold back into this document.
 
+## Guard-validated settings are immutable or re-guarded (#4462, 2026-07-22)
+
+The 2026-07-10 `/prod-audit` Part C found `RESEND_API_KEY` boot-validated by
+`DpaGuardLive` (which resolves the *transport* through `resolveResendApiKey()` =
+registry override → env) yet freely mutable at runtime, so a platform admin
+could delete the override post-boot and silently flip the platform email
+transport to the `ATLAS_SMTP_URL` bridge — or to nothing — with no re-guard until
+the next restart. Triage found the identical shape on `ATLAS_PROVIDER`
+(`ProactiveProviderKeyGuardLive`).
+
+**Decision (maintainer-approved 2026-07-16): both keys join
+`SAAS_IMMUTABLE_KEYS`.** A validate-on-write hook in the settings registry was
+considered and rejected — no such seam exists, and the immutable-key mechanism
+is already proven, symmetric across `setSetting`/`deleteSetting`, fail-closed
+(`isSaasModeForGuard`), and SaaS-only. Key rotation stays available out-of-band:
+change the env value, restart, and the boot guard re-validates.
+
+**Recorded invariant** (stated at the `SAAS_IMMUTABLE_KEYS` definition in
+`lib/settings.ts` and in the operator reference):
+
+> A platform-scoped setting validated by a SaaS boot guard must either be in
+> `SAAS_IMMUTABLE_KEYS` or be explicitly re-guarded on write. A restart *hint* is
+> never a guard.
+
+`requiresRestart` is annotation-only — it neither blocks a write nor defers
+application (values hot-apply through the live settings cache), so a guard whose
+rationale rests on it is unsound. The `ProactiveProviderKeyGuardLive` docstring
+made exactly that argument before #4462 and was corrected.
+
+**Known warn-only cousin, deliberately left mutable:** the nine
+`STRIPE_*_PRICE_ID` keys. Their boot check only warns, so a runtime change
+cannot slip past a fail-boot guard; they stay Admin-editable by design.
+
+**Operator note:** an existing registry-only `RESEND_API_KEY` override keeps
+working but becomes undeletable at runtime. Confirm each region's key source and
+migrate any registry-only region to the env var at the next deploy.
+
 ## Tracked work
 
 See the umbrella issue and its children in `AtlasDevHQ/atlas` (search label

--- a/packages/api/src/lib/__tests__/settings-saas.test.ts
+++ b/packages/api/src/lib/__tests__/settings-saas.test.ts
@@ -248,6 +248,46 @@ describe("settings (SaaS mode)", () => {
       expect(queryCalls).toHaveLength(0);
     });
 
+    // #4462 — DpaGuardLive validates the RESOLVED transport at boot via
+    // `resolveResendApiKey()` (registry override → env). A runtime write is a
+    // guard bypass, so the key joined SAAS_IMMUTABLE_KEYS.
+    it("setSetting rejects RESEND_API_KEY in SaaS mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      let captured: unknown;
+      try {
+        await setSetting("RESEND_API_KEY", "re_rotated", "admin-1");
+      } catch (err) {
+        captured = err;
+      }
+
+      expect(captured).toBeInstanceOf(SaasImmutableSettingError);
+      expect((captured as InstanceType<typeof SaasImmutableSettingError>).key).toBe("RESEND_API_KEY");
+      expect((captured as InstanceType<typeof SaasImmutableSettingError>)._tag).toBe("SaasImmutableSettingError");
+      // No DB write — rejection precedes persist.
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    // #4462 — ProactiveProviderKeyGuardLive validates the settings-resolved
+    // proactive provider at boot; `requiresRestart` is a display hint that
+    // defers nothing, so membership in SAAS_IMMUTABLE_KEYS is the real guard.
+    it("setSetting rejects ATLAS_PROVIDER in SaaS mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      let captured: unknown;
+      try {
+        await setSetting("ATLAS_PROVIDER", "openai", "admin-1");
+      } catch (err) {
+        captured = err;
+      }
+
+      expect(captured).toBeInstanceOf(SaasImmutableSettingError);
+      expect((captured as InstanceType<typeof SaasImmutableSettingError>).key).toBe("ATLAS_PROVIDER");
+      expect(queryCalls).toHaveLength(0);
+    });
+
     it("setSetting allows non-immutable keys in SaaS mode", async () => {
       enableInternalDB();
       setResults({ rows: [] });
@@ -294,6 +334,30 @@ describe("settings (SaaS mode)", () => {
       await expect(
         deleteSetting("ATLAS_RATE_LIMIT_RPM", "admin-1"),
       ).rejects.toThrow(SaasImmutableSettingError);
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    // #4462 — the original report: deleting a registry-only RESEND_API_KEY
+    // override post-boot silently flips the platform transport to the
+    // ATLAS_SMTP_URL bridge (a DPA violation) or to "none" (mail dropped),
+    // with no re-guard until restart. Both write verbs must reject.
+    it("deleteSetting rejects RESEND_API_KEY and ATLAS_PROVIDER in SaaS mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      let captured: unknown;
+      try {
+        await deleteSetting("RESEND_API_KEY", "admin-1");
+      } catch (err) {
+        captured = err;
+      }
+      expect(captured).toBeInstanceOf(SaasImmutableSettingError);
+      expect((captured as InstanceType<typeof SaasImmutableSettingError>).key).toBe("RESEND_API_KEY");
+
+      await expect(
+        deleteSetting("ATLAS_PROVIDER", "admin-1"),
+      ).rejects.toThrow(SaasImmutableSettingError);
+      // No DB delete for either key.
       expect(queryCalls).toHaveLength(0);
     });
 

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -371,6 +371,25 @@ describe("settings module", () => {
       expect(getSetting("ATLAS_EMAIL_PROVIDER")).toBe("sendgrid");
     });
 
+    // #4462 — RESEND_API_KEY and ATLAS_PROVIDER joined SAAS_IMMUTABLE_KEYS.
+    // Self-hosted must stay runtime-editable: the DPA guard early-returns
+    // outside SaaS, and the proactive provider guard is SaaS-only too.
+    it("permits writes to the #4462 immutable keys in self-hosted mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      await expect(
+        setSetting("RESEND_API_KEY", "re_local", "admin-1"),
+      ).resolves.toBeUndefined();
+      expect(getSetting("RESEND_API_KEY")).toBe("re_local");
+
+      setResults({ rows: [] });
+      await expect(
+        setSetting("ATLAS_PROVIDER", "openai", "admin-1"),
+      ).resolves.toBeUndefined();
+      expect(getSetting("ATLAS_PROVIDER")).toBe("openai");
+    });
+
     it("upserts platform setting (no orgId) and updates cache", async () => {
       enableInternalDB();
       setResults({ rows: [] }); // for the upsert query
@@ -445,6 +464,19 @@ describe("settings module", () => {
 
       await expect(
         deleteSetting("ATLAS_EMAIL_PROVIDER", "admin-1"),
+      ).resolves.toBeUndefined();
+    });
+
+    // #4462 — same mirror for the two keys added in #4462.
+    it("permits deletes of the #4462 immutable keys in self-hosted mode", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      await expect(
+        deleteSetting("RESEND_API_KEY", "admin-1"),
+      ).resolves.toBeUndefined();
+      await expect(
+        deleteSetting("ATLAS_PROVIDER", "admin-1"),
       ).resolves.toBeUndefined();
     });
 

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -977,11 +977,19 @@ export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError | 
  * getDefaultProvider()`. A DB-persisted `ATLAS_PROVIDER` whose key is absent
  * passes {@link ProviderKeyGuardLive}'s env-only check (the main chat still
  * resolves to the env/gateway provider) yet fails every proactive answer at model
- * init despite green boot/health. `ATLAS_PROVIDER` is `requiresRestart: true`, so
- * a post-boot settings change only takes effect on the next boot — which re-runs
- * this guard — making the boot-time check authoritative without a revalidation
- * fiber. (And `setSetting` can't mutate `process.env`, so the boot decision can't
- * be bypassed at runtime.)
+ * init despite green boot/health.
+ *
+ * The boot-time check is authoritative because `ATLAS_PROVIDER` is a member of
+ * `SAAS_IMMUTABLE_KEYS` in `lib/settings.ts` (#4462): on SaaS both `setSetting`
+ * and `deleteSetting` reject it, so the resolution this guard validated cannot
+ * drift until the next restart — which re-runs the guard. It is NOT because of
+ * the key's `requiresRestart: true` annotation: that flag is a display hint. It
+ * neither blocks a write nor defers application — `resolveModelFromSettings()`
+ * reads through the live settings cache, so a post-boot override would apply
+ * immediately. Reasoning from the restart hint (as this docstring did before
+ * #4462) would leave a real guard-bypass hole. The general invariant — a
+ * boot-guard-validated platform setting is either immutable or re-guarded on
+ * write — is recorded at the `SAAS_IMMUTABLE_KEYS` definition.
  *
  * Split from {@link ProviderKeyGuardLive} rather than folded in because validating
  * the settings-backed provider needs the settings cache: it depends on `Settings`

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -984,9 +984,10 @@ export const ProviderKeyGuardLive: Layer.Layer<never, ProviderKeyMissingError | 
  * and `deleteSetting` reject it, so the resolution this guard validated cannot
  * drift until the next restart — which re-runs the guard. It is NOT because of
  * the key's `requiresRestart: true` annotation: that flag is a display hint. It
- * neither blocks a write nor defers application — `resolveModelFromSettings()`
- * reads through the live settings cache, so a post-boot override would apply
- * immediately. Reasoning from the restart hint (as this docstring did before
+ * neither blocks a write nor defers application — `setSetting` updates the
+ * in-process settings cache that `getSettingAuto` reads, so a post-boot
+ * override would reach `resolveModelFromSettings()` on the very next proactive
+ * answer. Reasoning from the restart hint (as this docstring did before
  * #4462) would leave a real guard-bypass hole. The general invariant — a
  * boot-guard-validated platform setting is either immutable or re-guarded on
  * write — is recorded at the `SAAS_IMMUTABLE_KEYS` definition.

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -614,6 +614,11 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     // hosted/SaaS and `anthropic` for self-hosted. A hardcoded "anthropic"
     // here would override that and make SaaS report/run the wrong default (#3098).
     envVar: "ATLAS_PROVIDER",
+    // #4462 — `requiresRestart` here is a display hint only (it neither
+    // blocks a write nor defers application). The real guard is membership
+    // in `SAAS_IMMUTABLE_KEYS` below: `ProactiveProviderKeyGuardLive`
+    // validates this key's settings-resolved value at boot, so on SaaS both
+    // writes and deletes are rejected. Self-hosted stays hot-reloadable.
     requiresRestart: true,
     scope: "platform",
     saasVisible: false,
@@ -844,6 +849,11 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     type: "string",
     secret: true,
     envVar: "RESEND_API_KEY",
+    // #4462 — DpaGuardLive validates the RESOLVED transport at boot
+    // (`resolveResendApiKey()` = this override → env), so on SaaS this key
+    // is in `SAAS_IMMUTABLE_KEYS` below: both writes and deletes are
+    // rejected, and the key is env-managed. Self-hosted keeps it
+    // runtime-editable (the DPA guard early-returns there).
     scope: "platform",
     saasVisible: false,
   },
@@ -2312,6 +2322,26 @@ export function isHotReloadedKey(key: string): boolean {
  * Self-hosted preserves the runtime-mutable behavior — the guards
  * either don't run there (DPA) or are advisory (#1978 family).
  *
+ * ## The invariant this set encodes (#4462)
+ *
+ * > A platform-scoped setting validated by a SaaS boot guard must either
+ * > be a member of this set or be explicitly re-guarded on write. A
+ * > `requiresRestart` hint is NEVER a guard.
+ *
+ * `requiresRestart` is annotation-only: it neither blocks a write nor
+ * defers application (values hot-apply through the live cache), so a
+ * guard whose "it only takes effect next boot" rationale rests on the
+ * flag is unsound. There is no validate-on-write seam in the registry,
+ * and adding one was rejected in #4462 — membership here is the
+ * mechanism: symmetric (blocks `setSetting` AND `deleteSetting`),
+ * fail-closed (`isSaasModeForGuard`), and SaaS-only. Rotation stays
+ * available out-of-band: change the env value, restart, and the boot
+ * guard re-validates.
+ *
+ * Known cousin that is deliberately NOT here: the Stripe price-ID keys.
+ * Their boot check is warn-only, so a runtime change can't slip past a
+ * fail-boot guard.
+ *
  * The `as const` is load-bearing: it preserves literal types so
  * `SaasImmutableKey` is a closed union and `SaasImmutableSettingError`
  * can refuse construction with an unknown key at compile time.
@@ -2320,6 +2350,19 @@ const SAAS_IMMUTABLE_KEYS_LITERAL = [
   "ATLAS_EMAIL_PROVIDER",
   "ATLAS_DEPLOY_MODE",
   "ATLAS_RATE_LIMIT_RPM",
+  // #4462 — `DpaGuardLive` validates the RESOLVED platform email
+  // transport at boot via `resolveResendApiKey()` (registry override →
+  // env). Deleting a registry-only override post-boot silently flips the
+  // transport to the `ATLAS_SMTP_URL` bridge (a DPA violation the guard
+  // never re-sees) or to "none" (platform mail silently dropped), with no
+  // re-guard until the next restart.
+  "RESEND_API_KEY",
+  // #4462 — `ProactiveProviderKeyGuardLive` validates the SETTINGS-backed
+  // proactive provider at boot via `getSettingAuto("ATLAS_PROVIDER")`.
+  // Writing/clearing the override post-boot re-resolves the proactive
+  // model live (`resolveModelFromSettings`), so an unkeyed provider fails
+  // every proactive answer while boot and /health stay green.
+  "ATLAS_PROVIDER",
 ] as const;
 const SAAS_IMMUTABLE_KEYS: ReadonlySet<SaasImmutableKey> = new Set(SAAS_IMMUTABLE_KEYS_LITERAL);
 

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -2329,7 +2329,9 @@ export function isHotReloadedKey(key: string): boolean {
  * > `requiresRestart` hint is NEVER a guard.
  *
  * `requiresRestart` is annotation-only: it neither blocks a write nor
- * defers application (values hot-apply through the live cache), so a
+ * defers application (`setSetting` updates the in-process settings
+ * cache that `getSetting`/`getSettingAuto` read, so the new value is
+ * live on the very next read), so a
  * guard whose "it only takes effect next boot" rationale rests on the
  * flag is unsound. There is no validate-on-write seam in the registry,
  * and adding one was rejected in #4462 — membership here is the


### PR DESCRIPTION
Closes #4462

## Problem

Two platform settings are validated by a SaaS **boot guard** yet were freely mutable at runtime by a platform admin:

- **`RESEND_API_KEY`** — `DpaGuardLive` validates the *resolved* platform email transport at boot via `resolveResendApiKey()` (registry override → env). Deleting a registry-only override post-boot silently flips the transport to the `ATLAS_SMTP_URL` bridge (a DPA violation the guard never re-sees) or to "none" (platform mail silently dropped), with no re-guard until the next restart.
- **`ATLAS_PROVIDER`** — same shape, found in triage. `ProactiveProviderKeyGuardLive` validates the *settings-resolved* proactive provider at boot, and its docstring justified boot-only checking with the premise that `requiresRestart: true` defers application. That premise is false: `requiresRestart` is annotation-only — `setSetting` updates the in-process settings cache that `getSettingAuto` reads, so an override applies on the very next read.

## Fix — option (a), maintainer-approved 2026-07-16

Both keys join `SAAS_IMMUTABLE_KEYS`. The enforcement already exists and is symmetric across `setSetting` **and** `deleteSetting`, fail-closed (`isSaasModeForGuard`), SaaS-only, and already mapped to a `409 saas_immutable` envelope in both admin route handlers — this is a membership addition, not new machinery.

Option (b) (re-guard on write) was rejected: no validate-on-write seam exists in the registry, and `requiresRestart` defers nothing. Rotation stays available out-of-band — change the env value, restart, and the boot guard re-validates.

Also corrects the `ProactiveProviderKeyGuardLive` docstring so it no longer rests on the restart-hint premise.

## Recorded invariant

> A platform-scoped setting validated by a SaaS boot guard must either be in `SAAS_IMMUTABLE_KEYS` or be explicitly re-guarded on write. A restart *hint* is never a guard.

Stated at the `SAAS_IMMUTABLE_KEYS` definition, in `docs/development/saas-env-audit.md`, and in the operator reference. The nine warn-only `STRIPE_*_PRICE_ID` keys are documented as the deliberate non-member (their boot check only warns, so a runtime change can't slip past a fail-boot guard).

## Blast radius

Nothing in production code writes either key — verified by grep across `packages/`, `ee/`, `plugins/`. Both are `saasVisible: false`, so no SaaS Admin-UI surface regresses; the billing/model pickers only *read* `ATLAS_PROVIDER` (and the model picker writes `/admin/model-config`, not the setting). Self-hosted behavior is unchanged.

## Acceptance criteria

- [x] `setSetting` and `deleteSetting` both reject `RESEND_API_KEY` and `ATLAS_PROVIDER` in SaaS mode (tests cover both keys × both paths)
- [x] Self-hosted mutability for both keys is unchanged (tests)
- [x] The proactive guard docstring no longer rests on the restart-hint premise
- [x] The invariant is recorded at the `SAAS_IMMUTABLE_KEYS` definition and in the SaaS env audit doc
- [x] Docs describing Admin-UI Resend-key setup note that on SaaS the key is env-managed

## ⚠️ Ops note (pre-deploy)

An existing registry-only `RESEND_API_KEY` override keeps working but becomes **undeletable at runtime** once this lands. Confirm each region's key source and migrate any registry-only region to the env var at the next deploy.

## Verification

- `/review-panel` — CLEAN (1 round; 3 MEDIUM comment-accuracy nits fixed in-branch)
- `/ci` — **30 of 31 gates PASS**. The `test` gate reported 925/927 files passing; the two failures (`teams.test.ts`, `teams-discord-always-mount.test.ts`) are the known WSL2 contention flake (`a beforeEach/afterEach hook timed out`, 5s hook cap — three sibling ship agents were running concurrently). Both pass in isolation. `test:others` additionally hit the known local-only `@atlas/mcp` smoke gap (`ECONNREFUSED 127.0.0.1:5432`, needs a migrated Postgres, #1472). Neither touches settings or boot guards — GitHub's sharded `api-tests (1/4)`–`(4/4)` are the arbiter here.