### PR TITLE
feat(api): brain substrate schema — episode/fact/edge tables (#4767)

### DIFF
--- a/apps/docs/content/docs/platform-ops/data-residency.mdx
+++ b/apps/docs/content/docs/platform-ops/data-residency.mdx
@@ -185,7 +185,7 @@ Set `ATLAS_STRICT_ROUTING=true` (or `residency.strictRouting: true` in config) t
 
 ## Region Migration
 
-When a workspace needs to move to a different region, Atlas performs a cross-region data migration. The migration moves the workspace's content — conversations, semantic entities, learned patterns, org-scoped settings, dashboards, knowledge documents, scheduled task definitions, and durable agent session memory — from the source region to the target. Operational state (caches, run history, in-flight agent checkpoints) and region-bound credentials deliberately do not move; the full per-item breakdown is in [What moves](#what-moves).
+When a workspace needs to move to a different region, Atlas performs a cross-region data migration. The migration moves the workspace's content — conversations, semantic entities, learned patterns, org-scoped settings, dashboards, knowledge documents, scheduled task definitions, durable agent session memory, and the company brain — from the source region to the target. Operational state (caches, run history, in-flight agent checkpoints) and region-bound credentials deliberately do not move; the full per-item breakdown is in [What moves](#what-moves).
 
 ### How it works
 
@@ -228,6 +228,7 @@ curl http://localhost:3001/api/v1/admin/residency/migration \
 | Knowledge documents (bodies, frontmatter, link graph, review status) | Moves in the bundle. Full-text search index rebuilds automatically. Sync credentials and sync state stay behind — re-enter the endpoint secret and re-sync in the target region |
 | Scheduled tasks (definitions) | Moves in the bundle; the next run time is recomputed in the target so its scheduler re-plans. Run history stays behind. Connection-group / plugin references resolve again once the datasource or plugin is re-installed in the target |
 | Durable agent session memory | Moves in the bundle (keyed to migrated conversations) |
+| Company brain (episodes, reviewed facts, provenance graph, audience membership) | Moves in the bundle. Each fact travels with its provenance, its visibility grant, its review status, and its full validity history — including retracted and superseded claims, so "what we believed on Monday" still answers correctly in the target. Audience membership moves with it, so `audience:`-scoped facts stay visible to the right people |
 | In-flight agent run checkpoints | Stays — resume leases are region-local and cannot be resumed cross-region; an interrupted turn is simply re-asked in the target |
 | Workspace integrations (chat platforms, action targets, datasource installs, credentials) | **Recreated in the target region.** Credentials are encrypted under per-region keys (the ciphertext is not portable) and OAuth callbacks/webhooks bind to region-specific hosts, so integrations are re-connected after migration — see the checklist below |
 | Caches, run/audit/usage history, derived data (suggestions, profiling state) | Stays — regenerates or re-accrues in the target |

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -51538,6 +51538,18 @@
                           },
                           "agentSessionMemory": {
                             "type": "number"
+                          },
+                          "brainEpisodes": {
+                            "type": "number"
+                          },
+                          "brainFacts": {
+                            "type": "number"
+                          },
+                          "brainEdges": {
+                            "type": "number"
+                          },
+                          "factAudienceMembers": {
+                            "type": "number"
                           }
                         },
                         "required": [
@@ -51585,6 +51597,18 @@
                     "items": {}
                   },
                   "agentSessionMemory": {
+                    "type": "array",
+                    "items": {}
+                  },
+                  "brainEpisodes": {
+                    "type": "array",
+                    "items": {}
+                  },
+                  "brainEdges": {
+                    "type": "array",
+                    "items": {}
+                  },
+                  "factAudienceMembers": {
                     "type": "array",
                     "items": {}
                   }
@@ -51727,6 +51751,66 @@
                         "imported",
                         "skipped"
                       ]
+                    },
+                    "brainEpisodes": {
+                      "type": "object",
+                      "properties": {
+                        "imported": {
+                          "type": "number"
+                        },
+                        "skipped": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "imported",
+                        "skipped"
+                      ]
+                    },
+                    "brainFacts": {
+                      "type": "object",
+                      "properties": {
+                        "imported": {
+                          "type": "number"
+                        },
+                        "skipped": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "imported",
+                        "skipped"
+                      ]
+                    },
+                    "brainEdges": {
+                      "type": "object",
+                      "properties": {
+                        "imported": {
+                          "type": "number"
+                        },
+                        "skipped": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "imported",
+                        "skipped"
+                      ]
+                    },
+                    "factAudienceMembers": {
+                      "type": "object",
+                      "properties": {
+                        "imported": {
+                          "type": "number"
+                        },
+                        "skipped": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "imported",
+                        "skipped"
+                      ]
                     }
                   },
                   "required": [
@@ -51737,7 +51821,11 @@
                     "dashboards",
                     "knowledgeDocuments",
                     "scheduledTasks",
-                    "agentSessionMemory"
+                    "agentSessionMemory",
+                    "brainEpisodes",
+                    "brainFacts",
+                    "brainEdges",
+                    "factAudienceMembers"
                   ]
                 }
               }

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -256,6 +256,10 @@ describe("bundle round-trip shape", () => {
       knowledgeDocuments: { imported: 4, skipped: 0 },
       scheduledTasks: { imported: 1, skipped: 0 },
       agentSessionMemory: { imported: 6, skipped: 2 },
+      brainEpisodes: { imported: 7, skipped: 1 },
+      brainFacts: { imported: 9, skipped: 3 },
+      brainEdges: { imported: 4, skipped: 0 },
+      factAudienceMembers: { imported: 2, skipped: 5 },
     };
 
     const total = (r: { imported: number; skipped: number }) => r.imported + r.skipped;
@@ -267,6 +271,10 @@ describe("bundle round-trip shape", () => {
     expect(total(result.knowledgeDocuments)).toBe(4);
     expect(total(result.scheduledTasks)).toBe(1);
     expect(total(result.agentSessionMemory)).toBe(8);
+    expect(total(result.brainEpisodes)).toBe(8);
+    expect(total(result.brainFacts)).toBe(12);
+    expect(total(result.brainEdges)).toBe(4);
+    expect(total(result.factAudienceMembers)).toBe(7);
   });
 });
 

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -913,9 +913,22 @@ describe("validateBundle — company brain (#4767)", () => {
   // CHECK catches `[]`; it does NOT catch `[null]` or `['']`, which are the
   // same denies-everyone state smuggled past it by the layer meant to
   // front-run the constraint.
-  it("rejects a fact grant that is absent, empty, or has blank principals", () => {
-    for (const bad of [undefined, [], [null], [""], ["  "], [123]]) {
+  it("rejects a fact grant that is absent, empty, or has no usable principal", () => {
+    for (const bad of [undefined, [], [null], [""], [123], [null, ""]]) {
       expectFactRejected((f) => { f.visibleTo = bad; }, "visibleTo");
+    }
+  });
+
+  it("accepts anything the CHECK accepts — the importer is never stricter than the DB", () => {
+    // Load-bearing: a workspace whose grant Postgres legally stores must stay
+    // migratable. An importer stricter than `chk_*_grant_nonempty` would leave
+    // that workspace permanently stuck in its current region, discovered only
+    // at cutover time. Grammar validity is #4768's read-time deny+log problem,
+    // not a reason to refuse a bundle.
+    for (const odd of [["everyone"], ["  "], ["org", null], ["org", ""]]) {
+      const bundle = brainBundle();
+      (bundle.brainEpisodes![0].facts[0] as unknown as Record<string, unknown>).visibleTo = odd;
+      expect(validateBundle(bundle).ok).toBe(true);
     }
   });
 

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -831,6 +831,247 @@ describe("validateBundle — v2 sections (#4460)", () => {
   });
 });
 
+describe("validateBundle — company brain (#4767)", () => {
+  /** A minimal, valid brain payload: one episode, one fact, one edge, one member. */
+  function brainBundle(): ExportBundle {
+    const bundle = validV2Bundle();
+    return {
+      ...bundle,
+      brainEpisodes: [
+        {
+          id: "ep-1",
+          source: "slack",
+          sourceId: "C1/1.0",
+          sourceActor: "U-alice",
+          body: "pricing is $49/seat",
+          locator: null,
+          occurredAt: "2026-06-01T00:00:00Z",
+          ingestedAt: "2026-06-01T00:00:00Z",
+          extractedAt: "2026-06-01T00:05:00Z",
+          visibleTo: ["org"],
+          createdAt: "2026-06-01T00:00:00Z",
+          facts: [
+            {
+              id: "fact-1",
+              subject: "acme:pro",
+              predicate: "price_per_seat",
+              object: "49",
+              validFrom: "2026-06-01T00:00:00Z",
+              validTo: null,
+              ingestedAt: "2026-06-01T00:05:00Z",
+              invalidatedAt: null,
+              extractedAt: "2026-06-01T00:05:00Z",
+              provenance: { actor: "U-alice" },
+              status: "published",
+              visibleTo: ["org"],
+              predicateCardinality: "single",
+              createdAt: "2026-06-01T00:05:00Z",
+              updatedAt: "2026-06-01T00:05:00Z",
+            },
+          ],
+        },
+      ],
+      brainEdges: [
+        {
+          edgeType: "provenance",
+          fromFactId: "fact-1",
+          fromEpisodeId: null,
+          toFactId: null,
+          toEpisodeId: "ep-1",
+          createdAt: "2026-06-01T00:05:00Z",
+        },
+      ],
+      factAudienceMembers: [
+        { audienceId: "eng", userId: "u1", source: "slack", createdAt: "2026-06-01T00:00:00Z" },
+      ],
+    };
+  }
+
+  /** Mutate the single fact and expect rejection naming `expected`. */
+  function expectFactRejected(mutate: (fact: Record<string, unknown>) => void, expected: string) {
+    const bundle = brainBundle();
+    mutate(bundle.brainEpisodes![0].facts[0] as unknown as Record<string, unknown>);
+    const result = validateBundle(bundle);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain(expected);
+  }
+
+  it("accepts a well-formed brain payload", () => {
+    expect(validateBundle(brainBundle()).ok).toBe(true);
+  });
+
+  it("accepts a v2 bundle with NO brain sections — the mid-rollout contract", () => {
+    // A source region still running pre-#4767 code emits exactly this. If the
+    // brain sections were ever added to the v2 REQUIRED list, every migration
+    // out of a not-yet-upgraded region would start failing hard.
+    const bundle = validV2Bundle();
+    expect(validateBundle(bundle).ok).toBe(true);
+  });
+
+  // ── no-grant-no-promotion ────────────────────────────────────────────────
+  // An absent, empty, or blank-element grant must never be defaulted. The DB
+  // CHECK catches `[]`; it does NOT catch `[null]` or `['']`, which are the
+  // same denies-everyone state smuggled past it by the layer meant to
+  // front-run the constraint.
+  it("rejects a fact grant that is absent, empty, or has blank principals", () => {
+    for (const bad of [undefined, [], [null], [""], ["  "], [123]]) {
+      expectFactRejected((f) => { f.visibleTo = bad; }, "visibleTo");
+    }
+  });
+
+  it("rejects an episode grant that is absent, empty, or has blank principals", () => {
+    for (const bad of [undefined, [], [null], [""]]) {
+      const bundle = brainBundle();
+      (bundle.brainEpisodes![0] as unknown as Record<string, unknown>).visibleTo = bad;
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("visibleTo");
+    }
+  });
+
+  // ── no-provenance-no-promotion ───────────────────────────────────────────
+  it("rejects a fact whose provenance is absent, empty, or not an object", () => {
+    for (const bad of [undefined, null, {}, [], "actor"]) {
+      expectFactRejected((f) => { f.provenance = bad; }, "provenance");
+    }
+  });
+
+  // ── content-mode + cardinality vocabularies ──────────────────────────────
+  it("rejects a fact with an unknown status or predicate cardinality", () => {
+    expectFactRejected((f) => { f.status = "live"; }, "status");
+    expectFactRejected((f) => { delete f.status; }, "status");
+    expectFactRejected((f) => { f.predicateCardinality = "one"; }, "predicateCardinality");
+    expectFactRejected((f) => { delete f.predicateCardinality; }, "predicateCardinality");
+  });
+
+  // ── NOT NULL timestamps ──────────────────────────────────────────────────
+  // node-pg binds `undefined` as NULL, and an explicit NULL overrides the
+  // column default — so an omitted timestamp is a 23502 that rolls back the
+  // entire import, not a silently-defaulted `now()`.
+  it("rejects a fact missing a NOT NULL timestamp", () => {
+    for (const field of ["ingestedAt", "createdAt", "updatedAt"]) {
+      expectFactRejected((f) => { delete f[field]; }, field);
+    }
+  });
+
+  it("rejects an episode missing a NOT NULL timestamp", () => {
+    for (const field of ["ingestedAt", "createdAt"]) {
+      const bundle = brainBundle();
+      delete (bundle.brainEpisodes![0] as unknown as Record<string, unknown>)[field];
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain(field);
+    }
+  });
+
+  it("rejects a fact whose closed validity interval runs backwards", () => {
+    expectFactRejected((f) => {
+      f.validFrom = "2026-06-01T00:00:00Z";
+      f.validTo = "2026-01-01T00:00:00Z";
+    }, "precedes");
+  });
+
+  // ── episode body XOR locator ─────────────────────────────────────────────
+  it("rejects an episode carrying both a body and a locator, or neither", () => {
+    for (const [body, locator] of [
+      ["b", "l"],
+      [undefined, undefined],
+      [null, null],
+    ] as const) {
+      const bundle = brainBundle();
+      const e = bundle.brainEpisodes![0] as unknown as Record<string, unknown>;
+      e.body = body;
+      e.locator = locator;
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("brainEpisodes[0]");
+    }
+  });
+
+  it("rejects an episode whose body is present but not a non-empty string", () => {
+    // The guard must reject the wrong TYPE rather than read it as "absent" —
+    // a numeric body would otherwise pass the XOR check and still be bound.
+    for (const bad of [5, "", {}]) {
+      const bundle = brainBundle();
+      const e = bundle.brainEpisodes![0] as unknown as Record<string, unknown>;
+      e.body = bad;
+      e.locator = null;
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  // ── edges ────────────────────────────────────────────────────────────────
+  it("rejects an unknown edge type", () => {
+    const bundle = brainBundle();
+    (bundle.brainEdges![0] as unknown as Record<string, unknown>).edgeType = "contradicts";
+    const result = validateBundle(bundle);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("edgeType");
+  });
+
+  it("rejects an edge with zero or two endpoints on a side", () => {
+    for (const patch of [
+      { toEpisodeId: null }, // zero on the `to` side
+      { toFactId: "fact-1" }, // two on the `to` side
+      { fromFactId: null }, // zero on the `from` side
+    ]) {
+      const bundle = brainBundle();
+      Object.assign(bundle.brainEdges![0] as unknown as Record<string, unknown>, patch);
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("brainEdges[0]");
+    }
+  });
+
+  it("rejects an edge whose endpoint kind contradicts its type", () => {
+    // Mirrors chk_brain_edges_endpoint_kinds: `provenance` is the EVIDENCE
+    // pointer and must reach an episode; arbitration types compare claims.
+    const provenanceAtFact = brainBundle();
+    Object.assign(provenanceAtFact.brainEdges![0] as unknown as Record<string, unknown>, {
+      toEpisodeId: null,
+      toFactId: "fact-1",
+    });
+    expect(validateBundle(provenanceAtFact).ok).toBe(false);
+
+    const supersedesAtEpisode = brainBundle();
+    Object.assign(supersedesAtEpisode.brainEdges![0] as unknown as Record<string, unknown>, {
+      edgeType: "supersedes",
+    });
+    expect(validateBundle(supersedesAtEpisode).ok).toBe(false);
+  });
+
+  it("rejects an edge pointing at an id the bundle does not carry", () => {
+    // Edges import LAST, so a dangling endpoint would otherwise abort the
+    // transaction after every other pillar has already been written.
+    const bundle = brainBundle();
+    (bundle.brainEdges![0] as unknown as Record<string, unknown>).toEpisodeId = "ep-missing";
+    const result = validateBundle(bundle);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("not carried by this bundle");
+  });
+
+  it("rejects a malformed audience member", () => {
+    for (const field of ["audienceId", "userId", "source", "createdAt"]) {
+      const bundle = brainBundle();
+      delete (bundle.factAudienceMembers![0] as unknown as Record<string, unknown>)[field];
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("factAudienceMembers[0]");
+    }
+  });
+
+  it("rejects non-array brain sections", () => {
+    for (const section of ["brainEpisodes", "brainEdges", "factAudienceMembers"] as const) {
+      const bundle = brainBundle();
+      (bundle as unknown as Record<string, unknown>)[section] = "nope";
+      const result = validateBundle(bundle);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain(section);
+    }
+  });
+});
+
 describe("importBundle — v2 sections (#4460)", () => {
   it("imports a dashboard with cards and drafts, preserving UUIDs and re-minting the share token", async () => {
     const { client, calls } = v2CaptureClient();

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -11,7 +11,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getInternalDB, type InternalPoolClient } from "@atlas/api/lib/db/internal";
 import { computeNextRun } from "@atlas/api/lib/scheduled-tasks";
-import { BRAIN_EDGE_TYPES } from "@atlas/api/lib/brain/types";
+import { BRAIN_EDGE_TYPES, type BrainEdgeType } from "@atlas/api/lib/brain/types";
 import type { ExportBundle, ImportResult, SupportedBundleVersion } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
@@ -21,19 +21,24 @@ const log = createLogger("admin-migrate");
 /**
  * Why a grant is unacceptable, or `null` if it is fine (#4767).
  *
- * `cardinality(visible_to) > 0` on both brain tables rejects the empty array,
- * but not `[null]` or `['']` — cardinality-1 arrays that are semantically the
- * same denies-everyone state the CHECK exists to refuse, smuggled past it by
- * the layer that is supposed to front-run it. Grammar validity (`org` vs
- * `everyone`) is deliberately NOT checked here: that is #4768's parser, whose
- * failure mode is deny+log rather than a rejected import.
+ * Deliberately mirrors `chk_brain_{facts,episodes}_grant_nonempty` EXACTLY —
+ * at least one non-NULL, non-empty principal. Not looser (an empty grant
+ * would abort the whole import transaction on the CHECK), and critically not
+ * stricter either: anything Postgres stores must remain migratable, so an
+ * importer that rejected a grant the source region legally holds would leave
+ * that workspace permanently stuck in its current region.
+ *
+ * Grammar validity (`org` vs `everyone`) is NOT checked here. That is #4768's
+ * parser, whose failure mode is deny+log at read time rather than a rejected
+ * import.
  */
 function grantProblem(value: unknown): string | null {
-  if (!Array.isArray(value) || value.length === 0) {
-    return "must be a non-empty array (no-grant-no-promotion).";
+  if (!Array.isArray(value)) {
+    return "must be an array of principals (no-grant-no-promotion).";
   }
-  if (value.some((p) => typeof p !== "string" || p.trim().length === 0)) {
-    return "every principal must be a non-empty string (no-grant-no-promotion).";
+  const usable = value.filter((p) => typeof p === "string" && p.length > 0);
+  if (usable.length === 0) {
+    return "must contain at least one non-empty principal (no-grant-no-promotion).";
   }
   return null;
 }
@@ -44,12 +49,17 @@ function grantProblem(value: unknown): string | null {
  *
  * node-pg binds `undefined` as NULL, and an explicit NULL OVERRIDES a column
  * default — so a producer that omitted `ingestedAt` doesn't get `now()`, it
- * gets a 23502 that rolls back the whole import.
+ * gets a 23502 that rolls back the whole import. An unparseable string is the
+ * same class of late failure (pg 22007), so it is caught here too.
  */
 function missingTimestamps(row: Record<string, unknown>, keys: readonly string[]): string | null {
   for (const key of keys) {
-    if (typeof row[key] !== "string" || (row[key] as string).length === 0) {
+    const value = row[key];
+    if (typeof value !== "string" || value.length === 0) {
       return `${key}: is required (a NOT NULL timestamp; an absent value binds as NULL and aborts the import).`;
+    }
+    if (Number.isNaN(Date.parse(value))) {
+      return `${key}: '${value}' is not a parseable timestamp (it would abort the import at INSERT time).`;
     }
   }
   return null;
@@ -352,23 +362,47 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
       if (typeof e.fromFactId !== "string") {
         return { ok: false, error: `brainEdges[${i}]: every committed edge type originates at a fact, so 'fromFactId' is required.` };
       }
-      if (e.edgeType === "provenance" && typeof e.toEpisodeId !== "string") {
-        return { ok: false, error: `brainEdges[${i}]: a 'provenance' edge must point at an episode ('toEpisodeId').` };
+      // Exhaustive on purpose: adding a fifth type to BRAIN_EDGE_TYPES and the
+      // CHECK without deciding its endpoint kind here would let the importer
+      // accept a shape Postgres refuses — a raw 23514 aborting the whole
+      // transaction, which is the failure this whole block exists to move
+      // earlier. `satisfies never` makes that a compile error instead.
+      const edgeType: BrainEdgeType = e.edgeType as BrainEdgeType;
+      switch (edgeType) {
+        case "provenance":
+          if (typeof e.toEpisodeId !== "string") {
+            return { ok: false, error: `brainEdges[${i}]: a 'provenance' edge is the evidence pointer and must point at an episode ('toEpisodeId').` };
+          }
+          break;
+        case "supersedes":
+        case "in-tension-with":
+          if (typeof e.toFactId !== "string") {
+            return { ok: false, error: `brainEdges[${i}]: a '${edgeType}' edge compares claims and must point at a fact ('toFactId').` };
+          }
+          break;
+        case "derives-from":
+          // Fork lineage — legitimately reaches either kind.
+          break;
+        default:
+          edgeType satisfies never;
+          break;
       }
-      if ((e.edgeType === "supersedes" || e.edgeType === "in-tension-with") && typeof e.toFactId !== "string") {
-        return { ok: false, error: `brainEdges[${i}]: a '${e.edgeType}' edge must point at a fact ('toFactId').` };
-      }
+      const edgeTsError = missingTimestamps(e, ["createdAt"]);
+      if (edgeTsError) return { ok: false, error: `brainEdges[${i}].${edgeTsError}` };
       // Referential pre-flight. Edges import LAST, so a dangling endpoint
       // would otherwise abort the transaction after every other pillar has
       // been written — the most expensive possible moment to discover it.
-      // Only ids the bundle itself carries can be checked; an endpoint the
-      // TARGET is expected to already hold is out of scope here.
+      //
+      // A bundle must be self-contained: the exporter always emits the whole
+      // workspace, so an endpoint the bundle doesn't carry is a malformed
+      // bundle, not a reference to target-resident state. (Gating this on
+      // "only check when we have some ids" would make rejection depend on
+      // whether an UNRELATED section happened to be non-empty.)
       const missing = ([
         ["fromFactId", e.fromFactId, factIds],
         ["toFactId", e.toFactId, factIds],
-        ["fromEpisodeId", e.fromEpisodeId, episodeIds],
         ["toEpisodeId", e.toEpisodeId, episodeIds],
-      ] as const).find(([, id, known]) => typeof id === "string" && known.size > 0 && !known.has(id));
+      ] as const).find(([, id, known]) => typeof id === "string" && !known.has(id));
       if (missing) {
         return { ok: false, error: `brainEdges[${i}].${missing[0]}: '${String(missing[1])}' is not carried by this bundle.` };
       }
@@ -900,6 +934,13 @@ export async function importBundle(
   // permissive fallback here would manufacture the very rows the table's
   // CHECKs exist to refuse, and would do it while claiming a successful
   // migration.
+  // bundle episode id → the id it actually resolved to in the target. Only
+  // populated on the adoption path (same source record, different uuid);
+  // empty in the ordinary case. Edges must be rewritten through this or they
+  // reference a uuid that was never inserted, and fail their endpoint FK at
+  // the very last import step.
+  const adoptedEpisodes = new Map<string, string>();
+
   for (const episode of bundle.brainEpisodes ?? []) {
     // Two ways the target can already know this episode, and they need
     // different answers:
@@ -924,6 +965,29 @@ export async function importBundle(
 
     if (typeof existingId === "string") {
       episodeId = existingId;
+      if (existingId !== episode.id) {
+        // ADOPTION: the target holds this source record under a different
+        // uuid. Every later reference to the bundle's id must be rewritten,
+        // because that id is never inserted here — see `adoptedEpisodes`.
+        adoptedEpisodes.set(episode.id, existingId);
+        // Adoption keeps the TARGET's episode row, so the bundle's grant,
+        // body, actor and extraction stamp are discarded. That can WIDEN
+        // visibility of raw source content (tier-3 is gated precisely because
+        // it is often more sensitive than the facts drawn from it), and the
+        // `skipped` counter reports it identically to a benign re-import — so
+        // it must not pass silently.
+        log.warn(
+          {
+            orgId,
+            bundleEpisodeId: episode.id,
+            targetEpisodeId: existingId,
+            source: episode.source,
+            sourceId: episode.sourceId,
+            bundleGrant: episode.visibleTo,
+          },
+          "Adopted an existing target episode under a different id — the bundle's episode row (body, grant, extractedAt) was discarded in favour of the target's",
+        );
+      }
       result.brainEpisodes.skipped++;
     } else {
       await client.query(
@@ -993,13 +1057,28 @@ export async function importBundle(
   }
 
   // Edges LAST — an endpoint can be a fact or an episode on either side, so
-  // this is the only point at which every endpoint could exist. "Could", not
-  // "does": a skipped endpoint resolves only because the skip path means the
-  // row is already in the target. `validateBundle` refuses edges pointing at
-  // ids the bundle doesn't carry, so what remains here is an endpoint the
-  // target was expected to hold and didn't — genuinely exceptional, and it
-  // surfaces as an FK error rather than being papered over.
+  // this is the only point at which every endpoint exists. `validateBundle`
+  // has already refused edges pointing at ids the bundle doesn't carry, and
+  // any episode id the target resolved differently is rewritten below, so an
+  // FK error here means the target lost a row mid-import: genuinely
+  // exceptional, and it surfaces rather than being papered over.
+  //
+  // Episode endpoints go through the adoption map. Skipping this is not a
+  // subtle bug: the adopted bundle id is never inserted, so a `provenance`
+  // edge — the most common type, fact→episode — fails its endpoint FK and
+  // rolls back the ENTIRE import, in exactly the scenario adoption exists to
+  // rescue.
+  const resolveEpisode = (id: string | null | undefined): string | null =>
+    id == null ? null : (adoptedEpisodes.get(id) ?? id);
+
   for (const edge of bundle.brainEdges ?? []) {
+    const endpoints = [
+      edge.fromFactId ?? null,
+      resolveEpisode(edge.fromEpisodeId),
+      edge.toFactId ?? null,
+      resolveEpisode(edge.toEpisodeId),
+    ];
+
     const existing = await client.query(
       `SELECT id FROM brain_edges
         WHERE workspace_id = $1 AND edge_type = $2
@@ -1007,14 +1086,7 @@ export async function importBundle(
           AND from_episode_id IS NOT DISTINCT FROM $4
           AND to_fact_id IS NOT DISTINCT FROM $5
           AND to_episode_id IS NOT DISTINCT FROM $6`,
-      [
-        orgId,
-        edge.edgeType,
-        edge.fromFactId ?? null,
-        edge.fromEpisodeId ?? null,
-        edge.toFactId ?? null,
-        edge.toEpisodeId ?? null,
-      ],
+      [orgId, edge.edgeType, ...endpoints],
     );
 
     if (existing.rows.length > 0) {
@@ -1025,15 +1097,7 @@ export async function importBundle(
     await client.query(
       `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, from_episode_id, to_fact_id, to_episode_id, created_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-      [
-        orgId,
-        edge.edgeType,
-        edge.fromFactId ?? null,
-        edge.fromEpisodeId ?? null,
-        edge.toFactId ?? null,
-        edge.toEpisodeId ?? null,
-        edge.createdAt,
-      ],
+      [orgId, edge.edgeType, ...endpoints, edge.createdAt],
     );
 
     result.brainEdges.imported++;

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -352,6 +352,17 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
       if (!(BRAIN_EDGE_TYPES as readonly string[]).includes(e.edgeType as string)) {
         return { ok: false, error: `brainEdges[${i}].edgeType: must be one of ${BRAIN_EDGE_TYPES.join(", ")}.` };
       }
+      // A wrong-TYPED endpoint must be rejected, not counted as absent: the
+      // XOR below would score `{fromFactId: "…", fromEpisodeId: 5}` as valid,
+      // and the 5 would still be bound into a uuid column at the INSERT — a
+      // 22P02 aborting the whole transaction at the last import step. Same
+      // class as the episode body guard above.
+      for (const key of ["fromFactId", "fromEpisodeId", "toFactId", "toEpisodeId"] as const) {
+        const endpoint = e[key];
+        if (endpoint !== undefined && endpoint !== null && typeof endpoint !== "string") {
+          return { ok: false, error: `brainEdges[${i}].${key}: must be a string id or absent (a non-string endpoint aborts the import at INSERT time).` };
+        }
+      }
       // Exactly one endpoint per side — guards chk_brain_edges_{from,to}_endpoint.
       const fromCount = Number(typeof e.fromFactId === "string") + Number(typeof e.fromEpisodeId === "string");
       const toCount = Number(typeof e.toFactId === "string") + Number(typeof e.toEpisodeId === "string");

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -11,6 +11,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getInternalDB, type InternalPoolClient } from "@atlas/api/lib/db/internal";
 import { computeNextRun } from "@atlas/api/lib/scheduled-tasks";
+import { BRAIN_EDGE_TYPES, type BrainEdgeType } from "@atlas/api/lib/brain/types";
 import type { ExportBundle, ImportResult, SupportedBundleVersion } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
@@ -212,6 +213,90 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
     }
   }
 
+  // Company brain (#4767, ADR-0036). Deliberately NOT added to the v2
+  // required-section list above: a source region still running pre-#4767 code
+  // produces a valid v2 bundle with no brain sections, and requiring them
+  // would turn every mid-rollout migration into a hard failure. Optional on
+  // the wire, imported whenever present.
+  //
+  // The shape guards below exist because the brain tables enforce their
+  // invariants with CHECK constraints. A malformed bundle reaching the INSERT
+  // aborts the WHOLE import transaction with a raw pg error; caught here it is
+  // an actionable message naming the offending index.
+  if ("brainEpisodes" in obj && obj.brainEpisodes !== undefined) {
+    if (!Array.isArray(obj.brainEpisodes)) {
+      return { ok: false, error: "Invalid 'brainEpisodes' field. Expected an array." };
+    }
+    for (let i = 0; i < obj.brainEpisodes.length; i++) {
+      const e = obj.brainEpisodes[i] as Record<string, unknown> | null;
+      if (!e || typeof e !== "object" || typeof e.id !== "string" || typeof e.source !== "string" || typeof e.sourceId !== "string" || !Array.isArray(e.facts)) {
+        return { ok: false, error: `brainEpisodes[${i}]: must have 'id', 'source', 'sourceId' (strings) and 'facts' (array).` };
+      }
+      // Body XOR locator — guards chk_brain_episodes_body_xor_locator.
+      const hasBody = typeof e.body === "string";
+      const hasLocator = typeof e.locator === "string";
+      if (hasBody === hasLocator) {
+        return { ok: false, error: `brainEpisodes[${i}]: must carry exactly one of 'body' or 'locator'.` };
+      }
+      // No-grant-no-promotion — an absent or empty grant must never be
+      // defaulted to `['org']`, which would publish private source content to
+      // the whole workspace in the target region.
+      if (!Array.isArray(e.visibleTo) || e.visibleTo.length === 0) {
+        return { ok: false, error: `brainEpisodes[${i}].visibleTo: must be a non-empty array (no-grant-no-promotion).` };
+      }
+      for (let j = 0; j < e.facts.length; j++) {
+        const f = e.facts[j] as Record<string, unknown> | null;
+        if (!f || typeof f !== "object" || typeof f.id !== "string" || typeof f.subject !== "string" || typeof f.predicate !== "string" || typeof f.object !== "string") {
+          return { ok: false, error: `brainEpisodes[${i}].facts[${j}]: must have 'id', 'subject', 'predicate', and 'object' (strings).` };
+        }
+        if (f.status !== "draft" && f.status !== "published" && f.status !== "archived") {
+          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].status: must be 'draft', 'published', or 'archived'.` };
+        }
+        if (f.predicateCardinality !== "single" && f.predicateCardinality !== "multi") {
+          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].predicateCardinality: must be 'single' or 'multi'.` };
+        }
+        if (!Array.isArray(f.visibleTo) || f.visibleTo.length === 0) {
+          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].visibleTo: must be a non-empty array (no-grant-no-promotion).` };
+        }
+        // No-provenance-no-promotion. `{}` is rejected at rest by the table,
+        // so reject it here rather than aborting the transaction on it.
+        if (!f.provenance || typeof f.provenance !== "object" || Array.isArray(f.provenance) || Object.keys(f.provenance).length === 0) {
+          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].provenance: must be a non-empty object (no-provenance-no-promotion).` };
+        }
+      }
+    }
+  }
+
+  if ("brainEdges" in obj && obj.brainEdges !== undefined) {
+    if (!Array.isArray(obj.brainEdges)) {
+      return { ok: false, error: "Invalid 'brainEdges' field. Expected an array." };
+    }
+    for (let i = 0; i < obj.brainEdges.length; i++) {
+      const e = obj.brainEdges[i] as Record<string, unknown> | null;
+      if (!e || typeof e !== "object" || !BRAIN_EDGE_TYPES.includes(e.edgeType as BrainEdgeType)) {
+        return { ok: false, error: `brainEdges[${i}].edgeType: must be one of ${BRAIN_EDGE_TYPES.join(", ")}.` };
+      }
+      // Exactly one endpoint per side — guards chk_brain_edges_{from,to}_endpoint.
+      const fromCount = Number(typeof e.fromFactId === "string") + Number(typeof e.fromEpisodeId === "string");
+      const toCount = Number(typeof e.toFactId === "string") + Number(typeof e.toEpisodeId === "string");
+      if (fromCount !== 1 || toCount !== 1) {
+        return { ok: false, error: `brainEdges[${i}]: each side must have exactly one endpoint ('fromFactId' XOR 'fromEpisodeId', 'toFactId' XOR 'toEpisodeId').` };
+      }
+    }
+  }
+
+  if ("factAudienceMembers" in obj && obj.factAudienceMembers !== undefined) {
+    if (!Array.isArray(obj.factAudienceMembers)) {
+      return { ok: false, error: "Invalid 'factAudienceMembers' field. Expected an array." };
+    }
+    for (let i = 0; i < obj.factAudienceMembers.length; i++) {
+      const m = obj.factAudienceMembers[i] as Record<string, unknown> | null;
+      if (!m || typeof m !== "object" || typeof m.audienceId !== "string" || typeof m.userId !== "string" || typeof m.source !== "string") {
+        return { ok: false, error: `factAudienceMembers[${i}]: must have 'audienceId', 'userId', and 'source' (strings).` };
+      }
+    }
+  }
+
   return { ok: true, bundle: obj as unknown as ExportBundle };
 }
 
@@ -228,6 +313,10 @@ const ImportResultSchema = z.object({
   knowledgeDocuments: z.object({ imported: z.number(), skipped: z.number() }),
   scheduledTasks: z.object({ imported: z.number(), skipped: z.number() }),
   agentSessionMemory: z.object({ imported: z.number(), skipped: z.number() }),
+  brainEpisodes: z.object({ imported: z.number(), skipped: z.number() }),
+  brainFacts: z.object({ imported: z.number(), skipped: z.number() }),
+  brainEdges: z.object({ imported: z.number(), skipped: z.number() }),
+  factAudienceMembers: z.object({ imported: z.number(), skipped: z.number() }),
 });
 
 const importRoute = createRoute({
@@ -266,6 +355,10 @@ const importRoute = createRoute({
                 knowledgeLinks: z.number().optional(),
                 scheduledTasks: z.number().optional(),
                 agentSessionMemory: z.number().optional(),
+                brainEpisodes: z.number().optional(),
+                brainFacts: z.number().optional(),
+                brainEdges: z.number().optional(),
+                factAudienceMembers: z.number().optional(),
               }),
             }),
             conversations: z.array(z.unknown()),
@@ -278,6 +371,12 @@ const importRoute = createRoute({
             knowledgeDocuments: z.array(z.unknown()).optional(),
             scheduledTasks: z.array(z.unknown()).optional(),
             agentSessionMemory: z.array(z.unknown()).optional(),
+            // Company brain (#4767). Same reason as above — an undeclared
+            // section is stripped by zod before the importer ever sees it,
+            // which would strand the whole brain silently.
+            brainEpisodes: z.array(z.unknown()).optional(),
+            brainEdges: z.array(z.unknown()).optional(),
+            factAudienceMembers: z.array(z.unknown()).optional(),
           }),
         },
       },
@@ -325,6 +424,10 @@ export async function importBundle(
     knowledgeDocuments: { imported: 0, skipped: 0 },
     scheduledTasks: { imported: 0, skipped: 0 },
     agentSessionMemory: { imported: 0, skipped: 0 },
+    brainEpisodes: { imported: 0, skipped: 0 },
+    brainFacts: { imported: 0, skipped: 0 },
+    brainEdges: { imported: 0, skipped: 0 },
+    factAudienceMembers: { imported: 0, skipped: 0 },
   };
 
   // --- 1. Conversations + Messages ---
@@ -692,6 +795,141 @@ export async function importBundle(
     );
 
     result.agentSessionMemory.imported++;
+  }
+
+  // --- 9. Company brain (#4767, ADR-0036) — facts ride inside their episode ---
+  // Ordering is load-bearing, and it is the reason facts are NESTED rather
+  // than a sibling array: episode → its facts → (later) edges. A fact's
+  // `source_episode_id` is NOT NULL, so writing facts before episodes would
+  // fail the FK; writing edges before both would fail theirs.
+  //
+  // Everything that makes a fact trustworthy is carried verbatim — provenance,
+  // grant, review status, all four temporal columns. Nothing is defaulted: a
+  // permissive fallback here would manufacture the very rows the table's
+  // CHECKs exist to refuse, and would do it while claiming a successful
+  // migration.
+  for (const episode of bundle.brainEpisodes ?? []) {
+    const existing = await client.query(
+      "SELECT id FROM brain_episodes WHERE id = $1 AND workspace_id = $2",
+      [episode.id, orgId],
+    );
+
+    if (existing.rows.length > 0) {
+      result.brainEpisodes.skipped++;
+      // Its facts are skipped with it — re-importing them would attach
+      // duplicate claims to an episode that already carries its own.
+      result.brainFacts.skipped += episode.facts.length;
+      continue;
+    }
+
+    await client.query(
+      `INSERT INTO brain_episodes (id, workspace_id, source, source_id, source_actor, body, locator, occurred_at, ingested_at, extracted_at, visible_to, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        episode.id,
+        orgId,
+        episode.source,
+        episode.sourceId,
+        episode.sourceActor ?? null,
+        episode.body ?? null,
+        episode.locator ?? null,
+        episode.occurredAt ?? null,
+        episode.ingestedAt,
+        // Preserved: re-extracting in the target would re-queue episodes a
+        // human has already reviewed.
+        episode.extractedAt ?? null,
+        episode.visibleTo,
+        episode.createdAt,
+      ],
+    );
+
+    result.brainEpisodes.imported++;
+
+    for (const fact of episode.facts) {
+      await client.query(
+        `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, valid_from, valid_to, ingested_at, invalidated_at, extracted_at, source_episode_id, provenance, status, visible_to, predicate_cardinality, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+        [
+          fact.id,
+          orgId,
+          fact.subject,
+          fact.predicate,
+          fact.object,
+          fact.validFrom ?? null,
+          fact.validTo ?? null,
+          fact.ingestedAt,
+          fact.invalidatedAt ?? null,
+          fact.extractedAt ?? null,
+          episode.id,
+          JSON.stringify(fact.provenance),
+          fact.status,
+          fact.visibleTo,
+          fact.predicateCardinality,
+          fact.createdAt,
+          fact.updatedAt,
+        ],
+      );
+      result.brainFacts.imported++;
+    }
+  }
+
+  // Edges LAST — an endpoint can be a fact or an episode on either side, so
+  // this is the only point at which every endpoint is guaranteed to exist.
+  // An edge whose endpoint was skipped (already present) still resolves,
+  // because the skip path means the row is in the target already.
+  for (const edge of bundle.brainEdges ?? []) {
+    const existing = await client.query(
+      `SELECT id FROM brain_edges
+        WHERE workspace_id = $1 AND edge_type = $2
+          AND from_fact_id IS NOT DISTINCT FROM $3
+          AND from_episode_id IS NOT DISTINCT FROM $4
+          AND to_fact_id IS NOT DISTINCT FROM $5
+          AND to_episode_id IS NOT DISTINCT FROM $6`,
+      [
+        orgId,
+        edge.edgeType,
+        edge.fromFactId ?? null,
+        edge.fromEpisodeId ?? null,
+        edge.toFactId ?? null,
+        edge.toEpisodeId ?? null,
+      ],
+    );
+
+    if (existing.rows.length > 0) {
+      result.brainEdges.skipped++;
+      continue;
+    }
+
+    await client.query(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, from_episode_id, to_fact_id, to_episode_id, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        orgId,
+        edge.edgeType,
+        edge.fromFactId ?? null,
+        edge.fromEpisodeId ?? null,
+        edge.toFactId ?? null,
+        edge.toEpisodeId ?? null,
+        edge.createdAt,
+      ],
+    );
+
+    result.brainEdges.imported++;
+  }
+
+  // Audience membership. Without it every `audience:` grant denies everyone in
+  // the target region — a total loss of access that surfaces as "the brain
+  // forgot everything" rather than as an error.
+  for (const member of bundle.factAudienceMembers ?? []) {
+    const inserted = await client.query(
+      `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source, created_at)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (workspace_id, audience_id, user_id) DO NOTHING`,
+      [orgId, member.audienceId, member.userId, member.source, member.createdAt],
+    );
+
+    if (inserted.rowCount === 0) result.factAudienceMembers.skipped++;
+    else result.factAudienceMembers.imported++;
   }
 
   return result;

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -11,12 +11,49 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getInternalDB, type InternalPoolClient } from "@atlas/api/lib/db/internal";
 import { computeNextRun } from "@atlas/api/lib/scheduled-tasks";
-import { BRAIN_EDGE_TYPES, type BrainEdgeType } from "@atlas/api/lib/brain/types";
+import { BRAIN_EDGE_TYPES } from "@atlas/api/lib/brain/types";
 import type { ExportBundle, ImportResult, SupportedBundleVersion } from "@useatlas/types";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
 const log = createLogger("admin-migrate");
+
+/**
+ * Why a grant is unacceptable, or `null` if it is fine (#4767).
+ *
+ * `cardinality(visible_to) > 0` on both brain tables rejects the empty array,
+ * but not `[null]` or `['']` — cardinality-1 arrays that are semantically the
+ * same denies-everyone state the CHECK exists to refuse, smuggled past it by
+ * the layer that is supposed to front-run it. Grammar validity (`org` vs
+ * `everyone`) is deliberately NOT checked here: that is #4768's parser, whose
+ * failure mode is deny+log rather than a rejected import.
+ */
+function grantProblem(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return "must be a non-empty array (no-grant-no-promotion).";
+  }
+  if (value.some((p) => typeof p !== "string" || p.trim().length === 0)) {
+    return "every principal must be a non-empty string (no-grant-no-promotion).";
+  }
+  return null;
+}
+
+/**
+ * The first missing NOT NULL timestamp among `keys`, as an error fragment, or
+ * `null` (#4767).
+ *
+ * node-pg binds `undefined` as NULL, and an explicit NULL OVERRIDES a column
+ * default — so a producer that omitted `ingestedAt` doesn't get `now()`, it
+ * gets a 23502 that rolls back the whole import.
+ */
+function missingTimestamps(row: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    if (typeof row[key] !== "string" || (row[key] as string).length === 0) {
+      return `${key}: is required (a NOT NULL timestamp; an absent value binds as NULL and aborts the import).`;
+    }
+  }
+  return null;
+}
 
 /**
  * The pre-#4460 bundle version — four sections only (conversations, semantic
@@ -220,9 +257,17 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
   // the wire, imported whenever present.
   //
   // The shape guards below exist because the brain tables enforce their
-  // invariants with CHECK constraints. A malformed bundle reaching the INSERT
-  // aborts the WHOLE import transaction with a raw pg error; caught here it is
-  // an actionable message naming the offending index.
+  // invariants with CHECK/NOT NULL constraints. A malformed bundle reaching
+  // the INSERT aborts the WHOLE import transaction with a raw pg error, after
+  // every earlier pillar has already been written; caught here it is an
+  // actionable message naming the offending array position.
+  //
+  // Note what these guards do NOT claim: a non-empty but malformed grant
+  // (`['everyone']`) is the #4768 parser's deny+log problem, not this
+  // function's. What is checked here is exactly what the DB would refuse.
+  const episodeIds = new Set<string>();
+  const factIds = new Set<string>();
+
   if ("brainEpisodes" in obj && obj.brainEpisodes !== undefined) {
     if (!Array.isArray(obj.brainEpisodes)) {
       return { ok: false, error: "Invalid 'brainEpisodes' field. Expected an array." };
@@ -232,37 +277,55 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
       if (!e || typeof e !== "object" || typeof e.id !== "string" || typeof e.source !== "string" || typeof e.sourceId !== "string" || !Array.isArray(e.facts)) {
         return { ok: false, error: `brainEpisodes[${i}]: must have 'id', 'source', 'sourceId' (strings) and 'facts' (array).` };
       }
-      // Body XOR locator — guards chk_brain_episodes_body_xor_locator.
-      const hasBody = typeof e.body === "string";
-      const hasLocator = typeof e.locator === "string";
-      if (hasBody === hasLocator) {
+      // Body XOR locator — guards chk_brain_episodes_body_xor_locator. Tests
+      // presence, not `typeof === "string"`: a non-string body would read as
+      // "absent" here and still be bound at the INSERT, so the guard has to
+      // reject the wrong TYPE rather than route around it.
+      const bodyPresent = e.body !== undefined && e.body !== null;
+      const locatorPresent = e.locator !== undefined && e.locator !== null;
+      if (bodyPresent === locatorPresent) {
         return { ok: false, error: `brainEpisodes[${i}]: must carry exactly one of 'body' or 'locator'.` };
       }
-      // No-grant-no-promotion — an absent or empty grant must never be
-      // defaulted to `['org']`, which would publish private source content to
-      // the whole workspace in the target region.
-      if (!Array.isArray(e.visibleTo) || e.visibleTo.length === 0) {
-        return { ok: false, error: `brainEpisodes[${i}].visibleTo: must be a non-empty array (no-grant-no-promotion).` };
+      if (bodyPresent && (typeof e.body !== "string" || e.body.length === 0)) {
+        return { ok: false, error: `brainEpisodes[${i}].body: must be a non-empty string.` };
       }
+      if (locatorPresent && (typeof e.locator !== "string" || e.locator.length === 0)) {
+        return { ok: false, error: `brainEpisodes[${i}].locator: must be a non-empty string.` };
+      }
+      const grantError = grantProblem(e.visibleTo);
+      if (grantError) {
+        return { ok: false, error: `brainEpisodes[${i}].visibleTo: ${grantError}` };
+      }
+      const tsError = missingTimestamps(e, ["ingestedAt", "createdAt"]);
+      if (tsError) return { ok: false, error: `brainEpisodes[${i}].${tsError}` };
+      episodeIds.add(e.id);
+
       for (let j = 0; j < e.facts.length; j++) {
         const f = e.facts[j] as Record<string, unknown> | null;
+        const at = `brainEpisodes[${i}].facts[${j}]`;
         if (!f || typeof f !== "object" || typeof f.id !== "string" || typeof f.subject !== "string" || typeof f.predicate !== "string" || typeof f.object !== "string") {
-          return { ok: false, error: `brainEpisodes[${i}].facts[${j}]: must have 'id', 'subject', 'predicate', and 'object' (strings).` };
+          return { ok: false, error: `${at}: must have 'id', 'subject', 'predicate', and 'object' (strings).` };
         }
         if (f.status !== "draft" && f.status !== "published" && f.status !== "archived") {
-          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].status: must be 'draft', 'published', or 'archived'.` };
+          return { ok: false, error: `${at}.status: must be 'draft', 'published', or 'archived'.` };
         }
         if (f.predicateCardinality !== "single" && f.predicateCardinality !== "multi") {
-          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].predicateCardinality: must be 'single' or 'multi'.` };
+          return { ok: false, error: `${at}.predicateCardinality: must be 'single' or 'multi'.` };
         }
-        if (!Array.isArray(f.visibleTo) || f.visibleTo.length === 0) {
-          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].visibleTo: must be a non-empty array (no-grant-no-promotion).` };
-        }
+        const factGrantError = grantProblem(f.visibleTo);
+        if (factGrantError) return { ok: false, error: `${at}.visibleTo: ${factGrantError}` };
         // No-provenance-no-promotion. `{}` is rejected at rest by the table,
         // so reject it here rather than aborting the transaction on it.
         if (!f.provenance || typeof f.provenance !== "object" || Array.isArray(f.provenance) || Object.keys(f.provenance).length === 0) {
-          return { ok: false, error: `brainEpisodes[${i}].facts[${j}].provenance: must be a non-empty object (no-provenance-no-promotion).` };
+          return { ok: false, error: `${at}.provenance: must be a non-empty object (no-provenance-no-promotion).` };
         }
+        const factTsError = missingTimestamps(f, ["ingestedAt", "createdAt", "updatedAt"]);
+        if (factTsError) return { ok: false, error: `${at}.${factTsError}` };
+        // chk_brain_facts_valid_interval — a closed interval running backwards.
+        if (typeof f.validFrom === "string" && typeof f.validTo === "string" && f.validTo < f.validFrom) {
+          return { ok: false, error: `${at}: 'validTo' (${f.validTo}) precedes 'validFrom' (${f.validFrom}).` };
+        }
+        factIds.add(f.id);
       }
     }
   }
@@ -273,7 +336,10 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
     }
     for (let i = 0; i < obj.brainEdges.length; i++) {
       const e = obj.brainEdges[i] as Record<string, unknown> | null;
-      if (!e || typeof e !== "object" || !BRAIN_EDGE_TYPES.includes(e.edgeType as BrainEdgeType)) {
+      if (!e || typeof e !== "object") {
+        return { ok: false, error: `brainEdges[${i}]: must be an object.` };
+      }
+      if (!(BRAIN_EDGE_TYPES as readonly string[]).includes(e.edgeType as string)) {
         return { ok: false, error: `brainEdges[${i}].edgeType: must be one of ${BRAIN_EDGE_TYPES.join(", ")}.` };
       }
       // Exactly one endpoint per side — guards chk_brain_edges_{from,to}_endpoint.
@@ -281,6 +347,30 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
       const toCount = Number(typeof e.toFactId === "string") + Number(typeof e.toEpisodeId === "string");
       if (fromCount !== 1 || toCount !== 1) {
         return { ok: false, error: `brainEdges[${i}]: each side must have exactly one endpoint ('fromFactId' XOR 'fromEpisodeId', 'toFactId' XOR 'toEpisodeId').` };
+      }
+      // Per-type endpoint kinds — guards chk_brain_edges_endpoint_kinds.
+      if (typeof e.fromFactId !== "string") {
+        return { ok: false, error: `brainEdges[${i}]: every committed edge type originates at a fact, so 'fromFactId' is required.` };
+      }
+      if (e.edgeType === "provenance" && typeof e.toEpisodeId !== "string") {
+        return { ok: false, error: `brainEdges[${i}]: a 'provenance' edge must point at an episode ('toEpisodeId').` };
+      }
+      if ((e.edgeType === "supersedes" || e.edgeType === "in-tension-with") && typeof e.toFactId !== "string") {
+        return { ok: false, error: `brainEdges[${i}]: a '${e.edgeType}' edge must point at a fact ('toFactId').` };
+      }
+      // Referential pre-flight. Edges import LAST, so a dangling endpoint
+      // would otherwise abort the transaction after every other pillar has
+      // been written — the most expensive possible moment to discover it.
+      // Only ids the bundle itself carries can be checked; an endpoint the
+      // TARGET is expected to already hold is out of scope here.
+      const missing = ([
+        ["fromFactId", e.fromFactId, factIds],
+        ["toFactId", e.toFactId, factIds],
+        ["fromEpisodeId", e.fromEpisodeId, episodeIds],
+        ["toEpisodeId", e.toEpisodeId, episodeIds],
+      ] as const).find(([, id, known]) => typeof id === "string" && known.size > 0 && !known.has(id));
+      if (missing) {
+        return { ok: false, error: `brainEdges[${i}].${missing[0]}: '${String(missing[1])}' is not carried by this bundle.` };
       }
     }
   }
@@ -294,6 +384,8 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
       if (!m || typeof m !== "object" || typeof m.audienceId !== "string" || typeof m.userId !== "string" || typeof m.source !== "string") {
         return { ok: false, error: `factAudienceMembers[${i}]: must have 'audienceId', 'userId', and 'source' (strings).` };
       }
+      const tsError = missingTimestamps(m, ["createdAt"]);
+      if (tsError) return { ok: false, error: `factAudienceMembers[${i}].${tsError}` };
     }
   }
 
@@ -809,43 +901,70 @@ export async function importBundle(
   // CHECKs exist to refuse, and would do it while claiming a successful
   // migration.
   for (const episode of bundle.brainEpisodes ?? []) {
+    // Two ways the target can already know this episode, and they need
+    // different answers:
+    //   * same UUID  — a re-import of the same bundle. Skip.
+    //   * same (source, source_id) under a DIFFERENT UUID — the target's own
+    //     connector ingested the same source record, which is routine after
+    //     cutover. A bare INSERT would hit uq_brain_episodes_source_id and
+    //     abort the ENTIRE import transaction, so adopt the existing row's id
+    //     and hang this bundle's facts off it instead.
     const existing = await client.query(
-      "SELECT id FROM brain_episodes WHERE id = $1 AND workspace_id = $2",
-      [episode.id, orgId],
+      `SELECT id FROM brain_episodes
+        WHERE workspace_id = $1 AND (id = $2 OR (source = $3 AND source_id = $4))
+        ORDER BY (id = $2) DESC
+        LIMIT 1`,
+      [orgId, episode.id, episode.source, episode.sourceId],
     );
+    const existingId = existing.rows[0]?.id;
 
-    if (existing.rows.length > 0) {
+    // The id facts must point at — the existing row's when one was found, so a
+    // fact is never orphaned by an id the target resolved differently.
+    let episodeId = episode.id;
+
+    if (typeof existingId === "string") {
+      episodeId = existingId;
       result.brainEpisodes.skipped++;
-      // Its facts are skipped with it — re-importing them would attach
-      // duplicate claims to an episode that already carries its own.
-      result.brainFacts.skipped += episode.facts.length;
-      continue;
+    } else {
+      await client.query(
+        `INSERT INTO brain_episodes (id, workspace_id, source, source_id, source_actor, body, locator, occurred_at, ingested_at, extracted_at, visible_to, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+        [
+          episode.id,
+          orgId,
+          episode.source,
+          episode.sourceId,
+          episode.sourceActor ?? null,
+          episode.body ?? null,
+          episode.locator ?? null,
+          episode.occurredAt ?? null,
+          episode.ingestedAt,
+          // Preserved: re-extracting in the target would re-queue episodes a
+          // human has already reviewed.
+          episode.extractedAt ?? null,
+          episode.visibleTo,
+          episode.createdAt,
+        ],
+      );
+      result.brainEpisodes.imported++;
     }
 
-    await client.query(
-      `INSERT INTO brain_episodes (id, workspace_id, source, source_id, source_actor, body, locator, occurred_at, ingested_at, extracted_at, visible_to, created_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
-      [
-        episode.id,
-        orgId,
-        episode.source,
-        episode.sourceId,
-        episode.sourceActor ?? null,
-        episode.body ?? null,
-        episode.locator ?? null,
-        episode.occurredAt ?? null,
-        episode.ingestedAt,
-        // Preserved: re-extracting in the target would re-queue episodes a
-        // human has already reviewed.
-        episode.extractedAt ?? null,
-        episode.visibleTo,
-        episode.createdAt,
-      ],
-    );
-
-    result.brainEpisodes.imported++;
-
+    // Facts are deduped on their OWN key, not on their episode's. An episode
+    // is immutable but its fact set GROWS — re-extraction and human
+    // corrections add claims to an episode the target already has. Skipping
+    // facts wholesale because their episode existed would strand every such
+    // claim while reporting it as "skipped", i.e. as already present.
     for (const fact of episode.facts) {
+      const existingFact = await client.query(
+        "SELECT id FROM brain_facts WHERE id = $1 AND workspace_id = $2",
+        [fact.id, orgId],
+      );
+
+      if (existingFact.rows.length > 0) {
+        result.brainFacts.skipped++;
+        continue;
+      }
+
       await client.query(
         `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, valid_from, valid_to, ingested_at, invalidated_at, extracted_at, source_episode_id, provenance, status, visible_to, predicate_cardinality, created_at, updated_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
@@ -860,7 +979,7 @@ export async function importBundle(
           fact.ingestedAt,
           fact.invalidatedAt ?? null,
           fact.extractedAt ?? null,
-          episode.id,
+          episodeId,
           JSON.stringify(fact.provenance),
           fact.status,
           fact.visibleTo,
@@ -874,9 +993,12 @@ export async function importBundle(
   }
 
   // Edges LAST — an endpoint can be a fact or an episode on either side, so
-  // this is the only point at which every endpoint is guaranteed to exist.
-  // An edge whose endpoint was skipped (already present) still resolves,
-  // because the skip path means the row is in the target already.
+  // this is the only point at which every endpoint could exist. "Could", not
+  // "does": a skipped endpoint resolves only because the skip path means the
+  // row is already in the target. `validateBundle` refuses edges pointing at
+  // ids the bundle doesn't carry, so what remains here is an endpoint the
+  // target was expected to hold and didn't — genuinely exceptional, and it
+  // surfaces as an FK error rather than being papered over.
   for (const edge of bundle.brainEdges ?? []) {
     const existing = await client.query(
       `SELECT id FROM brain_edges

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -535,6 +535,12 @@ describe("migrateAuthTables", () => {
             // be in the already-applied set so this "all applied" test sees
             // zero new migrations.
             { name: "0179_drop_conversations_notebook_state.sql" },
+            // 0180 (#4767, ADR-0036) — brain substrate (episodes / facts /
+            // edges / fact_audience_member). Additive CREATE TABLE on
+            // Atlas-internal tables, no Better Auth involvement, so it runs
+            // in every auth mode — must be in the already-applied set so this
+            // "all applied" test sees zero new migrations.
+            { name: "0180_brain_substrate.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/brain/__tests__/types.test.ts
+++ b/packages/api/src/lib/brain/__tests__/types.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  BRAIN_EDGE_TYPES,
+  BRAIN_FACT_STATUSES,
+  PREDICATE_CARDINALITIES,
+  TRUST_TIERS,
+} from "@atlas/api/lib/brain/types";
+
+// Source-level drift guard between the TypeScript vocabulary and migration
+// 0180's CHECK constraints (#4767, ADR-0036).
+//
+// Why this is worth a test rather than a comment: the enum and the constraint
+// are the SAME decision written twice, and they fail asymmetrically. Widen the
+// TS union and forget the CHECK, and the extra value is rejected at INSERT
+// with a 23514 that surfaces to a user as a failed ingest. Widen the CHECK and
+// forget the TS union, and rows land that no reader can narrow — the far worse
+// direction, because it's silent. Neither shows up in a type-check.
+//
+// These run in every shard: no Postgres required, just the SQL text.
+const MIGRATION_SQL = readFileSync(
+  join(import.meta.dir, "..", "..", "db", "migrations", "0180_brain_substrate.sql"),
+  "utf8",
+);
+
+/**
+ * Pull the quoted values out of a `CHECK (... IN ('a', 'b'))` constraint.
+ * Line comments are stripped first — the migration's prose header names these
+ * same values repeatedly, and a comment must never be able to satisfy (or
+ * corrupt) the assertion.
+ */
+function checkConstraintValues(constraintName: string): string[] {
+  const withoutComments = MIGRATION_SQL.replace(/--.*$/gm, "");
+  const constraint = new RegExp(
+    `CONSTRAINT\\s+${constraintName}\\s*CHECK\\s*\\(([^)]*)\\)`,
+    "i",
+  ).exec(withoutComments);
+  if (!constraint) {
+    throw new Error(
+      `constraint ${constraintName} not found in 0180_brain_substrate.sql — ` +
+        `renamed or dropped? The TS vocabulary in lib/brain/types.ts is now unpinned.`,
+    );
+  }
+  return [...constraint[1]!.matchAll(/'([^']+)'/g)].map((m) => m[1]!);
+}
+
+describe("brain substrate vocabulary (#4767)", () => {
+  it("BRAIN_EDGE_TYPES matches the migration's edge-type CHECK exactly", () => {
+    expect(checkConstraintValues("chk_brain_edges_type").toSorted()).toEqual(
+      [...BRAIN_EDGE_TYPES].toSorted(),
+    );
+  });
+
+  it("pins the four ADR-0036 edge types — extending needs a migration, not an edit here", () => {
+    // Spelled out rather than derived: this is the committed set from the ADR,
+    // and a future slice widening the union should have to change a line that
+    // says so out loud.
+    expect([...BRAIN_EDGE_TYPES].toSorted()).toEqual([
+      "derives-from",
+      "in-tension-with",
+      "provenance",
+      "supersedes",
+    ]);
+  });
+
+  it("BRAIN_FACT_STATUSES matches the migration's status CHECK exactly", () => {
+    expect(checkConstraintValues("chk_brain_facts_status").toSorted()).toEqual(
+      [...BRAIN_FACT_STATUSES].toSorted(),
+    );
+  });
+
+  it("carries the content-mode triple so facts can join the review gate (#4769)", () => {
+    expect([...BRAIN_FACT_STATUSES].toSorted()).toEqual(["archived", "draft", "published"]);
+  });
+
+  it("PREDICATE_CARDINALITIES matches the migration's cardinality CHECK exactly", () => {
+    expect(checkConstraintValues("chk_brain_facts_predicate_cardinality").toSorted()).toEqual(
+      [...PREDICATE_CARDINALITIES].toSorted(),
+    );
+  });
+
+  it("defaults predicate cardinality to the conservative arm in the schema", () => {
+    // Coexisting wrongly is recoverable at the review gate; superseding
+    // wrongly destroys a belief. If someone flips this default to 'single',
+    // the M2 engine starts silently overwriting history.
+    expect(MIGRATION_SQL).toContain("predicate_cardinality text NOT NULL DEFAULT 'multi'");
+  });
+
+  it("orders trust tiers warehouse < fact < episode (the arbitration order)", () => {
+    expect(TRUST_TIERS.warehouse).toBeLessThan(TRUST_TIERS.fact);
+    expect(TRUST_TIERS.fact).toBeLessThan(TRUST_TIERS.episode);
+  });
+
+  it("keeps tier-1 out of the brain tables — no table stores a warehouse fact", () => {
+    // ADR-0036: warehouse facts resolve live through the semantic layer and
+    // are gated by warehouse RLS. If a `trust_tier`/`tier` column ever appears
+    // on brain_facts, tier-1 has been given a home here and the no-double-
+    // gating decision (T5) needs revisiting before this test is updated.
+    expect(MIGRATION_SQL).not.toMatch(/^\s*(trust_)?tier\s+(int|smallint|text)/mi);
+  });
+});

--- a/packages/api/src/lib/brain/types.ts
+++ b/packages/api/src/lib/brain/types.ts
@@ -1,0 +1,167 @@
+/**
+ * Company brain substrate — the shared vocabulary (#4767, ADR-0036).
+ *
+ * Types only. The behaviour that uses them lands in the sibling M1 slices:
+ * the grant parser + fail-closed visibility predicate (#4768), the
+ * content-mode registration (#4769), the connector (#4770), the extraction
+ * fiber + reconcile stage (#4771), the review surface (#4772), and
+ * `searchBrain` (#4773). Mirrors migration 0180.
+ *
+ * This module is deliberately dependency-free so every one of those slices can
+ * import the vocabulary without dragging in a database handle.
+ */
+
+/**
+ * The three trust tiers, in the vocabulary reserved by the ADR-0036 re-aim
+ * guide. The ordering is the arbitration order: a lower tier wins any overlap.
+ *
+ * Tier 1 has NO representation in the brain tables — warehouse facts resolve
+ * live through the semantic layer and are gated by warehouse RLS, which is
+ * precisely why they are authoritative by construction and why the ACL
+ * primitive deliberately does not double-gate them. The tier exists in this
+ * enum so that retrieval can LABEL a result's provenance tier to the caller;
+ * trust labelling is the wedge, and a tier that can't be named can't be shown.
+ */
+export const TRUST_TIERS = {
+  /** Warehouse facts — authoritative by construction. Never stored here. */
+  warehouse: 1,
+  /** Reviewed facts — authoritative for their class; yield to the warehouse. */
+  fact: 2,
+  /** Raw episodes — source-of-truth for what was said, not for what is true. */
+  episode: 3,
+} as const;
+
+export type TrustTier = (typeof TRUST_TIERS)[keyof typeof TRUST_TIERS];
+
+/**
+ * The four committed edge types (ADR-0036 §Temporal). M2 extends the engine
+ * that walks these, never this list — the enum is pinned here and by
+ * `chk_brain_edges_type` in migration 0180, and `types.test.ts` fails if the
+ * two ever drift.
+ */
+export const BRAIN_EDGE_TYPES = [
+  /** fact → fact. The M2 arbitration outcome; supersession is not deletion. */
+  "supersedes",
+  /**
+   * fact → fact. Genuine coexisting conflict. Surfaced with BOTH provenances
+   * and never ranked — refusing to auto-arbitrate is the point, not a gap.
+   */
+  "in-tension-with",
+  /** fact → fact | episode. Fork lineage. */
+  "derives-from",
+  /** fact → episode. The evidence pointer. */
+  "provenance",
+] as const;
+
+export type BrainEdgeType = (typeof BRAIN_EDGE_TYPES)[number];
+
+/**
+ * Content-mode lifecycle for a fact. Every candidate lands `draft`; only the
+ * atomic publish endpoint promotes it, because the review gate IS the brain's
+ * conflict-resolution mechanism.
+ */
+export const BRAIN_FACT_STATUSES = ["draft", "published", "archived"] as const;
+export type BrainFactStatus = (typeof BRAIN_FACT_STATUSES)[number];
+
+/**
+ * The supersede-vs-coexist switch. `single` (a person has one manager) means a
+ * new value supersedes the old; `multi` (a person knows many languages) means
+ * values coexist and corroborate.
+ *
+ * `multi` is the default in the schema on purpose: coexisting wrongly is
+ * recoverable at the review gate, superseding wrongly destroys a belief.
+ */
+export const PREDICATE_CARDINALITIES = ["single", "multi"] as const;
+export type PredicateCardinality = (typeof PREDICATE_CARDINALITIES)[number];
+
+/**
+ * A grant is a self-contained principal set, derived at ingest and evaluated
+ * read-time-local. Grammar:
+ *
+ *   `org` | `role:{owner,admin,member}` | `user:<id>` | `audience:<name>`
+ *
+ * The parser and the fail-closed push-down predicate are #4768's; this type is
+ * the wire shape they agree on. A grant is never empty — `cardinality > 0` is
+ * a CHECK on both brain tables, so "visible to everyone" is always the
+ * explicit `org` principal and never a forgotten field.
+ */
+export type BrainGrant = readonly string[];
+
+/** tier-3. Immutable, append-only, deduped by `(workspaceId, source, sourceId)`. */
+export interface BrainEpisode {
+  readonly id: string;
+  readonly workspaceId: string;
+  /** Connector class/vendor — `slack`, `warehouse`, `human`. */
+  readonly source: string;
+  /** The source's own stable id. Must be stable across webhook AND poll. */
+  readonly sourceId: string;
+  /** Source-side author principal; NULL when the source has no author. */
+  readonly sourceActor: string | null;
+  /** Body XOR locator — by-value for chat, by-reference for warehouse/KB. */
+  readonly body: string | null;
+  readonly locator: string | null;
+  /** Event time at the source. */
+  readonly occurredAt: Date | null;
+  /** Transaction time — when Atlas learned of it. */
+  readonly ingestedAt: Date;
+  /** Extraction work-queue marker; `null` means still queued. */
+  readonly extractedAt: Date | null;
+  readonly visibleTo: BrainGrant;
+  readonly createdAt: Date;
+}
+
+/** tier-2. Bi-temporal, review-gated, invalidate-never-delete. */
+export interface BrainFact {
+  readonly id: string;
+  readonly workspaceId: string;
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  /** Valid time — when the claim held in the world. */
+  readonly validFrom: Date | null;
+  /** Stamped by a HUMAN promotion. There is no autonomous supersession. */
+  readonly validTo: Date | null;
+  /** Transaction time. */
+  readonly ingestedAt: Date;
+  /** The tombstone. Nothing ever DELETEs a fact row. */
+  readonly invalidatedAt: Date | null;
+  /** When the extraction pass that produced this claim ran; null if authored. */
+  readonly extractedAt: Date | null;
+  /** Never null — no-provenance-no-promotion, enforced at rest. */
+  readonly sourceEpisodeId: string;
+  readonly provenance: Record<string, unknown>;
+  readonly status: BrainFactStatus;
+  /** Never empty — no-grant-no-promotion, enforced at rest. */
+  readonly visibleTo: BrainGrant;
+  readonly predicateCardinality: PredicateCardinality;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * A typed edge. Each endpoint is a fact OR an episode — exactly one of the two
+ * id columns is set, enforced by `chk_brain_edges_{from,to}_endpoint`.
+ */
+export interface BrainEdge {
+  readonly id: string;
+  readonly workspaceId: string;
+  readonly edgeType: BrainEdgeType;
+  readonly fromFactId: string | null;
+  readonly fromEpisodeId: string | null;
+  readonly toFactId: string | null;
+  readonly toEpisodeId: string | null;
+  readonly createdAt: Date;
+}
+
+/**
+ * Atlas-owned audience membership — the live-revocation escape hatch for
+ * derive-at-ingest grants.
+ */
+export interface FactAudienceMember {
+  readonly workspaceId: string;
+  /** WITHOUT the `audience:` prefix — the prefix belongs to the grammar. */
+  readonly audienceId: string;
+  readonly userId: string;
+  readonly source: string;
+  readonly createdAt: Date;
+}

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3135,6 +3135,348 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     );
     expect(rows[0]?.fts).toBe("'alpha':1A 'omega':2");
   }, PG_TEST_TIMEOUT_MS);
+
+  // -------------------------------------------------------------------------
+  // 0180 — brain substrate (#4767, ADR-0036)
+  // -------------------------------------------------------------------------
+  //
+  // These assert the invariants ADR-0036 states as absolutes, at the level
+  // where they're actually absolute. "No-grant-no-promotion" and
+  // "no-provenance-no-promotion" enforced in application code are conventions
+  // a future call site can forget; enforced by CHECK they are properties of
+  // the data. Each test therefore tries to write the forbidden row and
+  // requires Postgres to refuse it.
+
+  /** Insert a minimal valid episode and return its id. */
+  async function insertEpisode(
+    ws: string,
+    sourceId: string,
+    overrides: { source?: string; visibleTo?: string[] } = {},
+  ): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, $2, $3, 'the thing that was said', $4)
+       RETURNING id`,
+      [ws, overrides.source ?? "slack", sourceId, overrides.visibleTo ?? ["org"]],
+    );
+    return rows[0]!.id;
+  }
+
+  /** Run a statement expected to violate a constraint; return the error. */
+  async function expectRejected(sql: string, params: unknown[]): Promise<Error> {
+    let err: Error | null = null;
+    try {
+      await pool.query(sql, params);
+    } catch (e) {
+      err = e instanceof Error ? e : new Error(String(e));
+    }
+    expect(err).not.toBeNull();
+    return err!;
+  }
+
+  it("0180: episodes dedupe on (workspace, source, source_id) — re-ingest is a no-op, never an upsert (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-ep-${stamp}`;
+    const id = await insertEpisode(ws, "slack-msg-1");
+
+    // The connector's actual write. ON CONFLICT DO NOTHING must leave the
+    // ORIGINAL row untouched: an episode is evidence, and a re-poll that
+    // rewrote the body would silently revise history under a live provenance
+    // claim. `DO NOTHING` returns no row, which is how the caller learns the
+    // record was already known.
+    const reInsert = await pool.query(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, 'slack', 'slack-msg-1', 'EDITED UPSTREAM', ARRAY['org'])
+       ON CONFLICT (workspace_id, source, source_id) DO NOTHING
+       RETURNING id`,
+      [ws],
+    );
+    expect(reInsert.rowCount).toBe(0);
+
+    const { rows } = await pool.query<{ id: string; body: string }>(
+      `SELECT id, body FROM brain_episodes WHERE workspace_id = $1`,
+      [ws],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(id);
+    expect(rows[0]!.body).toBe("the thing that was said");
+
+    // A bare re-insert (no ON CONFLICT clause) is a hard 23505 — the UNIQUE
+    // index is what makes dedupe structural rather than a call-site habit.
+    const err = await expectRejected(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, 'slack', 'slack-msg-1', 'dup', ARRAY['org'])`,
+      [ws],
+    );
+    expect(err.message).toMatch(/uq_brain_episodes_source_id|23505|duplicate key/i);
+
+    // Same source_id under a DIFFERENT source is a different episode: two
+    // connectors can mint the same opaque id without colliding.
+    await insertEpisode(ws, "slack-msg-1", { source: "notion" });
+    const after = await pool.query(`SELECT 1 FROM brain_episodes WHERE workspace_id = $1`, [ws]);
+    expect(after.rowCount).toBe(2);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: an episode carries a body XOR a locator — never both, never neither (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-xor-${stamp}`;
+
+    // By-reference: warehouse/KB-derived content that already has an
+    // authoritative home elsewhere.
+    await pool.query(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, locator, visible_to)
+       VALUES ($1, 'warehouse', 'q-1', 'snapshot://runs/1', ARRAY['org'])`,
+      [ws],
+    );
+
+    for (const [label, cols, vals] of [
+      ["neither", "", ""],
+      ["both", ", body, locator", ", 'b', 'l'"],
+    ] as const) {
+      const err = await expectRejected(
+        `INSERT INTO brain_episodes (workspace_id, source, source_id, visible_to${cols})
+         VALUES ($1, 'slack', 'x-${label}', ARRAY['org']${vals})`,
+        [ws],
+      );
+      expect(err.message).toMatch(/chk_brain_episodes_body_xor_locator|23514|check constraint/i);
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: facts default to draft and reject an unknown status (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-fact-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+
+    const { rows } = await pool.query<{ status: string; predicate_cardinality: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 'acme', 'uses', 'postgres', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+       RETURNING status, predicate_cardinality`,
+      [ws, episodeId],
+    );
+    // Every candidate lands draft — the review gate, not a fast path.
+    expect(rows[0]!.status).toBe("draft");
+    // The conservative arm: coexist rather than supersede.
+    expect(rows[0]!.predicate_cardinality).toBe("multi");
+
+    const err = await expectRejected(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to, status)
+       VALUES ($1, 'acme', 'uses', 'mysql', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], 'live')`,
+      [ws, episodeId],
+    );
+    expect(err.message).toMatch(/chk_brain_facts_status|23514|check constraint/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: no-grant-no-promotion and no-provenance-no-promotion are unrepresentable at rest (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-gate-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+
+    const base = `INSERT INTO brain_facts
+        (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)`;
+
+    // An EMPTY grant is the dangerous case, and the one NOT NULL alone misses:
+    // it denies everyone, which reads as "hidden" but behaves as "unreviewed".
+    const emptyGrant = await expectRejected(
+      `${base} VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[]::text[])`,
+      [ws, episodeId],
+    );
+    expect(emptyGrant.message).toMatch(/chk_brain_facts_grant_nonempty|23514|check constraint/i);
+
+    // Likewise an empty JSON object — a claim with no evidence wearing the
+    // shape of a real one.
+    const emptyProvenance = await expectRejected(
+      `${base} VALUES ($1, 's', 'p', 'o', $2, '{}'::jsonb, ARRAY['org'])`,
+      [ws, episodeId],
+    );
+    expect(emptyProvenance.message).toMatch(
+      /chk_brain_facts_provenance_nonempty|23514|check constraint/i,
+    );
+
+    // And a fact with no episode at all: provenance made structural.
+    const noEpisode = await expectRejected(
+      `${base} VALUES ($1, 's', 'p', 'o', NULL, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
+      [ws],
+    );
+    expect(noEpisode.message).toMatch(/source_episode_id|23502|null value/i);
+
+    // The same empty-grant refusal holds for tier-3: episodes are gated too,
+    // and are frequently more sensitive than the facts drawn from them.
+    const episodeGrant = await expectRejected(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, 'slack', 'no-grant', 'x', ARRAY[]::text[])`,
+      [ws],
+    );
+    expect(episodeGrant.message).toMatch(
+      /chk_brain_episodes_grant_nonempty|23514|check constraint/i,
+    );
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: a closed validity interval cannot run backwards (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-temporal-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+
+    // An OPEN interval is the normal case — a live claim has no valid_to until
+    // a human promotion stamps one.
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to,
+          valid_from)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], now())`,
+      [ws, episodeId],
+    );
+
+    const err = await expectRejected(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to,
+          valid_from, valid_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'],
+               now(), now() - interval '1 day')`,
+      [ws, episodeId],
+    );
+    expect(err.message).toMatch(/chk_brain_facts_valid_interval|23514|check constraint/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: edges accept exactly the four committed types and reject a fifth (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-edge-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+    const { rows: factRows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org']),
+              ($1, 's', 'p', 'o2', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+       RETURNING id`,
+      [ws, episodeId],
+    );
+    const [factA, factB] = [factRows[0]!.id, factRows[1]!.id];
+
+    // fact → fact for the arbitration/conflict types.
+    for (const type of ["supersedes", "in-tension-with", "derives-from"]) {
+      await pool.query(
+        `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
+         VALUES ($1, $2, $3, $4)`,
+        [ws, type, factA, factB],
+      );
+    }
+    // fact → episode for the evidence pointer.
+    await pool.query(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+       VALUES ($1, 'provenance', $2, $3)`,
+      [ws, factA, episodeId],
+    );
+
+    const { rows: counted } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM brain_edges WHERE workspace_id = $1`,
+      [ws],
+    );
+    expect(counted[0]!.n).toBe("4");
+
+    // M2 extends the engine that walks these, never the list.
+    const unknown = await expectRejected(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
+       VALUES ($1, 'contradicts', $2, $3)`,
+      [ws, factA, factB],
+    );
+    expect(unknown.message).toMatch(/chk_brain_edges_type|23514|check constraint/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: an edge endpoint is a fact XOR an episode on each side (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-endpoint-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+    const { rows: factRows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+       RETURNING id`,
+      [ws, episodeId],
+    );
+    const factId = factRows[0]!.id;
+
+    // Dangling endpoint — an edge to nothing.
+    const dangling = await expectRejected(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id) VALUES ($1, 'provenance', $2)`,
+      [ws, factId],
+    );
+    expect(dangling.message).toMatch(/chk_brain_edges_to_endpoint|23514|check constraint/i);
+
+    // Two endpoints on one side — ambiguous about what the edge asserts.
+    const ambiguous = await expectRejected(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id, to_episode_id)
+       VALUES ($1, 'derives-from', $2, $2, $3)`,
+      [ws, factId, episodeId],
+    );
+    expect(ambiguous.message).toMatch(/chk_brain_edges_to_endpoint|23514|check constraint/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: deleting an episode out from under a live fact is refused (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-restrict-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+    await pool.query(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
+      [ws, episodeId],
+    );
+
+    // RESTRICT, not CASCADE: evidence disappearing under a live claim must
+    // fail loudly rather than quietly leave an unprovenanced fact standing.
+    const err = await expectRejected(`DELETE FROM brain_episodes WHERE id = $1`, [episodeId]);
+    expect(err.message).toMatch(/foreign key|23503|still referenced/i);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: fact_audience_member keys on (workspace, audience, user) for live revocation (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-aud-${stamp}`;
+
+    await pool.query(
+      `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source)
+       VALUES ($1, 'eng-private', 'u1', 'slack'), ($1, 'eng-private', 'u2', 'slack')`,
+      [ws],
+    );
+
+    // Idempotent re-sync — a membership poll re-running must not duplicate.
+    const resync = await pool.query(
+      `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source)
+       VALUES ($1, 'eng-private', 'u1', 'slack')
+       ON CONFLICT (workspace_id, audience_id, user_id) DO NOTHING`,
+      [ws],
+    );
+    expect(resync.rowCount).toBe(0);
+
+    // Revocation flows through membership LIVE — no re-ingest of any fact.
+    // This is what the derive-at-ingest grant model buys back.
+    await pool.query(
+      `DELETE FROM fact_audience_member
+        WHERE workspace_id = $1 AND audience_id = 'eng-private' AND user_id = 'u2'`,
+      [ws],
+    );
+    const { rows } = await pool.query<{ user_id: string }>(
+      `SELECT user_id FROM fact_audience_member WHERE workspace_id = $1`,
+      [ws],
+    );
+    expect(rows.map((r) => r.user_id)).toEqual(["u1"]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: the grant columns are GIN-indexed for the push-down visibility predicate (#4767)", async () => {
+    // #4768 pushes visibility down as `visible_to && ARRAY[...principals]`.
+    // Without a GIN index that clause is a seq scan on every brain read, and
+    // the fail-closed predicate becomes the reason retrieval is slow — the
+    // usual pressure to "just filter after fetch", which is the thing T5
+    // explicitly forbids.
+    const { rows } = await pool.query<{ tablename: string; indexdef: string }>(
+      `SELECT tablename, indexdef FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND indexname IN ('idx_brain_facts_visible_to', 'idx_brain_episodes_visible_to')
+        ORDER BY tablename`,
+    );
+    expect(rows.map((r) => r.tablename)).toEqual(["brain_episodes", "brain_facts"]);
+    for (const row of rows) expect(row.indexdef).toContain("USING gin");
+  }, PG_TEST_TIMEOUT_MS);
 });
 
 // #2606 — source-level revert guard for the integration-store SQL formatter.

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3162,16 +3162,29 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     return rows[0]!.id;
   }
 
-  /** Run a statement expected to violate a constraint; return the error. */
-  async function expectRejected(sql: string, params: unknown[]): Promise<Error> {
-    let err: Error | null = null;
+  /**
+   * Run a statement expected to violate `constraint`, and assert THAT
+   * constraint is what fired.
+   *
+   * Matching on the message with a `|23514|check constraint` alternation
+   * would be satisfied by any check violation on the table — so dropping the
+   * constraint under test and having a different one fire would still pass.
+   * pg's DatabaseError exposes `.constraint` directly, which makes the
+   * assertion exact for the same line count.
+   */
+  async function expectRejected(
+    constraint: string,
+    sql: string,
+    params: unknown[],
+  ): Promise<void> {
+    let err: (Error & { constraint?: string }) | null = null;
     try {
       await pool.query(sql, params);
     } catch (e) {
       err = e instanceof Error ? e : new Error(String(e));
     }
-    expect(err).not.toBeNull();
-    return err!;
+    expect(err, `expected ${constraint} to reject the statement`).not.toBeNull();
+    expect(err?.constraint ?? err?.message).toBe(constraint);
   }
 
   it("0180: episodes dedupe on (workspace, source, source_id) — re-ingest is a no-op, never an upsert (#4767)", async () => {
@@ -3203,12 +3216,12 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
 
     // A bare re-insert (no ON CONFLICT clause) is a hard 23505 — the UNIQUE
     // index is what makes dedupe structural rather than a call-site habit.
-    const err = await expectRejected(
+    await expectRejected(
+      "uq_brain_episodes_source_id",
       `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
        VALUES ($1, 'slack', 'slack-msg-1', 'dup', ARRAY['org'])`,
       [ws],
     );
-    expect(err.message).toMatch(/uq_brain_episodes_source_id|23505|duplicate key/i);
 
     // Same source_id under a DIFFERENT source is a different episode: two
     // connectors can mint the same opaque id without colliding.
@@ -3233,12 +3246,12 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
       ["neither", "", ""],
       ["both", ", body, locator", ", 'b', 'l'"],
     ] as const) {
-      const err = await expectRejected(
+      await expectRejected(
+        "chk_brain_episodes_body_xor_locator",
         `INSERT INTO brain_episodes (workspace_id, source, source_id, visible_to${cols})
          VALUES ($1, 'slack', 'x-${label}', ARRAY['org']${vals})`,
         [ws],
       );
-      expect(err.message).toMatch(/chk_brain_episodes_body_xor_locator|23514|check constraint/i);
     }
   }, PG_TEST_TIMEOUT_MS);
 
@@ -3254,18 +3267,18 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
        RETURNING status, predicate_cardinality`,
       [ws, episodeId],
     );
-    // Every candidate lands draft — the review gate, not a fast path.
+    // Every extraction candidate lands draft — the review gate, not a fast path.
     expect(rows[0]!.status).toBe("draft");
     // The conservative arm: coexist rather than supersede.
     expect(rows[0]!.predicate_cardinality).toBe("multi");
 
-    const err = await expectRejected(
+    await expectRejected(
+      "chk_brain_facts_status",
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to, status)
        VALUES ($1, 'acme', 'uses', 'mysql', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'], 'live')`,
       [ws, episodeId],
     );
-    expect(err.message).toMatch(/chk_brain_facts_status|23514|check constraint/i);
   }, PG_TEST_TIMEOUT_MS);
 
   it("0180: no-grant-no-promotion and no-provenance-no-promotion are unrepresentable at rest (#4767)", async () => {
@@ -3278,38 +3291,57 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
 
     // An EMPTY grant is the dangerous case, and the one NOT NULL alone misses:
     // it denies everyone, which reads as "hidden" but behaves as "unreviewed".
-    const emptyGrant = await expectRejected(
+    await expectRejected(
+      "chk_brain_facts_grant_nonempty",
       `${base} VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[]::text[])`,
       [ws, episodeId],
     );
-    expect(emptyGrant.message).toMatch(/chk_brain_facts_grant_nonempty|23514|check constraint/i);
 
     // Likewise an empty JSON object — a claim with no evidence wearing the
     // shape of a real one.
-    const emptyProvenance = await expectRejected(
+    await expectRejected(
+      "chk_brain_facts_provenance_nonempty",
       `${base} VALUES ($1, 's', 'p', 'o', $2, '{}'::jsonb, ARRAY['org'])`,
       [ws, episodeId],
     );
-    expect(emptyProvenance.message).toMatch(
-      /chk_brain_facts_provenance_nonempty|23514|check constraint/i,
-    );
 
-    // And a fact with no episode at all: provenance made structural.
-    const noEpisode = await expectRejected(
-      `${base} VALUES ($1, 's', 'p', 'o', NULL, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
-      [ws],
-    );
-    expect(noEpisode.message).toMatch(/source_episode_id|23502|null value/i);
+    // And a fact with no episode at all: provenance made structural. NOT NULL
+    // has no constraint name, so this one matches on the message.
+    let nullErr: (Error & { column?: string }) | null = null;
+    try {
+      await pool.query(`${base} VALUES ($1, 's', 'p', 'o', NULL, '{"actor":"u1"}'::jsonb, ARRAY['org'])`, [ws]);
+    } catch (e) {
+      nullErr = e instanceof Error ? e : new Error(String(e));
+    }
+    expect(nullErr).not.toBeNull();
+    expect(nullErr?.column ?? nullErr?.message).toMatch(/source_episode_id/);
 
     // The same empty-grant refusal holds for tier-3: episodes are gated too,
     // and are frequently more sensitive than the facts drawn from them.
-    const episodeGrant = await expectRejected(
+    await expectRejected(
+      "chk_brain_episodes_grant_nonempty",
       `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
        VALUES ($1, 'slack', 'no-grant', 'x', ARRAY[]::text[])`,
       [ws],
     );
-    expect(episodeGrant.message).toMatch(
-      /chk_brain_episodes_grant_nonempty|23514|check constraint/i,
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: a fact cannot hang off another workspace's episode (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const wsA = `ws-tenant-a-${stamp}`;
+    const wsB = `ws-tenant-b-${stamp}`;
+    const episodeB = await insertEpisode(wsB, `ep-${stamp}`);
+
+    // The composite FK is what makes the export's episode-join scoping and the
+    // cleanup sweep's parent-scoped delete agree. Without it, a fact in A
+    // hanging off B's episode is exported into the WRONG tenant's bundle and
+    // survives A's residency sweep entirely.
+    await expectRejected(
+      "fk_brain_facts_episode",
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])`,
+      [wsA, episodeB],
     );
   }, PG_TEST_TIMEOUT_MS);
 
@@ -3328,7 +3360,8 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
       [ws, episodeId],
     );
 
-    const err = await expectRejected(
+    await expectRejected(
+      "chk_brain_facts_valid_interval",
       `INSERT INTO brain_facts
          (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to,
           valid_from, valid_to)
@@ -3336,7 +3369,6 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
                now(), now() - interval '1 day')`,
       [ws, episodeId],
     );
-    expect(err.message).toMatch(/chk_brain_facts_valid_interval|23514|check constraint/i);
   }, PG_TEST_TIMEOUT_MS);
 
   it("0180: edges accept exactly the four committed types and reject a fifth (#4767)", async () => {
@@ -3375,15 +3407,15 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     expect(counted[0]!.n).toBe("4");
 
     // M2 extends the engine that walks these, never the list.
-    const unknown = await expectRejected(
+    await expectRejected(
+      "chk_brain_edges_type",
       `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
        VALUES ($1, 'contradicts', $2, $3)`,
       [ws, factA, factB],
     );
-    expect(unknown.message).toMatch(/chk_brain_edges_type|23514|check constraint/i);
   }, PG_TEST_TIMEOUT_MS);
 
-  it("0180: an edge endpoint is a fact XOR an episode on each side (#4767)", async () => {
+  it("0180: an edge endpoint is a fact XOR an episode on EACH side (#4767)", async () => {
     const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
     const ws = `ws-endpoint-${stamp}`;
     const episodeId = await insertEpisode(ws, `ep-${stamp}`);
@@ -3396,20 +3428,103 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     );
     const factId = factRows[0]!.id;
 
+    // Both cases use `derives-from`, the one type whose endpoint-kinds arm is
+    // unconditional — so the failure isolates to the constraint under test.
+    // (A `provenance` edge with no `to` endpoint violates BOTH this and
+    // chk_brain_edges_endpoint_kinds, which is covered in its own test below.)
+    //
+    // --- the `to` side ---
     // Dangling endpoint — an edge to nothing.
-    const dangling = await expectRejected(
-      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id) VALUES ($1, 'provenance', $2)`,
+    await expectRejected(
+      "chk_brain_edges_to_endpoint",
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id) VALUES ($1, 'derives-from', $2)`,
       [ws, factId],
     );
-    expect(dangling.message).toMatch(/chk_brain_edges_to_endpoint|23514|check constraint/i);
-
     // Two endpoints on one side — ambiguous about what the edge asserts.
-    const ambiguous = await expectRejected(
+    await expectRejected(
+      "chk_brain_edges_to_endpoint",
       `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id, to_episode_id)
        VALUES ($1, 'derives-from', $2, $2, $3)`,
       [ws, factId, episodeId],
     );
-    expect(ambiguous.message).toMatch(/chk_brain_edges_to_endpoint|23514|check constraint/i);
+
+    // --- the `from` side, which the CHECK constrains symmetrically ---
+    // Only the two-endpoints case isolates cleanly: a NULL `from_fact_id`
+    // also trips endpoint_kinds (every committed type originates at a fact),
+    // and that arm is asserted in the endpoint-kinds test instead.
+    await expectRejected(
+      "chk_brain_edges_from_endpoint",
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, from_episode_id, to_fact_id)
+       VALUES ($1, 'supersedes', $2, $3, $2)`,
+      [ws, factId, episodeId],
+    );
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: edge endpoint KINDS are constrained per type, not just documented (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-kinds-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+    const { rows: factRows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+       RETURNING id`,
+      [ws, episodeId],
+    );
+    const factId = factRows[0]!.id;
+
+    // `derives-from` is the one type legitimately allowed to point at either.
+    await pool.query(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+       VALUES ($1, 'derives-from', $2, $3)`,
+      [ws, factId, episodeId],
+    );
+
+    // A `provenance` edge pointing at a fact is meaningless — it is the
+    // EVIDENCE pointer, and evidence is an episode.
+    await expectRejected(
+      "chk_brain_edges_endpoint_kinds",
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
+       VALUES ($1, 'provenance', $2, $2)`,
+      [ws, factId],
+    );
+    // Arbitration types compare CLAIMS, so they cannot point at an episode.
+    await expectRejected(
+      "chk_brain_edges_endpoint_kinds",
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+       VALUES ($1, 'supersedes', $2, $3)`,
+      [ws, factId, episodeId],
+    );
+    // Every committed type originates at a fact.
+    await expectRejected(
+      "chk_brain_edges_endpoint_kinds",
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_episode_id, to_episode_id)
+       VALUES ($1, 'provenance', $2, $2)`,
+      [ws, episodeId],
+    );
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: an edge cannot join rows from another workspace (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const wsA = `ws-edge-a-${stamp}`;
+    const wsB = `ws-edge-b-${stamp}`;
+    const episodeA = await insertEpisode(wsA, `ep-a-${stamp}`);
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+       RETURNING id`,
+      [wsA, episodeA],
+    );
+    const factA = rows[0]!.id;
+
+    // Composite endpoint FK: workspace B cannot mint an edge into A's graph.
+    await expectRejected(
+      "fk_brain_edges_from_fact",
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+       VALUES ($1, 'provenance', $2, $3)`,
+      [wsB, factA, episodeA],
+    );
   }, PG_TEST_TIMEOUT_MS);
 
   it("0180: deleting an episode out from under a live fact is refused (#4767)", async () => {
@@ -3425,8 +3540,36 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
 
     // RESTRICT, not CASCADE: evidence disappearing under a live claim must
     // fail loudly rather than quietly leave an unprovenanced fact standing.
-    const err = await expectRejected(`DELETE FROM brain_episodes WHERE id = $1`, [episodeId]);
-    expect(err.message).toMatch(/foreign key|23503|still referenced/i);
+    await expectRejected(
+      "fk_brain_facts_episode",
+      `DELETE FROM brain_episodes WHERE id = $1`,
+      [episodeId],
+    );
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: deleting a fact CASCADES its edges — they are derived, not evidence (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-cascade-${stamp}`;
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY['org'])
+       RETURNING id`,
+      [ws, episodeId],
+    );
+    const factId = rows[0]!.id;
+    await pool.query(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+       VALUES ($1, 'provenance', $2, $3)`,
+      [ws, factId, episodeId],
+    );
+
+    // The asymmetry with the RESTRICT above is the point — and it is what
+    // keeps the #4458 cleanup sweep's column phase sound.
+    await pool.query(`DELETE FROM brain_facts WHERE id = $1`, [factId]);
+    const remaining = await pool.query(`SELECT 1 FROM brain_edges WHERE workspace_id = $1`, [ws]);
+    expect(remaining.rowCount).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
   it("0180: fact_audience_member keys on (workspace, audience, user) for live revocation (#4767)", async () => {

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3245,6 +3245,13 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     for (const [label, cols, vals] of [
       ["neither", "", ""],
       ["both", ", body, locator", ", 'b', 'l'"],
+      // An EMPTY string is refused outright rather than treated as absent.
+      // Were '' merely absent-equivalent, `body='x', locator=''` would be
+      // legal at rest while the importer still rejects it — the
+      // stricter-than-the-DB trap that makes a workspace unmigratable.
+      ["empty-body", ", body", ", ''"],
+      ["empty-locator", ", locator", ", ''"],
+      ["body-plus-empty-locator", ", body, locator", ", 'b', ''"],
     ] as const) {
       await expectRejected(
         "chk_brain_episodes_body_xor_locator",
@@ -3253,6 +3260,50 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
         [ws],
       );
     }
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0180: a grant of only NULL or empty principals is refused at rest (#4767)", async () => {
+    const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const ws = `ws-grant-${stamp}`;
+
+    // `cardinality > 0` alone would ACCEPT all three of these: they are
+    // non-empty arrays that grant access to nobody — the denies-everyone state
+    // wearing a non-empty shape. Pins the array_remove semantics (in
+    // particular that `array_remove(x, NULL)` really does strip NULLs), which
+    // the guard in admin-migrate.ts is written to mirror exactly.
+    for (const [label, grant] of [
+      ["null-only", `ARRAY[NULL]::text[]`],
+      ["empty-only", `ARRAY['']::text[]`],
+      ["null-and-empty", `ARRAY[NULL, '']::text[]`],
+    ] as const) {
+      await expectRejected(
+        "chk_brain_episodes_grant_nonempty",
+        `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+         VALUES ($1, 'slack', 'g-${label}', 'x', ${grant})`,
+        [ws],
+      );
+    }
+
+    // One usable principal alongside junk is ACCEPTED — the importer must not
+    // be stricter than this, or a workspace Postgres stores becomes
+    // unmigratable.
+    const { rows } = await pool.query<{ visible_to: string[] }>(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, 'slack', 'g-mixed', 'x', ARRAY['org', NULL, '']::text[])
+       RETURNING visible_to`,
+      [ws],
+    );
+    expect(rows[0]!.visible_to).toEqual(["org", null as unknown as string, ""]);
+
+    // Same rule on the tier-2 half.
+    const episodeId = await insertEpisode(ws, `ep-${stamp}`);
+    await expectRejected(
+      "chk_brain_facts_grant_nonempty",
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, visible_to)
+       VALUES ($1, 's', 'p', 'o', $2, '{"actor":"u1"}'::jsonb, ARRAY[NULL, '']::text[])`,
+      [ws, episodeId],
+    );
   }, PG_TEST_TIMEOUT_MS);
 
   it("0180: facts default to draft and reject an unknown status (#4767)", async () => {

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -237,7 +237,10 @@ describe("runMigrations", () => {
     //   Plus 0179 (drop conversations.notebook_state — notebook retirement
     //   phase 2 of the two-phase drop, readers/writers removed by #4587 in
     //   v0.0.47, ADR-0035, #4588) = 180.
-    expect(count).toBe(180);
+    //   Plus 0180 (brain substrate — brain_episodes / brain_facts /
+    //   brain_edges / fact_audience_member, the first net-new company-brain
+    //   code, ADR-0036, #4767) = 181.
+    expect(count).toBe(181);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -446,6 +449,7 @@ describe("runMigrations", () => {
         "0177_backups_scheduled_window.sql",
         "0178_region_migrations_source_cleaned_at.sql",
         "0179_drop_conversations_notebook_state.sql",
+        "0180_brain_substrate.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
+++ b/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
@@ -22,11 +22,20 @@
 -- scope — but every column and the edge-type enum it will need land NOW, so
 -- M2 is purely additive and never rewrites a table under live data.
 --
--- Two invariants are enforced by CHECK rather than by application code,
--- because ADR-0036 states them as absolutes ("no-provenance-no-promotion",
--- "no-grant-no-promotion"). A row that violates either is UNREPRESENTABLE AT
--- REST: there is no code path, present or future, that can persist a fact
--- with no provenance or an empty grant.
+-- ADR-0036 states two rules as absolutes ("no-provenance-no-promotion",
+-- "no-grant-no-promotion"), so they are CHECKs rather than application code:
+-- an empty grant array and an empty provenance object are refused AT REST,
+-- by every writer. Note the exact boundary — a non-empty but MALFORMED grant
+-- (`ARRAY[NULL]`, `ARRAY['']`, `['everyone']`) still lands here; that is
+-- #4768's parser and its deny+log path, not this CHECK's job.
+--
+-- Workspace containment is structural too: a fact's `(workspace_id,
+-- source_episode_id)` is a COMPOSITE FK onto the episode's `(workspace_id,
+-- id)`, and each edge endpoint composes the same way. A fact hanging off
+-- another workspace's episode would otherwise be exportable into the wrong
+-- tenant's bundle and invisible to the residency cleanup sweep — the sweep
+-- scopes facts through the episode. Nothing writes these tables yet, which
+-- makes this the cheapest possible moment to make it unrepresentable.
 
 -- ---------------------------------------------------------------------------
 -- brain_episodes — tier-3. Immutable, append-only, deduped by stable
@@ -36,11 +45,14 @@
 -- Append-only is the point, not an optimization: an episode is evidence, and
 -- evidence that can be edited after the fact cannot back a provenance claim.
 -- There is deliberately NO `updated_at` column — its absence is the signal.
--- Re-ingesting the same source record is a NO-OP (ON CONFLICT DO NOTHING at
--- the call site), never an upsert: the ADR-0030 connector engine's subtractive
--- archive + path-upsert half is bypassed entirely for episodes (that half
--- scopes to facts), because a chat message that was edited upstream is a NEW
--- episode, not a mutation of the old one.
+--
+-- Re-ingest must be a NO-OP rather than an upsert: the ADR-0030 connector
+-- engine's subtractive-archive + path-upsert half is bypassed entirely for
+-- episodes (that half scopes to facts), because a chat message edited
+-- upstream is a NEW episode, not a mutation of the old one. The connector
+-- that writes `ON CONFLICT (workspace_id, source, source_id) DO NOTHING`
+-- ships in #4770; the UNIQUE index below is what makes that the only
+-- available behaviour rather than a call-site convention.
 CREATE TABLE IF NOT EXISTS brain_episodes (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   -- Better-Auth organization id. Workspace-global, TEXT/no-FK like the other
@@ -98,6 +110,13 @@ CREATE TABLE IF NOT EXISTS brain_episodes (
 -- tenants) can legitimately mint the same opaque source id.
 CREATE UNIQUE INDEX IF NOT EXISTS uq_brain_episodes_source_id
   ON brain_episodes (workspace_id, source, source_id);
+
+-- Referent for the composite FK from brain_facts / brain_edges. `id` is
+-- already the PK, so this adds no new uniqueness — it exists purely to give
+-- `(workspace_id, id)` a unique index to point at, which is what lets the FK
+-- prove an episode and the rows referencing it share a workspace.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_brain_episodes_workspace_id
+  ON brain_episodes (workspace_id, id);
 
 -- The extraction fiber's drain query: oldest-unextracted-first, per workspace.
 -- PARTIAL so the index holds only the backlog — once an episode is extracted
@@ -163,9 +182,12 @@ CREATE TABLE IF NOT EXISTS brain_facts (
   -- first-class authored episode, and a write-back proposal lazily
   -- materializes a session episode at propose time. A fact with no episode is
   -- a claim with no evidence, and there is no such thing here.
-  -- RESTRICT, not CASCADE: deleting the evidence under a live fact must fail
-  -- loudly. Episodes are append-only anyway, so this should never fire.
-  source_episode_id uuid NOT NULL REFERENCES brain_episodes (id) ON DELETE RESTRICT,
+  -- COMPOSITE FK with workspace_id (see the header): the episode must be in
+  -- the SAME workspace as the fact, so a cross-tenant claim is unrepresentable
+  -- rather than merely unlikely. RESTRICT, not CASCADE: deleting the evidence
+  -- under a live fact must fail loudly. Episodes are append-only anyway, so
+  -- this should never fire in normal operation.
+  source_episode_id uuid NOT NULL,
 
   -- Provenance payload — the actor, the source pointer, and for warehouse-
   -- derived facts the pinned SQL + data snapshot (pinned, NOT a live view: a
@@ -174,11 +196,17 @@ CREATE TABLE IF NOT EXISTS brain_facts (
   -- edges rather than by rewriting this.
   provenance jsonb NOT NULL,
 
-  -- Content-mode lifecycle. Every candidate lands `draft`; only the atomic
-  -- publish endpoint promotes it. The review gate IS the brain's conflict-
-  -- resolution mechanism (ADR-0036 §Temporal) — this column is where "trust
-  -- over breadth" stops being a slogan. Registered with the content-mode
-  -- registry in #4769.
+  -- Content-mode lifecycle. DEFAULTS to `draft`: an extraction candidate
+  -- lands there and is promoted only by the atomic publish endpoint. The
+  -- review gate IS the brain's conflict-resolution mechanism (ADR-0036
+  -- §Temporal) — this column is where "trust over breadth" stops being a
+  -- slogan. Registered with the content-mode registry in #4769.
+  --
+  -- A default, NOT an enforcement, and deliberately so: human corrections are
+  -- the second human-authoritative entry point and land authoritative
+  -- immediately (ADR-0036 §Temporal), and a region import preserves the source
+  -- workspace's review status verbatim rather than demoting reviewed facts
+  -- back to draft.
   status text NOT NULL DEFAULT 'draft',
 
   -- The ACL grant: a SELF-CONTAINED principal set, derived at ingest and
@@ -216,8 +244,17 @@ CREATE TABLE IF NOT EXISTS brain_facts (
     CHECK (jsonb_typeof(provenance) = 'object' AND provenance <> '{}'::jsonb),
   -- A closed validity interval must not run backwards.
   CONSTRAINT chk_brain_facts_valid_interval
-    CHECK (valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from)
+    CHECK (valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from),
+
+  CONSTRAINT fk_brain_facts_episode
+    FOREIGN KEY (workspace_id, source_episode_id)
+    REFERENCES brain_episodes (workspace_id, id) ON DELETE RESTRICT
 );
+
+-- Referent for brain_edges' composite endpoint FKs — see the note on
+-- uq_brain_episodes_workspace_id.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_brain_facts_workspace_id
+  ON brain_facts (workspace_id, id);
 
 -- Content-mode status filter (published-only read + admin/dev-mode overlay),
 -- mirroring idx_knowledge_documents_status.
@@ -254,11 +291,22 @@ CREATE INDEX IF NOT EXISTS idx_brain_facts_visible_to
 -- referential integrity — and an edge whose endpoint has silently vanished is
 -- precisely the corruption a provenance graph must not tolerate.
 --
---   supersedes      fact  → fact     the M2 arbitration outcome
---   in-tension-with fact  → fact     genuine coexisting conflict; SURFACED
---                                    with both provenances, never ranked
---   derives-from    fact  → fact/episode   fork lineage
---   provenance      fact  → episode   the evidence pointer
+-- Endpoint KINDS are constrained per type, not merely documented — M2's
+-- arbitration walker and #4773's retrieval both assume these shapes, and an
+-- episode→episode `provenance` edge would satisfy a bare exactly-one-per-side
+-- rule while being meaningless:
+--
+--   supersedes      fact  → fact          the M2 arbitration outcome
+--   in-tension-with fact  → fact          genuine coexisting conflict;
+--                                         SURFACED with both provenances,
+--                                         never ranked
+--   derives-from    fact  → fact|episode  fork lineage
+--   provenance      fact  → episode       the evidence pointer
+--
+-- Every type originates at a fact, so `from_episode_id` is currently always
+-- NULL. The column exists anyway: it keeps the two sides symmetric for a
+-- future episode-rooted type, and the CHECK is what stops one appearing by
+-- accident in the meantime.
 --
 -- Endpoint FKs CASCADE, deliberately asymmetric with the RESTRICT on
 -- brain_facts.source_episode_id. The asymmetry tracks what each reference
@@ -268,18 +316,20 @@ CREATE INDEX IF NOT EXISTS idx_brain_facts_visible_to
 -- once an endpoint is gone the edge is dangling structure, so it should
 -- vanish with it (CASCADE) rather than block the delete.
 --
--- This also keeps the #4458 source-cleanup sweep sound: that sweep's column
--- phase assumes every FK between in-scope tables is CASCADE, so a RESTRICT
--- here would make a workspace's post-migration cleanup fail on live data.
+-- That asymmetry also keeps the #4458 source-cleanup sweep sound. The sweep's
+-- column phase assumes CASCADE between in-scope tables; `brain_facts` is the
+-- one exception and is handled by PHASE instead (it carries a `parent` rule
+-- in cleanup.ts so its delete is ordered ahead of brain_episodes). A RESTRICT
+-- here would need the same treatment and doesn't have it.
 CREATE TABLE IF NOT EXISTS brain_edges (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   workspace_id text NOT NULL,
   edge_type text NOT NULL,
 
-  from_fact_id uuid REFERENCES brain_facts (id) ON DELETE CASCADE,
-  from_episode_id uuid REFERENCES brain_episodes (id) ON DELETE CASCADE,
-  to_fact_id uuid REFERENCES brain_facts (id) ON DELETE CASCADE,
-  to_episode_id uuid REFERENCES brain_episodes (id) ON DELETE CASCADE,
+  from_fact_id uuid,
+  from_episode_id uuid,
+  to_fact_id uuid,
+  to_episode_id uuid,
 
   created_at timestamptz NOT NULL DEFAULT now(),
 
@@ -289,7 +339,33 @@ CREATE TABLE IF NOT EXISTS brain_edges (
   CONSTRAINT chk_brain_edges_from_endpoint
     CHECK (num_nonnulls(from_fact_id, from_episode_id) = 1),
   CONSTRAINT chk_brain_edges_to_endpoint
-    CHECK (num_nonnulls(to_fact_id, to_episode_id) = 1)
+    CHECK (num_nonnulls(to_fact_id, to_episode_id) = 1),
+  -- The per-type endpoint kinds from the table above.
+  CONSTRAINT chk_brain_edges_endpoint_kinds CHECK (
+    from_fact_id IS NOT NULL
+    AND CASE edge_type
+          WHEN 'provenance' THEN to_episode_id IS NOT NULL
+          WHEN 'derives-from' THEN TRUE
+          ELSE to_fact_id IS NOT NULL
+        END
+  ),
+
+  -- Composite endpoint FKs — an edge can only join rows in its OWN workspace.
+  -- Postgres's default MATCH SIMPLE skips the check when any referencing
+  -- column is NULL, which is exactly right for the nullable-endpoint design:
+  -- the unused side of each pair is simply not constrained.
+  CONSTRAINT fk_brain_edges_from_fact
+    FOREIGN KEY (workspace_id, from_fact_id)
+    REFERENCES brain_facts (workspace_id, id) ON DELETE CASCADE,
+  CONSTRAINT fk_brain_edges_from_episode
+    FOREIGN KEY (workspace_id, from_episode_id)
+    REFERENCES brain_episodes (workspace_id, id) ON DELETE CASCADE,
+  CONSTRAINT fk_brain_edges_to_fact
+    FOREIGN KEY (workspace_id, to_fact_id)
+    REFERENCES brain_facts (workspace_id, id) ON DELETE CASCADE,
+  CONSTRAINT fk_brain_edges_to_episode
+    FOREIGN KEY (workspace_id, to_episode_id)
+    REFERENCES brain_episodes (workspace_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_brain_edges_from_fact

--- a/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
+++ b/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
@@ -259,15 +259,27 @@ CREATE INDEX IF NOT EXISTS idx_brain_facts_visible_to
 --                                    with both provenances, never ranked
 --   derives-from    fact  → fact/episode   fork lineage
 --   provenance      fact  → episode   the evidence pointer
+--
+-- Endpoint FKs CASCADE, deliberately asymmetric with the RESTRICT on
+-- brain_facts.source_episode_id. The asymmetry tracks what each reference
+-- MEANS: a fact's episode is its evidence, and evidence must not be
+-- deletable out from under a live claim (RESTRICT). An edge is a derived
+-- assertion ABOUT facts and episodes with no independent evidentiary value —
+-- once an endpoint is gone the edge is dangling structure, so it should
+-- vanish with it (CASCADE) rather than block the delete.
+--
+-- This also keeps the #4458 source-cleanup sweep sound: that sweep's column
+-- phase assumes every FK between in-scope tables is CASCADE, so a RESTRICT
+-- here would make a workspace's post-migration cleanup fail on live data.
 CREATE TABLE IF NOT EXISTS brain_edges (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   workspace_id text NOT NULL,
   edge_type text NOT NULL,
 
-  from_fact_id uuid REFERENCES brain_facts (id) ON DELETE RESTRICT,
-  from_episode_id uuid REFERENCES brain_episodes (id) ON DELETE RESTRICT,
-  to_fact_id uuid REFERENCES brain_facts (id) ON DELETE RESTRICT,
-  to_episode_id uuid REFERENCES brain_episodes (id) ON DELETE RESTRICT,
+  from_fact_id uuid REFERENCES brain_facts (id) ON DELETE CASCADE,
+  from_episode_id uuid REFERENCES brain_episodes (id) ON DELETE CASCADE,
+  to_fact_id uuid REFERENCES brain_facts (id) ON DELETE CASCADE,
+  to_episode_id uuid REFERENCES brain_episodes (id) ON DELETE CASCADE,
 
   created_at timestamptz NOT NULL DEFAULT now(),
 

--- a/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
+++ b/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
@@ -24,10 +24,17 @@
 --
 -- ADR-0036 states two rules as absolutes ("no-provenance-no-promotion",
 -- "no-grant-no-promotion"), so they are CHECKs rather than application code:
--- an empty grant array and an empty provenance object are refused AT REST,
--- by every writer. Note the exact boundary — a non-empty but MALFORMED grant
--- (`ARRAY[NULL]`, `ARRAY['']`, `['everyone']`) still lands here; that is
--- #4768's parser and its deny+log path, not this CHECK's job.
+-- an empty provenance object and a grant with no usable principal are refused
+-- AT REST, by every writer.
+--
+-- "No usable principal" is stricter than `cardinality > 0` on purpose:
+-- `ARRAY[NULL]` and `ARRAY['']` both have cardinality 1 while granting access
+-- to nobody — the same denies-everyone state the rule exists to refuse,
+-- wearing a non-empty shape. Structural VALIDITY stops there: whether
+-- `['everyone']` is a MEANINGFUL principal is #4768's parser and its deny+log
+-- path. The split matters because anything legal at rest must be migratable,
+-- and an importer stricter than the CHECK would make a workspace that Postgres
+-- happily stores impossible to move between regions.
 --
 -- Workspace containment is structural too: a fact's `(workspace_id,
 -- source_episode_id)` is a COMPOSITE FK onto the episode's `(workspace_id,
@@ -96,13 +103,16 @@ CREATE TABLE IF NOT EXISTS brain_episodes (
   created_at timestamptz NOT NULL DEFAULT now(),
 
   -- Body XOR locator — never both, never neither.
+  -- `nullif(…, '')` so an EMPTY body doesn't count as present: an episode
+  -- whose evidence is the empty string backs a provenance claim with nothing.
   CONSTRAINT chk_brain_episodes_body_xor_locator
-    CHECK (num_nonnulls(body, locator) = 1),
-  -- No-grant-no-promotion, tier-3 half. An empty array is a grant that denies
-  -- everyone, which reads as "hidden" but behaves as "unreviewed" — refuse it
-  -- at rest rather than let it mean two things.
+    CHECK (num_nonnulls(nullif(body, ''), nullif(locator, '')) = 1),
+  -- No-grant-no-promotion, tier-3 half. A grant that denies everyone reads as
+  -- "hidden" but behaves as "unreviewed" — refuse it at rest rather than let
+  -- it mean two things. NULL and '' elements are refused for the same reason:
+  -- they pass a bare cardinality test while granting access to nobody.
   CONSTRAINT chk_brain_episodes_grant_nonempty
-    CHECK (cardinality(visible_to) > 0)
+    CHECK (cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0)
 );
 
 -- The dedupe key. UNIQUE is what makes re-ingest a no-op rather than a
@@ -235,9 +245,11 @@ CREATE TABLE IF NOT EXISTS brain_facts (
     CHECK (predicate_cardinality IN ('single', 'multi')),
   -- No-grant-no-promotion, tier-2 half. The public majority carries an
   -- explicit `org` — "visible to everyone" is a stated grant, never an
-  -- omission, so that a forgotten grant can never read as "public".
+  -- omission, so that a forgotten grant can never read as "public". NULL and
+  -- '' elements are refused too: they pass a bare cardinality test while
+  -- granting access to nobody.
   CONSTRAINT chk_brain_facts_grant_nonempty
-    CHECK (cardinality(visible_to) > 0),
+    CHECK (cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0),
   -- No-provenance-no-promotion. NOT NULL alone would admit `'{}'::jsonb`,
   -- which is an empty claim wearing the shape of a real one.
   CONSTRAINT chk_brain_facts_provenance_nonempty

--- a/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
+++ b/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
@@ -102,17 +102,23 @@ CREATE TABLE IF NOT EXISTS brain_episodes (
   visible_to text[] NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
 
-  -- Body XOR locator — never both, never neither.
-  -- `nullif(…, '')` so an EMPTY body doesn't count as present: an episode
-  -- whose evidence is the empty string backs a provenance claim with nothing.
+  -- Body XOR locator — never both, never neither. An empty string is refused
+  -- outright rather than treated as absent: evidence that is '' backs a
+  -- provenance claim with nothing, and "'' means absent" would make
+  -- `body='x', locator=''` legal at rest while every reader has to remember
+  -- which emptiness counts.
   CONSTRAINT chk_brain_episodes_body_xor_locator
-    CHECK (num_nonnulls(nullif(body, ''), nullif(locator, '')) = 1),
+    CHECK (
+      num_nonnulls(body, locator) = 1
+      AND coalesce(body, 'x') <> ''
+      AND coalesce(locator, 'x') <> ''
+    ),
   -- No-grant-no-promotion, tier-3 half. A grant that denies everyone reads as
   -- "hidden" but behaves as "unreviewed" — refuse it at rest rather than let
   -- it mean two things. NULL and '' elements are refused for the same reason:
   -- they pass a bare cardinality test while granting access to nobody.
   CONSTRAINT chk_brain_episodes_grant_nonempty
-    CHECK (cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0)
+    CHECK (cardinality(array_remove(array_remove(visible_to, NULL::text), '')) > 0)
 );
 
 -- The dedupe key. UNIQUE is what makes re-ingest a no-op rather than a
@@ -249,7 +255,7 @@ CREATE TABLE IF NOT EXISTS brain_facts (
   -- '' elements are refused too: they pass a bare cardinality test while
   -- granting access to nobody.
   CONSTRAINT chk_brain_facts_grant_nonempty
-    CHECK (cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0),
+    CHECK (cardinality(array_remove(array_remove(visible_to, NULL::text), '')) > 0),
   -- No-provenance-no-promotion. NOT NULL alone would admit `'{}'::jsonb`,
   -- which is an empty claim wearing the shape of a real one.
   CONSTRAINT chk_brain_facts_provenance_nonempty

--- a/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
+++ b/packages/api/src/lib/db/migrations/0180_brain_substrate.sql
@@ -1,0 +1,331 @@
+-- 0180 — Brain substrate: episodes, facts, edges (#4767, ADR-0036 §The
+-- knowledge substrate / §Temporal, conflict & provenance / §Access control).
+--
+-- The first net-new code of the company-brain bet. ADR-0036 decided a fact/
+-- edge/episode substrate with its OWN trust identity, reusing the Knowledge
+-- Base's LIFECYCLE (review gate, per-org mirror, ingest seam) but explicitly
+-- NOT extending ADR-0028's descriptive-document model — extending KB in place
+-- was considered and rejected, because the fact class breaks ADR-0028's flat
+-- "descriptive-only" line and that break has to be visible in the schema.
+--
+-- The three trust tiers, in the vocabulary reserved by the re-aim guide:
+--   * tier-1 — warehouse facts, authoritative BY CONSTRUCTION. Not stored
+--     here at all: they are computed live through the semantic layer and
+--     gated by warehouse RLS. No table in this migration holds a tier-1 fact.
+--   * tier-2 — reviewed facts (`brain_facts`), authoritative FOR THEIR CLASS;
+--     they yield to the warehouse in any overlap.
+--   * tier-3 — raw episodes (`brain_episodes`), source-of-truth for what was
+--     actually said, never for what is true.
+--
+-- SCOPE: schema only. The M2 conflict machinery (as-of reads, in-tension
+-- clustering, `correct_fact`, the predicate-cardinality *engine*) is out of
+-- scope — but every column and the edge-type enum it will need land NOW, so
+-- M2 is purely additive and never rewrites a table under live data.
+--
+-- Two invariants are enforced by CHECK rather than by application code,
+-- because ADR-0036 states them as absolutes ("no-provenance-no-promotion",
+-- "no-grant-no-promotion"). A row that violates either is UNREPRESENTABLE AT
+-- REST: there is no code path, present or future, that can persist a fact
+-- with no provenance or an empty grant.
+
+-- ---------------------------------------------------------------------------
+-- brain_episodes — tier-3. Immutable, append-only, deduped by stable
+-- source-id. The raw record of what a source actually said.
+-- ---------------------------------------------------------------------------
+--
+-- Append-only is the point, not an optimization: an episode is evidence, and
+-- evidence that can be edited after the fact cannot back a provenance claim.
+-- There is deliberately NO `updated_at` column — its absence is the signal.
+-- Re-ingesting the same source record is a NO-OP (ON CONFLICT DO NOTHING at
+-- the call site), never an upsert: the ADR-0030 connector engine's subtractive
+-- archive + path-upsert half is bypassed entirely for episodes (that half
+-- scopes to facts), because a chat message that was edited upstream is a NEW
+-- episode, not a mutation of the old one.
+CREATE TABLE IF NOT EXISTS brain_episodes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Better-Auth organization id. Workspace-global, TEXT/no-FK like the other
+  -- org-scoped Atlas tables (knowledge_documents, dashboards, …).
+  workspace_id text NOT NULL,
+  -- Connector class/vendor that produced this episode ('slack', 'warehouse',
+  -- 'human'). Class-major per ADR-0036 §Ingestion; `human` is the correction
+  -- entry point, `warehouse` the SQL-pinned one.
+  source text NOT NULL,
+  -- The source's OWN stable identifier for this record. The dedupe key, and a
+  -- per-connector obligation: it must be stable across BOTH the webhook
+  -- fast-path and the polling path, or the two writers duplicate every
+  -- episode they race on.
+  source_id text NOT NULL,
+  -- The source-side principal who authored the record (e.g. a Slack user id).
+  -- Feeds grant derivation and entity resolution at the reconcile stage; NULL
+  -- when the source has no meaningful author (a warehouse snapshot).
+  source_actor text,
+  -- Body XOR locator. ADR-0036 stores episodes BY REFERENCE for warehouse- and
+  -- KB-derived facts (the content already has an authoritative home and
+  -- copying it would fork the truth), and BY VALUE for chat, where the source
+  -- may delete the message out from under us and the evidence must survive.
+  -- Exactly one, enforced below — "both" would make it ambiguous which one the
+  -- provenance claim actually rests on.
+  body text,
+  locator text,
+  -- Event time: when the thing was said/happened at the source. Distinct from
+  -- ingested_at (when Atlas learned of it) — the gap between them is the
+  -- freshness lag the connector's high-water mark is chasing.
+  occurred_at timestamptz,
+  ingested_at timestamptz NOT NULL DEFAULT now(),
+  -- Extraction work-queue marker. The async extraction fiber (#4771) drains
+  -- `extracted_at IS NULL`; stamping it is what takes an episode off the
+  -- queue. NULL forever is a visible backlog, not a silent drop — which is why
+  -- this is a nullable timestamp and not a boolean.
+  extracted_at timestamptz,
+  -- ACL grant (see brain_facts.visible_to for the grammar). Tiers 2 AND 3 are
+  -- gated: an episode is raw source content and is frequently MORE sensitive
+  -- than the facts extracted from it.
+  visible_to text[] NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  -- Body XOR locator — never both, never neither.
+  CONSTRAINT chk_brain_episodes_body_xor_locator
+    CHECK (num_nonnulls(body, locator) = 1),
+  -- No-grant-no-promotion, tier-3 half. An empty array is a grant that denies
+  -- everyone, which reads as "hidden" but behaves as "unreviewed" — refuse it
+  -- at rest rather than let it mean two things.
+  CONSTRAINT chk_brain_episodes_grant_nonempty
+    CHECK (cardinality(visible_to) > 0)
+);
+
+-- The dedupe key. UNIQUE is what makes re-ingest a no-op rather than a
+-- duplicate; scoped per workspace + source because two connectors (or two
+-- tenants) can legitimately mint the same opaque source id.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_brain_episodes_source_id
+  ON brain_episodes (workspace_id, source, source_id);
+
+-- The extraction fiber's drain query: oldest-unextracted-first, per workspace.
+-- PARTIAL so the index holds only the backlog — once an episode is extracted
+-- it leaves the index, which keeps the queue scan proportional to work
+-- remaining rather than to history.
+CREATE INDEX IF NOT EXISTS idx_brain_episodes_extraction_queue
+  ON brain_episodes (workspace_id, ingested_at)
+  WHERE extracted_at IS NULL;
+
+-- Per-tenant source browsing / connector backfill inspection.
+CREATE INDEX IF NOT EXISTS idx_brain_episodes_source
+  ON brain_episodes (workspace_id, source, occurred_at);
+
+-- Grant containment for the fail-closed visibility predicate (#4768), which
+-- pushes down as `visible_to && ARRAY[...principals]`. GIN is the index that
+-- makes array-overlap a lookup instead of a seq scan.
+CREATE INDEX IF NOT EXISTS idx_brain_episodes_visible_to
+  ON brain_episodes USING gin (visible_to);
+
+-- ---------------------------------------------------------------------------
+-- brain_facts — tier-2. Subject-predicate-object claims, bi-temporal,
+-- review-gated, invalidate-never-delete.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS brain_facts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id text NOT NULL,
+
+  -- SPO shape. Plain text at this stage: entity resolution is the reconcile
+  -- stage's job (#4771), and a failed subject/object resolution FLAGS the
+  -- candidate provisional rather than blocking it (a quality problem the
+  -- reviewer clears), so these columns must be able to hold an unresolved
+  -- surface form.
+  subject text NOT NULL,
+  predicate text NOT NULL,
+  object text NOT NULL,
+
+  -- Bi-temporal, four columns, invalidate-never-delete:
+  --   valid_from/valid_to — VALID time: when the claim was true in the world.
+  --     `valid_to` is stamped by a HUMAN promotion at the review gate. There
+  --     is no autonomous supersession; staleness decay only SURFACES a fact
+  --     for review, it never demotes one on its own.
+  --   ingested_at        — TRANSACTION time: when Atlas learned the claim.
+  --   invalidated_at     — the tombstone. Supersession is NOT deletion: a
+  --     superseded fact stays readable so "what we believed on Monday" still
+  --     answers correctly. Retraction (the only tombstone verb, and the
+  --     GDPR-erasure path) stamps this; nothing ever DELETEs a fact row.
+  valid_from timestamptz,
+  valid_to timestamptz,
+  ingested_at timestamptz NOT NULL DEFAULT now(),
+  invalidated_at timestamptz,
+
+  -- When the extraction pass that produced this candidate ran. Distinct from
+  -- the episode's own `extracted_at` queue marker: this one dates the CLAIM,
+  -- and lets a re-extraction (better model, revised prompt) be told apart from
+  -- the original pass over the same episode. NULL for human-authored facts,
+  -- which are not extracted from anything.
+  extracted_at timestamptz,
+
+  -- The episode this fact derives from. NOT NULL by construction — this is
+  -- "no-provenance-no-promotion" made structural. Every entry point onto the
+  -- reconcile stage has an episode: connector records have theirs, warehouse-
+  -- derived facts pin an SQL + snapshot episode, human corrections ARE a
+  -- first-class authored episode, and a write-back proposal lazily
+  -- materializes a session episode at propose time. A fact with no episode is
+  -- a claim with no evidence, and there is no such thing here.
+  -- RESTRICT, not CASCADE: deleting the evidence under a live fact must fail
+  -- loudly. Episodes are append-only anyway, so this should never fire.
+  source_episode_id uuid NOT NULL REFERENCES brain_episodes (id) ON DELETE RESTRICT,
+
+  -- Provenance payload — the actor, the source pointer, and for warehouse-
+  -- derived facts the pinned SQL + data snapshot (pinned, NOT a live view: a
+  -- provenance claim that re-runs is not a record of what was seen).
+  -- Immutable/append-only by convention; forks are recorded as `derives-from`
+  -- edges rather than by rewriting this.
+  provenance jsonb NOT NULL,
+
+  -- Content-mode lifecycle. Every candidate lands `draft`; only the atomic
+  -- publish endpoint promotes it. The review gate IS the brain's conflict-
+  -- resolution mechanism (ADR-0036 §Temporal) — this column is where "trust
+  -- over breadth" stops being a slogan. Registered with the content-mode
+  -- registry in #4769.
+  status text NOT NULL DEFAULT 'draft',
+
+  -- The ACL grant: a SELF-CONTAINED principal set, derived at ingest and
+  -- evaluated read-time-local. Grammar (#4768 owns the parser):
+  --   org | role:{owner,admin,member} | user:<id> | audience:<source-derived>
+  -- Per-version IMMUTABLE: a read of "what we believed Monday" evaluates
+  -- Monday's grant against as-of-now membership. That is why the grant is a
+  -- column on the fact rather than a join to a policy table — a policy table
+  -- would retroactively rewrite who could see history.
+  visible_to text[] NOT NULL,
+
+  -- Predicate cardinality — the supersede-vs-coexist switch M2 needs, landing
+  -- now so M2 adds an engine and not a column. `single` (a person has one
+  -- manager) means a new value SUPERSEDES; `multi` (a person knows many
+  -- languages) means values COEXIST and corroborate. Defaults to the
+  -- conservative arm: coexisting is recoverable, wrongly superseding destroys
+  -- a belief.
+  predicate_cardinality text NOT NULL DEFAULT 'multi',
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT chk_brain_facts_status
+    CHECK (status IN ('draft', 'published', 'archived')),
+  CONSTRAINT chk_brain_facts_predicate_cardinality
+    CHECK (predicate_cardinality IN ('single', 'multi')),
+  -- No-grant-no-promotion, tier-2 half. The public majority carries an
+  -- explicit `org` — "visible to everyone" is a stated grant, never an
+  -- omission, so that a forgotten grant can never read as "public".
+  CONSTRAINT chk_brain_facts_grant_nonempty
+    CHECK (cardinality(visible_to) > 0),
+  -- No-provenance-no-promotion. NOT NULL alone would admit `'{}'::jsonb`,
+  -- which is an empty claim wearing the shape of a real one.
+  CONSTRAINT chk_brain_facts_provenance_nonempty
+    CHECK (jsonb_typeof(provenance) = 'object' AND provenance <> '{}'::jsonb),
+  -- A closed validity interval must not run backwards.
+  CONSTRAINT chk_brain_facts_valid_interval
+    CHECK (valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from)
+);
+
+-- Content-mode status filter (published-only read + admin/dev-mode overlay),
+-- mirroring idx_knowledge_documents_status.
+CREATE INDEX IF NOT EXISTS idx_brain_facts_status
+  ON brain_facts (workspace_id, status);
+
+-- The retrieval read (#4773): look up live claims about a subject. PARTIAL on
+-- the live set — the overwhelming majority of reads want current belief, and
+-- excluding tombstones keeps the index from growing with retracted history.
+CREATE INDEX IF NOT EXISTS idx_brain_facts_subject
+  ON brain_facts (workspace_id, subject, predicate)
+  WHERE invalidated_at IS NULL;
+
+-- M2's as-of reads and the staleness sweep walk validity, not insertion order.
+CREATE INDEX IF NOT EXISTS idx_brain_facts_valid_from
+  ON brain_facts (workspace_id, valid_from);
+
+-- Walk every fact extracted from one episode — the reviewer's "what did this
+-- message produce?" view, and the re-extraction path.
+CREATE INDEX IF NOT EXISTS idx_brain_facts_source_episode
+  ON brain_facts (source_episode_id);
+
+-- Grant containment for the push-down visibility predicate (#4768).
+CREATE INDEX IF NOT EXISTS idx_brain_facts_visible_to
+  ON brain_facts USING gin (visible_to);
+
+-- ---------------------------------------------------------------------------
+-- brain_edges — the typed graph. Enum pinned to ADR-0036's committed set.
+-- ---------------------------------------------------------------------------
+--
+-- Endpoints are fact-or-episode on BOTH sides, expressed as two nullable FK
+-- columns per endpoint with an exactly-one CHECK, rather than a polymorphic
+-- (kind, id) pair. The polymorphic shape is shorter but throws away
+-- referential integrity — and an edge whose endpoint has silently vanished is
+-- precisely the corruption a provenance graph must not tolerate.
+--
+--   supersedes      fact  → fact     the M2 arbitration outcome
+--   in-tension-with fact  → fact     genuine coexisting conflict; SURFACED
+--                                    with both provenances, never ranked
+--   derives-from    fact  → fact/episode   fork lineage
+--   provenance      fact  → episode   the evidence pointer
+CREATE TABLE IF NOT EXISTS brain_edges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id text NOT NULL,
+  edge_type text NOT NULL,
+
+  from_fact_id uuid REFERENCES brain_facts (id) ON DELETE RESTRICT,
+  from_episode_id uuid REFERENCES brain_episodes (id) ON DELETE RESTRICT,
+  to_fact_id uuid REFERENCES brain_facts (id) ON DELETE RESTRICT,
+  to_episode_id uuid REFERENCES brain_episodes (id) ON DELETE RESTRICT,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  -- The four committed types. M2 extends the ENGINE, not this list.
+  CONSTRAINT chk_brain_edges_type
+    CHECK (edge_type IN ('supersedes', 'in-tension-with', 'derives-from', 'provenance')),
+  CONSTRAINT chk_brain_edges_from_endpoint
+    CHECK (num_nonnulls(from_fact_id, from_episode_id) = 1),
+  CONSTRAINT chk_brain_edges_to_endpoint
+    CHECK (num_nonnulls(to_fact_id, to_episode_id) = 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_brain_edges_from_fact
+  ON brain_edges (from_fact_id, edge_type)
+  WHERE from_fact_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_brain_edges_to_fact
+  ON brain_edges (to_fact_id, edge_type)
+  WHERE to_fact_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_brain_edges_to_episode
+  ON brain_edges (to_episode_id, edge_type)
+  WHERE to_episode_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_brain_edges_workspace_type
+  ON brain_edges (workspace_id, edge_type);
+
+-- ---------------------------------------------------------------------------
+-- fact_audience_member — Atlas-owned audience membership.
+-- ---------------------------------------------------------------------------
+--
+-- Backs the `audience:<name>` arm of the grant grammar. ADR-0036 accepted a
+-- real cost in choosing derive-at-ingest grants: source membership changes do
+-- NOT propagate to already-ingested facts. This table is the escape hatch —
+-- a sensitive fact grants to an `audience:`, membership is synced here, and
+-- revocation therefore flows through LIVE without re-ingesting anything.
+--
+-- Deliberately NOT Better Auth teams: Atlas has none, and "group" in this
+-- codebase means a connection-group (a set of datasources), not a set of
+-- people. Populated by #4771's source-membership entity resolution; consumed
+-- by #4768's visibility predicate.
+CREATE TABLE IF NOT EXISTS fact_audience_member (
+  workspace_id text NOT NULL,
+  -- The source-derived audience identifier, WITHOUT the `audience:` prefix
+  -- (the prefix belongs to the grant grammar, not to the identity).
+  audience_id text NOT NULL,
+  -- Better-Auth user id.
+  user_id text NOT NULL,
+  -- Which connector derived this membership. An audience belongs to exactly
+  -- one source by construction, so this is not part of the key — it is here so
+  -- a re-sync can scope its reconciliation and so an operator can answer "why
+  -- can this person see that?" without guessing.
+  source text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (workspace_id, audience_id, user_id)
+);
+
+-- "Which audiences is this user in?" — the per-request principal expansion the
+-- visibility predicate performs before it can push anything down.
+CREATE INDEX IF NOT EXISTS idx_fact_audience_member_user
+  ON fact_audience_member (workspace_id, user_id);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3191,6 +3191,11 @@ export const brainEpisodes = pgTable(
     // Dedupe key — makes re-ingest a no-op. Scoped per workspace + source
     // because two connectors can mint the same opaque source id.
     uniqueIndex("uq_brain_episodes_source_id").on(t.workspaceId, t.source, t.sourceId),
+    // Referent for the composite FKs from brain_facts / brain_edges. Adds no
+    // new uniqueness (id is the PK) — it exists so `(workspace_id, id)` has a
+    // unique index to point at, which is what lets those FKs prove that an
+    // episode and the rows referencing it share a workspace.
+    uniqueIndex("uq_brain_episodes_workspace_id").on(t.workspaceId, t.id),
     // Extraction drain, PARTIAL so the index holds only the backlog.
     index("idx_brain_episodes_extraction_queue")
       .on(t.workspaceId, t.ingestedAt)
@@ -3236,18 +3241,19 @@ export const brainFacts = pgTable(
     // The evidence. NOT NULL is "no-provenance-no-promotion" made structural:
     // every entry point onto the reconcile stage has an episode (connector
     // record, warehouse SQL+snapshot pin, human correction, lazily
-    // materialized session episode). RESTRICT so deleting evidence under a
-    // live fact fails loudly.
-    sourceEpisodeId: uuid("source_episode_id")
-      .notNull()
-      .references(() => brainEpisodes.id, { onDelete: "restrict" }),
+    // materialized session episode). The FK is COMPOSITE with workspaceId (see
+    // the table extras below) so the episode must be in the same workspace,
+    // and RESTRICT so deleting evidence under a live fact fails loudly.
+    sourceEpisodeId: uuid("source_episode_id").notNull(),
     // Actor, source pointer, and for warehouse-derived facts the PINNED SQL +
     // data snapshot (pinned, not a live view). Forks are recorded as
     // `derives-from` edges rather than by rewriting this.
     provenance: jsonb("provenance").notNull(),
-    // Content-mode lifecycle — every candidate lands `draft`, promoted only by
-    // the atomic publish endpoint. Registered with the content-mode registry
-    // in #4769.
+    // Content-mode lifecycle — DEFAULTS to `draft`, promoted by the atomic
+    // publish endpoint. Registered with the content-mode registry in #4769.
+    // A default, not an enforcement: human corrections land authoritative
+    // immediately, and a region import preserves the source's review status
+    // rather than demoting reviewed facts back to draft.
     status: text("status").notNull().default("draft"),
     // Self-contained principal set, derived at ingest, evaluated read-time
     // local. Grammar (parser in #4768):
@@ -3292,6 +3298,15 @@ export const brainFacts = pgTable(
       "chk_brain_facts_valid_interval",
       sql`valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from`,
     ),
+    // Composite FK — the episode must live in the SAME workspace as the fact,
+    // so a cross-tenant claim is unrepresentable rather than merely unlikely.
+    foreignKey({
+      name: "fk_brain_facts_episode",
+      columns: [t.workspaceId, t.sourceEpisodeId],
+      foreignColumns: [brainEpisodes.workspaceId, brainEpisodes.id],
+    }).onDelete("restrict"),
+    // Referent for brain_edges' composite endpoint FKs.
+    uniqueIndex("uq_brain_facts_workspace_id").on(t.workspaceId, t.id),
   ],
 );
 
@@ -3302,12 +3317,18 @@ export const brainFacts = pgTable(
 // whose endpoint silently vanished is exactly the corruption a provenance
 // graph must not tolerate.
 //
+// Endpoint KINDS are constrained per type, not merely documented: an
+// episode→episode `provenance` edge would satisfy a bare exactly-one-per-side
+// rule while being meaningless, and M2's walker assumes the shapes.
+//
 // Endpoint FKs CASCADE, deliberately asymmetric with the RESTRICT on
 // `brainFacts.sourceEpisodeId`. A fact's episode is its EVIDENCE and must not
 // be deletable under a live claim; an edge is a derived assertion ABOUT facts
 // and episodes, so once an endpoint is gone it is dangling structure and
-// should vanish with it. The asymmetry also keeps the #4458 cleanup sweep
-// sound — its column phase assumes CASCADE between in-scope tables.
+// should vanish with it. That asymmetry also keeps the #4458 cleanup sweep
+// sound: its column phase assumes CASCADE between in-scope tables, and
+// `brain_facts` — the one exception — is handled by phase instead (a `parent`
+// rule in cleanup.ts orders its delete ahead of brain_episodes).
 export const brainEdges = pgTable(
   "brain_edges",
   {
@@ -3315,16 +3336,17 @@ export const brainEdges = pgTable(
     workspaceId: text("workspace_id").notNull(),
     // supersedes (fact→fact, the M2 arbitration outcome) · in-tension-with
     // (fact→fact, genuine conflict — SURFACED with both provenances, never
-    // ranked) · derives-from (fork lineage) · provenance (evidence pointer).
+    // ranked) · derives-from (fact→fact|episode, fork lineage) · provenance
+    // (fact→episode, the evidence pointer).
     edgeType: text("edge_type").notNull(),
-    fromFactId: uuid("from_fact_id").references(() => brainFacts.id, { onDelete: "cascade" }),
-    fromEpisodeId: uuid("from_episode_id").references(() => brainEpisodes.id, {
-      onDelete: "cascade",
-    }),
-    toFactId: uuid("to_fact_id").references(() => brainFacts.id, { onDelete: "cascade" }),
-    toEpisodeId: uuid("to_episode_id").references(() => brainEpisodes.id, {
-      onDelete: "cascade",
-    }),
+    // Every committed type originates at a fact, so `fromEpisodeId` is
+    // currently always NULL. The column keeps the two sides symmetric for a
+    // future episode-rooted type; the endpoint-kinds CHECK is what stops one
+    // appearing by accident meanwhile.
+    fromFactId: uuid("from_fact_id"),
+    fromEpisodeId: uuid("from_episode_id"),
+    toFactId: uuid("to_fact_id"),
+    toEpisodeId: uuid("to_episode_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
@@ -3348,6 +3370,40 @@ export const brainEdges = pgTable(
       sql`num_nonnulls(from_fact_id, from_episode_id) = 1`,
     ),
     check("chk_brain_edges_to_endpoint", sql`num_nonnulls(to_fact_id, to_episode_id) = 1`),
+    // The per-type endpoint kinds documented above.
+    check(
+      "chk_brain_edges_endpoint_kinds",
+      sql`from_fact_id IS NOT NULL
+    AND CASE edge_type
+          WHEN 'provenance' THEN to_episode_id IS NOT NULL
+          WHEN 'derives-from' THEN TRUE
+          ELSE to_fact_id IS NOT NULL
+        END`,
+    ),
+    // Composite endpoint FKs — an edge can only join rows in its OWN
+    // workspace. Postgres's default MATCH SIMPLE skips the check when any
+    // referencing column is NULL, which is exactly right here: the unused side
+    // of each pair is simply not constrained.
+    foreignKey({
+      name: "fk_brain_edges_from_fact",
+      columns: [t.workspaceId, t.fromFactId],
+      foreignColumns: [brainFacts.workspaceId, brainFacts.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_brain_edges_from_episode",
+      columns: [t.workspaceId, t.fromEpisodeId],
+      foreignColumns: [brainEpisodes.workspaceId, brainEpisodes.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_brain_edges_to_fact",
+      columns: [t.workspaceId, t.toFactId],
+      foreignColumns: [brainFacts.workspaceId, brainFacts.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_brain_edges_to_episode",
+      columns: [t.workspaceId, t.toEpisodeId],
+      foreignColumns: [brainEpisodes.workspaceId, brainEpisodes.id],
+    }).onDelete("cascade"),
   ],
 );
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3203,9 +3203,18 @@ export const brainEpisodes = pgTable(
     index("idx_brain_episodes_source").on(t.workspaceId, t.source, t.occurredAt),
     // Array-overlap lookups for the fail-closed push-down predicate (#4768).
     index("idx_brain_episodes_visible_to").using("gin", t.visibleTo),
-    check("chk_brain_episodes_body_xor_locator", sql`num_nonnulls(body, locator) = 1`),
-    // No-grant-no-promotion, tier-3 half.
-    check("chk_brain_episodes_grant_nonempty", sql`cardinality(visible_to) > 0`),
+    // `nullif(…, '')` so an EMPTY body doesn't count as present — evidence
+    // that is the empty string backs a provenance claim with nothing.
+    check(
+      "chk_brain_episodes_body_xor_locator",
+      sql`num_nonnulls(nullif(body, ''), nullif(locator, '')) = 1`,
+    ),
+    // No-grant-no-promotion, tier-3 half. NULL/'' elements are refused too:
+    // they pass a bare cardinality test while granting access to nobody.
+    check(
+      "chk_brain_episodes_grant_nonempty",
+      sql`cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0`,
+    ),
   ],
 );
 
@@ -3287,7 +3296,10 @@ export const brainFacts = pgTable(
     // No-grant-no-promotion. The public majority carries an explicit `org` —
     // "visible to everyone" is a stated grant, never an omission, so a
     // forgotten grant can never read as public.
-    check("chk_brain_facts_grant_nonempty", sql`cardinality(visible_to) > 0`),
+    check(
+      "chk_brain_facts_grant_nonempty",
+      sql`cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0`,
+    ),
     // NOT NULL alone would admit `'{}'::jsonb` — an empty claim wearing the
     // shape of a real one.
     check(

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3203,17 +3203,20 @@ export const brainEpisodes = pgTable(
     index("idx_brain_episodes_source").on(t.workspaceId, t.source, t.occurredAt),
     // Array-overlap lookups for the fail-closed push-down predicate (#4768).
     index("idx_brain_episodes_visible_to").using("gin", t.visibleTo),
-    // `nullif(…, '')` so an EMPTY body doesn't count as present — evidence
-    // that is the empty string backs a provenance claim with nothing.
+    // An empty string is refused outright rather than treated as absent:
+    // evidence that is '' backs a provenance claim with nothing, and
+    // "'' means absent" would leave `body='x', locator=''` legal at rest.
     check(
       "chk_brain_episodes_body_xor_locator",
-      sql`num_nonnulls(nullif(body, ''), nullif(locator, '')) = 1`,
+      sql`num_nonnulls(body, locator) = 1
+      AND coalesce(body, 'x') <> ''
+      AND coalesce(locator, 'x') <> ''`,
     ),
     // No-grant-no-promotion, tier-3 half. NULL/'' elements are refused too:
     // they pass a bare cardinality test while granting access to nobody.
     check(
       "chk_brain_episodes_grant_nonempty",
-      sql`cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0`,
+      sql`cardinality(array_remove(array_remove(visible_to, NULL::text), '')) > 0`,
     ),
   ],
 );
@@ -3298,7 +3301,7 @@ export const brainFacts = pgTable(
     // forgotten grant can never read as public.
     check(
       "chk_brain_facts_grant_nonempty",
-      sql`cardinality(array_remove(array_remove(visible_to, NULL), '')) > 0`,
+      sql`cardinality(array_remove(array_remove(visible_to, NULL::text), '')) > 0`,
     ),
     // NOT NULL alone would admit `'{}'::jsonb` — an empty claim wearing the
     // shape of a real one.

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3301,6 +3301,13 @@ export const brainFacts = pgTable(
 // polymorphic shape is shorter but discards referential integrity, and an edge
 // whose endpoint silently vanished is exactly the corruption a provenance
 // graph must not tolerate.
+//
+// Endpoint FKs CASCADE, deliberately asymmetric with the RESTRICT on
+// `brainFacts.sourceEpisodeId`. A fact's episode is its EVIDENCE and must not
+// be deletable under a live claim; an edge is a derived assertion ABOUT facts
+// and episodes, so once an endpoint is gone it is dangling structure and
+// should vanish with it. The asymmetry also keeps the #4458 cleanup sweep
+// sound — its column phase assumes CASCADE between in-scope tables.
 export const brainEdges = pgTable(
   "brain_edges",
   {
@@ -3310,13 +3317,13 @@ export const brainEdges = pgTable(
     // (fact→fact, genuine conflict — SURFACED with both provenances, never
     // ranked) · derives-from (fork lineage) · provenance (evidence pointer).
     edgeType: text("edge_type").notNull(),
-    fromFactId: uuid("from_fact_id").references(() => brainFacts.id, { onDelete: "restrict" }),
+    fromFactId: uuid("from_fact_id").references(() => brainFacts.id, { onDelete: "cascade" }),
     fromEpisodeId: uuid("from_episode_id").references(() => brainEpisodes.id, {
-      onDelete: "restrict",
+      onDelete: "cascade",
     }),
-    toFactId: uuid("to_fact_id").references(() => brainFacts.id, { onDelete: "restrict" }),
+    toFactId: uuid("to_fact_id").references(() => brainFacts.id, { onDelete: "cascade" }),
     toEpisodeId: uuid("to_episode_id").references(() => brainEpisodes.id, {
-      onDelete: "restrict",
+      onDelete: "cascade",
     }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -3131,3 +3131,248 @@ export const connectionGroupDescriptions = pgTable(
     check("chk_connection_group_descriptions_source", sql`source IN ('auto', 'manual')`),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// Company brain substrate (0180 — #4767, ADR-0036)
+// ---------------------------------------------------------------------------
+//
+// A fact/edge/episode substrate with its OWN trust identity, reusing the
+// Knowledge Base's lifecycle (review gate, per-org mirror, ingest seam) but
+// NOT extending ADR-0028's descriptive-document model — the fact class breaks
+// ADR-0028's flat "descriptive-only" line, and that break is deliberate.
+//
+// Trust tiers, in the vocabulary reserved by the ADR-0036 re-aim guide:
+// tier-1 warehouse facts are authoritative by construction and are NOT stored
+// here (they resolve live through the semantic layer, gated by warehouse RLS);
+// tier-2 reviewed facts (`brainFacts`) are authoritative for their class and
+// yield to the warehouse in any overlap; tier-3 raw episodes (`brainEpisodes`)
+// are source-of-truth for what was *said*, never for what is *true*.
+//
+// Mirrors migration 0180.
+
+// brain_episodes — tier-3. Immutable, append-only, deduped by stable
+// source-id. Note the absence of `updatedAt`: an episode is evidence, and
+// evidence that can be edited cannot back a provenance claim. Re-ingesting the
+// same source record is a no-op, never an upsert.
+export const brainEpisodes = pgTable(
+  "brain_episodes",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // Better-Auth organization id — workspace-global, TEXT/no-FK like the
+    // other org-scoped Atlas tables.
+    workspaceId: text("workspace_id").notNull(),
+    // Connector class/vendor ('slack', 'warehouse', 'human').
+    source: text("source").notNull(),
+    // The source's own stable id — the dedupe key. Per-connector obligation:
+    // stable across BOTH the webhook fast-path and the polling path.
+    sourceId: text("source_id").notNull(),
+    // Source-side author principal; feeds grant derivation + entity
+    // resolution. NULL when the source has no meaningful author.
+    sourceActor: text("source_actor"),
+    // Body XOR locator (CHECK below). By-reference for warehouse/KB-derived
+    // content that already has an authoritative home; by-value for chat, where
+    // the source can delete the message and the evidence must survive.
+    body: text("body"),
+    locator: text("locator"),
+    // Event time at the source, distinct from `ingestedAt` (when Atlas learned
+    // of it). The gap is the freshness lag the high-water mark chases.
+    occurredAt: timestamp("occurred_at", { withTimezone: true }),
+    ingestedAt: timestamp("ingested_at", { withTimezone: true }).notNull().defaultNow(),
+    // Extraction work-queue marker — the fiber (#4771) drains
+    // `extracted_at IS NULL`. Nullable timestamp, not a boolean, so a stuck
+    // backlog is visible rather than silent.
+    extractedAt: timestamp("extracted_at", { withTimezone: true }),
+    // ACL grant (grammar documented on `brainFacts.visibleTo`). Tiers 2 AND 3
+    // are gated — raw episodes are often *more* sensitive than their facts.
+    visibleTo: text("visible_to").array().notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // Dedupe key — makes re-ingest a no-op. Scoped per workspace + source
+    // because two connectors can mint the same opaque source id.
+    uniqueIndex("uq_brain_episodes_source_id").on(t.workspaceId, t.source, t.sourceId),
+    // Extraction drain, PARTIAL so the index holds only the backlog.
+    index("idx_brain_episodes_extraction_queue")
+      .on(t.workspaceId, t.ingestedAt)
+      .where(sql`extracted_at IS NULL`),
+    index("idx_brain_episodes_source").on(t.workspaceId, t.source, t.occurredAt),
+    // Array-overlap lookups for the fail-closed push-down predicate (#4768).
+    index("idx_brain_episodes_visible_to").using("gin", t.visibleTo),
+    check("chk_brain_episodes_body_xor_locator", sql`num_nonnulls(body, locator) = 1`),
+    // No-grant-no-promotion, tier-3 half.
+    check("chk_brain_episodes_grant_nonempty", sql`cardinality(visible_to) > 0`),
+  ],
+);
+
+// brain_facts — tier-2. SPO claims, bi-temporal, review-gated,
+// invalidate-never-delete.
+export const brainFacts = pgTable(
+  "brain_facts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workspaceId: text("workspace_id").notNull(),
+    // SPO. Plain text: entity resolution happens at the reconcile stage
+    // (#4771), and a failed subject/object resolution flags the candidate
+    // provisional rather than blocking it — so these must hold an unresolved
+    // surface form.
+    subject: text("subject").notNull(),
+    predicate: text("predicate").notNull(),
+    object: text("object").notNull(),
+    // Bi-temporal, invalidate-never-delete. `validFrom`/`validTo` are VALID
+    // time (when the claim held in the world); `validTo` is stamped by a HUMAN
+    // promotion — there is no autonomous supersession, and staleness decay
+    // only surfaces a fact for review. `ingestedAt` is transaction time.
+    // `invalidatedAt` is the tombstone: supersession is not deletion, so
+    // "what we believed on Monday" still answers correctly. Nothing DELETEs.
+    validFrom: timestamp("valid_from", { withTimezone: true }),
+    validTo: timestamp("valid_to", { withTimezone: true }),
+    ingestedAt: timestamp("ingested_at", { withTimezone: true }).notNull().defaultNow(),
+    invalidatedAt: timestamp("invalidated_at", { withTimezone: true }),
+    // When the extraction pass that produced this candidate ran — dates the
+    // CLAIM, distinct from the episode's queue marker of the same name, so a
+    // re-extraction is distinguishable from the original pass. NULL for
+    // human-authored facts, which are not extracted from anything.
+    extractedAt: timestamp("extracted_at", { withTimezone: true }),
+    // The evidence. NOT NULL is "no-provenance-no-promotion" made structural:
+    // every entry point onto the reconcile stage has an episode (connector
+    // record, warehouse SQL+snapshot pin, human correction, lazily
+    // materialized session episode). RESTRICT so deleting evidence under a
+    // live fact fails loudly.
+    sourceEpisodeId: uuid("source_episode_id")
+      .notNull()
+      .references(() => brainEpisodes.id, { onDelete: "restrict" }),
+    // Actor, source pointer, and for warehouse-derived facts the PINNED SQL +
+    // data snapshot (pinned, not a live view). Forks are recorded as
+    // `derives-from` edges rather than by rewriting this.
+    provenance: jsonb("provenance").notNull(),
+    // Content-mode lifecycle — every candidate lands `draft`, promoted only by
+    // the atomic publish endpoint. Registered with the content-mode registry
+    // in #4769.
+    status: text("status").notNull().default("draft"),
+    // Self-contained principal set, derived at ingest, evaluated read-time
+    // local. Grammar (parser in #4768):
+    //   org | role:{owner,admin,member} | user:<id> | audience:<source-derived>
+    // Per-version IMMUTABLE — a column rather than a join to a policy table,
+    // because a policy table would retroactively rewrite who could see history.
+    visibleTo: text("visible_to").array().notNull(),
+    // The supersede-vs-coexist switch M2 needs, landing now so M2 adds an
+    // engine and not a column. `single` supersedes, `multi` coexists +
+    // corroborates. Defaults to the conservative arm: coexisting is
+    // recoverable, wrongly superseding destroys a belief.
+    predicateCardinality: text("predicate_cardinality").notNull().default("multi"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("idx_brain_facts_status").on(t.workspaceId, t.status),
+    // The retrieval read (#4773) — PARTIAL on the live set, since almost every
+    // read wants current belief and tombstones would grow the index forever.
+    index("idx_brain_facts_subject")
+      .on(t.workspaceId, t.subject, t.predicate)
+      .where(sql`invalidated_at IS NULL`),
+    index("idx_brain_facts_valid_from").on(t.workspaceId, t.validFrom),
+    index("idx_brain_facts_source_episode").on(t.sourceEpisodeId),
+    index("idx_brain_facts_visible_to").using("gin", t.visibleTo),
+    check("chk_brain_facts_status", sql`status IN ('draft', 'published', 'archived')`),
+    check(
+      "chk_brain_facts_predicate_cardinality",
+      sql`predicate_cardinality IN ('single', 'multi')`,
+    ),
+    // No-grant-no-promotion. The public majority carries an explicit `org` —
+    // "visible to everyone" is a stated grant, never an omission, so a
+    // forgotten grant can never read as public.
+    check("chk_brain_facts_grant_nonempty", sql`cardinality(visible_to) > 0`),
+    // NOT NULL alone would admit `'{}'::jsonb` — an empty claim wearing the
+    // shape of a real one.
+    check(
+      "chk_brain_facts_provenance_nonempty",
+      sql`jsonb_typeof(provenance) = 'object' AND provenance <> '{}'::jsonb`,
+    ),
+    check(
+      "chk_brain_facts_valid_interval",
+      sql`valid_to IS NULL OR valid_from IS NULL OR valid_to >= valid_from`,
+    ),
+  ],
+);
+
+// brain_edges — the typed graph, enum pinned to ADR-0036's committed set.
+// Endpoints are fact-or-episode on both sides via two nullable FKs + an
+// exactly-one CHECK, rather than a polymorphic (kind, id) pair: the
+// polymorphic shape is shorter but discards referential integrity, and an edge
+// whose endpoint silently vanished is exactly the corruption a provenance
+// graph must not tolerate.
+export const brainEdges = pgTable(
+  "brain_edges",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workspaceId: text("workspace_id").notNull(),
+    // supersedes (fact→fact, the M2 arbitration outcome) · in-tension-with
+    // (fact→fact, genuine conflict — SURFACED with both provenances, never
+    // ranked) · derives-from (fork lineage) · provenance (evidence pointer).
+    edgeType: text("edge_type").notNull(),
+    fromFactId: uuid("from_fact_id").references(() => brainFacts.id, { onDelete: "restrict" }),
+    fromEpisodeId: uuid("from_episode_id").references(() => brainEpisodes.id, {
+      onDelete: "restrict",
+    }),
+    toFactId: uuid("to_fact_id").references(() => brainFacts.id, { onDelete: "restrict" }),
+    toEpisodeId: uuid("to_episode_id").references(() => brainEpisodes.id, {
+      onDelete: "restrict",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index("idx_brain_edges_from_fact")
+      .on(t.fromFactId, t.edgeType)
+      .where(sql`from_fact_id IS NOT NULL`),
+    index("idx_brain_edges_to_fact")
+      .on(t.toFactId, t.edgeType)
+      .where(sql`to_fact_id IS NOT NULL`),
+    index("idx_brain_edges_to_episode")
+      .on(t.toEpisodeId, t.edgeType)
+      .where(sql`to_episode_id IS NOT NULL`),
+    index("idx_brain_edges_workspace_type").on(t.workspaceId, t.edgeType),
+    // The four committed types. M2 extends the ENGINE, not this list.
+    check(
+      "chk_brain_edges_type",
+      sql`edge_type IN ('supersedes', 'in-tension-with', 'derives-from', 'provenance')`,
+    ),
+    check(
+      "chk_brain_edges_from_endpoint",
+      sql`num_nonnulls(from_fact_id, from_episode_id) = 1`,
+    ),
+    check("chk_brain_edges_to_endpoint", sql`num_nonnulls(to_fact_id, to_episode_id) = 1`),
+  ],
+);
+
+// fact_audience_member — Atlas-owned audience membership, backing the
+// `audience:<name>` arm of the grant grammar.
+//
+// ADR-0036 accepted a real cost in choosing derive-at-ingest grants: source
+// membership changes do NOT propagate to already-ingested facts. This table is
+// the escape hatch — a sensitive fact grants to an `audience:`, membership is
+// synced here, and revocation therefore flows through LIVE without re-ingest.
+//
+// Deliberately NOT Better Auth teams: Atlas has none, and "group" in this
+// codebase means a connection-group (datasources), not a set of people.
+// Populated by #4771; consumed by #4768's visibility predicate.
+export const factAudienceMember = pgTable(
+  "fact_audience_member",
+  {
+    workspaceId: text("workspace_id").notNull(),
+    // Source-derived audience id, WITHOUT the `audience:` prefix — the prefix
+    // belongs to the grant grammar, not to the identity.
+    audienceId: text("audience_id").notNull(),
+    userId: text("user_id").notNull(),
+    // Which connector derived this membership. An audience belongs to exactly
+    // one source by construction, so this is not part of the key — it scopes a
+    // re-sync's reconciliation and answers "why can this person see that?".
+    source: text("source").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.workspaceId, t.audienceId, t.userId] }),
+    // "Which audiences is this user in?" — the per-request principal expansion
+    // the visibility predicate performs before it can push anything down.
+    index("idx_fact_audience_member_user").on(t.workspaceId, t.userId),
+  ],
+);

--- a/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
+++ b/packages/api/src/lib/residency/__tests__/bundle-scope.test.ts
@@ -80,12 +80,23 @@ describe("bundle-scope drift tripwire (#4460)", () => {
   it("pins the decided v2 bundle scope exactly", () => {
     // The maintainer-approved scope from #4460. Changing this list is a
     // product decision — update the issue trail + data-residency.mdx with it.
+    //
+    // Extended by #4767 (ADR-0036) with the four company-brain tables. The
+    // decision: a workspace's brain is the same class of asset as its
+    // knowledge base, so it moves. The alternative classification ('stays')
+    // is not neutral — stays rows are DELETED from the source after the
+    // grace period, which would make a region migration silently destroy the
+    // workspace's accumulated knowledge.
     expect([...EXPORTED_TABLES].toSorted()).toEqual([
       "agent_session_memory",
+      "brain_edges",
+      "brain_episodes",
+      "brain_facts",
       "conversations",
       "dashboard_cards",
       "dashboard_user_drafts",
       "dashboards",
+      "fact_audience_member",
       "knowledge_documents",
       "knowledge_links",
       "learned_patterns",

--- a/packages/api/src/lib/residency/__tests__/cleanup.test.ts
+++ b/packages/api/src/lib/residency/__tests__/cleanup.test.ts
@@ -297,6 +297,45 @@ describe("cleanup scope tripwire (#4458 ↔ #4460 lockstep)", () => {
     expect(columnsOf("chat_cache")).not.toContain("org_id");
   });
 
+  it("brain_facts is parent-scoped for PHASE, not for scoping (#4767)", () => {
+    // brain_facts carries its own workspace_id, so a `column` rule would scope
+    // it correctly — and would still be a bug. `brain_facts.source_episode_id`
+    // is the one RESTRICT FK between in-scope tables, so the facts must be
+    // deleted before the column phase reaches brain_episodes or the whole
+    // sweep fails on any workspace that actually has a brain.
+    //
+    // Demoting this to `{ kind: "column", column: "workspace_id" }` currently
+    // *happens* to still work, because declaration order puts brain_facts
+    // ahead of brain_episodes in the column phase. That is an invisible,
+    // unasserted property of literal ordering — this test is what makes the
+    // decision explicit instead.
+    expect(CLEANUP_TABLE_RULES.brain_facts).toEqual({
+      kind: "parent",
+      fkColumn: "source_episode_id",
+      parentTable: "brain_episodes",
+      parentColumn: "workspace_id",
+    });
+    // Non-vacuous: the column really does exist, so the parent rule is a
+    // deliberate choice rather than the only option.
+    expect(columnsOf("brain_facts")).toContain("workspace_id");
+  });
+
+  it("every parent-scoped delete precedes its parent table's delete", () => {
+    // The general form of the rule above: a parent rule's subquery needs the
+    // parent rows to still exist, and (for RESTRICT FKs) the child rows must
+    // be gone before the parent is deleted. Either way the child statement
+    // has to come first.
+    const statements = buildCleanupStatements();
+    const indexOf = (table: string) => statements.findIndex((s) => s.table === table);
+    for (const [table, rule] of Object.entries(CLEANUP_TABLE_RULES)) {
+      if (rule.kind !== "parent") continue;
+      const parentIdx = indexOf(rule.parentTable);
+      if (parentIdx === -1) continue; // parent has no delete of its own
+      expect(indexOf(table), `${table} must be deleted before ${rule.parentTable}`)
+        .toBeLessThan(parentIdx);
+    }
+  });
+
   it("orders parent/expression-scoped deletes before the direct-column phase", () => {
     const statements = buildCleanupStatements();
     const kindOf = (table: string) => ruleFor[table]?.kind;

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -477,6 +477,126 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
     PG_TEST_TIMEOUT_MS,
   );
 
+  it(
+    "adopts a target episode already present under a DIFFERENT uuid, remapping facts AND edges (#4767)",
+    async () => {
+      // The scenario adoption exists for: after cutover the target's own
+      // connector ingests the same source record, minting its own uuid. A bare
+      // INSERT would hit uq_brain_episodes_source_id and abort the entire
+      // import; the importer instead adopts the target's row.
+      //
+      // The subtle half — and the one that was wrong first time — is that the
+      // adopted id must be threaded to EDGES too, not just facts. The bundle's
+      // episode uuid is never inserted on this path, so a `provenance` edge
+      // (fact→episode, the most common type) would otherwise reference a row
+      // that does not exist and fail its composite endpoint FK at the very last
+      // import step, rolling back everything.
+      const ADOPT_ORG = "org-migrate-adopt";
+      const SOURCE_EP = "dddddddd-0000-4000-8000-00000000000d";
+      const TARGET_EP = "eeeeeeee-0000-4000-8000-00000000000e";
+      const ADOPT_FACT = "dddddddd-0000-4000-8000-00000000000f";
+
+      // The target already holds the same (source, source_id) under its own id.
+      await pool.query(
+        `INSERT INTO brain_episodes (id, workspace_id, source, source_id, body, visible_to)
+         VALUES ($1, $2, 'slack', 'C-adopt/1', 'target-side copy', ARRAY['org'])`,
+        [TARGET_EP, ADOPT_ORG],
+      );
+
+      const bundle = {
+        manifest: {
+          version: 2 as const,
+          exportedAt: "2026-06-01T00:00:00Z",
+          source: { label: "adopt-test" },
+          counts: {
+            conversations: 0, messages: 0, semanticEntities: 0, learnedPatterns: 0, settings: 0,
+            brainEpisodes: 1, brainFacts: 1, brainEdges: 1, factAudienceMembers: 0,
+          },
+        },
+        conversations: [], semanticEntities: [], learnedPatterns: [], settings: [],
+        dashboards: [], knowledgeDocuments: [], scheduledTasks: [], agentSessionMemory: [],
+        brainEpisodes: [
+          {
+            id: SOURCE_EP,
+            source: "slack",
+            sourceId: "C-adopt/1",
+            sourceActor: null,
+            body: "source-side copy",
+            locator: null,
+            occurredAt: null,
+            ingestedAt: "2026-06-01T00:00:00Z",
+            extractedAt: null,
+            visibleTo: ["org"],
+            createdAt: "2026-06-01T00:00:00Z",
+            facts: [
+              {
+                id: ADOPT_FACT,
+                subject: "s", predicate: "p", object: "o",
+                validFrom: null, validTo: null,
+                ingestedAt: "2026-06-01T00:00:00Z",
+                invalidatedAt: null, extractedAt: null,
+                provenance: { actor: "u1" },
+                status: "published" as const,
+                visibleTo: ["org"],
+                predicateCardinality: "multi" as const,
+                createdAt: "2026-06-01T00:00:00Z",
+                updatedAt: "2026-06-01T00:00:00Z",
+              },
+            ],
+          },
+        ],
+        // Points at the BUNDLE's episode id — the id that is never inserted.
+        brainEdges: [
+          {
+            edgeType: "provenance" as const,
+            fromFactId: ADOPT_FACT,
+            fromEpisodeId: null,
+            toFactId: null,
+            toEpisodeId: SOURCE_EP,
+            createdAt: "2026-06-01T00:00:00Z",
+          },
+        ],
+        factAudienceMembers: [],
+      };
+
+      const client = await pool.connect();
+      let result: ImportResult;
+      try {
+        await client.query("BEGIN");
+        result = await importBundle(client, bundle as never, ADOPT_ORG);
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        throw err;
+      } finally {
+        client.release();
+      }
+
+      expect(result.brainEpisodes).toEqual({ imported: 0, skipped: 1 });
+      expect(result.brainFacts).toEqual({ imported: 1, skipped: 0 });
+      expect(result.brainEdges).toEqual({ imported: 1, skipped: 0 });
+
+      // The bundle's episode uuid was never inserted…
+      const orphan = await pool.query(`SELECT 1 FROM brain_episodes WHERE id = $1`, [SOURCE_EP]);
+      expect(orphan.rowCount).toBe(0);
+
+      // …so both the fact and the edge must reference the TARGET's uuid.
+      const fact = await pool.query<{ source_episode_id: string }>(
+        `SELECT source_episode_id FROM brain_facts WHERE id = $1`,
+        [ADOPT_FACT],
+      );
+      expect(fact.rows[0].source_episode_id).toBe(TARGET_EP);
+
+      const edge = await pool.query<{ to_episode_id: string }>(
+        `SELECT to_episode_id FROM brain_edges WHERE workspace_id = $1`,
+        [ADOPT_ORG],
+      );
+      expect(edge.rows).toHaveLength(1);
+      expect(edge.rows[0].to_episode_id).toBe(TARGET_EP);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
   // ── #4458 — Phase 4 source cleanup against the real schema ──────────
   // The mock-level suite (`cleanup.test.ts`) pins scope + transaction
   // behavior but can't catch a typo'd column in one of the ~70 generated

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -42,6 +42,10 @@ const DASH_ID = "33333333-3333-4333-8333-333333333333";
 const CARD_ID = "44444444-4444-4444-8444-444444444444";
 const DOC_ID = "55555555-5555-4555-8555-555555555555";
 const TASK_ID = "66666666-6666-4666-8666-666666666666";
+// Company brain (#4767, ADR-0036).
+const EPISODE_ID = "77777777-7777-4777-8777-777777777777";
+const FACT_ID = "88888888-8888-4888-8888-888888888888";
+const SUPERSEDED_FACT_ID = "99999999-9999-4999-8999-999999999999";
 
 describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => {
   let pool: Pool;
@@ -140,6 +144,55 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
                '["ops@example.com"]'::jsonb, 'g-prod', 'auto', true, now(), now())`,
       [TASK_ID, SOURCE_ORG],
     );
+
+    // ── Company brain (#4767, ADR-0036) ──
+    // One episode carrying TWO facts: a live published one and a superseded,
+    // tombstoned one. The retracted fact is the interesting case — it proves
+    // invalidate-never-delete survives the hop, so an as-of read in the
+    // target still answers "what we believed on Monday" correctly. An export
+    // that quietly dropped invalidated rows would look perfectly healthy.
+    await pool.query(
+      `INSERT INTO brain_episodes (id, workspace_id, source, source_id, source_actor, body,
+                                   occurred_at, extracted_at, visible_to)
+       VALUES ($1, $2, 'slack', 'C123/1700000000.1', 'U-alice', 'Pricing moved to $49/seat.',
+               '2026-06-01T00:00:00Z', '2026-06-01T00:05:00Z', ARRAY['org', 'audience:eng'])`,
+      [EPISODE_ID, SOURCE_ORG],
+    );
+    await pool.query(
+      `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, valid_from,
+                                ingested_at, extracted_at, source_episode_id, provenance,
+                                status, visible_to, predicate_cardinality)
+       VALUES ($1, $2, 'acme:pro-plan', 'price_per_seat', '49',
+               '2026-06-01T00:00:00Z', '2026-06-01T00:05:00Z', '2026-06-01T00:05:00Z', $3,
+               '{"actor":"U-alice","episode":"C123/1700000000.1"}'::jsonb,
+               'published', ARRAY['org'], 'single')`,
+      [FACT_ID, SOURCE_ORG, EPISODE_ID],
+    );
+    await pool.query(
+      `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object, valid_from, valid_to,
+                                ingested_at, invalidated_at, source_episode_id, provenance,
+                                status, visible_to, predicate_cardinality)
+       VALUES ($1, $2, 'acme:pro-plan', 'price_per_seat', '39',
+               '2026-01-01T00:00:00Z', '2026-06-01T00:00:00Z',
+               '2026-01-01T00:00:00Z', '2026-06-01T00:00:00Z', $3,
+               '{"actor":"U-bob"}'::jsonb, 'published', ARRAY['org'], 'single')`,
+      [SUPERSEDED_FACT_ID, SOURCE_ORG, EPISODE_ID],
+    );
+    await pool.query(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
+       VALUES ($1, 'supersedes', $2, $3)`,
+      [SOURCE_ORG, FACT_ID, SUPERSEDED_FACT_ID],
+    );
+    await pool.query(
+      `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+       VALUES ($1, 'provenance', $2, $3)`,
+      [SOURCE_ORG, FACT_ID, EPISODE_ID],
+    );
+    await pool.query(
+      `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source)
+       VALUES ($1, 'eng', 'user-1', 'slack')`,
+      [SOURCE_ORG],
+    );
   }, PG_TEST_TIMEOUT_MS);
 
   afterAll(async () => {
@@ -190,6 +243,10 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         knowledgeLinks: 1,
         scheduledTasks: 1,
         agentSessionMemory: 1, // the deleted conversation's slot is excluded
+        brainEpisodes: 1,
+        brainFacts: 2, // the live claim AND the superseded/tombstoned one
+        brainEdges: 2,
+        factAudienceMembers: 1,
       });
 
       // ── Simulate the cross-region hop on one DB: preserved UUIDs would
@@ -199,6 +256,12 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       await pool.query(`DELETE FROM dashboards WHERE org_id = $1`, [SOURCE_ORG]); // cascades cards + drafts
       await pool.query(`DELETE FROM knowledge_documents WHERE workspace_id = $1`, [SOURCE_ORG]); // cascades links
       await pool.query(`DELETE FROM scheduled_tasks WHERE org_id = $1`, [SOURCE_ORG]);
+      // Brain: edges first, then facts, then episodes — the FKs are RESTRICT,
+      // not CASCADE, precisely so evidence can't vanish under a live claim.
+      await pool.query(`DELETE FROM brain_edges WHERE workspace_id = $1`, [SOURCE_ORG]);
+      await pool.query(`DELETE FROM brain_facts WHERE workspace_id = $1`, [SOURCE_ORG]);
+      await pool.query(`DELETE FROM brain_episodes WHERE workspace_id = $1`, [SOURCE_ORG]);
+      await pool.query(`DELETE FROM fact_audience_member WHERE workspace_id = $1`, [SOURCE_ORG]);
       await pool.query(`DELETE FROM semantic_entities WHERE org_id = $1`, [SOURCE_ORG]);
       await pool.query(`DELETE FROM learned_patterns WHERE org_id = $1`, [SOURCE_ORG]);
       await pool.query(`DELETE FROM settings WHERE org_id = $1`, [SOURCE_ORG]);
@@ -213,6 +276,81 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       expect(result.knowledgeDocuments).toEqual({ imported: 1, skipped: 0 });
       expect(result.scheduledTasks).toEqual({ imported: 1, skipped: 0 });
       expect(result.agentSessionMemory).toEqual({ imported: 1, skipped: 0 });
+      expect(result.brainEpisodes).toEqual({ imported: 1, skipped: 0 });
+      expect(result.brainFacts).toEqual({ imported: 2, skipped: 0 });
+      expect(result.brainEdges).toEqual({ imported: 2, skipped: 0 });
+      expect(result.factAudienceMembers).toEqual({ imported: 1, skipped: 0 });
+
+      // The brain survives the hop INTACT — not just row counts, but every
+      // property that makes a fact trustworthy. A migration that moved the
+      // rows while dropping the grant or the provenance would pass a count
+      // assertion and quietly publish private claims in the target region.
+      const brainFact = await pool.query<{
+        object: string;
+        status: string;
+        visible_to: string[];
+        provenance: Record<string, unknown>;
+        predicate_cardinality: string;
+        invalidated_at: Date | null;
+        source_episode_id: string;
+      }>(
+        `SELECT object, status, visible_to, provenance, predicate_cardinality,
+                invalidated_at, source_episode_id
+           FROM brain_facts WHERE id = $1 AND workspace_id = $2`,
+        [FACT_ID, TARGET_ORG],
+      );
+      expect(brainFact.rows).toHaveLength(1);
+      expect(brainFact.rows[0].object).toBe("49");
+      expect(brainFact.rows[0].status).toBe("published");
+      expect(brainFact.rows[0].visible_to).toEqual(["org"]);
+      expect(brainFact.rows[0].provenance).toEqual({
+        actor: "U-alice",
+        episode: "C123/1700000000.1",
+      });
+      expect(brainFact.rows[0].predicate_cardinality).toBe("single");
+      // FK re-resolved against the imported episode, UUID preserved.
+      expect(brainFact.rows[0].source_episode_id).toBe(EPISODE_ID);
+
+      // Invalidate-never-delete survives: the tombstoned claim is still here,
+      // still carrying the instant it stopped being true.
+      const superseded = await pool.query<{ invalidated_at: Date | null; valid_to: Date | null }>(
+        `SELECT invalidated_at, valid_to FROM brain_facts WHERE id = $1 AND workspace_id = $2`,
+        [SUPERSEDED_FACT_ID, TARGET_ORG],
+      );
+      expect(superseded.rows).toHaveLength(1);
+      expect(superseded.rows[0].invalidated_at).not.toBeNull();
+      expect(superseded.rows[0].valid_to).not.toBeNull();
+
+      // The episode's grant (including its audience arm) and its extraction
+      // stamp travel — the latter so the target doesn't re-queue an episode a
+      // human already reviewed.
+      const episode = await pool.query<{ visible_to: string[]; extracted_at: Date | null }>(
+        `SELECT visible_to, extracted_at FROM brain_episodes WHERE id = $1 AND workspace_id = $2`,
+        [EPISODE_ID, TARGET_ORG],
+      );
+      expect(episode.rows[0].visible_to).toEqual(["org", "audience:eng"]);
+      expect(episode.rows[0].extracted_at).not.toBeNull();
+
+      // Audience membership moved, so the `audience:eng` grant still resolves
+      // to a real person rather than denying everyone.
+      const audience = await pool.query(
+        `SELECT 1 FROM fact_audience_member
+          WHERE workspace_id = $1 AND audience_id = 'eng' AND user_id = 'user-1'`,
+        [TARGET_ORG],
+      );
+      expect(audience.rowCount).toBe(1);
+
+      // Both edge shapes re-resolved: fact→fact and fact→episode.
+      const edges = await pool.query<{ edge_type: string; to_fact_id: string | null; to_episode_id: string | null }>(
+        `SELECT edge_type, to_fact_id, to_episode_id FROM brain_edges
+          WHERE workspace_id = $1 ORDER BY edge_type ASC`,
+        [TARGET_ORG],
+      );
+      expect(edges.rows).toHaveLength(2);
+      expect(edges.rows[0].edge_type).toBe("provenance");
+      expect(edges.rows[0].to_episode_id).toBe(EPISODE_ID);
+      expect(edges.rows[1].edge_type).toBe("supersedes");
+      expect(edges.rows[1].to_fact_id).toBe(SUPERSEDED_FACT_ID);
 
       // UUIDs preserved; carve-outs enforced on the dashboard row.
       const dash = await pool.query(
@@ -295,6 +433,12 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         knowledgeDocuments: { imported: 0, skipped: 1 },
         scheduledTasks: { imported: 0, skipped: 1 },
         agentSessionMemory: { imported: 0, skipped: 1 },
+        brainEpisodes: { imported: 0, skipped: 1 },
+        // Skipped WITH their episode — re-importing them would attach
+        // duplicate claims to an episode that already carries its own.
+        brainFacts: { imported: 0, skipped: 2 },
+        brainEdges: { imported: 0, skipped: 2 },
+        factAudienceMembers: { imported: 0, skipped: 1 },
       });
     },
     PG_TEST_TIMEOUT_MS,
@@ -420,6 +564,36 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         [CLEAN_ORG],
       );
 
+      // Company brain residue (#4767). This is the ONE place the sweep's
+      // phase ordering is load-bearing: `brain_facts.source_episode_id` is
+      // RESTRICT, so if facts were deleted in the same phase as episodes the
+      // sweep would fail outright on any workspace that actually has a brain.
+      // Seeding a full episode → fact → edge chain here is what makes that a
+      // test failure instead of a production incident.
+      const cleanEpisode = "aaaaaaaa-0000-4000-8000-00000000000a";
+      const cleanFact = "aaaaaaaa-0000-4000-8000-00000000000b";
+      await pool.query(
+        `INSERT INTO brain_episodes (id, workspace_id, source, source_id, body, visible_to)
+         VALUES ($1, $2, 'slack', 'C-clean/1', 'residue', ARRAY['org'])`,
+        [cleanEpisode, CLEAN_ORG],
+      );
+      await pool.query(
+        `INSERT INTO brain_facts (id, workspace_id, subject, predicate, object,
+                                  source_episode_id, provenance, visible_to)
+         VALUES ($1, $2, 's', 'p', 'o', $3, '{"actor":"u"}'::jsonb, ARRAY['org'])`,
+        [cleanFact, CLEAN_ORG, cleanEpisode],
+      );
+      await pool.query(
+        `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_episode_id)
+         VALUES ($1, 'provenance', $2, $3)`,
+        [CLEAN_ORG, cleanFact, cleanEpisode],
+      );
+      await pool.query(
+        `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source)
+         VALUES ($1, 'eng', 'user-1', 'slack')`,
+        [CLEAN_ORG],
+      );
+
       // ── A workspace that migrated away but came BACK before cleanup ran:
       // the cutover guard must refuse to delete its (live) data ──
       await pool.query(
@@ -478,6 +652,15 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         expect(await countIn(`SELECT count(*)::int AS n FROM settings WHERE org_id = $1`, [CLEAN_ORG])).toBe(0);
         expect(await countIn(`SELECT count(*)::int AS n FROM audit_log WHERE org_id = $1`, [CLEAN_ORG])).toBe(0);
         expect(await countIn(`SELECT count(*)::int AS n FROM chat_cache WHERE key = 'slack:installation:T-clean'`, [])).toBe(0);
+        // The brain chain is fully swept — facts ahead of episodes despite the
+        // RESTRICT FK between them, edges cascaded, audience membership gone.
+        expect(await countIn(`SELECT count(*)::int AS n FROM brain_facts WHERE workspace_id = $1`, [CLEAN_ORG])).toBe(0);
+        expect(await countIn(`SELECT count(*)::int AS n FROM brain_episodes WHERE workspace_id = $1`, [CLEAN_ORG])).toBe(0);
+        expect(await countIn(`SELECT count(*)::int AS n FROM brain_edges WHERE workspace_id = $1`, [CLEAN_ORG])).toBe(0);
+        expect(await countIn(`SELECT count(*)::int AS n FROM fact_audience_member WHERE workspace_id = $1`, [CLEAN_ORG])).toBe(0);
+        // The TARGET org's imported brain is untouched — the sweep is scoped
+        // to the migrated-away workspace, not to the tables.
+        expect(await countIn(`SELECT count(*)::int AS n FROM brain_facts WHERE workspace_id = $1`, [TARGET_ORG])).toBe(2);
 
         // Survivors: platform settings row, unattributable cache row, the
         // TARGET org's imported data (seeded by the round-trip test above —

--- a/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate-roundtrip-pg.test.ts
@@ -256,8 +256,10 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       await pool.query(`DELETE FROM dashboards WHERE org_id = $1`, [SOURCE_ORG]); // cascades cards + drafts
       await pool.query(`DELETE FROM knowledge_documents WHERE workspace_id = $1`, [SOURCE_ORG]); // cascades links
       await pool.query(`DELETE FROM scheduled_tasks WHERE org_id = $1`, [SOURCE_ORG]);
-      // Brain: edges first, then facts, then episodes — the FKs are RESTRICT,
-      // not CASCADE, precisely so evidence can't vanish under a live claim.
+      // Brain: facts before episodes — brain_facts.source_episode_id is the
+      // one RESTRICT FK here (evidence can't vanish under a live claim). The
+      // edge delete is belt-and-braces: those FKs CASCADE, so the rows are
+      // already gone once their endpoints are.
       await pool.query(`DELETE FROM brain_edges WHERE workspace_id = $1`, [SOURCE_ORG]);
       await pool.query(`DELETE FROM brain_facts WHERE workspace_id = $1`, [SOURCE_ORG]);
       await pool.query(`DELETE FROM brain_episodes WHERE workspace_id = $1`, [SOURCE_ORG]);
@@ -312,14 +314,17 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
       expect(brainFact.rows[0].source_episode_id).toBe(EPISODE_ID);
 
       // Invalidate-never-delete survives: the tombstoned claim is still here,
-      // still carrying the instant it stopped being true.
+      // still carrying the instant it stopped being true. Asserted as the
+      // EXACT instant, not merely non-null — an importer that stamped
+      // `new Date()` instead of forwarding the source value would pass a
+      // non-null check while silently rewriting bi-temporal history.
       const superseded = await pool.query<{ invalidated_at: Date | null; valid_to: Date | null }>(
         `SELECT invalidated_at, valid_to FROM brain_facts WHERE id = $1 AND workspace_id = $2`,
         [SUPERSEDED_FACT_ID, TARGET_ORG],
       );
       expect(superseded.rows).toHaveLength(1);
-      expect(superseded.rows[0].invalidated_at).not.toBeNull();
-      expect(superseded.rows[0].valid_to).not.toBeNull();
+      expect(superseded.rows[0].invalidated_at?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+      expect(superseded.rows[0].valid_to?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
 
       // The episode's grant (including its audience arm) and its extraction
       // stamp travel — the latter so the target doesn't re-queue an episode a
@@ -329,7 +334,10 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         [EPISODE_ID, TARGET_ORG],
       );
       expect(episode.rows[0].visible_to).toEqual(["org", "audience:eng"]);
-      expect(episode.rows[0].extracted_at).not.toBeNull();
+      // Exact instant: a re-stamped extracted_at is indistinguishable from a
+      // correct one under a non-null check, and it silently re-queues an
+      // episode a human already reviewed.
+      expect(episode.rows[0].extracted_at?.toISOString()).toBe("2026-06-01T00:05:00.000Z");
 
       // Audience membership moved, so the `audience:eng` grant still resolves
       // to a real person rather than denying everyone.
@@ -434,12 +442,37 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         scheduledTasks: { imported: 0, skipped: 1 },
         agentSessionMemory: { imported: 0, skipped: 1 },
         brainEpisodes: { imported: 0, skipped: 1 },
-        // Skipped WITH their episode — re-importing them would attach
-        // duplicate claims to an episode that already carries its own.
+        // Deduped on the FACT's own key, not the episode's — see the catch-up
+        // case below for why that distinction is load-bearing.
         brainFacts: { imported: 0, skipped: 2 },
         brainEdges: { imported: 0, skipped: 2 },
         factAudienceMembers: { imported: 0, skipped: 1 },
       });
+
+      // ── Catch-up import: an episode the target already has, carrying a
+      // fact it does NOT. An episode is immutable but its fact set GROWS
+      // (re-extraction, human corrections), so skipping facts wholesale
+      // because their episode existed would strand the new claim while
+      // reporting it as "skipped" — i.e. as already present.
+      const LATE_FACT_ID = "cccccccc-0000-4000-8000-00000000000c";
+      const catchUp = structuredClone(bundle);
+      catchUp.brainEpisodes![0].facts.push({
+        ...catchUp.brainEpisodes![0].facts[0],
+        id: LATE_FACT_ID,
+        object: "59",
+      });
+      const third = await runImport(catchUp);
+      expect(third.brainEpisodes).toEqual({ imported: 0, skipped: 1 });
+      expect(third.brainFacts).toEqual({ imported: 1, skipped: 2 });
+
+      const late = await pool.query<{ object: string; source_episode_id: string }>(
+        `SELECT object, source_episode_id FROM brain_facts WHERE id = $1 AND workspace_id = $2`,
+        [LATE_FACT_ID, TARGET_ORG],
+      );
+      expect(late.rows).toHaveLength(1);
+      expect(late.rows[0].object).toBe("59");
+      // Attached to the episode the target already held.
+      expect(late.rows[0].source_episode_id).toBe(EPISODE_ID);
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -659,8 +692,10 @@ describeIfPg("region-migration bundle round-trip (real Postgres, #4460)", () => 
         expect(await countIn(`SELECT count(*)::int AS n FROM brain_edges WHERE workspace_id = $1`, [CLEAN_ORG])).toBe(0);
         expect(await countIn(`SELECT count(*)::int AS n FROM fact_audience_member WHERE workspace_id = $1`, [CLEAN_ORG])).toBe(0);
         // The TARGET org's imported brain is untouched — the sweep is scoped
-        // to the migrated-away workspace, not to the tables.
-        expect(await countIn(`SELECT count(*)::int AS n FROM brain_facts WHERE workspace_id = $1`, [TARGET_ORG])).toBe(2);
+        // to the migrated-away workspace, not to the tables. Three facts: the
+        // live one, the tombstoned one, and the catch-up fact from the
+        // round-trip block above.
+        expect(await countIn(`SELECT count(*)::int AS n FROM brain_facts WHERE workspace_id = $1`, [TARGET_ORG])).toBe(3);
 
         // Survivors: platform settings row, unattributable cache row, the
         // TARGET org's imported data (seeded by the round-trip test above —

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -102,16 +102,37 @@ let mockFetchResponse: { ok: boolean; status: number; body?: unknown } = { ok: t
 let mockFetchError: Error | null = null;
 let capturedFetchCalls: Array<{ url: string; options: RequestInit }> = [];
 
+/**
+ * A target region that understood every section, derived from the bundle it
+ * was actually sent (#4767).
+ *
+ * `transferBundleToTarget` reconciles the acknowledged per-section counts
+ * against `manifest.counts` before cutover — a target that silently dropped a
+ * section it didn't recognize must not be treated as success. So the default
+ * mock has to answer like a CURRENT target; a test that wants the
+ * older-target behaviour sets `mockFetchResponse.body` explicitly.
+ */
+function acknowledgeAll(options?: RequestInit): Record<string, { imported: number; skipped: number }> {
+  const raw = typeof options?.body === "string" ? options.body : "{}";
+  const counts = (JSON.parse(raw) as { manifest?: { counts?: Record<string, number> } }).manifest?.counts ?? {};
+  const ack: Record<string, { imported: number; skipped: number }> = {};
+  for (const [section, n] of Object.entries(counts)) {
+    ack[section] = { imported: n, skipped: 0 };
+  }
+  return ack;
+}
+
 const _originalFetch = globalThis.fetch;
 globalThis.fetch = ((url: string | URL | Request, options?: RequestInit) => {
   const urlStr = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
   capturedFetchCalls.push({ url: urlStr, options: options ?? {} });
   if (mockFetchError) return Promise.reject(mockFetchError);
+  const body = mockFetchResponse.body ?? acknowledgeAll(options);
   return Promise.resolve({
     ok: mockFetchResponse.ok,
     status: mockFetchResponse.status,
     statusText: mockFetchResponse.ok ? "OK" : "Error",
-    json: () => Promise.resolve(mockFetchResponse.body ?? {}),
+    json: () => Promise.resolve(body),
   } as Response);
 }) as typeof fetch;
 
@@ -140,7 +161,10 @@ function resetMocks() {
   mockPoolQueryResult = { rows: [{ id: "org-1" }] };
   mockPoolQueryError = null;
   capturedQueries.length = 0;
-  mockFetchResponse = { ok: true, status: 200, body: {} };
+  // `body: undefined` ⇒ the mock derives a full acknowledgement from the
+  // bundle it was sent (see acknowledgeAll). A test that needs a target which
+  // dropped sections sets `body` explicitly.
+  mockFetchResponse = { ok: true, status: 200, body: undefined };
   mockFetchError = null;
   capturedFetchCalls = [];
   mockConfig = { ...DEFAULT_MOCK_CONFIG };
@@ -271,6 +295,48 @@ describe("executeRegionMigration", () => {
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain("apiUrl");
     // mockConfig is auto-restored by resetMocks in beforeEach
+  });
+
+  it("fails BEFORE cutover when the target silently drops a bundle section (#4767)", async () => {
+    // The failure this prevents: `z.object()` STRIPS unknown keys, so a target
+    // region running an older build drops every section it has no schema for,
+    // imports the rest, and answers 200. The source then cuts over and
+    // schedules the destructive cleanup, which deletes the dropped pillar from
+    // the source after the grace period — total data loss, no error logged.
+    //
+    // Regions deploy independently, so a window where one region has a section
+    // and another doesn't is routine, not exceptional. Before #4767 the bundle
+    // VERSION was the guard; the brain sections are deliberately optional on
+    // the wire (so a pre-#4767 source can still migrate), which removed it.
+    mockQueryResults["SELECT id, workspace_id"] = [
+      { id: "mig-1", workspace_id: "org-1", source_region: "us-east", target_region: "eu-west", status: "pending" },
+    ];
+    mockQueryResults["UPDATE region_migrations"] = [];
+    // An old target: acknowledges the sections it knows, silently omits the
+    // brain. The exporter's manifest says otherwise.
+    mockFetchResponse = {
+      ok: true,
+      status: 200,
+      body: { conversations: { imported: 1, skipped: 0 } },
+    };
+
+    const result = await executeRegionMigration("mig-1");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Actionable: names the section, the shortfall, and that nothing was
+      // deleted — an operator must not have to guess whether to panic.
+      expect(result.error).toContain("older build");
+      expect(result.error).toContain("no source data");
+    }
+
+    // The cutover must NOT have run. `region_updated` is what flips the
+    // workspace's home region; reaching it would mean the source already
+    // considers itself migrated.
+    const cutover = capturedQueries.find(
+      (q) => q.sql.includes("UPDATE organization") || q.sql.includes("region_updated = TRUE"),
+    );
+    expect(cutover).toBeUndefined();
   });
 
   it("fails when transfer HTTP call returns error", async () => {

--- a/packages/api/src/lib/residency/bundle-scope.ts
+++ b/packages/api/src/lib/residency/bundle-scope.ts
@@ -51,6 +51,10 @@ export const BUNDLE_TABLE_DECISIONS = {
   knowledge_links: { decision: "exported", reason: "Link graph rides inline with its source document (no re-derive step needed at import)." },
   scheduled_tasks: { decision: "exported", reason: "Task definitions move; next_run_at recomputed at import so the target scheduler re-plans. Group/plugin refs dangle until re-install." },
   agent_session_memory: { decision: "exported", reason: "Long-lived durable working memory (ADR-0020); FK resolves against the bundle's conversations." },
+  brain_episodes: { decision: "exported", reason: "Company brain tier-3 (ADR-0036) — raw evidence, UUIDs preserved so fact/edge references survive. extracted_at rides along so the target doesn't re-queue episodes a human already reviewed." },
+  brain_facts: { decision: "exported", reason: "Company brain tier-2 (ADR-0036) — the workspace's reviewed knowledge, same asset class as the KB. Provenance, grant, review status and all four temporal columns travel with the claim; a fact stripped of any of them would land unprovenanced and ungated." },
+  brain_edges: { decision: "exported", reason: "The typed provenance/conflict graph (ADR-0036). Imported last, once every fact/episode endpoint exists." },
+  fact_audience_member: { decision: "exported", reason: "Audience membership backing the `audience:` grant arm (ADR-0036). Without it every audience-granted fact denies everyone in the target — a silent total loss of access, not a visible error." },
 
   // ── Stays: caches, derived data, history, region-bound state ───────────────
   // (Deleted from the source region by the #4458 cleanup after the grace period.)

--- a/packages/api/src/lib/residency/cleanup.ts
+++ b/packages/api/src/lib/residency/cleanup.ts
@@ -158,6 +158,23 @@ export const CLEANUP_TABLE_RULES = {
   },
   scheduled_tasks: { kind: "column", column: "org_id" },
   agent_session_memory: { kind: "column", column: "org_id" },
+  // Company brain (#4767, ADR-0036). Facts are scoped THROUGH their episode
+  // rather than by their own workspace_id — not for scoping (the column
+  // exists) but for PHASE: `brain_facts.source_episode_id` is the one
+  // RESTRICT FK among the in-scope tables, so the facts must be gone before
+  // the column phase deletes the episodes, or the sweep fails on any
+  // workspace that actually has a brain. Edges CASCADE from both endpoints
+  // and are already gone by then; their rule is kept explicit so the
+  // registry stays a complete map, and the DELETE is a harmless no-op.
+  brain_facts: {
+    kind: "parent",
+    fkColumn: "source_episode_id",
+    parentTable: "brain_episodes",
+    parentColumn: "workspace_id",
+  },
+  brain_episodes: { kind: "column", column: "workspace_id" },
+  brain_edges: { kind: "column", column: "workspace_id" },
+  fact_audience_member: { kind: "column", column: "workspace_id" },
 
   // ── Stays residue (region-local; registry says NOT retained) ─────────────
   // No org column: cache keys have no org dimension, but the Slack
@@ -279,7 +296,15 @@ export interface CleanupStatement {
  * in-scope tables is `ON DELETE CASCADE` (or `SET NULL` for
  * `conversations.bound_dashboard_id`), so no column-phase delete can be
  * blocked by remaining child rows — pinned against real Postgres by
- * `migrate-roundtrip-pg.test.ts`. Exported for the tripwire + PG tests.
+ * `migrate-roundtrip-pg.test.ts`.
+ *
+ * The single exception is `brain_facts.source_episode_id`, which is RESTRICT
+ * on purpose (evidence must not vanish under a live claim). That is why
+ * `brain_facts` carries a `parent` rule despite having its own
+ * `workspace_id`: the parent phase is what puts its delete ahead of
+ * `brain_episodes` in the column phase. A future RESTRICT FK between two
+ * in-scope tables needs the same treatment. Exported for the tripwire + PG
+ * tests.
  */
 export function buildCleanupStatements(): readonly CleanupStatement[] {
   const first: CleanupStatement[] = [];

--- a/packages/api/src/lib/residency/cleanup.ts
+++ b/packages/api/src/lib/residency/cleanup.ts
@@ -159,13 +159,19 @@ export const CLEANUP_TABLE_RULES = {
   scheduled_tasks: { kind: "column", column: "org_id" },
   agent_session_memory: { kind: "column", column: "org_id" },
   // Company brain (#4767, ADR-0036). Facts are scoped THROUGH their episode
-  // rather than by their own workspace_id — not for scoping (the column
-  // exists) but for PHASE: `brain_facts.source_episode_id` is the one
-  // RESTRICT FK among the in-scope tables, so the facts must be gone before
-  // the column phase deletes the episodes, or the sweep fails on any
-  // workspace that actually has a brain. Edges CASCADE from both endpoints
-  // and are already gone by then; their rule is kept explicit so the
-  // registry stays a complete map, and the DELETE is a harmless no-op.
+  // rather than by their own workspace_id — not for scoping but for PHASE:
+  // `brain_facts.source_episode_id` is the one RESTRICT FK among the in-scope
+  // tables, so the facts must be gone before the column phase deletes the
+  // episodes, or the sweep fails outright on any workspace that has a brain.
+  //
+  // The two predicates select the same rows because a composite FK
+  // (`fk_brain_facts_episode`) makes a fact and its episode share a workspace
+  // at rest — without that constraint this rule would silently leave residue
+  // behind, which is a residency-deletion promise quietly broken.
+  //
+  // Edges CASCADE from both endpoints, so the explicit DELETE is usually
+  // redundant; the rule is kept so the registry stays a complete map of every
+  // workspace-scoped table.
   brain_facts: {
     kind: "parent",
     fkColumn: "source_episode_id",

--- a/packages/api/src/lib/residency/export.ts
+++ b/packages/api/src/lib/residency/export.ts
@@ -71,8 +71,10 @@ function scopeClause(columnRef: string, orgScope: string | null): string {
  * org-scoped settings, dashboards (cards + per-user drafts; share tokens
  * dropped — the owner re-shares in the target), knowledge documents (with
  * link graph + review status), scheduled-task definitions (next run
- * recomputed at import), and durable agent session memory. The returned
- * bundle is ready to POST to the target region's import endpoint.
+ * recomputed at import), durable agent session memory, and the company brain
+ * (#4767 — episodes with their facts nested, the typed edge graph, audience
+ * membership). The returned bundle is ready to POST to the target region's
+ * import endpoint.
  *
  * @param orgScope - Org id to export, or `null` to export rows with
  *   `org_id IS NULL` (no-auth self-hosted instances, CLI path).
@@ -232,6 +234,12 @@ export async function exportWorkspaceBundle(
     // four temporal columns. Exporting facts without those would land
     // unprovenanced, ungated claims in the target region, which is strictly
     // worse than not migrating them at all.
+    //
+    // Structurally empty on the `orgScope === null` path (the no-auth
+    // self-hosted / CLI export): all four brain tables declare `workspace_id
+    // NOT NULL`, so `IS NULL` matches nothing. That differs from
+    // `conversations.org_id`, which is nullable and does carry rows there —
+    // a no-auth instance has no workspace identity to hang a brain off.
     pool.query(
       `SELECT id, source, source_id, source_actor, body, locator, occurred_at,
               ingested_at, extracted_at, visible_to, created_at
@@ -242,6 +250,9 @@ export async function exportWorkspaceBundle(
     // Scoped via the episode join rather than the fact's own workspace_id, so
     // a fact travels iff its episode travels — the import-side NOT NULL FK
     // then resolves by construction (same discipline as session memory above).
+    // The two scopings agree because `fk_brain_facts_episode` is a composite
+    // FK on (workspace_id, source_episode_id): a fact hanging off another
+    // workspace's episode is unrepresentable, so the join can't widen scope.
     pool.query(
       `SELECT f.id, f.source_episode_id, f.subject, f.predicate, f.object,
               f.valid_from, f.valid_to, f.ingested_at, f.invalidated_at,
@@ -253,9 +264,11 @@ export async function exportWorkspaceBundle(
        ORDER BY f.source_episode_id, f.ingested_at, f.id ASC`,
       params,
     ),
-    // Edges are workspace-scoped directly: an edge's endpoints are always in
-    // the same workspace, and scoping through four nullable endpoint joins
-    // would be strictly harder to read for the same row set.
+    // Edges are workspace-scoped directly. Safe because the composite
+    // endpoint FKs (`fk_brain_edges_*`) pin every endpoint to the edge's own
+    // workspace — so this selects the same rows four nullable endpoint joins
+    // would, and cannot export an edge whose endpoint is absent from the
+    // bundle (which would fail the FK at import).
     pool.query(
       `SELECT edge_type, from_fact_id, from_episode_id, to_fact_id, to_episode_id,
               created_at

--- a/packages/api/src/lib/residency/export.ts
+++ b/packages/api/src/lib/residency/export.ts
@@ -31,6 +31,10 @@ import {
   type ExportedKnowledgeLink,
   type ExportedScheduledTask,
   type ExportedAgentSessionMemory,
+  type ExportedBrainEpisode,
+  type ExportedBrainFact,
+  type ExportedBrainEdge,
+  type ExportedFactAudienceMember,
 } from "@useatlas/types";
 
 const log = createLogger("region-export");
@@ -97,6 +101,10 @@ export async function exportWorkspaceBundle(
     knowledgeLinkResult,
     scheduledTaskResult,
     sessionMemoryResult,
+    brainEpisodeResult,
+    brainFactResult,
+    brainEdgeResult,
+    factAudienceResult,
   ] = await Promise.all([
     // --- 1. Conversations + Messages (2 queries, no N+1) ---
     pool.query(
@@ -215,6 +223,52 @@ export async function exportWorkspaceBundle(
        JOIN conversations c ON c.id = m.conversation_id
        WHERE ${scopeClause("c.org_id", orgScope)} AND c.deleted_at IS NULL
        ORDER BY m.conversation_id, m.namespace ASC`,
+      params,
+    ),
+    // --- 9. Company brain: episodes, facts, edges, audiences (#4767, ADR-0036) ---
+    // The whole substrate moves. A workspace's brain is the same class of
+    // asset as its knowledge base, and everything that makes a fact
+    // TRUSTWORTHY travels with it — provenance, grant, review status, and all
+    // four temporal columns. Exporting facts without those would land
+    // unprovenanced, ungated claims in the target region, which is strictly
+    // worse than not migrating them at all.
+    pool.query(
+      `SELECT id, source, source_id, source_actor, body, locator, occurred_at,
+              ingested_at, extracted_at, visible_to, created_at
+       FROM brain_episodes WHERE ${scopeClause("workspace_id", orgScope)}
+       ORDER BY ingested_at, id ASC`,
+      params,
+    ),
+    // Scoped via the episode join rather than the fact's own workspace_id, so
+    // a fact travels iff its episode travels — the import-side NOT NULL FK
+    // then resolves by construction (same discipline as session memory above).
+    pool.query(
+      `SELECT f.id, f.source_episode_id, f.subject, f.predicate, f.object,
+              f.valid_from, f.valid_to, f.ingested_at, f.invalidated_at,
+              f.extracted_at, f.provenance, f.status, f.visible_to,
+              f.predicate_cardinality, f.created_at, f.updated_at
+       FROM brain_facts f
+       JOIN brain_episodes e ON e.id = f.source_episode_id
+       WHERE ${scopeClause("e.workspace_id", orgScope)}
+       ORDER BY f.source_episode_id, f.ingested_at, f.id ASC`,
+      params,
+    ),
+    // Edges are workspace-scoped directly: an edge's endpoints are always in
+    // the same workspace, and scoping through four nullable endpoint joins
+    // would be strictly harder to read for the same row set.
+    pool.query(
+      `SELECT edge_type, from_fact_id, from_episode_id, to_fact_id, to_episode_id,
+              created_at
+       FROM brain_edges WHERE ${scopeClause("workspace_id", orgScope)}
+       ORDER BY created_at, edge_type ASC`,
+      params,
+    ),
+    // Audience membership travels or every `audience:` grant silently denies
+    // everyone in the target region — a total, invisible loss of access.
+    pool.query(
+      `SELECT audience_id, user_id, source, created_at
+       FROM fact_audience_member WHERE ${scopeClause("workspace_id", orgScope)}
+       ORDER BY audience_id, user_id ASC`,
       params,
     ),
   ]);
@@ -421,6 +475,77 @@ export async function exportWorkspaceBundle(
     updatedAt: toISO(m.updated_at),
   }));
 
+  // Facts nest under their episode, mirroring links-under-documents above:
+  // the nesting IS the FK ordering the importer needs, so it can never write a
+  // fact before the episode its NOT NULL provenance FK points at.
+  const factsByEpisode = new Map<string, ExportedBrainFact[]>();
+  for (const f of brainFactResult.rows) {
+    const episodeId = f.source_episode_id as string;
+    let facts = factsByEpisode.get(episodeId);
+    if (!facts) {
+      facts = [];
+      factsByEpisode.set(episodeId, facts);
+    }
+    facts.push({
+      id: f.id as string,
+      subject: f.subject as string,
+      predicate: f.predicate as string,
+      object: f.object as string,
+      validFrom: toISOOrNull(f.valid_from),
+      validTo: toISOOrNull(f.valid_to),
+      ingestedAt: toISO(f.ingested_at),
+      invalidatedAt: toISOOrNull(f.invalidated_at),
+      extractedAt: toISOOrNull(f.extracted_at),
+      // NOT NULL / CHECK-guarded columns — bound raw with no permissive
+      // fallback. A `?? {}` here would manufacture the empty provenance the
+      // table refuses to store, and `?? ['org']` would invent a public grant.
+      provenance: f.provenance,
+      status: f.status as ExportedBrainFact["status"],
+      visibleTo: f.visible_to as string[],
+      predicateCardinality: f.predicate_cardinality as ExportedBrainFact["predicateCardinality"],
+      createdAt: toISO(f.created_at),
+      updatedAt: toISO(f.updated_at),
+    });
+  }
+
+  let totalBrainFacts = 0;
+  const brainEpisodes: ExportedBrainEpisode[] = brainEpisodeResult.rows.map((e) => {
+    const facts = factsByEpisode.get(e.id as string) ?? [];
+    totalBrainFacts += facts.length;
+    return {
+      id: e.id as string,
+      source: e.source as string,
+      sourceId: e.source_id as string,
+      sourceActor: (e.source_actor as string | null) ?? null,
+      body: (e.body as string | null) ?? null,
+      locator: (e.locator as string | null) ?? null,
+      occurredAt: toISOOrNull(e.occurred_at),
+      ingestedAt: toISO(e.ingested_at),
+      // Preserved, not reset: re-extracting in the target would mint fresh
+      // candidates for episodes a human has already reviewed.
+      extractedAt: toISOOrNull(e.extracted_at),
+      visibleTo: e.visible_to as string[],
+      createdAt: toISO(e.created_at),
+      facts,
+    };
+  });
+
+  const brainEdges: ExportedBrainEdge[] = brainEdgeResult.rows.map((e) => ({
+    edgeType: e.edge_type as ExportedBrainEdge["edgeType"],
+    fromFactId: (e.from_fact_id as string | null) ?? null,
+    fromEpisodeId: (e.from_episode_id as string | null) ?? null,
+    toFactId: (e.to_fact_id as string | null) ?? null,
+    toEpisodeId: (e.to_episode_id as string | null) ?? null,
+    createdAt: toISO(e.created_at),
+  }));
+
+  const factAudienceMembers: ExportedFactAudienceMember[] = factAudienceResult.rows.map((a) => ({
+    audienceId: a.audience_id as string,
+    userId: a.user_id as string,
+    source: a.source as string,
+    createdAt: toISO(a.created_at),
+  }));
+
   // --- Build bundle ---
   const bundle: ExportBundle = {
     manifest: {
@@ -443,6 +568,10 @@ export async function exportWorkspaceBundle(
         knowledgeLinks: totalLinks,
         scheduledTasks: scheduledTasks.length,
         agentSessionMemory: agentSessionMemory.length,
+        brainEpisodes: brainEpisodes.length,
+        brainFacts: totalBrainFacts,
+        brainEdges: brainEdges.length,
+        factAudienceMembers: factAudienceMembers.length,
       },
     },
     conversations,
@@ -453,6 +582,9 @@ export async function exportWorkspaceBundle(
     knowledgeDocuments,
     scheduledTasks,
     agentSessionMemory,
+    brainEpisodes,
+    brainEdges,
+    factAudienceMembers,
   };
 
   log.info(

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -21,12 +21,43 @@ import { hasInternalDB, internalQuery, getInternalDB } from "@atlas/api/lib/db/i
 import { getConfig } from "@atlas/api/lib/config";
 import { UnsafeRegionMigrationResetError } from "@atlas/api/lib/effect/errors";
 import { exportWorkspaceBundle } from "./export";
-import type { MigrationStatus, MigrationPhase, ExportBundle } from "@useatlas/types";
+import type { MigrationStatus, MigrationPhase, ExportBundle, ExportManifest, ImportResult } from "@useatlas/types";
 
 /** Days to wait before cleaning up source region data after migration. */
 const CLEANUP_GRACE_PERIOD_DAYS = 7;
 
 const log = createLogger("region-migration");
+
+/**
+ * Bundle sections whose exported count is reconciled against the target
+ * region's acknowledgement before cutover (#4767).
+ *
+ * The type bound is the point: a member must be a key of BOTH
+ * `manifest.counts` AND `ImportResult`, so the compiler rejects a
+ * manifest-only count (`messages`, `dashboardCards`, `dashboardUserDrafts`,
+ * `knowledgeLinks` — child rows the importer folds into their parent's
+ * counter and never reports separately). Reconciling one of those would
+ * compare against a counter that structurally does not exist and abort every
+ * migration.
+ *
+ * A new bundle section belongs here the moment it gets its own ImportResult
+ * counter — that is what makes "the target silently dropped it" a failure
+ * instead of a silent success.
+ */
+const RECONCILED_SECTIONS = [
+  "conversations",
+  "semanticEntities",
+  "learnedPatterns",
+  "settings",
+  "dashboards",
+  "knowledgeDocuments",
+  "scheduledTasks",
+  "agentSessionMemory",
+  "brainEpisodes",
+  "brainFacts",
+  "brainEdges",
+  "factAudienceMembers",
+] as const satisfies readonly (keyof ExportManifest["counts"] & keyof ImportResult)[];
 
 /**
  * Stale migration threshold: 5 minutes.
@@ -182,6 +213,46 @@ async function transferBundleToTarget(
       detail = `HTTP ${response.status} ${response.statusText}`;
     }
     return { ok: false, error: `Target region import failed: ${detail}` };
+  }
+
+  // A 200 is not proof the target understood the bundle. `z.object()` STRIPS
+  // unknown keys, so a target region running an older build silently drops
+  // every section it has no schema for, imports the rest, and answers 200 —
+  // after which this migration cuts over and schedules the destructive source
+  // cleanup. The dropped pillar is then deleted from the source after the
+  // grace period, with no error logged anywhere.
+  //
+  // Before #4767 the bundle VERSION was the guard: a v1 target rejected a v2
+  // bundle outright. The brain sections are deliberately optional-on-the-wire
+  // (so a pre-#4767 SOURCE can still migrate), which removes that guard —
+  // this reconciliation replaces it, and generalizes to every future section.
+  //
+  // Deployment reality that makes this a live hazard rather than a theoretical
+  // one: regions deploy independently, so a window where US has #4767 and EU
+  // does not is routine, not exceptional.
+  let acknowledged: Partial<Record<string, { imported?: number; skipped?: number }>>;
+  try {
+    acknowledged = await response.json() as typeof acknowledged;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Target region returned an unreadable import result: ${msg}` };
+  }
+
+  for (const section of RECONCILED_SECTIONS) {
+    const expected = bundle.manifest.counts[section];
+    if (!expected) continue; // nothing exported ⇒ nothing to reconcile
+    const got = acknowledged[section];
+    const total = (got?.imported ?? 0) + (got?.skipped ?? 0);
+    if (total !== expected) {
+      return {
+        ok: false,
+        error:
+          `Target region accounted for ${got ? total : 0}/${expected} '${section}' rows. ` +
+          `The target is most likely running an older build that does not understand this ` +
+          `bundle section. Migration ${migrationId} aborted BEFORE cutover — no source data ` +
+          `has been deleted. Upgrade the target region and re-run the migration.`,
+      };
+    }
   }
 
   return { ok: true };

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -68,11 +68,15 @@ const RECONCILED_SECTIONS = [
  * no-op — the target drops it, the guard doesn't look, and the source cleanup
  * deletes it after the grace period. That is precisely the failure the guard
  * exists to prevent, so it must be a compile error rather than a review catch.
+ *
+ * Bounded on `keyof ImportResult` ALONE, deliberately — not on the
+ * intersection the `satisfies` uses. Intersecting here would re-open the hole:
+ * a new section added to ImportResult but whose `counts:` line was forgotten
+ * would drop out of the intersection and pass unnoticed. Bounded this way it
+ * is forced into RECONCILED_SECTIONS, where the `satisfies` then fails until
+ * the manifest count exists — so both halves of the mistake are caught.
  */
-type UnreconciledSection = Exclude<
-  keyof ExportManifest["counts"] & keyof ImportResult,
-  (typeof RECONCILED_SECTIONS)[number]
->;
+type UnreconciledSection = Exclude<keyof ImportResult, (typeof RECONCILED_SECTIONS)[number]>;
 const _everySectionReconciled: [UnreconciledSection] extends [never] ? true : never = true;
 void _everySectionReconciled;
 
@@ -274,7 +278,17 @@ async function transferBundleToTarget(
     // top-level array (facts nest inside their episode), so it necessarily
     // trusts the manifest.
     const payload = (bundle as unknown as Record<string, unknown>)[section];
-    const expected = Array.isArray(payload) ? payload.length : bundle.manifest.counts[section];
+    const declared = bundle.manifest.counts[section];
+    const expected = Array.isArray(payload) ? payload.length : declared;
+    // The manifest is what both regions LOG and what the CLI prints, so a
+    // divergence between it and the payload must not pass unremarked even
+    // though reconciliation trusts the payload.
+    if (Array.isArray(payload) && declared !== undefined && declared !== payload.length) {
+      log.warn(
+        { migrationId, section, declared, actual: payload.length },
+        "Manifest count disagrees with the exported payload — reconciling against the payload; this is an exporter bug",
+      );
+    }
     if (expected === undefined) {
       return {
         ok: false,

--- a/packages/api/src/lib/residency/migrate.ts
+++ b/packages/api/src/lib/residency/migrate.ts
@@ -60,6 +60,23 @@ const RECONCILED_SECTIONS = [
 ] as const satisfies readonly (keyof ExportManifest["counts"] & keyof ImportResult)[];
 
 /**
+ * Completeness half of the bound above: every section that HAS both a manifest
+ * count and an ImportResult counter must be listed.
+ *
+ * The `satisfies` proves each member is legal; this proves none is missing.
+ * Without it, adding a section and forgetting to reconcile it is a silent
+ * no-op — the target drops it, the guard doesn't look, and the source cleanup
+ * deletes it after the grace period. That is precisely the failure the guard
+ * exists to prevent, so it must be a compile error rather than a review catch.
+ */
+type UnreconciledSection = Exclude<
+  keyof ExportManifest["counts"] & keyof ImportResult,
+  (typeof RECONCILED_SECTIONS)[number]
+>;
+const _everySectionReconciled: [UnreconciledSection] extends [never] ? true : never = true;
+void _everySectionReconciled;
+
+/**
  * Stale migration threshold: 5 minutes.
  *
  * Exported for the `region_migration_stale_reap` periodic fiber (#4459) and
@@ -215,12 +232,14 @@ async function transferBundleToTarget(
     return { ok: false, error: `Target region import failed: ${detail}` };
   }
 
-  // A 200 is not proof the target understood the bundle. `z.object()` STRIPS
-  // unknown keys, so a target region running an older build silently drops
-  // every section it has no schema for, imports the rest, and answers 200 —
-  // after which this migration cuts over and schedules the destructive source
-  // cleanup. The dropped pillar is then deleted from the source after the
-  // grace period, with no error logged anywhere.
+  // A 200 is not proof the target understood the bundle. An older build's
+  // `importBundle` simply has no loop for a section it doesn't know about: it
+  // ignores those keys, imports the rest, and answers 200 — after which this
+  // migration cuts over and schedules the destructive source cleanup. The
+  // dropped pillar is then deleted from the source after the grace period,
+  // with no error logged anywhere. (On the ADMIN import route the same outcome
+  // arrives one step earlier, because its zod request schema strips unknown
+  // keys before the importer ever sees them.)
   //
   // Before #4767 the bundle VERSION was the guard: a v1 target rejected a v2
   // bundle outright. The brain sections are deliberately optional-on-the-wire
@@ -230,17 +249,42 @@ async function transferBundleToTarget(
   // Deployment reality that makes this a live hazard rather than a theoretical
   // one: regions deploy independently, so a window where US has #4767 and EU
   // does not is routine, not exceptional.
-  let acknowledged: Partial<Record<string, { imported?: number; skipped?: number }>>;
+  let acknowledged: Partial<Record<(typeof RECONCILED_SECTIONS)[number], { imported?: number; skipped?: number }>>;
   try {
     acknowledged = await response.json() as typeof acknowledged;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { ok: false, error: `Target region returned an unreadable import result: ${msg}` };
   }
+  if (!acknowledged || typeof acknowledged !== "object" || Array.isArray(acknowledged)) {
+    return {
+      ok: false,
+      error:
+        "Target region returned a non-object import result — it is most likely not an Atlas " +
+        `import endpoint (or a proxy answered in its place). Migration ${migrationId} aborted ` +
+        "BEFORE cutover; no source data has been deleted.",
+    };
+  }
 
   for (const section of RECONCILED_SECTIONS) {
-    const expected = bundle.manifest.counts[section];
-    if (!expected) continue; // nothing exported ⇒ nothing to reconcile
+    // Ground truth from the payload where the section IS a top-level array;
+    // the manifest is a self-report written in a different literal, so a
+    // forgotten `counts:` line would otherwise turn the guard off for that
+    // section without anyone noticing. `brainFacts` is the one section with no
+    // top-level array (facts nest inside their episode), so it necessarily
+    // trusts the manifest.
+    const payload = (bundle as unknown as Record<string, unknown>)[section];
+    const expected = Array.isArray(payload) ? payload.length : bundle.manifest.counts[section];
+    if (expected === undefined) {
+      return {
+        ok: false,
+        error:
+          `Bundle section '${section}' carries no manifest count, so the target's handling of ` +
+          `it cannot be verified. Migration ${migrationId} aborted BEFORE cutover; no source ` +
+          "data has been deleted. This is an exporter bug — the section needs a manifest count.",
+      };
+    }
+    if (expected === 0) continue; // nothing exported ⇒ nothing to reconcile
     const got = acknowledged[section];
     const total = (got?.imported ?? 0) + (got?.skipped ?? 0);
     if (total !== expected) {
@@ -250,7 +294,9 @@ async function transferBundleToTarget(
           `Target region accounted for ${got ? total : 0}/${expected} '${section}' rows. ` +
           `The target is most likely running an older build that does not understand this ` +
           `bundle section. Migration ${migrationId} aborted BEFORE cutover — no source data ` +
-          `has been deleted. Upgrade the target region and re-run the migration.`,
+          `has been deleted and the workspace is still served from its current region. ` +
+          `NOTE: the target has already COMMITTED a partial import; the import is idempotent, ` +
+          `so upgrade the target and re-run, or tear down the partial copy if abandoning.`,
       };
     }
   }

--- a/packages/cli/src/commands/migrate-import.ts
+++ b/packages/cli/src/commands/migrate-import.ts
@@ -166,7 +166,7 @@ export async function handleMigrateImport(
     // claim more than the runtime guards below check.
     type CrossVersionImportResult =
       Pick<import("@useatlas/types").ImportResult, "conversations" | "semanticEntities" | "learnedPatterns" | "settings"> &
-      Partial<Pick<import("@useatlas/types").ImportResult, "dashboards" | "knowledgeDocuments" | "scheduledTasks" | "agentSessionMemory">>;
+      Partial<Pick<import("@useatlas/types").ImportResult, "dashboards" | "knowledgeDocuments" | "scheduledTasks" | "agentSessionMemory" | "brainEpisodes" | "brainFacts" | "brainEdges" | "factAudienceMembers">>;
     let result: CrossVersionImportResult;
     try {
       result =
@@ -234,6 +234,30 @@ export async function handleMigrateImport(
     if (result.agentSessionMemory) {
       console.log(
         `  Session memory    ${String(result.agentSessionMemory.imported).padStart(8)}  ${String(result.agentSessionMemory.skipped).padStart(7)}`,
+      );
+    }
+    // Company brain (#4767). Reported per-section so a migration that moved
+    // ZERO brain rows can't print a summary identical to one that moved
+    // everything — the operator-visible half of "silent loss is worse than
+    // loud failure".
+    if (result.brainEpisodes) {
+      console.log(
+        `  Brain episodes    ${String(result.brainEpisodes.imported).padStart(8)}  ${String(result.brainEpisodes.skipped).padStart(7)}`,
+      );
+    }
+    if (result.brainFacts) {
+      console.log(
+        `  Brain facts       ${String(result.brainFacts.imported).padStart(8)}  ${String(result.brainFacts.skipped).padStart(7)}`,
+      );
+    }
+    if (result.brainEdges) {
+      console.log(
+        `  Brain edges       ${String(result.brainEdges.imported).padStart(8)}  ${String(result.brainEdges.skipped).padStart(7)}`,
+      );
+    }
+    if (result.factAudienceMembers) {
+      console.log(
+        `  Fact audiences    ${String(result.factAudienceMembers.imported).padStart(8)}  ${String(result.factAudienceMembers.skipped).padStart(7)}`,
       );
     }
   } catch (err) {

--- a/packages/cli/src/commands/operator/export.ts
+++ b/packages/cli/src/commands/operator/export.ts
@@ -57,6 +57,8 @@ export async function handleExport(args: string[]): Promise<void> {
     console.log(`  Knowledge docs:     ${counts.knowledgeDocuments ?? 0} (${counts.knowledgeLinks ?? 0} links)`);
     console.log(`  Scheduled tasks:    ${counts.scheduledTasks ?? 0}`);
     console.log(`  Session memory:     ${counts.agentSessionMemory ?? 0}`);
+    console.log(`  Brain episodes:     ${counts.brainEpisodes ?? 0} (${counts.brainFacts ?? 0} facts, ${counts.brainEdges ?? 0} edges)`);
+    console.log(`  Fact audiences:     ${counts.factAudienceMembers ?? 0}`);
 
     // Write output
     const date = new Date().toISOString().slice(0, 10);

--- a/packages/types/src/__tests__/migration.test.ts
+++ b/packages/types/src/__tests__/migration.test.ts
@@ -182,11 +182,17 @@ describe("migration types", () => {
       knowledgeDocuments: { imported: 6, skipped: 1 },
       scheduledTasks: { imported: 1, skipped: 0 },
       agentSessionMemory: { imported: 3, skipped: 0 },
+      brainEpisodes: { imported: 4, skipped: 1 },
+      brainFacts: { imported: 8, skipped: 2 },
+      brainEdges: { imported: 5, skipped: 0 },
+      factAudienceMembers: { imported: 3, skipped: 1 },
     };
 
     expect(result.conversations.imported + result.conversations.skipped).toBe(7);
     expect(result.dashboards.imported).toBe(2);
     expect(result.knowledgeDocuments.skipped).toBe(1);
+    expect(result.brainFacts.imported).toBe(8);
+    expect(result.factAudienceMembers.skipped).toBe(1);
   });
 
   it("ExportManifest includes optional apiUrl", () => {

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -454,7 +454,7 @@ export interface ImportResult {
   knowledgeDocuments: { imported: number; skipped: number };
   scheduledTasks: { imported: number; skipped: number };
   agentSessionMemory: { imported: number; skipped: number };
-  /** Company brain (#4767) — episodes counted with their nested facts. */
+  /** Company brain (#4767). Facts are counted on their own key, not their episode's. */
   brainEpisodes: { imported: number; skipped: number };
   brainFacts: { imported: number; skipped: number };
   brainEdges: { imported: number; skipped: number };

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -50,6 +50,11 @@ export interface ExportManifest {
     knowledgeLinks?: number;
     scheduledTasks?: number;
     agentSessionMemory?: number;
+    /** Company brain (#4767, ADR-0036). */
+    brainEpisodes?: number;
+    brainFacts?: number;
+    brainEdges?: number;
+    factAudienceMembers?: number;
   };
 }
 
@@ -310,6 +315,96 @@ export interface ExportedAgentSessionMemory {
   updatedAt: string;
 }
 
+/**
+ * Exported brain fact — tier-2, a reviewed SPO claim (#4767, ADR-0036).
+ * Rides inline with its source episode, the way a knowledge link rides with
+ * its document: `sourceEpisodeId` is implied by the nesting, which also gives
+ * the importer its FK ordering for free (episode, then facts, then edges).
+ *
+ * Everything that makes the claim trustworthy travels with it — provenance,
+ * the grant, review `status`, and all four temporal columns. A brain fact
+ * stripped of any of those would arrive in the target region as an
+ * unprovenanced, ungated claim, which is worse than not arriving at all.
+ */
+export interface ExportedBrainFact {
+  /** Original UUID, preserved so edge endpoints survive the import. */
+  id: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  validFrom: string | null;
+  validTo: string | null;
+  ingestedAt: string;
+  /** The tombstone — preserved, because invalidate-never-delete travels too. */
+  invalidatedAt: string | null;
+  extractedAt: string | null;
+  /** Provenance payload (JSONB, opaque passthrough). Never empty. */
+  provenance: unknown;
+  /** Content-mode review status — preserved across the migration. */
+  status: "draft" | "published" | "archived";
+  /** The grant principal set. Never empty (`cardinality > 0` is a CHECK). */
+  visibleTo: string[];
+  predicateCardinality: "single" | "multi";
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Exported brain episode — tier-3 raw evidence, with its extracted facts
+ * inline (#4767, ADR-0036).
+ *
+ * `extractedAt` is preserved rather than reset: re-running extraction in the
+ * target region would mint fresh candidates for episodes already reviewed,
+ * flooding the target's review queue with work a human has already done.
+ */
+export interface ExportedBrainEpisode {
+  /** Original UUID, preserved so fact and edge references survive. */
+  id: string;
+  source: string;
+  sourceId: string;
+  sourceActor: string | null;
+  /** Body XOR locator — exactly one is set (a CHECK on the table). */
+  body: string | null;
+  locator: string | null;
+  occurredAt: string | null;
+  ingestedAt: string;
+  extractedAt: string | null;
+  /** The grant principal set. Never empty. */
+  visibleTo: string[];
+  createdAt: string;
+  facts: ExportedBrainFact[];
+}
+
+/**
+ * Exported brain edge (#4767, ADR-0036). Top-level rather than nested,
+ * because an edge can point at a fact or an episode on either side and
+ * therefore belongs to neither. The importer writes edges LAST, once every
+ * endpoint exists.
+ */
+export interface ExportedBrainEdge {
+  edgeType: "supersedes" | "in-tension-with" | "derives-from" | "provenance";
+  /** Exactly one `from*` and one `to*` is set (a CHECK on the table). */
+  fromFactId: string | null;
+  fromEpisodeId: string | null;
+  toFactId: string | null;
+  toEpisodeId: string | null;
+  createdAt: string;
+}
+
+/**
+ * Exported audience membership (#4767, ADR-0036). Moves with the workspace
+ * because it is what makes an `audience:` grant mean anything: without it,
+ * every fact granted to an audience becomes invisible to everyone in the
+ * target region — a silent, total loss of access rather than a visible error.
+ */
+export interface ExportedFactAudienceMember {
+  /** WITHOUT the `audience:` prefix — the prefix belongs to the grammar. */
+  audienceId: string;
+  userId: string;
+  source: string;
+  createdAt: string;
+}
+
 // ---------------------------------------------------------------------------
 // Full bundle
 // ---------------------------------------------------------------------------
@@ -331,6 +426,14 @@ export interface ExportBundle {
   knowledgeDocuments?: ExportedKnowledgeDocument[];
   scheduledTasks?: ExportedScheduledTask[];
   agentSessionMemory?: ExportedAgentSessionMemory[];
+  /**
+   * Company brain sections (#4767, ADR-0036). Same optional-on-the-wire shape
+   * as the other v2 sections. Facts nest inside their episode; edges and
+   * audience membership are top-level because they reference both classes.
+   */
+  brainEpisodes?: ExportedBrainEpisode[];
+  brainEdges?: ExportedBrainEdge[];
+  factAudienceMembers?: ExportedFactAudienceMember[];
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +454,11 @@ export interface ImportResult {
   knowledgeDocuments: { imported: number; skipped: number };
   scheduledTasks: { imported: number; skipped: number };
   agentSessionMemory: { imported: number; skipped: number };
+  /** Company brain (#4767) — episodes counted with their nested facts. */
+  brainEpisodes: { imported: number; skipped: number };
+  brainFacts: { imported: number; skipped: number };
+  brainEdges: { imported: number; skipped: number };
+  factAudienceMembers: { imported: number; skipped: number };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4767. First slice of **Brain M1** — targets `milestone/v0.2.0-brain-m1`, not `main`.

## What lands

Migration `0180` + the Drizzle mirror: `brain_episodes` / `brain_facts` / `brain_edges` / `fact_audience_member`, per [ADR-0036](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0036-atlas-as-company-brain.md). A substrate with its **own trust identity** reusing the KB's lifecycle — not a KB extension, because the fact class breaks ADR-0028's flat "descriptive-only" line and that break has to be visible in the schema.

Trust tiers in the reserved vocabulary: **tier-1** warehouse facts are authoritative by construction and stored in **no table here** (they resolve live through the semantic layer under warehouse RLS — which is exactly why T5 doesn't double-gate them); **tier-2** reviewed facts yield to the warehouse in any overlap; **tier-3** raw episodes are source-of-truth for what was *said*, never for what is *true*.

ADR absolutes are CHECKs, not conventions — a convention a call site can forget is not an invariant:

- **no-grant-no-promotion** — at least one usable principal. Stricter than `cardinality > 0` on purpose: `[NULL]` and `['']` are non-empty arrays that grant access to nobody, the denies-everyone state wearing a valid shape.
- **no-provenance-no-promotion** — provenance non-`{}`, and `source_episode_id` NOT NULL. Every entry point onto the reconcile stage has an episode, so a claim with no evidence is unrepresentable.
- **Workspace containment** — composite FKs tie a fact and every edge endpoint to their own workspace.

Episodes are append-only by construction (no `updated_at` — the absence is the signal; an upstream edit is a *new* episode). M2's columns land now so M2 is additive: four temporal columns, `predicate_cardinality`, the four committed edge types with their per-type endpoint kinds enforced.

## Scope note: this grew past "schema only"

The `#4460` bundle-scope tripwire fired on the four new tables and there was only one honest answer. `stays` rows are **deleted** from the source region after the grace period, so classifying the brain as `stays` would make a region migration silently destroy the workspace's accumulated knowledge. So it's `exported`, and the tripwire requires that be really wired: types, export, import, cleanup rules, and the customer-facing "What moves" table. Each fact travels with its provenance, grant, review status, and full validity history — including retracted claims, so an as-of read still answers correctly in the target.

## Review panel: 3 rounds

The panel found real defects, including two I introduced while fixing the first round. Worth naming since they're the interesting part:

1. **Silent brain loss across a mid-rollout migration.** A target region on an older build ignores sections it has no code for, imports the rest, answers 200 — then the source cuts over and the cleanup deletes them. The bundle *version* used to be the guard; making the brain sections optional (so a pre-#4767 source can still migrate) removed it. `transferBundleToTarget` now reconciles acknowledged counts against the manifest and fails **before** cutover.
2. **Episode adoption remapped facts but not edges** (my round-1 fix). The adopted episode uuid is never inserted, so a `provenance` edge failed its FK and rolled back the entire import — in exactly the scenario adoption exists to rescue. Both round-2 reviewers reproduced it independently.
3. **A guard stricter than the constraint it mirrors** is its own failure mode: a workspace Postgres legally stores becomes permanently unmigratable, discovered at cutover. Hit this twice — once on grants, then again on body/locator in the very commit that fixed grants.

## Testing

`/ci` green — **all 31 gates**. Real-Postgres coverage asserts each invariant by *attempting the forbidden write* and requiring Postgres to refuse it; `expectRejected` pins `err.constraint` rather than matching `|23514|check constraint` (which any check violation satisfied — it immediately caught two cases that tripped a different constraint than advertised). The round-trip seeds a **tombstoned** fact alongside a live one, since an export that quietly dropped invalidated rows would look perfectly healthy on counts.

## Gate note

CodeQL (`Analyze (javascript-typescript)`) is default-setup and `main`-only, so it does not run on this PR — **deferred**, not waived; it runs when the milestone branch PRs into `main`. Everything else (`ci`, `api-tests`, `Deploy Validation`, `Symlink Stub Build`) runs here via the `milestone/**` filters added in #4795.