### PR TITLE
refactor(api): give conversation scope a first-class module (#4351)

### DIFF
--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -802,30 +802,13 @@ export function createApiTestMocks(
     // exercise the routing override this mock locally via mock.module.
     resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-    // #2518 — three-state Auto/Pin/All picker write path. Default to a
-    // no-op success — chat-route tests don't write the row unless they
-    // exercise the picker toggle path, and they override locally when
-    // they do.
-    updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-    // #3066 — per-conversation REST exclude-set write path. Same no-op
-    // success default as the routing-mode write: chat-route tests don't
-    // persist the row unless they exercise the scope-picker toggle, and
-    // they override locally when they do.
-    updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-    updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-    // #3895 — per-conversation Group reach write path. Same no-op success
-    // default; chat.ts statically imports it, so the shared mock MUST export it
-    // (a partial mock omitting it breaks every route test's module load with a
-    // "Export named 'updateConversationGroupReach' not found" SyntaxError).
-    updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-    updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
-    // NULL → "pin" back-compat default helper used by the chat route to
-    // resolve a conversation's persisted `routing_mode`. Mocked as a pure
-    // pass-through so tests can simulate either an explicit mode or the
-    // legacy NULL → "pin" coercion without further wiring.
-    resolveRoutingMode: mock(
-      (m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin",
-    ),
+    // #4351 — the SINGLE conversation-scope write path (it replaced the five
+    // per-axis writers). Default to a no-op success: chat-route tests don't
+    // write the row unless they exercise a picker toggle, and they override
+    // locally when they do. chat.ts statically imports it, so the shared mock
+    // MUST export it — a partial mock omitting it breaks every route test's
+    // module load with an "Export named ... not found" SyntaxError.
+    updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   }));
 
   // ── Security ──────────────────────────────────────────────────

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -132,11 +132,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -336,11 +336,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -348,11 +348,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -304,11 +304,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -241,11 +241,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -600,11 +600,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat-resume.test.ts
+++ b/packages/api/src/api/__tests__/chat-resume.test.ts
@@ -128,11 +128,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat-stop.test.ts
+++ b/packages/api/src/api/__tests__/chat-stop.test.ts
@@ -110,11 +110,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -124,28 +124,15 @@ const mockCreateConversation = mock((): Promise<{ id: string } | null> =>
 const mockAddMessage = mock(() => {});
 const mockGetConversationChat = mock((): Promise<{ ok: boolean; reason?: string; data?: unknown }> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockGenerateTitle = mock((q: string) => q.slice(0, 80));
-// #3066 — captured so tests can assert the REST exclude-set persist path
-// (incl. the re-include `[]` case, the #3073 transport-omits-null bug class).
-const mockUpdateConversationRestExcluded = mock(() =>
-  Promise.resolve({ ok: true as const }),
-);
-// #3067 — captured so tests can assert the REST-only focus persist path,
-// incl. the clear-via-null case (the #3073 transport-omits-null bug class).
-const mockUpdateConversationRestFocus = mock(() =>
-  Promise.resolve({ ok: true as const }),
-);
-// #3895 — captured so tests can assert the Group-reach persist path, incl. the
-// widen-via-null case (the #3073 transport-omits-null bug class). The chat route
-// imports + CALLS this synchronously (before .catch), so it MUST be mocked or
-// the persist-reach branch throws a TypeError the moment the picker is touched.
-const mockUpdateConversationGroupReach = mock(() =>
-  Promise.resolve({ ok: true as const }),
-);
-// #4302 — captured so tests can assert the answer-style persist path (persist
-// on explicit change, no UPDATE when unchanged/omitted). Like the reach helper
-// above, chat.ts calls this synchronously (before .catch), so it MUST be
-// mocked or the persist-style branch throws the moment the picker is touched.
-const mockUpdateConversationAnswerStyle = mock(() =>
+// #4351 — the single conversation-scope writer, captured so tests can assert
+// the persist path for every axis (routing mode / REST exclude-set / REST
+// focus / group reach / answer style) — incl. the clear-via-`null` and
+// re-include-via-`[]` cases (the #3073 transport-omits-null bug class). The
+// chat route imports + CALLS this synchronously (before `.then`), so it MUST
+// be mocked or the persist branch throws the moment a picker is touched.
+// The second argument is the DIFFED patch: only the axes that actually
+// changed, which is exactly what these tests assert on.
+const mockUpdateConversationScope = mock(() =>
   Promise.resolve({ ok: true as const }),
 );
 type ReservationResult =
@@ -182,12 +169,7 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mockUpdateConversationRestExcluded,
-  updateConversationRestFocus: mockUpdateConversationRestFocus,
-  updateConversationGroupReach: mockUpdateConversationGroupReach,
-  updateConversationAnswerStyle: mockUpdateConversationAnswerStyle,
-  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
+  updateConversationScope: mockUpdateConversationScope,
 }));
 
 const mockGetPluginTools: Mock<() => unknown> = mock(() => undefined);
@@ -309,14 +291,8 @@ describe("POST /api/v1/chat", () => {
     mockAddMessage.mockReset();
     mockGetConversationChat.mockReset();
     mockGetConversationChat.mockResolvedValue({ ok: false, reason: "not_found" });
-    mockUpdateConversationRestExcluded.mockReset();
-    mockUpdateConversationRestExcluded.mockResolvedValue({ ok: true as const });
-    mockUpdateConversationRestFocus.mockReset();
-    mockUpdateConversationRestFocus.mockResolvedValue({ ok: true as const });
-    mockUpdateConversationGroupReach.mockReset();
-    mockUpdateConversationGroupReach.mockResolvedValue({ ok: true as const });
-    mockUpdateConversationAnswerStyle.mockReset();
-    mockUpdateConversationAnswerStyle.mockResolvedValue({ ok: true as const });
+    mockUpdateConversationScope.mockReset();
+    mockUpdateConversationScope.mockResolvedValue({ ok: true as const });
     mockReserveConversationBudget.mockReset();
     mockReserveConversationBudget.mockResolvedValue({ status: "ok", totalStepsBefore: 0 });
     mockSettleConversationSteps.mockReset();
@@ -549,15 +525,16 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationRestExcluded).toHaveBeenCalledTimes(1);
-    const calls = mockUpdateConversationRestExcluded.mock.calls as unknown as unknown[][];
-    // Second arg is the new (now-empty) set persisted to the row.
-    expect(calls[0]![1]).toEqual([]);
+    expect(mockUpdateConversationScope).toHaveBeenCalledTimes(1);
+    const calls = mockUpdateConversationScope.mock.calls as unknown as unknown[][];
+    // Second arg is the diffed patch — the exclude-set axis ONLY, carrying the
+    // now-empty set. No other axis changed, so no other axis is written.
+    expect(calls[0]![1]).toEqual({ restExcludedDatasourceIds: [] });
   });
 
   // #3066 — when the body OMITS the exclude-set (the common follow-up turn),
-  // the stored set is inherited and NO redundant UPDATE fires (sameStringSet
-  // gate). This is the counterpart to the re-include test above.
+  // the stored set is inherited and NO redundant UPDATE fires (the
+  // `diffConversationScope` set-equality gate). This is the counterpart to the re-include test above.
   it("inherits the stored exclude-set and skips the UPDATE when the body omits it (#3066)", async () => {
     const convId = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
     mockGetConversationChat.mockResolvedValueOnce({
@@ -594,10 +571,10 @@ describe("POST /api/v1/chat", () => {
     // Inherited the stored set into the ALS frame…
     expect(capturedContext?.restExcludedDatasourceIds).toEqual(["ds-1"]);
     // …and did NOT burn an UPDATE (body matched the stored set / was absent).
-    expect(mockUpdateConversationRestExcluded).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
-  // #3066 — the `sameStringSet` gate: a body that sends a non-empty set EQUAL
+  // #3066 — the exclude-set equality gate (`diffConversationScope`): a body that sends a non-empty set EQUAL
   // to the stored set (here reordered) must NOT burn an UPDATE. A regression to
   // order-sensitive (e.g. JSON.stringify) comparison would bump `updated_at`
   // and reshuffle the conversation list on every turn.
@@ -625,7 +602,7 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationRestExcluded).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
   // #3067 — the conversation's REST-only focus must reach the agent via the ALS
@@ -704,10 +681,10 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationRestFocus).toHaveBeenCalledTimes(1);
-    const calls = mockUpdateConversationRestFocus.mock.calls as unknown as unknown[][];
-    // Second arg is the new (null) focus persisted to the row.
-    expect(calls[0]![1]).toBeNull();
+    expect(mockUpdateConversationScope).toHaveBeenCalledTimes(1);
+    const calls = mockUpdateConversationScope.mock.calls as unknown as unknown[][];
+    // Diffed patch — the focus axis ONLY, cleared to null.
+    expect(calls[0]![1]).toEqual({ restFocusDatasourceId: null });
   });
 
   // #3067 — when the body OMITS focus (the common follow-up turn), the stored
@@ -749,7 +726,7 @@ describe("POST /api/v1/chat", () => {
     // Inherited the stored focus into the ALS frame…
     expect(capturedContext?.restFocusDatasourceId).toBe("ds-stripe");
     // …and did NOT burn an UPDATE (body absent → inherit, no change).
-    expect(mockUpdateConversationRestFocus).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
   // #3895 — the conversation's Group reach (a Focus group id) must reach the
@@ -828,10 +805,10 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationGroupReach).toHaveBeenCalledTimes(1);
-    const calls = mockUpdateConversationGroupReach.mock.calls as unknown as unknown[][];
-    // Second arg is the new (null) reach persisted to the row.
-    expect(calls[0]![1]).toBeNull();
+    expect(mockUpdateConversationScope).toHaveBeenCalledTimes(1);
+    const calls = mockUpdateConversationScope.mock.calls as unknown as unknown[][];
+    // Diffed patch — the reach axis ONLY, widened to null (All sources).
+    expect(calls[0]![1]).toEqual({ groupReach: null });
   });
 
   // #3895 — when the body OMITS groupReach (the common follow-up turn), the
@@ -874,7 +851,7 @@ describe("POST /api/v1/chat", () => {
     // Inherited the stored Focus into the ALS frame…
     expect(capturedContext?.groupReach).toBe("g_prod");
     // …and did NOT burn an UPDATE (body absent → inherit, no change).
-    expect(mockUpdateConversationGroupReach).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
   // #4302 — per-conversation answer style: the header picker's selection
@@ -949,7 +926,7 @@ describe("POST /api/v1/chat", () => {
     const runCalls = mockRunAgent.mock.calls as unknown as unknown[][];
     expect((runCalls[0]![0] as { answerStyle?: string }).answerStyle).toBe("executive");
     // Inherit is not a change — no UPDATE burned.
-    expect(mockUpdateConversationAnswerStyle).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
   // #4302 — the pre-#4302 back-compat path: an existing conversation whose
@@ -983,7 +960,7 @@ describe("POST /api/v1/chat", () => {
     expect(response.status).toBe(200);
     const runCalls = mockRunAgent.mock.calls as unknown as unknown[][];
     expect((runCalls[0]![0] as { answerStyle?: string }).answerStyle).toBeUndefined();
-    expect(mockUpdateConversationAnswerStyle).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
   // #4302 — an explicit picker change persists onto the row (that's what
@@ -1014,10 +991,10 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationAnswerStyle).toHaveBeenCalledTimes(1);
-    const updateCalls = mockUpdateConversationAnswerStyle.mock.calls as unknown as unknown[][];
+    expect(mockUpdateConversationScope).toHaveBeenCalledTimes(1);
+    const updateCalls = mockUpdateConversationScope.mock.calls as unknown as unknown[][];
     expect(updateCalls[0]![0]).toBe(convId);
-    expect(updateCalls[0]![1]).toBe("plain-english");
+    expect(updateCalls[0]![1]).toEqual({ answerStyle: "plain-english" });
     // The changed style also voices THIS turn.
     const runCalls = mockRunAgent.mock.calls as unknown as unknown[][];
     expect((runCalls[0]![0] as { answerStyle?: string }).answerStyle).toBe("plain-english");
@@ -1052,9 +1029,9 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationAnswerStyle).toHaveBeenCalledTimes(1);
-    const updateCalls = mockUpdateConversationAnswerStyle.mock.calls as unknown as unknown[][];
-    expect(updateCalls[0]![1]).toBe("executive");
+    expect(mockUpdateConversationScope).toHaveBeenCalledTimes(1);
+    const updateCalls = mockUpdateConversationScope.mock.calls as unknown as unknown[][];
+    expect(updateCalls[0]![1]).toEqual({ answerStyle: "executive" });
   });
 
   // #4302 — re-sending the stored style (the transport re-sends it every turn
@@ -1086,7 +1063,7 @@ describe("POST /api/v1/chat", () => {
       }),
     );
     expect(response.status).toBe(200);
-    expect(mockUpdateConversationAnswerStyle).not.toHaveBeenCalled();
+    expect(mockUpdateConversationScope).not.toHaveBeenCalled();
   });
 
   // #4302 — no explicit choice anywhere ⇒ runAgent gets NO answerStyle (prompt

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -137,11 +137,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   // #2518 — three-state routing-mode picker. Default to a no-op
   // success — tests that exercise the picker write path override
   // locally.
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -485,11 +485,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   settleConversationSteps: mock(() => {}),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -128,11 +128,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -180,11 +180,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -166,11 +166,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -128,11 +128,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -344,11 +344,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -282,11 +282,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -48,13 +48,14 @@ import {
   reserveConversationBudget,
   resolveGroupForConnection,
   settleConversationSteps,
-  updateConversationRoutingMode,
-  updateConversationRestExcluded,
-  updateConversationRestFocus,
-  updateConversationGroupReach,
-  updateConversationAnswerStyle,
-  resolveRoutingMode,
+  updateConversationScope,
 } from "@atlas/api/lib/conversations";
+import {
+  conversationScopeFrom,
+  conversationScopePatchFrom,
+  diffConversationScope,
+  routingModeFromColumn,
+} from "@atlas/api/lib/conversation-scope";
 import { ANSWER_STYLE_NAMES } from "@atlas/api/lib/answer-styles";
 import type { AnswerStyle } from "@atlas/api/lib/answer-styles";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
@@ -90,21 +91,6 @@ function getConversationStepCap(orgId?: string): number {
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) return DEFAULT_CONVERSATION_STEP_CAP;
   return Math.floor(n);
-}
-
-/**
- * #3066 — order-independent equality for two string sets. Used to decide
- * whether the body's REST exclude-set differs from the conversation's
- * stored set before burning an UPDATE. Duplicates collapse (a set, not a
- * list), so `["a","a"]` and `["a"]` compare equal — which is correct for
- * an exclude-set keyed on `install_id`.
- */
-function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
-  const setA = new Set(a);
-  const setB = new Set(b);
-  if (setA.size !== setB.size) return false;
-  for (const v of setA) if (!setB.has(v)) return false;
-  return true;
 }
 
 /**
@@ -1161,153 +1147,56 @@ chat.openapi(chatRoute, async (c) => {
             if (effectiveAnswerStyle === undefined && existing.data.answerStyle) {
               effectiveAnswerStyle = existing.data.answerStyle;
             }
-            // Persist the picker mode if the body explicitly set one for
-            // this turn. We compare against the stored value to avoid
-            // burning an UPDATE on every chat turn when nothing changed.
-            if (
-              parsed.data.routingMode !== undefined &&
-              parsed.data.routingMode !== existing.data.routingMode
-            ) {
-              // Fire-and-forget within the request lifetime: a transient
-              // write failure shouldn't block the chat turn (the runtime
-              // will still honor the body's routingMode for this turn).
-              // Note we don't await — the helper logs its own failures.
-              updateConversationRoutingMode(
+            // #4351 — persist the conversation's scope in ONE diffed,
+            // org-scoped, atomic UPDATE. Previously this was five parallel
+            // "body explicitly set X AND X differs from the row" guards, each
+            // firing its own per-field writer: a turn that changed reach AND
+            // style issued two independent fire-and-forget writes that could
+            // land — or fail — separately, leaving the row half-updated.
+            //
+            // The presence semantics are unchanged and load-bearing (#3073,
+            // the transport-omits-null bug class): `conversationScopePatchFrom`
+            // keeps only the axes the BODY carries, so an omitted field
+            // inherits the row while an explicit `null` (clear REST focus,
+            // widen reach to All sources) is a real change that persists.
+            // `diffConversationScope` then drops the axes that already match
+            // the row, so a turn that changes nothing burns no write — the
+            // transport re-sends the picker state on every turn, so that skip
+            // is the common path, not the exception.
+            const scopeChanges = diffConversationScope(
+              conversationScopeFrom(existing.data),
+              conversationScopePatchFrom(parsed.data),
+            );
+            if (Object.keys(scopeChanges).length > 0) {
+              // Fire-and-forget within the request lifetime: a transient write
+              // failure must not block the chat turn (the runtime honours the
+              // body's scope for this turn either way). The writer never
+              // rejects (it catches internally and returns a CrudResult), so
+              // inspect the RESOLUTION too: an `ok: false` that isn't the
+              // already-logged `error` arm — `not_found` (conversation deleted
+              // mid-turn, or an ownership-scope miss) — would otherwise be
+              // silent at both layers, and a scope pick that didn't stick
+              // reverts on reopen with zero breadcrumb.
+              updateConversationScope(
                 conversationId,
-                parsed.data.routingMode,
-                authResult.user?.id,
-                authResult.user?.activeOrganizationId,
-              ).catch((err: unknown) => {
-                log.warn(
-                  {
-                    err: err instanceof Error ? err.message : String(err),
-                    conversationId,
-                  },
-                  "updateConversationRoutingMode rejected",
-                );
-              });
-            }
-            // #3066 — persist the exclude-set when the body explicitly set
-            // one this turn AND it differs from the stored set. Set-equality
-            // is order-independent so a reorder doesn't burn an UPDATE; an
-            // explicit `[]` that clears a prior non-empty set DOES persist
-            // (that's the re-include path the transport must support).
-            if (
-              parsed.data.restExcludedDatasourceIds !== undefined &&
-              !sameStringSet(
-                parsed.data.restExcludedDatasourceIds,
-                existing.data.restExcludedDatasourceIds ?? [],
-              )
-            ) {
-              // Fire-and-forget, same contract as routing-mode above: the
-              // runtime honours the body's set for this turn even if the
-              // persist fails; the helper logs its own failures.
-              updateConversationRestExcluded(
-                conversationId,
-                parsed.data.restExcludedDatasourceIds,
-                authResult.user?.id,
-                authResult.user?.activeOrganizationId,
-              ).catch((err: unknown) => {
-                log.warn(
-                  {
-                    err: err instanceof Error ? err.message : String(err),
-                    conversationId,
-                  },
-                  "updateConversationRestExcluded rejected",
-                );
-              });
-            }
-            // #3067 — persist REST-only focus when the body explicitly set one
-            // this turn AND it differs from the stored value. An explicit
-            // `null` that clears a prior focus DOES persist (the clear path the
-            // transport must support); normalize the row's value with `?? null`
-            // so a string→null or null→string change is detected.
-            if (
-              parsed.data.restFocusDatasourceId !== undefined &&
-              parsed.data.restFocusDatasourceId !==
-                (existing.data.restFocusDatasourceId ?? null)
-            ) {
-              // Fire-and-forget, same contract as routing-mode / exclude-set
-              // above: the runtime honours the body's focus for this turn even
-              // if the persist fails; the helper logs its own failures.
-              updateConversationRestFocus(
-                conversationId,
-                parsed.data.restFocusDatasourceId,
-                authResult.user?.id,
-                authResult.user?.activeOrganizationId,
-              ).catch((err: unknown) => {
-                log.warn(
-                  {
-                    err: err instanceof Error ? err.message : String(err),
-                    conversationId,
-                  },
-                  "updateConversationRestFocus rejected",
-                );
-              });
-            }
-            // #3895 — persist Group reach when the body explicitly set one this
-            // turn AND it differs from the stored value. An explicit `null` that
-            // widens a prior Focus back to All sources DOES persist (the widen
-            // path the transport must support); normalize the row's value with
-            // `?? null` so a string→null or null→string change is detected.
-            if (
-              parsed.data.groupReach !== undefined &&
-              parsed.data.groupReach !== (existing.data.groupReach ?? null)
-            ) {
-              // Fire-and-forget, same contract as routing-mode / REST scope
-              // above: the runtime honours the body's reach for this turn even
-              // if the persist fails; the helper logs its own failures.
-              updateConversationGroupReach(
-                conversationId,
-                parsed.data.groupReach,
-                authResult.user?.id,
-                authResult.user?.activeOrganizationId,
-              ).catch((err: unknown) => {
-                log.warn(
-                  {
-                    err: err instanceof Error ? err.message : String(err),
-                    conversationId,
-                  },
-                  "updateConversationGroupReach rejected",
-                );
-              });
-            }
-            // #4302 — persist the answer style when the body explicitly set
-            // one this turn AND it differs from the stored value, so the
-            // choice restores on reopen. Compared against the row to avoid
-            // burning an UPDATE on every turn: the transport re-sends the
-            // style whenever its state holds one — touched this session OR
-            // restored from the row on reopen — so the reopen path is the
-            // main beneficiary of this skip-UPDATE gate.
-            if (
-              parsed.data.answerStyle !== undefined &&
-              parsed.data.answerStyle !== existing.data.answerStyle
-            ) {
-              // Fire-and-forget, same contract as routing-mode / REST scope /
-              // Group reach above: the runtime honours the body's style for
-              // this turn even if the persist fails. The helper never rejects
-              // (it catches internally and returns a CrudResult), so inspect
-              // the RESOLUTION: an `ok: false` that isn't the logged `error`
-              // arm — `not_found` (conversation deleted mid-turn, or an
-              // ownership-scope miss) — would otherwise be silent at both
-              // layers, and a style pin that didn't stick reverts the voice
-              // on reopen with zero breadcrumb.
-              updateConversationAnswerStyle(
-                conversationId,
-                parsed.data.answerStyle,
+                scopeChanges,
                 authResult.user?.id,
                 authResult.user?.activeOrganizationId,
               ).then(
                 (result) => {
                   if (!result.ok) {
                     log.warn(
-                      { conversationId, reason: result.reason },
-                      "answer-style persist did not apply — the conversation will revert to its stored voice on reopen",
+                      {
+                        conversationId,
+                        reason: result.reason,
+                        axes: Object.keys(scopeChanges),
+                      },
+                      "conversation-scope persist did not apply — the conversation will revert to its stored scope on reopen",
                     );
                   }
                 },
                 (err: unknown) => {
-                  // Contract breach only: the helper catches internally, so a
+                  // Contract breach only: the writer catches internally, so a
                   // rejection means that changed — log it rather than letting a
                   // fire-and-forget path emit an unhandled rejection.
                   log.warn(
@@ -1315,7 +1204,7 @@ chat.openapi(chatRoute, async (c) => {
                       err: err instanceof Error ? err.message : String(err),
                       conversationId,
                     },
-                    "updateConversationAnswerStyle rejected",
+                    "updateConversationScope rejected",
                   );
                 },
               );
@@ -1710,12 +1599,13 @@ chat.openapi(chatRoute, async (c) => {
               // before reaching `resolveRoutingPlan`. When neither the
               // body nor the persisted row carries a value, the
               // conversation predates the picker column (NULL on the row)
-              // — apply the back-compat default 'pin' here so the agent's
-              // scope hints don't suddenly start fanning out on
-              // pre-#2518 chats. The tool's own default ('auto') only
-              // kicks in for non-chat callers (MCP / scheduler / direct
-              // tool tests).
-              routingMode: resolveRoutingMode(effectiveRoutingMode),
+              // — `routingModeFromColumn` (#4351, the ONE decoder of that
+              // column) applies the back-compat 'pin' default here so the
+              // agent's scope hints don't suddenly start fanning out on
+              // pre-#2518 chats. `ROUTING_MODE_WITHOUT_CONVERSATION` ('auto')
+              // is the separate, documented default for callers with no
+              // conversation at all (MCP / scheduler / direct tool tests).
+              routingMode: routingModeFromColumn(effectiveRoutingMode),
               // #3066 — the resolved exclude-set reaches the REST datasource
               // resolver (agent.ts) via the request context. Stripped when
               // undefined (and when empty — an empty set excludes nothing,

--- a/packages/api/src/lib/__tests__/conversation-scope.test.ts
+++ b/packages/api/src/lib/__tests__/conversation-scope.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for the pure conversation-scope module (#4351).
+ *
+ * Pure + total by construction — no DB, no mocks. The writer that consumes
+ * these values (`updateConversationScope`) is exercised table-driven in
+ * `conversations.test.ts`.
+ */
+import { describe, it, expect } from "bun:test";
+import type { ConversationRoutingMode } from "@useatlas/types/conversation";
+import {
+  CONVERSATION_ROUTING_MODE_DEFAULT,
+  CONVERSATION_SCOPE_COLUMNS,
+  CONVERSATION_SCOPE_KEYS,
+  ROUTING_MODE_WITHOUT_CONVERSATION,
+  conversationScopeColumnValues,
+  conversationScopeFrom,
+  conversationScopePatchFrom,
+  diffConversationScope,
+  routingModeFromColumn,
+  type ConversationScope,
+} from "../conversation-scope";
+
+describe("routingModeFromColumn()", () => {
+  // Exhaustive over the column's inhabitable values: the three legal modes,
+  // both absent shapes, and the garbage a manual edit / future release could
+  // leave behind. Total — every input yields a mode, none throw.
+  const cases: ReadonlyArray<{
+    readonly label: string;
+    readonly input: unknown;
+    readonly expected: ConversationRoutingMode;
+  }> = [
+    { label: "null (the column default / pre-#2518 row)", input: null, expected: "pin" },
+    { label: "undefined (column omitted from the SELECT)", input: undefined, expected: "pin" },
+    { label: "explicit auto", input: "auto", expected: "auto" },
+    { label: "explicit pin", input: "pin", expected: "pin" },
+    { label: "explicit all", input: "all", expected: "all" },
+    { label: "unknown string (manual edit / retired mode)", input: "sideways", expected: "pin" },
+    { label: "empty string", input: "", expected: "pin" },
+    { label: "wrong type (number)", input: 3, expected: "pin" },
+    { label: "wrong type (object)", input: { mode: "all" }, expected: "pin" },
+  ];
+
+  for (const { label, input, expected } of cases) {
+    it(`decodes ${label} → "${expected}"`, () => {
+      expect(routingModeFromColumn(input)).toBe(expected);
+    });
+  }
+
+  it("uses the documented NULL default constant", () => {
+    expect(CONVERSATION_ROUTING_MODE_DEFAULT).toBe("pin");
+    expect(routingModeFromColumn(null)).toBe(CONVERSATION_ROUTING_MODE_DEFAULT);
+  });
+
+  // The two defaults answer different questions and must NOT be collapsed:
+  // "the row says nothing" (pin, back-compat for pre-#2518 chats) vs. "there
+  // is no row at all" (auto, agent-decides for MCP / scheduler / direct tool
+  // callers). Pinning the divergence here keeps a well-meaning future
+  // simplification from silently regressing one of the two.
+  it("keeps the no-conversation default distinct from the NULL-column default", () => {
+    expect(ROUTING_MODE_WITHOUT_CONVERSATION).toBe("auto");
+    expect(ROUTING_MODE_WITHOUT_CONVERSATION).not.toBe(CONVERSATION_ROUTING_MODE_DEFAULT);
+  });
+});
+
+describe("scope value + column mapping", () => {
+  it("maps every axis to a column, with no gaps", () => {
+    for (const key of CONVERSATION_SCOPE_KEYS) {
+      expect(CONVERSATION_SCOPE_COLUMNS[key]).toBeTruthy();
+    }
+    expect(Object.keys(CONVERSATION_SCOPE_COLUMNS).sort()).toEqual(
+      [...CONVERSATION_SCOPE_KEYS].sort(),
+    );
+  });
+
+  it("normalises a partial source to the persisted defaults", () => {
+    expect(conversationScopeFrom({})).toEqual({
+      routingMode: null,
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+      groupReach: null,
+      answerStyle: null,
+    });
+    expect(conversationScopeFrom(null)).toEqual(conversationScopeFrom({}));
+  });
+
+  it("carries every axis through unchanged when the source is total", () => {
+    const scope: ConversationScope = {
+      routingMode: "all",
+      restExcludedDatasourceIds: ["ds-1"],
+      restFocusDatasourceId: "ds-stripe",
+      groupReach: "g_prod",
+      answerStyle: "executive",
+    };
+    expect(conversationScopeFrom(scope)).toEqual(scope);
+  });
+
+  // AC — fork/convert style derivation inherits scope via ONE spread. The
+  // scope keys are the `createConversation` option keys by construction, so a
+  // derived conversation picks up a new axis without touching the call site.
+  it("inherits a parent conversation's scope through a single spread", () => {
+    const parent = {
+      id: "conv-parent",
+      title: "Parent",
+      routingMode: "pin" as const,
+      restExcludedDatasourceIds: ["ds-9"],
+      restFocusDatasourceId: null,
+      groupReach: "g_eu",
+      answerStyle: "analyst" as const,
+    };
+    const derived = { ...conversationScopeFrom(parent), userId: "u1", title: "Fork" };
+    for (const key of CONVERSATION_SCOPE_KEYS) {
+      expect(derived[key]).toEqual(parent[key]);
+    }
+    // …and nothing non-scope rides along on the spread.
+    expect("id" in derived).toBe(false);
+  });
+
+  it("emits column/value pairs in persisted order, omitting absent axes", () => {
+    expect(conversationScopeColumnValues({ groupReach: "g_prod", routingMode: "all" })).toEqual([
+      ["routing_mode", "all"],
+      ["group_reach", "g_prod"],
+    ]);
+    expect(conversationScopeColumnValues({})).toEqual([]);
+    // A `null` axis is a real change (clear), not an absent one.
+    expect(conversationScopeColumnValues({ restFocusDatasourceId: null })).toEqual([
+      ["rest_focus_datasource_id", null],
+    ]);
+  });
+});
+
+describe("conversationScopePatchFrom()", () => {
+  it("keeps explicitly-null axes and drops undefined ones (#3073)", () => {
+    expect(
+      conversationScopePatchFrom({
+        groupReach: null,
+        restFocusDatasourceId: undefined,
+        answerStyle: "executive",
+      }),
+    ).toEqual({ groupReach: null, answerStyle: "executive" });
+  });
+
+  it("ignores non-scope keys on the source", () => {
+    // A parsed request body carries far more than scope; only the axes are
+    // picked (the chat route hands the whole body straight in).
+    const body = { routingMode: "auto" as const, conversationId: "c1", messages: [] };
+    expect(conversationScopePatchFrom(body)).toEqual({ routingMode: "auto" });
+  });
+});
+
+describe("diffConversationScope()", () => {
+  const stored: ConversationScope = {
+    routingMode: "pin",
+    restExcludedDatasourceIds: ["ds-1", "ds-2"],
+    restFocusDatasourceId: "ds-stripe",
+    groupReach: "g_prod",
+    answerStyle: "executive",
+  };
+
+  it("returns an empty patch when the request matches the row", () => {
+    expect(diffConversationScope(stored, { ...stored })).toEqual({});
+  });
+
+  it("returns an empty patch when the request carries nothing", () => {
+    expect(diffConversationScope(stored, {})).toEqual({});
+  });
+
+  it("treats a reordered exclude-set as unchanged (set equality)", () => {
+    expect(
+      diffConversationScope(stored, { restExcludedDatasourceIds: ["ds-2", "ds-1"] }),
+    ).toEqual({});
+  });
+
+  it("treats duplicates in the exclude-set as unchanged (a set, not a list)", () => {
+    expect(
+      diffConversationScope(stored, { restExcludedDatasourceIds: ["ds-1", "ds-1", "ds-2"] }),
+    ).toEqual({});
+  });
+
+  it("detects an explicit [] that re-includes everything", () => {
+    expect(diffConversationScope(stored, { restExcludedDatasourceIds: [] })).toEqual({
+      restExcludedDatasourceIds: [],
+    });
+  });
+
+  it("detects clears (null) on the nullable axes", () => {
+    expect(
+      diffConversationScope(stored, { restFocusDatasourceId: null, groupReach: null }),
+    ).toEqual({ restFocusDatasourceId: null, groupReach: null });
+  });
+
+  it("detects the first explicit pick on a never-touched row", () => {
+    const fresh = conversationScopeFrom({});
+    expect(diffConversationScope(fresh, { answerStyle: "plain-english" })).toEqual({
+      answerStyle: "plain-english",
+    });
+    // A NULL routing_mode row reads as "pin", but the ROW is null — an
+    // explicit "pin" from the body is still a change worth persisting, so the
+    // decoded default never freezes into the row behind the user's back.
+    expect(diffConversationScope(fresh, { routingMode: "pin" })).toEqual({ routingMode: "pin" });
+  });
+
+  it("collects a multi-axis change into ONE patch", () => {
+    expect(
+      diffConversationScope(stored, {
+        routingMode: "all",
+        groupReach: null,
+        answerStyle: "executive", // unchanged — must not ride along
+      }),
+    ).toEqual({ routingMode: "all", groupReach: null });
+  });
+});

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -19,11 +19,9 @@ import {
   getShareStatus,
   getSharedConversation,
   cleanupExpiredShares,
-  updateConversationRestExcluded,
-  updateConversationRestFocus,
-  updateConversationGroupReach,
-  updateConversationAnswerStyle,
+  updateConversationScope,
 } from "../conversations";
+import type { ConversationScopePatch } from "../conversation-scope";
 
 // ---------------------------------------------------------------------------
 // Mock pool
@@ -1319,138 +1317,131 @@ describe("conversations module", () => {
       expect(queryCalls[0].params).toEqual([true, "c1", "u1", "org-B"]);
     });
 
-    // #3066 — the REST exclude-set write helper. Binds the JS array directly to
-    // the text[] column ($1), org/user-scopes the UPDATE, and returns the same
-    // fail-soft result contract as updateConversationRoutingMode.
-    it("updateConversationRestExcluded writes the array, scoped + parameterized", async () => {
-      enableInternalDB();
-      setResults({ rows: [{ id: "c1" }] });
+    // #4351 — the ONE conversation-scope writer, table-driven. Replaces the
+    // five parallel per-axis writer suites: the axis ↔ column mapping, the
+    // parameter order, and the auth-scope offset are all derived from one
+    // list, so a new axis is one row here rather than a new copied suite.
+    const scopeWriteCases: ReadonlyArray<{
+      readonly label: string;
+      readonly patch: ConversationScopePatch;
+      readonly assignments: string;
+      readonly values: readonly unknown[];
+    }> = [
+      {
+        label: "routing mode (#2518)",
+        patch: { routingMode: "all" },
+        assignments: "routing_mode = $1",
+        values: ["all"],
+      },
+      {
+        label: "REST exclude-set (#3066) — pg binds the JS array to text[]",
+        patch: { restExcludedDatasourceIds: ["ds-1", "ds-2"] },
+        assignments: "rest_excluded_datasource_ids = $1",
+        values: [["ds-1", "ds-2"]],
+      },
+      {
+        label: "REST exclude-set re-include — an explicit [] clears the set",
+        patch: { restExcludedDatasourceIds: [] },
+        assignments: "rest_excluded_datasource_ids = $1",
+        values: [[]],
+      },
+      {
+        label: "REST focus (#3067)",
+        patch: { restFocusDatasourceId: "ds-stripe" },
+        assignments: "rest_focus_datasource_id = $1",
+        values: ["ds-stripe"],
+      },
+      {
+        label: "REST focus clear — an explicit null returns to default scope",
+        patch: { restFocusDatasourceId: null },
+        assignments: "rest_focus_datasource_id = $1",
+        values: [null],
+      },
+      {
+        label: "group reach (#3895) — Focus a group",
+        patch: { groupReach: "g_prod" },
+        assignments: "group_reach = $1",
+        values: ["g_prod"],
+      },
+      {
+        label: "group reach widen — an explicit null returns to All sources",
+        patch: { groupReach: null },
+        assignments: "group_reach = $1",
+        values: [null],
+      },
+      {
+        label: "answer style (#4302)",
+        patch: { answerStyle: "executive" },
+        assignments: "answer_style = $1",
+        values: ["executive"],
+      },
+      {
+        label: "MULTI-AXIS — one atomic UPDATE, columns in persisted order",
+        patch: {
+          routingMode: "pin",
+          restFocusDatasourceId: null,
+          groupReach: "g_eu",
+          answerStyle: "plain-english",
+        },
+        assignments:
+          "routing_mode = $1, rest_focus_datasource_id = $2, group_reach = $3, answer_style = $4",
+        values: ["pin", null, "g_eu", "plain-english"],
+      },
+    ];
 
-      const result = await updateConversationRestExcluded("c1", ["ds-1", "ds-2"], "u1", "org-B");
-      expect(result).toEqual({ ok: true });
-      expect(queryCalls[0].sql).toContain("UPDATE conversations SET rest_excluded_datasource_ids = $1");
-      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
-      // $1 is the array bound directly; $2 the id; $3 user; $4 org.
-      expect(queryCalls[0].params).toEqual([["ds-1", "ds-2"], "c1", "u1", "org-B"]);
-    });
+    for (const testCase of scopeWriteCases) {
+      it(`updateConversationScope writes ${testCase.label}, scoped + parameterized`, async () => {
+        enableInternalDB();
+        setResults({ rows: [{ id: "c1" }] });
 
-    it("updateConversationRestExcluded returns not_found when no row matches (cross-org)", async () => {
+        const result = await updateConversationScope("c1", testCase.patch, "u1", "org-B");
+        expect(result).toEqual({ ok: true });
+        // Exactly ONE statement, whatever the patch width — a multi-axis
+        // change must never fan out into several fire-and-forget writes.
+        expect(queryCalls).toHaveLength(1);
+        expect(queryCalls[0].sql).toContain(`SET ${testCase.assignments}, updated_at = now()`);
+        // The id placeholder follows the SET params; the auth scope follows it.
+        const idIdx = testCase.values.length + 1;
+        expect(queryCalls[0].sql).toContain(`WHERE id = $${idIdx}`);
+        expect(queryCalls[0].sql).toContain(`user_id = $${idIdx + 1}`);
+        expect(queryCalls[0].sql).toContain(`(org_id = $${idIdx + 2} OR org_id IS NULL)`);
+        expect(queryCalls[0].params).toEqual([...testCase.values, "c1", "u1", "org-B"]);
+      });
+    }
+
+    it("updateConversationScope returns not_found when no row matches (cross-org)", async () => {
       enableInternalDB();
       setResults({ rows: [] });
 
-      const result = await updateConversationRestExcluded("c1", [], "u1", "org-B");
+      const result = await updateConversationScope("c1", { groupReach: "g_prod" }, "u1", "org-B");
       expect(result).toEqual({ ok: false, reason: "not_found" });
     });
 
-    it("updateConversationRestExcluded short-circuits to no_db when the internal DB is off", async () => {
-      // No enableInternalDB() — hasInternalDB() is false.
-      const result = await updateConversationRestExcluded("c1", ["ds-1"]);
+    it("updateConversationScope short-circuits to no_db when the internal DB is off", async () => {
+      const result = await updateConversationScope("c1", { answerStyle: "executive" });
       expect(result).toEqual({ ok: false, reason: "no_db" });
       expect(queryCalls).toHaveLength(0);
     });
 
-    // #3067 — the REST-only focus write helper. Binds the install_id (or null
-    // to clear) to the nullable text column ($1), org/user-scopes the UPDATE,
-    // and returns the same fail-soft result contract.
-    it("updateConversationRestFocus writes the install_id, scoped + parameterized", async () => {
+    // An empty patch is a no-op SUCCESS — the caller diffed first and nothing
+    // changed. It must not issue a statement (that would bump `updated_at` and
+    // reshuffle the conversation list on every turn) and must not even consult
+    // the DB availability check.
+    it("updateConversationScope no-ops (ok) on an empty patch without querying", async () => {
       enableInternalDB();
       setResults({ rows: [{ id: "c1" }] });
 
-      const result = await updateConversationRestFocus("c1", "ds-stripe", "u1", "org-B");
+      const result = await updateConversationScope("c1", {}, "u1", "org-B");
       expect(result).toEqual({ ok: true });
-      expect(queryCalls[0].sql).toContain("UPDATE conversations SET rest_focus_datasource_id = $1");
-      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
-      expect(queryCalls[0].params).toEqual(["ds-stripe", "c1", "u1", "org-B"]);
-    });
-
-    it("updateConversationRestFocus persists null to CLEAR focus (back to default scope)", async () => {
-      enableInternalDB();
-      setResults({ rows: [{ id: "c1" }] });
-
-      const result = await updateConversationRestFocus("c1", null, "u1", "org-B");
-      expect(result).toEqual({ ok: true });
-      // $1 is null — the clear path the transport must support.
-      expect(queryCalls[0].params).toEqual([null, "c1", "u1", "org-B"]);
-    });
-
-    it("updateConversationRestFocus returns not_found when no row matches (cross-org)", async () => {
-      enableInternalDB();
-      setResults({ rows: [] });
-
-      const result = await updateConversationRestFocus("c1", "ds-stripe", "u1", "org-B");
-      expect(result).toEqual({ ok: false, reason: "not_found" });
-    });
-
-    it("updateConversationRestFocus short-circuits to no_db when the internal DB is off", async () => {
-      const result = await updateConversationRestFocus("c1", "ds-stripe");
-      expect(result).toEqual({ ok: false, reason: "no_db" });
       expect(queryCalls).toHaveLength(0);
     });
 
-    // #3895 — Group reach persistence. Same org-scoped / fail-open contract as
-    // updateConversationRestFocus; uses scopeClause(3, …) so the org param lands
-    // at $4 (an off-by-one in the SQL would surface in the param assertion).
-    it("updateConversationGroupReach writes the Focus group id, scoped + parameterized", async () => {
+    it("updateConversationScope returns error and logs when the query throws", async () => {
       enableInternalDB();
-      setResults({ rows: [{ id: "c1" }] });
+      queryThrow = new Error("connection reset");
 
-      const result = await updateConversationGroupReach("c1", "g_prod", "u1", "org-B");
-      expect(result).toEqual({ ok: true });
-      expect(queryCalls[0].sql).toContain("UPDATE conversations SET group_reach = $1");
-      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
-      expect(queryCalls[0].params).toEqual(["g_prod", "c1", "u1", "org-B"]);
-    });
-
-    it("updateConversationGroupReach persists null to WIDEN back to All sources", async () => {
-      enableInternalDB();
-      setResults({ rows: [{ id: "c1" }] });
-
-      const result = await updateConversationGroupReach("c1", null, "u1", "org-B");
-      expect(result).toEqual({ ok: true });
-      // $1 is null — the widen path the transport must support (#3073).
-      expect(queryCalls[0].params).toEqual([null, "c1", "u1", "org-B"]);
-    });
-
-    it("updateConversationGroupReach returns not_found when no row matches (cross-org)", async () => {
-      enableInternalDB();
-      setResults({ rows: [] });
-
-      const result = await updateConversationGroupReach("c1", "g_prod", "u1", "org-B");
-      expect(result).toEqual({ ok: false, reason: "not_found" });
-    });
-
-    it("updateConversationGroupReach short-circuits to no_db when the internal DB is off", async () => {
-      const result = await updateConversationGroupReach("c1", "g_prod");
-      expect(result).toEqual({ ok: false, reason: "no_db" });
-      expect(queryCalls).toHaveLength(0);
-    });
-
-    // #4302 — answer-style persistence. Same org-scoped / fail-open contract
-    // as the reach helper; uses scopeClause(3, ...) so the org param lands at
-    // $4 (an off-by-one in the SQL would surface in the param assertion).
-    it("updateConversationAnswerStyle writes the style, scoped + parameterized", async () => {
-      enableInternalDB();
-      setResults({ rows: [{ id: "c1" }] });
-
-      const result = await updateConversationAnswerStyle("c1", "executive", "u1", "org-B");
-      expect(result).toEqual({ ok: true });
-      expect(queryCalls[0].sql).toContain("UPDATE conversations SET answer_style = $1");
-      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
-      expect(queryCalls[0].params).toEqual(["executive", "c1", "u1", "org-B"]);
-    });
-
-    it("updateConversationAnswerStyle returns not_found when no row matches (cross-org)", async () => {
-      enableInternalDB();
-      setResults({ rows: [] });
-
-      const result = await updateConversationAnswerStyle("c1", "executive", "u1", "org-B");
-      expect(result).toEqual({ ok: false, reason: "not_found" });
-    });
-
-    it("updateConversationAnswerStyle short-circuits to no_db when the internal DB is off", async () => {
-      const result = await updateConversationAnswerStyle("c1", "executive");
-      expect(result).toEqual({ ok: false, reason: "no_db" });
-      expect(queryCalls).toHaveLength(0);
+      const result = await updateConversationScope("c1", { groupReach: "g_prod" }, "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "error" });
     });
 
     it("shareConversation scopes the preflight SELECT by orgId (shareMode='org')", async () => {

--- a/packages/api/src/lib/conversation-scope.ts
+++ b/packages/api/src/lib/conversation-scope.ts
@@ -1,0 +1,276 @@
+/**
+ * Conversation **scope** — the per-conversation policy value that decides
+ * where a turn may read from and how it answers (ADR-0011, ADR-0022).
+ *
+ * Scope is a first-class domain concept with, until #4351, no code home: it
+ * lived as a loose bag of columns written by five byte-identical-bar-the-column
+ * writers, hand-copied into every `INSERT INTO conversations`, and re-derived
+ * field-by-field in the chat route. Every new axis had to touch all of them
+ * (`#2518 → #3066 → #3067 → #3895 → #4302`). This module is the seam: one
+ * value, one patch type, one column mapping, one diff, one total `routing_mode`
+ * decoder. The writer itself lives next to the table it writes
+ * (`lib/conversations.ts` — it needs that module's private auth `scopeClause`
+ * and its `CrudResult` contract); everything here is **pure**.
+ *
+ * The axes, in persisted order:
+ *
+ * | key                         | column                        | issue | null means                        |
+ * |-----------------------------|-------------------------------|-------|-----------------------------------|
+ * | `routingMode`               | `routing_mode`                | #2518 | back-compat `"pin"` (see below)   |
+ * | `restExcludedDatasourceIds` | `rest_excluded_datasource_ids`| #3066 | (never null — `[]` = nothing out) |
+ * | `restFocusDatasourceId`     | `rest_focus_datasource_id`    | #3067 | not focused                       |
+ * | `groupReach`                | `group_reach`                 | #3895 | All sources (ADR-0022)            |
+ * | `answerStyle`               | `answer_style`                | #4302 | no explicit choice → live default |
+ *
+ * Modelled on `lib/group-reach/index.ts` (`reachStateFromColumn`): a pure,
+ * total column decoder consumed uniformly, so the column's meaning can never
+ * depend on which caller reads it.
+ */
+
+import type { AnswerStyle } from "@atlas/api/lib/answer-styles";
+import type { ConversationRoutingMode } from "@useatlas/types/conversation";
+
+// ---------------------------------------------------------------------------
+// routing_mode — the one decoder
+// ---------------------------------------------------------------------------
+
+/**
+ * The `routing_mode` a conversation has when its column is NULL.
+ *
+ * `"pin"` — a NULL column is a row that predates the #2518 picker (or a
+ * caller that never offered one). Reading it as `"pin"` preserves pre-#2518
+ * single-execution semantics: the agent's `scope` hints don't suddenly start
+ * fanning out queries across every member of the conversation's group.
+ */
+export const CONVERSATION_ROUTING_MODE_DEFAULT: ConversationRoutingMode = "pin";
+
+/**
+ * The routing mode a caller runs under when there is **no conversation at
+ * all** — the direct-tool surfaces (MCP, scheduler, unit tests) that never go
+ * through the chat route and therefore never carry a `routing_mode` column.
+ *
+ * `"auto"` — "the agent decides": the tool honours the agent's own `scope`
+ * argument, which is the whole point of those surfaces. This is deliberately
+ * **not** {@link CONVERSATION_ROUTING_MODE_DEFAULT}: the two constants answer
+ * different questions ("the row says nothing" vs. "there is no row"), and
+ * collapsing them would either freeze MCP/scheduler callers into `pin` (losing
+ * agent-decided fanout) or fan legacy chats out (the regression #2518 guarded).
+ * Naming both here, side by side, is what keeps the divergence a documented
+ * decision instead of the accident it was — pre-#4351 the `"pin"` default lived
+ * in `lib/conversations.ts` and the `"auto"` default was an inline `?? "auto"`
+ * literal in `lib/tools/`, and nothing said they were different questions.
+ */
+export const ROUTING_MODE_WITHOUT_CONVERSATION: ConversationRoutingMode = "auto";
+
+/**
+ * Decode a persisted `conversations.routing_mode` value into the runtime
+ * three-state union. **Pure and total** — every input shape produces a mode,
+ * never throws.
+ *
+ * NULL / undefined / an unrecognised string (a manual edit, a value from a
+ * future release) all decode to {@link CONVERSATION_ROUTING_MODE_DEFAULT}.
+ * This is the *only* decoder of that column; callers must not re-derive a
+ * default of their own.
+ *
+ * Web's `effectiveMode` helper in `chat/env-picker.tsx` mirrors this default
+ * for the picker's trigger label. Drift between them is a UX bug, not a
+ * correctness bug, so the duplication is acceptable until web can import
+ * api-internal helpers (which it deliberately cannot per CLAUDE.md "frontend
+ * is a pure HTTP client").
+ */
+export function routingModeFromColumn(value: unknown): ConversationRoutingMode {
+  return value === "auto" || value === "pin" || value === "all"
+    ? value
+    : CONVERSATION_ROUTING_MODE_DEFAULT;
+}
+
+// ---------------------------------------------------------------------------
+// The value
+// ---------------------------------------------------------------------------
+
+/**
+ * A conversation's scope, in its **persisted** representation — the exact
+ * shape of the row's scope columns, nulls and all. Total: every axis is
+ * present, so a new axis is a compile error at every producer rather than a
+ * silently dropped field.
+ *
+ * Deliberately NOT the resolved runtime shape: `routingMode` stays nullable
+ * here so "the row predates the picker" survives to the edge that decodes it
+ * ({@link routingModeFromColumn}). Baking the default into the value would
+ * make a NULL row indistinguishable from an explicit `"pin"` and quietly
+ * freeze the default into the next write.
+ */
+export interface ConversationScope {
+  /** #2518 — intra-group member routing. NULL ⇒ {@link routingModeFromColumn}. */
+  readonly routingMode: ConversationRoutingMode | null;
+  /** #3066 — excluded REST datasource `install_id`s. `[]` ⇒ nothing excluded. */
+  readonly restExcludedDatasourceIds: string[];
+  /** #3067 — REST-only focus (`install_id`); null ⇒ not focused. */
+  readonly restFocusDatasourceId: string | null;
+  /** #3895 — cross-group reach (ADR-0022); null ⇒ All sources. */
+  readonly groupReach: string | null;
+  /** #4302 — editorial voice; null ⇒ no explicit choice (track the default). */
+  readonly answerStyle: AnswerStyle | null;
+}
+
+/**
+ * A partial scope change. **Key presence is the signal**: a key that is absent
+ * (or `undefined`) is untouched; a key present with `null` *clears* that axis.
+ * That distinction is the transport-omits-null bug class (#3073) — an explicit
+ * `null` groupReach widens to All sources, an omitted one inherits the row.
+ */
+export type ConversationScopePatch = {
+  -readonly [K in keyof ConversationScope]?: ConversationScope[K];
+};
+
+/** The scope axes, in persisted column order. Drives the INSERT and the UPDATE. */
+export const CONVERSATION_SCOPE_KEYS = [
+  "routingMode",
+  "restExcludedDatasourceIds",
+  "restFocusDatasourceId",
+  "groupReach",
+  "answerStyle",
+] as const satisfies readonly (keyof ConversationScope)[];
+
+/** Scope axis → its `conversations` column. The single statement of the mapping. */
+export const CONVERSATION_SCOPE_COLUMNS: {
+  readonly [K in keyof ConversationScope]: string;
+} = {
+  routingMode: "routing_mode",
+  restExcludedDatasourceIds: "rest_excluded_datasource_ids",
+  restFocusDatasourceId: "rest_focus_datasource_id",
+  groupReach: "group_reach",
+  answerStyle: "answer_style",
+};
+
+/**
+ * Loosely-typed source for {@link conversationScopeFrom} — a row read back
+ * from the DB, a wire type, a create-options bag. Every axis is optional and
+ * nullable, because each of those shapes spells "absent" differently.
+ */
+export type ConversationScopeSource = {
+  readonly [K in keyof ConversationScope]?: ConversationScope[K] | null | undefined;
+};
+
+/**
+ * Normalise any scope-bearing source (a `Conversation` read back from the DB,
+ * a create-options bag, a request body) into a total {@link ConversationScope}
+ * with the persisted defaults applied.
+ *
+ * This is the **one spread** a derived conversation inherits scope through:
+ * `createConversation({ ...conversationScopeFrom(parent), userId, title })`.
+ * The scope keys are the create-options keys by construction, so a new axis
+ * is inherited without touching the derivation site.
+ */
+export function conversationScopeFrom(
+  source: ConversationScopeSource | null | undefined,
+): ConversationScope {
+  return {
+    routingMode: source?.routingMode ?? null,
+    restExcludedDatasourceIds: Array.isArray(source?.restExcludedDatasourceIds)
+      ? source.restExcludedDatasourceIds
+      : [],
+    restFocusDatasourceId: source?.restFocusDatasourceId ?? null,
+    groupReach: source?.groupReach ?? null,
+    answerStyle: source?.answerStyle ?? null,
+  };
+}
+
+/**
+ * Pick the scope axes a source **explicitly carries** into a patch — the
+ * request-body → patch adapter. `undefined` values are dropped (absent =
+ * inherit); `null` values are kept (present = clear).
+ */
+export function conversationScopePatchFrom(
+  source: ConversationScopePatch,
+): ConversationScopePatch {
+  // Per-axis assignment rather than a keyed loop: a generic
+  // `patch[key] = source[key]` widens every axis to the union of all axis
+  // types and needs a cast to land. Five explicit lines type-check exactly,
+  // and the compiler flags a new axis here the moment it joins the value.
+  const patch: ConversationScopePatch = {};
+  if (source.routingMode !== undefined) patch.routingMode = source.routingMode;
+  if (source.restExcludedDatasourceIds !== undefined) {
+    patch.restExcludedDatasourceIds = source.restExcludedDatasourceIds;
+  }
+  if (source.restFocusDatasourceId !== undefined) {
+    patch.restFocusDatasourceId = source.restFocusDatasourceId;
+  }
+  if (source.groupReach !== undefined) patch.groupReach = source.groupReach;
+  if (source.answerStyle !== undefined) patch.answerStyle = source.answerStyle;
+  return patch;
+}
+
+/**
+ * #3066 — order-independent equality for two id sets, used to decide whether
+ * the requested REST exclude-set differs from the stored one before burning
+ * an UPDATE. Duplicates collapse (a set, not a list), so `["a","a"]` and
+ * `["a"]` compare equal — correct for an exclude-set keyed on `install_id`.
+ */
+function sameIdSet(a: readonly string[], b: readonly string[]): boolean {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size !== setB.size) return false;
+  for (const id of setA) if (!setB.has(id)) return false;
+  return true;
+}
+
+/**
+ * Narrow a requested patch to the axes that would actually change `current`.
+ *
+ * Returns an empty patch when nothing differs, so the caller can skip the
+ * UPDATE entirely — every chat turn re-sends the picker state, and burning a
+ * write per turn is what the five per-field `!==` guards existed to avoid.
+ * The exclude-set compares as a set (a reorder is not a change); an explicit
+ * `[]` that clears a non-empty set IS a change (the re-include path).
+ */
+export function diffConversationScope(
+  current: ConversationScope,
+  requested: ConversationScopePatch,
+): ConversationScopePatch {
+  const changed: ConversationScopePatch = {};
+  if (
+    requested.routingMode !== undefined &&
+    requested.routingMode !== current.routingMode
+  ) {
+    changed.routingMode = requested.routingMode;
+  }
+  if (
+    requested.restExcludedDatasourceIds !== undefined &&
+    !sameIdSet(requested.restExcludedDatasourceIds, current.restExcludedDatasourceIds)
+  ) {
+    changed.restExcludedDatasourceIds = requested.restExcludedDatasourceIds;
+  }
+  if (
+    requested.restFocusDatasourceId !== undefined &&
+    requested.restFocusDatasourceId !== current.restFocusDatasourceId
+  ) {
+    changed.restFocusDatasourceId = requested.restFocusDatasourceId;
+  }
+  if (
+    requested.groupReach !== undefined &&
+    requested.groupReach !== current.groupReach
+  ) {
+    changed.groupReach = requested.groupReach;
+  }
+  if (
+    requested.answerStyle !== undefined &&
+    requested.answerStyle !== current.answerStyle
+  ) {
+    changed.answerStyle = requested.answerStyle;
+  }
+  return changed;
+}
+
+/**
+ * The `(column, value)` pairs a patch writes, in persisted column order.
+ * Absent / `undefined` axes are omitted — the shared basis for both the
+ * `UPDATE … SET` list and the `INSERT` column list.
+ */
+export function conversationScopeColumnValues(
+  patch: ConversationScopePatch,
+): readonly (readonly [column: string, value: unknown])[] {
+  return CONVERSATION_SCOPE_KEYS.filter((key) => patch[key] !== undefined).map(
+    (key) => [CONVERSATION_SCOPE_COLUMNS[key], patch[key]] as const,
+  );
+}

--- a/packages/api/src/lib/conversation-scope.ts
+++ b/packages/api/src/lib/conversation-scope.ts
@@ -79,9 +79,26 @@ export const ROUTING_MODE_WITHOUT_CONVERSATION: ConversationRoutingMode = "auto"
  * is a pure HTTP client").
  */
 export function routingModeFromColumn(value: unknown): ConversationRoutingMode {
-  return value === "auto" || value === "pin" || value === "all"
+  return isConversationRoutingMode(value)
     ? value
     : CONVERSATION_ROUTING_MODE_DEFAULT;
+}
+
+/**
+ * Type guard for the three legal routing modes — the single statement of
+ * which values the column may hold. Keeps an unknown DB string (a manual
+ * edit, a mode from a future release) from leaking into the typed union.
+ *
+ * Distinct from {@link routingModeFromColumn} on purpose: the guard preserves
+ * "this row says nothing" as a *representable* state, which the read mapper
+ * (`rowToConversation`) needs so the chat route can tell "user picked Auto"
+ * from "row predates the column". The default lands at the routing edge, not
+ * at the read.
+ */
+export function isConversationRoutingMode(
+  value: unknown,
+): value is ConversationRoutingMode {
+  return value === "auto" || value === "pin" || value === "all";
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -16,6 +16,7 @@ import { isAnswerStyle, type AnswerStyle } from "@atlas/api/lib/answer-styles";
 import {
   conversationScopeColumnValues,
   conversationScopeFrom,
+  isConversationRoutingMode,
   type ConversationScopePatch,
 } from "@atlas/api/lib/conversation-scope";
 import {
@@ -185,13 +186,6 @@ function readAnswerStyleColumn(r: Record<string, unknown>): AnswerStyle | null {
   return null;
 }
 
-/** Type guard — keeps an unknown DB string from leaking into a typed union. */
-function isConversationRoutingMode(
-  value: unknown,
-): value is import("@useatlas/types/conversation").ConversationRoutingMode {
-  return value === "auto" || value === "pin" || value === "all";
-}
-
 /** Generate a short title from the first user question. */
 export function generateTitle(question: string): string {
   const cleaned = question.replace(/[\r\n]+/g, " ").trim();
@@ -298,7 +292,7 @@ export async function createConversation(opts: {
  *
  * Replaces the five per-field writers it grew out of (#2518 / #3066 / #3067 /
  * #3895 / #4302), which were byte-identical bar the column name and — worse —
- * meant a multi-axis change from one chat turn issued up to four independent
+ * meant a multi-axis change from one chat turn issued up to five independent
  * fire-and-forget writes that could land, or fail, individually. One statement
  * means the row never observes a half-applied scope.
  *
@@ -314,6 +308,13 @@ export async function createConversation(opts: {
  * `undefined` axes are untouched; an axis present with `null` clears it
  * (widen reach to All sources, clear REST focus, …). pg binds the JS
  * `string[]` directly to the `text[]` exclude-set column.
+ *
+ * @security The SET list is assembled from column names, but none of them
+ * are caller-supplied: `conversationScopeColumnValues` only ever emits
+ * `CONVERSATION_SCOPE_COLUMNS` values, a closed module constant keyed by
+ * `CONVERSATION_SCOPE_KEYS`. An unknown key on the patch yields no column and
+ * no parameter. Every *value* is bound, never interpolated, and the auth
+ * scope is the same parameterised {@link scopeClause} every other writer uses.
  */
 export async function updateConversationScope(
   id: string,

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -14,6 +14,11 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { isAnswerStyle, type AnswerStyle } from "@atlas/api/lib/answer-styles";
 import {
+  conversationScopeColumnValues,
+  conversationScopeFrom,
+  type ConversationScopePatch,
+} from "@atlas/api/lib/conversation-scope";
+import {
   hasInternalDB,
   internalQuery,
   internalExecute,
@@ -97,28 +102,6 @@ export type CrudDataResult<T> = { ok: true; data: T } | { ok: false; reason: Cru
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Resolve a persisted `routing_mode` value into the runtime three-state
- * union, applying the documented NULL → `"pin"` back-compat default.
- *
- * Centralises the default in one place — pre-fix, the chat route resolved
- * NULL → "pin" while `tools/sql.ts` resolved missing-routingMode → "auto",
- * which is a real correctness gap for any caller that didn't go through
- * the chat route's stamping step (MCP, scheduler, unit tests).
- *
- * Web's `effectiveMode` helper in `chat/env-picker.tsx` must mirror this
- * default — the picker UI converts NULL → "pin" for the trigger label
- * and the mode-row highlight. Drift between them is a UX bug, not a
- * correctness bug, so the duplication is acceptable until web can import
- * api-internal helpers (which it deliberately cannot per CLAUDE.md
- * "frontend is a pure HTTP client").
- */
-export function resolveRoutingMode(
-  stored: import("@useatlas/types/conversation").ConversationRoutingMode | null | undefined,
-): import("@useatlas/types/conversation").ConversationRoutingMode {
-  return stored ?? "pin";
-}
 
 function rowToConversation(r: Record<string, unknown>): Conversation {
   return {
@@ -274,55 +257,33 @@ export async function createConversation(opts: {
   orgId?: string | null;
 }): Promise<{ id: string } | null> {
   if (!hasInternalDB()) return null;
-  // #3066 — null/undefined ⇒ let the column default ('{}') apply; an
-  // explicit [] is equivalent (nothing excluded). pg binds a JS string[]
-  // directly to the text[] column.
-  const restExcluded = opts.restExcludedDatasourceIds ?? [];
-  // #3067 — null/undefined ⇒ persist NULL ("not focused").
-  const restFocus = opts.restFocusDatasourceId ?? null;
-  // #3895 — null/undefined ⇒ persist NULL ("All sources").
-  const groupReach = opts.groupReach ?? null;
-  // #4302 — null/undefined ⇒ persist NULL ("no explicit choice").
-  const answerStyle = opts.answerStyle ?? null;
+  // #4351 — the scope axes (`routing_mode`, the two REST-scope columns,
+  // `group_reach`, `answer_style`) come from ONE normalised value, so a new
+  // axis lands in `lib/conversation-scope.ts` and nothing here changes. The
+  // normalisation is the per-axis persisted default: `[]` for the exclude-set
+  // (nothing excluded), NULL for the rest (not focused / All sources / no
+  // explicit choice / read as the back-compat routing default).
+  const scope = conversationScopeFrom(opts);
   try {
-    const rows = opts.id
-      ? await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, answer_style, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    // One column list for both the caller-supplied-id and generated-id
+    // branches — the `id` column is the only difference, and hand-copying the
+    // 11-column list twice is exactly the tax #4351 removes.
+    const fields: (readonly [column: string, value: unknown])[] = [
+      ...(opts.id ? [["id", opts.id] as const] : []),
+      ["user_id", opts.userId ?? null],
+      ["title", opts.title ?? null],
+      ["surface", opts.surface ?? "web"],
+      ["connection_id", opts.connectionId ?? null],
+      ["connection_group_id", opts.connectionGroupId ?? null],
+      ...conversationScopeColumnValues(scope),
+      ["org_id", opts.orgId ?? null],
+    ];
+    const rows = await internalQuery<{ id: string }>(
+      `INSERT INTO conversations (${fields.map(([column]) => column).join(", ")})
+           VALUES (${fields.map((_, i) => `$${i + 1}`).join(", ")})
            RETURNING id`,
-          [
-            opts.id,
-            opts.userId ?? null,
-            opts.title ?? null,
-            opts.surface ?? "web",
-            opts.connectionId ?? null,
-            opts.connectionGroupId ?? null,
-            opts.routingMode ?? null,
-            restExcluded,
-            restFocus,
-            groupReach,
-            answerStyle,
-            opts.orgId ?? null,
-          ],
-        )
-      : await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, group_reach, answer_style, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-           RETURNING id`,
-          [
-            opts.userId ?? null,
-            opts.title ?? null,
-            opts.surface ?? "web",
-            opts.connectionId ?? null,
-            opts.connectionGroupId ?? null,
-            opts.routingMode ?? null,
-            restExcluded,
-            restFocus,
-            groupReach,
-            answerStyle,
-            opts.orgId ?? null,
-          ],
-        );
+      fields.map(([, value]) => value),
+    );
     return rows[0] ?? null;
   } catch (err) {
     log.error({ err: errorMessage(err) }, "createConversation failed");
@@ -331,148 +292,59 @@ export async function createConversation(opts: {
 }
 
 /**
- * #2518 — update the conversation's `routing_mode`. Returns { ok: true }
- * on a row update, `not_found` when the conversation doesn't belong to
- * the caller (scoped via {@link scopeClause}). Fail-open semantics
- * match the rest of this file: a no-DB / error result is logged but the
- * chat turn still proceeds (the row stays at its previous value and the
- * runtime falls back to its read-side default).
+ * #4351 — the **single** conversation-scope writer. Applies a
+ * {@link ConversationScopePatch} (routing mode / REST exclude-set / REST
+ * focus / group reach / answer style) as **one** org-scoped, atomic UPDATE.
+ *
+ * Replaces the five per-field writers it grew out of (#2518 / #3066 / #3067 /
+ * #3895 / #4302), which were byte-identical bar the column name and — worse —
+ * meant a multi-axis change from one chat turn issued up to four independent
+ * fire-and-forget writes that could land, or fail, individually. One statement
+ * means the row never observes a half-applied scope.
+ *
+ * Contract, unchanged from the writers it replaces:
+ *   - Auth-scoped via {@link scopeClause} — `not_found` when the row isn't the
+ *     caller's (a cross-org / cross-user id is indistinguishable from missing).
+ *   - Fail-open: a `no_db` / `error` result is logged but never throws; the
+ *     chat turn still proceeds honouring the request body for this turn.
+ *   - An **empty patch is a no-op success** (`{ ok: true }`, no statement
+ *     issued) — the caller diffs first (`diffConversationScope`) and a turn
+ *     that changes nothing must not burn a write.
+ *
+ * `undefined` axes are untouched; an axis present with `null` clears it
+ * (widen reach to All sources, clear REST focus, …). pg binds the JS
+ * `string[]` directly to the `text[]` exclude-set column.
  */
-export async function updateConversationRoutingMode(
+export async function updateConversationScope(
   id: string,
-  routingMode: import("@useatlas/types/conversation").ConversationRoutingMode,
+  patch: ConversationScopePatch,
   userId?: string | null,
   orgId?: string | null,
 ): Promise<CrudResult> {
+  const fields = conversationScopeColumnValues(patch);
+  if (fields.length === 0) return { ok: true };
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
-    const scope = scopeClause(3, userId, orgId);
+    // $1..$n are the scope columns, $n+1 is the id, the auth scope follows.
+    const idIdx = fields.length + 1;
+    const scope = scopeClause(idIdx + 1, userId, orgId);
+    const assignments = fields
+      .map(([column], i) => `${column} = $${i + 1}`)
+      .join(", ");
     const rows = await internalQuery<{ id: string }>(
-      `UPDATE conversations SET routing_mode = $1, updated_at = now()
-       WHERE id = $2${scope.sql} RETURNING id`,
-      [routingMode, id, ...scope.params],
-    );
-    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
-  } catch (err) {
-    log.error({ err: errorMessage(err) }, "updateConversationRoutingMode failed");
-    return { ok: false, reason: "error" };
-  }
-}
-
-/**
- * #3066 — update the conversation's `rest_excluded_datasource_ids`. Same
- * fail-open / org-scoped contract as {@link updateConversationRoutingMode}:
- * a no-DB / error result is logged but the chat turn still proceeds (the
- * runtime honours the body's exclude-set for this turn even if the persist
- * fails). pg binds the JS string[] directly to the text[] column; `[]`
- * clears any prior exclusion (re-includes everything).
- */
-export async function updateConversationRestExcluded(
-  id: string,
-  restExcludedDatasourceIds: string[],
-  userId?: string | null,
-  orgId?: string | null,
-): Promise<CrudResult> {
-  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
-  try {
-    const scope = scopeClause(3, userId, orgId);
-    const rows = await internalQuery<{ id: string }>(
-      `UPDATE conversations SET rest_excluded_datasource_ids = $1, updated_at = now()
-       WHERE id = $2${scope.sql} RETURNING id`,
-      [restExcludedDatasourceIds, id, ...scope.params],
-    );
-    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
-  } catch (err) {
-    log.error({ err: errorMessage(err) }, "updateConversationRestExcluded failed");
-    return { ok: false, reason: "error" };
-  }
-}
-
-/**
- * #3067 — update the conversation's `rest_focus_datasource_id`. Same
- * fail-open / org-scoped contract as {@link updateConversationRestExcluded}.
- * Pass an `install_id` to focus that datasource (suspends `executeSQL`), or
- * `null` to clear focus (return to default scope — SQL routing + exclude-set
- * apply again). pg binds the string|null directly to the nullable text column.
- */
-export async function updateConversationRestFocus(
-  id: string,
-  restFocusDatasourceId: string | null,
-  userId?: string | null,
-  orgId?: string | null,
-): Promise<CrudResult> {
-  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
-  try {
-    const scope = scopeClause(3, userId, orgId);
-    const rows = await internalQuery<{ id: string }>(
-      `UPDATE conversations SET rest_focus_datasource_id = $1, updated_at = now()
-       WHERE id = $2${scope.sql} RETURNING id`,
-      [restFocusDatasourceId, id, ...scope.params],
-    );
-    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
-  } catch (err) {
-    log.error({ err: errorMessage(err) }, "updateConversationRestFocus failed");
-    return { ok: false, reason: "error" };
-  }
-}
-
-/**
- * #3895 (ADR-0022) — update the conversation's `group_reach`. Same fail-open /
- * org-scoped contract as {@link updateConversationRestFocus}: a no-DB / error
- * result is logged but the chat turn still proceeds (the runtime honours the
- * body's reach for this turn even if the persist fails). Pass a
- * `connection_group_id` to Focus that group (hard/exclusive — only it is
- * reachable), or `null` to widen back to All sources (every visible group
- * reachable). pg binds the string|null directly to the nullable text column.
- */
-export async function updateConversationGroupReach(
-  id: string,
-  groupReach: string | null,
-  userId?: string | null,
-  orgId?: string | null,
-): Promise<CrudResult> {
-  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
-  try {
-    const scope = scopeClause(3, userId, orgId);
-    const rows = await internalQuery<{ id: string }>(
-      `UPDATE conversations SET group_reach = $1, updated_at = now()
-       WHERE id = $2${scope.sql} RETURNING id`,
-      [groupReach, id, ...scope.params],
-    );
-    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
-  } catch (err) {
-    log.error({ err: errorMessage(err) }, "updateConversationGroupReach failed");
-    return { ok: false, reason: "error" };
-  }
-}
-
-/**
- * #4302 — update the conversation's `answer_style` (the editorial voice of
- * the agent's answers — lib/answer-styles.ts). Same fail-open / org-scoped
- * contract as {@link updateConversationRoutingMode}: a no-DB / error result
- * is logged but the chat turn still proceeds (the runtime honours the
- * body's style for this turn even if the persist fails). The chat route's
- * Zod schema is the validation seam — only registry names reach here.
- */
-export async function updateConversationAnswerStyle(
-  id: string,
-  answerStyle: AnswerStyle,
-  userId?: string | null,
-  orgId?: string | null,
-): Promise<CrudResult> {
-  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
-  try {
-    const scope = scopeClause(3, userId, orgId);
-    const rows = await internalQuery<{ id: string }>(
-      `UPDATE conversations SET answer_style = $1, updated_at = now()
-       WHERE id = $2${scope.sql} RETURNING id`,
-      [answerStyle, id, ...scope.params],
+      `UPDATE conversations SET ${assignments}, updated_at = now()
+       WHERE id = $${idIdx}${scope.sql} RETURNING id`,
+      [...fields.map(([, value]) => value), id, ...scope.params],
     );
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error(
-      { err: errorMessage(err), conversationId: id },
-      "updateConversationAnswerStyle failed",
+      {
+        err: errorMessage(err),
+        conversationId: id,
+        columns: fields.map(([column]) => column),
+      },
+      "updateConversationScope failed",
     );
     return { ok: false, reason: "error" };
   }

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -136,11 +136,9 @@ void mock.module("@atlas/api/lib/conversations", () => ({
   getSharedConversation: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
-  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationGroupReach: mock(() => Promise.resolve({ ok: true as const })),
-  updateConversationAnswerStyle: mock(() => Promise.resolve({ ok: true as const })),
+  // #4351 — the single conversation-scope write path. No-op success by
+  // default; tests that exercise a picker toggle override locally.
+  updateConversationScope: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/lib/tools/sql-execution-plan.ts
+++ b/packages/api/src/lib/tools/sql-execution-plan.ts
@@ -59,6 +59,7 @@ import {
   type ReachState,
 } from "@atlas/api/lib/group-reach";
 import { resolveReachableGroups } from "@atlas/api/lib/group-reach/resolve";
+import { ROUTING_MODE_WITHOUT_CONVERSATION } from "@atlas/api/lib/conversation-scope";
 import {
   resolveExecutionTarget,
   type ExecutionTarget,
@@ -262,9 +263,13 @@ export async function resolveSqlExecutionPlan(
     groupTargetMember ?? connectionId ?? reqCtx?.connectionId ?? "default";
 
   // #2518 — three-state picker. Undefined here means the caller never went
-  // through the chat route (tools / MCP / scheduler / unit tests), where the
-  // legacy "agent decides" (`auto`) semantics are the right answer.
-  const routingMode = reqCtx?.routingMode ?? "auto";
+  // through the chat route (tools / MCP / scheduler / unit tests), i.e. there
+  // is no conversation and therefore no `routing_mode` column to decode, where
+  // the legacy "agent decides" semantics are the right answer. #4351 — this is
+  // deliberately NOT the NULL-column default (`routingModeFromColumn` → 'pin');
+  // both constants live side by side in `lib/conversation-scope.ts` with the
+  // rationale for why the two questions get different answers.
+  const routingMode = reqCtx?.routingMode ?? ROUTING_MODE_WITHOUT_CONVERSATION;
 
   // --- 3. Fast path — only when EVERY override path collapses to "single
   // execution against currentMember": the agent emitted no scope (or "this")

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -53,6 +53,7 @@ import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
 import { appendRowLimit, hasLimitClause } from "./auto-limit";
 import { type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { resolveExecutionTarget, type ExecutionTarget } from "@atlas/api/lib/group-reach/execution-target";
+import { ROUTING_MODE_WITHOUT_CONVERSATION } from "@atlas/api/lib/conversation-scope";
 import { resolveSqlExecutionPlan } from "./sql-execution-plan";
 import { mergeMemberResults, type ConnectionContribution } from "@atlas/api/lib/multi-env-merger";
 import type { ExecuteSqlSuccessResult, ExecuteSqlFailureResult } from "@useatlas/types";
@@ -1334,7 +1335,10 @@ export function buildSqlExecuteSpanAttrs(opts: {
   const attrs: Record<string, string | number | boolean> = {
     "db.system": opts.dbType,
     "atlas.connection_id": opts.connectionId,
-    "atlas.routing_mode": opts.routingMode ?? "auto",
+    // #4351 — no routing mode threaded ⇒ the caller has no conversation
+    // (direct tool / MCP / scheduler); attribute the span to the same
+    // documented default the planner uses for that case.
+    "atlas.routing_mode": opts.routingMode ?? ROUTING_MODE_WITHOUT_CONVERSATION,
   };
   if (opts.connectionGroupId) {
     attrs["atlas.connection_group_id"] = opts.connectionGroupId;


### PR DESCRIPTION
Closes #4351.

Conversation **scope** (SQL routing + REST scope + cross-group reach + answer voice — ADR-0011, ADR-0022) was a first-class domain concept with no code home. It lived as a loose column bag:

- five `updateConversationX` writers, byte-identical bar the column name;
- an 11-column `INSERT INTO conversations` hand-copied across the id / no-id branches;
- five parallel declare→inherit→persist-if-changed blocks in the chat route;
- and a `routing_mode` decoder that disagreed with itself.

The `#2518 / #3066 / #3067 / #3895 / #4302` breadcrumbs at every one of those sites are the receipt: each new axis had to touch all of them.

## What changed

**New pure module `packages/api/src/lib/conversation-scope.ts`** — modelled on `group-reach/index.ts`'s `reachStateFromColumn`:

| export | role |
|---|---|
| `ConversationScope` | the total, persisted-shape value (5 axes) |
| `ConversationScopePatch` | partial change; key **presence** is the signal (`null` = clear, absent = inherit — #3073) |
| `CONVERSATION_SCOPE_KEYS` / `_COLUMNS` | the one axis list + the one axis→column mapping |
| `routingModeFromColumn` | the one **total** decoder |
| `isConversationRoutingMode` | the one statement of the legal values |
| `conversationScopeFrom` | normalise any source → total value (**the one spread** a derived conversation inherits through) |
| `conversationScopePatchFrom` | request-body → patch |
| `diffConversationScope` | patch → only-what-changed |
| `conversationScopeColumnValues` | `(column, value)` pairs — shared basis for the INSERT and the UPDATE |

**One writer.** `updateConversationScope(id, patch, userId, orgId)` replaces the five per-axis writers: a single diffed, org-scoped, **atomic** UPDATE. Previously a turn that changed reach *and* voice issued two independent fire-and-forget writes that could land — or fail — separately, leaving the row half-applied. An empty patch is a no-op success (no statement, no `updated_at` bump).

**One INSERT.** `createConversation` derives its column list from the shared axis list; the two hand-copied 11-column branches collapse to one.

**One chat-route block.** Five persist guards → `diffConversationScope(conversationScopeFrom(existing.data), conversationScopePatchFrom(parsed.data))` + one write. The answer-style path's `!result.ok` breadcrumb (a `not_found` that would otherwise be silent at both layers) now covers every axis. The route's local `sameStringSet` moves into the module as the exclude-set comparator, duplicates-collapse semantics preserved exactly.

## The NULL-decode decision — please read this bit

The issue frames `routing_mode` as split-brain: NULL → `"pin"` in `conversations.ts`, `"auto"` in `sql.ts`. Reading the two sites closely, they are **not the same question**:

- `conversations.ts` decoded the **persisted column**. NULL there means *"this row predates the #2518 picker."*
- `sql.ts` / `sql-execution-plan.ts` decoded an **absent `RequestContext.routingMode`**. No column is in play at all — the caller (MCP, scheduler, a direct tool test) has **no conversation**.

Collapsing them to one value necessarily regresses one side:

- unify on `"pin"` → MCP/scheduler/direct-tool callers lose agent-decided fanout (`pin` overrides the agent's `scope`);
- unify on `"auto"` → legacy NULL-column chats start honouring `scope: "all"` and fan out across every member of their group — precisely the regression #2518's `"pin"` default was added to prevent, and it desyncs web's `effectiveMode` picker label too.

**Chosen:** keep both behaviours, but end the *accident*. `routingModeFromColumn` is the single total decoder of the column and owns `CONVERSATION_ROUTING_MODE_DEFAULT = "pin"`. The two inline `?? "auto"` literals in the tools layer become the named `ROUTING_MODE_WITHOUT_CONVERSATION`, exported from the **same module, immediately adjacent**, with the rationale for the divergence written down once and a test pinning that the two stay distinct. Result: one module owns routing-mode decoding, no magic literal survives, and **no observable behaviour changes**. If you'd rather force the collapse (accepting one of the two regressions), say so and I'll do it in a follow-up — I don't think a refactor should be the thing that changes it.

## Tests

- `conversation-scope.test.ts` (new): exhaustive decoder table — `null` / `undefined` / `auto` / `pin` / `all` / unknown string / empty string / number / object; plus the two-constants-stay-distinct pin, the column-mapping completeness check, the one-spread inheritance case, and a `diffConversationScope` matrix (reorder, duplicates, `[]` re-include, `null` clears, first-pick-on-NULL-row, multi-axis).
- `conversations.test.ts`: the five parallel writer suites become **one table-driven `patch → columns`** suite (9 cases incl. a multi-axis one asserting exactly ONE statement), plus `not_found` / `no_db` / empty-patch-no-op / throw→`error`.
- 19 route-test mock files collapse their five writer stubs to one.

## Notes

- The fork/convert INSERT sites named in the issue were removed with the notebook surface (#4589). The "inherit via one spread" criterion is satisfied structurally by `conversationScopeFrom` + spread and covered by a test, so the next derivation site gets it for free.
- `@security`: the writer's SET list is assembled from column names, but only from the closed `CONVERSATION_SCOPE_COLUMNS` constant — never caller input. Every value is bound; the auth scope is the same parameterised `scopeClause`.

## Acceptance criteria

- [x] One `updateConversationScope(id, patch, userId, orgId)` writer replaces the five per-field writers (single diffed org-scoped UPDATE)
- [x] A multi-field scope change is one atomic UPDATE, not up to four fire-and-forget writes
- [x] Fork and convert inherit scope via one spread of the scope value
- [x] One total `routingModeFromColumn(value)` decoder owns the NULL default; `resolveRoutingMode` and the inline `sql.ts` decode are deleted
- [x] The reconciled NULL default is documented in one place
- [x] A table-driven `patch → columns` test replaces the five parallel writer tests
- [x] An exhaustive `null / "auto" / "pin" / "all" / garbage` test covers the decoder
