### PR TITLE
www/docs: fix accuracy drifts from /www-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## What is Atlas?
 
-Atlas turns a directory of YAML files into a complete semantic layer for analytics — entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics. Humans author the YAML. AI agents consume it through a built-in chat UI, an embeddable widget, Slack-native chat, or the **Model Context Protocol (MCP)** for Claude Desktop / Cursor / Continue — all returning deterministic, validated, read-only SQL.
+Atlas turns a directory of YAML files into a complete semantic layer for analytics — entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics. Humans author the YAML. AI agents consume it through a built-in chat UI, an embeddable widget, Slack-native chat (with Teams, Discord, Telegram, WhatsApp and Google Chat wired next), or the **Model Context Protocol (MCP)** for Claude Desktop / Cursor / Continue — all returning deterministic, validated, read-only SQL.
 
 Every YAML field exists because an LLM needs it to write correct SQL: `sample_values` ground the agent in real data, `glossary.status: ambiguous` forces clarifying questions, `metrics.objective` picks `MAX` vs `MIN`, `query_patterns` teach the canonical join shapes for your domain.
 
@@ -131,7 +131,7 @@ The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `A
 |---|---|---|---|
 | **Semantic layer** | YAML on disk — `query_patterns`, `virtual_dimensions`, `glossary.status: ambiguous`, `metrics.objective` are all first-class | Proprietary metadata, GUI-authored | None or limited |
 | **Agent-native** | MCP server first — Claude Desktop, Cursor, Continue with `bunx @useatlas/mcp init` | Bolted-on AI feature | Standalone chat UI |
-| **Embeddable** | Script tag, React component, headless API, MCP, Slack, Teams | Standalone app | Standalone app |
+| **Embeddable** | Script tag, React component, headless API, MCP, Slack-native chat (5 more chat platforms + GitHub + Linear wired) | Standalone app | Standalone app |
 | **Deploy anywhere** | Docker, Railway, Vercel, or your own infra | Vendor-hosted | Vendor-hosted |
 | **Plugin ecosystem** | 24 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
@@ -159,7 +159,7 @@ docker compose up
 
 ## How It Works
 
-1. User (or agent) asks a natural language question — over MCP, the chat widget, the API, Slack, or Teams
+1. User (or agent) asks a natural language question — over MCP, the chat widget, the API, or Slack (Teams, Discord, Telegram, WhatsApp, and Google Chat wired next)
 2. Agent explores the **YAML semantic layer** — entities, glossary, metrics, query patterns
 3. Agent writes SQL, validated through a 7-layer security pipeline (empty check, regex guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout)
 4. Results are returned with charts and an interpreted narrative

--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -49,17 +49,17 @@ export default defineConfig({
   residency: {
     regions: {
       "us-east": {
-        label: "US East (Virginia)",
+        label: "US East",
         databaseUrl: "postgresql://us-east-db.example.com/atlas",
         datasourceUrl: "postgresql://us-east-analytics.example.com/warehouse",
       },
       "eu-west": {
-        label: "EU West (Ireland)",
+        label: "EU West",
         databaseUrl: "postgresql://eu-west-db.example.com/atlas",
         datasourceUrl: "postgresql://eu-west-analytics.example.com/warehouse",
       },
       "ap-southeast": {
-        label: "Asia Pacific (Singapore)",
+        label: "Asia Pacific",
         databaseUrl: "postgresql://ap-southeast-db.example.com/atlas",
       },
     },
@@ -102,8 +102,8 @@ Response:
 ```json
 {
   "regions": [
-    { "region": "us-east", "label": "US East (Virginia)", "workspaceCount": 12, "healthy": true },
-    { "region": "eu-west", "label": "EU West (Ireland)", "workspaceCount": 5, "healthy": true }
+    { "region": "us-east", "label": "US East", "workspaceCount": 12, "healthy": true },
+    { "region": "eu-west", "label": "EU West", "workspaceCount": 5, "healthy": true }
   ],
   "defaultRegion": "us-east"
 }

--- a/apps/www/data/sub-processors.json
+++ b/apps/www/data/sub-processors.json
@@ -2,7 +2,7 @@
   {
     "name": "Railway",
     "purpose": "Cloud infrastructure (compute, storage, Postgres)",
-    "region": "Customer’s selected region — United States (Virginia), Europe (Netherlands), or Asia Pacific (Singapore)",
+    "region": "Customer’s selected region — United States, Europe, or Asia Pacific",
     "since": "2026-01",
     "changed_at": "2026-01-15"
   },

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -142,7 +142,7 @@ const TIERS: Tier[] = [
       "Unlimited seats & connections",
       "Default model: Sonnet 5",
       "BYOK for unlimited queries",
-      "8 integrations: 6 chat + Linear + GitHub (Google Chat coming soon)",
+      "8 integrations: Slack live; 5 more chat platforms + Linear + GitHub rolling out",
       "SSO, SCIM & custom roles",
       "IP allowlist & approval workflows",
       "PII masking & audit retention",
@@ -172,7 +172,7 @@ const CORE_SECTION: ComparisonSection = {
     { feature: "Default model", selfHosted: "Your choice", starter: "Haiku 4.5", pro: "Sonnet 5", business: "Sonnet 5" },
     { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
     { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
-    { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 6 (Google Chat soon)" },
+    { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "Up to 6 (Slack live; more rolling out)" },
     { feature: "Past the included credit", selfHosted: "No limit (BYOK)", starter: "At cost, to spend cap", pro: "At cost, to spend cap", business: "At cost, to spend cap" },
   ],
 };

--- a/apps/www/src/app/privacy/page.tsx
+++ b/apps/www/src/app/privacy/page.tsx
@@ -158,7 +158,7 @@ const SECTIONS: LegalSectionData[] = [
     id: "transfers",
     title: "International transfers",
     legal: [
-      "Atlas Cloud is hosted in three Customer-selectable regions, available on every paid plan: United States (Ashburn, Virginia), Europe (Eemshaven, Netherlands), and Asia Pacific (Singapore). Customer Data does not leave the selected region except for transactional services (billing, status email) which are processed in the United States.",
+      "Atlas Cloud is hosted in three Customer-selectable regions, available on every paid plan: the United States, Europe, and Asia Pacific. Customer Data does not leave the selected region except for transactional services (billing, status email) which are processed in the United States.",
       "Where personal data is transferred from the EEA, UK, or Switzerland to the US, we rely on Standard Contractual Clauses and the EU-US Data Privacy Framework where available. Custom enterprise contracts can negotiate additional regions.",
     ],
     plain:

--- a/apps/www/src/app/security/page.tsx
+++ b/apps/www/src/app/security/page.tsx
@@ -56,7 +56,7 @@ const PILLARS: Pillar[] = [
   {
     mono: "sandboxed",
     label: "Sandboxed tool execution",
-    sub: "The agent's explore and Python tools run in an isolated sandbox — a network-denied microVM on Atlas Cloud — with read-only access scoped to your semantic layer, never your filesystem or secrets.",
+    sub: "The agent's explore and Python tools run in an isolated sandbox — a network-denied microVM on Atlas Cloud. It's read-only by isolation: anything the shell writes lands in the sandbox's throwaway layer and never reaches your filesystem, your secrets, or the host.",
   },
   {
     mono: "encrypted",
@@ -109,10 +109,10 @@ const SECTIONS: LegalSectionData[] = [
       "Beyond writing SQL, the agent can explore your semantic layer (ls, cat, grep, find) and, where enabled, run Python. These tools execute in an isolated sandbox — never directly on the host.",
       "On Atlas Cloud, the sandbox is a Vercel Sandbox: a Firecracker microVM with its network policy set to deny-all, so sandboxed code cannot make outbound connections. Self-hosted deployments get the same isolation through nsjail (Linux namespaces) or an isolated sidecar service, selected by a documented priority chain.",
       "One locality note: Vercel Sandbox provisions only in the United States (iad1), so on Atlas Cloud sandbox execution runs in the US regardless of your workspace's data-residency region. What transits is semantic-layer content — including sampled values — plus knowledge-base documents the agent browses and, for Python, query-result rows. Networking is deny-all for explore and deny-all by default for Python (egress can open only to an installed REST datasource's own hosts, with no credential attached); sandboxes are never snapshotted, so nothing persists at Vercel once they stop. This is disclosed in our sub-processor list; workspaces that need in-region execution can connect their own sandbox on a provider account whose execution region they control — today that covers the explore tool, with Python support in progress.",
-      "Inside the sandbox, the explore tool has read-only access scoped to your semantic-layer directory and nothing else. There are no writes, no shell escapes, and path-traversal attempts outside the semantic directory are blocked. The agent's tools can read the map of your data — never your filesystem, your environment, or your database credentials.",
+      "Inside the sandbox, the explore tool reads the semantic-layer content staged for it. Containment is structural, not a path check: the sandbox is read-only by isolation — an ephemeral microVM on Atlas Cloud, read-only bind mounts or an in-memory overlay when self-hosted. There is no command allowlist and no semantic-scoped path jail, so a shell write or a `..` traversal may succeed inside the sandbox — but it lands in an ephemeral or in-memory layer that is discarded when the sandbox stops and never touches host files. What the agent's tools can never reach is the host itself: your real filesystem, your environment, or your database credentials.",
     ],
     plain:
-      "The agent's file and Python tools run in a locked-down sandbox — a network-denied microVM on Cloud, nsjail or a sidecar when self-hosted — with read-only access to your semantic layer and nothing else. On Cloud, sandbox execution runs in the US (iad1) regardless of workspace region; bring your own sandbox — on a provider account whose region you control — for in-region explore execution (Python coverage is in progress).",
+      "The agent's file and Python tools run in a locked-down sandbox — a network-denied microVM on Cloud, nsjail or a sidecar when self-hosted. It's read-only by isolation: writes stay inside the throwaway sandbox and never reach the host filesystem or your secrets. On Cloud, sandbox execution runs in the US (iad1) regardless of workspace region; bring your own sandbox — on a provider account whose region you control — for in-region explore execution (Python coverage is in progress).",
   },
   {
     id: "credentials",

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -26,7 +26,7 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "Embeddable",
     atlas:
-      "Script-tag widget, <AtlasChat /> React component, typed @useatlas/sdk, MCP, 6 chat platforms",
+      "Script-tag widget, <AtlasChat /> React component, typed @useatlas/sdk, MCP, 6 chat platforms (Slack live; Google Chat coming soon)",
     bi: "Standalone app",
     textToSql: "Standalone app",
   },


### PR DESCRIPTION
Fixes the accuracy drifts a `/www-audit` surfaced across marketing/legal/docs surfaces. Content-only edits — no code, types, or JSX structure changed. **Do not merge without the normal gates** (`/ci`, `/pr`).

## Checklist

- [x] **1 (HIGH) — EU region mismatch → resolved as area-level.** www said EU = Netherlands/Eemshaven; docs said EU = Ireland. Confirmed the **real** Railway EU region from `deploy/api-eu/railway.json` = `europe-west4-drams3a` (GCP europe-west4 = **Eemshaven, Netherlands**) — so www was the correct pair and docs (Ireland) were stale. Per direction, genericized both to **area-level** (US / EU / APAC), dropping city/country pins so the copy stays true if a region moves. Changed: `privacy/page.tsx` (International transfers), `sub-processors.json` (Railway row), `data-residency.mdx` (example config + API-response labels → `US East` / `EU West` / `Asia Pacific`). **Did not** touch the DPA's Ireland governing-law/forum (`dpa/page.tsx:148,151`) — that's legal jurisdiction, correct.
- [x] **2 (HIGH) — /security path-jail overclaim.** Reworded the pillar sub (`:59`), legal (`:112`), and plain (`:115`) from "no writes / path-traversal blocked / scoped to the semantic-layer directory" to the true property: **read-only by ISOLATION** — shell writes and `..` traversal may succeed inside the ephemeral sandbox but land in throwaway/in-memory layers and never touch host files; there is no command allowlist or semantic-scoped path check. (Repo rule #4781.)
- [x] **3 (MEDIUM) — README understated chat reach.** `:25`, `:134`, `:162` now tell the 8-integration / 6-chat-platform story with **Slack live, others wired** (not implying all installable today).
- [x] **4 (MEDIUM) — /pricing overstated chat availability.** `pricing-content.tsx:145` → "8 integrations: Slack live; 5 more chat platforms + Linear + GitHub rolling out". `:175` chat-integrations row business cell → "Up to 6 (Slack live; more rolling out)". **Enforcement count (`maxChatIntegrations` in billing `plans.ts`) unchanged** — only customer-facing wording.
- [ ] **5 (LOW) — blog `announcing-atlas` — INTENTIONALLY SKIPPED.** This is `blog/announcing-atlas/page.tsx`, i.e. **launch content**, excluded by the "do NOT touch any blog/launch content" instruction. ⚠️ Note it has a *larger* accuracy problem than the count nit the audit flagged: `:318-322` claims "Slack, Teams, Discord, Telegram, and WhatsApp **live today** ... plus Linear and GitHub, **also live**" — false (only Slack is live). Left untouched for a human to decide.
- [x] **6 (LOW) — landing comparison caveat.** `comparison.tsx:29` → "6 chat platforms **(Slack live; Google Chat coming soon)**". The `:57` "Chat-platform reach" row (Slack-only proactive answering) was **not** touched. No stale "21+ plugins" string exists — `:70` already reads "24 plugins".

## Verification
- `bun x oxlint` on all changed `.tsx` — **clean (exit 0)**.
- `sub-processors.json` — validates as JSON.
- Did **not** run `bun run dev` render check / full `bun run type`: the worktree has no `node_modules` (would need a full monorepo install), and every edit is a string-literal content change with no type/JSX-structure surface. oxlint parsed the files successfully. CI (`/ci`) runs the full type + build + drift gates before merge.

## Canonical facts used
8 SQL datasource families + REST/OpenAPI · 24 plugins across 5 types (CI-enforced) · 8 chat/workflow integrations = 6 chat platforms (Slack live; Teams/Discord/Telegram/WhatsApp/Google Chat wired, Google Chat coming soon) + GitHub + Linear (built-not-wired) · 3 regions (US/EU/APAC).
