### PR TITLE
feat: per-tier Knowledge Base caps as a SaaS entitlement lever

### DIFF
--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -116,15 +116,31 @@ All Knowledge Base knobs are platform-scoped operator guardrails (abuse caps and
 
 | Setting | Default | What it does |
 |---------|---------|--------------|
-| `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` | `1000` | Max documents per ingested bundle |
+| `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` | `1000` | Max documents per ingested bundle (`5000` on Atlas Cloud — see plan limits below) |
 | `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` | `1000000` (1 MB) | Max decoded size per document (oversized files rejected per-file) |
-| `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) | Max bundle upload size; also bounds decompression |
+| `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) | Max bundle upload size; also bounds decompression (`100000000` on Atlas Cloud — see plan limits below) |
 | `ATLAS_KNOWLEDGE_TOC_MAX_BYTES` | `12000` | Cap on the collection table of contents injected into the agent's system prompt |
 | `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often synced collections pull their endpoint (hot-reloaded — applies by the next scheduled tick) |
 | `ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS` | `60` | Per-sync download time budget |
 | `ATLAS_KNOWLEDGE_SYNC_RECONCILE_INTERVAL_HOURS` | `168` | How often a connector-synced collection runs a full reconciliation crawl (archives vendor-deleted pages) instead of the cheap incremental fetch |
 
 See the [environment variables reference](/reference/environment-variables#knowledge-base) for details.
+
+### Plan limits on Atlas Cloud
+
+On the hosted SaaS the settings above are the operator's fleet-wide ceiling and your **plan** carries its own Knowledge Base limits. The limit that applies is the smaller of the two:
+
+| Limit | Starter (and trial) | Pro | Business |
+|-------|--------------------|-----|----------|
+| Knowledge collections per workspace | 1 | 3 | Unlimited |
+| Bundle size per ingest | 10 MB | 25 MB | 100 MB |
+| Documents per ingest | 250 | 1,000 | 5,000 |
+
+Creating a collection or ingesting a bundle beyond your plan's limit returns a `plan_upgrade_required` response naming the tier that would admit it. Existing collections are never removed when a workspace changes plan: a workspace above its new limit keeps what it has and simply cannot add more, and editing or re-syncing an existing collection is never blocked.
+
+The per-document 1 MB cap is not a plan limit — it is an abuse guardrail that applies identically on every tier.
+
+Self-hosted deployments have no plan limits at all: the settings above remain the only Knowledge Base caps.
 
 ---
 

--- a/apps/docs/content/docs/guides/knowledge-base.mdx
+++ b/apps/docs/content/docs/guides/knowledge-base.mdx
@@ -116,9 +116,9 @@ All Knowledge Base knobs are platform-scoped operator guardrails (abuse caps and
 
 | Setting | Default | What it does |
 |---------|---------|--------------|
-| `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` | `1000` | Max documents per ingested bundle (`5000` on Atlas Cloud — see plan limits below) |
+| `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` | `1000` self-hosted / `5000` Cloud | Max documents per ingested bundle (see plan limits below) |
 | `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` | `1000000` (1 MB) | Max decoded size per document (oversized files rejected per-file) |
-| `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) | Max bundle upload size; also bounds decompression (`100000000` on Atlas Cloud — see plan limits below) |
+| `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) self-hosted / `100000000` (100 MB) Cloud | Max bundle upload size; also bounds decompression (see plan limits below) |
 | `ATLAS_KNOWLEDGE_TOC_MAX_BYTES` | `12000` | Cap on the collection table of contents injected into the agent's system prompt |
 | `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often synced collections pull their endpoint (hot-reloaded — applies by the next scheduled tick) |
 | `ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS` | `60` | Per-sync download time budget |
@@ -136,7 +136,9 @@ On the hosted SaaS the settings above are the operator's fleet-wide ceiling and 
 | Bundle size per ingest | 10 MB | 25 MB | 100 MB |
 | Documents per ingest | 250 | 1,000 | 5,000 |
 
-Creating a collection or ingesting a bundle beyond your plan's limit returns a `plan_upgrade_required` response naming the tier that would admit it. Existing collections are never removed when a workspace changes plan: a workspace above its new limit keeps what it has and simply cannot add more, and editing or re-syncing an existing collection is never blocked.
+Creating a collection or uploading a bundle beyond your plan's limit returns a `plan_upgrade_required` response naming the cheapest plan that would admit it — when a higher plan would. Scheduled syncs have no HTTP response to carry that, so they surface the same limit as an error on the collection's sync status instead.
+
+Existing collections are never removed when a workspace changes plan: a workspace above its new limit keeps what it has and simply cannot add more, and editing an existing collection is never blocked by the collections cap. Note that a re-sync is still subject to your plan's per-ingest size and document limits, so a collection that outgrew a downgraded plan will report a limit error until it fits or the plan is raised.
 
 The per-document 1 MB cap is not a plan limit — it is an abuse guardrail that applies identically on every tier.
 

--- a/apps/docs/content/shared/reference/environment-variables.mdx
+++ b/apps/docs/content/shared/reference/environment-variables.mdx
@@ -200,9 +200,9 @@ Caps and cadence for hosted <AudienceLink saas="/guides/knowledge-base">Knowledg
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` | `1000` | Maximum number of documents a single knowledge bundle may ingest |
+| `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS` | `1000` self-hosted / `5000` on Atlas Cloud | Maximum number of documents a single knowledge bundle may ingest. On Atlas Cloud the unset default is the Business-tier ceiling and each workspace is additionally bound by its plan — the effective limit is the smaller of the two |
 | `ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES` | `1000000` (1 MB) | Maximum decoded size of any single document in a knowledge bundle; oversized documents are rejected per-file (surfaced in the upload result, never silently skipped) |
-| `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) | Maximum raw upload size of a knowledge bundle; also reused as the decoded-total cap that aborts a decompression bomb mid-inflate |
+| `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES` | `25000000` (25 MB) self-hosted / `100000000` (100 MB) on Atlas Cloud | Maximum raw upload size of a knowledge bundle; also reused as the decoded-total cap that aborts a decompression bomb mid-inflate. On Atlas Cloud the unset default is the Business-tier ceiling and each workspace is additionally bound by its plan |
 | `ATLAS_KNOWLEDGE_TOC_MAX_BYTES` | `12000` (≈3k tokens) | Maximum size of the Knowledge Base collection table-of-contents injected into the agent's system prompt. Collections beyond the cap are omitted from the prompt but remain browsable via the explore tool |
 | `ATLAS_KNOWLEDGE_SYNC_INTERVAL_HOURS` | `24` | How often bundle-sync collections pull their endpoint (default nightly). Hot-reloaded — a change takes effect by the next scheduled tick, no restart needed |
 | `ATLAS_KNOWLEDGE_SYNC_FETCH_TIMEOUT_SECONDS` | `60` | Per-sync time budget for downloading a collection's bundle endpoint, bounding the whole fetch including redirects and body streaming |

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -79774,6 +79774,12 @@
                             "number",
                             "null"
                           ]
+                        },
+                        "maxKnowledgeCollections": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
                         }
                       },
                       "required": [
@@ -79782,7 +79788,8 @@
                         "totalUsageDollars",
                         "maxSeats",
                         "maxConnections",
-                        "maxChatIntegrations"
+                        "maxChatIntegrations",
+                        "maxKnowledgeCollections"
                       ]
                     },
                     "usage": {

--- a/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
@@ -46,7 +46,9 @@ void mock.module("@atlas/api/lib/billing/enforcement", () => ({
   checkChatIntegrationLimit: mock(async () => ({ allowed: true })),
   checkChatIntegrationLimitAndInstall: mock(async () => ({ outcome: "installed" })),
   KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
   checkKnowledgeCollectionLimit: mock(async () => ({ allowed: true })),
+  checkKnowledgeCollectionFanOutLimit: mock(async () => ({ allowed: true })),
   checkKnowledgeCollectionLimitAndInstall: mock(async () => ({ allowed: true, rows: [] })),
 }));
 
@@ -81,6 +83,7 @@ describe("POST /api/v1/admin/connections resource-limit arms (#3433)", () => {
       reason: "cap_reached",
       errorMessage: "Your starter plan allows up to 3 connections. Upgrade to add more.",
       limit: 3,
+    tier: "starter" as const,
     }));
 
     const res = await app.fetch(createRequest());

--- a/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
@@ -45,6 +45,9 @@ void mock.module("@atlas/api/lib/billing/enforcement", () => ({
   CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
   checkChatIntegrationLimit: mock(async () => ({ allowed: true })),
   checkChatIntegrationLimitAndInstall: mock(async () => ({ outcome: "installed" })),
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  checkKnowledgeCollectionLimit: mock(async () => ({ allowed: true })),
+  checkKnowledgeCollectionLimitAndInstall: mock(async () => ({ allowed: true, rows: [] })),
 }));
 
 const { app } = await import("../index");

--- a/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-resource-limit.test.ts
@@ -83,7 +83,7 @@ describe("POST /api/v1/admin/connections resource-limit arms (#3433)", () => {
       reason: "cap_reached",
       errorMessage: "Your starter plan allows up to 3 connections. Upgrade to add more.",
       limit: 3,
-    tier: "starter" as const,
+      tier: "starter" as const,
     }));
 
     const res = await app.fetch(createRequest());

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -281,6 +281,9 @@ describe("billing routes", () => {
       // #3438 — the chat-integration cap the install gate enforces must reach
       // the wire so the billing page can display it (Starter = 1).
       expect(body.limits.maxChatIntegrations).toBe(1);
+      // #4235 — same for the Knowledge Base collections cap (Starter = 1), so a
+      // customer can SEE the limit their next install will hit, not only a 403.
+      expect(body.limits.maxKnowledgeCollections).toBe(1);
       expect(body.usage.queryCount).toBe(500);
       // Per-seat pricing fields
       expect(body.seats).toEqual({ count: 3, max: 10 });

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -107,8 +107,20 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: () => ({ connect: async () => fakeTxClient() }),
 }));
 
+// The real bridge catches a handler throw and maps the tagged error to HTTP.
+// This stub keeps the pass-through shape but records the thrown error, so a
+// test can assert the TAG the bridge would have mapped (the 403 envelope
+// mapping itself is pinned in the bridge's own tests).
+let lastHandlerError: unknown = null;
 void mock.module("@atlas/api/lib/effect/hono", () => ({
-  runHandler: async (_c: unknown, _label: string, fn: () => unknown) => fn(),
+  runHandler: async (_c: unknown, _label: string, fn: () => unknown) => {
+    try {
+      return await fn();
+    } catch (err) {
+      lastHandlerError = err;
+      throw err;
+    }
+  },
 }));
 
 void mock.module("@atlas/api/lib/logger", () => {
@@ -257,6 +269,18 @@ void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({
   },
 }));
 
+// Per-tier KB caps (#4235). `resolveIngestCaps` composes the mocked platform
+// getters above with this workspace's tier, so setting a tier here is how a
+// test makes the TIER the binding cap. Only `getCachedWorkspace` is reachable
+// from this file's graph via `billing/knowledge-limits`; the two collection-cap
+// entries come in through `okf-upload-form-handler`.
+let WORKSPACE_TIER: string | null = null;
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  getCachedWorkspace: async () => (WORKSPACE_TIER === null ? null : { plan_tier: WORKSPACE_TIER }),
+  checkKnowledgeCollectionLimit: async () => ({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: async () => ({ allowed: true, rows: [] }),
+}));
+
 void mock.module("../admin-router", () => ({
   createAdminRouter: () => new OpenAPIHono(),
   requireOrgContext: () => async (c: { set: (k: string, v: unknown) => void }, next: () => Promise<void>) => {
@@ -266,6 +290,7 @@ void mock.module("../admin-router", () => ({
 }));
 
 const { adminKnowledge } = await import("../admin-knowledge");
+const { FeatureEntitlementError } = await import("@atlas/api/lib/effect/errors");
 
 function ingest(path: string, body: Uint8Array) {
   return adminKnowledge.request(path, {
@@ -276,6 +301,8 @@ function ingest(path: string, body: Uint8Array) {
 }
 
 beforeEach(() => {
+  WORKSPACE_TIER = null;
+  lastHandlerError = null;
   TX_INSTALL_STATUS = "published";
   MAX_DOCS = 100;
   MAX_DOC_BYTES = 100_000;
@@ -369,6 +396,60 @@ describe("POST /{collectionSlug}/ingest — guards", () => {
     const res = await ingest("/runbooks/ingest", strToU8("just some text, not an archive"));
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: string }).error).toBe("invalid_bundle");
+  });
+
+  describe("per-tier caps (#4235)", () => {
+    // `runHandler` is stubbed to call the handler directly in this file, so a
+    // tagged error propagates instead of being mapped. The tag IS the contract:
+    // the Hono bridge turns `FeatureEntitlementError` into the standard 403
+    // `plan_upgrade_required` envelope (pinned in the bridge's own tests).
+    it("raises the 403 upgrade envelope when the workspace's TIER is the binding bundle-size cap", async () => {
+      MAX_BUNDLE_BYTES = 100_000_000; // the SaaS platform ceiling
+      WORKSPACE_TIER = "starter"; // 10 MB — the binding cap
+      await adminKnowledge.request("/runbooks/ingest", {
+        method: "POST",
+        body: zipSync({ "a.md": strToU8("# A") }),
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": "20000000",
+        },
+      });
+      expect(lastHandlerError).toBeInstanceOf(FeatureEntitlementError);
+      const typed = lastHandlerError as InstanceType<typeof FeatureEntitlementError>;
+      expect(typed.currentPlan).toBe("starter");
+      expect(typed.requiredPlan).toBe("pro");
+    });
+
+    it("raises the 403 upgrade envelope when the TIER is the binding doc-count cap", async () => {
+      MAX_DOCS = 5_000; // the SaaS platform ceiling
+      MAX_BUNDLE_BYTES = 100_000_000;
+      WORKSPACE_TIER = "starter";
+      const files: Record<string, Uint8Array> = {};
+      for (let i = 0; i < 251; i++) files[`d${i}.md`] = strToU8(`# ${i}`);
+      await ingest("/runbooks/ingest", zipSync(files));
+      expect(lastHandlerError).toBeInstanceOf(FeatureEntitlementError);
+      expect((lastHandlerError as InstanceType<typeof FeatureEntitlementError>).requiredPlan).toBe(
+        "pro",
+      );
+    });
+
+    it("stays a plain 400 when the PLATFORM ceiling bound — upgrading would change nothing", async () => {
+      MAX_BUNDLE_BYTES = 10;
+      WORKSPACE_TIER = "business";
+      const res = await ingest("/runbooks/ingest", zipSync({ "a.md": strToU8("# A longer body") }));
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBe("bundle_too_large");
+      expect(lastHandlerError).toBeNull();
+    });
+
+    it("leaves a self-hosted (free-tier) workspace on the platform caps alone", async () => {
+      MAX_BUNDLE_BYTES = 10;
+      WORKSPACE_TIER = "free";
+      const res = await ingest("/runbooks/ingest", zipSync({ "a.md": strToU8("# A longer body") }));
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBe("bundle_too_large");
+      expect(lastHandlerError).toBeNull();
+    });
   });
 
   it("400s when the doc count exceeds the cap", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -458,6 +458,23 @@ describe("POST /{collectionSlug}/ingest — guards", () => {
       );
     });
 
+    it("keeps the STREAMED-overflow path a plain 400 with a tier present — never a spurious 403", async () => {
+      // The streamed path (no content-length) hits `BodyCapExceededError`, whose
+      // `assertNotTierBound({exact:false})` guard must never name an upgrade
+      // target from a lower bound. Here the platform ceiling binds (tie → the
+      // operator side), so the assertion is that a resolved tier context does
+      // not turn the abort into a 403. The `exact:false` decline-to-name
+      // behaviour itself is unit-tested in knowledge-limits.test.ts.
+      MAX_BUNDLE_BYTES = 10;
+      WORKSPACE_TIER = "starter";
+      const res = await ingest("/runbooks/ingest", zipSync({ "a.md": strToU8("# A longer body") }));
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("bundle_too_large");
+      expect(body.message).toContain("upload aborted");
+      expect(lastHandlerError).toBeNull();
+    });
+
     it("stays a plain 400 when the PLATFORM ceiling bound — upgrading would change nothing", async () => {
       MAX_BUNDLE_BYTES = 10;
       WORKSPACE_TIER = "business";

--- a/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-knowledge.test.ts
@@ -275,10 +275,32 @@ void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({
 // from this file's graph via `billing/knowledge-limits`; the two collection-cap
 // entries come in through `okf-upload-form-handler`.
 let WORKSPACE_TIER: string | null = null;
+let WORKSPACE_LOOKUP_THROWS = false;
+// Mock every value export — a partial `mock.module()` breaks other importers
+// of the module (CLAUDE.md "mock all exports").
 void mock.module("@atlas/api/lib/billing/enforcement", () => ({
-  getCachedWorkspace: async () => (WORKSPACE_TIER === null ? null : { plan_tier: WORKSPACE_TIER }),
-  checkKnowledgeCollectionLimit: async () => ({ allowed: true }),
-  checkKnowledgeCollectionLimitAndInstall: async () => ({ allowed: true, rows: [] }),
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
+  getCachedWorkspace: async () => {
+    if (WORKSPACE_LOOKUP_THROWS) throw new Error("workspace lookup exploded");
+    return WORKSPACE_TIER === null ? null : { plan_tier: WORKSPACE_TIER };
+  },
 }));
 
 void mock.module("../admin-router", () => ({
@@ -290,7 +312,9 @@ void mock.module("../admin-router", () => ({
 }));
 
 const { adminKnowledge } = await import("../admin-knowledge");
-const { FeatureEntitlementError } = await import("@atlas/api/lib/effect/errors");
+const { BillingCheckFailedError, FeatureEntitlementError } = await import(
+  "@atlas/api/lib/effect/errors"
+);
 
 function ingest(path: string, body: Uint8Array) {
   return adminKnowledge.request(path, {
@@ -302,6 +326,7 @@ function ingest(path: string, body: Uint8Array) {
 
 beforeEach(() => {
   WORKSPACE_TIER = null;
+  WORKSPACE_LOOKUP_THROWS = false;
   lastHandlerError = null;
   TX_INSTALL_STATUS = "published";
   MAX_DOCS = 100;
@@ -440,6 +465,16 @@ describe("POST /{collectionSlug}/ingest — guards", () => {
       expect(res.status).toBe(400);
       expect(((await res.json()) as { error: string }).error).toBe("bundle_too_large");
       expect(lastHandlerError).toBeNull();
+    });
+
+    it("fails CLOSED with a 503-class error when the workspace lookup faults", async () => {
+      // `resolveIngestCaps` is now the FIRST thing the ingest handler does, so
+      // a transient internal-DB fault must refuse the upload rather than run it
+      // against a cap we could not verify.
+      WORKSPACE_LOOKUP_THROWS = true;
+      await ingest("/runbooks/ingest", zipSync({ "a.md": strToU8("# A") }));
+      expect(lastHandlerError).toBeInstanceOf(BillingCheckFailedError);
+      expect(store.size).toBe(0);
     });
 
     it("leaves a self-hosted (free-tier) workspace on the platform caps alone", async () => {

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -42,7 +42,10 @@ import { runHandler } from "@atlas/api/lib/effect/hono";
 import { ingestBundle } from "@atlas/api/lib/knowledge/ingest-bundle";
 import { uninstallCollection } from "@atlas/api/lib/knowledge/collection-lifecycle";
 import { readBodyWithCap, BodyCapExceededError } from "@atlas/api/lib/knowledge/read-body-cap";
-import { getIngestMaxBundleBytes } from "@atlas/api/lib/knowledge/ingest-limits";
+import {
+  assertNotTierBound,
+  resolveIngestCaps,
+} from "@atlas/api/lib/billing/knowledge-limits";
 import {
   buildCollectionDocumentsQuery,
   buildDocumentStatusCountsQuery,
@@ -607,10 +610,21 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
     // cumulative cap (the same `readBodyWithCap` guard the sync fetch uses) — a
     // chunked or lying upload aborts the moment it crosses the limit instead of
     // fully materializing in memory first. The remaining caps (decompression
-    // bomb, doc count/bytes) live inside `ingestBundle` (the shared seam).
-    const maxBundleBytes = getIngestMaxBundleBytes();
+    // bomb, doc count/bytes) live inside `ingestBundle` (the shared seam) — the
+    // SAME `caps` object is handed down, so one tier lookup governs both stages
+    // and the body cap can never disagree with the seam's (#4235).
+    const caps = await resolveIngestCaps(orgId);
+    const { value: maxBundleBytes, boundBy: bundleBoundBy } = caps.maxBundleBytes;
     const declaredLength = Number(c.req.header("content-length"));
     if (Number.isFinite(declaredLength) && declaredLength > maxBundleBytes) {
+      await assertNotTierBound({
+        orgId,
+        field: "maxKnowledgeBundleBytes",
+        boundBy: bundleBoundBy,
+        required: declaredLength,
+        limit: maxBundleBytes,
+        noun: "bytes per bundle",
+      });
       return c.json(
         {
           error: "bundle_too_large",
@@ -625,6 +639,17 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
       bytes = await readBodyWithCap(c.req.raw.body, maxBundleBytes, { requestId });
     } catch (err) {
       if (err instanceof BodyCapExceededError) {
+        // The body was streamed and aborted at the cap, so the true size is
+        // unknown — `maxBundleBytes + 1` is the smallest value that provably
+        // breached it, which is exactly what naming an upgrade target needs.
+        await assertNotTierBound({
+          orgId,
+          field: "maxKnowledgeBundleBytes",
+          boundBy: bundleBoundBy,
+          required: maxBundleBytes + 1,
+          limit: maxBundleBytes,
+          noun: "bytes per bundle",
+        });
         return c.json(
           {
             error: "bundle_too_large",
@@ -647,6 +672,7 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
       collectionId: collectionSlug,
       source: "upload",
       bytes,
+      caps,
       publish: shouldPublish,
     });
 
@@ -667,6 +693,14 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
             400,
           );
         case "bundle_too_large":
+          await assertNotTierBound({
+            orgId,
+            field: "maxKnowledgeBundleBytes",
+            boundBy: outcome.boundBy,
+            required: outcome.bytes,
+            limit: outcome.maxBundleBytes,
+            noun: "bytes per bundle",
+          });
           return c.json(
             {
               error: "bundle_too_large",
@@ -678,6 +712,14 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
         case "invalid_bundle":
           return c.json({ error: "invalid_bundle", message: outcome.message, requestId }, 400);
         case "too_many_documents":
+          await assertNotTierBound({
+            orgId,
+            field: "maxKnowledgeDocsPerBundle",
+            boundBy: outcome.boundBy,
+            required: outcome.count,
+            limit: outcome.maxDocs,
+            noun: "documents in one bundle",
+          });
           return c.json(
             {
               error: "too_many_documents",

--- a/packages/api/src/api/routes/admin-knowledge.ts
+++ b/packages/api/src/api/routes/admin-knowledge.ts
@@ -617,8 +617,9 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
     const { value: maxBundleBytes, boundBy: bundleBoundBy } = caps.maxBundleBytes;
     const declaredLength = Number(c.req.header("content-length"));
     if (Number.isFinite(declaredLength) && declaredLength > maxBundleBytes) {
-      await assertNotTierBound({
+      assertNotTierBound({
         orgId,
+        tier: caps.tier,
         field: "maxKnowledgeBundleBytes",
         boundBy: bundleBoundBy,
         required: declaredLength,
@@ -639,14 +640,18 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
       bytes = await readBodyWithCap(c.req.raw.body, maxBundleBytes, { requestId });
     } catch (err) {
       if (err instanceof BodyCapExceededError) {
-        // The body was streamed and aborted at the cap, so the true size is
-        // unknown — `maxBundleBytes + 1` is the smallest value that provably
-        // breached it, which is exactly what naming an upgrade target needs.
-        await assertNotTierBound({
+        // The body was streamed and aborted AT the cap, so its true size is
+        // unknown — only that it exceeded `maxBundleBytes`. `exact: false`
+        // says so: a lower bound proves this tier was breached but not that
+        // any higher one admits the real body, so no upgrade target is named
+        // and the plain over-limit 400 below stands.
+        assertNotTierBound({
           orgId,
+          tier: caps.tier,
           field: "maxKnowledgeBundleBytes",
           boundBy: bundleBoundBy,
           required: maxBundleBytes + 1,
+          exact: false,
           limit: maxBundleBytes,
           noun: "bytes per bundle",
         });
@@ -693,8 +698,9 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
             400,
           );
         case "bundle_too_large":
-          await assertNotTierBound({
+          assertNotTierBound({
             orgId,
+            tier: caps.tier,
             field: "maxKnowledgeBundleBytes",
             boundBy: outcome.boundBy,
             required: outcome.bytes,
@@ -712,8 +718,9 @@ adminKnowledge.openapi(ingestRoute, async (c) =>
         case "invalid_bundle":
           return c.json({ error: "invalid_bundle", message: outcome.message, requestId }, 400);
         case "too_many_documents":
-          await assertNotTierBound({
+          assertNotTierBound({
             orgId,
+            tier: caps.tier,
             field: "maxKnowledgeDocsPerBundle",
             boundBy: outcome.boundBy,
             required: outcome.count,

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -505,6 +505,9 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         maxSeats: isUnlimited(limits.maxSeats) ? null : limits.maxSeats,
         maxConnections: isUnlimited(limits.maxConnections) ? null : limits.maxConnections,
         maxChatIntegrations: isUnlimited(limits.maxChatIntegrations) ? null : limits.maxChatIntegrations,
+        maxKnowledgeCollections: isUnlimited(limits.maxKnowledgeCollections)
+          ? null
+          : limits.maxKnowledgeCollections,
       },
       usage: {
         queryCount: usage.queryCount,

--- a/packages/api/src/lib/__tests__/settings.test.ts
+++ b/packages/api/src/lib/__tests__/settings.test.ts
@@ -821,6 +821,34 @@ describe("settings module", () => {
   // ATLAS_DEFAULT_ANSWER_STYLE — the workspace "house voice" (#4303, PRD #4292)
   // ---------------------------------------------------------------------------
 
+  describe("Knowledge Base ingest-cap registry entries (#4235)", () => {
+    // The ABSENCE of a static `default` on these two keys is load-bearing, not
+    // an oversight: `getSetting`'s precedence is override → env → registry
+    // default, so a static default would SHADOW the deploy-mode-aware fallback
+    // in `lib/knowledge/ingest-limits.ts` and silently clamp the SaaS ceiling
+    // back to the self-hosted 25 MB / 1000 docs — re-capping the Business tier
+    // at a quarter of what it was sold, with a fully green suite (the
+    // ingest-limits tests mock `getSettingAuto` wholesale and cannot see it).
+    // Same pattern as ATLAS_RATE_LIMIT_RPM.
+    it.each([
+      ["ATLAS_KNOWLEDGE_INGEST_MAX_DOCS"],
+      ["ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES"],
+    ])("%s carries NO static default (the resolver owns it)", (key) => {
+      const def = getSettingDefinition(key);
+      expect(def).toBeDefined();
+      expect(def!.scope).toBe("platform");
+      expect(def!.default).toBeUndefined();
+    });
+
+    it("keeps a static default on the per-document cap — it is not deploy-mode-aware", () => {
+      // Platform-only by design: an abuse guardrail on one row, never a
+      // pricing lever, so it has no tier half and no SaaS ceiling to reach.
+      const def = getSettingDefinition("ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES");
+      expect(def).toBeDefined();
+      expect(def!.default).toBe("1000000");
+    });
+  });
+
   describe("ATLAS_DEFAULT_ANSWER_STYLE registry entry (#4303)", () => {
     it("is a workspace-scoped, hot-reloadable select with no built-in default", () => {
       const def = getSettingDefinition("ATLAS_DEFAULT_ANSWER_STYLE");

--- a/packages/api/src/lib/auth/__tests__/invitations-seat-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/invitations-seat-limit.test.ts
@@ -73,6 +73,7 @@ describe("enforceInvitationSeatLimit error-arm mapping (#3433)", () => {
       reason: "cap_reached",
       errorMessage: "Your starter plan allows up to 5 seats. Upgrade to add more.",
       limit: 5,
+    tier: "starter" as const,
     }));
 
     const err = await expectAPIError();

--- a/packages/api/src/lib/auth/__tests__/invitations-seat-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/invitations-seat-limit.test.ts
@@ -73,7 +73,7 @@ describe("enforceInvitationSeatLimit error-arm mapping (#3433)", () => {
       reason: "cap_reached",
       errorMessage: "Your starter plan allows up to 5 seats. Upgrade to add more.",
       limit: 5,
-    tier: "starter" as const,
+      tier: "starter" as const,
     }));
 
     const err = await expectAPIError();

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -139,7 +139,7 @@ void mock.module("@atlas/api/lib/logger", () => ({
 // bypass-alert assertion unable to observe `log.error`. Types are erased at
 // compile time, so they stay as a static `import type`.
 import type {
-  ChatIntegrationInstallResult,
+  CapGatedInstallResult,
   PlanCheckResult,
   ResourceLimitResult,
 } from "@atlas/api/lib/billing/enforcement";
@@ -255,20 +255,20 @@ function makeFakeTxnClient(opts: FakeTxnClientOpts = {}) {
 
 /** Narrow a chat-install gate cap_reached denial for `.limit` access. */
 function expectInstallCapReached<T extends Record<string, unknown>>(
-  result: ChatIntegrationInstallResult<T>,
-): Extract<ChatIntegrationInstallResult<T>, { reason: "cap_reached" }> {
+  result: CapGatedInstallResult<T>,
+): Extract<CapGatedInstallResult<T>, { reason: "cap_reached" }> {
   expect(result.allowed).toBe(false);
   if (!result.allowed) expect(result.reason).toBe("cap_reached");
-  return result as Extract<ChatIntegrationInstallResult<T>, { reason: "cap_reached" }>;
+  return result as Extract<CapGatedInstallResult<T>, { reason: "cap_reached" }>;
 }
 
 /** Narrow a chat-install gate check_failed (fail-closed) denial. */
 function expectInstallCheckFailed<T extends Record<string, unknown>>(
-  result: ChatIntegrationInstallResult<T>,
-): Extract<ChatIntegrationInstallResult<T>, { reason: "check_failed" }> {
+  result: CapGatedInstallResult<T>,
+): Extract<CapGatedInstallResult<T>, { reason: "check_failed" }> {
   expect(result.allowed).toBe(false);
   if (!result.allowed) expect(result.reason).toBe("check_failed");
-  return result as Extract<ChatIntegrationInstallResult<T>, { reason: "check_failed" }>;
+  return result as Extract<CapGatedInstallResult<T>, { reason: "check_failed" }>;
 }
 
 /** Create a standard workspace fixture (defaults to starter tier). */

--- a/packages/api/src/lib/billing/__tests__/knowledge-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/knowledge-cap-pg.test.ts
@@ -27,6 +27,8 @@ import {
 } from "@atlas/api/lib/db/internal";
 import {
   KNOWLEDGE_COLLECTION_COUNT_SQL,
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL,
+  checkKnowledgeCollectionFanOutLimit,
   checkKnowledgeCollectionLimitAndInstall,
   invalidatePlanCache,
 } from "@atlas/api/lib/billing/enforcement";
@@ -142,6 +144,159 @@ describeIfPg("KNOWLEDGE_COLLECTION_COUNT_SQL (real Postgres)", () => {
   );
 });
 
+describeIfPg("KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `kb_cap_fanout_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `knowledge-cap-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    await seedCatalog(pool, "okf-upload", "knowledge", "context");
+    await seedCatalog(pool, "zendesk", "knowledge", "context");
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it(
+    "counts only collections OUTSIDE the batch, so a re-install of the same slugs is free",
+    async () => {
+      const ws = `ws-fanout-${Date.now()}`;
+      await seedInstall(pool, { id: `${ws}-1`, workspaceId: ws, catalog: "catalog:okf-upload", installId: "keep", pillar: "knowledge" });
+      await seedInstall(pool, { id: `${ws}-2`, workspaceId: ws, catalog: "catalog:zendesk", installId: "zd-a", pillar: "knowledge" });
+      await seedInstall(pool, { id: `${ws}-3`, workspaceId: ws, catalog: "catalog:zendesk", installId: "zd-b", pillar: "knowledge" });
+
+      // Re-installing the two Zendesk brands: only "keep" is outside the batch,
+      // and both batch members already exist (so the batch adds nothing).
+      const reinstall = await pool.query<{ others: number; this_count: number }>(
+        KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL,
+        [ws, ["zd-a", "zd-b"]],
+      );
+      expect(reinstall.rows[0]?.others).toBe(1);
+      expect(reinstall.rows[0]?.this_count).toBe(2);
+
+      // A net-new batch: all three existing collections are "others".
+      const netNew = await pool.query<{ others: number; this_count: number }>(
+        KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL,
+        [ws, ["new-a", "new-b"]],
+      );
+      expect(netNew.rows[0]?.others).toBe(3);
+      expect(netNew.rows[0]?.this_count).toBe(0);
+      expect(typeof netNew.rows[0]?.others).toBe("number");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});
+
+describeIfPg("checkKnowledgeCollectionFanOutLimit (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `kb_cap_fanout_gate_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `knowledge-cap-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    await pool.query(
+      `CREATE TABLE organization (
+         id text PRIMARY KEY, name text, slug text,
+         workspace_status text NOT NULL DEFAULT 'active',
+         plan_tier text NOT NULL DEFAULT 'free',
+         byot boolean NOT NULL DEFAULT false,
+         "stripeCustomerId" text, trial_ends_at timestamptz,
+         suspended_at timestamptz, suspension_source text,
+         plan_override_until timestamptz, deleted_at timestamptz,
+         region text, region_assigned_at timestamptz,
+         "createdAt" timestamptz NOT NULL DEFAULT now()
+       )`,
+    );
+    await seedCatalog(pool, "zendesk", "knowledge", "context");
+    process.env.DATABASE_URL = TEST_DB_URL;
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    invalidatePlanCache();
+    await pool.query(`DELETE FROM workspace_plugins`);
+    await pool.query(`DELETE FROM organization`);
+  });
+
+  it(
+    "refuses a whole 3-brand fan-out that would breach a Pro workspace's cap of 3",
+    async () => {
+      const ws = "ws-fanout-pro";
+      await pool.query(`INSERT INTO organization (id, name, slug, plan_tier) VALUES ($1,$1,$1,'pro')`, [ws]);
+      await seedInstall(pool, { id: "row-a", workspaceId: ws, catalog: "catalog:zendesk", installId: "existing", pillar: "knowledge" });
+
+      // 1 existing + 3 net-new = 4 > cap 3. A per-slug precheck would pass all
+      // three (each sees `others = 1`) and strand a partial install.
+      const decision = await checkKnowledgeCollectionFanOutLimit(ws, ["b1", "b2", "b3"]);
+      expect(decision.allowed).toBe(false);
+      if (decision.allowed || decision.reason !== "cap_reached") {
+        throw new Error("expected a cap_reached denial");
+      }
+      expect(decision.tier).toBe("pro");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "admits a fan-out that exactly fills the cap",
+    async () => {
+      const ws = "ws-fanout-fits";
+      await pool.query(`INSERT INTO organization (id, name, slug, plan_tier) VALUES ($1,$1,$1,'pro')`, [ws]);
+      await seedInstall(pool, { id: "row-a", workspaceId: ws, catalog: "catalog:zendesk", installId: "existing", pillar: "knowledge" });
+      expect((await checkKnowledgeCollectionFanOutLimit(ws, ["b1", "b2"])).allowed).toBe(true);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "never blocks re-installing the SAME brands an over-cap workspace already owns",
+    async () => {
+      const ws = "ws-fanout-reinstall";
+      await pool.query(`INSERT INTO organization (id, name, slug, plan_tier) VALUES ($1,$1,$1,'starter')`, [ws]);
+      await seedInstall(pool, { id: "row-a", workspaceId: ws, catalog: "catalog:zendesk", installId: "b1", pillar: "knowledge" });
+      await seedInstall(pool, { id: "row-b", workspaceId: ws, catalog: "catalog:zendesk", installId: "b2", pillar: "knowledge" });
+      // Starter's cap is 1 and the workspace holds 2 (a downgrade), yet
+      // re-running the same install adds nothing and must still be admitted.
+      expect((await checkKnowledgeCollectionFanOutLimit(ws, ["b1", "b2"])).allowed).toBe(true);
+      // Adding a THIRD brand on top does grow the set, so it is refused.
+      expect(
+        (await checkKnowledgeCollectionFanOutLimit(ws, ["b1", "b2", "b3"])).allowed,
+      ).toBe(false);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});
+
 describeIfPg("checkKnowledgeCollectionLimitAndInstall (real Postgres)", () => {
   let pool: Pool;
   const schemaName = `kb_cap_gate_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
@@ -241,8 +396,9 @@ describeIfPg("checkKnowledgeCollectionLimitAndInstall (real Postgres)", () => {
         collectionInsert("row-2", ws, "handbook"),
       );
       expect(second.allowed).toBe(false);
-      if (second.allowed) throw new Error("unreachable");
-      expect(second.reason).toBe("cap_reached");
+      if (second.allowed || second.reason !== "cap_reached") {
+        throw new Error("expected a cap_reached denial");
+      }
 
       // The refused INSERT must have rolled back — no orphan row.
       const rows = await pool.query(`SELECT install_id FROM workspace_plugins WHERE workspace_id = $1`, [ws]);
@@ -292,6 +448,58 @@ describeIfPg("checkKnowledgeCollectionLimitAndInstall (real Postgres)", () => {
         [ws],
       );
       expect(Number(count.rows[0]?.n)).toBe(3);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses the churn tier's FIRST collection — locked is a real zero, not unlimited",
+    async () => {
+      const ws = "ws-locked";
+      await seedOrg(ws, "locked"); // cap = 0
+      const r = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+        ws,
+        "docs",
+        collectionInsert("row-1", ws, "docs"),
+      );
+      expect(r.allowed).toBe(false);
+      if (r.allowed || r.reason !== "cap_reached") {
+        throw new Error("expected a cap_reached denial");
+      }
+      expect(r.limit).toBe(0);
+      expect(r.tier).toBe("locked");
+      const rows = await pool.query(
+        `SELECT 1 FROM workspace_plugins WHERE workspace_id = $1`,
+        [ws],
+      );
+      expect(rows.rowCount).toBe(0);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "caps a trial workspace exactly like starter (the highest-traffic SaaS tier)",
+    async () => {
+      const ws = "ws-trial";
+      await seedOrg(ws, "trial"); // cap = 1, mirroring starter
+      const first = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+        ws,
+        "docs",
+        collectionInsert("row-1", ws, "docs"),
+      );
+      expect(first.allowed).toBe(true);
+      const second = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+        ws,
+        "handbook",
+        collectionInsert("row-2", ws, "handbook"),
+      );
+      expect(second.allowed).toBe(false);
+      if (second.allowed || second.reason !== "cap_reached") {
+        throw new Error("expected a cap_reached denial");
+      }
+      // The denial carries the tier that set the cap, so the upgrade prompt
+      // never has to re-resolve (and can't name a stale plan).
+      expect(second.tier).toBe("trial");
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/billing/__tests__/knowledge-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/knowledge-cap-pg.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Real-Postgres coverage for the per-tier Knowledge Base **collections** cap
+ * (#4235). Mirrors `chat-cap-pg.test.ts`'s harness: skips cleanly when
+ * `TEST_DATABASE_URL` is unset, runs every migration into a unique per-test
+ * schema, and exercises what mock-pool tests can't see.
+ *
+ * What this catches that the mock-based tests can't:
+ *   - `KNOWLEDGE_COLLECTION_COUNT_SQL` is never executed by the unit tests
+ *     (they script the count rows). Knowledge partitions by `install_id`, NOT
+ *     by `catalog_id` like the chat aggregate — a copy-paste of the chat
+ *     predicate would still typecheck, still pass every unit test, and would
+ *     silently count several collections from one connector as a single slot.
+ *   - The `pg_advisory_xact_lock` serialization: two concurrent net-new
+ *     collections at cap-minus-1 must admit exactly one.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import {
+  KNOWLEDGE_COLLECTION_COUNT_SQL,
+  checkKnowledgeCollectionLimitAndInstall,
+  invalidatePlanCache,
+} from "@atlas/api/lib/billing/enforcement";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Seed a `plugin_catalog` row so `workspace_plugins.catalog_id` FK resolves.
+ * `type` and `pillar` are separate vocabularies — `chk_plugin_catalog_type`
+ * has no `knowledge` member, so knowledge catalogs carry `type = 'context'`
+ * (matching the built-in knowledge seeder).
+ */
+async function seedCatalog(
+  pool: Pool,
+  slug: string,
+  pillar: string,
+  type: string,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (id) DO NOTHING`,
+    [`catalog:${slug}`, slug, slug, type, pillar],
+  );
+}
+
+/** Seed one collection (or any pillar's install) row. */
+async function seedInstall(
+  pool: Pool,
+  opts: {
+    id: string;
+    workspaceId: string;
+    catalog: string;
+    installId: string;
+    pillar: string;
+    status?: "published" | "draft" | "archived";
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO workspace_plugins
+       (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, true, $6, NOW(), NOW())`,
+    [opts.id, opts.workspaceId, opts.catalog, opts.installId, opts.pillar, opts.status ?? "published"],
+  );
+}
+
+describeIfPg("KNOWLEDGE_COLLECTION_COUNT_SQL (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `kb_cap_count_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `knowledge-cap-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    await seedCatalog(pool, "okf-upload", "knowledge", "context");
+    await seedCatalog(pool, "zendesk", "knowledge", "context");
+    await seedCatalog(pool, "slack", "chat", "chat");
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it(
+    "partitions by install_id and excludes chat / archived / other-workspace rows",
+    async () => {
+      const ws = `ws-kb-count-${Date.now()}`;
+      const otherWs = `ws-kb-other-${Date.now()}`;
+      await seedInstall(pool, { id: `${ws}-a`, workspaceId: ws, catalog: "catalog:okf-upload", installId: "docs", pillar: "knowledge" });
+      // Two collections from the SAME catalog — knowledge is multi-instance, so
+      // both consume a slot. A catalog_id-based partition (the chat shape)
+      // would count these as one.
+      await seedInstall(pool, { id: `${ws}-b`, workspaceId: ws, catalog: "catalog:zendesk", installId: "zd-brand-1", pillar: "knowledge" });
+      await seedInstall(pool, { id: `${ws}-c`, workspaceId: ws, catalog: "catalog:zendesk", installId: "zd-brand-2", pillar: "knowledge" });
+      // Chat pillar — must NOT count toward the collections cap.
+      await seedInstall(pool, { id: `${ws}-chat`, workspaceId: ws, catalog: "catalog:slack", installId: "slack", pillar: "chat" });
+      // Archived collection — must NOT count.
+      await seedInstall(pool, { id: `${ws}-old`, workspaceId: ws, catalog: "catalog:okf-upload", installId: "retired", pillar: "knowledge", status: "archived" });
+      // Another workspace's collection — must NOT count.
+      await seedInstall(pool, { id: `${otherWs}-a`, workspaceId: otherWs, catalog: "catalog:okf-upload", installId: "docs", pillar: "knowledge" });
+
+      // Edit case — "docs" already exists for this workspace.
+      const edit = await pool.query<{ others: number; this_count: number }>(
+        KNOWLEDGE_COLLECTION_COUNT_SQL,
+        [ws, "docs"],
+      );
+      expect(edit.rows[0]?.others).toBe(2); // zd-brand-1 + zd-brand-2
+      expect(edit.rows[0]?.this_count).toBe(1);
+
+      // Net-new case — "handbook" does not exist yet.
+      const netNew = await pool.query<{ others: number; this_count: number }>(
+        KNOWLEDGE_COLLECTION_COUNT_SQL,
+        [ws, "handbook"],
+      );
+      expect(netNew.rows[0]?.others).toBe(3);
+      expect(netNew.rows[0]?.this_count).toBe(0);
+
+      // `::int` casts must return JS numbers, not strings.
+      expect(typeof netNew.rows[0]?.others).toBe("number");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});
+
+describeIfPg("checkKnowledgeCollectionLimitAndInstall (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `kb_cap_gate_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+  /** The okf-upload handler's UPSERT shape, with RETURNING id. */
+  function collectionInsert(rowId: string, ws: string, slug: string) {
+    return {
+      sql: `INSERT INTO workspace_plugins
+             (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+           VALUES ($1, $2, $3, $4, 'knowledge', '{}'::jsonb, true, 'published', NOW(), NOW())
+           ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+             SET enabled = true, status = 'published', updated_at = NOW()
+           RETURNING id`,
+      params: [rowId, ws, "catalog:okf-upload", slug],
+    };
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `knowledge-cap-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Minimal `organization` — only the columns getWorkspaceDetails reads.
+    // Better-Auth owns this table in production, so it is not in our migration
+    // set; the columns from MANAGED_AUTH_MIGRATIONS must be carried here or
+    // every plan lookup fails with `column "..." does not exist`.
+    await pool.query(
+      `CREATE TABLE organization (
+         id text PRIMARY KEY,
+         name text,
+         slug text,
+         workspace_status text NOT NULL DEFAULT 'active',
+         plan_tier text NOT NULL DEFAULT 'free',
+         byot boolean NOT NULL DEFAULT false,
+         "stripeCustomerId" text,
+         trial_ends_at timestamptz,
+         suspended_at timestamptz,
+         suspension_source text,
+         plan_override_until timestamptz,
+         deleted_at timestamptz,
+         region text,
+         region_assigned_at timestamptz,
+         "createdAt" timestamptz NOT NULL DEFAULT now()
+       )`,
+    );
+    await seedCatalog(pool, "okf-upload", "knowledge", "context");
+
+    process.env.DATABASE_URL = TEST_DB_URL;
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    invalidatePlanCache();
+    await pool.query(`DELETE FROM workspace_plugins`);
+    await pool.query(`DELETE FROM organization`);
+  });
+
+  async function seedOrg(id: string, planTier: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO organization (id, name, slug, plan_tier) VALUES ($1, $1, $1, $2)`,
+      [id, planTier],
+    );
+  }
+
+  it(
+    "admits a starter workspace's first collection and refuses its second",
+    async () => {
+      const ws = "ws-starter";
+      await seedOrg(ws, "starter"); // cap = 1
+
+      const first = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+        ws,
+        "docs",
+        collectionInsert("row-1", ws, "docs"),
+      );
+      expect(first.allowed).toBe(true);
+
+      const second = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+        ws,
+        "handbook",
+        collectionInsert("row-2", ws, "handbook"),
+      );
+      expect(second.allowed).toBe(false);
+      if (second.allowed) throw new Error("unreachable");
+      expect(second.reason).toBe("cap_reached");
+
+      // The refused INSERT must have rolled back — no orphan row.
+      const rows = await pool.query(`SELECT install_id FROM workspace_plugins WHERE workspace_id = $1`, [ws]);
+      expect(rows.rows.map((r) => (r as { install_id: string }).install_id)).toEqual(["docs"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "never blocks EDITING an existing collection, even for an over-cap workspace",
+    async () => {
+      const ws = "ws-grandfathered";
+      await seedOrg(ws, "starter"); // cap = 1, but seeded with 2 (a downgrade)
+      await seedInstall(pool, { id: "row-a", workspaceId: ws, catalog: "catalog:okf-upload", installId: "docs", pillar: "knowledge" });
+      await seedInstall(pool, { id: "row-b", workspaceId: ws, catalog: "catalog:okf-upload", installId: "handbook", pillar: "knowledge" });
+
+      const edit = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+        ws,
+        "docs",
+        collectionInsert("row-new", ws, "docs"),
+      );
+      expect(edit.allowed).toBe(true);
+      if (!edit.allowed) throw new Error("unreachable");
+      // ON CONFLICT DO UPDATE keeps the ORIGINAL row id.
+      expect(edit.rows[0]?.id).toBe("row-a");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "lets exactly one of two concurrent net-new collections through at cap-minus-one",
+    async () => {
+      const ws = "ws-race";
+      await seedOrg(ws, "pro"); // cap = 3
+      await seedInstall(pool, { id: "row-a", workspaceId: ws, catalog: "catalog:okf-upload", installId: "c1", pillar: "knowledge" });
+      await seedInstall(pool, { id: "row-b", workspaceId: ws, catalog: "catalog:okf-upload", installId: "c2", pillar: "knowledge" });
+
+      const [a, b] = await Promise.all([
+        checkKnowledgeCollectionLimitAndInstall<{ id: string }>(ws, "c3", collectionInsert("row-c", ws, "c3")),
+        checkKnowledgeCollectionLimitAndInstall<{ id: string }>(ws, "c4", collectionInsert("row-d", ws, "c4")),
+      ]);
+
+      const allowed = [a, b].filter((r) => r.allowed);
+      expect(allowed).toHaveLength(1);
+      const count = await pool.query<{ n: string }>(
+        `SELECT COUNT(*)::int AS n FROM workspace_plugins WHERE workspace_id = $1 AND pillar = 'knowledge'`,
+        [ws],
+      );
+      expect(Number(count.rows[0]?.n)).toBe(3);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "applies no cap on the free (self-hosted) tier",
+    async () => {
+      const ws = "ws-selfhosted";
+      await seedOrg(ws, "free");
+      for (const slug of ["a", "b", "c", "d", "e"]) {
+        const r = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+          ws,
+          slug,
+          collectionInsert(`row-${slug}`, ws, slug),
+        );
+        expect(r.allowed).toBe(true);
+      }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/billing/__tests__/knowledge-limits.test.ts
+++ b/packages/api/src/lib/billing/__tests__/knowledge-limits.test.ts
@@ -9,7 +9,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { PlanTier } from "@useatlas/types";
-import { buildInternalDbMockDefaults } from "@atlas/api/__mocks__/api-test-mocks";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
 
 let PLATFORM = { docs: 1000, docBytes: 1_000_000, bundleBytes: 25_000_000 };
 void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({

--- a/packages/api/src/lib/billing/__tests__/knowledge-limits.test.ts
+++ b/packages/api/src/lib/billing/__tests__/knowledge-limits.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the per-tier Knowledge Base cap seam (#4235).
+ *
+ * Covers the four things the slice promises: the `min(platform, tier)`
+ * composition and which side it attributes; the fail-closed / fail-open arms of
+ * tier resolution; that a self-hosted (`free`) workspace is untouched; and that
+ * only a TIER-bound over-limit produces the 403 upgrade envelope.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { PlanTier } from "@useatlas/types";
+import { buildInternalDbMockDefaults } from "@atlas/api/__mocks__/api-test-mocks";
+
+let PLATFORM = { docs: 1000, docBytes: 1_000_000, bundleBytes: 25_000_000 };
+void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({
+  getIngestMaxDocs: () => PLATFORM.docs,
+  getIngestMaxDocBytes: () => PLATFORM.docBytes,
+  getIngestMaxBundleBytes: () => PLATFORM.bundleBytes,
+}));
+
+let HAS_INTERNAL_DB = true;
+let WORKSPACE: { plan_tier: PlanTier } | null = { plan_tier: "starter" };
+let WORKSPACE_THROWS: Error | null = null;
+
+void mock.module("@atlas/api/lib/db/internal", () => ({
+  ...buildInternalDbMockDefaults({ internalQuery: mock(async () => []) }),
+  hasInternalDB: () => HAS_INTERNAL_DB,
+}));
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  getCachedWorkspace: async () => {
+    if (WORKSPACE_THROWS) throw WORKSPACE_THROWS;
+    return WORKSPACE;
+  },
+}));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const {
+  assertNotTierBound,
+  lowestTierAdmitting,
+  minKnowledgeCap,
+  resolveIngestCaps,
+  resolveKnowledgeTierLimits,
+} = await import("@atlas/api/lib/billing/knowledge-limits");
+const { FeatureEntitlementError, BillingCheckFailedError } = await import(
+  "@atlas/api/lib/effect/errors"
+);
+
+const ORG = "org-1";
+
+beforeEach(() => {
+  PLATFORM = { docs: 1000, docBytes: 1_000_000, bundleBytes: 25_000_000 };
+  HAS_INTERNAL_DB = true;
+  WORKSPACE = { plan_tier: "starter" };
+  WORKSPACE_THROWS = null;
+});
+afterEach(() => {
+  WORKSPACE_THROWS = null;
+});
+
+describe("minKnowledgeCap", () => {
+  it("takes the smaller of the two", () => {
+    expect(minKnowledgeCap(25_000_000, 10_000_000)).toBe(10_000_000);
+    expect(minKnowledgeCap(10_000_000, 25_000_000)).toBe(10_000_000);
+  });
+  it("treats an unlimited tier limit as 'the platform ceiling governs'", () => {
+    expect(minKnowledgeCap(25_000_000, -1)).toBe(25_000_000);
+  });
+  it("treats a zero tier limit as a real cap of zero, not unlimited", () => {
+    // The `locked` churn tier: nothing may be ingested at all.
+    expect(minKnowledgeCap(25_000_000, 0)).toBe(0);
+  });
+});
+
+describe("lowestTierAdmitting", () => {
+  it("names the cheapest tier above the current one that admits the value", () => {
+    expect(lowestTierAdmitting("maxKnowledgeBundleBytes", 20_000_000, "starter")).toBe("pro");
+    expect(lowestTierAdmitting("maxKnowledgeBundleBytes", 60_000_000, "starter")).toBe("business");
+    expect(lowestTierAdmitting("maxKnowledgeDocsPerBundle", 400, "starter")).toBe("pro");
+  });
+  it("never names the current tier or a lower one", () => {
+    expect(lowestTierAdmitting("maxKnowledgeDocsPerBundle", 900, "pro")).toBe("business");
+    expect(lowestTierAdmitting("maxKnowledgeDocsPerBundle", 100, "pro")).toBe("business");
+  });
+  it("returns null when no higher tier admits the value", () => {
+    // Beyond even Business — "upgrade" would be a lie, so the caller falls back
+    // to a plain over-limit response.
+    expect(lowestTierAdmitting("maxKnowledgeBundleBytes", 500_000_000, "business")).toBeNull();
+    expect(lowestTierAdmitting("maxKnowledgeBundleBytes", 1, "business")).toBeNull();
+  });
+  it("treats an unlimited tier limit as admitting anything", () => {
+    expect(lowestTierAdmitting("maxKnowledgeCollections", 9_999, "pro")).toBe("business");
+  });
+});
+
+describe("resolveKnowledgeTierLimits", () => {
+  it("returns null with no orgId, the self-hosted sentinel, or no internal DB", async () => {
+    expect(await resolveKnowledgeTierLimits(undefined)).toBeNull();
+    expect(await resolveKnowledgeTierLimits("self-hosted")).toBeNull();
+    HAS_INTERNAL_DB = false;
+    expect(await resolveKnowledgeTierLimits(ORG)).toBeNull();
+  });
+
+  it("returns null for a workspace with no organization row (deliberate fail-open)", async () => {
+    WORKSPACE = null;
+    expect(await resolveKnowledgeTierLimits(ORG)).toBeNull();
+  });
+
+  it("returns null on the free tier — self-hosted keeps the platform knob as its only cap", async () => {
+    WORKSPACE = { plan_tier: "free" };
+    expect(await resolveKnowledgeTierLimits(ORG)).toBeNull();
+  });
+
+  it("fails CLOSED on a workspace-lookup fault", async () => {
+    WORKSPACE_THROWS = new Error("db down");
+    await expect(resolveKnowledgeTierLimits(ORG)).rejects.toBeInstanceOf(BillingCheckFailedError);
+  });
+
+  it("resolves the tier's limits otherwise", async () => {
+    WORKSPACE = { plan_tier: "pro" };
+    const ctx = await resolveKnowledgeTierLimits(ORG);
+    expect(ctx?.tier).toBe("pro");
+    expect(ctx?.limits.maxKnowledgeDocsPerBundle).toBe(1_000);
+  });
+});
+
+describe("resolveIngestCaps", () => {
+  it("hands back the platform ceilings verbatim when no tier applies (self-hosted)", async () => {
+    WORKSPACE = { plan_tier: "free" };
+    const caps = await resolveIngestCaps(ORG);
+    expect(caps.maxDocs).toEqual({ value: 1000, boundBy: "platform" });
+    expect(caps.maxBundleBytes).toEqual({ value: 25_000_000, boundBy: "platform" });
+    expect(caps.maxDocBytes).toBe(1_000_000);
+  });
+
+  it("clamps to the tier when the tier is lower, and says so", async () => {
+    PLATFORM = { docs: 5_000, docBytes: 1_000_000, bundleBytes: 100_000_000 }; // the SaaS ceiling
+    WORKSPACE = { plan_tier: "starter" };
+    const caps = await resolveIngestCaps(ORG);
+    expect(caps.maxDocs).toEqual({ value: 250, boundBy: "tier" });
+    expect(caps.maxBundleBytes).toEqual({ value: 10_000_000, boundBy: "tier" });
+  });
+
+  it("clamps to the platform ceiling when the operator set it below the tier", async () => {
+    PLATFORM = { docs: 100, docBytes: 1_000_000, bundleBytes: 1_000_000 };
+    WORKSPACE = { plan_tier: "business" };
+    const caps = await resolveIngestCaps(ORG);
+    expect(caps.maxDocs).toEqual({ value: 100, boundBy: "platform" });
+    expect(caps.maxBundleBytes).toEqual({ value: 1_000_000, boundBy: "platform" });
+  });
+
+  it("attributes a tie to the platform — an upgrade would gain nothing", async () => {
+    PLATFORM = { docs: 1_000, docBytes: 1_000_000, bundleBytes: 25_000_000 };
+    WORKSPACE = { plan_tier: "pro" }; // pro is exactly 1000 / 25 MB
+    const caps = await resolveIngestCaps(ORG);
+    expect(caps.maxDocs.boundBy).toBe("platform");
+    expect(caps.maxBundleBytes.boundBy).toBe("platform");
+  });
+
+  it("never tiers the per-document byte cap — it is a guardrail, not a lever", async () => {
+    WORKSPACE = { plan_tier: "starter" };
+    expect((await resolveIngestCaps(ORG)).maxDocBytes).toBe(PLATFORM.docBytes);
+    WORKSPACE = { plan_tier: "business" };
+    expect((await resolveIngestCaps(ORG)).maxDocBytes).toBe(PLATFORM.docBytes);
+  });
+
+  it("collapses the locked churn tier to zero", async () => {
+    WORKSPACE = { plan_tier: "locked" };
+    const caps = await resolveIngestCaps(ORG);
+    expect(caps.maxDocs).toEqual({ value: 0, boundBy: "tier" });
+    expect(caps.maxBundleBytes).toEqual({ value: 0, boundBy: "tier" });
+  });
+});
+
+describe("assertNotTierBound", () => {
+  const base = {
+    orgId: ORG,
+    field: "maxKnowledgeDocsPerBundle",
+    required: 400,
+    limit: 250,
+    noun: "documents in one bundle",
+  } as const;
+
+  it("is a no-op when the PLATFORM ceiling bound", async () => {
+    // Upgrading changes nothing — the operator's guardrail refused.
+    await expect(assertNotTierBound({ ...base, boundBy: "platform" })).resolves.toBeUndefined();
+  });
+
+  it("throws the 403 upgrade envelope when the TIER bound", async () => {
+    WORKSPACE = { plan_tier: "starter" };
+    const err = await assertNotTierBound({ ...base, boundBy: "tier" }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FeatureEntitlementError);
+    const typed = err as InstanceType<typeof FeatureEntitlementError>;
+    expect(typed.currentPlan).toBe("starter");
+    expect(typed.requiredPlan).toBe("pro");
+    expect(typed.feature).toBe("maxKnowledgeDocsPerBundle");
+    expect(typed.message).toContain("250 documents in one bundle");
+  });
+
+  it("stays silent when no higher tier admits the value", async () => {
+    WORKSPACE = { plan_tier: "business" };
+    await expect(
+      assertNotTierBound({ ...base, boundBy: "tier", required: 99_999, limit: 5_000 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("degrades to the plain over-limit response when the tier lookup faults", async () => {
+    // The cap decision was already made upstream; this call only phrases it, so
+    // a lookup fault must not convert a correct refusal into a 503.
+    WORKSPACE_THROWS = new Error("db down");
+    await expect(assertNotTierBound({ ...base, boundBy: "tier" })).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/knowledge-limits.test.ts
+++ b/packages/api/src/lib/billing/__tests__/knowledge-limits.test.ts
@@ -18,6 +18,11 @@ void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({
   getIngestMaxBundleBytes: () => PLATFORM.bundleBytes,
 }));
 
+let DEPLOY_MODE: "saas" | "self-hosted" = "self-hosted";
+void mock.module("@atlas/api/lib/effect/deploy-mode", () => ({
+  resolveDeployMode: () => DEPLOY_MODE,
+}));
+
 let HAS_INTERNAL_DB = true;
 let WORKSPACE: { plan_tier: PlanTier } | null = { plan_tier: "starter" };
 let WORKSPACE_THROWS: Error | null = null;
@@ -26,7 +31,28 @@ void mock.module("@atlas/api/lib/db/internal", () => ({
   ...buildInternalDbMockDefaults({ internalQuery: mock(async () => []) }),
   hasInternalDB: () => HAS_INTERNAL_DB,
 }));
+// Mock every value export — a partial `mock.module()` breaks other importers
+// of the module (CLAUDE.md "mock all exports"). Only `getCachedWorkspace` is
+// exercised; the rest are inert.
 void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
   getCachedWorkspace: async () => {
     if (WORKSPACE_THROWS) throw WORKSPACE_THROWS;
     return WORKSPACE;
@@ -39,7 +65,9 @@ void mock.module("@atlas/api/lib/logger", () => {
 });
 
 const {
+  assertIngestCapsFor,
   assertNotTierBound,
+  capIsOperatorTunable,
   lowestTierAdmitting,
   minKnowledgeCap,
   resolveIngestCaps,
@@ -54,6 +82,7 @@ const ORG = "org-1";
 beforeEach(() => {
   PLATFORM = { docs: 1000, docBytes: 1_000_000, bundleBytes: 25_000_000 };
   HAS_INTERNAL_DB = true;
+  DEPLOY_MODE = "self-hosted";
   WORKSPACE = { plan_tier: "starter" };
   WORKSPACE_THROWS = null;
 });
@@ -94,6 +123,18 @@ describe("lowestTierAdmitting", () => {
   it("treats an unlimited tier limit as admitting anything", () => {
     expect(lowestTierAdmitting("maxKnowledgeCollections", 9_999, "pro")).toBe("business");
   });
+
+  it("offers the churn tier a real recovery target", () => {
+    // `locked` ranks below every paid plan (PLAN_RANK -1), so the cheapest
+    // resubscribe target must be named — a null here would leave a churned
+    // customer with a 403 and no way forward.
+    expect(lowestTierAdmitting("maxKnowledgeCollections", 1, "locked")).toBe("starter");
+    expect(lowestTierAdmitting("maxKnowledgeDocsPerBundle", 100, "locked")).toBe("starter");
+  });
+
+  it("offers a trial workspace the starter tier", () => {
+    expect(lowestTierAdmitting("maxKnowledgeDocsPerBundle", 200, "trial")).toBe("starter");
+  });
 });
 
 describe("resolveKnowledgeTierLimits", () => {
@@ -109,9 +150,22 @@ describe("resolveKnowledgeTierLimits", () => {
     expect(await resolveKnowledgeTierLimits(ORG)).toBeNull();
   });
 
-  it("returns null on the free tier — self-hosted keeps the platform knob as its only cap", async () => {
+  it("returns null on the free tier OFF SaaS — the platform knob is the only cap there", async () => {
+    DEPLOY_MODE = "self-hosted";
     WORKSPACE = { plan_tier: "free" };
     expect(await resolveKnowledgeTierLimits(ORG)).toBeNull();
+  });
+
+  it("fails CLOSED to starter on a SaaS `free` workspace — there is no SaaS free tier", async () => {
+    // `organization.plan_tier` DEFAULTS to 'free', so a `free` row on SaaS
+    // means trial provisioning never landed. Treating that as "no plan to
+    // enforce" would hand a provisioning failure the raised SaaS ceiling
+    // (100 MB / 5,000 docs) — strictly more than any paying tier gets.
+    DEPLOY_MODE = "saas";
+    WORKSPACE = { plan_tier: "free" };
+    const ctx = await resolveKnowledgeTierLimits(ORG);
+    expect(ctx?.tier).toBe("starter");
+    expect(ctx?.limits.maxKnowledgeBundleBytes).toBe(10_000_000);
   });
 
   it("fails CLOSED on a workspace-lookup fault", async () => {
@@ -131,9 +185,22 @@ describe("resolveIngestCaps", () => {
   it("hands back the platform ceilings verbatim when no tier applies (self-hosted)", async () => {
     WORKSPACE = { plan_tier: "free" };
     const caps = await resolveIngestCaps(ORG);
+    expect(caps.tier).toBeNull();
     expect(caps.maxDocs).toEqual({ value: 1000, boundBy: "platform" });
     expect(caps.maxBundleBytes).toEqual({ value: 25_000_000, boundBy: "platform" });
     expect(caps.maxDocBytes).toBe(1_000_000);
+  });
+
+  it("stamps the workspace it resolved FOR, so a seam can refuse another tenant's caps", async () => {
+    const caps = await resolveIngestCaps(ORG);
+    expect(caps.workspaceId).toBe(ORG);
+    expect(() => assertIngestCapsFor(caps, ORG)).not.toThrow();
+    expect(() => assertIngestCapsFor(caps, "org-2")).toThrow(/another tenant's plan limits/);
+  });
+
+  it("carries the resolved tier so the upgrade prompt never re-looks it up", async () => {
+    WORKSPACE = { plan_tier: "pro" };
+    expect((await resolveIngestCaps(ORG)).tier).toBe("pro");
   });
 
   it("clamps to the tier when the tier is lower, and says so", async () => {
@@ -184,14 +251,20 @@ describe("assertNotTierBound", () => {
     noun: "documents in one bundle",
   } as const;
 
-  it("is a no-op when the PLATFORM ceiling bound", async () => {
+  it("is a no-op when the PLATFORM ceiling bound", () => {
     // Upgrading changes nothing — the operator's guardrail refused.
-    await expect(assertNotTierBound({ ...base, boundBy: "platform" })).resolves.toBeUndefined();
+    expect(() => assertNotTierBound({ ...base, tier: "starter", boundBy: "platform" })).not.toThrow();
   });
 
-  it("throws the 403 upgrade envelope when the TIER bound", async () => {
-    WORKSPACE = { plan_tier: "starter" };
-    const err = await assertNotTierBound({ ...base, boundBy: "tier" }).catch((e: unknown) => e);
+  it("throws the 403 upgrade envelope when the TIER bound", () => {
+    const err = (() => {
+      try {
+        assertNotTierBound({ ...base, tier: "starter", boundBy: "tier" });
+        return null;
+      } catch (e) {
+        return e;
+      }
+    })();
     expect(err).toBeInstanceOf(FeatureEntitlementError);
     const typed = err as InstanceType<typeof FeatureEntitlementError>;
     expect(typed.currentPlan).toBe("starter");
@@ -200,17 +273,45 @@ describe("assertNotTierBound", () => {
     expect(typed.message).toContain("250 documents in one bundle");
   });
 
-  it("stays silent when no higher tier admits the value", async () => {
-    WORKSPACE = { plan_tier: "business" };
-    await expect(
-      assertNotTierBound({ ...base, boundBy: "tier", required: 99_999, limit: 5_000 }),
-    ).resolves.toBeUndefined();
+  it("stays silent when no higher tier admits the value", () => {
+    expect(() =>
+      assertNotTierBound({ ...base, tier: "business", boundBy: "tier", required: 99_999, limit: 5_000 }),
+    ).not.toThrow();
   });
 
-  it("degrades to the plain over-limit response when the tier lookup faults", async () => {
-    // The cap decision was already made upstream; this call only phrases it, so
-    // a lookup fault must not convert a correct refusal into a 503.
+  it("stays silent for a LOWER-BOUND `required` — no upgrade target is provable", () => {
+    // The streamed-body path aborts AT the cap, so the true size is unknown.
+    // Naming the next tier up would be a guess that a 500 MB body disproves.
+    expect(() =>
+      assertNotTierBound({ ...base, tier: "starter", boundBy: "tier", exact: false }),
+    ).not.toThrow();
+  });
+
+  it("stays silent when no tier context produced the cap", () => {
+    expect(() => assertNotTierBound({ ...base, tier: null, boundBy: "tier" })).not.toThrow();
+  });
+
+  it("never reads the workspace — it cannot fault, and cannot name a stale plan", () => {
+    // The tier arrives with the cap; a second lookup could 503 or name a
+    // different plan than the one whose limit is being quoted.
     WORKSPACE_THROWS = new Error("db down");
-    await expect(assertNotTierBound({ ...base, boundBy: "tier" })).resolves.toBeUndefined();
+    expect(() => assertNotTierBound({ ...base, tier: "starter", boundBy: "platform" })).not.toThrow();
+  });
+});
+
+describe("capIsOperatorTunable", () => {
+  it("is true only for a platform-bound cap OFF SaaS", () => {
+    DEPLOY_MODE = "self-hosted";
+    expect(capIsOperatorTunable("platform")).toBe(true);
+    expect(capIsOperatorTunable("tier")).toBe(false);
+  });
+
+  it("is false on SaaS even for a platform-bound cap", () => {
+    // A hosted workspace admin cannot reach the settings registry, and the
+    // SaaS ceiling IS the Business tier — so naming `ATLAS_KNOWLEDGE_INGEST_*`
+    // sends them after a knob they can never turn.
+    DEPLOY_MODE = "saas";
+    expect(capIsOperatorTunable("platform")).toBe(false);
+    expect(capIsOperatorTunable("tier")).toBe(false);
   });
 });

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -67,6 +67,53 @@ describe("billing/plans", () => {
       expect(getPlanLimits("locked").monthlyProactiveClassifierCap).toBe(0);
     });
 
+    it("carries the maintainer-approved Knowledge Base matrix (#4235)", () => {
+      // The decided ladder, pinned so a pricing change is a deliberate edit
+      // here rather than a silent drift in one tier. Self-hosted (`free`) is
+      // unlimited on every field — the `ATLAS_KNOWLEDGE_INGEST_*` platform
+      // knobs stay its only caps.
+      const free = getPlanLimits("free");
+      expect(isUnlimited(free.maxKnowledgeCollections)).toBe(true);
+      expect(isUnlimited(free.maxKnowledgeBundleBytes)).toBe(true);
+      expect(isUnlimited(free.maxKnowledgeDocsPerBundle)).toBe(true);
+
+      for (const tier of ["trial", "starter"] as const) {
+        const limits = getPlanLimits(tier);
+        expect(limits.maxKnowledgeCollections).toBe(1);
+        expect(limits.maxKnowledgeBundleBytes).toBe(10_000_000);
+        expect(limits.maxKnowledgeDocsPerBundle).toBe(250);
+      }
+
+      const pro = getPlanLimits("pro");
+      expect(pro.maxKnowledgeCollections).toBe(3);
+      expect(pro.maxKnowledgeBundleBytes).toBe(25_000_000);
+      expect(pro.maxKnowledgeDocsPerBundle).toBe(1_000);
+
+      const business = getPlanLimits("business");
+      expect(isUnlimited(business.maxKnowledgeCollections)).toBe(true);
+      expect(business.maxKnowledgeBundleBytes).toBe(100_000_000);
+      expect(business.maxKnowledgeDocsPerBundle).toBe(5_000);
+
+      // The churn tier adds nothing — zero, not unlimited.
+      const locked = getPlanLimits("locked");
+      expect(locked.maxKnowledgeCollections).toBe(0);
+      expect(locked.maxKnowledgeBundleBytes).toBe(0);
+      expect(locked.maxKnowledgeDocsPerBundle).toBe(0);
+    });
+
+    it("ladders the Knowledge Base caps monotonically across the paid tiers (#4235)", () => {
+      // A non-monotonic ladder would make `lowestTierAdmitting` name a tier
+      // that doesn't actually help — the upgrade prompt would be a lie.
+      const ladder = ["starter", "pro", "business"] as const;
+      for (const field of ["maxKnowledgeBundleBytes", "maxKnowledgeDocsPerBundle"] as const) {
+        for (let i = 1; i < ladder.length; i++) {
+          const lower = getPlanLimits(ladder[i - 1])[field];
+          const higher = getPlanLimits(ladder[i])[field];
+          expect(isUnlimited(higher) || higher >= lower).toBe(true);
+        }
+      }
+    });
+
     it("starter tier has finite limits", () => {
       const limits = getPlanLimits("starter");
       expect(isUnlimited(limits.tokenBudgetPerSeat)).toBe(false);

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -819,7 +819,11 @@ export type ResourceLimitResult =
   | { allowed: false; reason: "check_failed"; errorMessage: string };
 
 /** Plan-capped resources. Each maps to a `PlanLimits` field. */
-export type CappedResource = "seats" | "connections" | "chat_integrations";
+export type CappedResource =
+  | "seats"
+  | "connections"
+  | "chat_integrations"
+  | "knowledge_collections";
 
 /**
  * Check whether adding one more resource (seat, connection, or chat
@@ -883,6 +887,7 @@ export async function checkResourceLimit(
     seats: limits.maxSeats,
     connections: limits.maxConnections,
     chat_integrations: limits.maxChatIntegrations,
+    knowledge_collections: limits.maxKnowledgeCollections,
   } satisfies Record<CappedResource, number>)[resource];
 
   if (isUnlimited(cap)) {
@@ -894,6 +899,7 @@ export async function checkResourceLimit(
       seats: cap === 1 ? "seat" : "seats",
       connections: cap === 1 ? "connection" : "connections",
       chat_integrations: cap === 1 ? "chat integration" : "chat integrations",
+      knowledge_collections: cap === 1 ? "knowledge collection" : "knowledge collections",
     } satisfies Record<CappedResource, string>)[resource];
     log.warn(
       { orgId, resource, currentCount, limit: cap, tier },
@@ -961,20 +967,38 @@ export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
    AND status <> 'archived'`;
 
 /**
- * Read-only chat-integration cap precheck — the pre-redirect gate (#2998).
+ * Everything the shared read-only cap precheck ({@link capPrecheck}) needs for
+ * ONE {@link CappedResource}. A subset of {@link CapGatedInstallSpec} — no lock
+ * namespace, because the precheck deliberately takes no lock.
+ */
+interface CapPrecheckSpec {
+  readonly orgId: string | undefined;
+  readonly resource: CappedResource;
+  readonly countSql: string;
+  readonly selfKey: string;
+  readonly checkFailedMessage: string;
+  readonly label: string;
+}
+
+/**
+ * Read-only resource-cap precheck — the fail-fast gate that runs BEFORE the
+ * expensive part of an install (#2998; generalized for Knowledge Base
+ * collections in #4235).
  *
- * {@link checkChatIntegrationLimitAndInstall} is the *atomic* check-and-INSERT
- * the chat handlers run at OAuth callback time. But by callback time the
- * customer has already completed the entire OAuth dance — Slack has minted a
- * bot token and installed the app — only to be refused. This function lets a
- * handler refuse an at-cap workspace BEFORE it mints the provider redirect, so
- * an at-cap Starter workspace never starts a dance it can't finish.
+ * The atomic {@link capGatedInstall} is the correctness boundary, but by the
+ * time it runs the caller may already have completed an entire OAuth dance
+ * (Slack has minted a bot token and installed the app) or written a credential
+ * — only to be refused. This lets a handler refuse an at-cap workspace before
+ * any of that, so an at-cap Starter workspace never starts something it can't
+ * finish.
  *
  * It is deliberately NOT serialized against concurrent installs and runs no
- * INSERT: it opens no transaction and takes no advisory lock. The callback's
- * atomic gate remains the TOCTOU guard — a workspace can reach its cap between
- * this precheck and the callback. This is a fail-fast precheck, not the
- * correctness boundary.
+ * INSERT: it opens no transaction and takes no advisory lock. The atomic gate
+ * remains the TOCTOU guard — a workspace can reach its cap between this
+ * precheck and the write. This is a fail-fast precheck, not the correctness
+ * boundary. (It also cannot see a *fan-out*: a handler planning N net-new
+ * collections in one install runs this per key against the same pre-write
+ * count, so only the atomic gate refuses the (cap+1)-th.)
  *
  * Mirrors the atomic gate's enforcement skips and reconnect carve-out exactly,
  * so the two never disagree on a workspace that isn't racing itself:
@@ -982,26 +1006,18 @@ export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
  *   - Workspace lookup *error* → `check_failed` (fail closed → 503 "try again").
  *   - No `organization` row (pre-migration / Better-Auth-only) → allowed (no
  *     plan, no cap — the same deliberate fail-open the atomic gate makes).
- *   - Reconnect (`this_count > 0`) → allowed: re-auth of an already-installed
- *     platform never increases the distinct count, so a grandfathered over-cap
- *     workspace can still re-auth what it owns.
- *   - Otherwise compare the *other* chat platforms to the plan cap via
+ *   - Reconnect/edit (`this_count > 0`) → allowed: re-installing an existing
+ *     key never increases the distinct count, so a grandfathered over-cap
+ *     workspace can still re-auth or edit what it owns.
+ *   - Otherwise compare the *other* installs to the plan cap via
  *     {@link checkResourceLimit}.
  *
- * Returns a {@link ResourceLimitResult}: `cap_reached` (→ 429 "upgrade") and
- * `check_failed` (→ 503 "try again") map to the same HTTP statuses the callback
- * path surfaces, so callers translate one set of arms regardless of which gate
- * fired.
- *
- * @param orgId - Workspace id. When absent (or no internal DB) there's no cap.
- * @param catalogId - Catalog row id of the platform being installed (e.g.
- *   `"catalog:slack"`). Excluded from the `others` count so reconnecting the
- *   same platform is never blocked.
+ * Returns a {@link ResourceLimitResult}: `cap_reached` and `check_failed`
+ * (→ 503 "try again") map to the same dispositions the atomic path surfaces, so
+ * callers translate one set of arms regardless of which gate fired.
  */
-export async function checkChatIntegrationLimit(
-  orgId: string | undefined,
-  catalogId: string,
-): Promise<ResourceLimitResult> {
+async function capPrecheck(spec: CapPrecheckSpec): Promise<ResourceLimitResult> {
+  const { orgId, resource, countSql, selfKey, checkFailedMessage, label } = spec;
   // No enforcement context — no cap to apply.
   if (!orgId || !hasInternalDB()) {
     return { allowed: true };
@@ -1014,10 +1030,10 @@ export async function checkChatIntegrationLimit(
     workspace = await getCachedWorkspace(orgId);
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-      "Failed to resolve workspace for chat-integration cap precheck — blocking as precaution",
+      { err: err instanceof Error ? err.message : String(err), orgId, selfKey, resource },
+      `Failed to resolve workspace for ${label} cap precheck — blocking as precaution`,
     );
-    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
   }
 
   // No `organization` row → no plan → no cap. The ONLY deliberate fail-open
@@ -1027,43 +1043,66 @@ export async function checkChatIntegrationLimit(
     return { allowed: true };
   }
 
-  // Count chat-pillar installs, partitioned the same way as the atomic gate
-  // (this platform vs. every other), via the SAME aggregate so the precheck and
-  // the callback gate never disagree.
+  // Count installs, partitioned the same way as the atomic gate (this key vs.
+  // every other), via the SAME aggregate so the precheck and the write gate
+  // never disagree.
   let counts: { others: number; this_count: number } | undefined;
   try {
-    const rows = await internalQuery<{ others: number; this_count: number }>(
-      CHAT_INTEGRATION_COUNT_SQL,
-      [orgId, catalogId],
-    );
+    const rows = await internalQuery<{ others: number; this_count: number }>(countSql, [
+      orgId,
+      selfKey,
+    ]);
     counts = rows[0];
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-      "Failed to count chat integrations for cap precheck — blocking as precaution",
+      { err: err instanceof Error ? err.message : String(err), orgId, selfKey, resource },
+      `Failed to count ${label}s for cap precheck — blocking as precaution`,
     );
-    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
   }
   // The aggregate always returns exactly one row; an empty result means the
   // driver/query contract was violated. Fail closed rather than coerce the
   // absent count to 0 — that would silently breach the cap.
   if (!counts) {
     log.error(
-      { orgId, catalogId },
-      "Chat-integration count query returned no row for cap precheck — blocking as precaution",
+      { orgId, selfKey, resource },
+      `Count query for ${label} returned no row for cap precheck — blocking as precaution`,
     );
-    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
   }
 
-  // Reconnect (already installed) is never blocked — re-auth doesn't grow the
+  // Reconnect/edit (already installed) is never blocked — it doesn't grow the
   // distinct count, so skip the cap comparison entirely.
   if (counts.this_count > 0) {
     return { allowed: true };
   }
 
-  // Net-new platform → compare the *other* chat platforms to the plan cap.
+  // Net-new key → compare the *other* installs to the plan cap.
   // getCachedWorkspace warmed the cache above, so this reads from cache.
-  return checkResourceLimit(orgId, "chat_integrations", counts.others);
+  return checkResourceLimit(orgId, resource, counts.others);
+}
+
+/**
+ * Read-only chat-integration cap precheck — the pre-redirect gate (#2998).
+ * Thin wrapper over {@link capPrecheck}; see it for the full contract.
+ *
+ * @param orgId - Workspace id. When absent (or no internal DB) there's no cap.
+ * @param catalogId - Catalog row id of the platform being installed (e.g.
+ *   `"catalog:slack"`). Excluded from the `others` count so reconnecting the
+ *   same platform is never blocked.
+ */
+export function checkChatIntegrationLimit(
+  orgId: string | undefined,
+  catalogId: string,
+): Promise<ResourceLimitResult> {
+  return capPrecheck({
+    orgId,
+    resource: "chat_integrations",
+    countSql: CHAT_INTEGRATION_COUNT_SQL,
+    selfKey: catalogId,
+    checkFailedMessage: CHAT_CAP_CHECK_FAILED_MSG,
+    label: "chat-integration",
+  });
 }
 
 /**
@@ -1090,22 +1129,57 @@ export interface WorkspacePluginInsert {
  * success** when the SQL omits a `RETURNING` clause. A caller that reads a
  * column must guard for absence (see the handlers' `rows[0]?.id` check).
  */
-export type ChatIntegrationInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
+export type CapGatedInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
   | { allowed: true; readonly rows: readonly T[] }
   | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
   | { allowed: false; reason: "check_failed"; errorMessage: string };
 
+/** @deprecated Prefer the resource-agnostic {@link CapGatedInstallResult}. */
+export type ChatIntegrationInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
+  CapGatedInstallResult<T>;
+
 /**
- * Atomically enforce the chat-integration cap and run the `workspace_plugins`
- * INSERT in a single transaction (#3001).
+ * Everything the shared atomic install gate ({@link capGatedInstall}) needs to
+ * enforce ONE {@link CappedResource} — extracted when the Knowledge Base
+ * collections cap (#4235) needed the identical advisory-lock → recount →
+ * decide → INSERT dance the chat-integration cap already ran (#3001). Both
+ * public entries are now thin wrappers, so the two caps cannot drift in their
+ * fail-closed arms.
+ */
+interface CapGatedInstallSpec {
+  /** Workspace id. When absent (or no internal DB) the INSERT runs unlocked. */
+  readonly orgId: string | undefined;
+  /** Which `PlanLimits` cap the recount is compared against. */
+  readonly resource: CappedResource;
+  /** `classkey` of the two-arg `pg_advisory_xact_lock` — one per resource. */
+  readonly lockNamespace: number;
+  /**
+   * Aggregate returning exactly one row of `{ others, this_count }` for
+   * `($1 = orgId, $2 = selfKey)`. `this_count > 0` is the reconnect/edit
+   * carve-out (never blocked); `others` is what the cap is compared against.
+   */
+  readonly countSql: string;
+  /** `$2` of {@link countSql} — the identity excluded from the `others` count. */
+  readonly selfKey: string;
+  /** Message on the fail-closed `check_failed` arm (→ 503 "try again"). */
+  readonly checkFailedMessage: string;
+  /** Log-facing resource label, e.g. `"chat-integration"`. */
+  readonly label: string;
+}
+
+/**
+ * Atomically enforce ONE resource cap and run the `workspace_plugins` INSERT in
+ * a single transaction — the shared engine behind
+ * {@link checkChatIntegrationLimitAndInstall} (#3001) and
+ * {@link checkKnowledgeCollectionLimitAndInstall} (#4235).
  *
  * The cap used to be a read-only precheck followed by a *separate* INSERT, so
- * two **distinct** net-new chat platforms installing concurrently (e.g. Slack
- * and Discord OAuth callbacks completing in the same window while the workspace
- * is one under its cap) could both pass the precheck and both insert, landing
- * the workspace one over its cap. (The same-platform case was already safe —
- * the `workspace_plugins_singleton` partial unique index collapses a duplicate
- * install into an UPSERT/reconnect, which is always allowed.)
+ * two **distinct** net-new resources installing concurrently (e.g. Slack and
+ * Discord OAuth callbacks completing in the same window while the workspace is
+ * one under its cap) could both pass the precheck and both insert, landing the
+ * workspace one over its cap. (The same-key case was already safe — the
+ * conflict target collapses a duplicate install into an UPSERT/reconnect, which
+ * is always allowed.)
  *
  * This closes that window:
  *   1. Resolve the workspace plan up front (outside the transaction). This
@@ -1119,36 +1193,27 @@ export type ChatIntegrationInstallResult<T extends Record<string, unknown> = Rec
  *   2. `pg_advisory_xact_lock(namespace, hashtext(workspaceId))` — a
  *      transaction-scoped advisory lock keyed on the workspace, released
  *      automatically on COMMIT/ROLLBACK. Concurrent installs for the *same*
- *      workspace serialize on it.
- *   3. Re-count chat installs INSIDE the lock, on the same client — this is
- *      the read the cap decision is based on, now serialized so a concurrent
- *      install can't slip a row in between the count and our INSERT.
- *   4. If a net-new platform would breach the cap, ROLLBACK and return
+ *      workspace and resource serialize on it.
+ *   3. Re-count installs INSIDE the lock, on the same client — this is the read
+ *      the cap decision is based on, now serialized so a concurrent install
+ *      can't slip a row in between the count and our INSERT.
+ *   4. If a net-new install would breach the cap, ROLLBACK and return
  *      `cap_reached`. Otherwise run the caller's INSERT and COMMIT.
  *
- * Reconnect is never blocked: re-auth of an already-installed platform
+ * Reconnect/edit is never blocked: re-installing an already-present key
  * (`this_count > 0`) skips the cap comparison, so a grandfathered over-cap
- * workspace can still re-auth what it owns.
+ * workspace can still re-auth or edit what it owns.
  *
- * Returns a denied result for cap / billing-check failures (mapped to 429 /
+ * Returns a denied result for cap / billing-check failures (mapped to 429/403 /
  * 503 by the caller). **Throws** for genuine write-path failures (lock, INSERT,
  * or COMMIT errors) so the caller surfaces a 5xx — identical to the pre-#3001
  * behaviour where a failed INSERT re-threw.
- *
- * @param orgId - Workspace id. When absent (or no internal DB) there's no cap
- *   to apply, so the INSERT runs directly with no lock.
- * @param catalogId - Catalog row id of the platform being installed (e.g.
- *   `"catalog:slack"`). Excluded from the `others` count.
- * @param insert - The `workspace_plugins` INSERT to run inside the gate. Its
- *   `RETURNING` rows (if any) come back on the success arm.
  */
-export async function checkChatIntegrationLimitAndInstall<
-  T extends Record<string, unknown> = Record<string, unknown>,
->(
-  orgId: string | undefined,
-  catalogId: string,
+async function capGatedInstall<T extends Record<string, unknown> = Record<string, unknown>>(
+  spec: CapGatedInstallSpec,
   insert: WorkspacePluginInsert,
-): Promise<ChatIntegrationInstallResult<T>> {
+): Promise<CapGatedInstallResult<T>> {
+  const { orgId, resource, lockNamespace, countSql, selfKey, checkFailedMessage, label } = spec;
   // No enforcement context — no cap to apply, nothing to serialize, so run the
   // INSERT directly. (workspace_plugins lives in the internal DB, so when
   // !hasInternalDB the INSERT itself can't run — internalQuery throws, matching
@@ -1167,10 +1232,10 @@ export async function checkChatIntegrationLimitAndInstall<
     workspace = await getCachedWorkspace(orgId);
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-      "Failed to resolve workspace for chat-integration cap — blocking as precaution",
+      { err: err instanceof Error ? err.message : String(err), orgId, selfKey, resource },
+      `Failed to resolve workspace for ${label} cap — blocking as precaution`,
     );
-    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
   }
 
   // No `organization` row → no plan tier → no cap to enforce (pre-migration /
@@ -1190,10 +1255,10 @@ export async function checkChatIntegrationLimitAndInstall<
     // plan breach. Fail closed as check_failed (→ 503 "try again") rather than
     // letting a raw pool error degrade into an unlabeled 500.
     log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-      "Failed to acquire internal DB client for chat-integration install gate — blocking as precaution",
+      { err: err instanceof Error ? err.message : String(err), orgId, selfKey, resource },
+      `Failed to acquire internal DB client for ${label} install gate — blocking as precaution`,
     );
-    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
   }
   // Destroy the client on a failed ROLLBACK so a dirty socket doesn't poison
   // the next borrower (matches cascadeWorkspaceDelete / hardDeleteWorkspace).
@@ -1202,8 +1267,8 @@ export async function checkChatIntegrationLimitAndInstall<
     await client.query("ROLLBACK").catch((rbErr: unknown) => {
       rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
       log.warn(
-        { orgId, catalogId, err: rollbackErr.message },
-        "ROLLBACK failed during chat-integration install gate — client will be destroyed",
+        { orgId, selfKey, err: rollbackErr.message },
+        `ROLLBACK failed during ${label} install gate — client will be destroyed`,
       );
     });
   };
@@ -1215,7 +1280,7 @@ export async function checkChatIntegrationLimitAndInstall<
     // collision only costs extra serialization, never correctness. Released
     // automatically on COMMIT/ROLLBACK.
     await client.query("SELECT pg_advisory_xact_lock($1, hashtext($2))", [
-      CHAT_INSTALL_LOCK_NAMESPACE,
+      lockNamespace,
       orgId,
     ]);
 
@@ -1223,34 +1288,34 @@ export async function checkChatIntegrationLimitAndInstall<
     // via internalQuery, which may use a different pooled connection).
     let counts: { others: number; this_count: number } | undefined;
     try {
-      const res = await client.query(CHAT_INTEGRATION_COUNT_SQL, [orgId, catalogId]);
+      const res = await client.query(countSql, [orgId, selfKey]);
       counts = res.rows[0] as { others: number; this_count: number } | undefined;
     } catch (err) {
       log.error(
-        { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-        "Failed to count chat integrations under lock — blocking as precaution",
+        { err: err instanceof Error ? err.message : String(err), orgId, selfKey, resource },
+        `Failed to count ${label}s under lock — blocking as precaution`,
       );
       await rollback();
-      return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+      return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
     }
     // The aggregate always returns exactly one row; an empty result means the
     // driver/query contract was violated. Fail closed rather than coerce the
     // absent count to 0 — that would silently breach the cap.
     if (!counts) {
       log.error(
-        { orgId, catalogId },
-        "Chat-integration count query returned no row under lock — blocking as precaution",
+        { orgId, selfKey, resource },
+        `Count query for ${label} returned no row under lock — blocking as precaution`,
       );
       await rollback();
-      return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+      return { allowed: false, reason: "check_failed", errorMessage: checkFailedMessage };
     }
 
-    // Net-new platform → compare the *other* chat platforms to the plan cap.
-    // Reconnect (this_count > 0) skips the comparison and is never blocked.
-    // getCachedWorkspace was warmed above, so checkResourceLimit reads from
-    // cache without a nested pool acquire.
+    // Net-new key → compare the *other* installs of this resource to the plan
+    // cap. Reconnect/edit (this_count > 0) skips the comparison and is never
+    // blocked. getCachedWorkspace was warmed above, so checkResourceLimit reads
+    // from cache without a nested pool acquire.
     if (counts.this_count === 0) {
-      const decision = await checkResourceLimit(orgId, "chat_integrations", counts.others);
+      const decision = await checkResourceLimit(orgId, resource, counts.others);
       if (!decision.allowed) {
         await rollback();
         return decision;
@@ -1267,13 +1332,149 @@ export async function checkChatIntegrationLimitAndInstall<
     // subsequent "ROLLBACK failed" warning isn't the only breadcrumb when COMMIT
     // was the real cause.
     log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-      "Chat-integration install gate write-path failed — rolling back",
+      { err: err instanceof Error ? err.message : String(err), orgId, selfKey, resource },
+      `Install gate write-path failed for ${label} — rolling back`,
     );
     await rollback();
     throw err;
   } finally {
     client.release(rollbackErr ?? undefined);
   }
+}
+
+/**
+ * Atomically enforce the chat-integration cap and run the `workspace_plugins`
+ * INSERT in one transaction (#3001). Thin wrapper over {@link capGatedInstall}
+ * — see that function for the full lock/recount/decide contract.
+ *
+ * @param orgId - Workspace id. When absent (or no internal DB) there's no cap
+ *   to apply, so the INSERT runs directly with no lock.
+ * @param catalogId - Catalog row id of the platform being installed (e.g.
+ *   `"catalog:slack"`). Excluded from the `others` count so reconnecting the
+ *   same platform is never blocked.
+ * @param insert - The `workspace_plugins` INSERT to run inside the gate. Its
+ *   `RETURNING` rows (if any) come back on the success arm.
+ */
+export function checkChatIntegrationLimitAndInstall<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
+  orgId: string | undefined,
+  catalogId: string,
+  insert: WorkspacePluginInsert,
+): Promise<CapGatedInstallResult<T>> {
+  return capGatedInstall<T>(
+    {
+      orgId,
+      resource: "chat_integrations",
+      lockNamespace: CHAT_INSTALL_LOCK_NAMESPACE,
+      countSql: CHAT_INTEGRATION_COUNT_SQL,
+      selfKey: catalogId,
+      checkFailedMessage: CHAT_CAP_CHECK_FAILED_MSG,
+      label: "chat-integration",
+    },
+    insert,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge Base collections cap (#4235)
+// ---------------------------------------------------------------------------
+
+/** Message surfaced when the collection count can't be determined (→ 503). */
+const KNOWLEDGE_CAP_CHECK_FAILED_MSG =
+  "Unable to verify your plan's Knowledge Base limits. Please try again.";
+
+/**
+ * Namespace for the per-workspace knowledge-collection install advisory lock —
+ * the `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`. Value
+ * is this issue's number, and is distinct from every other two-arg user
+ * (`lead-outbox` 2870, chat-install 3001, last-admin 3158, stripe-subscription
+ * 3445, demo-seed 3683) so knowledge installs never serialize behind them.
+ */
+const KNOWLEDGE_INSTALL_LOCK_NAMESPACE = 4235;
+
+/**
+ * Counts the workspace's knowledge collections, partitioned into the collection
+ * being installed (`this_count`) vs. every other collection (`others`).
+ *
+ * A *collection* is one `pillar = 'knowledge'` `workspace_plugins` row keyed by
+ * `install_id` (the collection slug) — so the partition is by `install_id`, NOT
+ * by `catalog_id` as the chat aggregate is: knowledge is multi-instance, and a
+ * workspace legitimately holds several collections from the same catalog (e.g.
+ * one Zendesk collection per brand). Archived collections don't count; their
+ * documents stay archived until an explicit re-ingest (ADR-0028 §5).
+ *
+ * Exported so the real-Postgres test exercises the EXACT aggregate the cap
+ * decision runs on — a typo in the FILTER predicate, an inverted `<>`/`=`, or a
+ * dropped `status <> 'archived'` would otherwise pass every mock-based test.
+ */
+export const KNOWLEDGE_COLLECTION_COUNT_SQL = `SELECT
+   COUNT(*) FILTER (WHERE install_id <> $2)::int AS others,
+   COUNT(*) FILTER (WHERE install_id = $2)::int  AS this_count
+ FROM workspace_plugins
+ WHERE workspace_id = $1
+   AND pillar = 'knowledge'
+   AND status <> 'archived'`;
+
+/**
+ * Read-only Knowledge Base collections precheck — the pre-write gate every
+ * knowledge form handler runs before it validates upstream credentials or
+ * writes a `knowledge_sync_credentials` row, so an at-cap workspace is refused
+ * before a secret is ever persisted. Thin wrapper over {@link capPrecheck};
+ * {@link checkKnowledgeCollectionLimitAndInstall} remains the TOCTOU guard.
+ *
+ * @param orgId - Workspace id. When absent (or no internal DB) there's no cap.
+ * @param collectionSlug - The collection's `install_id`. Excluded from the
+ *   `others` count, so editing an existing collection is never blocked.
+ */
+export function checkKnowledgeCollectionLimit(
+  orgId: string | undefined,
+  collectionSlug: string,
+): Promise<ResourceLimitResult> {
+  return capPrecheck({
+    orgId,
+    resource: "knowledge_collections",
+    countSql: KNOWLEDGE_COLLECTION_COUNT_SQL,
+    selfKey: collectionSlug,
+    checkFailedMessage: KNOWLEDGE_CAP_CHECK_FAILED_MSG,
+    label: "knowledge-collection",
+  });
+}
+
+/**
+ * Atomically enforce the per-tier Knowledge Base **collections** cap
+ * (`PlanLimits.maxKnowledgeCollections`, #4235) and run the collection UPSERT
+ * in one transaction. Thin wrapper over {@link capGatedInstall} — same
+ * lock/recount/decide contract the chat-integration cap uses, so two knowledge
+ * collections created concurrently can't both slip past a shared last slot.
+ *
+ * Editing / re-installing an existing collection slug (`this_count > 0`) is
+ * never blocked, so a workspace that dropped a tier keeps what it has and is
+ * simply unable to add more — the same grandfathering the sibling caps apply.
+ *
+ * @param orgId - Workspace id. When absent (or no internal DB) there's no cap.
+ * @param collectionSlug - The collection's `install_id`. Excluded from the
+ *   `others` count.
+ * @param insert - The collection UPSERT to run inside the gate.
+ */
+export function checkKnowledgeCollectionLimitAndInstall<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
+  orgId: string | undefined,
+  collectionSlug: string,
+  insert: WorkspacePluginInsert,
+): Promise<CapGatedInstallResult<T>> {
+  return capGatedInstall<T>(
+    {
+      orgId,
+      resource: "knowledge_collections",
+      lockNamespace: KNOWLEDGE_INSTALL_LOCK_NAMESPACE,
+      countSql: KNOWLEDGE_COLLECTION_COUNT_SQL,
+      selfKey: collectionSlug,
+      checkFailedMessage: KNOWLEDGE_CAP_CHECK_FAILED_MSG,
+      label: "knowledge-collection",
+    },
+    insert,
+  );
 }
 

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -48,13 +48,16 @@ import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
 import { getSettingLive } from "@atlas/api/lib/settings";
 import { getSeatCount, SeatCountUnavailableError } from "./seat-count";
 import { computeUsageDollarBudget, getPlanLimits, isUnlimited } from "./plans";
+// Single-homed in a leaf module so the two producers of the same KB 503 can't
+// drift; `knowledge-limits.ts` imports THIS file, so it can't own the constant.
+import { KNOWLEDGE_CAP_CHECK_FAILED_MSG } from "./knowledge-limits-message";
 import {
   effectiveTrialEndsAt,
   isTrialExpiredAt,
   isTrialTier,
   trialDaysRemaining,
 } from "./trial-state";
-import type { OverageStatus, PlanLimitStatus } from "@useatlas/types";
+import type { OverageStatus, PlanLimitStatus, PlanTier } from "@useatlas/types";
 
 const log = createLogger("billing:enforcement");
 
@@ -795,7 +798,7 @@ export async function getTrialDaysRemaining(
 }
 
 // ---------------------------------------------------------------------------
-// Resource limit enforcement (seats, connections, chat integrations)
+// Resource limit enforcement — every member of `CappedResource`
 // ---------------------------------------------------------------------------
 
 /**
@@ -806,17 +809,30 @@ export async function getTrialDaysRemaining(
  * (429) vs `billing_check_failed` (503) split in {@link checkPlanLimits}:
  *
  *  - `cap_reached` — the workspace is genuinely at/over its plan cap. The
- *    actionable response is "upgrade your plan" (429). Carries `limit`, the
- *    cap that was hit.
+ *    actionable response is "upgrade your plan" — 429 `plan_limit_exceeded`
+ *    for chat integrations, 403 `plan_upgrade_required` for knowledge
+ *    collections. Carries `limit` (the cap that was hit) and `tier` (the plan
+ *    that set it).
  *  - `check_failed` — we could NOT determine the count (DB error, missing
  *    row). Fail-closed: the request is blocked, but the actionable response
- *    is "try again" (503), NOT "upgrade your plan". Carries no `limit` —
- *    there is no meaningful cap to report.
+ *    is "try again" (503), NOT "upgrade your plan". Carries no `limit`/`tier`
+ *    — there is no meaningful cap to report.
+ *
+ * `tier` rides on the denial so a caller composing an upgrade prompt never has
+ * to re-resolve the workspace (#4235): a second `getCachedWorkspace` read can
+ * return a DIFFERENT tier (60s per-replica TTL) or fault outright, which would
+ * make the prompt name a plan that didn't set the cap it quotes.
  */
 export type ResourceLimitResult =
-  | { allowed: true }
-  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
-  | { allowed: false; reason: "check_failed"; errorMessage: string };
+  | { readonly allowed: true }
+  | {
+      readonly allowed: false;
+      readonly reason: "cap_reached";
+      readonly errorMessage: string;
+      readonly limit: number;
+      readonly tier: PlanTier;
+    }
+  | { readonly allowed: false; readonly reason: "check_failed"; readonly errorMessage: string };
 
 /** Plan-capped resources. Each maps to a `PlanLimits` field. */
 export type CappedResource =
@@ -826,8 +842,8 @@ export type CappedResource =
   | "knowledge_collections";
 
 /**
- * Check whether adding one more resource (seat, connection, or chat
- * integration) would exceed the plan's limit for the given workspace.
+ * Check whether adding `pending` more of a {@link CappedResource} would exceed
+ * the plan's limit for the given workspace.
  *
  * `currentCount` is the count of that resource the workspace already has;
  * the check blocks when `currentCount >= cap`. Because the block fires
@@ -913,6 +929,7 @@ export async function checkResourceLimit(
       reason: "cap_reached",
       errorMessage: `Your ${tier} plan allows up to ${cap} ${resourceLabel}. Upgrade to add more.`,
       limit: cap,
+      tier,
     };
   }
 
@@ -934,8 +951,9 @@ const CHAT_CAP_CHECK_FAILED_MSG = "Unable to verify plan limits. Please try agai
  * `(int4, int4)` lock spaces fully disjoint, so this lock can never collide
  * with any single-arg user regardless of value (migrations
  * `hashtext('atlas_migrations')`, `rotate-encryption-key` `0x1f47`,
- * `backfill-plugin-config` `0x1f42`). The only peer in the two-arg space is
- * `lead-outbox` (`2870`), and `3001 ≠ 2870` keeps them disjoint there too.
+ * `backfill-plugin-config` `0x1f42`). Its peers in the two-arg space are
+ * `lead-outbox` (2870), `last-admin` (3158), `stripe-subscription` (3445),
+ * `demo-seed` (3683), and `knowledge-install` (4235) — all pairwise distinct.
  * Value is this issue's number.
  */
 const CHAT_INSTALL_LOCK_NAMESPACE = 3001;
@@ -967,18 +985,12 @@ export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
    AND status <> 'archived'`;
 
 /**
- * Everything the shared read-only cap precheck ({@link capPrecheck}) needs for
- * ONE {@link CappedResource}. A subset of {@link CapGatedInstallSpec} — no lock
- * namespace, because the precheck deliberately takes no lock.
+ * What the shared read-only cap precheck ({@link capPrecheck}) needs. Derived
+ * from {@link CapGatedInstallSpec} rather than hand-copied, so a field added
+ * there can't silently fall out of the precheck: the precheck differs only in
+ * dropping `lockNamespace`, because it deliberately takes no lock.
  */
-interface CapPrecheckSpec {
-  readonly orgId: string | undefined;
-  readonly resource: CappedResource;
-  readonly countSql: string;
-  readonly selfKey: string;
-  readonly checkFailedMessage: string;
-  readonly label: string;
-}
+type CapPrecheckSpec = Omit<CapGatedInstallSpec, "lockNamespace">;
 
 /**
  * Read-only resource-cap precheck — the fail-fast gate that runs BEFORE the
@@ -996,9 +1008,11 @@ interface CapPrecheckSpec {
  * INSERT: it opens no transaction and takes no advisory lock. The atomic gate
  * remains the TOCTOU guard — a workspace can reach its cap between this
  * precheck and the write. This is a fail-fast precheck, not the correctness
- * boundary. (It also cannot see a *fan-out*: a handler planning N net-new
- * collections in one install runs this per key against the same pre-write
- * count, so only the atomic gate refuses the (cap+1)-th.)
+ * boundary. It is also single-key: a handler planning N net-new collections in
+ * one install must NOT loop this (every iteration would see the same pre-write
+ * count and pass, leaving the atomic gate to refuse the (cap+1)-th mid-fan-out
+ * and strand a partial install) — it calls
+ * {@link checkKnowledgeCollectionFanOutLimit} once with the whole batch instead.
  *
  * Mirrors the atomic gate's enforcement skips and reconnect carve-out exactly,
  * so the two never disagree on a workspace that isn't racing itself:
@@ -1012,8 +1026,9 @@ interface CapPrecheckSpec {
  *   - Otherwise compare the *other* installs to the plan cap via
  *     {@link checkResourceLimit}.
  *
- * Returns a {@link ResourceLimitResult}: `cap_reached` and `check_failed`
- * (→ 503 "try again") map to the same dispositions the atomic path surfaces, so
+ * Returns a {@link ResourceLimitResult}: `cap_reached` (→ 429 for chat, 403
+ * `plan_upgrade_required` for knowledge collections) and `check_failed` (→ 503
+ * "try again") map to the same dispositions the atomic path surfaces, so
  * callers translate one set of arms regardless of which gate fired.
  */
 async function capPrecheck(spec: CapPrecheckSpec): Promise<ResourceLimitResult> {
@@ -1109,9 +1124,12 @@ export function checkChatIntegrationLimit(
  * The `workspace_plugins` INSERT the gate runs inside its transaction. Raw
  * SQL + params (rather than a structured descriptor) because each caller owns
  * its own UPSERT shape; the gate stays agnostic and just executes it under the
- * lock. Both current callers (Slack and Discord) append `RETURNING id` so the
- * handler can read back the persisted row id (#3005). Callers are trusted
- * in-process code — this is internal-DB write SQL, not user analytics SQL.
+ * lock. Every caller — the two chat handlers (#3005) and the twelve knowledge
+ * collection handlers (#4235) — appends `RETURNING id` so the handler can read
+ * back the persisted row id; the knowledge seam
+ * (`upsertKnowledgeCollectionRow`) additionally REQUIRES it and rejects SQL
+ * without it up front. Callers are trusted in-process code — this is
+ * internal-DB write SQL, not user analytics SQL.
  */
 export interface WorkspacePluginInsert {
   readonly sql: string;
@@ -1119,24 +1137,28 @@ export interface WorkspacePluginInsert {
 }
 
 /**
- * Outcome of {@link checkChatIntegrationLimitAndInstall}. Mirrors the
- * {@link ResourceLimitResult} arms (so callers map `cap_reached` → 429 and
- * `check_failed` → 503 exactly as elsewhere), but the success arm carries the
- * INSERT's `RETURNING` rows — the Slack and Discord handlers read the upserted
- * row id from them (#3005).
+ * Outcome of {@link capGatedInstall}. Mirrors the {@link ResourceLimitResult}
+ * arms, so callers map `cap_reached` to their resource's upgrade disposition
+ * (chat → 429 `plan_limit_exceeded`; knowledge collections → 403
+ * `plan_upgrade_required`) and `check_failed` → 503 exactly as elsewhere. The
+ * success arm additionally carries the INSERT's `RETURNING` rows — the two
+ * chat handlers (#3005) and the twelve knowledge handlers (#4235) read the
+ * upserted row id from them.
  *
  * `rows` is the INSERT's `RETURNING` output and **may be empty even on
  * success** when the SQL omits a `RETURNING` clause. A caller that reads a
  * column must guard for absence (see the handlers' `rows[0]?.id` check).
  */
 export type CapGatedInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
-  | { allowed: true; readonly rows: readonly T[] }
-  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
-  | { allowed: false; reason: "check_failed"; errorMessage: string };
-
-/** @deprecated Prefer the resource-agnostic {@link CapGatedInstallResult}. */
-export type ChatIntegrationInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
-  CapGatedInstallResult<T>;
+  | { readonly allowed: true; readonly rows: readonly T[] }
+  | {
+      readonly allowed: false;
+      readonly reason: "cap_reached";
+      readonly errorMessage: string;
+      readonly limit: number;
+      readonly tier: PlanTier;
+    }
+  | { readonly allowed: false; readonly reason: "check_failed"; readonly errorMessage: string };
 
 /**
  * Everything the shared atomic install gate ({@link capGatedInstall}) needs to
@@ -1380,9 +1402,7 @@ export function checkChatIntegrationLimitAndInstall<
 // Knowledge Base collections cap (#4235)
 // ---------------------------------------------------------------------------
 
-/** Message surfaced when the collection count can't be determined (→ 503). */
-const KNOWLEDGE_CAP_CHECK_FAILED_MSG =
-  "Unable to verify your plan's Knowledge Base limits. Please try again.";
+
 
 /**
  * Namespace for the per-workspace knowledge-collection install advisory lock —
@@ -1440,6 +1460,100 @@ export function checkKnowledgeCollectionLimit(
     label: "knowledge-collection",
   });
 }
+
+/**
+ * Batch variant of {@link checkKnowledgeCollectionLimit} for the **fan-out**
+ * handlers — Zendesk (one collection per brand), Front (per knowledge base),
+ * Freshdesk (per category), Help Scout (per site) — which create N collections
+ * from one install submit (#4235).
+ *
+ * Looping the single-key precheck would pass N times against the same pre-write
+ * count, so the atomic gate would refuse the (cap+1)-th *after* earlier brands
+ * had already written their rows and credentials — a partial install the admin
+ * then has to unpick. This compares the whole batch up front.
+ *
+ * The decision is on NET-NEW growth, not batch size:
+ *   - `others` = collections outside the batch; `this_count` = how many of the
+ *     batch already exist, so the workspace holds `others + this_count` today.
+ *   - `netNew = collectionSlugs.length - this_count`.
+ *   - `netNew <= 0` (a pure re-install / edit) is ALWAYS allowed, so a
+ *     workspace that dropped a tier can still re-run the install for what it
+ *     already owns — the same grandfathering the single-key path applies.
+ *   - Otherwise the post-install total is `others + this_count + netNew`, and
+ *     `checkResourceLimit` blocks at `>= cap`, so it is handed
+ *     `others + this_count + netNew - 1` ("one more would breach").
+ *
+ * Like every precheck this takes no lock; {@link checkKnowledgeCollectionLimitAndInstall}
+ * remains the correctness boundary for each individual row.
+ */
+export async function checkKnowledgeCollectionFanOutLimit(
+  orgId: string | undefined,
+  collectionSlugs: readonly string[],
+): Promise<ResourceLimitResult> {
+  if (!orgId || !hasInternalDB() || collectionSlugs.length === 0) {
+    return { allowed: true };
+  }
+
+  let counts: { others: number; this_count: number } | undefined;
+  try {
+    const rows = await internalQuery<{ others: number; this_count: number }>(
+      KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL,
+      [orgId, [...collectionSlugs]],
+    );
+    counts = rows[0];
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, planned: collectionSlugs.length },
+      "Failed to count knowledge collections for the fan-out cap precheck — blocking as precaution",
+    );
+    return {
+      allowed: false,
+      reason: "check_failed",
+      errorMessage: KNOWLEDGE_CAP_CHECK_FAILED_MSG,
+    };
+  }
+  // The aggregate always returns exactly one row; an empty result means the
+  // driver/query contract was violated. Fail closed rather than coerce the
+  // absent count to 0 — that would silently breach the cap.
+  if (!counts) {
+    log.error(
+      { orgId, planned: collectionSlugs.length },
+      "Fan-out knowledge-collection count query returned no row — blocking as precaution",
+    );
+    return {
+      allowed: false,
+      reason: "check_failed",
+      errorMessage: KNOWLEDGE_CAP_CHECK_FAILED_MSG,
+    };
+  }
+
+  // A pure re-install adds nothing, so it is never measured against the cap.
+  const netNew = collectionSlugs.length - counts.this_count;
+  if (netNew <= 0) return { allowed: true };
+
+  const existingTotal = counts.others + counts.this_count;
+  return checkResourceLimit(
+    orgId,
+    "knowledge_collections",
+    existingTotal + netNew - 1,
+  );
+}
+
+/**
+ * Partitions the workspace's knowledge collections against the batch being
+ * installed: `others` are outside it, `this_count` are members of it that
+ * already exist (the re-install carve-out). Exported so the real-Postgres test
+ * executes this exact aggregate — an inverted `<> ALL` / `= ANY` would pass
+ * every mock test while either refusing a plain re-install or ignoring the
+ * workspace's existing collections entirely.
+ */
+export const KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL = `SELECT
+   COUNT(*) FILTER (WHERE install_id <> ALL($2::text[]))::int AS others,
+   COUNT(*) FILTER (WHERE install_id = ANY($2::text[]))::int  AS this_count
+ FROM workspace_plugins
+ WHERE workspace_id = $1
+   AND pillar = 'knowledge'
+   AND status <> 'archived'`;
 
 /**
  * Atomically enforce the per-tier Knowledge Base **collections** cap

--- a/packages/api/src/lib/billing/knowledge-limits-message.ts
+++ b/packages/api/src/lib/billing/knowledge-limits-message.ts
@@ -1,0 +1,17 @@
+/**
+ * The one Knowledge Base fail-closed message (#4235).
+ *
+ * Both producers of the KB `billing_check_failed` 503 need it —
+ * `enforcement.ts` (the collections count could not be determined) and
+ * `knowledge-limits.ts` (the workspace's tier could not be resolved) — and
+ * `knowledge-limits.ts` already imports `enforcement.ts`, so a constant owned
+ * by either would close an import cycle. It lives in this leaf module instead,
+ * so the two 503s cannot drift into saying different things about the same
+ * subsystem.
+ *
+ * @module
+ */
+
+/** Surfaced when a KB cap could not be verified — "try again", never "upgrade". */
+export const KNOWLEDGE_CAP_CHECK_FAILED_MSG =
+  "Unable to verify your plan's Knowledge Base limits. Please try again.";

--- a/packages/api/src/lib/billing/knowledge-limits.ts
+++ b/packages/api/src/lib/billing/knowledge-limits.ts
@@ -19,27 +19,33 @@
  * `lib/knowledge/ingest-limits.ts`.
  *
  * The composition lives HERE rather than next to the platform readers because
- * `knowledge/ingest-limits.ts` is imported by the knowledge mirror and by every
- * connector client: pulling the billing stack (enforcement → metering →
- * seat-count) into that module would widen their dependency graph for a concern
- * none of them have.
+ * `knowledge/ingest-limits.ts` is imported by the knowledge mirror and by the
+ * connector clients that bound their own fetch: pulling the billing stack
+ * (enforcement → metering → seat-count) into that module would widen their
+ * dependency graph for a concern none of them have.
  *
  * ## Fail-closed posture
  *
- * {@link resolveKnowledgeTierLimits} mirrors `checkResourceLimit`'s arms so the
- * KB caps and the chat/connection caps can never disagree about what a
- * workspace is:
+ * {@link resolveKnowledgeTierLimits} follows `checkResourceLimit`'s arms, plus
+ * the `"self-hosted"` sentinel `orgId` that `checkResourceLimit` never sees:
  *
- *   - No `orgId` / no internal DB → `null` (no billing context, no tier cap).
+ *   - No `orgId` / the `"self-hosted"` sentinel / no internal DB → `null` (no
+ *     billing context, no tier cap).
  *   - Workspace lookup **error** → throws {@link BillingCheckFailedError}
  *     (→ 503 "try again"). A transient DB fault must never silently widen a
  *     cap.
  *   - No `organization` row (pre-migration / Better-Auth-only) → `null`. The
  *     one deliberate fail-open, identical to the sibling gates: a genuine
  *     *absence* of a plan means there is no plan to enforce.
- *   - `free` tier (self-hosted) → `null`. Every KB limit is unlimited there, so
+ *   - `free` tier **off SaaS** → `null`. Every KB limit is unlimited there, so
  *     collapsing to `null` keeps the platform knob authoritative and the
  *     self-hosted path allocation-free.
+ *   - `free` tier **on SaaS** → the `starter` limits, with a warn. There is no
+ *     SaaS free tier: `organization.plan_tier` merely DEFAULTS to `'free'`, so
+ *     a `free` row on SaaS means trial provisioning never landed. Reading that
+ *     as "no plan to enforce" would hand a provisioning failure the raised
+ *     SaaS ceiling (100 MB / 5,000 docs) — a strictly wider entitlement than
+ *     any paying tier. Fail closed to the cheapest tier instead.
  *
  * There is no operator-workspace bypass here, matching the resource-cap family
  * (`checkResourceLimit` has none either) rather than the feature-entitlement
@@ -52,6 +58,7 @@ import type { PlanTier } from "@useatlas/types";
 import { PLAN_RANK } from "@atlas/api/lib/integrations/install/plan-rank";
 import { BillingCheckFailedError, FeatureEntitlementError } from "@atlas/api/lib/effect/errors";
 import { hasInternalDB, type WorkspaceRow } from "@atlas/api/lib/db/internal";
+import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   getIngestMaxBundleBytes,
@@ -59,12 +66,12 @@ import {
   getIngestMaxDocs,
 } from "@atlas/api/lib/knowledge/ingest-limits";
 import { getCachedWorkspace } from "./enforcement";
+import { KNOWLEDGE_CAP_CHECK_FAILED_MSG } from "./knowledge-limits-message";
 import { getPlanLimits, isUnlimited, type PlanLimits } from "./plans";
 
 const log = createLogger("billing:knowledge-limits");
 
-/** Message surfaced when the tier can't be resolved (fail-closed → 503). */
-const TIER_CHECK_FAILED_MSG = "Unable to verify your plan's Knowledge Base limits. Please try again.";
+
 
 /**
  * The three numeric {@link PlanLimits} fields that ladder the Knowledge Base.
@@ -107,19 +114,44 @@ export async function resolveKnowledgeTierLimits(
       { err: err instanceof Error ? err.message : String(err), orgId },
       "Failed to resolve workspace for Knowledge Base tier caps — blocking as precaution",
     );
-    throw new BillingCheckFailedError({ message: TIER_CHECK_FAILED_MSG, workspaceId: orgId });
+    throw new BillingCheckFailedError({ message: KNOWLEDGE_CAP_CHECK_FAILED_MSG, workspaceId: orgId });
   }
 
   // Genuine absence of a plan → no tier cap (the sibling gates' one fail-open).
   if (!workspace) return null;
   const tier = workspace.plan_tier;
-  // `free` is unlimited on every KB field — the platform knob stays the only cap.
-  if (tier === "free") return null;
+  if (tier === "free") {
+    // Off SaaS `free` is the real, unlimited self-hosted tier — the platform
+    // knob stays the only cap. On SaaS it is an anomaly (see the module
+    // docblock): fail closed to `starter` rather than to "unlimited".
+    if (resolveDeployMode() !== "saas") return null;
+    log.warn(
+      { orgId },
+      "SaaS workspace resolved to the `free` tier — applying starter Knowledge Base caps; its trial provisioning may have failed",
+    );
+    return { tier: "starter", limits: getPlanLimits("starter") };
+  }
   return { tier, limits: getPlanLimits(tier) };
 }
 
 /** Which side of `min(platform ceiling, tier limit)` produced an effective cap. */
 export type CapBoundBy = "platform" | "tier";
+
+/**
+ * Is the cap that refused something the READER can actually change?
+ *
+ * Only off SaaS. A hosted workspace admin cannot reach the platform settings
+ * registry at all, and on SaaS the platform ceiling is deliberately pinned to
+ * the Business tier's values — so even a `boundBy: "platform"` refusal there is
+ * effectively a plan ceiling to them. Naming `ATLAS_KNOWLEDGE_INGEST_*` in a
+ * hosted error message sends the reader after a knob they can never turn.
+ *
+ * Used by the sync paths, which surface a status row rather than an HTTP
+ * response and so have no upgrade envelope to fall back on — only wording.
+ */
+export function capIsOperatorTunable(boundBy: CapBoundBy): boolean {
+  return boundBy === "platform" && resolveDeployMode() !== "saas";
+}
 
 /**
  * Turn a **tier-bound** over-limit into the standard 403 upgrade envelope, or
@@ -134,47 +166,55 @@ export type CapBoundBy = "platform" | "tier";
  *   - `boundBy === "platform"` → return. The operator's fleet-wide guardrail
  *     bound, not the customer's plan; upgrading would change nothing.
  *
- * A tier-resolution fault here degrades to `null` (→ `"free"` in the prompt)
- * rather than replacing a correct refusal with a 503: the cap decision was
- * already made upstream, and this call only phrases it.
+ * `tier` is the plan that was resolved when the cap was COMPUTED
+ * ({@link EffectiveIngestCaps.tier}), never a fresh lookup: `getCachedWorkspace`
+ * has a 60s per-replica TTL, so re-resolving could name a different plan than
+ * the one whose limit is being quoted — and could fault, turning a correct
+ * refusal into a 503. This function is pure; it neither reads nor can fail.
+ *
+ * `required` is the value that breached the cap. When the true value is only
+ * known to be *at least* something (a streamed body aborted at the cap), pass
+ * `exact: false` — an upgrade target cannot be named honestly from a lower
+ * bound, so the caller falls through to its plain over-limit response.
  */
-export async function assertNotTierBound(input: {
-  readonly orgId: string | undefined;
+export function assertNotTierBound(input: {
   readonly field: KnowledgeLimitField;
   readonly boundBy: CapBoundBy;
+  /** The plan that set `limit`, as resolved when the cap was composed. */
+  readonly tier: PlanTier | null;
   /** The value that breached the cap (document count, byte count, …). */
   readonly required: number;
+  /** False when `required` is a lower bound rather than the true value. */
+  readonly exact?: boolean;
   /** The effective cap that was enforced. */
   readonly limit: number;
   /** Human noun for the message, e.g. `"documents in one bundle"`. */
   readonly noun: string;
-}): Promise<void> {
-  const { orgId, field, boundBy, required, limit, noun } = input;
+  /** Log/forensic context only — never part of the customer-facing message. */
+  readonly orgId?: string;
+}): void {
+  const { field, boundBy, tier, required, limit, noun, orgId } = input;
   if (boundBy !== "tier") return;
+  // A lower bound can only prove the CURRENT tier was breached, not that any
+  // higher one admits the real value — naming one would be a guess.
+  if (input.exact === false) return;
+  // `boundBy === "tier"` is only produced by `compose`, which runs only when a
+  // tier context exists, so `tier` is non-null here by construction; the guard
+  // is belt-and-braces rather than a fabricated "free".
+  if (tier === null) return;
 
-  let currentPlan: PlanTier = "free";
-  try {
-    currentPlan = (await resolveKnowledgeTierLimits(orgId))?.tier ?? "free";
-  } catch (err) {
-    log.error(
-      { err: err instanceof Error ? err.message : String(err), orgId, field },
-      "Could not resolve the plan tier for a Knowledge Base over-limit — falling back to the plain over-limit response",
-    );
-    return;
-  }
-
-  const requiredPlan = lowestTierAdmitting(field, required, currentPlan);
+  const requiredPlan = lowestTierAdmitting(field, required, tier);
   if (requiredPlan === null) return;
 
   log.info(
-    { orgId, field, required, limit, currentPlan, requiredPlan },
+    { orgId, field, required, limit, currentPlan: tier, requiredPlan },
     "Knowledge Base ingest denied: the workspace's plan tier is the binding cap",
   );
   throw new FeatureEntitlementError({
-    message: `Your "${currentPlan}" plan allows up to ${limit} ${noun}. Upgrade to "${requiredPlan}" to raise the limit.`,
+    message: `Your "${tier}" plan allows up to ${limit} ${noun}. Upgrade to "${requiredPlan}" to raise the limit.`,
     feature: field,
     requiredPlan,
-    currentPlan,
+    currentPlan: tier,
   });
 }
 
@@ -195,8 +235,10 @@ export function minKnowledgeCap(platformCap: number, tierCap: number): number {
  * `null` when no higher tier admits the value, so the caller reports a plain
  * over-limit error instead of telling a Business customer to "upgrade".
  *
- * Only the self-serve paid ladder is considered: `free` is self-hosted-only and
- * `locked` is the churn tier, so neither is ever a legitimate upgrade target.
+ * Only the self-serve paid ladder is considered: `free` is self-hosted-only,
+ * `locked` is the churn tier, and `trial` is not something you upgrade *to* —
+ * none is ever a legitimate upgrade target. (A workspace ON `trial` still gets
+ * a target: it ranks below `starter`, so `starter` is offered when it helps.)
  */
 export function lowestTierAdmitting(
   field: KnowledgeLimitField,
@@ -223,12 +265,41 @@ export interface EffectiveCap {
   readonly boundBy: CapBoundBy;
 }
 
-/** The caps one ingest enforces, already composed with the workspace's tier. */
+/**
+ * The caps one ingest enforces, already composed with the workspace's tier.
+ *
+ * `workspaceId` is load-bearing, not informational: this object is passed
+ * between the route (which caps the raw request body) and the ingest seam, and
+ * both `assertIngestCapsFor` it against the workspace they are actually writing
+ * to. Without that, a refactor that hoists a caps resolution out of a loop
+ * would silently apply one tenant's cap to another's ingest.
+ */
 export interface EffectiveIngestCaps {
+  /** The workspace these caps were resolved FOR. Checked at every seam. */
+  readonly workspaceId: string;
+  /** The plan that set the tier half, or `null` when no tier context applied. */
+  readonly tier: PlanTier | null;
   readonly maxDocs: EffectiveCap;
   readonly maxBundleBytes: EffectiveCap;
   /** Platform-only, so it carries no provenance. */
   readonly maxDocBytes: number;
+}
+
+/**
+ * Guard a caller-supplied {@link EffectiveIngestCaps} against the workspace it
+ * is about to govern. `caps` is an optional parameter on the ingest seams (so
+ * the route and the seam share ONE tier lookup), which makes it the one place a
+ * plan cap could be crossed between tenants — fail loud rather than enforce the
+ * wrong tenant's limit.
+ */
+export function assertIngestCapsFor(
+  caps: EffectiveIngestCaps,
+  workspaceId: string,
+): void {
+  if (caps.workspaceId === workspaceId) return;
+  throw new Error(
+    `Knowledge ingest caps were resolved for workspace "${caps.workspaceId}" but are being applied to "${workspaceId}" — refusing to enforce another tenant's plan limits.`,
+  );
 }
 
 function compose(platform: number, tier: number): EffectiveCap {
@@ -255,18 +326,26 @@ export async function resolveIngestCaps(orgId: string | undefined): Promise<Effe
   const platformDocs = getIngestMaxDocs();
   const platformBundle = getIngestMaxBundleBytes();
   const maxDocBytes = getIngestMaxDocBytes();
+  // `orgId` is optional upstream (self-hosted no-auth has no workspace); the
+  // sentinel keeps `workspaceId` a plain string so the correlation check has a
+  // total comparison rather than a null-vs-null hole.
+  const workspaceId = orgId ?? "";
 
-  const tier = await resolveKnowledgeTierLimits(orgId);
-  if (!tier) {
+  const ctx = await resolveKnowledgeTierLimits(orgId);
+  if (!ctx) {
     return {
+      workspaceId,
+      tier: null,
       maxDocs: { value: platformDocs, boundBy: "platform" },
       maxBundleBytes: { value: platformBundle, boundBy: "platform" },
       maxDocBytes,
     };
   }
   return {
-    maxDocs: compose(platformDocs, tier.limits.maxKnowledgeDocsPerBundle),
-    maxBundleBytes: compose(platformBundle, tier.limits.maxKnowledgeBundleBytes),
+    workspaceId,
+    tier: ctx.tier,
+    maxDocs: compose(platformDocs, ctx.limits.maxKnowledgeDocsPerBundle),
+    maxBundleBytes: compose(platformBundle, ctx.limits.maxKnowledgeBundleBytes),
     maxDocBytes,
   };
 }

--- a/packages/api/src/lib/billing/knowledge-limits.ts
+++ b/packages/api/src/lib/billing/knowledge-limits.ts
@@ -1,0 +1,272 @@
+/**
+ * Per-tier Knowledge Base caps — the composition seam between the **platform**
+ * guardrails (`ATLAS_KNOWLEDGE_INGEST_*`, one value for the whole region) and
+ * the **plan tier** limits in `PlanLimits` (#4235).
+ *
+ * The two tiers of cap answer different questions and neither replaces the
+ * other:
+ *
+ *   - The platform setting is the operator's fleet-wide abuse guardrail. It
+ *     is the only cap on self-hosted, where every workspace sits on the
+ *     unlimited `free` tier.
+ *   - The plan limit is the SaaS pricing lever — KB size is storage plus
+ *     prompt-token cost, so it ladders with the plan.
+ *
+ * The effective cap is therefore `min(platform ceiling, tier limit)`
+ * ({@link minKnowledgeCap}, composed per-ingest by {@link resolveIngestCaps}).
+ * A tier that ranks *above* the platform ceiling is clamped by it, which is
+ * exactly why the SaaS ceiling is pinned to the Business values — see
+ * `lib/knowledge/ingest-limits.ts`.
+ *
+ * The composition lives HERE rather than next to the platform readers because
+ * `knowledge/ingest-limits.ts` is imported by the knowledge mirror and by every
+ * connector client: pulling the billing stack (enforcement → metering →
+ * seat-count) into that module would widen their dependency graph for a concern
+ * none of them have.
+ *
+ * ## Fail-closed posture
+ *
+ * {@link resolveKnowledgeTierLimits} mirrors `checkResourceLimit`'s arms so the
+ * KB caps and the chat/connection caps can never disagree about what a
+ * workspace is:
+ *
+ *   - No `orgId` / no internal DB → `null` (no billing context, no tier cap).
+ *   - Workspace lookup **error** → throws {@link BillingCheckFailedError}
+ *     (→ 503 "try again"). A transient DB fault must never silently widen a
+ *     cap.
+ *   - No `organization` row (pre-migration / Better-Auth-only) → `null`. The
+ *     one deliberate fail-open, identical to the sibling gates: a genuine
+ *     *absence* of a plan means there is no plan to enforce.
+ *   - `free` tier (self-hosted) → `null`. Every KB limit is unlimited there, so
+ *     collapsing to `null` keeps the platform knob authoritative and the
+ *     self-hosted path allocation-free.
+ *
+ * There is no operator-workspace bypass here, matching the resource-cap family
+ * (`checkResourceLimit` has none either) rather than the feature-entitlement
+ * guard. An operator workspace is capped by its own tier like any other.
+ *
+ * @module
+ */
+
+import type { PlanTier } from "@useatlas/types";
+import { PLAN_RANK } from "@atlas/api/lib/integrations/install/plan-rank";
+import { BillingCheckFailedError, FeatureEntitlementError } from "@atlas/api/lib/effect/errors";
+import { hasInternalDB, type WorkspaceRow } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  getIngestMaxBundleBytes,
+  getIngestMaxDocBytes,
+  getIngestMaxDocs,
+} from "@atlas/api/lib/knowledge/ingest-limits";
+import { getCachedWorkspace } from "./enforcement";
+import { getPlanLimits, isUnlimited, type PlanLimits } from "./plans";
+
+const log = createLogger("billing:knowledge-limits");
+
+/** Message surfaced when the tier can't be resolved (fail-closed → 503). */
+const TIER_CHECK_FAILED_MSG = "Unable to verify your plan's Knowledge Base limits. Please try again.";
+
+/**
+ * The three numeric {@link PlanLimits} fields that ladder the Knowledge Base.
+ * The first two are composed with a platform ceiling at ingest; the third is a
+ * countable resource enforced by the `checkResourceLimit` family at install.
+ * All three share {@link lowestTierAdmitting} so every KB upgrade prompt names
+ * the tier from the same table.
+ */
+export type KnowledgeLimitField =
+  | "maxKnowledgeBundleBytes"
+  | "maxKnowledgeDocsPerBundle"
+  | "maxKnowledgeCollections";
+
+/** The subset composed with a platform ceiling at ingest time. */
+export type KnowledgeIngestLimitField = Exclude<KnowledgeLimitField, "maxKnowledgeCollections">;
+
+/** A workspace's resolved KB tier context, or `null` when no tier applies. */
+export interface KnowledgeTierContext {
+  readonly tier: PlanTier;
+  readonly limits: Readonly<PlanLimits>;
+}
+
+/**
+ * Resolve the workspace's plan tier and its KB limits, or `null` when no tier
+ * cap applies (see the module docblock for every arm).
+ *
+ * @throws {BillingCheckFailedError} when the workspace lookup faults — the
+ *   caller surfaces a 503 "try again", never a silently-widened cap.
+ */
+export async function resolveKnowledgeTierLimits(
+  orgId: string | undefined,
+): Promise<KnowledgeTierContext | null> {
+  if (!orgId || orgId === "self-hosted" || !hasInternalDB()) return null;
+
+  let workspace: WorkspaceRow | null;
+  try {
+    workspace = await getCachedWorkspace(orgId);
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "Failed to resolve workspace for Knowledge Base tier caps — blocking as precaution",
+    );
+    throw new BillingCheckFailedError({ message: TIER_CHECK_FAILED_MSG, workspaceId: orgId });
+  }
+
+  // Genuine absence of a plan → no tier cap (the sibling gates' one fail-open).
+  if (!workspace) return null;
+  const tier = workspace.plan_tier;
+  // `free` is unlimited on every KB field — the platform knob stays the only cap.
+  if (tier === "free") return null;
+  return { tier, limits: getPlanLimits(tier) };
+}
+
+/** Which side of `min(platform ceiling, tier limit)` produced an effective cap. */
+export type CapBoundBy = "platform" | "tier";
+
+/**
+ * Turn a **tier-bound** over-limit into the standard 403 upgrade envelope, or
+ * return so the caller emits its ordinary over-limit 4xx.
+ *
+ * Three cases, and only the first is an upgrade prompt:
+ *   - `boundBy === "tier"` and a higher tier admits `required` → throw
+ *     {@link FeatureEntitlementError} (→ 403 `plan_upgrade_required`), the same
+ *     envelope the integration install endpoints emit.
+ *   - `boundBy === "tier"` but no higher tier admits it → return. The value
+ *     exceeds even the top plan, so "upgrade" would be a lie.
+ *   - `boundBy === "platform"` → return. The operator's fleet-wide guardrail
+ *     bound, not the customer's plan; upgrading would change nothing.
+ *
+ * A tier-resolution fault here degrades to `null` (→ `"free"` in the prompt)
+ * rather than replacing a correct refusal with a 503: the cap decision was
+ * already made upstream, and this call only phrases it.
+ */
+export async function assertNotTierBound(input: {
+  readonly orgId: string | undefined;
+  readonly field: KnowledgeLimitField;
+  readonly boundBy: CapBoundBy;
+  /** The value that breached the cap (document count, byte count, …). */
+  readonly required: number;
+  /** The effective cap that was enforced. */
+  readonly limit: number;
+  /** Human noun for the message, e.g. `"documents in one bundle"`. */
+  readonly noun: string;
+}): Promise<void> {
+  const { orgId, field, boundBy, required, limit, noun } = input;
+  if (boundBy !== "tier") return;
+
+  let currentPlan: PlanTier = "free";
+  try {
+    currentPlan = (await resolveKnowledgeTierLimits(orgId))?.tier ?? "free";
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, field },
+      "Could not resolve the plan tier for a Knowledge Base over-limit — falling back to the plain over-limit response",
+    );
+    return;
+  }
+
+  const requiredPlan = lowestTierAdmitting(field, required, currentPlan);
+  if (requiredPlan === null) return;
+
+  log.info(
+    { orgId, field, required, limit, currentPlan, requiredPlan },
+    "Knowledge Base ingest denied: the workspace's plan tier is the binding cap",
+  );
+  throw new FeatureEntitlementError({
+    message: `Your "${currentPlan}" plan allows up to ${limit} ${noun}. Upgrade to "${requiredPlan}" to raise the limit.`,
+    feature: field,
+    requiredPlan,
+    currentPlan,
+  });
+}
+
+/**
+ * Compose the effective cap: the smaller of the platform ceiling and the tier
+ * limit, with `-1` (unlimited) on the tier side meaning "the platform ceiling
+ * governs". `tierCap` of `0` (the `locked` churn tier) is a real cap of zero,
+ * NOT unlimited — a locked workspace ingests nothing.
+ */
+export function minKnowledgeCap(platformCap: number, tierCap: number): number {
+  if (isUnlimited(tierCap)) return platformCap;
+  return Math.min(platformCap, tierCap);
+}
+
+/**
+ * The lowest plan tier whose `field` limit admits `required`, ranking strictly
+ * above `currentTier` — i.e. the tier the upgrade prompt should name. Returns
+ * `null` when no higher tier admits the value, so the caller reports a plain
+ * over-limit error instead of telling a Business customer to "upgrade".
+ *
+ * Only the self-serve paid ladder is considered: `free` is self-hosted-only and
+ * `locked` is the churn tier, so neither is ever a legitimate upgrade target.
+ */
+export function lowestTierAdmitting(
+  field: KnowledgeLimitField,
+  required: number,
+  currentTier: PlanTier,
+): PlanTier | null {
+  const currentRank = PLAN_RANK[currentTier];
+  // Ascending rank order — the first match is the cheapest tier that works.
+  for (const tier of ["starter", "pro", "business"] as const) {
+    if (PLAN_RANK[tier] <= currentRank) continue;
+    const cap = getPlanLimits(tier)[field];
+    if (isUnlimited(cap) || cap >= required) return tier;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Effective ingest caps — the composition itself
+// ---------------------------------------------------------------------------
+
+/** One effective cap plus the provenance a caller needs to phrase a refusal. */
+export interface EffectiveCap {
+  readonly value: number;
+  readonly boundBy: CapBoundBy;
+}
+
+/** The caps one ingest enforces, already composed with the workspace's tier. */
+export interface EffectiveIngestCaps {
+  readonly maxDocs: EffectiveCap;
+  readonly maxBundleBytes: EffectiveCap;
+  /** Platform-only, so it carries no provenance. */
+  readonly maxDocBytes: number;
+}
+
+function compose(platform: number, tier: number): EffectiveCap {
+  const value = minKnowledgeCap(platform, tier);
+  // Ties attribute to the platform: with equal caps nothing is gained by
+  // telling a customer to upgrade, so the honest refusal is "too large".
+  return { value, boundBy: value < platform ? "tier" : "platform" };
+}
+
+/**
+ * Resolve the caps a single ingest must satisfy for `orgId`:
+ * `min(platform ceiling, plan-tier limit)` per field, with `boundBy` naming the
+ * binding side.
+ *
+ * A workspace with no tier context (self-hosted, no internal DB, no
+ * `organization` row, or the unlimited `free` tier) gets the platform ceilings
+ * verbatim — the self-hosted path is unchanged by #4235.
+ *
+ * @throws {BillingCheckFailedError} when the workspace lookup faults (→ 503
+ *   "try again"). An ingest is refused rather than run against a cap we could
+ *   not verify.
+ */
+export async function resolveIngestCaps(orgId: string | undefined): Promise<EffectiveIngestCaps> {
+  const platformDocs = getIngestMaxDocs();
+  const platformBundle = getIngestMaxBundleBytes();
+  const maxDocBytes = getIngestMaxDocBytes();
+
+  const tier = await resolveKnowledgeTierLimits(orgId);
+  if (!tier) {
+    return {
+      maxDocs: { value: platformDocs, boundBy: "platform" },
+      maxBundleBytes: { value: platformBundle, boundBy: "platform" },
+      maxDocBytes,
+    };
+  }
+  return {
+    maxDocs: compose(platformDocs, tier.limits.maxKnowledgeDocsPerBundle),
+    maxBundleBytes: compose(platformBundle, tier.limits.maxKnowledgeBundleBytes),
+    maxDocBytes,
+  };
+}

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -64,6 +64,38 @@ export interface PlanLimits {
    * `ee/src/proactive/quota.ts:getEffectiveMonthlyClassifierCap` (relocated #3999).
    */
   monthlyProactiveClassifierCap: number;
+  /**
+   * Max Knowledge Base **collections** a workspace may hold (#4235). -1 =
+   * unlimited. The cap counts `workspace_plugins WHERE pillar = 'knowledge'
+   * AND status <> 'archived'` — one row per collection, whatever its catalog
+   * (upload, bundle-sync, or any connector). Marketed ladder: Starter 1 / Pro
+   * 3 / Business unlimited, mirroring {@link maxChatIntegrations}. Enforced
+   * atomically at collection-install time by
+   * `checkKnowledgeCollectionLimitAndInstall`; re-installing an existing
+   * collection slug (an edit / re-auth) never consumes a new slot.
+   */
+  maxKnowledgeCollections: number;
+  /**
+   * Max raw bytes of a single knowledge-bundle ingest (#4235). -1 = unlimited.
+   * The **tier** half of the effective cap: ingest enforces
+   * `min(platform ceiling, tier limit)`, where the platform ceiling is the
+   * operator guardrail `ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES`. KB size is a
+   * storage + prompt-token cost, hence a pricing lever. Decimal MB (matching
+   * `DEFAULT_INGEST_MAX_BUNDLE_BYTES`): Starter 10 MB / Pro 25 MB /
+   * Business 100 MB.
+   */
+  maxKnowledgeBundleBytes: number;
+  /**
+   * Max documents in a single knowledge-bundle ingest (#4235). -1 = unlimited.
+   * The tier half of `min(platform ceiling, tier limit)` against
+   * `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS`. Starter 250 / Pro 1,000 /
+   * Business 5,000.
+   *
+   * The **per-document** byte cap (`ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES`, 1 MB)
+   * deliberately has NO tier field: it is an abuse guardrail on a single row,
+   * not a pricing lever, so it stays platform-only.
+   */
+  maxKnowledgeDocsPerBundle: number;
 }
 
 export interface PlanDefinition {
@@ -146,6 +178,11 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxConnections: UNLIMITED,
       maxChatIntegrations: UNLIMITED,
       monthlyProactiveClassifierCap: UNLIMITED,
+      // Self-hosted is always free: the `ATLAS_KNOWLEDGE_INGEST_*` platform
+      // knobs stay the ONLY knowledge caps there (#4235).
+      maxKnowledgeCollections: UNLIMITED,
+      maxKnowledgeBundleBytes: UNLIMITED,
+      maxKnowledgeDocsPerBundle: UNLIMITED,
     },
     features: { ...NO_FEATURES },
   },
@@ -166,6 +203,10 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxConnections: 1,
       maxChatIntegrations: 1,
       monthlyProactiveClassifierCap: 5_000,
+      // Trial mirrors Starter (#4235).
+      maxKnowledgeCollections: 1,
+      maxKnowledgeBundleBytes: 10_000_000,
+      maxKnowledgeDocsPerBundle: 250,
     },
     // Data residency is available at every active paid tier (entitlement floor
     // is `trial`); see FEATURE_ENTITLEMENTS.residency.
@@ -183,6 +224,9 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxConnections: 1,
       maxChatIntegrations: 1,
       monthlyProactiveClassifierCap: 5_000,
+      maxKnowledgeCollections: 1,
+      maxKnowledgeBundleBytes: 10_000_000,
+      maxKnowledgeDocsPerBundle: 250,
     },
     features: { ...NO_FEATURES, dataResidency: true },
   },
@@ -198,6 +242,9 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxConnections: 3,
       maxChatIntegrations: 3,
       monthlyProactiveClassifierCap: 20_000,
+      maxKnowledgeCollections: 3,
+      maxKnowledgeBundleBytes: 25_000_000,
+      maxKnowledgeDocsPerBundle: 1_000,
     },
     features: {
       customDomain: true,
@@ -223,6 +270,9 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxConnections: 0,
       maxChatIntegrations: 0,
       monthlyProactiveClassifierCap: 0,
+      maxKnowledgeCollections: 0,
+      maxKnowledgeBundleBytes: 0,
+      maxKnowledgeDocsPerBundle: 0,
     },
     features: { ...NO_FEATURES },
   },
@@ -238,6 +288,9 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       maxConnections: UNLIMITED,
       maxChatIntegrations: UNLIMITED,
       monthlyProactiveClassifierCap: 100_000,
+      maxKnowledgeCollections: UNLIMITED,
+      maxKnowledgeBundleBytes: 100_000_000,
+      maxKnowledgeDocsPerBundle: 5_000,
     },
     features: {
       customDomain: true,

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -3211,8 +3211,9 @@ export async function setWorkspaceRegion(
  * keeps the single-arg `pg_advisory_lock(bigint)` and two-arg `(int4, int4)`
  * lock spaces fully disjoint, so this can never collide with any single-arg
  * user. The two-arg peers are the chat-install gate (`3001`), `lead-outbox`
- * (`2870`), and the Stripe webhook lock (`3445`); all four namespaces are
- * pairwise distinct. Value is this guard's issue number (#3158).
+ * (`2870`), the Stripe webhook lock (`3445`), the demo seed (`3683`), and the
+ * knowledge-collection install gate (`4235`); all six namespaces are pairwise
+ * distinct. Value is this guard's issue number (#3158).
  */
 const LAST_ADMIN_LOCK_NAMESPACE = 3158;
 

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -376,8 +376,9 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         message: error.message,
         body: { limit: error.limit },
       };
-    // #2953 — the chat-integration count could not be determined (DB error
-    // / missing row), so the cap check failed closed. This is a transient
+    // A plan-cap count could not be determined (DB error / missing row), so
+    // the check failed closed — chat integrations (#2953) or Knowledge Base
+    // collections / tier resolution (#4235). This is a transient
     // infra fault, NOT a plan-cap hit: 503 + `billing_check_failed` (same
     // code the token-budget check surfaces) so the user sees "try again",
     // not a misleading "upgrade your plan".

--- a/packages/api/src/lib/integrations/install/__tests__/chat-integration-cap-gate.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/chat-integration-cap-gate.test.ts
@@ -44,6 +44,11 @@ void mock.module("@atlas/api/lib/billing/enforcement", () => ({
   computeOverageDollars: () => 0,
   getTrialDaysRemaining: () => Promise.resolve(null),
   CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkKnowledgeCollectionLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
 }));
 
 const { makeChatIntegrationCapGate } = await import("../chat-integration-cap-gate");

--- a/packages/api/src/lib/integrations/install/__tests__/freshdesk-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/freshdesk-form-handler.test.ts
@@ -34,6 +34,38 @@ const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<
 });
 
 void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+
+// The per-tier cap gates (#4235) run against the internal DB; this suite tests
+// the handler's OWN fan-out logic (slug computation, credential order,
+// rollback), so let the caps pass and keep the UPSERT observable through the
+// same `internalQuery` mock. The cap gates themselves have dedicated tests.
+// Mock every value export — a partial `mock.module()` breaks other importers.
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: async (
+    _org: string,
+    _slug: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => ({ allowed: true, rows: await internalQuery(insert.sql, [...insert.params]) }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
+}));
+
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };

--- a/packages/api/src/lib/integrations/install/__tests__/front-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/front-form-handler.test.ts
@@ -33,6 +33,38 @@ const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<
 });
 
 void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+
+// The per-tier cap gates (#4235) run against the internal DB; this suite tests
+// the handler's OWN fan-out logic (slug computation, credential order,
+// rollback), so let the caps pass and keep the UPSERT observable through the
+// same `internalQuery` mock. The cap gates themselves have dedicated tests.
+// Mock every value export — a partial `mock.module()` breaks other importers.
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: async (
+    _org: string,
+    _slug: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => ({ allowed: true, rows: await internalQuery(insert.sql, [...insert.params]) }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
+}));
+
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };

--- a/packages/api/src/lib/integrations/install/__tests__/helpscout-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/helpscout-form-handler.test.ts
@@ -33,6 +33,38 @@ const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<
 });
 
 void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+
+// The per-tier cap gates (#4235) run against the internal DB; this suite tests
+// the handler's OWN fan-out logic (slug computation, credential order,
+// rollback), so let the caps pass and keep the UPSERT observable through the
+// same `internalQuery` mock. The cap gates themselves have dedicated tests.
+// Mock every value export — a partial `mock.module()` breaks other importers.
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: async (
+    _org: string,
+    _slug: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => ({ allowed: true, rows: await internalQuery(insert.sql, [...insert.params]) }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
+}));
+
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };

--- a/packages/api/src/lib/integrations/install/__tests__/knowledge-collection-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/knowledge-collection-install.test.ts
@@ -13,7 +13,7 @@
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { PlanTier, WorkspaceId } from "@useatlas/types";
-import { buildInternalDbMockDefaults } from "@atlas/api/__mocks__/api-test-mocks";
+import { buildInternalDbMockDefaults } from "@atlas/api/testing/api-test-mocks";
 
 type LimitResult =
   | { allowed: true }

--- a/packages/api/src/lib/integrations/install/__tests__/knowledge-collection-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/knowledge-collection-install.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the two knowledge-collection install gates (#4235):
+ * the pre-write {@link assertCollectionInstallable} and the atomic
+ * {@link upsertKnowledgeCollectionRow}.
+ *
+ * The point of both is the DISPOSITION: a genuine cap hit must surface the
+ * standard 403 `plan_upgrade_required` envelope (naming a real upgrade target),
+ * while an inability to DETERMINE the count must fail closed as a transient 503
+ * — never a misleading "upgrade your plan".
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { PlanTier, WorkspaceId } from "@useatlas/types";
+import { buildInternalDbMockDefaults } from "@atlas/api/__mocks__/api-test-mocks";
+
+type LimitResult =
+  | { allowed: true }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+
+let PRECHECK: LimitResult = { allowed: true };
+let INSTALL: LimitResult | { allowed: true; rows: Array<{ id: string }> } = {
+  allowed: true,
+  rows: [{ id: "row-1" }],
+};
+let TIER: PlanTier | null = "starter";
+let TIER_THROWS: Error | null = null;
+
+/** Rows the cross-catalog slug guard sees; empty = slug is free. */
+let CROSS_CATALOG_ROWS: Array<{ catalog_id: string }> = [];
+const internalQuery = mock(async () => CROSS_CATALOG_ROWS);
+
+void mock.module("@atlas/api/lib/db/internal", () =>
+  buildInternalDbMockDefaults({ internalQuery }),
+);
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkKnowledgeCollectionLimit: async () => PRECHECK,
+  checkKnowledgeCollectionLimitAndInstall: async () => INSTALL,
+}));
+void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
+  resolveKnowledgeTierLimits: async () => {
+    if (TIER_THROWS) throw TIER_THROWS;
+    return TIER === null ? null : { tier: TIER, limits: {} };
+  },
+  lowestTierAdmitting: (_field: string, _required: number, current: PlanTier) =>
+    current === "starter" ? "pro" : null,
+}));
+void mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
+});
+
+const { assertCollectionInstallable, upsertKnowledgeCollectionRow } = await import(
+  "@atlas/api/lib/integrations/install/knowledge-collection-install"
+);
+const { FormInstallValidationError } = await import(
+  "@atlas/api/lib/integrations/install/email-form-handler"
+);
+const { BillingCheckFailedError, FeatureEntitlementError } = await import(
+  "@atlas/api/lib/effect/errors"
+);
+
+const WORKSPACE = "org-1" as WorkspaceId;
+const noopLog = { error: () => {}, info: () => {} };
+
+beforeEach(() => {
+  PRECHECK = { allowed: true };
+  INSTALL = { allowed: true, rows: [{ id: "row-1" }] };
+  TIER = "starter";
+  TIER_THROWS = null;
+  CROSS_CATALOG_ROWS = [];
+  internalQuery.mockClear();
+});
+
+describe("assertCollectionInstallable", () => {
+  it("passes when the slug is free and the tier has room", async () => {
+    await expect(
+      assertCollectionInstallable(WORKSPACE, "docs", "catalog:okf-upload", noopLog),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a slug owned by another knowledge catalog with a field-level 400", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const err = await assertCollectionInstallable(
+      WORKSPACE,
+      "docs",
+      "catalog:okf-upload",
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FormInstallValidationError);
+  });
+
+  it("checks the slug BEFORE the cap — a taken slug is a 400, not an upgrade prompt", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    PRECHECK = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 1 };
+    const err = await assertCollectionInstallable(
+      WORKSPACE,
+      "docs",
+      "catalog:okf-upload",
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FormInstallValidationError);
+  });
+
+  it("turns a cap hit into the 403 upgrade envelope naming a real target", async () => {
+    PRECHECK = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 1 };
+    const err = await assertCollectionInstallable(
+      WORKSPACE,
+      "docs",
+      "catalog:okf-upload",
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FeatureEntitlementError);
+    const typed = err as InstanceType<typeof FeatureEntitlementError>;
+    expect(typed.currentPlan).toBe("starter");
+    expect(typed.requiredPlan).toBe("pro");
+    expect(typed.message).toContain("1 knowledge collection");
+  });
+
+  it("fails CLOSED as a 503 when the count could not be determined", async () => {
+    // NOT a 429/403 "upgrade": we don't know the count, so telling the customer
+    // to buy a bigger plan would be a guess.
+    PRECHECK = { allowed: false, reason: "check_failed", errorMessage: "try again" };
+    const err = await assertCollectionInstallable(
+      WORKSPACE,
+      "docs",
+      "catalog:okf-upload",
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BillingCheckFailedError);
+  });
+
+  it("still emits a 403 (naming the top plan) when the tier can't be resolved for the prompt", async () => {
+    // The cap decision is authoritative; a prompt-cosmetics fault must not
+    // downgrade a correct 403 into a 503.
+    PRECHECK = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 3 };
+    TIER_THROWS = new Error("db down");
+    const err = await assertCollectionInstallable(
+      WORKSPACE,
+      "docs",
+      "catalog:okf-upload",
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FeatureEntitlementError);
+    const typed = err as InstanceType<typeof FeatureEntitlementError>;
+    expect(typed.currentPlan).toBe("free");
+    expect(typed.requiredPlan).toBe("business");
+  });
+});
+
+describe("upsertKnowledgeCollectionRow", () => {
+  const input = {
+    workspaceId: WORKSPACE,
+    collectionSlug: "docs",
+    sql: "INSERT ... RETURNING id",
+    params: ["cand-1"],
+    candidateId: "cand-1",
+    log: noopLog,
+  };
+
+  it("returns the persisted row id from RETURNING", async () => {
+    // Deliberately NOT candidateId — on the ON-CONFLICT path the row keeps its
+    // existing id, so echoing the candidate would be wrong.
+    INSTALL = { allowed: true, rows: [{ id: "existing-row" }] };
+    expect(await upsertKnowledgeCollectionRow(input)).toBe("existing-row");
+  });
+
+  it("fails loud when RETURNING yields no row", async () => {
+    INSTALL = { allowed: true, rows: [] };
+    await expect(upsertKnowledgeCollectionRow(input)).rejects.toThrow(/returned no id/);
+  });
+
+  it("turns an under-lock cap hit into the 403 upgrade envelope", async () => {
+    INSTALL = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 1 };
+    const err = await upsertKnowledgeCollectionRow(input).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FeatureEntitlementError);
+    expect((err as InstanceType<typeof FeatureEntitlementError>).requiredPlan).toBe("pro");
+  });
+
+  it("fails CLOSED as a 503 when the under-lock count check failed", async () => {
+    INSTALL = { allowed: false, reason: "check_failed", errorMessage: "try again" };
+    await expect(upsertKnowledgeCollectionRow(input)).rejects.toBeInstanceOf(
+      BillingCheckFailedError,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/knowledge-collection-install.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/knowledge-collection-install.test.ts
@@ -1,12 +1,14 @@
 /**
- * Unit tests for the two knowledge-collection install gates (#4235):
- * the pre-write {@link assertCollectionInstallable} and the atomic
+ * Unit tests for the three knowledge-collection install gates (#4235): the
+ * pre-write {@link assertCollectionInstallable}, its fan-out sibling
+ * {@link assertCollectionBatchInstallable}, and the atomic
  * {@link upsertKnowledgeCollectionRow}.
  *
- * The point of both is the DISPOSITION: a genuine cap hit must surface the
- * standard 403 `plan_upgrade_required` envelope (naming a real upgrade target),
- * while an inability to DETERMINE the count must fail closed as a transient 503
- * — never a misleading "upgrade your plan".
+ * The point of all three is the DISPOSITION: a genuine cap hit must surface the
+ * standard 403 `plan_upgrade_required` envelope naming a real upgrade target
+ * and the tier that actually set the cap, while an inability to DETERMINE the
+ * count must fail closed as a transient 503 — never a misleading "upgrade your
+ * plan".
  */
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -15,16 +17,23 @@ import { buildInternalDbMockDefaults } from "@atlas/api/__mocks__/api-test-mocks
 
 type LimitResult =
   | { allowed: true }
-  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | {
+      allowed: false;
+      reason: "cap_reached";
+      errorMessage: string;
+      limit: number;
+      tier: PlanTier;
+    }
   | { allowed: false; reason: "check_failed"; errorMessage: string };
 
 let PRECHECK: LimitResult = { allowed: true };
+let FANOUT: LimitResult = { allowed: true };
+/** How many times the BATCH cap check ran — pins "once per install, not per slug". */
+let fanoutCalls = 0;
 let INSTALL: LimitResult | { allowed: true; rows: Array<{ id: string }> } = {
   allowed: true,
   rows: [{ id: "row-1" }],
 };
-let TIER: PlanTier | null = "starter";
-let TIER_THROWS: Error | null = null;
 
 /** Rows the cross-catalog slug guard sees; empty = slug is free. */
 let CROSS_CATALOG_ROWS: Array<{ catalog_id: string }> = [];
@@ -33,27 +42,72 @@ const internalQuery = mock(async () => CROSS_CATALOG_ROWS);
 void mock.module("@atlas/api/lib/db/internal", () =>
   buildInternalDbMockDefaults({ internalQuery }),
 );
+
+// Mock every value export — a partial `mock.module()` breaks other importers of
+// the module (CLAUDE.md "mock all exports"). The three knowledge entries are
+// what this suite drives; the rest are inert.
 void mock.module("@atlas/api/lib/billing/enforcement", () => ({
   checkKnowledgeCollectionLimit: async () => PRECHECK,
-  checkKnowledgeCollectionLimitAndInstall: async () => INSTALL,
-}));
-void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
-  resolveKnowledgeTierLimits: async () => {
-    if (TIER_THROWS) throw TIER_THROWS;
-    return TIER === null ? null : { tier: TIER, limits: {} };
+  checkKnowledgeCollectionFanOutLimit: async () => {
+    fanoutCalls++;
+    return FANOUT;
   },
+  checkKnowledgeCollectionLimitAndInstall: async () => INSTALL,
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({
+    metric: "tokens",
+    currentUsage: 0,
+    limit: 0,
+    usagePercent: 0,
+    status: "ok",
+  }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
+}));
+
+// The gates take the tier off the DENIAL rather than re-resolving it, so only
+// the upgrade-target lookup matters here. Every value export is listed
+// (mock-all-exports); the rest are inert.
+void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
   lowestTierAdmitting: (_field: string, _required: number, current: PlanTier) =>
     current === "starter" ? "pro" : null,
+  resolveKnowledgeTierLimits: async () => null,
+  resolveIngestCaps: async () => ({
+    workspaceId: "org-1",
+    tier: null,
+    maxDocs: { value: 1000, boundBy: "platform" },
+    maxBundleBytes: { value: 25_000_000, boundBy: "platform" },
+    maxDocBytes: 1_000_000,
+  }),
+  assertIngestCapsFor: () => {},
+  assertNotTierBound: () => {},
+  minKnowledgeCap: (a: number, b: number) => (b === -1 ? a : Math.min(a, b)),
+  capIsOperatorTunable: () => false,
 }));
+
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
   return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
 });
 
-const { assertCollectionInstallable, upsertKnowledgeCollectionRow } = await import(
-  "@atlas/api/lib/integrations/install/knowledge-collection-install"
-);
+const {
+  assertCollectionBatchInstallable,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} = await import("@atlas/api/lib/integrations/install/knowledge-collection-install");
 const { FormInstallValidationError } = await import(
   "@atlas/api/lib/integrations/install/email-form-handler"
 );
@@ -62,13 +116,22 @@ const { BillingCheckFailedError, FeatureEntitlementError } = await import(
 );
 
 const WORKSPACE = "org-1" as WorkspaceId;
+const CATALOG = "catalog:okf-upload";
 const noopLog = { error: () => {}, info: () => {} };
+
+const capReached = (limit: number, tier: PlanTier): LimitResult => ({
+  allowed: false,
+  reason: "cap_reached",
+  errorMessage: "nope",
+  limit,
+  tier,
+});
 
 beforeEach(() => {
   PRECHECK = { allowed: true };
+  FANOUT = { allowed: true };
+  fanoutCalls = 0;
   INSTALL = { allowed: true, rows: [{ id: "row-1" }] };
-  TIER = "starter";
-  TIER_THROWS = null;
   CROSS_CATALOG_ROWS = [];
   internalQuery.mockClear();
 });
@@ -76,41 +139,32 @@ beforeEach(() => {
 describe("assertCollectionInstallable", () => {
   it("passes when the slug is free and the tier has room", async () => {
     await expect(
-      assertCollectionInstallable(WORKSPACE, "docs", "catalog:okf-upload", noopLog),
+      assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog),
     ).resolves.toBeUndefined();
   });
 
   it("rejects a slug owned by another knowledge catalog with a field-level 400", async () => {
     CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
-    const err = await assertCollectionInstallable(
-      WORKSPACE,
-      "docs",
-      "catalog:okf-upload",
-      noopLog,
-    ).catch((e: unknown) => e);
+    const err = await assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog).catch(
+      (e: unknown) => e,
+    );
     expect(err).toBeInstanceOf(FormInstallValidationError);
   });
 
   it("checks the slug BEFORE the cap — a taken slug is a 400, not an upgrade prompt", async () => {
     CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
-    PRECHECK = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 1 };
-    const err = await assertCollectionInstallable(
-      WORKSPACE,
-      "docs",
-      "catalog:okf-upload",
-      noopLog,
-    ).catch((e: unknown) => e);
+    PRECHECK = capReached(1, "starter");
+    const err = await assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog).catch(
+      (e: unknown) => e,
+    );
     expect(err).toBeInstanceOf(FormInstallValidationError);
   });
 
   it("turns a cap hit into the 403 upgrade envelope naming a real target", async () => {
-    PRECHECK = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 1 };
-    const err = await assertCollectionInstallable(
-      WORKSPACE,
-      "docs",
-      "catalog:okf-upload",
-      noopLog,
-    ).catch((e: unknown) => e);
+    PRECHECK = capReached(1, "starter");
+    const err = await assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog).catch(
+      (e: unknown) => e,
+    );
     expect(err).toBeInstanceOf(FeatureEntitlementError);
     const typed = err as InstanceType<typeof FeatureEntitlementError>;
     expect(typed.currentPlan).toBe("starter");
@@ -118,34 +172,83 @@ describe("assertCollectionInstallable", () => {
     expect(typed.message).toContain("1 knowledge collection");
   });
 
-  it("fails CLOSED as a 503 when the count could not be determined", async () => {
-    // NOT a 429/403 "upgrade": we don't know the count, so telling the customer
-    // to buy a bigger plan would be a guess.
-    PRECHECK = { allowed: false, reason: "check_failed", errorMessage: "try again" };
-    const err = await assertCollectionInstallable(
-      WORKSPACE,
-      "docs",
-      "catalog:okf-upload",
-      noopLog,
-    ).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(BillingCheckFailedError);
+  it("names the tier carried on the DENIAL, never a re-resolved one", async () => {
+    // The whole point of `ResourceLimitResult.tier`: the plan quoted in the
+    // message is provably the plan whose cap was enforced. A second lookup
+    // could return a different tier (60s per-replica cache) and tell a Pro
+    // customer they are on `free`.
+    PRECHECK = capReached(3, "pro");
+    const err = await assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog).catch(
+      (e: unknown) => e,
+    );
+    const typed = err as InstanceType<typeof FeatureEntitlementError>;
+    expect(typed.currentPlan).toBe("pro");
+    expect(typed.message).toContain('Your "pro" plan');
+    expect(typed.message).toContain("3 knowledge collections");
+    // No plan admits more in this stub, so the top plan is the honest answer.
+    expect(typed.requiredPlan).toBe("business");
   });
 
-  it("still emits a 403 (naming the top plan) when the tier can't be resolved for the prompt", async () => {
-    // The cap decision is authoritative; a prompt-cosmetics fault must not
-    // downgrade a correct 403 into a 503.
-    PRECHECK = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 3 };
-    TIER_THROWS = new Error("db down");
-    const err = await assertCollectionInstallable(
+  it("never leaks the internal workspace id into the customer-facing message", async () => {
+    // Correlation is `requestId`'s job; the id is on the structured log line.
+    PRECHECK = capReached(1, "starter");
+    const err = await assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog).catch(
+      (e: unknown) => e,
+    );
+    expect((err as Error).message).not.toContain(WORKSPACE);
+  });
+
+  it("fails CLOSED as a 503 when the count could not be determined", async () => {
+    // NOT a 403 "upgrade": we don't know the count, so telling the customer to
+    // buy a bigger plan would be a guess.
+    PRECHECK = { allowed: false, reason: "check_failed", errorMessage: "try again" };
+    const err = await assertCollectionInstallable(WORKSPACE, "docs", CATALOG, noopLog).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(BillingCheckFailedError);
+  });
+});
+
+describe("assertCollectionBatchInstallable", () => {
+  it("checks every slug for a cross-catalog collision", async () => {
+    CROSS_CATALOG_ROWS = [{ catalog_id: "catalog:bundle-sync" }];
+    const err = await assertCollectionBatchInstallable(
       WORKSPACE,
-      "docs",
-      "catalog:okf-upload",
+      ["a", "b", "c"],
+      CATALOG,
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FormInstallValidationError);
+  });
+
+  it("runs ONE cap check for the whole batch, not one per slug", async () => {
+    // A per-slug loop would see the same pre-write count N times and pass,
+    // stranding a partial install when the atomic gate refused the (cap+1)-th.
+    await assertCollectionBatchInstallable(WORKSPACE, ["a", "b", "c"], CATALOG, noopLog);
+    expect(fanoutCalls).toBe(1);
+  });
+
+  it("refuses the whole batch with the 403 envelope before anything is written", async () => {
+    FANOUT = capReached(1, "starter");
+    const err = await assertCollectionBatchInstallable(
+      WORKSPACE,
+      ["a", "b"],
+      CATALOG,
       noopLog,
     ).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(FeatureEntitlementError);
-    const typed = err as InstanceType<typeof FeatureEntitlementError>;
-    expect(typed.currentPlan).toBe("free");
-    expect(typed.requiredPlan).toBe("business");
+    expect((err as InstanceType<typeof FeatureEntitlementError>).requiredPlan).toBe("pro");
+  });
+
+  it("fails CLOSED as a 503 when the batch count could not be determined", async () => {
+    FANOUT = { allowed: false, reason: "check_failed", errorMessage: "try again" };
+    const err = await assertCollectionBatchInstallable(
+      WORKSPACE,
+      ["a", "b"],
+      CATALOG,
+      noopLog,
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BillingCheckFailedError);
   });
 });
 
@@ -166,13 +269,21 @@ describe("upsertKnowledgeCollectionRow", () => {
     expect(await upsertKnowledgeCollectionRow(input)).toBe("existing-row");
   });
 
+  it("rejects SQL without RETURNING id BEFORE taking the lock", async () => {
+    // Otherwise the omission is only detectable after the write has already run
+    // inside the transaction.
+    await expect(
+      upsertKnowledgeCollectionRow({ ...input, sql: "INSERT INTO workspace_plugins ..." }),
+    ).rejects.toThrow(/requires SQL ending in "RETURNING id"/);
+  });
+
   it("fails loud when RETURNING yields no row", async () => {
     INSTALL = { allowed: true, rows: [] };
     await expect(upsertKnowledgeCollectionRow(input)).rejects.toThrow(/returned no id/);
   });
 
   it("turns an under-lock cap hit into the 403 upgrade envelope", async () => {
-    INSTALL = { allowed: false, reason: "cap_reached", errorMessage: "nope", limit: 1 };
+    INSTALL = capReached(1, "starter");
     const err = await upsertKnowledgeCollectionRow(input).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(FeatureEntitlementError);
     expect((err as InstanceType<typeof FeatureEntitlementError>).requiredPlan).toBe("pro");

--- a/packages/api/src/lib/integrations/install/__tests__/knowledge-handler-gate-wiring.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/knowledge-handler-gate-wiring.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Every knowledge form handler must route its collection write through BOTH
+ * shared gates (#4235) — the pre-write cap check and the atomic
+ * cap-check-and-UPSERT.
+ *
+ * Why a source-level test rather than a behavioral one: each handler's own
+ * suite mocks the internal DB with `getWorkspaceDetails → null`, which is the
+ * "no `organization` row → no plan → no cap" fail-open. Every one of those
+ * suites therefore passes IDENTICALLY whether the cap is wired or not, so a
+ * handler that silently lost its gate — the most likely regression, given the
+ * cap was threaded through twelve files by hand — would be invisible. This
+ * asserts the wiring itself, which is exactly the property those suites cannot
+ * see.
+ *
+ * The list is DISCOVERED, not enumerated: any file that writes a
+ * `pillar='knowledge'` `workspace_plugins` row is in scope, so a thirteenth
+ * connector is covered the day it lands.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+const INSTALL_DIR = join(import.meta.dir, "..");
+
+/** Handler files that persist a knowledge collection, discovered from source. */
+function knowledgeHandlerFiles(): string[] {
+  return readdirSync(INSTALL_DIR)
+    .filter((f) => f.endsWith("-form-handler.ts"))
+    .filter((f) => {
+      const src = readFileSync(join(INSTALL_DIR, f), "utf8");
+      // The shape every collection UPSERT shares: a knowledge-pillar insert.
+      return src.includes("'knowledge',") && src.includes("INSERT INTO workspace_plugins");
+    })
+    .sort();
+}
+
+const HANDLERS = knowledgeHandlerFiles();
+
+describe("knowledge form handlers are wired to the shared cap gates (#4235)", () => {
+  it("discovers the expected handler set", () => {
+    // A floor, not an exact list — the point is that discovery actually found
+    // the handlers, so a broken predicate can't vacuously pass every test below.
+    expect(HANDLERS.length).toBeGreaterThanOrEqual(12);
+    expect(HANDLERS).toContain("okf-upload-form-handler.ts");
+    expect(HANDLERS).toContain("zendesk-form-handler.ts");
+  });
+
+  for (const file of HANDLERS) {
+    describe(file, () => {
+      const src = readFileSync(join(INSTALL_DIR, file), "utf8");
+
+      it("runs a pre-write cap gate before persisting anything", () => {
+        // Single-collection handlers use the per-slug gate; fan-out handlers
+        // (one collection per brand / KB / category / site) MUST use the batch
+        // gate instead — a per-slug loop passes N times against the same
+        // pre-write count and strands a partial install.
+        const single = src.includes("assertCollectionInstallable(");
+        const batch = src.includes("assertCollectionBatchInstallable(");
+        expect(single || batch).toBe(true);
+      });
+
+      it("persists through the atomic cap-gated upsert, never a bare internalQuery", () => {
+        expect(src).toContain("upsertKnowledgeCollectionRow(");
+        // The pre-#4235 shape: a direct UPSERT that bypasses the advisory-locked
+        // recount entirely.
+        expect(src).not.toMatch(/internalQuery<\{ id: string \}>\(\s*\w*_UPSERT_SQL/);
+      });
+
+      it("appends RETURNING id to its collection upsert", () => {
+        // `upsertKnowledgeCollectionRow` rejects SQL without it, but that is a
+        // runtime error on the install path; catching it here is free.
+        expect(src).toMatch(/RETURNING id/);
+      });
+    });
+  }
+});
+
+describe("fan-out handlers use the BATCH gate (#4235)", () => {
+  // These four create one collection per vendor object in a single install, so
+  // they are the only handlers for which the per-slug gate is wrong.
+  const FANOUT = [
+    "zendesk-form-handler.ts",
+    "front-form-handler.ts",
+    "freshdesk-form-handler.ts",
+    "helpscout-form-handler.ts",
+  ];
+
+  for (const file of FANOUT) {
+    it(`${file} calls the batch gate and not the per-slug one`, () => {
+      expect(HANDLERS).toContain(file);
+      const src = readFileSync(join(INSTALL_DIR, file), "utf8");
+      expect(src).toContain("assertCollectionBatchInstallable(");
+      expect(src).not.toMatch(/\bassertCollectionInstallable\(/);
+    });
+
+    it(`${file} lets a tagged plan denial reach the route unwrapped`, () => {
+      // `retryableInstallError` would otherwise flatten `FeatureEntitlementError`
+      // / `BillingCheckFailedError` into a plain Error, turning a 403/503 into a
+      // 500 that also claims "retrying the install is safe".
+      const src = readFileSync(join(INSTALL_DIR, file), "utf8");
+      expect(src).toContain('from "./retryable-install-error"');
+      expect(src).toContain("isPlanDenial(err)");
+      // No local copy of the wrapper may survive — that copy would not have the
+      // tagged-error passthrough.
+      expect(src).not.toMatch(/function retryableInstallError\(/);
+    });
+  }
+});

--- a/packages/api/src/lib/integrations/install/__tests__/okf-upload-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/okf-upload-form-handler.test.ts
@@ -34,8 +34,11 @@ void mock.module("@atlas/api/lib/logger", () => {
   return { createLogger: () => logger, getRequestContext: () => ({ requestId: "test" }) };
 });
 
-const { OkfUploadFormInstallHandler, resolveCollectionSlug, OKF_UPLOAD_SLUG } = await import(
+const { OkfUploadFormInstallHandler, OKF_UPLOAD_SLUG } = await import(
   "@atlas/api/lib/integrations/install/okf-upload-form-handler"
+);
+const { resolveCollectionSlug } = await import(
+  "@atlas/api/lib/integrations/install/knowledge-collection-slug"
 );
 const { FormInstallValidationError } = await import(
   "@atlas/api/lib/integrations/install/email-form-handler"

--- a/packages/api/src/lib/integrations/install/__tests__/retryable-install-error.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/retryable-install-error.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the shared mid-fan-out failure wrapper (#4235). The
+ * load-bearing property is the tagged-error PASSTHROUGH: a plan/billing denial
+ * must reach the route with its `_tag` intact (so it maps to 403/503), never
+ * flattened into a plain Error that would surface as a 500 claiming "retrying
+ * is safe". The handler suites all mock the cap to `allowed`, so this is the
+ * only place that passthrough is exercised behaviorally.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isPlanDenial, retryableInstallError } from "../retryable-install-error";
+import {
+  BillingCheckFailedError,
+  FeatureEntitlementError,
+} from "@atlas/api/lib/effect/errors";
+
+const denial = new FeatureEntitlementError({
+  message: "over cap",
+  feature: "knowledge_collections",
+  requiredPlan: "pro",
+  currentPlan: "starter",
+});
+const checkFailed = new BillingCheckFailedError({ message: "try again", workspaceId: "org-1" });
+
+describe("isPlanDenial", () => {
+  it("is true for both tagged plan/billing errors", () => {
+    expect(isPlanDenial(denial)).toBe(true);
+    expect(isPlanDenial(checkFailed)).toBe(true);
+  });
+  it("is false for a plain error or a non-error value", () => {
+    expect(isPlanDenial(new Error("db down"))).toBe(false);
+    expect(isPlanDenial("nope")).toBe(false);
+    expect(isPlanDenial(null)).toBe(false);
+  });
+});
+
+describe("retryableInstallError", () => {
+  it("returns a plan denial UNCHANGED — preserving its _tag for the route mapper", () => {
+    // Identity, not a copy: the tagged error must reach `classifyError` intact.
+    expect(retryableInstallError("brand-1", denial, "brand")).toBe(denial);
+    expect(retryableInstallError("brand-1", checkFailed, "brand")).toBe(checkFailed);
+  });
+
+  it("wraps a genuine write-path failure with retry-safe guidance and the cause", () => {
+    const cause = new Error("row write failed");
+    const wrapped = retryableInstallError("brand-1", cause, "brand");
+    expect(wrapped).toBeInstanceOf(Error);
+    expect(wrapped).not.toBe(cause);
+    const err = wrapped as Error;
+    expect(err.message).toContain("brand-1");
+    expect(err.message).toContain("Retrying the install is safe");
+    expect(err.message).toContain("brand collections");
+    expect(err.cause).toBe(cause);
+  });
+
+  it("stringifies a non-error cause rather than throwing", () => {
+    const wrapped = retryableInstallError("kb-1", "weird", "KB") as Error;
+    expect(wrapped.message).toContain("weird");
+    expect(wrapped.message).toContain("KB collections");
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -254,6 +254,7 @@ describe("SlackOAuthInstallHandler.startInstall", () => {
         reason: "cap_reached" as const,
         errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
         limit: 1,
+        tier: "starter" as const,
       }),
     );
     const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
@@ -459,6 +460,7 @@ describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () 
         reason: "cap_reached" as const,
         errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
         limit: 1,
+        tier: "starter" as const,
       }),
     );
     const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);

--- a/packages/api/src/lib/integrations/install/__tests__/zendesk-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/zendesk-form-handler.test.ts
@@ -34,6 +34,38 @@ const internalQuery = mock(async (sql: string, params: unknown[] = []): Promise<
 });
 
 void mock.module("@atlas/api/lib/db/internal", () => buildInternalDbMockDefaults({ internalQuery }));
+
+// The per-tier cap gates (#4235) run against the internal DB; this suite tests
+// the handler's OWN fan-out logic (slug computation, credential order,
+// rollback), so let the caps pass and keep the UPSERT observable through the
+// same `internalQuery` mock. The cap gates themselves have dedicated tests.
+// Mock every value export — a partial `mock.module()` breaks other importers.
+void mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkKnowledgeCollectionLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionFanOutLimit: () => Promise.resolve({ allowed: true }),
+  checkKnowledgeCollectionLimitAndInstall: async (
+    _org: string,
+    _slug: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => ({ allowed: true, rows: await internalQuery(insert.sql, [...insert.params]) }),
+  checkChatIntegrationLimit: () => Promise.resolve({ allowed: true }),
+  checkChatIntegrationLimitAndInstall: () => Promise.resolve({ allowed: true, rows: [] }),
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
+  resolveAbuseCeilingPercent: () => Promise.resolve(null),
+  resolveSpendPolicy: () => Promise.resolve("continue"),
+  resolveUsageCeiling: () => Promise.resolve({ spendPolicy: "continue", ceilingPercent: null }),
+  computeOverageDollars: () => 0,
+  getTrialDaysRemaining: () => Promise.resolve(null),
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_COUNT_SQL: "SELECT 1",
+  KNOWLEDGE_COLLECTION_FANOUT_COUNT_SQL: "SELECT 1",
+}));
+
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };

--- a/packages/api/src/lib/integrations/install/bundle-sync-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/bundle-sync-form-handler.ts
@@ -189,8 +189,8 @@ export class BundleSyncFormInstallHandler implements FormBasedInstallHandler {
     }
     const catalogId = catalogRows[0].id;
 
-    // A slug taken by another knowledge catalog (okf-upload) would merge
-    // document trees — reject before any write (#4211).
+    // Slug not taken by another knowledge catalog (#4211), and the workspace's
+    // plan tier has room for another collection (#4235) — both before the write.
     await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Credential first (mirrors the Twenty handler's write order) ────────

--- a/packages/api/src/lib/integrations/install/bundle-sync-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/bundle-sync-form-handler.ts
@@ -53,6 +53,7 @@ import {
   assertCollectionInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial } from "./retryable-install-error";
 import {
   KNOWLEDGE_INSTALL_ID_FIELD,
   resolveCollectionSlug,
@@ -235,7 +236,9 @@ export class BundleSyncFormInstallHandler implements FormBasedInstallHandler {
     } catch (err) {
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist bundle-sync collection install — aborting install (the credential write, if any, is idempotent; retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist bundle-sync collection install — aborting install (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist bundle-sync collection install — aborting install (the credential write, if any, is idempotent; retrying the install is safe)",
       );
       throw err;
     }

--- a/packages/api/src/lib/integrations/install/bundle-sync-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/bundle-sync-form-handler.ts
@@ -50,10 +50,13 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 /** The built-in Knowledge Base (Bundle Sync) catalog slug + row id. */
@@ -188,7 +191,7 @@ export class BundleSyncFormInstallHandler implements FormBasedInstallHandler {
 
     // A slug taken by another knowledge catalog (okf-upload) would merge
     // document trees — reject before any write (#4211).
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Credential first (mirrors the Twenty handler's write order) ────────
     if (authSecret !== null) {
@@ -220,25 +223,14 @@ export class BundleSyncFormInstallHandler implements FormBasedInstallHandler {
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(BUNDLE_SYNC_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // See the okf-upload handler for why an empty RETURNING is fail-loud
-        // (candidateId would be WRONG on the conflict path).
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: collectionSlug,
+        sql: BUNDLE_SYNC_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       persistedId = returned;
     } catch (err) {
       this.log.error(

--- a/packages/api/src/lib/integrations/install/confluence-datacenter-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/confluence-datacenter-form-handler.ts
@@ -55,10 +55,13 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config-datacenter.ts.
@@ -144,7 +147,7 @@ export class ConfluenceDatacenterFormInstallHandler implements FormBasedInstallH
     }
     const catalogId = catalogRows[0].id;
 
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Verify the connection loudly BEFORE persisting anything ─────────────
     await this.verifyConnection({ baseUrl, apiToken, spaceKey, collectionSlug });
@@ -171,23 +174,14 @@ export class ConfluenceDatacenterFormInstallHandler implements FormBasedInstallH
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(CONFLUENCE_DC_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: collectionSlug,
+        sql: CONFLUENCE_DC_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       persistedId = returned;
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a failed

--- a/packages/api/src/lib/integrations/install/confluence-datacenter-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/confluence-datacenter-form-handler.ts
@@ -58,6 +58,7 @@ import {
   assertCollectionInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial } from "./retryable-install-error";
 import {
   KNOWLEDGE_INSTALL_ID_FIELD,
   resolveCollectionSlug,
@@ -190,7 +191,9 @@ export class ConfluenceDatacenterFormInstallHandler implements FormBasedInstallH
       // failure is logged, never masks the original error.
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist confluence-datacenter collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist confluence-datacenter collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist confluence-datacenter collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, collectionSlug);

--- a/packages/api/src/lib/integrations/install/confluence-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/confluence-form-handler.ts
@@ -55,6 +55,7 @@ import {
   assertCollectionInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial } from "./retryable-install-error";
 import {
   KNOWLEDGE_INSTALL_ID_FIELD,
   resolveCollectionSlug,
@@ -187,7 +188,9 @@ export class ConfluenceFormInstallHandler implements FormBasedInstallHandler {
       // failure is logged, never masks the original error.
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist confluence collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist confluence collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist confluence collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, collectionSlug);

--- a/packages/api/src/lib/integrations/install/confluence-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/confluence-form-handler.ts
@@ -52,10 +52,13 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -140,7 +143,7 @@ export class ConfluenceFormInstallHandler implements FormBasedInstallHandler {
     }
     const catalogId = catalogRows[0].id;
 
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Verify the connection loudly BEFORE persisting anything ─────────────
     await this.verifyConnection({ baseUrl, email, apiToken, spaceKey, collectionSlug });
@@ -168,23 +171,14 @@ export class ConfluenceFormInstallHandler implements FormBasedInstallHandler {
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(CONFLUENCE_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: collectionSlug,
+        sql: CONFLUENCE_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       persistedId = returned;
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a failed

--- a/packages/api/src/lib/integrations/install/freshdesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/freshdesk-form-handler.ts
@@ -61,9 +61,10 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionInstallable,
+  assertCollectionBatchInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial, retryableInstallError } from "./retryable-install-error";
 import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
@@ -181,8 +182,17 @@ export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
+    // ONE cap check for the WHOLE fan-out, before any credential or row is
+    // written: a per-slug loop would pass N times against the same pre-write
+    // count and strand a partial install when the atomic gate refused the
+    // (cap+1)-th mid-batch (#4235).
+    await assertCollectionBatchInstallable(
+      workspaceId,
+      planned.map((p) => p.slug),
+      catalogId,
+      this.log,
+    );
 
     // ── Per-category writes: credential first, then the collection row ────────
     assertSaasEncryptionKeyset(this.log, workspaceId, "api_key");
@@ -237,7 +247,7 @@ export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
         { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
         "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed category collections stay installed)",
       );
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "category");
     }
 
     const candidateId = this.newId();
@@ -270,7 +280,9 @@ export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
           categoryId: category.id,
           err: err instanceof Error ? err.message : String(err),
         },
-        "Failed to persist freshdesk collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist freshdesk collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist freshdesk collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, slug);
@@ -284,7 +296,7 @@ export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
           "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
         );
       }
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "category");
     }
   }
 
@@ -423,9 +435,3 @@ function fieldError(field: string, message: string): FormInstallValidationError 
  * needs: all writes are idempotent upserts converging on the same slugs, so
  * re-running the install is always safe. The original failure rides as cause.
  */
-function retryableInstallError(slug: string, err: unknown): Error {
-  return new Error(
-    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed category collections are simply updated in place.`,
-    { cause: err },
-  );
-}

--- a/packages/api/src/lib/integrations/install/freshdesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/freshdesk-form-handler.ts
@@ -61,11 +61,14 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -178,7 +181,7 @@ export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
 
     // ── Per-category writes: credential first, then the collection row ────────
@@ -239,23 +242,14 @@ export class FreshdeskFormInstallHandler implements FormBasedInstallHandler {
 
     const candidateId = this.newId();
     try {
-      const rows = await internalQuery<{ id: string }>(FRESHDESK_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        slug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug: slug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: slug,
+        sql: FRESHDESK_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, slug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       return { id: returned, workspaceId, catalogId: FRESHDESK_SLUG };
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a

--- a/packages/api/src/lib/integrations/install/front-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/front-form-handler.ts
@@ -57,11 +57,14 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -171,7 +174,7 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
 
     // ── Per-KB writes: credential first, then the collection row ─────────────
@@ -231,23 +234,14 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
 
     const candidateId = this.newId();
     try {
-      const rows = await internalQuery<{ id: string }>(FRONT_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        slug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug: slug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: slug,
+        sql: FRONT_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, slug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       return { id: returned, workspaceId, catalogId: FRONT_SLUG };
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a

--- a/packages/api/src/lib/integrations/install/front-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/front-form-handler.ts
@@ -57,9 +57,10 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionInstallable,
+  assertCollectionBatchInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial, retryableInstallError } from "./retryable-install-error";
 import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
@@ -174,8 +175,17 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
+    // ONE cap check for the WHOLE fan-out, before any credential or row is
+    // written: a per-slug loop would pass N times against the same pre-write
+    // count and strand a partial install when the atomic gate refused the
+    // (cap+1)-th mid-batch (#4235).
+    await assertCollectionBatchInstallable(
+      workspaceId,
+      planned.map((p) => p.slug),
+      catalogId,
+      this.log,
+    );
 
     // ── Per-KB writes: credential first, then the collection row ─────────────
     assertSaasEncryptionKeyset(this.log, workspaceId, "api_token");
@@ -229,7 +239,7 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
         { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
         "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed KB collections stay installed)",
       );
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "KB");
     }
 
     const candidateId = this.newId();
@@ -263,7 +273,9 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
           knowledgeBaseId: kb.id,
           err: err instanceof Error ? err.message : String(err),
         },
-        "Failed to persist front collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist front collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist front collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, slug);
@@ -277,7 +289,7 @@ export class FrontFormInstallHandler implements FormBasedInstallHandler {
           "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
         );
       }
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "KB");
     }
   }
 
@@ -376,9 +388,3 @@ function fieldError(field: string, message: string): FormInstallValidationError 
  * needs: all writes are idempotent upserts converging on the same slugs, so
  * re-running the install is always safe. The original failure rides as cause.
  */
-function retryableInstallError(slug: string, err: unknown): Error {
-  return new Error(
-    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed KB collections are simply updated in place.`,
-    { cause: err },
-  );
-}

--- a/packages/api/src/lib/integrations/install/gitbook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/gitbook-form-handler.ts
@@ -52,6 +52,7 @@ import {
   assertCollectionInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial } from "./retryable-install-error";
 import {
   KNOWLEDGE_INSTALL_ID_FIELD,
   resolveCollectionSlug,
@@ -183,7 +184,9 @@ export class GitbookFormInstallHandler implements FormBasedInstallHandler {
       // Confluence/Notion handlers — keep them in step.
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist gitbook collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist gitbook collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist gitbook collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, collectionSlug);

--- a/packages/api/src/lib/integrations/install/gitbook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/gitbook-form-handler.ts
@@ -49,10 +49,13 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -137,7 +140,7 @@ export class GitbookFormInstallHandler implements FormBasedInstallHandler {
     }
     const catalogId = catalogRows[0].id;
 
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Verify the connection loudly BEFORE persisting anything ─────────────
     await this.verifyConnection({ spaceId, apiToken, collectionSlug });
@@ -163,23 +166,14 @@ export class GitbookFormInstallHandler implements FormBasedInstallHandler {
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(GITBOOK_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: collectionSlug,
+        sql: GITBOOK_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       persistedId = returned;
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a failed

--- a/packages/api/src/lib/integrations/install/helpscout-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/helpscout-form-handler.ts
@@ -51,11 +51,14 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -163,7 +166,7 @@ export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
 
     // ── Per-site writes: credential first, then the collection row ───────────
@@ -223,23 +226,14 @@ export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
 
     const candidateId = this.newId();
     try {
-      const rows = await internalQuery<{ id: string }>(HELPSCOUT_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        slug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug: slug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: slug,
+        sql: HELPSCOUT_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, slug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       return { id: returned, workspaceId, catalogId: HELPSCOUT_SLUG };
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a failed

--- a/packages/api/src/lib/integrations/install/helpscout-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/helpscout-form-handler.ts
@@ -51,9 +51,10 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionInstallable,
+  assertCollectionBatchInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial, retryableInstallError } from "./retryable-install-error";
 import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
@@ -166,8 +167,17 @@ export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
+    // ONE cap check for the WHOLE fan-out, before any credential or row is
+    // written: a per-slug loop would pass N times against the same pre-write
+    // count and strand a partial install when the atomic gate refused the
+    // (cap+1)-th mid-batch (#4235).
+    await assertCollectionBatchInstallable(
+      workspaceId,
+      planned.map((p) => p.slug),
+      catalogId,
+      this.log,
+    );
 
     // ── Per-site writes: credential first, then the collection row ───────────
     assertSaasEncryptionKeyset(this.log, workspaceId, "api_key");
@@ -221,7 +231,7 @@ export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
         { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
         "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed site collections stay installed)",
       );
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "site");
     }
 
     const candidateId = this.newId();
@@ -247,7 +257,9 @@ export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
           siteId: site.id,
           err: err instanceof Error ? err.message : String(err),
         },
-        "Failed to persist helpscout collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist helpscout collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist helpscout collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, slug);
@@ -261,7 +273,7 @@ export class HelpScoutFormInstallHandler implements FormBasedInstallHandler {
           "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
         );
       }
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "site");
     }
   }
 
@@ -348,9 +360,3 @@ function fieldError(field: string, message: string): FormInstallValidationError 
  * needs: all writes are idempotent upserts converging on the same slugs, so
  * re-running the install is always safe. The original failure rides as cause.
  */
-function retryableInstallError(slug: string, err: unknown): Error {
-  return new Error(
-    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed site collections are simply updated in place.`,
-    { cause: err },
-  );
-}

--- a/packages/api/src/lib/integrations/install/intercom-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/intercom-form-handler.ts
@@ -52,6 +52,7 @@ import {
   assertCollectionInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial } from "./retryable-install-error";
 import {
   KNOWLEDGE_INSTALL_ID_FIELD,
   resolveCollectionSlug,
@@ -176,7 +177,9 @@ export class IntercomFormInstallHandler implements FormBasedInstallHandler {
       // GitBook/Notion handlers — keep them in step.
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist intercom collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist intercom collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist intercom collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, collectionSlug);

--- a/packages/api/src/lib/integrations/install/intercom-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/intercom-form-handler.ts
@@ -49,10 +49,13 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -131,7 +134,7 @@ export class IntercomFormInstallHandler implements FormBasedInstallHandler {
     }
     const catalogId = catalogRows[0].id;
 
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Verify the connection loudly BEFORE persisting anything ─────────────
     await this.verifyConnection({ accessToken, collectionSlug });
@@ -156,23 +159,14 @@ export class IntercomFormInstallHandler implements FormBasedInstallHandler {
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(INTERCOM_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: collectionSlug,
+        sql: INTERCOM_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       persistedId = returned;
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a failed

--- a/packages/api/src/lib/integrations/install/knowledge-collection-install.ts
+++ b/packages/api/src/lib/integrations/install/knowledge-collection-install.ts
@@ -1,0 +1,213 @@
+/**
+ * The two gates every knowledge form handler runs around its collection UPSERT
+ * — one pre-write, one atomic — plus the shared `RETURNING id` invariant.
+ *
+ * A *collection* is a `pillar='knowledge'` `workspace_plugins` row keyed by
+ * `install_id` (the collection slug). Twelve handlers create them (upload,
+ * bundle-sync, and ten connectors), and before #4235 each carried its own copy
+ * of the slug-collision check and the upsert-plus-id-validation block. Both now
+ * live here, alongside the per-tier collections cap the same slice added:
+ *
+ *   1. {@link assertCollectionInstallable} — the PRE-WRITE gate. Runs before a
+ *      handler validates upstream credentials or writes a
+ *      `knowledge_sync_credentials` row, so an at-cap workspace is refused
+ *      before a secret is ever persisted.
+ *   2. {@link upsertKnowledgeCollectionRow} — the ATOMIC gate. Runs the caller's
+ *      UPSERT inside `checkKnowledgeCollectionLimitAndInstall`'s advisory-locked
+ *      recount, so two concurrent creations can't both take a shared last slot,
+ *      and validates the `RETURNING id` invariant.
+ *
+ * Denials surface as {@link FeatureEntitlementError} — HTTP 403
+ * `plan_upgrade_required` carrying the same `PlanUpgradeRequiredBody` envelope
+ * the integration install endpoints emit — never a generic error. A failure to
+ * *determine* the count is a {@link BillingCheckFailedError} (503 "try again"),
+ * never a misleading "upgrade your plan".
+ *
+ * @module
+ */
+
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { PlanTier, WorkspaceId } from "@useatlas/types";
+import {
+  checkKnowledgeCollectionLimit,
+  checkKnowledgeCollectionLimitAndInstall,
+} from "@atlas/api/lib/billing/enforcement";
+import {
+  lowestTierAdmitting,
+  resolveKnowledgeTierLimits,
+} from "@atlas/api/lib/billing/knowledge-limits";
+import { BillingCheckFailedError, FeatureEntitlementError } from "@atlas/api/lib/effect/errors";
+import type { createLogger } from "@atlas/api/lib/logger";
+import { FormInstallValidationError } from "./email-form-handler";
+import { KNOWLEDGE_INSTALL_ID_FIELD } from "./knowledge-collection-slug";
+
+/** The handlers only ever log errors from these seams — narrow to that. */
+type CollectionInstallLogger = Pick<ReturnType<typeof createLogger>, "error" | "info">;
+
+/**
+ * Compose the 403 upgrade error for a collections-cap denial.
+ *
+ * `requiredPlan` is the cheapest tier that admits one more collection. Business
+ * is unlimited, so a real denial always has a named upgrade target; the
+ * `"business"` fallback is reachable only if the tier changed between the cap
+ * decision and this resolution, and naming the top plan is the honest answer
+ * there. `currentPlan` collapses an unresolved tier to `"free"`, matching the
+ * feature-entitlement guard's handling of the same case.
+ */
+function collectionCapError(
+  workspaceId: WorkspaceId,
+  limit: number,
+  tier: PlanTier | null,
+): FeatureEntitlementError {
+  const currentPlan: PlanTier = tier ?? "free";
+  const requiredPlan =
+    lowestTierAdmitting("maxKnowledgeCollections", limit + 1, currentPlan) ?? "business";
+  const noun = limit === 1 ? "knowledge collection" : "knowledge collections";
+  return new FeatureEntitlementError({
+    message: `Your "${currentPlan}" plan allows up to ${limit} ${noun}. Upgrade to "${requiredPlan}" to add more. (workspace ${workspaceId})`,
+    feature: "knowledge_collections",
+    requiredPlan,
+    currentPlan,
+  });
+}
+
+/**
+ * Resolve the workspace's tier for an upgrade prompt without letting a lookup
+ * fault mask the cap denial we already have. The cap decision is authoritative;
+ * this is prompt cosmetics, so a fault degrades to `null` (→ `"free"`) rather
+ * than replacing a correct 403 with a 503.
+ */
+async function tierForPrompt(
+  workspaceId: WorkspaceId,
+  log: CollectionInstallLogger,
+): Promise<PlanTier | null> {
+  try {
+    return (await resolveKnowledgeTierLimits(workspaceId))?.tier ?? null;
+  } catch (err) {
+    log.error(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      "Could not resolve the plan tier for a knowledge-collection cap denial — naming the free tier in the upgrade prompt",
+    );
+    return null;
+  }
+}
+
+/**
+ * The pre-write gate: reject before any credential or row is written when
+ * either the slug is taken by a different knowledge catalog, or the workspace's
+ * plan tier has no room for another collection.
+ *
+ * The slug half exists because `knowledge_documents` keys on
+ * `(workspace_id, collection_id, path)` with NO catalog dimension, so two
+ * catalogs sharing an `install_id` would silently merge their document trees —
+ * and a bundle-sync's archive-absent pass would archive the other collection's
+ * docs (#4211). Archived installs count too: their documents still live under
+ * the slug and an explicit re-ingest may resurrect them (ADR-0028 §5).
+ *
+ * @throws {FormInstallValidationError} 400 field error — the slug is taken.
+ * @throws {FeatureEntitlementError} 403 upgrade — the tier cap is reached.
+ * @throws {BillingCheckFailedError} 503 — the count couldn't be determined.
+ */
+export async function assertCollectionInstallable(
+  workspaceId: WorkspaceId,
+  collectionSlug: string,
+  ownCatalogId: string,
+  log: CollectionInstallLogger,
+): Promise<void> {
+  const rows = await internalQuery<{ catalog_id: string }>(
+    `SELECT catalog_id
+       FROM workspace_plugins
+      WHERE workspace_id = $1 AND install_id = $2 AND pillar = 'knowledge'
+        AND catalog_id <> $3
+      LIMIT 1`,
+    [workspaceId, collectionSlug, ownCatalogId],
+  );
+  if (rows.length > 0) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        [KNOWLEDGE_INSTALL_ID_FIELD]: [
+          `Collection id "${collectionSlug}" is already used by another Knowledge Base integration in this workspace.`,
+        ],
+      },
+      formErrors: [],
+    });
+  }
+
+  const decision = await checkKnowledgeCollectionLimit(workspaceId, collectionSlug);
+  if (decision.allowed) return;
+  if (decision.reason === "cap_reached") {
+    log.info(
+      { workspaceId, collectionSlug, limit: decision.limit },
+      "Knowledge collection install blocked — workspace at plan collections cap (precheck)",
+    );
+    throw collectionCapError(workspaceId, decision.limit, await tierForPrompt(workspaceId, log));
+  }
+  // `check_failed` — and, defensively, any future non-cap denial reason: the
+  // count couldn't be determined, so fail closed as a transient 503 "try
+  // again", never a misleading 403 "upgrade your plan".
+  log.error(
+    { workspaceId, collectionSlug },
+    "Knowledge collection install blocked — collection count check failed (failing closed)",
+  );
+  throw new BillingCheckFailedError({ message: decision.errorMessage, workspaceId });
+}
+
+/**
+ * Run a handler's collection UPSERT inside the atomic collections-cap gate and
+ * return the persisted row id.
+ *
+ * `INSERT ... ON CONFLICT ... DO UPDATE RETURNING` emits exactly one row on both
+ * paths; an empty result is a driver/RLS/query-rewrite anomaly. Returning the
+ * caller's candidate id instead would be WRONG on the conflict path (the row
+ * keeps its existing id), so this fails loud rather than guessing.
+ *
+ * @throws {FeatureEntitlementError} 403 upgrade — the tier cap is reached.
+ * @throws {BillingCheckFailedError} 503 — the count couldn't be determined.
+ * @throws {Error} write-path failures (lock / UPSERT / COMMIT), for the
+ *   caller's own rollback-and-rethrow block to handle.
+ */
+export async function upsertKnowledgeCollectionRow(input: {
+  readonly workspaceId: WorkspaceId;
+  readonly collectionSlug: string;
+  /** The handler's own UPSERT, which MUST end in `RETURNING id`. */
+  readonly sql: string;
+  readonly params: readonly unknown[];
+  /** Candidate row id — logged on the invariant violation for correlation. */
+  readonly candidateId: string;
+  readonly log: CollectionInstallLogger;
+}): Promise<string> {
+  const { workspaceId, collectionSlug, sql, params, candidateId, log } = input;
+
+  const result = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
+    workspaceId,
+    collectionSlug,
+    { sql, params },
+  );
+
+  if (!result.allowed) {
+    if (result.reason === "cap_reached") {
+      log.info(
+        { workspaceId, collectionSlug, limit: result.limit },
+        "Knowledge collection install blocked — workspace at plan collections cap",
+      );
+      throw collectionCapError(workspaceId, result.limit, await tierForPrompt(workspaceId, log));
+    }
+    log.error(
+      { workspaceId, collectionSlug },
+      "Knowledge collection install blocked — collection count check failed under lock (failing closed)",
+    );
+    throw new BillingCheckFailedError({ message: result.errorMessage, workspaceId });
+  }
+
+  const returned = result.rows[0]?.id;
+  if (typeof returned !== "string" || returned.length === 0) {
+    log.error(
+      { workspaceId, candidateId, collectionSlug },
+      "workspace_plugins upsert returned no id — Postgres invariant violation",
+    );
+    throw new Error(
+      "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+    );
+  }
+  return returned;
+}

--- a/packages/api/src/lib/integrations/install/knowledge-collection-install.ts
+++ b/packages/api/src/lib/integrations/install/knowledge-collection-install.ts
@@ -23,19 +23,23 @@
  * *determine* the count is a {@link BillingCheckFailedError} (503 "try again"),
  * never a misleading "upgrade your plan".
  *
+ * Both are `Data.TaggedError`s, so every handler must let them propagate with
+ * their `_tag` intact; the fan-out handlers' `retryableInstallError` wrapper
+ * passes them through unchanged for exactly this reason (see
+ * `./retryable-install-error.ts`).
+ *
  * @module
  */
 
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { PlanTier, WorkspaceId } from "@useatlas/types";
 import {
+  checkKnowledgeCollectionFanOutLimit,
   checkKnowledgeCollectionLimit,
   checkKnowledgeCollectionLimitAndInstall,
+  type ResourceLimitResult,
 } from "@atlas/api/lib/billing/enforcement";
-import {
-  lowestTierAdmitting,
-  resolveKnowledgeTierLimits,
-} from "@atlas/api/lib/billing/knowledge-limits";
+import { lowestTierAdmitting } from "@atlas/api/lib/billing/knowledge-limits";
 import { BillingCheckFailedError, FeatureEntitlementError } from "@atlas/api/lib/effect/errors";
 import type { createLogger } from "@atlas/api/lib/logger";
 import { FormInstallValidationError } from "./email-form-handler";
@@ -47,48 +51,98 @@ type CollectionInstallLogger = Pick<ReturnType<typeof createLogger>, "error" | "
 /**
  * Compose the 403 upgrade error for a collections-cap denial.
  *
- * `requiredPlan` is the cheapest tier that admits one more collection. Business
- * is unlimited, so a real denial always has a named upgrade target; the
- * `"business"` fallback is reachable only if the tier changed between the cap
- * decision and this resolution, and naming the top plan is the honest answer
- * there. `currentPlan` collapses an unresolved tier to `"free"`, matching the
- * feature-entitlement guard's handling of the same case.
+ * `tier` rides on the denial itself (`ResourceLimitResult.cap_reached.tier`),
+ * so the plan named here is provably the one whose `limit` is being quoted —
+ * a second `getCachedWorkspace` read could return a different tier (60s
+ * per-replica TTL) and tell a Pro customer they are on `free`.
+ *
+ * `requiredPlan` is the cheapest tier admitting one more collection. Business
+ * is unlimited on this field, so a real denial always has a named target; the
+ * `"business"` fallback is unreachable in practice and is the honest answer if
+ * the ladder is ever edited to have a finite top.
  */
-function collectionCapError(
-  workspaceId: WorkspaceId,
-  limit: number,
-  tier: PlanTier | null,
-): FeatureEntitlementError {
-  const currentPlan: PlanTier = tier ?? "free";
+function collectionCapError(limit: number, tier: PlanTier): FeatureEntitlementError {
   const requiredPlan =
-    lowestTierAdmitting("maxKnowledgeCollections", limit + 1, currentPlan) ?? "business";
+    lowestTierAdmitting("maxKnowledgeCollections", limit + 1, tier) ?? "business";
   const noun = limit === 1 ? "knowledge collection" : "knowledge collections";
   return new FeatureEntitlementError({
-    message: `Your "${currentPlan}" plan allows up to ${limit} ${noun}. Upgrade to "${requiredPlan}" to add more. (workspace ${workspaceId})`,
+    message: `Your "${tier}" plan allows up to ${limit} ${noun}. Upgrade to "${requiredPlan}" to add more.`,
     feature: "knowledge_collections",
     requiredPlan,
-    currentPlan,
+    currentPlan: tier,
   });
 }
 
 /**
- * Resolve the workspace's tier for an upgrade prompt without letting a lookup
- * fault mask the cap denial we already have. The cap decision is authoritative;
- * this is prompt cosmetics, so a fault degrades to `null` (→ `"free"`) rather
- * than replacing a correct 403 with a 503.
+ * Translate a collections-cap DENIAL into the right throw. Shared by the
+ * single-key precheck, the fan-out precheck, and the atomic gate so all three
+ * map `cap_reached` → 403 upgrade and `check_failed` → 503 fail-closed
+ * identically.
+ *
+ * Returns `never`, so a call site's `if (!decision.allowed)` narrows the
+ * admitted arm afterwards without a second runtime branch. The parameter is
+ * the denial union alone, which `ResourceLimitResult` and
+ * `CapGatedInstallResult` share structurally.
  */
-async function tierForPrompt(
+function throwCollectionDenial(
+  decision: Extract<ResourceLimitResult, { allowed: false }>,
   workspaceId: WorkspaceId,
+  context: Record<string, unknown>,
   log: CollectionInstallLogger,
-): Promise<PlanTier | null> {
-  try {
-    return (await resolveKnowledgeTierLimits(workspaceId))?.tier ?? null;
-  } catch (err) {
-    log.error(
-      { workspaceId, err: err instanceof Error ? err.message : String(err) },
-      "Could not resolve the plan tier for a knowledge-collection cap denial — naming the free tier in the upgrade prompt",
+): never {
+  if (decision.reason === "cap_reached") {
+    log.info(
+      { workspaceId, ...context, limit: decision.limit, tier: decision.tier },
+      "Knowledge collection install blocked — workspace at plan collections cap",
     );
-    return null;
+    throw collectionCapError(decision.limit, decision.tier);
+  }
+  // `check_failed` — and, defensively, any future non-cap denial reason: the
+  // count couldn't be determined, so fail closed as a transient 503 "try
+  // again", never a misleading 403 "upgrade your plan".
+  log.error(
+    { workspaceId, ...context },
+    "Knowledge collection install blocked — collection count check failed (failing closed)",
+  );
+  throw new BillingCheckFailedError({ message: decision.errorMessage, workspaceId });
+}
+
+/**
+ * The cross-catalog slug probe: reject a slug already owned by a DIFFERENT
+ * knowledge catalog in this workspace.
+ *
+ * `knowledge_documents` keys on `(workspace_id, collection_id, path)` with NO
+ * catalog dimension, so two catalogs sharing an `install_id` would silently
+ * merge their document trees — and a bundle-sync's archive-absent pass would
+ * archive the other collection's docs (#4211).
+ *
+ * Unlike the cap aggregate (`KNOWLEDGE_COLLECTION_COUNT_SQL`, which filters
+ * `status <> 'archived'`), this probe deliberately INCLUDES archived installs:
+ * their documents still live under the slug and an explicit re-ingest may
+ * resurrect them (ADR-0028 §5).
+ */
+async function assertCollectionSlugFree(
+  workspaceId: WorkspaceId,
+  collectionSlug: string,
+  ownCatalogId: string,
+): Promise<void> {
+  const rows = await internalQuery<{ catalog_id: string }>(
+    `SELECT catalog_id
+       FROM workspace_plugins
+      WHERE workspace_id = $1 AND install_id = $2 AND pillar = 'knowledge'
+        AND catalog_id <> $3
+      LIMIT 1`,
+    [workspaceId, collectionSlug, ownCatalogId],
+  );
+  if (rows.length > 0) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        [KNOWLEDGE_INSTALL_ID_FIELD]: [
+          `Collection id "${collectionSlug}" is already used by another Knowledge Base integration in this workspace.`,
+        ],
+      },
+      formErrors: [],
+    });
   }
 }
 
@@ -114,42 +168,39 @@ export async function assertCollectionInstallable(
   ownCatalogId: string,
   log: CollectionInstallLogger,
 ): Promise<void> {
-  const rows = await internalQuery<{ catalog_id: string }>(
-    `SELECT catalog_id
-       FROM workspace_plugins
-      WHERE workspace_id = $1 AND install_id = $2 AND pillar = 'knowledge'
-        AND catalog_id <> $3
-      LIMIT 1`,
-    [workspaceId, collectionSlug, ownCatalogId],
-  );
-  if (rows.length > 0) {
-    throw new FormInstallValidationError({
-      fieldErrors: {
-        [KNOWLEDGE_INSTALL_ID_FIELD]: [
-          `Collection id "${collectionSlug}" is already used by another Knowledge Base integration in this workspace.`,
-        ],
-      },
-      formErrors: [],
-    });
-  }
-
+  await assertCollectionSlugFree(workspaceId, collectionSlug, ownCatalogId);
   const decision = await checkKnowledgeCollectionLimit(workspaceId, collectionSlug);
-  if (decision.allowed) return;
-  if (decision.reason === "cap_reached") {
-    log.info(
-      { workspaceId, collectionSlug, limit: decision.limit },
-      "Knowledge collection install blocked — workspace at plan collections cap (precheck)",
-    );
-    throw collectionCapError(workspaceId, decision.limit, await tierForPrompt(workspaceId, log));
+  if (!decision.allowed) throwCollectionDenial(decision, workspaceId, { collectionSlug }, log);
+}
+
+/**
+ * The pre-write gate for a **fan-out** install — one collection per vendor
+ * object (Zendesk per brand, Front per knowledge base, Freshdesk per category,
+ * Help Scout per site).
+ *
+ * Looping {@link assertCollectionInstallable} would be wrong: every iteration
+ * sees the same pre-write count, so all N pass, and the atomic gate then
+ * refuses the (cap+1)-th *after* earlier items have written their rows AND
+ * their credentials — a partial install the admin has to unpick. This checks
+ * the whole batch against the cap once, before anything is written.
+ *
+ * @throws {FormInstallValidationError} 400 — a slug is taken by another catalog.
+ * @throws {FeatureEntitlementError} 403 upgrade — the batch exceeds the cap.
+ * @throws {BillingCheckFailedError} 503 — the count couldn't be determined.
+ */
+export async function assertCollectionBatchInstallable(
+  workspaceId: WorkspaceId,
+  collectionSlugs: readonly string[],
+  ownCatalogId: string,
+  log: CollectionInstallLogger,
+): Promise<void> {
+  for (const slug of collectionSlugs) {
+    await assertCollectionSlugFree(workspaceId, slug, ownCatalogId);
   }
-  // `check_failed` — and, defensively, any future non-cap denial reason: the
-  // count couldn't be determined, so fail closed as a transient 503 "try
-  // again", never a misleading 403 "upgrade your plan".
-  log.error(
-    { workspaceId, collectionSlug },
-    "Knowledge collection install blocked — collection count check failed (failing closed)",
-  );
-  throw new BillingCheckFailedError({ message: decision.errorMessage, workspaceId });
+  const decision = await checkKnowledgeCollectionFanOutLimit(workspaceId, collectionSlugs);
+  if (!decision.allowed) {
+    throwCollectionDenial(decision, workspaceId, { planned: collectionSlugs.length }, log);
+  }
 }
 
 /**
@@ -177,6 +228,15 @@ export async function upsertKnowledgeCollectionRow(input: {
   readonly log: CollectionInstallLogger;
 }): Promise<string> {
   const { workspaceId, collectionSlug, sql, params, candidateId, log } = input;
+  // The `RETURNING id` invariant below is only detectable AFTER the write has
+  // run inside the transaction. Catch the omission before we take the lock, so
+  // a handler wired with the wrong SQL fails loudly instead of rolling back a
+  // committed-looking install.
+  if (!/\breturning\s+id\b/i.test(sql)) {
+    throw new Error(
+      `upsertKnowledgeCollectionRow requires SQL ending in "RETURNING id" (collection "${collectionSlug}")`,
+    );
+  }
 
   const result = await checkKnowledgeCollectionLimitAndInstall<{ id: string }>(
     workspaceId,
@@ -185,18 +245,7 @@ export async function upsertKnowledgeCollectionRow(input: {
   );
 
   if (!result.allowed) {
-    if (result.reason === "cap_reached") {
-      log.info(
-        { workspaceId, collectionSlug, limit: result.limit },
-        "Knowledge collection install blocked — workspace at plan collections cap",
-      );
-      throw collectionCapError(workspaceId, result.limit, await tierForPrompt(workspaceId, log));
-    }
-    log.error(
-      { workspaceId, collectionSlug },
-      "Knowledge collection install blocked — collection count check failed under lock (failing closed)",
-    );
-    throw new BillingCheckFailedError({ message: result.errorMessage, workspaceId });
+    throwCollectionDenial(result, workspaceId, { collectionSlug, underLock: true }, log);
   }
 
   const returned = result.rows[0]?.id;

--- a/packages/api/src/lib/integrations/install/knowledge-collection-slug.ts
+++ b/packages/api/src/lib/integrations/install/knowledge-collection-slug.ts
@@ -1,0 +1,70 @@
+/**
+ * Collection-slug vocabulary shared by every knowledge form handler.
+ *
+ * Split out of `okf-upload-form-handler.ts` (#4235) so the two collection
+ * gates in `knowledge-collection-install.ts` can reach
+ * {@link KNOWLEDGE_INSTALL_ID_FIELD} without importing a concrete handler —
+ * which would close an import cycle, since every handler imports those gates.
+ *
+ * @module
+ */
+
+import { FormInstallValidationError } from "./email-form-handler";
+
+/**
+ * Reserved form key carrying the collection slug (= `install_id`). Same wire key
+ * the datasource install modal uses (`__install_id__`), so the shared web
+ * install form drives collection creation with no new field. Stripped from the
+ * persisted config. When omitted, the first collection defaults to the catalog
+ * slug, matching the datasource single-instance default.
+ */
+export const KNOWLEDGE_INSTALL_ID_FIELD = "__install_id__";
+
+/** Max collection-slug length — generous, bounded so a paste can't bloat the row key. */
+export const COLLECTION_SLUG_MAX = 128;
+
+/**
+ * A collection slug becomes the `install_id` (row key), the `collection_id` on
+ * every document, and the URL path segment of the ingest endpoint — so restrict
+ * it to the same URL-safe id alphabet a connection id uses (letters, digits,
+ * `.`, `-`, `_`), rejecting slashes/whitespace/delimiters.
+ */
+const COLLECTION_SLUG_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Resolve the collection slug from the reserved form value, defaulting to
+ * `defaultSlug` when omitted/blank. A supplied slug is trimmed and validated
+ * against {@link COLLECTION_SLUG_PATTERN} — an invalid one is a field-level 400
+ * (it becomes the row key, document `collection_id`, and URL segment), never
+ * silently coerced.
+ */
+export function resolveCollectionSlug(raw: unknown, defaultSlug: string): string {
+  if (raw === undefined || raw === null) return defaultSlug;
+  if (typeof raw !== "string") {
+    throw new FormInstallValidationError({
+      fieldErrors: { [KNOWLEDGE_INSTALL_ID_FIELD]: ["Collection id must be a string."] },
+      formErrors: [],
+    });
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return defaultSlug;
+  if (trimmed.length > COLLECTION_SLUG_MAX) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        [KNOWLEDGE_INSTALL_ID_FIELD]: [`Collection id must be ${COLLECTION_SLUG_MAX} characters or fewer.`],
+      },
+      formErrors: [],
+    });
+  }
+  if (!COLLECTION_SLUG_PATTERN.test(trimmed)) {
+    throw new FormInstallValidationError({
+      fieldErrors: {
+        [KNOWLEDGE_INSTALL_ID_FIELD]: [
+          "Collection id may contain only letters, digits, dots, dashes, and underscores.",
+        ],
+      },
+      formErrors: [],
+    });
+  }
+  return trimmed;
+}

--- a/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
@@ -133,8 +133,8 @@ export class NotionKnowledgeFormInstallHandler implements FormBasedInstallHandle
     }
     const catalogId = catalogRows[0].id;
 
-    // A slug taken by another knowledge catalog (okf-upload / bundle-sync) would
-    // merge document trees — reject before any write.
+    // Slug not taken by another knowledge catalog (#4211), and the workspace's
+    // plan tier has room for another collection (#4235) — both before the write.
     await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Verify the token loudly BEFORE persisting anything ─────────────────────

--- a/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
@@ -46,6 +46,7 @@ import {
   assertCollectionInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial } from "./retryable-install-error";
 import {
   KNOWLEDGE_INSTALL_ID_FIELD,
   resolveCollectionSlug,
@@ -179,7 +180,9 @@ export class NotionKnowledgeFormInstallHandler implements FormBasedInstallHandle
       // Confluence handler (confluence-form-handler.ts) — keep them in step.
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist notion-knowledge collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist notion-knowledge collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist notion-knowledge collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, collectionSlug);

--- a/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/notion-knowledge-form-handler.ts
@@ -43,10 +43,13 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 /** Defensive upper bound — a Notion token is ~50 chars; guard against a paste. */
@@ -132,7 +135,7 @@ export class NotionKnowledgeFormInstallHandler implements FormBasedInstallHandle
 
     // A slug taken by another knowledge catalog (okf-upload / bundle-sync) would
     // merge document trees — reject before any write.
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     // ── Verify the token loudly BEFORE persisting anything ─────────────────────
     await this.verifyToken(workspaceId, collectionSlug, token);
@@ -159,23 +162,14 @@ export class NotionKnowledgeFormInstallHandler implements FormBasedInstallHandle
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: collectionSlug,
+        sql: NOTION_KNOWLEDGE_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       persistedId = returned;
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a failed

--- a/packages/api/src/lib/integrations/install/okf-upload-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/okf-upload-form-handler.ts
@@ -36,31 +36,16 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import type { WorkspaceId } from "@useatlas/types";
 import { FormInstallValidationError } from "./email-form-handler";
+import {
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import { KNOWLEDGE_INSTALL_ID_FIELD, resolveCollectionSlug } from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 /** The built-in Knowledge Base (Upload) catalog slug + row id. */
 export const OKF_UPLOAD_SLUG = "okf-upload";
 export const OKF_UPLOAD_CATALOG_ID = "catalog:okf-upload";
-
-/**
- * Reserved form key carrying the collection slug (= `install_id`). Same wire key
- * the datasource install modal uses (`__install_id__`), so the shared web
- * install form drives collection creation with no new field. Stripped from the
- * persisted config. When omitted, the first collection defaults to the catalog
- * slug (`okf-upload`), matching the datasource single-instance default.
- */
-export const KNOWLEDGE_INSTALL_ID_FIELD = "__install_id__";
-
-/** Max collection-slug length — generous, bounded so a paste can't bloat the row key. */
-export const COLLECTION_SLUG_MAX = 128;
-
-/**
- * A collection slug becomes the `install_id` (row key), the `collection_id` on
- * every document, and the URL path segment of the ingest endpoint — so restrict
- * it to the same URL-safe id alphabet a connection id uses (letters, digits,
- * `.`, `-`, `_`), rejecting slashes/whitespace/delimiters.
- */
-const COLLECTION_SLUG_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 /**
  * The multi-instance collection upsert (post-0092 shape). `install_id = $4` (the
@@ -145,35 +130,21 @@ export class OkfUploadFormInstallHandler implements FormBasedInstallHandler {
     }
     const catalogId = catalogRows[0].id;
 
-    // A slug taken by another knowledge catalog (bundle-sync) would merge
-    // document trees — reject before the upsert (#4211).
-    await assertCollectionSlugAvailable(workspaceId, collectionSlug, catalogId);
+    // Slug not taken by another knowledge catalog (#4211), and the workspace's
+    // plan tier has room for another collection (#4235) — both before the write.
+    await assertCollectionInstallable(workspaceId, collectionSlug, catalogId, this.log);
 
     const candidateId = this.newId();
     let persistedId: string;
     try {
-      const rows = await internalQuery<{ id: string }>(KNOWLEDGE_INSTALL_UPSERT_SQL, [
-        candidateId,
+      persistedId = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
         collectionSlug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING emits exactly one row on
-        // both paths; an empty result is a driver/RLS/query-rewrite anomaly.
-        // Returning candidateId would be WRONG on the conflict path (the row keeps
-        // its existing id). Fail loud.
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
+        sql: KNOWLEDGE_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, collectionSlug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
     } catch (err) {
       this.log.error(
         { workspaceId, collectionSlug, err: err instanceof Error ? err.message : String(err) },
@@ -191,80 +162,4 @@ export class OkfUploadFormInstallHandler implements FormBasedInstallHandler {
       credentialWritten: false,
     };
   }
-}
-
-/**
- * Reject a collection slug already used by a DIFFERENT knowledge catalog in
- * this workspace (#4211 — the guard became necessary the moment a second
- * knowledge catalog row, `bundle-sync`, existed). `knowledge_documents` keys
- * on `(workspace_id, collection_id, path)` with NO catalog dimension, so two
- * catalogs sharing an `install_id` would silently merge their document trees
- * — and a bundle-sync's archive-absent pass would archive the other
- * collection's docs. Archived installs count too: their documents still live
- * under the slug and an explicit re-ingest may resurrect them (ADR-0028 §5).
- *
- * Shared by both knowledge form handlers ({@link OkfUploadFormInstallHandler}
- * and `BundleSyncFormInstallHandler`); each passes its own catalog id.
- */
-export async function assertCollectionSlugAvailable(
-  workspaceId: WorkspaceId,
-  collectionSlug: string,
-  ownCatalogId: string,
-): Promise<void> {
-  const rows = await internalQuery<{ catalog_id: string }>(
-    `SELECT catalog_id
-       FROM workspace_plugins
-      WHERE workspace_id = $1 AND install_id = $2 AND pillar = 'knowledge'
-        AND catalog_id <> $3
-      LIMIT 1`,
-    [workspaceId, collectionSlug, ownCatalogId],
-  );
-  if (rows.length > 0) {
-    throw new FormInstallValidationError({
-      fieldErrors: {
-        [KNOWLEDGE_INSTALL_ID_FIELD]: [
-          `Collection id "${collectionSlug}" is already used by another Knowledge Base integration in this workspace.`,
-        ],
-      },
-      formErrors: [],
-    });
-  }
-}
-
-/**
- * Resolve the collection slug from the reserved form value, defaulting to
- * `defaultSlug` when omitted/blank. A supplied slug is trimmed and validated
- * against {@link COLLECTION_SLUG_PATTERN} — an invalid one is a field-level 400
- * (it becomes the row key, document `collection_id`, and URL segment), never
- * silently coerced.
- */
-export function resolveCollectionSlug(raw: unknown, defaultSlug: string): string {
-  if (raw === undefined || raw === null) return defaultSlug;
-  if (typeof raw !== "string") {
-    throw new FormInstallValidationError({
-      fieldErrors: { [KNOWLEDGE_INSTALL_ID_FIELD]: ["Collection id must be a string."] },
-      formErrors: [],
-    });
-  }
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return defaultSlug;
-  if (trimmed.length > COLLECTION_SLUG_MAX) {
-    throw new FormInstallValidationError({
-      fieldErrors: {
-        [KNOWLEDGE_INSTALL_ID_FIELD]: [`Collection id must be ${COLLECTION_SLUG_MAX} characters or fewer.`],
-      },
-      formErrors: [],
-    });
-  }
-  if (!COLLECTION_SLUG_PATTERN.test(trimmed)) {
-    throw new FormInstallValidationError({
-      fieldErrors: {
-        [KNOWLEDGE_INSTALL_ID_FIELD]: [
-          "Collection id may contain only letters, digits, dots, dashes, and underscores.",
-        ],
-      },
-      formErrors: [],
-    });
-  }
-  return trimmed;
 }

--- a/packages/api/src/lib/integrations/install/retryable-install-error.ts
+++ b/packages/api/src/lib/integrations/install/retryable-install-error.ts
@@ -1,0 +1,57 @@
+/**
+ * `retryableInstallError` — the shared mid-fan-out failure wrapper for the four
+ * knowledge connectors that create one collection per vendor object (Zendesk
+ * per brand, Help Scout per site, Front per knowledge base, Freshdesk per
+ * category).
+ *
+ * Each of those handlers writes its collections in a loop, so a failure on item
+ * N leaves items 1..N-1 installed. The wrapper's job is to say so: the install
+ * is idempotent, so retrying re-runs the whole batch and simply updates what
+ * already landed.
+ *
+ * **A plan/billing denial is NOT wrapped.** `FeatureEntitlementError` (403
+ * `plan_upgrade_required`) and `BillingCheckFailedError` (503) are
+ * `Data.TaggedError`s whose `_tag` is what `classifyError` maps to an HTTP
+ * response. Flattening them into a plain `Error` would erase the tag — the
+ * request would land on the unmapped-error arm as a **500 `internal_error`**,
+ * and the message would tell the admin that "retrying the install is safe" when
+ * retrying a cap denial fails identically every time (#4235). They are returned
+ * unchanged so the caller's `throw` re-raises the original tagged error.
+ *
+ * Single-homed because all four copies were byte-identical apart from the noun,
+ * and the passthrough above is exactly the kind of rule that must not exist in
+ * four places.
+ *
+ * @module
+ */
+
+import {
+  BillingCheckFailedError,
+  FeatureEntitlementError,
+} from "@atlas/api/lib/effect/errors";
+
+/**
+ * True when `err` already carries its own HTTP envelope and must reach the
+ * route untouched. Exported so a handler's `catch` can also skip the "rolling
+ * back — retrying is safe" log line for these.
+ */
+export function isPlanDenial(err: unknown): boolean {
+  return err instanceof FeatureEntitlementError || err instanceof BillingCheckFailedError;
+}
+
+/**
+ * Wrap a mid-fan-out install failure with retry guidance — or pass a plan
+ * denial straight through (see the module docblock).
+ *
+ * @param slug - The collection whose write failed.
+ * @param err - The originating error.
+ * @param itemNoun - What this connector fans out over ("brand", "site", …),
+ *   used only in the retry-guidance sentence.
+ */
+export function retryableInstallError(slug: string, err: unknown, itemNoun: string): unknown {
+  if (isPlanDenial(err)) return err;
+  return new Error(
+    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed ${itemNoun} collections are simply updated in place.`,
+    { cause: err },
+  );
+}

--- a/packages/api/src/lib/integrations/install/salesforce-knowledge-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/salesforce-knowledge-form-handler.ts
@@ -48,10 +48,13 @@ import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
 import { hostForLog } from "@atlas/api/lib/openapi/egress-guard";
 import { FormInstallValidationError } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -134,7 +137,7 @@ export class SalesforceKnowledgeFormInstallHandler implements FormBasedInstallHa
     }
     const catalogId = catalogRows[0].id;
 
-    await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+    await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
 
     // ── Verify the reused Salesforce connection loudly BEFORE persisting ────
     const instance = await this.resolveInstance(workspaceId);
@@ -158,23 +161,14 @@ export class SalesforceKnowledgeFormInstallHandler implements FormBasedInstallHa
       ...(description !== null ? { description } : {}),
     };
     const candidateId = this.newId();
-    const rows = await internalQuery<{ id: string }>(SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL, [
-      candidateId,
+    const returned = await upsertKnowledgeCollectionRow({
       workspaceId,
-      catalogId,
-      slug,
-      JSON.stringify(config),
-    ]);
-    const returned = rows[0]?.id;
-    if (typeof returned !== "string" || returned.length === 0) {
-      this.log.error(
-        { workspaceId, candidateId, collectionSlug: slug },
-        "workspace_plugins upsert returned no id — Postgres invariant violation",
-      );
-      throw new Error(
-        "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-      );
-    }
+      collectionSlug: slug,
+      sql: SALESFORCE_KNOWLEDGE_INSTALL_UPSERT_SQL,
+      params: [candidateId, workspaceId, catalogId, slug, JSON.stringify(config)],
+      candidateId,
+      log: this.log,
+    });
 
     this.log.info(
       { workspaceId, collectionSlug: slug, articleObject, channel, host: instanceHost },

--- a/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
@@ -63,9 +63,10 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionInstallable,
+  assertCollectionBatchInstallable,
   upsertKnowledgeCollectionRow,
 } from "./knowledge-collection-install";
+import { isPlanDenial, retryableInstallError } from "./retryable-install-error";
 import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
@@ -199,8 +200,17 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
+    // ONE cap check for the WHOLE fan-out, before any credential or row is
+    // written: a per-slug loop would pass N times against the same pre-write
+    // count and strand a partial install when the atomic gate refused the
+    // (cap+1)-th mid-batch (#4235).
+    await assertCollectionBatchInstallable(
+      workspaceId,
+      planned.map((p) => p.slug),
+      catalogId,
+      this.log,
+    );
 
     // ── Per-brand writes: credential first, then the collection row ──────────
     assertSaasEncryptionKeyset(this.log, workspaceId, "api_token");
@@ -257,7 +267,7 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
         { workspaceId, collectionSlug: slug, err: err instanceof Error ? err.message : String(err) },
         "Failed to persist knowledge_sync_credentials row — aborting install (retrying is safe; completed brand collections stay installed)",
       );
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "brand");
     }
 
     const candidateId = this.newId();
@@ -283,7 +293,9 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
           brandId: brand.id,
           err: err instanceof Error ? err.message : String(err),
         },
-        "Failed to persist zendesk collection install — rolling back the orphaned credential (retrying the install is safe)",
+        isPlanDenial(err)
+          ? "Failed to persist zendesk collection install — rolling back the orphaned credential (the workspace is at a plan limit — retrying will not help)"
+          : "Failed to persist zendesk collection install — rolling back the orphaned credential (retrying the install is safe)",
       );
       try {
         await deleteSyncCredential(workspaceId, slug);
@@ -297,7 +309,7 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
           "Failed to roll back the orphaned credential after an install-row failure — a re-install overwrites it",
         );
       }
-      throw retryableInstallError(slug, err);
+      throw retryableInstallError(slug, err, "brand");
     }
   }
 
@@ -438,9 +450,3 @@ function fieldError(field: string, message: string): FormInstallValidationError 
  * needs: all writes are idempotent upserts converging on the same slugs, so
  * re-running the install is always safe. The original failure rides as cause.
  */
-function retryableInstallError(slug: string, err: unknown): Error {
-  return new Error(
-    `Failed to install the "${slug}" collection: ${err instanceof Error ? err.message : String(err)}. Retrying the install is safe — already-installed brand collections are simply updated in place.`,
-    { cause: err },
-  );
-}

--- a/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/zendesk-form-handler.ts
@@ -63,11 +63,14 @@ import {
   FormInstallValidationError,
 } from "./persist-form-install";
 import {
-  assertCollectionSlugAvailable,
-  resolveCollectionSlug,
+  assertCollectionInstallable,
+  upsertKnowledgeCollectionRow,
+} from "./knowledge-collection-install";
+import {
   COLLECTION_SLUG_MAX,
   KNOWLEDGE_INSTALL_ID_FIELD,
-} from "./okf-upload-form-handler";
+  resolveCollectionSlug,
+} from "./knowledge-collection-slug";
 import type { FormBasedInstallHandler, InstallRecord } from "./types";
 
 // Re-exported for the register.ts boot wiring; both are single-homed in config.ts.
@@ -196,7 +199,7 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
           formErrors: [],
         });
       }
-      await assertCollectionSlugAvailable(workspaceId, slug, catalogId);
+      await assertCollectionInstallable(workspaceId, slug, catalogId, this.log);
     }
 
     // ── Per-brand writes: credential first, then the collection row ──────────
@@ -259,23 +262,14 @@ export class ZendeskFormInstallHandler implements FormBasedInstallHandler {
 
     const candidateId = this.newId();
     try {
-      const rows = await internalQuery<{ id: string }>(ZENDESK_INSTALL_UPSERT_SQL, [
-        candidateId,
+      const returned = await upsertKnowledgeCollectionRow({
         workspaceId,
-        catalogId,
-        slug,
-        JSON.stringify(config),
-      ]);
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        this.log.error(
-          { workspaceId, candidateId, collectionSlug: slug },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
+        collectionSlug: slug,
+        sql: ZENDESK_INSTALL_UPSERT_SQL,
+        params: [candidateId, workspaceId, catalogId, slug, JSON.stringify(config)],
+        candidateId,
+        log: this.log,
+      });
       return { id: returned, workspaceId, catalogId: ZENDESK_SLUG };
     } catch (err) {
       // Roll back the just-written credential so a secret can't outlive a

--- a/packages/api/src/lib/knowledge/__tests__/connector-sync.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/connector-sync.test.ts
@@ -275,10 +275,40 @@ function maybeRateLimit(): void {
   }
 }
 
+
+// Explicit stand-in for the billing composition seam (#4235) — without it this
+// suite reaches the real `billing/enforcement` → `db/internal` stack and passes
+// only because the shared internal-DB mock stubs `getWorkspaceDetails → null`.
+// Stating the shape on purpose also makes the TIER branch reachable.
+let CAP_TIER: string | null = null;
+void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
+  resolveIngestCaps: async (orgId: string | undefined) => {
+    const boundBy = CAP_TIER === null ? "platform" : "tier";
+    return {
+      workspaceId: orgId ?? "",
+      tier: CAP_TIER,
+      maxDocs: { value: MAX_DOCS, boundBy },
+      maxBundleBytes: { value: MAX_BUNDLE_BYTES, boundBy },
+      maxDocBytes: MAX_DOC_BYTES,
+    };
+  },
+  assertIngestCapsFor: () => {},
+  assertNotTierBound: () => {},
+  capIsOperatorTunable: (boundBy: string) => boundBy === "platform",
+  minKnowledgeCap: (a: number, b: number) => (b === -1 ? a : Math.min(a, b)),
+  lowestTierAdmitting: () => null,
+  resolveKnowledgeTierLimits: async () => null,
+}));
+
+/** The effective per-sync doc cap the engine handed the connector. */
+let clientMaxDocs: number | null = null;
+
 const fixtureConnector: KnowledgeSyncConnector = {
   catalogId: FIXTURE_CATALOG_ID,
   vendor: "fixture",
-  createClient: () => ({
+  createClient: (ctx) => {
+    clientMaxDocs = ctx.maxDocs;
+    return {
     async fetchChanges({ since, cursor }): Promise<ConnectorChanges> {
       maybeRateLimit();
       fetchCalls.push({ kind: "changes", since, cursor });
@@ -300,7 +330,8 @@ const fixtureConnector: KnowledgeSyncConnector = {
         coverageIncomplete: vendorCoverageIncomplete,
       };
     },
-  }),
+    };
+  },
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -346,6 +377,7 @@ const state = () => syncState.get(stateKey(ORG, COLLECTION));
 
 beforeEach(() => {
   MAX_DOCS = 100;
+  CAP_TIER = null;
   store = new Map();
   syncState = new Map();
   nextId = 1;
@@ -509,6 +541,30 @@ describe("reconciliation crawls", () => {
     expect(state()?.report).toMatchObject({ coverageIncomplete: true });
   });
 
+  it("bounds the vendor fetch by the EFFECTIVE cap, not the raw platform ceiling", async () => {
+    // Otherwise a lower-tier workspace pulls documents it can never ingest —
+    // every scheduled sync, forever, burning the vendor's rate limit.
+    CAP_TIER = "starter";
+    MAX_DOCS = 250;
+    await runSync();
+    expect(clientMaxDocs).toBe(250);
+  });
+
+  it("points a tier-capped workspace at its PLAN, not at an operator setting", async () => {
+    // A hosted workspace admin cannot reach `ATLAS_KNOWLEDGE_INGEST_MAX_DOCS`;
+    // naming it sends them after a knob they can never turn.
+    CAP_TIER = "starter";
+    MAX_DOCS = 1;
+    vendorPages = [
+      { path: "a.md", body: md("A"), lastModified: "2026-07-01T00:00:00.000Z" },
+      { path: "b.md", body: md("B"), lastModified: "2026-07-01T00:00:00.000Z" },
+    ];
+    const outcome = await runSync();
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toContain("your plan's 1-document per-sync limit");
+    expect(outcome.error).not.toContain("ATLAS_KNOWLEDGE_INGEST_MAX_DOCS");
+  });
+
   it("validates the ingest caps over the FULL set with real numbers", async () => {
     MAX_DOCS = 1;
     vendorPages = [
@@ -518,6 +574,9 @@ describe("reconciliation crawls", () => {
     const outcome = await runSync();
     expect(outcome.status).toBe("error");
     expect(outcome.error).toMatch(/2 documents, over the 1-document limit/);
+    // Platform-bound off SaaS → the operator can actually raise this one, so
+    // naming the setting is the useful hint.
+    expect(outcome.error).toMatch(/ATLAS_KNOWLEDGE_INGEST_MAX_DOCS/);
     expect(outcome.error).toMatch(/ATLAS_KNOWLEDGE_INGEST_MAX_DOCS/);
     expect(store.size).toBe(0);
     // The failed attempt didn't stamp a reconciliation success.

--- a/packages/api/src/lib/knowledge/__tests__/connector-sync.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/connector-sync.test.ts
@@ -281,8 +281,10 @@ function maybeRateLimit(): void {
 // only because the shared internal-DB mock stubs `getWorkspaceDetails → null`.
 // Stating the shape on purpose also makes the TIER branch reachable.
 let CAP_TIER: string | null = null;
+let CAPS_THROW = false;
 void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
   resolveIngestCaps: async (orgId: string | undefined) => {
+    if (CAPS_THROW) throw new Error("settings backend exploded");
     const boundBy = CAP_TIER === null ? "platform" : "tier";
     return {
       workspaceId: orgId ?? "",
@@ -378,6 +380,7 @@ const state = () => syncState.get(stateKey(ORG, COLLECTION));
 beforeEach(() => {
   MAX_DOCS = 100;
   CAP_TIER = null;
+  CAPS_THROW = false;
   store = new Map();
   syncState = new Map();
   nextId = 1;
@@ -400,6 +403,19 @@ beforeEach(() => {
 });
 
 // ── Reconciliation (the correctness anchor) ─────────────────────────────────
+
+describe("effective-cap resolution", () => {
+  it("returns an error state (never throws) when the caps lookup faults", async () => {
+    // `resolveIngestCaps` is the FIRST thing the engine does; a settings-backend
+    // fault must surface as the collection's error state, not crash the cycle.
+    CAPS_THROW = true;
+    const outcome = await runSync();
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toContain("Could not verify this workspace's Knowledge Base limits");
+    // No vendor fetch was even attempted.
+    expect(fetchCalls).toEqual([]);
+  });
+});
 
 describe("reconciliation crawls", () => {
   it("a collection with no sync state runs a FULL crawl: drafts seeded, mark + reconciled-at persisted", async () => {

--- a/packages/api/src/lib/knowledge/__tests__/ingest-bundle.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/ingest-bundle.test.ts
@@ -120,6 +120,34 @@ void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({
   getIngestMaxBundleBytes: () => MAX_BUNDLE_BYTES,
 }));
 
+// Explicit stand-in for the billing composition seam (#4235) — without it the
+// no-`caps` default path reaches the real `billing/knowledge-limits` →
+// `db/internal` stack and passes only because the shared internal-DB mock stubs
+// `getWorkspaceDetails → null` (the same implementation-detail coupling the
+// sync suites were fixed to remove). Platform-only shape stated on purpose.
+void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
+  resolveIngestCaps: async (orgId: string | undefined) => ({
+    workspaceId: orgId ?? "",
+    tier: null,
+    maxDocs: { value: MAX_DOCS, boundBy: "platform" },
+    maxBundleBytes: { value: MAX_BUNDLE_BYTES, boundBy: "platform" },
+    maxDocBytes: MAX_DOC_BYTES,
+  }),
+  assertIngestCapsFor: (
+    caps: { workspaceId: string },
+    workspaceId: string,
+  ) => {
+    if (caps.workspaceId !== workspaceId) {
+      throw new Error("caps workspace mismatch");
+    }
+  },
+  assertNotTierBound: () => {},
+  capIsOperatorTunable: (boundBy: string) => boundBy === "platform",
+  minKnowledgeCap: (a: number, b: number) => (b === -1 ? a : Math.min(a, b)),
+  lowestTierAdmitting: () => null,
+  resolveKnowledgeTierLimits: async () => null,
+}));
+
 // The mirror-invalidation seam lazy-imports semantic/sync; only the
 // invalidation entrypoint is reachable from this module's graph.
 let invalidations: Array<{ orgId: string; scope: string }> = [];

--- a/packages/api/src/lib/knowledge/__tests__/ingest-bundle.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/ingest-bundle.test.ts
@@ -175,7 +175,45 @@ describe("typed failure outcomes (no writes)", () => {
     MAX_BUNDLE_BYTES = 10;
     const bytes = zipSync({ "a.md": strToU8("# A longer body") });
     const outcome = await run(bytes);
-    expect(outcome).toMatchObject({ kind: "bundle_too_large", bytes: bytes.length, maxBundleBytes: 10 });
+    expect(outcome).toMatchObject({
+      kind: "bundle_too_large",
+      bytes: bytes.length,
+      maxBundleBytes: 10,
+      // Nothing tiered the cap, so the operator's ceiling is what refused.
+      boundBy: "platform",
+    });
+  });
+
+  it("carries the caller's cap provenance onto both over-limit outcomes (#4235)", async () => {
+    // The route turns `boundBy: "tier"` into a 403 upgrade envelope instead of
+    // a flat 400, so the seam must not flatten it.
+    const tierCaps = {
+      maxDocs: { value: 1, boundBy: "tier" as const },
+      maxBundleBytes: { value: 10, boundBy: "tier" as const },
+      maxDocBytes: MAX_DOC_BYTES,
+    };
+    const tooBig = await run(zipSync({ "a.md": strToU8("# A longer body") }), { caps: tierCaps });
+    expect(tooBig).toMatchObject({ kind: "bundle_too_large", maxBundleBytes: 10, boundBy: "tier" });
+
+    const tooMany = await run(zipSync({ "a.md": strToU8("# A"), "b.md": strToU8("# B") }), {
+      caps: { ...tierCaps, maxBundleBytes: { value: 10_000_000, boundBy: "tier" as const } },
+    });
+    expect(tooMany).toMatchObject({ kind: "too_many_documents", count: 2, maxDocs: 1, boundBy: "tier" });
+  });
+
+  it("prefers a caller-supplied cap over its own resolution so both ingest stages agree", async () => {
+    // The upload route caps the raw request body BEFORE the seam sees it; if
+    // the seam re-resolved independently the two could disagree mid-request.
+    MAX_BUNDLE_BYTES = 10_000_000;
+    const bytes = zipSync({ "a.md": strToU8("# A longer body") });
+    const outcome = await run(bytes, {
+      caps: {
+        maxDocs: { value: 1000, boundBy: "platform" as const },
+        maxBundleBytes: { value: 5, boundBy: "platform" as const },
+        maxDocBytes: MAX_DOC_BYTES,
+      },
+    });
+    expect(outcome).toMatchObject({ kind: "bundle_too_large", maxBundleBytes: 5 });
   });
 
   it("unrecognized format → invalid_bundle with the format error message", async () => {
@@ -187,7 +225,7 @@ describe("typed failure outcomes (no writes)", () => {
   it("doc cap exceeded → too_many_documents", async () => {
     MAX_DOCS = 1;
     const outcome = await run(zipSync({ "a.md": strToU8("# A"), "b.md": strToU8("# B") }));
-    expect(outcome).toMatchObject({ kind: "too_many_documents", count: 2, maxDocs: 1 });
+    expect(outcome).toMatchObject({ kind: "too_many_documents", count: 2, maxDocs: 1, boundBy: "platform" });
   });
 
   it("every file rejected → no_documents with per-file reasons", async () => {

--- a/packages/api/src/lib/knowledge/__tests__/ingest-bundle.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/ingest-bundle.test.ts
@@ -188,6 +188,8 @@ describe("typed failure outcomes (no writes)", () => {
     // The route turns `boundBy: "tier"` into a 403 upgrade envelope instead of
     // a flat 400, so the seam must not flatten it.
     const tierCaps = {
+      workspaceId: WS,
+      tier: "starter" as const,
       maxDocs: { value: 1, boundBy: "tier" as const },
       maxBundleBytes: { value: 10, boundBy: "tier" as const },
       maxDocBytes: MAX_DOC_BYTES,
@@ -208,6 +210,8 @@ describe("typed failure outcomes (no writes)", () => {
     const bytes = zipSync({ "a.md": strToU8("# A longer body") });
     const outcome = await run(bytes, {
       caps: {
+        workspaceId: WS,
+        tier: null,
         maxDocs: { value: 1000, boundBy: "platform" as const },
         maxBundleBytes: { value: 5, boundBy: "platform" as const },
         maxDocBytes: MAX_DOC_BYTES,

--- a/packages/api/src/lib/knowledge/__tests__/ingest-limits.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/ingest-limits.test.ts
@@ -29,6 +29,7 @@ const {
   DEFAULT_INGEST_MAX_DOC_BYTES,
   DEFAULT_INGEST_MAX_BUNDLE_BYTES,
 } = await import("@atlas/api/lib/knowledge/ingest-limits");
+const { getPlanLimits } = await import("@atlas/api/lib/billing/plans");
 
 beforeEach(() => {
   SETTINGS = {};
@@ -109,6 +110,18 @@ describe("cap readers thread the registry key → default", () => {
       DEPLOY_MODE = "saas";
       SETTINGS.ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES = "7";
       expect(getIngestMaxBundleBytes()).toBe(7);
+    });
+
+    it("never sits BELOW the Business tier it is meant to make reachable", () => {
+      // The invariant `SAAS_CEILING >= PlanLimits.business` is stated in a
+      // comment and asserted against literals in two SEPARATE files — raising
+      // Business in plans.ts and updating only its own test would leave the
+      // ceiling behind and silently downgrade what that tier was sold. Compare
+      // the two sides directly so that edit is a red test.
+      DEPLOY_MODE = "saas";
+      const business = getPlanLimits("business");
+      expect(getIngestMaxDocs()).toBeGreaterThanOrEqual(business.maxKnowledgeDocsPerBundle);
+      expect(getIngestMaxBundleBytes()).toBeGreaterThanOrEqual(business.maxKnowledgeBundleBytes);
     });
   });
 });

--- a/packages/api/src/lib/knowledge/__tests__/ingest-limits.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/ingest-limits.test.ts
@@ -10,6 +10,10 @@ let SETTINGS: Record<string, string | undefined> = {};
 void mock.module("@atlas/api/lib/settings", () => ({
   getSettingAuto: (key: string) => SETTINGS[key],
 }));
+let DEPLOY_MODE: "saas" | "self-hosted" = "self-hosted";
+void mock.module("@atlas/api/lib/effect/deploy-mode", () => ({
+  resolveDeployMode: () => DEPLOY_MODE,
+}));
 void mock.module("@atlas/api/lib/logger", () => {
   const noop = () => {};
   const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
@@ -28,9 +32,11 @@ const {
 
 beforeEach(() => {
   SETTINGS = {};
+  DEPLOY_MODE = "self-hosted";
 });
 afterEach(() => {
   SETTINGS = {};
+  DEPLOY_MODE = "self-hosted";
 });
 
 describe("positiveIntSetting", () => {
@@ -77,5 +83,32 @@ describe("cap readers thread the registry key → default", () => {
   it("fall back on a garbage override", () => {
     SETTINGS.ATLAS_KNOWLEDGE_INGEST_MAX_DOCS = "nope";
     expect(getIngestMaxDocs()).toBe(DEFAULT_INGEST_MAX_DOCS);
+  });
+
+  describe("deploy-mode-aware ceilings (#4235)", () => {
+    it("raises the unset ceiling to the Business-tier values on SaaS", () => {
+      // Without this the 25 MB / 1000-doc self-hosted defaults would silently
+      // clamp what the Business tier was sold (100 MB / 5000 docs).
+      DEPLOY_MODE = "saas";
+      expect(getIngestMaxDocs()).toBe(5_000);
+      expect(getIngestMaxBundleBytes()).toBe(100_000_000);
+    });
+
+    it("leaves the shipped self-hosted defaults untouched", () => {
+      DEPLOY_MODE = "self-hosted";
+      expect(getIngestMaxDocs()).toBe(DEFAULT_INGEST_MAX_DOCS);
+      expect(getIngestMaxBundleBytes()).toBe(DEFAULT_INGEST_MAX_BUNDLE_BYTES);
+    });
+
+    it("keeps the per-document cap deploy-mode-invariant — it is a guardrail, not a lever", () => {
+      DEPLOY_MODE = "saas";
+      expect(getIngestMaxDocBytes()).toBe(DEFAULT_INGEST_MAX_DOC_BYTES);
+    });
+
+    it("lets an operator override still win on SaaS", () => {
+      DEPLOY_MODE = "saas";
+      SETTINGS.ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES = "7";
+      expect(getIngestMaxBundleBytes()).toBe(7);
+    });
   });
 });

--- a/packages/api/src/lib/knowledge/__tests__/sync.test.ts
+++ b/packages/api/src/lib/knowledge/__tests__/sync.test.ts
@@ -45,6 +45,35 @@ void mock.module("@atlas/api/lib/knowledge/ingest-limits", () => ({
   },
 }));
 
+
+// Explicit stand-in for the billing composition seam (#4235). Without it this
+// suite reaches the real `billing/enforcement` → `db/internal` stack and passes
+// only because the shared internal-DB mock happens to stub
+// `getWorkspaceDetails → null` — an implementation-detail dependency. Stating
+// the platform-only shape on purpose also makes the TIER branch reachable.
+let CAP_TIER: string | null = null;
+void mock.module("@atlas/api/lib/billing/knowledge-limits", () => ({
+  resolveIngestCaps: async (orgId: string | undefined) => {
+    // Cap resolution reads the platform ceiling, so a settings-backend fault
+    // surfaces here — the `LIMITS_THROW` pin for "the engine never throws".
+    if (LIMITS_THROW) throw new Error("settings backend exploded");
+    const boundBy = CAP_TIER === null ? "platform" : "tier";
+    return {
+      workspaceId: orgId ?? "",
+      tier: CAP_TIER,
+      maxDocs: { value: MAX_DOCS, boundBy },
+      maxBundleBytes: { value: MAX_BUNDLE_BYTES, boundBy },
+      maxDocBytes: MAX_DOC_BYTES,
+    };
+  },
+  assertIngestCapsFor: () => {},
+  assertNotTierBound: () => {},
+  capIsOperatorTunable: (boundBy: string) => boundBy === "platform",
+  minKnowledgeCap: (a: number, b: number) => (b === -1 ? a : Math.min(a, b)),
+  lowestTierAdmitting: () => null,
+  resolveKnowledgeTierLimits: async () => null,
+}));
+
 // ── Credential store ─────────────────────────────────────────────────────────
 let CREDENTIAL: string | null = null;
 let CREDENTIAL_THROWS = false;
@@ -262,6 +291,7 @@ beforeEach(() => {
   MAX_DOCS = 100;
   MAX_DOC_BYTES = 100_000;
   MAX_BUNDLE_BYTES = 200_000;
+  CAP_TIER = null;
   LIMITS_THROW = false;
   TX_INSERT_THROWS = false;
   STATE_WRITE_THROWS = false;
@@ -623,6 +653,27 @@ describe("syncCollection — fetch hardening", () => {
     });
     expect(outcome.status).toBe("error");
     expect(outcome.error).toMatch(/byte limit/);
+    // Platform-bound off SaaS → the operator-tunable wording, with no
+    // "your plan" claim attached to an operator setting.
+    expect(outcome.error).not.toContain("your plan");
+  });
+
+  it("says the limit is the PLAN's when the tier is what bound the download", async () => {
+    // The tier-tightened download cap is the security-relevant half: a Starter
+    // workspace must not be able to PULL a bundle it would be refused on
+    // upload. The wording must point at the lever the reader can actually use.
+    CAP_TIER = "starter";
+    const { impl } = fetchReturning(
+      fakeResponse({ headers: { "content-length": String(MAX_BUNDLE_BYTES + 1) } }),
+    );
+    const outcome = await syncCollection({
+      workspaceId: ORG,
+      collectionSlug: COLLECTION,
+      config: baseConfig(),
+      fetchImpl: impl,
+    });
+    expect(outcome.status).toBe("error");
+    expect(outcome.error).toContain("limit on your plan");
   });
 
   it("aborts a streamed body that exceeds the cap (lying/chunked endpoint)", async () => {

--- a/packages/api/src/lib/knowledge/confluence/__tests__/connector-datacenter.test.ts
+++ b/packages/api/src/lib/knowledge/confluence/__tests__/connector-datacenter.test.ts
@@ -32,7 +32,7 @@ const VALID_CONFIG = {
 };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "confluence-dc-eng", config };
+  return { workspaceId: "org-1", collectionSlug: "confluence-dc-eng", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/confluence/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/confluence/__tests__/connector.test.ts
@@ -30,7 +30,7 @@ const VALID_CONFIG = {
 };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "confluence-eng", config };
+  return { workspaceId: "org-1", collectionSlug: "confluence-eng", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/connector-sync.ts
+++ b/packages/api/src/lib/knowledge/connector-sync.ts
@@ -546,7 +546,14 @@ async function runConnectorAttempt(
       return {
         kind: "error",
         mode,
-        error: `The vendor returned ${outcome.count} documents, over the ${outcome.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the connector's scope or raise the cap.`,
+        // Name the ACTUAL binding cap (#4235): on SaaS the workspace's plan
+        // tier is often lower than the operator ceiling, and pointing an admin
+        // at a setting they can't reach (or that isn't what refused them) is
+        // worse than no hint at all.
+        error:
+          outcome.boundBy === "tier"
+            ? `The vendor returned ${outcome.count} documents, over your plan's ${outcome.maxDocs}-document per-sync limit — narrow the connector's scope or upgrade your plan.`
+            : `The vendor returned ${outcome.count} documents, over the ${outcome.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the connector's scope or raise the cap.`,
         rejected: outcome.rejected,
       };
     case "no_documents":

--- a/packages/api/src/lib/knowledge/connector-sync.ts
+++ b/packages/api/src/lib/knowledge/connector-sync.ts
@@ -52,6 +52,11 @@ import type { KnowledgeIngestDocumentCounts } from "@useatlas/types";
 import type { BundleEntryError } from "./bundle-archive";
 import { ingestDocuments } from "./ingest-bundle";
 import {
+  capIsOperatorTunable,
+  resolveIngestCaps,
+  type EffectiveIngestCaps,
+} from "@atlas/api/lib/billing/knowledge-limits";
+import {
   ConnectorRateLimitError,
   type ConnectorChanges,
   type ConnectorVendorClient,
@@ -418,10 +423,31 @@ async function runConnectorAttempt(
   const mode: ConnectorSyncMode = due || sinceIso === null ? "reconciliation" : "incremental";
   onModeDecided(mode);
 
+  // ── Effective caps ─────────────────────────────────────────────────────────
+  // Resolved ONCE and used for both the vendor fetch bound and the ingest, so
+  // the client never pulls more documents than this workspace could ever
+  // commit (#4235) and both stages agree on the same numbers.
+  let caps: EffectiveIngestCaps;
+  try {
+    caps = await resolveIngestCaps(workspaceId);
+  } catch (err) {
+    return {
+      kind: "error",
+      mode,
+      error: `Could not verify this workspace's Knowledge Base limits: ${err instanceof Error ? err.message : String(err)}`,
+      rejected: [],
+    };
+  }
+
   // ── Vendor client ──────────────────────────────────────────────────────────
   let client: ConnectorVendorClient;
   try {
-    client = await connector.createClient({ workspaceId, collectionSlug, config });
+    client = await connector.createClient({
+      workspaceId,
+      collectionSlug,
+      config,
+      maxDocs: caps.maxDocs.value,
+    });
   } catch (err) {
     return {
       kind: "error",
@@ -496,6 +522,7 @@ async function runConnectorAttempt(
       workspaceId,
       collectionId: collectionSlug,
       source: `connector:${connector.vendor}`,
+      caps,
       files: changes.documents.map((d) => ({ path: d.path, content: d.content })),
       archiveAbsent: mode === "reconciliation" && !coverageIncomplete,
     });
@@ -546,14 +573,15 @@ async function runConnectorAttempt(
       return {
         kind: "error",
         mode,
-        // Name the ACTUAL binding cap (#4235): on SaaS the workspace's plan
-        // tier is often lower than the operator ceiling, and pointing an admin
-        // at a setting they can't reach (or that isn't what refused them) is
-        // worse than no hint at all.
-        error:
-          outcome.boundBy === "tier"
-            ? `The vendor returned ${outcome.count} documents, over your plan's ${outcome.maxDocs}-document per-sync limit — narrow the connector's scope or upgrade your plan.`
-            : `The vendor returned ${outcome.count} documents, over the ${outcome.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the connector's scope or raise the cap.`,
+        // Name a lever the reader can actually pull (#4235). The operator
+        // setting is only nameable OFF SaaS: a hosted workspace admin can't
+        // reach it, and on SaaS the platform ceiling is pinned to the Business
+        // tier, so even a `boundBy: "platform"` refusal there is effectively a
+        // plan ceiling to them. Pointing at an unreachable env var is worse
+        // than no hint at all.
+        error: capIsOperatorTunable(outcome.boundBy)
+          ? `The vendor returned ${outcome.count} documents, over the ${outcome.maxDocs}-document limit (ATLAS_KNOWLEDGE_INGEST_MAX_DOCS) — narrow the connector's scope or raise the cap.`
+          : `The vendor returned ${outcome.count} documents, over your plan's ${outcome.maxDocs}-document per-sync limit — narrow the connector's scope or upgrade your plan.`,
         rejected: outcome.rejected,
       };
     case "no_documents":

--- a/packages/api/src/lib/knowledge/connectors.ts
+++ b/packages/api/src/lib/knowledge/connectors.ts
@@ -122,6 +122,17 @@ export interface ConnectorInstallContext {
   readonly collectionSlug: string;
   /** The install row's config (vendor endpoint/scope fields; never secrets). */
   readonly config: Record<string, unknown> | null;
+  /**
+   * The EFFECTIVE per-sync document cap for this workspace —
+   * `min(platform ceiling, plan tier)` (#4235) — which every vendor client
+   * MUST use to bound its fetch.
+   *
+   * Required, not optional, so a connector cannot silently fall back to the
+   * raw platform ceiling: on SaaS that ceiling is the Business tier's 5,000,
+   * so a Starter workspace (250) would pull 20× the documents it can ever
+   * ingest, burning the vendor's rate limit on every scheduled sync forever.
+   */
+  readonly maxDocs: number;
 }
 
 /**

--- a/packages/api/src/lib/knowledge/freshdesk/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/__tests__/connector.test.ts
@@ -31,7 +31,7 @@ const VALID_CONFIG = {
 };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "freshdesk-support", config };
+  return { workspaceId: "org-1", collectionSlug: "freshdesk-support", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/freshdesk/connector.ts
+++ b/packages/api/src/lib/knowledge/freshdesk/connector.ts
@@ -63,7 +63,10 @@ export function createFreshdeskConnector(
           apiKey,
           collectionSlug: ctx.collectionSlug,
         },
-        deps.clientDeps ?? {},
+        // Bound the vendor fetch by the EFFECTIVE per-sync cap, not the raw
+        // platform ceiling — otherwise a lower-tier workspace pulls documents
+        // it can never ingest, every sync (#4235).
+        { ...(deps.clientDeps ?? {}), maxDocs: ctx.maxDocs },
       );
     },
   };

--- a/packages/api/src/lib/knowledge/front/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/front/__tests__/connector.test.ts
@@ -27,7 +27,7 @@ const VALID_CONFIG = {
 };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "front-support", config };
+  return { workspaceId: "org-1", collectionSlug: "front-support", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/front/connector.ts
+++ b/packages/api/src/lib/knowledge/front/connector.ts
@@ -61,7 +61,10 @@ export function createFrontConnector(
           apiToken,
           collectionSlug: ctx.collectionSlug,
         },
-        deps.clientDeps ?? {},
+        // Bound the vendor fetch by the EFFECTIVE per-sync cap, not the raw
+        // platform ceiling — otherwise a lower-tier workspace pulls documents
+        // it can never ingest, every sync (#4235).
+        { ...(deps.clientDeps ?? {}), maxDocs: ctx.maxDocs },
       );
     },
   };

--- a/packages/api/src/lib/knowledge/gitbook/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/gitbook/__tests__/connector.test.ts
@@ -24,7 +24,7 @@ const { GITBOOK_CATALOG_ID, GITBOOK_VENDOR } = await import("@atlas/api/lib/know
 const VALID_CONFIG = { space_id: "space-123" };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "gitbook-docs", config };
+  return { workspaceId: "org-1", collectionSlug: "gitbook-docs", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/gitbook/connector.ts
+++ b/packages/api/src/lib/knowledge/gitbook/connector.ts
@@ -57,7 +57,10 @@ export function createGitbookConnector(
           apiToken,
           collectionSlug: ctx.collectionSlug,
         },
-        deps.clientDeps ?? {},
+        // Bound the vendor fetch by the EFFECTIVE per-sync cap, not the raw
+        // platform ceiling — otherwise a lower-tier workspace pulls documents
+        // it can never ingest, every sync (#4235).
+        { ...(deps.clientDeps ?? {}), maxDocs: ctx.maxDocs },
       );
     },
   };

--- a/packages/api/src/lib/knowledge/helpscout/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/helpscout/__tests__/connector.test.ts
@@ -29,7 +29,7 @@ const { HELPSCOUT_CATALOG_ID, HELPSCOUT_VENDOR } = await import(
 const VALID_CONFIG = { site_id: "site-1", site_name: "Acme Docs", subdomain: "acme" };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "helpscout-acme", config };
+  return { workspaceId: "org-1", collectionSlug: "helpscout-acme", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/ingest-bundle.ts
+++ b/packages/api/src/lib/knowledge/ingest-bundle.ts
@@ -51,6 +51,7 @@ import {
   type IngestSource,
 } from "./ingest";
 import {
+  assertIngestCapsFor,
   resolveIngestCaps,
   type CapBoundBy,
   type EffectiveIngestCaps,
@@ -222,6 +223,9 @@ export async function ingestDocuments(
   // The bundle path already enforced the doc cap during streaming extraction;
   // document-level callers (connectors) get the SAME cap here so an oversized
   // vendor page is a counted per-file rejection, never an unbounded row.
+  // A caller-supplied cap object is the one place another tenant's plan limit
+  // could be applied here, so it is checked against this ingest's workspace.
+  if (params.caps) assertIngestCapsFor(params.caps, workspaceId);
   const caps = params.caps ?? (await resolveIngestCaps(workspaceId));
   const maxDocBytes = caps.maxDocBytes;
   const encoder = new TextEncoder();
@@ -341,6 +345,9 @@ export async function ingestDocuments(
 export async function ingestBundle(params: IngestBundleParams): Promise<IngestBundleOutcome> {
   const { workspaceId, collectionId, source, bytes } = params;
 
+  // A caller-supplied cap object is the one place another tenant's plan limit
+  // could be applied here, so it is checked against this ingest's workspace.
+  if (params.caps) assertIngestCapsFor(params.caps, workspaceId);
   const caps = params.caps ?? (await resolveIngestCaps(workspaceId));
   const { value: maxBundleBytes, boundBy } = caps.maxBundleBytes;
   if (bytes.length === 0) return { kind: "empty_bundle" };

--- a/packages/api/src/lib/knowledge/ingest-bundle.ts
+++ b/packages/api/src/lib/knowledge/ingest-bundle.ts
@@ -51,10 +51,10 @@ import {
   type IngestSource,
 } from "./ingest";
 import {
-  getIngestMaxBundleBytes,
-  getIngestMaxDocBytes,
-  getIngestMaxDocs,
-} from "./ingest-limits";
+  resolveIngestCaps,
+  type CapBoundBy,
+  type EffectiveIngestCaps,
+} from "@atlas/api/lib/billing/knowledge-limits";
 import { archiveCollectionDocuments, INSTALL_RECHECK_SQL } from "./collection-lifecycle";
 import { invalidateKnowledgeMirror } from "./mirror-invalidation";
 
@@ -85,6 +85,15 @@ export interface IngestBundleParams {
    * archive its previously-reviewed document.
    */
   readonly archiveAbsent?: boolean;
+  /**
+   * Pre-resolved effective caps (`min(platform ceiling, plan tier)`, #4235).
+   * Optional: when omitted the seam resolves them itself from `workspaceId`.
+   * Callers that already had to resolve them — the upload route, which caps the
+   * raw request body before it reads it, and `ingestBundle`, which caps bytes
+   * before handing files to the document seam — pass theirs so ONE tier lookup
+   * governs the whole ingest and the two stages can't disagree.
+   */
+  readonly caps?: EffectiveIngestCaps;
 }
 
 /** The document-level entry (#4376): already-extracted files → transaction. */
@@ -112,6 +121,15 @@ export interface IngestDocumentsParams {
    * previously-reviewed document.
    */
   readonly upstreamRejections?: readonly BundleEntryError[];
+  /**
+   * Pre-resolved effective caps (`min(platform ceiling, plan tier)`, #4235).
+   * Optional: when omitted the seam resolves them itself from `workspaceId`.
+   * Callers that already had to resolve them — the upload route, which caps the
+   * raw request body before it reads it, and `ingestBundle`, which caps bytes
+   * before handing files to the document seam — pass theirs so ONE tier lookup
+   * governs the whole ingest and the two stages can't disagree.
+   */
+  readonly caps?: EffectiveIngestCaps;
 }
 
 /**
@@ -136,6 +154,12 @@ export type IngestDocumentsFailure =
       readonly kind: "too_many_documents";
       readonly count: number;
       readonly maxDocs: number;
+      /**
+       * Which cap bound (#4235): `"tier"` means the workspace's plan — not the
+       * fleet-wide operator ceiling — refused the bundle, so the caller owes an
+       * upgrade prompt rather than a flat "too many documents".
+       */
+      readonly boundBy: CapBoundBy;
       readonly rejected: readonly BundleEntryError[];
     }
   | { readonly kind: "no_documents"; readonly rejected: readonly BundleEntryError[] };
@@ -144,7 +168,13 @@ export type IngestDocumentsFailure =
 export type IngestBundleFailure =
   | IngestDocumentsFailure
   | { readonly kind: "empty_bundle" }
-  | { readonly kind: "bundle_too_large"; readonly bytes: number; readonly maxBundleBytes: number }
+  | {
+      readonly kind: "bundle_too_large";
+      readonly bytes: number;
+      readonly maxBundleBytes: number;
+      /** See {@link IngestDocumentsFailure} `too_many_documents.boundBy` (#4235). */
+      readonly boundBy: CapBoundBy;
+    }
   | { readonly kind: "invalid_bundle"; readonly message: string };
 
 /** The successful-transaction shape shared by both entries. */
@@ -192,7 +222,8 @@ export async function ingestDocuments(
   // The bundle path already enforced the doc cap during streaming extraction;
   // document-level callers (connectors) get the SAME cap here so an oversized
   // vendor page is a counted per-file rejection, never an unbounded row.
-  const maxDocBytes = getIngestMaxDocBytes();
+  const caps = params.caps ?? (await resolveIngestCaps(workspaceId));
+  const maxDocBytes = caps.maxDocBytes;
   const encoder = new TextEncoder();
   const oversize: BundleEntryError[] = [];
   const eligible: InteropFile[] = [];
@@ -217,9 +248,9 @@ export async function ingestDocuments(
     ...parsed.errors,
   ];
 
-  const maxDocs = getIngestMaxDocs();
+  const { value: maxDocs, boundBy } = caps.maxDocs;
   if (parsed.docs.length > maxDocs) {
-    return { kind: "too_many_documents", count: parsed.docs.length, maxDocs, rejected };
+    return { kind: "too_many_documents", count: parsed.docs.length, maxDocs, boundBy, rejected };
   }
   if (parsed.docs.length === 0) {
     return { kind: "no_documents", rejected };
@@ -310,17 +341,18 @@ export async function ingestDocuments(
 export async function ingestBundle(params: IngestBundleParams): Promise<IngestBundleOutcome> {
   const { workspaceId, collectionId, source, bytes } = params;
 
-  const maxBundleBytes = getIngestMaxBundleBytes();
+  const caps = params.caps ?? (await resolveIngestCaps(workspaceId));
+  const { value: maxBundleBytes, boundBy } = caps.maxBundleBytes;
   if (bytes.length === 0) return { kind: "empty_bundle" };
   if (bytes.length > maxBundleBytes) {
-    return { kind: "bundle_too_large", bytes: bytes.length, maxBundleBytes };
+    return { kind: "bundle_too_large", bytes: bytes.length, maxBundleBytes, boundBy };
   }
 
   // ── Extract (in memory), then hand the files to the document seam ─────────
   let extracted: ExtractedBundle;
   try {
     extracted = extractBundle(bytes, {
-      maxDocBytes: getIngestMaxDocBytes(),
+      maxDocBytes: caps.maxDocBytes,
       maxTotalBytes: maxBundleBytes,
     });
   } catch (err) {
@@ -334,6 +366,7 @@ export async function ingestBundle(params: IngestBundleParams): Promise<IngestBu
     workspaceId,
     collectionId,
     source,
+    caps,
     files: extracted.files,
     publish: params.publish,
     archiveAbsent: params.archiveAbsent,

--- a/packages/api/src/lib/knowledge/ingest-limits.ts
+++ b/packages/api/src/lib/knowledge/ingest-limits.ts
@@ -1,11 +1,37 @@
 /**
- * Knowledge-ingest caps — resolved from the settings registry, NOT env vars
- * (ADR-0028 §5 "caps via the settings registry"; CLAUDE.md SaaS-first
- * configuration rule). A platform operator tunes these from the Admin console
- * without a redeploy; the three keys are declared platform-scoped in
- * `lib/settings.ts` (`ATLAS_KNOWLEDGE_INGEST_*`, operator-only —
- * `saasVisible: false`), so `getSettingAuto` resolves platform-override → env →
- * registry default and hot-reloads in SaaS mode.
+ * Knowledge-ingest caps — TWO tiers that compose, never replace each other.
+ *
+ * **Platform ceiling.** The `ATLAS_KNOWLEDGE_INGEST_*` settings-registry keys,
+ * NOT env vars (ADR-0028 §5 "caps via the settings registry"; CLAUDE.md
+ * SaaS-first configuration rule). A platform operator tunes these from the Admin
+ * console without a redeploy; the three keys are declared platform-scoped in
+ * `lib/settings.ts` (operator-only — `saasVisible: false`), so `getSettingAuto`
+ * resolves platform-override → env → default and hot-reloads in SaaS mode. This
+ * is the fleet-wide abuse guardrail, and on self-hosted it is the ONLY cap.
+ *
+ * **Plan tier.** `PlanLimits.maxKnowledgeBundleBytes` / `maxKnowledgeDocsPerBundle`
+ * (#4235) — the SaaS pricing lever. The effective cap an ingest enforces is
+ * `min(platform ceiling, tier limit)`, composed by `resolveIngestCaps` in
+ * `lib/billing/knowledge-limits.ts`. That composition deliberately lives on the
+ * BILLING side of the seam: this module is imported by the knowledge mirror and
+ * by every connector client, and pulling the billing stack (enforcement →
+ * metering → seat-count) in here would widen those modules' dependency graph —
+ * and break the partial `mock.module` shims their tests rely on — for a concern
+ * none of them have.
+ *
+ * The per-document byte cap has no tier field: it is an abuse guardrail on a
+ * single row, not a pricing lever, so {@link getIngestMaxDocBytes} stays
+ * platform-only.
+ *
+ * **Deploy-mode-aware defaults.** For the Business tier's values to be
+ * *reachable* on SaaS, the platform ceiling must sit at or above them — a 25 MB
+ * ceiling would silently clamp a 100 MB Business entitlement. So the two
+ * tier-composed keys carry NO static `default` in the registry (a static default
+ * shadows a downstream default in `getSetting`'s precedence — the same pattern
+ * `ATLAS_RATE_LIMIT_RPM` uses), and their fallback is applied here:
+ * {@link SAAS_CEILING} on SaaS, the shipped `DEFAULT_INGEST_*` constants
+ * everywhere else. Self-hosted behavior is therefore unchanged, and a SaaS
+ * operator can still tighten or widen the fleet with a single override.
  *
  * The registry stores every value as a string; each reader coerces to a
  * positive integer and clamps a garbage / non-positive override back to the
@@ -22,6 +48,7 @@ import {
   DEFAULT_INGEST_MAX_DOCS,
 } from "@atlas/okf-bundle/wire";
 import { getSettingAuto } from "@atlas/api/lib/settings";
+import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("knowledge.ingest-limits");
@@ -30,6 +57,18 @@ const log = createLogger("knowledge.ingest-limits");
 // builders validate against the SAME values at generation time. Re-exported
 // so this module remains the api-side home of the ingest-cap surface.
 export { DEFAULT_INGEST_MAX_DOCS, DEFAULT_INGEST_MAX_DOC_BYTES, DEFAULT_INGEST_MAX_BUNDLE_BYTES };
+
+/**
+ * The SaaS platform ceilings — deliberately equal to the **Business** tier's
+ * `PlanLimits` values (#4235), so the top plan is reachable and every lower
+ * plan is bound by its own tier limit rather than by a fleet-wide clamp. Raise
+ * these (or set a platform override) only alongside a matching `plans.ts` move;
+ * a ceiling BELOW a tier limit silently downgrades what that tier was sold.
+ */
+const SAAS_CEILING = {
+  maxDocs: 5_000,
+  maxBundleBytes: 100_000_000,
+} as const;
 
 /**
  * Coerce a settings string to a positive int, falling back to `fallback`. An
@@ -57,16 +96,24 @@ export function positiveIntSetting(key: string, raw: string | undefined, fallbac
   return fallback;
 }
 
-/** Max number of concept documents a single bundle may ingest. */
+/**
+ * Max number of concept documents a single bundle may ingest — the PLATFORM
+ * ceiling. Prefer `resolveIngestCaps` (billing/knowledge-limits.ts), which
+ * composes this with the workspace's tier limit; this raw reader is for callers
+ * with no workspace in hand (e.g. a connector client's fetch bound).
+ */
 export function getIngestMaxDocs(): number {
   return positiveIntSetting(
     "ATLAS_KNOWLEDGE_INGEST_MAX_DOCS",
     getSettingAuto("ATLAS_KNOWLEDGE_INGEST_MAX_DOCS"),
-    DEFAULT_INGEST_MAX_DOCS,
+    resolveDeployMode() === "saas" ? SAAS_CEILING.maxDocs : DEFAULT_INGEST_MAX_DOCS,
   );
 }
 
-/** Max decoded size of any single document in a bundle (bytes). */
+/**
+ * Max decoded size of any single document in a bundle (bytes). Platform-only by
+ * design — an abuse guardrail on one row, not a pricing lever (#4235).
+ */
 export function getIngestMaxDocBytes(): number {
   return positiveIntSetting(
     "ATLAS_KNOWLEDGE_INGEST_MAX_DOC_BYTES",
@@ -76,15 +123,17 @@ export function getIngestMaxDocBytes(): number {
 }
 
 /**
- * Max raw upload size of the whole bundle (bytes). The route enforces it against
- * the raw request body (the first line of defense); it is ALSO passed as the
- * decoded-total cap that the streaming extractor uses to abort a decompression
- * bomb mid-inflate (the second).
+ * Max raw upload size of the whole bundle (bytes) — the PLATFORM ceiling. The
+ * route enforces the *effective* cap against the raw request body (the first
+ * line of defense); it is ALSO passed as the decoded-total cap that the
+ * streaming extractor uses to abort a decompression bomb mid-inflate (the
+ * second). Prefer `resolveIngestCaps` (billing/knowledge-limits.ts) where a
+ * workspace is known.
  */
 export function getIngestMaxBundleBytes(): number {
   return positiveIntSetting(
     "ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES",
     getSettingAuto("ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES"),
-    DEFAULT_INGEST_MAX_BUNDLE_BYTES,
+    resolveDeployMode() === "saas" ? SAAS_CEILING.maxBundleBytes : DEFAULT_INGEST_MAX_BUNDLE_BYTES,
   );
 }

--- a/packages/api/src/lib/knowledge/ingest-limits.ts
+++ b/packages/api/src/lib/knowledge/ingest-limits.ts
@@ -14,10 +14,10 @@
  * `min(platform ceiling, tier limit)`, composed by `resolveIngestCaps` in
  * `lib/billing/knowledge-limits.ts`. That composition deliberately lives on the
  * BILLING side of the seam: this module is imported by the knowledge mirror and
- * by every connector client, and pulling the billing stack (enforcement →
- * metering → seat-count) in here would widen those modules' dependency graph —
- * and break the partial `mock.module` shims their tests rely on — for a concern
- * none of them have.
+ * by the connector clients that bound their own fetch, and pulling the billing
+ * stack (enforcement → metering → seat-count) in here would widen those
+ * modules' dependency graph — and break the partial `mock.module` shims their
+ * tests rely on — for a concern none of them have.
  *
  * The per-document byte cap has no tier field: it is an abuse guardrail on a
  * single row, not a pricing lever, so {@link getIngestMaxDocBytes} stays

--- a/packages/api/src/lib/knowledge/intercom/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/intercom/__tests__/connector.test.ts
@@ -22,7 +22,7 @@ const { createIntercomConnector } = await import("@atlas/api/lib/knowledge/inter
 const { INTERCOM_CATALOG_ID, INTERCOM_VENDOR } = await import("@atlas/api/lib/knowledge/intercom/config");
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "intercom-docs", config };
+  return { workspaceId: "org-1", collectionSlug: "intercom-docs", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/knowledge/intercom/connector.ts
+++ b/packages/api/src/lib/knowledge/intercom/connector.ts
@@ -54,7 +54,10 @@ export function createIntercomConnector(
           apiToken,
           collectionSlug: ctx.collectionSlug,
         },
-        deps.clientDeps ?? {},
+        // Bound the vendor fetch by the EFFECTIVE per-sync cap, not the raw
+        // platform ceiling — otherwise a lower-tier workspace pulls documents
+        // it can never ingest, every sync (#4235).
+        { ...(deps.clientDeps ?? {}), maxDocs: ctx.maxDocs },
       );
     },
   };

--- a/packages/api/src/lib/knowledge/notion/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/notion/__tests__/connector.test.ts
@@ -48,7 +48,7 @@ describe("registerNotionKnowledgeConnector", () => {
 });
 
 describe("notionKnowledgeConnector.createClient", () => {
-  const ctx = { workspaceId: "ws1", collectionSlug: "notion", config: null };
+  const ctx = { workspaceId: "ws1", collectionSlug: "notion", config: null, maxDocs: 1000 };
 
   it("builds a NotionVendorClient from the stored integration token", async () => {
     const built = await notionKnowledgeConnector.createClient(ctx);

--- a/packages/api/src/lib/knowledge/notion/connector.ts
+++ b/packages/api/src/lib/knowledge/notion/connector.ts
@@ -45,7 +45,13 @@ async function createNotionClient(ctx: ConnectorInstallContext): Promise<Connect
       "This Notion collection has no integration token stored — re-install it with a valid internal-integration token (Admin → Integrations → Notion).",
     );
   }
-  return new NotionVendorClient({ http: new NotionHttpClient({ token }) });
+  // Bound the vendor fetch by the EFFECTIVE per-sync cap, not the raw platform
+  // ceiling — otherwise a lower-tier workspace pulls documents it can never
+  // ingest, every sync (#4235).
+  return new NotionVendorClient({
+    http: new NotionHttpClient({ token }),
+    maxDocs: ctx.maxDocs,
+  });
 }
 
 /** The registered connector for the built-in Notion knowledge catalog row. */

--- a/packages/api/src/lib/knowledge/salesforce/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/salesforce/__tests__/connector.test.ts
@@ -52,7 +52,7 @@ function loaderReturning(result: SalesforcePluginInstance | (() => never)): Sale
 }
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: WSID, collectionSlug: "sf-kb", config };
+  return { workspaceId: WSID, collectionSlug: "sf-kb", config, maxDocs: 1000 };
 }
 
 describe("createSalesforceKnowledgeConnector", () => {

--- a/packages/api/src/lib/knowledge/sync.ts
+++ b/packages/api/src/lib/knowledge/sync.ts
@@ -63,7 +63,12 @@ import type { BundleEntryError } from "./bundle-archive";
 import { readBodyWithCap, BodyCapExceededError } from "./read-body-cap";
 import type { IngestReport } from "./ingest";
 import { ingestBundle } from "./ingest-bundle";
-import { getIngestMaxBundleBytes, positiveIntSetting } from "./ingest-limits";
+import { positiveIntSetting } from "./ingest-limits";
+import {
+  resolveIngestCaps,
+  type CapBoundBy,
+  type EffectiveIngestCaps,
+} from "@atlas/api/lib/billing/knowledge-limits";
 import { readSyncCredential } from "./sync-credentials";
 import {
   getKnowledgeSyncConnector,
@@ -77,6 +82,16 @@ import {
 } from "@atlas/api/lib/integrations/install/bundle-sync-form-handler";
 
 const log = createLogger("knowledge.sync");
+
+/**
+ * Name the side that actually refused, so a sync-state error line points a
+ * workspace admin at the right lever (#4235): their plan, or the operator's
+ * fleet-wide setting. A sync surfaces a status row, not an HTTP response, so
+ * there is no upgrade envelope here — only honest wording.
+ */
+function capOwner(boundBy: CapBoundBy): string {
+  return boundBy === "tier" ? "limit on your plan" : "limit";
+}
 
 export const DEFAULT_SYNC_FETCH_TIMEOUT_SECONDS = 60;
 
@@ -271,7 +286,15 @@ async function runSyncAttempt(params: SyncCollectionParams): Promise<SyncAttempt
   }
 
   // ── Fetch (SSRF-guarded, time-budgeted, size-capped) ─────────────────────
-  const maxBundleBytes = getIngestMaxBundleBytes();
+  // The download cap is the workspace's EFFECTIVE cap — `min(platform ceiling,
+  // plan tier)` (#4235) — so a synced collection can't pull past what an upload
+  // of the same size would be refused. Resolved once and handed to
+  // `ingestBundle` below so both stages agree. A tier-lookup fault throws
+  // (`check_failed`); it is deliberately NOT caught here — `syncCollection`'s
+  // outer net records it as an error state, so the failure is surfaced once
+  // with its own message rather than reworded into a cap error it isn't.
+  const caps: EffectiveIngestCaps = await resolveIngestCaps(workspaceId);
+  const maxBundleBytes = caps.maxBundleBytes.value;
   const timeoutMs = getKnowledgeSyncFetchTimeoutMs();
   const host = hostForLog(endpointUrl);
 
@@ -293,7 +316,7 @@ async function runSyncAttempt(params: SyncCollectionParams): Promise<SyncAttempt
     if (Number.isFinite(declared) && declared > maxBundleBytes) {
       return {
         kind: "error",
-        error: `Bundle from "${host}" declares ${declared} bytes, over the ${maxBundleBytes}-byte limit.`,
+        error: `Bundle from "${host}" declares ${declared} bytes, over the ${maxBundleBytes}-byte ${capOwner(caps.maxBundleBytes.boundBy)}.`,
         rejected: [],
       };
     }
@@ -312,7 +335,7 @@ async function runSyncAttempt(params: SyncCollectionParams): Promise<SyncAttempt
     if (err instanceof BodyCapExceededError) {
       return {
         kind: "error",
-        error: `Bundle from "${host}" exceeds the ${maxBundleBytes}-byte limit — download aborted.`,
+        error: `Bundle from "${host}" exceeds the ${maxBundleBytes}-byte ${capOwner(caps.maxBundleBytes.boundBy)} — download aborted.`,
         rejected: [],
       };
     }
@@ -343,6 +366,7 @@ async function runSyncAttempt(params: SyncCollectionParams): Promise<SyncAttempt
   let outcome: Awaited<ReturnType<typeof ingestBundle>>;
   try {
     outcome = await ingestBundle({
+      caps,
       workspaceId,
       collectionId: collectionSlug,
       source: "bundle-sync",
@@ -398,7 +422,7 @@ async function runSyncAttempt(params: SyncCollectionParams): Promise<SyncAttempt
       // stream — but the seam reports it, so map it.
       return {
         kind: "error",
-        error: `Bundle from "${host}" is ${outcome.bytes} bytes, over the ${outcome.maxBundleBytes}-byte limit.`,
+        error: `Bundle from "${host}" is ${outcome.bytes} bytes, over the ${outcome.maxBundleBytes}-byte ${capOwner(outcome.boundBy)}.`,
         rejected: [],
       };
     case "invalid_bundle":
@@ -406,7 +430,7 @@ async function runSyncAttempt(params: SyncCollectionParams): Promise<SyncAttempt
     case "too_many_documents":
       return {
         kind: "error",
-        error: `Bundle has ${outcome.count} documents, over the ${outcome.maxDocs}-document limit.`,
+        error: `Bundle has ${outcome.count} documents, over the ${outcome.maxDocs}-document ${capOwner(outcome.boundBy)}.`,
         rejected: outcome.rejected,
       };
     case "no_documents":

--- a/packages/api/src/lib/knowledge/sync.ts
+++ b/packages/api/src/lib/knowledge/sync.ts
@@ -65,6 +65,7 @@ import type { IngestReport } from "./ingest";
 import { ingestBundle } from "./ingest-bundle";
 import { positiveIntSetting } from "./ingest-limits";
 import {
+  capIsOperatorTunable,
   resolveIngestCaps,
   type CapBoundBy,
   type EffectiveIngestCaps,
@@ -84,13 +85,14 @@ import {
 const log = createLogger("knowledge.sync");
 
 /**
- * Name the side that actually refused, so a sync-state error line points a
- * workspace admin at the right lever (#4235): their plan, or the operator's
- * fleet-wide setting. A sync surfaces a status row, not an HTTP response, so
- * there is no upgrade envelope here — only honest wording.
+ * Name the lever a sync-state error line should point at (#4235). A sync
+ * surfaces a status row, not an HTTP response, so there is no upgrade envelope
+ * here — only honest wording. `capIsOperatorTunable` is the shared rule: the
+ * plain "limit" wording is reserved for the operator-tunable case, because on
+ * SaaS even a platform-bound refusal is a plan ceiling to the reader.
  */
 function capOwner(boundBy: CapBoundBy): string {
-  return boundBy === "tier" ? "limit on your plan" : "limit";
+  return capIsOperatorTunable(boundBy) ? "limit" : "limit on your plan";
 }
 
 export const DEFAULT_SYNC_FETCH_TIMEOUT_SECONDS = 60;

--- a/packages/api/src/lib/knowledge/zendesk/__tests__/connector.test.ts
+++ b/packages/api/src/lib/knowledge/zendesk/__tests__/connector.test.ts
@@ -33,7 +33,7 @@ const VALID_CONFIG = {
 };
 
 function ctx(config: Record<string, unknown> | null) {
-  return { workspaceId: "org-1", collectionSlug: "zendesk-acme", config };
+  return { workspaceId: "org-1", collectionSlug: "zendesk-acme", config, maxDocs: 1000 };
 }
 
 afterEach(() => {

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -1607,14 +1607,19 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
   // Knowledge Base — OKF bundle ingest caps (#4207, ADR-0028 §5). Platform-
   // scoped operator knobs, read at ingest by `lib/knowledge/ingest-limits.ts`.
   // Registry-backed (not env) so a SaaS operator tunes them without a redeploy.
+  //
+  // The two tier-composed keys (docs, bundle bytes) deliberately carry NO static
+  // `default` (#4235): a static default would shadow the deploy-mode-aware
+  // fallback `ingest-limits.ts` applies — self-hosted keeps the shipped 1000 /
+  // 25 MB, SaaS raises the ceiling to the Business tier's 5000 / 100 MB so that
+  // entitlement is reachable. Same pattern as `ATLAS_RATE_LIMIT_RPM`.
   {
     key: "ATLAS_KNOWLEDGE_INGEST_MAX_DOCS",
     section: "Knowledge Base",
     label: "Ingest Max Documents",
     description:
-      "Maximum number of documents a single knowledge bundle may ingest (default 1000; non-positive values fall back to the default).",
+      "Maximum number of documents a single knowledge bundle may ingest. Unset defaults to 1000 self-hosted and 5000 on Atlas Cloud (the Business-tier ceiling); non-positive values fall back to that default. On Atlas Cloud each workspace is additionally capped by its plan tier — the effective limit is the smaller of the two.",
     type: "number",
-    default: "1000",
     envVar: "ATLAS_KNOWLEDGE_INGEST_MAX_DOCS",
     scope: "platform",
     saasVisible: false,
@@ -1636,9 +1641,8 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     section: "Knowledge Base",
     label: "Ingest Max Bundle Size (bytes)",
     description:
-      "Maximum raw upload size of a knowledge bundle (default 25000000 / 25 MB); also reused as the decoded-total cap that aborts a decompression bomb mid-inflate during extraction.",
+      "Maximum raw upload size of a knowledge bundle. Unset defaults to 25000000 (25 MB) self-hosted and 100000000 (100 MB) on Atlas Cloud (the Business-tier ceiling). Also reused as the decoded-total cap that aborts a decompression bomb mid-inflate during extraction. On Atlas Cloud each workspace is additionally capped by its plan tier — the effective limit is the smaller of the two.",
     type: "number",
-    default: "25000000",
     envVar: "ATLAS_KNOWLEDGE_INGEST_MAX_BUNDLE_BYTES",
     scope: "platform",
     saasVisible: false,

--- a/packages/schemas/src/__tests__/billing.test.ts
+++ b/packages/schemas/src/__tests__/billing.test.ts
@@ -25,6 +25,7 @@ const validStatus = {
     maxSeats: 10,
     maxConnections: 1,
     maxChatIntegrations: 1,
+    maxKnowledgeCollections: 1,
   },
   usage: {
     queryCount: 423,
@@ -58,6 +59,7 @@ const selfHostedStatus = {
     maxSeats: null,
     maxConnections: null,
     maxChatIntegrations: null,
+    maxKnowledgeCollections: null,
   },
   seats: { count: 1, max: null },
   connections: { count: 0, max: null },

--- a/packages/schemas/src/billing.ts
+++ b/packages/schemas/src/billing.ts
@@ -117,6 +117,14 @@ export interface BillingLimits {
    * billing page can display the cap alongside seats / connections (#3438).
    */
   maxChatIntegrations: number | null;
+  /**
+   * Max Knowledge Base collections the workspace may hold (null = unlimited).
+   * Enforced server-side by `checkKnowledgeCollectionLimitAndInstall` via
+   * `PlanLimits.maxKnowledgeCollections` (#4235); surfaced here for the same
+   * reason as the sibling caps — a customer should be able to SEE the limit
+   * their next install will hit, not only discover it from a 403.
+   */
+  maxKnowledgeCollections: number | null;
 }
 
 /** Current-period usage counters. */
@@ -270,6 +278,7 @@ export const BillingLimitsSchema = z.object({
   maxSeats: z.number().nullable(),
   maxConnections: z.number().nullable(),
   maxChatIntegrations: z.number().nullable(),
+  maxKnowledgeCollections: z.number().nullable(),
 }) satisfies z.ZodType<BillingLimits>;
 
 export const BillingUsageSchema = z.object({

--- a/packages/web/src/app/admin/billing/__tests__/model-row-workspace-seam.test.tsx
+++ b/packages/web/src/app/admin/billing/__tests__/model-row-workspace-seam.test.tsx
@@ -119,6 +119,7 @@ function makeBillingData(overrides: { byot: boolean }): BillingStatus {
       maxSeats: 10,
       maxConnections: 1,
       maxChatIntegrations: 1,
+      maxKnowledgeCollections: 1,
     },
     usage: {
       queryCount: 10,


### PR DESCRIPTION
## Summary

KB ingest caps shipped platform-scoped only (`ATLAS_KNOWLEDGE_INGEST_*`), so on SaaS the only lever for an enterprise customer's 100 MB knowledge base was raising the cap for **every** tenant in the region. KB size is storage + prompt-token cost — a natural billing lever. This makes it one.

`PlanLimits` now carries three KB fields (maintainer-approved matrix), enforced as `min(platform ceiling, tier limit)`:

| Limit | Trial / Starter | Pro | Business | Free (self-hosted) | Locked |
|---|---|---|---|---|---|
| Max collections / workspace | 1 | 3 | unlimited | unlimited | 0 |
| Max bundle bytes / ingest | 10 MB | 25 MB | 100 MB | unlimited | 0 |
| Max docs / bundle | 250 | 1,000 | 5,000 | unlimited | 0 |

- **Collections** gate atomically at install (`checkKnowledgeCollectionLimitAndInstall`, the advisory-locked check-and-UPSERT), with a batch variant for the fan-out connectors (Zendesk-per-brand etc.) so an over-cap fan-out is refused before any row/credential is written. The chat-integration gate's lock/recount/decide engine is now shared (`capGatedInstall`/`capPrecheck`), so the caps can't drift.
- **Bundle bytes / doc count** gate at the one ingest seam (`ingestBundle`/`ingestDocuments`), covering upload, bundle-sync, and every connector. A **tier**-bound refusal returns the standard `403 plan_upgrade_required` envelope naming a real upgrade target; a **platform**-bound one stays a plain 400.
- The 12 knowledge form handlers lose their duplicated slug-guard + upsert + RETURNING-id blocks to two shared gates.
- Platform ceilings for the two tier-composed keys become deploy-mode-aware (self-hosted 1000 / 25 MB **unchanged**; SaaS 5000 / 100 MB — the Business values — so the top tier is reachable), following the `ATLAS_RATE_LIMIT_RPM` no-static-default pattern.
- Per-doc bytes (1 MB) stays platform-only — an abuse guardrail, not a lever. Self-hosted (`free` = unlimited) behavior is unchanged.
- `maxKnowledgeCollections` surfaced on the billing wire so a customer can see the cap, not only hit a 403.

Two internal review-panel rounds (silent-failure / type-design / test-coverage / comment) drove fixes to a SaaS `free`-tier fail-open, a fabricated-plan-name upgrade prompt, a tagged-error-flattening 500 in the four fan-out handlers, and a cross-tenant caps hazard.

## Test plan
- [x] `bun run type` / `bun run lint` / `bun run lint:type-aware` — green
- [x] Full `scripts/ci-local.sh` gate battery — 30/30 non-test gates green
- [x] Unit: `knowledge-limits`, `knowledge-collection-install`, `retryable-install-error`, `plans` (matrix + monotonicity), `settings` (load-bearing absent defaults), `ingest-limits` (deploy-mode ceilings + SAAS_CEILING ≥ Business parity)
- [x] Real-Postgres (`knowledge-cap-pg`): both count aggregates, the fan-out net-new formula + re-install carve-out, the advisory-lock race, locked/trial/free tiers — all green in isolation
- [x] Route: 403/503 dispositions, self-hosted bypass, streamed-body path, fail-closed on lookup fault
- [x] All 12 handler suites + a source-level gate-wiring guard (mutation-verified)
- [ ] Real CI sharded `api-tests` exercise the `-pg` suites against Postgres (local full-suite `-pg` failures are the known WSL2 contention flake; all pass in isolation)

Closes #4235