### PR TITLE
fix(test): sandbox the semantic root so -pg suites stop littering the checkout (#4655)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -409,6 +409,10 @@ export function createApiTestMocks(
   // ── Temp semantic directory ────────────────────────────────────
 
   const wantSemanticDir = overrides?.semanticDir !== false;
+  // The preload's per-process sandbox root (#4655). `cleanup()` restores it
+  // rather than deleting the var, so a suite that tears these mocks down
+  // mid-run can't drop the process back to `{cwd}/semantic`.
+  const priorSemanticRoot = process.env.ATLAS_SEMANTIC_ROOT;
   let tmpRoot: string | undefined;
   if (wantSemanticDir) {
     tmpRoot = path.join(
@@ -1080,7 +1084,8 @@ export function createApiTestMocks(
   function cleanup(): void {
     if (tmpRoot) {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
-      delete process.env.ATLAS_SEMANTIC_ROOT;
+      if (priorSemanticRoot === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+      else process.env.ATLAS_SEMANTIC_ROOT = priorSemanticRoot;
     }
   }
 

--- a/packages/api/src/__tests__/semantic-root-sandbox.test.ts
+++ b/packages/api/src/__tests__/semantic-root-sandbox.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression lock for #4655 — the test preload must sandbox the semantic root.
+ *
+ * `getSemanticRoot()` defaults to `{cwd}/semantic`, and the dual-write sync
+ * layer persists per-org YAML under `{root}/.orgs/<orgId>/`. Before this guard,
+ * every suite that exercised the real write path (the `-pg` amendment /
+ * connection-profile family, the wizard, `importFromDisk`, …) littered
+ * `packages/api/semantic/` on the developer's actual checkout — untracked
+ * (`.gitignore`'s `/semantic/` entry is anchored to the repo root, so it does
+ * not cover this one), noisy in `git status`, and load-bearing in the worst
+ * way: first-boot suites walk `.orgs/` and fail on the orgs a previous run
+ * left behind, so a second full run went red.
+ *
+ * `src/test-setup.ts` (the `bunfig.toml` preload) now points
+ * `ATLAS_SEMANTIC_ROOT` at a per-process `mkdtemp` sandbox. These tests pin
+ * that contract so it can't silently regress.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { getSemanticRoot as getBaseSemanticRoot } from "@atlas/api/lib/semantic/files";
+import { getSemanticRoot, syncEntityToDisk, cleanupOrgDirectory } from "@atlas/api/lib/semantic/sync";
+import { outputDirForGroup } from "@atlas/api/lib/profiler";
+
+/** The preload's sandbox root — absent means the guard itself has regressed. */
+function sandboxRoot(): string {
+  const root = process.env.ATLAS_SEMANTIC_ROOT;
+  if (!root) {
+    throw new Error(
+      "ATLAS_SEMANTIC_ROOT is unset — the test preload (src/test-setup.ts) no longer sandboxes the semantic root (#4655)",
+    );
+  }
+  return path.resolve(root);
+}
+
+/** Real path (macOS `/tmp` is a symlink to `/private/tmp`). */
+function realpath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    // Not yet materialized on disk — the lexical path is the best answer.
+    return path.resolve(p);
+  }
+}
+
+describe("test preload semantic-root sandbox (#4655)", () => {
+  it("sets ATLAS_SEMANTIC_ROOT to an existing directory", () => {
+    expect(fs.existsSync(sandboxRoot())).toBe(true);
+  });
+
+  it("places the sandbox under the OS temp dir, not the checkout", () => {
+    const root = realpath(sandboxRoot());
+    expect(root.startsWith(realpath(os.tmpdir()) + path.sep)).toBe(true);
+    expect(root.startsWith(realpath(process.cwd()) + path.sep)).toBe(false);
+  });
+
+  it("routes the base semantic root away from {cwd}/semantic", () => {
+    expect(getBaseSemanticRoot()).not.toBe(path.resolve(process.cwd(), "semantic"));
+  });
+
+  it("routes org-scoped write paths into the sandbox", () => {
+    expect(getSemanticRoot("org-4655")).toBe(path.join(sandboxRoot(), ".orgs", "org-4655"));
+  });
+
+  it("routes the profiler's generation output into the sandbox too", () => {
+    // profiler.ts used to resolve `path.resolve("semantic")` at module load,
+    // which ignored the override entirely — both in tests and in any
+    // deployment that configured ATLAS_SEMANTIC_ROOT.
+    expect(outputDirForGroup("default", "org-4655")).toBe(
+      path.join(sandboxRoot(), ".orgs", "org-4655"),
+    );
+    expect(outputDirForGroup("warehouse")).toBe(path.join(sandboxRoot(), "groups", "warehouse"));
+  });
+
+  it("a real dual-write sync leaves {cwd}/semantic untouched", async () => {
+    // The end-to-end shape of the bug: this is the exact call the `-pg`
+    // amendment suites reach through, and it used to materialize
+    // `packages/api/semantic/.orgs/<orgId>/entities/*.yml` in the checkout.
+    const checkoutRoot = path.resolve(process.cwd(), "semantic");
+    const preexisting = fs.existsSync(checkoutRoot);
+    const orgId = `org-4655-sandbox-${process.pid}`;
+
+    try {
+      await syncEntityToDisk(orgId, "orders", "entity", "table: orders\n");
+
+      expect(
+        fs.existsSync(path.join(sandboxRoot(), ".orgs", orgId, "entities", "orders.yml")),
+      ).toBe(true);
+      // Not merely "the org dir is absent" — the whole checkout-level semantic
+      // root must not have been conjured into existence by the write.
+      expect(fs.existsSync(checkoutRoot)).toBe(preexisting);
+      expect(fs.existsSync(path.join(checkoutRoot, ".orgs", orgId))).toBe(false);
+    } finally {
+      await cleanupOrgDirectory(orgId);
+    }
+  });
+});

--- a/packages/api/src/lib/__tests__/org-isolation.test.ts
+++ b/packages/api/src/lib/__tests__/org-isolation.test.ts
@@ -435,7 +435,12 @@ describe("explore root isolation", () => {
 
   it("no-org root is the base semantic/ directory (self-hosted fallback)", () => {
     const root = getSemanticRoot();
-    const expected = path.resolve(process.cwd(), "semantic");
+    // The test preload points ATLAS_SEMANTIC_ROOT at a per-process sandbox
+    // (#4655); the invariant under test is that the no-org root IS the
+    // configured base root, whatever that is — not that it is cwd-relative.
+    const expected = process.env.ATLAS_SEMANTIC_ROOT
+      ? path.resolve(process.env.ATLAS_SEMANTIC_ROOT)
+      : path.resolve(process.cwd(), "semantic");
 
     expect(root).toBe(expected);
     // Base root should NOT be under .orgs/

--- a/packages/api/src/lib/__tests__/semantic-files-root.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-files-root.test.ts
@@ -11,9 +11,19 @@ import * as os from "os";
 import * as path from "path";
 import { getSemanticRoot } from "../semantic/files";
 
-afterEach(() => {
-  delete process.env.ATLAS_SEMANTIC_ROOT;
-});
+/**
+ * The test preload points `ATLAS_SEMANTIC_ROOT` at a per-process sandbox
+ * (#4655). Restore that value rather than deleting the var, or every suite
+ * that runs after this one writes org YAML into the checkout again.
+ */
+const SANDBOX_ROOT = process.env.ATLAS_SEMANTIC_ROOT;
+
+function restoreSandboxRoot(): void {
+  if (SANDBOX_ROOT === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+  else process.env.ATLAS_SEMANTIC_ROOT = SANDBOX_ROOT;
+}
+
+afterEach(restoreSandboxRoot);
 
 describe("getSemanticRoot", () => {
   it("defaults to cwd/semantic when env var is not set", () => {

--- a/packages/api/src/lib/__tests__/semantic-multisource.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-multisource.test.ts
@@ -546,9 +546,12 @@ describe("cross-source join hints", () => {
       ].join("\n"),
     );
 
-    // Temporarily change CWD so getWhitelistedTables() without args finds semantic/
-    const originalCwd = process.cwd();
-    process.chdir(tmpRoot);
+    // Point the default semantic root at the fixture so getWhitelistedTables()
+    // without args finds it. This used to `process.chdir(tmpRoot)`, which only
+    // worked while the root resolved from cwd; ATLAS_SEMANTIC_ROOT is the
+    // documented override and is what the test preload now sets (#4655).
+    const originalRoot = process.env.ATLAS_SEMANTIC_ROOT;
+    process.env.ATLAS_SEMANTIC_ROOT = join(tmpRoot, "semantic");
     try {
       // Call without custom paths — populates global cache (_tablesByConnection + _crossSourceJoins)
       const tables = getWhitelistedTables();
@@ -565,7 +568,8 @@ describe("cross-source join hints", () => {
       expect(joins[0].relationship).toBe("one_to_many");
       expect(joins[0].description).toBe("User activity events");
     } finally {
-      process.chdir(originalCwd);
+      if (originalRoot === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+      else process.env.ATLAS_SEMANTIC_ROOT = originalRoot;
     }
   });
 });

--- a/packages/api/src/lib/__tests__/semantic-sync.test.ts
+++ b/packages/api/src/lib/__tests__/semantic-sync.test.ts
@@ -8,10 +8,11 @@
  * - syncAllEntitiesToDisk() — full rebuild from DB mock, verifies disk output
  * - cleanupOrgDirectory() — directory removal
  *
- * The tests call the real production functions. Since getSemanticRoot
- * delegates to getBaseSemanticRoot() (which defaults to cwd/semantic
- * unless ATLAS_SEMANTIC_ROOT is set), syncEntityToDisk/syncAllEntitiesToDisk
- * write to the real semantic/.orgs/ directory. Tests clean up after themselves.
+ * The tests call the real production functions, so syncEntityToDisk /
+ * syncAllEntitiesToDisk really do hit the filesystem. The test preload points
+ * ATLAS_SEMANTIC_ROOT at a per-process sandbox under os.tmpdir() (#4655), so
+ * those writes land there rather than in the checkout; tests still clean up
+ * their own org directories so cases can't see each other's leftovers.
  *
  * Uses mock.module() to mock the DB layer.
  */
@@ -97,6 +98,23 @@ import {
 // Test setup — use a unique org ID per test to avoid collisions
 // ---------------------------------------------------------------------------
 
+/**
+ * The preload's per-process sandbox root. Suites restore this value instead of
+ * deleting the var — a bare `delete` would drop the process back to
+ * `{cwd}/semantic` and litter the checkout again (#4655).
+ */
+const SANDBOX_ROOT = process.env.ATLAS_SEMANTIC_ROOT;
+
+function restoreSandboxRoot(): void {
+  if (SANDBOX_ROOT === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+  else process.env.ATLAS_SEMANTIC_ROOT = SANDBOX_ROOT;
+}
+
+/** Whatever base root the process is currently configured with. */
+function baseRoot(): string {
+  return SANDBOX_ROOT ?? path.resolve(process.cwd(), "semantic");
+}
+
 /** Org IDs created during tests — cleaned up in afterEach. */
 const createdOrgIds: string[] = [];
 
@@ -151,12 +169,21 @@ afterEach(() => {
 describe("getSemanticRoot", () => {
   it("returns base semantic root when no orgId", () => {
     const root = getSemanticRoot();
-    expect(root).toBe(path.resolve(process.cwd(), "semantic"));
+    expect(root).toBe(baseRoot());
   });
 
   it("returns org-scoped root when orgId provided", () => {
     const root = getSemanticRoot("org-123");
-    expect(root).toBe(path.resolve(process.cwd(), "semantic", ".orgs", "org-123"));
+    expect(root).toBe(path.join(baseRoot(), ".orgs", "org-123"));
+  });
+
+  it("falls back to cwd/semantic when ATLAS_SEMANTIC_ROOT is unset", () => {
+    try {
+      delete process.env.ATLAS_SEMANTIC_ROOT;
+      expect(getSemanticRoot()).toBe(path.resolve(process.cwd(), "semantic"));
+    } finally {
+      restoreSandboxRoot();
+    }
   });
 
   it("returns different roots for different orgs", () => {
@@ -194,7 +221,7 @@ describe("getSemanticRoot", () => {
       const root = getSemanticRoot();
       expect(root).toBe(tmpDir);
     } finally {
-      delete process.env.ATLAS_SEMANTIC_ROOT;
+      restoreSandboxRoot();
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
@@ -206,7 +233,7 @@ describe("getSemanticRoot", () => {
       const root = getSemanticRoot("org-test");
       expect(root).toBe(path.join(tmpDir, ".orgs", "org-test"));
     } finally {
-      delete process.env.ATLAS_SEMANTIC_ROOT;
+      restoreSandboxRoot();
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/packages/api/src/lib/profiler.ts
+++ b/packages/api/src/lib/profiler.ts
@@ -149,17 +149,30 @@ export {
 
 import * as path from "path";
 import { GROUPS_DIR } from "./semantic/scanner";
+import { getSemanticRoot } from "./semantic/files";
 
-const SEMANTIC_DIR = path.resolve("semantic");
-
-/** Root for a (possibly org-scoped) semantic layer. */
+/**
+ * Root for a (possibly org-scoped) semantic layer.
+ *
+ * Resolved through `getSemanticRoot()` (call time, not module-load time) so
+ * the documented `ATLAS_SEMANTIC_ROOT` override applies to the *write* path
+ * too. This used to be a module-level `path.resolve("semantic")`, which meant
+ * a configured deployment read from the override but generated YAML into
+ * `{cwd}/semantic` — and tests wrote real per-org dirs into the checkout
+ * (#4655). With the env var unset the resolution is byte-identical.
+ *
+ * Inherits `getSemanticRoot()`'s fail-loud contract: an `ATLAS_SEMANTIC_ROOT`
+ * set to an empty string throws rather than silently generating into `{cwd}`,
+ * which is the same posture the read path has always had.
+ */
 function semanticBaseDir(orgId?: string): string {
-  if (!orgId) return SEMANTIC_DIR;
+  const base = getSemanticRoot();
+  if (!orgId) return base;
   // orgId becomes a path segment under `.orgs/`; a value like `../../outside`
   // (e.g. from --org / ATLAS_ORG_ID) would escape the semantic root. Same guard
   // sync.ts:getSemanticRoot already applies on the read side.
   assertSafePathSegment(orgId, "org");
-  return path.join(SEMANTIC_DIR, ".orgs", orgId);
+  return path.join(base, ".orgs", orgId);
 }
 
 /**

--- a/packages/api/src/lib/semantic/enrich/index.ts
+++ b/packages/api/src/lib/semantic/enrich/index.ts
@@ -25,8 +25,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
 import { loadYaml } from "../yaml";
-
-const SEMANTIC_DIR = path.resolve("semantic");
+import { getSemanticRoot } from "../files";
 
 // ---------------------------------------------------------------------------
 // Token usage tracking
@@ -375,7 +374,7 @@ export async function enrichGlossary(
   profiles: TableProfile[],
   model: ReturnType<typeof getModel>,
   usage: TokenUsage,
-  semanticDir: string = SEMANTIC_DIR
+  semanticDir: string = getSemanticRoot()
 ): Promise<void> {
   const glossaryPath = path.join(semanticDir, "glossary.yml");
   if (!fs.existsSync(glossaryPath)) {
@@ -601,7 +600,7 @@ export async function enrichSemanticLayer(
   profiles: TableProfile[],
   options?: { semanticDir?: string }
 ): Promise<void> {
-  const semanticDir = options?.semanticDir ?? SEMANTIC_DIR;
+  const semanticDir = options?.semanticDir ?? getSemanticRoot();
   const entitiesDir = path.join(semanticDir, "entities");
   const metricsDir = path.join(semanticDir, "metrics");
 

--- a/packages/api/src/test-setup.ts
+++ b/packages/api/src/test-setup.ts
@@ -6,9 +6,14 @@
  * Individual tests set the vars they need in beforeEach; this preload ensures a
  * clean baseline. Original values are restored in a top-level afterAll so the
  * process isn't permanently modified.
+ *
+ * It also sandboxes the semantic-layer root (#4655) — see below.
  */
 
 import { afterAll } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 const prefixes = ["ATLAS_", "BETTER_AUTH_"];
 const exactVars = [
@@ -38,8 +43,66 @@ for (const key of Object.keys(process.env)) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Semantic-root sandbox (#4655)
+// ---------------------------------------------------------------------------
+
+/**
+ * Point the semantic-layer root at a throwaway directory for the whole test
+ * process.
+ *
+ * `getSemanticRoot()` defaults to `{cwd}/semantic`, and the dual-write sync
+ * layer persists per-org YAML under `{root}/.orgs/<orgId>/`. Any suite that
+ * exercises the real write path (the `-pg` amendment / connection-profile
+ * family, the wizard, `importFromDisk`, …) therefore used to litter
+ * `packages/api/semantic/` on the developer's actual checkout. That litter is
+ * untracked (the `.gitignore` entry is anchored `/semantic/`, so it only
+ * covers the repo root), makes `git status` noisy in shared worktrees, and —
+ * worse — is *discovered* by first-boot suites like `semantic-sync.test.ts`
+ * (`reconcileAllOrgs` walks `.orgs/`), so a second full run fails on orgs the
+ * first run left behind.
+ *
+ * The sandbox is created with `mkdtempSync`, so it is unique per test process.
+ * Cleanup only ever removes this process's own directory — concurrent runs
+ * (sibling worktrees, the sharded CI lanes, `test-isolated.ts`'s per-file
+ * processes) can never delete each other's fixtures.
+ *
+ * The leaf is literally named `semantic` so the sandbox is shaped like a real
+ * semantic root, and suites that set their own `ATLAS_SEMANTIC_ROOT` keep
+ * working unchanged — they just need to *restore* this value rather than
+ * `delete` the var, or writes fall back to `{cwd}/semantic` again.
+ */
+const semanticSandboxParent = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-test-semantic-"));
+const semanticSandbox = path.join(semanticSandboxParent, "semantic");
+fs.mkdirSync(semanticSandbox, { recursive: true });
+process.env.ATLAS_SEMANTIC_ROOT = semanticSandbox;
+
+let sandboxRemoved = false;
+function removeSemanticSandbox(): void {
+  if (sandboxRemoved) return;
+  sandboxRemoved = true;
+  try {
+    fs.rmSync(semanticSandboxParent, { recursive: true, force: true });
+  } catch (err) {
+    // Best effort: a leftover dir in os.tmpdir() is harmless, but never hide it.
+    console.debug(
+      `test-setup: failed to remove semantic sandbox ${semanticSandboxParent}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+  }
+}
+
+// Removal is deliberately bound to `exit` rather than `afterAll`: hook order
+// across the preload and a test file's own `afterAll` is not guaranteed, and a
+// file-level hook that still writes must not find the sandbox already gone.
+// `exit` also covers what `afterAll` can't — a suite that throws during load,
+// or a hard `process.exit`.
+process.on("exit", removeSemanticSandbox);
+
 afterAll(() => {
-  // Restore snapshotted vars
+  // Restore snapshotted vars. The sandbox directory itself survives until the
+  // `exit` hook fires; only the env var is rolled back here.
+  delete process.env.ATLAS_SEMANTIC_ROOT;
   for (const [key, value] of Object.entries(snapshot)) {
     process.env[key] = value;
   }


### PR DESCRIPTION
## Problem

`-pg` suites that exercise the real dual-write path littered `packages/api/semantic/.orgs/<orgId>/` in the checkout on every run.

`getSemanticRoot()` defaults to `{cwd}/semantic`, and `syncEntityToDisk` persists per-org YAML under `{root}/.orgs/<orgId>/`. So the `-pg` amendment / connection-profile family, the wizard, and `importFromDisk` all wrote real directories into `packages/api/`. That litter is untracked — `.gitignore`'s `/semantic/` entry is anchored to the repo root, so it never covered this one — which makes `git status` noisy in shared worktrees and can trip fs/drift gates.

It is also load-bearing, not merely cosmetic (per the #4660 repro folded into this issue): first-boot suites walk `.orgs/`, so a **second** full run with `TEST_DATABASE_URL` set discovers the `org-nodraft-*` dirs the first run left behind and fails.

Reproduced on a clean worktree before the fix:

```
$ bun test src/lib/semantic/__tests__/amendment-dual-apply-pg.test.ts   # 2 pass
$ git status --porcelain
?? packages/api/semantic/
    .orgs/org-dualapply-444445/entities/orders.yml
    .orgs/org-nodraft-599880/entities/orders.yml
```

## Fix

**The class fix is in the preload, not per-suite.** `packages/api/src/test-setup.ts` (the `bunfig.toml` preload, which already scrubs `ATLAS_*` / `DATABASE_URL` / provider keys) now also points `ATLAS_SEMANTIC_ROOT` at a per-process `mkdtemp` sandbox, removed on process `exit`. Every suite — including ones written tomorrow — is covered by construction, rather than each `-pg` file having to remember its own `beforeAll`/`afterAll`.

**Safe under concurrent runs.** `mkdtempSync` yields a directory unique to the test process, and cleanup only ever `rmSync`s *that* directory. Sibling worktrees, the sharded `api-tests (1/4)`–`(4/4)` lanes, and `test-isolated.ts`'s per-file processes can never delete each other's fixtures. Removal is bound to `exit` rather than `afterAll` deliberately: hook ordering between the preload and a file's own `afterAll` is not guaranteed, and a file-level hook that still writes must not find the sandbox already gone.

**Two production reads were ignoring the override.** `lib/profiler.ts` and `lib/semantic/enrich/index.ts` both resolved `path.resolve("semantic")` at *module load*, so a deployment that configured `ATLAS_SEMANTIC_ROOT` read from the override but generated YAML into `{cwd}/semantic`. Both now resolve through `getSemanticRoot()` at call time. With the env var unset the resolution is byte-identical, so self-hosted/CLI behavior is unchanged.

**Suites that manage their own root now restore, not delete.** A bare `delete process.env.ATLAS_SEMANTIC_ROOT` drops the process back to `{cwd}/semantic` mid-run, which would re-open the hole. `semantic-multisource.test.ts` also swaps a `process.chdir()` for the documented env override (`process.chdir` in tests is against CLAUDE.md's self-contained-tests rule anyway, and it stopped working once the root no longer resolved from cwd).

## Regression lock

New `packages/api/src/__tests__/semantic-root-sandbox.test.ts` pins the contract: the sandbox exists, lives under `os.tmpdir()` and not the checkout, both the org-scoped write path and the profiler's generation output route into it — and, end-to-end, a real `syncEntityToDisk` leaves `{cwd}/semantic` uncreated.

`semantic-sync.test.ts` keeps an explicit `ATLAS_SEMANTIC_ROOT`-unset case so the `{cwd}/semantic` default itself is still covered.

## Verification

- Aggressor suites re-run against a live Postgres — `git status` clean, no `packages/api/semantic/`.
- Touched suites all green: `semantic-sync` (54), `semantic-multisource` (23), `org-isolation` (27), `semantic-files-root` (4), `profiler` (50), `semantic-root-sandbox` (6), `amendment-dual-apply-pg` (2), `connection-profile-pg` (8), `admin` (220), `wizard` (83), `semantic` (16).
- `bun run scripts/test-isolated.ts --affected`: 138/138.
- `bash scripts/ci-local.sh` with `TEST_DATABASE_URL` set.

Closes #4655
