### PR TITLE
fix(api): cap parser-fed inputs — validate-sql sql + admin yamlContent (#4780)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -10846,7 +10846,8 @@
                 "properties": {
                   "sql": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 100000
                   },
                   "connectionId": {
                     "type": "string"
@@ -67152,7 +67153,8 @@
                 "type": "object",
                 "properties": {
                   "yamlContent": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 256000
                   },
                   "entityType": {
                     "type": "string"

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -3278,6 +3278,39 @@ describe("PUT /api/v1/admin/semantic/org/entities/:name", () => {
     }));
     expect(res.status).toBe(400);
   });
+
+  it("returns 422 for yamlContent over the max length bound (#4780 — YAML parse DoS cap)", async () => {
+    setOrgAdmin("org-1");
+    // Prior tests in this block exercise the draft-upsert path; reset so the
+    // "never persisted" assertion below is about THIS request only.
+    mockUpsertDraftEntityAdmin.mockReset();
+    // An over-cap `yamlContent` is rejected at the request schema BEFORE it ever
+    // reaches the js-yaml parser or the draft upsert — the missing byte ceiling
+    // that let a 3 MB body persist on staging.
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/org/entities/users", "PUT", {
+      yamlContent: `table: users\n${"a".repeat(256_001)}`,
+    }));
+    expect(res.status).toBe(422);
+    // Short-circuited at validation — the persistence path never ran.
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("accepts yamlContent at exactly the max length bound (#4780 — cap is inclusive)", async () => {
+    setOrgAdmin("org-1");
+    mockUpsertDraftEntityAdmin.mockReset();
+    mockUpsertDraftEntityAdmin.mockResolvedValue(undefined);
+    // Boundary guard: valid entity YAML sized to EXACTLY the ceiling must pass
+    // the schema and reach the handler (catches an off-by-one that made the
+    // bound stricter than intended). Pad with a YAML comment js-yaml ignores.
+    const cap = 256_000; // mirrors MAX_ENTITY_YAML_LEN in admin.ts
+    const prefix = "table: users\n# ";
+    const yamlContent = prefix + "a".repeat(cap - prefix.length);
+    expect(yamlContent).toHaveLength(cap);
+    const res = await app.fetch(adminRequest("/api/v1/admin/semantic/org/entities/users", "PUT", { yamlContent }));
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("DELETE /api/v1/admin/semantic/org/entities/:name", () => {

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -527,6 +527,9 @@ void mock.module("@atlas/api/lib/tools/sql", () => ({
   parserDatabase: mock(() => "PostgreSQL"),
   executeSQL: {},
   runUserQueryPipeline: mockRunUserQueryPipeline,
+  // A route in this app's graph statically imports the shared SQL cap for its
+  // request schema (#4780); mirror the real value so that import resolves.
+  MAX_SQL_LEN: 100_000,
 }));
 
 void mock.module("@atlas/api/lib/auth/detect", () => ({

--- a/packages/api/src/api/__tests__/validate-sql.test.ts
+++ b/packages/api/src/api/__tests__/validate-sql.test.ts
@@ -68,6 +68,9 @@ void mock.module("@atlas/api/lib/tools/sql", () => ({
   validateSQL: mockValidateSQL,
   parserDatabase: mockParserDatabase,
   executeSQL: {},
+  // The route statically imports this cap for its request schema (#4780);
+  // mirror the real value so the schema constructs with a real `.max()` bound.
+  MAX_SQL_LEN: 100_000,
 }));
 
 const mockTableList: Mock<(sql: string, opts?: unknown) => string[]> = mock(
@@ -335,6 +338,27 @@ describe("POST /api/v1/validate-sql", () => {
 
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.error).toBe("validation_error");
+  });
+
+  it("returns 422 for sql over the max length bound (#4780 — parse DoS cap)", async () => {
+    // Mirror the execute-sql cap: an over-cap `sql` is rejected at the request
+    // schema BEFORE it ever reaches validateSQL / the node-sql-parser event loop.
+    const response = await app.fetch(makeRequest({ sql: `SELECT ${"a".repeat(100_001)}` }));
+    expect(response.status).toBe(422);
+
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.error).toBe("validation_error");
+    // Short-circuited at validation — the parser pipeline never ran.
+    expect(mockValidateSQL).not.toHaveBeenCalled();
+  });
+
+  it("accepts sql at exactly the max length bound (#4780 — cap is inclusive)", async () => {
+    // Boundary guard: a payload AT the ceiling must pass the schema (catches an
+    // off-by-one that made the bound stricter than intended). No leading/trailing
+    // whitespace so `.trim()` leaves the length at exactly the cap.
+    const response = await app.fetch(makeRequest({ sql: "a".repeat(100_000) }));
+    expect(response.status).toBe(200);
+    expect(mockValidateSQL).toHaveBeenCalledTimes(1);
   });
 
   it("preserves schema qualifier for non-null schemas", async () => {

--- a/packages/api/src/api/routes/__tests__/execute-sql.test.ts
+++ b/packages/api/src/api/routes/__tests__/execute-sql.test.ts
@@ -169,6 +169,9 @@ void mock.module("@atlas/api/lib/tools/sql", () => ({
   parserDatabase: () => "PostgresQL",
   extractClassification: () => ({ tablesAccessed: [], columnsAccessed: [] }),
   buildSqlExecuteSpanAttrs: () => ({}),
+  // The route statically imports this cap for its request schema (#4780);
+  // mirror the real value so the schema constructs with a real `.max()` bound.
+  MAX_SQL_LEN: 100_000,
 }));
 
 const { executeSql } = await import("../execute-sql");

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -1085,6 +1085,18 @@ const getOrgEntityRoute = createRoute({
   },
 });
 
+/**
+ * Upper bound on a raw entity-YAML upload. Generous for any realistic semantic
+ * entity (a large entity with many dimensions/measures is a few tens of KB)
+ * while capping the payload a hostile admin can force through the js-yaml
+ * parser on the API event loop (#4780) — staging accepted a 3 MB body before
+ * this cap. The handler loads this string with `js-yaml`'s default `load`
+ * options, which impose no input-size or depth limit, so this char ceiling is
+ * the only pre-parse size guard. Enforced at the request schema, before the
+ * parse.
+ */
+const MAX_ENTITY_YAML_LEN = 256_000;
+
 const putOrgEntityRoute = createRoute({
   method: "put",
   path: "/semantic/org/entities/{name}",
@@ -1099,7 +1111,9 @@ const putOrgEntityRoute = createRoute({
       content: {
         "application/json": {
           schema: z.object({
-            yamlContent: z.string(),
+            yamlContent: z
+              .string()
+              .max(MAX_ENTITY_YAML_LEN, `yamlContent must be at most ${MAX_ENTITY_YAML_LEN} characters`),
             entityType: z.string().optional(),
             connectionId: z.string().optional(),
           }),

--- a/packages/api/src/api/routes/execute-sql.ts
+++ b/packages/api/src/api/routes/execute-sql.ts
@@ -79,18 +79,16 @@ import {
 } from "@atlas/api/lib/mcp/action-policy";
 import type { ExecuteSqlRestResponse } from "@useatlas/types";
 import type { UserQueryOutcome } from "@atlas/api/lib/tools/sql";
+import { MAX_SQL_LEN } from "@atlas/api/lib/tools/sql";
 import { validationHook } from "./validation-hook";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 
 const log = createLogger("execute-sql-route");
 
-/**
- * Upper bound on a single SQL string. Generous for any realistic analytical
- * SELECT (deep CTE stacks, long IN lists) while capping the payload a hostile
- * client can force through the parser. Tunable if a real need surfaces.
- */
-const MAX_SQL_LEN = 100_000;
+// The `MAX_SQL_LEN` parser cap is shared with `validate-sql` from
+// `lib/tools/sql.ts` (the parse entrypoint it guards) so the two sibling
+// endpoints can't drift (#4780).
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/packages/api/src/api/routes/validate-sql.ts
+++ b/packages/api/src/api/routes/validate-sql.ts
@@ -15,7 +15,7 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { Parser } from "node-sql-parser";
 import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
-import { validateSQL, parserDatabase } from "@atlas/api/lib/tools/sql";
+import { validateSQL, parserDatabase, MAX_SQL_LEN } from "@atlas/api/lib/tools/sql";
 import { connections, detectDBType, ConnectionNotRegisteredError } from "@atlas/api/lib/db/connection";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
@@ -24,7 +24,14 @@ const log = createLogger("validate-sql");
 const parser = new Parser();
 
 export const ValidateSQLRequestSchema = z.object({
-  sql: z.string().trim().min(1, "sql must not be empty"),
+  // Cap the caller-authored SQL at the same ceiling `execute-sql` enforces
+  // (shared `MAX_SQL_LEN`): both feed the same `node-sql-parser` on the API
+  // event loop, so an unbounded string here is a parse-time DoS lever (#4780).
+  sql: z
+    .string()
+    .trim()
+    .min(1, "sql must not be empty")
+    .max(MAX_SQL_LEN, `sql must be at most ${MAX_SQL_LEN} characters`),
   connectionId: z.string().optional(),
 });
 

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -154,6 +154,17 @@ function warnWhitelistDisabled() {
 
 const parser = new Parser();
 
+/**
+ * Upper bound on a single SQL string fed to the parser. Generous for any
+ * realistic analytical SELECT (deep CTE stacks, long IN lists) while capping
+ * the payload a hostile client can force through `node-sql-parser` on the API
+ * event loop (#4780). Every route that parses caller-authored SQL — both
+ * `execute-sql` and `validate-sql` — enforces this same ceiling at its request
+ * schema, so the cap can't drift between the two sibling endpoints. Tunable if
+ * a real need surfaces.
+ */
+export const MAX_SQL_LEN = 100_000;
+
 // ── Parse-once seam (#4349) ─────────────────────────────────────────
 //
 // The validate-then-execute path used to parse the same query string ~5–6


### PR DESCRIPTION
## Summary

Closes two authenticated DoS levers surfaced by the #3351 live pass — unbounded inputs that reach a parser on the API event loop. Pure input-bound hardening; no behavior change for legitimate inputs.

- **`POST /api/v1/validate-sql`** accepted a 2 MB `sql` body (no cap) while its sibling `execute-sql` capped at 100k — both feed the same `node-sql-parser`. Hoisted `MAX_SQL_LEN` into `lib/tools/sql.ts` (the parse entrypoint it guards) and imported it into **both** routes so the caps can't drift, then added `.max()` to `validate-sql`'s request schema.
- **`PUT /api/v1/admin/semantic/org/entities/{name}`** accepted a 3 MB `yamlContent` string (js-yaml default `load`, no size/depth limit). Added a 256k-char `.max()` ceiling on the request-body schema — enforced before the parse.
- Regenerated `apps/docs/openapi.json` for the two new `maxLength` bounds.

## Test plan
- [x] `validate-sql`: over-cap `sql` → 422 (parser never called); at-cap → accepted
- [x] admin `yamlContent`: over-cap → 422 (persistence never called); at-cap (exactly 256k) → accepted
- [x] Existing `execute-sql` cap test still green (shared constant)
- [x] Mock-all-exports: added `MAX_SQL_LEN` to the three `lib/tools/sql` mocks whose graph imports it
- [x] `/ci` local: all gates green (type, lint, test suite, openapi-drift)

Closes #4780