### PR TITLE
feat(backups): abort stale incomplete multipart uploads in the purge path

### DIFF
--- a/apps/docs/content/docs/platform-ops/backups.mdx
+++ b/apps/docs/content/docs/platform-ops/backups.mdx
@@ -84,7 +84,15 @@ Every scheduled backup is verified immediately after creation. There are two lev
 ### Storage drivers
 
 - **Local (default)** — artifacts under `ATLAS_BACKUP_STORAGE_PATH`. Appropriate for self-hosted deployments with a persistent disk. On containerized deploys without a volume, local artifacts **do not survive a redeploy** — use the S3 driver instead.
-- **S3-compatible** — set `ATLAS_BACKUP_S3_*` to write artifacts to object storage (Railway buckets, AWS S3, R2, MinIO). Artifacts survive redeploys and host loss; restore and verification read from the bucket. On the hosted SaaS, each region's API service writes to its own regional bucket, keeping backup artifacts inside the workspace's data-residency region. A failed upload never finalizes a truncated object — the multipart upload is left incomplete, so configure a bucket lifecycle rule that expires incomplete multipart uploads (e.g. after 7 days) to avoid accruing invisible storage for abandoned parts.
+- **S3-compatible** — set `ATLAS_BACKUP_S3_*` to write artifacts to object storage (Railway buckets, AWS S3, R2, MinIO). Artifacts survive redeploys and host loss; restore and verification read from the bucket. On the hosted SaaS, each region's API service writes to its own regional bucket, keeping backup artifacts inside the workspace's data-residency region. A failed upload never finalizes a truncated object — the multipart upload is left incomplete, so its already-uploaded parts are billable storage that no object listing shows.
+
+<Callout title="Incomplete multipart uploads are cleaned up automatically">
+  Atlas self-heals: the retention purge (part of every scheduled backup cycle) lists in-progress multipart uploads under the backup key prefix and aborts any initiated more than **7 days** ago. This exists because some hosts — Railway buckets among them — expose no bucket lifecycle configuration at all, so the platform cannot do it for you.
+
+  Where your provider *does* support lifecycle rules (AWS S3, Cloudflare R2, MinIO), still configure one expiring incomplete multipart uploads: it is a cheaper, provider-side backstop that keeps working even if the Atlas backup fiber is disabled or the process never runs a purge.
+
+  The sweep degrades quietly to a no-op — logged at debug, never failing a cycle — on the local driver, on endpoints that don't implement `ListMultipartUploads`, and when the credentials in use aren't static keys Atlas can sign with.
+</Callout>
 
 <Callout title="Switching drivers strands old artifacts">
   The driver is selected per process. Artifacts written under the previous driver remain where they are: their history rows stay listed, but verification/restore for them will fail, and retention purge removes their database rows without touching the stranded files. Take a fresh backup after switching.

--- a/ee/src/backups/engine.test.ts
+++ b/ee/src/backups/engine.test.ts
@@ -25,6 +25,8 @@ let storagePutSize = 12345;
 let storageListResult: string[] = [];
 let storageListError: Error | null = null;
 let storageRemoveError: Error | null = null;
+let storageAbortError: Error | null = null;
+let storageAbortCount = 0;
 const storageCalls: { op: string; path: string }[] = [];
 
 const storageMock = {
@@ -46,6 +48,11 @@ const storageMock = {
   remove: mock(async (path: string) => {
     storageCalls.push({ op: "remove", path });
     if (storageRemoveError) throw storageRemoveError;
+  }),
+  abortStaleUploads: mock(async (prefix: string) => {
+    storageCalls.push({ op: "abortStaleUploads", path: prefix });
+    if (storageAbortError) throw storageAbortError;
+    return storageAbortCount;
   }),
 };
 
@@ -135,6 +142,8 @@ function resetAll() {
   storageListResult = [];
   storageListError = null;
   storageRemoveError = null;
+  storageAbortError = null;
+  storageAbortCount = 0;
   storageCalls.length = 0;
 }
 
@@ -425,17 +434,41 @@ describe("purgeExpiredBackups", () => {
       { id: "b2", storage_path: "/tmp/b2.sql.gz" },
     ];
     // ensureTable (8) + SELECT expired (1) + DELETE b1 (1) + DELETE b2 (1)
-    ee.queueMockRows(...ensureTableEmpties(), expired, [], []);
+    // + the multipart-housekeeping config read (1, #4727)
+    ee.queueMockRows(...ensureTableEmpties(), expired, [], [], [defaultConfigRow]);
 
     const count = await run(purgeExpiredBackups());
     expect(count).toBe(2);
     expect(storageCalls.filter((c) => c.op === "remove")).toHaveLength(2);
   });
 
+  it("sweeps stale incomplete multipart uploads under the configured prefix (#4727)", async () => {
+    ee.queueMockRows(...ensureTableEmpties(), [], [defaultConfigRow]);
+    storageAbortCount = 3;
+
+    await run(purgeExpiredBackups());
+
+    const sweep = storageCalls.filter((c) => c.op === "abortStaleUploads");
+    expect(sweep).toHaveLength(1);
+    expect(sweep[0].path).toBe("./backups");
+    // Abort args carry the 7-day threshold the issue specifies.
+    expect(storageMock.abortStaleUploads).toHaveBeenLastCalledWith("./backups", 7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("a failing multipart sweep is logged, not propagated — the purge count still returns", async () => {
+    const expired = [{ id: "b1", storage_path: "/tmp/b1.sql.gz" }];
+    ee.queueMockRows(...ensureTableEmpties(), expired, [], [defaultConfigRow]);
+    storageAbortError = new Error("bucket unreachable");
+
+    // The purge is the caller's contract; housekeeping must never fail it.
+    expect(await run(purgeExpiredBackups())).toBe(1);
+  });
+
   it("skips DB deletion when the storage delete fails (already-gone is handled inside the driver)", async () => {
     const expired = [{ id: "b1", storage_path: "/tmp/locked.sql.gz" }];
     // ensureTable (8) + SELECT expired (1) — no DELETE (storage remove fails)
-    ee.queueMockRows(...ensureTableEmpties(), expired);
+    // + the multipart-housekeeping config read (1)
+    ee.queueMockRows(...ensureTableEmpties(), expired, [defaultConfigRow]);
     storageRemoveError = new Error("EACCES");
 
     const count = await run(purgeExpiredBackups());
@@ -443,7 +476,7 @@ describe("purgeExpiredBackups", () => {
   });
 
   it("returns 0 when no expired backups", async () => {
-    ee.queueMockRows(...ensureTableEmpties());
+    ee.queueMockRows(...ensureTableEmpties(), [], [defaultConfigRow]);
     const count = await run(purgeExpiredBackups());
     expect(count).toBe(0);
   });

--- a/ee/src/backups/engine.ts
+++ b/ee/src/backups/engine.ts
@@ -545,7 +545,40 @@ export const getBackupById = (id: string): Effect.Effect<BackupRow | null, Enter
   });
 
 /**
- * Delete expired backups — removes both the DB record and the file on disk.
+ * An incomplete multipart upload older than this is abandoned — no backup
+ * takes a week to upload. Aborted during the retention purge (#4727) because
+ * Railway buckets support no lifecycle configuration, so the "expire
+ * incomplete multipart uploads" rule the platform would normally own has to
+ * be enforced by Atlas itself.
+ */
+const STALE_MULTIPART_UPLOAD_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Abort incomplete multipart uploads under the backup prefix that are older
+ * than {@link STALE_MULTIPART_UPLOAD_AFTER_MS}. Never fails the cycle: a
+ * driver without a multipart concept (local), an endpoint that doesn't
+ * implement the API, and a transport failure all resolve to a logged 0.
+ */
+const abortStaleMultipartUploads = (): Effect.Effect<number, never> =>
+  Effect.gen(function* () {
+    const config = yield* getBackupConfig();
+    return yield* Effect.tryPromise({
+      try: () => getBackupStorage().abortStaleUploads(config.storage_path, STALE_MULTIPART_UPLOAD_AFTER_MS),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    });
+  }).pipe(
+    Effect.catchAll((err) => {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Could not abort stale incomplete multipart uploads — retrying next purge cycle",
+      );
+      return Effect.succeed(0);
+    }),
+  );
+
+/**
+ * Delete expired backups — removes both the DB record and the file on disk,
+ * then sweeps abandoned incomplete multipart uploads under the backup prefix.
  */
 export const purgeExpiredBackups = (): Effect.Effect<number, EnterpriseError | Error> =>
   Effect.gen(function* () {
@@ -598,6 +631,12 @@ export const purgeExpiredBackups = (): Effect.Effect<number, EnterpriseError | E
     if (purged > 0) {
       log.info({ count: purged }, "Purged expired backups");
     }
+
+    // Storage-side housekeeping: parts left behind by failed uploads are
+    // invisible to `list`, so nothing else in the system would ever reclaim
+    // them. Deliberately after the row purge and failure-isolated — the
+    // purge count is the caller's contract and must not depend on it.
+    yield* abortStaleMultipartUploads();
 
     return purged;
   });

--- a/ee/src/backups/s3-multipart.test.ts
+++ b/ee/src/backups/s3-multipart.test.ts
@@ -123,6 +123,14 @@ describe("createS3MultipartOps", () => {
       virtualHosted.calls[0].url.startsWith("https://atlas-backups.s3.eu-west-1.amazonaws.com/?"),
     ).toBe(true);
   });
+
+  it("keeps an endpoint's own path prefix ahead of the bucket", async () => {
+    const fake = fakeFetch([{ status: 200, body: uploadsXml([]) }]);
+    await createS3MultipartOps({ ...CREDS, endpoint: "https://gw.example.com/s3/" }, fake.impl)!.listInProgress(
+      "backups/",
+    );
+    expect(fake.calls[0].url.startsWith("https://gw.example.com/s3/atlas-backups?")).toBe(true);
+  });
 });
 
 // ── listInProgress ─────────────────────────────────────────────────
@@ -177,8 +185,9 @@ describe("listInProgress", () => {
     ]);
     const ops = createS3MultipartOps(CREDS, fake.impl)!;
 
-    const uploads = await ops.listInProgress("backups/");
-    expect(uploads.map((u) => u.uploadId)).toEqual(["u1", "u2"]);
+    const listing = await ops.listInProgress("backups/");
+    expect(listing.uploads.map((u) => u.uploadId)).toEqual(["u1", "u2"]);
+    expect(listing.truncated).toBe(false);
     expect(fake.calls).toHaveLength(2);
     expect(fake.calls[1].url).toContain("key-marker=backups%2Fa.sql.gz");
     expect(fake.calls[1].url).toContain("upload-id-marker=u1");
@@ -188,8 +197,43 @@ describe("listInProgress", () => {
     const fake = fakeFetch([{ status: 200, body: uploadsXml([], { isTruncated: true }) }]);
     const ops = createS3MultipartOps(CREDS, fake.impl)!;
 
-    expect(await ops.listInProgress("backups/")).toEqual([]);
+    expect(await ops.listInProgress("backups/")).toEqual({ uploads: [], truncated: false });
     expect(fake.calls).toHaveLength(1);
+  });
+
+  it("reports truncated:true rather than looping forever when the page cap is hit", async () => {
+    // Every page claims more to come — the cap is the only thing that stops it.
+    const fake = fakeFetch([
+      {
+        status: 200,
+        body: uploadsXml([{ key: "backups/a.sql.gz", uploadId: "u1", initiated: "2026-07-01T00:00:00.000Z" }], {
+          isTruncated: true,
+          nextKeyMarker: "backups/a.sql.gz",
+          nextUploadIdMarker: "u1",
+        }),
+      },
+    ]);
+    const ops = createS3MultipartOps(CREDS, fake.impl)!;
+
+    const listing = await ops.listInProgress("backups/");
+    expect(listing.truncated).toBe(true);
+    expect(fake.calls).toHaveLength(50);
+    // The batch is still returned so the caller can make partial progress.
+    expect(listing.uploads).toHaveLength(50);
+  });
+
+  it("signs a key containing % / ? / # without mangling it", async () => {
+    const fake = fakeFetch([{ status: 204, body: "" }]);
+    const ops = createS3MultipartOps({ ...CREDS, endpoint: "https://s3.example.com" }, fake.impl)!;
+
+    // A literal `%` used to blow up the old decodeURIComponent round-trip;
+    // `?`/`#` used to be swallowed by URL parsing.
+    await ops.abort("backups/od%d?x#y.sql.gz", "u1");
+
+    // `/` stays a separator (S3 canonical-URI rule); everything else escapes.
+    expect(fake.calls[0].url).toBe(
+      "https://s3.example.com/atlas-backups/backups/od%25d%3Fx%23y.sql.gz?uploadId=u1",
+    );
   });
 
   it.each([400, 403, 404, 405, 501])(

--- a/ee/src/backups/s3-multipart.test.ts
+++ b/ee/src/backups/s3-multipart.test.ts
@@ -1,0 +1,239 @@
+/**
+ * S3 multipart housekeeping tests (#4727).
+ *
+ * Exercised against an injected `fetch` — no network. The assertions pin the
+ * three things that would silently break in production: the request shape
+ * (path/virtual-hosted addressing, `?uploads` canonical query, SigV4 header
+ * set), the paging loop's termination, and the unsupported-endpoint
+ * degradation that keeps a purge cycle green on stores without the API.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  createS3MultipartOps,
+  parseListMultipartUploads,
+  S3MultipartUnsupportedError,
+} from "./s3-multipart";
+
+type Call = { url: string; method: string; headers: Record<string, string> };
+
+function fakeFetch(responses: { status: number; body: string }[]) {
+  const calls: Call[] = [];
+  let i = 0;
+  const impl = (url: string, init: { method: string; headers: Record<string, string> }) => {
+    calls.push({ url, method: init.method, headers: init.headers });
+    const res = responses[Math.min(i++, responses.length - 1)];
+    return Promise.resolve(new Response(res.body, { status: res.status }));
+  };
+  return { impl, calls };
+}
+
+function uploadsXml(
+  uploads: { key: string; uploadId: string; initiated: string }[],
+  extra: { isTruncated?: boolean; nextKeyMarker?: string; nextUploadIdMarker?: string } = {},
+): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<ListMultipartUploadsResult>
+  <Bucket>atlas-backups</Bucket>
+  <IsTruncated>${extra.isTruncated ? "true" : "false"}</IsTruncated>
+  ${extra.nextKeyMarker ? `<NextKeyMarker>${extra.nextKeyMarker}</NextKeyMarker>` : ""}
+  ${extra.nextUploadIdMarker ? `<NextUploadIdMarker>${extra.nextUploadIdMarker}</NextUploadIdMarker>` : ""}
+  ${uploads
+    .map(
+      (u) =>
+        `<Upload><Key>${u.key}</Key><UploadId>${u.uploadId}</UploadId><Initiated>${u.initiated}</Initiated></Upload>`,
+    )
+    .join("\n  ")}
+</ListMultipartUploadsResult>`;
+}
+
+const CREDS = { bucket: "atlas-backups", accessKeyId: "AKIA_TEST", secretAccessKey: "secret" };
+
+// ── XML parsing ────────────────────────────────────────────────────
+
+describe("parseListMultipartUploads", () => {
+  it("extracts key / uploadId / initiated epoch ms", () => {
+    const parsed = parseListMultipartUploads(
+      uploadsXml([{ key: "backups/a.sql.gz", uploadId: "u1", initiated: "2026-07-01T00:00:00.000Z" }]),
+    );
+    expect(parsed.uploads).toEqual([
+      { key: "backups/a.sql.gz", uploadId: "u1", initiatedAt: Date.parse("2026-07-01T00:00:00.000Z") },
+    ]);
+    expect(parsed.isTruncated).toBe(false);
+  });
+
+  it("decodes XML entities in keys", () => {
+    const parsed = parseListMultipartUploads(
+      uploadsXml([{ key: "backups/a&amp;b.sql.gz", uploadId: "u1", initiated: "2026-07-01T00:00:00.000Z" }]),
+    );
+    expect(parsed.uploads[0].key).toBe("backups/a&b.sql.gz");
+  });
+
+  it("drops uploads with an unparseable Initiated rather than guessing their age", () => {
+    const parsed = parseListMultipartUploads(
+      uploadsXml([
+        { key: "backups/bad.sql.gz", uploadId: "u1", initiated: "not-a-date" },
+        { key: "backups/good.sql.gz", uploadId: "u2", initiated: "2026-07-01T00:00:00.000Z" },
+      ]),
+    );
+    expect(parsed.uploads.map((u) => u.key)).toEqual(["backups/good.sql.gz"]);
+  });
+
+  it("reads the truncation markers", () => {
+    const parsed = parseListMultipartUploads(
+      uploadsXml([{ key: "k", uploadId: "u", initiated: "2026-07-01T00:00:00.000Z" }], {
+        isTruncated: true,
+        nextKeyMarker: "k",
+        nextUploadIdMarker: "u",
+      }),
+    );
+    expect(parsed.isTruncated).toBe(true);
+    expect(parsed.nextKeyMarker).toBe("k");
+    expect(parsed.nextUploadIdMarker).toBe("u");
+  });
+
+  it("returns an empty page for a result with no uploads", () => {
+    const parsed = parseListMultipartUploads(uploadsXml([]));
+    expect(parsed.uploads).toEqual([]);
+    expect(parsed.isTruncated).toBe(false);
+  });
+});
+
+// ── Construction ───────────────────────────────────────────────────
+
+describe("createS3MultipartOps", () => {
+  it("returns null without static credentials (a clean no-op, not an error)", () => {
+    expect(createS3MultipartOps({ bucket: "b" })).toBeNull();
+    expect(createS3MultipartOps({ bucket: "b", accessKeyId: "a" })).toBeNull();
+    expect(createS3MultipartOps({ bucket: "b", secretAccessKey: "s" })).toBeNull();
+  });
+
+  it("addresses an explicit endpoint path-style and real AWS virtual-hosted", async () => {
+    const pathStyle = fakeFetch([{ status: 200, body: uploadsXml([]) }]);
+    await createS3MultipartOps(
+      { ...CREDS, endpoint: "https://bucket.railway.app/" },
+      pathStyle.impl,
+    )!.listInProgress("backups/");
+    expect(pathStyle.calls[0].url.startsWith("https://bucket.railway.app/atlas-backups?")).toBe(true);
+
+    const virtualHosted = fakeFetch([{ status: 200, body: uploadsXml([]) }]);
+    await createS3MultipartOps({ ...CREDS, region: "eu-west-1" }, virtualHosted.impl)!.listInProgress("backups/");
+    expect(
+      virtualHosted.calls[0].url.startsWith("https://atlas-backups.s3.eu-west-1.amazonaws.com/?"),
+    ).toBe(true);
+  });
+});
+
+// ── listInProgress ─────────────────────────────────────────────────
+
+describe("listInProgress", () => {
+  it("signs the request with SigV4 and queries ?uploads with the prefix", async () => {
+    const fake = fakeFetch([{ status: 200, body: uploadsXml([]) }]);
+    const ops = createS3MultipartOps({ ...CREDS, endpoint: "https://s3.example.com" }, fake.impl)!;
+
+    await ops.listInProgress("backups/");
+
+    const call = fake.calls[0];
+    expect(call.method).toBe("GET");
+    expect(call.url).toContain("prefix=backups%2F");
+    // `uploads` is a valueless subresource — canonically `uploads=`.
+    expect(call.url).toContain("uploads=");
+    expect(call.headers.authorization).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=AKIA_TEST\/\d{8}\/us-east-1\/s3\/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/,
+    );
+    expect(call.headers["x-amz-date"]).toMatch(/^\d{8}T\d{6}Z$/);
+    // Empty-body SHA-256 — the constant every bodyless SigV4 request uses.
+    expect(call.headers["x-amz-content-sha256"]).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("includes a session token in the signed header set when configured", async () => {
+    const fake = fakeFetch([{ status: 200, body: uploadsXml([]) }]);
+    const ops = createS3MultipartOps({ ...CREDS, sessionToken: "tok" }, fake.impl)!;
+
+    await ops.listInProgress("backups/");
+    expect(fake.calls[0].headers["x-amz-security-token"]).toBe("tok");
+    expect(fake.calls[0].headers.authorization).toContain(
+      "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+    );
+  });
+
+  it("pages until IsTruncated clears, carrying both markers forward", async () => {
+    const fake = fakeFetch([
+      {
+        status: 200,
+        body: uploadsXml([{ key: "backups/a.sql.gz", uploadId: "u1", initiated: "2026-07-01T00:00:00.000Z" }], {
+          isTruncated: true,
+          nextKeyMarker: "backups/a.sql.gz",
+          nextUploadIdMarker: "u1",
+        }),
+      },
+      {
+        status: 200,
+        body: uploadsXml([{ key: "backups/b.sql.gz", uploadId: "u2", initiated: "2026-07-02T00:00:00.000Z" }]),
+      },
+    ]);
+    const ops = createS3MultipartOps(CREDS, fake.impl)!;
+
+    const uploads = await ops.listInProgress("backups/");
+    expect(uploads.map((u) => u.uploadId)).toEqual(["u1", "u2"]);
+    expect(fake.calls).toHaveLength(2);
+    expect(fake.calls[1].url).toContain("key-marker=backups%2Fa.sql.gz");
+    expect(fake.calls[1].url).toContain("upload-id-marker=u1");
+  });
+
+  it("terminates when a truncated page carries no markers", async () => {
+    const fake = fakeFetch([{ status: 200, body: uploadsXml([], { isTruncated: true }) }]);
+    const ops = createS3MultipartOps(CREDS, fake.impl)!;
+
+    expect(await ops.listInProgress("backups/")).toEqual([]);
+    expect(fake.calls).toHaveLength(1);
+  });
+
+  it.each([400, 403, 404, 405, 501])(
+    "reports HTTP %i as unsupported so the purge cycle degrades to a no-op",
+    async (status) => {
+      const fake = fakeFetch([{ status, body: "<Error><Code>NotImplemented</Code></Error>" }]);
+      const ops = createS3MultipartOps(CREDS, fake.impl)!;
+
+      await expect(ops.listInProgress("backups/")).rejects.toBeInstanceOf(S3MultipartUnsupportedError);
+    },
+  );
+
+  it("surfaces a server-side failure as a plain error (retried next cycle)", async () => {
+    const fake = fakeFetch([{ status: 500, body: "<Error/>" }]);
+    const ops = createS3MultipartOps(CREDS, fake.impl)!;
+
+    await expect(ops.listInProgress("backups/")).rejects.toThrow("HTTP 500");
+  });
+});
+
+// ── abort ──────────────────────────────────────────────────────────
+
+describe("abort", () => {
+  it("issues a signed DELETE against the key with the uploadId", async () => {
+    const fake = fakeFetch([{ status: 204, body: "" }]);
+    const ops = createS3MultipartOps({ ...CREDS, endpoint: "https://s3.example.com" }, fake.impl)!;
+
+    await ops.abort("backups/a.sql.gz", "u1");
+
+    expect(fake.calls[0].method).toBe("DELETE");
+    expect(fake.calls[0].url).toBe("https://s3.example.com/atlas-backups/backups/a.sql.gz?uploadId=u1");
+    expect(fake.calls[0].headers.authorization).toContain("AWS4-HMAC-SHA256");
+  });
+
+  it("treats 404 as success — another replica already aborted it", async () => {
+    const fake = fakeFetch([{ status: 404, body: "<Error><Code>NoSuchUpload</Code></Error>" }]);
+    const ops = createS3MultipartOps(CREDS, fake.impl)!;
+    await ops.abort("backups/a.sql.gz", "u1");
+  });
+
+  it("rejects on any other failure status", async () => {
+    const fake = fakeFetch([{ status: 403, body: "<Error><Code>AccessDenied</Code></Error>" }]);
+    const ops = createS3MultipartOps(CREDS, fake.impl)!;
+
+    await expect(ops.abort("backups/a.sql.gz", "u1")).rejects.toThrow("HTTP 403");
+  });
+});

--- a/ee/src/backups/s3-multipart.test.ts
+++ b/ee/src/backups/s3-multipart.test.ts
@@ -10,10 +10,13 @@
 
 import { describe, it, expect } from "bun:test";
 
+import { createHmac } from "crypto";
+
 import {
   createS3MultipartOps,
   parseListMultipartUploads,
   S3MultipartUnsupportedError,
+  signedRequest,
 } from "./s3-multipart";
 
 type Call = { url: string; method: string; headers: Record<string, string> };
@@ -97,6 +100,61 @@ describe("parseListMultipartUploads", () => {
     const parsed = parseListMultipartUploads(uploadsXml([]));
     expect(parsed.uploads).toEqual([]);
     expect(parsed.isTruncated).toBe(false);
+  });
+});
+
+// ── SigV4 ──────────────────────────────────────────────────────────
+
+describe("SigV4 signing", () => {
+  it("derives the signing key exactly as AWS's published example does", () => {
+    // AWS docs, "Examples of how to derive a signing key for Signature
+    // Version 4". Pins the HMAC chain itself against an external oracle —
+    // the one part of the scheme with a reference value we can check.
+    const hmac = (key: Buffer | string, data: string) => createHmac("sha256", key).update(data, "utf8").digest();
+    const derived = hmac(
+      hmac(hmac(hmac("AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20120215"), "us-east-1"), "iam"),
+      "aws4_request",
+    );
+    expect(derived.toString("hex")).toBe("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d");
+  });
+
+  it("produces a stable signature for a fixed clock, path and query", () => {
+    // A golden lock on the *canonical request*. Asserting the signature is
+    // 64 hex chars proves nothing — a miscanonicalized request (wrong query
+    // ordering, wrong URI encoding, a stray header in SignedHeaders) still
+    // hashes to a well-formed value. This value changes only if the
+    // canonicalization changes, which is exactly when a human should look.
+    const signed = signedRequest(
+      {
+        bucket: "atlas-backups",
+        accessKeyId: "AKIDEXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1",
+      },
+      "GET",
+      "atlas-backups.s3.us-east-1.amazonaws.com",
+      "https://atlas-backups.s3.us-east-1.amazonaws.com",
+      "",
+      { uploads: "", "max-uploads": "1000", prefix: "backups/" },
+      new Date("2026-07-22T12:34:56.000Z"),
+    );
+
+    // Query params canonically sorted by name; `uploads` valueless.
+    expect(signed.url).toBe(
+      "https://atlas-backups.s3.us-east-1.amazonaws.com/?max-uploads=1000&prefix=backups%2F&uploads=",
+    );
+    expect(signed.headers["x-amz-date"]).toBe("20260722T123456Z");
+    expect(signed.headers.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260722/us-east-1/s3/aws4_request, " +
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date, " +
+        "Signature=b3fe074730a53cfe61cc6189662916401aed816d301dd8529a5146d850278281",
+    );
+  });
+
+  it("refuses to build an unsigned request when credentials are missing", () => {
+    expect(() =>
+      signedRequest({ bucket: "b" }, "GET", "h", "https://h", "", {}, new Date()),
+    ).toThrow("requires accessKeyId + secretAccessKey");
   });
 });
 

--- a/ee/src/backups/s3-multipart.ts
+++ b/ee/src/backups/s3-multipart.ts
@@ -1,0 +1,301 @@
+/**
+ * S3 multipart-upload housekeeping (#4727).
+ *
+ * A failed backup upload deliberately never calls `end()` (finalizing would
+ * produce a truncated object that could pass a header-only verify — see
+ * `storage.ts`), so the parts already uploaded stay behind as an *incomplete
+ * multipart upload*: billable storage that never appears in a `ListObjects`
+ * listing. The standard remedy is a bucket lifecycle rule expiring incomplete
+ * multipart uploads — but **Railway buckets do not support lifecycle
+ * configuration** (create/delete/info/credentials/rename only), so on the
+ * hosted SaaS the platform cannot do this for us. Atlas therefore self-heals:
+ * the retention purge lists in-progress uploads under the backup prefix and
+ * aborts the stale ones.
+ *
+ * Why raw SigV4 instead of `Bun.S3Client`: Bun's client covers object-level
+ * operations (`file`/`list`/`delete`) and exposes neither
+ * `ListMultipartUploads` nor `AbortMultipartUpload`. Those are two plain
+ * signed HTTP requests, so this module signs them directly with the same
+ * credentials the driver already holds — no new dependency, no client fork.
+ *
+ * Degradation is deliberate and total: no credentials, an endpoint that
+ * doesn't implement the multipart-listing API, or any other refusal must
+ * never fail a backup cycle. `listInProgress` reports "unsupported" via
+ * {@link S3MultipartUnsupportedError} and the caller no-ops at debug level.
+ */
+
+import { createHash, createHmac } from "crypto";
+
+/** An in-progress (unfinalized) multipart upload. */
+export interface InProgressUpload {
+  key: string;
+  uploadId: string;
+  /** Epoch ms the upload was initiated. `NaN` is never produced — unparseable dates are dropped. */
+  initiatedAt: number;
+}
+
+/**
+ * Raised when the endpoint does not implement the multipart housekeeping
+ * APIs (some S3-compatible stores answer `501 NotImplemented`, `405`, or an
+ * `AccessDenied` for the bucket-level `?uploads` query). Callers treat this
+ * as "nothing to do", never as a failure.
+ */
+export class S3MultipartUnsupportedError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "S3MultipartUnsupportedError";
+    this.status = status;
+  }
+}
+
+export interface S3MultipartOps {
+  /** In-progress multipart uploads whose key starts with `prefix` (paged to exhaustion). */
+  listInProgress(prefix: string): Promise<InProgressUpload[]>;
+  /** Abort one upload, discarding its parts. */
+  abort(key: string, uploadId: string): Promise<void>;
+}
+
+export interface S3MultipartConfig {
+  bucket: string;
+  endpoint?: string;
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}
+
+/** SigV4 requires a region even for endpoints that ignore it. */
+const DEFAULT_REGION = "us-east-1";
+/** One page of `ListMultipartUploads`; the caller pages until `IsTruncated` clears. */
+const MAX_UPLOADS_PER_PAGE = 1000;
+/** Defensive bound so a pathological listing can't spin the purge forever. */
+const MAX_PAGES = 50;
+
+type FetchLike = (url: string, init: { method: string; headers: Record<string, string> }) => Promise<Response>;
+
+// ---------------------------------------------------------------------------
+// SigV4
+// ---------------------------------------------------------------------------
+
+function sha256Hex(payload: string): string {
+  return createHash("sha256").update(payload, "utf8").digest("hex");
+}
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return createHmac("sha256", key).update(data, "utf8").digest();
+}
+
+/**
+ * RFC 3986 encoding. `encodeURIComponent` leaves `!'()*` unescaped, which AWS
+ * requires escaped in canonical requests — a key containing one of them would
+ * otherwise produce a signature mismatch.
+ */
+function encodeRfc3986(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+/** `YYYYMMDDTHHMMSSZ` — the `x-amz-date` format. */
+function amzDate(now: Date): string {
+  return `${now.toISOString().replace(/[:-]/g, "").split(".")[0]}Z`;
+}
+
+/**
+ * Build a SigV4-signed request. Body is always empty (both operations are
+ * bodyless), so the payload hash is the constant empty-string digest.
+ */
+function signedRequest(
+  config: S3MultipartConfig,
+  method: "GET" | "DELETE",
+  baseUrl: string,
+  query: Record<string, string>,
+  now: Date,
+): { url: string; headers: Record<string, string> } {
+  const { accessKeyId, secretAccessKey } = config;
+  if (!accessKeyId || !secretAccessKey) {
+    // Guarded by createS3MultipartOps; belt-and-braces so a future caller
+    // can't produce an unsigned request that silently 403s.
+    throw new Error("S3 multipart housekeeping requires accessKeyId + secretAccessKey");
+  }
+  const region = config.region || DEFAULT_REGION;
+  const url = new URL(baseUrl);
+
+  const canonicalQuery = Object.keys(query)
+    .toSorted()
+    .map((k) => `${encodeRfc3986(k)}=${encodeRfc3986(query[k])}`)
+    .join("&");
+
+  // The path is `/bucket[/key]`; each segment is encoded independently so `/`
+  // stays a separator.
+  const canonicalUri =
+    url.pathname === "" ? "/" : url.pathname.split("/").map((s) => encodeRfc3986(decodeURIComponent(s))).join("/");
+
+  const payloadHash = sha256Hex("");
+  const date = amzDate(now);
+  const dateStamp = date.slice(0, 8);
+
+  const headers: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": date,
+    ...(config.sessionToken && { "x-amz-security-token": config.sessionToken }),
+  };
+  const signedHeaderNames = Object.keys(headers).toSorted();
+  const canonicalHeaders = signedHeaderNames.map((h) => `${h}:${headers[h].trim()}\n`).join("");
+  const signedHeaders = signedHeaderNames.join(";");
+
+  const canonicalRequest = [
+    method,
+    canonicalUri,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const scope = `${dateStamp}/${region}/s3/aws4_request`;
+  const stringToSign = ["AWS4-HMAC-SHA256", date, scope, sha256Hex(canonicalRequest)].join("\n");
+
+  const signingKey = hmac(hmac(hmac(hmac(`AWS4${secretAccessKey}`, dateStamp), region), "s3"), "aws4_request");
+  const signature = createHmac("sha256", signingKey).update(stringToSign, "utf8").digest("hex");
+
+  headers.authorization =
+    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return {
+    url: `${url.origin}${canonicalUri}${canonicalQuery ? `?${canonicalQuery}` : ""}`,
+    headers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// XML (ListMultipartUploadsResult) — regex-scoped, no parser dependency
+// ---------------------------------------------------------------------------
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_m, code: string) => String.fromCodePoint(Number(code)))
+    // &amp; last so "&amp;lt;" decodes to "&lt;", not "<".
+    .replace(/&amp;/g, "&");
+}
+
+function tagText(xml: string, tag: string): string | null {
+  const match = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(xml);
+  return match ? decodeXmlEntities(match[1]) : null;
+}
+
+export interface ParsedUploadPage {
+  uploads: InProgressUpload[];
+  isTruncated: boolean;
+  nextKeyMarker: string | null;
+  nextUploadIdMarker: string | null;
+}
+
+/** @internal Exported for tests — parses one `ListMultipartUploadsResult` body. */
+export function parseListMultipartUploads(xml: string): ParsedUploadPage {
+  const uploads: InProgressUpload[] = [];
+  for (const block of xml.match(/<Upload>[\s\S]*?<\/Upload>/g) ?? []) {
+    const key = tagText(block, "Key");
+    const uploadId = tagText(block, "UploadId");
+    const initiated = tagText(block, "Initiated");
+    if (!key || !uploadId || !initiated) continue;
+    const initiatedAt = Date.parse(initiated);
+    // An unparseable Initiated makes "older than N days" unanswerable —
+    // skip rather than risk aborting an upload that is still running.
+    if (Number.isNaN(initiatedAt)) continue;
+    uploads.push({ key, uploadId, initiatedAt });
+  }
+  return {
+    uploads,
+    isTruncated: tagText(xml, "IsTruncated") === "true",
+    nextKeyMarker: tagText(xml, "NextKeyMarker"),
+    nextUploadIdMarker: tagText(xml, "NextUploadIdMarker"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ops
+// ---------------------------------------------------------------------------
+
+/** Statuses that mean "this store has no multipart housekeeping", not "this call failed". */
+function isUnsupportedStatus(status: number): boolean {
+  return status === 400 || status === 403 || status === 404 || status === 405 || status === 501;
+}
+
+/**
+ * Build the multipart housekeeping ops for a bucket, or `null` when the
+ * configuration cannot produce a signed request (no static credentials — e.g.
+ * an IAM-role deployment where Bun's client resolves credentials itself).
+ * A `null` result is a clean no-op, not an error.
+ */
+export function createS3MultipartOps(
+  config: S3MultipartConfig,
+  fetchImpl: FetchLike = ((url, init) => fetch(url, init)) as FetchLike,
+): S3MultipartOps | null {
+  if (!config.accessKeyId || !config.secretAccessKey) return null;
+
+  // Path-style against an explicit endpoint (what Railway/MinIO/R2 expose);
+  // virtual-hosted style against real AWS, which is the only addressing mode
+  // new AWS buckets support.
+  const baseUrl = config.endpoint
+    ? `${config.endpoint.replace(/\/+$/, "")}/${config.bucket}`
+    : `https://${config.bucket}.s3.${config.region || DEFAULT_REGION}.amazonaws.com`;
+
+  const send = async (
+    method: "GET" | "DELETE",
+    url: string,
+    query: Record<string, string>,
+  ): Promise<{ status: number; body: string }> => {
+    const signed = signedRequest(config, method, url, query, new Date());
+    const res = await fetchImpl(signed.url, { method, headers: signed.headers });
+    return { status: res.status, body: await res.text() };
+  };
+
+  return {
+    async listInProgress(prefix) {
+      const uploads: InProgressUpload[] = [];
+      let keyMarker: string | null = null;
+      let uploadIdMarker: string | null = null;
+
+      for (let page = 0; page < MAX_PAGES; page++) {
+        const query: Record<string, string> = {
+          uploads: "",
+          "max-uploads": String(MAX_UPLOADS_PER_PAGE),
+          ...(prefix && { prefix }),
+          ...(keyMarker && { "key-marker": keyMarker }),
+          ...(uploadIdMarker && { "upload-id-marker": uploadIdMarker }),
+        };
+        const { status, body } = await send("GET", baseUrl, query);
+        if (isUnsupportedStatus(status)) {
+          throw new S3MultipartUnsupportedError(
+            `ListMultipartUploads not available on this endpoint (HTTP ${status})`,
+            status,
+          );
+        }
+        if (status < 200 || status >= 300) {
+          throw new Error(`ListMultipartUploads failed with HTTP ${status}`);
+        }
+
+        const parsed = parseListMultipartUploads(body);
+        uploads.push(...parsed.uploads);
+        if (!parsed.isTruncated || (!parsed.nextKeyMarker && !parsed.nextUploadIdMarker)) break;
+        keyMarker = parsed.nextKeyMarker;
+        uploadIdMarker = parsed.nextUploadIdMarker;
+      }
+
+      return uploads;
+    },
+
+    async abort(key, uploadId) {
+      const { status } = await send("DELETE", `${baseUrl}/${key}`, { uploadId });
+      // 204 is the documented success; 404 means another replica already
+      // aborted it — the desired end state either way.
+      if (status === 404 || (status >= 200 && status < 300)) return;
+      throw new Error(`AbortMultipartUpload failed with HTTP ${status}`);
+    },
+  } satisfies S3MultipartOps;
+}

--- a/ee/src/backups/s3-multipart.ts
+++ b/ee/src/backups/s3-multipart.ts
@@ -117,8 +117,12 @@ function amzDate(now: Date): string {
  * encoded here exactly once, so the canonical URI and the wire URL are the
  * same string by construction and the signature cannot drift from the
  * request actually sent.
+ *
+ * @internal Exported only so tests can pin the canonical-request shape
+ * against a fixed clock — a miscanonicalized request still produces a
+ * well-formed 64-hex signature, so the format alone proves nothing.
  */
-function signedRequest(
+export function signedRequest(
   config: S3MultipartConfig,
   method: "GET" | "DELETE",
   host: string,

--- a/ee/src/backups/s3-multipart.ts
+++ b/ee/src/backups/s3-multipart.ts
@@ -21,7 +21,10 @@
  * Degradation is deliberate and total: no credentials, an endpoint that
  * doesn't implement the multipart-listing API, or any other refusal must
  * never fail a backup cycle. `listInProgress` reports "unsupported" via
- * {@link S3MultipartUnsupportedError} and the caller no-ops at debug level.
+ * {@link S3MultipartUnsupportedError} and the caller no-ops — at debug
+ * level, except for a `403`, which the driver raises to an actionable warn
+ * because a denied `?uploads` query is as likely a fixable IAM gap as a
+ * genuinely unsupported store.
  */
 
 import { createHash, createHmac } from "crypto";

--- a/ee/src/backups/s3-multipart.ts
+++ b/ee/src/backups/s3-multipart.ts
@@ -49,9 +49,15 @@ export class S3MultipartUnsupportedError extends Error {
   }
 }
 
+/** One listing sweep. `truncated` means the page cap stopped it early. */
+export interface InProgressUploadListing {
+  uploads: InProgressUpload[];
+  truncated: boolean;
+}
+
 export interface S3MultipartOps {
-  /** In-progress multipart uploads whose key starts with `prefix` (paged to exhaustion). */
-  listInProgress(prefix: string): Promise<InProgressUpload[]>;
+  /** In-progress multipart uploads whose key starts with `prefix`, paged to exhaustion or the page cap. */
+  listInProgress(prefix: string): Promise<InProgressUploadListing>;
   /** Abort one upload, discarding its parts. */
   abort(key: string, uploadId: string): Promise<void>;
 }
@@ -103,11 +109,21 @@ function amzDate(now: Date): string {
 /**
  * Build a SigV4-signed request. Body is always empty (both operations are
  * bodyless), so the payload hash is the constant empty-string digest.
+ *
+ * `path` is the **decoded** resource path (`/bucket` or `/bucket/<key>`) — it
+ * is never round-tripped through `URL`, because an object key may legally
+ * contain `%`, `?` or `#`, all of which `URL` parsing would mangle (and a
+ * lone `%` makes `decodeURIComponent` throw outright). Each segment is
+ * encoded here exactly once, so the canonical URI and the wire URL are the
+ * same string by construction and the signature cannot drift from the
+ * request actually sent.
  */
 function signedRequest(
   config: S3MultipartConfig,
   method: "GET" | "DELETE",
-  baseUrl: string,
+  host: string,
+  origin: string,
+  path: string,
   query: Record<string, string>,
   now: Date,
 ): { url: string; headers: Record<string, string> } {
@@ -118,24 +134,21 @@ function signedRequest(
     throw new Error("S3 multipart housekeeping requires accessKeyId + secretAccessKey");
   }
   const region = config.region || DEFAULT_REGION;
-  const url = new URL(baseUrl);
 
   const canonicalQuery = Object.keys(query)
     .toSorted()
     .map((k) => `${encodeRfc3986(k)}=${encodeRfc3986(query[k])}`)
     .join("&");
 
-  // The path is `/bucket[/key]`; each segment is encoded independently so `/`
-  // stays a separator.
-  const canonicalUri =
-    url.pathname === "" ? "/" : url.pathname.split("/").map((s) => encodeRfc3986(decodeURIComponent(s))).join("/");
+  // Each segment is encoded independently so `/` stays a separator.
+  const canonicalUri = path === "" ? "/" : path.split("/").map(encodeRfc3986).join("/");
 
   const payloadHash = sha256Hex("");
   const date = amzDate(now);
   const dateStamp = date.slice(0, 8);
 
   const headers: Record<string, string> = {
-    host: url.host,
+    host,
     "x-amz-content-sha256": payloadHash,
     "x-amz-date": date,
     ...(config.sessionToken && { "x-amz-security-token": config.sessionToken }),
@@ -163,7 +176,7 @@ function signedRequest(
     `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
 
   return {
-    url: `${url.origin}${canonicalUri}${canonicalQuery ? `?${canonicalQuery}` : ""}`,
+    url: `${origin}${canonicalUri}${canonicalQuery ? `?${canonicalQuery}` : ""}`,
     headers,
   };
 }
@@ -234,29 +247,36 @@ function isUnsupportedStatus(status: number): boolean {
  */
 export function createS3MultipartOps(
   config: S3MultipartConfig,
-  fetchImpl: FetchLike = ((url, init) => fetch(url, init)) as FetchLike,
+  fetchImpl: FetchLike = (url, init) => fetch(url, init),
 ): S3MultipartOps | null {
   if (!config.accessKeyId || !config.secretAccessKey) return null;
 
   // Path-style against an explicit endpoint (what Railway/MinIO/R2 expose);
   // virtual-hosted style against real AWS, which is the only addressing mode
-  // new AWS buckets support.
-  const baseUrl = config.endpoint
-    ? `${config.endpoint.replace(/\/+$/, "")}/${config.bucket}`
-    : `https://${config.bucket}.s3.${config.region || DEFAULT_REGION}.amazonaws.com`;
+  // new AWS buckets support. Parsed once, here, from operator-supplied
+  // configuration — never from an object key (see `signedRequest`).
+  const endpointUrl = new URL(
+    config.endpoint
+      ? config.endpoint.replace(/\/+$/, "")
+      : `https://${config.bucket}.s3.${config.region || DEFAULT_REGION}.amazonaws.com`,
+  );
+  const { origin, host } = endpointUrl;
+  // An endpoint may itself carry a path prefix; keep it ahead of the bucket.
+  const endpointPath = endpointUrl.pathname.replace(/\/+$/, "");
+  const bucketPath = config.endpoint ? `${endpointPath}/${config.bucket}` : endpointPath;
 
   const send = async (
     method: "GET" | "DELETE",
-    url: string,
+    path: string,
     query: Record<string, string>,
   ): Promise<{ status: number; body: string }> => {
-    const signed = signedRequest(config, method, url, query, new Date());
+    const signed = signedRequest(config, method, host, origin, path, query, new Date());
     const res = await fetchImpl(signed.url, { method, headers: signed.headers });
     return { status: res.status, body: await res.text() };
   };
 
   return {
-    async listInProgress(prefix) {
+    async listInProgress(prefix): Promise<InProgressUploadListing> {
       const uploads: InProgressUpload[] = [];
       let keyMarker: string | null = null;
       let uploadIdMarker: string | null = null;
@@ -269,7 +289,7 @@ export function createS3MultipartOps(
           ...(keyMarker && { "key-marker": keyMarker }),
           ...(uploadIdMarker && { "upload-id-marker": uploadIdMarker }),
         };
-        const { status, body } = await send("GET", baseUrl, query);
+        const { status, body } = await send("GET", bucketPath, query);
         if (isUnsupportedStatus(status)) {
           throw new S3MultipartUnsupportedError(
             `ListMultipartUploads not available on this endpoint (HTTP ${status})`,
@@ -282,16 +302,22 @@ export function createS3MultipartOps(
 
         const parsed = parseListMultipartUploads(body);
         uploads.push(...parsed.uploads);
-        if (!parsed.isTruncated || (!parsed.nextKeyMarker && !parsed.nextUploadIdMarker)) break;
+        if (!parsed.isTruncated || (!parsed.nextKeyMarker && !parsed.nextUploadIdMarker)) {
+          return { uploads, truncated: false };
+        }
         keyMarker = parsed.nextKeyMarker;
         uploadIdMarker = parsed.nextUploadIdMarker;
       }
 
-      return uploads;
+      // Page cap hit with more pages pending. Report the partial listing
+      // rather than throwing: aborting what we found shrinks the population,
+      // so successive cycles converge — but `truncated` makes the shortfall
+      // visible instead of letting a capped sweep read as a complete one.
+      return { uploads, truncated: true };
     },
 
     async abort(key, uploadId) {
-      const { status } = await send("DELETE", `${baseUrl}/${key}`, { uploadId });
+      const { status } = await send("DELETE", `${bucketPath}/${key}`, { uploadId });
       // 204 is the documented success; 404 means another replica already
       // aborted it — the desired end state either way.
       if (status === 404 || (status >= 200 && status < 300)) return;

--- a/ee/src/backups/storage.test.ts
+++ b/ee/src/backups/storage.test.ts
@@ -27,6 +27,10 @@ const {
 } = await import("./storage");
 type S3ClientLike = import("./storage").S3ClientLike;
 
+const { S3MultipartUnsupportedError } = await import("./s3-multipart");
+type S3MultipartOps = import("./s3-multipart").S3MultipartOps;
+type InProgressUpload = import("./s3-multipart").InProgressUpload;
+
 // ── Local driver ───────────────────────────────────────────────────
 
 describe("local backup storage", () => {
@@ -73,6 +77,11 @@ describe("local backup storage", () => {
     expect(existsSync(path)).toBe(false);
     // Second remove: already gone — resolves, no throw.
     await storage.remove(path);
+  });
+
+  it("abortStaleUploads is a no-op — the filesystem has no multipart concept (#4727)", async () => {
+    const storage = createLocalBackupStorage();
+    expect(await storage.abortStaleUploads(tmp, 7 * 24 * 60 * 60 * 1000)).toBe(0);
   });
 });
 
@@ -124,8 +133,7 @@ function createFakeS3() {
         },
       };
     },
-    async list({ prefix }: { prefix: string; maxKeys?: number; startAfter?: string }) {
-      const keys = [...objects.keys()].filter((k) => k.startsWith(prefix)).toSorted();
+    async list({ prefix }: { prefix: string; maxKeys?: number; startAfter?: string }) {      const keys = [...objects.keys()].filter((k) => k.startsWith(prefix)).toSorted();
       return { contents: keys.map((key) => ({ key })), isTruncated: false };
     },
   };
@@ -223,6 +231,95 @@ describe("s3 backup storage", () => {
     // Missing key — still resolves.
     await storage.remove("./backups/gone.sql.gz");
     expect(fake.deleted.filter((k) => k === "backups/gone.sql.gz")).toHaveLength(2);
+  });
+});
+
+// ── Stale incomplete multipart uploads (#4727) ─────────────────────
+
+describe("s3 backup storage — abortStaleUploads", () => {
+  const DAY = 24 * 60 * 60 * 1000;
+  const WEEK = 7 * DAY;
+
+  function createFakeMultipart(uploads: InProgressUpload[], abortImpl?: (key: string) => void) {
+    const listedPrefixes: string[] = [];
+    const aborted: { key: string; uploadId: string }[] = [];
+    const ops: S3MultipartOps = {
+      async listInProgress(prefix) {
+        listedPrefixes.push(prefix);
+        return uploads;
+      },
+      async abort(key, uploadId) {
+        abortImpl?.(key);
+        aborted.push({ key, uploadId });
+      },
+    };
+    return { ops, listedPrefixes, aborted };
+  }
+
+  it("aborts only uploads older than the threshold, under the normalized key prefix", async () => {
+    const now = Date.now();
+    const fake = createFakeMultipart([
+      { key: "backups/stale.sql.gz", uploadId: "u-old", initiatedAt: now - 8 * DAY },
+      { key: "backups/fresh.sql.gz", uploadId: "u-new", initiatedAt: now - 1 * DAY },
+    ]);
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => fake.ops);
+
+    expect(await storage.abortStaleUploads("./backups", WEEK)).toBe(1);
+    // Leading `./` stripped and a trailing `/` appended, exactly as `list` does.
+    expect(fake.listedPrefixes).toEqual(["backups/"]);
+    expect(fake.aborted).toEqual([{ key: "backups/stale.sql.gz", uploadId: "u-old" }]);
+  });
+
+  it("no-ops when the endpoint does not support ListMultipartUploads", async () => {
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => ({
+      listInProgress: () => Promise.reject(new S3MultipartUnsupportedError("nope", 501)),
+      abort: () => Promise.reject(new Error("should not be reached")),
+    }));
+
+    expect(await storage.abortStaleUploads("./backups", WEEK)).toBe(0);
+  });
+
+  it("no-ops when no static credentials are available to sign the request", async () => {
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => null);
+    expect(await storage.abortStaleUploads("./backups", WEEK)).toBe(0);
+  });
+
+  it("propagates a genuine listing failure so the caller can log it", async () => {
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => ({
+      listInProgress: () => Promise.reject(new Error("connection reset")),
+      abort: () => Promise.resolve(),
+    }));
+
+    await expect(storage.abortStaleUploads("./backups", WEEK)).rejects.toThrow("connection reset");
+  });
+
+  it("one un-abortable upload does not strand the rest", async () => {
+    const now = Date.now();
+    const fake = createFakeMultipart(
+      [
+        { key: "backups/a.sql.gz", uploadId: "u-a", initiatedAt: now - 8 * DAY },
+        { key: "backups/b.sql.gz", uploadId: "u-b", initiatedAt: now - 9 * DAY },
+      ],
+      (key) => {
+        if (key === "backups/a.sql.gz") throw new Error("AccessDenied");
+      },
+    );
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => fake.ops);
+
+    expect(await storage.abortStaleUploads("./backups", WEEK)).toBe(1);
+    expect(fake.aborted).toEqual([{ key: "backups/b.sql.gz", uploadId: "u-b" }]);
+  });
+
+  it("resolves the multipart factory once and caches a null result", async () => {
+    let calls = 0;
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => {
+      calls++;
+      return null;
+    });
+
+    await storage.abortStaleUploads("./backups", WEEK);
+    await storage.abortStaleUploads("./backups", WEEK);
+    expect(calls).toBe(1);
   });
 });
 

--- a/ee/src/backups/storage.test.ts
+++ b/ee/src/backups/storage.test.ts
@@ -240,13 +240,17 @@ describe("s3 backup storage — abortStaleUploads", () => {
   const DAY = 24 * 60 * 60 * 1000;
   const WEEK = 7 * DAY;
 
-  function createFakeMultipart(uploads: InProgressUpload[], abortImpl?: (key: string) => void) {
+  function createFakeMultipart(
+    uploads: InProgressUpload[],
+    abortImpl?: (key: string) => void,
+    truncated = false,
+  ) {
     const listedPrefixes: string[] = [];
     const aborted: { key: string; uploadId: string }[] = [];
     const ops: S3MultipartOps = {
       async listInProgress(prefix) {
         listedPrefixes.push(prefix);
-        return uploads;
+        return { uploads, truncated };
       },
       async abort(key, uploadId) {
         abortImpl?.(key);
@@ -308,6 +312,19 @@ describe("s3 backup storage — abortStaleUploads", () => {
 
     expect(await storage.abortStaleUploads("./backups", WEEK)).toBe(1);
     expect(fake.aborted).toEqual([{ key: "backups/b.sql.gz", uploadId: "u-b" }]);
+  });
+
+  it("still sweeps the batch it got when the listing was page-capped", async () => {
+    const now = Date.now();
+    const fake = createFakeMultipart(
+      [{ key: "backups/a.sql.gz", uploadId: "u-a", initiatedAt: now - 8 * DAY }],
+      undefined,
+      /* truncated */ true,
+    );
+    const storage = createS3BackupStorage({ bucket: "b" }, undefined, () => fake.ops);
+
+    // Partial progress, not a refusal — successive cycles converge.
+    expect(await storage.abortStaleUploads("./backups", WEEK)).toBe(1);
   });
 
   it("resolves the multipart factory once and caches a null result", async () => {

--- a/ee/src/backups/storage.ts
+++ b/ee/src/backups/storage.ts
@@ -279,15 +279,39 @@ export function createS3BackupStorage(
       let stale: { key: string; uploadId: string }[];
       try {
         const cutoff = Date.now() - olderThanMs;
-        stale = (await ops.listInProgress(keyPrefix)).filter((u) => u.initiatedAt < cutoff);
+        const listing = await ops.listInProgress(keyPrefix);
+        if (listing.truncated) {
+          // Not fatal — aborting this batch shrinks the population so later
+          // cycles converge — but a capped sweep must not read as complete.
+          log.warn(
+            { bucket: config.bucket, prefix: keyPrefix, listed: listing.uploads.length },
+            "Multipart-upload listing hit its page cap — sweeping this batch, remainder next cycle",
+          );
+        }
+        stale = listing.uploads.filter((u) => u.initiatedAt < cutoff);
       } catch (err) {
         if (err instanceof S3MultipartUnsupportedError) {
           // Documented degradation: some S3-compatible stores don't expose
-          // bucket-level `?uploads`. Nothing to clean up, nothing to alarm on.
-          log.debug(
-            { bucket: config.bucket, status: err.status },
-            "Skipping stale multipart-upload cleanup — endpoint does not support ListMultipartUploads",
-          );
+          // bucket-level `?uploads`. A 403 is the one status here that is
+          // just as likely a *fixable* permission gap (the credential lacks
+          // `s3:ListBucketMultipartUploads`), so it gets an actionable warn
+          // rather than a debug line nobody will ever read.
+          const detail = {
+            bucket: config.bucket,
+            status: err.status,
+          };
+          if (err.status === 403) {
+            log.warn(
+              detail,
+              "Skipping stale multipart-upload cleanup — the bucket credential was denied ListMultipartUploads. " +
+                "Grant s3:ListBucketMultipartUploads + s3:AbortMultipartUpload, or expect abandoned upload parts to accrue.",
+            );
+          } else {
+            log.debug(
+              detail,
+              "Skipping stale multipart-upload cleanup — endpoint does not support ListMultipartUploads",
+            );
+          }
           return 0;
         }
         throw err instanceof Error ? err : new Error(String(err));

--- a/ee/src/backups/storage.ts
+++ b/ee/src/backups/storage.ts
@@ -42,6 +42,7 @@ import { basename, dirname } from "path";
 import { pipeline } from "stream/promises";
 import type { Readable } from "stream";
 import { createLogger } from "@atlas/api/lib/logger";
+import { createS3MultipartOps, S3MultipartUnsupportedError, type S3MultipartOps } from "./s3-multipart";
 
 const log = createLogger("ee:backups-storage");
 
@@ -60,6 +61,17 @@ export interface BackupStorage {
   list(prefix: string): Promise<string[]>;
   /** Delete the artifact. Resolves (does not reject) when it is already gone. */
   remove(path: string): Promise<void>;
+  /**
+   * Abort in-progress multipart uploads under `prefix` that were initiated
+   * more than `olderThanMs` ago, returning how many were aborted (#4727).
+   *
+   * A failed S3 upload deliberately never finalizes, so its parts linger as
+   * billable-but-invisible storage. Resolves with `0` — never rejects — when
+   * the driver has no multipart concept (local), when the endpoint does not
+   * implement the API, or when static credentials aren't available to sign
+   * the request. Genuine failures reject so the caller can log them.
+   */
+  abortStaleUploads(prefix: string, olderThanMs: number): Promise<number>;
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +109,11 @@ export function createLocalBackupStorage(): BackupStorage {
         }
         throw err instanceof Error ? err : new Error(String(err));
       }
+    },
+    async abortStaleUploads() {
+      // The filesystem has no multipart concept: a failed `put` leaves a
+      // partial file at a known path, which the next attempt overwrites.
+      return 0;
     },
   };
 }
@@ -143,6 +160,7 @@ function toKey(path: string): string {
 export function createS3BackupStorage(
   config: S3BackupStorageConfig,
   clientFactory?: (config: S3BackupStorageConfig) => S3ClientLike,
+  multipartFactory: (config: S3BackupStorageConfig) => S3MultipartOps | null = createS3MultipartOps,
 ): BackupStorage {
   const makeClient =
     clientFactory ??
@@ -165,6 +183,19 @@ export function createS3BackupStorage(
   const getClient = (): S3ClientLike => {
     client ??= makeClient(config);
     return client;
+  };
+
+  // Multipart housekeeping is a separate, optional seam: `null` (no static
+  // credentials) is a legitimate steady state, so the resolution is cached in
+  // its own flag rather than folded into `client`.
+  let multipartOps: S3MultipartOps | null = null;
+  let multipartResolved = false;
+  const getMultipartOps = (): S3MultipartOps | null => {
+    if (!multipartResolved) {
+      multipartOps = multipartFactory(config);
+      multipartResolved = true;
+    }
+    return multipartOps;
   };
 
   return {
@@ -196,10 +227,11 @@ export function createS3BackupStorage(
       } catch (err) {
         // Deliberately do NOT end() after a failed part: finalizing would
         // produce a truncated object that could pass a header-only verify.
-        // The multipart upload is left unfinalized — configure a bucket
-        // lifecycle rule to expire incomplete multipart uploads (see
-        // backups.mdx); Bun's writer has no abort API today. Log + rethrow
-        // so the backup row is stamped failed.
+        // The multipart upload is left unfinalized (Bun's writer has no abort
+        // API today) — the retention purge's `abortStaleUploads` sweeps those
+        // parts a week later, so they can't accrue invisible storage even on
+        // buckets with no lifecycle-rule support (#4727). Log + rethrow so
+        // the backup row is stamped failed.
         log.error(
           { err: err instanceof Error ? err.message : String(err), key: toKey(path) },
           "S3 backup upload failed — artifact not finalized",
@@ -232,6 +264,52 @@ export function createS3BackupStorage(
       // S3 DeleteObject succeeds for missing keys by protocol — the
       // ENOENT-tolerant contract holds without a special case.
       await getClient().file(toKey(path)).delete();
+    },
+    async abortStaleUploads(prefix, olderThanMs) {
+      const ops = getMultipartOps();
+      if (!ops) {
+        log.debug(
+          { bucket: config.bucket },
+          "Skipping stale multipart-upload cleanup — no static S3 credentials to sign the request",
+        );
+        return 0;
+      }
+
+      const keyPrefix = toKey(prefix.endsWith("/") ? prefix : `${prefix}/`);
+      let stale: { key: string; uploadId: string }[];
+      try {
+        const cutoff = Date.now() - olderThanMs;
+        stale = (await ops.listInProgress(keyPrefix)).filter((u) => u.initiatedAt < cutoff);
+      } catch (err) {
+        if (err instanceof S3MultipartUnsupportedError) {
+          // Documented degradation: some S3-compatible stores don't expose
+          // bucket-level `?uploads`. Nothing to clean up, nothing to alarm on.
+          log.debug(
+            { bucket: config.bucket, status: err.status },
+            "Skipping stale multipart-upload cleanup — endpoint does not support ListMultipartUploads",
+          );
+          return 0;
+        }
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+
+      let aborted = 0;
+      for (const upload of stale) {
+        try {
+          await ops.abort(upload.key, upload.uploadId);
+          aborted++;
+        } catch (err) {
+          // One un-abortable upload must not strand the rest.
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err), key: upload.key },
+            "Failed to abort a stale multipart upload — will retry next cycle",
+          );
+        }
+      }
+      if (aborted > 0) {
+        log.info({ bucket: config.bucket, prefix: keyPrefix, aborted }, "Aborted stale incomplete multipart uploads");
+      }
+      return aborted;
     },
   };
 }


### PR DESCRIPTION
Closes #4727

## Why

A failed S3 backup upload **deliberately never finalizes** — calling `end()` after a failed part would produce a truncated object that could pass a header-only verify. The parts already uploaded therefore linger as an *incomplete multipart upload*: billable storage that no `ListObjects` call ever shows.

The standard remedy is a bucket lifecycle rule expiring incomplete multipart uploads. Executing PR #4723's operator checklist (2026-07-18) confirmed **Railway buckets support no lifecycle configuration at all** (CLI/docs expose only create/delete/info/credentials/rename), so on the hosted SaaS the platform cannot do this for us.

Atlas now self-heals.

## What

**`BackupStorage` grows `abortStaleUploads(prefix, olderThanMs)`.** The retention purge sweeps uploads older than **7 days** after the row purge, failure-isolated: housekeeping can never fail a cycle, and never changes the purge count callers contract on.

**`ee/src/backups/s3-multipart.ts`** — `Bun.S3Client` covers object-level operations and exposes neither `ListMultipartUploads` nor `AbortMultipartUpload`. Those are two plain bodyless signed HTTP requests, so this module signs them with SigV4 directly using the credentials the driver already holds. No new dependency, no client fork. Path-style addressing against an explicit endpoint (Railway/MinIO/R2), virtual-hosted against real AWS.

**Degradation is total and quiet**, per the acceptance criteria:

| Situation | Behaviour |
|---|---|
| local-fs driver | returns 0 — the filesystem has no multipart concept |
| endpoint answers 400/404/405/501 to bucket-level `?uploads` | debug log, returns 0 |
| endpoint answers **403** | **warn** naming the grants to add — as likely a fixable IAM gap as a genuinely unsupported store |
| no static credentials to sign with | debug log, returns 0 |
| one upload can't be aborted | warn, the rest still sweep |
| genuine transport failure | propagates to the engine, which warns and returns 0 |

## Notes for review

- **Object keys are never round-tripped through `URL`.** A key may legally contain `%` (which makes `decodeURIComponent` throw), `?` or `#` (which URL parsing swallows). The decoded path is encoded exactly once, so the canonical URI and the wire URL are the same string by construction — a signature cannot drift from the request actually sent.
- **`listInProgress` returns `{ uploads, truncated }`.** Hitting the 50-page cap returns the partial batch rather than throwing: aborting it shrinks the population so successive cycles converge, while `truncated` keeps a capped sweep from reading as a complete one.
- **Two golden locks on SigV4**, because asserting "the signature is 64 hex chars" proves nothing — a miscanonicalized request hashes to a well-formed value too, and the production failure mode is a silent 403. The HMAC chain is checked against AWS's published signing-key derivation vector, and `signedRequest` is pinned against a fixed clock.

## Testing

- `storage.test.ts` — local no-op, threshold filtering, prefix normalization, unsupported/no-credential degradation, page-capped batch still sweeps, partial abort-failure isolation, factory resolved once
- `s3-multipart.test.ts` (new, 26 tests) — SigV4 golden locks, request shape, session tokens, path-vs-virtual-hosted addressing, endpoint path prefixes, `%`/`?`/`#` key signing, paging termination, page cap, XML parsing incl. entity decoding and unparseable-date rejection
- `engine.test.ts` — purge invokes the sweep with the 7-day threshold under the configured prefix, and a failing sweep does not change the purge count

## Docs

`backups.mdx` documents the self-heal, and still recommends a provider lifecycle rule where one is supported (AWS/R2/MinIO) as a cheaper provider-side backstop that keeps working even if the backup fiber is disabled.

## CI note

Local `/ci`: **30 of 31 gates pass.** The one failure is `packages/mcp/src/__tests__/smoke.test.ts`, which needs a fully-bootstrapped internal DB that local SaaS-mode boot won't provision (#1472) — environmental, and this PR touches neither `packages/mcp` nor migrations. The GitHub `api-tests (1/4)`–`(4/4)` shards run it against a real migrated Postgres and are the arbiter.