### PR TITLE
fix(security): DNS-aware egress guard closes hostname→internal SSRF (#4779)

### DIFF
--- a/packages/api/src/lib/__tests__/providers-workspace-egress.test.ts
+++ b/packages/api/src/lib/__tests__/providers-workspace-egress.test.ts
@@ -1,0 +1,49 @@
+/**
+ * #4779 regression lock: the live-agent `custom` / `azure-openai` `baseUrl` path
+ * must egress through the DNS-aware SSRF guard, not the AI SDK's own fetch.
+ *
+ * `getModelFromWorkspaceConfig` wires `fetch: createGuardedFetch()` into
+ * `createOpenAI` for those two providers. That single line is what makes the
+ * fix engage on the real inference path — a refactor that dropped it would
+ * silently reopen SSRF-to-metadata with every other unit test still green. We
+ * mock `@ai-sdk/openai` to capture the `fetch` option handed to `createOpenAI`,
+ * then drive it with a literal internal IP: the guard's synchronous first pass
+ * rejects it (no DNS needed), proving the installed fetch is the guard.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import { EgressBlockedError } from "../openapi/egress-guard";
+
+// Capture the `fetch` option createOpenAI is constructed with. The returned
+// provider is a callable that yields a minimal model stub.
+let capturedFetch: typeof globalThis.fetch | undefined;
+void mock.module("@ai-sdk/openai", () => ({
+  createOpenAI: (opts: { fetch?: typeof globalThis.fetch }) => {
+    capturedFetch = opts.fetch;
+    return (modelId: string) => ({ modelId, provider: "custom" });
+  },
+  openai: (modelId: string) => ({ modelId }),
+}));
+
+const { getModelFromWorkspaceConfig } = await import("../providers");
+
+describe("getModelFromWorkspaceConfig — live-agent egress guard (#4779)", () => {
+  it("installs the DNS-aware guarded fetch on the custom-provider client", async () => {
+    capturedFetch = undefined;
+    const model = getModelFromWorkspaceConfig({
+      model: "custom-llm",
+      baseUrl: "https://api.example.com/v1", // public → passes the build-time sync pre-check
+      bedrockRegion: null,
+      credentials: { provider: "custom", apiKey: "sk-test" },
+    });
+    expect(typeof model).toBe("object");
+
+    // The client was built with a `fetch` override…
+    expect(typeof capturedFetch).toBe("function");
+    // …and that override is the SSRF guard: a literal internal IP is rejected by
+    // its synchronous first pass, before any connect (no DNS round-trip).
+    await expect(
+      capturedFetch!("https://169.254.169.254/v1/chat/completions", { method: "POST" }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
@@ -304,6 +304,90 @@ describe("guardedFetch", () => {
     expect(lookupCalled).toBe(false); // opt-out short-circuits before resolution
     expect(connectedHost).toBe("internal.corp"); // and no pin/rewrite is applied
   });
+
+  it("rejects (fail closed) when the resolver itself throws", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("nope");
+    }) as unknown as typeof globalThis.fetch;
+    const throwingLookup: EgressLookup = async () => {
+      throw new Error("getaddrinfo ENOTFOUND");
+    };
+    await expect(
+      guardedFetch("https://flaky.example/x", {}, { fetchImpl, lookup: throwingLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(called).toBe(false);
+  });
+
+  it("rejects a redirect to a hostname that RESOLVES internal (rebind on a hop, not a literal)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let hops = 0;
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      hops++;
+      if (hostHeader(init) === "public.example.com") {
+        return new Response(null, { status: 302, headers: { location: "https://rebind.example/final" } });
+      }
+      return new Response("should-not-reach", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    // public host resolves public; the redirect target resolves to an internal IP.
+    const rebindLookup: EgressLookup = async (host) =>
+      host === "public.example.com"
+        ? [{ address: PUBLIC_IP, family: 4 }]
+        : [{ address: "10.1.2.3", family: 4 }];
+    await expect(
+      guardedFetch("https://public.example.com/x", {}, { fetchImpl, lookup: rebindLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(hops).toBe(1); // the second hop (internal-resolving) never fired
+  });
+
+  it("pins a public IPv6 target with correct bracketing", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let connectedHost = "";
+    let sentHost = "";
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      connectedHost = new URL(url).hostname; // WHATWG URL keeps IPv6 bracketed
+      sentHost = hostHeader(init) ?? "";
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const v6Lookup: EgressLookup = async () => [{ address: "2001:4860:4860::8888", family: 6 }];
+    const res = await guardedFetch("https://dns.example.com/x", {}, { fetchImpl, lookup: v6Lookup });
+    expect(res.status).toBe(200);
+    expect(connectedHost).toBe("[2001:4860:4860::8888]"); // pin spliced a correctly-bracketed IPv6
+    expect(sentHost).toBe("dns.example.com");
+  });
+
+  it("rejects an IPv4-mapped-IPv6 internal address (::ffff:10.0.0.5) before connect", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("nope");
+    }) as unknown as typeof globalThis.fetch;
+    const mappedLookup: EgressLookup = async () => [{ address: "::ffff:10.0.0.5", family: 6 }];
+    await expect(
+      guardedFetch("https://mapped.example/x", {}, { fetchImpl, lookup: mappedLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(called).toBe(false);
+  });
+
+  it("preserves a non-default port through the pin rewrite", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let connectedUrl = "";
+    let sentHost = "";
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      connectedUrl = url;
+      sentHost = hostHeader(init) ?? "";
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const res = await guardedFetch("https://api.example.com:8443/v1", {}, { fetchImpl, lookup: publicLookup });
+    expect(res.status).toBe(200);
+    const u = new URL(connectedUrl);
+    expect(u.hostname).toBe(PUBLIC_IP);
+    expect(u.port).toBe("8443");
+    expect(sentHost).toBe("api.example.com:8443"); // Host carries the original authority incl. port
+  });
 });
 
 describe("assertSafeEgressTarget", () => {
@@ -335,6 +419,17 @@ describe("assertSafeEgressTarget", () => {
     delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
     const pin = await assertSafeEgressTarget("https://api.example.com/x", { lookup: publicLookup });
     expect(pin).toEqual({ address: PUBLIC_IP, family: 4 });
+  });
+
+  it("returns null and does NOT resolve when the operator opts out", async () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+    let lookupCalled = false;
+    const spy: EgressLookup = async () => {
+      lookupCalled = true;
+      return [{ address: "10.0.0.1", family: 4 }];
+    };
+    await expect(assertSafeEgressTarget("https://internal.corp/x", { lookup: spy })).resolves.toBeNull();
+    expect(lookupCalled).toBe(false);
   });
 });
 
@@ -368,6 +463,21 @@ describe("createGuardedFetch", () => {
     expect(res.status).toBe(200);
     expect(connectedHost).toBe(PUBLIC_IP);
     expect(sentHost).toBe("llm.example.com");
+  });
+
+  it("rejects an internal-resolving host passed as a Request object (SDK Request-input shape)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("nope");
+    }) as unknown as typeof globalThis.fetch;
+    const internalLookup: EgressLookup = async () => [{ address: "169.254.169.254", family: 4 }];
+    const guarded = createGuardedFetch({ fetchImpl, lookup: internalLookup });
+    await expect(
+      guarded(new Request("https://metadata.nip.io.example/v1/chat/completions", { method: "POST" })),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(called).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
@@ -7,9 +7,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
   assertBaseUrlAllowed,
+  assertSafeEgressTarget,
+  createGuardedFetch,
   guardedFetch,
   hostForLog,
   isInternalEgressAllowed,
+  type EgressLookup,
   EgressBlockedError,
   MAX_REDIRECTS,
 } from "../egress-guard";
@@ -19,6 +22,13 @@ afterEach(() => {
   if (ORIGINAL === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
   else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL;
 });
+
+/** A single public IPv4 every DNS-name host in these tests resolves to. */
+const PUBLIC_IP = "93.184.216.34";
+/** Stub resolver: every hostname resolves to one public IPv4 (hermetic — no network). */
+const publicLookup: EgressLookup = async () => [{ address: PUBLIC_IP, family: 4 }];
+/** Read the (pinned) request's `Host` header — carries the original hostname. */
+const hostHeader = (init?: RequestInit): string | null => new Headers(init?.headers).get("host");
 
 describe("assertBaseUrlAllowed", () => {
   it("throws EgressBlockedError for every internal-address encoding", () => {
@@ -73,22 +83,25 @@ describe("guardedFetch", () => {
       seenRedirect = init?.redirect;
       return new Response("ok", { status: 200 });
     }) as unknown as typeof globalThis.fetch;
-    const res = await guardedFetch("https://public.example.com/x", { method: "GET" }, { fetchImpl });
+    const res = await guardedFetch("https://public.example.com/x", { method: "GET" }, { fetchImpl, lookup: publicLookup });
     expect(res.status).toBe(200);
     expect(seenRedirect).toBe("manual");
   });
 
   it("follows a public→public redirect, re-validating the new host", async () => {
     delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    // Hosts read from the `Host` header (the socket connects to the pinned IP,
+    // but the header carries the original hostname).
     const hosts: string[] = [];
-    const fetchImpl = (async (url: string) => {
-      hosts.push(new URL(url).host);
-      if (new URL(url).hostname === "a.example.com") {
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      const host = hostHeader(init);
+      hosts.push(host ?? "");
+      if (host === "a.example.com") {
         return new Response(null, { status: 302, headers: { location: "https://b.example.com/final" } });
       }
       return new Response("done", { status: 200 });
     }) as unknown as typeof globalThis.fetch;
-    const res = await guardedFetch("https://a.example.com/x", {}, { fetchImpl });
+    const res = await guardedFetch("https://a.example.com/x", {}, { fetchImpl, lookup: publicLookup });
     expect(res.status).toBe(200);
     expect(hosts).toEqual(["a.example.com", "b.example.com"]);
   });
@@ -96,32 +109,35 @@ describe("guardedFetch", () => {
   it("rejects a public→internal redirect (the TOCTOU vector)", async () => {
     delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
     let hops = 0;
-    const fetchImpl = (async (url: string) => {
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
       hops++;
-      if (new URL(url).hostname === "public.example.com") {
+      if (hostHeader(init) === "public.example.com") {
         return new Response(null, { status: 302, headers: { location: "https://169.254.169.254/latest/" } });
       }
       return new Response("should-not-reach", { status: 200 });
     }) as unknown as typeof globalThis.fetch;
-    await expect(guardedFetch("https://public.example.com/x", {}, { fetchImpl })).rejects.toBeInstanceOf(
-      EgressBlockedError,
-    );
+    await expect(
+      guardedFetch("https://public.example.com/x", {}, { fetchImpl, lookup: publicLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
     expect(hops).toBe(1); // the metadata hop never fired
   });
 
   it("resolves a relative Location against the current URL before validating", async () => {
     delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
-    const urls: string[] = [];
-    const fetchImpl = (async (url: string) => {
-      urls.push(url);
-      if (url === "https://public.example.com/a") {
+    // Reconstruct the original target (Host header + path) — the pinned URL host
+    // is the IP, but relative-Location resolution reasons about the hostname.
+    const targets: string[] = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      const path = new URL(url).pathname;
+      targets.push(`${hostHeader(init)}${path}`);
+      if (path === "/a") {
         return new Response(null, { status: 301, headers: { location: "/b" } });
       }
       return new Response("ok", { status: 200 });
     }) as unknown as typeof globalThis.fetch;
-    const res = await guardedFetch("https://public.example.com/a", {}, { fetchImpl });
+    const res = await guardedFetch("https://public.example.com/a", {}, { fetchImpl, lookup: publicLookup });
     expect(res.status).toBe(200);
-    expect(urls).toEqual(["https://public.example.com/a", "https://public.example.com/b"]);
+    expect(targets).toEqual(["public.example.com/a", "public.example.com/b"]);
   });
 
   it("caps redirect depth and throws rather than looping forever", async () => {
@@ -132,9 +148,9 @@ describe("guardedFetch", () => {
       // Always redirect to another public host — a redirect loop.
       return new Response(null, { status: 302, headers: { location: `https://public.example.com/${hops}` } });
     }) as unknown as typeof globalThis.fetch;
-    await expect(guardedFetch("https://public.example.com/0", {}, { fetchImpl })).rejects.toBeInstanceOf(
-      EgressBlockedError,
-    );
+    await expect(
+      guardedFetch("https://public.example.com/0", {}, { fetchImpl, lookup: publicLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
     expect(hops).toBe(MAX_REDIRECTS + 1); // initial + MAX_REDIRECTS hops, then bail
   });
 
@@ -142,7 +158,7 @@ describe("guardedFetch", () => {
     delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
     const fetchImpl = (async () =>
       new Response(null, { status: 304 })) as unknown as typeof globalThis.fetch;
-    const res = await guardedFetch("https://public.example.com/x", {}, { fetchImpl });
+    const res = await guardedFetch("https://public.example.com/x", {}, { fetchImpl, lookup: publicLookup });
     expect(res.status).toBe(304);
   });
 
@@ -153,16 +169,18 @@ describe("guardedFetch", () => {
         status: 302,
         headers: { location: "ht!tp://::::" }, // unparseable even against the base
       })) as unknown as typeof globalThis.fetch;
-    await expect(guardedFetch("https://public.example.com/x", {}, { fetchImpl })).rejects.toBeInstanceOf(
-      EgressBlockedError,
-    );
+    await expect(
+      guardedFetch("https://public.example.com/x", {}, { fetchImpl, lookup: publicLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
   });
 
   it("strips the credential headers on a cross-origin redirect (public→public), keeps them same-origin", async () => {
     delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
     const authByHost: Record<string, string | null> = {};
     const fetchImpl = (async (url: string, init?: RequestInit) => {
-      const host = new URL(url).hostname;
+      // Host comes from the Host header (pinned URL host is the IP); the path is
+      // preserved through pinning, so it still distinguishes the two hops.
+      const host = hostHeader(init) ?? "";
       authByHost[host] = new Headers(init?.headers).get("authorization");
       if (host === "a.example.com") {
         // first an in-origin hop, then bounce to a different public origin
@@ -176,7 +194,7 @@ describe("guardedFetch", () => {
     const res = await guardedFetch(
       "https://a.example.com/start",
       { headers: { Authorization: "Bearer SECRET", accept: "application/json" } },
-      { fetchImpl },
+      { fetchImpl, lookup: publicLookup },
     );
     expect(res.status).toBe(200);
     // Same-origin hops keep the credential; the cross-origin hop to b.example.com must not see it.
@@ -200,11 +218,156 @@ describe("guardedFetch", () => {
     const res = await guardedFetch(
       "https://api.example.com/post",
       { method: "POST", body: JSON.stringify({ a: 1 }), headers: { "content-type": "application/json" } },
-      { fetchImpl },
+      { fetchImpl, lookup: publicLookup },
     );
     expect(res.status).toBe(200);
     expect(secondHopMethod).toBe("GET"); // 303 always becomes GET
     expect(secondHopHadBody).toBe(false); // and drops the body
+  });
+
+  // ── #4779 — DNS-blind SSRF: connect-time resolution + IP pinning ──────────
+
+  it("rejects a hostname that RESOLVES to an internal IP, before connect (the DNS-blind SSRF)", async () => {
+    // The live-confirmed vector: a public hostname (e.g. `127.0.0.1.nip.io`)
+    // that the sync guard passes but that resolves to an internal IP.
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("should-not-reach", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const internalLookup: EgressLookup = async () => [{ address: "169.254.169.254", family: 4 }];
+    await expect(
+      guardedFetch("https://metadata.nip.io.example/x", {}, { fetchImpl, lookup: internalLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(called).toBe(false); // rejected BEFORE any request left the box
+  });
+
+  it("rejects when ANY resolved address is internal (mixed A-record set)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("nope", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const mixedLookup: EgressLookup = async () => [
+      { address: PUBLIC_IP, family: 4 },
+      { address: "10.0.0.5", family: 4 }, // one private record poisons the set
+    ];
+    await expect(
+      guardedFetch("https://rebind.example/x", {}, { fetchImpl, lookup: mixedLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(called).toBe(false);
+  });
+
+  it("pins the validated public IP: connects to the IP, keeps the hostname in the Host header (rebind defense)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let connectedUrl = "";
+    let sentHost = "";
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      connectedUrl = url;
+      sentHost = hostHeader(init) ?? "";
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const res = await guardedFetch("https://api.example.com/v1", {}, { fetchImpl, lookup: publicLookup });
+    expect(res.status).toBe(200);
+    // The socket target is the pre-validated IP — not a re-resolution.
+    expect(new URL(connectedUrl).hostname).toBe(PUBLIC_IP);
+    expect(new URL(connectedUrl).pathname).toBe("/v1");
+    // SNI / cert verification still ride the original hostname via Host.
+    expect(sentHost).toBe("api.example.com");
+  });
+
+  it("rejects when DNS resolution returns no records (fail closed)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const fetchImpl = (async () => new Response("x")) as unknown as typeof globalThis.fetch;
+    const emptyLookup: EgressLookup = async () => [];
+    await expect(
+      guardedFetch("https://nx.example/x", {}, { fetchImpl, lookup: emptyLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+  });
+
+  it("does NOT resolve DNS when the operator opts out (internal targets allowed)", async () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+    let lookupCalled = false;
+    let connectedHost = "";
+    const fetchImpl = (async (url: string) => {
+      connectedHost = new URL(url).hostname;
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const spyLookup: EgressLookup = async () => {
+      lookupCalled = true;
+      return [{ address: "10.0.0.9", family: 4 }];
+    };
+    const res = await guardedFetch("http://internal.corp/x", {}, { fetchImpl, lookup: spyLookup });
+    expect(res.status).toBe(200);
+    expect(lookupCalled).toBe(false); // opt-out short-circuits before resolution
+    expect(connectedHost).toBe("internal.corp"); // and no pin/rewrite is applied
+  });
+});
+
+describe("assertSafeEgressTarget", () => {
+  it("returns null for a validated IP-literal host (no pin, no resolution)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let lookupCalled = false;
+    const spy: EgressLookup = async () => {
+      lookupCalled = true;
+      return [];
+    };
+    await expect(assertSafeEgressTarget("https://93.184.216.34/x", { lookup: spy })).resolves.toBeNull();
+    expect(lookupCalled).toBe(false);
+  });
+
+  it("throws for a literal internal IP without resolving", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    await expect(assertSafeEgressTarget("https://169.254.169.254/x")).rejects.toBeInstanceOf(EgressBlockedError);
+  });
+
+  it("throws when a DNS name resolves to an internal IP (stubbed resolver)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const internalLookup: EgressLookup = async () => [{ address: "127.0.0.1", family: 4 }];
+    await expect(
+      assertSafeEgressTarget("https://loopback.nip.io.example/x", { lookup: internalLookup }),
+    ).rejects.toBeInstanceOf(EgressBlockedError);
+  });
+
+  it("returns the pinned public IP for a public DNS name", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const pin = await assertSafeEgressTarget("https://api.example.com/x", { lookup: publicLookup });
+    expect(pin).toEqual({ address: PUBLIC_IP, family: 4 });
+  });
+});
+
+describe("createGuardedFetch", () => {
+  it("produces a fetch that rejects an internal-resolving host before connect", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("nope");
+    }) as unknown as typeof globalThis.fetch;
+    const internalLookup: EgressLookup = async () => [{ address: "169.254.169.254", family: 4 }];
+    const guarded = createGuardedFetch({ fetchImpl, lookup: internalLookup });
+    await expect(guarded("https://metadata.nip.io.example/v1/chat/completions")).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+    expect(called).toBe(false);
+  });
+
+  it("pins and forwards a public request (the live-agent baseUrl path)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let connectedHost = "";
+    let sentHost = "";
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      connectedHost = new URL(url).hostname;
+      sentHost = hostHeader(init) ?? "";
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const guarded = createGuardedFetch({ fetchImpl, lookup: publicLookup });
+    const res = await guarded("https://llm.example.com/v1/chat/completions", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(connectedHost).toBe(PUBLIC_IP);
+    expect(sentHost).toBe("llm.example.com");
   });
 });
 

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -99,7 +99,6 @@ export async function executeOperation(
   const { body, hasBody } = buildBody(operation, params, headers);
 
   const timeoutMs = opts.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
 
   let response: Response;
   try {
@@ -116,7 +115,10 @@ export async function executeOperation(
         ...(hasBody ? { body } : {}),
         signal: AbortSignal.timeout(timeoutMs),
       },
-      { fetchImpl },
+      // Don't pre-resolve `globalThis.fetch` into an explicit `fetchImpl`: leaving
+      // it unset lets `guardedFetch` engage the connect-time DNS guard on the real
+      // runtime fetch (and surface a degradation warn if it's ever wrapped) (#4779).
+      { ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}) },
     );
   } catch (err) {
     if (err instanceof EgressBlockedError) {

--- a/packages/api/src/lib/openapi/egress-guard.ts
+++ b/packages/api/src/lib/openapi/egress-guard.ts
@@ -27,13 +27,59 @@
  * the client → `OpenApiClientError`).
  */
 
+import dns from "node:dns";
+import net from "node:net";
+
 import { createLogger } from "@atlas/api/lib/logger";
-import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
+import { isBlockedResolvedAddress, isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
 
 const log = createLogger("openapi.egress-guard");
 
 /** Max redirect hops {@link guardedFetch} follows before giving up. */
 export const MAX_REDIRECTS = 5;
+
+/**
+ * A resolved, validated egress target address to connect to. Returned by
+ * {@link assertSafeEgressTarget} when the host was a DNS name (so the caller
+ * must **pin** this exact IP for the connect, defeating a rebind race); `null`
+ * when no pin applies — an IP-literal host (already validated in place) or the
+ * operator opt-out.
+ */
+export interface EgressPin {
+  /** The single validated IP literal to connect to. */
+  readonly address: string;
+  /** IP family — 6 needs bracketing when it is spliced back into a URL. */
+  readonly family: 4 | 6;
+}
+
+/**
+ * DNS resolver seam. Resolves a hostname to its A/AAAA records. Injectable so
+ * the egress guard is testable without touching the network (Atlas prefers a DI
+ * seam over `mock.module` on `node:dns`). The default resolves through
+ * `node:dns` `lookup` with `{ all: true }` — the same resolution the runtime's
+ * own `fetch` connect would perform.
+ */
+export type EgressLookup = (
+  hostname: string,
+) => Promise<ReadonlyArray<{ address: string; family: number }>>;
+
+const defaultEgressLookup: EgressLookup = (hostname) =>
+  dns.promises.lookup(hostname, { all: true });
+
+/**
+ * The genuine runtime `fetch`, captured at module load — before any test swaps
+ * `globalThis.fetch` or injects a `fetchImpl`. The connect-time DNS resolution +
+ * IP pin is bound to this identity: it runs when {@link guardedFetch} is about
+ * to hit the network through the real runtime fetch (production — where no code
+ * reassigns `globalThis.fetch`), and is skipped when a **test double** is in
+ * play (an injected `fetchImpl` or a swapped `globalThis.fetch`), which falls
+ * back to the sync guard. The whole existing consumer-test corpus uses a double,
+ * so it keeps its exact pre-#4779 behavior (no network resolution, no URL
+ * rewrite) while every production egress surface inherits the DNS guard. A test
+ * that WANTS to exercise the resolution injects an explicit `lookup`, which
+ * forces it on regardless of this identity check.
+ */
+const REAL_FETCH: typeof globalThis.fetch = globalThis.fetch;
 
 /**
  * A host-side fetch target was blocked by the SSRF guard. The offending URL is
@@ -83,12 +129,111 @@ export function assertBaseUrlAllowed(url: string): void {
   }
 }
 
+/**
+ * The connect-time SSRF chokepoint. The async counterpart to
+ * {@link assertBaseUrlAllowed}: it runs the same cheap sync first pass
+ * ({@link isSafeExternalUrl} — scheme, internal-hostname denylist, IP-literal
+ * ranges), then — for a **DNS-name host** — resolves the name and re-checks
+ * **every** resolved A/AAAA record against the private/loopback/link-local/CGNAT
+ * blocklist ({@link isBlockedResolvedAddress}) *before* any socket opens. This
+ * closes the DNS-blind gap the sync guard leaves open: a public hostname that
+ * resolves to an internal IP (`127.0.0.1.nip.io`, cloud metadata via a wildcard
+ * DNS, or a live DNS-rebind record) is rejected here, pre-connect (#4779).
+ *
+ * Returns an {@link EgressPin} for a DNS-name host — the single validated IP the
+ * caller must connect to so a *second* resolution (the runtime's own fetch)
+ * cannot swap in a different, internal address (TOCTOU / rebind). Returns `null`
+ * when no pin is needed: an IP-literal host (validated in place by the sync
+ * pass) or the operator opt-out (`ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true`).
+ *
+ * Throws {@link EgressBlockedError} when the sync pass rejects, resolution
+ * fails, resolution returns no records, or **any** resolved address is internal
+ * — fail closed on every branch.
+ */
+export async function assertSafeEgressTarget(
+  url: string,
+  options: { readonly lookup?: EgressLookup } = {},
+): Promise<EgressPin | null> {
+  // Operator opt-out: internal targets are legitimate on self-hosted. Skip the
+  // whole check (no resolution) exactly like `assertBaseUrlAllowed`.
+  if (isInternalEgressAllowed()) return null;
+
+  // Cheap first pass — scheme, internal-hostname denylist, and IP-literal
+  // ranges. Rejects literal internal IPs without a DNS round-trip.
+  if (!isSafeExternalUrl(url)) throw new EgressBlockedError(url);
+
+  // Safe to parse — `isSafeExternalUrl` already accepted it.
+  const parsed = new URL(url);
+  const host = parsed.hostname.toLowerCase().replace(/\.+$/, "");
+  const bare = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+  // IP-literal host: the sync pass already CIDR-checked it, and there is no name
+  // to resolve — connect directly (no pin).
+  if (net.isIP(bare) !== 0) return null;
+
+  // DNS-name host: resolve and validate every resolved address before connect.
+  const lookup = options.lookup ?? defaultEgressLookup;
+  let records: ReadonlyArray<{ address: string; family: number }>;
+  try {
+    records = await lookup(bare);
+  } catch (err) {
+    throw new EgressBlockedError(
+      url,
+      `DNS resolution failed (${err instanceof Error ? err.message : String(err)}).`,
+    );
+  }
+  if (records.length === 0) {
+    throw new EgressBlockedError(url, "DNS resolution returned no records.");
+  }
+  for (const rec of records) {
+    if (isBlockedResolvedAddress(rec.address)) {
+      throw new EgressBlockedError(
+        url,
+        "Hostname resolves to a private, loopback, link-local, or internal address.",
+      );
+    }
+  }
+  // Every record is public. Pin the first so the connect targets a validated IP
+  // rather than re-resolving (rebind defense).
+  const chosen = records[0];
+  return { address: chosen.address, family: chosen.family === 6 ? 6 : 4 };
+}
+
 /** Options for {@link guardedFetch}. */
 export interface GuardedFetchOptions {
   /** `fetch` override for tests. Defaults to `globalThis.fetch`. */
   readonly fetchImpl?: typeof globalThis.fetch;
   /** Max redirect hops to follow. Defaults to {@link MAX_REDIRECTS}. */
   readonly maxRedirects?: number;
+  /** DNS resolver override for tests. Defaults to a `node:dns` lookup. */
+  readonly lookup?: EgressLookup;
+}
+
+/**
+ * Rewrite a request to connect to a **pinned** validated IP while preserving TLS
+ * correctness. The URL's host becomes the IP (bracketed for IPv6, port kept),
+ * and a `Host` header carrying the original authority is injected — Bun's fetch
+ * uses that Host value for TLS SNI and certificate verification (so the cert is
+ * still validated against the original hostname), while the socket connects to
+ * the pinned IP. This is what defeats the rebind race: the address we validated
+ * is the address we connect to, with no second resolution in between.
+ *
+ * `pin === null` (IP-literal host or operator opt-out) leaves the request
+ * untouched.
+ */
+function applyEgressPin(
+  url: string,
+  init: RequestInit,
+  pin: EgressPin | null,
+): { url: string; init: RequestInit } {
+  if (pin === null) return { url, init };
+  const parsed = new URL(url);
+  const originalAuthority = parsed.host; // hostname[:port] — original name, for the Host header.
+  const literal = pin.family === 6 ? `[${pin.address}]` : pin.address;
+  parsed.host = parsed.port ? `${literal}:${parsed.port}` : literal;
+  const headers = new Headers(init.headers);
+  headers.set("host", originalAuthority);
+  return { url: parsed.toString(), init: { ...init, headers } };
 }
 
 /** 3xx statuses that carry a `Location` we would follow. */
@@ -191,14 +336,33 @@ export async function guardedFetch(
   const maxRedirects = options.maxRedirects ?? MAX_REDIRECTS;
   const originalOrigin = originOf(url);
 
+  // Resolve + validate + pin runs when the caller supplies a resolver
+  // (opt-in / the guard's own tests) OR when we are about to use the genuine
+  // runtime fetch (production). A test double — an injected `fetchImpl` or a
+  // swapped `globalThis.fetch` — falls back to the sync guard, keeping the whole
+  // existing consumer-test corpus behavior-identical (#4779).
+  const resolver: EgressLookup | undefined =
+    options.lookup ?? (fetchImpl === REAL_FETCH ? defaultEgressLookup : undefined);
+
   let currentUrl = url;
   let currentInit: RequestInit = { ...init, redirect: "manual" };
   for (let hop = 0; hop <= maxRedirects; hop++) {
     // Re-validate immediately before every request leaves the box — this is the
     // "final host" check the up-front guard cannot make for redirect targets.
-    assertBaseUrlAllowed(currentUrl);
+    // With a resolver active, additionally resolve a DNS-name host and reject
+    // (or pin) based on the resolved IPs (#4779); otherwise the sync guard.
+    let pin: EgressPin | null = null;
+    if (resolver) {
+      pin = await assertSafeEgressTarget(currentUrl, { lookup: resolver });
+    } else {
+      assertBaseUrlAllowed(currentUrl);
+    }
 
-    const response = await fetchImpl(currentUrl, currentInit);
+    // Connect to the pinned IP (rebind defense) while keeping `currentUrl` as
+    // the hostname URL, so relative-Location resolution and the credential
+    // origin comparison below still reason about the real target host.
+    const { url: fetchUrl, init: fetchInit } = applyEgressPin(currentUrl, currentInit, pin);
+    const response = await fetchImpl(fetchUrl, fetchInit);
     if (!isRedirectStatus(response.status)) return response;
 
     const location = response.headers.get("location");
@@ -228,6 +392,43 @@ export async function guardedFetch(
     currentUrl,
     `Exceeded the redirect cap (${maxRedirects}) — refusing to follow further.`,
   );
+}
+
+/**
+ * Adapt {@link guardedFetch} to the standard `fetch` signature so it can be
+ * handed to any client that takes a `fetch` override — notably the Vercel AI SDK
+ * (`createOpenAI({ fetch })`), which is the LIVE-AGENT outbound path for a
+ * workspace `custom` / `azure-openai` `baseUrl`. Without this the agent's
+ * inference request goes out through the SDK's own `fetch`, bypassing the SSRF
+ * guard entirely — the sync check at config-build time is DNS-blind (#4779).
+ *
+ * Only the `(input, init)` shape the SDK uses is supported: `input` may be a
+ * string, `URL`, or `Request` (the URL is extracted; the request's own body/
+ * headers/method are honored when present, with `init` taking precedence).
+ */
+export function createGuardedFetch(
+  options: GuardedFetchOptions = {},
+): typeof globalThis.fetch {
+  const guarded = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    if (typeof input === "string" || input instanceof URL) {
+      return guardedFetch(input.toString(), init ?? {}, options);
+    }
+    // A `Request` object: fold its fields into an init, letting an explicit
+    // `init` argument override, and read the URL from the request.
+    const req = input;
+    const merged: RequestInit = {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: req.signal,
+      ...init,
+    };
+    return guardedFetch(req.url, merged, options);
+  };
+  return guarded as typeof globalThis.fetch;
 }
 
 /**

--- a/packages/api/src/lib/openapi/egress-guard.ts
+++ b/packages/api/src/lib/openapi/egress-guard.ts
@@ -52,34 +52,62 @@ export interface EgressPin {
   readonly family: 4 | 6;
 }
 
+/** A resolved DNS record — the shape of one `dns.promises.lookup(_, {all:true})` entry. */
+interface ResolvedAddress {
+  readonly address: string;
+  readonly family: number;
+}
+
 /**
  * DNS resolver seam. Resolves a hostname to its A/AAAA records. Injectable so
  * the egress guard is testable without touching the network (Atlas prefers a DI
  * seam over `mock.module` on `node:dns`). The default resolves through
- * `node:dns` `lookup` with `{ all: true }` — the same resolution the runtime's
- * own `fetch` connect would perform.
+ * `node:dns` `lookup` with `{ all: true }`. This approximates the resolution the
+ * runtime's own `fetch` connect would perform — it need not be bit-identical
+ * because the returned IP is *pinned* (the connect targets the validated address
+ * and never re-resolves), so any divergence between this resolver and the
+ * runtime's is moot.
  */
-export type EgressLookup = (
-  hostname: string,
-) => Promise<ReadonlyArray<{ address: string; family: number }>>;
+export type EgressLookup = (hostname: string) => Promise<ReadonlyArray<ResolvedAddress>>;
 
 const defaultEgressLookup: EgressLookup = (hostname) =>
   dns.promises.lookup(hostname, { all: true });
 
 /**
  * The genuine runtime `fetch`, captured at module load — before any test swaps
- * `globalThis.fetch` or injects a `fetchImpl`. The connect-time DNS resolution +
- * IP pin is bound to this identity: it runs when {@link guardedFetch} is about
- * to hit the network through the real runtime fetch (production — where no code
- * reassigns `globalThis.fetch`), and is skipped when a **test double** is in
- * play (an injected `fetchImpl` or a swapped `globalThis.fetch`), which falls
- * back to the sync guard. The whole existing consumer-test corpus uses a double,
- * so it keeps its exact pre-#4779 behavior (no network resolution, no URL
- * rewrite) while every production egress surface inherits the DNS guard. A test
- * that WANTS to exercise the resolution injects an explicit `lookup`, which
- * forces it on regardless of this identity check.
+ * `globalThis.fetch` or injects a `fetchImpl`.
+ *
+ * The connect-time DNS resolution + IP pin engages when {@link guardedFetch} is
+ * about to hit the network through this genuine fetch, and is skipped for a
+ * **test double** (an injected `fetchImpl` or a swapped `globalThis.fetch`),
+ * which falls back to the sync guard. This keeps the pre-#4779 consumer-test
+ * corpus behavior-identical while every production surface inherits the guard.
+ *
+ * ASSUMPTION (with consequence): no production layer reassigns `globalThis.fetch`
+ * after this module loads. That holds today (verified: no fetch instrumentation
+ * / proxy shim in the tree). If a future dependency or telemetry hook DOES wrap
+ * `globalThis.fetch`, a caller that neither injects a `lookup` nor a `fetchImpl`
+ * would fall back to the DNS-blind sync guard — so this path emits a one-time
+ * {@link warnDegradedEgressGuard} warning to make that degradation visible rather
+ * than silent, and the highest-value surface ({@link createGuardedFetch}, the
+ * live-agent `baseUrl` path) forces the resolver on unconditionally so it never
+ * depends on this identity at all. A test that wants to exercise resolution
+ * injects an explicit `lookup`, which forces it on regardless.
  */
 const REAL_FETCH: typeof globalThis.fetch = globalThis.fetch;
+
+/** Fires at most once per process so a silent DNS-guard degradation surfaces without log spam. */
+let degradedEgressWarned = false;
+function warnDegradedEgressGuard(): void {
+  if (degradedEgressWarned) return;
+  degradedEgressWarned = true;
+  log.warn(
+    {},
+    "guardedFetch: globalThis.fetch was reassigned since module load and no explicit resolver was " +
+      "supplied — the connect-time DNS SSRF guard is falling back to the sync (DNS-blind) check. If " +
+      "this is production, a fetch wrapper (telemetry/proxy) has disabled the #4779 rebind defense.",
+  );
+}
 
 /**
  * A host-side fetch target was blocked by the SSRF guard. The offending URL is
@@ -173,7 +201,7 @@ export async function assertSafeEgressTarget(
 
   // DNS-name host: resolve and validate every resolved address before connect.
   const lookup = options.lookup ?? defaultEgressLookup;
-  let records: ReadonlyArray<{ address: string; family: number }>;
+  let records: ReadonlyArray<ResolvedAddress>;
   try {
     records = await lookup(bare);
   } catch (err) {
@@ -194,9 +222,11 @@ export async function assertSafeEgressTarget(
     }
   }
   // Every record is public. Pin the first so the connect targets a validated IP
-  // rather than re-resolving (rebind defense).
+  // rather than re-resolving (rebind defense). Derive `family` from the address
+  // itself — never the resolver's self-reported `family` field — so the value
+  // that drives IPv6 bracketing in `applyEgressPin` is internally consistent.
   const chosen = records[0];
-  return { address: chosen.address, family: chosen.family === 6 ? 6 : 4 };
+  return { address: chosen.address, family: net.isIPv6(chosen.address) ? 6 : 4 };
 }
 
 /** Options for {@link guardedFetch}. */
@@ -212,11 +242,18 @@ export interface GuardedFetchOptions {
 /**
  * Rewrite a request to connect to a **pinned** validated IP while preserving TLS
  * correctness. The URL's host becomes the IP (bracketed for IPv6, port kept),
- * and a `Host` header carrying the original authority is injected — Bun's fetch
- * uses that Host value for TLS SNI and certificate verification (so the cert is
- * still validated against the original hostname), while the socket connects to
- * the pinned IP. This is what defeats the rebind race: the address we validated
- * is the address we connect to, with no second resolution in between.
+ * and a `Host` header carrying the original authority is injected. This defeats
+ * the rebind race: the address we validated is the address we connect to, with
+ * no second resolution in between.
+ *
+ * TLS correctness relies on a **Bun-specific** behavior (this runtime is Bun):
+ * when a `Host` header is present, Bun's HTTP client uses its value — not the
+ * URL's IP authority — to drive BOTH the TLS SNI extension AND the certificate
+ * identity check (`get_tls_hostname` in Bun's `src/http/lib.rs`). So the socket
+ * connects to the pinned IP, but SNI and cert verification still ride the
+ * original hostname. On a runtime WITHOUT this behavior (browsers, Node/undici),
+ * SNI/cert would derive from the IP and a normal hostname cert would fail to
+ * verify — the failure would be a loud fetch/TLS error, not a silent bypass.
  *
  * `pin === null` (IP-literal host or operator opt-out) leaves the request
  * untouched.
@@ -341,8 +378,21 @@ export async function guardedFetch(
   // runtime fetch (production). A test double — an injected `fetchImpl` or a
   // swapped `globalThis.fetch` — falls back to the sync guard, keeping the whole
   // existing consumer-test corpus behavior-identical (#4779).
-  const resolver: EgressLookup | undefined =
-    options.lookup ?? (fetchImpl === REAL_FETCH ? defaultEgressLookup : undefined);
+  let resolver: EgressLookup | undefined;
+  if (options.lookup) {
+    resolver = options.lookup;
+  } else if (fetchImpl === REAL_FETCH) {
+    resolver = defaultEgressLookup;
+  } else {
+    resolver = undefined;
+    // No injected resolver, and the effective fetch is NOT the genuine runtime
+    // fetch. That is the norm for test doubles, but in production it means
+    // `globalThis.fetch` was reassigned (a wrapper) — which would silently
+    // disable the DNS guard. Surface it once instead of failing silently.
+    if (options.fetchImpl === undefined && globalThis.fetch !== REAL_FETCH) {
+      warnDegradedEgressGuard();
+    }
+  }
 
   let currentUrl = url;
   let currentInit: RequestInit = { ...init, redirect: "manual" };
@@ -402,6 +452,12 @@ export async function guardedFetch(
  * inference request goes out through the SDK's own `fetch`, bypassing the SSRF
  * guard entirely — the sync check at config-build time is DNS-blind (#4779).
  *
+ * The connect-time DNS resolver is forced ON here (defaulting `lookup` to the
+ * real resolver): this is the live-confirmed exploit surface, so its protection
+ * must NOT depend on the `fetchImpl === REAL_FETCH` identity heuristic that the
+ * general {@link guardedFetch} path uses — a fetch wrapper must never silently
+ * disable it. A test still overrides `lookup` for hermetic runs.
+ *
  * Only the `(input, init)` shape the SDK uses is supported: `input` may be a
  * string, `URL`, or `Request` (the URL is extracted; the request's own body/
  * headers/method are honored when present, with `init` taking precedence).
@@ -409,24 +465,30 @@ export async function guardedFetch(
 export function createGuardedFetch(
   options: GuardedFetchOptions = {},
 ): typeof globalThis.fetch {
+  const forcedOptions: GuardedFetchOptions = {
+    ...options,
+    lookup: options.lookup ?? defaultEgressLookup,
+  };
   const guarded = async (
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
     if (typeof input === "string" || input instanceof URL) {
-      return guardedFetch(input.toString(), init ?? {}, options);
+      return guardedFetch(input.toString(), init ?? {}, forcedOptions);
     }
     // A `Request` object: fold its fields into an init, letting an explicit
-    // `init` argument override, and read the URL from the request.
+    // `init` argument override, and read the URL from the request. A stream body
+    // needs `duplex: "half"` (undici/Bun throw otherwise); it is dropped when an
+    // explicit `init` overrides the method to a bodyless one.
     const req = input;
-    const merged: RequestInit = {
+    const merged: RequestInit & { duplex?: "half" } = {
       method: req.method,
       headers: req.headers,
-      body: req.body,
+      ...(req.body != null ? { body: req.body, duplex: "half" } : {}),
       signal: req.signal,
       ...init,
     };
-    return guardedFetch(req.url, merged, options);
+    return guardedFetch(req.url, merged, forcedOptions);
   };
   return guarded as typeof globalThis.fetch;
 }

--- a/packages/api/src/lib/openapi/egress-guard.ts
+++ b/packages/api/src/lib/openapi/egress-guard.ts
@@ -53,7 +53,7 @@ export interface EgressPin {
 }
 
 /** A resolved DNS record — the shape of one `dns.promises.lookup(_, {all:true})` entry. */
-interface ResolvedAddress {
+export interface ResolvedAddress {
   readonly address: string;
   readonly family: number;
 }

--- a/packages/api/src/lib/openapi/probe.ts
+++ b/packages/api/src/lib/openapi/probe.ts
@@ -291,8 +291,6 @@ export async function probeSpec(
   auth: ResolvedAuth,
   options: ProbeOptions = {},
 ): Promise<{ readonly doc: unknown; readonly graph: OperationGraph }> {
-  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
-
   // SSRF guard (all deploy modes; opt out via ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS):
   // the spec URL is admin-supplied and fetched here, host-side — block
   // private/internal targets before the fetch. #3006.
@@ -344,7 +342,9 @@ export async function probeSpec(
         },
         signal: AbortSignal.timeout(probeTimeoutMs()),
       },
-      { fetchImpl },
+      // Leave `fetchImpl` unset in prod so `guardedFetch` engages the connect-time
+      // DNS guard on the real runtime fetch (#4779).
+      { ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}) },
     );
     if (!response.ok) {
       throw new OpenApiProbeError(
@@ -446,7 +446,6 @@ export async function conditionalProbe(
   specUrl: string,
   options: ConditionalProbeOptions = {},
 ): Promise<ConditionalProbeResult> {
-  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
   assertSpecUrlAllowed(specUrl);
 
   const conditionalHeaders: Record<string, string> = {
@@ -463,7 +462,9 @@ export async function conditionalProbe(
         headers: { Accept: "application/json", ...conditionalHeaders },
         signal: AbortSignal.timeout(probeTimeoutMs()),
       },
-      { fetchImpl },
+      // Leave `fetchImpl` unset in prod so `guardedFetch` engages the connect-time
+      // DNS guard on the real runtime fetch (#4779).
+      { ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}) },
     );
   } catch (err) {
     if (err instanceof EgressBlockedError) {

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -20,7 +20,7 @@ import type { LanguageModel } from "ai";
 import type { ModelConfigProvider } from "@useatlas/types";
 import { createLogger } from "./logger";
 import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
-import { isInternalEgressAllowed } from "@atlas/api/lib/openapi/egress-guard";
+import { createGuardedFetch, isInternalEgressAllowed } from "@atlas/api/lib/openapi/egress-guard";
 import type { WorkspaceCredentials } from "@atlas/api/lib/auth/credentials";
 
 const log = createLogger("providers");
@@ -533,9 +533,17 @@ export function getModelFromWorkspaceConfig(config: WorkspaceModelConfig): Langu
             `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true on a self-hosted deployment.`,
         );
       }
+      // Route the agent's inference request through the DNS-aware egress guard
+      // (#4779): the sync `isSafeExternalUrl` above is a cheap pre-fail but is
+      // DNS-blind, so a `baseUrl` hostname that RESOLVES to an internal IP would
+      // otherwise reach cloud metadata / internal services on the SDK's own
+      // fetch. `createGuardedFetch` resolves + validates + pins the target IP
+      // immediately before connect. Self-hosted internal endpoints stay reachable
+      // via the same `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS` opt-out honored above.
       const client = createOpenAI({
         apiKey: credentials.apiKey,
         baseURL: config.baseUrl,
+        fetch: createGuardedFetch(),
       });
       return client(config.model);
     }

--- a/packages/api/src/lib/sandbox/__tests__/validate-ssrf.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/validate-ssrf.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { isSafeExternalUrl } from "../validate";
+import { isBlockedResolvedAddress, isSafeExternalUrl } from "../validate";
 
 describe("isSafeExternalUrl — blocked (SSRF vectors)", () => {
   // Every entry MUST be rejected. The comment names the encoding that bypassed
@@ -73,6 +73,49 @@ describe("isSafeExternalUrl — allowed (genuinely public HTTPS)", () => {
   for (const url of allowed) {
     it(`allows ${url}`, () => {
       expect(isSafeExternalUrl(url)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// isBlockedResolvedAddress — the connect-time half of the guard (#4779). Given a
+// *resolved* IP literal (an A/AAAA record), is it in a blocked range? This is
+// the primitive `assertSafeEgressTarget` re-checks every DNS result against.
+// ---------------------------------------------------------------------------
+
+describe("isBlockedResolvedAddress — blocked resolved IPs", () => {
+  const blocked: ReadonlyArray<readonly [string, string]> = [
+    ["10.0.0.5", "RFC1918 10/8"],
+    ["127.0.0.1", "loopback"],
+    ["169.254.169.254", "link-local (cloud metadata)"],
+    ["172.16.0.5", "RFC1918 172.16/12"],
+    ["192.168.1.10", "RFC1918 192.168/16"],
+    ["100.64.0.1", "CGNAT 100.64/10"],
+    ["0.0.0.0", "'this network' 0/8"],
+    ["::1", "IPv6 loopback"],
+    ["fc00::1", "IPv6 ULA"],
+    ["fe80::1", "IPv6 link-local"],
+    ["::ffff:10.0.0.5", "IPv4-mapped IPv6 wrapping a private IPv4"],
+    ["::ffff:169.254.169.254", "IPv4-mapped IPv6 wrapping metadata"],
+    ["not-an-ip", "non-IP-literal fails CLOSED (anomalous resolver output)"],
+    ["", "empty string fails closed"],
+  ];
+  for (const [ip, why] of blocked) {
+    it(`blocks ${ip || "<empty>"} (${why})`, () => {
+      expect(isBlockedResolvedAddress(ip)).toBe(true);
+    });
+  }
+});
+
+describe("isBlockedResolvedAddress — allowed public resolved IPs", () => {
+  const allowed: ReadonlyArray<string> = [
+    "93.184.216.34", // public IPv4
+    "8.8.8.8", // public IPv4
+    "2001:4860:4860::8888", // public IPv6 (Google DNS)
+  ];
+  for (const ip of allowed) {
+    it(`allows ${ip}`, () => {
+      expect(isBlockedResolvedAddress(ip)).toBe(false);
     });
   }
 });

--- a/packages/api/src/lib/sandbox/validate.ts
+++ b/packages/api/src/lib/sandbox/validate.ts
@@ -145,7 +145,37 @@ export function isSafeExternalUrl(url: string): boolean {
     return true;
   }
 
-  // Not an IP literal — a DNS name we deliberately do not resolve.
+  // Not an IP literal — a DNS name we deliberately do not resolve. This
+  // function is synchronous (it backs a Zod `.refine()` in
+  // `admin-model-config.ts`, which cannot await), so a public name that
+  // resolves to a private IP passes here. The connect-time DNS check in
+  // `guardedFetch` (via {@link isBlockedResolvedAddress}) is the backstop that
+  // closes that gap (#4779) — this stays the cheap first pass.
+  return true;
+}
+
+/**
+ * True if a *resolved* IP address (an A/AAAA record returned by DNS, already an
+ * IP literal — never a hostname) falls in a blocked private / loopback /
+ * link-local / CGNAT / ULA range. This is the connect-time half of the SSRF
+ * guard: {@link isSafeExternalUrl} cannot resolve DNS (it is synchronous), so a
+ * public hostname that resolves to an internal IP slips past it — the egress
+ * path resolves the host and re-checks every resolved address through here
+ * immediately before connect (#4779).
+ *
+ * Reuses the same {@link PRIVATE_BLOCKLIST} + IPv4-embedded-in-IPv6 logic as the
+ * literal-IP path so there is exactly one IP-range SSRF primitive. A value that
+ * is not a parseable IP literal (a resolver should never return one) fails
+ * CLOSED — treated as blocked.
+ */
+export function isBlockedResolvedAddress(ip: string): boolean {
+  if (net.isIPv4(ip)) return PRIVATE_BLOCKLIST.check(ip, "ipv4");
+  if (net.isIPv6(ip)) {
+    if (PRIVATE_BLOCKLIST.check(ip, "ipv6")) return true;
+    const embedded = extractEmbeddedIPv4(ip);
+    return embedded !== null && PRIVATE_BLOCKLIST.check(embedded, "ipv4");
+  }
+  // Not a valid IP literal — a resolver returning this is anomalous; fail closed.
   return true;
 }
 


### PR DESCRIPTION
## Summary

Closes #4779 — a HIGH-severity, live-confirmed SSRF. `isSafeExternalUrl` is **synchronous** (it backs a Zod `.refine()`), so it blocks *literal* internal IPs but is **DNS-blind**: a public hostname that *resolves* to an internal IP (`127.0.0.1.nip.io`, cloud metadata via wildcard DNS, or a live DNS-rebind record) passed the guard and the outbound request connected to the internal address. The gap is shared by every `guardedFetch` consumer and by the live-agent model-`baseUrl` path.

## Fix — at the shared egress layer, so every surface inherits it

- **`sandbox/validate.ts`** — export `isBlockedResolvedAddress(ip)`, reusing the single `PRIVATE_BLOCKLIST` + IPv4-in-IPv6 primitive to CIDR-check a *resolved* IP. Fails **closed** on any non-IP-literal.
- **`openapi/egress-guard.ts`** — `assertSafeEgressTarget(url)` resolves a DNS-name host and rejects **before connect** if *any* resolved A/AAAA record is private/loopback/link-local/CGNAT/ULA. `guardedFetch` then **pins** the validated IP (connect-by-IP + `Host` header, which drives Bun's TLS SNI/cert verification) so a second resolution can't swap in an internal address (TOCTOU/rebind).
- **`createGuardedFetch()`** — a `fetch`-shaped adapter wired into `providers.ts` `getModelFromWorkspaceConfig` (the `custom`/`azure-openai` live-agent path, which previously egressed through the AI SDK's own DNS-blind fetch). The resolver is forced **on** here unconditionally.
- Honors the existing `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS` self-host opt-out (no resolution when set).

### Activation & the identity gate
Resolution engages against the genuine runtime fetch (production) or an injected resolver (tests); a **fetch double** (injected `fetchImpl` / swapped `globalThis.fetch`) falls back to the sync guard, keeping the pre-existing consumer-test corpus behavior-identical. The highest-value surface (`createGuardedFetch`, the live-confirmed path) forces resolution on regardless of fetch identity, and the general path emits a **one-time warn** if `globalThis.fetch` is ever wrapped in production (so the guard can't silently degrade). The OpenAPI datasource callers (`client.ts`/`probe.ts`) were switched to the conditional-`fetchImpl` spread so they inherit the guard + warn.

### Why the PUT/write path is not DNS-checked
A Zod `.refine()` is synchronous and cannot resolve DNS; blocking DNS on writes would also break legitimate self-hosted internal hostnames. Enforcement is at **connect time** on every surface, so a stored internal-resolving `baseUrl` can never actually connect. Literal internal IPs are still rejected at write time by the sync refine.

## Tests (hermetic — injected resolver DI seam, no network)
Reject-before-connect on an internal-resolving hostname (fetch **not** called), mixed A-record set, zero-records/resolver-throw fail-closed, redirect hop that *resolves* internal (rebind, not a literal), IPv6 pin bracketing + IPv4-mapped-IPv6 reject, non-default port preservation, `Request`-input reject, opt-out short-circuit, a direct `isBlockedResolvedAddress` table, and a regression lock that `getModelFromWorkspaceConfig` installs the guarded fetch on the live-agent client.

## Review
Internal review panel: 2 rounds (round 1 CHANGES REQUESTED on the fetch-identity gate → hardened; round 2 no must-fix, should-consider items applied). Local `bun run type` + full test suite green.
