### PR TITLE
refactor(notebook): phase-2 — DROP COLUMN conversations.notebook_state (ADR-0035)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -528,6 +528,13 @@ describe("migrateAuthTables", () => {
             // be in the already-applied set so this "all applied" test sees
             // zero new migrations.
             { name: "0178_region_migrations_source_cleaned_at.sql" },
+            // 0179 (#4588, ADR-0035) — drop conversations.notebook_state
+            // (notebook retirement phase 2; readers/writers removed by #4587
+            // in v0.0.47). Plain DROP COLUMN on an Atlas-internal table, no
+            // Better Auth involvement, so it runs in every auth mode — must
+            // be in the already-applied set so this "all applied" test sees
+            // zero new migrations.
+            { name: "0179_drop_conversations_notebook_state.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -234,7 +234,10 @@ describe("runMigrations", () => {
     //   Plus 0178 (region_migrations.source_cleaned_at — the retry-safe stamp
     //   the #4458 source-cleanup fiber writes transactionally with its
     //   deletes) = 179.
-    expect(count).toBe(179);
+    //   Plus 0179 (drop conversations.notebook_state — notebook retirement
+    //   phase 2 of the two-phase drop, readers/writers removed by #4587 in
+    //   v0.0.47, ADR-0035, #4588) = 180.
+    expect(count).toBe(180);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -442,6 +445,7 @@ describe("runMigrations", () => {
         "0176_drop_dashboard_stage_changes.sql",
         "0177_backups_scheduled_window.sql",
         "0178_region_migrations_source_cleaned_at.sql",
+        "0179_drop_conversations_notebook_state.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0179_drop_conversations_notebook_state.sql
+++ b/packages/api/src/lib/db/migrations/0179_drop_conversations_notebook_state.sql
@@ -1,0 +1,30 @@
+-- 0179 — Drop conversations.notebook_state (notebook retirement phase 2, #4588).
+--
+-- Phase 2 of the two-phase drop that retires the notebook surface
+-- (ADR-0035, parent #4587). Phase 1 (#4587, shipped in v0.0.47) removed
+-- every reader and writer of this column: the /notebook route and its
+-- components, the fork/branch endpoints, the chat→notebook conversion, the
+-- `PATCH /:id/notebook-state` persistence route, and the "Share as Report"
+-- path are all gone, and migration 0169 converted the remaining
+-- `surface = 'notebook'` rows to `'web'`. Nothing has read or written
+-- `notebook_state` since v0.0.47.
+--
+-- expand-contract: this is the contract half of the two-phase drop staged by
+-- #4587 / migration 0169. It ships many releases AFTER v0.0.47, so during the
+-- N-1 ↔ N deploy-overlap window the draining old container is already
+-- notebook-free code — no query can reference the missing column. See #4588
+-- and db/migrations/README.md § Two-phase drop discipline.
+--
+-- The Drizzle mirror (`notebookState` on `conversations` in db/schema.ts) is
+-- removed in the same commit, so the next `drizzle-kit generate` cannot emit
+-- a destructive re-add/drop diff.
+--
+-- The branch pointers that lived in `notebook_state.branches` die with the
+-- column — ADR-0035 accepts that: branching exploration is dropped with no
+-- successor, and message history (the user-visible content) was preserved by
+-- 0169's conversion rather than living in this column.
+--
+-- IF EXISTS keeps the migration idempotent for any environment that was
+-- provisioned after the column was already gone.
+
+ALTER TABLE conversations DROP COLUMN IF EXISTS notebook_state;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -185,6 +185,7 @@ export const conversations = pgTable(
     // Notebook — RETIRED (ADR-0035, #4587). The `notebook_state` column and its
     // Drizzle mirror were dropped in phase 2 of the two-phase drop (migration
     // 0179, #4588). Do not re-add.
+    //
     // Org scoping
     orgId: text("org_id"),
     // Soft-delete

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -182,12 +182,9 @@ export const conversations = pgTable(
     shareToken: varchar("share_token", { length: 64 }),
     shareExpiresAt: timestamp("share_expires_at", { withTimezone: true }),
     shareMode: varchar("share_mode", { length: 10 }).notNull().default("public"),
-    // Notebook — RETIRED (ADR-0035, #4587). The notebook surface is gone and no
-    // shipped code reads or writes this column as of #4587. Kept here for phase 1
-    // of the two-phase drop: the column still exists in the DB so a draining N-1
-    // pod can't 500 on it during deploy overlap. Dropped (column + this mirror)
-    // in the phase-2 follow-up (#4588). Do not add new readers/writers.
-    notebookState: jsonb("notebook_state"),
+    // Notebook — RETIRED (ADR-0035, #4587). The `notebook_state` column and its
+    // Drizzle mirror were dropped in phase 2 of the two-phase drop (migration
+    // 0179, #4588). Do not re-add.
     // Org scoping
     orgId: text("org_id"),
     // Soft-delete


### PR DESCRIPTION
Contract half of the two-phase drop that retires the notebook surface (ADR-0035).

Phase 1 (#4587, PR #4589, commit `8a552d375`) removed every reader and writer of `notebook_state` and converted the remaining `surface = 'notebook'` rows to `'web'` (migration 0169). It first shipped in **v0.0.47** and is an ancestor of `origin/prod` — verified before starting, so the N-1↔N deploy-overlap window is safe: any draining old container is already notebook-free code.

## What changed

- **`0179_drop_conversations_notebook_state.sql`** — `ALTER TABLE conversations DROP COLUMN IF EXISTS notebook_state`, carrying a justified `-- expand-contract:` marker so `check-migration-rename-discipline.sh` recognizes it as the legal phase-2 half rather than a single-phase drop.
- **`db/schema.ts`** — the `notebookState` Drizzle mirror removed in the same commit (replaced by a tombstone comment, matching the `mcp_tokens` / `dashboard_stage_changes` idiom), so the next `drizzle-kit generate` can't emit a destructive diff.
- **`db/__tests__/migrate.test.ts`** — count bumped 179 → 180 **and** the filename appended to the applied-set list (both, per the `--affected`-blind gotcha).
- **`auth/__tests__/migrate.test.ts`** — 0179 appended to the already-applied set.

The `"notebook"` `Surface` value was already removed in #4587; a repo-wide sweep of `packages/`, `ee/`, `plugins/`, `apps/`, and `create-atlas/` confirms **zero** remaining `notebook_state` / `notebookState` readers or writers outside comments and the phase-1 migration header.

## Verification

- `check-migration-rename-discipline.sh` — PASS, and explicitly reports the exemption: `exempt … — DROP COLUMN declared expand-contract`.
- `check-schema-drift.sh` — PASS.
- **Real-Postgres `migrate-pg.test.ts` — 99 pass / 0 fail**, genuinely run (not skipped) against a dedicated scratch database; `\d conversations` afterwards confirms `notebook_state` is absent.
- Local `/ci`: **30 of 31 gates PASS**. The `test` gate flagged 6 `-pg` suites (including `migrate-pg`) with Postgres `3F000` "no schema has been selected" — shared-scratch-DB contention from concurrent `-pg` suites plus sibling agents on this box, not a regression. All 6 re-run **green serially** against a fresh database. GitHub's sharded `api-tests (1/4)`–`(4/4)`, which give each shard a real dedicated Postgres, are the arbiter here.
- Internal `/review-panel`: CLEAN in one round (silent-failure / type-design / test / comment axes).

Closes #4588