### PR TITLE
www/docs: correct chat-reach copy from #4787 (installable today)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## What is Atlas?
 
-Atlas turns a directory of YAML files into a complete semantic layer for analytics — entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics. Humans author the YAML. AI agents consume it through a built-in chat UI, an embeddable widget, Slack-native chat (with Teams, Discord, Telegram, WhatsApp and Google Chat wired next), or the **Model Context Protocol (MCP)** for Claude Desktop / Cursor / Continue — all returning deterministic, validated, read-only SQL.
+Atlas turns a directory of YAML files into a complete semantic layer for analytics — entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics. Humans author the YAML. AI agents consume it through a built-in chat UI, an embeddable widget, six chat platforms (Slack one-click, or connect your own bot for Teams, Discord, Telegram, and WhatsApp — Google Chat coming soon), or the **Model Context Protocol (MCP)** for Claude Desktop / Cursor / Continue — all returning deterministic, validated, read-only SQL.
 
 Every YAML field exists because an LLM needs it to write correct SQL: `sample_values` ground the agent in real data, `glossary.status: ambiguous` forces clarifying questions, `metrics.objective` picks `MAX` vs `MIN`, `query_patterns` teach the canonical join shapes for your domain.
 
@@ -131,7 +131,7 @@ The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `A
 |---|---|---|---|
 | **Semantic layer** | YAML on disk — `query_patterns`, `virtual_dimensions`, `glossary.status: ambiguous`, `metrics.objective` are all first-class | Proprietary metadata, GUI-authored | None or limited |
 | **Agent-native** | MCP server first — Claude Desktop, Cursor, Continue with `bunx @useatlas/mcp init` | Bolted-on AI feature | Standalone chat UI |
-| **Embeddable** | Script tag, React component, headless API, MCP, Slack-native chat (5 more chat platforms + GitHub + Linear wired) | Standalone app | Standalone app |
+| **Embeddable** | Script tag, React component, headless API, MCP, 6 chat platforms (Slack one-click; Teams/Discord/Telegram/WhatsApp bring-your-own-bot; Google Chat coming soon) | Standalone app | Standalone app |
 | **Deploy anywhere** | Docker, Railway, Vercel, or your own infra | Vendor-hosted | Vendor-hosted |
 | **Plugin ecosystem** | 24 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
@@ -159,7 +159,7 @@ docker compose up
 
 ## How It Works
 
-1. User (or agent) asks a natural language question — over MCP, the chat widget, the API, or Slack (Teams, Discord, Telegram, WhatsApp, and Google Chat wired next)
+1. User (or agent) asks a natural language question — over MCP, the chat widget, the API, or a chat platform (Slack, Teams, Discord, Telegram, or WhatsApp; Google Chat coming soon)
 2. Agent explores the **YAML semantic layer** — entities, glossary, metrics, query patterns
 3. Agent writes SQL, validated through a 7-layer security pipeline (empty check, regex guard, AST parse, table whitelist, RLS injection, auto-LIMIT, statement timeout)
 4. Results are returned with charts and an interpreted narrative

--- a/apps/www/src/app/pricing/pricing-content.tsx
+++ b/apps/www/src/app/pricing/pricing-content.tsx
@@ -142,7 +142,7 @@ const TIERS: Tier[] = [
       "Unlimited seats & connections",
       "Default model: Sonnet 5",
       "BYOK for unlimited queries",
-      "8 integrations: Slack live; 5 more chat platforms + Linear + GitHub rolling out",
+      "8 integrations: 6 chat + Linear + GitHub (Google Chat coming soon)",
       "SSO, SCIM & custom roles",
       "IP allowlist & approval workflows",
       "PII masking & audit retention",
@@ -172,7 +172,7 @@ const CORE_SECTION: ComparisonSection = {
     { feature: "Default model", selfHosted: "Your choice", starter: "Haiku 4.5", pro: "Sonnet 5", business: "Sonnet 5" },
     { feature: "Seats", selfHosted: "Unlimited", starter: "Up to 10", pro: "Up to 25", business: "Unlimited" },
     { feature: "Database connections", selfHosted: "Unlimited", starter: "1", pro: "3", business: "Unlimited" },
-    { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "Up to 6 (Slack live; more rolling out)" },
+    { feature: "Chat integrations", selfHosted: "Config-based", starter: "1 platform", pro: "3 platforms", business: "All 6 (Google Chat coming soon)" },
     { feature: "Past the included credit", selfHosted: "No limit (BYOK)", starter: "At cost, to spend cap", pro: "At cost, to spend cap", business: "At cost, to spend cap" },
   ],
 };

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -26,7 +26,7 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "Embeddable",
     atlas:
-      "Script-tag widget, <AtlasChat /> React component, typed @useatlas/sdk, MCP, 6 chat platforms (Slack live; Google Chat coming soon)",
+      "Script-tag widget, <AtlasChat /> React component, typed @useatlas/sdk, MCP, 6 chat platforms (Google Chat coming soon)",
     bi: "Standalone app",
     textToSql: "Standalone app",
   },


### PR DESCRIPTION
Corrects the chat-availability wording merged in **#4787**, which was written on a wrong premise ("only Slack is live"). **Do not merge without the normal gates** (`/ci`, `/pr`).

## Why
#4787 took the audit's "only Slack fully live" claim as given. Verified against the code, that's wrong:
- `plugins/chat/src/adapter-registry.ts` + the static-bot install handlers — Slack, Teams, Discord, Telegram, WhatsApp, Google Chat all ship real builders + install handlers (#2994).
- `deploy/api/atlas.config.ts` (prod SaaS catalog, no `overrideImplementationStatus`): Teams / Discord / Telegram / WhatsApp = `implementation_status: "available"`; **only Google Chat = `coming_soon`** (#3154). Install route gates only `coming_soon`.
- Product-state confirmed: on Atlas Cloud the static-bot family is **installable today** (bring-your-own-bot); Slack is the one-click managed flagship.
- Linear + GitHub = action integrations (Linear is a live default agent tool) — the 7th/8th of "8 integrations".

So #4787's "rolling out" / "wired next" language **understated** availability. This PR reverts it to the accurate framing: *Slack one-click, plus Teams/Discord/Telegram/WhatsApp with your own bot, Google Chat coming soon.*

## Changes
- **README.md** `:25` — six chat platforms (Slack one-click; Teams/Discord/Telegram/WhatsApp bring-your-own-bot; Google Chat coming soon).
- **README.md** `:134` (Embeddable row) — dropped "wired"; same installable-today framing.
- **README.md** `:162` (How It Works step 1) — Slack/Teams/Discord/Telegram/WhatsApp available; Google Chat coming soon.
- **pricing-content.tsx** `:145` — reverted to "8 integrations: 6 chat + Linear + GitHub (Google Chat coming soon)".
- **pricing-content.tsx** `:175` (Business "Chat integrations") — reverted to "All 6 (Google Chat coming soon)".
- **comparison.tsx** `:29` — simplified to "6 chat platforms (Google Chat coming soon)".

## Not touched
- Region (area-level) fix and `/security` read-only-by-isolation fix from #4787 — correct, unaffected.
- `blog/announcing-atlas/page.tsx` — its "Eight integrations" line was already accurate; left alone (launch content).

## Verification
- `bun x oxlint` on changed `.tsx` — clean (exit 0).
- Content-only edits (string literals); no type/JSX-structure surface. CI runs full type/build/drift gates before merge.
