### PR TITLE
feat(telemetry): trace every agent tool at the ToolRegistry seam (#4464)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Guidance for Claude Code when working in this repository.
 - [ ] **Default tool set lives in the registry** — `defaultRegistry` (`lib/tools/registry.ts`) registers `explore`, `executeSQL`, `searchKnowledge`, `createDashboard`, `sendEmail`, `createLinearIssue`, and OAuth-gated `querySalesforce`; `buildRegistry` adds `executePython` (when `ATLAS_PYTHON_ENABLED`) + configured action tools. Never wire a tool around the registry
 - [ ] **Explore is read-only by isolation, not command validation** — There is no command allowlist; the agent may run arbitrary shell (`awk`/`sed`/pipes included). Read-only scoping to `semantic/` is enforced structurally by each backend (ephemeral microVM / read-only bind mounts / OverlayFs): writes land in ephemeral or in-memory layers and never touch host files. Output is capped at 1 MB at the tool seam. Sandbox priority documented under **Security (General)** above
 - [ ] **Agent max steps** — `stopWhen: stepCountIs(getAgentMaxSteps())`. Default 25, via `ATLAS_AGENT_MAX_STEPS` (1–100)
+- [ ] **Tools are traced by registration, not by diligence** — `ToolRegistry.getAll()` wraps every executable tool in an `atlas.tool.<name>` span (`lib/tools/tool-spans.ts`), so a new tool needs no telemetry code; a tool that wants more detail adds an inner span that nests under it. Span/attribute conventions + the grandfathered off-prefix names: [docs/development/telemetry.md](docs/development/telemetry.md)
 - [ ] **Semantic layer drives the agent** — Read entity YAMLs before writing SQL
 
 ### Semantic Layer

--- a/apps/docs/content/docs/platform-ops/observability.mdx
+++ b/apps/docs/content/docs/platform-ops/observability.mdx
@@ -36,16 +36,24 @@ Atlas creates spans at each layer of the request lifecycle, forming a proper par
 HTTP Request (http.request)
   └── Agent Loop (atlas.agent)
       ├── Step 1
-      │   ├── atlas.explore
-      │   └── atlas.explore
+      │   ├── atlas.tool.explore
+      │   │   └── atlas.explore
+      │   └── atlas.tool.searchKnowledge
       └── Step 2
-          └── atlas.sql.execute
+          └── atlas.tool.executeSQL
+              └── atlas.sql.execute
 ```
+
+Every agent tool Atlas executes server-side emits an `atlas.tool.<name>` span,
+so a turn has no un-segmented tool time. The tools that instrument themselves in more detail
+(`atlas.sql.execute`, `atlas.explore`, `atlas.python.execute`,
+`atlas.profile.table`) keep their own span, nested one level deeper.
 
 | Span Name | Attributes | Description |
 |-----------|------------|-------------|
 | `http.request` | `http.method`, `http.target`, `http.status_code` | Root span per API request (Hono middleware) |
 | `atlas.agent` | `atlas.provider`, `atlas.model`, `atlas.message_count`, `atlas.finish_reason`, `atlas.total_steps`, `atlas.total_input_tokens`, `atlas.total_output_tokens` | Full agent loop (one per `streamText` call) |
+| `atlas.tool.<name>` | `atlas.tool.name`, `atlas.tool.call_id`, `atlas.tool.error`, `atlas.tool.streaming` (streaming tools), `atlas.tool.aborted` (turn cancelled mid-call) | One per agent tool invocation, for **every** server-executed tool. `atlas.tool.error` is `true` when the tool returned an error envelope (`{ error }` or `success: false`) rather than throwing — a thrown error sets the span status to ERROR instead. Tool arguments and results are **not** recorded |
 | `atlas.sql.execute` | `db.system`, `atlas.connection_id`, `atlas.row_count`, `atlas.column_count` | SQL query execution. SQL content is **not** included for security |
 | `atlas.explore` | `atlas.command` (truncated), `atlas.backend` | Semantic layer file exploration (ls, cat, grep, find) |
 | `atlas.python.execute` | `code.length` | Python code execution in sandbox |
@@ -61,6 +69,8 @@ Each span records success/failure status and captures exceptions on error, makin
 
 <Callout title="Agent per-step spans">
 When OTel is active, the agent loop also enables the Vercel AI SDK's telemetry, so each `streamText` step emits `ai.streamText` / `ai.streamText.doStream` child spans **under** `atlas.agent`. These carry per-step structure — finish reason, token split, tool-call count — so a multi-step run no longer collapses into a single span. Prompt and completion **content is deliberately not recorded** on these spans (same stance as `atlas.sql.execute`, which omits SQL text); they carry structural metadata only.
+
+That telemetry also emits the SDK's own `ai.toolCall` span per tool call, so an `atlas.tool.<name>` span nests **inside** an `ai.toolCall` one — expect both. They are not redundant: `ai.toolCall` marks a call that *returned* an error envelope as a success, which is exactly what `atlas.tool.error` exists to count, and the seam span is the stable parent for the self-instrumented tool spans.
 </Callout>
 
 <Callout title="MCP span vs. counter leaf names">

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -1,0 +1,216 @@
+# Telemetry — span naming and attribute conventions
+
+How Atlas names OpenTelemetry spans and their attributes, and where the
+instrumentation seams are. Read this before adding a span (or a tool, which
+gets one for free — see [Tool spans](#tool-spans-the-registry-seam)).
+
+Tracing is opt-in at runtime: `@opentelemetry/api` returns a no-op tracer when
+the SDK isn't initialized (no `OTEL_EXPORTER_OTLP_ENDPOINT`), so every wrapper
+below exports nothing and does no exporter work on a deployment with tracing
+off (the tool seam still costs a closure and a couple of function calls per
+call). SDK setup lives in
+`packages/api/src/lib/telemetry.ts`; the wrappers live in
+`packages/api/src/lib/tracing.ts`.
+
+## The wrappers
+
+| Helper | Use for |
+|---|---|
+| `withSpan(name, attrs, fn, setResultAttributes?)` | Promise-returning work |
+| `withEffectSpan(name, attrs, effect, setResultAttributes?)` | Effect-returning work — keeps `Data.TaggedError` types intact across the span so downstream `Effect.retry({ while })` policies can still discriminate on the tag |
+
+Both set `SpanStatusCode.OK` on success and record the exception + `ERROR`
+status on failure. `withEffectSpan` deliberately leaves a pure-interrupt cause
+(clean shutdown via `Fiber.interrupt`) at `UNSET` so a graceful stop doesn't
+read as an error in the trace explorer.
+
+Prefer a wrapper over driving the tracer directly. Three places don't, each for
+a reason the wrappers can't express:
+
+- `http.request` (`api/index.ts`) reads its outcome from `c.res.status` after
+  `next()` resolves — a 4xx/5xx is a returned response, not a throw, which
+  `withSpan`'s OK-on-success contract can't say.
+- `atlas.agent` (`agent.ts`) outlives the function that starts it: the span is
+  ended from `onFinish` / `onError` once the stream completes.
+- `atlas.tool.*` (`lib/tools/tool-spans.ts`) must not await: `withSpan` is
+  typed `Promise<T>`, which would collapse the AI SDK's non-promise `execute`
+  return arms (a plain value, or an `AsyncIterable` for a streaming tool) into
+  a promise and change the shape the wrapper hands back to its caller.
+
+## Span names
+
+**`atlas.<subsystem>.<operation>`** — dotted, lowercase, `snake_case` within a
+segment (`atlas.scheduler.oauth_state_cleanup`, not `oauthStateCleanup`).
+
+One deliberate exception: the final segment of `atlas.tool.<name>` is a
+verbatim tool identifier, not an operation phrase — it must match the name the
+model calls and the SDK's `ai.toolCall.name` — so `atlas.tool.searchKnowledge`
+is intentional, not the `healthCheckAll` class of drift below.
+
+The `atlas.` prefix is what makes prefix-filtered dashboards work, so it is the
+part that matters most. Subsystem segments in use today:
+
+| Prefix | Emitted by |
+|---|---|
+| `atlas.agent` | the agent turn (root of the tool spans below) |
+| `atlas.tool.<toolName>` | every registered agent tool — the registry seam |
+| `atlas.sql.execute`, `atlas.explore`, `atlas.python.execute`, `atlas.profile.table` | tools that additionally self-instrument (nested under their seam span) |
+| `atlas.profile.*` | schema profiling — `profiler.ts`, plus `atlas.profile.connection` (`effect/semantic-generator.ts`) and `atlas.profile.live_datasource` (`datasources/mcp-lifecycle.ts`). Most build their attributes via `profileSpanAttributes` |
+| `atlas.plugin.*` | plugin lifecycle — init / refresh / teardown |
+| `atlas.scheduler.*` | scheduler engine + delivery, plus the per-tick periodic-fiber spans whose names are pinned by `SCHEDULER_CLEANUP_SPAN_NAMES` / `SCHEDULER_WORK_SPAN_NAMES` in `effect/layers.ts` |
+| `atlas.mcp.tool.run` | MCP tool dispatch (`packages/mcp/src/telemetry.ts`) |
+
+A **name segment must be low-cardinality**. Per-tool span names are bounded by
+what registers at boot — core tools plus whatever plugins wire in — so
+`atlas.tool.<name>` is safe and keeps a trace waterfall readable. Anything
+unbounded — a workspace id, a connection id, a query — belongs in an attribute,
+never the name. Where a count would do, emit the count: the profiler emits
+`atlas.profile.selected_table_count`, not the table names.
+
+## Attributes
+
+Two shapes are in use, both legitimate:
+
+- **`atlas.<subsystem>.<attribute>`** when the attribute belongs to one
+  subsystem — `atlas.tool.name`, `atlas.profile.db_type`,
+  `atlas.compaction.*`, `atlas.durable.*`, `atlas.billing.*`.
+- **`atlas.<attribute>`** (flat) for cross-cutting identifiers that ride spans
+  from several subsystems — `atlas.connection_id`, `atlas.connection_group_id`,
+  `atlas.org_id`, `atlas.row_count`, `atlas.model`, `atlas.backend`. This is
+  the older and still the more common form; don't "fix" it, and don't invent a
+  subsystem prefix for an id that genuinely crosses subsystems.
+
+New subsystem-owned attributes should take the first form.
+
+**No secrets on a span** — connection strings, API keys, tokens. Beyond that,
+weigh what you attach: spans go to an external collector. Sizes, counts, ids
+and enum-ish values are always safe. Two known exceptions ride today:
+`atlas.command` on `atlas.explore` carries 200 chars of model-authored shell,
+and `recordException` (used by both wrappers and by the tool seam) sends the
+error message and stack, which for a driver error can include host/database/user.
+Both are operator-facing and pre-existing; treat them as the ceiling, not a
+licence to add more.
+
+## Tool spans (the registry seam)
+
+Every tool handed to the agent is wrapped in an **`atlas.tool.<name>`** span by
+`withToolSpans` (`lib/tools/tool-spans.ts`), applied inside
+`ToolRegistry.getAll()` — the point where tools leave the registry for the AI
+SDK. Every *executable* tool is wrapped; client-side / provider-executed tools
+(no `execute`) pass through untouched. **Adding a tool requires no telemetry
+code**: registering it is what traces it. (#4464 exists because the previous
+per-tool convention left `searchKnowledge`, `createDashboard`,
+`executeRestOperation` and the action tools with no `atlas.*` segment at all —
+only the tools that remembered to self-instrument had one.)
+
+- The seam span is the **floor, not the ceiling.** A tool with richer
+  instrumentation keeps its own inner span (`atlas.sql.execute` and friends),
+  which nests *under* the seam span — the wrapper uses `startActiveSpan`, so
+  the tool body runs inside the seam span's context.
+- `ToolRegistry.get()` / `.entries()` deliberately return the **raw** entries:
+  they feed metadata and `ToolRegistry.merge()`, and re-registering a wrapped
+  tool would nest a redundant span. `getAll()` mints fresh wrapper closures per
+  call, so its result is not identity-stable.
+- Attributes: `atlas.tool.name` and `atlas.tool.call_id` (the AI SDK
+  `toolCallId`) always; `atlas.tool.error` on completion; `atlas.tool.streaming`
+  and `atlas.tool.aborted` on those paths only.
+- Most Atlas tools report failure by *returning* an error envelope rather than
+  throwing (the model needs to read the failure and retry), so that outcome
+  rides as `atlas.tool.error` and the span status stays OK; a *thrown* error
+  sets `ERROR` and records the exception. Two envelopes are recognized:
+  `{ error: "..." }` and `success: false`. **Known gap:** two shapes read as
+  no-error — a tool that discriminates on its own vocabulary (`sendEmail` /
+  `createLinearIssue` return `{ status: "no_workspace" | … }`), because a
+  generic seam can't know each tool's success words; and a tool that returns a
+  bare string (`explore` returns `Error (exit N): …` as text), which can carry
+  no envelope at all. Treat `atlas.tool.error` as a **lower bound** on returned
+  failures.
+- Telemetry can't fail a turn: every mutation after the span starts is guarded
+  individually, so an exporter or attribute-validation throw is logged
+  (`log.warn`), costs only its own operation, and leaves the tool's result — or
+  its error, unmodified — to propagate. Span *creation* itself is not guarded: a
+  provider that throws at `startActiveSpan` would fail the call.
+
+### Boundaries of the seam span
+
+`agent.ts` composes `getAll()` → `wrapToolsWithHooks` → `wrapToolsWithDurableState`,
+so the seam span is the **innermost** wrapper. Consequences worth knowing before
+reading a waterfall:
+
+- Plugin `beforeToolCall` / `afterToolCall` dispatch falls **outside** the
+  span: it measures tool execution, not the full per-call overhead. (The
+  durable-state wrapper is `AsyncLocalStorage` context propagation only — no
+  I/O; memory and transcript commits ride `onStepFinish`, outside any tool
+  span.)
+- A call rejected by a plugin `beforeToolCall` hook never reaches `execute`, so
+  it emits **no** tool span at all — a rejected call is invisible, not fast.
+  Symmetrically, an `afterToolCall` hook that rejects a *result* replaces it
+  after the span has already closed OK, so the trace shows a success the model
+  saw as an error.
+- The AI SDK emits its own `ai.toolCall` span around `execute` when
+  `experimental_telemetry` is on, so `atlas.tool.*` nests inside it — expect
+  both. The seam still earns its keep: it carries the returned-error signal the
+  SDK can't see (`ai.toolCall` marks a call that *returned* `{ error }` a
+  success) and is the stable parent for the self-instrumented spans. It does
+  not survive SDK telemetry being off — both are gated on
+  `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- When any plugin is registered, `wrapToolsWithHooks` awaits `execute`, which
+  collapses a streaming tool's `AsyncIterable` into a promise before the SDK
+  sees it. Pre-existing, and moot while no Atlas tool streams — but the next
+  person adding one needs to know.
+- A **streaming** tool (`execute` returning an `AsyncIterable`) closes its span
+  when `execute` returns the iterable — *before* the first chunk is pulled — so
+  the span measures setup only and cannot see a mid-stream failure. It carries
+  `atlas.tool.streaming` and its status is left `UNSET`: outcome unknown must
+  not read as success. No Atlas tool streams today.
+- A turn aborted mid-call closes the span with `atlas.tool.aborted`, so a
+  disconnect doesn't leak an open span. The span closes **at abort time**: any
+  later outcome — result, error, exception — is not recorded, so
+  `atlas.tool.aborted` means "outcome unknown", the same stance the streaming
+  arm takes. A signal already aborted when the call starts ends the span
+  immediately, leaving a zero-duration span over an untraced execution.
+
+## Grandfathered exceptions
+
+Renaming a span or attribute breaks live trace queries and dashboards, so these
+stay as-is until someone coordinates the rename with the dashboard owners.
+Don't drive-by-fix them; don't copy them either. Not exhaustive — the flat
+`atlas.<attribute>` family is described under [Attributes](#attributes) and is
+a convention, not drift.
+
+| Span / attribute | Where | Drift |
+|---|---|---|
+| `http.request` | `api/index.ts` | Intentional — OTel semantic-convention name for the HTTP root span, not Atlas drift |
+| `db.system` on `atlas.sql.execute` | `lib/tools/sql.ts` | Same — OTel semantic convention |
+| `stripe.webhook.process` | `lib/auth/server.ts` | Missing the `atlas.` prefix; prefix-filtered dashboards miss it |
+| `billing.agent_gate` | `lib/billing/agent-gate.ts` | Missing the `atlas.` prefix |
+| `atlas.plugin.healthCheckAll` | `lib/plugins/registry.ts` | camelCase operation segment; should be `health_check_all` |
+| `code.length`, `streaming` on `atlas.python.execute` | `lib/tools/python.ts` | Bare attribute names; should be `atlas.python.*` |
+| `tool.name`, `workspace.id`, `transport`, `deploy.mode`, `tool.success`, `tool.error_code` on `atlas.mcp.tool.run` | `packages/mcp/src/telemetry.ts` | Bare attribute names; should be `atlas.mcp.*` |
+
+## Testing
+
+`@opentelemetry/sdk-trace-base` is not a declared dependency of `@atlas/api`
+(only transitive, via `sdk-node`), and declaring one to stand up an
+`InMemorySpanExporter` has repeatedly not been judged worth it. Pick by what
+the code actually needs:
+
+- **Pure attribute builders** — extract the attribute construction and test it
+  directly (`profileSpanAttributes`, `buildStripeWebhookSpanAttributes`,
+  `toolResultAttributes`). What `profiler-span.test.ts` and
+  `stripe-webhook-span.test.ts` settled for, judging the exporter wiring
+  heavier than the typos it would catch.
+- **Single-source name records** — pin structurally
+  (`SCHEDULER_CLEANUP_SPAN_NAMES` / `SCHEDULER_WORK_SPAN_NAMES` asserted from
+  `lib/effect/__tests__/layers.test.ts`), so a rename or a deleted registration
+  fails a test.
+- **Pass-through semantics** — result, arguments, error propagation. What could
+  actually break a request (`tracing.test.ts`).
+- **The full span lifecycle**, when the code hand-rolls it rather than
+  delegating to `withSpan`. A stub `TracerProvider` built from
+  `@opentelemetry/api` alone captures name/attributes/status/`end()`, so that
+  cost was avoidable after all. See `tool-spans.test.ts`, which uses one to
+  assert span naming,
+  end-exactly-once on every exit path, and that an exploding span mutation
+  still can't fail the tool call. Install it in `beforeAll` and `trace.disable()`
+  in `afterAll` — never at module top level, per the self-contained-tests rule.

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -1451,8 +1451,9 @@ export async function runAgent({
       "atlas.connection_group_id": connectionGroupId ?? "",
     },
   });
-  // Make the agent span the active context so tool spans (withSpan in
-  // sql.ts, explore.ts) become children in the trace hierarchy.
+  // Make the agent span the active context so tool spans become children in
+  // the trace hierarchy — the per-tool `atlas.tool.*` seam spans (#4464) and,
+  // nested under those, the self-instrumented ones in sql.ts / explore.ts.
   const agentCtx = trace.setSpan(otelContext.active(), span);
 
   let spanEnded = false;
@@ -1716,8 +1717,13 @@ export async function runAgent({
     subagent: subagent ?? false,
   });
 
-  const rawTools = activeRegistry.getAll();
-  const hookedTools = wrapToolsWithHooks(rawTools, { userId: userId ?? undefined, conversationId });
+  // #4464 — already span-wrapped by the registry seam (`atlas.tool.<name>`),
+  // so the two wrappers below sit OUTSIDE that span: plugin hook dispatch is
+  // not counted in it, and a call rejected by a `beforeToolCall` hook never
+  // reaches `execute` and so emits no tool span at all. See
+  // docs/development/telemetry.md § Boundaries of the seam span.
+  const registryTools = activeRegistry.getAll();
+  const hookedTools = wrapToolsWithHooks(registryTools, { userId: userId ?? undefined, conversationId });
   const tools = wrapToolsWithDurableState(hookedTools, memoryStore);
 
   // #3755 — render the deterministic working-memory block from the slots loaded

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -76,8 +76,55 @@ describe("ToolRegistry", () => {
 
     const all = registry.getAll();
     expect(Object.keys(all).sort()).toEqual(["bar", "foo"]);
-    expect(all.foo).toBe(fooTool);
-    expect(all.bar).toBe(barTool);
+    // #4464 — getAll() is the span seam, so entries are the span-wrapped tools
+    // rather than the raw registered ones; get() still returns the raw entry.
+    expect(all.foo.description).toBe(fooTool.description);
+    expect(all.bar.description).toBe(barTool.description);
+    expect(registry.get("foo")!.tool).toBe(fooTool);
+  });
+
+  // #4464 — the span wrapper is a property of registration, not of each tool
+  // remembering to self-instrument. A brand-new tool must be traced with zero
+  // per-tool code, so assert the seam rewrote its execute.
+  it("getAll() span-wraps every tool, including a newly registered one", () => {
+    const registry = new ToolRegistry();
+    const rawTool = makeTool("brandNew");
+    registry.register({ name: "brandNew", description: "New", tool: rawTool });
+
+    const wrapped = registry.getAll().brandNew;
+    expect(wrapped.execute).toBeDefined();
+    expect(wrapped.execute).not.toBe(rawTool.execute);
+  });
+
+  it("getAll() span-wraps every default-registry tool", () => {
+    const raw = new Map(defaultRegistry.entries());
+    let checked = 0;
+    for (const [name, entry] of Object.entries(defaultRegistry.getAll())) {
+      const rawExecute = raw.get(name)?.tool.execute;
+      if (!rawExecute) continue; // client-side tool — nothing to wrap
+      expect(entry.execute).not.toBe(rawExecute);
+      checked++;
+    }
+    // Guard against the loop passing vacuously if the registry ever yields
+    // only execute-less entries.
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  // #4464 — merge() must consume the RAW entries. If it ever consumed
+  // getAll(), each merge hop would wrap an already-wrapped tool and nest a
+  // redundant span; the span-lifecycle behaviour itself is covered by
+  // tool-spans.test.ts.
+  it("merge() carries raw tools, so spans cannot nest per merge hop", () => {
+    const base = new ToolRegistry();
+    const fooTool = makeTool("foo");
+    base.register({ name: "foo", description: "Foo", tool: fooTool });
+    const overlay = new ToolRegistry();
+    const barTool = makeTool("bar");
+    overlay.register({ name: "bar", description: "Bar", tool: barTool });
+
+    const merged = ToolRegistry.merge(base, overlay);
+    expect(merged.get("foo")!.tool).toBe(fooTool);
+    expect(merged.get("bar")!.tool).toBe(barTool);
   });
 
   it("describe concatenates descriptions with \\n\\n separator", () => {

--- a/packages/api/src/lib/tools/__tests__/tool-spans.test.ts
+++ b/packages/api/src/lib/tools/__tests__/tool-spans.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Tests for the registry-seam tool-span wrapper (#4464).
+ *
+ * Unlike the `atlas.profile.*` / `stripe.webhook.process` span tests — which
+ * instrument code paths you can't call directly, and so settle for testing the
+ * pure attribute builder — `withToolSpans` is a directly-callable function that
+ * re-implements the whole span lifecycle inline (it can't reuse `withSpan`; see
+ * the module header). So the lifecycle IS tested here, with a stub
+ * `TracerProvider` built from `@opentelemetry/api` alone — no
+ * `@opentelemetry/sdk-trace-base` devDep, which is the cost those other tests
+ * declined to pay.
+ *
+ * The provider is installed in `beforeAll` and torn down in `afterAll` (never
+ * at module top level) so the file stays self-contained under the isolated
+ * runner.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  trace,
+  SpanStatusCode,
+  type Attributes,
+  type Span,
+  type SpanOptions,
+  type TracerProvider,
+} from "@opentelemetry/api";
+import type { ToolSet, ToolExecutionOptions } from "ai";
+import {
+  withToolSpans,
+  toolSpanName,
+  toolResultAttributes,
+  TOOL_SPAN_PREFIX,
+} from "../tool-spans";
+
+// ── Stub tracer ────────────────────────────────────────────────────────────
+interface RecordedSpan {
+  name: string;
+  attributes: Attributes;
+  statusCode?: SpanStatusCode;
+  statusMessage?: string;
+  exceptions: unknown[];
+  endCount: number;
+}
+
+let recorded: RecordedSpan[] = [];
+/** Span methods that should throw, to prove telemetry can't fail a tool call. */
+let faults = new Set<"setAttributes" | "setStatus" | "recordException" | "end">();
+/**
+ * `Span` has ~11 members and the stub implements 4. Any other member the
+ * wrapper reaches for would throw INSIDE the production guard, be logged as
+ * degraded telemetry, and leave the test green with the span silently lost —
+ * so unimplemented access is recorded and the happy-path tests assert it stayed
+ * empty.
+ */
+let unstubbed: string[] = [];
+
+function fault(method: "setAttributes" | "setStatus" | "recordException" | "end") {
+  if (faults.has(method)) throw new Error(`span.${method} exploded`);
+}
+
+function makeStubSpan(name: string, attributes: Attributes): Span {
+  const rec: RecordedSpan = { name, attributes: { ...attributes }, exceptions: [], endCount: 0 };
+  recorded.push(rec);
+  const impl = {
+    setAttributes(attrs: Attributes) {
+      fault("setAttributes");
+      Object.assign(rec.attributes, attrs);
+      return this;
+    },
+    setStatus(status: { code: SpanStatusCode; message?: string }) {
+      fault("setStatus");
+      rec.statusCode = status.code;
+      rec.statusMessage = status.message;
+      return this;
+    },
+    recordException(err: unknown) {
+      fault("recordException");
+      rec.exceptions.push(err);
+    },
+    end() {
+      fault("end");
+      rec.endCount++;
+    },
+  };
+  return new Proxy(impl, {
+    get(target, prop, receiver) {
+      if (prop in target) return Reflect.get(target, prop, receiver);
+      unstubbed.push(String(prop));
+      return () => {
+        throw new Error(`stub Span has no ${String(prop)}`);
+      };
+    },
+  }) as unknown as Span;
+}
+
+const stubProvider = {
+  getTracer: () => ({
+    // The seam MUST use startActiveSpan: that is the only reason a
+    // self-instrumented tool's inner span (atlas.sql.execute, …) nests under
+    // it. A regression to startSpan would flatten the hierarchy in production
+    // and still pass a stub that recorded both — so this one refuses.
+    startSpan: () => {
+      throw new Error(
+        "tool-spans must use startActiveSpan so the tool body runs in the span's context",
+      );
+    },
+    startActiveSpan: (name: string, options: SpanOptions, fn: (span: Span) => unknown) =>
+      fn(makeStubSpan(name, options.attributes ?? {})),
+  }),
+} as unknown as TracerProvider;
+
+beforeAll(() => {
+  // The module-level `trace.getTracer("atlas")` in tool-spans.ts already ran at
+  // import time; this still reaches it because @opentelemetry/api hands back a
+  // ProxyTracer that resolves its delegate lazily, per span. Assert the
+  // registration took, so a pre-registered provider fails here rather than as a
+  // pile of confusing "no span named …" errors.
+  expect(trace.setGlobalTracerProvider(stubProvider)).toBe(true);
+});
+afterAll(() => {
+  trace.disable();
+});
+beforeEach(() => {
+  recorded = [];
+  faults = new Set();
+  unstubbed = [];
+});
+
+function spanFor(name: string): RecordedSpan {
+  const span = recorded.find((s) => s.name === toolSpanName(name));
+  if (!span) {
+    throw new Error(
+      `no span named ${toolSpanName(name)} — recorded: ${recorded.map((s) => s.name).join(", ") || "(none)"}`,
+    );
+  }
+  return span;
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+function makeTool(execute?: ToolSet[string]["execute"]) {
+  return tool({
+    description: "test tool",
+    inputSchema: z.object({ value: z.string().optional() }),
+    ...(execute ? { execute } : {}),
+  });
+}
+
+/** Invoke a wrapped tool's execute with the AI SDK's (input, options) shape. */
+function call(
+  entry: ToolSet[string],
+  input: Record<string, unknown> = {},
+  options: Partial<ToolExecutionOptions> = {},
+): unknown {
+  const execute = entry.execute;
+  if (!execute) throw new Error("tool has no execute");
+  return execute(input, { toolCallId: "call-1", messages: [], ...options });
+}
+
+describe("toolSpanName", () => {
+  it("prefixes the tool name with the atlas.* seam prefix", () => {
+    expect(toolSpanName("searchKnowledge")).toBe("atlas.tool.searchKnowledge");
+    expect(TOOL_SPAN_PREFIX).toBe("atlas.tool.");
+  });
+});
+
+describe("toolResultAttributes", () => {
+  it("flags a returned { error } result as failed", () => {
+    expect(toolResultAttributes({ error: "no workspace" })).toEqual({
+      "atlas.tool.error": true,
+    });
+  });
+
+  it("does not flag a normal result", () => {
+    expect(toolResultAttributes({ columns: ["a"], rows: [] })).toEqual({
+      "atlas.tool.error": false,
+    });
+  });
+
+  it("does not flag a non-string error field or a non-object result", () => {
+    // A tool returning `{ error: false }` / a bare string is reporting success.
+    expect(toolResultAttributes({ error: false })).toEqual({ "atlas.tool.error": false });
+    expect(toolResultAttributes("ok")).toEqual({ "atlas.tool.error": false });
+    expect(toolResultAttributes(null)).toEqual({ "atlas.tool.error": false });
+  });
+});
+
+describe("withToolSpans — pass-through semantics", () => {
+  it("wraps every executable tool without changing its result", async () => {
+    const wrapped = withToolSpans({
+      alpha: makeTool(async () => "alpha-result"),
+      beta: makeTool(async () => ({ rows: [1] })),
+    });
+
+    expect(Object.keys(wrapped).sort()).toEqual(["alpha", "beta"]);
+    expect(await call(wrapped.alpha)).toBe("alpha-result");
+    expect(await call(wrapped.beta)).toEqual({ rows: [1] });
+  });
+
+  it("passes input and options through to the original execute", async () => {
+    let seen: { input: unknown; toolCallId: unknown } | undefined;
+    const wrapped = withToolSpans({
+      echo: makeTool(async (input, options) => {
+        seen = { input, toolCallId: options.toolCallId };
+        return "ok";
+      }),
+    });
+
+    await call(wrapped.echo, { value: "hi" }, { toolCallId: "call-42" });
+    expect(seen).toEqual({ input: { value: "hi" }, toolCallId: "call-42" });
+  });
+
+  it("rethrows the ORIGINAL error object, never a telemetry one", async () => {
+    const sentinel = new Error("tool exploded");
+    const wrapped = withToolSpans({
+      boom: makeTool(async () => {
+        throw sentinel;
+      }),
+    });
+
+    await expect(call(wrapped.boom) as Promise<unknown>).rejects.toBe(sentinel);
+  });
+
+  it("propagates an error thrown synchronously by execute", () => {
+    const sentinel = new Error("sync boom");
+    const wrapped = withToolSpans({
+      sync: makeTool(() => {
+        throw sentinel;
+      }),
+    });
+
+    expect(() => call(wrapped.sync)).toThrow(sentinel);
+  });
+
+  it("passes through tools with no execute (client-side / provider-executed)", () => {
+    const clientTool = makeTool();
+    const wrapped = withToolSpans({ clientSide: clientTool });
+    expect(wrapped.clientSide).toBe(clientTool);
+    expect(recorded).toHaveLength(0);
+  });
+
+  it("does not mutate the input tool set", () => {
+    const original = makeTool(async () => "ok");
+    const toolSet: ToolSet = { alpha: original };
+    const wrapped = withToolSpans(toolSet);
+
+    expect(toolSet.alpha).toBe(original);
+    expect(wrapped.alpha).not.toBe(original);
+  });
+
+  it("preserves every non-execute tool property", () => {
+    const original = makeTool(async () => "ok");
+    const wrapped = withToolSpans({ alpha: original });
+    expect(Object.keys(wrapped.alpha).sort()).toEqual(Object.keys(original).sort());
+    expect(wrapped.alpha.description).toBe(original.description);
+    expect(wrapped.alpha.inputSchema).toBe(original.inputSchema);
+  });
+});
+
+describe("withToolSpans — span lifecycle", () => {
+  it("emits one atlas.tool.<name> span per call, named and attributed", async () => {
+    const wrapped = withToolSpans({ searchKnowledge: makeTool(async () => "ok") });
+
+    await call(wrapped.searchKnowledge, {}, { toolCallId: "call-7" });
+
+    expect(recorded).toHaveLength(1);
+    const span = spanFor("searchKnowledge");
+    expect(span.attributes["atlas.tool.name"]).toBe("searchKnowledge");
+    expect(span.attributes["atlas.tool.call_id"]).toBe("call-7");
+    expect(span.statusCode).toBe(SpanStatusCode.OK);
+    expect(span.endCount).toBe(1);
+    expect(unstubbed).toEqual([]);
+  });
+
+  it("keeps concurrent calls of one tool on independent spans", async () => {
+    let release: Array<(value: string) => void> = [];
+    const wrapped = withToolSpans({
+      parallel: makeTool(() => new Promise<string>((resolve) => { release.push(resolve); })),
+    });
+
+    const a = call(wrapped.parallel, {}, { toolCallId: "call-a" }) as Promise<string>;
+    const b = call(wrapped.parallel, {}, { toolCallId: "call-b" }) as Promise<string>;
+    release[0]?.("a");
+    release[1]?.("b");
+    expect(await Promise.all([a, b])).toEqual(["a", "b"]);
+
+    // Two spans, each ended once — a `guardSpan` hoisted per tool instead of
+    // per call would cross-latch `ended` and silently drop the second.
+    expect(recorded).toHaveLength(2);
+    expect(recorded.map((s) => s.endCount)).toEqual([1, 1]);
+    expect(
+      recorded.map((s) => String(s.attributes["atlas.tool.call_id"])).toSorted(),
+    ).toEqual(["call-a", "call-b"]);
+    release = [];
+  });
+
+  it("tags a RETURNED { error } result without failing the span", async () => {
+    const wrapped = withToolSpans({
+      failing: makeTool(async () => ({ error: "no active workspace" })),
+    });
+
+    const result = await call(wrapped.failing);
+
+    expect(result).toEqual({ error: "no active workspace" });
+    const span = spanFor("failing");
+    expect(span.attributes["atlas.tool.error"]).toBe(true);
+    expect(span.statusCode).toBe(SpanStatusCode.OK);
+    expect(span.endCount).toBe(1);
+  });
+
+  it("records ERROR status + the exception when execute rejects", async () => {
+    const sentinel = new Error("query failed");
+    const wrapped = withToolSpans({
+      boom: makeTool(async () => {
+        throw sentinel;
+      }),
+    });
+
+    await expect(call(wrapped.boom) as Promise<unknown>).rejects.toBe(sentinel);
+
+    const span = spanFor("boom");
+    expect(span.statusCode).toBe(SpanStatusCode.ERROR);
+    expect(span.statusMessage).toBe("query failed");
+    expect(span.exceptions).toEqual([sentinel]);
+    expect(span.endCount).toBe(1);
+  });
+
+  it("records a non-Error rejection as a narrowed Error", async () => {
+    const wrapped = withToolSpans({
+      stringy: makeTool(async () => {
+        throw "just a string";
+      }),
+    });
+
+    await expect(call(wrapped.stringy) as Promise<unknown>).rejects.toBe("just a string");
+
+    const span = spanFor("stringy");
+    expect(span.statusMessage).toBe("just a string");
+    expect(span.exceptions[0]).toBeInstanceOf(Error);
+  });
+
+  it("ends the span exactly once on the sync-throw path", () => {
+    const wrapped = withToolSpans({
+      sync: makeTool(() => {
+        throw new Error("sync boom");
+      }),
+    });
+
+    expect(() => call(wrapped.sync)).toThrow("sync boom");
+    const span = spanFor("sync");
+    expect(span.statusCode).toBe(SpanStatusCode.ERROR);
+    expect(span.endCount).toBe(1);
+  });
+});
+
+describe("withToolSpans — the three execute return arms", () => {
+  it("treats a plain synchronous return as a result, not as a stream", () => {
+    const wrapped = withToolSpans({
+      syncValue: makeTool(() => ({ error: "sync failure" })),
+    });
+
+    expect(call(wrapped.syncValue)).toEqual({ error: "sync failure" });
+
+    const span = spanFor("syncValue");
+    // The bug this pins: keying the stream branch on "not a promise" would
+    // mislabel this call as streaming AND drop its error attribute.
+    expect(span.attributes["atlas.tool.streaming"]).toBeUndefined();
+    expect(span.attributes["atlas.tool.error"]).toBe(true);
+    expect(span.statusCode).toBe(SpanStatusCode.OK);
+    expect(span.endCount).toBe(1);
+  });
+
+  it("returns a streaming (AsyncIterable) result unwrapped and leaves status UNSET", async () => {
+    async function* stream() {
+      yield "chunk";
+    }
+    const wrapped = withToolSpans({ streamer: makeTool(() => stream()) });
+
+    const out = call(wrapped.streamer);
+    expect(typeof (out as { then?: unknown }).then).not.toBe("function");
+    expect(typeof (out as AsyncIterable<string>)[Symbol.asyncIterator]).toBe("function");
+
+    const chunks: string[] = [];
+    for await (const chunk of out as AsyncIterable<string>) chunks.push(chunk);
+    expect(chunks).toEqual(["chunk"]);
+
+    const span = spanFor("streamer");
+    expect(span.attributes["atlas.tool.streaming"]).toBe(true);
+    // The span closed before the first chunk was pulled, so it cannot claim
+    // the stream succeeded — "outcome unknown" must not read as OK.
+    expect(span.statusCode).toBeUndefined();
+    expect(span.endCount).toBe(1);
+  });
+});
+
+describe("withToolSpans — telemetry never fails the tool call", () => {
+  it("returns the result even when every span mutation throws", async () => {
+    faults = new Set(["setAttributes", "setStatus", "recordException", "end"]);
+    const wrapped = withToolSpans({ alpha: makeTool(async () => "still fine") });
+
+    expect(await call(wrapped.alpha)).toBe("still fine");
+  });
+
+  it("preserves the tool's own error when span mutation throws", async () => {
+    faults = new Set(["setStatus", "recordException", "end"]);
+    const sentinel = new Error("the real failure");
+    const wrapped = withToolSpans({
+      boom: makeTool(async () => {
+        throw sentinel;
+      }),
+    });
+
+    await expect(call(wrapped.boom) as Promise<unknown>).rejects.toBe(sentinel);
+  });
+
+  it("degrades one mutation at a time — a failing setStatus still records the exception", async () => {
+    faults = new Set(["setStatus"]);
+    const sentinel = new Error("the real failure");
+    const wrapped = withToolSpans({
+      boom: makeTool(async () => {
+        throw sentinel;
+      }),
+    });
+
+    await expect(call(wrapped.boom) as Promise<unknown>).rejects.toBe(sentinel);
+
+    const span = spanFor("boom");
+    expect(span.statusCode).toBeUndefined(); // the faulted mutation
+    expect(span.exceptions).toEqual([sentinel]); // …did not cost us this one
+    expect(span.endCount).toBe(1);
+  });
+});
+
+describe("withToolSpans — aborted turn", () => {
+  it("closes the span when the turn aborts before the tool settles", async () => {
+    const controller = new AbortController();
+    const wrapped = withToolSpans({
+      hung: makeTool(() => new Promise<string>(() => {})), // never settles
+    });
+
+    void call(wrapped.hung, {}, { abortSignal: controller.signal });
+    const span = spanFor("hung");
+    expect(span.endCount).toBe(0);
+
+    controller.abort();
+
+    expect(span.attributes["atlas.tool.aborted"]).toBe(true);
+    expect(span.endCount).toBe(1);
+  });
+
+  it("does not double-end when the tool settles after an abort", async () => {
+    const controller = new AbortController();
+    let release: (value: string) => void = () => {};
+    const wrapped = withToolSpans({
+      slow: makeTool(() => new Promise<string>((resolve) => { release = resolve; })),
+    });
+
+    const pending = call(wrapped.slow, {}, { abortSignal: controller.signal }) as Promise<string>;
+    controller.abort();
+    release("late");
+
+    expect(await pending).toBe("late");
+    expect(spanFor("slow").endCount).toBe(1);
+  });
+
+  // The common real shape: the client disconnects, the tool's own AbortError
+  // rejects. The rejection must still reach the SDK, and the span must not
+  // end twice.
+  it("still propagates a rejection that arrives after the abort", async () => {
+    const controller = new AbortController();
+    let reject: (err: unknown) => void = () => {};
+    const sentinel = new Error("aborted by caller");
+    const wrapped = withToolSpans({
+      cancelled: makeTool(() => new Promise<string>((_resolve, rej) => { reject = rej; })),
+    });
+
+    const pending = call(wrapped.cancelled, {}, { abortSignal: controller.signal }) as Promise<string>;
+    controller.abort();
+    reject(sentinel);
+
+    await expect(pending).rejects.toBe(sentinel);
+    expect(spanFor("cancelled").endCount).toBe(1);
+  });
+
+  it("ends the span when the signal is already aborted before the call", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const wrapped = withToolSpans({ late: makeTool(async () => "ok") });
+
+    expect(await (call(wrapped.late, {}, { abortSignal: controller.signal }) as Promise<string>)).toBe("ok");
+    const span = spanFor("late");
+    expect(span.attributes["atlas.tool.aborted"]).toBe(true);
+    expect(span.endCount).toBe(1);
+  });
+
+  // The abort signal is turn-scoped and shared by every tool call in the turn:
+  // a listener left attached per completed call retains its span for the rest
+  // of the turn.
+  it("detaches its abort listener once the call settles", async () => {
+    const listeners = new Map<object, number>();
+    const signal = {
+      aborted: false,
+      addEventListener: (_type: string, fn: object) => {
+        listeners.set(fn, (listeners.get(fn) ?? 0) + 1);
+      },
+      removeEventListener: (_type: string, fn: object) => {
+        listeners.delete(fn);
+      },
+    } as unknown as AbortSignal;
+
+    const wrapped = withToolSpans({ tidy: makeTool(async () => "ok") });
+    await call(wrapped.tidy, {}, { abortSignal: signal });
+
+    expect(listeners.size).toBe(0);
+  });
+});
+
+describe("withToolSpans — the guard logs rather than swallows", () => {
+  // Structural source guard, in the style of the scheduler span-name check in
+  // `lib/effect/__tests__/layers.test.ts`. The fault-injection tests above
+  // prove a telemetry failure can't break a tool call — but they would stay
+  // green if `safe()`'s catch were collapsed to a bare `catch {}`, which
+  // CLAUDE.md forbids. This pins that the catch still reports.
+  it("keeps a log call in the guard's catch block", async () => {
+    const source = await Bun.file(
+      new URL("../tool-spans.ts", import.meta.url).pathname,
+    ).text();
+    const guard = source.slice(
+      source.indexOf("const safe = (phase: SpanPhase"),
+      source.indexOf("return {\n    safe,"),
+    );
+    expect(guard).toContain("} catch (err) {");
+    expect(guard).toContain("log.warn(");
+    expect(guard).toContain("err instanceof Error ? err.message : String(err)");
+  });
+});

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -19,6 +19,7 @@ import {
   isSalesforceOAuthConfigured,
 } from "@atlas/api/lib/integrations/salesforce-tool";
 import { searchKnowledge, SEARCH_KNOWLEDGE_DESCRIPTION } from "./search-knowledge";
+import { withToolSpans } from "./tool-spans";
 
 export type { AtlasAction, DashboardUrlResolver };
 export { isAction, WORKSPACE_DASHBOARD_URL_RESOLVER };
@@ -57,12 +58,27 @@ export class ToolRegistry {
     return this.tools.get(name);
   }
 
+  /**
+   * The executable tool set handed to the agent — every entry wrapped in an
+   * `atlas.tool.<name>` span (#4464). This is where tools leave the registry
+   * for the AI SDK, so instrumenting here (rather than per tool) means a newly
+   * registered tool is traced by construction. `get()` / `entries()`
+   * deliberately return the RAW entries: they feed metadata and `merge()`, and
+   * re-registering a wrapped tool would nest a redundant span.
+   *
+   * The wrappers are minted per call, so the returned tools are NOT
+   * identity-stable across calls — callers that only need names (`config.ts`)
+   * are unaffected; callers that compare tool identity should use `entries()`.
+   * The span's known boundaries (plugin hook dispatch sits outside it; a
+   * hook-rejected call emits none) are documented in
+   * `docs/development/telemetry.md`.
+   */
   getAll(): ToolSet {
     const result: ToolSet = {};
     for (const [name, entry] of this.tools) {
       result[name] = entry.tool;
     }
-    return result;
+    return withToolSpans(result);
   }
 
   /** Concatenate all tool descriptions. Output order follows registration order. */
@@ -97,7 +113,9 @@ export class ToolRegistry {
 
   /**
    * Create a new registry by merging one or more registries on top of a base.
-   * Entries in later registries take precedence. The returned registry is
+   * The BASE takes precedence: a name already present is not overwritten (see
+   * {@link shadowedNames}, which surfaces exactly those shadowed overlay
+   * entries). The returned registry is
    * **unfrozen** — the caller should freeze it when ready.
    */
   static merge(base: ToolRegistry, ...others: ToolRegistry[]): ToolRegistry {

--- a/packages/api/src/lib/tools/tool-spans.ts
+++ b/packages/api/src/lib/tools/tool-spans.ts
@@ -1,0 +1,262 @@
+/**
+ * Per-tool OTel spans, applied once at the `ToolRegistry` seam (#4464).
+ *
+ * Before this wrapper only the tools that remembered to self-instrument
+ * (`atlas.sql.execute`, `atlas.explore`, `atlas.python.execute`,
+ * `atlas.profile.table`) carried an `atlas.*` segment of their own;
+ * `searchKnowledge`, `createDashboard`, `executeRestOperation` and the action
+ * tools had none, so latency could not be attributed within a turn by the
+ * `atlas.`-prefixed views. Wrapping at the seam makes the span a property of
+ * *being registered* rather than of each tool's own diligence: a newly
+ * registered tool gets one with zero per-tool code.
+ *
+ * The seam span is the FLOOR, not the ceiling — a tool that self-instruments
+ * keeps its inner span, which simply nests under the seam span (the wrapper
+ * uses `startActiveSpan`, so the tool body runs inside the seam span's
+ * context). It nests in turn under the AI SDK's own `ai.toolCall` span when
+ * `experimental_telemetry` is on; what it adds over that one is documented in
+ * `docs/development/telemetry.md`.
+ *
+ * `withSpan` is deliberately NOT reused here: it is typed `Promise<T>` and
+ * always awaits, which would collapse the AI SDK's non-promise `execute`
+ * return arms (a plain value, or an `AsyncIterable` for a streaming tool) into
+ * a promise and change the shape this wrapper hands back to its caller.
+ *
+ * Naming/attribute convention + the seam's known boundaries:
+ * `docs/development/telemetry.md`.
+ */
+
+import { trace, SpanStatusCode, type Attributes, type Span } from "@opentelemetry/api";
+import type { ToolSet, ToolExecutionOptions } from "ai";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const tracer = trace.getTracer("atlas");
+const log = createLogger("tool-spans");
+
+/** Span-name prefix for the seam wrapper: `atlas.tool.<toolName>`. */
+export const TOOL_SPAN_PREFIX = "atlas.tool.";
+
+/** Span name for a registered tool. Exported so tests assert one spelling. */
+export function toolSpanName(toolName: string): string {
+  return `${TOOL_SPAN_PREFIX}${toolName}`;
+}
+
+// The async-iterable predicate is copied from the SDK's own `executeTool`
+// dispatch (@ai-sdk/provider-utils) rather than tightened, so the seam can
+// never classify the streaming arm differently from the SDK that consumes it.
+// The SDK has no promise predicate — it just awaits — so this one mirrors what
+// that await does.
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return value != null && typeof (value as { then?: unknown }).then === "function";
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    value != null &&
+    typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function"
+  );
+}
+
+/**
+ * Most Atlas tools report failure by RETURNING an error envelope rather than
+ * throwing — the model needs to read the failure and retry. Those calls are
+ * successful spans (the tool answered) but must still be countable, so the
+ * outcome rides as an attribute instead of the span status.
+ *
+ * Two envelopes are recognized: a string `error` field (`searchKnowledge`,
+ * `profileTable`, `proposeAmendment`, …) and `success: false` (`executeSQL`).
+ * KNOWN GAP, deliberate — two shapes read as `false` here:
+ *   - tools that discriminate on their own vocabulary (`sendEmail` /
+ *     `createLinearIssue` return `{ status: "no_workspace" | … }`), because a
+ *     generic seam cannot know each tool's per-status success words without
+ *     encoding a table that silently rots; and
+ *   - tools that return a bare string (`explore` returns `Error (exit N): …`
+ *     as text), which can carry no envelope at all.
+ * Treat `atlas.tool.error` as a lower bound on returned failures, and see
+ * `docs/development/telemetry.md`.
+ */
+export function toolResultAttributes(result: unknown): Attributes {
+  if (typeof result !== "object" || result === null) {
+    return { "atlas.tool.error": false };
+  }
+  const envelope = result as { error?: unknown; success?: unknown };
+  return {
+    "atlas.tool.error": typeof envelope.error === "string" || envelope.success === false,
+  };
+}
+
+/** Span-mutation phases, for the degraded-telemetry log. */
+type SpanPhase = "result" | "status" | "exception" | "streaming" | "abort" | "end";
+
+interface GuardedSpan {
+  /** Run a span-adjacent operation. Never throws. */
+  readonly safe: (phase: SpanPhase, op: () => void) => void;
+  /** Mutate the span. No-ops once ended; never throws. */
+  readonly mutate: (phase: SpanPhase, op: () => void) => void;
+  /** End the span. Idempotent; never throws. */
+  readonly end: () => void;
+}
+
+/**
+ * Span mutation must never become a new way for a tool call to fail. The
+ * wrapper now sits in front of EVERY tool, so an exporter that throws on
+ * `end()`, or an SDK that rejects an attribute value, would otherwise turn a
+ * successful call into a failed turn — or, worse on the error path, replace
+ * the tool's real error with a telemetry one. Same stance as the
+ * durable-session span attributes in `agent.ts` (which logs) and `withSpan`'s
+ * result callback in `tracing.ts` (which swallows silently): never propagate.
+ *
+ * Each mutation is guarded separately, so one failing operation degrades only
+ * itself — a `setStatus` that throws must not also cost the span its recorded
+ * exception. `end()` latches BEFORE calling through, so a throwing exporter
+ * cannot unlatch it, and `mutate` no-ops afterwards so nothing touches a
+ * closed span.
+ */
+function guardSpan(span: Span, toolName: string): GuardedSpan {
+  let ended = false;
+
+  const safe = (phase: SpanPhase, op: () => void): void => {
+    try {
+      op();
+    } catch (err) {
+      log.warn(
+        { tool: toolName, phase, err: err instanceof Error ? err.message : String(err) },
+        "Tool span mutation failed — telemetry degraded, tool result unaffected",
+      );
+    }
+  };
+
+  return {
+    safe,
+    mutate: (phase, op) => {
+      if (ended) return;
+      safe(phase, op);
+    },
+    end: () => {
+      if (ended) return;
+      ended = true;
+      safe("end", () => span.end());
+    },
+  };
+}
+
+/**
+ * Wrap every executable tool in `toolSet` with an `atlas.tool.<name>` span.
+ * Tools without an `execute` (client-side / provider-executed) pass through
+ * untouched. Returns a new ToolSet; the input is not mutated.
+ */
+export function withToolSpans(toolSet: ToolSet): ToolSet {
+  const wrapped: ToolSet = {};
+
+  for (const [name, entry] of Object.entries(toolSet)) {
+    if (!entry.execute) {
+      wrapped[name] = entry;
+      continue;
+    }
+
+    const origExecute = entry.execute;
+    const spanName = toolSpanName(name);
+
+    wrapped[name] = {
+      ...entry,
+      execute: (input: unknown, options: ToolExecutionOptions) =>
+        tracer.startActiveSpan(
+          spanName,
+          {
+            attributes: {
+              "atlas.tool.name": name,
+              "atlas.tool.call_id": options.toolCallId,
+            },
+          },
+          (span) => {
+            const guarded = guardSpan(span, name);
+
+            // Backstop for a turn aborted mid-call (client disconnect): a tool
+            // that doesn't honour the signal may never settle, which would
+            // otherwise leave the span open forever and the call invisible.
+            const signal = options.abortSignal;
+            const onAbort = () => {
+              guarded.mutate("abort", () => span.setAttributes({ "atlas.tool.aborted": true }));
+              guarded.end();
+            };
+            // Guarded like every other span-adjacent operation: a signal-like
+            // object with a missing/throwing listener API must not become the
+            // tool's failure, and a throwing `detach` must not pre-empt the
+            // status/exception recording that follows it.
+            guarded.safe("abort", () =>
+              signal?.addEventListener("abort", onAbort, { once: true }),
+            );
+            const detach = () =>
+              guarded.safe("abort", () => signal?.removeEventListener("abort", onAbort));
+            // A signal already aborted before the call started never fires the
+            // listener, so close the span here rather than leak it.
+            if (signal?.aborted) onAbort();
+
+            const succeed = (result: unknown) => {
+              detach();
+              guarded.mutate("result", () => span.setAttributes(toolResultAttributes(result)));
+              guarded.mutate("status", () => span.setStatus({ code: SpanStatusCode.OK }));
+              guarded.end();
+            };
+
+            const fail = (err: unknown) => {
+              detach();
+              const error = err instanceof Error ? err : new Error(String(err));
+              guarded.mutate("status", () =>
+                span.setStatus({ code: SpanStatusCode.ERROR, message: error.message }),
+              );
+              guarded.mutate("exception", () => span.recordException(error));
+              guarded.end();
+            };
+
+            try {
+              // `.call(entry, …)` because the SDK invokes tools as
+              // `tool.execute.bind(tool)` — a tool authored with method
+              // shorthand may rely on `this`.
+              const out: unknown = origExecute.call(entry, input, options);
+
+              // `execute` has three legal return arms (`ToolExecuteFunction`):
+              // an AsyncIterable, a PromiseLike, or a plain value. The arm
+              // dispatch itself is inside the try: a thenable whose `then` is a
+              // throwing getter must not escape with the span still open.
+              if (isAsyncIterable(out)) {
+                // Streaming tool. The span closes when `execute` RETURNS the
+                // iterable — before any chunk is pulled — so it measures setup
+                // only and cannot see a mid-stream failure. Status is therefore
+                // left UNSET rather than OK: "outcome unknown" must not be
+                // laundered into "succeeded" (same rationale as the
+                // pure-interrupt case in `withEffectSpan`).
+                detach();
+                guarded.mutate("streaming", () =>
+                  span.setAttributes({ "atlas.tool.streaming": true }),
+                );
+                guarded.end();
+                return out;
+              }
+
+              if (!isPromiseLike(out)) {
+                succeed(out);
+                return out;
+              }
+
+              return out.then(
+                (result) => {
+                  succeed(result);
+                  return result;
+                },
+                (err: unknown) => {
+                  fail(err);
+                  throw err;
+                },
+              );
+            } catch (err) {
+              fail(err);
+              throw err;
+            }
+          },
+        ),
+    };
+  }
+
+  return wrapped;
+}


### PR DESCRIPTION
Closes #4464.

## Problem

Inside the `atlas.agent` trace, only the tools that remembered to self-instrument (`atlas.sql.execute`, `atlas.explore`, `atlas.python.execute`, `atlas.profile.table`) carried an `atlas.*` span. `searchKnowledge` (a default-registry hot-path tool), `createDashboard`, `executeRestOperation` and the action tools had none, so per-tool latency couldn't be attributed from the `atlas.`-prefixed views. The registry had no span logic, so every tool had to remember — which is how the gap grew.

## Change

`ToolRegistry.getAll()` — the point where tools leave the registry for the AI SDK — now wraps every **executable** tool in an `atlas.tool.<name>` span via `withToolSpans` (`lib/tools/tool-spans.ts`). Tracing becomes a property of *being registered*: a newly registered tool gets a span with **zero per-tool code**.

- **Floor, not ceiling** — a self-instrumenting tool keeps its inner span, nested under the seam span (`startActiveSpan`, so the tool body runs in its context).
- **`get()` / `entries()` stay raw** — they feed metadata and `merge()`; wrapping there would nest a redundant span per merge hop. Pinned by a regression test.
- **Shape-preserving** — all three `ToolExecuteFunction` arms are dispatched explicitly (`AsyncIterable` → `PromiseLike` → plain value). The streaming arm is returned unwrapped and left `UNSET`, not `OK`: the span closes before the first chunk is pulled, so "outcome unknown" isn't laundered into "succeeded".
- **Telemetry can't fail a turn** — every span-adjacent operation is individually guarded and logged on failure, so one throwing mutation costs only itself; `end()` is latched so no path double-ends or leaks; both throw paths rethrow the *original* error object. An aborted turn closes the span with `atlas.tool.aborted` rather than leaving it open.

`atlas.tool.error` counts the dominant Atlas failure convention — tools that *return* `{ error }` / `success: false` rather than throwing, which the AI SDK's own `ai.toolCall` span scores as a success. Its known gaps (status-discriminated tools like `sendEmail`/`createLinearIssue`, string-returning `explore`) are documented as a lower bound rather than papered over with a per-tool success table that would silently rot.

## Docs

New `docs/development/telemetry.md`: the span/attribute conventions, where the wrappers are, the seam's honest boundaries (plugin hook dispatch sits outside the span; a `beforeToolCall`-rejected call emits **no** span; `atlas.tool.*` nests inside `ai.toolCall`), and a grandfathered-exceptions table. Per the issue's acceptance criteria, the off-convention names (`stripe.webhook.process`, `billing.agent_gate`, bare python/MCP attributes) are **documented, not renamed** — renames break live trace queries. The operator-facing `platform-ops/observability.mdx` is updated for the new hierarchy, which it previously misstated.

## Testing

`tool-spans.test.ts` uses a stub `TracerProvider` built from `@opentelemetry/api` alone — no new devDep — so the hand-rolled span lifecycle is directly asserted: span naming, attributes, status, exception recording, `end()` exactly once on every exit path (sync throw / reject / error-result / streaming / abort), concurrent calls on independent spans, and that an exploding span mutation still can't fail the call or mask the tool's error. The stub's `startSpan` throws, so a regression from `startActiveSpan` (which would flatten the hierarchy in prod) fails the suite.

- 28 span tests + the registry seam tests green
- `--affected`: 123 files green
- `/ci`: all 31 gates green
- Internal review panel: 3 rounds (silent-failure, type-design, test-coverage, comment accuracy) — converged; every must-fix addressed inline