### PR TITLE
refactor(billing): route all trial-clock stampers through fullTrialEndsAtFrom (#4354)

### DIFF
--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -80,8 +80,9 @@ import {
   assertBusinessEmail,
   assertNoPlusAddressing,
 } from "@atlas/api/lib/auth/business-email";
-import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
+import { getStripePlans, resolvePlanTierFromPriceId } from "@atlas/api/lib/billing/plans";
 import { userHasConsumedTrial, claimTrialGrant, extendTrialOnClaim } from "@atlas/api/lib/billing/trial-eligibility";
+import { fullTrialEndsAtFrom } from "@atlas/api/lib/billing/trial-state";
 import { getStripeClient } from "@atlas/api/lib/billing/stripe-client";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import { ensureOverageSubscriptionItem } from "@atlas/api/lib/billing/overage-meter";
@@ -293,14 +294,17 @@ export async function assignSaasTrial(args: {
       return;
     }
 
-    const trialEndsAt = new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000);
+    // The one trial-clock stamper (#4354) — shares its fragment with the
+    // reader (`effectiveTrialEndsAt`) Gate 0 enforces, so the stamped date
+    // can't drift from the enforced one. Never re-inline the arithmetic.
+    const trialEndsAt = fullTrialEndsAtFrom(Date.now());
     await internalQuery(
       `UPDATE organization SET plan_tier = 'trial', trial_ends_at = $1
        WHERE id = $2 AND plan_tier = 'free'`,
-      [trialEndsAt.toISOString(), org.id],
+      [trialEndsAt, org.id],
     );
     log.info(
-      { userId: user.id, orgId: org.id, trialEndsAt: trialEndsAt.toISOString() },
+      { userId: user.id, orgId: org.id, trialEndsAt },
       "Assigned SaaS trial to new workspace",
     );
   } catch (err) {

--- a/packages/api/src/lib/billing/__tests__/trial-state.test.ts
+++ b/packages/api/src/lib/billing/__tests__/trial-state.test.ts
@@ -16,6 +16,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { dirname, join, relative } from "path";
 import { TRIAL_DAYS, TRIAL_GRACE_HOURS } from "../plans";
 import {
   deriveTrialState,
@@ -254,6 +256,137 @@ describe("trial clock stamps", () => {
     expect(Date.parse(unclaimedGraceHorizonFrom(NOW.getTime()))).toBeLessThan(
       Date.parse(fullTrialEndsAtFrom(NOW.getTime())),
     );
+  });
+});
+
+/**
+ * The write-side/read-side pin (#4354). `fullTrialEndsAtFrom` is now the ONE
+ * stamper — `assignSaasTrial`, the boot backfill, and `extendTrialOnClaim`
+ * all write what it returns — and `effectiveTrialEndsAt` is the reader Gate 0
+ * enforces. If those two ever drift, every new trial is silently mis-dated
+ * and enforcement cuts the workspace off on the wrong day. This table walks a
+ * fixed set of stamp instants (no `Date.now()` anywhere) and asserts, for
+ * each, that what the stamper writes is exactly what the reader reads back —
+ * and that a NULL-`trial_ends_at` workspace created at the same instant lands
+ * on the same date via the #3434 `createdAt` fallback.
+ *
+ * The clocks deliberately include both sides of a US and an EU DST
+ * transition, a leap day, and a UTC year boundary: the clock is epoch-ms
+ * arithmetic, so `TRIAL_DAYS` means exactly `TRIAL_DAYS * 24h` regardless of
+ * what the local calendar did in between.
+ */
+describe("the stamped clock is the enforced clock (write side == read side, #4354)", () => {
+  const STAMP_CLOCKS: ReadonlyArray<readonly [label: string, iso: string]> = [
+    ["mid-year UTC noon", "2026-06-12T12:00:00.000Z"],
+    ["just before US DST spring-forward", "2026-03-08T06:59:59.999Z"],
+    ["just after US DST spring-forward", "2026-03-08T07:00:00.000Z"],
+    ["just before EU DST fall-back", "2026-10-25T00:59:59.999Z"],
+    ["leap day", "2024-02-29T23:30:00.000Z"],
+    ["UTC year boundary", "2025-12-31T23:59:59.999Z"],
+    ["unix epoch", "1970-01-01T00:00:00.000Z"],
+  ];
+
+  for (const [label, iso] of STAMP_CLOCKS) {
+    describe(label, () => {
+      const stampedAt = Date.parse(iso);
+      const stamped = fullTrialEndsAtFrom(stampedAt);
+      const expectedEndMs = stampedAt + TRIAL_DAYS * DAY;
+      // `createdAt` is irrelevant when trial_ends_at is set — deliberately a
+      // wildly different date, so a reader that ignored the stamp would fail.
+      const stampedWorkspace = {
+        trial_ends_at: stamped,
+        createdAt: new Date(stampedAt - 400 * DAY).toISOString(),
+      };
+      // The #3434 pre-backfill shape: no stamp, clock implied from createdAt.
+      const unstampedWorkspace = {
+        trial_ends_at: null,
+        createdAt: new Date(stampedAt).toISOString(),
+      };
+
+      it("the reader reads back exactly the stamped instant", () => {
+        expect(effectiveTrialEndsAt(stampedWorkspace)?.getTime()).toBe(expectedEndMs);
+      });
+
+      it("the createdAt fallback lands on the same instant the stamper would have written", () => {
+        expect(effectiveTrialEndsAt(unstampedWorkspace)?.getTime()).toBe(
+          Date.parse(fullTrialEndsAtFrom(stampedAt)),
+        );
+      });
+
+      it("Gate 0 expires the stamped trial exactly one ms after the stamped end, not before", () => {
+        for (const workspace of [stampedWorkspace, unstampedWorkspace]) {
+          const end = effectiveTrialEndsAt(workspace);
+          expect(isTrialExpiredAt(end, new Date(expectedEndMs))).toBe(false);
+          expect(isTrialExpiredAt(end, new Date(expectedEndMs + 1))).toBe(true);
+        }
+      });
+
+      it("the countdown reads a full TRIAL_DAYS at the stamp instant on both shapes", () => {
+        const now = new Date(stampedAt);
+        expect(trialDaysRemaining(stampedWorkspace, now)).toBe(TRIAL_DAYS);
+        expect(trialDaysRemaining(unstampedWorkspace, now)).toBe(TRIAL_DAYS);
+      });
+    });
+  }
+});
+
+/**
+ * STRUCTURAL ENFORCEMENT (#4354) — one home for the trial clock.
+ *
+ * The table above pins that the stamper and the reader agree TODAY; this pins
+ * that they still CAN'T disagree tomorrow. `trial-state.ts` is the only module
+ * allowed to turn `TRIAL_DAYS` into a duration; every other call site must go
+ * through `fullTrialEndsAtFrom`. Sources are DISCOVERED by walking the tree,
+ * not enumerated, so a new stamper in a file nobody thought of is auto-enrolled
+ * rather than silently skipped. Non-arithmetic reads of the constant (plan
+ * metadata like `trialDays: TRIAL_DAYS`, Stripe's `freeTrial: { days }`) are
+ * fine — only multiplication into a millisecond span is the drift hazard.
+ */
+describe("structural: TRIAL_DAYS arithmetic lives only in trial-state.ts (#4354)", () => {
+  /** Walk up to the monorepo root (has both `packages/` and `ee/`). */
+  function repoRoot(): string {
+    let dir = import.meta.dir;
+    for (let i = 0; i < 12; i++) {
+      if (existsSync(join(dir, "packages")) && existsSync(join(dir, "ee"))) return dir;
+      dir = dirname(dir);
+    }
+    throw new Error(`repo root not found from ${import.meta.dir}`);
+  }
+
+  function collectSources(dir: string, out: string[]): string[] {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "__tests__") continue;
+        collectSources(full, out);
+      } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  it("no source outside trial-state.ts multiplies TRIAL_DAYS into a duration", () => {
+    const root = repoRoot();
+    const canonical = join(root, "packages/api/src/lib/billing/trial-state.ts");
+    const files = [
+      ...collectSources(join(root, "packages/api/src"), []),
+      ...collectSources(join(root, "ee/src"), []),
+    ].filter((f) => f !== canonical);
+    // Sanity: the walk actually found the tree it claims to guard.
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders = files.filter((file) => {
+      // Strip block + line comments — prose citing `NOW() + TRIAL_DAYS` is
+      // documentation, not a second stamper.
+      const source = readFileSync(file, "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "");
+      return /TRIAL_DAYS\s*\*|\*\s*TRIAL_DAYS/.test(source);
+    });
+
+    expect(offenders.map((f) => relative(root, f))).toEqual([]);
   });
 });
 

--- a/packages/api/src/lib/billing/__tests__/trial-state.test.ts
+++ b/packages/api/src/lib/billing/__tests__/trial-state.test.ts
@@ -270,10 +270,11 @@ describe("trial clock stamps", () => {
  * and that a NULL-`trial_ends_at` workspace created at the same instant lands
  * on the same date via the #3434 `createdAt` fallback.
  *
- * The clocks deliberately include both sides of a US and an EU DST
- * transition, a leap day, and a UTC year boundary: the clock is epoch-ms
- * arithmetic, so `TRIAL_DAYS` means exactly `TRIAL_DAYS * 24h` regardless of
- * what the local calendar did in between.
+ * The clocks deliberately straddle a US DST spring-forward, sit on the edge
+ * of an EU DST fall-back, and include a leap day and a UTC year boundary: the
+ * clock is epoch-ms arithmetic, so `TRIAL_DAYS` means exactly
+ * `TRIAL_DAYS * 24h` regardless of what any local calendar did in between, and
+ * regardless of the TZ the test process happens to run under.
  */
 describe("the stamped clock is the enforced clock (write side == read side, #4354)", () => {
   const STAMP_CLOCKS: ReadonlyArray<readonly [label: string, iso: string]> = [
@@ -341,13 +342,18 @@ describe("the stamped clock is the enforced clock (write side == read side, #435
  * rather than silently skipped. Non-arithmetic reads of the constant (plan
  * metadata like `trialDays: TRIAL_DAYS`, Stripe's `freeTrial: { days }`) are
  * fine — only multiplication into a millisecond span is the drift hazard.
+ *
+ * CAVEAT: this reads sources off disk rather than importing them, so it is
+ * `--affected`-blind — editing some far-away file does not schedule it in the
+ * local `test-isolated.ts --affected` loop. The full `bun run test` / CI
+ * `api-tests` shards are what actually catch a re-inlined stamper.
  */
 describe("structural: TRIAL_DAYS arithmetic lives only in trial-state.ts (#4354)", () => {
-  /** Walk up to the monorepo root (has both `packages/` and `ee/`). */
+  /** Walk up to the monorepo root (has both `packages/` and `plugins/`). */
   function repoRoot(): string {
     let dir = import.meta.dir;
     for (let i = 0; i < 12; i++) {
-      if (existsSync(join(dir, "packages")) && existsSync(join(dir, "ee"))) return dir;
+      if (existsSync(join(dir, "packages")) && existsSync(join(dir, "plugins"))) return dir;
       dir = dirname(dir);
     }
     throw new Error(`repo root not found from ${import.meta.dir}`);
@@ -370,10 +376,14 @@ describe("structural: TRIAL_DAYS arithmetic lives only in trial-state.ts (#4354)
   it("no source outside trial-state.ts multiplies TRIAL_DAYS into a duration", () => {
     const root = repoRoot();
     const canonical = join(root, "packages/api/src/lib/billing/trial-state.ts");
-    const files = [
-      ...collectSources(join(root, "packages/api/src"), []),
-      ...collectSources(join(root, "ee/src"), []),
-    ].filter((f) => f !== canonical);
+    const roots = ["packages/api/src", "ee/src"].map((r) => join(root, r));
+    // Assert the scanned trees are actually THERE rather than quietly
+    // guarding nothing — `ee/` in particular is stub-swappable, and a guard
+    // that silently stops covering the SaaS trial provisioner is worse than
+    // no guard at all.
+    for (const dir of roots) expect({ dir, exists: existsSync(dir) }).toEqual({ dir, exists: true });
+
+    const files = roots.flatMap((dir) => collectSources(dir, [])).filter((f) => f !== canonical);
     // Sanity: the walk actually found the tree it claims to guard.
     expect(files.length).toBeGreaterThan(100);
 

--- a/packages/api/src/lib/billing/backfill-saas-trial.ts
+++ b/packages/api/src/lib/billing/backfill-saas-trial.ts
@@ -48,7 +48,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { getConfig } from "@atlas/api/lib/config";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
-import { TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
+import { fullTrialEndsAtFrom } from "@atlas/api/lib/billing/trial-state";
 
 const log = createLogger("billing.backfill-saas-trial");
 
@@ -74,7 +74,10 @@ export async function backfillSaasTrial(): Promise<BackfillResult> {
   if (getConfig()?.deployMode !== "saas") return SKIPPED;
   if (!hasInternalDB()) return SKIPPED;
 
-  const trialEndsAt = new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000);
+  // The one trial-clock stamper (#4354) — shares its fragment with the
+  // reader (`effectiveTrialEndsAt`) Gate 0 enforces, so a backfilled
+  // workspace's stamped date can't drift from the enforced one.
+  const trialEndsAt = fullTrialEndsAtFrom(Date.now());
 
   try {
     // 1) One-trial-per-user arm (#3426): free orgs with an owner who
@@ -123,7 +126,7 @@ export async function backfillSaasTrial(): Promise<BackfillResult> {
         WHERE plan_tier = 'free'
           AND trial_ends_at IS NULL
         RETURNING id`,
-      [trialEndsAt.toISOString()],
+      [trialEndsAt],
     );
     const orgIds = rows.map((r) => r.id);
 
@@ -143,7 +146,7 @@ export async function backfillSaasTrial(): Promise<BackfillResult> {
       );
     }
     log.info(
-      { updatedCount: orgIds.length, orgIds, lockedOrgIds, trialEndsAt: trialEndsAt.toISOString() },
+      { updatedCount: orgIds.length, orgIds, lockedOrgIds, trialEndsAt },
       orgIds.length === 0 && lockedOrgIds.length === 0
         ? "SaaS trial backfill: no free workspaces to promote"
         : "SaaS trial backfill: promoted free workspaces (trial-consumed owners landed on locked)",

--- a/packages/api/src/lib/billing/trial-state.ts
+++ b/packages/api/src/lib/billing/trial-state.ts
@@ -25,6 +25,17 @@
  * ({@link trialTierSql}, {@link unclaimedOwnerExistsSql}) colocated with the
  * TS predicate and pinned against it by `trial-state.test.ts`, so drift is
  * caught rather than silent.
+ *
+ * #4127 folded the predicates but left the CLOCK in four places — a canonical
+ * stamper with only one caller, a reader that re-derived the same rule, and
+ * two hand-inlined `now + TRIAL_DAYS` stampers. #4354 closed that: the write
+ * side ({@link fullTrialEndsAtFrom}, now the ONLY stamper — `assignSaasTrial`,
+ * the boot backfill, and `extendTrialOnClaim` all write what it returns) and
+ * the read side ({@link effectiveTrialEndsAt}, the date Gate 0 enforces) share
+ * one arithmetic fragment, so a stamped trial cannot be dated differently from
+ * the trial enforcement expires. `trial-state.test.ts` pins write-against-read
+ * over a table of fixed clocks and structurally forbids re-inlining the
+ * arithmetic anywhere else.
  */
 
 import type { PlanTier, WorkspaceRow } from "@atlas/api/lib/db/internal";
@@ -90,6 +101,27 @@ function toMs(value: string | Date): number {
 }
 
 /**
+ * THE trial-clock fragment: the epoch-ms instant a full {@link TRIAL_DAYS}
+ * clock started at `startMs` runs out. Every trial-clock computation in the
+ * codebase — read side and write side — bottoms out here (#4354):
+ *
+ *   - write: {@link fullTrialEndsAtFrom}, the one stamper, consumed by
+ *     `assignSaasTrial`, the boot backfill, and `extendTrialOnClaim`;
+ *   - read: {@link effectiveTrialEndsAt}'s `createdAt` fallback (#3434), the
+ *     date Gate 0 actually enforces.
+ *
+ * Sharing the fragment is the point: if the write side could drift from the
+ * read side, every new trial would be silently mis-dated and enforcement
+ * would expire it on the wrong day. Pure epoch-ms arithmetic — deliberately
+ * NOT calendar-day arithmetic, so the horizon is timezone- and DST-invariant
+ * (a trial stamped across a DST boundary still lasts exactly
+ * `TRIAL_DAYS * 24h`).
+ */
+function fullTrialEndMsFrom(startMs: number): number {
+  return startMs + TRIAL_DAYS * MS_PER_DAY;
+}
+
+/**
  * The date enforcement treats as the end of the trial: `trial_ends_at` when
  * set and parseable, else `createdAt + TRIAL_DAYS` (#3434). Returns null only
  * when neither input parses — expiry treats that as "not expired" and
@@ -104,7 +136,7 @@ export function effectiveTrialEndsAt(workspace: TrialExpiryInput): Date | null {
   }
   const createdMs = toMs(workspace.createdAt);
   if (!Number.isFinite(createdMs)) return null;
-  return new Date(createdMs + TRIAL_DAYS * MS_PER_DAY);
+  return new Date(fullTrialEndMsFrom(createdMs));
 }
 
 /**
@@ -134,13 +166,17 @@ export function trialDaysRemaining(
 /**
  * ISO timestamp of the full {@link TRIAL_DAYS} clock end measured from
  * `nowMs` — the `trial_ends_at` a trial carries once its clock has started
- * (web signup at org creation, or MCP signup at claim time). Consumed by
- * `extendTrialOnClaim`; `assignSaasTrial` and the boot backfill still stamp
- * the same arithmetic inline — #4127 folded the predicates, not the
- * stampers.
+ * (web signup at org creation, or MCP signup at claim time).
+ *
+ * The ONLY trial-clock stamper (#4354): `assignSaasTrial`, the boot backfill
+ * (`backfill-saas-trial.ts`), and `extendTrialOnClaim` all write what this
+ * returns, and it shares {@link fullTrialEndMsFrom} with the reader
+ * {@link effectiveTrialEndsAt} that Gate 0 enforces — so the stamped date and
+ * the enforced date cannot drift. Don't re-inline the arithmetic at a call
+ * site; `trial-state.test.ts` pins write-against-read.
  */
 export function fullTrialEndsAtFrom(nowMs: number): string {
-  return new Date(nowMs + TRIAL_DAYS * MS_PER_DAY).toISOString();
+  return new Date(fullTrialEndMsFrom(nowMs)).toISOString();
 }
 
 /**


### PR DESCRIPTION
Closes #4354.

## The drift

The rule "a full trial clock = now + `TRIAL_DAYS`" lived in **four** places:

| # | Site | What it did |
|---|------|-------------|
| 1 | `trial-state.ts` `fullTrialEndsAtFrom` | the canonical stamper — **one** caller (`extendTrialOnClaim`) |
| 2 | `trial-state.ts` `effectiveTrialEndsAt` | the **reader Gate 0 enforces** — independently re-derived `createdAt + TRIAL_DAYS` |
| 3 | `auth/server.ts` `assignSaasTrial` | inline `new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000)` |
| 4 | `backfill-saas-trial.ts` | the same inline arithmetic again |

#4127 folded the trial *predicates* into `trial-state.ts` but not the *stampers* — its own docstring said so. If any write-side copy drifted from the reader, every new trial would be silently mis-dated and Gate 0 would cut the workspace off on the wrong day.

## Behaviour: unchanged — this really is a pure refactor

Billing-adjacent, so I enumerated all four and diffed the instant each produces before claiming that:

- All four compute `X + TRIAL_DAYS * 86_400_000` on **epoch milliseconds**. `24 * 60 * 60 * 1000` is exactly `MS_PER_DAY`, so every stamped instant is byte-identical before and after — **no customer's trial end moves by so much as a millisecond.**
- **No timezone/DST difference.** None of the four ever did calendar-day arithmetic (no `setDate`, no local-time components), so there was no DST hazard to preserve or introduce; the horizon is `TRIAL_DAYS * 24h` regardless of TZ. The new fragment documents that this is deliberate.
- **No truncation difference.** All four ended in `new Date(ms).toISOString()`, which is millisecond-precision. The two inline sites previously carried a `Date` and called `.toISOString()` at each use; they now carry the ISO string the stamper returns — same characters on the wire, one fewer conversion.
- Out of scope, deliberately: `unclaimedGraceHorizonFrom` / the `TRIAL_GRACE_HOURS` grace axis (`ee/src/onboarding/provision-trial.ts`'s `graceMs`). That's the claim axis, not the trial clock, and this issue is scoped to the latter.

**If any of the four had computed a different instant I would have flagged it as a behaviour change rather than shipping it as a refactor — none did.**

## The change

`trial-state.ts` now owns the clock on **both** sides via one private fragment:

```ts
function fullTrialEndMsFrom(startMs: number): number {
  return startMs + TRIAL_DAYS * MS_PER_DAY;
}
```

- **write:** `fullTrialEndsAtFrom` — now the *only* stamper; `assignSaasTrial`, the boot backfill, and `extendTrialOnClaim` all write what it returns.
- **read:** `effectiveTrialEndsAt`'s `createdAt` fallback (#3434) — the date Gate 0 actually enforces.

The write can no longer drift from the read, because there is one arithmetic site.

## Tests — pinned against a fixed clock

No `Date.now()` appears in any new assertion.

1. **The write/read table.** Seven fixed stamp instants — straddling a US DST spring-forward, on the edge of an EU DST fall-back, a leap day, a UTC year boundary, and the unix epoch. For each: the reader reads back exactly the stamped instant (with a deliberately unrelated `createdAt`, so a reader ignoring the stamp fails); the NULL-`trial_ends_at` fallback lands on the same instant the stamper would have written; Gate 0 flips expired exactly one ms after the end, not before; and the countdown reads a full `TRIAL_DAYS` on both shapes.
2. **A structural guard** that *discovers* every source under `packages/api/src` and `ee/src` (comments stripped, tests excluded) and fails if any file outside `trial-state.ts` multiplies `TRIAL_DAYS` into a duration. Verified it bites: re-inlining the arithmetic into `reap-unclaimed-grace.ts` turns it red. It asserts its scanned roots exist rather than quietly guarding nothing, and its docstring records that it is `--affected`-blind (the full suite / `api-tests` shards are what catch a regression).

## Verification

- `/review-panel`: **CLEAN** (2 rounds — round 1 tightened the guard's root detection, added the existence assertion and the `--affected`-blind caveat, and corrected the DST wording).
- `/ci`: **31/31 gates green**, including the full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
