### PR TITLE
fix(sandbox): byte-accurate explore truncation signal + accurate containment docs (#4785)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Guidance for Claude Code when working in this repository.
 - [ ] **Statement timeout** — PostgreSQL/MySQL get a session-level timeout. Default 30s, via `ATLAS_QUERY_TIMEOUT`
 
 ### Security (General)
-- [ ] **Path traversal protection** — Each explore backend enforces read-only access scoped to `semantic/`
+- [ ] **Explore is read-only by isolation, not a path jail** — Each explore backend is read-only *structurally* (ephemeral microVM / read-only bind mounts / in-memory overlay): shell writes and `..` traversal may succeed *inside* the sandbox but never touch host files, and there is no command allowlist or `semantic/`-scoped path check. See the fuller "read-only by isolation, not command validation" note under **Agent Tools**; don't lean on a path-traversal guard that isn't enforced (#4781)
 - [ ] **No secrets in responses** — Never expose connection strings, API keys, or stack traces to the user or agent
 - [ ] **Readonly DB connections** — PostgreSQL via validation; MySQL via read-only session variable; ClickHouse via `readonly: 1`
 - [ ] **Encrypted at rest** — New integration + datasource credentials use `encryptSecret` / `decryptSecret` from `db/secret-encryption.ts` (versioned AES-256-GCM). New credential table = one-line add to `INTEGRATION_TABLES` in `db/integration-tables.ts` + an `_encrypted` column. Datasource URLs use selective-field encryption (`encryptSecretFields`) keyed on the `config_schema` `secret: true` flag. The legacy `db/internal.ts` passthrough is frozen to two columns — no new call sites. See [ADR-0005](docs/adr/0005-integration-credentials-table.md), [ADR-0007](docs/adr/0007-unified-install-pipeline.md)

--- a/packages/api/src/lib/tools/__tests__/explore-nsjail.test.ts
+++ b/packages/api/src/lib/tools/__tests__/explore-nsjail.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, spyOn, mock } from "bun:test";
 import * as fs from "fs";
+import { capOutput, markCappedStream, MAX_OUTPUT } from "@atlas/api/lib/tools/backends/shared";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -176,6 +177,88 @@ describe("exec", () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+  });
+
+  it("reports byte-accurate stdout truncation the seam surfaces as a notice (#4785)", async () => {
+    process.env.ATLAS_NSJAIL_PATH = "/usr/local/bin/nsjail";
+    const spy = mockAccessSync(new Set(["/usr/local/bin/nsjail", SEMANTIC_ROOT]));
+
+    const huge = "x".repeat(MAX_OUTPUT + 500);
+    setSpawnResult(huge, "", 0);
+    const backend = await createNsjailBackend(SEMANTIC_ROOT, callbacks);
+    const result = await backend.exec("cat big");
+
+    // stdout is byte-capped and the cut is reported as a fact, not re-derived.
+    expect(result.stdout.length).toBe(MAX_OUTPUT);
+    expect(result.stdoutTruncated).toBe(true);
+    // The tool seam appends the notice from that flag.
+    const marked = markCappedStream(result.stdout, result.stdoutTruncated ?? false);
+    expect(marked).toContain("[output truncated: exceeded 1 MB limit]");
+
+    spy.mockRestore();
+  });
+
+  it("flags truncation for MULTI-BYTE output whose code-unit length is under the cap (#4785)", async () => {
+    process.env.ATLAS_NSJAIL_PATH = "/usr/local/bin/nsjail";
+    const spy = mockAccessSync(new Set(["/usr/local/bin/nsjail", SEMANTIC_ROOT]));
+
+    // "é" (U+00E9) is 2 UTF-8 bytes but 1 UTF-16 code unit. Emit well over the
+    // 1 MB BYTE cap while keeping the string's .length under MAX_OUTPUT — the
+    // exact case where deriving truncation from string length silently missed
+    // the cut. The byte-layer flag must still report it.
+    const multibyte = "é".repeat(MAX_OUTPUT); // ~2 MB bytes, MAX_OUTPUT code units
+    setSpawnResult(multibyte, "", 0);
+    const backend = await createNsjailBackend(SEMANTIC_ROOT, callbacks);
+    const result = await backend.exec("cat unicode");
+
+    expect(result.stdout.length).toBeLessThan(MAX_OUTPUT); // code units below cap
+    expect(result.stdoutTruncated).toBe(true); // but the bytes were cut
+    // The old length-only check would NOT have marked this — the flag does.
+    expect(capOutput(result.stdout)).not.toContain("[output truncated");
+    expect(markCappedStream(result.stdout, result.stdoutTruncated ?? false)).toContain(
+      "[output truncated: exceeded 1 MB limit]",
+    );
+
+    spy.mockRestore();
+  });
+
+  it("does not flag a complete output sitting exactly at the cap", async () => {
+    process.env.ATLAS_NSJAIL_PATH = "/usr/local/bin/nsjail";
+    const spy = mockAccessSync(new Set(["/usr/local/bin/nsjail", SEMANTIC_ROOT]));
+
+    const exact = "y".repeat(MAX_OUTPUT);
+    setSpawnResult(exact, "", 0);
+    const backend = await createNsjailBackend(SEMANTIC_ROOT, callbacks);
+    const result = await backend.exec("cat exact");
+
+    // Exactly at the cap is complete, not cut — must not be falsely flagged.
+    expect(result.stdout.length).toBe(MAX_OUTPUT);
+    expect(result.stdoutTruncated).toBe(false);
+    expect(markCappedStream(result.stdout, result.stdoutTruncated ?? false)).not.toContain(
+      "[output truncated",
+    );
+
+    spy.mockRestore();
+  });
+
+  it("flags stderr truncation on the non-zero-exit path (#4785)", async () => {
+    process.env.ATLAS_NSJAIL_PATH = "/usr/local/bin/nsjail";
+    const spy = mockAccessSync(new Set(["/usr/local/bin/nsjail", SEMANTIC_ROOT]));
+
+    // A failing command's large stderr is the diagnostically most important
+    // truncation case — the seam marks stderr on the exitCode !== 0 branch.
+    setSpawnResult("", "z".repeat(MAX_OUTPUT + 500), 1);
+    const backend = await createNsjailBackend(SEMANTIC_ROOT, callbacks);
+    const result = await backend.exec("cat bigerr");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.length).toBe(MAX_OUTPUT);
+    expect(result.stderrTruncated).toBe(true);
+    expect(markCappedStream(result.stderr, result.stderrTruncated ?? false)).toContain(
+      "[output truncated: exceeded 1 MB limit]",
+    );
+
+    spy.mockRestore();
   });
 
   it("constructs correct nsjail args", async () => {

--- a/packages/api/src/lib/tools/__tests__/python-nsjail.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-nsjail.test.ts
@@ -381,8 +381,9 @@ describe("createPythonNsjailBackend", () => {
   });
 
   it("detects stdout truncation and reports it", async () => {
-    // Simulate output that is exactly MAX_OUTPUT (1MB) — truncated
-    const bigOutput = "x".repeat(1024 * 1024);
+    // Simulate output that exceeds the 1 MB byte cap so readLimited reports it
+    // truncated (exactly-at-cap would be complete, not cut).
+    const bigOutput = "x".repeat(1024 * 1024 + 500);
     setSpawnResult(bigOutput, "", 0);
 
     const backend = createPythonNsjailBackend("/usr/local/bin/nsjail");

--- a/packages/api/src/lib/tools/backends/nsjail.ts
+++ b/packages/api/src/lib/tools/backends/nsjail.ts
@@ -311,10 +311,12 @@ export async function testNsjailCapabilities(
 
     const timer = setTimeout(() => proc.kill(), TIMEOUT_MS);
     try {
-      const [stdout, stderr] = await Promise.all([
+      const [stdoutRead, stderrRead] = await Promise.all([
         readLimited(proc.stdout, MAX_OUTPUT),
         readLimited(proc.stderr, MAX_OUTPUT),
       ]);
+      const stdout = stdoutRead.text;
+      const stderr = stderrRead.text;
       const exitCode = await proc.exited;
       clearTimeout(timer);
 

--- a/packages/api/src/lib/tools/backends/shared.ts
+++ b/packages/api/src/lib/tools/backends/shared.ts
@@ -11,21 +11,52 @@ import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
 /** Maximum bytes to read from stdout/stderr (1 MB). */
 export const MAX_OUTPUT = 1024 * 1024;
 
+/** The notice appended to any output that was cut at the MAX_OUTPUT cap. */
+function truncationNotice(max = MAX_OUTPUT): string {
+  return `\n[output truncated: exceeded ${Math.floor(max / (1024 * 1024))} MB limit]`;
+}
+
 /**
  * Cap a fully-buffered output string destined for agent context, appending a
  * truncation notice so the model knows the output was cut rather than complete.
  *
  * Complements readLimited: readLimited bounds subprocess-stream memory during
- * the read; capOutput bounds already-buffered strings from backends that return
- * whole outputs (Vercel sandbox, just-bash, plugin/BYOC backends).
+ * the read (and reports whether it truncated); capOutput bounds already-buffered
+ * strings from backends that return whole outputs (Vercel sandbox, just-bash,
+ * plugin/BYOC backends).
  */
 export function capOutput(output: string, max = MAX_OUTPUT): string {
   if (output.length <= max) return output;
-  return `${output.slice(0, max)}\n[output truncated: exceeded ${Math.floor(max / (1024 * 1024))} MB limit]`;
+  return `${output.slice(0, max)}${truncationNotice(max)}`;
+}
+
+/**
+ * Mark a stream that a backend already capped at read time (nsjail), appending
+ * the truncation notice iff readLimited reported it cut the stream.
+ *
+ * The nsjail path caps by BYTES in readLimited, so its truncation cannot be
+ * re-derived from the decoded string's `.length` (UTF-16 code units): a
+ * multi-byte output cut at the byte cap can decode to fewer code units than
+ * MAX_OUTPUT, which is why relying on capOutput's `length > max` check silently
+ * dropped the notice for non-ASCII output (#4781/#4785). Carrying the truncation
+ * fact out of the byte layer makes the notice encoding-independent.
+ */
+export function markCappedStream(text: string, truncated: boolean, max = MAX_OUTPUT): string {
+  return truncated ? `${text}${truncationNotice(max)}` : text;
+}
+
+/** Result of readLimited: the decoded text plus whether the cap cut the stream. */
+export interface LimitedRead {
+  readonly text: string;
+  readonly truncated: boolean;
 }
 
 /**
  * Read up to `max` bytes from a stream, releasing the reader on completion or error.
+ *
+ * Returns the decoded text and whether the `max`-byte cap actually cut the
+ * stream — callers surface truncation from this byte-accurate flag rather than
+ * re-deriving it from the decoded string length (see markCappedStream).
  *
  * Used by nsjail backends (explore + python) to cap subprocess output
  * and by testNsjailCapabilities for capability checks.
@@ -33,10 +64,11 @@ export function capOutput(output: string, max = MAX_OUTPUT): string {
 export async function readLimited(
   stream: ReadableStream,
   max: number,
-): Promise<string> {
+): Promise<LimitedRead> {
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  let truncated = false;
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -44,6 +76,7 @@ export async function readLimited(
       total += value.byteLength;
       if (total > max) {
         chunks.push(value.slice(0, max - (total - value.byteLength)));
+        truncated = true;
         break;
       }
       chunks.push(value);
@@ -52,7 +85,7 @@ export async function readLimited(
     // intentionally ignored: stream cancel errors are non-critical during cleanup
     await reader.cancel().catch(() => {});
   }
-  return new TextDecoder().decode(Buffer.concat(chunks));
+  return { text: new TextDecoder().decode(Buffer.concat(chunks)), truncated };
 }
 
 /**

--- a/packages/api/src/lib/tools/backends/types.ts
+++ b/packages/api/src/lib/tools/backends/types.ts
@@ -10,6 +10,14 @@ export interface ExecResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  /**
+   * Whether the backend cut stdout/stderr at the MAX_OUTPUT cap. Set by
+   * backends that pre-truncate at read time (nsjail); omitted by backends that
+   * return whole buffers (Vercel/just-bash/plugin), which the tool seam caps
+   * and marks via capOutput. The seam appends the truncation notice from these.
+   */
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
 }
 
 /**

--- a/packages/api/src/lib/tools/explore-nsjail.ts
+++ b/packages/api/src/lib/tools/explore-nsjail.ts
@@ -77,12 +77,19 @@ export async function createNsjailBackend(
         );
       }
 
+      let stdoutRead: Awaited<ReturnType<typeof readLimited>>;
+      let stderrRead: Awaited<ReturnType<typeof readLimited>>;
       let stdout: string, stderr: string, exitCode: number;
       try {
-        [stdout, stderr] = await Promise.all([
+        // readLimited caps by bytes and reports whether it cut the stream; the
+        // tool seam surfaces truncation from that flag (encoding-independent),
+        // instead of re-deriving it from the decoded string length (#4785).
+        [stdoutRead, stderrRead] = await Promise.all([
           readLimited(proc.stdout, MAX_OUTPUT),
           readLimited(proc.stderr, MAX_OUTPUT),
         ]);
+        stdout = stdoutRead.text;
+        stderr = stderrRead.text;
         exitCode = await proc.exited;
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
@@ -114,7 +121,13 @@ export async function createNsjailBackend(
         );
       }
 
-      return { stdout, stderr, exitCode };
+      return {
+        stdout,
+        stderr,
+        exitCode,
+        stdoutTruncated: stdoutRead.truncated,
+        stderrTruncated: stderrRead.truncated,
+      };
     },
   };
 }

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -148,6 +148,14 @@ export async function createSandboxBackend(
   try {
     sandbox = await Sandbox.create({
       runtime: "node24",
+      // "deny-all" blocks all routed egress. NOTE: it does NOT block the
+      // link-local Firecracker MMDS (169.254.169.254), which the guest reaches
+      // at L3 regardless — that is a provider/Firecracker-level control, not an
+      // app-layer one. As of 2026-07 (Vercel Sandbox v2), networkPolicy is
+      // host-allowlist-only with no CIDR/IP denylist to subtract link-local
+      // ranges, and the MMDS is empty for Atlas sandboxes (no instance creds),
+      // so this is a defense-in-depth gap, not an exposure. #4785/#4781 track
+      // the current status (source of truth if the vendor surface changes).
       networkPolicy: "deny-all",
       // v2 persists (snapshots) by default — force ephemeral so semantic
       // files never linger in Vercel snapshot storage after stop().

--- a/packages/api/src/lib/tools/explore.ts
+++ b/packages/api/src/lib/tools/explore.ts
@@ -30,7 +30,7 @@ import { getSemanticRoot, ensureOrgModeSemanticRoot } from "@atlas/api/lib/seman
 import { getSetting } from "@atlas/api/lib/settings";
 import { getWorkspaceSandboxOverride } from "@atlas/api/lib/sandbox/workspace-override";
 import { useVercelSandbox, useSidecar } from "./backends/detect";
-import { capOutput } from "./backends/shared";
+import { capOutput, markCappedStream } from "./backends/shared";
 import {
   planSandboxSelection,
   runSandboxPlan,
@@ -667,14 +667,21 @@ export const explore = tool({
       );
 
       // Cap output at the tool seam so every backend is covered — nsjail caps
-      // at stream-read time, but Vercel/just-bash/plugin/BYOC backends return
+      // at stream-read time (and reports it via *Truncated so we mark the notice
+      // encoding-independently), but Vercel/just-bash/plugin/BYOC backends return
       // whole buffered outputs that would otherwise flow into agent context
-      // (and the MCP/REST explore surfaces) unbounded.
+      // (and the MCP/REST explore surfaces) unbounded, so capOutput bounds those.
       if (result.exitCode !== 0) {
-        return `Error (exit ${result.exitCode}):\n${capOutput(result.stderr)}`;
+        const stderr = result.stderrTruncated
+          ? markCappedStream(result.stderr, true)
+          : capOutput(result.stderr);
+        return `Error (exit ${result.exitCode}):\n${stderr}`;
       }
 
-      const output = capOutput(result.stdout) || "(no output)";
+      const capped = result.stdoutTruncated
+        ? markCappedStream(result.stdout, true)
+        : capOutput(result.stdout);
+      const output = capped || "(no output)";
       await dispatchHook("afterExplore", { command: execCommand, output });
 
       return output;

--- a/packages/api/src/lib/tools/python-nsjail.ts
+++ b/packages/api/src/lib/tools/python-nsjail.ts
@@ -134,10 +134,12 @@ export function createPythonNsjailBackend(nsjailPath: string): PythonBackend {
           }
         }
 
-        const [stdout, stderr] = await Promise.all([
+        const [stdoutRead, stderrRead] = await Promise.all([
           readLimited(proc.stdout, MAX_OUTPUT),
           readLimited(proc.stderr, MAX_OUTPUT),
         ]);
+        const stdout = stdoutRead.text;
+        const stderr = stderrRead.text;
         const exitCode = await proc.exited;
 
         log.debug({ execId, exitCode, stdoutLen: stdout.length }, "python nsjail execution finished");
@@ -158,8 +160,11 @@ export function createPythonNsjailBackend(nsjailPath: string): PythonBackend {
           }
         }
 
-        // No structured result — process errored before the wrapper could emit one
-        if (stdout.length >= MAX_OUTPUT) {
+        // No structured result — process errored before the wrapper could emit
+        // one. Use readLimited's byte-accurate truncation flag rather than the
+        // decoded string length, which under-counts multi-byte UTF-8 output and
+        // would misreport a truncated non-ASCII result as a generic failure.
+        if (stdoutRead.truncated) {
           return {
             success: false,
             error: "Python output exceeded 1 MB limit — the result was likely truncated. " +


### PR DESCRIPTION
## Summary

Defense-in-depth residue from the #3351 live security pass (follows #4779/#4780/#4781). Three items, all LOW/non-exploitable — the real boundaries hold; each removes a reliance on something staying benign or corrects an over-claim.

1. **Explore truncation is no longer silently dropped.** The nsjail explore path caps output by **bytes** (`readLimited`) but the seam re-derived truncation from decoded **string length** (UTF-16 code units) — so multi-byte UTF-8 output cut at the 1 MB byte cap decoded to fewer code units than the cap and the `[output truncated]` notice was silently dropped. `readLimited` now returns `{ text, truncated }`, the flag rides `ExecResult.stdoutTruncated/stderrTruncated`, and the tool seam appends the notice via `markCappedStream` — encoding-independent. The same byte-accurate flag replaces the multi-byte-buggy `stdout.length >= MAX_OUTPUT` check in `python-nsjail`.
2. **CLAUDE.md path-jail over-claim reworded.** The "Path traversal protection — each explore backend enforces read-only access scoped to `semantic/`" bullet was the same claim #4781 walked back everywhere else. Reworded to "read-only by isolation, not a path jail" (writes/traversal may succeed inside the sandbox but never touch host files; no command allowlist or path check).
3. **Link-local MMDS egress documented as provider-controlled.** Blocking the Firecracker MMDS (`169.254.169.254`) is not implementable at our app layer — Vercel's `networkPolicy` is host-allowlist-only (no CIDR/IP denylist) and explore already pins `deny-all`; nsjail has no network; sidecar/just-bash have no egress seam. Rather than ship a non-functional "block", the `deny-all` pin now carries an accurate, dated comment explaining the gap is provider/Firecracker-level and empty today (no instance creds).

Design note: the truncation fix keeps the explore tool's **string** contract (no `truncated` field on the REST wire type) — the signal stays the inline notice, now marked accurately for any encoding.

## Test plan
- [x] `explore-nsjail.test.ts`: ASCII truncation flag, **multi-byte** (`"é".repeat`) truncation flag (code-unit length < cap yet `truncated === true`), exactly-at-cap not flagged, stderr-on-non-zero-exit flagged
- [x] `python-nsjail.test.ts`: truncation test updated to genuinely-over-cap output
- [x] Local `/ci`: all 31 gates green (type, lint-type-aware, openapi-drift, full suite)
- [x] Internal review panel: 2 rounds → CLEAN (round 1 caught the multi-byte gap in the initial sentinel approach; reworked to the byte-accurate flag; python sibling fixed inline)

## Follow-up noticed
- None new. The optional execute-level seam integration test was assessed should-consider (not must-fix) by the panel and skipped as adequately covered by construction (backend flag + `markCappedStream` + `capOutput` each independently tested; seam is two ternaries).

Closes #4785