### PR TITLE
feat(api): minimal per-fact ACL — visible_to grammar, audience membership, fail-closed push-down predicate (#4768)

### DIFF
--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -28,13 +28,17 @@ const log = createLogger("admin-migrate");
  * importer that rejected a grant the source region legally holds would leave
  * that workspace permanently stuck in its current region.
  *
- * Grammar validity (`org` vs `everyone`) is NOT checked here. That is
- * `lib/brain/acl.ts`'s parser (#4768), whose failure mode is deny+log at READ
+ * The matched pair is THIS function ↔ 0180's `chk_*_grant_nonempty`; they must
+ * stay exactly as permissive as each other.
+ *
+ * Grammar validity (`org` vs `everyone`) is NOT checked here, and must never
+ * be added. That belongs to `lib/brain/acl.ts`'s parser (#4768), which is
+ * deliberately STRICTER than both and whose failure mode is deny+log at READ
  * time: a malformed token matches no reader principal, so it grants nobody
- * anything without ever making the row unimportable. The two guards are a
- * matched pair and move together — if either starts rejecting what the other
- * admits, a legally-stored workspace becomes unmigratable, and that surfaces
- * at region cutover rather than here.
+ * anything without ever making the row unimportable. Hoisting that parser to
+ * import time would reject a legally-stored `['everyone']` bundle and leave
+ * that workspace permanently stuck in its current region — a failure that
+ * surfaces at cutover, not here.
  */
 function grantProblem(value: unknown): string | null {
   if (!Array.isArray(value)) {

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -28,9 +28,13 @@ const log = createLogger("admin-migrate");
  * importer that rejected a grant the source region legally holds would leave
  * that workspace permanently stuck in its current region.
  *
- * Grammar validity (`org` vs `everyone`) is NOT checked here. That is #4768's
- * parser, whose failure mode is deny+log at read time rather than a rejected
- * import.
+ * Grammar validity (`org` vs `everyone`) is NOT checked here. That is
+ * `lib/brain/acl.ts`'s parser (#4768), whose failure mode is deny+log at READ
+ * time: a malformed token matches no reader principal, so it grants nobody
+ * anything without ever making the row unimportable. The two guards are a
+ * matched pair and move together — if either starts rejecting what the other
+ * admits, a legally-stored workspace becomes unmigratable, and that surfaces
+ * at region cutover rather than here.
  */
 function grantProblem(value: unknown): string | null {
   if (!Array.isArray(value)) {

--- a/packages/api/src/lib/brain/__tests__/acl-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-logging.test.ts
@@ -16,8 +16,12 @@
  * the failure "deny + log" is written to prevent.
  *
  * Spy installed via `mock.module` before the dynamic import, mirroring
- * `lib/__tests__/config-deploy-mode-warning.test.ts`. All logger exports are
- * mocked, per the mock-all-exports rule.
+ * `lib/__tests__/config-deploy-mode-warning.test.ts` (which mocks only the
+ * four exports its own graph touches). Every VALUE export of `lib/logger.ts`
+ * is stubbed here instead, per the mock-all-exports rule: a partial factory
+ * works right up until some module in the import graph reaches one of the
+ * missing names, and then fails at link time with `Export named 'X' not found`
+ * in a file that has nothing to do with this one.
  */
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -35,6 +39,14 @@ void mock.module("@atlas/api/lib/logger", () => ({
   getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
   setLogLevel: () => true,
   getRequestContext: () => undefined,
+  // The rest of lib/logger.ts's value exports. Unused by this file's graph
+  // today; present so widening that graph can't break the link.
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler", "api_key"] as const,
+  withRequestContext: <T,>(_ctx: unknown, fn: () => T): T => fn(),
+  redactPaths: [] as string[],
+  scrubErrSerializer: (value: unknown) => value,
+  scrubLogFormatter: (obj: unknown) => obj,
+  hashShareToken: (token: string) => token,
 }));
 
 const {
@@ -97,7 +109,9 @@ describe("reader-side denies are logged (#4768)", () => {
   });
 
   it("logs when a reader is asked about a row outside their workspace", () => {
-    expect(isVisibleTo({ workspaceId: "other-ws", visibleTo: ["org"] }, ctx())).toBe(false);
+    expect(
+      isVisibleTo({ table: "brain_facts", workspaceId: "other-ws", visibleTo: ["org"] }, ctx()),
+    ).toBe(false);
     expect(warns()).toHaveLength(1);
     expect(warns()[0]!.message).toContain("outside the reader's workspace");
     expect(payloads()[0]).toMatchObject({ rowWorkspaceId: "other-ws", readerWorkspaceId: WS });
@@ -106,8 +120,12 @@ describe("reader-side denies are logged (#4768)", () => {
   it("does not log on the ordinary allow and deny paths", () => {
     // A grant that simply doesn't match is not an anomaly — logging it would
     // make the signal useless at any real read volume.
-    expect(isVisibleTo({ workspaceId: WS, visibleTo: ["role:admin"] }, ctx())).toBe(false);
-    expect(isVisibleTo({ workspaceId: WS, visibleTo: ["org"] }, ctx())).toBe(true);
+    expect(
+      isVisibleTo({ table: "brain_facts", workspaceId: WS, visibleTo: ["role:admin"] }, ctx()),
+    ).toBe(false);
+    expect(
+      isVisibleTo({ table: "brain_facts", workspaceId: WS, visibleTo: ["org"] }, ctx()),
+    ).toBe(true);
     aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 });
     expect(warns()).toHaveLength(0);
   });
@@ -191,8 +209,7 @@ describe("resolution-side anomalies are logged (#4768)", () => {
       workspaceId: WS,
       mode: "managed",
       userId: undefined,
-      role: "admin",
-      roleResolvedForOrgId: WS,
+      resolvedRole: { role: "admin", orgId: WS },
       requestId: "req-13",
     });
     expect(resolved.origin).toBe("unresolved");
@@ -206,8 +223,7 @@ describe("resolution-side anomalies are logged (#4768)", () => {
       workspaceId: WS,
       mode: "managed",
       userId: "user-1",
-      role: "owner",
-      roleResolvedForOrgId: "some-other-org",
+      resolvedRole: { role: "owner", orgId: "some-other-org" },
       requestId: "req-14",
     });
     expect(resolved.role).toBeNull();
@@ -219,13 +235,46 @@ describe("resolution-side anomalies are logged (#4768)", () => {
     });
   });
 
+  it("logs when audience rows are dropped by narrowing", async () => {
+    // `audience_id` is `text NOT NULL`, so a dropped row can only mean the
+    // query or the row shape changed. Silently returning fewer memberships
+    // would strip a reader's audience grants with no signal — the same silent
+    // downgrade this function refuses to perform on a DB error.
+    const drifted = { query: async () => ({ rows: [{ aud: "eng" }, { audience_id: "exec" }] }) };
+    const resolved = await resolvePrincipalContext(drifted, {
+      workspaceId: WS,
+      mode: "managed",
+      userId: "user-1",
+      resolvedRole: { role: "member", orgId: WS },
+      requestId: "req-15",
+    });
+    expect(resolved.audienceIds).toEqual(["exec"]);
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("membership query shape changed");
+    expect(payloads()[0]).toMatchObject({ returned: 2, usable: 1, requestId: "req-15" });
+  });
+
+  it("logs an unrecognised principal origin", () => {
+    const rogue = { ...ctx(), origin: "service" } as unknown as Parameters<
+      typeof aclVisibilityClause
+    >[0];
+    expect(aclVisibilityClause(rogue, { table: "brain_facts", paramIndex: 1 }).decision).toBe(
+      "deny-all",
+    );
+    // Two lines: the `principalTokens` default, then the clause's own backstop
+    // — which is the arm that makes an out-of-union origin observable at all.
+    expect(warns().map((w) => w.message)).toEqual([
+      expect.stringContaining("unrecognised principal origin"),
+      expect.stringContaining("resolved to no principals"),
+    ]);
+  });
+
   it("logs an unrecognised auth mode", async () => {
     const resolved = await resolvePrincipalContext(db, {
       workspaceId: WS,
       mode: "quantum" as unknown as "managed",
       userId: "user-1",
-      role: undefined,
-      roleResolvedForOrgId: undefined,
+      resolvedRole: undefined,
     });
     expect(resolved.origin).toBe("unresolved");
     expect(warns()[0]!.message).toContain("unrecognised auth mode");

--- a/packages/api/src/lib/brain/__tests__/acl-logging.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-logging.test.ts
@@ -1,0 +1,233 @@
+/**
+ * The "log" half of #4768's first acceptance criterion — "unknown/malformed
+ * grant ⇒ row invisible **and logged**, never visible" (ADR-0036 §Access
+ * control).
+ *
+ * Split into its own file because it needs `mock.module("@atlas/api/lib/logger")`
+ * installed before the module under test is imported, and the sibling files
+ * deliberately run without any module mocking at all.
+ *
+ * Why this file exists rather than trusting the log calls to stay put: every
+ * `log.warn` in `acl.ts` could be deleted and the other two suites would stay
+ * green, because the ENFORCEMENT is structural (a `(FALSE)` clause, an empty
+ * token set) and entirely independent of the reporting. The most consequential
+ * line is the audit-override one: that log is the ONLY artifact of a
+ * workspace-wide grant bypass, and an unlogged privilege escalation is exactly
+ * the failure "deny + log" is written to prevent.
+ *
+ * Spy installed via `mock.module` before the dynamic import, mirroring
+ * `lib/__tests__/config-deploy-mode-warning.test.ts`. All logger exports are
+ * mocked, per the mock-all-exports rule.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+type LogCall = { level: "error" | "warn" | "info" | "debug"; payload: unknown; message: string };
+const logCalls: LogCall[] = [];
+
+void mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    error: (payload: unknown, message: string) => logCalls.push({ level: "error", payload, message }),
+    warn: (payload: unknown, message: string) => logCalls.push({ level: "warn", payload, message }),
+    info: (payload: unknown, message: string) => logCalls.push({ level: "info", payload, message }),
+    debug: (payload: unknown, message: string) => logCalls.push({ level: "debug", payload, message }),
+  }),
+  getLogger: () => ({ error: () => {}, warn: () => {}, info: () => {}, debug: () => {}, level: "info" }),
+  setLogLevel: () => true,
+  getRequestContext: () => undefined,
+}));
+
+const {
+  aclVisibilityClause,
+  isVisibleTo,
+  logGrantAnomalies,
+  resolvePrincipalContext,
+  impliedRoles,
+} = await import("@atlas/api/lib/brain/acl");
+type BrainPrincipalContext = Awaited<ReturnType<typeof resolvePrincipalContext>>;
+
+const WS = "ws-acl-log";
+
+function ctx(partial: Partial<Extract<BrainPrincipalContext, { origin: "authenticated" }>> = {}) {
+  return {
+    origin: "authenticated" as const,
+    workspaceId: WS,
+    userId: "user-1",
+    role: "member" as const,
+    audienceIds: [] as readonly string[],
+    ...partial,
+  };
+}
+
+const warns = () => logCalls.filter((c) => c.level === "warn");
+const payloads = () => warns().map((c) => c.payload as Record<string, unknown>);
+
+beforeEach(() => {
+  logCalls.length = 0;
+});
+
+describe("reader-side denies are logged (#4768)", () => {
+  it("logs when an unresolved reader is denied, and says an override was attempted", () => {
+    const clause = aclVisibilityClause(
+      { origin: "unresolved", workspaceId: WS, userId: null, role: null, audienceIds: [] },
+      { table: "brain_facts", paramIndex: 1, override: { reason: "sneaky" }, requestId: "req-9" },
+    );
+    expect(clause.decision).toBe("deny-all");
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("identity could not be resolved");
+    // Attempted privilege escalation must be visible in the deny line —
+    // otherwise an operator reading it cannot tell that somebody also tried to
+    // invoke a workspace-wide ACL bypass.
+    expect(payloads()[0]).toMatchObject({
+      overrideRequested: true,
+      requestId: "req-9",
+      table: "brain_facts",
+    });
+  });
+
+  it("logs when a context carries no workspace, with the request id", () => {
+    aclVisibilityClause(ctx({ workspaceId: "" }), {
+      table: "brain_episodes",
+      paramIndex: 1,
+      requestId: "req-10",
+    });
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("no workspace");
+    expect(payloads()[0]).toMatchObject({ requestId: "req-10", overrideRequested: false });
+  });
+
+  it("logs when a reader is asked about a row outside their workspace", () => {
+    expect(isVisibleTo({ workspaceId: "other-ws", visibleTo: ["org"] }, ctx())).toBe(false);
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("outside the reader's workspace");
+    expect(payloads()[0]).toMatchObject({ rowWorkspaceId: "other-ws", readerWorkspaceId: WS });
+  });
+
+  it("does not log on the ordinary allow and deny paths", () => {
+    // A grant that simply doesn't match is not an anomaly — logging it would
+    // make the signal useless at any real read volume.
+    expect(isVisibleTo({ workspaceId: WS, visibleTo: ["role:admin"] }, ctx())).toBe(false);
+    expect(isVisibleTo({ workspaceId: WS, visibleTo: ["org"] }, ctx())).toBe(true);
+    aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 });
+    expect(warns()).toHaveLength(0);
+  });
+
+  it("logs an unknown org role instead of throwing an unattributed TypeError", () => {
+    expect(impliedRoles("superuser" as unknown as "owner")).toEqual([]);
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("unknown org role");
+  });
+});
+
+describe("the audit override is always recorded (#4768)", () => {
+  it("logs every granted override with actor, workspace, and reason", () => {
+    const clause = aclVisibilityClause(ctx({ role: "admin" }), {
+      table: "brain_episodes",
+      paramIndex: 1,
+      override: { reason: "GDPR subject access request" },
+      requestId: "req-11",
+    });
+    expect(clause.decision).toBe("audit-override");
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("per-grant visibility bypassed");
+    expect(payloads()[0]).toMatchObject({
+      table: "brain_episodes",
+      workspaceId: WS,
+      userId: "user-1",
+      role: "admin",
+      reason: "GDPR subject access request",
+      requestId: "req-11",
+    });
+  });
+
+  it("logs every refused override too", () => {
+    aclVisibilityClause(ctx({ role: "member" }), {
+      table: "brain_facts",
+      paramIndex: 1,
+      override: { reason: "let me in" },
+    });
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("audit override refused");
+    expect(payloads()[0]).toMatchObject({ reason: "let me in", role: "member" });
+  });
+});
+
+describe("stored-side grant anomalies are logged (#4768)", () => {
+  it("logs the malformed tokens of a grant that otherwise passes", () => {
+    // The case that actually bites: `['user:abc', 'everyone']` passes the
+    // predicate on its valid token while the author believed `everyone` was
+    // doing something.
+    logGrantAnomalies(["user:abc", "everyone"], {
+      table: "brain_facts",
+      rowId: "fact-1",
+      workspaceId: WS,
+      requestId: "req-12",
+    });
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("outside the grammar");
+    expect(payloads()[0]).toMatchObject({
+      rowId: "fact-1",
+      malformed: ["everyone"],
+      usablePrincipals: 1,
+      requestId: "req-12",
+    });
+  });
+
+  it("stays silent on a clean grant", () => {
+    logGrantAnomalies(["org", "user:abc"], {
+      table: "brain_facts",
+      rowId: "fact-2",
+      workspaceId: WS,
+    });
+    expect(warns()).toHaveLength(0);
+  });
+});
+
+describe("resolution-side anomalies are logged (#4768)", () => {
+  const db = { query: async () => ({ rows: [] as unknown[] }) };
+
+  it("logs an authenticated request with no user id", async () => {
+    const resolved = await resolvePrincipalContext(db, {
+      workspaceId: WS,
+      mode: "managed",
+      userId: undefined,
+      role: "admin",
+      roleResolvedForOrgId: WS,
+      requestId: "req-13",
+    });
+    expect(resolved.origin).toBe("unresolved");
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("no user id");
+    expect(payloads()[0]).toMatchObject({ requestId: "req-13" });
+  });
+
+  it("logs a role resolved against a different org than the read target", async () => {
+    const resolved = await resolvePrincipalContext(db, {
+      workspaceId: WS,
+      mode: "managed",
+      userId: "user-1",
+      role: "owner",
+      roleResolvedForOrgId: "some-other-org",
+      requestId: "req-14",
+    });
+    expect(resolved.role).toBeNull();
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0]!.message).toContain("different org than the read target");
+    expect(payloads()[0]).toMatchObject({
+      roleResolvedForOrgId: "some-other-org",
+      workspaceId: WS,
+    });
+  });
+
+  it("logs an unrecognised auth mode", async () => {
+    const resolved = await resolvePrincipalContext(db, {
+      workspaceId: WS,
+      mode: "quantum" as unknown as "managed",
+      userId: "user-1",
+      role: undefined,
+      roleResolvedForOrgId: undefined,
+    });
+    expect(resolved.origin).toBe("unresolved");
+    expect(warns()[0]!.message).toContain("unrecognised auth mode");
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
@@ -16,14 +16,15 @@
  *   - NULL and `''` elements inside a stored grant. Migration 0180's CHECK
  *     tolerates them (it requires one USABLE principal, not that all are), so
  *     they reach the predicate — and `ARRAY[''] && ARRAY['']` is TRUE.
- *   - Cross-tenant audience collision. Audience ids are workspace-scoped and
- *     not globally unique; two tenants minting `engineering` is normal.
- *   - That the predicate stays INDEXABLE against the GIN index the migration
- *     created for it. A rewrite to `EXISTS (SELECT … unnest(visible_to))`
- *     would pass every row-level assertion and quietly become a seq scan.
+ *   - Cross-tenant audience collision, in both directions: a colliding grant
+ *     (the predicate's job) and a colliding MEMBERSHIP row (the audience
+ *     lookup's job — the one leak workspace containment cannot catch, because
+ *     the stolen token gets applied inside the reader's own tenant).
+ *   - That the grant match stays a pushed-down array overlap rather than a
+ *     per-row subplan.
  *
  * Opt in locally with:
- *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas_dev
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
@@ -43,15 +44,17 @@ const describeIfPg = TEST_DB_URL ? describe : describe.skip;
 const PG_TEST_TIMEOUT_MS = 60_000;
 
 const WS = "ws-acl-pg";
-const OTHER_WS = "ws-acl-pg-other";
+const EPISODE_WS = "ws-acl-pg-episodes";
 
-function ctx(partial: Partial<BrainPrincipalContext> = {}): BrainPrincipalContext {
+type AuthedContext = Extract<BrainPrincipalContext, { origin: "authenticated" }>;
+
+function ctx(partial: Partial<AuthedContext> = {}): BrainPrincipalContext {
   return {
+    origin: "authenticated",
     workspaceId: WS,
     userId: "user-1",
     role: "member",
     audienceIds: [],
-    origin: "authenticated",
     ...partial,
   };
 }
@@ -111,16 +114,128 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
     return rows.map((r) => r.label);
   }
 
+  /**
+   * The parity matrix, shared by both gated tables. Every grant is legal at
+   * rest under `chk_brain_*_grant_nonempty` — including the ones that grant
+   * nobody anything, which is the half a stricter parser would have made
+   * unrepresentable and therefore untested.
+   */
+  const GRANTS: ReadonlyArray<{ label: string; visibleTo: (string | null)[] }> = [
+    { label: "org-wide", visibleTo: ["org"] },
+    { label: "members", visibleTo: ["role:member"] },
+    { label: "admins", visibleTo: ["role:admin"] },
+    { label: "owners", visibleTo: ["role:owner"] },
+    { label: "u1-only", visibleTo: ["user:user-1"] },
+    { label: "u2-only", visibleTo: ["user:user-2"] },
+    { label: "aud-eng", visibleTo: ["audience:eng"] },
+    { label: "aud-exec", visibleTo: ["audience:exec"] },
+    { label: "mixed", visibleTo: ["user:user-2", "audience:eng"] },
+    // Malformed-but-legal: `everyone` reads as public and grants nobody.
+    { label: "malformed", visibleTo: ["everyone"] },
+    // A valid token beside a malformed one — passes on the valid half only.
+    { label: "half-malformed", visibleTo: ["everyone", "user:user-1"] },
+    // NULL / '' elements alongside one usable principal. The CHECK admits
+    // this; `ARRAY[''] && ARRAY['']` is TRUE, so an empty reader token would
+    // match here. `principalTokens` never emits one.
+    { label: "padded", visibleTo: ["org", null, ""] },
+    { label: "empty-only-plus-user", visibleTo: ["", "user:user-2"] },
+    // A bare prefix is itself malformed and legal at rest — an unguarded
+    // reader arm emitting `user:` would raw-match this.
+    { label: "bare-prefix", visibleTo: ["user:", "audience:"] },
+    // Case variants must NOT match — enforcement is byte-exact.
+    { label: "shouty", visibleTo: ["ORG"] },
+  ];
+
+  function readersFor(workspaceId: string): ReadonlyArray<{
+    name: string;
+    ctx: BrainPrincipalContext;
+    /** Absolute expectation — what this reader must see, independent of the mirror. */
+    expected: string[];
+  }> {
+    const base = { workspaceId, userId: "user-1" } as const;
+    return [
+      {
+        name: "member/no-audience",
+        ctx: { ...base, origin: "authenticated", role: "member", audienceIds: [] },
+        expected: ["half-malformed", "members", "org-wide", "padded", "u1-only"],
+      },
+      {
+        name: "admin",
+        ctx: { ...base, origin: "authenticated", role: "admin", audienceIds: [] },
+        expected: ["admins", "half-malformed", "members", "org-wide", "padded", "u1-only"],
+      },
+      {
+        name: "owner",
+        ctx: { ...base, origin: "authenticated", role: "owner", audienceIds: [] },
+        expected: [
+          "admins",
+          "half-malformed",
+          "members",
+          "org-wide",
+          "owners",
+          "padded",
+          "u1-only",
+        ],
+      },
+      {
+        name: "member in eng",
+        ctx: { ...base, origin: "authenticated", role: "member", audienceIds: ["eng"] },
+        expected: [
+          "aud-eng",
+          "half-malformed",
+          "members",
+          "mixed",
+          "org-wide",
+          "padded",
+          "u1-only",
+        ],
+      },
+      {
+        name: "other user",
+        ctx: { ...base, origin: "authenticated", userId: "user-9", role: "member", audienceIds: [] },
+        expected: ["members", "org-wide", "padded"],
+      },
+      {
+        name: "auth:none local",
+        ctx: {
+          origin: "unauthenticated-local",
+          workspaceId,
+          userId: null,
+          role: null,
+          audienceIds: [],
+        },
+        expected: ["org-wide", "padded"],
+      },
+      {
+        name: "unresolved",
+        // The deny arm, composed into a REAL query rather than only asserted
+        // in memory — the clause's own doc warns that arity mismatches "fail
+        // at execution, which is late".
+        ctx: { origin: "unresolved", workspaceId, userId: null, role: null, audienceIds: [] },
+        expected: [],
+      },
+    ];
+  }
+
   beforeAll(async () => {
-    pool = new Pool({ connectionString: TEST_DB_URL });
-    pool.on("connect", (client) => {
-      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
-        console.error(
-          `acl-visibility-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+    // `search_path` is baked into the connection string rather than SET from an
+    // unawaited `pool.on("connect")` handler: server-side at startup, so there
+    // is no window in which a checked-out client is still pointed at `public`,
+    // and no failure path that logs and then silently runs 180 migrations
+    // against the developer's real database. Same pattern as
+    // `api/__tests__/admin-last-admin-pg.test.ts`.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
     });
-    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    // The schema must exist before any pooled client sets search_path to it,
+    // so this one connection opts out via an explicit fresh pool.
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
     await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
   }, PG_TEST_TIMEOUT_MS);
 
@@ -133,78 +248,37 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
   it(
     "selects exactly the rows `isVisibleTo` predicts, for every grant × reader pair",
     async () => {
-      // The parity matrix. Every grant here is legal at rest under
-      // `chk_brain_facts_grant_nonempty` — including the ones that grant
-      // nobody anything, which is the half a stricter parser would have made
-      // unrepresentable and therefore untested.
-      const grants: ReadonlyArray<{ subject: string; visibleTo: (string | null)[] }> = [
-        { subject: "org-wide", visibleTo: ["org"] },
-        { subject: "members", visibleTo: ["role:member"] },
-        { subject: "admins", visibleTo: ["role:admin"] },
-        { subject: "owners", visibleTo: ["role:owner"] },
-        { subject: "u1-only", visibleTo: ["user:user-1"] },
-        { subject: "u2-only", visibleTo: ["user:user-2"] },
-        { subject: "aud-eng", visibleTo: ["audience:eng"] },
-        { subject: "aud-exec", visibleTo: ["audience:exec"] },
-        { subject: "mixed", visibleTo: ["user:user-2", "audience:eng"] },
-        // Malformed-but-legal: `everyone` reads as public and grants nobody.
-        { subject: "malformed", visibleTo: ["everyone"] },
-        // A valid token beside a malformed one — passes on the valid half only.
-        { subject: "half-malformed", visibleTo: ["everyone", "user:user-1"] },
-        // NULL / '' elements alongside one usable principal. The CHECK admits
-        // this; `ARRAY[''] && ARRAY['']` is TRUE, so an empty reader token
-        // would match here. `principalTokens` never emits one.
-        { subject: "padded", visibleTo: ["org", null, ""] },
-        { subject: "empty-only-plus-user", visibleTo: ["", "user:user-2"] },
-        // Case variants must NOT match — enforcement is byte-exact.
-        { subject: "shouty", visibleTo: ["ORG"] },
-      ];
-
       const episode = await seedEpisode(WS, "parity", ["org"]);
-      for (const g of grants) {
+      for (const g of GRANTS) {
         await seedFact({
           workspaceId: WS,
           episodeId: episode,
-          subject: g.subject,
+          subject: g.label,
           visibleTo: g.visibleTo,
         });
       }
 
-      const readers: ReadonlyArray<{ name: string; ctx: BrainPrincipalContext }> = [
-        { name: "member/no-audience", ctx: ctx({ role: "member" }) },
-        { name: "admin", ctx: ctx({ role: "admin" }) },
-        { name: "owner", ctx: ctx({ role: "owner" }) },
-        { name: "member in eng", ctx: ctx({ role: "member", audienceIds: ["eng"] }) },
-        { name: "other user", ctx: ctx({ role: "member", userId: "user-9" }) },
-        { name: "auth:none local", ctx: ctx({ role: null, userId: null, origin: "unauthenticated-local" }) },
-      ];
-
-      for (const reader of readers) {
+      for (const reader of readersFor(WS)) {
         const fromSql = await selectVisible(reader.ctx, "brain_facts");
-        const fromMirror = grants
-          .filter((g) => isVisibleTo(g.visibleTo, reader.ctx))
-          .map((g) => g.subject)
+        const fromMirror = GRANTS.filter((g) =>
+          isVisibleTo({ workspaceId: WS, visibleTo: g.visibleTo }, reader.ctx),
+        )
+          .map((g) => g.label)
           .toSorted();
+
+        // Parity — but parity alone is circular (both sides derive tokens from
+        // `principalTokens`), so every reader also carries an ABSOLUTE
+        // expectation. A token-derivation bug moves both sides together and is
+        // caught only by the second assertion.
         expect({ reader: reader.name, rows: fromSql }).toEqual({
           reader: reader.name,
           rows: fromMirror,
         });
+        expect({ reader: reader.name, rows: fromSql }).toEqual({
+          reader: reader.name,
+          rows: reader.expected,
+        });
       }
-
-      // Spot-check the absolute claims the matrix is supposed to encode, so a
-      // mirror that broke in the SAME way as the SQL still fails here.
-      expect(await selectVisible(ctx({ role: "member" }), "brain_facts")).toEqual([
-        "half-malformed",
-        "members",
-        "org-wide",
-        "padded",
-        "u1-only",
-      ]);
-      expect(await selectVisible(ctx({ role: "owner" }), "brain_facts")).toContain("admins");
-      expect(await selectVisible(ctx({ role: "member" }), "brain_facts")).not.toContain(
-        "malformed",
-      );
-      expect(await selectVisible(ctx({ role: "member" }), "brain_facts")).not.toContain("shouty");
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -212,18 +286,17 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
   it(
     "gates tier-3 episodes on the same grammar — raw source is often more sensitive than the facts",
     async () => {
-      await seedEpisode(OTHER_WS, "ep-org", ["org"]);
-      await seedEpisode(OTHER_WS, "ep-exec", ["audience:exec"]);
-      await seedEpisode(OTHER_WS, "ep-u2", ["user:user-2"]);
-
-      const reader = ctx({ workspaceId: OTHER_WS, role: "member" });
-      expect(await selectVisible(reader, "brain_episodes")).toEqual(["ep-org"]);
-      expect(
-        await selectVisible(
-          ctx({ workspaceId: OTHER_WS, role: "member", audienceIds: ["exec"] }),
-          "brain_episodes",
-        ),
-      ).toEqual(["ep-exec", "ep-org"]);
+      // The migration itself notes episodes are "frequently MORE sensitive
+      // than the facts extracted from it", so the full matrix runs over both
+      // tables rather than giving tier-3 a three-row happy path.
+      for (const g of GRANTS) {
+        await seedEpisode(EPISODE_WS, g.label, g.visibleTo);
+      }
+      for (const reader of readersFor(EPISODE_WS)) {
+        expect({ reader: reader.name, rows: await selectVisible(reader.ctx, "brain_episodes") }).toEqual(
+          { reader: reader.name, rows: reader.expected },
+        );
+      }
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -254,6 +327,51 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
 
       const readerInA = ctx({ workspaceId: wsA, audienceIds: ["engineering"] });
       expect(await selectVisible(readerInA, "brain_facts")).toEqual(["a-secret"]);
+      // The in-memory mirror must agree — an earlier cut took a bare grant and
+      // answered TRUE here.
+      expect(
+        isVisibleTo({ workspaceId: wsB, visibleTo: ["audience:engineering"] }, readerInA),
+      ).toBe(false);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "scopes the audience-membership lookup to the workspace — the one leak containment cannot catch",
+    async () => {
+      // If this query ever returned another workspace's memberships, the
+      // reader would acquire `audience:finance` and immediately read their OWN
+      // tenant's `audience:finance` facts. The predicate's workspace
+      // containment is powerless there: the stolen token is applied inside the
+      // right tenant. This is the module's only cross-tenant-sensitive read.
+      const home = `${WS}-membership-home`;
+      const foreign = `${WS}-membership-foreign`;
+      await pool.query(
+        `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source)
+         VALUES ($1, 'exec', 'user-1', 'test'),
+                ($2, 'finance', 'user-1', 'test')`,
+        [home, foreign],
+      );
+
+      const resolved = await resolvePrincipalContext(pool, {
+        workspaceId: home,
+        mode: "managed",
+        userId: "user-1",
+        role: "member",
+        roleResolvedForOrgId: home,
+      });
+      expect(resolved.audienceIds).toEqual(["exec"]);
+
+      const episode = await seedEpisode(home, "membership-scope", ["org"]);
+      await seedFact({
+        workspaceId: home,
+        episodeId: episode,
+        subject: "home-finance",
+        visibleTo: ["audience:finance"],
+      });
+      // The foreign membership must not unlock the home tenant's like-named
+      // audience.
+      expect(await selectVisible(resolved, "brain_facts")).toEqual([]);
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -276,8 +394,8 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
       const v2 = await seedFact({
         workspaceId: wsV,
         episodeId: episode,
-        subject: "v2-wide",
-        visibleTo: ["org"],
+        subject: "v2-superseding",
+        visibleTo: ["audience:exec"],
       });
       await pool.query(
         `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
@@ -285,16 +403,25 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         [wsV, v2, v1],
       );
 
-      // A plain member sees only the widened CURRENT version. The superseded
-      // one keeps its own narrower grant — supersession is not deletion, and
-      // it is not declassification either.
       const member = ctx({ workspaceId: wsV, role: "member" });
-      expect(await selectVisible(member, "brain_facts")).toEqual(["v2-wide"]);
-
-      // And the exec still sees both, as-of-now membership against each
-      // version's own frozen grant.
       const exec = ctx({ workspaceId: wsV, role: "member", audienceIds: ["exec"] });
-      expect(await selectVisible(exec, "brain_facts")).toEqual(["v1-narrow", "v2-wide"]);
+      // Both versions start narrow.
+      expect(await selectVisible(member, "brain_facts")).toEqual([]);
+      expect(await selectVisible(exec, "brain_facts")).toEqual(["v1-narrow", "v2-superseding"]);
+
+      // Now WIDEN the current version — the actual mutation the criterion is
+      // about. Without it the test is just "two rows filter independently",
+      // which is trivially true of any per-row column and would pass against
+      // an implementation that DID have the retroactive-rewrite property.
+      await pool.query(
+        `UPDATE brain_facts SET visible_to = ARRAY['org']::text[] WHERE id = $1`,
+        [v2],
+      );
+
+      // The superseded version keeps its own frozen grant. Supersession is not
+      // deletion, and widening the successor is not declassification.
+      expect(await selectVisible(member, "brain_facts")).toEqual(["v2-superseding"]);
+      expect(await selectVisible(exec, "brain_facts")).toEqual(["v1-narrow", "v2-superseding"]);
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -320,12 +447,14 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         [wsR],
       );
 
-      const before = await resolvePrincipalContext(pool, {
+      const input = {
         workspaceId: wsR,
         mode: "managed",
         userId: "user-1",
         role: "member",
-      });
+        roleResolvedForOrgId: wsR,
+      } as const;
+      const before = await resolvePrincipalContext(pool, input);
       expect(before.audienceIds).toEqual(["exec"]);
       expect(await selectVisible(before, "brain_facts")).toEqual(["exec-only"]);
 
@@ -333,12 +462,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         `DELETE FROM fact_audience_member WHERE workspace_id = $1 AND user_id = 'user-1'`,
         [wsR],
       );
-      const after = await resolvePrincipalContext(pool, {
-        workspaceId: wsR,
-        mode: "managed",
-        userId: "user-1",
-        role: "member",
-      });
+      const after = await resolvePrincipalContext(pool, input);
       // The fact's `visible_to` never changed. Only membership did.
       expect(await selectVisible(after, "brain_facts")).toEqual([]);
     },
@@ -346,7 +470,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
   );
 
   it(
-    "composes as one of four AND-ed gates — failing any one hides the row",
+    "composes as one of four AND-ed gates — each is independently load-bearing",
     async () => {
       // ADR-0036: residency-invariant (by construction — the process IS the
       // region) AND org/group reach AND content mode AND the grant. The status
@@ -371,7 +495,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         alias: "f",
         paramIndex: 2,
       });
-      const { rows } = await pool.query<{ subject: string }>(
+      const composed = await pool.query<{ subject: string }>(
         `SELECT f.subject
            FROM brain_facts f
           WHERE f.workspace_id = $1
@@ -380,17 +504,39 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
           ORDER BY 1`,
         [wsC, ...clause.params],
       );
-      expect(rows.map((r) => r.subject)).toEqual(["all-gates-pass"]);
+      expect(composed.rows.map((r) => r.subject)).toEqual(["all-gates-pass"]);
 
-      // And each gate is load-bearing on its own: drop the ACL clause and the
-      // grant-gated row reappears, which is what makes this a real AND rather
-      // than three clauses one of which happens to be redundant.
+      // Each gate is load-bearing ON ITS OWN — drop one at a time and a
+      // different row reappears. Without these controls the composed query
+      // above would pass even if two of the three clauses were inert.
       const withoutAcl = await pool.query<{ subject: string }>(
         `SELECT f.subject FROM brain_facts f
           WHERE f.workspace_id = $1 AND f.status = 'published' ORDER BY 1`,
         [wsC],
       );
       expect(withoutAcl.rows.map((r) => r.subject)).toEqual(["all-gates-pass", "fails-grant"]);
+
+      const withoutMode = await pool.query<{ subject: string }>(
+        `SELECT f.subject FROM brain_facts f WHERE f.workspace_id = $1 AND ${clause.sql} ORDER BY 1`,
+        [wsC, ...clause.params],
+      );
+      expect(withoutMode.rows.map((r) => r.subject)).toEqual(["all-gates-pass", "fails-mode"]);
+
+      // The reach gate is spelled `workspace_id = $1`, which the ACL clause
+      // already enforces — so dropping the caller's copy changes nothing here.
+      // That redundancy is the deliberate "safe standalone" property, and this
+      // asserts it rather than leaving the reader to wonder whether the gate
+      // was simply inert.
+      const soloClause = aclVisibilityClause(reader, {
+        table: "brain_facts",
+        alias: "f",
+        paramIndex: 1,
+      });
+      const withoutReach = await pool.query<{ subject: string }>(
+        `SELECT f.subject FROM brain_facts f WHERE f.status = 'published' AND ${soloClause.sql} ORDER BY 1`,
+        [...soloClause.params],
+      );
+      expect(withoutReach.rows.map((r) => r.subject)).toEqual(["all-gates-pass"]);
     },
     PG_TEST_TIMEOUT_MS,
   );
@@ -422,7 +568,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
   );
 
   it(
-    "keeps the grant match a pushed-down array-overlap the planner can serve from an index",
+    "keeps the grant match a pushed-down array overlap the planner can serve from an index",
     async () => {
       // The whole point of push-down is that the grant match happens IN the
       // scan. A rewrite to `EXISTS (SELECT 1 FROM unnest(t.visible_to) …)`
@@ -433,8 +579,8 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
       // `idx_brain_facts_visible_to` (GIN) only wins when the grant is the
       // selective half; on a query that also pins `workspace_id` the planner
       // will usually lead with a btree on workspace_id and apply the overlap
-      // as a filter — that is correct, and asserting an index NAME here would
-      // be asserting a cost estimate over a handful of test rows.
+      // as a filter — that is correct, and asserting an index NAME on the real
+      // shape would be asserting a cost estimate over a handful of test rows.
       const clause = aclVisibilityClause(ctx(), {
         table: "brain_facts",
         alias: "t",
@@ -445,12 +591,6 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         // `SET LOCAL` outside a transaction is a no-op that only warns, so the
         // BEGIN is load-bearing, not tidiness.
         await client.query("BEGIN");
-        // Set search_path explicitly rather than leaning on the pool's
-        // `connect` handler: that handler fires its SET without being awaited,
-        // so on a freshly-checked-out client it can still be in flight here —
-        // and an EXPLAIN that resolved against `public` would report on tables
-        // this test never created.
-        await client.query(`SET LOCAL search_path TO "${schemaName}"`);
         await client.query("SET LOCAL enable_seqscan = off");
         const { rows } = await client.query<{ "QUERY PLAN": string }>(
           `EXPLAIN SELECT t.id FROM brain_facts t WHERE ${clause.sql}`,
@@ -458,7 +598,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         );
         const plan = rows.map((r) => r["QUERY PLAN"]).join("\n");
         // The overlap survives into the plan verbatim, as a scan-level
-        // condition on the column.
+        // condition on the column…
         expect(plan).toMatch(/visible_to && /);
         // …and never as a subquery or a set-returning function, which is what
         // every non-pushed-down rewrite of this predicate looks like.
@@ -466,9 +606,11 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         expect(plan).not.toContain("unnest");
         expect(plan).not.toContain("Seq Scan");
 
-        // The GIN index IS reachable for the grant half on its own — proven by
-        // asking for exactly that half, which is the query shape #4773 issues
-        // once a workspace has more than a handful of facts.
+        // Separately: the migration's GIN index really is usable for `&&`.
+        // This bare-overlap query is a TEST-ONLY probe — `aclVisibilityClause`
+        // always carries workspace containment, so #4773 never issues this
+        // shape. Under `enable_seqscan = off` it proves only that the index
+        // and this predicate's operator agree, which is the durable claim.
         const ginPlan = await client.query<{ "QUERY PLAN": string }>(
           `EXPLAIN SELECT t.id FROM brain_facts t WHERE t.visible_to && $1::text[]`,
           [clause.params[1]],

--- a/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
@@ -108,7 +108,12 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
     const clause = aclVisibilityClause(reader, { table, alias: "t", paramIndex: 1, override });
     const label = table === "brain_facts" ? "subject" : "source_id";
     const { rows } = await pool.query<{ label: string }>(
-      `SELECT ${label} AS label FROM ${table} t WHERE ${clause.sql} ORDER BY 1`,
+      // `COLLATE "C"` so the DB's sort matches the JS `toSorted()` / hardcoded
+      // arrays these results are compared against. The labels are hyphenated,
+      // which is exactly where glibc's punctuation-ignoring collation diverges
+      // from byte order. It names the column rather than the `1` ordinal —
+      // `COLLATE` on an ordinal is a 42804.
+      `SELECT ${label} AS label FROM ${table} t WHERE ${clause.sql} ORDER BY t.${label} COLLATE "C"`,
       [...clause.params],
     );
     return rows.map((r) => r.label);
@@ -221,8 +226,8 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
     // `search_path` is baked into the connection string rather than SET from an
     // unawaited `pool.on("connect")` handler: server-side at startup, so there
     // is no window in which a checked-out client is still pointed at `public`,
-    // and no failure path that logs and then silently runs 180 migrations
-    // against the developer's real database. Same pattern as
+    // and no failure path that logs and then silently runs the whole migration
+    // set against the developer's real database. Same pattern as
     // `api/__tests__/admin-last-admin-pg.test.ts`.
     pool = new Pool({
       connectionString: TEST_DB_URL,
@@ -261,7 +266,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
       for (const reader of readersFor(WS)) {
         const fromSql = await selectVisible(reader.ctx, "brain_facts");
         const fromMirror = GRANTS.filter((g) =>
-          isVisibleTo({ workspaceId: WS, visibleTo: g.visibleTo }, reader.ctx),
+          isVisibleTo({ table: "brain_facts", workspaceId: WS, visibleTo: g.visibleTo }, reader.ctx),
         )
           .map((g) => g.label)
           .toSorted();
@@ -330,7 +335,10 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
       // The in-memory mirror must agree — an earlier cut took a bare grant and
       // answered TRUE here.
       expect(
-        isVisibleTo({ workspaceId: wsB, visibleTo: ["audience:engineering"] }, readerInA),
+        isVisibleTo(
+          { table: "brain_facts", workspaceId: wsB, visibleTo: ["audience:engineering"] },
+          readerInA,
+        ),
       ).toBe(false);
     },
     PG_TEST_TIMEOUT_MS,
@@ -357,8 +365,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         workspaceId: home,
         mode: "managed",
         userId: "user-1",
-        role: "member",
-        roleResolvedForOrgId: home,
+        resolvedRole: { role: "member", orgId: home },
       });
       expect(resolved.audienceIds).toEqual(["exec"]);
 
@@ -379,10 +386,11 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
   it(
     "keeps grants immutable per fact version — widening the current one does not widen a superseded one",
     async () => {
-      // ADR-0036: a read of "what we believed Monday" evaluates MONDAY's grant
-      // against as-of-now membership. That is why the grant is a column on the
-      // fact and not a join to a policy table — a policy table would
-      // retroactively rewrite who could see history.
+      // ADR-0036 §Access control: a read of "what we believed Monday"
+      // evaluates MONDAY's grant against as-of-now membership. Migration
+      // 0180's own rationale supplies the schema half — the grant is a COLUMN
+      // on the fact rather than a join to a policy table, because a policy
+      // table would retroactively rewrite who could see history.
       const wsV = `${WS}-versions`;
       const episode = await seedEpisode(wsV, "versioned", ["org"]);
       const v1 = await seedFact({
@@ -451,8 +459,7 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
         workspaceId: wsR,
         mode: "managed",
         userId: "user-1",
-        role: "member",
-        roleResolvedForOrgId: wsR,
+        resolvedRole: { role: "member", orgId: wsR },
       } as const;
       const before = await resolvePrincipalContext(pool, input);
       expect(before.audienceIds).toEqual(["exec"]);
@@ -501,39 +508,42 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
           WHERE f.workspace_id = $1
             AND f.status = 'published'
             AND ${clause.sql}
-          ORDER BY 1`,
+          ORDER BY f.subject COLLATE "C"`,
         [wsC, ...clause.params],
       );
       expect(composed.rows.map((r) => r.subject)).toEqual(["all-gates-pass"]);
 
-      // Each gate is load-bearing ON ITS OWN — drop one at a time and a
-      // different row reappears. Without these controls the composed query
-      // above would pass even if two of the three clauses were inert.
+      // Drop-one controls. The ACL and content-mode gates are each
+      // independently load-bearing: remove either and a row the composed query
+      // excluded comes back. The third clause — the caller's own
+      // `workspace_id = $1` reach stand-in — is REDUNDANT with the ACL
+      // clause's own containment, so dropping it changes nothing; the control
+      // below asserts that redundancy rather than a filter, which is the whole
+      // point of the predicate being safe standalone.
+      //
+      // ADR-0022 reach is connection-group scoped, not workspace scoped, so
+      // the real fourth gate lands with #4773's `resolveReachableGroups`;
+      // residency is invariant by construction and has no clause at all.
       const withoutAcl = await pool.query<{ subject: string }>(
         `SELECT f.subject FROM brain_facts f
-          WHERE f.workspace_id = $1 AND f.status = 'published' ORDER BY 1`,
+          WHERE f.workspace_id = $1 AND f.status = 'published' ORDER BY f.subject COLLATE "C"`,
         [wsC],
       );
       expect(withoutAcl.rows.map((r) => r.subject)).toEqual(["all-gates-pass", "fails-grant"]);
 
       const withoutMode = await pool.query<{ subject: string }>(
-        `SELECT f.subject FROM brain_facts f WHERE f.workspace_id = $1 AND ${clause.sql} ORDER BY 1`,
+        `SELECT f.subject FROM brain_facts f WHERE f.workspace_id = $1 AND ${clause.sql} ORDER BY f.subject COLLATE "C"`,
         [wsC, ...clause.params],
       );
       expect(withoutMode.rows.map((r) => r.subject)).toEqual(["all-gates-pass", "fails-mode"]);
 
-      // The reach gate is spelled `workspace_id = $1`, which the ACL clause
-      // already enforces — so dropping the caller's copy changes nothing here.
-      // That redundancy is the deliberate "safe standalone" property, and this
-      // asserts it rather than leaving the reader to wonder whether the gate
-      // was simply inert.
       const soloClause = aclVisibilityClause(reader, {
         table: "brain_facts",
         alias: "f",
         paramIndex: 1,
       });
       const withoutReach = await pool.query<{ subject: string }>(
-        `SELECT f.subject FROM brain_facts f WHERE f.status = 'published' AND ${soloClause.sql} ORDER BY 1`,
+        `SELECT f.subject FROM brain_facts f WHERE f.status = 'published' AND ${soloClause.sql} ORDER BY f.subject COLLATE "C"`,
         [...soloClause.params],
       );
       expect(withoutReach.rows.map((r) => r.subject)).toEqual(["all-gates-pass"]);

--- a/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
@@ -32,6 +32,7 @@ import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import {
+  USER_PREFIX,
   aclVisibilityClause,
   isVisibleTo,
   resolvePrincipalContext,
@@ -149,6 +150,15 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
     { label: "bare-prefix", visibleTo: ["user:", "audience:"] },
     // Case variants must NOT match — enforcement is byte-exact.
     { label: "shouty", visibleTo: ["ORG"] },
+    // Array-literal metacharacters. `visible_to` binds as a JS array through
+    // `$n::text[]`; if that serialization ever stopped quoting, `user:a,org`
+    // would split into `user:a` AND `org` — a token the reader never held,
+    // granting the workspace's entire public set. Fail-OPEN, and invisible to
+    // every assertion above. node-pg quotes correctly today; this pins it.
+    { label: "comma-token", visibleTo: [`${USER_PREFIX}user-1,org`] },
+    { label: "quote-token", visibleTo: [`${USER_PREFIX}q"uote`] },
+    { label: "backslash-token", visibleTo: [`${USER_PREFIX}back\\slash`] },
+    { label: "brace-token", visibleTo: [`${USER_PREFIX}{braced}`] },
   ];
 
   function readersFor(workspaceId: string): ReadonlyArray<{
@@ -210,6 +220,20 @@ describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
           audienceIds: [],
         },
         expected: ["org-wide", "padded"],
+      },
+      {
+        name: "metacharacter user",
+        // Holds the comma-bearing id verbatim. It must match `comma-token`
+        // and NOTHING else — in particular not `org-wide`, which is what a
+        // split-on-comma serialization bug would hand it.
+        ctx: {
+          ...base,
+          origin: "authenticated",
+          userId: "user-1,org",
+          role: null,
+          audienceIds: [],
+        },
+        expected: ["comma-token", "org-wide", "padded"],
       },
       {
         name: "unresolved",

--- a/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl-visibility-pg.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Real-Postgres coverage for the brain ACL's push-down visibility predicate
+ * (#4768, ADR-0036 §Access control).
+ *
+ * `acl.test.ts` pins the DECISIONS — which branch fires, what SQL text comes
+ * out. This file pins what that SQL actually SELECTS, which is a different
+ * claim and the one that matters: a predicate can be textually perfect and
+ * still return the wrong rows because `&&` does not mean what the author
+ * assumed about NULL elements, or because a grant token collides across
+ * tenants, or because `visible_to` was compared with `@>` instead.
+ *
+ * What only real Postgres can catch here:
+ *   - `isVisibleTo` / `&&` PARITY. The in-memory mirror is what the review
+ *     surface and every other test reasons with; if it and the SQL disagree
+ *     about one token shape, every downstream assertion is testing a fiction.
+ *   - NULL and `''` elements inside a stored grant. Migration 0180's CHECK
+ *     tolerates them (it requires one USABLE principal, not that all are), so
+ *     they reach the predicate — and `ARRAY[''] && ARRAY['']` is TRUE.
+ *   - Cross-tenant audience collision. Audience ids are workspace-scoped and
+ *     not globally unique; two tenants minting `engineering` is normal.
+ *   - That the predicate stays INDEXABLE against the GIN index the migration
+ *     created for it. A rewrite to `EXISTS (SELECT … unnest(visible_to))`
+ *     would pass every row-level assertion and quietly become a seq scan.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5433/atlas_dev
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import {
+  aclVisibilityClause,
+  isVisibleTo,
+  resolvePrincipalContext,
+  type AclGatedTable,
+  type BrainPrincipalContext,
+} from "@atlas/api/lib/brain/acl";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const WS = "ws-acl-pg";
+const OTHER_WS = "ws-acl-pg-other";
+
+function ctx(partial: Partial<BrainPrincipalContext> = {}): BrainPrincipalContext {
+  return {
+    workspaceId: WS,
+    userId: "user-1",
+    role: "member",
+    audienceIds: [],
+    origin: "authenticated",
+    ...partial,
+  };
+}
+
+describeIfPg("brain ACL visibility predicate (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `brain_acl_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  /** Insert an episode and return its id. Facts FK onto `(workspace_id, id)`. */
+  async function seedEpisode(
+    workspaceId: string,
+    sourceId: string,
+    visibleTo: readonly (string | null)[],
+  ): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_episodes (workspace_id, source, source_id, body, visible_to)
+       VALUES ($1, 'test', $2, 'evidence', $3::text[])
+       RETURNING id`,
+      [workspaceId, sourceId, visibleTo],
+    );
+    return rows[0]!.id;
+  }
+
+  /** Insert a fact hanging off `episodeId`. Returns its id. */
+  async function seedFact(opts: {
+    workspaceId: string;
+    episodeId: string;
+    subject: string;
+    visibleTo: readonly (string | null)[];
+    status?: "draft" | "published" | "archived";
+  }): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO brain_facts
+         (workspace_id, subject, predicate, object, source_episode_id, provenance, status, visible_to)
+       VALUES ($1, $2, 'is', 'thing', $3, '{"actor":"test"}'::jsonb, $4, $5::text[])
+       RETURNING id`,
+      [opts.workspaceId, opts.subject, opts.episodeId, opts.status ?? "published", opts.visibleTo],
+    );
+    return rows[0]!.id;
+  }
+
+  /**
+   * Run the predicate standalone over one table and return the matching
+   * subjects (facts) or source ids (episodes), sorted.
+   */
+  async function selectVisible(
+    reader: BrainPrincipalContext,
+    table: AclGatedTable,
+    override?: { reason: string },
+  ): Promise<string[]> {
+    const clause = aclVisibilityClause(reader, { table, alias: "t", paramIndex: 1, override });
+    const label = table === "brain_facts" ? "subject" : "source_id";
+    const { rows } = await pool.query<{ label: string }>(
+      `SELECT ${label} AS label FROM ${table} t WHERE ${clause.sql} ORDER BY 1`,
+      [...clause.params],
+    );
+    return rows.map((r) => r.label);
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        console.error(
+          `acl-visibility-pg: SET search_path failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it(
+    "selects exactly the rows `isVisibleTo` predicts, for every grant × reader pair",
+    async () => {
+      // The parity matrix. Every grant here is legal at rest under
+      // `chk_brain_facts_grant_nonempty` — including the ones that grant
+      // nobody anything, which is the half a stricter parser would have made
+      // unrepresentable and therefore untested.
+      const grants: ReadonlyArray<{ subject: string; visibleTo: (string | null)[] }> = [
+        { subject: "org-wide", visibleTo: ["org"] },
+        { subject: "members", visibleTo: ["role:member"] },
+        { subject: "admins", visibleTo: ["role:admin"] },
+        { subject: "owners", visibleTo: ["role:owner"] },
+        { subject: "u1-only", visibleTo: ["user:user-1"] },
+        { subject: "u2-only", visibleTo: ["user:user-2"] },
+        { subject: "aud-eng", visibleTo: ["audience:eng"] },
+        { subject: "aud-exec", visibleTo: ["audience:exec"] },
+        { subject: "mixed", visibleTo: ["user:user-2", "audience:eng"] },
+        // Malformed-but-legal: `everyone` reads as public and grants nobody.
+        { subject: "malformed", visibleTo: ["everyone"] },
+        // A valid token beside a malformed one — passes on the valid half only.
+        { subject: "half-malformed", visibleTo: ["everyone", "user:user-1"] },
+        // NULL / '' elements alongside one usable principal. The CHECK admits
+        // this; `ARRAY[''] && ARRAY['']` is TRUE, so an empty reader token
+        // would match here. `principalTokens` never emits one.
+        { subject: "padded", visibleTo: ["org", null, ""] },
+        { subject: "empty-only-plus-user", visibleTo: ["", "user:user-2"] },
+        // Case variants must NOT match — enforcement is byte-exact.
+        { subject: "shouty", visibleTo: ["ORG"] },
+      ];
+
+      const episode = await seedEpisode(WS, "parity", ["org"]);
+      for (const g of grants) {
+        await seedFact({
+          workspaceId: WS,
+          episodeId: episode,
+          subject: g.subject,
+          visibleTo: g.visibleTo,
+        });
+      }
+
+      const readers: ReadonlyArray<{ name: string; ctx: BrainPrincipalContext }> = [
+        { name: "member/no-audience", ctx: ctx({ role: "member" }) },
+        { name: "admin", ctx: ctx({ role: "admin" }) },
+        { name: "owner", ctx: ctx({ role: "owner" }) },
+        { name: "member in eng", ctx: ctx({ role: "member", audienceIds: ["eng"] }) },
+        { name: "other user", ctx: ctx({ role: "member", userId: "user-9" }) },
+        { name: "auth:none local", ctx: ctx({ role: null, userId: null, origin: "unauthenticated-local" }) },
+      ];
+
+      for (const reader of readers) {
+        const fromSql = await selectVisible(reader.ctx, "brain_facts");
+        const fromMirror = grants
+          .filter((g) => isVisibleTo(g.visibleTo, reader.ctx))
+          .map((g) => g.subject)
+          .toSorted();
+        expect({ reader: reader.name, rows: fromSql }).toEqual({
+          reader: reader.name,
+          rows: fromMirror,
+        });
+      }
+
+      // Spot-check the absolute claims the matrix is supposed to encode, so a
+      // mirror that broke in the SAME way as the SQL still fails here.
+      expect(await selectVisible(ctx({ role: "member" }), "brain_facts")).toEqual([
+        "half-malformed",
+        "members",
+        "org-wide",
+        "padded",
+        "u1-only",
+      ]);
+      expect(await selectVisible(ctx({ role: "owner" }), "brain_facts")).toContain("admins");
+      expect(await selectVisible(ctx({ role: "member" }), "brain_facts")).not.toContain(
+        "malformed",
+      );
+      expect(await selectVisible(ctx({ role: "member" }), "brain_facts")).not.toContain("shouty");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "gates tier-3 episodes on the same grammar — raw source is often more sensitive than the facts",
+    async () => {
+      await seedEpisode(OTHER_WS, "ep-org", ["org"]);
+      await seedEpisode(OTHER_WS, "ep-exec", ["audience:exec"]);
+      await seedEpisode(OTHER_WS, "ep-u2", ["user:user-2"]);
+
+      const reader = ctx({ workspaceId: OTHER_WS, role: "member" });
+      expect(await selectVisible(reader, "brain_episodes")).toEqual(["ep-org"]);
+      expect(
+        await selectVisible(
+          ctx({ workspaceId: OTHER_WS, role: "member", audienceIds: ["exec"] }),
+          "brain_episodes",
+        ),
+      ).toEqual(["ep-exec", "ep-org"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "never matches another tenant's grant, even on an identically-named audience",
+    async () => {
+      // Audience ids are workspace-scoped identities with no global
+      // uniqueness. Two tenants both minting `engineering` is normal, and it
+      // is precisely why the predicate carries its own workspace containment
+      // rather than trusting the caller's.
+      const wsA = `${WS}-tenant-a`;
+      const wsB = `${WS}-tenant-b`;
+      const epA = await seedEpisode(wsA, "collide-a", ["org"]);
+      const epB = await seedEpisode(wsB, "collide-b", ["org"]);
+      await seedFact({
+        workspaceId: wsA,
+        episodeId: epA,
+        subject: "a-secret",
+        visibleTo: ["audience:engineering"],
+      });
+      await seedFact({
+        workspaceId: wsB,
+        episodeId: epB,
+        subject: "b-secret",
+        visibleTo: ["audience:engineering"],
+      });
+
+      const readerInA = ctx({ workspaceId: wsA, audienceIds: ["engineering"] });
+      expect(await selectVisible(readerInA, "brain_facts")).toEqual(["a-secret"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps grants immutable per fact version — widening the current one does not widen a superseded one",
+    async () => {
+      // ADR-0036: a read of "what we believed Monday" evaluates MONDAY's grant
+      // against as-of-now membership. That is why the grant is a column on the
+      // fact and not a join to a policy table — a policy table would
+      // retroactively rewrite who could see history.
+      const wsV = `${WS}-versions`;
+      const episode = await seedEpisode(wsV, "versioned", ["org"]);
+      const v1 = await seedFact({
+        workspaceId: wsV,
+        episodeId: episode,
+        subject: "v1-narrow",
+        visibleTo: ["audience:exec"],
+      });
+      const v2 = await seedFact({
+        workspaceId: wsV,
+        episodeId: episode,
+        subject: "v2-wide",
+        visibleTo: ["org"],
+      });
+      await pool.query(
+        `INSERT INTO brain_edges (workspace_id, edge_type, from_fact_id, to_fact_id)
+         VALUES ($1, 'supersedes', $2, $3)`,
+        [wsV, v2, v1],
+      );
+
+      // A plain member sees only the widened CURRENT version. The superseded
+      // one keeps its own narrower grant — supersession is not deletion, and
+      // it is not declassification either.
+      const member = ctx({ workspaceId: wsV, role: "member" });
+      expect(await selectVisible(member, "brain_facts")).toEqual(["v2-wide"]);
+
+      // And the exec still sees both, as-of-now membership against each
+      // version's own frozen grant.
+      const exec = ctx({ workspaceId: wsV, role: "member", audienceIds: ["exec"] });
+      expect(await selectVisible(exec, "brain_facts")).toEqual(["v1-narrow", "v2-wide"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "revokes live through audience membership without touching the stored grant",
+    async () => {
+      // The accepted cost of derive-at-ingest grants is that source membership
+      // changes don't propagate to already-ingested facts. `fact_audience_member`
+      // is the escape hatch — and it must be a LOCAL set-membership read, with
+      // no connector call at read time.
+      const wsR = `${WS}-revoke`;
+      const episode = await seedEpisode(wsR, "revoke", ["org"]);
+      await seedFact({
+        workspaceId: wsR,
+        episodeId: episode,
+        subject: "exec-only",
+        visibleTo: ["audience:exec"],
+      });
+      await pool.query(
+        `INSERT INTO fact_audience_member (workspace_id, audience_id, user_id, source)
+         VALUES ($1, 'exec', 'user-1', 'test')`,
+        [wsR],
+      );
+
+      const before = await resolvePrincipalContext(pool, {
+        workspaceId: wsR,
+        mode: "managed",
+        userId: "user-1",
+        role: "member",
+      });
+      expect(before.audienceIds).toEqual(["exec"]);
+      expect(await selectVisible(before, "brain_facts")).toEqual(["exec-only"]);
+
+      await pool.query(
+        `DELETE FROM fact_audience_member WHERE workspace_id = $1 AND user_id = 'user-1'`,
+        [wsR],
+      );
+      const after = await resolvePrincipalContext(pool, {
+        workspaceId: wsR,
+        mode: "managed",
+        userId: "user-1",
+        role: "member",
+      });
+      // The fact's `visible_to` never changed. Only membership did.
+      expect(await selectVisible(after, "brain_facts")).toEqual([]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "composes as one of four AND-ed gates — failing any one hides the row",
+    async () => {
+      // ADR-0036: residency-invariant (by construction — the process IS the
+      // region) AND org/group reach AND content mode AND the grant. The status
+      // clause is written literally here because `brain_facts` joins the
+      // content-mode registry in #4769; when it does, this becomes
+      // `resolveStatusClause("brain_facts", mode, "f")` and must keep meaning
+      // exactly this.
+      const wsC = `${WS}-compose`;
+      const otherC = `${WS}-compose-other`;
+      const epC = await seedEpisode(wsC, "compose", ["org"]);
+      const epOther = await seedEpisode(otherC, "compose-other", ["org"]);
+
+      await seedFact({ workspaceId: wsC, episodeId: epC, subject: "all-gates-pass", visibleTo: ["org"] });
+      await seedFact({ workspaceId: wsC, episodeId: epC, subject: "fails-mode", visibleTo: ["org"], status: "draft" });
+      await seedFact({ workspaceId: wsC, episodeId: epC, subject: "fails-grant", visibleTo: ["audience:exec"] });
+      await seedFact({ workspaceId: otherC, episodeId: epOther, subject: "fails-reach", visibleTo: ["org"] });
+
+      const reader = ctx({ workspaceId: wsC, role: "member" });
+      // The caller's own reach param is $1; the ACL clause starts after it.
+      const clause = aclVisibilityClause(reader, {
+        table: "brain_facts",
+        alias: "f",
+        paramIndex: 2,
+      });
+      const { rows } = await pool.query<{ subject: string }>(
+        `SELECT f.subject
+           FROM brain_facts f
+          WHERE f.workspace_id = $1
+            AND f.status = 'published'
+            AND ${clause.sql}
+          ORDER BY 1`,
+        [wsC, ...clause.params],
+      );
+      expect(rows.map((r) => r.subject)).toEqual(["all-gates-pass"]);
+
+      // And each gate is load-bearing on its own: drop the ACL clause and the
+      // grant-gated row reappears, which is what makes this a real AND rather
+      // than three clauses one of which happens to be redundant.
+      const withoutAcl = await pool.query<{ subject: string }>(
+        `SELECT f.subject FROM brain_facts f
+          WHERE f.workspace_id = $1 AND f.status = 'published' ORDER BY 1`,
+        [wsC],
+      );
+      expect(withoutAcl.rows.map((r) => r.subject)).toEqual(["all-gates-pass", "fails-grant"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "audit override returns the whole workspace and nothing outside it",
+    async () => {
+      const wsO = `${WS}-override`;
+      const outside = `${WS}-override-outside`;
+      const epO = await seedEpisode(wsO, "ovr", ["org"]);
+      const epOut = await seedEpisode(outside, "ovr-out", ["org"]);
+      await seedFact({ workspaceId: wsO, episodeId: epO, subject: "o-public", visibleTo: ["org"] });
+      await seedFact({ workspaceId: wsO, episodeId: epO, subject: "o-secret", visibleTo: ["audience:exec"] });
+      await seedFact({ workspaceId: outside, episodeId: epOut, subject: "not-mine", visibleTo: ["org"] });
+
+      const admin = ctx({ workspaceId: wsO, role: "admin" });
+      expect(await selectVisible(admin, "brain_facts")).toEqual(["o-public"]);
+      expect(await selectVisible(admin, "brain_facts", { reason: "audit" })).toEqual([
+        "o-public",
+        "o-secret",
+      ]);
+
+      // Region scoping is by construction (the process IS the region, ADR-0024)
+      // — but workspace scoping is not, and the override must still respect it.
+      const member = ctx({ workspaceId: wsO, role: "member" });
+      expect(await selectVisible(member, "brain_facts", { reason: "nope" })).toEqual(["o-public"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps the grant match a pushed-down array-overlap the planner can serve from an index",
+    async () => {
+      // The whole point of push-down is that the grant match happens IN the
+      // scan. A rewrite to `EXISTS (SELECT 1 FROM unnest(t.visible_to) …)`
+      // would pass every row-level assertion above and silently turn the ACL
+      // into a per-row subplan on a table that grows without bound.
+      //
+      // What is asserted is the SHAPE, not which index the planner picks.
+      // `idx_brain_facts_visible_to` (GIN) only wins when the grant is the
+      // selective half; on a query that also pins `workspace_id` the planner
+      // will usually lead with a btree on workspace_id and apply the overlap
+      // as a filter — that is correct, and asserting an index NAME here would
+      // be asserting a cost estimate over a handful of test rows.
+      const clause = aclVisibilityClause(ctx(), {
+        table: "brain_facts",
+        alias: "t",
+        paramIndex: 1,
+      });
+      const client = await pool.connect();
+      try {
+        // `SET LOCAL` outside a transaction is a no-op that only warns, so the
+        // BEGIN is load-bearing, not tidiness.
+        await client.query("BEGIN");
+        // Set search_path explicitly rather than leaning on the pool's
+        // `connect` handler: that handler fires its SET without being awaited,
+        // so on a freshly-checked-out client it can still be in flight here —
+        // and an EXPLAIN that resolved against `public` would report on tables
+        // this test never created.
+        await client.query(`SET LOCAL search_path TO "${schemaName}"`);
+        await client.query("SET LOCAL enable_seqscan = off");
+        const { rows } = await client.query<{ "QUERY PLAN": string }>(
+          `EXPLAIN SELECT t.id FROM brain_facts t WHERE ${clause.sql}`,
+          [...clause.params],
+        );
+        const plan = rows.map((r) => r["QUERY PLAN"]).join("\n");
+        // The overlap survives into the plan verbatim, as a scan-level
+        // condition on the column.
+        expect(plan).toMatch(/visible_to && /);
+        // …and never as a subquery or a set-returning function, which is what
+        // every non-pushed-down rewrite of this predicate looks like.
+        expect(plan).not.toContain("SubPlan");
+        expect(plan).not.toContain("unnest");
+        expect(plan).not.toContain("Seq Scan");
+
+        // The GIN index IS reachable for the grant half on its own — proven by
+        // asking for exactly that half, which is the query shape #4773 issues
+        // once a workspace has more than a handful of facts.
+        const ginPlan = await client.query<{ "QUERY PLAN": string }>(
+          `EXPLAIN SELECT t.id FROM brain_facts t WHERE t.visible_to && $1::text[]`,
+          [clause.params[1]],
+        );
+        expect(ginPlan.rows.map((r) => r["QUERY PLAN"]).join("\n")).toContain(
+          "idx_brain_facts_visible_to",
+        );
+      } finally {
+        await client.query("ROLLBACK").catch((err) => {
+          console.error(
+            `acl-visibility-pg: ROLLBACK failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+        client.release();
+      }
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/brain/__tests__/acl.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Unit coverage for the brain ACL grammar, principal resolution, and the
+ * fail-closed push-down predicate (#4768, ADR-0036 §Access control).
+ *
+ * The real-Postgres half — that the emitted SQL actually selects the rows this
+ * file says it should, and that `isVisibleTo` agrees with `&&` token for token
+ * — lives in `acl-visibility-pg.test.ts`. Both halves are load-bearing: this
+ * one pins the DECISIONS, that one pins the SQL, and a bug in either shows up
+ * as a row the wrong person can read.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  ACL_GATED_TABLES,
+  AUDIENCE_PREFIX,
+  ORG_PRINCIPAL,
+  ROLE_PREFIX,
+  USER_PREFIX,
+  aclVisibilityClause,
+  formatPrincipal,
+  impliedRoles,
+  isVisibleTo,
+  logGrantAnomalies,
+  parseGrant,
+  parsePrincipal,
+  principalTokens,
+  resolvePrincipalContext,
+  type AudienceMembershipReader,
+  type BrainPrincipalContext,
+} from "@atlas/api/lib/brain/acl";
+
+const WS = "ws-acl-test";
+
+function ctx(partial: Partial<BrainPrincipalContext> = {}): BrainPrincipalContext {
+  return {
+    workspaceId: WS,
+    userId: "user-1",
+    role: "member",
+    audienceIds: [],
+    origin: "authenticated",
+    ...partial,
+  };
+}
+
+describe("grant grammar (#4768)", () => {
+  it("parses each arm of `org | role:… | user:… | audience:…`", () => {
+    expect(parsePrincipal("org")).toEqual({ kind: "org" });
+    expect(parsePrincipal("role:owner")).toEqual({ kind: "role", role: "owner" });
+    expect(parsePrincipal("role:admin")).toEqual({ kind: "role", role: "admin" });
+    expect(parsePrincipal("role:member")).toEqual({ kind: "role", role: "member" });
+    expect(parsePrincipal("user:abc123")).toEqual({ kind: "user", userId: "abc123" });
+    expect(parsePrincipal("audience:eng-leads")).toEqual({
+      kind: "audience",
+      audienceId: "eng-leads",
+    });
+  });
+
+  it("round-trips every parsed principal back to its stored token", () => {
+    for (const token of ["org", "role:owner", "user:u-1", "audience:a-1"]) {
+      const parsed = parsePrincipal(token);
+      expect(parsed).not.toBeNull();
+      expect(formatPrincipal(parsed!)).toBe(token);
+    }
+  });
+
+  it("rejects tokens outside the grammar without throwing", () => {
+    // `everyone` is THE canonical malformed grant: it reads as public and
+    // grants nobody. ADR-0036 requires an explicit `org` instead.
+    expect(parsePrincipal("everyone")).toBeNull();
+    expect(parsePrincipal("team:eng")).toBeNull();
+    expect(parsePrincipal("")).toBeNull();
+    expect(parsePrincipal("role:")).toBeNull();
+    expect(parsePrincipal("user:")).toBeNull();
+    expect(parsePrincipal("audience:")).toBeNull();
+  });
+
+  it("refuses `role:platform_admin` — a platform role is not an org grant", () => {
+    expect(parsePrincipal("role:platform_admin")).toBeNull();
+  });
+
+  it("is byte-exact: no case folding, no trimming", () => {
+    // Enforcement is Postgres's `&&`, which is byte-exact. A parser that
+    // helpfully normalised here would disagree with the SQL about the same
+    // row — and `isVisibleTo` exists to be trusted about what the SQL does.
+    expect(parsePrincipal("ORG")).toBeNull();
+    expect(parsePrincipal("Org")).toBeNull();
+    expect(parsePrincipal(" org")).toBeNull();
+    expect(parsePrincipal("org ")).toBeNull();
+    expect(parsePrincipal("ROLE:admin")).toBeNull();
+  });
+
+  it("accepts any non-empty id — never stricter than the 0180 CHECK", () => {
+    // Better Auth ids and source-derived audience ids have no shape this
+    // module may assume. A stricter pattern would make a workspace Postgres
+    // legally stores impossible to migrate between regions.
+    for (const id of ["u", "a-b_c.d", "01HZY9", "user:with:colons", "  spaced  ", "🙂"]) {
+      expect(parsePrincipal(`${USER_PREFIX}${id}`)).toEqual({ kind: "user", userId: id });
+      expect(parsePrincipal(`${AUDIENCE_PREFIX}${id}`)).toEqual({
+        kind: "audience",
+        audienceId: id,
+      });
+    }
+  });
+});
+
+describe("parseGrant (#4768)", () => {
+  it("splits usable principals from malformed tokens", () => {
+    const parsed = parseGrant(["org", "everyone", "user:u1", "role:nope"]);
+    expect(parsed.principals).toEqual([{ kind: "org" }, { kind: "user", userId: "u1" }]);
+    expect(parsed.malformed).toEqual(["everyone", "role:nope"]);
+  });
+
+  it("reports NULL and '' elements as malformed rather than dropping them", () => {
+    // Both are legal at rest: `chk_brain_facts_grant_nonempty` requires ONE
+    // usable principal, not that every element is usable. So a grant can
+    // arrive off `pg` with a null in it and must still parse.
+    const parsed = parseGrant(["org", null, "", undefined]);
+    expect(parsed.principals).toEqual([{ kind: "org" }]);
+    expect(parsed.malformed).toEqual(["", "", ""]);
+  });
+
+  it("never throws on an entirely malformed grant — the deny is the result", () => {
+    const parsed = parseGrant(["everyone", "public", ""]);
+    expect(parsed.principals).toEqual([]);
+    expect(parsed.malformed).toHaveLength(3);
+  });
+
+  it("logGrantAnomalies returns the parse and is a no-op on a clean grant", () => {
+    const clean = logGrantAnomalies(["org"], {
+      table: "brain_facts",
+      rowId: "f1",
+      workspaceId: WS,
+    });
+    expect(clean.malformed).toEqual([]);
+    const dirty = logGrantAnomalies(["user:u1", "everyone"], {
+      table: "brain_facts",
+      rowId: "f2",
+      workspaceId: WS,
+    });
+    // The case that actually bites: a grant that PASSES the predicate on its
+    // valid token while carrying a second one the author thought did something.
+    expect(dirty.principals).toHaveLength(1);
+    expect(dirty.malformed).toEqual(["everyone"]);
+  });
+});
+
+describe("principal tokens (#4768)", () => {
+  it("always seeds `org`", () => {
+    expect(principalTokens(ctx({ role: null, userId: null }))).toEqual([ORG_PRINCIPAL]);
+  });
+
+  it("expands roles monotonically: owner ⊇ admin ⊇ member", () => {
+    expect(impliedRoles("owner")).toEqual(["owner", "admin", "member"]);
+    expect(impliedRoles("admin")).toEqual(["admin", "member"]);
+    expect(impliedRoles("member")).toEqual(["member"]);
+    expect(principalTokens(ctx({ role: "owner" }))).toEqual([
+      ORG_PRINCIPAL,
+      `${ROLE_PREFIX}owner`,
+      `${ROLE_PREFIX}admin`,
+      `${ROLE_PREFIX}member`,
+      `${USER_PREFIX}user-1`,
+    ]);
+  });
+
+  it("lets an owner read a `role:member` fact", () => {
+    // Exact-match role grants would hide member-scoped facts from the
+    // workspace OWNER — a hole that reads as a bug every time it is hit.
+    expect(isVisibleTo(["role:member"], ctx({ role: "owner" }))).toBe(true);
+    expect(isVisibleTo(["role:admin"], ctx({ role: "owner" }))).toBe(true);
+  });
+
+  it("does not let a member read a `role:admin` fact", () => {
+    expect(isVisibleTo(["role:admin"], ctx({ role: "member" }))).toBe(false);
+    expect(isVisibleTo(["role:owner"], ctx({ role: "member" }))).toBe(false);
+  });
+
+  it("prefixes audience ids, which are stored unprefixed", () => {
+    const tokens = principalTokens(ctx({ audienceIds: ["eng", "exec"] }));
+    expect(tokens).toContain(`${AUDIENCE_PREFIX}eng`);
+    expect(tokens).toContain(`${AUDIENCE_PREFIX}exec`);
+    // The bare id must never be a token — it would match a stored `eng`, which
+    // is a malformed grant, not an audience grant.
+    expect(tokens).not.toContain("eng");
+  });
+
+  it("never emits an empty-string token", () => {
+    // `ARRAY[''] && ARRAY['']` is TRUE in Postgres, and a stored `''` element
+    // is legal at rest — so an empty reader token would match a grant that
+    // grants nobody anything.
+    const tokens = principalTokens(ctx({ userId: "", audienceIds: ["", "ok"] }));
+    expect(tokens).not.toContain("");
+    expect(tokens).not.toContain(USER_PREFIX);
+    expect(tokens).not.toContain(AUDIENCE_PREFIX);
+    expect(tokens).toContain(`${AUDIENCE_PREFIX}ok`);
+  });
+
+  it("matches user grants only for the named user", () => {
+    expect(isVisibleTo(["user:user-1"], ctx({ userId: "user-1" }))).toBe(true);
+    expect(isVisibleTo(["user:user-2"], ctx({ userId: "user-1" }))).toBe(false);
+  });
+
+  it("treats malformed stored tokens as granting nobody", () => {
+    for (const grant of [["everyone"], ["public"], ["ORG"], [""], [null]]) {
+      expect(isVisibleTo(grant, ctx({ role: "owner", audienceIds: ["eng"] }))).toBe(false);
+    }
+  });
+});
+
+describe("resolvePrincipalContext (#4768)", () => {
+  function reader(rows: unknown[], onQuery?: (sql: string, params?: unknown[]) => void) {
+    return {
+      query: async (sql: string, params?: unknown[]) => {
+        onQuery?.(sql, params);
+        return { rows };
+      },
+    } satisfies AudienceMembershipReader;
+  }
+
+  it("reads audience membership locally, scoped to workspace + user", async () => {
+    let seen: unknown[] | undefined;
+    const resolved = await resolvePrincipalContext(
+      reader([{ audience_id: "eng" }, { audience_id: "exec" }], (_sql, params) => {
+        seen = params;
+      }),
+      { workspaceId: WS, mode: "managed", userId: "user-1", role: "member" },
+    );
+    expect(seen).toEqual([WS, "user-1"]);
+    expect(resolved.audienceIds).toEqual(["eng", "exec"]);
+    expect(resolved.origin).toBe("authenticated");
+  });
+
+  it("drops non-string / empty audience ids rather than minting a bare prefix", async () => {
+    const resolved = await resolvePrincipalContext(
+      reader([{ audience_id: "eng" }, { audience_id: null }, { audience_id: "" }, {}]),
+      { workspaceId: WS, mode: "managed", userId: "user-1", role: "member" },
+    );
+    expect(resolved.audienceIds).toEqual(["eng"]);
+  });
+
+  it("gives `auth: none` the org principal ONLY, without touching the DB", async () => {
+    let queried = false;
+    const resolved = await resolvePrincipalContext(
+      reader([], () => {
+        queried = true;
+      }),
+      { workspaceId: WS, mode: "none", userId: undefined, role: undefined },
+    );
+    expect(queried).toBe(false);
+    expect(resolved.origin).toBe("unauthenticated-local");
+    expect(principalTokens(resolved)).toEqual([ORG_PRINCIPAL]);
+    // Narrowed content stays hidden even from the local operator.
+    expect(isVisibleTo(["role:owner"], resolved)).toBe(false);
+    expect(isVisibleTo(["audience:eng"], resolved)).toBe(false);
+    expect(isVisibleTo(["org"], resolved)).toBe(true);
+  });
+
+  it("maps a bare platform_admin to no org-role principal", async () => {
+    const resolved = await resolvePrincipalContext(reader([]), {
+      workspaceId: WS,
+      mode: "managed",
+      userId: "op-1",
+      role: "platform_admin",
+    });
+    expect(resolved.role).toBeNull();
+    expect(principalTokens(resolved)).toEqual([ORG_PRINCIPAL, `${USER_PREFIX}op-1`]);
+    expect(isVisibleTo(["role:admin"], resolved)).toBe(false);
+  });
+
+  it("resolves `unresolved` when an authenticated request carries no user id", async () => {
+    const resolved = await resolvePrincipalContext(reader([]), {
+      workspaceId: WS,
+      mode: "managed",
+      userId: undefined,
+      role: "admin",
+    });
+    expect(resolved.origin).toBe("unresolved");
+  });
+
+  it("propagates database failures instead of silently downgrading the reader", async () => {
+    // Swallowing this would report success while quietly stripping every
+    // audience grant from an authorization decision.
+    const failing: AudienceMembershipReader = {
+      query: () => Promise.reject(new Error("connection terminated")),
+    };
+    await expect(
+      resolvePrincipalContext(failing, {
+        workspaceId: WS,
+        mode: "managed",
+        userId: "user-1",
+        role: "member",
+      }),
+    ).rejects.toThrow("connection terminated");
+  });
+});
+
+describe("aclVisibilityClause (#4768)", () => {
+  it("emits workspace containment AND grant overlap, in that param order", () => {
+    const clause = aclVisibilityClause(ctx({ audienceIds: ["eng"] }), {
+      table: "brain_facts",
+      alias: "f",
+      paramIndex: 3,
+    });
+    expect(clause.decision).toBe("grant-match");
+    expect(clause.sql).toBe("(f.workspace_id = $3 AND f.visible_to && $4::text[])");
+    expect(clause.params).toEqual([
+      WS,
+      ["org", "role:member", "user:user-1", "audience:eng"],
+    ]);
+  });
+
+  it("scopes to the workspace even though callers already do — audience ids collide across tenants", () => {
+    // Two tenants can both mint `audience:engineering`. Without the redundant
+    // containment, a reader in tenant A holding that token would match tenant
+    // B's fact if the caller's own scoping were missing or accidentally OR-ed.
+    const clause = aclVisibilityClause(ctx(), { table: "brain_episodes", paramIndex: 1 });
+    expect(clause.sql).toContain("brain_episodes.workspace_id = $1");
+  });
+
+  it("defaults the alias to the table name", () => {
+    const clause = aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 });
+    expect(clause.sql).toBe(
+      "(brain_facts.workspace_id = $1 AND brain_facts.visible_to && $2::text[])",
+    );
+  });
+
+  it("gates both tier-2 and tier-3 tables", () => {
+    for (const table of ACL_GATED_TABLES) {
+      const clause = aclVisibilityClause(ctx(), { table, paramIndex: 1 });
+      expect(clause.sql).toContain(`${table}.visible_to && $2::text[]`);
+    }
+  });
+
+  it("denies outright when the reader is unresolved", () => {
+    const clause = aclVisibilityClause(ctx({ origin: "unresolved" }), {
+      table: "brain_facts",
+      paramIndex: 1,
+    });
+    expect(clause.decision).toBe("deny-all");
+    expect(clause.sql).toBe("FALSE");
+    expect(clause.params).toEqual([]);
+  });
+
+  it("denies outright when there is no workspace", () => {
+    const clause = aclVisibilityClause(ctx({ workspaceId: "" }), {
+      table: "brain_facts",
+      paramIndex: 1,
+    });
+    expect(clause.decision).toBe("deny-all");
+    expect(clause.sql).toBe("FALSE");
+  });
+
+  it("rejects a non-identifier alias rather than interpolating it", () => {
+    expect(() =>
+      aclVisibilityClause(ctx(), { table: "brain_facts", alias: "f; DROP TABLE x --", paramIndex: 1 }),
+    ).toThrow(/plain SQL identifier/);
+    expect(() =>
+      aclVisibilityClause(ctx(), { table: "brain_facts", alias: "", paramIndex: 1 }),
+    ).toThrow(/plain SQL identifier/);
+  });
+
+  it("rejects a non-positive-integer paramIndex rather than emitting `$0`", () => {
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      expect(() =>
+        aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: bad }),
+      ).toThrow(/positive integer/);
+    }
+  });
+
+  it("declares its own arity — callers advance by params.length, never a constant", () => {
+    const deny = aclVisibilityClause(ctx({ origin: "unresolved" }), {
+      table: "brain_facts",
+      paramIndex: 1,
+    });
+    const normal = aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 });
+    const override = aclVisibilityClause(ctx({ role: "admin" }), {
+      table: "brain_facts",
+      paramIndex: 1,
+      override: { reason: "audit" },
+    });
+    expect(deny.params).toHaveLength(0);
+    expect(normal.params).toHaveLength(2);
+    expect(override.params).toHaveLength(1);
+    // Every emitted placeholder must be backed by a supplied param — Postgres
+    // rejects a bind that supplies more than the statement references.
+    for (const clause of [deny, normal, override]) {
+      const placeholders = new Set([...clause.sql.matchAll(/\$(\d+)/g)].map((m) => m[1]));
+      expect(placeholders.size).toBe(clause.params.length);
+    }
+  });
+});
+
+describe("audit override (#4768, ADR-0036 — region-scoped, no super-admin)", () => {
+  it("bypasses grants for a workspace owner/admin, still scoped to the workspace", () => {
+    for (const role of ["owner", "admin"] as const) {
+      const clause = aclVisibilityClause(ctx({ role }), {
+        table: "brain_facts",
+        alias: "f",
+        paramIndex: 2,
+        override: { reason: "GDPR subject access request", requestId: "req-1" },
+      });
+      expect(clause.decision).toBe("audit-override");
+      expect(clause.sql).toBe("(f.workspace_id = $2)");
+      expect(clause.params).toEqual([WS]);
+    }
+  });
+
+  it("refuses a member's override and falls back to grant matching", () => {
+    // Not fatal: blinding a reader to their OWN facts because a caller
+    // over-asked would be a worse failure than the over-ask.
+    const clause = aclVisibilityClause(ctx({ role: "member" }), {
+      table: "brain_facts",
+      alias: "f",
+      paramIndex: 1,
+      override: { reason: "oops" },
+    });
+    expect(clause.decision).toBe("override-refused");
+    expect(clause.sql).toBe("(f.workspace_id = $1 AND f.visible_to && $2::text[])");
+  });
+
+  it("refuses a bare platform_admin — a platform operator is not a tenant member", () => {
+    const clause = aclVisibilityClause(ctx({ role: null, userId: "op-1" }), {
+      table: "brain_facts",
+      paramIndex: 1,
+      override: { reason: "operator poke" },
+    });
+    expect(clause.decision).toBe("override-refused");
+  });
+
+  it("refuses an override from `auth: none` and from an unresolved reader", () => {
+    expect(
+      aclVisibilityClause(
+        ctx({ role: null, userId: null, origin: "unauthenticated-local" }),
+        { table: "brain_facts", paramIndex: 1, override: { reason: "local" } },
+      ).decision,
+    ).toBe("override-refused");
+    expect(
+      aclVisibilityClause(ctx({ origin: "unresolved" }), {
+        table: "brain_facts",
+        paramIndex: 1,
+        override: { reason: "x" },
+      }).decision,
+    ).toBe("deny-all");
+  });
+});
+
+describe("no /ee coupling (#4768 acceptance — T8)", () => {
+  it("the ACL module imports nothing from @atlas/ee", async () => {
+    // The minimal ACL is CORE and fail-closed: a self-hosted build with no
+    // enterprise package must gate the brain identically. Corrector-masking
+    // and the richer enterprise surfaces layer ON TOP; they never supply the
+    // primitive. `scripts/check-ee-imports.sh` is the repo-wide guard — this
+    // pins the specific file the acceptance criterion names.
+    const source = await Bun.file(
+      new URL("../acl.ts", import.meta.url).pathname,
+    ).text();
+    expect(source).not.toContain("@atlas/ee");
+  });
+});

--- a/packages/api/src/lib/brain/__tests__/acl.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl.test.ts
@@ -217,6 +217,17 @@ describe("principal tokens (#4768)", () => {
     expect(clause.decision).toBe("deny-all");
     expect(clause.sql).toBe("(FALSE)");
     expect(isVisibleTo(row(["org"]), rogue)).toBe(false);
+
+    // The override branch runs BEFORE the token backstop, so it is the arm
+    // where a permissive fallthrough would have been worth the most. Pin it:
+    // entitlement requires `origin === "authenticated"`, so a rogue origin is
+    // refused and then denied outright.
+    const withOverride = aclVisibilityClause(
+      { ...rogue, role: "owner" } as unknown as BrainPrincipalContext,
+      { table: "brain_facts", paramIndex: 1, override: { reason: "audit" } },
+    );
+    expect(withOverride.decision).toBe("deny-all");
+    expect(withOverride.sql).toBe("(FALSE)");
   });
 
   it("grants nothing at all when there is no workspace", () => {
@@ -342,8 +353,10 @@ describe("resolvePrincipalContext (#4768)", () => {
     // — a membership row from another tenant hands this reader a token that
     // then matches their OWN tenant's facts, which the predicate's workspace
     // containment cannot catch.
-    expect(seenSql).toContain("workspace_id = $1");
-    expect(seenSql).toContain("user_id = $2");
+    // Positive form, deliberately: the earlier `not.toContain("OR")` guard was
+    // a tripwire rather than a check ("ORDER BY" contains "OR"). This pins the
+    // AND-composition itself, and cannot be tripped by a benign addition.
+    expect(seenSql).toMatch(/workspace_id = \$1\s+AND\s+user_id = \$2/);
     expect(resolved.audienceIds).toEqual(["eng", "exec"]);
     expect(resolved.origin).toBe("authenticated");
   });

--- a/packages/api/src/lib/brain/__tests__/acl.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl.test.ts
@@ -2,11 +2,13 @@
  * Unit coverage for the brain ACL grammar, principal resolution, and the
  * fail-closed push-down predicate (#4768, ADR-0036 §Access control).
  *
- * The real-Postgres half — that the emitted SQL actually selects the rows this
- * file says it should, and that `isVisibleTo` agrees with `&&` token for token
- * — lives in `acl-visibility-pg.test.ts`. Both halves are load-bearing: this
- * one pins the DECISIONS, that one pins the SQL, and a bug in either shows up
- * as a row the wrong person can read.
+ * Three files cover this module, because it makes three separable claims:
+ *   - this one pins the DECISIONS (which branch fires, what SQL comes out);
+ *   - `acl-visibility-pg.test.ts` pins what that SQL actually SELECTS against
+ *     real Postgres, and that `isVisibleTo` agrees with `&&` token for token;
+ *   - `acl-logging.test.ts` pins that every deny and every override is
+ *     LOGGED — "deny + log" is the acceptance criterion, and the log half is
+ *     otherwise deletable without a single test going red.
  */
 
 import { describe, expect, it } from "bun:test";
@@ -31,15 +33,39 @@ import {
 
 const WS = "ws-acl-test";
 
-function ctx(partial: Partial<BrainPrincipalContext> = {}): BrainPrincipalContext {
+type AuthedContext = Extract<BrainPrincipalContext, { origin: "authenticated" }>;
+
+/** An authenticated reader. The default arm — most tests want this. */
+function ctx(partial: Partial<AuthedContext> = {}): BrainPrincipalContext {
   return {
+    origin: "authenticated",
     workspaceId: WS,
     userId: "user-1",
     role: "member",
     audienceIds: [],
-    origin: "authenticated",
     ...partial,
   };
+}
+
+/** `auth: none` — the deployment has declared there is no identity. */
+function localCtx(workspaceId = WS): BrainPrincipalContext {
+  return {
+    origin: "unauthenticated-local",
+    workspaceId,
+    userId: null,
+    role: null,
+    audienceIds: [],
+  };
+}
+
+/** An authenticated request whose identity could not be established. */
+function unresolvedCtx(workspaceId = WS): BrainPrincipalContext {
+  return { origin: "unresolved", workspaceId, userId: null, role: null, audienceIds: [] };
+}
+
+/** A row in `ctx`'s own workspace unless told otherwise. */
+function row(visibleTo: readonly unknown[], workspaceId = WS) {
+  return { workspaceId, visibleTo };
 }
 
 describe("grant grammar (#4768)", () => {
@@ -145,8 +171,8 @@ describe("parseGrant (#4768)", () => {
 });
 
 describe("principal tokens (#4768)", () => {
-  it("always seeds `org`", () => {
-    expect(principalTokens(ctx({ role: null, userId: null }))).toEqual([ORG_PRINCIPAL]);
+  it("always seeds `org` for a reader that has any access at all", () => {
+    expect(principalTokens(localCtx())).toEqual([ORG_PRINCIPAL]);
   });
 
   it("expands roles monotonically: owner ⊇ admin ⊇ member", () => {
@@ -162,16 +188,36 @@ describe("principal tokens (#4768)", () => {
     ]);
   });
 
+  it("grants no role principals for a role outside ORG_ROLES", () => {
+    // Unreachable through the type; reachable through a cast or a future role
+    // addition. Must deny, not fall out of the switch as `undefined` and turn
+    // the caller's `for…of` into an unattributed TypeError.
+    const rogue = "superuser" as unknown as "owner";
+    expect(impliedRoles(rogue)).toEqual([]);
+    expect(principalTokens(ctx({ role: rogue }))).toEqual([
+      ORG_PRINCIPAL,
+      `${USER_PREFIX}user-1`,
+    ]);
+  });
+
+  it("grants nothing at all to an unresolved reader", () => {
+    expect(principalTokens(unresolvedCtx())).toEqual([]);
+  });
+
+  it("grants nothing at all when there is no workspace", () => {
+    expect(principalTokens(ctx({ workspaceId: "" }))).toEqual([]);
+  });
+
   it("lets an owner read a `role:member` fact", () => {
     // Exact-match role grants would hide member-scoped facts from the
     // workspace OWNER — a hole that reads as a bug every time it is hit.
-    expect(isVisibleTo(["role:member"], ctx({ role: "owner" }))).toBe(true);
-    expect(isVisibleTo(["role:admin"], ctx({ role: "owner" }))).toBe(true);
+    expect(isVisibleTo(row(["role:member"]), ctx({ role: "owner" }))).toBe(true);
+    expect(isVisibleTo(row(["role:admin"]), ctx({ role: "owner" }))).toBe(true);
   });
 
   it("does not let a member read a `role:admin` fact", () => {
-    expect(isVisibleTo(["role:admin"], ctx({ role: "member" }))).toBe(false);
-    expect(isVisibleTo(["role:owner"], ctx({ role: "member" }))).toBe(false);
+    expect(isVisibleTo(row(["role:admin"]), ctx({ role: "member" }))).toBe(false);
+    expect(isVisibleTo(row(["role:owner"]), ctx({ role: "member" }))).toBe(false);
   });
 
   it("prefixes audience ids, which are stored unprefixed", () => {
@@ -183,10 +229,11 @@ describe("principal tokens (#4768)", () => {
     expect(tokens).not.toContain("eng");
   });
 
-  it("never emits an empty-string token", () => {
-    // `ARRAY[''] && ARRAY['']` is TRUE in Postgres, and a stored `''` element
-    // is legal at rest — so an empty reader token would match a grant that
-    // grants nobody anything.
+  it("never emits an empty token or a bare prefix", () => {
+    // Two hazards, not one. `ARRAY[''] && ARRAY['']` is TRUE and a stored `''`
+    // element is legal at rest; and a bare `user:` is itself MALFORMED, so
+    // emitting one would break the "no reader token is ever malformed"
+    // invariant that makes the permissive parser safe.
     const tokens = principalTokens(ctx({ userId: "", audienceIds: ["", "ok"] }));
     expect(tokens).not.toContain("");
     expect(tokens).not.toContain(USER_PREFIX);
@@ -195,14 +242,44 @@ describe("principal tokens (#4768)", () => {
   });
 
   it("matches user grants only for the named user", () => {
-    expect(isVisibleTo(["user:user-1"], ctx({ userId: "user-1" }))).toBe(true);
-    expect(isVisibleTo(["user:user-2"], ctx({ userId: "user-1" }))).toBe(false);
+    expect(isVisibleTo(row(["user:user-1"]), ctx({ userId: "user-1" }))).toBe(true);
+    expect(isVisibleTo(row(["user:user-2"]), ctx({ userId: "user-1" }))).toBe(false);
   });
 
   it("treats malformed stored tokens as granting nobody", () => {
     for (const grant of [["everyone"], ["public"], ["ORG"], [""], [null]]) {
-      expect(isVisibleTo(grant, ctx({ role: "owner", audienceIds: ["eng"] }))).toBe(false);
+      expect(isVisibleTo(row(grant), ctx({ role: "owner", audienceIds: ["eng"] }))).toBe(false);
     }
+  });
+});
+
+describe("isVisibleTo mirrors the predicate's denies, not just its matches (#4768)", () => {
+  // The first cut of this helper took a bare grant and skipped both gates, so
+  // it answered TRUE exactly where the SQL answers FALSE. A mirror that is
+  // permissive where the predicate denies is worse than no mirror.
+  it("denies a row from another workspace even on a matching token", () => {
+    // Audience ids collide across tenants by design — this is the leak the
+    // predicate's redundant workspace containment exists to stop.
+    const reader = ctx({ audienceIds: ["engineering"] });
+    expect(isVisibleTo(row(["audience:engineering"], "other-ws"), reader)).toBe(false);
+    expect(isVisibleTo(row(["audience:engineering"], WS), reader)).toBe(true);
+  });
+
+  it("denies an org-granted row to an unresolved reader", () => {
+    expect(isVisibleTo(row(["org"]), unresolvedCtx())).toBe(false);
+    expect(aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 1 }).decision)
+      .toBe("deny-all");
+  });
+
+  it("denies when the reader has no workspace", () => {
+    expect(isVisibleTo(row(["org"], ""), ctx({ workspaceId: "" }))).toBe(false);
+  });
+
+  it("gives `auth: none` the org principal only", () => {
+    expect(isVisibleTo(row(["org"]), localCtx())).toBe(true);
+    expect(isVisibleTo(row(["role:owner"]), localCtx())).toBe(false);
+    expect(isVisibleTo(row(["audience:eng"]), localCtx())).toBe(false);
+    expect(isVisibleTo(row(["user:user-1"]), localCtx())).toBe(false);
   });
 });
 
@@ -216,15 +293,32 @@ describe("resolvePrincipalContext (#4768)", () => {
     } satisfies AudienceMembershipReader;
   }
 
+  const authed = {
+    workspaceId: WS,
+    mode: "managed",
+    userId: "user-1",
+    role: "member",
+    roleResolvedForOrgId: WS,
+  } as const;
+
   it("reads audience membership locally, scoped to workspace + user", async () => {
-    let seen: unknown[] | undefined;
+    let seenSql: string | undefined;
+    let seenParams: unknown[] | undefined;
     const resolved = await resolvePrincipalContext(
-      reader([{ audience_id: "eng" }, { audience_id: "exec" }], (_sql, params) => {
-        seen = params;
+      reader([{ audience_id: "eng" }, { audience_id: "exec" }], (sql, params) => {
+        seenSql = sql;
+        seenParams = params;
       }),
-      { workspaceId: WS, mode: "managed", userId: "user-1", role: "member" },
+      authed,
     );
-    expect(seen).toEqual([WS, "user-1"]);
+    expect(seenParams).toEqual([WS, "user-1"]);
+    // The workspace predicate is the module's only cross-tenant-sensitive read
+    // — a membership row from another tenant hands this reader a token that
+    // then matches their OWN tenant's facts, which the predicate's workspace
+    // containment cannot catch.
+    expect(seenSql).toContain("workspace_id = $1");
+    expect(seenSql).toContain("user_id = $2");
+    expect(seenSql).not.toContain("OR");
     expect(resolved.audienceIds).toEqual(["eng", "exec"]);
     expect(resolved.origin).toBe("authenticated");
   });
@@ -232,7 +326,7 @@ describe("resolvePrincipalContext (#4768)", () => {
   it("drops non-string / empty audience ids rather than minting a bare prefix", async () => {
     const resolved = await resolvePrincipalContext(
       reader([{ audience_id: "eng" }, { audience_id: null }, { audience_id: "" }, {}]),
-      { workspaceId: WS, mode: "managed", userId: "user-1", role: "member" },
+      authed,
     );
     expect(resolved.audienceIds).toEqual(["eng"]);
   });
@@ -243,37 +337,88 @@ describe("resolvePrincipalContext (#4768)", () => {
       reader([], () => {
         queried = true;
       }),
-      { workspaceId: WS, mode: "none", userId: undefined, role: undefined },
+      {
+        workspaceId: WS,
+        mode: "none",
+        userId: undefined,
+        role: undefined,
+        roleResolvedForOrgId: undefined,
+      },
     );
     expect(queried).toBe(false);
     expect(resolved.origin).toBe("unauthenticated-local");
     expect(principalTokens(resolved)).toEqual([ORG_PRINCIPAL]);
     // Narrowed content stays hidden even from the local operator.
-    expect(isVisibleTo(["role:owner"], resolved)).toBe(false);
-    expect(isVisibleTo(["audience:eng"], resolved)).toBe(false);
-    expect(isVisibleTo(["org"], resolved)).toBe(true);
+    expect(isVisibleTo(row(["role:owner"]), resolved)).toBe(false);
+    expect(isVisibleTo(row(["audience:eng"]), resolved)).toBe(false);
+    expect(isVisibleTo(row(["org"]), resolved)).toBe(true);
+  });
+
+  it("resolves the other authenticated modes without special-casing them", async () => {
+    for (const mode of ["simple-key", "byot"] as const) {
+      const resolved = await resolvePrincipalContext(reader([{ audience_id: "eng" }]), {
+        ...authed,
+        mode,
+      });
+      expect(resolved.origin).toBe("authenticated");
+      expect(principalTokens(resolved)).toEqual([
+        ORG_PRINCIPAL,
+        `${ROLE_PREFIX}member`,
+        `${USER_PREFIX}user-1`,
+        `${AUDIENCE_PREFIX}eng`,
+      ]);
+    }
+  });
+
+  it("resolves `unresolved` for an unrecognised auth mode", async () => {
+    const resolved = await resolvePrincipalContext(reader([]), {
+      ...authed,
+      mode: "quantum" as unknown as "managed",
+    });
+    expect(resolved.origin).toBe("unresolved");
   });
 
   it("maps a bare platform_admin to no org-role principal", async () => {
     const resolved = await resolvePrincipalContext(reader([]), {
-      workspaceId: WS,
-      mode: "managed",
+      ...authed,
       userId: "op-1",
       role: "platform_admin",
     });
     expect(resolved.role).toBeNull();
     expect(principalTokens(resolved)).toEqual([ORG_PRINCIPAL, `${USER_PREFIX}op-1`]);
-    expect(isVisibleTo(["role:admin"], resolved)).toBe(false);
+    expect(isVisibleTo(row(["role:admin"]), resolved)).toBe(false);
+  });
+
+  it("drops role grants when the role was resolved against a different org", async () => {
+    // `member.role` is per-org (#2890). A role carried over from the session's
+    // ACTIVE org while reading a DIFFERENT workspace would grant `role:` tokens
+    // — and audit-override entitlement — derived from another tenant.
+    const resolved = await resolvePrincipalContext(reader([]), {
+      ...authed,
+      role: "owner",
+      roleResolvedForOrgId: "some-other-org",
+    });
+    expect(resolved.role).toBeNull();
+    expect(principalTokens(resolved)).not.toContain(`${ROLE_PREFIX}owner`);
+    expect(
+      aclVisibilityClause(resolved, {
+        table: "brain_facts",
+        paramIndex: 1,
+        override: { reason: "audit" },
+      }).decision,
+    ).toBe("override-refused");
+  });
+
+  it("keeps role grants when the role was resolved against the read target", async () => {
+    const resolved = await resolvePrincipalContext(reader([]), { ...authed, role: "owner" });
+    expect(resolved.role).toBe("owner");
+    expect(principalTokens(resolved)).toContain(`${ROLE_PREFIX}owner`);
   });
 
   it("resolves `unresolved` when an authenticated request carries no user id", async () => {
-    const resolved = await resolvePrincipalContext(reader([]), {
-      workspaceId: WS,
-      mode: "managed",
-      userId: undefined,
-      role: "admin",
-    });
+    const resolved = await resolvePrincipalContext(reader([]), { ...authed, userId: undefined });
     expect(resolved.origin).toBe("unresolved");
+    expect(principalTokens(resolved)).toEqual([]);
   });
 
   it("propagates database failures instead of silently downgrading the reader", async () => {
@@ -282,14 +427,9 @@ describe("resolvePrincipalContext (#4768)", () => {
     const failing: AudienceMembershipReader = {
       query: () => Promise.reject(new Error("connection terminated")),
     };
-    await expect(
-      resolvePrincipalContext(failing, {
-        workspaceId: WS,
-        mode: "managed",
-        userId: "user-1",
-        role: "member",
-      }),
-    ).rejects.toThrow("connection terminated");
+    await expect(resolvePrincipalContext(failing, authed)).rejects.toThrow(
+      "connection terminated",
+    );
   });
 });
 
@@ -309,9 +449,6 @@ describe("aclVisibilityClause (#4768)", () => {
   });
 
   it("scopes to the workspace even though callers already do — audience ids collide across tenants", () => {
-    // Two tenants can both mint `audience:engineering`. Without the redundant
-    // containment, a reader in tenant A holding that token would match tenant
-    // B's fact if the caller's own scoping were missing or accidentally OR-ed.
     const clause = aclVisibilityClause(ctx(), { table: "brain_episodes", paramIndex: 1 });
     expect(clause.sql).toContain("brain_episodes.workspace_id = $1");
   });
@@ -331,12 +468,9 @@ describe("aclVisibilityClause (#4768)", () => {
   });
 
   it("denies outright when the reader is unresolved", () => {
-    const clause = aclVisibilityClause(ctx({ origin: "unresolved" }), {
-      table: "brain_facts",
-      paramIndex: 1,
-    });
+    const clause = aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 1 });
     expect(clause.decision).toBe("deny-all");
-    expect(clause.sql).toBe("FALSE");
+    expect(clause.sql).toBe("(FALSE)");
     expect(clause.params).toEqual([]);
   });
 
@@ -346,7 +480,24 @@ describe("aclVisibilityClause (#4768)", () => {
       paramIndex: 1,
     });
     expect(clause.decision).toBe("deny-all");
-    expect(clause.sql).toBe("FALSE");
+    expect(clause.sql).toBe("(FALSE)");
+  });
+
+  it("parenthesises every arm so composition can never re-associate", () => {
+    const clauses = [
+      aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 }),
+      aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 1 }),
+      aclVisibilityClause(ctx({ role: "admin" }), {
+        table: "brain_facts",
+        paramIndex: 1,
+        override: { reason: "audit" },
+      }),
+    ];
+    for (const clause of clauses) {
+      expect(clause.sql.startsWith("(")).toBe(true);
+      expect(clause.sql.endsWith(")")).toBe(true);
+      expect(clause.sql.trimStart().startsWith("AND")).toBe(false);
+    }
   });
 
   it("rejects a non-identifier alias rather than interpolating it", () => {
@@ -367,10 +518,7 @@ describe("aclVisibilityClause (#4768)", () => {
   });
 
   it("declares its own arity — callers advance by params.length, never a constant", () => {
-    const deny = aclVisibilityClause(ctx({ origin: "unresolved" }), {
-      table: "brain_facts",
-      paramIndex: 1,
-    });
+    const deny = aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 1 });
     const normal = aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 });
     const override = aclVisibilityClause(ctx({ role: "admin" }), {
       table: "brain_facts",
@@ -390,13 +538,14 @@ describe("aclVisibilityClause (#4768)", () => {
 });
 
 describe("audit override (#4768, ADR-0036 — region-scoped, no super-admin)", () => {
-  it("bypasses grants for a workspace owner/admin, still scoped to the workspace", () => {
+  it("bypasses grants for an authenticated workspace owner/admin, still workspace-scoped", () => {
     for (const role of ["owner", "admin"] as const) {
       const clause = aclVisibilityClause(ctx({ role }), {
         table: "brain_facts",
         alias: "f",
         paramIndex: 2,
-        override: { reason: "GDPR subject access request", requestId: "req-1" },
+        override: { reason: "GDPR subject access request" },
+        requestId: "req-1",
       });
       expect(clause.decision).toBe("audit-override");
       expect(clause.sql).toBe("(f.workspace_id = $2)");
@@ -426,20 +575,42 @@ describe("audit override (#4768, ADR-0036 — region-scoped, no super-admin)", (
     expect(clause.decision).toBe("override-refused");
   });
 
-  it("refuses an override from `auth: none` and from an unresolved reader", () => {
+  it("refuses an override from `auth: none` even if the arm carried a role", () => {
+    // The union makes `{ origin: "unauthenticated-local", role: "owner" }`
+    // unconstructible, which is the point — the flat shape typechecked and
+    // earned a workspace-wide bypass on a deployment with no identity at all.
+    // The entitlement check requires `authenticated` regardless.
     expect(
-      aclVisibilityClause(
-        ctx({ role: null, userId: null, origin: "unauthenticated-local" }),
-        { table: "brain_facts", paramIndex: 1, override: { reason: "local" } },
-      ).decision,
+      aclVisibilityClause(localCtx(), {
+        table: "brain_facts",
+        paramIndex: 1,
+        override: { reason: "local" },
+      }).decision,
     ).toBe("override-refused");
+  });
+
+  it("denies (does not merely refuse) an override from an unresolved reader", () => {
     expect(
-      aclVisibilityClause(ctx({ origin: "unresolved" }), {
+      aclVisibilityClause(unresolvedCtx(), {
         table: "brain_facts",
         paramIndex: 1,
         override: { reason: "x" },
       }).decision,
     ).toBe("deny-all");
+  });
+
+  it("refuses an override with an empty or whitespace reason", () => {
+    // "Required — an unexplained override is not one" must be enforced, not
+    // merely asserted in prose.
+    for (const reason of ["", "   ", "\t\n"]) {
+      expect(
+        aclVisibilityClause(ctx({ role: "owner" }), {
+          table: "brain_facts",
+          paramIndex: 1,
+          override: { reason },
+        }).decision,
+      ).toBe("override-refused");
+    }
   });
 });
 
@@ -448,11 +619,11 @@ describe("no /ee coupling (#4768 acceptance — T8)", () => {
     // The minimal ACL is CORE and fail-closed: a self-hosted build with no
     // enterprise package must gate the brain identically. Corrector-masking
     // and the richer enterprise surfaces layer ON TOP; they never supply the
-    // primitive. `scripts/check-ee-imports.sh` is the repo-wide guard — this
-    // pins the specific file the acceptance criterion names.
-    const source = await Bun.file(
-      new URL("../acl.ts", import.meta.url).pathname,
-    ).text();
-    expect(source).not.toContain("@atlas/ee");
+    // primitive. `scripts/check-ee-imports.sh` is the repo-wide gate (and the
+    // one that catches indirect coupling); this pins the file #4768's Key
+    // files section names, as intent documentation.
+    const source = await Bun.file(new URL("../acl.ts", import.meta.url).pathname).text();
+    expect(source).not.toMatch(/from\s+["']@atlas\/ee/);
+    expect(source).not.toMatch(/import\(["']@atlas\/ee/);
   });
 });

--- a/packages/api/src/lib/brain/__tests__/acl.test.ts
+++ b/packages/api/src/lib/brain/__tests__/acl.test.ts
@@ -65,7 +65,7 @@ function unresolvedCtx(workspaceId = WS): BrainPrincipalContext {
 
 /** A row in `ctx`'s own workspace unless told otherwise. */
 function row(visibleTo: readonly unknown[], workspaceId = WS) {
-  return { workspaceId, visibleTo };
+  return { table: "brain_facts", workspaceId, visibleTo } as const;
 }
 
 describe("grant grammar (#4768)", () => {
@@ -204,6 +204,21 @@ describe("principal tokens (#4768)", () => {
     expect(principalTokens(unresolvedCtx())).toEqual([]);
   });
 
+  it("grants nothing at all for an origin outside the union", () => {
+    // The regression this exists for: an earlier cut spelled the switch as
+    // `if (origin !== "authenticated") return [ORG]`, which handed an origin
+    // arriving through a cast — or from a checkpoint rehydrated under an older
+    // shape — the workspace's entire org-granted fact set, unlogged. A
+    // permissive fallthrough on the discriminant that decides whether a reader
+    // is authenticated at all is the worst possible place for one.
+    const rogue = { ...ctx(), origin: "service" } as unknown as BrainPrincipalContext;
+    expect(principalTokens(rogue)).toEqual([]);
+    const clause = aclVisibilityClause(rogue, { table: "brain_facts", paramIndex: 1 });
+    expect(clause.decision).toBe("deny-all");
+    expect(clause.sql).toBe("(FALSE)");
+    expect(isVisibleTo(row(["org"]), rogue)).toBe(false);
+  });
+
   it("grants nothing at all when there is no workspace", () => {
     expect(principalTokens(ctx({ workspaceId: "" }))).toEqual([]);
   });
@@ -275,6 +290,18 @@ describe("isVisibleTo mirrors the predicate's denies, not just its matches (#476
     expect(isVisibleTo(row(["org"], ""), ctx({ workspaceId: "" }))).toBe(false);
   });
 
+  it("denies a row whose grant is not an array rather than throwing", () => {
+    // `visibleTo` is typed `readonly unknown[]`, but rows arrive off `pg` as
+    // `visible_to`; a caller that maps `workspaceId` right and this field wrong
+    // would otherwise get a bare TypeError out of a security primitive.
+    const malformedRow = {
+      table: "brain_facts",
+      workspaceId: WS,
+      visibleTo: undefined,
+    } as unknown as Parameters<typeof isVisibleTo>[0];
+    expect(isVisibleTo(malformedRow, ctx())).toBe(false);
+  });
+
   it("gives `auth: none` the org principal only", () => {
     expect(isVisibleTo(row(["org"]), localCtx())).toBe(true);
     expect(isVisibleTo(row(["role:owner"]), localCtx())).toBe(false);
@@ -297,8 +324,7 @@ describe("resolvePrincipalContext (#4768)", () => {
     workspaceId: WS,
     mode: "managed",
     userId: "user-1",
-    role: "member",
-    roleResolvedForOrgId: WS,
+    resolvedRole: { role: "member", orgId: WS },
   } as const;
 
   it("reads audience membership locally, scoped to workspace + user", async () => {
@@ -318,7 +344,6 @@ describe("resolvePrincipalContext (#4768)", () => {
     // containment cannot catch.
     expect(seenSql).toContain("workspace_id = $1");
     expect(seenSql).toContain("user_id = $2");
-    expect(seenSql).not.toContain("OR");
     expect(resolved.audienceIds).toEqual(["eng", "exec"]);
     expect(resolved.origin).toBe("authenticated");
   });
@@ -337,13 +362,7 @@ describe("resolvePrincipalContext (#4768)", () => {
       reader([], () => {
         queried = true;
       }),
-      {
-        workspaceId: WS,
-        mode: "none",
-        userId: undefined,
-        role: undefined,
-        roleResolvedForOrgId: undefined,
-      },
+      { workspaceId: WS, mode: "none", userId: undefined, resolvedRole: undefined },
     );
     expect(queried).toBe(false);
     expect(resolved.origin).toBe("unauthenticated-local");
@@ -382,7 +401,7 @@ describe("resolvePrincipalContext (#4768)", () => {
     const resolved = await resolvePrincipalContext(reader([]), {
       ...authed,
       userId: "op-1",
-      role: "platform_admin",
+      resolvedRole: { role: "platform_admin", orgId: WS },
     });
     expect(resolved.role).toBeNull();
     expect(principalTokens(resolved)).toEqual([ORG_PRINCIPAL, `${USER_PREFIX}op-1`]);
@@ -395,8 +414,7 @@ describe("resolvePrincipalContext (#4768)", () => {
     // — and audit-override entitlement — derived from another tenant.
     const resolved = await resolvePrincipalContext(reader([]), {
       ...authed,
-      role: "owner",
-      roleResolvedForOrgId: "some-other-org",
+      resolvedRole: { role: "owner", orgId: "some-other-org" },
     });
     expect(resolved.role).toBeNull();
     expect(principalTokens(resolved)).not.toContain(`${ROLE_PREFIX}owner`);
@@ -410,7 +428,10 @@ describe("resolvePrincipalContext (#4768)", () => {
   });
 
   it("keeps role grants when the role was resolved against the read target", async () => {
-    const resolved = await resolvePrincipalContext(reader([]), { ...authed, role: "owner" });
+    const resolved = await resolvePrincipalContext(reader([]), {
+      ...authed,
+      resolvedRole: { role: "owner", orgId: WS },
+    });
     expect(resolved.role).toBe("owner");
     expect(principalTokens(resolved)).toContain(`${ROLE_PREFIX}owner`);
   });
@@ -517,6 +538,36 @@ describe("aclVisibilityClause (#4768)", () => {
     }
   });
 
+  it("reports where the caller's next placeholder goes", () => {
+    // `nextParamIndex` makes the composition rule mechanical rather than
+    // readable-and-forgettable, and must always equal paramIndex + arity.
+    const cases = [
+      aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 5 }),
+      aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 5 }),
+      aclVisibilityClause(ctx({ role: "admin" }), {
+        table: "brain_facts",
+        paramIndex: 5,
+        override: { reason: "audit" },
+      }),
+    ];
+    for (const clause of cases) {
+      expect(clause.nextParamIndex).toBe(5 + clause.params.length);
+    }
+  });
+
+  it("never hands out a mutable shared deny clause", () => {
+    // One frozen template backs every deny in the process; a caller mutating
+    // `.params` would otherwise poison every subsequent denied read for every
+    // tenant on the instance.
+    const a = aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 1 });
+    const b = aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 7 });
+    expect(Object.isFrozen(a.params)).toBe(true);
+    expect(() => (a.params as unknown as unknown[]).push("x")).toThrow();
+    // …and the per-call cursor is still per-call.
+    expect(a.nextParamIndex).toBe(1);
+    expect(b.nextParamIndex).toBe(7);
+  });
+
   it("declares its own arity — callers advance by params.length, never a constant", () => {
     const deny = aclVisibilityClause(unresolvedCtx(), { table: "brain_facts", paramIndex: 1 });
     const normal = aclVisibilityClause(ctx(), { table: "brain_facts", paramIndex: 1 });
@@ -599,10 +650,12 @@ describe("audit override (#4768, ADR-0036 — region-scoped, no super-admin)", (
     ).toBe("deny-all");
   });
 
-  it("refuses an override with an empty or whitespace reason", () => {
+  it("refuses an override with an empty, whitespace, or non-string reason", () => {
     // "Required — an unexplained override is not one" must be enforced, not
-    // merely asserted in prose.
-    for (const reason of ["", "   ", "\t\n"]) {
+    // merely asserted in prose. The non-string arm matters because `reason`
+    // originates in a request body: an un-narrowed `.trim()` would turn an
+    // override probe into a 500 instead of a recorded escalation attempt.
+    for (const reason of ["", "   ", "\t\n", null as unknown as string, 42 as unknown as string]) {
       expect(
         aclVisibilityClause(ctx({ role: "owner" }), {
           table: "brain_facts",

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -2,13 +2,15 @@
  * The company brain's minimal per-fact/per-episode ACL (#4768, ADR-0036
  * §Access control & residency).
  *
- * Three things live here, in dependency order:
+ * Four things live here:
  *
- *   1. **The grant grammar** — `org | role:{owner,admin,member} | user:<id> |
+ *   1. **The gated tables** — the tier-2/tier-3 targets this predicate may be
+ *      composed onto.
+ *   2. **The grant grammar** — `org | role:{owner,admin,member} | user:<id> |
  *      audience:<source-derived>` — parsed into a discriminated union.
- *   2. **Principal-set resolution** — turning a reader's identity into the set
+ *   3. **Principal-set resolution** — turning a reader's identity into the set
  *      of tokens that grant them access, including live `audience:` membership.
- *   3. **`aclVisibilityClause`** — a FAIL-CLOSED, PUSH-DOWN SQL predicate.
+ *   4. **`aclVisibilityClause`** — a FAIL-CLOSED, PUSH-DOWN SQL predicate.
  *      #4773's `searchBrain` ANDs it into its WHERE clause; it is never a
  *      post-fetch filter, because a post-fetch filter has already loaded the
  *      row it is about to hide, and every LIMIT above it counts rows the
@@ -19,22 +21,29 @@
  * Tiers 2 and 3 only — `brain_facts` and `brain_episodes`. Tier-1 warehouse
  * facts are computed live through the semantic layer and gated by warehouse
  * RLS; double-gating them here would mean two systems that must agree about
- * the same row and will eventually not. `AclGatedTable` makes that a
- * compile-time fact rather than a comment: there is no way to spell a tier-1
- * target in a call to `aclVisibilityClause`.
+ * the same row and will eventually not. `AclGatedTable` constrains the NAMED
+ * target so a tier-1 table cannot be requested — note that it constrains the
+ * name, not the emitted SQL, which is built from `alias`; an alias pointed at
+ * some other relation produces a predicate that fails loudly at runtime (no
+ * `visible_to` column) rather than one that quietly gates the wrong thing.
  *
  * ## Fail-closed, in both directions
  *
  * **Reader side** — a reader whose principal set cannot be resolved gets
- * `FALSE`, not "everything" and not "the public subset". Every deny is logged.
+ * `FALSE`, not "everything" and not "the public subset". Every reader-side
+ * deny in this module is logged.
  *
  * **Stored side** — a malformed token (`everyone`, `team:eng`, `ROLE:admin`)
  * is invisible by CONSTRUCTION: the predicate is array overlap against the
  * reader's tokens, and no reader token is ever malformed, so a malformed grant
- * token can match nothing. That is why the parser can be permissive without
- * being unsafe. The logging half of "deny + log" is `logGrantAnomalies`, which
- * callers apply to rows they already hold — see its own doc comment for why
- * that is the only honest read-time seam a push-down predicate leaves open.
+ * token can match nothing. That invariant is load-bearing and is why
+ * `principalTokens` guards every arm on non-empty input. It also means the
+ * parser can be permissive without being unsafe.
+ *
+ * Stored-side anomalies are logged only where a caller invokes
+ * `logGrantAnomalies` on rows it already holds — see that function's comment
+ * for why that is the only honest read-time seam a push-down predicate leaves
+ * open. #4773 is expected to call it on its result set.
  *
  * ## The one thing that must never become stricter
  *
@@ -46,15 +55,26 @@
  * `parseGrant` REPORTS malformed tokens and never throws, and this module has
  * no write-side validation at all. Structural validity stops at "has a usable
  * principal"; whether `everyone` is a MEANINGFUL principal is a read-time
- * deny, never an import rejection. `grantProblem` in `api/routes/admin-migrate.ts`
- * is the mirrored guard on the import side — the two are a matched pair and
- * move together.
+ * deny, never an import rejection.
+ *
+ * The IMPORT-side counterpart is `grantProblem` in
+ * `api/routes/admin-migrate.ts`, which is paired with the 0180 CHECK (not with
+ * this parser) and must stay exactly as permissive as it. This module's parser
+ * is deliberately stricter than both, and must never be hoisted to import time.
  */
 
 import { ORG_ROLES, type AtlasRole, type AuthMode, type OrgRole } from "@useatlas/types/auth";
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("brain-acl");
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  The gated tables
+// ══════════════════════════════════════════════════════════════════════
+
+/** The tier-2/3 tables this predicate may gate. Tier-1 is not spellable. */
+export const ACL_GATED_TABLES = ["brain_facts", "brain_episodes"] as const;
+export type AclGatedTable = (typeof ACL_GATED_TABLES)[number];
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  The grant grammar
@@ -79,7 +99,10 @@ export type BrainPrincipal =
   | { readonly kind: "user"; readonly userId: string }
   | { readonly kind: "audience"; readonly audienceId: string };
 
-const ORG_ROLE_SET: ReadonlySet<string> = new Set(ORG_ROLES);
+/** Narrow an arbitrary string to an org role without a cast. */
+function isOrgRole(value: string): value is OrgRole {
+  return (ORG_ROLES as readonly string[]).includes(value);
+}
 
 /**
  * Parse one grant token, or `null` if it is not in the grammar.
@@ -87,9 +110,8 @@ const ORG_ROLE_SET: ReadonlySet<string> = new Set(ORG_ROLES);
  * Comparison is BYTE-EXACT and case-sensitive on purpose. The enforcement is
  * Postgres's `&&` operator over `text[]`, which is byte-exact; if this parser
  * lower-cased (or trimmed) while Postgres did not, `isVisibleTo` and
- * `aclVisibilityClause` would disagree about the same row — and the in-memory
- * mirror exists precisely to be trustworthy about what the SQL will do. So
- * `ROLE:admin` and `org ` are malformed rather than helpfully coerced.
+ * `aclVisibilityClause` would disagree about the same row. So `ROLE:admin` and
+ * `org ` are malformed rather than helpfully coerced.
  *
  * The `<id>` arms accept ANY non-empty remainder. Better Auth ids and
  * source-derived audience ids have no shape this module is entitled to assume,
@@ -101,9 +123,9 @@ export function parsePrincipal(raw: string): BrainPrincipal | null {
   if (raw.startsWith(ROLE_PREFIX)) {
     const role = raw.slice(ROLE_PREFIX.length);
     // `role:platform_admin` is malformed: platform roles are cross-tenant and
-    // deliberately outside the grammar (ADR-0036 — admin/audit override is
-    // region- and workspace-scoped, there is no super-admin arm).
-    return ORG_ROLE_SET.has(role) ? { kind: "role", role: role as OrgRole } : null;
+    // deliberately outside the grammar. ADR-0036 scopes the admin/audit
+    // override to a region and admits no super-admin arm.
+    return isOrgRole(role) ? { kind: "role", role } : null;
   }
   if (raw.startsWith(USER_PREFIX)) {
     const userId = raw.slice(USER_PREFIX.length);
@@ -130,13 +152,23 @@ export function formatPrincipal(principal: BrainPrincipal): string {
   }
 }
 
-/** What `parseGrant` found. Both halves matter; neither is an error. */
+/**
+ * What `parseGrant` found. Both halves matter; neither is an error.
+ *
+ * DISPLAY AND ANOMALY REPORTING ONLY. `principals` plays no part in
+ * enforcement — a visibility question goes through `isVisibleTo` or the
+ * predicate and nothing else. Hand-rolling `principals.some(p => p.kind ===
+ * "role" && p.role === ctx.role)` looks right and silently drops the monotone
+ * owner ⊇ admin ⊇ member implication that `impliedRoles` supplies.
+ */
 export interface ParsedGrant {
   readonly principals: readonly BrainPrincipal[];
   /**
-   * Tokens outside the grammar, verbatim. NULL and `''` elements — both legal
-   * at rest under the CHECK, which only requires ONE usable principal — are
-   * reported here as the empty string so a caller counting anomalies sees them.
+   * Tokens outside the grammar, verbatim — except non-string elements (NULL,
+   * `undefined`, anything a hand-edited import bundle smuggled in), which are
+   * reported as `''` so the COUNT still reflects them. NULL and `''` elements
+   * are both legal at rest: the CHECK requires one USABLE principal, not that
+   * every element is usable.
    */
   readonly malformed: readonly string[];
 }
@@ -183,7 +215,12 @@ export function parseGrant(grant: readonly unknown[]): ParsedGrant {
  */
 export function logGrantAnomalies(
   grant: readonly unknown[],
-  meta: { readonly table: AclGatedTable; readonly rowId: string; readonly workspaceId: string },
+  meta: {
+    readonly table: AclGatedTable;
+    readonly rowId: string;
+    readonly workspaceId: string;
+    readonly requestId?: string;
+  },
 ): ParsedGrant {
   const parsed = parseGrant(grant);
   if (parsed.malformed.length > 0) {
@@ -192,6 +229,7 @@ export function logGrantAnomalies(
         table: meta.table,
         rowId: meta.rowId,
         workspaceId: meta.workspaceId,
+        requestId: meta.requestId,
         malformed: parsed.malformed,
         usablePrincipals: parsed.principals.length,
       },
@@ -205,47 +243,59 @@ export function logGrantAnomalies(
 // ██  Principal-set resolution
 // ══════════════════════════════════════════════════════════════════════
 
-/** The tier-2/3 tables this predicate may gate. Tier-1 is not spellable. */
-export const ACL_GATED_TABLES = ["brain_facts", "brain_episodes"] as const;
-export type AclGatedTable = (typeof ACL_GATED_TABLES)[number];
-
 /**
  * A reader's resolved identity within one workspace.
  *
- * `audienceIds` is a SNAPSHOT of as-of-now membership, read locally from
- * `fact_audience_member` — never a live connector call (ADR-0036: grants are
- * derived at ingest and immutable per fact version; membership is the live
- * half, and it is the revocation path, so it must be cheap enough to evaluate
- * on every read).
+ * A DISCRIMINATED UNION rather than a flat record with an `origin` label,
+ * because the three arms carry materially different obligations and the flat
+ * shape made illegal combinations constructible. Specifically,
+ * `{ origin: "unauthenticated-local", role: "owner" }` typechecked and earned
+ * a full audit override — a workspace-wide grant bypass on a deployment that
+ * has declared it has no identity at all.
+ *
+ *   - `authenticated` — a real identity. `userId` is non-null BY THE TYPE.
+ *     `audienceIds` is a SNAPSHOT of as-of-now membership, read locally from
+ *     `fact_audience_member` — never a live connector call (ADR-0036: grants
+ *     are derived at ingest and immutable per fact version; membership is the
+ *     live half and the revocation path, so it must be cheap enough to
+ *     evaluate on every read).
+ *   - `unauthenticated-local` — `auth: none`, where the deployment has
+ *     DECLARED there is no identity to resolve. Granted the `org` principal
+ *     ONLY, so anything deliberately narrowed to a role, user, or audience
+ *     stays hidden even from the local operator. That is strictly narrower
+ *     than what the rest of Atlas hands `none` mode, and intentionally so.
+ *   - `unresolved` — an authenticated request whose identity could NOT be
+ *     established. Denied outright. Distinct from `unauthenticated-local`
+ *     because "there is no identity" and "there should have been an identity
+ *     and there isn't" are opposite situations that must not share a path.
  */
-export interface BrainPrincipalContext {
-  readonly workspaceId: string;
-  /** `null` when the deployment has no authenticated identity (`auth: none`). */
-  readonly userId: string | null;
-  /**
-   * The reader's ORG role. `null` for `auth: none`, for a reader with no org
-   * membership, and for a bare `platform_admin` — a platform role is not an
-   * org role and confers no brain grant.
-   */
-  readonly role: OrgRole | null;
-  readonly audienceIds: readonly string[];
-  /**
-   * How this context came to be.
-   *
-   * `unauthenticated-local` is `auth: none`, where the deployment has DECLARED
-   * there is no identity to resolve. It is granted the `org` principal ONLY,
-   * so anything deliberately narrowed to a role, user, or audience stays
-   * hidden even from the local operator. That is strictly narrower than what
-   * the rest of Atlas hands `none` mode, and intentionally so.
-   *
-   * `unresolved` is the failure arm — an authenticated request whose identity
-   * could not be established. `aclVisibilityClause` denies it outright.
-   * Distinct from `unauthenticated-local` because "there is no identity" and
-   * "there should have been an identity and there isn't" are opposite
-   * situations that would otherwise share a code path.
-   */
-  readonly origin: "authenticated" | "unauthenticated-local" | "unresolved";
-}
+export type BrainPrincipalContext =
+  | {
+      readonly origin: "authenticated";
+      readonly workspaceId: string;
+      readonly userId: string;
+      /**
+       * The reader's ORG role IN `workspaceId`. `null` for a reader with no org
+       * membership and for a bare `platform_admin` — a platform role is not an
+       * org role and confers no brain grant.
+       */
+      readonly role: OrgRole | null;
+      readonly audienceIds: readonly string[];
+    }
+  | {
+      readonly origin: "unauthenticated-local";
+      readonly workspaceId: string;
+      readonly userId: null;
+      readonly role: null;
+      readonly audienceIds: readonly [];
+    }
+  | {
+      readonly origin: "unresolved";
+      readonly workspaceId: string;
+      readonly userId: null;
+      readonly role: null;
+      readonly audienceIds: readonly [];
+    };
 
 /**
  * The narrow slice of a database handle this module needs. Structurally
@@ -260,13 +310,50 @@ export interface AudienceMembershipReader {
 /**
  * "Which audiences is this user in?" — the per-request expansion, served by
  * `idx_fact_audience_member_user`.
+ *
+ * The `workspace_id` predicate is the module's ONLY cross-tenant-sensitive
+ * read: `audience_id` is explicitly not globally unique (two tenants both
+ * minting `engineering` is normal), so a membership row leaking in from
+ * another workspace would hand this reader a token that then matches their
+ * OWN tenant's facts — a leak the visibility predicate's workspace containment
+ * cannot catch, because the token is being applied inside the right tenant.
  */
 export const AUDIENCE_MEMBERSHIP_SQL = `
-  SELECT audience_id
+  SELECT DISTINCT audience_id
     FROM fact_audience_member
    WHERE workspace_id = $1
      AND user_id = $2
 ` as const;
+
+export interface ResolvePrincipalInput {
+  readonly workspaceId: string;
+  readonly mode: AuthMode;
+  readonly userId: string | undefined;
+  /**
+   * The reader's role **in `workspaceId`** — i.e. the org-plugin `member.role`
+   * for that org, as produced by `resolveEffectiveRole(userRole, userId,
+   * workspaceId)` from `lib/auth/effective-role.ts`.
+   *
+   * NOT `getUserRole(user)` from `lib/auth/permissions.ts`. That helper
+   * back-fills an auth-mode DEFAULT, and its `simple-key` default is `admin` —
+   * so passing it would mint `role:admin` + `role:member` tokens AND
+   * audit-override entitlement for every holder of a shared API key, out of
+   * nothing. `AtlasUser.role` raw is safe; the defaulting helper is not.
+   */
+  readonly role: AtlasRole | undefined;
+  /**
+   * The org `role` was resolved against. Must equal `workspaceId`.
+   *
+   * `member.role` is per-org (#2890), so a `role` resolved against the
+   * session's ACTIVE org while reading a DIFFERENT workspace would grant
+   * `role:` tokens — and audit-override entitlement — derived from another
+   * tenant. Naming the org here makes that mismatch detectable instead of
+   * invisible; on mismatch the role grants are dropped and the event logged.
+   */
+  readonly roleResolvedForOrgId: string | undefined;
+  /** Correlates this module's log lines with the originating request. */
+  readonly requestId?: string;
+}
 
 /**
  * Resolve a reader's principal context, including live audience membership.
@@ -279,27 +366,34 @@ export const AUDIENCE_MEMBERSHIP_SQL = `
  */
 export async function resolvePrincipalContext(
   db: AudienceMembershipReader,
-  input: {
-    readonly workspaceId: string;
-    readonly mode: AuthMode;
-    readonly userId: string | undefined;
-    readonly role: AtlasRole | undefined;
-  },
+  input: ResolvePrincipalInput,
 ): Promise<BrainPrincipalContext> {
-  const { workspaceId, mode, userId, role } = input;
+  const { workspaceId, mode, userId, role, roleResolvedForOrgId, requestId } = input;
 
-  if (mode === "none") {
-    return {
-      workspaceId,
-      userId: null,
-      role: null,
-      audienceIds: [],
-      origin: "unauthenticated-local",
-    };
+  // An exhaustive switch rather than `mode === "none"`, so a fifth AuthMode
+  // forces a conscious decision instead of silently inheriting the
+  // authenticated arm.
+  switch (mode) {
+    case "none":
+      return {
+        origin: "unauthenticated-local",
+        workspaceId,
+        userId: null,
+        role: null,
+        audienceIds: [],
+      };
+    case "simple-key":
+    case "managed":
+    case "byot":
+      break;
+    default: {
+      log.warn(
+        { workspaceId, mode, requestId },
+        "brain ACL: unrecognised auth mode — reader identity is unresolvable",
+      );
+      return { origin: "unresolved", workspaceId, userId: null, role: null, audienceIds: [] };
+    }
   }
-
-  // A platform role is not an org role; `AtlasUser.role` spans both surfaces.
-  const orgRole = role !== undefined && ORG_ROLE_SET.has(role) ? (role as OrgRole) : null;
 
   if (!userId) {
     // Authenticated mode with no user id should be unreachable — auth
@@ -308,10 +402,24 @@ export async function resolvePrincipalContext(
     // returning the `org`-only context here would hand an unidentified caller
     // the workspace's public facts on the strength of a middleware bug.
     log.warn(
-      { workspaceId, mode },
+      { workspaceId, mode, requestId },
       "brain ACL: authenticated request carries no user id — principal set is unresolvable",
     );
-    return { workspaceId, userId: null, role: orgRole, audienceIds: [], origin: "unresolved" };
+    return { origin: "unresolved", workspaceId, userId: null, role: null, audienceIds: [] };
+  }
+
+  let orgRole: OrgRole | null = null;
+  if (role !== undefined) {
+    if (roleResolvedForOrgId !== workspaceId) {
+      log.warn(
+        { workspaceId, roleResolvedForOrgId, userId, requestId },
+        "brain ACL: role was resolved against a different org than the read target — dropping role grants",
+      );
+    } else if (isOrgRole(role)) {
+      orgRole = role;
+    }
+    // Anything else is a platform role (`platform_admin`), which is not an org
+    // grant. Falls through as `null` — deliberately, not by omission.
   }
 
   const result = await db.query(AUDIENCE_MEMBERSHIP_SQL, [workspaceId, userId]);
@@ -319,7 +427,7 @@ export async function resolvePrincipalContext(
     .map((row) => (row as { audience_id?: unknown }).audience_id)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
 
-  return { workspaceId, userId, role: orgRole, audienceIds, origin: "authenticated" };
+  return { origin: "authenticated", workspaceId, userId, role: orgRole, audienceIds };
 }
 
 /**
@@ -334,9 +442,9 @@ export async function resolvePrincipalContext(
  * on every grant.
  *
  * The widening is bounded and has no leak case: owner ⊇ admin ⊇ member is the
- * same containment Atlas's own `org-permissions.ts` role table already spells
- * out row by row, and every role a reader gains access through is one they
- * already outrank.
+ * same containment Atlas's own `auth/org-permissions.ts` role table already
+ * spells out row by row, and every role a reader gains access through is one
+ * they already outrank.
  */
 export function impliedRoles(role: OrgRole): readonly OrgRole[] {
   switch (role) {
@@ -346,21 +454,44 @@ export function impliedRoles(role: OrgRole): readonly OrgRole[] {
       return ["admin", "member"];
     case "member":
       return ["member"];
+    default:
+      // Unreachable through the type, reachable through a cast or a future
+      // ORG_ROLES addition. Deny the role grants loudly rather than fall out
+      // of the switch as `undefined` — which the caller's `for…of` would turn
+      // into an unattributed `TypeError` from a security primitive.
+      log.warn({ role }, "brain ACL: unknown org role — granting no role principals");
+      return [];
   }
 }
 
 /**
  * The reader's grant tokens — the exact array the push-down predicate binds,
- * and the exact set `isVisibleTo` tests against.
+ * and the exact set `isVisibleTo` tests against. THE single place a reader's
+ * access is derived, and therefore the single place it is denied.
  *
- * Never contains `''`: `ARRAY[''] && ARRAY['']` is TRUE in Postgres, so an
- * empty reader token would match a stored `''` element that migration 0180
- * explicitly tolerates (the CHECK requires one USABLE principal, not that
- * every element is usable). Every arm below is guarded on non-empty input for
- * that reason, not for tidiness.
+ * Returns `[]` (grants nothing) for an `unresolved` reader and for a context
+ * with no workspace. `aclVisibilityClause` checks both again before calling
+ * this so it can emit a specific log line for each, but the deny itself lives
+ * here — a helper that skipped it would be a fail-open sibling of the
+ * predicate, which is exactly the defect the review panel found in the first
+ * cut of this module.
+ *
+ * Never contains `''` or a bare prefix. Two distinct hazards:
+ *   - `ARRAY[''] && ARRAY['']` is TRUE in Postgres, and a stored `''` element
+ *     is legal at rest, so an empty reader token would match a grant that
+ *     grants nobody anything.
+ *   - An unguarded `user:`/`audience:` arm emits the BARE PREFIX (`user:`),
+ *     which `parsePrincipal` classifies as malformed — and a malformed reader
+ *     token could raw-match a malformed STORED token, breaking the module
+ *     header's load-bearing "no reader token is ever malformed" invariant.
+ * Both are why every arm below is guarded, not tidiness.
  */
 export function principalTokens(ctx: BrainPrincipalContext): readonly string[] {
+  if (ctx.origin === "unresolved" || !ctx.workspaceId) return [];
+
   const tokens: string[] = [ORG_PRINCIPAL];
+  if (ctx.origin !== "authenticated") return tokens;
+
   if (ctx.role) {
     for (const role of impliedRoles(ctx.role)) tokens.push(`${ROLE_PREFIX}${role}`);
   }
@@ -373,22 +504,51 @@ export function principalTokens(ctx: BrainPrincipalContext): readonly string[] {
   return tokens;
 }
 
+/** A row this module can answer a visibility question about. */
+export interface AclGatedRow {
+  readonly workspaceId: string;
+  readonly visibleTo: readonly unknown[];
+}
+
 /**
- * In-memory mirror of the push-down predicate: would `grant` be visible to
- * `ctx`?
+ * In-memory mirror of the push-down predicate's grant-match arm: would `row`
+ * be visible to `ctx`?
+ *
+ * Takes the ROW, not just its grant, so tenant containment is unskippable.
+ * That is not ceremony: `aclVisibilityClause` emits `workspace_id = $n`
+ * precisely because audience ids collide across tenants, and an earlier cut of
+ * this helper took the bare grant — which made it answer TRUE for another
+ * tenant's row, and for an `unresolved` reader the SQL denies outright. A
+ * "mirror" that disagrees with the predicate in the permissive direction is
+ * worse than no mirror, because callers trust it.
  *
  * Deliberately array-overlap-shaped rather than "parse then compare", because
  * the thing it must agree with is Postgres's `&&`. A parse-based mirror would
- * drift the moment the two disagreed about a token's shape — which is exactly
- * the drift the SQL/mirror parity test exists to catch.
+ * drift the moment the two disagreed about a token's shape.
+ *
+ * Does NOT model the audit override — an override read bypasses grants
+ * entirely and must go through the predicate, not through this.
  *
  * NOT a substitute for the predicate. It answers a question about a row the
- * caller already holds (a review surface, a test, an assertion); it cannot
- * keep an unreadable row from being fetched, and only the WHERE clause can.
+ * caller already holds; it cannot keep an unreadable row from being fetched,
+ * and only the WHERE clause can.
  */
-export function isVisibleTo(grant: readonly unknown[], ctx: BrainPrincipalContext): boolean {
+export function isVisibleTo(row: AclGatedRow, ctx: BrainPrincipalContext): boolean {
+  if (row.workspaceId !== ctx.workspaceId) {
+    log.warn(
+      {
+        rowWorkspaceId: row.workspaceId,
+        readerWorkspaceId: ctx.workspaceId,
+        origin: ctx.origin,
+        userId: ctx.userId,
+      },
+      "brain ACL: visibility asked about a row outside the reader's workspace — denying",
+    );
+    return false;
+  }
   const tokens = new Set(principalTokens(ctx));
-  return grant.some((token) => typeof token === "string" && tokens.has(token));
+  if (tokens.size === 0) return false;
+  return row.visibleTo.some((token) => typeof token === "string" && tokens.has(token));
 }
 
 // ══════════════════════════════════════════════════════════════════════
@@ -406,55 +566,79 @@ export type AclDecision =
   | "audit-override"
   /** An override was requested by a reader not entitled to one. Falls back to `grant-match` SQL. */
   | "override-refused"
-  /** No usable principal. `FALSE`. */
+  /** No workspace, an unresolvable reader identity, or no usable principal. `(FALSE)`. */
   | "deny-all";
 
 /**
- * A region- and workspace-scoped admin/audit read (ADR-0036: "admin/audit
- * override is region-scoped — no cross-region super-admin").
+ * A region- and workspace-scoped admin/audit read.
  *
- * Region scoping is by construction: the process IS the region (ADR-0024), so
- * there is no region to name. Workspace scoping is NOT by construction and is
- * enforced in the emitted SQL. Entitlement is the reader's ORG role being
- * `owner` or `admin` — a bare `platform_admin` is a platform operator, not a
- * member of the tenant, and gets nothing.
+ * ADR-0036 states the override is REGION-scoped ("no cross-region
+ * super-admin"). Region scoping is by construction: the process IS the region
+ * (ADR-0024), so there is no region to name. WORKSPACE scoping is this
+ * module's own addition — it is not by construction, and it is enforced in the
+ * emitted SQL.
+ *
+ * Entitlement is an `authenticated` reader with an org role of `owner` or
+ * `admin`. A bare `platform_admin` is a platform operator, not a member of the
+ * tenant, and gets nothing.
  */
 export interface AclAuditOverride {
-  /** Recorded verbatim in the audit log line. Required — an unexplained override is not one. */
+  /**
+   * Why the override was invoked. Required, and an empty/whitespace reason is
+   * REFUSED — an unexplained override is not one.
+   *
+   * Recorded verbatim in a structured `log.warn` from the `brain-acl` logger.
+   * This is NOT written to the durable `audit_log` table; a caller that needs
+   * a durable record must write one.
+   */
   readonly reason: string;
-  /** Correlates the log line with the originating request. */
-  readonly requestId?: string;
 }
 
 export interface AclClauseOptions {
   /** Tier-2 or tier-3 target. Tier-1 warehouse facts are not gated here. */
   readonly table: AclGatedTable;
-  /** Table alias used in the caller's query. Defaults to the table name. */
+  /**
+   * Table alias used in the caller's query. Defaults to the table name. Must
+   * alias one of `ACL_GATED_TABLES` — it is what the emitted SQL references.
+   */
   readonly alias?: string;
   /** 1-based index of the FIRST placeholder this clause may use. */
   readonly paramIndex: number;
   readonly override?: AclAuditOverride;
+  /** Correlates this clause's log lines with the originating request. */
+  readonly requestId?: string;
 }
 
-export interface AclClause {
-  /** WHERE fragment, already parenthesised. No leading `AND`. */
-  readonly sql: string;
-  /**
-   * Values for `$paramIndex … $(paramIndex + params.length - 1)`, in order.
-   *
-   * The LENGTH VARIES BY DECISION — 2 for `grant-match`/`override-refused`,
-   * 1 for `audit-override`, 0 for `deny-all`. Callers must advance their own
-   * placeholder counter by `params.length` and never by a hardcoded number;
-   * Postgres rejects a bind that supplies more parameters than the statement
-   * references, so guessing fails loudly rather than silently — but it fails
-   * at execution, which is late.
-   */
-  readonly params: readonly unknown[];
-  readonly decision: AclDecision;
-}
+/**
+ * A WHERE fragment plus the values it binds.
+ *
+ * A discriminated union on `decision` because the parameter ARITY VARIES by
+ * branch, and the type has that information: a caller who switches on
+ * `decision` gets the arity from the compiler instead of from a comment.
+ * Regardless, advance your own placeholder counter by `params.length` and
+ * never by a constant — Postgres rejects a bind that supplies more parameters
+ * than the statement references, so guessing fails loudly, but it fails at
+ * execution, which is late.
+ *
+ * `sql` is always parenthesised and carries no leading `AND`.
+ */
+export type AclClause =
+  | { readonly decision: "deny-all"; readonly sql: string; readonly params: readonly [] }
+  | {
+      readonly decision: "audit-override";
+      readonly sql: string;
+      readonly params: readonly [workspaceId: string];
+    }
+  | {
+      readonly decision: "grant-match" | "override-refused";
+      readonly sql: string;
+      readonly params: readonly [workspaceId: string, tokens: readonly string[]];
+    };
 
 /** A SQL identifier safe to interpolate as an alias. */
 const SAFE_ALIAS = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const DENY_ALL: AclClause = { sql: "(FALSE)", params: [], decision: "deny-all" };
 
 /**
  * The fail-closed, push-down visibility predicate. AND this into the WHERE
@@ -483,7 +667,7 @@ export function aclVisibilityClause(
   ctx: BrainPrincipalContext,
   options: AclClauseOptions,
 ): AclClause {
-  const { table, paramIndex, override } = options;
+  const { table, paramIndex, override, requestId } = options;
   const alias = options.alias ?? table;
 
   if (!Number.isInteger(paramIndex) || paramIndex < 1) {
@@ -496,37 +680,53 @@ export function aclVisibilityClause(
       `aclVisibilityClause: alias ${JSON.stringify(alias)} is not a plain SQL identifier`,
     );
   }
+
+  // Both deny arms record whether an override was ATTEMPTED. An operator
+  // reading "identity could not be resolved" must be able to tell that
+  // somebody also tried to invoke a workspace-wide ACL bypass — attempted
+  // privilege escalation is exactly the event you want in the log.
+  const denyContext = {
+    table,
+    origin: ctx.origin,
+    userId: ctx.userId,
+    requestId,
+    overrideRequested: !!override,
+  };
   if (!ctx.workspaceId) {
     // No workspace means no tenant boundary to enforce, and a predicate with
     // no tenant boundary is worse than none at all.
-    log.warn(
-      { table, origin: ctx.origin },
-      "brain ACL: principal context has no workspace — denying all rows",
-    );
-    return { sql: "FALSE", params: [], decision: "deny-all" };
+    log.warn(denyContext, "brain ACL: principal context has no workspace — denying all rows");
+    return DENY_ALL;
   }
   if (ctx.origin === "unresolved") {
     log.warn(
-      { table, workspaceId: ctx.workspaceId },
+      { ...denyContext, workspaceId: ctx.workspaceId },
       "brain ACL: reader identity could not be resolved — denying all rows",
     );
-    return { sql: "FALSE", params: [], decision: "deny-all" };
+    return DENY_ALL;
   }
 
   const workspaceClause = `${alias}.workspace_id = $${paramIndex}`;
 
   if (override) {
-    const entitled = ctx.role === "owner" || ctx.role === "admin";
+    const reason = override.reason.trim();
+    const entitled =
+      ctx.origin === "authenticated" &&
+      !!ctx.userId &&
+      (ctx.role === "owner" || ctx.role === "admin") &&
+      reason.length > 0;
+    const auditContext = {
+      table,
+      workspaceId: ctx.workspaceId,
+      userId: ctx.userId,
+      role: ctx.role,
+      origin: ctx.origin,
+      reason: override.reason,
+      requestId,
+    };
     if (entitled) {
       log.warn(
-        {
-          table,
-          workspaceId: ctx.workspaceId,
-          userId: ctx.userId,
-          role: ctx.role,
-          reason: override.reason,
-          requestId: override.requestId,
-        },
+        auditContext,
         "brain ACL: audit override — per-grant visibility bypassed for this read",
       );
       return {
@@ -540,30 +740,24 @@ export function aclVisibilityClause(
     // reader to their own facts because a caller over-asked would be a worse
     // failure than the over-ask itself. It is logged either way.
     log.warn(
-      {
-        table,
-        workspaceId: ctx.workspaceId,
-        userId: ctx.userId,
-        role: ctx.role,
-        reason: override.reason,
-        requestId: override.requestId,
-      },
-      "brain ACL: audit override refused — reader is not a workspace owner/admin; falling back to grant matching",
+      auditContext,
+      "brain ACL: audit override refused — reader is not an authenticated workspace owner/admin with a stated reason; falling back to grant matching",
     );
   }
 
   const tokens = principalTokens(ctx);
   if (tokens.length === 0) {
-    // Unreachable today — `principalTokens` always seeds `org` — but the deny
-    // arm is written out rather than assumed, because "the token set can never
-    // be empty" is exactly the kind of invariant a later edit quietly breaks,
-    // and `visible_to && ARRAY[]` would then silently become the fail-OPEN
-    // shape's near neighbour.
+    // Reachable whenever `principalTokens` denies — today that is exactly the
+    // two arms handled above, so this is a backstop rather than a distinct
+    // cause. It is written out anyway: `visible_to && ARRAY[]` is already
+    // FALSE in Postgres, so the ROW-level outcome would be identical, but it
+    // would be a silent, unlogged deny reported as `grant-match`. The explicit
+    // arm exists to make the deny OBSERVABLE, not because the SQL would leak.
     log.warn(
-      { table, workspaceId: ctx.workspaceId, userId: ctx.userId, origin: ctx.origin },
+      { table, workspaceId: ctx.workspaceId, userId: ctx.userId, origin: ctx.origin, requestId },
       "brain ACL: reader resolved to no principals — denying all rows",
     );
-    return { sql: "FALSE", params: [], decision: "deny-all" };
+    return DENY_ALL;
   }
 
   return {

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -1,0 +1,574 @@
+/**
+ * The company brain's minimal per-fact/per-episode ACL (#4768, ADR-0036
+ * §Access control & residency).
+ *
+ * Three things live here, in dependency order:
+ *
+ *   1. **The grant grammar** — `org | role:{owner,admin,member} | user:<id> |
+ *      audience:<source-derived>` — parsed into a discriminated union.
+ *   2. **Principal-set resolution** — turning a reader's identity into the set
+ *      of tokens that grant them access, including live `audience:` membership.
+ *   3. **`aclVisibilityClause`** — a FAIL-CLOSED, PUSH-DOWN SQL predicate.
+ *      #4773's `searchBrain` ANDs it into its WHERE clause; it is never a
+ *      post-fetch filter, because a post-fetch filter has already loaded the
+ *      row it is about to hide, and every LIMIT above it counts rows the
+ *      reader may not see.
+ *
+ * ## What this gates, and what it deliberately does not
+ *
+ * Tiers 2 and 3 only — `brain_facts` and `brain_episodes`. Tier-1 warehouse
+ * facts are computed live through the semantic layer and gated by warehouse
+ * RLS; double-gating them here would mean two systems that must agree about
+ * the same row and will eventually not. `AclGatedTable` makes that a
+ * compile-time fact rather than a comment: there is no way to spell a tier-1
+ * target in a call to `aclVisibilityClause`.
+ *
+ * ## Fail-closed, in both directions
+ *
+ * **Reader side** — a reader whose principal set cannot be resolved gets
+ * `FALSE`, not "everything" and not "the public subset". Every deny is logged.
+ *
+ * **Stored side** — a malformed token (`everyone`, `team:eng`, `ROLE:admin`)
+ * is invisible by CONSTRUCTION: the predicate is array overlap against the
+ * reader's tokens, and no reader token is ever malformed, so a malformed grant
+ * token can match nothing. That is why the parser can be permissive without
+ * being unsafe. The logging half of "deny + log" is `logGrantAnomalies`, which
+ * callers apply to rows they already hold — see its own doc comment for why
+ * that is the only honest read-time seam a push-down predicate leaves open.
+ *
+ * ## The one thing that must never become stricter
+ *
+ * Migration 0180's `chk_brain_{facts,episodes}_grant_nonempty` accepts any
+ * grant with at least one non-NULL, non-empty element. NOTHING here may reject
+ * a grant that CHECK admits. A row Postgres legally stores but Atlas code
+ * refuses is a workspace that cannot be migrated between regions — and the
+ * failure surfaces at cutover, long after the offending row landed. So
+ * `parseGrant` REPORTS malformed tokens and never throws, and this module has
+ * no write-side validation at all. Structural validity stops at "has a usable
+ * principal"; whether `everyone` is a MEANINGFUL principal is a read-time
+ * deny, never an import rejection. `grantProblem` in `api/routes/admin-migrate.ts`
+ * is the mirrored guard on the import side — the two are a matched pair and
+ * move together.
+ */
+
+import { ORG_ROLES, type AtlasRole, type AuthMode, type OrgRole } from "@useatlas/types/auth";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("brain-acl");
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  The grant grammar
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * The `org`-wide principal, spelled out. ADR-0036's "the public majority
+ * carries an explicit `[org]`" — "visible to everyone" is a stated grant, so
+ * that a forgotten grant can never READ as public.
+ */
+export const ORG_PRINCIPAL = "org" as const;
+
+/** Prefixes of the parameterised arms. Exported so writers format, not concat. */
+export const ROLE_PREFIX = "role:" as const;
+export const USER_PREFIX = "user:" as const;
+export const AUDIENCE_PREFIX = "audience:" as const;
+
+/** A parsed grant token. */
+export type BrainPrincipal =
+  | { readonly kind: "org" }
+  | { readonly kind: "role"; readonly role: OrgRole }
+  | { readonly kind: "user"; readonly userId: string }
+  | { readonly kind: "audience"; readonly audienceId: string };
+
+const ORG_ROLE_SET: ReadonlySet<string> = new Set(ORG_ROLES);
+
+/**
+ * Parse one grant token, or `null` if it is not in the grammar.
+ *
+ * Comparison is BYTE-EXACT and case-sensitive on purpose. The enforcement is
+ * Postgres's `&&` operator over `text[]`, which is byte-exact; if this parser
+ * lower-cased (or trimmed) while Postgres did not, `isVisibleTo` and
+ * `aclVisibilityClause` would disagree about the same row — and the in-memory
+ * mirror exists precisely to be trustworthy about what the SQL will do. So
+ * `ROLE:admin` and `org ` are malformed rather than helpfully coerced.
+ *
+ * The `<id>` arms accept ANY non-empty remainder. Better Auth ids and
+ * source-derived audience ids have no shape this module is entitled to assume,
+ * and a stricter pattern here would be exactly the "stricter than the CHECK"
+ * failure the module header forbids.
+ */
+export function parsePrincipal(raw: string): BrainPrincipal | null {
+  if (raw === ORG_PRINCIPAL) return { kind: "org" };
+  if (raw.startsWith(ROLE_PREFIX)) {
+    const role = raw.slice(ROLE_PREFIX.length);
+    // `role:platform_admin` is malformed: platform roles are cross-tenant and
+    // deliberately outside the grammar (ADR-0036 — admin/audit override is
+    // region- and workspace-scoped, there is no super-admin arm).
+    return ORG_ROLE_SET.has(role) ? { kind: "role", role: role as OrgRole } : null;
+  }
+  if (raw.startsWith(USER_PREFIX)) {
+    const userId = raw.slice(USER_PREFIX.length);
+    return userId.length > 0 ? { kind: "user", userId } : null;
+  }
+  if (raw.startsWith(AUDIENCE_PREFIX)) {
+    const audienceId = raw.slice(AUDIENCE_PREFIX.length);
+    return audienceId.length > 0 ? { kind: "audience", audienceId } : null;
+  }
+  return null;
+}
+
+/** Render a principal back to its stored token. Round-trips `parsePrincipal`. */
+export function formatPrincipal(principal: BrainPrincipal): string {
+  switch (principal.kind) {
+    case "org":
+      return ORG_PRINCIPAL;
+    case "role":
+      return `${ROLE_PREFIX}${principal.role}`;
+    case "user":
+      return `${USER_PREFIX}${principal.userId}`;
+    case "audience":
+      return `${AUDIENCE_PREFIX}${principal.audienceId}`;
+  }
+}
+
+/** What `parseGrant` found. Both halves matter; neither is an error. */
+export interface ParsedGrant {
+  readonly principals: readonly BrainPrincipal[];
+  /**
+   * Tokens outside the grammar, verbatim. NULL and `''` elements — both legal
+   * at rest under the CHECK, which only requires ONE usable principal — are
+   * reported here as the empty string so a caller counting anomalies sees them.
+   */
+  readonly malformed: readonly string[];
+}
+
+/**
+ * Parse a stored `visible_to` array. Never throws, never rejects.
+ *
+ * A grant that is entirely malformed yields `principals: []`, which grants
+ * nobody anything — the deny is the RESULT, not an exception. That is the
+ * whole shape of this module's contract with migration 0180: everything the
+ * CHECK admits parses, and the ones that mean nothing simply match nothing.
+ *
+ * Accepts `readonly unknown[]` rather than `BrainGrant` because the caller is
+ * usually holding a `text[]` straight off `pg`, where a NULL element arrives
+ * as `null` and no type has narrowed it yet.
+ */
+export function parseGrant(grant: readonly unknown[]): ParsedGrant {
+  const principals: BrainPrincipal[] = [];
+  const malformed: string[] = [];
+  for (const raw of grant) {
+    if (typeof raw !== "string" || raw.length === 0) {
+      malformed.push("");
+      continue;
+    }
+    const principal = parsePrincipal(raw);
+    if (principal) principals.push(principal);
+    else malformed.push(raw);
+  }
+  return { principals, malformed };
+}
+
+/**
+ * The logging half of "malformed grants deny + log".
+ *
+ * A push-down predicate cannot log the rows it excluded — it never sees them,
+ * which is the point. So the seam is here: a caller that ALREADY holds a row
+ * (the review surface, the exporter, `searchBrain`'s result set) passes its
+ * grant through and any malformed token is surfaced. This costs nothing — no
+ * extra fetch — and catches the case that actually matters in practice: a
+ * grant like `['user:abc', 'everyone']` that PASSES the predicate on its valid
+ * token while carrying a second one the author believed was doing something.
+ *
+ * Returns the parse so callers do not pay for it twice.
+ */
+export function logGrantAnomalies(
+  grant: readonly unknown[],
+  meta: { readonly table: AclGatedTable; readonly rowId: string; readonly workspaceId: string },
+): ParsedGrant {
+  const parsed = parseGrant(grant);
+  if (parsed.malformed.length > 0) {
+    log.warn(
+      {
+        table: meta.table,
+        rowId: meta.rowId,
+        workspaceId: meta.workspaceId,
+        malformed: parsed.malformed,
+        usablePrincipals: parsed.principals.length,
+      },
+      "brain ACL: grant contains tokens outside the grammar — they grant nobody access",
+    );
+  }
+  return parsed;
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  Principal-set resolution
+// ══════════════════════════════════════════════════════════════════════
+
+/** The tier-2/3 tables this predicate may gate. Tier-1 is not spellable. */
+export const ACL_GATED_TABLES = ["brain_facts", "brain_episodes"] as const;
+export type AclGatedTable = (typeof ACL_GATED_TABLES)[number];
+
+/**
+ * A reader's resolved identity within one workspace.
+ *
+ * `audienceIds` is a SNAPSHOT of as-of-now membership, read locally from
+ * `fact_audience_member` — never a live connector call (ADR-0036: grants are
+ * derived at ingest and immutable per fact version; membership is the live
+ * half, and it is the revocation path, so it must be cheap enough to evaluate
+ * on every read).
+ */
+export interface BrainPrincipalContext {
+  readonly workspaceId: string;
+  /** `null` when the deployment has no authenticated identity (`auth: none`). */
+  readonly userId: string | null;
+  /**
+   * The reader's ORG role. `null` for `auth: none`, for a reader with no org
+   * membership, and for a bare `platform_admin` — a platform role is not an
+   * org role and confers no brain grant.
+   */
+  readonly role: OrgRole | null;
+  readonly audienceIds: readonly string[];
+  /**
+   * How this context came to be.
+   *
+   * `unauthenticated-local` is `auth: none`, where the deployment has DECLARED
+   * there is no identity to resolve. It is granted the `org` principal ONLY,
+   * so anything deliberately narrowed to a role, user, or audience stays
+   * hidden even from the local operator. That is strictly narrower than what
+   * the rest of Atlas hands `none` mode, and intentionally so.
+   *
+   * `unresolved` is the failure arm — an authenticated request whose identity
+   * could not be established. `aclVisibilityClause` denies it outright.
+   * Distinct from `unauthenticated-local` because "there is no identity" and
+   * "there should have been an identity and there isn't" are opposite
+   * situations that would otherwise share a code path.
+   */
+  readonly origin: "authenticated" | "unauthenticated-local" | "unresolved";
+}
+
+/**
+ * The narrow slice of a database handle this module needs. Structurally
+ * satisfied by `InternalPoolClient`, `pg.Pool`, and `pg.PoolClient`, so
+ * callers pass their existing handle straight through — and tests pass a
+ * literal, with no `mock.module()` and no top-level singleton to mutate.
+ */
+export interface AudienceMembershipReader {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
+}
+
+/**
+ * "Which audiences is this user in?" — the per-request expansion, served by
+ * `idx_fact_audience_member_user`.
+ */
+export const AUDIENCE_MEMBERSHIP_SQL = `
+  SELECT audience_id
+    FROM fact_audience_member
+   WHERE workspace_id = $1
+     AND user_id = $2
+` as const;
+
+/**
+ * Resolve a reader's principal context, including live audience membership.
+ *
+ * Database failures PROPAGATE. Catching them and returning zero audiences
+ * would be fail-closed in the narrow sense and wrong in every other one: it
+ * silently downgrades a reader mid-incident and reports success while doing
+ * it. The caller surfaces a 500 with a requestId, which is what a failed
+ * authorization lookup deserves.
+ */
+export async function resolvePrincipalContext(
+  db: AudienceMembershipReader,
+  input: {
+    readonly workspaceId: string;
+    readonly mode: AuthMode;
+    readonly userId: string | undefined;
+    readonly role: AtlasRole | undefined;
+  },
+): Promise<BrainPrincipalContext> {
+  const { workspaceId, mode, userId, role } = input;
+
+  if (mode === "none") {
+    return {
+      workspaceId,
+      userId: null,
+      role: null,
+      audienceIds: [],
+      origin: "unauthenticated-local",
+    };
+  }
+
+  // A platform role is not an org role; `AtlasUser.role` spans both surfaces.
+  const orgRole = role !== undefined && ORG_ROLE_SET.has(role) ? (role as OrgRole) : null;
+
+  if (!userId) {
+    // Authenticated mode with no user id should be unreachable — auth
+    // middleware attaches one — so this is a bug signal, not a routine branch.
+    // It resolves `unresolved`, which `aclVisibilityClause` denies outright:
+    // returning the `org`-only context here would hand an unidentified caller
+    // the workspace's public facts on the strength of a middleware bug.
+    log.warn(
+      { workspaceId, mode },
+      "brain ACL: authenticated request carries no user id — principal set is unresolvable",
+    );
+    return { workspaceId, userId: null, role: orgRole, audienceIds: [], origin: "unresolved" };
+  }
+
+  const result = await db.query(AUDIENCE_MEMBERSHIP_SQL, [workspaceId, userId]);
+  const audienceIds = result.rows
+    .map((row) => (row as { audience_id?: unknown }).audience_id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+
+  return { workspaceId, userId, role: orgRole, audienceIds, origin: "authenticated" };
+}
+
+/**
+ * Roles a reader with `role` satisfies, most-privileged first.
+ *
+ * Role matching is MONOTONE: an owner matches `role:owner`, `role:admin`, and
+ * `role:member`. Exact-match was considered and rejected. `role:member` means
+ * "at least a member" in every RBAC system anyone has used, and under exact
+ * matching a fact granted to `role:member` would be invisible to the workspace
+ * OWNER — a hole that reads as a bug every time it is hit, and that the ingest
+ * deriver (#4771) could only avoid by remembering to enumerate all three arms
+ * on every grant.
+ *
+ * The widening is bounded and has no leak case: owner ⊇ admin ⊇ member is the
+ * same containment Atlas's own `org-permissions.ts` role table already spells
+ * out row by row, and every role a reader gains access through is one they
+ * already outrank.
+ */
+export function impliedRoles(role: OrgRole): readonly OrgRole[] {
+  switch (role) {
+    case "owner":
+      return ["owner", "admin", "member"];
+    case "admin":
+      return ["admin", "member"];
+    case "member":
+      return ["member"];
+  }
+}
+
+/**
+ * The reader's grant tokens — the exact array the push-down predicate binds,
+ * and the exact set `isVisibleTo` tests against.
+ *
+ * Never contains `''`: `ARRAY[''] && ARRAY['']` is TRUE in Postgres, so an
+ * empty reader token would match a stored `''` element that migration 0180
+ * explicitly tolerates (the CHECK requires one USABLE principal, not that
+ * every element is usable). Every arm below is guarded on non-empty input for
+ * that reason, not for tidiness.
+ */
+export function principalTokens(ctx: BrainPrincipalContext): readonly string[] {
+  const tokens: string[] = [ORG_PRINCIPAL];
+  if (ctx.role) {
+    for (const role of impliedRoles(ctx.role)) tokens.push(`${ROLE_PREFIX}${role}`);
+  }
+  if (ctx.userId) tokens.push(`${USER_PREFIX}${ctx.userId}`);
+  for (const audienceId of ctx.audienceIds) {
+    // Stored WITHOUT the prefix in `fact_audience_member` — the prefix belongs
+    // to the grammar, not to the identity — so it is added here, once.
+    if (audienceId.length > 0) tokens.push(`${AUDIENCE_PREFIX}${audienceId}`);
+  }
+  return tokens;
+}
+
+/**
+ * In-memory mirror of the push-down predicate: would `grant` be visible to
+ * `ctx`?
+ *
+ * Deliberately array-overlap-shaped rather than "parse then compare", because
+ * the thing it must agree with is Postgres's `&&`. A parse-based mirror would
+ * drift the moment the two disagreed about a token's shape — which is exactly
+ * the drift the SQL/mirror parity test exists to catch.
+ *
+ * NOT a substitute for the predicate. It answers a question about a row the
+ * caller already holds (a review surface, a test, an assertion); it cannot
+ * keep an unreadable row from being fetched, and only the WHERE clause can.
+ */
+export function isVisibleTo(grant: readonly unknown[], ctx: BrainPrincipalContext): boolean {
+  const tokens = new Set(principalTokens(ctx));
+  return grant.some((token) => typeof token === "string" && tokens.has(token));
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  The fail-closed push-down predicate
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Why a clause is the shape it is. Observable so a caller can log it and a
+ * test can assert the branch rather than pattern-matching SQL text.
+ */
+export type AclDecision =
+  /** Normal path — workspace containment AND grant overlap. */
+  | "grant-match"
+  /** An entitled workspace admin's audit read. Workspace containment only. */
+  | "audit-override"
+  /** An override was requested by a reader not entitled to one. Falls back to `grant-match` SQL. */
+  | "override-refused"
+  /** No usable principal. `FALSE`. */
+  | "deny-all";
+
+/**
+ * A region- and workspace-scoped admin/audit read (ADR-0036: "admin/audit
+ * override is region-scoped — no cross-region super-admin").
+ *
+ * Region scoping is by construction: the process IS the region (ADR-0024), so
+ * there is no region to name. Workspace scoping is NOT by construction and is
+ * enforced in the emitted SQL. Entitlement is the reader's ORG role being
+ * `owner` or `admin` — a bare `platform_admin` is a platform operator, not a
+ * member of the tenant, and gets nothing.
+ */
+export interface AclAuditOverride {
+  /** Recorded verbatim in the audit log line. Required — an unexplained override is not one. */
+  readonly reason: string;
+  /** Correlates the log line with the originating request. */
+  readonly requestId?: string;
+}
+
+export interface AclClauseOptions {
+  /** Tier-2 or tier-3 target. Tier-1 warehouse facts are not gated here. */
+  readonly table: AclGatedTable;
+  /** Table alias used in the caller's query. Defaults to the table name. */
+  readonly alias?: string;
+  /** 1-based index of the FIRST placeholder this clause may use. */
+  readonly paramIndex: number;
+  readonly override?: AclAuditOverride;
+}
+
+export interface AclClause {
+  /** WHERE fragment, already parenthesised. No leading `AND`. */
+  readonly sql: string;
+  /**
+   * Values for `$paramIndex … $(paramIndex + params.length - 1)`, in order.
+   *
+   * The LENGTH VARIES BY DECISION — 2 for `grant-match`/`override-refused`,
+   * 1 for `audit-override`, 0 for `deny-all`. Callers must advance their own
+   * placeholder counter by `params.length` and never by a hardcoded number;
+   * Postgres rejects a bind that supplies more parameters than the statement
+   * references, so guessing fails loudly rather than silently — but it fails
+   * at execution, which is late.
+   */
+  readonly params: readonly unknown[];
+  readonly decision: AclDecision;
+}
+
+/** A SQL identifier safe to interpolate as an alias. */
+const SAFE_ALIAS = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * The fail-closed, push-down visibility predicate. AND this into the WHERE
+ * clause of any read over `brain_facts` or `brain_episodes`.
+ *
+ * ## Why it emits workspace containment too
+ *
+ * The clause is `workspace_id = $n AND visible_to && $m`, not the overlap
+ * alone — even though every caller already scopes to a workspace. Audience ids
+ * are workspace-scoped identities with no global uniqueness: two tenants can
+ * both mint `audience:engineering`, and a reader in tenant A holding that
+ * token would match tenant B's fact if this predicate were composed into a
+ * query whose own workspace scoping was missing or was accidentally OR-ed.
+ * Redundant tenant scoping inside a security predicate is the difference
+ * between a primitive that is safe standalone and one that is safe only when
+ * used correctly. Postgres folds the duplicate condition for free.
+ *
+ * ## Composition (ADR-0036 — four gates, AND-ed)
+ *
+ * This is ONE of four. The others are residency (invariant by construction —
+ * the process is the region), org/group reach (ADR-0022), and content mode
+ * (`draft`/`published`; `brain_facts` joins the registry in #4769). AND them;
+ * never OR, and never substitute one for another.
+ */
+export function aclVisibilityClause(
+  ctx: BrainPrincipalContext,
+  options: AclClauseOptions,
+): AclClause {
+  const { table, paramIndex, override } = options;
+  const alias = options.alias ?? table;
+
+  if (!Number.isInteger(paramIndex) || paramIndex < 1) {
+    throw new Error(
+      `aclVisibilityClause: paramIndex must be a positive integer, got ${paramIndex}`,
+    );
+  }
+  if (!SAFE_ALIAS.test(alias)) {
+    throw new Error(
+      `aclVisibilityClause: alias ${JSON.stringify(alias)} is not a plain SQL identifier`,
+    );
+  }
+  if (!ctx.workspaceId) {
+    // No workspace means no tenant boundary to enforce, and a predicate with
+    // no tenant boundary is worse than none at all.
+    log.warn(
+      { table, origin: ctx.origin },
+      "brain ACL: principal context has no workspace — denying all rows",
+    );
+    return { sql: "FALSE", params: [], decision: "deny-all" };
+  }
+  if (ctx.origin === "unresolved") {
+    log.warn(
+      { table, workspaceId: ctx.workspaceId },
+      "brain ACL: reader identity could not be resolved — denying all rows",
+    );
+    return { sql: "FALSE", params: [], decision: "deny-all" };
+  }
+
+  const workspaceClause = `${alias}.workspace_id = $${paramIndex}`;
+
+  if (override) {
+    const entitled = ctx.role === "owner" || ctx.role === "admin";
+    if (entitled) {
+      log.warn(
+        {
+          table,
+          workspaceId: ctx.workspaceId,
+          userId: ctx.userId,
+          role: ctx.role,
+          reason: override.reason,
+          requestId: override.requestId,
+        },
+        "brain ACL: audit override — per-grant visibility bypassed for this read",
+      );
+      return {
+        sql: `(${workspaceClause})`,
+        params: [ctx.workspaceId],
+        decision: "audit-override",
+      };
+    }
+    // Refused, not fatal: the reader still sees what their own grants allow.
+    // Falling through to `grant-match` is not a widening, and blinding a
+    // reader to their own facts because a caller over-asked would be a worse
+    // failure than the over-ask itself. It is logged either way.
+    log.warn(
+      {
+        table,
+        workspaceId: ctx.workspaceId,
+        userId: ctx.userId,
+        role: ctx.role,
+        reason: override.reason,
+        requestId: override.requestId,
+      },
+      "brain ACL: audit override refused — reader is not a workspace owner/admin; falling back to grant matching",
+    );
+  }
+
+  const tokens = principalTokens(ctx);
+  if (tokens.length === 0) {
+    // Unreachable today — `principalTokens` always seeds `org` — but the deny
+    // arm is written out rather than assumed, because "the token set can never
+    // be empty" is exactly the kind of invariant a later edit quietly breaks,
+    // and `visible_to && ARRAY[]` would then silently become the fail-OPEN
+    // shape's near neighbour.
+    log.warn(
+      { table, workspaceId: ctx.workspaceId, userId: ctx.userId, origin: ctx.origin },
+      "brain ACL: reader resolved to no principals — denying all rows",
+    );
+    return { sql: "FALSE", params: [], decision: "deny-all" };
+  }
+
+  return {
+    sql: `(${workspaceClause} AND ${alias}.visible_to && $${paramIndex + 1}::text[])`,
+    params: [ctx.workspaceId, tokens],
+    decision: override ? "override-refused" : "grant-match",
+  };
+}

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -33,10 +33,10 @@
  *
  * **Reader side** — a reader whose principal set cannot be resolved gets
  * `FALSE`, not "everything" and not "the public subset". Every deny in
- * `aclVisibilityClause` is logged. `isVisibleTo` logs only the two denies that
- * indicate a BUG upstream (a cross-workspace ask, an unusable principal set);
- * an ordinary no-overlap answer stays silent, because it is called per row and
- * would flood the signal at read volume.
+ * `aclVisibilityClause` is logged. `isVisibleTo` logs only the three denies
+ * that indicate a BUG UPSTREAM — a cross-workspace ask, a row with no grant
+ * array, an unusable principal set — and stays silent on an ordinary
+ * no-overlap answer, which is the common case and is evaluated per row.
  *
  * **Stored side** — a malformed token (`everyone`, `team:eng`, `ROLE:admin`)
  * is invisible by CONSTRUCTION: the predicate is array overlap against the
@@ -52,7 +52,7 @@
  * (`['everyone']`) is correctly invisible and is logged by nobody, because no
  * reader ever holds the row. Closing that needs a write-time or sweep-time
  * observer (#4771's deriver, or a `registerPeriodicFiber` scan) and is
- * deliberately out of this slice — tracked on #4773.
+ * deliberately out of this slice — tracked on #4797.
  *
  * ## The one thing that must never become stricter
  *
@@ -111,6 +111,16 @@ export type BrainPrincipal =
 /** Narrow an arbitrary string to an org role without a cast. */
 function isOrgRole(value: string): value is OrgRole {
   return ORG_ROLES.some((role) => role === value);
+}
+
+/**
+ * `Array.isArray` narrows to `any[]`, which would make the grant elements
+ * implicitly `any` in the one line that performs the actual overlap — and
+ * would stop rejecting a future simplification to a bare `tokens.has(token)`.
+ * This keeps them `unknown`.
+ */
+function isUnknownArray(value: unknown): value is readonly unknown[] {
+  return Array.isArray(value);
 }
 
 /**
@@ -445,16 +455,25 @@ export async function resolvePrincipalContext(
   const audienceIds = result.rows
     .map((row) =>
       typeof row === "object" && row !== null && "audience_id" in row
-        ? (row as { audience_id: unknown }).audience_id
+        ? row.audience_id
         : undefined,
     )
     .filter((id): id is string => typeof id === "string" && id.length > 0);
   if (audienceIds.length !== result.rows.length) {
-    // `fact_audience_member.audience_id` is `text NOT NULL`, so a dropped row
-    // can only mean the query or the row shape changed (an added alias, a
-    // join). Silently returning fewer memberships would quietly strip a
-    // reader's audience grants — the same silent downgrade this function
+    // Two different faults land here and an operator must be able to tell them
+    // apart. A row with no `audience_id` key at all is QUERY DRIFT (an added
+    // alias, a join) — diff the SQL. A row that has the column but an unusable
+    // value is a DATA defect: `audience_id` is `text NOT NULL` but 0180 adds no
+    // non-empty CHECK, so `''` is legally storable and points at the deriver
+    // (#4771), not at this query. Reporting both as "the query changed" would
+    // send that investigation to the wrong file.
+    //
+    // Either way, silently returning fewer memberships would strip a reader's
+    // audience grants with no signal — the same silent downgrade this function
     // refuses to perform on a DB error.
+    const missingColumn = result.rows.filter(
+      (row) => !(typeof row === "object" && row !== null && "audience_id" in row),
+    ).length;
     log.warn(
       {
         workspaceId,
@@ -462,8 +481,12 @@ export async function resolvePrincipalContext(
         requestId,
         returned: result.rows.length,
         usable: audienceIds.length,
+        missingColumn,
+        unusableValue: result.rows.length - audienceIds.length - missingColumn,
       },
-      "brain ACL: audience membership rows dropped by narrowing — the membership query shape changed",
+      missingColumn > 0
+        ? "brain ACL: audience membership rows lack an audience_id column — the membership query shape changed"
+        : "brain ACL: audience membership rows carry an unusable audience_id — the writer stored an empty id",
     );
   }
 
@@ -624,7 +647,7 @@ export function isVisibleTo(row: AclGatedRow, ctx: BrainPrincipalContext): boole
     );
     return false;
   }
-  if (!Array.isArray(row.visibleTo)) {
+  if (!isUnknownArray(row.visibleTo)) {
     // Typed `readonly unknown[]`, but rows arrive off `pg` as `visible_to` and
     // a caller that maps `workspaceId` correctly and this field by mistake
     // would otherwise get a bare `TypeError` from a security primitive.
@@ -639,6 +662,13 @@ export function isVisibleTo(row: AclGatedRow, ctx: BrainPrincipalContext): boole
     // An unusable principal set is a bug upstream, not a routine answer — the
     // SQL path logs it and so does this one. The ordinary no-overlap deny
     // below stays silent on purpose: it is the common case, per row.
+    //
+    // This condition is per READER, not per row, so a caller looping a result
+    // set emits one identical line per row. That is bounded (this is the
+    // mirror, used by review surfaces and exporters over a page of rows — the
+    // hot retrieval path is the SQL predicate, which logs once) and it is a
+    // signal you want loud. A caller that loops should still hoist
+    // `principalTokens(ctx).length === 0` above the loop and skip it entirely.
     log.warn(
       { table: row.table, workspaceId: ctx.workspaceId, origin: ctx.origin, userId: ctx.userId },
       "brain ACL: reader resolved to no principals — denying",
@@ -747,16 +777,16 @@ export type AclDecision = AclClause["decision"];
 const SAFE_ALIAS = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
- * Frozen, not merely `readonly`. `readonly` is compile-time only, and this one
- * object is returned by reference from every deny in the process — so a single
- * type-violating caller mutating `.params` would poison every subsequent
- * denied read for every tenant on the instance, surfacing as a Postgres bind
- * error that points at the caller's query rather than at the mutation.
- * `lib/auth/types.ts` freezes `createAtlasUser`'s result for the same reason.
+ * The deny template. `nextParamIndex` depends on the caller's `paramIndex`, so
+ * `denyAll` spreads this into a fresh clause per call rather than returning it.
  *
- * `nextParamIndex` is filled in per call — it depends on the caller's
- * `paramIndex` — so the deny arm is built from this template rather than
- * returned directly.
+ * `params` is therefore the one part still shared by reference across every
+ * deny in the process — and it is frozen, because `readonly` is compile-time
+ * only. A type-violating `.push` on it would otherwise poison every subsequent
+ * denied read for every tenant on the instance, surfacing as a Postgres bind
+ * error pointing at the caller's query rather than at the mutation. Frozen, it
+ * throws at the mutation site instead. `lib/auth/types.ts` freezes
+ * `createAtlasUser`'s result for the same reason.
  */
 const DENY_ALL = Object.freeze({
   sql: "(FALSE)",

--- a/packages/api/src/lib/brain/acl.ts
+++ b/packages/api/src/lib/brain/acl.ts
@@ -21,29 +21,38 @@
  * Tiers 2 and 3 only — `brain_facts` and `brain_episodes`. Tier-1 warehouse
  * facts are computed live through the semantic layer and gated by warehouse
  * RLS; double-gating them here would mean two systems that must agree about
- * the same row and will eventually not. `AclGatedTable` constrains the NAMED
- * target so a tier-1 table cannot be requested — note that it constrains the
- * name, not the emitted SQL, which is built from `alias`; an alias pointed at
- * some other relation produces a predicate that fails loudly at runtime (no
- * `visible_to` column) rather than one that quietly gates the wrong thing.
+ * the same row and will eventually not. There IS no tier-1 table — migration
+ * 0180 stores none — so what `AclGatedTable` actually prevents is aiming this
+ * predicate at some OTHER relation. It constrains the NAMED target, not the
+ * emitted SQL, which is built from `alias`: an alias pointed elsewhere
+ * produces a predicate that fails loudly at runtime (no `visible_to` column)
+ * rather than one that quietly gates the wrong thing. `table` is otherwise
+ * used only for the default alias and for log payloads.
  *
  * ## Fail-closed, in both directions
  *
  * **Reader side** — a reader whose principal set cannot be resolved gets
- * `FALSE`, not "everything" and not "the public subset". Every reader-side
- * deny in this module is logged.
+ * `FALSE`, not "everything" and not "the public subset". Every deny in
+ * `aclVisibilityClause` is logged. `isVisibleTo` logs only the two denies that
+ * indicate a BUG upstream (a cross-workspace ask, an unusable principal set);
+ * an ordinary no-overlap answer stays silent, because it is called per row and
+ * would flood the signal at read volume.
  *
  * **Stored side** — a malformed token (`everyone`, `team:eng`, `ROLE:admin`)
  * is invisible by CONSTRUCTION: the predicate is array overlap against the
  * reader's tokens, and no reader token is ever malformed, so a malformed grant
  * token can match nothing. That invariant is load-bearing and is why
- * `principalTokens` guards every arm on non-empty input. It also means the
+ * `principalTokens` guards its `user:`/`audience:` arms. It also means the
  * parser can be permissive without being unsafe.
  *
  * Stored-side anomalies are logged only where a caller invokes
  * `logGrantAnomalies` on rows it already holds — see that function's comment
  * for why that is the only honest read-time seam a push-down predicate leaves
- * open. #4773 is expected to call it on its result set.
+ * open. NOTE THE RESIDUAL GAP: a grant that is ENTIRELY malformed
+ * (`['everyone']`) is correctly invisible and is logged by nobody, because no
+ * reader ever holds the row. Closing that needs a write-time or sweep-time
+ * observer (#4771's deriver, or a `registerPeriodicFiber` scan) and is
+ * deliberately out of this slice — tracked on #4773.
  *
  * ## The one thing that must never become stricter
  *
@@ -72,7 +81,7 @@ const log = createLogger("brain-acl");
 // ██  The gated tables
 // ══════════════════════════════════════════════════════════════════════
 
-/** The tier-2/3 tables this predicate may gate. Tier-1 is not spellable. */
+/** The tier-2/3 tables this predicate may gate. See the header on tier-1. */
 export const ACL_GATED_TABLES = ["brain_facts", "brain_episodes"] as const;
 export type AclGatedTable = (typeof ACL_GATED_TABLES)[number];
 
@@ -87,7 +96,7 @@ export type AclGatedTable = (typeof ACL_GATED_TABLES)[number];
  */
 export const ORG_PRINCIPAL = "org" as const;
 
-/** Prefixes of the parameterised arms. Exported so writers format, not concat. */
+/** Prefixes of the parameterised arms. Exported so writers never hardcode the literal. */
 export const ROLE_PREFIX = "role:" as const;
 export const USER_PREFIX = "user:" as const;
 export const AUDIENCE_PREFIX = "audience:" as const;
@@ -101,7 +110,7 @@ export type BrainPrincipal =
 
 /** Narrow an arbitrary string to an org role without a cast. */
 function isOrgRole(value: string): value is OrgRole {
-  return (ORG_ROLES as readonly string[]).includes(value);
+  return ORG_ROLES.some((role) => role === value);
 }
 
 /**
@@ -206,8 +215,9 @@ export function parseGrant(grant: readonly unknown[]): ParsedGrant {
  * A push-down predicate cannot log the rows it excluded — it never sees them,
  * which is the point. So the seam is here: a caller that ALREADY holds a row
  * (the review surface, the exporter, `searchBrain`'s result set) passes its
- * grant through and any malformed token is surfaced. This costs nothing — no
- * extra fetch — and catches the case that actually matters in practice: a
+ * grant through and any malformed token is surfaced. No extra fetch — it
+ * parses grants the caller already holds — and it catches the case that
+ * actually matters in practice: a
  * grant like `['user:abc', 'everyone']` that PASSES the predicate on its valid
  * token while carrying a second one the author believed was doing something.
  *
@@ -304,7 +314,7 @@ export type BrainPrincipalContext =
  * literal, with no `mock.module()` and no top-level singleton to mutate.
  */
 export interface AudienceMembershipReader {
-  query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: readonly unknown[] }>;
 }
 
 /**
@@ -317,6 +327,10 @@ export interface AudienceMembershipReader {
  * another workspace would hand this reader a token that then matches their
  * OWN tenant's facts — a leak the visibility predicate's workspace containment
  * cannot catch, because the token is being applied inside the right tenant.
+ *
+ * `DISTINCT` is belt-and-braces: the PK `(workspace_id, audience_id, user_id)`
+ * already makes a duplicate row unrepresentable. It survives a future PK
+ * relaxation without silently doubling the token list.
  */
 export const AUDIENCE_MEMBERSHIP_SQL = `
   SELECT DISTINCT audience_id
@@ -330,27 +344,30 @@ export interface ResolvePrincipalInput {
   readonly mode: AuthMode;
   readonly userId: string | undefined;
   /**
-   * The reader's role **in `workspaceId`** — i.e. the org-plugin `member.role`
-   * for that org, as produced by `resolveEffectiveRole(userRole, userId,
-   * workspaceId)` from `lib/auth/effective-role.ts`.
+   * The reader's role AND the org it was resolved against, as one value.
    *
-   * NOT `getUserRole(user)` from `lib/auth/permissions.ts`. That helper
+   * They travel together because they are only meaningful together.
+   * `member.role` is per-org (#2890), so a role resolved against the session's
+   * ACTIVE org while reading a DIFFERENT workspace would grant `role:` tokens —
+   * and audit-override entitlement — derived from another tenant. Carrying
+   * `orgId` alongside makes that mismatch detectable instead of invisible: on
+   * mismatch the role grants are dropped and the event logged. As two separate
+   * fields, "a role with no provenance" and "provenance for no role" were both
+   * constructible; as one object neither is.
+   *
+   * `role` must come from `resolveEffectiveRole(userRole, userId, orgId)` in
+   * `lib/auth/effective-role.ts`, or from `AtlasUser.role` raw.
+   *
+   * NOT from `getUserRole(user)` in `lib/auth/permissions.ts`. That helper
    * back-fills an auth-mode DEFAULT, and its `simple-key` default is `admin` —
    * so passing it would mint `role:admin` + `role:member` tokens AND
    * audit-override entitlement for every holder of a shared API key, out of
-   * nothing. `AtlasUser.role` raw is safe; the defaulting helper is not.
-   */
-  readonly role: AtlasRole | undefined;
-  /**
-   * The org `role` was resolved against. Must equal `workspaceId`.
+   * nothing.
    *
-   * `member.role` is per-org (#2890), so a `role` resolved against the
-   * session's ACTIVE org while reading a DIFFERENT workspace would grant
-   * `role:` tokens — and audit-override entitlement — derived from another
-   * tenant. Naming the org here makes that mismatch detectable instead of
-   * invisible; on mismatch the role grants are dropped and the event logged.
+   * Required-with-`undefined` rather than optional: omitting a reader's role
+   * must be a deliberate keystroke, not a forgotten one.
    */
-  readonly roleResolvedForOrgId: string | undefined;
+  readonly resolvedRole: { readonly role: AtlasRole; readonly orgId: string } | undefined;
   /** Correlates this module's log lines with the originating request. */
   readonly requestId?: string;
 }
@@ -368,11 +385,12 @@ export async function resolvePrincipalContext(
   db: AudienceMembershipReader,
   input: ResolvePrincipalInput,
 ): Promise<BrainPrincipalContext> {
-  const { workspaceId, mode, userId, role, roleResolvedForOrgId, requestId } = input;
+  const { workspaceId, mode, userId, resolvedRole, requestId } = input;
 
-  // An exhaustive switch rather than `mode === "none"`, so a fifth AuthMode
-  // forces a conscious decision instead of silently inheriting the
-  // authenticated arm.
+  // A switch rather than `mode === "none"`, so a fifth AuthMode cannot silently
+  // inherit the authenticated arm. The `never` binding in `default` is what
+  // makes that a COMPILE error rather than only a runtime deny — a `default`
+  // arm on its own would have swallowed the new mode quietly.
   switch (mode) {
     case "none":
       return {
@@ -387,8 +405,9 @@ export async function resolvePrincipalContext(
     case "byot":
       break;
     default: {
+      const unexpected: never = mode;
       log.warn(
-        { workspaceId, mode, requestId },
+        { workspaceId, mode: unexpected, requestId },
         "brain ACL: unrecognised auth mode — reader identity is unresolvable",
       );
       return { origin: "unresolved", workspaceId, userId: null, role: null, audienceIds: [] };
@@ -409,14 +428,14 @@ export async function resolvePrincipalContext(
   }
 
   let orgRole: OrgRole | null = null;
-  if (role !== undefined) {
-    if (roleResolvedForOrgId !== workspaceId) {
+  if (resolvedRole) {
+    if (resolvedRole.orgId !== workspaceId) {
       log.warn(
-        { workspaceId, roleResolvedForOrgId, userId, requestId },
+        { workspaceId, roleResolvedForOrgId: resolvedRole.orgId, userId, requestId },
         "brain ACL: role was resolved against a different org than the read target — dropping role grants",
       );
-    } else if (isOrgRole(role)) {
-      orgRole = role;
+    } else if (isOrgRole(resolvedRole.role)) {
+      orgRole = resolvedRole.role;
     }
     // Anything else is a platform role (`platform_admin`), which is not an org
     // grant. Falls through as `null` — deliberately, not by omission.
@@ -424,8 +443,29 @@ export async function resolvePrincipalContext(
 
   const result = await db.query(AUDIENCE_MEMBERSHIP_SQL, [workspaceId, userId]);
   const audienceIds = result.rows
-    .map((row) => (row as { audience_id?: unknown }).audience_id)
+    .map((row) =>
+      typeof row === "object" && row !== null && "audience_id" in row
+        ? (row as { audience_id: unknown }).audience_id
+        : undefined,
+    )
     .filter((id): id is string => typeof id === "string" && id.length > 0);
+  if (audienceIds.length !== result.rows.length) {
+    // `fact_audience_member.audience_id` is `text NOT NULL`, so a dropped row
+    // can only mean the query or the row shape changed (an added alias, a
+    // join). Silently returning fewer memberships would quietly strip a
+    // reader's audience grants — the same silent downgrade this function
+    // refuses to perform on a DB error.
+    log.warn(
+      {
+        workspaceId,
+        userId,
+        requestId,
+        returned: result.rows.length,
+        usable: audienceIds.length,
+      },
+      "brain ACL: audience membership rows dropped by narrowing — the membership query shape changed",
+    );
+  }
 
   return { origin: "authenticated", workspaceId, userId, role: orgRole, audienceIds };
 }
@@ -454,13 +494,17 @@ export function impliedRoles(role: OrgRole): readonly OrgRole[] {
       return ["admin", "member"];
     case "member":
       return ["member"];
-    default:
-      // Unreachable through the type, reachable through a cast or a future
-      // ORG_ROLES addition. Deny the role grants loudly rather than fall out
-      // of the switch as `undefined` — which the caller's `for…of` would turn
-      // into an unattributed `TypeError` from a security primitive.
-      log.warn({ role }, "brain ACL: unknown org role — granting no role principals");
+    default: {
+      // The `never` binding makes a future ORG_ROLES addition a COMPILE error
+      // rather than a silent read-time deny of a legitimate role. The runtime
+      // arm still stands for the value that arrives through a cast: deny the
+      // role grants loudly rather than fall out of the switch as `undefined`,
+      // which the caller's `for…of` would turn into an unattributed
+      // `TypeError` from a security primitive.
+      const unexpected: never = role;
+      log.warn({ role: unexpected }, "brain ACL: unknown org role — granting no role principals");
       return [];
+    }
   }
 }
 
@@ -476,36 +520,69 @@ export function impliedRoles(role: OrgRole): readonly OrgRole[] {
  * predicate, which is exactly the defect the review panel found in the first
  * cut of this module.
  *
- * Never contains `''` or a bare prefix. Two distinct hazards:
- *   - `ARRAY[''] && ARRAY['']` is TRUE in Postgres, and a stored `''` element
- *     is legal at rest, so an empty reader token would match a grant that
- *     grants nobody anything.
- *   - An unguarded `user:`/`audience:` arm emits the BARE PREFIX (`user:`),
- *     which `parsePrincipal` classifies as malformed — and a malformed reader
- *     token could raw-match a malformed STORED token, breaking the module
- *     header's load-bearing "no reader token is ever malformed" invariant.
- * Both are why every arm below is guarded, not tidiness.
+ * The output property is that no token is ever `''` or a bare prefix. The `''`
+ * half is free — every arm emits either a constant or a prefixed value — but
+ * it is worth stating, because `ARRAY[''] && ARRAY['']` is TRUE in Postgres and
+ * a stored `''` element is legal at rest. The GUARDS exist for the other half:
+ * an unguarded `user:`/`audience:` arm emits the BARE PREFIX (`user:`), which
+ * `parsePrincipal` classifies as malformed — and a malformed reader token could
+ * raw-match a malformed STORED token, breaking the module header's load-bearing
+ * "no reader token is ever malformed" invariant.
+ *
+ * The `origin` switch is exhaustive with a DENYING default. An earlier cut
+ * spelled the same logic as `if (origin !== "authenticated") return [ORG]`,
+ * which handed an unrecognised origin — one from a cast, or from a
+ * checkpoint rehydrated under an older shape — the workspace's entire
+ * org-granted fact set, unlogged. A permissive fallthrough on the discriminant
+ * that decides whether a reader is authenticated at all is the worst place in
+ * the module to have one.
  */
 export function principalTokens(ctx: BrainPrincipalContext): readonly string[] {
-  if (ctx.origin === "unresolved" || !ctx.workspaceId) return [];
+  if (!ctx.workspaceId) return [];
 
-  const tokens: string[] = [ORG_PRINCIPAL];
-  if (ctx.origin !== "authenticated") return tokens;
-
-  if (ctx.role) {
-    for (const role of impliedRoles(ctx.role)) tokens.push(`${ROLE_PREFIX}${role}`);
+  switch (ctx.origin) {
+    case "unresolved":
+      return [];
+    case "unauthenticated-local":
+      return [ORG_PRINCIPAL];
+    case "authenticated": {
+      const tokens: string[] = [ORG_PRINCIPAL];
+      if (ctx.role) {
+        for (const role of impliedRoles(ctx.role)) tokens.push(`${ROLE_PREFIX}${role}`);
+      }
+      if (ctx.userId) tokens.push(`${USER_PREFIX}${ctx.userId}`);
+      for (const audienceId of ctx.audienceIds) {
+        // Stored WITHOUT the prefix in `fact_audience_member` — the prefix
+        // belongs to the grammar, not to the identity — so it is added here.
+        if (audienceId.length > 0) tokens.push(`${AUDIENCE_PREFIX}${audienceId}`);
+      }
+      return tokens;
+    }
+    default: {
+      // Compile error if a fourth arm is added without a decision here; deny
+      // at runtime for anything that arrives through a cast.
+      const unexpected: never = ctx;
+      log.warn(
+        {
+          origin: (unexpected as { origin?: unknown }).origin,
+          workspaceId: (unexpected as { workspaceId?: unknown }).workspaceId,
+        },
+        "brain ACL: unrecognised principal origin — granting no principals",
+      );
+      return [];
+    }
   }
-  if (ctx.userId) tokens.push(`${USER_PREFIX}${ctx.userId}`);
-  for (const audienceId of ctx.audienceIds) {
-    // Stored WITHOUT the prefix in `fact_audience_member` — the prefix belongs
-    // to the grammar, not to the identity — so it is added here, once.
-    if (audienceId.length > 0) tokens.push(`${AUDIENCE_PREFIX}${audienceId}`);
-  }
-  return tokens;
 }
 
-/** A row this module can answer a visibility question about. */
+/**
+ * A row this module can answer a visibility question about.
+ *
+ * Carries `table` for the same reason `aclVisibilityClause` takes it: the SQL
+ * path cannot be aimed at a non-gated relation, and the mirror should not be
+ * either. It also lets the cross-workspace warning name what was asked about.
+ */
 export interface AclGatedRow {
+  readonly table: AclGatedTable;
   readonly workspaceId: string;
   readonly visibleTo: readonly unknown[];
 }
@@ -537,6 +614,7 @@ export function isVisibleTo(row: AclGatedRow, ctx: BrainPrincipalContext): boole
   if (row.workspaceId !== ctx.workspaceId) {
     log.warn(
       {
+        table: row.table,
         rowWorkspaceId: row.workspaceId,
         readerWorkspaceId: ctx.workspaceId,
         origin: ctx.origin,
@@ -546,28 +624,33 @@ export function isVisibleTo(row: AclGatedRow, ctx: BrainPrincipalContext): boole
     );
     return false;
   }
+  if (!Array.isArray(row.visibleTo)) {
+    // Typed `readonly unknown[]`, but rows arrive off `pg` as `visible_to` and
+    // a caller that maps `workspaceId` correctly and this field by mistake
+    // would otherwise get a bare `TypeError` from a security primitive.
+    log.warn(
+      { table: row.table, workspaceId: row.workspaceId, origin: ctx.origin },
+      "brain ACL: row carries no grant array — denying",
+    );
+    return false;
+  }
   const tokens = new Set(principalTokens(ctx));
-  if (tokens.size === 0) return false;
+  if (tokens.size === 0) {
+    // An unusable principal set is a bug upstream, not a routine answer — the
+    // SQL path logs it and so does this one. The ordinary no-overlap deny
+    // below stays silent on purpose: it is the common case, per row.
+    log.warn(
+      { table: row.table, workspaceId: ctx.workspaceId, origin: ctx.origin, userId: ctx.userId },
+      "brain ACL: reader resolved to no principals — denying",
+    );
+    return false;
+  }
   return row.visibleTo.some((token) => typeof token === "string" && tokens.has(token));
 }
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  The fail-closed push-down predicate
 // ══════════════════════════════════════════════════════════════════════
-
-/**
- * Why a clause is the shape it is. Observable so a caller can log it and a
- * test can assert the branch rather than pattern-matching SQL text.
- */
-export type AclDecision =
-  /** Normal path — workspace containment AND grant overlap. */
-  | "grant-match"
-  /** An entitled workspace admin's audit read. Workspace containment only. */
-  | "audit-override"
-  /** An override was requested by a reader not entitled to one. Falls back to `grant-match` SQL. */
-  | "override-refused"
-  /** No workspace, an unresolvable reader identity, or no usable principal. `(FALSE)`. */
-  | "deny-all";
 
 /**
  * A region- and workspace-scoped admin/audit read.
@@ -615,30 +698,76 @@ export interface AclClauseOptions {
  * A discriminated union on `decision` because the parameter ARITY VARIES by
  * branch, and the type has that information: a caller who switches on
  * `decision` gets the arity from the compiler instead of from a comment.
- * Regardless, advance your own placeholder counter by `params.length` and
- * never by a constant — Postgres rejects a bind that supplies more parameters
- * than the statement references, so guessing fails loudly, but it fails at
- * execution, which is late.
+ *
+ * `nextParamIndex` is the first placeholder the caller may use AFTER this
+ * clause — always `paramIndex + params.length`. Composing from it makes the
+ * rule mechanical rather than readable-and-forgettable; Postgres rejects a
+ * bind that supplies more parameters than the statement references, so
+ * counting by hand fails loudly, but it fails at execution, which is late.
  *
  * `sql` is always parenthesised and carries no leading `AND`.
  */
 export type AclClause =
-  | { readonly decision: "deny-all"; readonly sql: string; readonly params: readonly [] }
+  /** No workspace, an unresolvable reader identity, or no usable principal. */
+  | {
+      readonly decision: "deny-all";
+      readonly sql: string;
+      readonly params: readonly [];
+      readonly nextParamIndex: number;
+    }
+  /** An entitled workspace admin's audit read. Workspace containment only. */
   | {
       readonly decision: "audit-override";
       readonly sql: string;
       readonly params: readonly [workspaceId: string];
+      readonly nextParamIndex: number;
     }
+  /**
+   * `grant-match` is the normal path — workspace containment AND grant
+   * overlap. `override-refused` is the same SQL, reached because an override
+   * was requested by a reader not entitled to one.
+   */
   | {
       readonly decision: "grant-match" | "override-refused";
       readonly sql: string;
       readonly params: readonly [workspaceId: string, tokens: readonly string[]];
+      readonly nextParamIndex: number;
     };
+
+/**
+ * Why a clause is the shape it is. Observable so a caller can log it and a
+ * test can assert the branch rather than pattern-matching SQL text.
+ *
+ * Derived, never hand-listed: a duplicated literal union drifts silently the
+ * first time a fifth decision is added to one of the two.
+ */
+export type AclDecision = AclClause["decision"];
 
 /** A SQL identifier safe to interpolate as an alias. */
 const SAFE_ALIAS = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-const DENY_ALL: AclClause = { sql: "(FALSE)", params: [], decision: "deny-all" };
+/**
+ * Frozen, not merely `readonly`. `readonly` is compile-time only, and this one
+ * object is returned by reference from every deny in the process — so a single
+ * type-violating caller mutating `.params` would poison every subsequent
+ * denied read for every tenant on the instance, surfacing as a Postgres bind
+ * error that points at the caller's query rather than at the mutation.
+ * `lib/auth/types.ts` freezes `createAtlasUser`'s result for the same reason.
+ *
+ * `nextParamIndex` is filled in per call — it depends on the caller's
+ * `paramIndex` — so the deny arm is built from this template rather than
+ * returned directly.
+ */
+const DENY_ALL = Object.freeze({
+  sql: "(FALSE)",
+  params: Object.freeze([]) as readonly [],
+  decision: "deny-all",
+}) satisfies Omit<Extract<AclClause, { decision: "deny-all" }>, "nextParamIndex">;
+
+/** The deny clause, carrying the caller's untouched placeholder cursor. */
+function denyAll(paramIndex: number): AclClause {
+  return { ...DENY_ALL, nextParamIndex: paramIndex };
+}
 
 /**
  * The fail-closed, push-down visibility predicate. AND this into the WHERE
@@ -681,7 +810,7 @@ export function aclVisibilityClause(
     );
   }
 
-  // Both deny arms record whether an override was ATTEMPTED. An operator
+  // Every deny arm records whether an override was ATTEMPTED. An operator
   // reading "identity could not be resolved" must be able to tell that
   // somebody also tried to invoke a workspace-wide ACL bypass — attempted
   // privilege escalation is exactly the event you want in the log.
@@ -696,20 +825,25 @@ export function aclVisibilityClause(
     // No workspace means no tenant boundary to enforce, and a predicate with
     // no tenant boundary is worse than none at all.
     log.warn(denyContext, "brain ACL: principal context has no workspace — denying all rows");
-    return DENY_ALL;
+    return denyAll(paramIndex);
   }
   if (ctx.origin === "unresolved") {
     log.warn(
       { ...denyContext, workspaceId: ctx.workspaceId },
       "brain ACL: reader identity could not be resolved — denying all rows",
     );
-    return DENY_ALL;
+    return denyAll(paramIndex);
   }
 
   const workspaceClause = `${alias}.workspace_id = $${paramIndex}`;
 
   if (override) {
-    const reason = override.reason.trim();
+    // Typed `string`, but the value originates in a request (a query param, a
+    // JSON body, an admin form). An un-narrowed `.trim()` would turn an
+    // override probe into an unattributed 500 instead of a logged refusal —
+    // i.e. into an error where the correct answer is a recorded escalation
+    // attempt.
+    const reason = typeof override.reason === "string" ? override.reason.trim() : "";
     const entitled =
       ctx.origin === "authenticated" &&
       !!ctx.userId &&
@@ -733,6 +867,7 @@ export function aclVisibilityClause(
         sql: `(${workspaceClause})`,
         params: [ctx.workspaceId],
         decision: "audit-override",
+        nextParamIndex: paramIndex + 1,
       };
     }
     // Refused, not fatal: the reader still sees what their own grants allow.
@@ -747,22 +882,26 @@ export function aclVisibilityClause(
 
   const tokens = principalTokens(ctx);
   if (tokens.length === 0) {
-    // Reachable whenever `principalTokens` denies — today that is exactly the
-    // two arms handled above, so this is a backstop rather than a distinct
-    // cause. It is written out anyway: `visible_to && ARRAY[]` is already
-    // FALSE in Postgres, so the ROW-level outcome would be identical, but it
-    // would be a silent, unlogged deny reported as `grant-match`. The explicit
-    // arm exists to make the deny OBSERVABLE, not because the SQL would leak.
+    // Reachable whenever `principalTokens` denies. The two arms above cover
+    // its known causes; this one also catches its `default` — an `origin`
+    // outside the union, arriving through a cast — which has no earlier check
+    // and would otherwise be the module's one unlogged path.
+    //
+    // `visible_to && ARRAY[]` is already FALSE in Postgres, so the ROW-level
+    // outcome of omitting this arm would be identical. It exists to make the
+    // deny OBSERVABLE — otherwise it would be a silent, unlogged deny reported
+    // as `grant-match` — not because the SQL would leak.
     log.warn(
-      { table, workspaceId: ctx.workspaceId, userId: ctx.userId, origin: ctx.origin, requestId },
+      { ...denyContext, workspaceId: ctx.workspaceId },
       "brain ACL: reader resolved to no principals — denying all rows",
     );
-    return DENY_ALL;
+    return denyAll(paramIndex);
   }
 
   return {
     sql: `(${workspaceClause} AND ${alias}.visible_to && $${paramIndex + 1}::text[])`,
     params: [ctx.workspaceId, tokens],
     decision: override ? "override-refused" : "grant-match",
+    nextParamIndex: paramIndex + 2,
   };
 }


### PR DESCRIPTION
Closes #4768.

The T5 core ACL primitive from [ADR-0036 §Access control & residency](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0036-atlas-as-company-brain.md), over tiers 2–3 only. Builds on #4767's substrate (migration 0180, `lib/brain/types.ts`).

**Targets `milestone/v0.2.0-brain-m1`**, not `main` — issue 2 of 9 in the Brain M1 stack. CodeQL (`Analyze (javascript-typescript)`) is default-setup and main-only, so it does not run here; that is **deferred to the milestone→main PR**, not waived.

## What's here

`packages/api/src/lib/brain/acl.ts` — four things:

1. **The gated tables.** Tiers 2 and 3 only. Tier-1 warehouse facts resolve live through the semantic layer under warehouse RLS; double-gating them would mean two systems that must agree about the same row and eventually won't.
2. **The grant grammar** — `org | role:{owner,admin,member} | user:<id> | audience:<source-derived>` — parsed into a discriminated union. Byte-exact and case-sensitive, because the enforcement is Postgres's `&&` over `text[]` and a parser that normalised would disagree with the SQL about the same row.
3. **Principal-set resolution**, including live `audience:` membership read locally from `fact_audience_member` — a set-membership check, never a connector call at read time.
4. **`aclVisibilityClause`** — the fail-closed push-down predicate #4773 ANDs into its WHERE clause. Push-down, not post-fetch: a post-fetch filter has already loaded the row it is about to hide, and every LIMIT above it counts rows the reader may not see.

## Decisions worth surfacing

**Role matching is monotone** (owner matches `role:admin` and `role:member`). Exact-match was considered and rejected: `role:member` means "at least a member" in every RBAC system anyone has used, and under exact matching a fact granted to `role:member` would be invisible to the workspace **owner**. The widening has no leak case — every role a reader gains through is one they already outrank — and it spares #4771 from enumerating three arms on every derived grant.

**The clause emits workspace containment alongside the grant overlap**, even though every caller already scopes to a workspace. Audience ids are workspace-scoped identities with no global uniqueness; two tenants both minting `audience:engineering` is normal. Redundant tenant scoping inside a security predicate is the difference between a primitive that is safe standalone and one that is safe only when used correctly. Postgres folds the duplicate for free.

**`auth: none` gets the `org` principal only** — strictly narrower than the full access the rest of Atlas hands that mode — so anything deliberately narrowed to a role, user, or audience stays hidden even from the local operator. A bare `platform_admin` gets no org-role principal and no audit override: a platform operator is not a member of the tenant.

**Nothing here is stricter than migration 0180's CHECK.** A row Postgres legally stores but Atlas code refuses is a workspace that cannot be migrated between regions, discovered at cutover. So `parseGrant` reports malformed tokens and never throws, and this module has no write-side validation at all. `grantProblem` in `admin-migrate.ts` is paired with the CHECK (not with this parser) and its comment now says so explicitly.

## Acceptance criteria

- [x] Predicate is fail-closed: unknown/malformed grant ⇒ row invisible + logged, never visible
- [x] Composition test: residency-invariant AND org/group-reach AND content-mode AND grant
- [x] Per-version grant immutability covered by test
- [x] `audience:` membership is a local set-membership check
- [x] Zero `/ee` imports

Two caveats stated rather than glossed. The composition test demonstrates **two** gates load-bearing, not four: residency has no clause (invariant by construction — the process is the region), and the reach stand-in is spelled `workspace_id = $1`, which the ACL clause already enforces, so its control asserts that *redundancy*. ADR-0022 reach is connection-group scoped and there is nothing real to compose until #4773 lands `resolveReachableGroups`. And an **entirely** malformed grant (`['everyone']`) is correctly invisible but logged by nobody, because no reader ever holds the row — a push-down predicate cannot log what it excluded. Filed as #4797.

## Review

`/review-panel` ran three rounds and found real defects in all three, including two introduced by earlier rounds' own fixes:

- **Round 1** — `isVisibleTo` was documented as a mirror of the predicate and mirrored one arm: it ignored `origin` and workspace containment, so it answered TRUE for an `unresolved` reader and for another tenant's row on a colliding `audience:` token. `BrainPrincipalContext` was a flat record, so `{ origin: "unauthenticated-local", role: "owner" }` typechecked and earned a full audit override. `resolvePrincipalContext` took `workspaceId` and `role` unrelated, allowing cross-tenant role elevation — made worse by `getUserRole`'s `simple-key` → `admin` default, which would have minted `role:admin` plus override entitlement for every holder of a shared API key.
- **Round 2** — caught a **new** fail-open created by round 1's own fix: `principalTokens` spelled its arms as `if (origin !== "authenticated") return [ORG_PRINCIPAL]`, so an origin outside the union got the workspace's entire org-granted fact set, unlogged, from the function round 1 had just designated as the deny point. Also: the two `default` arms added in round 1 denied correctly at runtime while silently removing TypeScript's exhaustiveness error, so their comments promised a compile-time guarantee they had just deleted.
- **Round 3** — clean, no blockers from any reviewer. The fail-open is verified closed at compile time (the `never` bindings genuinely bind), at runtime, and against real Postgres. Remaining low-severity residue was fixed inline.

## Tests

79 tests across three files, split because the module makes three separable claims:

- `acl.test.ts` — the decisions: which branch fires, what SQL comes out, the arity contract.
- `acl-visibility-pg.test.ts` — what that SQL actually **selects**, against real Postgres. A grant × reader parity matrix over both gated tables, where every reader also carries an **absolute** expectation, because parity alone is circular (both sides derive tokens from `principalTokens`). Includes NULL/`''`/bare-prefix elements that 0180's CHECK legally admits, cross-tenant collision in both directions (colliding grant **and** colliding membership row — the leak workspace containment cannot catch), array-literal metacharacters (a serialization that stopped quoting would split `user:a,org` into two tokens — fail-open), live revocation through membership, per-version grant immutability *with an actual widening step*, and an `EXPLAIN` assertion that the grant match stays a pushed-down overlap rather than a per-row subplan.
- `acl-logging.test.ts` — that every deny and every override is **logged**. Every `log.warn` in the module was deletable with the other two suites green, because enforcement is structural and independent of reporting. The audit-override line is the only artifact of a workspace-wide grant bypass.

Note `bun test src/lib/brain/__tests__/` (bare, on the directory) will report failures — `acl-logging.test.ts` needs `mock.module` to bind before the module loads, which a sibling file's import defeats. CI's isolated per-file runner is the supported path, per CLAUDE.md.
